### PR TITLE
Document shipping taste choices and correct compound-assignment anchoring

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -26,6 +26,8 @@ Two reasons:
 1. **It is an established, versioned, externally documented choice.** Picking canonical representatives stops being a per-change taste debate, and the target moves with the runtime repo's own style evolution rather than ossifying into ours.
 2. **It makes testing coherent.** The fidelity fixture corpus is runtime-shaped code written under that style — so fixer-style output and recompile fidelity are the same goal, not competing ones.
 
+Two clarifications on scope. First, the oracle is a **default**, not a reconstruction of the input's own style: real assemblies — runtime included — are stylistically mixed, and an `.editorconfig` is *directional* (it names where a codebase is converging over time, not what its current text says), so "match the source style" is not a well-defined target. Picking a published, versioned community default is the honest substitute. Second, the oracle settles only **class-3 no-anchor cosmetics** (below); it never overrides a class-1 or class-2 IL distinction. Where a no-anchor choice is not yet a stable default it is exposed opt-in rather than imposed — see [Line wrapping](#line-wrapping) and [Names](#names).
+
 ## The three-class rule
 
 Every proposed rendering falls into one of three classes, and the class decides the answer:
@@ -33,9 +35,10 @@ Every proposed rendering falls into one of three classes, and the class decides 
 **1. IL-exact preferred forms — adopt freely.** The modern spelling is precisely what the IL in hand compiles from, so it is the better representative — sometimes the *more faithful* one:
 
 - `is null` / `is not null` for null tests that compile to a reference `ceq`/branch. (`== null` could mean an `op_Equality` call; render `==` exactly when the IL calls the operator.)
-- Is-pattern matching (`if (x is Foo f)`) for the `isinst` + branch + cast shape.
+- Is-pattern matching for the `isinst` + branch + captured-cast shape (`if (x is Foo f)`), where the stored-and-used cast binding is the anchor. Bare `x is Foo` with no binding is IL-identical to `(x as Foo) != null`, so *that* choice is a class-3 tiebreaker, not an IL-exact form.
 - Switch expressions for switch-plus-returns shapes.
-- Compound assignment and increment (`_size++`), `continue`/`break` for loop-edge branches.
+- `continue`/`break` for loop-edge branches.
+- Compound assignment/increment, **but IL-anchored only where the target's storage location is computed once** — array and pointer elements compile to a distinct `ldelema` + `dup` address form (`a[i]++` differs from the re-indexing `a[i] = a[i] + 1`), and a member over a side-effecting receiver has *no* single-evaluation `x = x + 1` spelling at all, so the compound form is the only source for that IL. For a local, static field, `this`- or local-rooted instance field, or ordinary property, `x++`, `x += 1`, and `x = x + 1` are byte-identical IL, so *that* spelling is a class-3 no-anchor pick (below) the oracle settles (`x++`/`x--` for ±1, `x op= v` otherwise).
 
 **2. Fidelity-erasing forms — decline, always.** A preferred form is never adopted when it would erase a distinction the IL actually makes:
 
@@ -48,6 +51,7 @@ Conflicts between class 1 and class 2 are rare by construction — most fixer su
 **3. No IL anchor — follow the oracle as a tiebreaker.** Conventions with no IL consequence at all (`var` policy, explicit types on declarations, brace style) follow the runtime `.editorconfig`, purely for corpus coherence.
 
 - LINQ query syntax (`from x in xs select f`) compiles to the *same* `Enumerable.Where/Select/...` calls as the fluent chain — query expressions are translated during binding, before any lowering, so the two forms are IL-identical. With no anchor to choose between them, the oracle decides: the runtime writes fluent method chains, so that is what we render. We do not re-sugar back to `from..select`. (This is why the `Query` row in the lowering ledger is `Declined` — a no-anchor mechanism distinct from `Unhandled`/owed, not a gap to fill.)
+- **Erased before lowering — render the constant.** Some constructs the compiler resolves to a bare constant before any lowering, leaving no IL to recover from. `nameof(x)` compiles to the string literal `ldstr "x"` — indistinguishable from writing `"x"` — so it comes back as the string; there is nothing to re-sugar. The same holds for constant folding (`60 * 60` → `3600`), primitive and reference `default` (`default(int)` → `0`, `default(string)` → `null`), and string spelling (verbatim, raw, and escaped forms collapse to one `ldstr`). A *struct* `default` is not in this set: `default(BigStruct)` emits `initobj`, an anchored shape recovered as `default`.
 
 ### Pointer member syntax
 
