### PR TITLE
Raise inner comparison-chain value switch expression (#2978 slice 1)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ComparisonChainSwitchExpressionRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ComparisonChainSwitchExpressionRaisingTests.cs
@@ -84,6 +84,82 @@ public class ComparisonChainSwitchExpressionRaisingTests
         Assert.Empty(function.Descendants.OfType<SwitchExpression>());
     }
 
+    // Builds the exact comparison-chain value-switch shape the raiser accepts —
+    // `v == 0 => 10, v == 1 => 20, _ => 30` storing one result temp — parameterized
+    // by the governing value's declared type. With <paramref name="extraTempRead"/>
+    // the join reads the result temp a second time, so the temp is no longer the
+    // single-read convergence signal a real switch expression produces.
+    static IrFunction BuildComparisonChainSwitch(TypeRef governingType, bool extraTempRead = false)
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        LoadArgument V() => new(0, "v", governingType);
+        Comparison Eq(int label) => new(ComparisonKind.Equal, isUnsigned: false, V(), new Constant(label, int32));
+
+        Block ValueBlock(int offset, int result) =>
+            AddAll(new Block(offset), new StoreLocal(0, int32, new Constant(result, int32)), new Branch(0x50));
+
+        var head = AddAll(new Block(0x00), new ConditionalBranch(Eq(0), 0x40));   // v == 0 => arm0
+        var test1 = AddAll(new Block(0x10), new ConditionalBranch(Eq(1), 0x30));  // v == 1 => arm1
+        var defaultArm = ValueBlock(0x20, 30);
+        var arm1 = ValueBlock(0x30, 20);
+        var arm0 = ValueBlock(0x40, 10);
+        var join = new Block(0x50);
+        if (extraTempRead)
+            join.Add(new StoreLocal(1, int32, new LoadLocal(0, int32)));   // a second read of the result temp
+        join.Add(new Return(new LoadLocal(0, int32)));                     // (single read in the faithful shape)
+
+        var container = new BlockContainer();
+        foreach (var block in new[] { head, test1, defaultArm, arm1, arm0, join })
+            container.Add(block);
+
+        var signature = new MethodSignature(int32, [new Parameter("v", governingType)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("System", "Sample"), signature, [int32, int32], container);
+    }
+
+    static Block AddAll(Block block, params IrNode[] children)
+    {
+        foreach (var child in children)
+            block.Add(child);
+        return block;
+    }
+
+    static bool RaisesSwitchExpression(IrFunction function)
+    {
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        return function.Descendants.OfType<SwitchExpression>().Any();
+    }
+
+    [Fact]
+    public void ReusedResultTemp_DeclinesAtConvergenceCheck()
+    {
+        // Isolates the single-read convergence guard. csc's real switch-expression
+        // lowering always reads its result temp exactly once (any downstream reuse
+        // reads a *later* copy), so a genuine multi-read of the result temp only
+        // arises in hand-written or obfuscated IL. The single-read twin raises,
+        // proving the shape is accepted, so the extra-read variant's decline is
+        // the convergence check's doing — not an earlier rejection.
+        Assert.True(RaisesSwitchExpression(
+            BuildComparisonChainSwitch(TypeRef.CoreLib("System", "Int32"))));
+        Assert.False(RaisesSwitchExpression(
+            BuildComparisonChainSwitch(TypeRef.CoreLib("System", "Int32"), extraTempRead: true)));
+    }
+
+    [Fact]
+    public void BooleanGoverningValue_DeclinesSwitchExpressionRaise()
+    {
+        // Self-validating twin: the identical chain on an Int32 governing value
+        // raises, proving the synthetic shape is one the raiser genuinely accepts.
+        Assert.True(RaisesSwitchExpression(
+            BuildComparisonChainSwitch(TypeRef.CoreLib("System", "Int32"))));
+
+        // So on a Boolean governing value the decline is the bool guard's doing.
+        // csc never lowers a bool `switch` to this equality chain; the guard
+        // defends the arbitrary/obfuscated-IL path from printing an invalid
+        // `b switch { 0 => …, 1 => … }` (int is not convertible to bool, CS0029).
+        Assert.False(RaisesSwitchExpression(
+            BuildComparisonChainSwitch(TypeRef.CoreLib("System", "Boolean"))));
+    }
+
     [Fact]
     public void UnsignedGoverningValue_DeclinesToAvoidInvalidLabel()
     {

--- a/src/ILInspector.Decompiler.Tests/ComparisonChainSwitchExpressionRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ComparisonChainSwitchExpressionRaisingTests.cs
@@ -83,4 +83,22 @@ public class ComparisonChainSwitchExpressionRaisingTests
 
         Assert.Empty(function.Descendants.OfType<SwitchExpression>());
     }
