### PR TITLE
Raise heterogeneous switch-arm intros to pattern switch expressions (#3028 PR A)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/HeterogeneousArmSample.cs
+++ b/src/ILInspector.Decompiler.Tests/HeterogeneousArmSample.cs
@@ -1,0 +1,47 @@
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Fixture for issue #3028 PR A: a <c>switch</c> expression over a plain receiver
+/// whose arms csc lowers to <em>heterogeneous</em> intros over the place read
+/// directly — no switch-value temp. csc emits the first arm as an intro-chain
+/// (<c>x = place as T; if (x is null) { … }</c>) and the remaining arms as
+/// inline-positive siblings (<c>if (place is U y) { … }</c>) nested in the
+/// leading arm's no-match branch, bottoming out in the default
+/// <c>return</c>. <see cref="ILInspector.Decompiler.Pipeline.PatternSwitchExpressionPass"/>
+/// raises the whole cascade back into a single switch expression.
+///
+/// <see cref="Area"/> is the mixed intro-chain-plus-inline shape. Isolated from
+/// <see cref="CfgSampleClass"/> so it does not perturb the fidelity gate's pinned
+/// population.
+/// </summary>
+public static class HeterogeneousArmSample
+{
+    public abstract class Shape
+    {
+    }
+
+    public sealed class Dot : Shape
+    {
+        public int Radius;
+    }
+
+    public sealed class Bar : Shape
+    {
+        public int Length;
+    }
+
+    public sealed class Box : Shape
+    {
+        public int Side;
+    }
+
+    // csc: intro-chain arm (`Dot d = shape as Dot; if (d is null) …`) followed by
+    // inline-positive sibling arms, over `shape` read directly.
+    public static int Area(Shape shape) => shape switch
+    {
+        Dot d => d.Radius,
+        Bar b => b.Length,
+        Box x => x.Side,
+        _ => -1,
+    };
+}

--- a/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
@@ -100,6 +100,39 @@ public class PatternSwitchExpressionPassTests
         Assert.Contains("_ => false,", output);
     }
 
+    // ── Compiler-backed positives: heterogeneous / inline arm intros (#3028) ─
+
+    [Fact]
+    public void HeterogeneousArmIntros_RaiseToPatternSwitchExpression()
+    {
+        // csc lowers this to a leading intro-chain arm (`Dot d = shape as Dot; if
+        // (d is null) …`) plus inline-positive sibling arms (`if (shape is Bar b)
+        // …`), over `shape` read directly (no switch-value temp). The pass folds
+        // the whole heterogeneous cascade back into one switch expression.
+        var function = Raised(typeof(HeterogeneousArmSample), nameof(HeterogeneousArmSample.Area));
+
+        var switchExpression = Assert.Single(function.Descendants.OfType<PatternSwitchExpression>());
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.True(switchExpression.HasDefault);
+        Assert.Equal(3, switchExpression.Arms.Count);
+        Assert.All(switchExpression.Arms, arm =>
+        {
+            Assert.Null(arm.Subpattern);
+            Assert.False(arm.HasGuard);
+            Assert.NotNull(arm.LocalIndex);
+        });
+        Assert.Contains("Dot", switchExpression.Arms[0].PatternType.ToDisplayString());
+        Assert.Contains("Bar", switchExpression.Arms[1].PatternType.ToDisplayString());
+        Assert.Contains("Box", switchExpression.Arms[2].PatternType.ToDisplayString());
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+        Assert.Contains("return shape switch", output);
+        Assert.Contains("Dot d => d.Radius,", output);
+        Assert.Contains("Bar b => b.Length,", output);
+        Assert.Contains("Box x => x.Side,", output);
+        Assert.Contains("_ => -1,", output);
+    }
+
     // ── Synthetic shape + negative guards ──────────────────────────────────
 
     // Minimal recognized shape (post-#3003 structuring): `sv = <place>; k = sv
