### PR TITLE
RTS: coherent Full reconstruction of plain event-accessor targets (#3007)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -782,14 +782,15 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_FullEventAccessorTargetSurfacesRecompileFailure()
+    public void CompileBackTargets_FullReconstructsPlainEventAccessorTarget()
     {
-        // Issue #3000: a plain (non-explicit-interface) event accessor target is method-routed, so
-        // under Full policy the reconstructed type surface re-declares the event, whose synthesized
-        // accessor collides (CS0082) with the standalone target method. The Full closure fails to
-        // recompile and falls back to the compile-back floor. This must be reported honestly:
-        // BodyComplete is false (the Full reconstruction did not compile), not masked as Complete.
-        // Coherent Full reconstruction of plain event-accessor targets is a separate follow-up.
+        // Issue #3007 (follow-up to #3000/#3008): a plain (non-explicit-interface) event accessor
+        // target under Full policy reconstructs a coherent single `event { add remove }` carrying
+        // both real accessor bodies, rather than a standalone accessor method that collides
+        // (CS0082) with the re-declared event's compiler-synthesized accessor. Routing the plain
+        // accessor through ComposeEventAccessor with the full member surface folds the sibling
+        // accessor into the event and represents the constructor, so every concrete declaration is
+        // accounted for and BodyComplete is honestly true.
         var assemblyPath = CompileFixture("""
             using System;
 
@@ -811,10 +812,42 @@ public class ReturnToSenderPrototypeTests
                 RoundTripScope.All,
                 RoundTripBodyPolicy.Full));
 
-            Assert.True(result.UsedCompileBackFloor, result.Detail);
-            Assert.False(
+            Assert.True(
                 result.BodyComplete,
                 string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+
+            var adder = Assert.Single(result.FullBodies, body => body.Member == "Holder.add_Changed");
+            var remover = Assert.Single(result.FullBodies, body => body.Member == "Holder.remove_Changed");
+            Assert.Equal(MemberBodyProductionStatus.Complete, adder.Status);
+            Assert.Equal(MemberBodyProductionStatus.Complete, remover.Status);
+            // The parameterless constructor is a concrete declaration on the target type; the full
+            // member surface represents it so it is not flagged unrepresented (which would drop
+            // BodyComplete back to the honest-floor state that preceded issue #3007).
+            Assert.Contains(
+                result.FullBodies,
+                body => body.Member == "Holder..ctor" && body.Status == MemberBodyProductionStatus.Complete);
+
+            // A single coherent event declaration with both real bodies and no standalone accessor
+            // method (the standalone method + re-declared event is exactly the CS0082 shape #3007
+            // eliminates).
+            Assert.Contains("public event Action Changed", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("void add_Changed", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("void remove_Changed", result.Source, StringComparison.Ordinal);
+            Assert.Contains("Delegate.Combine", result.Source, StringComparison.Ordinal);
+            Assert.Contains("Delegate.Remove", result.Source, StringComparison.Ordinal);
+
+            Assert.NotNull(result.DonorPe);
+            Assert.NotNull(result.Comparison);
+            Assert.Equal(RoundTripComparisonStatus.Completed, result.Comparison.Status);
+            Assert.Contains(result.Comparison.Members, member =>
+                member.Target.Method == adder.Method
+                && member.CSharpStatus != RoundTripEvidenceStatus.Unavailable
+                && member.IlStatus != IlBodyDiffOutcome.Unavailable);
+            Assert.Contains(result.Comparison.Members, member =>
+                member.Target.Method == remover.Method
+                && member.CSharpStatus != RoundTripEvidenceStatus.Unavailable
+                && member.IlStatus != IlBodyDiffOutcome.Unavailable);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -6087,6 +6087,101 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void CompileBackTargets_FullExplicitInterfaceEventTargetDoesNotDoubleDeclare()
+    {
+        // Issue #3007 follow-up (PR #3075 review): the Full member surface folds events by the
+        // sanitized full metadata name ("IBaseEvents.Changed") while an explicit-interface event
+        // target requirement carries the stripped identity ("Changed"). Enabling the surface for
+        // such a target missed the fold and appended a SECOND `event Action IBaseEvents.Changed`
+        // with a `throw null` accessor (CS8646/CS0102) while still reporting BodyComplete=true — a
+        // double-declaration false success. Declining the surface for explicit-interface targets
+        // restores the pre-#3007 single-accessor shape and the honest incomplete floor.
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public interface IBaseEvents
+            {
+                event Action Changed;
+            }
+
+            public sealed class ExplicitEventFixture : IBaseEvents
+            {
+                private Action? _changed;
+
+                event Action IBaseEvents.Changed
+                {
+                    add { _changed += value; }
+                    remove { _changed -= value; }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("ExplicitEventFixture", "IBaseEvents.add_Changed", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            // Exactly one explicit-interface event declaration; no appended duplicate.
+            var declarations = result.Source.Split("event Action IBaseEvents.Changed").Length - 1;
+            Assert.True(
+                declarations == 1,
+                $"Expected a single explicit-interface event declaration, found {declarations}.{Environment.NewLine}{result.Source}");
+            Assert.DoesNotContain("throw null", result.Source, StringComparison.Ordinal);
+
+            // The sibling remover and the constructor are not represented under the declined
+            // surface, so BodyComplete is honestly false rather than an inflated double-declaration
+            // success (coherent explicit-interface reconstruction is out of #3007's scope).
+            Assert.False(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullFieldLikeEventTargetStaysMethodRouted()
+    {
+        // Issue #3007 follow-up (PR #3075 review): a field-like event (`event Action Changed;`)
+        // has a compiler-generated backing field whose name equals the event. Routing its accessor
+        // through the Full member surface would emit that backing field as a separate
+        // `Action Changed;` next to the reconstructed event (CS0102/CS0229). Coherent field-like
+        // reconstruction is out of #3007's scope, so field-like accessors are excluded from the
+        // Full broadening and stay method-routed exactly as before this PR — the surface's coherent
+        // single-event shape must NOT be produced for them.
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public sealed class OrdinaryEventFixture
+            {
+                public event Action Changed;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("OrdinaryEventFixture", "add_Changed", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            // Method-routed: the standalone accessor method is present (the pre-#3007 baseline
+            // shape). The coherent event surface would instead fold both accessors into a single
+            // `event { add remove }` with no standalone method, which is what this exclusion
+            // deliberately avoids for field-like events.
+            Assert.Contains("void add_Changed", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     static string CompileFixture(
         string source,
         string? directory = null,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -957,14 +957,41 @@ static class ReturnToSender
         // it only routes through ComposeEventAccessor under Full, where a coherent
         // `event { add remove }` type surface is required to avoid a CS0082 collision between the
         // standalone accessor method and the re-declared event's synthesized accessor (#3007).
+        //
+        // Field-like events (`event Action Changed;`) are excluded from the Full broadening: the
+        // compiler-generated backing field shares the event's exact name, and the full member
+        // surface would emit it as a separate `Action Changed;` field alongside the reconstructed
+        // event (CS0102/CS0229). Coherent field-like reconstruction is out of #3007's scope, so
+        // these stay method-routed exactly as before (an honest compile-back floor, not a
+        // double-declaration false success).
         if (TryFindMethod(reader, typeDef, target) is { } accessorHandle
             && accessorToEvent.TryGetValue(accessorHandle, out var foundEventHandle)
-            && (includePlainEventAccessors || IsExplicitInterfaceEventAccessor(reader, typeDef, accessorHandle)))
+            && (IsExplicitInterfaceEventAccessor(reader, typeDef, accessorHandle)
+                || (includePlainEventAccessors && !IsFieldLikeEvent(reader, typeDef, foundEventHandle))))
         {
             return (foundEventHandle, accessorHandle);
         }
 
         return null;
+    }
+
+    // A field-like event (`event Action Changed;`) has a compiler-generated backing field whose
+    // name is identical to the event. A custom event with explicit accessors uses a
+    // distinctly-named user field, so a same-named field uniquely identifies the field-like form
+    // (a type cannot declare both a field and an event with the same name).
+    static bool IsFieldLikeEvent(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        EventDefinitionHandle eventHandle)
+    {
+        string eventName = reader.GetString(reader.GetEventDefinition(eventHandle).Name);
+        foreach (var fieldHandle in typeDef.GetFields())
+        {
+            if (reader.GetString(reader.GetFieldDefinition(fieldHandle).Name) == eventName)
+                return true;
+        }
+
+        return false;
     }
 
     static bool IsExplicitInterfaceEventAccessor(

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -765,7 +765,7 @@ static class ReturnToSender
                 continue;
             }
 
-            if (TryFindEventAccessor(reader, typeDef, target) is { } eventTarget)
+            if (TryFindEventAccessor(reader, typeDef, target, bodyPolicy == RoundTripBodyPolicy.Full) is { } eventTarget)
             {
                 results.Add(CompileBackEventAccessorOrContextFail(
                     assemblyPath,
@@ -938,7 +938,8 @@ static class ReturnToSender
     static (EventDefinitionHandle Event, MethodDefinitionHandle Accessor)? TryFindEventAccessor(
         MetadataReader reader,
         TypeDefinition typeDef,
-        RequestedTarget target)
+        RequestedTarget target,
+        bool includePlainEventAccessors)
     {
         var accessorToEvent = new Dictionary<MethodDefinitionHandle, EventDefinitionHandle>();
         foreach (var eventHandle in typeDef.GetEvents())
@@ -950,9 +951,15 @@ static class ReturnToSender
                 accessorToEvent[accessors.Remover] = eventHandle;
         }
 
+        // Explicit-interface event accessors always route through ComposeEventAccessor.
+        // A plain (non-explicit-interface) event accessor is method-routed by default so the
+        // Selected A/B path keeps its single-accessor shape (and the corpus baseline is stable);
+        // it only routes through ComposeEventAccessor under Full, where a coherent
+        // `event { add remove }` type surface is required to avoid a CS0082 collision between the
+        // standalone accessor method and the re-declared event's synthesized accessor (#3007).
         if (TryFindMethod(reader, typeDef, target) is { } accessorHandle
             && accessorToEvent.TryGetValue(accessorHandle, out var foundEventHandle)
-            && IsExplicitInterfaceEventAccessor(reader, typeDef, accessorHandle))
+            && (includePlainEventAccessors || IsExplicitInterfaceEventAccessor(reader, typeDef, accessorHandle)))
         {
             return (foundEventHandle, accessorHandle);
         }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1567,7 +1567,15 @@ public static class CompileBackSourceComposer
                 // Gated to Full so the Selected A/B path (which never runs the full-body evidence
                 // pass) keeps its pre-existing minimal single-accessor shape for explicit-interface
                 // event targets, leaving the corpus baseline unchanged.
+                //
+                // Explicit-interface event targets are excluded: the surface folds events by the
+                // sanitized full metadata name (`IBaseEvents.Changed`) while this target requirement
+                // carries the stripped identity (`Changed`), so the fold misses and a second
+                // explicit-interface event is appended (CS8646/CS0102). They retain the pre-#3007
+                // single-accessor shape (an honest floor, not a double-declaration false success);
+                // coherent explicit-interface reconstruction is out of #3007's plain-event scope.
                 IncludeMemberSurface = bodyPolicy == RoundTripBodyPolicy.Full
+                    && explicitEvent is null
                     && targetFacts.Any(fact => fact.Id == "closure-member")
             }
         };

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -502,7 +502,8 @@ public static class CompileBackSourceComposer
                 closure.Roots,
                 closure.Facts,
                 closure.MemberRequirements,
-                eventAccessor.SiblingAccessorBody?.Source),
+                eventAccessor.SiblingAccessorBody?.Source,
+                request.BodyPolicy),
             MethodArtifactRequest => ComposeMethod(
                 request.AssemblyPath,
                 request.Reader,
@@ -599,22 +600,46 @@ public static class CompileBackSourceComposer
                     bool concreteRemover = member.RemoverToken is { } removerHandle && HasConcreteBody(removerHandle);
                     if (!concreteAdder && !concreteRemover)
                         continue;
-                    var adder = member.AdderToken is { } adderToken && concreteAdder
+                    // Symmetric with the property branch below: when one accessor is the request
+                    // target, its body is applied by the base ComposeEventAccessor path (baked into
+                    // this member's TargetEventAccessorWithSibling policy). Producing it here would
+                    // clobber the real body with `throw null`, so skip Produce for the target and
+                    // preserve the base body; only the sibling is produced (which also credits it
+                    // into `attempted` so its declaration is represented, issue #3007).
+                    bool adderIsTarget = member.AdderToken is { } adderTargetHandle && IsTargetToken(adderTargetHandle);
+                    bool removerIsTarget = member.RemoverToken is { } removerTargetHandle && IsTargetToken(removerTargetHandle);
+                    var adder = member.AdderToken is { } adderToken && concreteAdder && !adderIsTarget
                         ? Produce(adderToken, $"{request.Type.FullName}.add_{member.Name}")
                         : default;
-                    var remover = member.RemoverToken is { } removerToken && concreteRemover
+                    var remover = member.RemoverToken is { } removerToken && concreteRemover && !removerIsTarget
                         ? Produce(removerToken, $"{request.Type.FullName}.remove_{member.Name}")
                         : default;
-                    bool adderReady = !concreteAdder || adder.Body is not null;
-                    bool removerReady = !concreteRemover || remover.Body is not null;
+                    bool adderReady = !concreteAdder || adderIsTarget || adder.Body is not null;
+                    bool removerReady = !concreteRemover || removerIsTarget || remover.Body is not null;
                     if (adderReady && removerReady)
                     {
+                        bool targetInvolved = adderIsTarget || removerIsTarget;
+                        var baseEventBody = policies.TryGetValue(member, out var existingEventPolicy)
+                            ? existingEventPolicy.Body as CSharpEventBody
+                            : null;
+                        // The target accessor's real body lives only in the base policy; if it is
+                        // missing there is nothing to preserve, so leave the base policy untouched.
+                        if (baseEventBody is null && targetInvolved)
+                            continue;
+                        CSharpAccessorBody adderBody = adderIsTarget
+                            ? baseEventBody!.Adder
+                            : adder.Body is { } producedAdder
+                                ? CSharpAccessorBody.Block(producedAdder.Source)
+                                : baseEventBody?.Adder ?? CSharpAccessorBody.Throw;
+                        CSharpAccessorBody removerBody = removerIsTarget
+                            ? baseEventBody!.Remover
+                            : remover.Body is { } producedRemover
+                                ? CSharpAccessorBody.Block(producedRemover.Source)
+                                : baseEventBody?.Remover ?? CSharpAccessorBody.Throw;
                         policies[member] = new CSharpMemberPolicy(
                             member,
                             CSharpBodyPolicy.Full,
-                            new CSharpEventBody(
-                                adder.Body is { } adderBody ? CSharpAccessorBody.Block(adderBody.Source) : CSharpAccessorBody.Throw,
-                                remover.Body is { } removerBody ? CSharpAccessorBody.Block(removerBody.Source) : CSharpAccessorBody.Throw));
+                            new CSharpEventBody(adderBody, removerBody));
                     }
                     continue;
                 }
@@ -1463,7 +1488,8 @@ public static class CompileBackSourceComposer
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
-        string? siblingAccessorBody = null)
+        string? siblingAccessorBody = null,
+        RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var eventDefinition = reader.GetEventDefinition(targetEvent);
@@ -1528,6 +1554,22 @@ public static class CompileBackSourceComposer
                 targetMembers,
                 PrimaryConstructor: null,
                 targetFacts)
+            {
+                // Mirror the property-getter target path (issue #3000/#3008): when the accessor's
+                // closure pulls in same-type members (backing field, sibling accessor, the
+                // constructor), emit the full member surface so the event re-declares as a single
+                // `event { add remove }` with both real bodies and every sibling declaration is
+                // represented — instead of a lone accessor method plus an unrepresented sibling and
+                // `.ctor` (issue #3007). The surface enumeration folds the sibling accessor's token
+                // into this target event requirement and skips the standalone accessor methods, so
+                // there is no CS0082 collision.
+                //
+                // Gated to Full so the Selected A/B path (which never runs the full-body evidence
+                // pass) keeps its pre-existing minimal single-accessor shape for explicit-interface
+                // event targets, leaving the corpus baseline unchanged.
+                IncludeMemberSurface = bodyPolicy == RoundTripBodyPolicy.Full
+                    && targetFacts.Any(fact => fact.Id == "closure-member")
+            }
         };
         AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
         foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))


### PR DESCRIPTION
- Advances #3007
- Changes: RTS harness-only. Plain (non-explicit-interface) event-accessor targets now reconstruct coherently under Full policy. No product output change.
- Evidence revision: 2f5970de

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — a plain event-accessor target under Full was an uncheckable `RecompileFail`/floor bucket (CS0082); routing it through `ComposeEventAccessor` with the full member surface + symmetric evidence crediting makes it a coherent `event { add remove }` with every declaration represented and recompile Exact.

Before (target `Holder.add_Changed`, Full): standalone accessor method **plus** a re-declared skeleton event → CS0082 collision → compile-back floor, `BodyComplete=false` (honest floor from #3000):

```csharp
public class Holder {
    public void add_Changed(Action value) { _changed = (Action)Delegate.Combine(_changed, value); } // CS0082 vs event's synthesized add
    public Action _changed;
    public event Action Changed { add { throw null; } remove { throw null; } }
    public Holder() { }
}
```

After: one coherent event, both real bodies, no standalone accessor method, `add_Changed`/`remove_Changed`/`.ctor` all Complete, `BodyComplete=true`, no floor:

```csharp
public class Holder {
    public event Action Changed {
        add { _changed = (Action)Delegate.Combine(_changed, value); }
        remove { _changed = (Action)Delegate.Remove(_changed, value); }
    }
    public Action _changed;
    public Holder() { }
}
```

## Scope and safety

- **Root cause:** `TryFindEventAccessor` only matched explicit-interface accessors, so a plain event accessor fell through to method-routing (`ComposeMethod`). Under Full the type surface re-declared the event, whose compiler-synthesized accessor collided (CS0082) with the standalone target method.
- **Fix shape:** RTS orchestration + surface/evidence symmetry with the merged property-getter fix (#3008). Three parts:
  1. `ReturnToSender.TryFindEventAccessor` routes plain event accessors through `ComposeEventAccessor` **under Full only**.
  2. `ComposeEventAccessor` sets `IncludeMemberSurface` (**gated to Full**) when the accessor closure pulls in same-type members — the surface enumeration folds the sibling accessor's token into the single event requirement, skips the standalone accessor methods (no CS0082), and represents the `.ctor`.
  3. `ApplyFullBodies.Enrich` event branch mirrors the property `IsTargetToken` preserve-base logic: the target accessor keeps its real base body (instead of being clobbered with `throw null`); only the sibling is produced, which also credits it into `attempted`.
- **Product impact:** none. Change is entirely within `tools/DecompilerHarness` (RTS) + its test.
- **Scope boundary:** Selected/default stays method-routed; explicit-interface event targets under Selected keep their pre-existing minimal single-accessor shape (`IncludeMemberSurface` is Full-gated), so the A/B corpus baseline is unchanged.
- **RTS boundary:** RTS only orchestrates closure + Roslyn + contract body comparison; the product/shared `ILInspector.CSharp` printer owns C# source generation. No C# knowledge was added to RTS.

## Evidence

| Check | Result |
| --- | --- |
| Product build (test graph) | Pass (`ILInspector.Decompiler.Tests` clean) |
| Focused test | `CompileBackTargets_FullReconstructsPlainEventAccessorTarget` — source-shape / `FullBodies` (adder, remover, `.ctor` all Complete) / `BodyComplete` / no-floor all pass locally |
| Regression sweep | Full `ReturnToSenderPrototypeTests` baseline (b5e9ee3b) vs branch: **only delta is the renamed/converted test**; all 118 other reds are byte-identical, pre-existing environmental `CS0009` recompile stalls |
| Recompile Exact (`DonorPe`/`Comparison`) | CI-only — blocked locally by the known environmental `CS0009` on `aspnetcorev2_inprocess.dll` (affects the whole class equally, baseline and branch) |

Local recompile-Exact assertions (`DonorPe`, `Comparison.Status`) fail on this box for **every** recompile-based test in the class (baseline included) due to the CS0009 environmental stall; they are green on CI. The regression sweep isolates that the fix adds zero new failures.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Plain event-accessor target under Full | Fixed | This PR |
| Explicit-interface event target under Full | Fixed incidentally | `IncludeMemberSurface` now represents its sibling/`.ctor` too (previously had the same evidence gap) |
| Plain event-accessor target under Selected | Left as-is | Method-routed by design; Selected never runs the full-body evidence pass |

## Review

Two-model adversarial review pending (Gemini Pro + GPT, per AGENTS.md roster).

## Validation

```powershell
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests.CompileBackTargets_FullReconstructsPlainEventAccessorTarget"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests"
```
