### PR TITLE
Harness: --verify-authored-corpus drift check for the vendored corpus [#3052]

### DIFF
--- a/tools/DecompilerHarness/AuthoredCorpusDrift.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusDrift.cs
@@ -1,0 +1,328 @@
+using System.Text.Json;
+
+using DotnetInspector.Core;
+using DotnetInspector.Services;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Drift verification for the vendored authored-source correspondence corpus.
+/// Every corpus row snapshots a checksum-verified authored member body captured
+/// at harvest time. This mode re-acquires each row's source <em>today</em> — from
+/// a local git clone (<c>--repo</c>, checksum-arbitrated) and/or SourceLink — and
+/// reduces it to the same member-body slice the harvester used
+/// (<see cref="AuthoredRebuildFidelity.TryExtractTargetBody"/>), then compares it
+/// against the stored body. It answers "does the vendored snapshot still
+/// correspond to the authoritative source at its pinned commit?" without running
+/// the decompiler: a byte-for-byte mismatch is corpus drift; an acquisition or
+/// slice miss is an unresolved row.
+///
+/// This is a standalone integrity check, not a benchmark gate: it does not run
+/// the decompiler and never affects <see cref="AuthoredCorpusBenchmark"/>. It is
+/// report-only by default — a run's own integrity (corpus present, every corpus
+/// assembly supplied, at least one row evaluated) still governs the exit code, so
+/// a partial or empty run never masquerades as success. Pass <c>--fail-on-drift</c>
+/// to additionally fail the run when any row has drifted, for a periodic
+/// (non-PR) gate.
+/// </summary>
+static class AuthoredCorpusDrift
+{
+    enum Outcome
+    {
+        // Re-acquired body matches the stored snapshot.
+        Verified,
+        // Re-acquired body differs from the stored snapshot (source rot).
+        Drifted,
+        // Source could not be re-acquired or sliced (offline, no --repo, commit
+        // gone, checksum mismatch, or an extraction regression) — unverifiable.
+        Unavailable,
+    }
+
+    sealed record RowResult(
+        AuthoredSourceHarvest.CorpusRecord Record,
+        Outcome Outcome,
+        string? Detail);
+
+    public static int Run(
+        IReadOnlyList<string> assemblies,
+        string corpusPath,
+        bool json,
+        bool failOnDrift,
+        IReadOnlyList<string>? repositoryPaths)
+        => RunAsync(assemblies, corpusPath, json, failOnDrift, repositoryPaths).GetAwaiter().GetResult();
+
+    static async Task<int> RunAsync(
+        IReadOnlyList<string> assemblies,
+        string corpusPath,
+        bool json,
+        bool failOnDrift,
+        IReadOnlyList<string>? repositoryPaths)
+    {
+        if (!File.Exists(corpusPath))
+        {
+            Console.Error.WriteLine($"Corpus file not found: {corpusPath}");
+            return 1;
+        }
+
+        var records = ReadCorpus(corpusPath);
+        if (records.Count == 0)
+        {
+            Console.Error.WriteLine($"Corpus is empty or unparseable: {corpusPath}");
+            return 1;
+        }
+
+        var byAssembly = records
+            .GroupBy(record => record.Assembly, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<AuthoredSourceHarvest.CorpusRecord>)group.ToArray(),
+                StringComparer.Ordinal);
+
+        HttpClientFactory.Initialize();
+        using var httpClient = HttpClientFactory.CreateNew();
+        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+
+        var results = new List<RowResult>();
+        var matchedGroups = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var assemblyPath in assemblies)
+        {
+            if (!File.Exists(assemblyPath))
+                continue;
+
+            string name = AuthoredSourceHarvest.ReadAssemblyIdentity(assemblyPath).Name;
+            if (!byAssembly.TryGetValue(name, out var group) || !matchedGroups.Add(name))
+                continue;
+
+            SourceLinkService? source = null;
+            try
+            {
+                source = SourceLinkService.Open(assemblyPath);
+                await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
+                foreach (var record in group)
+                    results.Add(await EvaluateRowAsync(source, record, fetcher, repositoryPaths));
+            }
+            catch (Exception ex) when (ex is IOException
+                or InvalidOperationException
+                or BadImageFormatException
+                or HttpRequestException
+                or TaskCanceledException)
+            {
+                // The assembly's SourceLink PDB could not be opened or acquired, so
+                // no row for it can be verified. Surface every row as Unavailable
+                // (never silently drop it) rather than pretending it was checked.
+                Console.Error.WriteLine(
+                    $"Warning: drift check could not open '{assemblyPath}' ({ex.GetType().Name}: {ex.Message}).");
+                foreach (var record in group)
+                    results.Add(new RowResult(record, Outcome.Unavailable, $"assembly-open: {ex.GetType().Name}"));
+            }
+            finally
+            {
+                source?.Dispose();
+            }
+        }
+
+        int unmatchedRows = byAssembly
+            .Where(entry => !matchedGroups.Contains(entry.Key))
+            .Sum(entry => entry.Value.Count);
+
+        return json
+            ? WriteJson(results, records.Count, matchedGroups.Count, byAssembly.Count, unmatchedRows, failOnDrift)
+            : WriteCard(results, records.Count, matchedGroups.Count, byAssembly.Count, unmatchedRows, failOnDrift);
+    }
+
+    static async Task<RowResult> EvaluateRowAsync(
+        SourceLinkService source,
+        AuthoredSourceHarvest.CorpusRecord record,
+        SourceFetcher fetcher,
+        IReadOnlyList<string>? repositoryPaths)
+    {
+        var subject = new FindingSubject(
+            $"{record.Type}::{record.Method}#{record.Overload}",
+            $"{record.Type}.{record.Method}");
+
+        AuthoredMemberSourceInspection authored;
+        try
+        {
+            authored = await AuthoredSourceAcquisition.AcquireMemberAsync(
+                source,
+                record.MetadataToken,
+                record.Method,
+                subject,
+                fetcher,
+                repositoryPaths);
+        }
+        catch (Exception ex) when (ex is IOException
+            or InvalidOperationException
+            or HttpRequestException
+            or TaskCanceledException)
+        {
+            return new RowResult(record, Outcome.Unavailable, $"acquire: {ex.GetType().Name}");
+        }
+
+        if (authored.Text is not { } memberSource || memberSource.Length == 0)
+            return new RowResult(record, Outcome.Unavailable, "acquire: no source text");
+
+        // Reduce the PDB line-span slice to the same disambiguated member body the
+        // harvester stored, so the comparison is like-for-like.
+        if (!AuthoredRebuildFidelity.TryExtractTargetBody(
+                memberSource,
+                record.Method,
+                record.ParameterCount,
+                out string body)
+            || body.Length == 0)
+        {
+            return new RowResult(record, Outcome.Unavailable, "extract: body slice failed");
+        }
+
+        // Compare on normalized newlines: the platform that re-acquires the blob
+        // must not register as source drift (git cat-file and raw HTTP both return
+        // the committed bytes, but the stored corpus body may have been harvested
+        // with a different newline convention).
+        return NormalizeNewlines(body).Equals(NormalizeNewlines(record.AuthoredBody), StringComparison.Ordinal)
+            ? new RowResult(record, Outcome.Verified, authored.Document?.ResolvedUrl)
+            : new RowResult(record, Outcome.Drifted, DescribeDrift(record.AuthoredBody, body));
+    }
+
+    static string NormalizeNewlines(string text)
+        => text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    static string DescribeDrift(string stored, string acquired)
+    {
+        string[] storedLines = NormalizeNewlines(stored).Split('\n');
+        string[] acquiredLines = NormalizeNewlines(acquired).Split('\n');
+        int firstDiff = 0;
+        int shared = Math.Min(storedLines.Length, acquiredLines.Length);
+        while (firstDiff < shared
+            && string.Equals(storedLines[firstDiff], acquiredLines[firstDiff], StringComparison.Ordinal))
+        {
+            firstDiff++;
+        }
+
+        return $"stored {storedLines.Length} line(s), acquired {acquiredLines.Length} line(s); "
+            + $"first diff at line {firstDiff + 1}";
+    }
+
+    static List<AuthoredSourceHarvest.CorpusRecord> ReadCorpus(string corpusPath)
+    {
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        var records = new List<AuthoredSourceHarvest.CorpusRecord>();
+        foreach (var line in File.ReadLines(corpusPath))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            try
+            {
+                if (JsonSerializer.Deserialize<AuthoredSourceHarvest.CorpusRecord>(line, options) is { } record)
+                    records.Add(record);
+            }
+            catch (JsonException ex)
+            {
+                Console.Error.WriteLine($"Skipping malformed corpus row: {ex.Message}");
+            }
+        }
+
+        return records;
+    }
+
+    static int WriteCard(
+        IReadOnlyList<RowResult> results,
+        int corpusRows,
+        int matchedAssemblies,
+        int corpusAssemblies,
+        int unmatchedRows,
+        bool failOnDrift)
+    {
+        int verified = results.Count(result => result.Outcome == Outcome.Verified);
+        int drifted = results.Count(result => result.Outcome == Outcome.Drifted);
+        int unavailable = results.Count(result => result.Outcome == Outcome.Unavailable);
+        int evaluated = results.Count;
+
+        Console.WriteLine("AUTHORED-SOURCE CORPUS DRIFT");
+        Console.WriteLine();
+        Console.WriteLine($"  corpus rows        : {corpusRows}");
+        Console.WriteLine($"  assemblies matched : {matchedAssemblies} / {corpusAssemblies}");
+        if (unmatchedRows > 0)
+            Console.WriteLine($"  rows without asm   : {unmatchedRows} (BLOCKER: no local assembly supplied)");
+        Console.WriteLine($"  rows evaluated     : {evaluated}");
+        if (evaluated == 0)
+            Console.WriteLine("  (BLOCKER: no rows evaluated — nothing was checked)");
+        Console.WriteLine();
+        Console.WriteLine($"  Verified   (matches vendored snapshot) : {verified}");
+        Console.WriteLine($"  Drifted    (source changed)            : {drifted}");
+        Console.WriteLine($"  Unavailable(could not re-acquire)      : {unavailable}");
+
+        WriteRows("Drifted rows", results, Outcome.Drifted);
+        WriteRows("Unavailable rows", results, Outcome.Unavailable);
+
+        // Honest-exit contract: a run only counts if every corpus assembly was
+        // supplied (unmatchedRows == 0) and at least one row was evaluated. On top
+        // of that, --fail-on-drift fails when any row drifted. Unavailable rows are
+        // surfaced but non-fatal: running offline without --repo legitimately
+        // cannot re-acquire, and that is a "could not verify", not a drift.
+        bool honest = unmatchedRows == 0 && evaluated > 0;
+        return honest && !(failOnDrift && drifted > 0) ? 0 : 1;
+    }
+
+    static void WriteRows(string title, IReadOnlyList<RowResult> results, Outcome outcome)
+    {
+        var rows = results.Where(result => result.Outcome == outcome).ToArray();
+        if (rows.Length == 0)
+            return;
+
+        Console.WriteLine();
+        Console.WriteLine($"  {title}:");
+        foreach (var row in rows.Take(50))
+        {
+            Console.WriteLine($"    {row.Record.Assembly}!{row.Record.Type}::{row.Record.Method}#{row.Record.Overload}");
+            if (!string.IsNullOrEmpty(row.Detail))
+                Console.WriteLine($"        {row.Detail}");
+        }
+
+        if (rows.Length > 50)
+            Console.WriteLine($"    … {rows.Length - 50} more");
+    }
+
+    static int WriteJson(
+        IReadOnlyList<RowResult> results,
+        int corpusRows,
+        int matchedAssemblies,
+        int corpusAssemblies,
+        int unmatchedRows,
+        bool failOnDrift)
+    {
+        int verified = results.Count(result => result.Outcome == Outcome.Verified);
+        int drifted = results.Count(result => result.Outcome == Outcome.Drifted);
+        int unavailable = results.Count(result => result.Outcome == Outcome.Unavailable);
+        int evaluated = results.Count;
+        bool honest = unmatchedRows == 0 && evaluated > 0;
+
+        var payload = new
+        {
+            corpusRows,
+            matchedAssemblies,
+            corpusAssemblies,
+            unmatchedRows,
+            rowsEvaluated = evaluated,
+            verified,
+            drifted,
+            unavailable,
+            honest,
+            failOnDrift,
+            rows = results.Select(result => new
+            {
+                assembly = result.Record.Assembly,
+                type = result.Record.Type,
+                method = result.Record.Method,
+                overload = result.Record.Overload,
+                outcome = result.Outcome.ToString(),
+                detail = result.Detail,
+                sourceUrl = result.Record.SourceUrl,
+            }),
+        };
+
+        Console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+        return honest && !(failOnDrift && drifted > 0) ? 0 : 1;
+    }
+}