@@ -187,6 +220,98 @@ public class PatternSwitchExpressionPassTests
             guard: null,
             armValue: new Constant(true, Bool),
             noMatchDefault: False());
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    static readonly TypeRef Twig = TypeRef.CoreLib("Synthetic", "Twig");
+
+    // Builds a temp-less, direct-place cascade whose head is an intro-chain arm
+    // (`L0 = place as Leaf; if (!L0) { REST } return 1;`) with `inlineArmCount`
+    // inline-positive sibling arms nested in REST, bottoming out in the default.
+    static IrFunction DirectIntroCascade(IrExpression place, int inlineArmCount)
+    {
+        var rest = new Block();
+        for (int k = 0; k < inlineArmCount; k++)
+        {
+            var thenK = new Block();
+            thenK.Add(new Return(new Constant(2 + k, Int32)));
+            rest.Add(new IfStatement(new IsPattern((IrExpression)place.Clone(), Twig, 1 + k), thenK, null));
+        }
+        rest.Add(new Return(new Constant(-1, Int32)));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, Leaf, new IsInstance(Leaf, (IrExpression)place.Clone())));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Leaf)), rest, null));
+        block.Add(new Return(new Constant(1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Twig, Twig, Node), container);
+    }
+
+    // Builds a temp-less, all-inline direct-place cascade (no intro-chain head):
+    //   `if (place is Leaf a) { return 1; } if (place is Twig b) { return 2; }
+    //   return <default>;`
+    static IrFunction AllInlineCascade(IrExpression place)
+    {
+        var thenA = new Block();
+        thenA.Add(new Return(new Constant(1, Int32)));
+        var thenB = new Block();
+        thenB.Add(new Return(new Constant(2, Int32)));
+
+        var block = new Block(0);
+        block.Add(new IfStatement(new IsPattern((IrExpression)place.Clone(), Leaf, 0), thenA, null));
+        block.Add(new IfStatement(new IsPattern((IrExpression)place.Clone(), Twig, 1), thenB, null));
+        block.Add(new Return(new Constant(-1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Twig, Node), container);
+    }
+
+    [Fact]
+    public void Synthetic_DirectIntroPlusInlineSibling_Raises()
+    {
+        // Intro-chain head arm plus one inline-positive sibling arm over the same
+        // re-evaluable place, no temp — the temp-less heterogeneous shape. Folds
+        // to a two-arm switch.
+        var function = DirectIntroCascade(new LoadArgument(0, "node", Node), inlineArmCount: 1);
+
+        RunPass(function);
+
+        var switchExpression = Assert.Single(function.Descendants.OfType<PatternSwitchExpression>());
+        Assert.Equal(2, switchExpression.Arms.Count);
+        Assert.True(switchExpression.HasDefault);
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+    }
+
+    [Fact]
+    public void Synthetic_DirectIntroSingleArm_DoesNotRaise()
+    {
+        // A single intro-chain arm over a re-evaluable place is indistinguishable
+        // from an ordinary `if (place is T t)` guard, which IsPatternPass renders
+        // idiomatically. The direct (temp-less) form requires at least two arms,
+        // so a lone guard is left as-is.
+        var function = DirectIntroCascade(new LoadArgument(0, "node", Node), inlineArmCount: 0);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    [Fact]
+    public void Synthetic_AllInlineWithoutIntroHead_DoesNotRaise()
+    {
+        // Every arm is an inline-positive test with no leading intro-chain arm —
+        // the shape a hand-written `if` chain lowers to, not a `switch`. PR A
+        // anchors only on cascades whose head csc lowered to an intro-chain arm,
+        // so this is left unfolded.
+        var function = AllInlineCascade(new LoadArgument(0, "node", Node));
 
         RunPass(function);
 

--- a/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
@@ -380,22 +380,20 @@ public class PatternSwitchExpressionPassTests
     }
 
     [Fact]
-    public void Synthetic_InlineGuardFallsThrough_Raises()
+    public void Synthetic_InlineGuardFallsThrough_DoesNotRaise()
     {
-        // The safe counterpart: a positive-form inline guard (`if (G) return V;`)
-        // whose failure falls out of the `then` block to the next sibling — the
-        // exact fall-through a switch `when` guard performs. This still folds, so
-        // Finding 1's fix rejects only the short-circuiting shape, not every
-        // guarded inline arm.
+        // #3028 PR A scopes the newly recognized heterogeneous surface (a direct
+        // scrutinee or any inline-positive arm) to UNGUARDED arms only. A guarded
+        // arm whose failure short-circuits to the default folds faithfully only
+        // when no later arm can match the same value, which needs a
+        // type-disjointness oracle this SRM-only pass does not have. Even the safe
+        // fall-through inline guard is therefore deferred to a follow-up; only the
+        // unguarded new-surface shape folds under PR A.
         var function = DirectIntroGuardedInline(new LoadArgument(0, "node", Node), shortCircuitToDefault: false);
 
         RunPass(function);
 
-        var switchExpression = Assert.Single(function.Descendants.OfType<PatternSwitchExpression>());
-        Assert.Equal(2, switchExpression.Arms.Count);
-        Assert.True(switchExpression.Arms[1].HasGuard);
-        Assert.True(switchExpression.HasDefault);
-        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
     }
 
     // Builds a direct-place cascade (intro head + one inline sibling) whose inline
@@ -438,6 +436,150 @@ public class PatternSwitchExpressionPassTests
         // folding to a single read would diverge. The stability check rejects any
         // store or address-of the direct scrutinee inside the cascade.
         var function = DirectIntroAddressOfScrutinee(argAddress);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    // Builds a direct-place cascade whose head is an intro-chain arm carrying a
+    // short-circuiting `when` guard (`if (!G) return <default>;`), followed by one
+    // inline sibling arm of `laterType`:
+    //   `L0 = place as Leaf; if (!L0) { if (place is laterType L1) return 2;
+    //    return -1; } if (!Guard(L0)) return -1; return 1;`
+    static IrFunction DirectIntroShortCircuitPlusInline(IrExpression place, TypeRef laterType)
+    {
+        IrExpression Guard() => new Call(new MethodRef(Leaf, "Ok", Bool, [Leaf], HasThis: false), isVirtual: false, [new LoadLocal(0, Leaf)]);
+
+        var innerThen = new Block();
+        innerThen.Add(new Return(new Constant(2, Int32)));
+        var rest = new Block();
+        rest.Add(new IfStatement(new IsPattern((IrExpression)place.Clone(), laterType, 1), innerThen, null));
+        rest.Add(new Return(new Constant(-1, Int32)));
+
+        var guardFail = new Block();
+        guardFail.Add(new Return(new Constant(-1, Int32)));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, Leaf, new IsInstance(Leaf, (IrExpression)place.Clone())));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Leaf)), rest, null));
+        block.Add(new IfStatement(new LogicalNot(Guard()), guardFail, null));
+        block.Add(new Return(new Constant(1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Leaf, Node), container);
+    }
+
+    [Fact]
+    public void Synthetic_IntroGuardShortCircuitOverlapsLaterArm_DoesNotRaise()
+    {
+        // #3028 review round 2 (GPT Finding A / Gemini Finding 1): a guarded
+        // intro arm in the direct (temp-less) form whose guard failure
+        // short-circuits to the default, followed by a later arm that can match
+        // the same value (`Leaf` again, or any base type of `Leaf`). Folding it
+        // makes the guard failure fall through to that later arm, whereas the IL
+        // routed it to the default — divergent. PR A rejects the whole class by
+        // declining any guarded arm on the new heterogeneous surface, so no
+        // type-disjointness oracle is needed.
+        var function = DirectIntroShortCircuitPlusInline(new LoadArgument(0, "node", Node), Leaf);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    [Fact]
+    public void Synthetic_IntroGuardDistinctLaterArmInDirectForm_DoesNotRaise()
+    {
+        // The same guarded intro arm with a distinct later type (`Twig`) is
+        // semantically foldable, but PR A still declines it: the direct
+        // (temp-less) form is the new heterogeneous surface, restricted to
+        // unguarded arms. Guarded heterogeneous folding is deferred to a follow-up
+        // that carries a real type-disjointness oracle. The pre-existing temp-form
+        // intro cascade (#3022) keeps its guarded arms.
+        var function = DirectIntroShortCircuitPlusInline(new LoadArgument(0, "node", Node), Twig);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    // A direct argument-scrutinee cascade preceded by an aliasing store
+    // (`ref9 = &arg;`) — the address escapes the cascade even though every arm
+    // test re-reads `arg` directly.
+    static IrFunction DirectCascadeWithArgAlias()
+    {
+        IrExpression Arg() => new LoadArgument(0, "node", Node);
+
+        var innerThen = new Block();
+        innerThen.Add(new Return(new Constant(2, Int32)));
+        var rest = new Block();
+        rest.Add(new IfStatement(new IsPattern(Arg(), Twig, 1), innerThen, null));
+        rest.Add(new Return(new Constant(-1, Int32)));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(9, TypeRef.ByRef(Node), new LoadArgumentAddress(0, "node", Node)));
+        block.Add(new StoreLocal(0, Leaf, new IsInstance(Leaf, Arg())));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Leaf)), rest, null));
+        block.Add(new Return(new Constant(1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Twig, Node, Node, Node, Node, Node, Node, Node, TypeRef.ByRef(Node)), container);
+    }
+
+    [Fact]
+    public void Synthetic_DirectScrutineeAliasedBeforeCascade_DoesNotRaise()
+    {
+        // #3028 review round 2 (GPT, Finding B): the scrutinee argument's address
+        // is taken into an alias BEFORE the cascade. A consumed-region-only scan
+        // misses it, but a by-ref call through that alias inside a guard could
+        // mutate `arg` between arm tests. The stability check scans the whole
+        // method for an address-of the direct scrutinee and declines.
+        var function = DirectCascadeWithArgAlias();
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    // A temp-form cascade (`SV = arg;` then arms testing `SV`) whose inline arm
+    // takes the address of the temp — `Mutate(ref SV)` — inside its value.
+    static IrFunction TempCascadeWithTempAddress()
+    {
+        IrExpression Sv() => new LoadLocal(5, Node);
+        var mutate = new MethodRef(Node, "Mutate", Int32, [TypeRef.ByRef(Node)], HasThis: false);
+
+        var innerThen = new Block();
+        innerThen.Add(new Return(new Call(mutate, isVirtual: false, [new LoadLocalAddress(5, Node)])));
+        var rest = new Block();
+        rest.Add(new IfStatement(new IsPattern(Sv(), Twig, 1), innerThen, null));
+        rest.Add(new Return(new Constant(-1, Int32)));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(5, Node, new LoadArgument(0, "node", Node)));
+        block.Add(new StoreLocal(0, Leaf, new IsInstance(Leaf, Sv())));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Leaf)), rest, null));
+        block.Add(new Return(new Constant(1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Twig, Node, Node, Node, Node), container);
+    }
+
+    [Fact]
+    public void Synthetic_TempScrutineeAddressTaken_DoesNotRaise()
+    {
+        // #3028 review round 2 (GPT, Finding C): the temp-form ownership check
+        // proves `SV` is referenced only inside the cascade, but an address-of
+        // `SV` in an arm (`Mutate(ref SV)`) is such a reference — and the fold
+        // deletes `SV`'s defining store, dangling it, while a by-ref mutation
+        // would change the value later arms read. The read-only check declines.
+        var function = TempCascadeWithTempAddress();
 
         RunPass(function);
 

--- a/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
@@ -24,6 +24,8 @@ public class PatternSwitchExpressionPassTests
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Node = TypeRef.CoreLib("Synthetic", "Node");
     static readonly TypeRef Leaf = TypeRef.CoreLib("Synthetic", "Leaf");
+    static readonly TypeRef Outer = TypeRef.CoreLib("Synthetic", "Outer");
+    static readonly TypeRef Inner = TypeRef.CoreLib("Synthetic", "Inner");
 
     static Constant False() => new(false, Bool);
 
@@ -580,6 +582,55 @@ public class PatternSwitchExpressionPassTests
         // deletes `SV`'s defining store, dangling it, while a by-ref mutation
         // would change the value later arms read. The read-only check declines.
         var function = TempCascadeWithTempAddress();
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    // Builds a direct-place cascade whose head is an intro-chain arm carrying a
+    // single-level property subpattern (`Outer { Inner: Leaf }`), followed by one
+    // inline sibling arm of the SAME outer type (`Outer`):
+    //   `L0 = place as Outer; if (!L0) { if (place is Outer) return 2; return -1; }
+    //    L1 = L0.Inner as Leaf; if (L1) return 1; return -1;`
+    // A failed subpattern (`Inner` not `Leaf`) routes straight to the default,
+    // exactly as a failed `when` guard does.
+    static IrFunction DirectSubpatternPlusInline(IrExpression place)
+    {
+        var accessor = new MethodRef(Outer, "get_Inner", Inner, [], HasThis: true);
+
+        var innerThen = new Block();
+        innerThen.Add(new Return(new Constant(2, Int32)));
+        var rest = new Block();
+        rest.Add(new IfStatement(new IsPattern((IrExpression)place.Clone(), Outer, 5), innerThen, null));
+        rest.Add(new Return(new Constant(-1, Int32)));
+
+        var subThen = new Block();
+        subThen.Add(new Return(new Constant(1, Int32)));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, Outer, new IsInstance(Outer, (IrExpression)place.Clone())));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Outer)), rest, null));
+        block.Add(new StoreLocal(1, Leaf, new IsInstance(Leaf, new LoadProperty(accessor, new LoadLocal(0, Outer), []))));
+        block.Add(new IfStatement(new LoadLocal(1, Leaf), subThen, null));
+        block.Add(new Return(new Constant(-1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Outer)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Outer, signature, ImmutableArray.Create(Outer, Leaf), container);
+    }
+
+    [Fact]
+    public void Synthetic_DirectSubpatternOverlapsLaterArm_DoesNotRaise()
+    {
+        // #3028 review round 2 (GPT): the unguarded-surface gate must also reject
+        // property-subpattern arms on the new surface. An `Outer { Inner: Leaf }`
+        // arm whose inner match fails routes to the default just like a failed
+        // guard; folding it (with a later overlapping `Outer` arm) would make that
+        // failure fall through to the `Outer` arm instead — divergent. The gate
+        // declines any guarded OR subpattern arm on the direct/inline surface.
+        var function = DirectSubpatternPlusInline(new LoadArgument(0, "node", Outer));
 
         RunPass(function);
 

--- a/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
@@ -317,4 +317,130 @@ public class PatternSwitchExpressionPassTests
 
         Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
     }