+
+    [Fact]
+    public void UnsignedGoverningValue_DeclinesToAvoidInvalidLabel()
+    {
+        // SwitchExpressionArm labels are signed int32. A uint governing value
+        // whose label is uint.MaxValue (IL ldc.i4.m1) would misprint as -1
+        // (CS0031). The raiser must decline on a non-Int32 governing type.
+        var function = Raised(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.ClassifyUnsigned));
+
+        Assert.Empty(function.Descendants.OfType<SwitchExpression>());
+
+        var output = Print(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.ClassifyUnsigned));
+        Assert.DoesNotContain("-1 =>", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/ComparisonChainSwitchExpressionRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ComparisonChainSwitchExpressionRaisingTests.cs
@@ -1,0 +1,86 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Slice 1 of the #2978 full-raise: csc lowers a small value <c>switch</c>
+/// expression (few labels) to an equality comparison chain (brfalse/beq) whose
+/// arms each store one dedicated result temp read exactly once at a convergence
+/// point (a <c>return</c> or a copy into another temp). <see
+/// cref="ILInspector.Decompiler.Pipeline.SwitchRaisingPass"/> raises that faithful
+/// signal back into a <see cref="SwitchExpression"/>. The close negative is a
+/// hand-written equality chain that returns directly with no result temp — it
+/// must stay <c>if</c>/<c>else</c>.
+/// </summary>
+public class ComparisonChainSwitchExpressionRaisingTests
+{
+    static IrFunction Raised(string type, string method)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, type, method);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function;
+    }
+
+    static string Print(string type, string method) =>
+        CSharpPrinter.Print(Raised(type, method)).Output!.ReplaceLineEndings("\n");
+
+    [Fact]
+    public void ReturnJoinValueChain_RaisesToSwitchExpression()
+    {
+        var function = Raised(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.ClassifyLength));
+
+        var expression = Assert.Single(function.Descendants.OfType<SwitchExpression>());
+        Assert.Equal(3, expression.Arms.Count);
+        Assert.Single(expression.Arms, arm => arm.IsDefault);
+
+        // The dispatch's equality tests and their branches are fully consumed.
+        Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
+        Assert.Empty(function.Descendants.OfType<Comparison>());
+    }
+
+    [Fact]
+    public void ReturnJoinValueChain_RendersGoverningExpressionAndArms()
+    {
+        var output = Print(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.ClassifyLength));
+
+        Assert.Contains("s.Length switch", output);
+        Assert.Contains("0 => Fail(out x),", output);
+        Assert.Contains("1 => Win(1, out x),", output);
+        Assert.Contains("_ => Fail(out x),", output);
+        Assert.DoesNotContain("if (", output);
+    }
+
+    [Fact]
+    public void CopyJoinInnerChain_RaisesInsideScatteredDispatchWitness()
+    {
+        // The #2978 witness's inner `s.Length switch` converges by copying its
+        // result temp into the outer temp (copy-to-temp join), not a return.
+        var output = Print(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.Dispatch));
+
+        Assert.Contains("s.Length switch", output);
+        Assert.Contains("0 => Fail(out x),", output);
+        Assert.Contains("1 => Win(1, out x),", output);
+        Assert.Contains("_ => Fail(out x),", output);
+    }
+
+    [Fact]
+    public void HandWrittenEqualityChain_DeclinesSwitchExpressionRaise()
+    {
+        // Direct returns per test — no result temp, no convergence read, and
+        // s.Length is re-read each time. Must stay if/else.
+        var function = Raised(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.ClassifyLengthManual));
+
+        Assert.Empty(function.Descendants.OfType<SwitchExpression>());
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ComparisonChainSwitchExpressionRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ComparisonChainSwitchExpressionRaisingTests.cs
@@ -87,9 +87,9 @@ public class ComparisonChainSwitchExpressionRaisingTests
     [Fact]
     public void UnsignedGoverningValue_DeclinesToAvoidInvalidLabel()
     {
-        // SwitchExpressionArm labels are signed int32. A uint governing value
-        // whose label is uint.MaxValue (IL ldc.i4.m1) would misprint as -1
-        // (CS0031). The raiser must decline on a non-Int32 governing type.
+        // A uint governing value whose label is uint.MaxValue (IL ldc.i4.m1) is
+        // recorded as a negative int32 and would misprint as -1 (CS0031). The
+        // raiser must decline a uint governing value with a negative label.
         var function = Raised(
             typeof(ScatteredReturnDispatchSample).FullName!,
             nameof(ScatteredReturnDispatchSample.ClassifyUnsigned));
@@ -100,5 +100,42 @@ public class ComparisonChainSwitchExpressionRaisingTests
             typeof(ScatteredReturnDispatchSample).FullName!,
             nameof(ScatteredReturnDispatchSample.ClassifyUnsigned));
         Assert.DoesNotContain("-1 =>", output);
