### PR TITLE
Split authored invalid failures by provenance

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -166,6 +166,42 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderInvalidClassifier_UsesTypedFaultIsolation()
+    {
+        var target = new ReturnToSender.RequestedTarget("T", "M", 0);
+
+        var product = new ReturnToSenderSourceProbeResult(
+            target,
+            ReturnToSenderSourceOutcome.Invalid,
+            FidelityCheck.CompileBackStatus.RecompileFail,
+            "CS0029",
+            Detail: "target body does not bind",
+            SourcePath: "Fixture.cs",
+            ExpectedBody: "return true;",
+            ActualBody: "return 1;",
+            FaultIsolationKind: ReturnToSender.FaultIsolationKind.BodyDefect);
+        var shell = product with
+        {
+            FaultIsolationKind = ReturnToSender.FaultIsolationKind.ShellOrClosureDefect,
+        };
+        var closure = product with
+        {
+            FaultIsolationKind = null,
+            Detail = "closure-stalled-unextracted[CS0246]: CS0246: missing closure type",
+        };
+        var valid = product with
+        {
+            Outcome = ReturnToSenderSourceOutcome.ValidDifferent,
+            CompileBackStatus = FidelityCheck.CompileBackStatus.Exact,
+        };
+
+        Assert.Equal(ReturnToSenderInvalidKind.ProductBodyDefect, ReturnToSenderInvalidClassifier.Classify(product));
+        Assert.Equal(ReturnToSenderInvalidKind.HarnessShellReconstruction, ReturnToSenderInvalidClassifier.Classify(shell));
+        Assert.Equal(ReturnToSenderInvalidKind.HarnessShellReconstruction, ReturnToSenderInvalidClassifier.Classify(closure));
+        Assert.Null(ReturnToSenderInvalidClassifier.Classify(valid));
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_BucketsResidualFrontiersAsStructuringResidue()
     {
         var result = new ReturnToSenderSourceProbeResult(

--- a/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
@@ -113,6 +113,7 @@ static class AuthoredCorpusBenchmark
         int unsupported = results.Count(result => ClassifyTaste(result) == TasteBucket.Unsupported);
         int evaluated = results.Count;
         int valid = match + different;
+        var invalidBreakdown = InvalidBreakdown(results);
 
         Console.WriteLine($"AUTHORED-SOURCE CORPUS BENCHMARK");
         Console.WriteLine();
@@ -139,6 +140,12 @@ static class AuthoredCorpusBenchmark
         if (frontierUnknown > 0)
             Console.WriteLine($"    frontier, IL-unknown              : {frontierUnknown}");
         Console.WriteLine($"  Invalid  (does not round-trip)      : {invalid}");
+        if (invalid > 0)
+        {
+            Console.WriteLine($"    product body defects              : {invalidBreakdown.ProductBodyDefect}");
+            Console.WriteLine($"    harness shell reconstruction      : {invalidBreakdown.HarnessShellReconstruction}");
+            Console.WriteLine($"    unclassified invalid              : {invalidBreakdown.Unclassified}");
+        }
         if (notFull > 0)
             Console.WriteLine($"  Not-Full (uncheckable at Full)      : {notFull}");
         if (drift > 0)
@@ -225,6 +232,40 @@ static class AuthoredCorpusBenchmark
         => reason.Contains("fidelity-unavailable", StringComparison.Ordinal)
             || reason.Equals("NotFull", StringComparison.Ordinal);
 
+    internal sealed record InvalidBreakdownCounts(
+        int ProductBodyDefect,
+        int HarnessShellReconstruction,
+        int Unclassified)
+    {
+        public int Total => ProductBodyDefect + HarnessShellReconstruction + Unclassified;
+    }
+
+    internal static InvalidBreakdownCounts InvalidBreakdown(IReadOnlyList<ReturnToSenderSourceProbeResult> results)
+    {
+        int productBodyDefect = 0;
+        int harnessShellReconstruction = 0;
+        int unclassified = 0;
+
+        foreach (var result in results.Where(result => ClassifyTaste(result) == TasteBucket.Invalid))
+        {
+            switch (ReturnToSenderInvalidClassifier.Classify(result))
+            {
+                case ReturnToSenderInvalidKind.ProductBodyDefect:
+                    productBodyDefect++;
+                    break;
+                case ReturnToSenderInvalidKind.HarnessShellReconstruction:
+                    harnessShellReconstruction++;
+                    break;
+                case ReturnToSenderInvalidKind.Unclassified:
+                case null:
+                    unclassified++;
+                    break;
+            }
+        }
+
+        return new InvalidBreakdownCounts(productBodyDefect, harnessShellReconstruction, unclassified);
+    }
+
     static void WriteReasonBuckets(
         string title,
         IReadOnlyList<ReturnToSenderSourceProbeResult> results,
@@ -259,6 +300,7 @@ static class AuthoredCorpusBenchmark
         int drift = results.Count(result => ClassifyTaste(result) == TasteBucket.Drift);
         int unsupported = results.Count(result => ClassifyTaste(result) == TasteBucket.Unsupported);
         int evaluated = results.Count;
+        var invalidBreakdown = InvalidBreakdown(results);
         // Honest-exit contract: an empty or partially unmatched run is never a
         // success — unmatched rows (assembly not supplied) and a zero-target run fail.
         bool honest = unmatchedRows == 0 && evaluated > 0;
@@ -282,6 +324,12 @@ static class AuthoredCorpusBenchmark
                 frontierIlUnknown = results.Count(result => ClassifyTaste(result) == TasteBucket.FrontierIlUnknown),
             },
             invalid,
+            invalidBreakdown = new
+            {
+                productBodyDefect = invalidBreakdown.ProductBodyDefect,
+                harnessShellReconstruction = invalidBreakdown.HarnessShellReconstruction,
+                unclassified = invalidBreakdown.Unclassified,
+            },
             notFull,
             drift,
             unsupported,
@@ -293,6 +341,8 @@ static class AuthoredCorpusBenchmark
                 outcome = result.Outcome.ToString(),
                 tasteBucket = ClassifyTaste(result).ToString(),
                 compileBackStatus = result.CompileBackStatus?.ToString(),
+                invalidKind = ReturnToSenderInvalidClassifier.Classify(result)?.ToString(),
+                faultIsolation = result.FaultIsolationKind?.ToString(),
                 reason = result.Reason,
                 detail = result.Detail,
                 sourceFile = result.SourcePath,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -674,6 +674,18 @@ static class ReturnToSender
             RoundTripScope.Cluster,
             RoundTripBodyPolicy.Selected);
 
+    internal static IReadOnlyList<Result> CompileBackTargets(
+        string assemblyPath,
+        IReadOnlyList<RequestedTarget> targets,
+        ReturnToSenderSourceIndex? sourceIndex)
+        => CompileBackTargets(
+            assemblyPath,
+            targets,
+            sourceIndex,
+            applyCompileBackFloor: true,
+            RoundTripScope.Cluster,
+            RoundTripBodyPolicy.Selected);
+
     public static IReadOnlyList<Result> CompileBackTargets(
         string assemblyPath,
         IReadOnlyList<RequestedTarget> targets,

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -38,12 +38,42 @@ sealed record ReturnToSenderSourceProbeResult(
     string? OriginalOpcodes = null,
     string? RecompiledOpcodes = null,
     IReadOnlyList<string>? IlDiffLines = null,
-    MemberAnchor? MemberAnchor = null)
+    MemberAnchor? MemberAnchor = null,
+    ReturnToSender.FaultIsolationKind? FaultIsolationKind = null)
 {
     public bool Passed => Outcome == ReturnToSenderSourceOutcome.ValidMatch;
     public bool Different => Outcome == ReturnToSenderSourceOutcome.ValidDifferent;
     public bool Failed => Outcome == ReturnToSenderSourceOutcome.Invalid;
     public bool Skipped => Outcome is ReturnToSenderSourceOutcome.SourceUnavailable or ReturnToSenderSourceOutcome.UnsupportedTarget;
+}
+
+enum ReturnToSenderInvalidKind
+{
+    ProductBodyDefect,
+    HarnessShellReconstruction,
+    Unclassified,
+}
+
+static class ReturnToSenderInvalidClassifier
+{
+    public static ReturnToSenderInvalidKind? Classify(ReturnToSenderSourceProbeResult result)
+    {
+        if (result.Outcome != ReturnToSenderSourceOutcome.Invalid)
+            return null;
+
+        return result.FaultIsolationKind switch
+        {
+            ReturnToSender.FaultIsolationKind.BodyDefect => ReturnToSenderInvalidKind.ProductBodyDefect,
+            ReturnToSender.FaultIsolationKind.ShellOrClosureDefect => ReturnToSenderInvalidKind.HarnessShellReconstruction,
+            _ when HasClosureStopDetail(result.Detail) => ReturnToSenderInvalidKind.HarnessShellReconstruction,
+            _ => ReturnToSenderInvalidKind.Unclassified,
+        };
+    }
+
+    static bool HasClosureStopDetail(string? detail)
+        => detail is not null
+            && (detail.StartsWith("closure-stalled", StringComparison.Ordinal)
+                || detail.StartsWith("closure-root-budget", StringComparison.Ordinal));
 }
 
 sealed record SourceCorrespondenceFinding(
@@ -244,7 +274,7 @@ static partial class ReturnToSenderSourceProbe
         if (targets.Count == 0)
             return [];
 
-        var rtsResults = ReturnToSender.CompileBackTargets(assemblyPath, targets.Distinct().ToArray())
+        var rtsResults = ReturnToSender.CompileBackTargets(assemblyPath, targets.Distinct().ToArray(), sourceIndex)
             .ToDictionary(
                 result => Key(
                     result.Plan.TargetMethod.Type,
@@ -283,7 +313,8 @@ static partial class ReturnToSenderSourceProbe
                     SourcePath: sourceMember?.SourcePath,
                     ExpectedBody: sourceMember?.Body,
                     ActualBody: result.TargetBody,
-                    MemberAnchor: result.MemberAnchor));
+                    MemberAnchor: result.MemberAnchor,
+                    FaultIsolationKind: result.FaultIsolation?.Kind));
                 continue;
             }
 
