### PR TITLE
docs: record unsafe(expr) gate met, emission deferred (#2021)

### DIFF
--- a/docs/design/memory-safety-modes.md
+++ b/docs/design/memory-safety-modes.md
@@ -92,9 +92,24 @@ pointerless `unsafe` method's requires-unsafe-ness. Legacy compilation stamps no
 `RequiresUnsafeAttribute` and the call carries no pointer, so the fact was erased
 — there is nothing to replay or recover. This is the principled limit of the mode.
 
+The `unsafe(expr)` compiler gate is now met: roslyn #84012 / csharplang #10196
+shipped, and the syntax `unsafe(expression)` parses and compiles on the
+`11.0.100-preview.7` SDK this repo builds with. (The earlier Preview 6 probe
+rejected the speculative `unsafe stackalloc` spelling, which never shipped.)
+Emission is nonetheless deferred: the compile-back rail's pinned
+`Microsoft.CodeAnalysis.CSharp` (5.6.0, the latest public package) does not yet
+parse `unsafe(expr)` — it reads `unsafe` as the block keyword — so the rail could
+not recompile narrowed output, and every new-rules compile-back harness would
+break. We keep the `unsafe { }` block wrap until the pinned Roslyn advances to a
+version that implements unsafe expressions, at which point new-rules rendering can
+narrow a single `return <unsafe-expr>;` to the tighter `return unsafe(<expr>);`
+form (return position only — `unsafe(...)` is a primary expression, legal as a
+returned value but not as a bare statement). Tracked: #2021.
+
 Still future (not built): emit `// SAFETY-TODO` audit comments at introduced
-blocks; emit the tighter `unsafe(expr)` expression form once it lands in a usable
-compiler (tracked: roslyn #84012 / csharplang #10196).
+blocks; narrow the introduced `unsafe { }` wrap to the `unsafe(expr)` expression
+form once the pinned compiler can validate it (tracked: roslyn #84012 /
+csharplang #10196, #2021).
 
 ## Opaque-contract classification (analysis surface)
 


### PR DESCRIPTION
## Summary

Documentation-only change recording the current state of C# 14 `unsafe(expr)` support for issue #2021.

**Conclusion:** the compiler gate is met (roslyn #84012 / csharplang #10196 shipped; `unsafe(expression)` parses/compiles on the preview.7 SDK this repo builds with), but **emission stays deferred** because the compile-back rail's pinned `Microsoft.CodeAnalysis.CSharp 5.6.0` (latest public package) cannot parse `unsafe(expr)` — it reads `unsafe` as the block keyword. Narrowing the introduced `unsafe { }` wrap now would break every new-rules compile-back harness.

We keep the block wrap until the pinned Roslyn advances, and document the return-position-only narrowing rule for when emission lands.

## Investigation notes
- Prototyped return-position narrowing (`return unsafe(<expr>);`); it fired across ~18 new-rules fixtures and broke the pinned-Roslyn compile-back rails, plus a `ref`-return correctness edge. Reverted; only the design note remains.

## Evidence
- Documentation-only; `markdownlint` clean. No product build/test claim.

## Risk
Low — doc-only, no behavior change. No adversarial review required.