+
+    // Builds a direct-place cascade whose head is an intro-chain arm and whose one
+    // inline sibling arm carries a `when` guard, in either the short-circuiting
+    // negated form (`if (!G) return <default>; return V;`) or the fall-through
+    // positive form (`if (G) return V;`):
+    //   `L0 = place as Leaf; if (!L0) { if (place is Twig L1) { <guarded> }
+    //    return <default>; } return 1;`
+    static IrFunction DirectIntroGuardedInline(IrExpression place, bool shortCircuitToDefault)
+    {
+        IrExpression Guard() => new Call(new MethodRef(Twig, "Ok", Bool, [Twig], HasThis: false), isVirtual: false, [new LoadLocal(1, Twig)]);
+
+        var armBody = new Block();
+        if (shortCircuitToDefault)
+        {
+            // Negated form: guard failure returns the default immediately, skipping
+            // any later arm that would still match the same value in a switch.
+            var guardFail = new Block();
+            guardFail.Add(new Return(new Constant(-1, Int32)));
+            armBody.Add(new IfStatement(new LogicalNot(Guard()), guardFail, null));
+            armBody.Add(new Return(new Constant(2, Int32)));
+        }
+        else
+        {
+            // Positive form: guard failure falls out of the `then` block to the
+            // following sibling — the switch `when` fall-through semantics.
+            var guardPass = new Block();
+            guardPass.Add(new Return(new Constant(2, Int32)));
+            armBody.Add(new IfStatement(Guard(), guardPass, null));
+        }
+
+        var rest = new Block();
+        rest.Add(new IfStatement(new IsPattern((IrExpression)place.Clone(), Twig, 1), armBody, null));
+        rest.Add(new Return(new Constant(-1, Int32)));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, Leaf, new IsInstance(Leaf, (IrExpression)place.Clone())));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Leaf)), rest, null));
+        block.Add(new Return(new Constant(1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Twig, Node), container);
+    }
+
+    [Fact]
+    public void Synthetic_InlineGuardShortCircuitsToDefault_DoesNotRaise()
+    {
+        // #3028 review (Gemini, Finding 1): an inline sibling arm whose guard
+        // failure returns the default immediately (`if (!G) return <default>;`)
+        // must not fold. Folding it to `Twig x when G => 2` makes a guard failure
+        // fall through to later arms, but the IL short-circuited straight to the
+        // default — divergent whenever a later arm matches the same value. Only
+        // csc's fall-through guard shape is foldable, so this hand-shaped IL is
+        // left alone.
+        var function = DirectIntroGuardedInline(new LoadArgument(0, "node", Node), shortCircuitToDefault: true);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    [Fact]
+    public void Synthetic_InlineGuardFallsThrough_Raises()
+    {
+        // The safe counterpart: a positive-form inline guard (`if (G) return V;`)
+        // whose failure falls out of the `then` block to the next sibling — the
+        // exact fall-through a switch `when` guard performs. This still folds, so
+        // Finding 1's fix rejects only the short-circuiting shape, not every
+        // guarded inline arm.
+        var function = DirectIntroGuardedInline(new LoadArgument(0, "node", Node), shortCircuitToDefault: false);
+
+        RunPass(function);
+
+        var switchExpression = Assert.Single(function.Descendants.OfType<PatternSwitchExpression>());
+        Assert.Equal(2, switchExpression.Arms.Count);
+        Assert.True(switchExpression.Arms[1].HasGuard);
+        Assert.True(switchExpression.HasDefault);
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+    }
+
+    // Builds a direct-place cascade (intro head + one inline sibling) whose inline
+    // arm value takes the address of the scrutinee place — the by-ref mutation
+    // vector. `argAddress` selects an argument scrutinee (`&arg`) versus a local
+    // scrutinee (`&local`) so both branches of the stability check are exercised.
+    static IrFunction DirectIntroAddressOfScrutinee(bool argAddress)
+    {
+        IrExpression place = argAddress ? new LoadArgument(0, "node", Node) : new LoadLocal(7, Node);
+        IrExpression address = argAddress ? new LoadArgumentAddress(0, "node", Node) : new LoadLocalAddress(7, Node);
+        var mutate = new MethodRef(Node, "Mutate", Int32, [TypeRef.ByRef(Node)], HasThis: false);
+
+        var armBody = new Block();
+        armBody.Add(new Return(new Call(mutate, isVirtual: false, [address])));
+
+        var rest = new Block();
+        rest.Add(new IfStatement(new IsPattern((IrExpression)place.Clone(), Twig, 1), armBody, null));
+        rest.Add(new Return(new Constant(-1, Int32)));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, Leaf, new IsInstance(Leaf, (IrExpression)place.Clone())));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Leaf)), rest, null));
+        block.Add(new Return(new Constant(1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Twig, Node, Node, Node, Node, Node, Node), container);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Synthetic_DirectScrutineeAddressTaken_DoesNotRaise(bool argAddress)
+    {
+        // #3028 review (Gemini, Finding 2): a direct (temp-less) scrutinee is
+        // re-read by every arm, but a switch expression reads it once. When the
+        // cascade takes the address of the scrutinee's place (`&arg` / `&local`),
+        // a by-ref call in a guard or value can mutate the value between arms, so
+        // folding to a single read would diverge. The stability check rejects any
+        // store or address-of the direct scrutinee inside the cascade.
+        var function = DirectIntroAddressOfScrutinee(argAddress);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -29,6 +29,25 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 
     sealed record ArmData(TypeRef PatternType, int? LocalIndex, PropertySubpattern? Subpattern, IrExpression? Guard, IrExpression Value);
 
+    /// <summary>
+    /// The value every arm of the cascade tests. csc reads it either through a
+    /// once-bound temp (<c>StoreLocal SV = place</c>; arms test <c>LoadLocal
+    /// SV</c>) or directly from a re-evaluable place (arms test the
+    /// <c>LoadArgument</c>/<c>LoadLocal</c> itself). <see cref="Matches"/> is the
+    /// single identity check both arm intros use, so temp and direct cascades
+    /// share one recognizer.
+    /// </summary>
+    readonly struct Scrutinee(int? tempLocal, IrExpression place)
+    {
+        public int? TempLocal { get; } = tempLocal;
+        public IrExpression Place { get; } = place;
+
+        public bool Matches(IrExpression? operand)
+            => TempLocal is { } t
+                ? operand is LoadLocal load && load.Index == t
+                : PlaceIdentity.SameOperand(operand, Place);
+    }
+
     public void Run(IrFunction function, PassContext context)
     {
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
@@ -49,87 +68,120 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         switchExpression = null;
 
         var children = block.Children;
-        if (children.Count < 3)
+        // Smallest cascade: one arm plus the default tail (inline form is
+        // `if (place is T x) { ... } return <default>`).
+        if (children.Count < 2)
             return false;
 
-        // Locate the switch-value binding: `StoreLocal SV = <re-evaluable place>`
-        // immediately followed by the first arm's `StoreLocal Lk = isinst Tk(LoadLocal SV)`.
-        for (int i = 0; i < children.Count - 2; i++)
+        for (int i = 0; i < children.Count - 1; i++)
         {
-            if (children[i] is not StoreLocal { Value: { } svValue } svStore)
-                continue;
-            if (!IsReEvaluablePlace(svValue))
-                continue;
-            if (!IsArmIntro(children[i + 1], svStore.Index, out _, out _, out _))
-                continue;
-
-            int svLocal = svStore.Index;
-            // The cascade region runs from the first arm intro to the end of the
-            // block. Each arm's matched body trails its dispatch test as sibling
-            // statements, and the no-match remainder (further arms, ultimately the
-            // default) nests inside that test's `then` branch.
-            var region = children.Skip(i + 1).ToList();
-            // The default is the value the innermost no-match path returns; it is
-            // discovered from the bottom of the dispatch chain, then every other
-            // no-match and guard-fail path is validated to yield the same value.
-            if (!TryDiscoverDefault(region, svLocal, out var defaultValue) || defaultValue is null)
-                continue;
-
-            var arms = new List<ArmData>();
-            if (!TryParseChain(region, 0, svLocal, defaultValue, arms) || arms.Count == 0)
-                continue;
-
-            // Consumed nodes: the switch-value store plus the entire cascade region.
-            var consumed = new List<IrNode> { svStore };
-            consumed.AddRange(children.Skip(i + 1));
-
-            // The switch-value temp must be read only inside the consumed cascade.
-            if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, svLocal, consumed))
-                continue;
-
-            // Each pattern-bound local must be referenced only inside the cascade.
-            bool ownershipHolds = true;
-            foreach (var arm in arms)
+            // Temp form: `StoreLocal SV = <re-evaluable place>` bound once, then
+            // arms testing `LoadLocal SV`. The cascade region runs from the first
+            // arm (children[i + 1]) to the end of the block; the switch-value
+            // store is consumed alongside it.
+            if (children[i] is StoreLocal { Value: { } svValue } svStore
+                && IsReEvaluablePlace(svValue)
+                && TestsScrutinee(children[i + 1], new Scrutinee(svStore.Index, svValue)))
             {
-                foreach (int local in PatternLocals(arm))
+                var scrutinee = new Scrutinee(svStore.Index, svValue);
+                if (TryFold(function, children, i + 1, scrutinee, svValue, new IrNode[] { svStore }, minArms: 1, out switchExpression))
                 {
-                    if (!ReferenceOwnership.LocalReferencedOrBoundOnlyWithin(function, local, consumed))
-                    {
-                        ownershipHolds = false;
-                        break;
-                    }
+                    startIndex = i;
+                    return true;
                 }
-                if (!ownershipHolds)
-                    break;
             }
-            if (!ownershipHolds)
-                continue;
 
-            var builtArms = arms.Select(a => new PatternSwitchExpressionArm(
-                a.PatternType,
-                a.LocalIndex,
-                a.Subpattern,
-                (IrExpression)a.Value.Clone(),
-                a.Guard is { } g ? (IrExpression)g.Clone() : null)).ToList();
-
-            switchExpression = new PatternSwitchExpression(
-                (IrExpression)svValue.Clone(),
-                builtArms,
-                (IrExpression)defaultValue.Clone());
-            startIndex = i;
-            return true;
+            // Direct form: no temp; the leading arm is an intro-chain arm reading
+            // a re-evaluable place directly (`Lk = place as T; if (!Lk) { REST }
+            // MATCHED`), and later arms may be inline-positive siblings. Temp form
+            // is tried first at each index, so a genuine temp cascade is consumed
+            // there (with its `StoreLocal SV`). A single-arm direct cascade is left
+            // alone: it is indistinguishable from an ordinary `if (place is T t)`
+            // guard, which IsPatternPass already renders idiomatically.
+            if (TryScrutineeFromDirectArm(children[i], out var directScrutinee)
+                && !IsScrutineeStoredBefore(children, i, directScrutinee)
+                && TryFold(function, children, i, directScrutinee, directScrutinee.Place, System.Array.Empty<IrNode>(), minArms: 2, out switchExpression))
+            {
+                startIndex = i;
+                return true;
+            }
         }
 
         return false;
     }
 