@@ -301,7 +332,8 @@ static partial class ReturnToSenderSourceProbe
                     SourcePath: null,
                     ExpectedBody: null,
                     ActualBody: result.TargetBody,
-                    MemberAnchor: result.MemberAnchor));
+                    MemberAnchor: result.MemberAnchor,
+                    FaultIsolationKind: result.FaultIsolation?.Kind));
                 continue;
             }
 
@@ -316,7 +348,8 @@ static partial class ReturnToSenderSourceProbe
                     SourcePath: null,
                     ExpectedBody: null,
                     ActualBody: result.TargetBody,
-                    MemberAnchor: result.MemberAnchor));
+                    MemberAnchor: result.MemberAnchor,
+                    FaultIsolationKind: result.FaultIsolation?.Kind));
                 continue;
             }
 
@@ -338,7 +371,8 @@ static partial class ReturnToSenderSourceProbe
                     SourcePath: null,
                     ExpectedBody: null,
                     ActualBody: result.TargetBody,
-                    MemberAnchor: result.MemberAnchor));
+                    MemberAnchor: result.MemberAnchor,
+                    FaultIsolationKind: result.FaultIsolation?.Kind));
                 continue;
             }
 
@@ -360,7 +394,8 @@ static partial class ReturnToSenderSourceProbe
                     sourceMember.SourcePath,
                     expected,
                     actual,
