### PR TITLE
Fully raise flags-enum accumulator slots to the enum type (#3009 sub-part 1)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FlagsEnumAccumulatorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FlagsEnumAccumulatorTests.cs
@@ -36,4 +36,22 @@ public class FlagsEnumAccumulatorTests
         Assert.Contains("FlagCaps64.MultiStatements", output);
         Assert.Contains("FlagCaps64.MultiResults", output);
     }
+
+    // #3009 sub-part 1: the spilled accumulator slot that holds a bare integer flag
+    // constant is only ever consumed as the enum in the OR chain, so it must testify —
+    // and materialize/fold — as the enum, not the `long` IL storage width. The
+    // pre-fix shape was `long S_0 = (long)512; ... (FlagCaps64)S_0 | ...`.
+    [Fact]
+    public void FlagsEnumAccumulator_FullyRaisesConstantSlot_NoLongSlotOrCast()
+    {
+        var output = Render(nameof(FlagsEnumAccumulatorSamples.Accumulate));
+
+        // No long-typed accumulator slot declaration survives.
+        Assert.DoesNotContain("long S_", output);
+        // No per-use cast of the accumulator slot back to the enum.
+        Assert.DoesNotContain("(FlagCaps64)S_", output);
+        // The 512 constant folded to its enum member and inlined into the chain.
+        Assert.DoesNotContain("(long)512", output);
+        Assert.Contains("FlagCaps64.Protocol", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -107,7 +107,7 @@ public static class CoercionSinks
         {
             if (ambiguous.Contains(load.Slot))
                 continue;
-            var evidence = load.Type ?? LoadSinkTargetType(load, returnType, shapes);
+            var evidence = BitwiseEnumSinkType(load, shapes) ?? load.Type ?? LoadSinkTargetType(load, returnType, shapes);
             if (evidence is null)
             {
                 types.Remove(load.Slot);
@@ -142,6 +142,32 @@ public static class CoercionSinks
             Return ret when ReferenceEquals(ret.Value, load) => returnType,
             _ => null,
         };
+
+    /// <summary>
+    /// The enum family a slot load contributes when it is an operand of a
+    /// flags-enum bitwise op (<c>and</c>/<c>or</c>/<c>xor</c>) whose sibling
+    /// operand is enum-typed. #3009: a spilled accumulator holding a bare
+    /// integer flag constant (<c>long S_0 = (long)512</c>) is only ever
+    /// consumed as the enum in the OR chain, so it should testify — and
+    /// materialize as — the enum, not the integer storage width the IL stack
+    /// load carries. This wins over the load's own primitive
+    /// <see cref="LoadStackSlot.Type"/>; a slot load feeding a non-enum sink
+    /// elsewhere still disagrees at the join and vetoes as before. A load
+    /// already carrying an enum type is left to the normal path so genuine
+    /// cross-enum disagreement is preserved.
+    /// </summary>
+    static TypeRef? BitwiseEnumSinkType(LoadStackSlot load, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+    {
+        if (load.Parent is not Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary)
+            return null;
+        var sibling = ReferenceEquals(binary.Left, load) ? binary.Right : binary.Left;
+        if (sibling is Constant || sibling.ResultType is not { } siblingType
+                || shapes.GetValueOrDefault(siblingType) != TypeShape.Enum)
+            return null;
+        if (load.Type is { } loadType && shapes.GetValueOrDefault(loadType) == TypeShape.Enum)
+            return null;
+        return siblingType;
+    }
 
     /// <summary>
     /// Walks one body scope. Nested bodies carry their own return types: a


### PR DESCRIPTION
- Advances #3009 (sub-part 1: enum slot typing)
- Changes: a spilled 64-bit flags-enum accumulator slot now materializes as the enum instead of `long` with per-use casts
- Card revision: `8ca6e44b`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a targeted slot-testimony rule retypes an enum-only accumulator slot to the enum; the `long` declaration, `(long)512`, and per-use `(FlagCaps64)` cast all collapse, with 0 new validity/corpus/fidelity diffs.

### Original source

```csharp
public static int Accumulate(FlagCaps64 server, bool interactive)
{
    FlagCaps64 caps = FlagCaps64.Protocol
        | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)
        | (server & FlagCaps64.LoadLocal)
        | FlagCaps64.Secure
        | (server & FlagCaps64.MultiStatements)
        | FlagCaps64.MultiResults;
    return (int)caps;
}
```

### Before

```csharp
public static int Accumulate(ILInspector.Decompiler.Tests.FlagCaps64 server, bool interactive)
{
    long S_0 = (long)512;
    FlagCaps64 S_1 = interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None;
    return (int)((FlagCaps64)S_0 | S_1 | server & FlagCaps64.LoadLocal | FlagCaps64.Secure | server & FlagCaps64.MultiStatements | FlagCaps64.MultiResults);
}
```

- Valid: True
- Correct: True

Valid and correct after #2990, but lower quality: the accumulator slot is declared `long`, its `512` seed renders as `(long)512`, and its single use is cast back to the enum (`(FlagCaps64)S_0`).

### After

```csharp
public static int Accumulate(ILInspector.Decompiler.Tests.FlagCaps64 server, bool interactive)
{
    FlagCaps64 S_1 = interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None;
    return (int)(FlagCaps64.Protocol | S_1 | server & FlagCaps64.LoadLocal | FlagCaps64.Secure | server & FlagCaps64.MultiStatements | FlagCaps64.MultiResults);
}
```

- Valid: True
- Correct: True

The `long` slot is gone: `(long)512` folded to `FlagCaps64.Protocol` and inlined, and the per-use cast collapsed. The remaining `S_1` ternary temporary and the single-line OR chain are the follow-up slices.

### Fully raised

```csharp
public static int Accumulate(FlagCaps64 server, bool interactive)
{
    FlagCaps64 caps = FlagCaps64.Protocol
        | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)
        | (server & FlagCaps64.LoadLocal)
        | FlagCaps64.Secure
        | (server & FlagCaps64.MultiStatements)
        | FlagCaps64.MultiResults;
    return (int)caps;
}
```

- Required tracking issue: #3009 — remaining slices: (2) inline the single-use ternary accumulator temporary into one expression; (3) multi-line OR-chain formatting (printer presentation).

## Evidence

| Check | Baseline (origin/main `96314a0e`) | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `FlagsEnumAccumulatorTests`: 1 passed (#2990 guard) | `FlagsEnumAccumulatorTests`: 2 passed (adds #3009 guard) |
| Decompiler fast suite | 3163, 0 failed | 3163, 0 failed |
| Validity area | 98, 1 failed (`LadderIteratorGateTests.IteratorFixture_RecoveredRowsCompileBackOpcodeExact`, OperandDiff) | 98, 1 failed (same, unchanged) |
| Corpus area | 61, 0 failed | 61, 0 failed |
| Fidelity area | 50, 1 failed (`FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket` — `StatementBodyLambdaInsideIf [OperandDiff]`) | 50, 1 failed (same, unchanged) |
| Reduced fixture validity | Pass | Pass |

Both baseline failures are pre-existing and unchanged by this PR: the `LadderIteratorGateTests` OperandDiff reproduces on base with the product change stashed, and `StatementBodyLambdaInsideIf` is the documented lambda-ordinal-rename diff (CI-green, unrelated to enum typing). This PR introduces **0 new** validity, corpus, or fidelity diffs.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — Corpus and Fidelity area gates are unchanged from baseline (0 new diffs); the change only retypes enum-only accumulator slots that already rendered validly.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.FlagsEnumAccumulatorTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait "Area=Corpus"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait "Area=Fidelity"
```