+    // Attempts to fold the cascade region `children[regionStart..]` into a switch
+    // expression over `switchValue`. `headConsumed` are nodes before the region
+    // that the fold also consumes (the switch-value temp store, for the temp
+    // form). Discovers the default, parses the arm chain, and enforces that the
+    // scrutinee temp and every pattern-bound local are referenced only inside the
+    // consumed cascade before building the expression.
+    bool TryFold(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int regionStart,
+        Scrutinee scrutinee,
+        IrExpression switchValue,
+        IReadOnlyList<IrNode> headConsumed,
+        int minArms,
+        out PatternSwitchExpression? switchExpression)
+    {
+        switchExpression = null;
+
+        var region = children.Skip(regionStart).ToList();
+        // The default is the value the innermost no-match path returns; it is
+        // discovered from the bottom of the cascade, then every other no-match and
+        // guard-fail path is validated to yield the same value.
+        if (!TryDiscoverDefault(region, 0, scrutinee, out var defaultValue) || defaultValue is null)
+            return false;
+
+        var arms = new List<ArmData>();
+        if (!TryParseChain(region, 0, scrutinee, defaultValue, arms) || arms.Count < minArms)
+            return false;
+
+        var consumed = new List<IrNode>(headConsumed);
+        consumed.AddRange(region);
+
+        // A temp scrutinee must be read only inside the consumed cascade.
+        if (scrutinee.TempLocal is { } tempLocal
+            && !ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, consumed))
+            return false;
+
+        // Each pattern-bound local must be referenced only inside the cascade.
+        foreach (var arm in arms)
+        {
+            foreach (int local in PatternLocals(arm))
+            {
+                if (!ReferenceOwnership.LocalReferencedOrBoundOnlyWithin(function, local, consumed))
+                    return false;
+            }
+        }
+
+        var builtArms = arms.Select(a => new PatternSwitchExpressionArm(
+            a.PatternType,
+            a.LocalIndex,
+            a.Subpattern,
+            (IrExpression)a.Value.Clone(),
+            a.Guard is { } g ? (IrExpression)g.Clone() : null)).ToList();
+
+        switchExpression = new PatternSwitchExpression(
+            (IrExpression)switchValue.Clone(),
+            builtArms,
+            (IrExpression)defaultValue.Clone());
+        return true;
+    }
+
     // A chain of arms whose collective no-match fall-through reaches the default.
