### PR TITLE
Reconcile enum-shift operands feeding a bitwise op (#3011)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5179,6 +5179,14 @@ public static class EnumCastSamples
 
     public static uint IntEnumShiftAndUnsigned(CfgPriority e, uint x) => ((uint)e << 4) & x;
 
+    // A bitwise CHAIN over an enum shift: the inner `|` inherits the shift's stale
+    // enum ResultType while rendering as an integer, so the outer `|` must not
+    // coerce the far sibling to the enum (`... | (E)y`, CS0019). The rewritten-
+    // integer detection and rendered-type reconciliation recurse through the chain.
+    public static uint ChainIntEnumShiftOrUnsigned(CfgPriority e, uint x, uint y) => ((uint)e << 24) | x | y;
+
+    public static ulong ChainLongEnumShiftOrUnsigned(CfgLongPriority e, ulong x, ulong y) => ((ulong)e << 8) | x | y;
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5187,6 +5187,16 @@ public static class EnumCastSamples
 
     public static ulong ChainLongEnumShiftOrUnsigned(CfgLongPriority e, ulong x, ulong y) => ((ulong)e << 8) | x | y;
 
+    // An enum shift RETURNED or STORED to an enum target: the shift renders as its
+    // underlying integer, so the sink is an int->enum conversion needing an outer
+    // `(E)` cast (CS0266). The shift's stale enum ResultType would otherwise read
+    // as an identity to the target and the cast would be dropped.
+    public static CfgPriority EnumShiftReturn(CfgPriority e, int n) => (CfgPriority)((int)e >> n);
+
+    public static CfgLongPriority EnumShiftReturnLong(CfgLongPriority e, int n) => (CfgLongPriority)((long)e >> n);
+
+    public static void EnumShiftStoreArray(CfgPriority[] arr, int n) => arr[0] = (CfgPriority)((int)arr[0] >> n);
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5164,6 +5164,21 @@ public static class EnumCastSamples
 
     public static int RefIntEnumLeftShift(ref CfgPriority e, int n) => (int)e << n;
 
+    // #3011 (review): an enum shift feeding a parent bitwise &/|/^ kept the shift
+    // node's enum ResultType, so the printer coerced the *sibling* integer to the
+    // enum (`(int)e << n | (E)x`, CS0019). The shift renders as its underlying
+    // integer, so the bitwise op is an integer op; a same-width mixed-sign sibling
+    // reconciles to one width rather than promoting to the wider signed common type
+    // (which changes the value) or failing to bind. Witness: Roslyn
+    // MetadataWriter.GetRawToken — `((uint)encoding << 24) | pseudoToken`.
+    public static uint IntEnumShiftOrUnsigned(CfgPriority e, uint x) => ((uint)e << 24) | x;
+
+    public static int IntEnumShiftOrSigned(CfgPriority e, int x) => ((int)e << 8) | x;
+
+    public static ulong LongEnumShiftOrUnsigned(CfgLongPriority e, ulong x) => ((ulong)e << 8) | x;
+
+    public static uint IntEnumShiftAndUnsigned(CfgPriority e, uint x) => ((uint)e << 4) & x;
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -194,6 +194,54 @@ public class EnumCastPrinterTests
         AssertCompiles("public static int M(ref CfgPriority e, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
+    // An enum shift feeding a parent bitwise &/|/^ must not coerce the *sibling*
+    // integer to the enum (`(int)e << n | (E)x`, CS0019). The shift renders as its
+    // underlying integer, so the bitwise op is integer; a mixed-sign same-width
+    // sibling reconciles to one width (uint|uint) rather than promoting to the wider
+    // signed common type. Witness: Roslyn MetadataWriter.GetRawToken.
+    [Fact]
+    public void EnumShiftInBitwiseOr_UnsignedSibling_ReconcilesToOneWidth()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumShiftOrUnsigned));
+
+        Assert.Contains("(uint)((int)e << 24) | x", body);
+        Assert.DoesNotContain("(CfgPriority)x", body);
+        AssertCompiles("public static uint M(CfgPriority e, uint x)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // Same-sign (int shift | int) binds bare — no reconciliation, no enum coercion.
+    [Fact]
+    public void EnumShiftInBitwiseOr_SignedSibling_BindsAsInteger()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumShiftOrSigned));
+
+        Assert.Contains("(int)e << 8 | x", body);
+        Assert.DoesNotContain("(CfgPriority)x", body);
+        AssertCompiles("public static int M(CfgPriority e, int x)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // A long-backed enum shift | ulong sibling has no C# common type (CS0019) unless
+    // the signed shift is reinterpreted to ulong — the mixed-sign reconciliation the
+    // stale enum ResultType would otherwise suppress.
+    [Fact]
+    public void EnumShiftInBitwiseOr_LongEnumUnsignedSibling_ReconcilesToOneWidth()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.LongEnumShiftOrUnsigned));
+
+        Assert.Contains("(ulong)((long)e << 8) | x", body);
+        AssertCompiles("public static ulong M(CfgLongPriority e, ulong x)", body, "public enum CfgLongPriority : long { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    [Fact]
+    public void EnumShiftInBitwiseAnd_UnsignedSibling_ReconcilesToOneWidth()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumShiftAndUnsigned));
+
+        Assert.Contains("(uint)((int)e << 4) & x", body);
+        Assert.DoesNotContain("(CfgPriority)x", body);
+        AssertCompiles("public static uint M(CfgPriority e, uint x)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
     // A sub-int (byte) backing promotes to int in a C# shift; the reinterpret
     // targets the 4-byte width the shift runs on. Synthetic to keep the enum load
     // a bare operand (a compiled `(byte)` narrowing could add a conv node).

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -266,6 +266,38 @@ public class EnumCastPrinterTests
         AssertCompiles("public static ulong M(CfgLongPriority e, ulong x, ulong y)", body, "public enum CfgLongPriority : long { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
+    // An enum shift RETURNED to an enum target renders as its underlying integer,
+    // so it needs an outer `(E)` cast (CS0266) — the shift's stale enum ResultType
+    // would otherwise read as an identity to the return type and drop the cast.
+    [Fact]
+    public void EnumShiftReturnedToEnum_KeepsOuterEnumCast()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftReturn));
+
+        Assert.Contains("(CfgPriority)((int)e >> n)", body);
+        AssertCompiles("public static CfgPriority M(CfgPriority e, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    [Fact]
+    public void EnumShiftReturnedToLongEnum_KeepsOuterEnumCast()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftReturnLong));
+
+        Assert.Contains("(CfgLongPriority)((long)e >> n)", body);
+        AssertCompiles("public static CfgLongPriority M(CfgLongPriority e, int n)", body, "public enum CfgLongPriority : long { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // An enum shift STORED to an enum array element: the same int->enum sink as a
+    // return, reached through the assignment coercion funnel.
+    [Fact]
+    public void EnumShiftStoredToEnumArray_KeepsOuterEnumCast()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftStoreArray));
+
+        Assert.Contains("(CfgPriority)((int)arr[0] >> n)", body);
+        AssertCompiles("public static void M(CfgPriority[] arr, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
     // A sub-int (byte) backing promotes to int in a C# shift; the reinterpret
     // targets the 4-byte width the shift runs on. Synthetic to keep the enum load
     // a bare operand (a compiled `(byte)` narrowing could add a conv node).

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -242,6 +242,30 @@ public class EnumCastPrinterTests
         AssertCompiles("public static uint M(CfgPriority e, uint x)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
+    // A bitwise CHAIN over an enum shift: the inner `|` inherits the shift's stale
+    // enum ResultType while rendering as an integer, so the far sibling `y` must not
+    // be coerced to the enum (`... | (E)y`, CS0019). The rewritten-integer detection
+    // recurses through the chain.
+    [Fact]
+    public void EnumShiftInBitwiseChain_UnsignedSiblings_DoNotCoerceFarSibling()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.ChainIntEnumShiftOrUnsigned));
+
+        Assert.Contains("(uint)((int)e << 24) | x | y", body);
+        Assert.DoesNotContain("(CfgPriority)y", body);
+        AssertCompiles("public static uint M(CfgPriority e, uint x, uint y)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    [Fact]
+    public void EnumShiftInBitwiseChain_LongEnumUnsignedSiblings_DoNotCoerceFarSibling()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.ChainLongEnumShiftOrUnsigned));
+
+        Assert.Contains("(ulong)((long)e << 8) | x | y", body);
+        Assert.DoesNotContain("(CfgLongPriority)y", body);
+        AssertCompiles("public static ulong M(CfgLongPriority e, ulong x, ulong y)", body, "public enum CfgLongPriority : long { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
     // A sub-int (byte) backing promotes to int in a C# shift; the reinterpret
     // targets the 4-byte width the shift runs on. Synthetic to keep the enum load
     // a bare operand (a compiled `(byte)` narrowing could add a conv node).

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -409,6 +409,53 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
+    /// Whether an operand is an enum shift the printer rewrites to its underlying
+    /// integer (<see cref="ShiftEnumLeftOperand"/>) — so its rendered type is that
+    /// integer, not the enum its IR <c>ResultType</c> still reports. A parent
+    /// bitwise <c>&amp;</c>/<c>|</c>/<c>^</c> must not coerce the sibling toward the
+    /// stale enum type: the shift is an integer expression (<c>(int)flags &lt;&lt; n</c>),
+    /// and <c>int | (E)x</c> would be CS0019.
+    /// </summary>
+    bool RendersEnumShiftAsInteger(IrExpression operand)
+        => operand is Binary { Kind: BinaryKind.ShiftLeft or BinaryKind.ShiftRight } shift
+            && ShiftEnumLeftOperand(shift.Left, shift.IsUnsigned) is not null;
+
+    /// <summary>
+    /// The integer type an enum shift renders as (matching the cast
+    /// <see cref="ShiftEnumLeftOperand"/> emits on its left operand), or null when
+    /// the operand is not an enum shift. Signedness follows the shift opcode
+    /// (<c>shr.un</c> renders unsigned; <c>shl</c>/<c>shr</c> render signed); width
+    /// follows the enum backing. A parent bitwise op reconciles against this
+    /// rendered type rather than the shift node's stale enum <c>ResultType</c>, so a
+    /// same-width mixed-sign pair (<c>(long)e &lt;&lt; n | ulongValue</c>) is
+    /// reinterpreted to a single width instead of binding to the wider signed
+    /// common type (which changes the value) or failing to bind at all (CS0019).
+    /// </summary>
+    TypeRef? ShiftRenderedIntegerType(IrExpression operand)
+    {
+        if (operand is not Binary { Kind: BinaryKind.ShiftLeft or BinaryKind.ShiftRight } shift
+            || ShiftLeftEnumType(shift.Left) is not { } enumType
+            || EnumUnderlyingType(enumType) is not { } underlying)
+        {
+            return null;
+        }
+        bool wide = Is8ByteInteger(underlying);
+        return shift.IsUnsigned
+            ? TypeRef.CoreLib("System", wide ? "UInt64" : "UInt32")
+            : TypeRef.CoreLib("System", wide ? "Int64" : "Int32");
+    }
+
+    /// <summary>
+    /// The type a bitwise operand <em>renders</em> as: an enum shift's
+    /// underlying-integer render (<see cref="ShiftRenderedIntegerType"/>), otherwise
+    /// its <see cref="EffectiveType"/>. Used to decide the mixed-sign reconciliation
+    /// so an enum-shift operand participates as its rendered integer, not its stale
+    /// enum <c>ResultType</c>.
+    /// </summary>
+    TypeRef? BitwiseOperandRenderedType(IrExpression operand)
+        => ShiftRenderedIntegerType(operand) ?? EffectiveType(operand);
+
+    /// <summary>
     /// Casts an integer operand to the enum type it is compared or combined with
     /// — <c>(MethodAttributes)access</c> — so an enum-vs-integer comparison or
     /// bitwise op type-checks (CS0019). The cast reinterprets the integer bits
@@ -569,13 +616,23 @@ public sealed partial class CSharpPrinter
         // integer operand to the enum type. A cross-assembly enum is unresolved
         // (TypeShape.Unknown), so the structural test inside the coercion is what
         // catches it. A bitwise op is never checked, so it never needs the `wrap`
-        // form.
+        // form. An enum-shift operand (`(enumFlags << n) | x`) is excluded: it
+        // renders as its underlying integer (ShiftEnumLeftOperand), not the enum,
+        // so coercing the sibling toward its enum ResultType would reintroduce
+        // CS0019 (`int | (E)x`). Left as an integer bitwise op, the mixed-sign path
+        // and normal reconciliation bind it.
         if (binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor)
         {
-            if (TryCoerceEnumOperand(binary.Right, binary.Left.ResultType) is { } coercedRight)
+            if (!RendersEnumShiftAsInteger(binary.Left)
+                && TryCoerceEnumOperand(binary.Right, binary.Left.ResultType) is { } coercedRight)
+            {
                 return $"{Operand(binary.Left)} {BinaryOperator(binary)} {coercedRight}";
-            if (TryCoerceEnumOperand(binary.Left, binary.Right.ResultType) is { } coercedLeft)
+            }
+            if (!RendersEnumShiftAsInteger(binary.Right)
+                && TryCoerceEnumOperand(binary.Left, binary.Right.ResultType) is { } coercedLeft)
+            {
                 return $"{coercedLeft} {BinaryOperator(binary)} {Operand(binary.Right)}";
+            }
         }
         // div.un/rem.un compute on unsigned operands; shr.un shifts an
         // unsigned left operand. Operands that are already unsigned (or
@@ -588,7 +645,8 @@ public sealed partial class CSharpPrinter
         // that width. Reinterpret the signed operand as unsigned — `S_0 | (ulong)S_1`,
         // `count * (nuint)stride` — a no-op same-width cast, so the opcode and its
         // stack width are unchanged.
-        bool mixedSign = MixedSignBitwise(binary) || MixedSignArithmetic(binary);
+        bool mixedSign = MixedSignBitwise(binary) || MixedSignArithmetic(binary)
+            || EnumShiftBitwiseMixedSign(binary);
         // A constant +/-/* whose subtree reinterprets an out-of-range signed
         // constant as unsigned (e.g. `(uint)-1 + 1`) is a C# *constant expression*:
         // the compiler evaluates it in a checked context (even unchecked add/sub/mul
@@ -843,6 +901,22 @@ public sealed partial class CSharpPrinter
             && MixedSignSameWidthIntegers(binary);
 
     /// <summary>
+    /// A bitwise <c>&amp;</c>/<c>|</c>/<c>^</c> with an enum-shift operand whose
+    /// <em>rendered</em> integer type (<see cref="ShiftRenderedIntegerType"/>) forms
+    /// a same-width mixed-sign pair with the sibling. <see cref="MixedSignBitwise"/>
+    /// misses these because the shift node's <c>ResultType</c> is still the enum, so
+    /// its <see cref="EffectiveType"/> is not an integer. Reinterpreting the signed
+    /// side keeps the op at one width (<c>(ulong)((long)e &lt;&lt; n) | x</c>)
+    /// instead of promoting to the wider signed common type or failing to bind.
+    /// </summary>
+    bool EnumShiftBitwiseMixedSign(Binary binary)
+        => binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor
+            && (RendersEnumShiftAsInteger(binary.Left) || RendersEnumShiftAsInteger(binary.Right))
+            && MixedSignSameWidthIntegers(
+                BitwiseOperandRenderedType(binary.Left),
+                BitwiseOperandRenderedType(binary.Right));
+
+    /// <summary>
     /// True when an <em>unchecked</em> <c>+</c>/<c>-</c>/<c>*</c> has one signed
     /// and one unsigned integer operand of the same stack width (e.g.
     /// <c>int * uint</c>, <c>nuint * nint</c>, <c>ulong - long</c>). Same
@@ -962,7 +1036,7 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string BitwiseUnsignedOperand(IrExpression operand, bool wrapConstantCast = true)
     {
-        var unsigned = TypeFamilies.UnsignedCounterpart(EffectiveType(operand));
+        var unsigned = TypeFamilies.UnsignedCounterpart(BitwiseOperandRenderedType(operand));
         if (unsigned is null)
             return Operand(operand);
         bool constantOutOfRange = wrapConstantCast && TryGetIntegerConstant(operand, out long value) && !CSharpConversionRules.ConstantFits(value, unsigned);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -447,13 +447,64 @@ public sealed partial class CSharpPrinter
 
     /// <summary>
     /// The type a bitwise operand <em>renders</em> as: an enum shift's
-    /// underlying-integer render (<see cref="ShiftRenderedIntegerType"/>), otherwise
-    /// its <see cref="EffectiveType"/>. Used to decide the mixed-sign reconciliation
-    /// so an enum-shift operand participates as its rendered integer, not its stale
-    /// enum <c>ResultType</c>.
+    /// underlying-integer render (<see cref="ShiftRenderedIntegerType"/>), a nested
+    /// bitwise chain that transitively contains one (<see cref="BitwiseChainRenderedType"/>),
+    /// otherwise its <see cref="EffectiveType"/>. Used to decide the mixed-sign
+    /// reconciliation so an enum-shift operand participates as its rendered integer,
+    /// not its stale enum <c>ResultType</c>.
     /// </summary>
     TypeRef? BitwiseOperandRenderedType(IrExpression operand)
-        => ShiftRenderedIntegerType(operand) ?? EffectiveType(operand);
+    {
+        if (ShiftRenderedIntegerType(operand) is { } shiftType)
+        {
+            return shiftType;
+        }
+        if (operand is Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } bitwise
+            && BitwiseOperandRendersAsInteger(bitwise))
+        {
+            return BitwiseChainRenderedType(bitwise.Left, bitwise.Right);
+        }
+        return EffectiveType(operand);
+    }
+
+    /// <summary>
+    /// Whether a bitwise operand renders as an integer despite carrying an enum
+    /// <c>ResultType</c>: either a direct enum shift (<see cref="RendersEnumShiftAsInteger"/>)
+    /// or a nested bitwise <c>&amp;</c>/<c>|</c>/<c>^</c> chain that transitively
+    /// contains one. The inner bitwise node inherits the shift's stale enum
+    /// <c>ResultType</c>, so an enclosing op must consult this — not
+    /// <c>ResultType</c> — before coercing the sibling; otherwise a chain like
+    /// <c>(enumFlags &lt;&lt; n) | x | y</c> re-casts the far sibling <c>y</c> to
+    /// the enum (<c>uint | (E)y</c>, CS0019).
+    /// </summary>
+    bool BitwiseOperandRendersAsInteger(IrExpression operand)
+        => RendersEnumShiftAsInteger(operand)
+            || (operand is Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } bitwise
+                && (BitwiseOperandRendersAsInteger(bitwise.Left) || BitwiseOperandRendersAsInteger(bitwise.Right)));
+
+    /// <summary>
+    /// The integer type a bitwise <c>&amp;</c>/<c>|</c>/<c>^</c> chain over an enum
+    /// shift renders as. IL bitwise ops require operands of the same stack width, so
+    /// both rendered operand types share a width; the result is unsigned when either
+    /// side is unsigned (a same-width mixed-sign pair reinterprets the signed side).
+    /// Null when either side is not a wide integer render (no enum-shift descendant),
+    /// leaving the caller on its <see cref="EffectiveType"/> path.
+    /// </summary>
+    TypeRef? BitwiseChainRenderedType(IrExpression left, IrExpression right)
+    {
+        var leftType = BitwiseOperandRenderedType(left);
+        var rightType = BitwiseOperandRenderedType(right);
+        if (!IsWideInteger(leftType) || !IsWideInteger(rightType))
+        {
+            return null;
+        }
+        bool wide = Is8ByteInteger(leftType) || Is8ByteInteger(rightType);
+        bool unsigned = TypeFamilies.IsUnsignedIntegerPrimitive(leftType)
+            || TypeFamilies.IsUnsignedIntegerPrimitive(rightType);
+        return TypeRef.CoreLib("System", unsigned
+            ? (wide ? "UInt64" : "UInt32")
+            : (wide ? "Int64" : "Int32"));
+    }
 
     /// <summary>
     /// Casts an integer operand to the enum type it is compared or combined with
