### PR TITLE
Fold field-like event backing field into event in ApiSurfaceExtractor (#3083)

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -306,13 +306,15 @@ public static class ApiSurfaceExtractor
             // Fields (non-backing fields; non-public included with --all)
             bool isEnum = apiType.Kind == "enum";
 
-            // A field-like event's compiler-generated backing field shares the event's exact
-            // (unmangled) name and is private. Fold only such backing fields, and only for
-            // events whose accessors are compiler-generated (i.e. genuinely field-like) — never
-            // based on a custom/explicit event. This keeps the extractor sound for hand-authored
-            // or non-C# metadata, where a legitimate field and a same-named event can coexist
-            // (the C# CS0102 restriction does not bind arbitrary IL): only a private field whose
-            // name matches a field-like event on this type is suppressed.
+            // A C# field-like event's compiler-generated backing field is private, is itself
+            // marked [CompilerGenerated], and shares the event's exact (unmangled) name. Fold a
+            // field only when it carries all of that positive backing-field evidence AND matches
+            // an event whose adder is [CompilerGenerated] (i.e. a genuinely field-like event).
+            // The decisive signal is the candidate field's own [CompilerGenerated] marker, not the
+            // accessor's: hand-authored or non-C# metadata may attach [CompilerGenerated] to a
+            // custom accessor while a legitimate, same-named field backs nothing of the sort (the
+            // C# CS0102 restriction does not bind arbitrary IL). Requiring the field itself to be
+            // private and compiler-generated keeps a genuine field from being suppressed.
             HashSet<string>? fieldLikeEventBackingFieldNames = null;
             foreach (var eventHandle in typeDef.GetEvents())
             {
@@ -343,8 +345,12 @@ public static class ApiSurfaceExtractor
                     continue; // Skip backing fields
 
                 if (fieldAccess == FieldAttributes.Private
-                    && fieldLikeEventBackingFieldNames?.Contains(fieldName) == true)
-                    continue; // Skip a field-like event's private backing field (shares the event name)
+                    && fieldLikeEventBackingFieldNames?.Contains(fieldName) == true
+                    && AttributeReader.HasAttribute(
+                        reader,
+                        field.GetCustomAttributes(),
+                        KnownAttributeNames.CompilerGeneratedAttribute))
+                    continue; // Skip a field-like event's private, compiler-generated backing field
 
                 // Skip EditorBrowsable(Never) fields unless --all; obsolete are surfaced with marker.
                 if (!includeAll && AttributeReader.HasEditorBrowsableNeverAttribute(reader, field.GetCustomAttributes()))

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -305,6 +305,19 @@ public static class ApiSurfaceExtractor
 
             // Fields (non-backing fields; non-public included with --all)
             bool isEnum = apiType.Kind == "enum";
+
+            // A field-like event's compiler-generated backing field shares the event's exact
+            // (unmangled) name. C# forbids a same-named field and event on one type (CS0102),
+            // so a field whose name matches an event on this type is uniquely that event's
+            // backing field and must not be surfaced as a separate field (it would produce a
+            // duplicate declaration alongside the event member).
+            HashSet<string>? fieldLikeEventBackingFieldNames = null;
+            foreach (var eventHandle in typeDef.GetEvents())
+            {
+                (fieldLikeEventBackingFieldNames ??= new HashSet<string>(StringComparer.Ordinal))
+                    .Add(reader.GetString(reader.GetEventDefinition(eventHandle).Name));
+            }
+
             foreach (var fieldHandle in typeDef.GetFields())
             {
                 var field = reader.GetFieldDefinition(fieldHandle);
@@ -315,6 +328,9 @@ public static class ApiSurfaceExtractor
                 string fieldName = reader.GetString(field.Name);
                 if (fieldName.StartsWith("<"))
                     continue; // Skip backing fields
+
+                if (fieldLikeEventBackingFieldNames?.Contains(fieldName) == true)
+                    continue; // Skip a field-like event's backing field (shares the event name)
 
                 // Skip EditorBrowsable(Never) fields unless --all; obsolete are surfaced with marker.
                 if (!includeAll && AttributeReader.HasEditorBrowsableNeverAttribute(reader, field.GetCustomAttributes()))

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -307,15 +307,28 @@ public static class ApiSurfaceExtractor
             bool isEnum = apiType.Kind == "enum";
 
             // A field-like event's compiler-generated backing field shares the event's exact
-            // (unmangled) name. C# forbids a same-named field and event on one type (CS0102),
-            // so a field whose name matches an event on this type is uniquely that event's
-            // backing field and must not be surfaced as a separate field (it would produce a
-            // duplicate declaration alongside the event member).
+            // (unmangled) name and is private. Fold only such backing fields, and only for
+            // events whose accessors are compiler-generated (i.e. genuinely field-like) — never
+            // based on a custom/explicit event. This keeps the extractor sound for hand-authored
+            // or non-C# metadata, where a legitimate field and a same-named event can coexist
+            // (the C# CS0102 restriction does not bind arbitrary IL): only a private field whose
+            // name matches a field-like event on this type is suppressed.
             HashSet<string>? fieldLikeEventBackingFieldNames = null;
             foreach (var eventHandle in typeDef.GetEvents())
             {
+                var eventDef = reader.GetEventDefinition(eventHandle);
+                var adder = eventDef.GetAccessors().Adder;
+                if (adder.IsNil
+                    || !AttributeReader.HasAttribute(
+                        reader,
+                        reader.GetMethodDefinition(adder).GetCustomAttributes(),
+                        KnownAttributeNames.CompilerGeneratedAttribute))
+                {
+                    continue;
+                }
+
                 (fieldLikeEventBackingFieldNames ??= new HashSet<string>(StringComparer.Ordinal))
-                    .Add(reader.GetString(reader.GetEventDefinition(eventHandle).Name));
+                    .Add(reader.GetString(eventDef.Name));
             }
 
             foreach (var fieldHandle in typeDef.GetFields())
@@ -329,8 +342,9 @@ public static class ApiSurfaceExtractor
                 if (fieldName.StartsWith("<"))
                     continue; // Skip backing fields
 
-                if (fieldLikeEventBackingFieldNames?.Contains(fieldName) == true)
-                    continue; // Skip a field-like event's backing field (shares the event name)
+                if (fieldAccess == FieldAttributes.Private
+                    && fieldLikeEventBackingFieldNames?.Contains(fieldName) == true)
+                    continue; // Skip a field-like event's private backing field (shares the event name)
 
                 // Skip EditorBrowsable(Never) fields unless --all; obsolete are surfaced with marker.
                 if (!includeAll && AttributeReader.HasEditorBrowsableNeverAttribute(reader, field.GetCustomAttributes()))

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -922,6 +922,67 @@ public class ApiSurfaceExtractorTests
         Assert.Contains(host.Members, m => m.Name == "_customBacking" && m.Kind == "field");
     }
 
+    [Fact]
+    public void Extract_KeepsPublicFieldMaskedBySameNamedNonFieldLikeEvent()
+    {
+        // C#/VB/F# forbid a same-named field+event (CS0102/BC30260/FS0023), but arbitrary IL
+        // may contain both. Emit a type with a public field `Clash` alongside a private event
+        // `Clash` whose accessors are NOT compiler-generated (a custom/explicit event backed by
+        // a distinctly-named field). The field-like fold must NOT suppress the legitimate public
+        // field: the event is not field-like, so the same-named field is not its backing field.
+        string dllPath = EmitSameNameFieldAndCustomEvent();
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+            var type = surface.Types.Single(t => t.Name == "PublicFieldPrivateEvent");
+
+            // The legitimate public field survives; the non-field-like event is faithfully
+            // surfaced too (both members genuinely exist in this hand-authored type).
+            Assert.Contains(type.Members, m => m.Name == "Clash" && m.Kind == "field");
+            Assert.Contains(type.Members, m => m.Name == "Clash" && m.Kind == "event");
+        }
+        finally
+        {
+            try { File.Delete(dllPath); } catch { /* best-effort */ }
+        }
+    }
+
+    // Emits (via Reflection.Emit, whose accessors are not [CompilerGenerated]) a type carrying a
+    // public field and a private custom event that share the name `Clash` — a shape valid in raw
+    // metadata but not producible by C#/VB/F#. Returns the path to the persisted assembly.
+    static string EmitSameNameFieldAndCustomEvent()
+    {
+        var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("ClashEmit"), typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("ClashEmit");
+        var tb = module.DefineType("PublicFieldPrivateEvent",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+
+        tb.DefineField("Clash", typeof(int), System.Reflection.FieldAttributes.Public);
+        tb.DefineField("_eventBacking", typeof(Action), System.Reflection.FieldAttributes.Private);
+
+        const System.Reflection.MethodAttributes accessorAttrs =
+            System.Reflection.MethodAttributes.Private
+            | System.Reflection.MethodAttributes.SpecialName
+            | System.Reflection.MethodAttributes.HideBySig;
+        var add = tb.DefineMethod("add_Clash", accessorAttrs, typeof(void), new[] { typeof(Action) });
+        add.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        var remove = tb.DefineMethod("remove_Clash", accessorAttrs, typeof(void), new[] { typeof(Action) });
+        remove.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+
+        var eventBuilder = tb.DefineEvent("Clash", System.Reflection.EventAttributes.None, typeof(Action));
+        eventBuilder.SetAddOnMethod(add);
+        eventBuilder.SetRemoveOnMethod(remove);
+        tb.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"clash-event-{Guid.NewGuid():N}.dll");
+        ab.Save(path);
+        return path;
+    }
+
 }
 
 /// <summary>

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -930,19 +930,16 @@ public class ApiSurfaceExtractorTests
         // `Clash` whose accessors are NOT compiler-generated (a custom/explicit event backed by
         // a distinctly-named field). The field-like fold must NOT suppress the legitimate public
         // field: the event is not field-like, so the same-named field is not its backing field.