-    // Post-lowering, each arm is `intro Lk = isinst Tk(SV); if (!Lk) { REST }
-    // MATCHED` where MATCHED (this arm's guard + value) trails the dispatch test
-    // as sibling statements, and REST (the remaining arms, ultimately a bare
-    // `return <default>`) nests inside the test's `then` branch. The dispatch
-    // test carries no `else`: its `then` always returns, so csc drops it.
-    bool TryParseChain(IReadOnlyList<IrNode> stmts, int index, int svLocal, IrExpression defaultValue, List<ArmData> arms)
+    // Two arm shapes are recognized and may be mixed:
+    //   * Intro-chain arm: `intro Lk = isinst Tk(SV); if (!Lk) { REST } MATCHED`
+    //     where MATCHED (this arm's guard + value) trails the dispatch test as
+    //     sibling statements and REST (the remaining arms, ultimately a bare
+    //     `return <default>`) nests inside the test's `then` branch. The dispatch
+    //     test carries no `else`: its `then` always returns, so csc drops it.
+    //   * Inline-positive arm: `if (SV is Tk x) { MATCHED }` whose no-match falls
+    //     straight through to the following sibling statement (the next arm, or the
+    //     bare `return <default>`).
+    bool TryParseChain(IReadOnlyList<IrNode> stmts, int index, Scrutinee scrutinee, IrExpression defaultValue, List<ArmData> arms)
     {
         if (index >= stmts.Count)
             return false;
@@ -138,7 +190,21 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         if (index == stmts.Count - 1 && stmts[index] is Return { Value: { } tailValue } && DefaultEquals(tailValue, defaultValue))
             return true;
 
-        if (!IsArmIntro(stmts[index], svLocal, out int patternLocal, out var patternType, out _))
+        // Inline-positive arm: the matched body lives in the `then` block and the
+        // remaining arms follow as siblings after the `if`.
+        if (IsInlineArm(stmts[index], scrutinee, out int inlineLocal, out var inlineType, out var inlineBody))
+        {
+            if (!TryParseGuardedValue(inlineBody.Children, 0, defaultValue, out var inlineGuard, out var inlineValue, out int inlineConsumed)
+                || !ReachesDefaultTail(inlineBody.Children, inlineConsumed, defaultValue))
+                return false;
+            int? inlineIndex = ReferencesLocalIn(inlineGuard, inlineLocal) || ReferenceOwnership.SubtreeReferencesLocal(inlineValue, inlineLocal)
+                ? inlineLocal
+                : null;
+            arms.Add(new ArmData(inlineType, inlineIndex, Subpattern: null, inlineGuard, inlineValue));
+            return TryParseChain(stmts, index + 1, scrutinee, defaultValue, arms);
+        }
+
+        if (!IsArmIntro(stmts[index], scrutinee, out int patternLocal, out var patternType, out _))
             return false;
         if (index + 1 >= stmts.Count || stmts[index + 1] is not IfStatement { HasElse: false } dispatch)
             return false;
@@ -155,33 +221,49 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 
         arms.Add(arm);
         // REST: the remaining arms (or the bare default) nest in the `then` branch.
-        return TryParseChain(dispatch.Then.Children, 0, svLocal, defaultValue, arms);
+        return TryParseChain(dispatch.Then.Children, 0, scrutinee, defaultValue, arms);
     }
 
-    // Walks the dispatch chain to its bottom to recover the default value: the
-    // value the innermost `if (!Llast) { return <default>; }` no-match path
-    // yields. Each level is `intro Lk = isinst Tk(SV); if (!Lk) { REST }`; when
-    // REST is a bare `return D`, D is the default; otherwise descend into REST.
-    bool TryDiscoverDefault(IReadOnlyList<IrNode> region, int svLocal, out IrExpression? defaultValue)
+    // Walks the cascade to its bottom to recover the default value: the value the
+    // innermost no-match path yields. An intro-chain arm's no-match nests in its
+    // dispatch `then` (descend into it); an inline-positive arm's no-match falls
+    // through to the following sibling (advance past it); the bottom is a bare
+    // trailing `return <default>`.
+    bool TryDiscoverDefault(IReadOnlyList<IrNode> stmts, int index, Scrutinee scrutinee, out IrExpression? defaultValue)
     {
         defaultValue = null;
-        var current = region;
-        // Bounded to the block's own statement budget so a malformed nest cannot loop.
-        for (int guard = 0; guard < 1024; guard++)
+        // Bounded to a generous statement budget so a malformed nest cannot loop.
+        for (int guard = 0; guard < 4096; guard++)
         {
-            if (current.Count < 2)
+            if (index >= stmts.Count)
                 return false;
-            if (!IsArmIntro(current[0], svLocal, out int local, out _, out _))
-                return false;
-            if (current[1] is not IfStatement { HasElse: false } dispatch || !IsNegatedLocalTest(dispatch.Condition, local))
-                return false;
-            var then = dispatch.Then.Children;
-            if (then is [Return { Value: { } value }])
+
+            // Bottom: a bare `return <default>` as the final statement.
+            if (index == stmts.Count - 1 && stmts[index] is Return { Value: { } tail })
             {
-                defaultValue = value;
+                defaultValue = tail;
                 return true;
             }
-            current = then;
+
+            // Inline-positive arm: no-match falls through to the next sibling.
+            if (IsInlineArm(stmts[index], scrutinee, out _, out _, out _))
+            {
+                index++;
+                continue;
+            }
+
+            // Intro-chain arm: no-match nests in the dispatch test's `then` branch.
+            if (IsArmIntro(stmts[index], scrutinee, out int local, out _, out _)
+                && index + 1 < stmts.Count
+                && stmts[index + 1] is IfStatement { HasElse: false } dispatch
+                && IsNegatedLocalTest(dispatch.Condition, local))
+            {
+                stmts = dispatch.Then.Children;
+                index = 0;
+                continue;
+            }
+
+            return false;
         }
         return false;
     }