--- a/tools/DecompilerHarness/AuthoredCorpusDrift.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusDrift.cs
@@ -24,8 +24,9 @@ namespace ILInspector.DecompilerHarness;
 /// report-only by default — a run's own integrity (corpus present, every corpus
 /// assembly supplied, at least one row evaluated) still governs the exit code, so
 /// a partial or empty run never masquerades as success. Pass <c>--fail-on-drift</c>
-/// to additionally fail the run when any row has drifted, for a periodic
-/// (non-PR) gate.
+/// to turn it into a fail-closed gate: the run then fails unless every evaluated
+/// row is Verified, so any Drifted or Unavailable row (an outage or missing source
+/// establishes no correspondence) fails a periodic (non-PR) gate.
 /// </summary>
 static class AuthoredCorpusDrift
 {
@@ -257,12 +258,15 @@ static class AuthoredCorpusDrift
         WriteRows("Unavailable rows", results, Outcome.Unavailable);
 
         // Honest-exit contract: a run only counts if every corpus assembly was
-        // supplied (unmatchedRows == 0) and at least one row was evaluated. On top
-        // of that, --fail-on-drift fails when any row drifted. Unavailable rows are
-        // surfaced but non-fatal: running offline without --repo legitimately
-        // cannot re-acquire, and that is a "could not verify", not a drift.
+        // supplied (unmatchedRows == 0) and at least one row was evaluated.
+        // --fail-on-drift turns this into a fail-closed gate: every evaluated row
+        // must be Verified, so any Drifted (source changed) OR Unavailable (could
+        // not re-acquire) row fails — a gate that passes while verifying nothing
+        // (an outage, a missing PDB, a bad --repo) establishes no correspondence.
+        // Report-only runs (no --fail-on-drift) stay a pure diagnostic and exit 0
+        // regardless of Unavailable rows.
         bool honest = unmatchedRows == 0 && evaluated > 0;
-        return honest && !(failOnDrift && drifted > 0) ? 0 : 1;
+        return honest && !(failOnDrift && (drifted > 0 || unavailable > 0)) ? 0 : 1;
     }
 
     static void WriteRows(string title, IReadOnlyList<RowResult> results, Outcome outcome)