@@ -106,8 +110,28 @@ differently or fail to compile:
 
 The discipline generalizes: a no-IL-anchor spelling is still declined when
 adopting it could change binding, and each decline is proven by recompile/corpus
-fidelity. Any future apparent-type spelling that shares this hazard is scoped the
-same way.
+fidelity. Optional-argument elision (below) is the other spelling that ships
+under this binding-hazard discipline; any future one that shares the hazard —
+apparent-type or argument-omission — is scoped the same way.
+
+### Optional-argument elision
+
+C# optional parameters are erased by the type system: the compiler bakes the
+declared default in at every call site, so `ToWords(gender, null)` and
+`ToWords(gender)` compile to the *same* call carrying the same trailing constant.
+Dropping the argument is opcode-neutral — recompiling re-inserts the identical
+default — so this is a taste transform (valid-but-different), not a fidelity
+change, and it renders the shorter call the runtime source would write.
+
+Like target-typed `new()`, it carries a **binding hazard**: a shorter argument
+list can rebind to a different same-named overload. It is therefore a sound
+conservative over-approximation, never a Roslyn overload-resolution clone. The
+pass (`OptionalArgumentElisionPass`) does not decide safety itself — it is bounded
+by the overload-safe count the importer stamps from metadata
+(`MethodRef.SafeTrailingElidableCount`, computed in `OptionalArgumentFacts`), and
+only drops a trailing argument that is still a bare constant equal to the
+recovered default while the call still carries the callee's full parameter list.
+Anything the count cannot prove safe stays explicit.
 
 ### Line wrapping
 


### PR DESCRIPTION
Documents taste choices the decompiler **already makes**, and corrects one misclassification. Doc-only; no product code changes.

## Changes to `docs/decompiler-taste.md`

1. **Optional-argument elision subsection.** `OptionalArgumentElisionPass` ships this today and self-describes as a taste transform bounded by `MethodRef.SafeTrailingElidableCount` / `OptionalArgumentFacts`. It is the other binding-hazard class-3 transform alongside target-typed `new()`, so the doc now covers it and the target-typed-`new` close is broadened from "apparent-type" to the general binding-hazard discipline.
2. **"Erased before lowering" class-3 rule.** Generalizes the one-off `Query` decline: constructs the compiler resolves to a bare constant before lowering leave no IL to recover. Examples: `nameof`, constant folding, primitive/reference `default`, string spelling.
3. **Compound/increment reclassification.** The doc listed `_size++` under class 1 (IL-exact). Verified it is a **class-3 no-anchor** pick for locals, static fields, `this`-rooted instance fields, and ordinary properties (all byte-identical IL), and IL-anchored **only** where the place is computed once (array/pointer `ldelema`+`dup`, or a side-effecting receiver).
4. **Oracle-as-default reframe.** The runtime `.editorconfig` is a *default*, not a source-style match (real assemblies are mixed; editorconfig is directional); it settles class-3 cosmetics only and never overrides a class-1/class-2 IL distinction.

## Evidence

IL-shape claims verified with a compiled Release canary (own-method IL via reflection):

- `nameof(x)` -> `ldstr` (identical to the string literal); `default(int)` -> `ldc.i4.0`; `default(string)` -> `ldnull`; `default(struct)` -> `initobj` (anchored).
- `i++` / `i += 1` / `i = i + 1` byte-identical for a local; same for a static field and a `this`-rooted instance field (`ldarg.0 ldarg.0 ldfld ... stfld`, no `dup`).
- Array element: `a[i]++` / `a[i] += 1` use `ldelema`+`dup`+`stind`, distinct from `a[i] = a[i] + 1` (`ldelem`/`stelem`).

## Risk

Documentation-only, describing shipped behavior. No adversarial review required. `markdownlint` runs in CI (no Node runtime on the authoring machine); `.markdownlint.yaml` disables MD013/MD032 so the long bullets conform.