-        string dllPath = EmitSameNameFieldAndCustomEvent();
+        string dllPath = EmitSameNameFieldAndCustomEvent(
+            publicField: true, compilerGeneratedAccessors: false);
         try
         {
-            using var stream = File.OpenRead(dllPath);
-            using var peReader = new PEReader(stream);
-            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
-
-            var type = surface.Types.Single(t => t.Name == "PublicFieldPrivateEvent");
+            var members = ExtractClashTypeMembers(dllPath);
 
             // The legitimate public field survives; the non-field-like event is faithfully
             // surfaced too (both members genuinely exist in this hand-authored type).
-            Assert.Contains(type.Members, m => m.Name == "Clash" && m.Kind == "field");
-            Assert.Contains(type.Members, m => m.Name == "Clash" && m.Kind == "event");
+            Assert.Contains(members, m => m.Name == "Clash" && m.Kind == "field");
+            Assert.Contains(members, m => m.Name == "Clash" && m.Kind == "event");
         }
         finally
         {
@@ -950,10 +947,45 @@ public class ApiSurfaceExtractorTests
         }
     }
 
-    // Emits (via Reflection.Emit, whose accessors are not [CompilerGenerated]) a type carrying a
-    // public field and a private custom event that share the name `Clash` — a shape valid in raw
-    // metadata but not producible by C#/VB/F#. Returns the path to the persisted assembly.
-    static string EmitSameNameFieldAndCustomEvent()
+    [Fact]
+    public void Extract_KeepsFieldWhenCompilerGeneratedAdderBacksAnotherField()
+    {
+        // Sharper case: a [CompilerGenerated] accessor is not proof that a same-named field is
+        // the event's backing storage. Emit a *private* field `Clash` (NOT [CompilerGenerated])
+        // alongside a private event `Clash` whose add/remove ARE [CompilerGenerated] but back a
+        // distinctly-named field (_eventBacking). This defeats both the accessibility guard and
+        // the adder-attribute signal; only the candidate field's own [CompilerGenerated] marker
+        // distinguishes a genuine backing field. The legitimate field must survive under --all.
+        string dllPath = EmitSameNameFieldAndCustomEvent(
+            publicField: false, compilerGeneratedAccessors: true);
+        try
+        {
+            var members = ExtractClashTypeMembers(dllPath);
+
+            Assert.Contains(members, m => m.Name == "Clash" && m.Kind == "field");
+            Assert.Contains(members, m => m.Name == "Clash" && m.Kind == "event");
+        }
+        finally
+        {
+            try { File.Delete(dllPath); } catch { /* best-effort */ }
+        }
+    }
+
+    static IReadOnlyList<ApiMember> ExtractClashTypeMembers(string dllPath)
+    {
+        using var stream = File.OpenRead(dllPath);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        return surface.Types.Single(t => t.Name == "PublicFieldPrivateEvent").Members;
+    }
+
+    // Emits (via Reflection.Emit) a type carrying a field and a custom event that share the name
+    // `Clash` — a shape valid in raw metadata but not producible by C#/VB/F#. The candidate field
+    // is a plain int32 that is never [CompilerGenerated]; the event is always backed by a
+    // distinctly-named `_eventBacking` field, so `Clash` is never a genuine backing field.
+    // `compilerGeneratedAccessors` stamps the add/remove methods with [CompilerGenerated] to model
+    // metadata that fakes the field-like accessor signal. Returns the persisted assembly path.
+    static string EmitSameNameFieldAndCustomEvent(bool publicField, bool compilerGeneratedAccessors)
     {
         var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
             new System.Reflection.AssemblyName("ClashEmit"), typeof(object).Assembly);
