### PR TITLE
Collapse redundant underlying cast on reconciled enum left-shift bitwise operands (#3076)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5179,6 +5179,13 @@ public static class EnumCastSamples
 
     public static uint IntEnumShiftAndUnsigned(CfgPriority e, uint x) => ((uint)e << 4) & x;
 
+    // Negative case for the #3076 left-shift cast collapse: a signed arithmetic
+    // right shift reconciled against an unsigned sibling must KEEP its double cast
+    // `(ulong)((long)e >> n)`. Collapsing to `(ulong)e >> n` would switch the
+    // arithmetic shift to a logical one and change the value, so the collapse is
+    // left-shift only.
+    public static ulong LongEnumShiftRightOrUnsigned(CfgLongPriority e, int n, ulong x) => ((ulong)((long)e >> n)) | x;
+
     // A bitwise CHAIN over an enum shift: the inner `|` inherits the shift's stale
     // enum ResultType while rendering as an integer, so the outer `|` must not
     // coerce the far sibling to the enum (`... | (E)y`, CS0019). The rewritten-

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5186,6 +5186,15 @@ public static class EnumCastSamples
     // left-shift only.
     public static ulong LongEnumShiftRightOrUnsigned(CfgLongPriority e, int n, ulong x) => ((ulong)((long)e >> n)) | x;
 
+    // Precedence guard for the #3076 collapse: an enum left shift reconciled inside
+    // a mixed-sign ARITHMETIC parent (`+`/`-`/`*`, which bind tighter than `<<`)
+    // must keep parentheses around the collapsed shift — `((uint)values[i] << n) + x`,
+    // not `(uint)values[i] << n + x` (which parses as `(uint)values[i] << (n + x)`).
+    // An enum ARRAY element masks the enum as its primitive width, so the shift's
+    // EffectiveType is an integer and MixedSignArithmetic reconciles it (a plain
+    // enum field stays enum-typed and never routes here).
+    public static uint EnumArrayShiftAddUnsigned(CfgPriority[] values, int i, int n, uint x) => ((uint)values[i] << n) + x;
+
     // A bitwise CHAIN over an enum shift: the inner `|` inherits the shift's stale
     // enum ResultType while rendering as an integer, so the outer `|` must not
     // coerce the far sibling to the enum (`... | (E)y`, CS0019). The rewritten-

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -258,6 +258,20 @@ public class EnumCastPrinterTests
         AssertCompiles("public static ulong M(CfgLongPriority e, int n, ulong x)", body, "public enum CfgLongPriority : long { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
+    // #3076 precedence guard: an enum array-element left shift reconciled inside a
+    // mixed-sign ARITHMETIC parent (`+`, which binds tighter than `<<`) must keep
+    // parentheses — `((uint)values[i] << n) + x`, never `(uint)values[i] << n + x`
+    // (which parses as `(uint)values[i] << (n + x)` and fails to bind).
+    [Fact]
+    public void EnumArrayShiftInArithmeticAdd_KeepsShiftParentheses()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumArrayShiftAddUnsigned));
+
+        Assert.Contains("((uint)values[i] << n) + x", body);
+        Assert.DoesNotContain("<< n + x", body);
+        AssertCompiles("public static uint M(CfgPriority[] values, int i, int n, uint x)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
     // A bitwise CHAIN over an enum shift: the inner `|` inherits the shift's stale
     // enum ResultType while rendering as an integer, so the far sibling `y` must not
     // be coerced to the enum (`... | (E)y`, CS0019). The rewritten-integer detection

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -204,7 +204,8 @@ public class EnumCastPrinterTests
     {
         string body = RenderFixture(nameof(EnumCastSamples.IntEnumShiftOrUnsigned));
 
-        Assert.Contains("(uint)((int)e << 24) | x", body);
+        Assert.Contains("(uint)e << 24 | x", body);
+        Assert.DoesNotContain("(int)e << 24", body);
         Assert.DoesNotContain("(CfgPriority)x", body);
         AssertCompiles("public static uint M(CfgPriority e, uint x)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
@@ -228,7 +229,8 @@ public class EnumCastPrinterTests
     {
         string body = RenderFixture(nameof(EnumCastSamples.LongEnumShiftOrUnsigned));
 
-        Assert.Contains("(ulong)((long)e << 8) | x", body);
+        Assert.Contains("(ulong)e << 8 | x", body);
+        Assert.DoesNotContain("(long)e << 8", body);
         AssertCompiles("public static ulong M(CfgLongPriority e, ulong x)", body, "public enum CfgLongPriority : long { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
@@ -237,9 +239,23 @@ public class EnumCastPrinterTests
     {
         string body = RenderFixture(nameof(EnumCastSamples.IntEnumShiftAndUnsigned));
 
-        Assert.Contains("(uint)((int)e << 4) & x", body);
+        Assert.Contains("(uint)e << 4 & x", body);
+        Assert.DoesNotContain("(int)e << 4", body);
         Assert.DoesNotContain("(CfgPriority)x", body);
         AssertCompiles("public static uint M(CfgPriority e, uint x)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3076 is a LEFT-shift-only collapse: a signed arithmetic right shift keeps its
+    // `(ulong)((long)e >> n)` double cast, because `(ulong)e >> n` is a logical shift
+    // and would change the value.
+    [Fact]
+    public void EnumRightShiftInBitwiseOr_KeepsDoubleCast()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.LongEnumShiftRightOrUnsigned));
+
+        Assert.Contains("(ulong)((long)e >> n)", body);
+        Assert.DoesNotContain("(ulong)e >> n", body);
+        AssertCompiles("public static ulong M(CfgLongPriority e, int n, ulong x)", body, "public enum CfgLongPriority : long { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
     // A bitwise CHAIN over an enum shift: the inner `|` inherits the shift's stale
@@ -251,7 +267,8 @@ public class EnumCastPrinterTests
     {
         string body = RenderFixture(nameof(EnumCastSamples.ChainIntEnumShiftOrUnsigned));
 
-        Assert.Contains("(uint)((int)e << 24) | x | y", body);
+        Assert.Contains("(uint)e << 24 | x | y", body);
+        Assert.DoesNotContain("(int)e << 24", body);
         Assert.DoesNotContain("(CfgPriority)y", body);
         AssertCompiles("public static uint M(CfgPriority e, uint x, uint y)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
@@ -261,7 +278,8 @@ public class EnumCastPrinterTests
     {
         string body = RenderFixture(nameof(EnumCastSamples.ChainLongEnumShiftOrUnsigned));
 
-        Assert.Contains("(ulong)((long)e << 8) | x | y", body);
+        Assert.Contains("(ulong)e << 8 | x | y", body);
+        Assert.DoesNotContain("(long)e << 8", body);
         Assert.DoesNotContain("(CfgLongPriority)y", body);
         AssertCompiles("public static ulong M(CfgLongPriority e, ulong x, ulong y)", body, "public enum CfgLongPriority : long { Low, Medium = 1, High = 2, Critical = 3 }");
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1094,6 +1094,18 @@ public sealed partial class CSharpPrinter
         var unsigned = TypeFamilies.UnsignedCounterpart(BitwiseOperandRenderedType(operand));
         if (unsigned is null)
             return Operand(operand);
+        // An enum LEFT shift renders its underlying cast with the shift opcode's
+        // signedness — `(int)e << n` — which this reconciliation would then wrap as
+        // `(uint)((int)e << n)`. A left shift is bit-identical regardless of the
+        // operand's signedness, so spell the enum cast directly as the unsigned
+        // target and drop the redundant outer cast — `(uint)e << n` (#3076). This
+        // is a left-shift-only collapse: a signed right shift is arithmetic, so
+        // `(uint)e >> n` (logical) would change the value and must keep the wrap.
+        if (operand is Binary { Kind: BinaryKind.ShiftLeft } leftShift
+            && ShiftEnumLeftOperand(leftShift.Left, isUnsigned: true) is { } unsignedShiftedEnum)
+        {
+            return $"{unsignedShiftedEnum} {BinaryOperator(leftShift)} {ShiftCount(leftShift)}";
+        }
         bool constantOutOfRange = wrapConstantCast && TryGetIntegerConstant(operand, out long value) && !CSharpConversionRules.ConstantFits(value, unsigned);
         return CheckedSafeCast(() => $"({TypeText(unsigned)}){Operand(operand)}", force: constantOutOfRange);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -726,12 +726,12 @@ public sealed partial class CSharpPrinter
         // type-checks; the cast's signedness follows the shift opcode (shr/shr.un),
         // not the enum backing, so it round-trips opcode-exact. (Count is int.)
         string left = isShift && ShiftEnumLeftOperand(binary.Left, binary.IsUnsigned) is { } shiftedEnum ? shiftedEnum
-            : mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !covered)
+            : mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !covered, context: demand)
             : castLeft ? UnsignedOperand(binary.Left)
             : preserveUnsignedConstants ? UnsignedConstantArithmeticOperand(binary.Left, EffectiveType(binary))
             : BinaryOperand(binary.Left, demand, rightSide: false);
         string right = isShift ? ShiftCount(binary)
-            : mixedSign ? BitwiseUnsignedOperand(binary.Right, wrapConstantCast: !covered)
+            : mixedSign ? BitwiseUnsignedOperand(binary.Right, wrapConstantCast: !covered, context: demand)
             : castBoth ? UnsignedOperand(binary.Right)
             : preserveUnsignedConstants ? UnsignedConstantArithmeticOperand(binary.Right, EffectiveType(binary))
             : BinaryOperand(binary.Right, demand, rightSide: true);
@@ -1089,7 +1089,7 @@ public sealed partial class CSharpPrinter
     /// legal (CS0221); any other signed operand takes the same-width reinterpret
     /// cast, which emits no opcode.
     /// </summary>
-    string BitwiseUnsignedOperand(IrExpression operand, bool wrapConstantCast = true)
+    string BitwiseUnsignedOperand(IrExpression operand, bool wrapConstantCast = true, Precedence context = Precedence.Shift)
     {
         var unsigned = TypeFamilies.UnsignedCounterpart(BitwiseOperandRenderedType(operand));
         if (unsigned is null)
@@ -1101,10 +1101,15 @@ public sealed partial class CSharpPrinter
         // target and drop the redundant outer cast — `(uint)e << n` (#3076). This
         // is a left-shift-only collapse: a signed right shift is arithmetic, so
         // `(uint)e >> n` (logical) would change the value and must keep the wrap.
+        // The collapsed text is a shift expression, so parenthesize it when the
+        // reconciling parent binds tighter than `<<` (a mixed-sign `+`/`-`/`*`,
+        // which an enum array/by-ref element shift reaches) — `((uint)e << n) + x`,
+        // not `(uint)e << n + x` (which parses as `(uint)e << (n + x)`).
         if (operand is Binary { Kind: BinaryKind.ShiftLeft } leftShift
             && ShiftEnumLeftOperand(leftShift.Left, isUnsigned: true) is { } unsignedShiftedEnum)
         {
-            return $"{unsignedShiftedEnum} {BinaryOperator(leftShift)} {ShiftCount(leftShift)}";
+            string collapsed = $"{unsignedShiftedEnum} {BinaryOperator(leftShift)} {ShiftCount(leftShift)}";
+            return new Rendered(collapsed, Precedence.Shift).At(context);
         }
         bool constantOutOfRange = wrapConstantCast && TryGetIntegerConstant(operand, out long value) && !CSharpConversionRules.ConstantFits(value, unsigned);
         return CheckedSafeCast(() => $"({TypeText(unsigned)}){Operand(operand)}", force: constantOutOfRange);


### PR DESCRIPTION
- Fixes #3076
- Changes reconciled enum **left**-shift bitwise operands to render `(T)e << n` instead of the double-cast `(T)((int)e << n)`
- Card revision: `9281e3e9`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a left shift is bit-identical regardless of operand signedness, so dropping the inner underlying cast is purely cosmetic and fidelity-preserving; the collapse is gated to left shifts and a negative test locks the right-shift guard.

### Original source

```csharp
public static uint IntEnumShiftOrUnsigned(CfgPriority e, uint x) => ((uint)e << 24) | x;
```

### Before

```csharp
public static uint IntEnumShiftOrUnsigned(ILInspector.Decompiler.Tests.CfgPriority e, uint x) => (uint)((uint)((int)e << 24) | x);
```

- Valid: True
- Correct: True

The shift spells its underlying cast with the opcode's signedness (`(int)e << 24`), then the mixed-sign reconciliation wraps it in `(uint)(...)` — an inner double cast `(uint)((int)e << 24)` that is pure noise.

### After

```csharp
public static uint IntEnumShiftOrUnsigned(ILInspector.Decompiler.Tests.CfgPriority e, uint x) => (uint)((uint)e << 24 | x);
```

- Valid: True
- Correct: True

The reconciliation now spells the enum cast directly as the unsigned target (`(uint)e << 24`), removing the redundant inner cast.

### Negative case (right shift is not collapsed)

A signed right shift is arithmetic; `(uint)e >> n` is logical and would change the value, so a reconciled right shift keeps its double cast. Before and After are identical here:

```csharp
public static ulong LongEnumShiftRightOrUnsigned(ILInspector.Decompiler.Tests.CfgLongPriority e, int n, ulong x) => (ulong)((ulong)((long)e >> n) | x);
```

- Valid: True
- Correct: True

### Precedence guard (arithmetic parent keeps parentheses)

The collapsed `(uint)e << n` is a shift fragment. It is bare under bitwise/equality operands (which bind looser than `<<`), but an enum array/by-ref element shift masks the enum as its primitive width, so it can be reconciled inside a mixed-sign `+`/`-`/`*` (which bind tighter than `<<`). There it must keep parentheses:

```csharp
public static uint EnumArrayShiftAddUnsigned(ILInspector.Decompiler.Tests.CfgPriority[] values, int i, int n, uint x) => ((uint)values[i] << n) + x;
```

- Valid: True
- Correct: True

The collapse threads the parent's precedence and wraps via `Rendered.At(context)` — `((uint)values[i] << n) + x`, never `(uint)values[i] << n + x` (which parses as `(uint)values[i] << (n + x)`).

### Fully raised

The residual outer identity wrap (`(uint)( ... | x)`) is a separate rendered-type redundancy — the reconciliation cannot yet see the collapsed operand as unsigned-rendered without instance access to enum widths.

- Required tracking issue: #3087 — central rendered-type fix that owns the outer-cast redundancy (and the other pre-existing mixed-sign consumers).

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `EnumCastPrinterTests`: 51 passed | `EnumCastPrinterTests`: 53 passed |
| Decompiler fast suite | 145, 0 failed | 145, 0 failed |
| Reduced fixture validity | Pass (AssertCompiles) | Pass (AssertCompiles) |
| Reduced fixture fidelity | Pass | Pass |

Head adds two tests — `EnumRightShiftInBitwiseOr_KeepsDoubleCast` (negative right-shift case) and `EnumArrayShiftInArithmeticAdd_KeepsShiftParentheses` (precedence guard) — plus their fixtures; the 51 pre-existing focused tests pass on both sides. Fidelity: `(uint)e << n` == `(uint)((int)e << n)` and the `ulong`/`long` variant verified bit-identical across high-bit and negative inputs.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.EnumCastPrinterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait "Area=RoundTrip" -trait- "Speed=Slow"
```