+    }
+
+    [Fact]
+    public void EnumGoverningValue_RaisesWithMemberNames()
+    {
+        // Enum labels are int-backed; the printer renders them as member names
+        // via the governing type. The uint guard must not decline enum switches.
+        var function = Raised(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.ClassifyEnum));
+
+        Assert.Single(function.Descendants.OfType<SwitchExpression>());
+
+        var output = Print(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.ClassifyEnum));
+        Assert.Contains("DispatchKind.Zero => Fail(out x),", output);
+        Assert.Contains("DispatchKind.One => Win(1, out x),", output);
+        Assert.DoesNotContain("if (", output);
+    }
+
+    [Fact]
+    public void ByteGoverningValue_RaisesToSwitchExpression()
+    {
+        // Byte labels are small non-negative int32 constants that print
+        // faithfully; the uint guard must not decline them.
+        var function = Raised(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.ClassifyByte));
+
+        Assert.Single(function.Descendants.OfType<SwitchExpression>());
+
+        var output = Print(
+            typeof(ScatteredReturnDispatchSample).FullName!,
+            nameof(ScatteredReturnDispatchSample.ClassifyByte));
+        Assert.DoesNotContain("-1 =>", output);
+        Assert.DoesNotContain("if (", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
@@ -66,6 +66,18 @@ public static class ScatteredReturnDispatchSample
         return Fail(out x);
     }
 