@@ -619,16 +670,19 @@ public sealed partial class CSharpPrinter
         // form. An enum-shift operand (`(enumFlags << n) | x`) is excluded: it
         // renders as its underlying integer (ShiftEnumLeftOperand), not the enum,
         // so coercing the sibling toward its enum ResultType would reintroduce
-        // CS0019 (`int | (E)x`). Left as an integer bitwise op, the mixed-sign path
-        // and normal reconciliation bind it.
+        // CS0019 (`int | (E)x`). The exclusion recurses through a bitwise chain
+        // (`(enumFlags << n) | x | y`): the inner op inherits the shift's stale
+        // enum ResultType while rendering as an integer, so the outer op must not
+        // coerce the far sibling either. Left as an integer bitwise op, the
+        // mixed-sign path and normal reconciliation bind it.
         if (binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor)
         {
-            if (!RendersEnumShiftAsInteger(binary.Left)
+            if (!BitwiseOperandRendersAsInteger(binary.Left)
                 && TryCoerceEnumOperand(binary.Right, binary.Left.ResultType) is { } coercedRight)
             {
                 return $"{Operand(binary.Left)} {BinaryOperator(binary)} {coercedRight}";
             }
-            if (!RendersEnumShiftAsInteger(binary.Right)
+            if (!BitwiseOperandRendersAsInteger(binary.Right)
                 && TryCoerceEnumOperand(binary.Left, binary.Right.ResultType) is { } coercedLeft)
             {
                 return $"{coercedLeft} {BinaryOperator(binary)} {Operand(binary.Right)}";
@@ -901,17 +955,18 @@ public sealed partial class CSharpPrinter
             && MixedSignSameWidthIntegers(binary);
 
     /// <summary>
-    /// A bitwise <c>&amp;</c>/<c>|</c>/<c>^</c> with an enum-shift operand whose
-    /// <em>rendered</em> integer type (<see cref="ShiftRenderedIntegerType"/>) forms
-    /// a same-width mixed-sign pair with the sibling. <see cref="MixedSignBitwise"/>
-    /// misses these because the shift node's <c>ResultType</c> is still the enum, so
-    /// its <see cref="EffectiveType"/> is not an integer. Reinterpreting the signed
-    /// side keeps the op at one width (<c>(ulong)((long)e &lt;&lt; n) | x</c>)
+    /// A bitwise <c>&amp;</c>/<c>|</c>/<c>^</c> with an enum-shift operand (possibly
+    /// nested in a bitwise chain) whose <em>rendered</em> integer type
+    /// (<see cref="BitwiseOperandRenderedType"/>) forms a same-width mixed-sign pair
+    /// with the sibling. <see cref="MixedSignBitwise"/> misses these because the
+    /// shift (or the chain that inherits its <c>ResultType</c>) is still enum-typed,
+    /// so its <see cref="EffectiveType"/> is not an integer. Reinterpreting the
+    /// signed side keeps the op at one width (<c>(ulong)((long)e &lt;&lt; n) | x</c>)
     /// instead of promoting to the wider signed common type or failing to bind.
     /// </summary>
     bool EnumShiftBitwiseMixedSign(Binary binary)
         => binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor
-            && (RendersEnumShiftAsInteger(binary.Left) || RendersEnumShiftAsInteger(binary.Right))
+            && (BitwiseOperandRendersAsInteger(binary.Left) || BitwiseOperandRendersAsInteger(binary.Right))
             && MixedSignSameWidthIntegers(
                 BitwiseOperandRenderedType(binary.Left),
                 BitwiseOperandRenderedType(binary.Right));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1494,6 +1494,22 @@ public sealed partial class CSharpPrinter
         {
             return $"({TypeText(target)}){Operand(value)}";
         }
+        // An enum shift — or a bitwise chain over one — renders as its underlying
+        // integer (ShiftEnumLeftOperand: `(int)e >> n`), not the enum its stale
+        // Binary ResultType still reports. Flowing into an enum target (a return,
+        // a local/field/array store) it is an int->enum conversion needing an
+        // explicit `(Enum)` cast (CS0266); without it CoerceText reads the stale
+        // enum ResultType as an identity to the target and drops the cast. The
+        // rendered integer drives the enum-spellability test, and EnumIntegerCast
+        // wraps the shift — `(MyEnum)((int)e >> n)`. Runs before the plain
+        // integer->enum branch, whose EffectiveType(value) would be the stale enum.
+        if (target is { } shiftEnumTarget
+            && BitwiseOperandRendersAsInteger(value)
+            && BitwiseOperandRenderedType(value) is { } shiftRenderedInteger
+            && CoercionRendering.CanSpellIntegerToEnum(shiftRenderedInteger, shiftEnumTarget, _function.TypeShapes))
+        {
+            return EnumIntegerCast(value, shiftEnumTarget);
+        }
         // An integer flowing into an enum-typed position — a comparison kind, a
         // flags value computed at run time — needs an explicit (Enum)x cast: C#
         // converts int→enum implicitly only for the literal 0. The cast is always


### PR DESCRIPTION
- Fixes/advances #3011 (follow-up landing after #3060 merged)
- Changes: an enum shift the printer rewrites to its underlying integer no longer misleads two downstream consumers — a sibling bitwise operand is no longer coerced to the enum (`int | (E)x`, CS0019), and a shift flowing into an enum target keeps its outer `(Enum)` cast (`(int)e >> n`, CS0266). Both now render valid and faithful.
- Card revision: `eda3d14f`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the merged #3011 fix left the rewritten enum shift's IR `Binary` node reporting a stale enum `ResultType`, which misleads two consumers. (1) A parent `&`/`|`/`^` coerced the *sibling* integer to the enum (`int | (E)x`, CS0019). (2) A shift returned/stored into an enum target read as an identity and dropped the required outer cast (`(int)e >> n` where an enum is expected, CS0266). This PR reconciles both printer-side without changing any previously-valid output.

### Original source

Real-world shape: Roslyn `Microsoft.Cci.MetadataWriter.GetRawToken` returns `((uint)encoding << 24) | pseudoToken`, where `encoding` is an enum. The compiled fixture `EnumCastSamples.IntEnumShiftOrUnsigned` reproduces that IL exactly (verbatim fixture source):

```csharp
public static uint IntEnumShiftOrUnsigned(CfgPriority e, uint x) => ((uint)e << 24) | x;
```

`(uint)e` is an identity reinterpret over the int-backed enum, so csc emits a bare enum-typed shift left operand — the same trace-free cast that #3011 targets, here feeding a parent `|`.

### Before

Base commit `d6af0165` (main, with #3060 already merged), same fixture IL, `-S "Decompiled Source"`:

```csharp
public static uint IntEnumShiftOrUnsigned(CfgPriority e, uint x) => (uint)(((int)e << 24) | (CfgPriority)x);
```

- Valid: False
- Correct: False

The shift's stale enum `ResultType` misleads the bitwise enum-coercion, which casts the sibling `x` to `CfgPriority`. `int | CfgPriority` has no predefined operator → CS0019 (confirmed by Roslyn: `error CS0019: Operator '|' cannot be applied to operands of type 'int' and 'CfgPriority'`). It does not compile, so correctness is moot.

### After

This PR's head `3bb28958`, same fixture IL, `-S "Decompiled Source"`:

```csharp
public static uint IntEnumShiftOrUnsigned(CfgPriority e, uint x) => (uint)((uint)((int)e << 24) | x);
```

- Valid: True
- Correct: True

The enum-coercion now skips the enum-shift operand (it renders as an integer, not the enum), and the mixed-sign reconciliation sees the shift's *rendered* integer type. The same-width mixed-sign pair reinterprets the signed side to `uint`, keeping the whole expression one width. Runtime-verified equal to the original across high-bit and negative inputs (see Evidence).

Companion shapes (same mechanism, all valid + faithful):

```csharp
// int-enum | signed int  -> both int, no reinterpret needed
public static int  IntEnumShiftOrSigned(CfgPriority e, int x)        => (int)((int)e << 8 | x);
// long-enum | ulong      -> reinterpret signed long side to ulong
public static ulong LongEnumShiftOrUnsigned(CfgLongPriority e, ulong x) => (ulong)((ulong)((long)e << 8) | x);
// int-enum & uint        -> AND reconciles the same way as OR
public static uint IntEnumShiftAndUnsigned(CfgPriority e, uint x)    => (uint)((uint)((int)e << 4) & x);
```

Bitwise **chains** recurse: in `(enum << n) | x | y` the inner `|` inherits the shift's stale enum `ResultType` while rendering as an integer, so the detection and rendered-type reconciliation walk the chain and the far sibling is not coerced (all valid + faithful):

```csharp
public static uint  ChainIntEnumShiftOrUnsigned(CfgPriority e, uint x, uint y)      => (uint)((uint)((int)e << 24) | x | y);
public static ulong ChainLongEnumShiftOrUnsigned(CfgLongPriority e, ulong x, ulong y) => (ulong)((ulong)((long)e << 8) | x | y);
```

### Enum-shift into an enum target (CS0266)

The same stale enum `ResultType` also breaks a shift that flows *into* an enum target — a return, or a local/field/array store. `CoerceText` compared the stale enum `ResultType` against the enum target, saw an identity, and dropped the int→enum cast. Two compiled witnesses (int- and long-backed):

```csharp
public static CfgPriority     EnumShiftReturn(CfgPriority e, int n)         => (CfgPriority)((int)e >> n);
public static CfgLongPriority EnumShiftReturnLong(CfgLongPriority e, int n) => (CfgLongPriority)((long)e >> n);
```

Before (base tool `d6af0165`, same fixture IL) — the outer cast is dropped:

```csharp
public static CfgPriority     EnumShiftReturn(CfgPriority e, int n)         => (int)e >> n;
public static CfgLongPriority EnumShiftReturnLong(CfgLongPriority e, int n) => (long)e >> n;
```

- Valid: False (CS0266: cannot implicitly convert `int`/`long` to the enum)
- Correct: False (does not compile)

After (this PR's head `eda3d14f`, same fixture IL) — the outer `(Enum)` cast is restored:

```csharp
public static CfgPriority     EnumShiftReturn(CfgPriority e, int n)         => (CfgPriority)((int)e >> n);
public static CfgLongPriority EnumShiftReturnLong(CfgLongPriority e, int n) => (CfgLongPriority)((long)e >> n);
```

- Valid: True
- Correct: True

A new branch in `CoerceText` (before the plain integer→enum branch) detects an enum shift — or a bitwise chain over one — via the recursive `BitwiseOperandRendersAsInteger` predicate, drives the enum-spellability test with the shift's *rendered* integer type, and wraps it with `EnumIntegerCast`. Genuine flags-enum bitwise ops (no shift descendant) are not caught, so the `flags | 0x20` idiom into an enum target still renders bare. A store to an enum array element (`EnumShiftStoreArray`) already rendered the cast at base through a different path and stays valid — it is kept as a regression guard.

### Fully raised

After is valid and correct. It carries a cosmetic double cast — `(uint)((int)e << 24)` where the cast-minimal spelling is `(uint)e << 24`:

```csharp
public static uint IntEnumShiftOrUnsigned(CfgPriority e, uint x) => ((uint)e << 24) | x;
```

- Required tracking issue: #3076 — collapse `(T)((int)e << n)` to `(T)e << n` when the outer reinterpret is the unsigned counterpart of the inner underlying cast. Non-blocking cosmetic; current output is already valid and correct.

## Evidence

| Check | Baseline (`d6af0165`) | Head (`eda3d14f`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `EnumCastPrinterTests`: 42 passed (9 new tests are added by this PR) | `EnumCastPrinterTests`: 51 passed |
| Decompiler fast suite | `Area=RoundTrip` `Speed!=Slow`: 145, 0 failed | `Area=RoundTrip` `Speed!=Slow`: 145, 0 failed |
| Reduced fixture validity | CS0019 (bitwise) / CS0266 (enum target) on the shapes (Before) | Valid (Roslyn recompile via `AssertCompiles` in the new tests) |
| Reduced fixture fidelity | not applicable (Before does not compile) | Runtime-equal to original across high-bit and negative inputs — `ALL FAITHFUL` |
| Real witness | `Microsoft.Cci.MetadataWriter::GetRawToken` shape broken (`int \| (E)x`) | fixed |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — these are printer validity/correctness fixes on previously-invalid renders; they cannot regress a previously-valid output because the new logic fires only on an enum shift (or a bitwise chain over one), which previously always emitted the invalid `int | (E)x` (CS0019) or the cast-dropped `(int)e >> n` into an enum target (CS0266). No raising, structuring, or lowering behavior changes, so the corpus quick/aggregate gates are not applicable.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.EnumCastPrinterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait "Area=RoundTrip" -trait- "Speed=Slow"
```