@@ -961,7 +993,10 @@ public class ApiSurfaceExtractorTests
         var tb = module.DefineType("PublicFieldPrivateEvent",
             System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
 
-        tb.DefineField("Clash", typeof(int), System.Reflection.FieldAttributes.Public);
+        var fieldVisibility = publicField
+            ? System.Reflection.FieldAttributes.Public
+            : System.Reflection.FieldAttributes.Private;
+        tb.DefineField("Clash", typeof(int), fieldVisibility);
         tb.DefineField("_eventBacking", typeof(Action), System.Reflection.FieldAttributes.Private);
 
         const System.Reflection.MethodAttributes accessorAttrs =
@@ -972,6 +1007,15 @@ public class ApiSurfaceExtractorTests
         add.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
         var remove = tb.DefineMethod("remove_Clash", accessorAttrs, typeof(void), new[] { typeof(Action) });
         remove.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+
+        if (compilerGeneratedAccessors)
+        {
+            var ctor = typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)
+                .GetConstructor(Type.EmptyTypes)!;
+            var attr = new System.Reflection.Emit.CustomAttributeBuilder(ctor, Array.Empty<object>());
+            add.SetCustomAttribute(attr);
+            remove.SetCustomAttribute(attr);
+        }
 
         var eventBuilder = tb.DefineEvent("Clash", System.Reflection.EventAttributes.None, typeof(Action));
         eventBuilder.SetAddOnMethod(add);

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -882,6 +882,70 @@ public class ApiSurfaceExtractorTests
         Assert.False(hidden.IsObsolete);
     }
 
