### PR TITLE
Model interpolation holes when shortening qualified names (#3064)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EscapedKeywordNamespaceFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/EscapedKeywordNamespaceFixture.cs
@@ -1,0 +1,10 @@
+namespace @event.Models;
+
+// A helper type whose namespace's first segment is the C# keyword 'event', so
+// the decompiler's printer escapes it as @event.Models when spelling a
+// fully-qualified reference. Used by MemberRenderSpecimen to exercise the
+// alias-qualified shortening guard against an @-escaped namespace (#3064 review).
+public static class TypeNameShadow
+{
+    public static int M(int x) => x;
+}

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
@@ -180,23 +180,29 @@ public sealed class MemberBodyProducerMemberRenderTests
         Assert.DoesNotContain("global::Math", rendered.Text);
     }
 
-    [Fact]
-    public void ProduceMember_PreservesAliasQualifiedNameWithEscapedKeywordNamespace()
+    [Theory]
+    [InlineData(nameof(MemberRenderSpecimen.EscapedAliasQualifiedShadow),
+        "global::@event.Models.TypeNameShadow", "global::@TypeNameShadow")]
+    [InlineData(nameof(MemberRenderSpecimen.SystemEscapedAliasQualifiedShadow),
+        "global::System.@event.Models.SystemNameShadow", "global::System.@SystemNameShadow")]
+    public void ProduceMember_PreservesAliasQualifiedNameWithEscapedKeywordNamespace(
+        string memberName, string expectedFullPath, string corruptedForm)
     {
         var type = Specimen();
-        var member = Assert.Single(type.Members, m => m.Name == nameof(MemberRenderSpecimen.EscapedAliasQualifiedShadow));
+        var member = Assert.Single(type.Members, m => m.Name == memberName);
 
         var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null);
 
         Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
-        // The namespace's first segment is a keyword, so the printer escapes it:
-        // global::@event.Models.TypeNameShadow. The '@' sits between the '::'
-        // alias qualifier and the matched metadata namespace (event.Models), so
-        // the guard must skip the escape and still decline — not strip to the
-        // invalid global::@TypeNameShadow (a stray escape on a name that does
-        // not bind, CS0400) (#3064 review).
-        Assert.Contains("global::@event.Models.TypeNameShadow", rendered.Text);
-        Assert.DoesNotContain("global::@TypeNameShadow", rendered.Text);
+        // A namespace segment that is a keyword is printed @-escaped, so an '@'
+        // sits between the '::' alias qualifier and the matched metadata
+        // namespace. For a System-rooted namespace the System.-stripped prefix
+        // even matches mid-chain (after "System.@"), so the guard must walk the
+        // whole qualified run back to its '::' root and decline — not strip to
+        // the invalid @-escaped form (a stray escape on a name that does not
+        // bind, CS0400/CS0234) (#3064 review).
+        Assert.Contains(expectedFullPath, rendered.Text);
+        Assert.DoesNotContain(corruptedForm, rendered.Text);
     }
 }
 
@@ -251,5 +257,14 @@ public sealed class MemberRenderSpecimen
     // to skip the escape (#3064 review).
     public static int EscapedAliasQualifiedShadow(int TypeNameShadow)
         => @event.Models.TypeNameShadow.M(TypeNameShadow);
+
+    // Same hazard, but the namespace is System-rooted with a keyword segment
+    // (System.@event.Models). The printer emits global::System.@event.Models.
+    // TypeNameShadow; the System.-stripped prefix "event.Models" matches
+    // mid-chain after "System.@", so a guard that only inspects the characters
+    // just before the match cannot see the '::' root. Shortening must still be
+    // declined, not corrupted to global::System.@TypeNameShadow (CS0234).
+    public static int SystemEscapedAliasQualifiedShadow(int SystemNameShadow)
+        => System.@event.Models.SystemNameShadow.M(SystemNameShadow);
 }
 #pragma warning restore CA1822

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
@@ -161,6 +161,24 @@ public sealed class MemberBodyProducerMemberRenderTests
         // must survive, not be mis-segmented and shortened to String (#3064).
         Assert.Contains("\"System.String\"", rendered.Text);
     }