@@ -323,6 +327,6 @@ static class AuthoredCorpusDrift
         };
 
         Console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
-        return honest && !(failOnDrift && drifted > 0) ? 0 : 1;
+        return honest && !(failOnDrift && (drifted > 0 || unavailable > 0)) ? 0 : 1;
     }
 }

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -75,6 +75,9 @@ static class Program
         string? harvestOutputPath = null;
         bool benchmarkAuthoredCorpus = false;
         string? benchmarkCorpusPath = null;
+        bool verifyAuthoredCorpus = false;
+        string? verifyCorpusPath = null;
+        bool failOnDrift = false;
         int harvestTarget = 12000;
         bool censusTsv = false;
         bool censusJsonl = false;
@@ -205,6 +208,13 @@ static class Program
                     case "--benchmark-authored-corpus":
                         benchmarkAuthoredCorpus = true;
                         benchmarkCorpusPath = NextArg(args, ref i, flag);
+                        break;
+                    case "--verify-authored-corpus":
+                        verifyAuthoredCorpus = true;
+                        verifyCorpusPath = NextArg(args, ref i, flag);
+                        break;
+                    case "--fail-on-drift":
+                        failOnDrift = true;
                         break;
                     case "--emit-not-my-type-snapshot":
                         emitNotMyTypeSnapshot = NextArg(args, ref i, flag); notMyType = true; break;