@@ -294,17 +376,74 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         return false;
     }
 
-    static bool IsArmIntro(IrNode node, int svLocal, out int patternLocal, out TypeRef patternType, out IsInstance isInstance)
+    static bool IsArmIntro(IrNode node, Scrutinee scrutinee, out int patternLocal, out TypeRef patternType, out IsInstance isInstance)
     {
         patternLocal = -1;
         patternType = null!;
         isInstance = null!;
-        if (node is StoreLocal { Value: IsInstance { Operand: LoadLocal receiver } test } store && receiver.Index == svLocal)
+        if (node is StoreLocal { Value: IsInstance { Operand: { } operand } test } store && scrutinee.Matches(operand))
         {
             patternLocal = store.Index;
             patternType = test.Type;
             isInstance = test;
             return true;
+        }
+        return false;
+    }
+
+    // An inline-positive arm: `if (scrutinee is Tk x) { MATCHED }` with no `else`.
+    // The matched body is the `then` block; the no-match path falls through to the
+    // following sibling statement.
+    static bool IsInlineArm(IrNode node, Scrutinee scrutinee, out int patternLocal, out TypeRef patternType, out Block matchedBody)
+    {
+        patternLocal = -1;
+        patternType = null!;
+        matchedBody = null!;
+        if (node is IfStatement { HasElse: false, Condition: IsPattern { Type: { } type, LocalIndex: var local, Value: { } operand }, Then: { } then }
+            && scrutinee.Matches(operand))
+        {
+            patternLocal = local;
+            patternType = type;
+            matchedBody = then;
+            return true;
+        }
+        return false;
+    }
+
+    // True when `node` is the first arm of a cascade over `scrutinee` — either an
+    // intro-chain arm or an inline-positive arm. Used to confirm a temp store is
+    // actually followed by a matching cascade before attempting the fold.
+    static bool TestsScrutinee(IrNode node, Scrutinee scrutinee)
+        => IsArmIntro(node, scrutinee, out _, out _, out _)
+            || IsInlineArm(node, scrutinee, out _, out _, out _);
+
+    // Recovers a direct (temp-less) scrutinee from a leading intro-chain arm that
+    // reads a re-evaluable place directly (`Lk = place as T; if (!Lk) …`). The
+    // all-inline form (a leading `if (place is T x)`) is deliberately not anchored
+    // here: a bare inline `is` guard is idiomatically an `if`, not a switch, so
+    // only cascades whose head csc lowered to an intro-chain arm are raised.
+    static bool TryScrutineeFromDirectArm(IrNode node, out Scrutinee scrutinee)
+    {
+        scrutinee = default;
+        if (node is StoreLocal { Value: IsInstance { Operand: { } introOperand } } && IsReEvaluablePlace(introOperand))
+        {
+            scrutinee = new Scrutinee(null, introOperand);
+            return true;
+        }
+        return false;
+    }
+
+    // True when the direct scrutinee's place is a local written by an earlier
+    // sibling statement — i.e. a switch-value temp. Such cascades belong to the
+    // temp form (which consumes the store); the direct form must not steal them.
+    static bool IsScrutineeStoredBefore(IReadOnlyList<IrNode> children, int index, Scrutinee scrutinee)
+    {
+        if (scrutinee.Place is not LoadLocal local)
+            return false;
+        for (int j = 0; j < index; j++)
+        {
+            if (children[j] is StoreLocal store && store.Index == local.Index)
+                return true;
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -147,6 +147,14 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             && !ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, consumed))
             return false;
 
