### PR TITLE
Wrap long splittable && / || chains across continuation lines (#3067)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
@@ -34,6 +34,7 @@ public sealed class DynamicCompilationSiteInventoryTests
             ["EnumCastPrinterTests.cs"] = (1, "Product-output validity: compiles printer-produced enum-cast source."),
             ["FinallyDisposePrinterTests.cs"] = (1, "Product-output validity: compiles printer-produced finally/dispose source."),
             ["FluentChainFormattingTests.cs"] = (1, "Product-output validity: compiles printer-produced broken fluent-chain source."),
+            ["SplittableExpressionWrapTests.cs"] = (1, "Product-output validity: compiles printer-produced wrapped &&/|| chain source."),
             ["MemberNameCollisionRenderingTests.cs"] = (1, "Product-output validity: compiles rendered colliding-member source."),
             ["MixedSignComparisonTests.cs"] = (1, "Product-output validity: compiles synthesized mixed-sign comparison source."),
             ["MultiDimensionalArrayPrinterTests.cs"] = (1, "Product-output validity: compiles printer-produced multidim-array source."),
@@ -83,9 +84,11 @@ public sealed class DynamicCompilationSiteInventoryTests
     //   This branch (#2864 comparison slice) adds a second compile-back oracle
     //     site to ExpressionTreeLambdaTests.cs (2 -> 3 sites): recompiles recovered
     //     comparison lambdas to assert their expression-tree node identity.
-    //   Combined: 32 files, 40 sites.
-    const int ExpectedDynamicFiles = 32;
-    const int ExpectedDynamicSites = 40;
+    //   #3067 adds SplittableExpressionWrapTests.cs (1 site): recompiles the
+    //     printer's wrapped &&/|| chain output.
+    //   Combined: 33 files, 41 sites.
+    const int ExpectedDynamicFiles = 33;
+    const int ExpectedDynamicSites = 41;
 
     // Migrated away from Dynamic in this change; must not reappear in the scan.
     static readonly string[] MigratedFiles = ["CompileBackTypeIdentityTests.cs"];

--- a/src/ILInspector.Decompiler.Tests/SplittableExpressionWrapTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SplittableExpressionWrapTests.cs
@@ -1,0 +1,194 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #3067: the opt-in PrinterOptions.WrapSplittableExpressions taste knob breaks a
+// long short-circuit &&/|| chain one operand per continuation line (operator
+// trailing each broken line), the boolean analog of the always-on fluent-chain
+// wrapper. Wrapping is whitespace-only: the broken body still compiles and
+// carries the same tokens as the inline form. Off by default.
+public sealed class SplittableExpressionWrapTests
+{
+    static readonly TypeRef Holder = TypeRef.Definition("synthetic", "", "Holder");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+
+    static readonly string[] Flags =
+    [
+        "firstConditionFlag",
+        "secondConditionFlag",
+        "thirdConditionFlag",
+        "fourthConditionFlag",
+        "fifthConditionFlag",
+        "sixthConditionFlag",
+    ];
+
+    static LoadArgument Flag(int index) => new(index, Flags[index], Bool);
+
+    // firstConditionFlag && ... && sixthConditionFlag — a left-associative chain
+    // well past the 120-column wrap width once `return ...;` is added.
+    static LogicalBinary LongChain(LogicalKind kind = LogicalKind.And)
+    {
+        IrExpression chain = Flag(0);
+        for (int i = 1; i < Flags.Length; i++)
+            chain = new LogicalBinary(kind, chain, Flag(i));
+        return (LogicalBinary)chain;
+    }
+
+    static string Render(IrExpression returnValue, PrinterOptions? options = null)
+    {
+        var block = new Block(0);
+        block.Add(new Return(returnValue));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Bool, ImmutableArray<Parameter>.Empty, HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", Holder, signature, [], container);
+        return CSharpPrinter.Print(function, options).Output!;
+    }
+
+    static DecompilerResult Result(IrExpression returnValue, PrinterOptions options)
+    {
+        var block = new Block(0);
+        block.Add(new Return(returnValue));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Bool, ImmutableArray<Parameter>.Empty, HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", Holder, signature, [], container);
+        return CSharpPrinter.Print(function, options);
+    }
+
+    static readonly PrinterOptions Wrap = new() { WrapSplittableExpressions = true };
+
+    [Fact]
+    public void LongChain_WithOption_BreaksOneOperandPerLine()
+    {
+        string body = Render(LongChain(), Wrap);
+
+        // Head operand on the return line with a trailing operator; every later
+        // operand on its own continuation-indented line, operator trailing each
+        // broken line, the last operand closing with the statement semicolon.
+        Assert.Contains(
+            "return firstConditionFlag &&\n"
+                + "    secondConditionFlag &&\n"
+                + "    thirdConditionFlag &&\n"
+                + "    fourthConditionFlag &&\n"
+                + "    fifthConditionFlag &&\n"
+                + "    sixthConditionFlag;",
+            body);
+        Assert.DoesNotContain("firstConditionFlag && secondConditionFlag", body);
+    }
+
+    [Fact]
+    public void LongOrChain_WithOption_BreaksOneOperandPerLine()
+    {
+        string body = Render(LongChain(LogicalKind.Or), Wrap);
+
+        Assert.Contains(
+            "return firstConditionFlag ||\n"
+                + "    secondConditionFlag ||\n"
+                + "    thirdConditionFlag ||\n"
+                + "    fourthConditionFlag ||\n"
+                + "    fifthConditionFlag ||\n"
+                + "    sixthConditionFlag;",
+            body);
+    }
+
+    [Fact]
+    public void LongChain_DefaultOptions_StaysInline()
+    {
+        string body = Render(LongChain());
+
+        Assert.Contains(
+            "return firstConditionFlag && secondConditionFlag && thirdConditionFlag "
+                + "&& fourthConditionFlag && fifthConditionFlag && sixthConditionFlag;",
+            body);
+        Assert.DoesNotContain(" &&\n", body);
+    }
+
+    [Fact]
+    public void ShortChain_WithOption_StaysInline()
+    {
+        // A two-operand chain is far under the wrap width, so it stays inline even
+        // with the option enabled.
+        var chain = new LogicalBinary(LogicalKind.And, Flag(0), Flag(1));
+
+        string body = Render(chain, Wrap);
+
+        Assert.Contains("return firstConditionFlag && secondConditionFlag;", body);
+        Assert.DoesNotContain(" &&\n", body);
+    }
+
+    // The broken form is whitespace-only: its whitespace-delimited token stream is
+    // identical to the inline chain's (same tokens, so identical IL).
+    [Fact]
+    public void WrappedChain_IsTokenIdenticalToInline()
+    {
+        string wrapped = Render(LongChain(), Wrap);
+        string inline = Render(LongChain());
+
+        Assert.Contains(" &&\n", wrapped);
+        Assert.DoesNotContain(" &&\n", inline);
+        Assert.Equal(Tokens(inline), Tokens(wrapped));
+    }
+
+    static string[] Tokens(string text)
+        => text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+
+    [Fact]
+    public void WrappedChain_EmitsTasteDecision()
+    {
+        DecompilerResult result = Result(LongChain(), Wrap);
+
+        Assert.Contains(
+            result.Decisions,
+            d => d is { RuleId: "expression.wrap-splittable-chain", Category: "taste" });
+        Assert.True(result.EffectiveOptions.WrapSplittableExpressions);
+    }
+
+    [Fact]
+    public void LongChain_DefaultOptions_EmitsNoWrapDecision()
+    {
+        DecompilerResult result = Result(LongChain(), PrinterOptions.Default);
+
+        Assert.DoesNotContain(
+            result.Decisions,
+            d => d.RuleId == "expression.wrap-splittable-chain");
+        Assert.False(result.EffectiveOptions.WrapSplittableExpressions);
+    }
+
+    [Fact]
+    public void WrappedChain_Compiles()
+    {
+        string body = Render(LongChain(), Wrap);
+
+        var errors = Recompile(body)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Wrapped chain must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<Diagnostic> Recompile(string body)
+    {
+        string parameters = string.Join(", ", Flags.Select(f => $"bool {f}"));
+        string source = $$"""
+            using System;
+            static class __Gate
+            {
+                public static bool M({{parameters}})
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RoslynTestReferences.TrustedPlatform,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        return compilation.GetDiagnostics();
+    }
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -62,6 +62,14 @@ public sealed record DecompilerOptions
     /// </summary>
     public ExpressionBodyArrowPlacement ExpressionBodyArrowPlacement { get; init; } = ExpressionBodyArrowPlacement.SameLine;
 
+    /// <summary>
+    /// Long splittable expressions (short-circuit <c>&amp;&amp;</c>/<c>||</c>
+    /// chains) may wrap one operand per continuation line instead of a single
+    /// wide line. Off by default; a whitespace-only tiebreaker that leaves the
+    /// tokens and IL unchanged.
+    /// </summary>
+    public bool WrapSplittableExpressions { get; init; }
+
     public static DecompilerOptions Default { get; } = new();
 }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -240,6 +240,7 @@ public sealed partial class CSharpPrinter
             ReadableLocalNames = _options.ReadableLocalNames,
             PreferFrameworkTypeImports = true,
             ExpressionBodyArrowPlacement = _options.ExpressionBodyArrowPlacement,
+            WrapSplittableExpressions = _options.WrapSplittableExpressions,
         };
 
     void AddDecision(string ruleId, string category, string subject, string detail, string? oldValue = null, string? newValue = null)
@@ -1814,7 +1815,8 @@ public sealed partial class CSharpPrinter
         }
         if (Statement(node) is { } line)
         {
-            if (!TryAppendFluentChain(sb, node, line, indent))
+            if (!TryAppendFluentChain(sb, node, line, indent)
+                && !TryAppendSplittableExpression(sb, node, line, indent))
                 sb.Append(pad).AppendLine(line);
         }
     }
@@ -2139,6 +2141,72 @@ public sealed partial class CSharpPrinter
                 return true;
             case StoreStackSlot store when store.Value is Call call && StackSlotTargetType(store) is { Kind: not TypeRefKind.ByRef }:
                 root = call;
+                prefix = _declaringStores.Contains(store)
+                    ? $"{DeclarationTypeText(StackSlotTargetType(store)!, store.Value)} {StackSlotName(store)} = "
+                    : $"{StackSlotName(store)} = ";
+                return true;
+            default:
+                root = null!;
+                prefix = "";
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Emits <paramref name="node"/> as a wrapped short-circuit
+    /// <c>&amp;&amp;</c>/<c>||</c> chain (one operand per line) when
+    /// <see cref="PrinterOptions.WrapSplittableExpressions"/> is set and the chain
+    /// is long enough, returning true after appending; false to fall through to
+    /// the flat single-line emit. Chosen only when the flat statement
+    /// <paramref name="line"/> is exactly <c>prefix + chain + ";"</c>, so any
+    /// coercion cast, compound assignment, or property-pattern rewrite the
+    /// renderer applied around the chain keeps the statement inline — wrapping
+    /// never drops or reshapes a token.
+    /// </summary>
+    bool TryAppendSplittableExpression(StringBuilder sb, IrNode node, string line, int indent)
+    {
+        if (!_options.WrapSplittableExpressions)
+            return false;
+        if (!TryLogicalChainStatement(node, out var root, out var prefix))
+            return false;
+        if (line != prefix + LogicalText(root) + ";")
+            return false;
+        if (LogicalChainLines(root, prefix, ";", indent) is not { } broken)
+            return false;
+        AddDecision(
+            "expression.wrap-splittable-chain",
+            "taste",
+            _function.Name,
+            $"Wrapped a long short-circuit {(root.Kind == LogicalKind.And ? "&&" : "||")} chain across continuation lines.");
+        sb.AppendLine(broken);
+        return true;
+    }
+
+    /// <summary>
+    /// Recognizes the statement positions whose value is a top-level short-circuit
+    /// <c>&amp;&amp;</c>/<c>||</c> chain — a <c>return</c> or a (non-ref) local or
+    /// stack-slot store — and yields the chain root plus the exact statement prefix
+    /// the flat renderer prints before it. (A bare chain as an expression statement
+    /// is CS0201, so there is no expression-statement case.) The caller re-derives
+    /// the flat text and only wraps when it matches, so the prefix here need only
+    /// cover the common (cast-free) spelling.
+    /// </summary>
+    bool TryLogicalChainStatement(IrNode node, out LogicalBinary root, out string prefix)
+    {
+        switch (node)
+        {
+            case Return { Value: LogicalBinary logical }:
+                root = logical;
+                prefix = "return ";
+                return true;
+            case StoreLocal { Type.Kind: not TypeRefKind.ByRef, Value: LogicalBinary logical } store:
+                root = logical;
+                prefix = _declaringStores.Contains(store)
+                    ? $"{DeclarationTypeText(store.Type, store.Value)} {LocalName(store.Index)} = "
+                    : $"{LocalName(store.Index)} = ";
+                return true;
+            case StoreStackSlot store when store.Value is LogicalBinary logical && StackSlotTargetType(store) is { Kind: not TypeRefKind.ByRef }:
+                root = logical;
                 prefix = _declaringStores.Contains(store)
                     ? $"{DeclarationTypeText(StackSlotTargetType(store)!, store.Value)} {StackSlotName(store)} = "
                     : $"{StackSlotName(store)} = ";
@@ -3475,24 +3543,99 @@ public sealed partial class CSharpPrinter
         if (TryPropertyPatternText(logical) is { } propertyPattern)
             return propertyPattern;
 
-        // Sides are condition positions: Condition() owns truthiness (a
-        // string operand spells 'is not null', never '!value') and the
-        // negation folds. Same-kind chains associate bare; mixed-kind
-        // LogicalBinary parenthesizes. Any other side renders at the
-        // operator's demand — a ternary or `??` (or one hidden behind a stale
-        // Coerce/Convert, the #2345/#2376 blind spot) is looser than `&&`/`||`
-        // and must parenthesize, while comparisons and unary forms out-bind it
-        // and stay bare (#2376 round-2: the enum/bool truthiness compositions
-        // share the one precedence rule, not just BoolToInteger).
-        var demand = logical.Kind == LogicalKind.And ? Precedence.ConditionalAnd : Precedence.ConditionalOr;
-        string Side(IrExpression side) => side switch
+        string op = logical.Kind == LogicalKind.And ? "&&" : "||";
+        return $"{LogicalOperandText(logical.Left, logical.Kind)} {op} {LogicalOperandText(logical.Right, logical.Kind)}";
+    }
+
+    // A single operand of a short-circuit chain of the given kind. Sides are
+    // condition positions: Condition() owns truthiness (a string operand spells
+    // 'is not null', never '!value') and the negation folds. Same-kind chains
+    // associate bare; a mixed-kind LogicalBinary parenthesizes. Any other side
+    // renders at the operator's demand — a ternary or `??` (or one hidden behind
+    // a stale Coerce/Convert, the #2345/#2376 blind spot) is looser than
+    // `&&`/`||` and must parenthesize, while comparisons and unary forms out-bind
+    // it and stay bare (#2376 round-2: the enum/bool truthiness compositions
+    // share the one precedence rule, not just BoolToInteger).
+    string LogicalOperandText(IrExpression side, LogicalKind kind)
+    {
+        var demand = kind == LogicalKind.And ? Precedence.ConditionalAnd : Precedence.ConditionalOr;
+        return side switch
         {
-            LogicalBinary nested when nested.Kind == logical.Kind => LogicalText(nested),
+            LogicalBinary nested when nested.Kind == kind => LogicalText(nested),
             LogicalBinary nested => $"({LogicalText(nested)})",
             _ => RenderedCondition(side).At(demand),
         };
-        string op = logical.Kind == LogicalKind.And ? "&&" : "||";
-        return $"{Side(logical.Left)} {op} {Side(logical.Right)}";
+    }
+
+    /// <summary>
+    /// Renders a short-circuit <c>&amp;&amp;</c>/<c>||</c> chain rooted at
+    /// <paramref name="root"/> as one operand per line — the first operand after
+    /// <paramref name="prefix"/> on the head line, each later operand under a
+    /// continuation indent, the operator trailing every broken line — when the
+    /// chain has at least <see cref="FluentChainMinSegments"/> operands and its
+    /// single-line form would exceed <see cref="FluentChainWrapWidth"/>. Returns
+    /// null (render inline) otherwise. Each operand's text is exactly the
+    /// <see cref="LogicalOperandText"/> the flat <see cref="LogicalText"/> emits,
+    /// and the routine declines unless the per-operand join reproduces that flat
+    /// text (so a property-pattern rewrite or any other reshaping keeps the
+    /// statement inline); the broken form is therefore token-identical to the
+    /// inline form — only whitespace differs and the IL is unchanged. Gated on
+    /// <see cref="PrinterOptions.WrapSplittableExpressions"/> by the caller.
+    /// </summary>
+    string? LogicalChainLines(LogicalBinary root, string prefix, string suffix, int indent)
+    {
+        var operands = new List<IrExpression>();
+        CollectLogicalChainOperands(root, root.Kind, operands);
+        if (operands.Count < FluentChainMinSegments)
+            return null;
+
+        string op = root.Kind == LogicalKind.And ? "&&" : "||";
+        var texts = new List<string>(operands.Count);
+        foreach (var operand in operands)
+            texts.Add(LogicalOperandText(operand, root.Kind));
+
+        // The broken form must be a pure whitespace variant of the flat chain:
+        // decline unless re-rendering the flattened operands reproduces the flat
+        // LogicalText exactly (guards the property-pattern rewrite and any other
+        // reshaping the flat renderer would apply).
+        string flat = LogicalText(root);
+        if (string.Join($" {op} ", texts) != flat)
+            return null;
+
+        if (indent * 4 + prefix.Length + flat.Length + suffix.Length <= FluentChainWrapWidth)
+            return null;
+
+        string pad = new(' ', indent * 4);
+        string continuation = pad + "    ";
+        var sb = new System.Text.StringBuilder();
+        sb.Append(pad).Append(prefix);
+        for (int i = 0; i < texts.Count; i++)
+        {
+            if (i > 0)
+                sb.Append('\n').Append(continuation);
+            sb.Append(texts[i]);
+            if (i < texts.Count - 1)
+                sb.Append(' ').Append(op);
+        }
+        sb.Append(suffix);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Flattens a same-kind short-circuit chain into its operands in
+    /// left-to-right source order; a nested chain of the <em>other</em> kind (or
+    /// any non-<see cref="LogicalBinary"/>) is one operand and is not descended
+    /// into — matching how <see cref="LogicalOperandText"/> parenthesizes it.
+    /// </summary>
+    static void CollectLogicalChainOperands(IrExpression expression, LogicalKind kind, List<IrExpression> operands)
+    {
+        if (expression is LogicalBinary logical && logical.Kind == kind)
+        {
+            CollectLogicalChainOperands(logical.Left, kind, operands);
+            CollectLogicalChainOperands(logical.Right, kind, operands);
+            return;
+        }
+        operands.Add(expression);
     }
 
     string? TryPropertyPatternText(LogicalBinary logical)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -44,6 +44,18 @@ public sealed record PrinterOptions
     /// </summary>
     public ExpressionBodyArrowPlacement ExpressionBodyArrowPlacement { get; init; } = ExpressionBodyArrowPlacement.SameLine;
 
+    /// <summary>
+    /// When set, a long, splittable expression — today a short-circuit
+    /// <c>&amp;&amp;</c>/<c>||</c> boolean chain — whose single-line form would
+    /// exceed the fluent-chain wrap width breaks each operand onto its own
+    /// continuation line (operator trailing each broken line) instead of one very
+    /// wide line. Off by default; this is a whitespace-only formatting
+    /// tiebreaker, so the broken form is token-identical to the inline form and
+    /// the IL is unchanged (the boolean analog of the always-on fluent-chain
+    /// wrapper).
+    /// </summary>
+    public bool WrapSplittableExpressions { get; init; }
+
     /// <summary>The shipped defaults — every knob off.</summary>
     public static PrinterOptions Default { get; } = new();
 }


### PR DESCRIPTION
- Fixes #3067
- Adds an opt-in `PrinterOptions.WrapSplittableExpressions` taste knob (default off) that breaks a long short-circuit `&&`/`||` chain one operand per continuation line
- Card revision: `963d11fe`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the knob is default-off and the wrap is a whitespace-only tiebreaker that is provably token-identical to the inline form (the emit path declines unless the per-operand re-render reproduces the flat chain text and the flat statement is exactly `prefix + chain + ";"`), so the IL is unchanged and default output is byte-for-byte unchanged.

This is the boolean analog of the always-on fluent-chain wrapper. When `WrapSplittableExpressions` is set and a short-circuit `&&`/`||` chain's single-line form would exceed the shared fluent-chain wrap width (120) with at least the shared min-segment count (2), each operand renders on its own continuation line with the operator trailing each broken line. It is surfaced through `DecompilerOptions` (effective options) and emits a taste `AddDecision("expression.wrap-splittable-chain", "taste", ...)`, mirroring how `ReadableLocalNames` is threaded. Matching the `ReadableLocalNames` precedent, this is an API-level knob with no new CLI flag.

Product paths stay SRM-only, Roslyn-free, and NativeAOT-friendly.

### Before

Default output (`PrinterOptions.Default`, and with the knob off) — unchanged:

```csharp
return firstConditionFlag && secondConditionFlag && thirdConditionFlag && fourthConditionFlag && fifthConditionFlag && sixthConditionFlag;
```

- Valid: True
- Correct: True

### After

With `WrapSplittableExpressions = true` (verbatim `CSharpPrinter` output, asserted by `SplittableExpressionWrapTests`):

```csharp
return firstConditionFlag &&
    secondConditionFlag &&
    thirdConditionFlag &&
    fourthConditionFlag &&
    fifthConditionFlag &&
    sixthConditionFlag;
```

- Valid: True
- Correct: True

The wrapped form's whitespace-delimited token stream is identical to the inline form's (`WrappedChain_IsTokenIdenticalToInline`), and it recompiles clean (`WrappedChain_Compiles`).

### Fully raised

Not a raising change — this is a printer formatting tiebreaker, not a lowering-inversion. No fully-raised endpoint or tracking issue applies.

## Evidence

| Check | Baseline (`d6af0165`) | Head (`963d11fe`) |
| --- | --- | --- |
| Product build (`src/dotnet-inspect`) | Pass | Pass |
| Focused tests | `DynamicCompilationSiteInventoryTests`: 4 passed | `SplittableExpressionWrapTests` + `DynamicCompilationSiteInventoryTests`: 12 passed |
| Decompiler fast suite (`-trait- "Speed=Slow"`) | 3370 total, 56 failed | 3378 total, 56 failed |
| Reduced fixture validity | not applicable (default off, no shape change) | not applicable |
| Reduced fixture fidelity | not applicable (default off, no shape change) | not applicable |
| Real witness | not applicable (opt-in knob; no CLI surface) | not applicable |

The 56 fast-suite failures are pre-existing and environmental on this Windows machine (native `aspnetcorev2_inprocess.dll` pulled into Roslyn recompile references → `CS0009` in `FidelityCheck`/`ReturnToSender`; one CRLF-vs-LF string-switch render; missing fixtures when building only the test csproj). The failing **set is byte-for-byte identical** between Baseline and Head (verified by diffing the two `[FAIL]` name lists — zero added, zero removed); Head adds 8 tests (Total 3370→3378) that all pass while the failed count stays 56.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — not applicable. The knob is default-off, so default decompiler output (hence corpus validity/fidelity/quality) is byte-for-byte unchanged. No corpus gate applies.

## Validation

```bash
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.SplittableExpressionWrapTests -class ILInspector.Decompiler.Tests.DynamicCompilationSiteInventoryTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Speed=Slow"
```