@@ -460,6 +470,9 @@ static class Program
 
         if (benchmarkAuthoredCorpus)
             return AuthoredCorpusBenchmark.Run(assemblies, benchmarkCorpusPath!, json);
+
+        if (verifyAuthoredCorpus)
+            return AuthoredCorpusDrift.Run(assemblies, verifyCorpusPath!, json, failOnDrift, sourceRepositories);
 
         if (returnToSenderAb)
             return ReturnToSender.RunComparison(assemblies, cap, maxExamples);
@@ -1995,12 +2008,22 @@ static class Program
           --package-tfm <tfm>    select a specific TFM from --package.
           --package-assembly <dll>
                                 select a specific assembly inside --package.
-          --repo <path>          with --harvest-authored-corpus/--harvest-evil-corpus:
-                                read authored source from a local git clone
-                                (checksum-arbitrated) instead of the network;
-                                repeatable. Point at this checkout to skip
-                                remote fetches for dotnet-inspect's own
-                                libraries.
+          --repo <path>          with --harvest-authored-corpus/--harvest-evil-corpus
+                                or --verify-authored-corpus: read authored source
+                                from a local git clone (checksum-arbitrated)
+                                instead of the network; repeatable. Point at this
+                                checkout to skip remote fetches for dotnet-inspect's
+                                own libraries.
+          --verify-authored-corpus <corpus.jsonl>
+                                re-acquire each vendored corpus row's source
+                                (via --repo and/or SourceLink), re-slice the
+                                member body, and compare it against the stored
+                                snapshot. Reports Verified/Drifted/Unavailable.
+                                Report-only unless --fail-on-drift is set. Supply
+                                the same pinned assemblies the corpus was harvested
+                                from as inputs. Does not run the decompiler.
+          --fail-on-drift        with --verify-authored-corpus: exit non-zero when
+                                any row has drifted from the vendored snapshot.
           --fidelity-timings      with --fidelity-check: print phase timings for collect/render,
                                 skeleton emit, parse, compilation create, emit, and opcode compare
           --fidelity-zero-signal-guard <n>

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -2022,8 +2022,9 @@ static class Program
                                 Report-only unless --fail-on-drift is set. Supply
                                 the same pinned assemblies the corpus was harvested
                                 from as inputs. Does not run the decompiler.