+        // A direct (temp-less) scrutinee is re-read by every arm from its
+        // underlying place. A switch expression evaluates the value once, so the
+        // fold is faithful only if that place is provably unmutated across the
+        // consumed cascade — otherwise a mutation in an earlier arm's guard would
+        // change the value later arms observe.
+        if (scrutinee.TempLocal is null && !DirectScrutineeUnmutated(scrutinee.Place, consumed))
+            return false;
+
         // Each pattern-bound local must be referenced only inside the cascade.
         foreach (var arm in arms)
         {
@@ -194,8 +202,17 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         // remaining arms follow as siblings after the `if`.
         if (IsInlineArm(stmts[index], scrutinee, out int inlineLocal, out var inlineType, out var inlineBody))
         {
-            if (!TryParseGuardedValue(inlineBody.Children, 0, defaultValue, out var inlineGuard, out var inlineValue, out int inlineConsumed)
+            if (!TryParseGuardedValue(inlineBody.Children, 0, defaultValue, out var inlineGuard, out var inlineValue, out int inlineConsumed, out bool inlineShortCircuits)
                 || !ReachesDefaultTail(inlineBody.Children, inlineConsumed, defaultValue))
+                return false;
+            // An inline arm's guard failure must fall through to the following
+            // sibling arm, exactly as a switch `when` guard does. The negated form
+            // (`if (!G) return <default>;`) short-circuits to the default on guard
+            // failure, and a positive guard with any trailing statement does the
+            // same — both skip later arms a switch expression would still test.
+            // Only fall-through shapes are safe here: an unguarded body, or a
+            // positive `if (G) { return V; }` that is the entire matched body.
+            if (inlineGuard is not null && (inlineShortCircuits || inlineConsumed != inlineBody.Children.Count))
                 return false;
             int? inlineIndex = ReferencesLocalIn(inlineGuard, inlineLocal) || ReferenceOwnership.SubtreeReferencesLocal(inlineValue, inlineLocal)
                 ? inlineLocal
@@ -297,7 +314,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             && stmts[index + 1] is IfStatement { HasElse: false } subIf
             && IsLocalTest(subIf.Condition, subStore.Index))
         {
-            if (!TryParseGuardedValue(subIf.Then.Children, 0, defaultValue, out var innerGuard, out var innerValue, out int innerConsumed)
+            if (!TryParseGuardedValue(subIf.Then.Children, 0, defaultValue, out var innerGuard, out var innerValue, out int innerConsumed, out _)
                 || !ReachesDefaultTail(subIf.Then.Children, innerConsumed, defaultValue))
                 return false;
             var subpattern = new PropertySubpattern(subProperty.Accessor, subType, subStore.Index);
@@ -312,7 +329,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         }
 
         // Bare type-pattern arm: a guarded (or unguarded) value run.
-        if (!TryParseGuardedValue(stmts, index, defaultValue, out var guard, out var value, out int consumed))
+        if (!TryParseGuardedValue(stmts, index, defaultValue, out var guard, out var value, out int consumed, out _))
             return false;
         int? localIndex = ReferencesLocalIn(guard, patternLocal) || ReferenceOwnership.SubtreeReferencesLocal(value, patternLocal)
             ? patternLocal
@@ -326,17 +343,23 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     //   `return V;`                              -> unguarded
     //   `if (!G) return <default>; return V;`    -> guarded, negated form
     //   `if (G) { return V; }`                   -> guarded, positive form
+    // `shortCircuitsToDefault` is true only for the negated form, whose guard
+    // failure returns the default immediately rather than falling through to the
+    // following statement — the caller uses it to reject short-circuiting shapes
+    // where fall-through order matters (inline sibling arms).
     bool TryParseGuardedValue(
         IReadOnlyList<IrNode> stmts,
         int index,
         IrExpression defaultValue,
         out IrExpression? guard,
         out IrExpression value,
-        out int consumed)
+        out int consumed,
+        out bool shortCircuitsToDefault)
     {
         guard = null;
         value = null!;
         consumed = 0;
+        shortCircuitsToDefault = false;
 
         if (index >= stmts.Count)
             return false;
@@ -361,6 +384,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             guard = negatedGuard;
             value = guardedValue;
             consumed = 2;
+            shortCircuitsToDefault = true;
             return true;
         }
 
@@ -460,6 +484,26 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 
     static bool IsReEvaluablePlace(IrExpression expression)
         => expression is LoadArgument or LoadLocal;
+
+    // A direct (temp-less) scrutinee's place must be re-readable with an identical
+    // value at each arm. Reject any write or address-of the underlying local or
+    // argument inside the consumed cascade: a store changes the value directly,
+    // and an address-of admits indirect mutation through a by-ref call in a guard
+    // or value. An unrecognized place kind is refused outright.
+    static bool DirectScrutineeUnmutated(IrExpression place, IReadOnlyCollection<IrNode> consumed)
+    {
+        System.Func<IrNode, bool> mutates = place switch
+        {
+            LoadLocal local => node =>
+                (node is StoreLocal store && store.Index == local.Index)
+                || (node is LoadLocalAddress address && address.Index == local.Index),
+            LoadArgument argument => node =>
+                (node is StoreArgument store && store.Index == argument.Index)
+                || (node is LoadArgumentAddress address && address.Index == argument.Index),
+            _ => _ => true,
+        };
+        return !consumed.Any(root => root.Descendants.Prepend(root).Any(mutates));
+    }
 
     static bool ReferencesLocalIn(IrExpression? expression, int local)
         => expression is not null && ReferenceOwnership.SubtreeReferencesLocal(expression, local);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -27,7 +27,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 {
     public string Name => "pattern-switch-expression";
 
-    sealed record ArmData(TypeRef PatternType, int? LocalIndex, PropertySubpattern? Subpattern, IrExpression? Guard, IrExpression Value);
+    sealed record ArmData(TypeRef PatternType, int? LocalIndex, PropertySubpattern? Subpattern, IrExpression? Guard, IrExpression Value, bool IsInline);
 
     /// <summary>
     /// The value every arm of the cascade tests. csc reads it either through a
@@ -139,20 +139,38 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         if (!TryParseChain(region, 0, scrutinee, defaultValue, arms) || arms.Count < minArms)
             return false;
 
+        // PR A (#3028) scopes the newly recognized heterogeneous surface — a
+        // direct (temp-less) scrutinee, or any inline-positive sibling arm — to
+        // unguarded arms. A guarded arm whose guard failure short-circuits to the
+        // trailing default folds faithfully only when no later arm can match the
+        // same value; in the folded switch a failed `when` guard falls through to
+        // the later arms instead. Proving no overlap needs a type-disjointness
+        // oracle this SRM-only, no-inspected-assembly-loading pass does not have.
+        // The pre-existing temp-form intro cascade (#3022) keeps its guarded arms
+        // under the compiler's proven mutual exclusivity; guarded heterogeneous
+        // arms are deferred to a follow-up that carries a real disjointness oracle.
+        bool isNewSurface = scrutinee.TempLocal is null || arms.Any(a => a.IsInline);
+        if (isNewSurface && arms.Any(a => a.Guard is not null))
+            return false;
+
         var consumed = new List<IrNode>(headConsumed);
         consumed.AddRange(region);
 
-        // A temp scrutinee must be read only inside the consumed cascade.
+        // A temp scrutinee must be read only inside the consumed cascade, and only
+        // read there: a store or address-of the temp inside the cascade would let a
+        // guard mutate the value later arms observe (and the fold deletes the temp's
+        // defining store, dangling any surviving reference).
         if (scrutinee.TempLocal is { } tempLocal
-            && !ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, consumed))
+            && (!ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, consumed)
+                || !TempScrutineeReadOnly(tempLocal, region, consumed)))
             return false;
 
         // A direct (temp-less) scrutinee is re-read by every arm from its
         // underlying place. A switch expression evaluates the value once, so the
-        // fold is faithful only if that place is provably unmutated across the
-        // consumed cascade — otherwise a mutation in an earlier arm's guard would
-        // change the value later arms observe.
-        if (scrutinee.TempLocal is null && !DirectScrutineeUnmutated(scrutinee.Place, consumed))
+        // fold is faithful only if that place cannot change across the cascade —
+        // neither by a direct store between arm tests nor by an aliased by-ref
+        // mutation through an address taken anywhere in the method.
+        if (scrutinee.TempLocal is null && !DirectScrutineeStable(function, scrutinee.Place, consumed))
             return false;
 
         // Each pattern-bound local must be referenced only inside the cascade.
@@ -217,7 +235,10 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             int? inlineIndex = ReferencesLocalIn(inlineGuard, inlineLocal) || ReferenceOwnership.SubtreeReferencesLocal(inlineValue, inlineLocal)
                 ? inlineLocal
                 : null;
-            arms.Add(new ArmData(inlineType, inlineIndex, Subpattern: null, inlineGuard, inlineValue));
+            // Inline arms are the newly recognized heterogeneous surface; PR A
+            // (#3028) folds them only unguarded (the guard gate in TryFold rejects
+            // a guarded new-surface fold). Tag the arm inline so that gate applies.
+            arms.Add(new ArmData(inlineType, inlineIndex, Subpattern: null, inlineGuard, inlineValue, IsInline: true));
             return TryParseChain(stmts, index + 1, scrutinee, defaultValue, arms);
         }
 
@@ -323,7 +344,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             int? outerLocal = ReferencesLocalIn(innerGuard, patternLocal) || ReferenceOwnership.SubtreeReferencesLocal(innerValue, patternLocal)
                 ? patternLocal
                 : null;
-            arm = new ArmData(patternType, outerLocal, subpattern, innerGuard, innerValue);
+            arm = new ArmData(patternType, outerLocal, subpattern, innerGuard, innerValue, IsInline: false);
             nextIndex = index + 2;
             return true;
         }
@@ -334,7 +355,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         int? localIndex = ReferencesLocalIn(guard, patternLocal) || ReferenceOwnership.SubtreeReferencesLocal(value, patternLocal)
             ? patternLocal
             : null;
-        arm = new ArmData(patternType, localIndex, Subpattern: null, guard, value);
+        arm = new ArmData(patternType, localIndex, Subpattern: null, guard, value, IsInline: false);
         nextIndex = index + consumed;
         return true;
     }
@@ -485,25 +506,38 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     static bool IsReEvaluablePlace(IrExpression expression)
         => expression is LoadArgument or LoadLocal;
 
