### PR TITLE
Escape keyword namespace segments in hoisted usings (#3090)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
@@ -204,6 +204,23 @@ public sealed class MemberBodyProducerMemberRenderTests
         Assert.Contains(expectedFullPath, rendered.Text);
         Assert.DoesNotContain(corruptedForm, rendered.Text);
     }
+
+    [Fact]
+    public void Project_EscapesKeywordSegmentsInHoistedUsings()
+    {
+        var type = Specimen();
+        var listing = MemberBodyProducer.Project(type, AssemblyPath, pdbPath: null).Output;
+        Assert.NotNull(listing);
+
+        // A non-shadowed reference to a type in a keyword-segment namespace is
+        // shortened to the simple name, harvesting the namespace into a hoisted
+        // using. Metadata namespaces carry no escape, so a keyword segment must
+        // be @-escaped in the emitted directive or it is invalid C# (#3090).
+        Assert.Contains("using System.@event.Models;", listing);
+        Assert.Contains("using @event.Models;", listing);
+        Assert.DoesNotContain("using System.event.Models;", listing);
+        Assert.DoesNotContain("using event.Models;", listing);
+    }
 }
 
 #pragma warning disable CA1822 // members are instance to exercise real signatures
@@ -266,5 +283,19 @@ public sealed class MemberRenderSpecimen
     // declined, not corrupted to global::System.@TypeNameShadow (CS0234).
     public static int SystemEscapedAliasQualifiedShadow(int SystemNameShadow)
         => System.@event.Models.SystemNameShadow.M(SystemNameShadow);
+
+    // A non-shadowed reference to a type in the keyword-segment namespace
+    // System.@event.Models: the printer emits it plain (no global::) and the
+    // shortener shortens it to the simple name, harvesting the namespace into a
+    // hoisted using. The metadata namespace carries no escape, so the emitted
+    // directive must be @-escaped (using System.@event.Models;) or it is invalid
+    // C# (#3090).
+    public static int SystemEscapedPlain(int n)
+        => System.@event.Models.SystemNameShadow.M(n);
+
+    // Same, for a top-level keyword-segment namespace @event.Models — the
+    // hoisted directive must be @-escaped (using @event.Models;) (#3090).
+    public static int EscapedPlain(int n)
+        => @event.Models.TypeNameShadow.M(n);
 }
 #pragma warning restore CA1822

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1511,8 +1511,12 @@ public static class MemberBodyProducer
         if (usings.Count == 0)
             return result;
 
-        // dotnet/runtime style: using directives precede the namespace.
-        string directives = string.Join('\n', usings.Select(ns => $"using {ns};"));
+        // dotnet/runtime style: using directives precede the namespace. The
+        // harvested namespaces are raw metadata strings with no keyword escapes,
+        // so a segment that is a C# keyword (e.g. "event" in System.event.Models)
+        // must be @-escaped or the directive is invalid C# — the same escape the
+        // sibling CSharpTypePrinter applies to its own usings.
+        string directives = string.Join('\n', usings.Select(ns => $"using {CSharpFormatter.EscapeNamespace(ns)};"));
         return $"{directives}\n\n{result}";
     }
 


### PR DESCRIPTION
Fixes #3090.

## Problem

`MemberBodyProducer.HoistUsings` emitted harvested namespaces verbatim (`using {ns};`). Namespaces enter as **raw metadata strings** (`reader.GetString(td.Namespace)`) with no source-level `@` escape, so a namespace whose segment is a C# keyword produced an **invalid directive**:

```csharp
using System.event.Models;   // CS1041: identifier expected; 'event' is a keyword
```

## Fix

Route the emission through `CSharpFormatter.EscapeNamespace` — the idempotent, layer-owned namespace escaper the sibling `CSharpTypePrinter` already applies to its own usings (CSharpTypePrinter.cs:122). Keyword segments now render `@`-escaped:

```csharp
using System.@event.Models;  // valid
```

The escaper splits on `.`, escapes each segment in declaration position, and skips segments already `@`-prefixed (idempotent). For all real assemblies the output is byte-identical: no shipping namespace has a keyword segment.

## Evidence

- New regression test `MemberBodyProducerMemberRenderTests.Project_EscapesKeywordSegmentsInHoistedUsings` renders the whole type via `MemberBodyProducer.Project` and asserts the hoisted directives are `using System.@event.Models;` / `using @event.Models;` (valid), not the unescaped forms. **Confirmed the test fails on the pre-fix emission** (`using System.event.Models;` not found) and passes with the fix.
- Two new non-shadowed specimen methods (`SystemEscapedPlain`, `EscapedPlain`) reference `System.@event.Models` / `@event.Models` types so the namespaces are actually harvested + hoisted (the existing alias-qualified fixtures decline shortening, so they never harvest).
- `MemberBodyProducerMemberRenderTests`: 13/13 pass (includes the byte-identical whole-type/per-member gate).
- Fast RoundTrip area: only the 31 pre-existing environmental `ReturnToSenderSourceProbe_*` compile-back reds (CS0009 native-DLL on this Windows machine, CI-green); identical baseline vs head, none related to this change.

## Risk / review

Low risk, mechanical: a single call site rerouted to an established idempotent escaper, output-identical for every shipping assembly (keyword-segment namespaces do not ship). No adversarial review needed under the AGENTS.md simple/mechanical exemption.