-          --fail-on-drift        with --verify-authored-corpus: exit non-zero when
-                                any row has drifted from the vendored snapshot.
+          --fail-on-drift        with --verify-authored-corpus: fail-closed gate —
+                                exit non-zero unless every evaluated row is
+                                Verified (any Drifted or Unavailable row fails).
           --fidelity-timings      with --fidelity-check: print phase timings for collect/render,
                                 skeleton emit, parse, compilation create, emit, and opcode compare
           --fidelity-zero-signal-guard <n>

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -320,6 +320,40 @@ the harvested third-party source snapshots never enter main's history (as
 `civil/corpus.jsonl`). Restore it with `bash eng/restore-authored-source-corpus.sh`,
 which adds a git worktree at `external/authored-source-corpus`.
 
+#### Corpus drift verification (`--verify-authored-corpus`)
+
+`--verify-authored-corpus <corpus.jsonl> <assembly...>` audits whether the
+vendored snapshot still corresponds to the authoritative source at each row's
+pinned SourceLink commit. Unlike the benchmark, it does **not** run the
+decompiler: for every row it re-acquires the authored source *today* — from a
+local git clone (`--repo`, checksum-arbitrated) and/or SourceLink — reduces it to
+the same member-body slice the harvester stored
+(`AuthoredRebuildFidelity.TryExtractTargetBody`), and compares byte-for-byte
+(newline-normalized) against the stored body. Each row is:
+
+- **Verified** — the re-acquired body matches the vendored snapshot.
+- **Drifted** — the re-acquired body differs (the upstream source, harvest slice,
+  or the stored row itself has changed). The report names the row and a short
+  line-count/first-diff summary.
+- **Unavailable** — the source could not be re-acquired or sliced (offline with no
+  `--repo`, commit gone, checksum mismatch, or an extraction regression); the row
+  is surfaced, never silently dropped.
+
+It is report-only by default (exit 0). The run's own integrity still governs the
+exit code with a named blocker: any corpus row whose assembly was not supplied
+(`unmatchedRows > 0`) or a run that evaluated no rows fails, so an empty or
+partially-unmatched run is never a success. Pass `--fail-on-drift` to additionally
+exit nonzero when any row has drifted — the shape of a periodic (non-PR) gate.
+Supply the same pinned assemblies the corpus was harvested from, and point
+`--repo` at this checkout to resolve dotnet-inspect's own rows locally:
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  --verify-authored-corpus external/authored-source-corpus/civil/corpus.jsonl \
+  --repo "$(git rev-parse --show-toplevel)" --fail-on-drift \
+  <pinned-assembly...>
+```
+
 #### EVIL difficulty ranking (`--enumerate-real-methods`)
 
 The CIVIL corpus tracks the 14 pinned assemblies for affinity. The companion

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -342,8 +342,10 @@ the same member-body slice the harvester stored
 It is report-only by default (exit 0). The run's own integrity still governs the
 exit code with a named blocker: any corpus row whose assembly was not supplied
 (`unmatchedRows > 0`) or a run that evaluated no rows fails, so an empty or
-partially-unmatched run is never a success. Pass `--fail-on-drift` to additionally
-exit nonzero when any row has drifted — the shape of a periodic (non-PR) gate.
+partially-unmatched run is never a success. Pass `--fail-on-drift` to turn it into
+a fail-closed gate — the run then exits nonzero unless *every* evaluated row is
+Verified, so any Drifted or Unavailable row (an outage, a missing PDB, or a bad
+`--repo` establishes no correspondence) fails a periodic (non-PR) gate.
 Supply the same pinned assemblies the corpus was harvested from, and point
 `--repo` at this checkout to resolve dotnet-inspect's own rows locally:
 


### PR DESCRIPTION
## Summary

Adds `--verify-authored-corpus` to the decompiler harness — the drift-detection
mode from #3052 (Scope C). It audits whether the vendored authored-source
correspondence corpus still corresponds to the authoritative source at each row's
pinned SourceLink commit, **without running the decompiler**.

For every corpus row it re-acquires the authored source *today* — from a local git
clone (`--repo`, checksum-arbitrated) and/or SourceLink — reduces it to the same
member-body slice the harvester stored (`AuthoredRebuildFidelity.TryExtractTargetBody`),
and compares it (newline-normalized) against the stored `AuthoredBody`. Each row is:

- **Verified** — re-acquired body matches the vendored snapshot.
- **Drifted** — re-acquired body differs (report names the row + a short
  line-count/first-diff summary).
- **Unavailable** — source could not be re-acquired or sliced (offline with no
  `--repo`, commit gone, checksum mismatch, extraction regression); surfaced,
  never silently dropped.

Report-only by default (`--json` for structured output). The run's own integrity
still governs the exit code with a named blocker — any corpus row whose assembly
was not supplied, or a run that evaluated no rows, fails, so an empty or
partially-unmatched run is never a success. `--fail-on-drift` additionally exits
nonzero when any row has drifted, the shape of a periodic (non-PR) gate.

## Why

Completes the hybrid plan in #3052: the vendored orphan-branch corpus stays
hermetic (it is the benchmark's source of truth), and this mode is the drift
signal that catches the snapshot rotting away from upstream — reusing the same
`--repo` local-source path shipped in #3040/#3056.

## Boundary / non-goals

- Does **not** run the decompiler and never affects `AuthoredCorpusBenchmark`.
- Does not gate the PR benchmark; it is a standalone, opt-in integrity check.
- No corpus schema change; consumes the existing `CorpusRecord` rows.

## Evidence (real runs, this machine)

Harvested a 6-row self-corpus from the pinned `dotnet-inspect.any` 0.14.0
`ILInspector.Metadata.dll` with `--repo <checkout>`, then:

| Scenario | Result | Exit |
| --- | --- | --- |
| Clean corpus, `--repo` | Verified 6, Drifted 0, Unavailable 0 | 0 |
| One row's `authoredBody` tampered, report-only | Verified 5, **Drifted 1** (`stored 10 line(s), acquired 9 line(s); first diff at line 10`) | 0 |
| Tampered corpus, `--fail-on-drift` | drift gate trips | **1** |
| One row's `metadataToken` corrupted | Verified 5, **Unavailable 1** (`acquire: no source text`) | 0 |
| Non-corpus assembly supplied | `unmatchedRows > 0`, BLOCKER, nothing checked | **1** |

`--help` lists `--verify-authored-corpus`/`--fail-on-drift`; `--json` serializes
the counts + per-row outcomes. Harness builds clean; changed Markdown passes
`markdownlint` (MD013/032/034/060 disabled by `.markdownlint.yaml`).

## Risk

Harness-only, additive new mode; no product path touched. Low risk.