-    // A direct (temp-less) scrutinee's place must be re-readable with an identical
-    // value at each arm. Reject any write or address-of the underlying local or
-    // argument inside the consumed cascade: a store changes the value directly,
-    // and an address-of admits indirect mutation through a by-ref call in a guard
-    // or value. An unrecognized place kind is refused outright.
-    static bool DirectScrutineeUnmutated(IrExpression place, IReadOnlyCollection<IrNode> consumed)
+    // A direct (temp-less) scrutinee's place must yield an identical value at each
+    // arm's re-read. Reject (a) a store to the underlying local/argument anywhere
+    // inside the cascade — a value change between arm tests — and (b) an address-of
+    // the place ANYWHERE in the method: a live alias admits an indirect by-ref
+    // mutation during the cascade that a consumed-only scan would miss. An
+    // unrecognized place kind is refused outright.
+    static bool DirectScrutineeStable(IrFunction function, IrExpression place, IReadOnlyCollection<IrNode> consumed)
     {
-        System.Func<IrNode, bool> mutates = place switch
+        switch (place)
         {
-            LoadLocal local => node =>
-                (node is StoreLocal store && store.Index == local.Index)
-                || (node is LoadLocalAddress address && address.Index == local.Index),
-            LoadArgument argument => node =>
-                (node is StoreArgument store && store.Index == argument.Index)
-                || (node is LoadArgumentAddress address && address.Index == argument.Index),
-            _ => _ => true,
-        };
-        return !consumed.Any(root => root.Descendants.Prepend(root).Any(mutates));
+            case LoadLocal local:
+                return !ConsumedContains(consumed, node => node is StoreLocal store && store.Index == local.Index)
+                    && !function.Descendants.Any(node => node is LoadLocalAddress address && address.Index == local.Index);
+            case LoadArgument argument:
+                return !ConsumedContains(consumed, node => node is StoreArgument store && store.Index == argument.Index)
+                    && !function.Descendants.Any(node => node is LoadArgumentAddress address && address.Index == argument.Index);
+            default:
+                return false;
+        }
     }
+
+    // A temp scrutinee (`StoreLocal SV = place`, its defining store consumed as
+    // head) must be read-only across the cascade: no re-store of SV inside the arm
+    // region, and no address-of SV anywhere in the consumed cascade. Either would
+    // let a guard mutate the switch value between arm tests while the fold keeps a
+    // single evaluation (and deletes SV's defining store).
+    static bool TempScrutineeReadOnly(int tempLocal, IReadOnlyCollection<IrNode> region, IReadOnlyCollection<IrNode> consumed)
+        => !ConsumedContains(region, node => node is StoreLocal store && store.Index == tempLocal)
+            && !ConsumedContains(consumed, node => node is LoadLocalAddress address && address.Index == tempLocal);
+
+    static bool ConsumedContains(IReadOnlyCollection<IrNode> roots, System.Func<IrNode, bool> predicate)
+        => roots.Any(root => root.Descendants.Prepend(root).Any(predicate));
 
     static bool ReferencesLocalIn(IrExpression? expression, int local)
         => expression is not null && ReferenceOwnership.SubtreeReferencesLocal(expression, local);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -141,16 +141,18 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 
         // PR A (#3028) scopes the newly recognized heterogeneous surface — a
         // direct (temp-less) scrutinee, or any inline-positive sibling arm — to
-        // unguarded arms. A guarded arm whose guard failure short-circuits to the
-        // trailing default folds faithfully only when no later arm can match the
-        // same value; in the folded switch a failed `when` guard falls through to
-        // the later arms instead. Proving no overlap needs a type-disjointness
-        // oracle this SRM-only, no-inspected-assembly-loading pass does not have.
-        // The pre-existing temp-form intro cascade (#3022) keeps its guarded arms
-        // under the compiler's proven mutual exclusivity; guarded heterogeneous
-        // arms are deferred to a follow-up that carries a real disjointness oracle.
+        // plain, unguarded type-pattern arms. A guarded arm, or a property-
+        // subpattern arm (`Outer { Inner: T }`), routes its guard/subpattern
+        // FAILURE straight to the trailing default; in the folded switch that
+        // failure instead falls through to the later arms. Reproducing the
+        // original routing is faithful only when no later arm can match the same
+        // value, which needs a type-disjointness oracle this SRM-only,
+        // no-inspected-assembly-loading pass does not have. The pre-existing
+        // temp-form intro cascade (#3022) keeps its guarded and subpattern arms
+        // under the compiler's proven mutual exclusivity; guarded/subpattern
+        // heterogeneous arms are deferred to a follow-up carrying a real oracle.
         bool isNewSurface = scrutinee.TempLocal is null || arms.Any(a => a.IsInline);
-        if (isNewSurface && arms.Any(a => a.Guard is not null))
+        if (isNewSurface && arms.Any(a => a.Guard is not null || a.Subpattern is not null))
             return false;
 
         var consumed = new List<IrNode>(headConsumed);


### PR DESCRIPTION
- Fixes/advances #3028 (PR A of A→B→C)
- Changes `PatternSwitchExpressionPass` to raise heterogeneous switch-arm intros (intro-chain arm1 + inline-positive sibling arms) over a re-evaluable scrutinee read through a temp or directly
- Card revision: `1506df38`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the pass now recognizes the inline-positive `if (place is T x) { … }` sibling-arm form and mixes it with the existing intro-chain form over a single scrutinee, folding the real csc shape for multi-arm bare type-pattern switches while leaving lone `is`-guards and temp-owned cascades untouched.

### Original source

Local compiled fixture (`HeterogeneousArmSample.cs`); SourceLink cannot serve a repo-built test DLL, so the authoritative C# source is quoted verbatim from the fixture:

```csharp
public static int Area(Shape shape) => shape switch
{
    Dot d => d.Radius,
    Bar b => b.Length,
    Box x => x.Side,
    _ => -1,
};
```

### Before

`dotnet-inspect member <fixture.dll> HeterogeneousArmSample Area -S "Decompiled Source"` at base `abe0eef6`:

```csharp
public static int Area(ILInspector.Decompiler.Tests.HeterogeneousArmSample.Shape shape)
{
    Dot d = shape as Dot;
    if (d is null)
    {
        if (shape is Bar b)
        {
            return b.Length;
        }
        if (shape is Box x)
        {
            return x.Side;
        }
        return -1;
    }
    return d.Radius;
}
```

- Valid: True
- Correct: True

Lower-quality: the switch is left as an unraised intro-chain + inline-sibling `if` cascade.

### After

`dotnet-inspect member <fixture.dll> HeterogeneousArmSample Area -S "Decompiled Source"` at head `1506df38`:

```csharp
public static int Area(ILInspector.Decompiler.Tests.HeterogeneousArmSample.Shape shape)
{
    return shape switch
    {
        Dot d => d.Radius,
        Bar b => b.Length,
        Box x => x.Side,
        _ => -1,
    };
}
```

- Valid: True
- Correct: True

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline (`abe0eef6`) | Head (`1506df38`) |
| --- | --- | --- |
| Product build (`dotnet-inspect`) | Pass | Pass |
| Focused tests (`PatternSwitchExpressionPassTests`) | n/a (fixture/tests new) | Pass |
| Decompiler fast suite (`-trait- Speed=Slow`) | 1206, 0 failed | 1211, 0 failed |
| Full decompiler slow suite | 1 failed (see below) | 3494 total, 1 failed (see below) |
| Reduced fixture validity/fidelity | Pass | Pass |

The sole full-suite failure is `FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket`, an ordinal-only compiler cached-delegate closure-field diff (`CfgSampleClass+<>c::<>9__N_0`, identical opcodes) on `StatementBodyLambdaInsideIf`. It reproduces **identically on untouched `origin/main`** (verified by running the same test on a clean `abe0eef6` worktree — there it flags both `ManualConstantOnlyComparisonFactory` and `StatementBodyLambdaInsideIf`), so it is pre-existing and unrelated to this change. It is a `[Trait("Speed","Slow")]` gate that CI excludes from the PR path (`ci.yml` runs `-trait- "Speed=Slow"`), so it does not block this PR. All corpus-sweep / cluster-capture / compile-back slow gates pass on head.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no new fidelity diffs beyond the pre-existing docket; the change is additive (raises a shape previously left unraised) and default-gated by the same ownership/re-evaluability checks as the existing temp form. `PlaceFromAddress` still does not fold (its recursive property-pattern arm fails the chain parse — deferred to PR B).

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=Pass" -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
```