+
+    [Theory]
+    [InlineData(nameof(MemberRenderSpecimen.AliasQualifiedShadow))]
+    [InlineData(nameof(MemberRenderSpecimen.AliasQualifiedShadowInHole))]
+    public void ProduceMember_PreservesAliasQualifiedNameUnderShadowing(string memberName)
+    {
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == memberName);
+
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null);
+
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        // The printer emits global::System.Math to escape the shadowing Math
+        // parameter. Shortening must keep the full alias-qualified path, not
+        // strip it to the invalid global::Math (CS0400) — in a hole or not.
+        Assert.Contains("global::System.Math", rendered.Text);
+        Assert.DoesNotContain("global::Math", rendered.Text);
+    }
 }
 
 #pragma warning disable CA1822 // members are instance to exercise real signatures
@@ -196,5 +214,13 @@ public sealed class MemberRenderSpecimen
     // $"…" as one literal mis-segments the hole and shortens System.String
     // inside the nested constant, corrupting the ldstr operand (#3064).
     public string InterpolatedQuotedTypeName(int n) => $"n={n} t={Echo("System.String")}";
+
+    // A parameter named Math shadows System.Math, so the printer emits the
+    // alias-qualified global::System.Math to disambiguate. Shortening must not
+    // strip it to global::Math, which re-introduces the collision and does not
+    // bind (CS0400) — both inside an interpolation hole and in plain code (#3064).
+    public static int AliasQualifiedShadow(int Math) => System.Math.Abs(Math) + Math;
+
+    public static string AliasQualifiedShadowInHole(int Math) => $"v={System.Math.Abs(Math) + Math}";
 }
 #pragma warning restore CA1822

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
@@ -143,6 +143,24 @@ public sealed class MemberBodyProducerMemberRenderTests
         // compile-back OperandDiff (#3062).
         Assert.Contains("System.String", rendered.Text);
     }
+
+    [Fact]
+    public void ProduceMember_PreservesQualifiedNameInsideInterpolationHoleLiteral()
+    {
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == nameof(MemberRenderSpecimen.InterpolatedQuotedTypeName));
+
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null);
+
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        // The body re-sugars to an interpolated string; guard that the shape is
+        // actually recovered so the hole scan is exercised.
+        Assert.Contains("$\"", rendered.Text);
+        // Name-shortening scans a hole's code but must copy nested literals
+        // verbatim: System.String inside the hole's "System.String" constant
+        // must survive, not be mis-segmented and shortened to String (#3064).
+        Assert.Contains("\"System.String\"", rendered.Text);
+    }
 }
 
 #pragma warning disable CA1822 // members are instance to exercise real signatures
@@ -169,5 +187,14 @@ public sealed class MemberRenderSpecimen
     // so a name-shortener that splits on '"' without honoring escapes flips its
     // in-literal parity and mutates System.String inside the constant (#3062).
     public string QuotedTypeName() => "a \"System.String\" b";
+
+    static string Echo(string value) => value;
+
+    // An interpolated string whose hole contains a nested string literal that
+    // is itself a fully-qualified type name. The decompiler re-sugars this to
+    // $"…{Echo("System.String")}…", so a name-shortener that treats the outer
+    // $"…" as one literal mis-segments the hole and shortens System.String
+    // inside the nested constant, corrupting the ldstr operand (#3064).
+    public string InterpolatedQuotedTypeName(int n) => $"n={n} t={Echo("System.String")}";
 }
 #pragma warning restore CA1822

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
@@ -179,6 +179,25 @@ public sealed class MemberBodyProducerMemberRenderTests
         Assert.Contains("global::System.Math", rendered.Text);
         Assert.DoesNotContain("global::Math", rendered.Text);
     }
+
+    [Fact]
+    public void ProduceMember_PreservesAliasQualifiedNameWithEscapedKeywordNamespace()
+    {
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == nameof(MemberRenderSpecimen.EscapedAliasQualifiedShadow));
+
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null);
+
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        // The namespace's first segment is a keyword, so the printer escapes it:
+        // global::@event.Models.TypeNameShadow. The '@' sits between the '::'
+        // alias qualifier and the matched metadata namespace (event.Models), so
+        // the guard must skip the escape and still decline — not strip to the
+        // invalid global::@TypeNameShadow (a stray escape on a name that does
+        // not bind, CS0400) (#3064 review).
+        Assert.Contains("global::@event.Models.TypeNameShadow", rendered.Text);
+        Assert.DoesNotContain("global::@TypeNameShadow", rendered.Text);
+    }
 }
 
 #pragma warning disable CA1822 // members are instance to exercise real signatures