-                    MemberAnchor: result.MemberAnchor));
+                    MemberAnchor: result.MemberAnchor,
+                    FaultIsolationKind: result.FaultIsolation?.Kind));
                 continue;
             }
 
@@ -383,7 +418,8 @@ static partial class ReturnToSenderSourceProbe
                 OriginalOpcodes: fidelityEvidence?.OriginalOpcodes,
                 RecompiledOpcodes: fidelityEvidence?.RecompiledOpcodes,
                 IlDiffLines: fidelityEvidence?.IlDiffLines,
-                MemberAnchor: result.MemberAnchor));
+                MemberAnchor: result.MemberAnchor,
+                FaultIsolationKind: result.FaultIsolation?.Kind));
         }
 
         return results;
@@ -554,6 +590,7 @@ static partial class ReturnToSenderSourceProbe
                 source_path = result.SourcePath,
                 expected_body = result.ExpectedBody,
                 actual_body = result.ActualBody,
+                fault_isolation = result.FaultIsolationKind?.ToString(),
                 original_opcodes = result.OriginalOpcodes,
                 recompiled_opcodes = result.RecompiledOpcodes,
                 il_diff = result.IlDiffLines,
@@ -578,7 +615,8 @@ static partial class ReturnToSenderSourceProbe
             sourcePath,
             ExpectedBody: null,
             ActualBody: result.TargetBody,
-            MemberAnchor: result.MemberAnchor));
+            MemberAnchor: result.MemberAnchor,
+            FaultIsolationKind: result.FaultIsolation?.Kind));
     }
 
 }


### PR DESCRIPTION
## Summary

Surfaced the authored-corpus `Invalid` headline as product-body vs harness-shell sub-counts in both the human benchmark card and `--json` payload. The split uses existing ReturnToSender typed fault-isolation evidence (`BodyDefect` vs `ShellOrClosureDefect`) carried through `ReturnToSenderSourceProbeResult`; the only fallback is the existing closure stop detail prefix for closure-budget/stall rows. Existing taste buckets and honest-exit behavior are preserved.

This is a non-trivial harness/output-shape change and requires two-model adversarial review per AGENTS.md before readiness. Please keep this PR in draft until that review is clean.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"`
- Small benchmark JSON/card validation using one Newtonsoft.Json target from `/tmp/evil-pool/assemblies.txt` and a one-row synthetic authored corpus (the checked-in `external/authored-source-corpus/evil/corpus.jsonl` path is not present in this checkout):

```json
{"targetsEvaluated":1,"invalid":1,"invalidBreakdown":{"productBodyDefect":0,"harnessShellReconstruction":1,"unclassified":0},"invalidBreakdownSum":1,"firstInvalidKind":"HarnessShellReconstruction","firstFaultIsolation":"ShellOrClosureDefect"}
```

```text
  Invalid  (does not round-trip)      : 1
    product body defects              : 0
    harness shell reconstruction      : 1
    unclassified invalid              : 0
json_pipeline_exit=1 card_pipeline_exit=1
```

The non-zero benchmark exits are expected for this synthetic validation row because the honest-exit contract still fails when an invalid row is present.

## Compatibility / boundaries

- No C#/AST/name heuristics were added to classify product defects.
- Existing `invalid`, taste bucket, row detail, and exit semantics remain intact.
- JSON adds `invalidBreakdown`, plus per-row `invalidKind` and `faultIsolation` for drill-down.