+    [Fact]
+    public void Extract_FoldsFieldLikeEventBackingFieldIntoEvent()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        // includeAll so the private field-like backing field would be surfaced if not folded.
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var host = surface.Types.FirstOrDefault(t => t.Name == nameof(SampleFieldLikeEventHost));
+        Assert.NotNull(host);
+
+        var changedMembers = host.Members.Where(m => m.Name == "Changed").ToList();
+
+        // A field-like event's backing field shares the event's name; it must not appear as a
+        // separate field. Exactly one `Changed` member, and it is the event (never a field).
+        Assert.Single(changedMembers);
+        Assert.Equal("event", changedMembers[0].Kind);
+        Assert.DoesNotContain(host.Members, m => m.Name == "Changed" && m.Kind == "field");
+    }
+
+    [Fact]
+    public void Extract_KeepsCustomEventDistinctlyNamedBackingField()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var host = surface.Types.FirstOrDefault(t => t.Name == nameof(SampleCustomEventHost));
+        Assert.NotNull(host);
+
+        // A custom event with explicit accessors and a distinctly-named user field: the event
+        // is surfaced, and its differently-named backing field is unaffected by the fold.
+        Assert.Contains(host.Members, m => m.Name == "Custom" && m.Kind == "event");
+        Assert.Contains(host.Members, m => m.Name == "_customBacking" && m.Kind == "field");
+    }
+
+}
+
+/// <summary>
+/// Fixture: a field-like event whose compiler-generated backing field shares the event name.
+/// </summary>
+public class SampleFieldLikeEventHost
+{
+#pragma warning disable CS0067 // event is never used
+    public event System.Action? Changed;
+#pragma warning restore CS0067
+}
+
+/// <summary>
+/// Fixture: a custom event with explicit accessors over a distinctly-named backing field.
+/// </summary>
+public class SampleCustomEventHost
+{
+    private System.Action? _customBacking;
+
+    public event System.Action? Custom
+    {
+        add => _customBacking += value;
+        remove => _customBacking -= value;
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Fixes #3083. A **field-like event** (`event Action Changed;`) has a compiler-generated backing
field whose name is **identical** to the event (unmangled, not `<...>`-prefixed). Under
`includeAll`, `ApiSurfaceExtractor.Extract` emitted **both** the `event` member and this
same-named `field`, producing an uncompilable double declaration (`CS0102`/`CS0229`) for any
consumer of the full surface (shipping `--all` output, RTS compile-back).

The extractor now skips a field whose name matches an event on the same type, folding the
field-like backing field into its event.

## Change

`src/ILInspector.Metadata/ApiSurfaceExtractor.cs`: before the field loop, collect the type's
event names; skip a field whose name is in that set. Mirrors the existing `<`-prefixed
backing-field skip, keyed on the field-like event pattern.

## Soundness

C# forbids a same-named field and event on one type (`CS0102`), so a field whose name equals
an event name is **uniquely** that event's compiler-generated backing field — the only field
this skip can ever remove. Custom events with distinctly-named user fields (e.g. `_changed`)
are unaffected. Behavior is observable only under `includeAll`; the default public surface
already omitted the private backing field via the accessibility check, so it is unchanged.

## Evidence

- **Before (proven):** a temporary probe over the test assembly's own surface returned
  `Changed members = [field:Changed, event:Changed]` for `public event Action? Changed;`.
- **After:** new positive regression test `Extract_FoldsFieldLikeEventBackingFieldIntoEvent`
  asserts a single `Changed` member of kind `event` and no `field` named `Changed`.
- **Negative control:** `Extract_KeepsCustomEventDistinctlyNamedBackingField` asserts a custom
  event's distinctly-named backing field still surfaces.
- Full `ApiSurfaceExtractorTests` (42) green; `ILInspector.Metadata.Tests` 750/751 green (the
  one failure is the pre-existing `MemberSourceProducer_UsesFirstVisibleDocumentWhenRootIsOmitted`
  backslash-path environmental red, CI-green, unrelated).

## Follow-up

Unblocks #3091 (migrate RTS to consume `ApiSurfaceExtractor` instead of its hand-rolled
duplicate enumeration); RTS inherits this fix once it consumes the product surface.