@@ -222,5 +241,15 @@ public sealed class MemberRenderSpecimen
     public static int AliasQualifiedShadow(int Math) => System.Math.Abs(Math) + Math;
 
     public static string AliasQualifiedShadowInHole(int Math) => $"v={System.Math.Abs(Math) + Math}";
+
+    // The referenced type lives in @event.Models, a namespace whose first
+    // segment is a keyword, so the printer escapes it. A parameter named
+    // TypeNameShadow shadows the type, forcing the alias-qualified
+    // global::@event.Models.TypeNameShadow. Shortening must keep the full path,
+    // not strip it to the invalid global::@TypeNameShadow: the '@' sits between
+    // the '::' alias qualifier and the raw metadata namespace, so the guard has
+    // to skip the escape (#3064 review).
+    public static int EscapedAliasQualifiedShadow(int TypeNameShadow)
+        => @event.Models.TypeNameShadow.M(TypeNameShadow);
 }
 #pragma warning restore CA1822

--- a/src/ILInspector.Decompiler.Tests/SystemEscapedKeywordNamespaceFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/SystemEscapedKeywordNamespaceFixture.cs
@@ -1,0 +1,11 @@
+namespace System.@event.Models;
+
+// A helper type whose namespace is System-rooted AND has a keyword segment
+// (@event), so the printer emits global::System.@event.Models.X while the
+// System.-stripped prefix registration ("event.Models") matches mid-chain,
+// after "System.@". Used to exercise the alias-root walk in the shortener
+// against a System-rooted @-escaped chain (#3064 review).
+public static class SystemNameShadow
+{
+    public static int M(int x) => x;
+}

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1857,6 +1857,12 @@ public static class MemberBodyProducer
                 // Word boundary before the prefix.
                 if (at > 0 && (char.IsLetterOrDigit(segment[at - 1]) || segment[at - 1] is '_' or '.'))
                     continue;
+                // An alias-qualified name (global::System.Math) must keep its
+                // full path; shortening to global::Math re-introduces the
+                // shadowing collision it was emitted to avoid and does not bind
+                // (CS0400). The alias qualifier is always the two-char '::'.
+                if (at >= 2 && segment[at - 1] == ':' && segment[at - 2] == ':')
+                    continue;
 
                 // The identifier after the prefix must be a type from this
                 // namespace, fully present (next char ends the identifier).

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1860,8 +1860,15 @@ public static class MemberBodyProducer
                 // An alias-qualified name (global::System.Math) must keep its
                 // full path; shortening to global::Math re-introduces the
                 // shadowing collision it was emitted to avoid and does not bind
-                // (CS0400). The alias qualifier is always the two-char '::'.
-                if (at >= 2 && segment[at - 1] == ':' && segment[at - 2] == ':')
+                // (CS0400). The alias qualifier is the two-char '::'; when the
+                // namespace's leading segment is a keyword the printer escapes
+                // it (global::@event.Models.X), so an optional '@' sits between
+                // the '::' and the matched metadata namespace and must be
+                // skipped before testing for the qualifier.
+                int aliasEnd = at;
+                if (aliasEnd > 0 && segment[aliasEnd - 1] == '@')
+                    aliasEnd--;
+                if (aliasEnd >= 2 && segment[aliasEnd - 1] == ':' && segment[aliasEnd - 2] == ':')
                     continue;
 
                 // The identifier after the prefix must be a type from this

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1591,10 +1591,16 @@ public static class MemberBodyProducer
     /// backslash escapes, so an escaped quote (<c>\"</c>) inside a literal — or a
     /// quote character constant (<c>'"'</c>) — does not end the literal early and
     /// expose its contents to shortening, which would corrupt the constant (a