+    // Close negative for the unsigned-label bug: the same store-to-temp
+    // switch-expression shape but on a uint governing value. SwitchExpressionArm
+    // labels are signed int32, so raising this would misprint uint.MaxValue (IL
+    // ldc.i4.m1) as -1 (CS0031: -1 cannot convert to uint). The raiser must
+    // decline on any non-Int32 governing type and leave it to the other raisers.
+    public static int ClassifyUnsigned(uint u) => u switch
+    {
+        0u => 10,
+        uint.MaxValue => 20,
+        _ => 30
+    };
+
     // #640 canary: two contiguous guards on a shared return — must stay `a && b`.
     public static int PlainAnd(int a, int b)
     {

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
@@ -37,6 +37,35 @@ public static class ScatteredReturnDispatchSample
 
     static bool Fail(out int x) { x = 0; return false; }
 
+    // Slice-1 isolate: the inner comparison-chain value switch expression on its
+    // own. csc lowers this to an equality chain (brfalse/beq) whose arms each
+    // store one dedicated result temp read once at the return join — the faithful
+    // signal SwitchRaisingPass recognizes.
+    public static bool ClassifyLength(string s, out int x) => s.Length switch
+    {
+        0 => Fail(out x),
+        1 => Win(1, out x),
+        _ => Fail(out x)
+    };
+
+    // Close negative: a hand-written equality chain returning directly. It reads
+    // s.Length once per test and has no result temp or convergence read, so it
+    // must stay if/else and never raise to a switch expression.
+    public static bool ClassifyLengthManual(string s, out int x)
+    {
+        if (s.Length == 0)
+        {
+            return Fail(out x);
+        }
+
+        if (s.Length == 1)
+        {
+            return Win(1, out x);
+        }
+
+        return Fail(out x);
+    }
+
     // #640 canary: two contiguous guards on a shared return — must stay `a && b`.
     public static int PlainAnd(int a, int b)
     {

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
@@ -3,6 +3,17 @@ using System;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
+/// Enum governing type for <see cref="ScatteredReturnDispatchSample.ClassifyEnum"/>:
+/// its comparison-chain labels are int-backed but must render as member names.
+/// </summary>
+public enum DispatchKind
+{
+    Zero = 0,
+    One = 1,
+    Two = 2,
+}
+
+/// <summary>
 /// Fixtures for issue #2978: a nested type-pattern <c>switch</c> expression whose
 /// shared <c>_ =&gt; Fail</c> default is reached by two conditional guards at
 /// different nesting levels (the outer <c>is not int</c> and the inner
@@ -67,15 +78,35 @@ public static class ScatteredReturnDispatchSample
     }
 
     // Close negative for the unsigned-label bug: the same store-to-temp
-    // switch-expression shape but on a uint governing value. SwitchExpressionArm
-    // labels are signed int32, so raising this would misprint uint.MaxValue (IL
-    // ldc.i4.m1) as -1 (CS0031: -1 cannot convert to uint). The raiser must
-    // decline on any non-Int32 governing type and leave it to the other raisers.
+    // switch-expression shape but on a uint governing value whose label is
+    // uint.MaxValue (IL ldc.i4.m1). That label is recorded as a negative int32,
+    // so raising would misprint it as -1 (CS0031: -1 cannot convert to uint).
+    // The raiser declines a uint governing value with a negative label and
+    // leaves it to the other raisers.
     public static int ClassifyUnsigned(uint u) => u switch
     {
         0u => 10,
         uint.MaxValue => 20,
         _ => 30
+    };
+
+    // Positive: an enum governing value. Labels are int-backed, but the printer
+    // renders them as enum member names via the governing type, so the raise is
+    // faithful and must be preserved (an Int32-only guard wrongly declined these).
+    public static bool ClassifyEnum(DispatchKind k, out int x) => k switch
+    {
+        DispatchKind.Zero => Fail(out x),
+        DispatchKind.One => Win(1, out x),
+        _ => Fail(out x)
+    };
+
+    // Positive: a byte governing value. Its labels are small non-negative int32
+    // constants that print faithfully, so it must keep raising.
+    public static bool ClassifyByte(byte b, out int x) => b switch
+    {
+        0 => Fail(out x),
+        1 => Win(1, out x),
+        _ => Fail(out x)
     };
 
     // #640 canary: two contiguous guards on a shared return — must stay `a && b`.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -581,6 +581,14 @@ public sealed class SwitchRaisingPass : IIrPass
         if (value is not (LoadLocal or LoadArgument) || !sawEquality || caseLabels.Count < 2)
             return false;
 
+        // SwitchExpressionArm.Labels are signed int32. Only an Int32 governing
+        // value renders those labels faithfully; other integral/enum/char types
+        // would misprint (e.g. a uint MaxValue label, IL ldc.i4.m1, as -1).
+        // Decline anything but Int32 and leave it to the other raisers.
+        TypeRef governingType = value is LoadLocal ll ? ll.Type : ((LoadArgument)value).Type;
+        if (!governingType.Equals(TypeRef.CoreLib("System", "Int32")))
+            return false;
+
         // No explicit default branch: the last test falls through to the default arm.
         if (defaultOffset is null)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -593,6 +593,16 @@ public sealed class SwitchRaisingPass : IIrPass
         if (governingType.Equals(TypeRef.CoreLib("System", "UInt32")) && caseLabels.Any(label => label < 0))
             return false;
 
+        // Every SwitchExpressionArm label recorded here is an int32 that prints as
+        // an integer literal, but a Boolean governing value needs bool constant
+        // patterns — int does not convert to bool (CS0029), so `b switch { 0 => …,
+        // 1 => … }` would not compile. csc never emits this shape on a bool (a
+        // bool switch lowers to a single brtrue/brfalse, not an equality chain
+        // with `== k` tests), so this only fires on arbitrary or obfuscated
+        // non-csc IL; decline it and leave the if/else intact.
+        if (governingType.Equals(TypeRef.CoreLib("System", "Boolean")))
+            return false;
+
         // No explicit default branch: the last test falls through to the default arm.
         if (defaultOffset is null)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -70,7 +70,8 @@ public sealed class SwitchRaisingPass : IIrPass
                         || RaiseCaseTargetJoin(container, s, sw, leaveTargets, stepper)))
                     return true;
                 if (blocks[s].Children is [.., ConditionalBranch]
-                    && (RaiseStringLengthBucketSwitch(container, s, leaveTargets, stepper)
+                    && (RaiseComparisonChainSwitchExpression(container, s, leaveTargets, stepper)
+                        || RaiseStringLengthBucketSwitch(container, s, leaveTargets, stepper)
                         || RaiseStringHashSwitch(container, s, leaveTargets, stepper)
                         || RaiseStringEqualityChain(container, s, leaveTargets, stepper)
                         || RaiseSparseIntSwitch(container, s, leaveTargets, stepper)))
@@ -510,6 +511,247 @@ public sealed class SwitchRaisingPass : IIrPass
             rebuilt.Add(all[idx]);
         stepper.StepOver("raise value-producing jump table to switch expression", container);
         container.ReplaceWith(rebuilt);
+    }
+
+    /// <summary>
+    /// Raises csc's <em>comparison-chain</em> value switch-expression lowering
+    /// into <c>local = value switch { … };</c>. When the case labels are too few
+    /// or too sparse for a jump table, csc dispatches a <c>switch</c> expression
+    /// with a linear equality chain (<c>if (v == k) goto arm;</c>, the <c>v == 0</c>
+    /// arm emitted as the <c>brfalse</c>/<c>!v</c> form) ending in a branch to the
+    /// default arm. Every arm — including the default — assigns one dedicated
+    /// result temp and converges to a single block that reads that temp exactly
+    /// once (a <c>return v</c> tail, or a <c>w = v</c> copy when the switch feeds
+    /// an enclosing expression). That single-read result temp is the faithful
+    /// switch-expression signal: a hand-written <c>if/else</c> cascade returns or
+    /// assigns each arm directly and has no such convergence temp, so it is
+    /// declined. Relational pivots are declined (they leave the collected span
+    /// untiled). Runs before structuring, mirroring the jump-table raiser above.
+    /// </summary>
+    static bool RaiseComparisonChainSwitchExpression(BlockContainer container, int s, HashSet<int> leaveTargets, Stepper stepper)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        // Collect the linear equality dispatch. The first block may carry leading
+        // setup (the value computation); the rest are single-statement tests.
+        IrExpression? value = null;
+        var caseLabels = new List<int>();
+        var caseTargetOffsets = new List<int>();
+        int? defaultOffset = null;
+        bool sawEquality = false;
+        int idx = s;
+        int dispatchEnd = s - 1;
+        while (idx < blocks.Count)
+        {
+            var children = blocks[idx].Children;
+            IrNode? term = idx == s
+                ? (children.Count > 0 ? children[^1] : null)
+                : (children is [var only] ? only : null);
+
+            if (term is ConditionalBranch cb && TryEqualityLabel(cb.Condition, out var testValue, out int label))
+            {
+                if (value is null)
+                    value = testValue;
+                else if (!PlaceIdentity.SameVariable(value, testValue))
+                    break;
+                if (cb.Condition is Comparison)
+                    sawEquality = true;   // a real `v == k` (not just the `!v` == 0 form)
+                if (caseLabels.Contains(label))
+                    return false;         // duplicate case label (CS0152)
+                caseLabels.Add(label);
+                caseTargetOffsets.Add(cb.TargetOffset);
+                dispatchEnd = idx;
+                idx++;
+                continue;
+            }
+
+            if (term is Branch br)
+            {
+                defaultOffset = br.TargetOffset;
+                dispatchEnd = idx;
+                break;
+            }
+
+            break;   // the first arm/body block
+        }
+
+        if (value is not (LoadLocal or LoadArgument) || !sawEquality || caseLabels.Count < 2)
+            return false;
+
+        // No explicit default branch: the last test falls through to the default arm.
+        if (defaultOffset is null)
+        {
+            if (dispatchEnd + 1 >= blocks.Count)
+                return false;
+            defaultOffset = blocks[dispatchEnd + 1].StartOffset;
+        }
+
+        var caseTargets = new int[caseTargetOffsets.Count];
+        for (int k = 0; k < caseTargets.Length; k++)
+            if (!offsetToIndex.TryGetValue(caseTargetOffsets[k], out caseTargets[k]) || caseTargets[k] <= dispatchEnd)
+                return false;
+        if (!offsetToIndex.TryGetValue(defaultOffset.Value, out int defaultIndex) || defaultIndex <= dispatchEnd)
+            return false;
+
+        // Every arm and the default is a value block assigning one shared local and
+        // converging to one join.
+        int? theLocal = null;
+        int? joinIndex = null;
+        bool Probe(int i)
+        {
+            if (!TryValueBlock(blocks, i, offsetToIndex, out int l, out int j))
+                return false;
+            if (theLocal is { } el && el != l)
+                return false;
+            if (joinIndex is { } ej && ej != j)
+                return false;
+            theLocal = l;
+            joinIndex = j;
+            return true;
+        }
+
+        var owned = new HashSet<int>();
+        foreach (int target in caseTargets.Distinct())
+        {
+            if (!Probe(target))
+                return false;
+            owned.Add(target);
+        }
+        if (!Probe(defaultIndex))
+            return false;
+        owned.Add(defaultIndex);
+        var defaultArm = (IrExpression)ValueBlockExpr(blocks[defaultIndex]).Clone();
+
+        int join = joinIndex!.Value;
+        int local = theLocal!.Value;
+
+        // The result temp is private to this switch: assigned only in the owned
+        // value blocks and read exactly once, in the join. This single-read
+        // convergence temp is what a hand-written if/else cascade lacks.
+        LoadLocal? joinRead = null;
+        foreach (var node in container.Descendants)
+        {
+            if (node is StoreLocal store && store.Index == local && !owned.Contains(BlockIndexOf(blocks, store)))
+                return false;
+            if (node is LoadLocal load && load.Index == local)
+            {
+                if (joinRead is not null)
+                    return false;   // more than one read — not a convergence temp
+                joinRead = load;
+            }
+        }
+        if (joinRead is null || BlockIndexOf(blocks, joinRead) != join)
+            return false;
+
+        // The owned value blocks must tile [dispatchEnd+1, join) exactly, with the
+        // join just past them and nothing outside the chain entering the bodies.
+        if (join <= dispatchEnd || owned.Contains(join))
+            return false;
+        if (owned.Count != join - (dispatchEnd + 1))
+            return false;
+        foreach (int o in owned)
+            if (o <= dispatchEnd || o >= join)
+                return false;
+        if (!OnlyReachedByChain(blocks, owned, s, dispatchEnd, leaveTargets))
+            return false;
+        if (!JoinOnlyReachedByValueBlocks(blocks, owned, join, leaveTargets))
+            return false;
+
+        // Build `value switch { k => armk, …, _ => default }`, grouping labels by
+        // their shared value block in first-appearance order.
+        var labelsByTarget = new Dictionary<int, List<int>>();
+        var targetOrder = new List<int>();
+        for (int i = 0; i < caseTargets.Length; i++)
+        {
+            if (!labelsByTarget.TryGetValue(caseTargets[i], out var list))
+            {
+                labelsByTarget[caseTargets[i]] = list = [];
+                targetOrder.Add(caseTargets[i]);
+            }
+            list.Add(caseLabels[i]);
+        }
+
+        var arms = new List<SwitchExpressionArm>();
+        foreach (int target in targetOrder)
+            arms.Add(new SwitchExpressionArm(
+                [.. labelsByTarget[target]], isDefault: false, (IrExpression)ValueBlockExpr(blocks[target]).Clone()));
+        arms.Add(new SwitchExpressionArm([], isDefault: true, defaultArm));
+
+        var switchExpression = new SwitchExpression((IrExpression)value.Clone(), arms);
+
+        // The result temp's declared type is taken from its own arm stores.
+        var localType = ((StoreLocal)blocks[defaultIndex].Children[0]).Type;
+
+        // Rewrite the dispatch head: keep its leading setup, drop the trailing
+        // dispatch branch, and assign the result temp the switch expression. Drop
+        // the dispatch + arm blocks; keep the join (its single read of the temp
+        // stays, and later inlining folds the temp into it).
+        var all = container.Blocks.ToList();
+        var head = all[s];
+        head.Children[^1].Detach();   // the trailing dispatch ConditionalBranch/Branch
+        head.Add(new StoreLocal(local, localType, switchExpression));
+
+        foreach (var block in all)
+            block.Detach();
+
+        var rebuilt = new BlockContainer();
+        for (int i = 0; i <= s; i++)
+            rebuilt.Add(all[i]);
+        for (int i = join; i < all.Count; i++)
+            rebuilt.Add(all[i]);
+        stepper.StepOver("raise value-producing comparison chain to switch expression", container);
+        container.ReplaceWith(rebuilt);
+        return true;
+    }
+
+    /// <summary>The block index owning a node, or -1 if it is not inside a block of <paramref name="blocks"/>.</summary>
+    static int BlockIndexOf(IReadOnlyList<Block> blocks, IrNode node)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+            if (current is Block block)
+            {
+                for (int i = 0; i < blocks.Count; i++)
+                    if (ReferenceEquals(blocks[i], block))
+                        return i;
+                return -1;
+            }
+        return -1;
+    }
+
+    /// <summary>
+    /// An int equality dispatch test yielding the governing value and its case
+    /// label: <c>v == k</c> / <c>k == v</c>, or the <c>brfalse</c> form <c>!v</c>
+    /// for the <c>0</c> arm.
+    /// </summary>
+    static bool TryEqualityLabel(IrExpression condition, out IrExpression value, out int label)
+    {
+        value = null!;
+        label = 0;
+        if (condition is LogicalNot { Operand: { } operand })
+        {
+            value = operand;
+            label = 0;
+            return true;
+        }
+        if (condition is Comparison { Kind: ComparisonKind.Equal } cmp)
+        {
+            if (cmp.Right is Constant { Value: int right })
+            {
+                value = cmp.Left;
+                label = right;
+                return true;
+            }
+            if (cmp.Left is Constant { Value: int left })
+            {
+                value = cmp.Right;
+                label = left;
+                return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>The default region escapes only through a conditional / unconditional branch to the join, a fall-through, or a terminator — every conditional must target the join (it becomes <c>if (c) break;</c>).</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -581,12 +581,16 @@ public sealed class SwitchRaisingPass : IIrPass
         if (value is not (LoadLocal or LoadArgument) || !sawEquality || caseLabels.Count < 2)
             return false;
 
-        // SwitchExpressionArm.Labels are signed int32. Only an Int32 governing
-        // value renders those labels faithfully; other integral/enum/char types
-        // would misprint (e.g. a uint MaxValue label, IL ldc.i4.m1, as -1).
-        // Decline anything but Int32 and leave it to the other raisers.
+        // A case label recorded from IL is a signed int32. When the governing
+        // value is an unsigned uint, a label with the high bit set (e.g.
+        // uint.MaxValue, IL ldc.i4.m1) is stored as negative and would misprint
+        // as an invalid signed switch label (CS0031) — the SwitchExpressionArm
+        // printer path does not reinterpret unsigned labels. Decline only that
+        // case and leave it to the other raisers. Small uint labels and all
+        // int/byte/short/ushort/enum labels are non-negative here and print
+        // faithfully (enum labels render as member names via the governing type).
         TypeRef governingType = value is LoadLocal ll ? ll.Type : ((LoadArgument)value).Type;
-        if (!governingType.Equals(TypeRef.CoreLib("System", "Int32")))
+        if (governingType.Equals(TypeRef.CoreLib("System", "UInt32")) && caseLabels.Any(label => label < 0))
             return false;
 
         // No explicit default branch: the last test falls through to the default arm.


### PR DESCRIPTION
- Advances #3113 (raise follow-up to the #2978 / #3063 witness; #2978 itself is already closed)
- Changes: raise the inner comparison-chain value `switch` expression inside `Dispatch`'s string arm, so `s.Length switch { 0 => .., 1 => .., _ => .. }` is recovered instead of a nested `if/else` cascade
- Card revision: `0217589e`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a surgical, shape-gated raise that recovers the inner switch expression with no corpus delta and no new test failures; both adversarial reviews were clean at the prior head and the merged head keeps the same 3-file diff (re-review pending on the new head — see note under Decompiler quality).

### Original source

<!-- dnx dotnet-inspect -y -- member ScatteredReturnDispatchSample -m Dispatch -S "Original Source" -->

```csharp
public static bool Dispatch(object o, out int x) => o switch
{
    string s => s.Length switch
    {
        0 => Fail(out x),
        1 => Win(1, out x),
        _ => Fail(out x)
    },
    int i when i > 0 => Win(i, out x),
    _ => Fail(out x)
};
```

### Before

<!-- base a223bded (origin/main), -S "Decompiled Source" -->

```csharp
public static bool Dispatch(object o, out int x)
{
    int i;
    int V_5;

    object V_3 = o;
    string s = V_3 as string;
    if (s is null)
    {
        if (V_3 is not int)
        {
            return Fail(out x);
        }
        i = (int)V_3;
    }
    else
    {
        V_5 = s.Length;
        if (V_5 != 0)
        {
            if (V_5 == 1)
            {
                return Win(1, out x);
            }
            return Fail(out x);
        }
        return Fail(out x);
    }
    if (i <= 0)
    {
        return Fail(out x);
    }
    return Win(i, out x);
}
```

- Valid: True
- Correct: True

The inner `s.Length` dispatch is a valid, behavior-preserving `if/else` cascade, but it is lower-quality than the original switch expression.

### After

<!-- head 0217589e, -S "Decompiled Source" -->

```csharp
public static bool Dispatch(object o, out int x)
{
    int i;

    object V_3 = o;
    string s = V_3 as string;
    if (s is null)
    {
        if (V_3 is not int)
        {
            return Fail(out x);
        }
        i = (int)V_3;
    }
    else
    {
        return s.Length switch
        {
            0 => Fail(out x),
            1 => Win(1, out x),
            _ => Fail(out x),
        };
    }
    if (i <= 0)
    {
        return Fail(out x);
    }
    return Win(i, out x);
}
```

- Valid: True
- Correct: True

The inner arm is now recovered as `s.Length switch { 0 => .., 1 => .., _ => .. }`. The outer type-pattern dispatch is still statement-form (tracked below); the whole method remains valid and behavior-preserving.

### Fully raised

```csharp
public static bool Dispatch(object o, out int x) => o switch
{
    string s => s.Length switch
    {
        0 => Fail(out x),
        1 => Win(1, out x),
        _ => Fail(out x)
    },
    int i when i > 0 => Win(i, out x),
    _ => Fail(out x)
};
```

- Required tracking issue: #3113 — recover the `string s` type-pattern arm (carrying the already-raised inner switch), recover the `int i when i > 0` arm (`isinst`/unbox + `when` guard, collapsing the duplicated default), and compose the outer `object`-governed type-pattern switch expression.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ComparisonChainSwitchExpressionRaisingTests`: not present (class added in PR) | `ComparisonChainSwitchExpressionRaisingTests`: 7 passed |
| Decompiler fast suite | 3413, 0 failed | 3420, 0 failed |
| Reduced fixture validity | not applicable | not applicable |
| Reduced fixture fidelity | not applicable | not applicable |
| Real witness | `ScatteredReturnDispatchSample::Dispatch` inner arm not raised (if/else cascade) | `ScatteredReturnDispatchSample::Dispatch` inner arm raised to `s.Length switch { .. }` (outer dispatch pending #2978) |

Baseline = `a223bded` (origin/main); head = `0217589e`. The head/baseline fast-suite delta is exactly the +7 focused tests added by this PR; no baseline test changed state.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the PR quick gate matched baseline tolerances (0 pp on every gated metric, 0 pass bugs). The generated card is byte-identical when run at base `a223bded` and head `0217589e`, so this PR introduces zero corpus delta on the sampled 1,500 methods (the narrow comparison-chain-switch-expression shape is not exercised by the sample).

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly (15 assemblies, 1,500 methods); validity not run, fidelity not run (`--compile-cap 0 --corpus-fidelity-cap 0`).

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 17.67% | 17.67% | 0 pp |
| Conditional-branch residue (-) | 3.00% | 3.00% | 0 pp |
| Pass bugs (-) | 0 | 0 | 0 |
| Fully raised (+) | not reported by PR-quick card | not reported by PR-quick card | n/a |

> **Conclusion:** **PASS** — pinned-subset gate unchanged at base and head.

### Aggregate context

Corpus: 15 assemblies, 1,500 methods. Baseline drift: the card shows a +2-method improvement (251 → 249 detected residue) relative to the pinned `pr-quick-baseline.json` snapshot; that drift is present identically at both base and head, so it predates this PR's diff and is not PR-attributable.

| Metric (goal) | Baseline (base render) | PR (head render) | Count delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 249 (16.60%) | 249 (16.60%) | 0 |
| Conditional-branch residue (-) | 44 (2.93%) | 44 (2.93%) | 0 |
| Forward-merge stops (-) | 30 (2.00%) | 30 (2.00%) | 0 |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — base and head renders are byte-identical on the sampled corpus; no method changed direction.

> **Re-review note:** the branch now merges current `origin/main` (which since landed the #3082 switch-raise pass refactor). This PR's net diff versus `origin/main` is unchanged (3 files: `SwitchRaisingPass.cs`, `ScatteredReturnDispatchSample.cs`, `ComparisonChainSwitchExpressionRaisingTests.cs`) and merges without conflict, but the surrounding pass moved, so the prior clean adversarial reviews at `abad3365` need re-confirmation on head `0217589e` before this supersedes the earlier "Ready to merge".

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter '/*/*/ComparisonChainSwitchExpressionRaisingTests/*'
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"

# PR quick corpus gate (run at base a223bded and head 0217589e; byte-identical):
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
bash eng/prepare-decompiler-pr-corpus.sh /tmp/pr-corpus-assemblies.txt
mapfile -t assemblies < /tmp/pr-corpus-assemblies.txt
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
  --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json \
  --quality-diff-card --corpus-method-cap 100 --compile-cap 0 --corpus-fidelity-cap 0 --max-examples 24
```