-    /// naive split on <c>"</c> flips its in-literal parity). The decompiler never
-    /// emits verbatim (<c>@"…"</c>) or raw (<c>"""…"""</c>) literals — every
-    /// control character and quote is backslash-escaped and no literal spans
-    /// lines — so a backslash-aware single-line scan is sufficient.
+    /// naive split on <c>"</c> flips its in-literal parity). Interpolated strings
+    /// (<c>$"…"</c>) are modeled structurally by <see cref="CopyInterpolatedString"/>:
+    /// their literal text (with <c>{{</c>/<c>}}</c> brace escapes) and each hole's
+    /// format clause are copied verbatim, while a hole's expression is scanned as
+    /// code — so a qualified name is shortened inside a hole but a nested string
+    /// literal inside a hole (<c>$"{Echo("System.String")}"</c>) is preserved
+    /// rather than mis-segmented and corrupted. The decompiler never emits
+    /// verbatim (<c>@"…"</c>) or raw (<c>"""…"""</c>) literals — every control
+    /// character and quote is backslash-escaped and no literal spans lines — so a
+    /// backslash-aware single-line scan is sufficient.
     /// </summary>
     static void ShortenLine(
         string line,
@@ -1608,34 +1614,225 @@ public static class MemberBodyProducer
         int codeStart = 0;
         while (i < line.Length)
         {
-            if (line[i] is not ('"' or '\''))
+            char c = line[i];
+            // An interpolated string ($"…") interleaves literal text with code
+            // holes; scan it structurally so holes shorten but their literal
+            // text and any nested literals are preserved.
+            if (c == '$' && i + 1 < line.Length && line[i + 1] == '"')
             {
-                i++;
+                output.Append(ShortenSegment(line[codeStart..i], prefixes, nsToNames, shortNameOwners, usings));
+                CopyInterpolatedString(line, ref i, output, prefixes, nsToNames, shortNameOwners, usings);
+                codeStart = i;
                 continue;
             }
-            // Flush the shortened code span preceding this literal.
-            output.Append(ShortenSegment(line[codeStart..i], prefixes, nsToNames, shortNameOwners, usings));
-            // Copy the literal verbatim, honoring backslash escapes so an
-            // escaped delimiter does not terminate it early.
-            char delimiter = line[i];
-            output.Append(line[i]);
-            i++;
-            while (i < line.Length)
+            if (c is '"' or '\'')
             {
-                char c = line[i];
-                if (c == '\\' && i + 1 < line.Length)
+                // Flush the shortened code span preceding this literal, then copy
+                // the literal verbatim (honoring backslash escapes).
+                output.Append(ShortenSegment(line[codeStart..i], prefixes, nsToNames, shortNameOwners, usings));
+                CopyLiteral(line, ref i, output);
+                codeStart = i;
+                continue;
+            }
+            i++;
+        }
+        if (codeStart < line.Length)
+            output.Append(ShortenSegment(line[codeStart..], prefixes, nsToNames, shortNameOwners, usings));
+    }
+
+    /// <summary>
+    /// Copies a string (<c>"…"</c>) or character (<c>'…'</c>) literal starting at
+    /// <paramref name="i"/> verbatim, honoring backslash escapes so an escaped
+    /// delimiter (<c>\"</c>) does not terminate it early. Advances
+    /// <paramref name="i"/> past the closing delimiter (or to the end of the line
+    /// if the literal is unterminated).
+    /// </summary>
+    static void CopyLiteral(string line, ref int i, StringBuilder output)
+    {
+        char delimiter = line[i];
+        output.Append(delimiter);
+        i++;
+        while (i < line.Length)
+        {
+            char c = line[i];
+            if (c == '\\' && i + 1 < line.Length)
+            {
+                output.Append(c).Append(line[i + 1]);
+                i += 2;
+                continue;
+            }
+            output.Append(c);
+            i++;
+            if (c == delimiter)
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Copies an interpolated string (<c>$"…"</c>) starting at <paramref name="i"/>
+    /// (the <c>$</c>), advancing past the closing quote. Literal text — including
+    /// <c>{{</c>/<c>}}</c> brace escapes — is copied verbatim, and each hole is
+    /// handed to <see cref="ShortenHole"/> so its code is shortened while its
+    /// nested literals and format clause are preserved. Only non-verbatim
+    /// interpolated strings are emitted, so a backslash escapes the next character
+    /// within the literal-text runs.
+    /// </summary>
+    static void CopyInterpolatedString(
+        string line,
+        ref int i,
+        StringBuilder output,
+        List<(string Text, string Namespace)> prefixes,
+        Dictionary<string, HashSet<string>> nsToNames,
+        Dictionary<string, int> shortNameOwners,
+        SortedSet<string> usings)
+    {
+        output.Append('$').Append('"');
+        i += 2;
+        while (i < line.Length)
+        {
+            char c = line[i];
+            if (c == '\\' && i + 1 < line.Length)
+            {
+                output.Append(c).Append(line[i + 1]);
+                i += 2;
+                continue;
+            }
+            if (c == '{')
+            {
+                // '{{' is a literal open-brace escape, not a hole.
+                if (i + 1 < line.Length && line[i + 1] == '{')
                 {
-                    output.Append(c).Append(line[i + 1]);
+                    output.Append("{{");
+                    i += 2;
+                    continue;
+                }
+                ShortenHole(line, ref i, output, prefixes, nsToNames, shortNameOwners, usings);
+                continue;
+            }
+            if (c == '}')
+            {
+                // '}}' is a literal close-brace escape.
+                if (i + 1 < line.Length && line[i + 1] == '}')
+                {
+                    output.Append("}}");
                     i += 2;
                     continue;
                 }
                 output.Append(c);
                 i++;
-                if (c == delimiter)
-                    break;
+                continue;
             }
-            codeStart = i;
+            output.Append(c);
+            i++;
+            if (c == '"')
+                return;
         }
+    }
+
+    /// <summary>
+    /// Scans one interpolation hole (<c>{expression[,alignment][:format]}</c>)
+    /// starting at the opening <c>{</c> in <paramref name="i"/>, advancing past
+    /// the matching <c>}</c>. The expression is shortened as code — skipping
+    /// nested string/char literals and nested interpolated strings — while the
+    /// format clause after an unnested <c>:</c> is literal text copied verbatim.
+    /// Brace/paren/bracket nesting is tracked so an object-initializer brace or a
+    /// parenthesized conditional's <c>:</c> inside the hole neither closes the
+    /// hole nor masquerades as the format separator; the alias qualifier
+    /// <c>::</c> is likewise not a format separator. Braces never appear in a
+    /// format spec (<c>MemberIdentity</c> keeps such handlers lowered), so the
+    /// first <c>}</c> after the format <c>:</c> closes the hole.
+    /// </summary>
+    static void ShortenHole(
+        string line,
+        ref int i,
+        StringBuilder output,
+        List<(string Text, string Namespace)> prefixes,
+        Dictionary<string, HashSet<string>> nsToNames,
+        Dictionary<string, int> shortNameOwners,
+        SortedSet<string> usings)
+    {
+        output.Append('{');
+        i++;
+        int codeStart = i;
+        int depth = 0;
+        while (i < line.Length)
+        {
+            char c = line[i];
+            // A nested interpolated string owns its own literal/hole scanning.
+            if (c == '$' && i + 1 < line.Length && line[i + 1] == '"')
+            {
+                output.Append(ShortenSegment(line[codeStart..i], prefixes, nsToNames, shortNameOwners, usings));
+                CopyInterpolatedString(line, ref i, output, prefixes, nsToNames, shortNameOwners, usings);
+                codeStart = i;
+                continue;
+            }
+            if (c is '"' or '\'')
+            {
+                output.Append(ShortenSegment(line[codeStart..i], prefixes, nsToNames, shortNameOwners, usings));
+                CopyLiteral(line, ref i, output);
+                codeStart = i;
+                continue;
+            }
+            if (c is '(' or '[' or '{')
+            {
+                depth++;
+                i++;
+                continue;
+            }
+            if (c is ')' or ']')
+            {
+                if (depth > 0)
+                    depth--;
+                i++;
+                continue;
+            }
+            if (c == '}')
+            {
+                if (depth == 0)
+                {
+                    // The hole closes: flush its remaining code, then copy '}'.
+                    output.Append(ShortenSegment(line[codeStart..i], prefixes, nsToNames, shortNameOwners, usings));
+                    output.Append('}');
+                    i++;
+                    return;
+                }
+                depth--;
+                i++;
+                continue;
+            }
+            if (c == ':' && depth == 0)
+            {
+                // '::' is the alias qualifier (global::), not a format separator.
+                if (i + 1 < line.Length && line[i + 1] == ':')
+                {
+                    i += 2;
+                    continue;
+                }
+                // The format clause is literal text up to the hole's '}'.
+                output.Append(ShortenSegment(line[codeStart..i], prefixes, nsToNames, shortNameOwners, usings));
+                output.Append(':');
+                i++;
+                while (i < line.Length && line[i] != '}')
+                {
+                    if (line[i] == '\\' && i + 1 < line.Length)
+                    {
+                        output.Append(line[i]).Append(line[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    output.Append(line[i]);
+                    i++;
+                }
+                if (i < line.Length)
+                {
+                    output.Append('}');
+                    i++;
+                }
+                return;
+            }
+            i++;
+        }
+        // Unterminated hole (malformed output): flush whatever remains as code.
         if (codeStart < line.Length)
             output.Append(ShortenSegment(line[codeStart..], prefixes, nsToNames, shortNameOwners, usings));
     }

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1857,18 +1857,21 @@ public static class MemberBodyProducer
                 // Word boundary before the prefix.
                 if (at > 0 && (char.IsLetterOrDigit(segment[at - 1]) || segment[at - 1] is '_' or '.'))
                     continue;
-                // An alias-qualified name (global::System.Math) must keep its
-                // full path; shortening to global::Math re-introduces the
-                // shadowing collision it was emitted to avoid and does not bind
-                // (CS0400). The alias qualifier is the two-char '::'; when the
-                // namespace's leading segment is a keyword the printer escapes
-                // it (global::@event.Models.X), so an optional '@' sits between
-                // the '::' and the matched metadata namespace and must be
-                // skipped before testing for the qualifier.
-                int aliasEnd = at;
-                if (aliasEnd > 0 && segment[aliasEnd - 1] == '@')
-                    aliasEnd--;
-                if (aliasEnd >= 2 && segment[aliasEnd - 1] == ':' && segment[aliasEnd - 2] == ':')
+                // An alias-qualified name must keep its full path; shortening
+                // any part of it re-introduces the shadowing collision the
+                // global:: was emitted to avoid and does not bind (CS0400 /
+                // CS0234). Only the System.-stripped prefix spelling can match
+                // mid-chain (e.g. "event.Models" inside
+                // global::System.@event.Models.X, after "System.@"), so a check
+                // of the characters immediately before the match is not enough:
+                // walk back over the whole qualified run (identifier chars, '.',
+                // and the '@' keyword escape) to the token that roots it. If that
+                // token is the two-char '::' alias qualifier, the match belongs
+                // to an alias-rooted chain — decline.
+                int root = at;
+                while (root > 0 && (char.IsLetterOrDigit(segment[root - 1]) || segment[root - 1] is '_' or '.' or '@'))
+                    root--;
+                if (root >= 2 && segment[root - 1] == ':' && segment[root - 2] == ':')
                     continue;
 
                 // The identifier after the prefix must be a type from this


### PR DESCRIPTION
## Summary

`MemberBodyProducer`'s qualified-name shortener (which rewrites fully-qualified
type names in already-emitted decompiled C# to simple names) had two coupled
defects. Both are **pre-existing** (not introduced by #3062) and are fixed here.
Fixes #3064.

## Fix 1 — model interpolation holes (`ShortenLine`)

`ShortenLine` skips string/char literals when shortening, but treated an
interpolated string (`$"…"`) as one opaque literal: it stopped at the first inner
`"`, mis-segmenting the hole. A fully-qualified name inside a **nested string
literal in a hole** — e.g. `$"{Echo("System.String")}"` — was then exposed to
shortening, corrupting the `ldstr` constant (`System.String` → `String`), which
changes the operand and can induce a false compile-back `OperandDiff`.

Make `ShortenLine` interpolation-aware:

- `CopyInterpolatedString` models the `$"…"` grammar structurally — literal text
  (with `{{`/`}}` brace escapes) is copied verbatim; each hole is handed to
  `ShortenHole`.
- `ShortenHole` scans the hole's expression as **code** (shortening qualified
  names, skipping nested string/char literals and nested `$"…"`), while copying
  the format clause after an unnested `:` verbatim. Brace/paren/bracket nesting
  is tracked so an object-initializer brace or a parenthesized conditional's `:`
  neither closes the hole nor masquerades as the format separator.
- `CopyLiteral` factors out the existing backslash-aware literal copy.

The soundness of "an unnested `:` at depth 0 is the format separator" rests on the
product printer always parenthesizing a conditional/switch inside a hole:
`InterpolatedExpression` renders each hole with `.At(Precedence.Primary)` (no
format) or `.At(Precedence.NullCoalescing)` (with format), both strictly above
`Precedence.Conditional`, so a ternary/switch `:` is always at depth > 0.

## Fix 2 — preserve alias-rooted (`global::`) names (`ShortenSegment`)

Surfaced and progressively hardened across adversarial review.
`ShortenSegment`'s word-boundary check declined only when the matched prefix was
preceded by a letter/digit/`_`/`.` — **not** by the `::` alias qualifier. The
printer emits `global::`-qualified names when a type name is shadowed in scope,
and shortening any part of such a chain re-introduces the collision it was emitted
to avoid and does not bind:

- `global::System.Runtime.CompilerServices.Unsafe` → `global::Unsafe` (CS0400).
  This occurs in real output — see blast-radius.
- With a keyword namespace segment the printer `@`-escapes it, and the
  `System.`-stripped prefix can match **mid-chain**:
  `global::System.@event.Models.X` (stripped `event.Models` matches after
  `System.@`) → `global::System.@X` (CS0234).

Because only the stripped prefix can match mid-chain, checking the characters
immediately before the match is insufficient. The fix walks back over the whole
qualified run (identifier chars, `.`, and the `@` keyword escape) to the token
that roots it, and declines when that token is the two-char `::`.

## Evidence

- **Regression tests** (`MemberBodyProducerMemberRenderTests`, 12 green):
  - `ProduceMember_PreservesQualifiedNameInsideInterpolationHoleLiteral` fails
    pre-Fix-1 (`"System.String"` → `"String"` inside the hole); the specimen
    re-sugars to a real `$"…"` shape (asserted).
  - `[Theory] ProduceMember_PreservesAliasQualifiedNameUnderShadowing` — plain and
    in-hole `global::System.Math`-under-shadowing (fails pre-Fix-2 as
    `global::Math`).
  - `[Theory] ProduceMember_PreservesAliasQualifiedNameWithEscapedKeywordNamespace`
    — `global::@event.Models.TypeNameShadow` and the System-rooted
    `global::System.@event.Models.SystemNameShadow` (both fail without the
    full-chain walk as `global::@…`).
- **Blast-radius (whole-assembly render diff vs `origin/main`):** rendering
  `System.Private.CoreLib` (11.0 preview, 321k lines) through the product
  `Project` path differs in **exactly one type, `System.Index`**, and the change
  is **invalid → valid C#**: base emitted `global::Unsafe.Unbox<Index>(value)`
  (CS0400) plus a coupled spurious `using System.Runtime.CompilerServices;`; head
  emits `global::System.Runtime.CompilerServices.Unsafe.Unbox<Index>` and no stray
  using. Every other line is byte-identical, and the alias-root hardening commits
  are each SHA256-identical to one another on corelib (they only add declines for
  `@`-escaped alias chains, which corelib does not contain).
- The only `Area=RoundTrip` reds are **31 pre-existing environmental**
  `ReturnToSenderFixtureCatalogTests` compile-back failures (identical count
  baseline vs head; known Windows native-reference issue), unrelated to this change.

## Compatibility

Behavior-preserving for all valid output. The only whole-corelib change replaces
one invalid `global::`-shortened render with the correct fully-qualified name.
Product paths remain SRM-only / Roslyn-free.
