### PR TITLE
Route enum-shift sibling/arm consumers through rendered integer type (#3087)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5213,6 +5213,41 @@ public static class EnumCastSamples
 
     public static void EnumShiftStoreArray(CfgPriority[] arr, int n) => arr[0] = (CfgPriority)((int)arr[0] >> n);
 
+    // #3087 defect 1: a bitwise op whose sibling is itself an ENUM value. The shift
+    // renders as its underlying integer, so the enum sibling must be coerced to that
+    // integer — `(int)e << n | (int)other`, not `(int)e << n | other` (int | E,
+    // CS0019). The stale enum ResultType makes the sibling render bare.
+    public static CfgPriority EnumShiftOrEnumSibling(CfgPriority e, int n, CfgPriority other) => (CfgPriority)(((int)e << n) | (int)other);
+
+    // #3087 defect 2: an enum shift COMPARED to an enum-constant sibling. The shift
+    // renders as int, so the comparison must be integer-vs-integer — the stale enum
+    // ResultType instead coerces the sibling to the enum (`(int)e << n == E.High`,
+    // int == E, CS0019).
+    public static bool EnumShiftCompareEnumConst(CfgPriority e, int n) => ((int)e << n) == (int)CfgPriority.High;
+
+    // #3087 defect 3: an enum shift as a ternary arm flowing into an ENUM target.
+    // The shift's ResultType matches the target enum, so the `(CfgPriority)` cast is
+    // dropped and the arm renders `(int)e << n` (int) while the other arm is the
+    // enum — no common type (CS1503/CS0173). The cast must be kept. A method-argument
+    // ternary stays a genuine conditional (it cannot be raised to if/return).
+    public static void TakeCfgPriority(CfgPriority value) { }
+
+    public static void EnumShiftTernaryToEnum(bool b, CfgPriority e, int n) => TakeCfgPriority(b ? (CfgPriority)((int)e << n) : CfgPriority.High);
+
+    // #3087 negatives/edges. Mixed-sign: an UNSIGNED enum shift (`shr.un`) rendering
+    // as uint whose enum sibling must be coerced to that width/sign — `(uint)other`,
+    // not `(int)other` (which would be a mixed-sign bitwise op, CS0019).
+    public static uint EnumShiftUnsignedOrEnumSibling(CfgPriority e, int n, CfgPriority other) => ((uint)e >> n) | (uint)other;
+
+    // A comparison whose enum sibling is a RUNTIME value (not a constant): coerced
+    // down to the shift's rendered integer — `(int)e << n == (int)other`.
+    public static bool EnumShiftCompareEnumValue(CfgPriority e, int n, CfgPriority other) => ((int)e << n) == (int)other;
+
+    // A bitwise CHAIN over an enum shift with an enum FAR sibling: the down-coercion
+    // recurses so the enum sibling at the end of `shift | y | other` renders as its
+    // underlying integer — `(int)e << 4 | y | (int)other`.
+    public static int EnumShiftChainEnumSibling(CfgPriority e, int y, CfgPriority other) => ((int)e << 4) | y | (int)other;
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5295,6 +5295,28 @@ public static class EnumCastSamples
     // (a plain `(int)CfgFlags.Top` is CS0221).
     public static bool EnumShiftCompareOverflowConst(CfgFlags e, int n) => ((int)e << n) == unchecked((int)CfgFlags.Top);
 
+    // #3087 follow-up (adversarial review R4, GPT + Gemini): EQUALITY against a
+    // plain `uint` sibling. Equality is bit-exact, so it reconciles to the shift's
+    // SIGNED stack width — `((int)e << n) == (int)x`. The stale-ResultType
+    // fallthrough dropped the sibling cast (`== x`), and `int == uint` widens to a
+    // signed 64-bit `ceq` in C# — with `e = (CfgPriority)(-1)`, `x = 0xFFFFFFFF` the
+    // IL 32-bit `ceq` is TRUE but `-1L == 4294967295L` is FALSE.
+    public static bool EnumShiftEqualsUintSibling(CfgPriority e, int n, uint x) => (uint)((int)e << n) == x;
+
+    // #3087 follow-up (adversarial review R4, GPT + Gemini): SIGNED ordering with a
+    // plain integer sibling reconciles to the shift's signed stack width —
+    // `((int)e << n) < other` (identity when the sibling already is `int`), never a
+    // sign-widened `int < uint` promotion.
+    public static bool EnumShiftSignedLessIntSibling(CfgPriority e, int n, int other) => ((int)e << n) < other;
+
+    // #3087 follow-up (adversarial review R4, GPT): a SIGNED ordering after an
+    // UNSIGNED shift (`shr.un` renders `uint`). The target is driven by the
+    // comparison (signed), not the shift's rendered sign, so the shift is
+    // reinterpreted back to `int` — `(int)((uint)e >> n) < (int)other`. Coercing to
+    // the shift's `uint` instead would emit an unsigned compare `((uint)e >> n) <
+    // (uint)other`, silently changing the ordering.
+    public static bool EnumShiftUnsignedShrSignedCompare(CfgPriority e, int n, CfgPriority other) => (int)((uint)e >> n) < (int)other;
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5256,11 +5256,32 @@ public static class EnumCastSamples
     // `(uint)((int)e << n) < (uint)other`, matching `clt.un` for any backing.
     public static bool EnumShiftUnsignedCompare(CfgFlags e, int n, CfgFlags other) => (uint)((uint)e << n) < (uint)other;
 
-    // #3087 follow-up: the same unsigned ordering with a BYTE-backed enum. Round-
+    // #3087 follow-up: the same unsigned ordering with a byte-backed enum. Round-
     // tripping through the byte enum (`(CfgTiny)((int)e << n)`) would re-narrow the
     // 32-bit shift to 8 bits and then compare signed — the unsigned-width spelling
     // `(uint)((int)e << n) < (uint)other` avoids both.
     public static bool EnumShiftUnsignedCompareByte(CfgTiny e, int n, CfgTiny other) => (uint)((byte)e << n) < (uint)other;
+
+    // #3087 follow-up (adversarial review R3, GPT): the unsigned ordering with a
+    // PLAIN INTEGER sibling (not an enum). The shift still needs the unsigned
+    // reinterpret so the compare is `clt.un` — `(uint)((int)e << n) < (uint)other` —
+    // not the sign-widened `((int)e << n) < (uint)other` (`int < uint` promotes to a
+    // signed `long` compare) the stale-ResultType fallthrough produced.
+    public static bool EnumShiftUnsignedCompareIntSibling(CfgPriority e, int n, int other) => (uint)((int)e << n) < (uint)other;
+
+    // #3087 follow-up (adversarial review R3, GPT): the 8-byte case with a plain
+    // `long` sibling. The fallthrough rendered `((long)e << n) < (ulong)other`
+    // (`long < ulong`, CS0034 — did not compile); both sides must reconcile to
+    // `ulong` — `(ulong)((long)e << n) < (ulong)other`.
+    public static bool EnumShiftUnsignedCompareLongSibling(CfgLongPriority e, int n, long other) => (ulong)((long)e << n) < (ulong)other;
+
+    // #3087 follow-up (adversarial review R3, Gemini): a bitwise chain mixing an
+    // enum shift with a NARROW (ushort) integer, compared unsigned. IL promotes the
+    // short to Int32, so the chain's stack type is wide; treating it as narrow made
+    // BitwiseChainRenderedType fall back to the stale enum ResultType and drop the
+    // unsigned reinterpret — `((int)e << n | mask) < other` (CS0019 / signed). The
+    // chain must reconcile to `(uint)((int)e << n | mask) < (uint)other`.
+    public static bool EnumShiftNarrowChainUnsignedCompare(CfgTiny e, int n, ushort mask, CfgTiny other) => (uint)(((int)e << n) | mask) < (uint)other;
 
     // #3087 follow-up: a bitwise sibling MASKED as its primitive by a typed ldelem —
     // `values[i]` renders enum-typed though its ResultType is the storage width, so

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5249,11 +5249,18 @@ public static class EnumCastSamples
     public static int EnumShiftChainEnumSibling(CfgPriority e, int y, CfgPriority other) => ((int)e << 4) | y | (int)other;
 
     // #3087 follow-up (adversarial review): an UNSIGNED ordering (`clt.un`) of an
-    // enum shift against an enum sibling. Down-coercing both to the shift's SIGNED
-    // rendered integer would silently turn the unsigned compare into a signed `<`;
-    // instead the shift up-coerces to the uint-backed enum so C#'s enum `<` compares
-    // the underlying uint — `(CfgFlags)((int)e << n) < other`, matching `clt.un`.
+    // enum shift against an enum sibling. The compare cannot round-trip through the
+    // enum backing — a signed backing would compare signed and a narrow backing
+    // would truncate the widened shift value — so BOTH sides reconcile to the
+    // unsigned counterpart of the shift's stack width:
+    // `(uint)((int)e << n) < (uint)other`, matching `clt.un` for any backing.
     public static bool EnumShiftUnsignedCompare(CfgFlags e, int n, CfgFlags other) => (uint)((uint)e << n) < (uint)other;
+
+    // #3087 follow-up: the same unsigned ordering with a BYTE-backed enum. Round-
+    // tripping through the byte enum (`(CfgTiny)((int)e << n)`) would re-narrow the
+    // 32-bit shift to 8 bits and then compare signed — the unsigned-width spelling
+    // `(uint)((int)e << n) < (uint)other` avoids both.
+    public static bool EnumShiftUnsignedCompareByte(CfgTiny e, int n, CfgTiny other) => (uint)((byte)e << n) < (uint)other;
 
     // #3087 follow-up: a bitwise sibling MASKED as its primitive by a typed ldelem —
     // `values[i]` renders enum-typed though its ResultType is the storage width, so

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5248,6 +5248,25 @@ public static class EnumCastSamples
     // underlying integer — `(int)e << 4 | y | (int)other`.
     public static int EnumShiftChainEnumSibling(CfgPriority e, int y, CfgPriority other) => ((int)e << 4) | y | (int)other;
 
+    // #3087 follow-up (adversarial review): an UNSIGNED ordering (`clt.un`) of an
+    // enum shift against an enum sibling. Down-coercing both to the shift's SIGNED
+    // rendered integer would silently turn the unsigned compare into a signed `<`;
+    // instead the shift up-coerces to the uint-backed enum so C#'s enum `<` compares
+    // the underlying uint — `(CfgFlags)((int)e << n) < other`, matching `clt.un`.
+    public static bool EnumShiftUnsignedCompare(CfgFlags e, int n, CfgFlags other) => (uint)((uint)e << n) < (uint)other;
+
+    // #3087 follow-up: a bitwise sibling MASKED as its primitive by a typed ldelem —
+    // `values[i]` renders enum-typed though its ResultType is the storage width, so
+    // it must still be down-coerced — `(int)e << n | (int)values[i]`, not
+    // `| values[i]` (int | E, CS0019).
+    public static CfgPriority EnumShiftOrArraySibling(CfgPriority e, int n, CfgPriority[] values, int i) => (CfgPriority)(((int)e << n) | (int)values[i]);
+
+    // #3087 follow-up: an enum-CONSTANT sibling whose unsigned-backed value overflows
+    // the shift's signed rendered integer (CfgFlags.Top = 0x80000000u > int.MaxValue):
+    // the down-coercion needs `unchecked` — `(int)e << n == unchecked((int)CfgFlags.Top)`
+    // (a plain `(int)CfgFlags.Top` is CS0221).
+    public static bool EnumShiftCompareOverflowConst(CfgFlags e, int n) => ((int)e << n) == unchecked((int)CfgFlags.Top);
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5317,6 +5317,27 @@ public static class EnumCastSamples
     // (uint)other`, silently changing the ordering.
     public static bool EnumShiftUnsignedShrSignedCompare(CfgPriority e, int n, CfgPriority other) => (int)((uint)e >> n) < (int)other;
 
+    // #3087 follow-up (adversarial review R5, GPT): the reconcile cast the printer
+    // INSERTS to reinterpret the shift is not in the IL, so under an enclosing
+    // `checked` region a signed->unsigned reinterpret (`(uint)(-1)`) would THROW
+    // though the IL (`shl; clt.un`) only reinterprets bits. The inserted cast must be
+    // `unchecked`-wrapped — `checked((unchecked((uint)((int)e << n)) < other ...))` —
+    // exactly as the enum and plain-integer reconcile paths already are.
+    public static int EnumShiftCheckedUnsignedCompare(CfgPriority e, int n, uint other, int y)
+        => checked((unchecked((uint)((int)e << n)) < unchecked((uint)other) ? 1 : 0) + y);
+
+    // #3087 follow-up (adversarial review R5, Gemini): a bitwise chain mixing an
+    // int enum-shift with an UNSIGNED-backed enum sibling (CfgFlags : uint),
+    // compared unsigned. BinaryBody coerces the enum sibling DOWN to the shift's
+    // signed stack type (`(int)x`), so the chain renders as `int`; the outer
+    // unsigned comparison must therefore keep the `(uint)` reinterpret —
+    // `(uint)((int)e << n | (int)x) > other`. Reporting the chain as `uint` (because
+    // a uint-backed sibling is present) would drop that cast, silently promoting
+    // `int > uint` to a signed 64-bit compare (inverting results for high-bit
+    // patterns) or emitting CS0034 at 8-byte width.
+    public static bool EnumShiftChainUintEnumSiblingCompare(CfgPriority e, int n, CfgFlags x, uint other)
+        => (uint)(((int)e << n) | (int)x) > other;
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -449,6 +449,51 @@ public class EnumCastPrinterTests
         AssertCompiles("public static bool M(CfgTiny e, int n, CfgTiny other)", body, "public enum CfgTiny : byte { A = 1, B = 2 }");
     }
 
+    // #3087 follow-up (adversarial review R3, GPT): the unsigned ordering with a
+    // PLAIN INTEGER sibling. The shift still needs the unsigned reinterpret so the
+    // compare is `clt.un` — `(uint)((int)e << n) < (uint)other` — not the sign-
+    // widened `((int)e << n) < (uint)other` (`int < uint` promotes to a signed
+    // `long`) the stale-enum-ResultType fallthrough produced.
+    [Fact]
+    public void EnumShiftUnsignedOrdering_PlainIntSibling_ReinterpretsBothUnsigned()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftUnsignedCompareIntSibling));
+
+        Assert.Contains("(uint)((int)e << n)", body);
+        Assert.Contains("< (uint)other", body);
+        AssertCompiles("public static bool M(CfgPriority e, int n, int other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 follow-up (adversarial review R3, GPT): the 8-byte unsigned ordering
+    // with a plain `long` sibling. The fallthrough rendered `((long)e << n) <
+    // (ulong)other` (`long < ulong`, CS0034 — did not compile); both sides must
+    // reconcile to `ulong`.
+    [Fact]
+    public void EnumShiftUnsignedOrdering_PlainLongSibling_ReinterpretsBothUnsigned()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftUnsignedCompareLongSibling));
+
+        Assert.Contains("(ulong)((long)e << n)", body);
+        Assert.Contains("< (ulong)other", body);
+        AssertCompiles("public static bool M(CfgLongPriority e, int n, long other)", body, "public enum CfgLongPriority : long { Low = 0, High = 2 }");
+    }
+
+    // #3087 follow-up (adversarial review R3, Gemini): a bitwise chain mixing an
+    // enum shift with a NARROW (ushort) integer, compared unsigned. IL promotes the
+    // short to Int32, so the chain is wide; the printer must reconcile both sides to
+    // `uint` — `(uint)((int)e << n | mask) < (uint)other` — not drop the casts
+    // (`((int)e << n | mask) < other`, CS0019 / silent signed compare).
+    [Fact]
+    public void EnumShiftUnsignedOrdering_NarrowBitwiseChain_ReinterpretsBothUnsigned()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftNarrowChainUnsignedCompare));
+
+        Assert.Contains("(uint)((int)e << n | mask)", body);
+        Assert.Contains("< (uint)other", body);
+        Assert.DoesNotContain("(CfgTiny)", body);
+        AssertCompiles("public static bool M(CfgTiny e, int n, ushort mask, CfgTiny other)", body, "public enum CfgTiny : byte { A = 1, B = 2 }");
+    }
+
     // #3087 follow-up (adversarial review, GPT): a bitwise sibling MASKED as its
     // primitive by a typed ldelem — `values[i]` renders enum-typed though its
     // ResultType is the storage width, so it must still be coerced DOWN —

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -521,6 +521,49 @@ public class EnumCastPrinterTests
         AssertCompiles("public static bool M(CfgFlags e, int n)", body, "public enum CfgFlags : uint { None = 0, Top = 0x80000000u }");
     }
 
+    // #3087 follow-up (adversarial review R4, GPT + Gemini): EQUALITY against a
+    // plain `uint` sibling reconciles to the shift's SIGNED stack width —
+    // `((int)e << n) == (int)x`. The stale-ResultType fallthrough dropped the cast
+    // (`== x`); `int == uint` widens to a signed 64-bit `ceq` in C#, so with
+    // `e = (CfgPriority)(-1)`, `x = 0xFFFFFFFF` the IL 32-bit `ceq` is TRUE but
+    // `-1L == 4294967295L` is FALSE — a silent behavior change.
+    [Fact]
+    public void EnumShiftEquality_PlainUintSibling_ReconcilesToSignedWidth()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftEqualsUintSibling));
+
+        Assert.Contains("((int)e << n) == (int)x", body);
+        Assert.DoesNotContain("(uint)", body);
+        AssertCompiles("public static bool M(CfgPriority e, int n, uint x)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 follow-up (adversarial review R4, GPT + Gemini): SIGNED ordering with a
+    // plain `int` sibling reconciles to the shift's signed stack width; the sibling
+    // is already `int`, so it stays bare — `((int)e << n) < other`, no promotion.
+    [Fact]
+    public void EnumShiftSignedOrdering_PlainIntSibling_StaysSigned()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftSignedLessIntSibling));
+
+        Assert.Contains("((int)e << n) < other", body);
+        Assert.DoesNotContain("(uint)", body);
+        AssertCompiles("public static bool M(CfgPriority e, int n, int other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 follow-up (adversarial review R4, GPT): a SIGNED ordering after an
+    // UNSIGNED shift (`shr.un` renders `uint`). The target follows the COMPARISON
+    // (signed), not the shift's rendered sign, so the shift is reinterpreted back to
+    // `int` — `(int)((uint)e >> n) < (int)other`. Coercing to the shift's `uint`
+    // instead would emit an unsigned compare, silently flipping the ordering.
+    [Fact]
+    public void EnumShiftUnsignedShr_SignedOrdering_ReinterpretsToSignedWidth()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftUnsignedShrSignedCompare));
+
+        Assert.Contains("(int)((uint)e >> n) < (int)other", body);
+        AssertCompiles("public static bool M(CfgPriority e, int n, CfgPriority other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
     // A sub-int (byte) backing promotes to int in a C# shift; the reinterpret
     // targets the 4-byte width the shift runs on. Synthetic to keep the enum load
     // a bare operand (a compiled `(byte)` narrowing could add a conv node).

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -564,6 +564,41 @@ public class EnumCastPrinterTests
         AssertCompiles("public static bool M(CfgPriority e, int n, CfgPriority other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
+    // #3087 follow-up (adversarial review R5, GPT): the reconcile cast the printer
+    // INSERTS is not in the IL (`shl; clt.un`), so under an enclosing `checked`
+    // region the signed->unsigned reinterpret must be `unchecked`-wrapped or it
+    // throws OverflowException on a negative shift value (`(uint)(-1)`), where the
+    // IL only reinterprets bits. Both reconcile paths (this shift side and the enum/
+    // plain-integer sides) route through CheckedSafeCast.
+    [Fact]
+    public void EnumShiftComparison_InCheckedContext_WrapsInsertedCastUnchecked()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftCheckedUnsignedCompare));
+
+        Assert.Contains("checked(", body);
+        Assert.Contains("unchecked((uint)((int)e << n))", body);
+        AssertCompiles("public static int M(CfgPriority e, int n, uint other, int y)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 follow-up (adversarial review R5, Gemini): a bitwise chain mixing an int
+    // enum-shift with an UNSIGNED-backed enum sibling, compared unsigned. The enum
+    // sibling is coerced DOWN to the shift's signed stack type (`(int)x`), so the
+    // chain is `int` and the outer unsigned comparison must keep the `(uint)`
+    // reinterpret. Reporting the chain as `uint` would drop it — a silent signed
+    // 64-bit promotion (or CS0034 at 8-byte width).
+    [Fact]
+    public void EnumShiftChain_UintEnumSibling_UnsignedCompare_KeepsOuterReinterpret()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftChainUintEnumSiblingCompare));
+
+        Assert.Contains("(uint)(((int)e << n) | (int)x) > other", body);
+        Assert.DoesNotContain("(CfgFlags)", body);
+        AssertCompiles(
+            "public static bool M(CfgPriority e, int n, CfgFlags x, uint other)",
+            body,
+            "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 } public enum CfgFlags : uint { None = 0, Top = 0x80000000u }");
+    }
+
     // A sub-int (byte) backing promotes to int in a C# shift; the reinterpret
     // targets the 4-byte width the shift runs on. Synthetic to keep the enum load
     // a bare operand (a compiled `(byte)` narrowing could add a conv node).

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -416,20 +416,37 @@ public class EnumCastPrinterTests
         AssertCompiles("public static int M(CfgPriority e, int y, CfgPriority other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
-    // #3087 follow-up (adversarial review, GPT): an UNSIGNED ordering (`clt.un`) of
-    // an enum shift against an enum sibling. Down-coercing both to the shift's SIGNED
-    // rendered integer would silently render a signed `<` — flipping high-bit values.
-    // The sign-safe guard skips the down-coercion for unsigned ordering, so the shift
-    // up-coerces to the uint-backed enum and C#'s enum `<` compares the underlying
-    // uint, matching `clt.un`. The rendered `<` must NOT be a bare signed int compare.
+    // #3087 follow-up (adversarial review, GPT + Gemini): an UNSIGNED ordering
+    // (`clt.un`) of an enum shift against an enum sibling. The compare cannot round-
+    // trip through the enum backing: down-coercing to the shift's SIGNED rendered
+    // integer renders a signed `<`, and up-coercing to a narrow enum backing
+    // truncates the widened shift value. Both sides reconcile to the unsigned stack-
+    // width integer — `(uint)((int)e << n) < (uint)other` — matching `clt.un`.
     [Fact]
     public void EnumShiftUnsignedOrdering_ComparesAsUnsignedEnum()
     {
         string body = RenderFixture(nameof(EnumCastSamples.EnumShiftUnsignedCompare));
 
-        Assert.Contains("(CfgFlags)((int)e << n) < other", body);
-        Assert.DoesNotContain("(int)other", body);
+        Assert.Contains("(uint)((int)e << n)", body);
+        Assert.Contains("< (uint)other", body);
+        Assert.DoesNotContain("(CfgFlags)", body);
         AssertCompiles("public static bool M(CfgFlags e, int n, CfgFlags other)", body, "public enum CfgFlags : uint { None = 0, Top = 0x80000000u }");
+    }
+
+    // #3087 follow-up (adversarial review, GPT + Gemini): the same unsigned ordering
+    // with a BYTE-backed enum. Up-coercing to the byte enum (`(CfgTiny)((int)e << n)`)
+    // would re-narrow the 32-bit shift to 8 bits and then compare signed — a
+    // soundness bug (`0x100 < y` becomes `0 < y`). The unsigned-width spelling
+    // `(uint)((int)e << n) < (uint)other` must be emitted instead.
+    [Fact]
+    public void EnumShiftUnsignedOrdering_ByteBacked_ComparesAsUnsignedWidth()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftUnsignedCompareByte));
+
+        Assert.Contains("(uint)((int)e << n)", body);
+        Assert.Contains("< (uint)other", body);
+        Assert.DoesNotContain("(CfgTiny)", body);
+        AssertCompiles("public static bool M(CfgTiny e, int n, CfgTiny other)", body, "public enum CfgTiny : byte { A = 1, B = 2 }");
     }
 
     // #3087 follow-up (adversarial review, GPT): a bitwise sibling MASKED as its

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -330,6 +330,92 @@ public class EnumCastPrinterTests
         AssertCompiles("public static void M(CfgPriority[] arr, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
+    // #3087 defect 1: a bitwise op whose sibling is itself an ENUM value. The shift
+    // renders as its underlying integer, so the enum sibling must be coerced DOWN to
+    // that integer — `(int)e << n | (int)other`, never `(int)e << n | other` (int |
+    // E, CS0019). The outer `(CfgPriority)` cast the chain flows into is kept too.
+    [Fact]
+    public void EnumShiftInBitwiseOr_EnumSibling_CoercesSiblingToInteger()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftOrEnumSibling));
+
+        Assert.Contains("(CfgPriority)(((int)e << n) | (int)other)", body);
+        Assert.DoesNotContain("<< n) | other", body);
+        AssertCompiles("public static CfgPriority M(CfgPriority e, int n, CfgPriority other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 defect 2: an enum shift COMPARED to an enum-constant sibling. The shift
+    // renders as int, so the sibling is coerced DOWN — `(int)e << n == (int)E.High`,
+    // never `int == E` (CS0019). The shift's stale enum ResultType must not coerce
+    // the sibling up to the enum.
+    [Fact]
+    public void EnumShiftComparedToEnumConstant_CoercesSiblingToInteger()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftCompareEnumConst));
+
+        Assert.Contains("((int)e << n) == (int)CfgPriority.High", body);
+        Assert.DoesNotContain("== CfgPriority.High", body);
+        AssertCompiles("public static bool M(CfgPriority e, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 defect 3: an enum shift as a ternary arm flowing into an ENUM target (a
+    // method argument, which stays a genuine conditional). The arm's stale enum
+    // ResultType matches the target, so the `(CfgPriority)` cast is dropped and the
+    // arm renders `(int)e << n` (int) against the enum arm — CS1503. The cast is
+    // kept: `b ? (CfgPriority)((int)e << n) : CfgPriority.High`.
+    [Fact]
+    public void EnumShiftAsConditionalArmToEnum_KeepsEnumCast()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftTernaryToEnum));
+
+        Assert.Contains("b ? (CfgPriority)((int)e << n) : CfgPriority.High", body);
+        Assert.DoesNotContain("b ? ((int)e << n) :", body);
+        AssertCompiles(
+            "public static void M(bool b, CfgPriority e, int n)",
+            "static void TakeCfgPriority(CfgPriority value) { }\n" + body,
+            "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 mixed-sign edge: an UNSIGNED enum shift (`shr.un`) renders as uint, so
+    // its enum sibling is coerced to that width and sign — `(uint)other`, never
+    // `(int)other` (a mixed-sign bitwise op, CS0019).
+    [Fact]
+    public void EnumUnsignedShiftInBitwiseOr_EnumSibling_CoercesSiblingToUnsigned()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftUnsignedOrEnumSibling));
+
+        Assert.Contains("((uint)e >> n) | (uint)other", body);
+        Assert.DoesNotContain(">> n) | other", body);
+        Assert.DoesNotContain("(int)other", body);
+        AssertCompiles("public static uint M(CfgPriority e, int n, CfgPriority other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 defect 2 edge: the enum sibling of a comparison is a RUNTIME value (not a
+    // constant) — still coerced down to the shift's rendered integer.
+    [Fact]
+    public void EnumShiftComparedToEnumValue_CoercesSiblingToInteger()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftCompareEnumValue));
+
+        Assert.Contains("((int)e << n) == (int)other", body);
+        Assert.DoesNotContain("== other", body);
+        AssertCompiles("public static bool M(CfgPriority e, int n, CfgPriority other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 defect 1 edge: an enum FAR sibling in a bitwise CHAIN over a shift — the
+    // down-coercion recurses through the chain so the trailing enum renders as its
+    // underlying integer (`(int)e << 4 | y | (int)other`).
+    [Fact]
+    public void EnumShiftChainWithEnumFarSibling_CoercesSiblingToInteger()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftChainEnumSibling));
+
+        Assert.Contains("(int)e << 4 | y", body);
+        Assert.Contains("| (int)other", body);
+        Assert.DoesNotContain("y | other", body);
+        AssertCompiles("public static int M(CfgPriority e, int y, CfgPriority other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
     // A sub-int (byte) backing promotes to int in a C# shift; the reinterpret
     // targets the 4-byte width the shift runs on. Synthetic to keep the enum load
     // a bare operand (a compiled `(byte)` narrowing could add a conv node).

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -416,6 +416,49 @@ public class EnumCastPrinterTests
         AssertCompiles("public static int M(CfgPriority e, int y, CfgPriority other)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
+    // #3087 follow-up (adversarial review, GPT): an UNSIGNED ordering (`clt.un`) of
+    // an enum shift against an enum sibling. Down-coercing both to the shift's SIGNED
+    // rendered integer would silently render a signed `<` — flipping high-bit values.
+    // The sign-safe guard skips the down-coercion for unsigned ordering, so the shift
+    // up-coerces to the uint-backed enum and C#'s enum `<` compares the underlying
+    // uint, matching `clt.un`. The rendered `<` must NOT be a bare signed int compare.
+    [Fact]
+    public void EnumShiftUnsignedOrdering_ComparesAsUnsignedEnum()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftUnsignedCompare));
+
+        Assert.Contains("(CfgFlags)((int)e << n) < other", body);
+        Assert.DoesNotContain("(int)other", body);
+        AssertCompiles("public static bool M(CfgFlags e, int n, CfgFlags other)", body, "public enum CfgFlags : uint { None = 0, Top = 0x80000000u }");
+    }
+
+    // #3087 follow-up (adversarial review, GPT): a bitwise sibling MASKED as its
+    // primitive by a typed ldelem — `values[i]` renders enum-typed though its
+    // ResultType is the storage width, so it must still be coerced DOWN —
+    // `(int)e << n | (int)values[i]`, never `| values[i]` (int | E, CS0019).
+    [Fact]
+    public void EnumShiftInBitwiseOr_MaskedArraySibling_CoercesSiblingToInteger()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftOrArraySibling));
+
+        Assert.Contains("(int)values[i]", body);
+        Assert.DoesNotContain("| values[i]", body);
+        AssertCompiles("public static CfgPriority M(CfgPriority e, int n, CfgPriority[] values, int i)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // #3087 follow-up (adversarial review, GPT): an enum-CONSTANT sibling whose
+    // unsigned-backed value overflows the shift's signed rendered integer
+    // (CfgFlags.Top = 0x80000000u > int.MaxValue). The down-coercion needs
+    // `unchecked` — a plain `(int)CfgFlags.Top` is a CS0221 constant overflow.
+    [Fact]
+    public void EnumShiftComparedToOverflowingConstant_WrapsUnchecked()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumShiftCompareOverflowConst));
+
+        Assert.Contains("== unchecked((int)CfgFlags.Top)", body);
+        AssertCompiles("public static bool M(CfgFlags e, int n)", body, "public enum CfgFlags : uint { None = 0, Top = 0x80000000u }");
+    }
+
     // A sub-int (byte) backing promotes to int in a C# shift; the reinterpret
     // targets the 4-byte width the shift runs on. Synthetic to keep the enum load
     // a bare operand (a compiled `(byte)` narrowing could add a conv node).

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -672,21 +672,22 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// Renders an enum shift (or a bitwise chain over one) compared to an enum
-    /// sibling, coercing the sibling so both sides bind, or null when
-    /// <paramref name="shiftSide"/> is not an integer-rendering shift or
-    /// <paramref name="enumSide"/> is not an enum. Equality (<c>ceq</c>/<c>bne.un</c>)
-    /// and signed ordering (<c>clt</c>/<c>cgt</c>) coerce the sibling DOWN to the
-    /// shift's rendered integer — <c>(int)e &lt;&lt; n == (int)other</c> — a faithful
-    /// same-width spelling.
+    /// Renders an enum shift (or a bitwise chain over one) compared to a sibling,
+    /// reconciling both operands to one C# type so the comparison binds and matches
+    /// the IL, or null when <paramref name="shiftSide"/> is not an integer-rendering
+    /// shift or <paramref name="enumSide"/> is not an integer/enum.
     /// <para>
-    /// An UNSIGNED ordering (<c>clt.un</c>/<c>cgt.un</c>) cannot use the enum's own
-    /// backing: a signed backing would compare signed and a narrow backing would
-    /// truncate the widened shift value on the round-trip through the enum
-    /// (<c>(U8)((int)e &lt;&lt; n)</c> re-narrows to a byte). Reconcile BOTH sides to
-    /// the unsigned counterpart of the shift's stack width — <c>(uint)((int)e &lt;&lt; n)
-    /// &lt; (uint)other</c> — so the comparison is the unsigned one the IL performs,
-    /// independent of the enum backing.
+    /// The common type is derived from the COMPARISON's signedness, not the shift's
+    /// rendered signedness: an unsigned ordering (<c>clt.un</c>/<c>cgt.un</c>) uses
+    /// the unsigned counterpart of the shift's stack width
+    /// (<c>(uint)((int)e &lt;&lt; n) &lt; (uint)other</c>), while a signed ordering
+    /// (<c>clt</c>/<c>cgt</c>) and equality (<c>ceq</c>/<c>bne.un</c>, bit-exact) use
+    /// the signed counterpart (<c>(int)((uint)e &gt;&gt; n) &lt; (int)other</c>).
+    /// Keying off the comparison keeps a signed compare after <c>shr.un</c> signed
+    /// and an unsigned compare after <c>shl</c> unsigned, independent of the enum
+    /// backing — a signed backing would otherwise compare signed, a narrow backing
+    /// would truncate the widened shift value on a round-trip through the enum, and a
+    /// plain unsigned sibling would sign-widen an <c>int</c>-rendered shift.
     /// </para>
     /// </summary>
     string? DownCoercedShiftComparison(ComparisonKind kind, bool isUnsigned, IrExpression shiftSide, IrExpression enumSide, bool shiftIsLeft)
@@ -696,30 +697,46 @@ public sealed partial class CSharpPrinter
             return null;
         bool ordering = kind is ComparisonKind.LessThan or ComparisonKind.LessThanOrEqual
             or ComparisonKind.GreaterThan or ComparisonKind.GreaterThanOrEqual;
-        if (isUnsigned && ordering)
-        {
-            var unsignedTarget = TypeRef.CoreLib("System", Is8ByteInteger(renderedInteger) ? "UInt64" : "UInt32");
-            // The sibling reconciles to the same unsigned stack width. An enum
-            // sibling goes through TryCoerceEnumToInteger (bare/masked/overflow);
-            // any other integer sibling (a plain `int`/`uint`, or another integer-
-            // rendering shift) still needs the unsigned reinterpret so the compare
-            // is `clt.un`, not a sign-widened `int < uint` — the fallthrough
-            // UnsignedOperand omits it because it trusts the shift's stale enum
-            // ResultType. CoerceText is identity when the sibling is already the
-            // target width and sign.
-            string unsignedSibling = TryCoerceEnumToInteger(enumSide, unsignedTarget)
-                ?? CoerceText(enumSide, unsignedTarget);
-            string unsignedShift = $"({TypeText(unsignedTarget)}){Operand(shiftSide)}";
-            return shiftIsLeft
-                ? $"{unsignedShift} {ComparisonOperator(kind)} {unsignedSibling}"
-                : $"{unsignedSibling} {ComparisonOperator(kind)} {unsignedShift}";
-        }
-        if (TryCoerceEnumToInteger(enumSide, renderedInteger) is not { } sibling)
+        bool eightByte = Is8ByteInteger(renderedInteger);
+        var target = TypeRef.CoreLib("System", (isUnsigned && ordering)
+            ? (eightByte ? "UInt64" : "UInt32")
+            : (eightByte ? "Int64" : "Int32"));
+        if (ReconcileComparisonOperand(enumSide, target) is not { } sibling)
             return null;
+        string shift = ReconcileComparisonOperand(shiftSide, target) ?? Operand(shiftSide);
         return shiftIsLeft
-            ? $"{Operand(shiftSide)} {ComparisonOperator(kind)} {sibling}"
-            : $"{sibling} {ComparisonOperator(kind)} {Operand(shiftSide)}";
+            ? $"{shift} {ComparisonOperator(kind)} {sibling}"
+            : $"{sibling} {ComparisonOperator(kind)} {shift}";
     }
+
+    /// <summary>
+    /// Reconciles a comparison operand to <paramref name="target"/> (the width/sign
+    /// the enclosing enum-shift comparison compares at): an enum through
+    /// <see cref="TryCoerceEnumToInteger"/> (bare/masked/overflow constant), an
+    /// integer-rendering shift/chain by a same-width bit-preserving reinterpret that
+    /// ignores the stale enum <c>ResultType</c>, and a plain integer through
+    /// <see cref="CoerceText"/> (identity when it already is that width and sign).
+    /// Null for a non-integer operand.
+    /// </summary>
+    string? ReconcileComparisonOperand(IrExpression operand, TypeRef target)
+    {
+        if (TryCoerceEnumToInteger(operand, target) is { } enumCoerced)
+            return enumCoerced;
+        if (BitwiseOperandRendersAsInteger(operand))
+        {
+            return BitwiseOperandRenderedType(operand) is { } rendered && SamePrimitive(rendered, target)
+                ? Operand(operand)
+                : $"({TypeText(target)}){Operand(operand)}";
+        }
+        return TypeFamilies.IsInteger(EffectiveType(operand))
+            ? CoerceText(operand, target)
+            : null;
+    }
+
+    static bool SamePrimitive(TypeRef a, TypeRef b)
+        => a is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            && b is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            && a.Name == b.Name;
 
     // True when a constant enum cast is CS0221 as a plain (checked) cast, so it must
     // be wrapped in `unchecked`: a value outside the backing type's range — negative

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -497,6 +497,28 @@ public sealed partial class CSharpPrinter
     /// </summary>
     TypeRef? BitwiseChainRenderedType(IrExpression left, IrExpression right)
     {
+        // Mirror BinaryBody's bitwise-with-enum-shift coercion FIRST: when one side
+        // renders as an integer (an enum shift or a chain over one) and the other is
+        // a bare enum, BinaryBody coerces the enum sibling DOWN to that side's
+        // rendered integer (`(int)e << n | (int)x`), so the chain renders as THAT
+        // integer — the enum sibling contributes the shift's type and SIGN, not its
+        // own backing. Using the mixed-sign "unsigned if either side unsigned" rule
+        // here would report a `uint`-backed enum sibling as unsigned though it is
+        // rendered `(int)x`, so an enclosing `clt.un` would (wrongly) find the chain
+        // already unsigned and drop the outer `(uint)` reinterpret — a silent signed
+        // 64-bit promotion (or CS0034 at 8-byte width).
+        if (BitwiseOperandRendersAsInteger(left)
+            && BitwiseOperandRenderedType(left) is { } leftShiftInteger
+            && TryCoerceEnumToInteger(right, leftShiftInteger) is not null)
+        {
+            return leftShiftInteger;
+        }
+        if (BitwiseOperandRendersAsInteger(right)
+            && BitwiseOperandRenderedType(right) is { } rightShiftInteger
+            && TryCoerceEnumToInteger(left, rightShiftInteger) is not null)
+        {
+            return rightShiftInteger;
+        }
         var leftType = ChainOperandRenderedInteger(left);
         var rightType = ChainOperandRenderedInteger(right);
         if (!IsWideInteger(leftType) || !IsWideInteger(rightType))
@@ -716,7 +738,10 @@ public sealed partial class CSharpPrinter
     /// integer-rendering shift/chain by a same-width bit-preserving reinterpret that
     /// ignores the stale enum <c>ResultType</c>, and a plain integer through
     /// <see cref="CoerceText"/> (identity when it already is that width and sign).
-    /// Null for a non-integer operand.
+    /// Null for a non-integer operand. The inserted reinterpret is not in the IL, so
+    /// it routes through <see cref="CheckedSafeCast"/> — under an enclosing
+    /// <c>checked</c> region a signed→unsigned cast is wrapped in <c>unchecked</c> so
+    /// it reinterprets (as the IL does) rather than throwing on a negative value.
     /// </summary>
     string? ReconcileComparisonOperand(IrExpression operand, TypeRef target)
     {
@@ -726,7 +751,7 @@ public sealed partial class CSharpPrinter
         {
             return BitwiseOperandRenderedType(operand) is { } rendered && SamePrimitive(rendered, target)
                 ? Operand(operand)
-                : $"({TypeText(target)}){Operand(operand)}";
+                : CheckedSafeCast(() => $"({TypeText(target)}){Operand(operand)}");
         }
         return TypeFamilies.IsInteger(EffectiveType(operand))
             ? CoerceText(operand, target)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -520,9 +520,19 @@ public sealed partial class CSharpPrinter
     TypeRef? ChainOperandRenderedInteger(IrExpression operand)
     {
         var rendered = BitwiseOperandRenderedType(operand);
-        return rendered is { } type && EnumUnderlyingType(type) is { } underlying
-            ? underlying
-            : rendered;
+        if (rendered is not { } type)
+            return null;
+        if (EnumUnderlyingType(type) is { } underlying)
+            type = underlying;
+        // A sub-int operand of an IL bitwise/shift op is promoted to Int32 on the
+        // evaluation stack (and C# promotes it identically), so a chain mixing an
+        // enum shift with a narrow integer — `(int)e << n | mask` (short) — still
+        // reconciles to a wide integer. Reporting the narrow width would make
+        // BitwiseChainRenderedType reject the chain and fall back to the stale enum
+        // ResultType, dropping the unsigned reinterpret an enclosing `clt.un` needs.
+        return TypeFamilies.IsInteger(type) && !IsWideInteger(type)
+            ? TypeRef.CoreLib("System", "Int32")
+            : type;
     }
 
     /// <summary>
@@ -689,8 +699,16 @@ public sealed partial class CSharpPrinter
         if (isUnsigned && ordering)
         {
             var unsignedTarget = TypeRef.CoreLib("System", Is8ByteInteger(renderedInteger) ? "UInt64" : "UInt32");
-            if (TryCoerceEnumToInteger(enumSide, unsignedTarget) is not { } unsignedSibling)
-                return null;
+            // The sibling reconciles to the same unsigned stack width. An enum
+            // sibling goes through TryCoerceEnumToInteger (bare/masked/overflow);
+            // any other integer sibling (a plain `int`/`uint`, or another integer-
+            // rendering shift) still needs the unsigned reinterpret so the compare
+            // is `clt.un`, not a sign-widened `int < uint` — the fallthrough
+            // UnsignedOperand omits it because it trusts the shift's stale enum
+            // ResultType. CoerceText is identity when the sibling is already the
+            // target width and sign.
+            string unsignedSibling = TryCoerceEnumToInteger(enumSide, unsignedTarget)
+                ?? CoerceText(enumSide, unsignedTarget);
             string unsignedShift = $"({TypeText(unsignedTarget)}){Operand(shiftSide)}";
             return shiftIsLeft
                 ? $"{unsignedShift} {ComparisonOperator(kind)} {unsignedSibling}"

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -661,6 +661,48 @@ public sealed partial class CSharpPrinter
             : $"({TypeText(integerType)}){Operand(value)}";
     }
 
+    /// <summary>
+    /// Renders an enum shift (or a bitwise chain over one) compared to an enum
+    /// sibling, coercing the sibling so both sides bind, or null when
+    /// <paramref name="shiftSide"/> is not an integer-rendering shift or
+    /// <paramref name="enumSide"/> is not an enum. Equality (<c>ceq</c>/<c>bne.un</c>)
+    /// and signed ordering (<c>clt</c>/<c>cgt</c>) coerce the sibling DOWN to the
+    /// shift's rendered integer — <c>(int)e &lt;&lt; n == (int)other</c> — a faithful
+    /// same-width spelling.
+    /// <para>
+    /// An UNSIGNED ordering (<c>clt.un</c>/<c>cgt.un</c>) cannot use the enum's own
+    /// backing: a signed backing would compare signed and a narrow backing would
+    /// truncate the widened shift value on the round-trip through the enum
+    /// (<c>(U8)((int)e &lt;&lt; n)</c> re-narrows to a byte). Reconcile BOTH sides to
+    /// the unsigned counterpart of the shift's stack width — <c>(uint)((int)e &lt;&lt; n)
+    /// &lt; (uint)other</c> — so the comparison is the unsigned one the IL performs,
+    /// independent of the enum backing.
+    /// </para>
+    /// </summary>
+    string? DownCoercedShiftComparison(ComparisonKind kind, bool isUnsigned, IrExpression shiftSide, IrExpression enumSide, bool shiftIsLeft)
+    {
+        if (!BitwiseOperandRendersAsInteger(shiftSide)
+            || BitwiseOperandRenderedType(shiftSide) is not { } renderedInteger)
+            return null;
+        bool ordering = kind is ComparisonKind.LessThan or ComparisonKind.LessThanOrEqual
+            or ComparisonKind.GreaterThan or ComparisonKind.GreaterThanOrEqual;
+        if (isUnsigned && ordering)
+        {
+            var unsignedTarget = TypeRef.CoreLib("System", Is8ByteInteger(renderedInteger) ? "UInt64" : "UInt32");
+            if (TryCoerceEnumToInteger(enumSide, unsignedTarget) is not { } unsignedSibling)
+                return null;
+            string unsignedShift = $"({TypeText(unsignedTarget)}){Operand(shiftSide)}";
+            return shiftIsLeft
+                ? $"{unsignedShift} {ComparisonOperator(kind)} {unsignedSibling}"
+                : $"{unsignedSibling} {ComparisonOperator(kind)} {unsignedShift}";
+        }
+        if (TryCoerceEnumToInteger(enumSide, renderedInteger) is not { } sibling)
+            return null;
+        return shiftIsLeft
+            ? $"{Operand(shiftSide)} {ComparisonOperator(kind)} {sibling}"
+            : $"{sibling} {ComparisonOperator(kind)} {Operand(shiftSide)}";
+    }
+
     // True when a constant enum cast is CS0221 as a plain (checked) cast, so it must
     // be wrapped in `unchecked`: a value outside the backing type's range — negative
     // into an unsigned backing (`(U)(-1)`) or a magnitude a narrow backing cannot
@@ -1393,25 +1435,16 @@ public sealed partial class CSharpPrinter
         // An enum shift (or a bitwise chain over one) compared to a bare enum
         // sibling renders as its underlying integer while the sibling renders as the
         // enum (`(int)e << n == other`, int == E, CS0019). Coerce the enum sibling
-        // DOWN to that rendered integer — `(int)e << n == (int)other` — not the shift
-        // up to the enum. Runs before the enum up-coercion below, whose stale
-        // enum-typed test would otherwise coerce the sibling the wrong way.
-        // Restricted to sign-safe kinds: equality (`ceq`/`bne.un`) compares the raw
-        // bits, so a same-width signed spelling is faithful, but an UNSIGNED ordering
-        // (`clt.un`/`cgt.un`) would silently become a signed `<`/`>` once both sides
-        // render signed — an unsigned enum-shift ordering keeps its loud CS0019 here
-        // (the sibling is not coerced) rather than a wrong-signedness comparison.
-        bool comparisonSignSafe = kind is ComparisonKind.Equal or ComparisonKind.NotEqual || !isUnsigned;
-        if (comparisonSignSafe
-            && BitwiseOperandRendersAsInteger(left)
-            && BitwiseOperandRenderedType(left) is { } leftRenderedInteger
-            && TryCoerceEnumToInteger(right, leftRenderedInteger) is { } downRight)
-            return $"{Operand(left)} {ComparisonOperator(kind)} {downRight}";
-        if (comparisonSignSafe
-            && BitwiseOperandRendersAsInteger(right)
-            && BitwiseOperandRenderedType(right) is { } rightRenderedInteger
-            && TryCoerceEnumToInteger(left, rightRenderedInteger) is { } downLeft)
-            return $"{downLeft} {ComparisonOperator(kind)} {Operand(right)}";
+        // DOWN to the shift's rendered integer — `(int)e << n == (int)other` — not
+        // the shift up to the enum. Runs before the enum up-coercion below, whose
+        // stale enum-typed test would otherwise coerce the sibling the wrong way.
+        // An UNSIGNED ordering (`clt.un`/`cgt.un`) reconciles both sides to the
+        // unsigned stack-width integer instead (see DownCoercedShiftComparison), so
+        // the enum backing's own signedness/width cannot change the comparison.
+        if (DownCoercedShiftComparison(kind, isUnsigned, left, right, shiftIsLeft: true) is { } downLeftCmp)
+            return downLeftCmp;
+        if (DownCoercedShiftComparison(kind, isUnsigned, right, left, shiftIsLeft: false) is { } downRightCmp)
+            return downRightCmp;
         // An enum compared to an integer (`access == bestAccess`,
         // `methodAccess == 6`) is CS0019 though the IL compares their shared
         // underlying integer; coerce the integer operand to the enum type. A

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -619,22 +619,46 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// Coerces a bare enum operand DOWN to <paramref name="integerType"/> — the
+    /// Coerces an enum operand DOWN to <paramref name="integerType"/> — the
     /// underlying-integer render of an enum shift it is combined or compared with,
     /// so both sides are integers (<c>(int)e &lt;&lt; n | (int)other</c>). Null when
     /// the operand already renders as an integer (an enum shift/chain needs no
-    /// down-coercion) or is not a bare enum (a plain integer sibling stays as-is,
-    /// falling through to its own spelling). The cast runs through
-    /// <see cref="CoerceText"/> — the one enum->integer door — so it matches the
-    /// shift's own <see cref="ShiftEnumLeftOperand"/> spelling.
+    /// down-coercion) or does not render as an enum (a plain integer sibling stays
+    /// as-is, falling through to its own spelling).
+    /// <para>
+    /// The enum comes from the rendered spelling, not the stack <c>ResultType</c>:
+    /// a bare enum load carries the enum in its <c>ResultType</c> and the cast runs
+    /// through <see cref="CoerceText"/> (the one enum->integer door, matching
+    /// <see cref="ShiftEnumLeftOperand"/>); a typed <c>ldelem</c>/<c>ldind</c> masks
+    /// the enum as its primitive storage width, so <see cref="CoerceText"/> would
+    /// see an int->int identity and drop the cast — the reinterpret is spelled
+    /// directly (mirroring <see cref="ShiftEnumLeftOperand"/>'s masked branch). An
+    /// out-of-range enum <em>constant</em> (an unsigned-backed member the signed
+    /// target cannot hold, <c>(int)F.Top</c>) is a constant-expression conversion
+    /// that is CS0221 without <c>unchecked</c>.
+    /// </para>
     /// </summary>
     string? TryCoerceEnumToInteger(IrExpression value, TypeRef integerType)
     {
         if (BitwiseOperandRendersAsInteger(value))
             return null;
-        if (value.ResultType is not { } valueType || !IsEnumLikeInteger(valueType))
+        if (ShiftLeftEnumType(value) is not { } enumType
+            || EnumUnderlyingType(enumType) is not { } underlying)
             return null;
-        return CoerceText(value, integerType);
+        // A constant cast that steps outside the target's range is CS0221 unless it
+        // is wrapped in `unchecked`; the underlying type's signedness decides range,
+        // not the masked stack width.
+        bool constantOverflows = value is Constant or Convert
+            && CSharpConversionRules.CheckedConversionCanThrow(underlying, integerType);
+        if (EnumUnderlyingType(value.ResultType) is not null)
+        {
+            return constantOverflows
+                ? CheckedSafeCast(() => CoerceText(value, integerType), force: true)
+                : CoerceText(value, integerType);
+        }
+        return CSharpConversionRules.CheckedConversionCanThrow(underlying, integerType)
+            ? CheckedSafeCast(() => $"({TypeText(integerType)}){Operand(value)}", force: constantOverflows)
+            : $"({TypeText(integerType)}){Operand(value)}";
     }
 
     // True when a constant enum cast is CS0221 as a plain (checked) cast, so it must
@@ -1372,11 +1396,19 @@ public sealed partial class CSharpPrinter
         // DOWN to that rendered integer — `(int)e << n == (int)other` — not the shift
         // up to the enum. Runs before the enum up-coercion below, whose stale
         // enum-typed test would otherwise coerce the sibling the wrong way.
-        if (BitwiseOperandRendersAsInteger(left)
+        // Restricted to sign-safe kinds: equality (`ceq`/`bne.un`) compares the raw
+        // bits, so a same-width signed spelling is faithful, but an UNSIGNED ordering
+        // (`clt.un`/`cgt.un`) would silently become a signed `<`/`>` once both sides
+        // render signed — an unsigned enum-shift ordering keeps its loud CS0019 here
+        // (the sibling is not coerced) rather than a wrong-signedness comparison.
+        bool comparisonSignSafe = kind is ComparisonKind.Equal or ComparisonKind.NotEqual || !isUnsigned;
+        if (comparisonSignSafe
+            && BitwiseOperandRendersAsInteger(left)
             && BitwiseOperandRenderedType(left) is { } leftRenderedInteger
             && TryCoerceEnumToInteger(right, leftRenderedInteger) is { } downRight)
             return $"{Operand(left)} {ComparisonOperator(kind)} {downRight}";
-        if (BitwiseOperandRendersAsInteger(right)
+        if (comparisonSignSafe
+            && BitwiseOperandRendersAsInteger(right)
             && BitwiseOperandRenderedType(right) is { } rightRenderedInteger
             && TryCoerceEnumToInteger(left, rightRenderedInteger) is { } downLeft)
             return $"{downLeft} {ComparisonOperator(kind)} {Operand(right)}";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -487,13 +487,18 @@ public sealed partial class CSharpPrinter
     /// shift renders as. IL bitwise ops require operands of the same stack width, so
     /// both rendered operand types share a width; the result is unsigned when either
     /// side is unsigned (a same-width mixed-sign pair reinterprets the signed side).
-    /// Null when either side is not a wide integer render (no enum-shift descendant),
-    /// leaving the caller on its <see cref="EffectiveType"/> path.
+    /// A bare enum operand is down-coerced to its underlying integer by
+    /// <see cref="BinaryBody"/> (<c>(int)e &lt;&lt; n | (int)other</c>), so it
+    /// contributes that underlying integer here — keeping the OUTER enum cast the
+    /// chain flows into (<c>(E)((int)e &lt;&lt; n | (int)other)</c>) in agreement
+    /// with the rendered operands. Null when either side is not a wide integer
+    /// render (no enum-shift descendant), leaving the caller on its
+    /// <see cref="EffectiveType"/> path.
     /// </summary>
     TypeRef? BitwiseChainRenderedType(IrExpression left, IrExpression right)
     {
-        var leftType = BitwiseOperandRenderedType(left);
-        var rightType = BitwiseOperandRenderedType(right);
+        var leftType = ChainOperandRenderedInteger(left);
+        var rightType = ChainOperandRenderedInteger(right);
         if (!IsWideInteger(leftType) || !IsWideInteger(rightType))
         {
             return null;
@@ -504,6 +509,20 @@ public sealed partial class CSharpPrinter
         return TypeRef.CoreLib("System", unsigned
             ? (wide ? "UInt64" : "UInt32")
             : (wide ? "Int64" : "Int32"));
+    }
+
+    /// <summary>
+    /// A bitwise-chain operand's rendered integer type, mapping a bare enum to its
+    /// underlying integer: inside a shift-containing chain the enum sibling is
+    /// down-coerced to that integer (<see cref="BinaryBody"/>), so the chain's
+    /// reconciled type must see it as the integer, not the stale enum.
+    /// </summary>
+    TypeRef? ChainOperandRenderedInteger(IrExpression operand)
+    {
+        var rendered = BitwiseOperandRenderedType(operand);
+        return rendered is { } type && EnumUnderlyingType(type) is { } underlying
+            ? underlying
+            : rendered;
     }
 
     /// <summary>
@@ -577,11 +596,45 @@ public sealed partial class CSharpPrinter
             return null;
         if (TypeFamilies.IsBoolean(EffectiveType(value)))
             return CheckedSafeEnumCast(value, enumSide, () => $"({TypeText(enumSide)})({RenderedCondition(value).At(Precedence.NullCoalescing)} ? 1 : 0)");
+        // An enum shift — or a bitwise chain over one — renders as its underlying
+        // integer (ShiftEnumLeftOperand: `(int)e << n`), not the enum its stale
+        // Binary ResultType still reports. Flowing into an enum-typed position (a
+        // conditional/switch arm, a coalesce right side, a method argument) it is an
+        // int->enum conversion needing an explicit `(E)` cast (CS1503/CS0266);
+        // without it the stale ResultType reads as identity and the cast is dropped.
+        // Mirrors CoerceText's store/return enum-shift branch, keeping this shared
+        // arm-coercion door in agreement with the sink. Runs before the plain
+        // integer branch, whose value.ResultType would be the stale enum.
+        if (BitwiseOperandRendersAsInteger(value)
+            && BitwiseOperandRenderedType(value) is { } renderedInteger
+            && CoercionRendering.CanSpellIntegerToEnum(renderedInteger, enumSide, _function.TypeShapes))
+        {
+            return EnumIntegerCast(value, enumSide);
+        }
         if (value.ResultType is not { } valueType || !TypeFamilies.IsIntegerLike(valueType))
             return null;
         return value is Constant { Value: int or long } konst
             ? EnumConstantText(konst, enumSide)
             : EnumIntegerCast(value, enumSide);
+    }
+
+    /// <summary>
+    /// Coerces a bare enum operand DOWN to <paramref name="integerType"/> — the
+    /// underlying-integer render of an enum shift it is combined or compared with,
+    /// so both sides are integers (<c>(int)e &lt;&lt; n | (int)other</c>). Null when
+    /// the operand already renders as an integer (an enum shift/chain needs no
+    /// down-coercion) or is not a bare enum (a plain integer sibling stays as-is,
+    /// falling through to its own spelling). The cast runs through
+    /// <see cref="CoerceText"/> — the one enum->integer door — so it matches the
+    /// shift's own <see cref="ShiftEnumLeftOperand"/> spelling.
+    /// </summary>
+    string? TryCoerceEnumToInteger(IrExpression value, TypeRef integerType)
+    {
+        if (BitwiseOperandRendersAsInteger(value))
+            return null;
+        if (value.ResultType is not { } valueType || !IsEnumLikeInteger(valueType))
+            return null;
+        return CoerceText(value, integerType);
     }
 
     // True when a constant enum cast is CS0221 as a plain (checked) cast, so it must
@@ -677,6 +730,24 @@ public sealed partial class CSharpPrinter
         // mixed-sign path and normal reconciliation bind it.
         if (binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor)
         {
+            // One operand is an enum shift (or a bitwise chain over one) rendering
+            // as its underlying integer while the sibling is a bare enum value
+            // (`(int)e << n | other`, int | E, CS0019). Coerce the enum sibling DOWN
+            // to that rendered integer — `(int)e << n | (int)other` — not the shift
+            // up to the enum. Runs before the integer-sibling up-coercion below,
+            // whose stale-enum-typed test would otherwise leave the sibling bare.
+            if (BitwiseOperandRendersAsInteger(binary.Left)
+                && BitwiseOperandRenderedType(binary.Left) is { } leftRenderedInteger
+                && TryCoerceEnumToInteger(binary.Right, leftRenderedInteger) is { } downRight)
+            {
+                return $"{Operand(binary.Left)} {BinaryOperator(binary)} {downRight}";
+            }
+            if (BitwiseOperandRendersAsInteger(binary.Right)
+                && BitwiseOperandRenderedType(binary.Right) is { } rightRenderedInteger
+                && TryCoerceEnumToInteger(binary.Left, rightRenderedInteger) is { } downLeft)
+            {
+                return $"{downLeft} {BinaryOperator(binary)} {Operand(binary.Right)}";
+            }
             if (!BitwiseOperandRendersAsInteger(binary.Left)
                 && TryCoerceEnumOperand(binary.Right, binary.Left.ResultType) is { } coercedRight)
             {
@@ -1295,14 +1366,33 @@ public sealed partial class CSharpPrinter
                 }
             }
         }
+        // An enum shift (or a bitwise chain over one) compared to a bare enum
+        // sibling renders as its underlying integer while the sibling renders as the
+        // enum (`(int)e << n == other`, int == E, CS0019). Coerce the enum sibling
+        // DOWN to that rendered integer — `(int)e << n == (int)other` — not the shift
+        // up to the enum. Runs before the enum up-coercion below, whose stale
+        // enum-typed test would otherwise coerce the sibling the wrong way.
+        if (BitwiseOperandRendersAsInteger(left)
+            && BitwiseOperandRenderedType(left) is { } leftRenderedInteger
+            && TryCoerceEnumToInteger(right, leftRenderedInteger) is { } downRight)
+            return $"{Operand(left)} {ComparisonOperator(kind)} {downRight}";
+        if (BitwiseOperandRendersAsInteger(right)
+            && BitwiseOperandRenderedType(right) is { } rightRenderedInteger
+            && TryCoerceEnumToInteger(left, rightRenderedInteger) is { } downLeft)
+            return $"{downLeft} {ComparisonOperator(kind)} {Operand(right)}";
         // An enum compared to an integer (`access == bestAccess`,
         // `methodAccess == 6`) is CS0019 though the IL compares their shared
         // underlying integer; coerce the integer operand to the enum type. A
         // cross-assembly enum is unresolved (TypeShape.Unknown), so the
-        // structural test inside the coercion is what fixes it.
-        if (TryCoerceEnumOperand(right, left.ResultType) is { } coercedRight)
+        // structural test inside the coercion is what fixes it. An enum-shift
+        // operand is excluded (it renders as its underlying integer, not the enum),
+        // so its stale enum ResultType never coerces the sibling up — the
+        // down-coercion above owns that shape.
+        if (!BitwiseOperandRendersAsInteger(left)
+            && TryCoerceEnumOperand(right, left.ResultType) is { } coercedRight)
             return $"{Operand(left)} {ComparisonOperator(kind)} {coercedRight}";
-        if (TryCoerceEnumOperand(left, right.ResultType) is { } coercedLeft)
+        if (!BitwiseOperandRendersAsInteger(right)
+            && TryCoerceEnumOperand(left, right.ResultType) is { } coercedLeft)
             return $"{coercedLeft} {ComparisonOperator(kind)} {Operand(right)}";
         // An equality test between a same-width signed/unsigned integer pair
         // (`ulong != (long)i`, `nuint == nint`) has no C# common type (CS0034),


### PR DESCRIPTION
- Fixes/advances #3087
- Changes the C# printer so enum-shift consumers (bitwise sibling, comparison, conditional/coalesce arm) reason about the shift's **rendered integer type** instead of its stale enum `ResultType`, eliminating three invalid-C# shapes.
- Card revision: `52a053c9`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — three pre-existing consumers of an enum shift's stale enum `ResultType` emitted uncompilable C# (CS0019/CS0019/CS1503); routing them through the existing rendered-integer predicates makes all three valid while preserving IL fidelity (every inserted cast is an identity reinterpret emitting zero IL).

### Background

An enum shift's IR `Binary` reports the enum as its `ResultType` (`TypeFamilies.BinaryResult` prefers the enum definition for the flags idiom), but the printer always renders the left operand as its underlying integer via `ShiftEnumLeftOperand` (`(int)e << n`). PR #3078/#3076 fixed the witnessed consumers; adversarial review surfaced three more latent consumers that still trust the stale enum type. This PR is the tracking follow-up (#3087).

### Defect 1 — bitwise op with an enum-typed sibling

**Original source**

```csharp
public static CfgPriority EnumShiftOrEnumSibling(CfgPriority e, int n, CfgPriority other) => (CfgPriority)(((int)e << n) | (int)other);
```

**Before**

```csharp
public static CfgPriority EnumShiftOrEnumSibling(CfgPriority e, int n, CfgPriority other) => (int)e << n | other;
```

- Valid: False — CS0019: operator `|` cannot be applied to `int` and `CfgPriority`.
- Correct: False (does not compile).

**After**

```csharp
public static CfgPriority EnumShiftOrEnumSibling(CfgPriority e, int n, CfgPriority other) => (CfgPriority)(((int)e << n) | (int)other);
```

- Valid: True
- Correct: True

### Defect 2 — comparison against an enum constant

**Original source**

```csharp
public static bool EnumShiftCompareEnumConst(CfgPriority e, int n) => ((int)e << n) == (int)CfgPriority.High;
```

**Before**

```csharp
public static bool EnumShiftCompareEnumConst(CfgPriority e, int n) => ((int)e << n) == CfgPriority.High;
```

- Valid: False — CS0019: operator `==` cannot be applied to `int` and `CfgPriority`.
- Correct: False (does not compile).

**After**

```csharp
public static bool EnumShiftCompareEnumConst(CfgPriority e, int n) => ((int)e << n) == (int)CfgPriority.High;
```

- Valid: True
- Correct: True

### Defect 3 — conditional arm into an enum target

**Original source**

```csharp
public static void EnumShiftTernaryToEnum(bool b, CfgPriority e, int n) => TakeCfgPriority(b ? (CfgPriority)((int)e << n) : CfgPriority.High);
```

**Before**

```csharp
public static void EnumShiftTernaryToEnum(bool b, CfgPriority e, int n) => TakeCfgPriority(b ? ((int)e << n) : CfgPriority.High);
```

- Valid: False — CS1503: cannot convert the target-typed conditional (best common type of `int` and `CfgPriority`) to `CfgPriority`.
- Correct: False (does not compile).

**After**

```csharp
public static void EnumShiftTernaryToEnum(bool b, CfgPriority e, int n) => TakeCfgPriority(b ? (CfgPriority)((int)e << n) : CfgPriority.High);
```

- Valid: True
- Correct: True

### Fully raised

The After decompilation is in the fully raised state.

## Design

Five coordinated edits in `CSharpPrinter.Numerics.cs`, all consulting the existing rendered-integer predicate cluster (`BitwiseOperandRendersAsInteger` / `BitwiseOperandRenderedType`) rather than `Binary.ResultType`:

1. **`BinaryBody` bitwise:** before the existing integer-sibling up-coercion, add a DOWN-coercion — when one operand renders as int and its sibling is a bare enum, coerce the sibling down to the shift's rendered integer (`(int)other`). (Defect 1)
2. **New `TryCoerceEnumToInteger(value, integerType)`** helper — `CoerceText(value, integerType)` only when `value` is a bare enum not already rendering as int; else null. Single enum→integer door, matching `ShiftEnumLeftOperand`'s spelling.
3. **`CompareText`:** add the same DOWN-coercion, and guard the pre-existing up-coercion with `!BitwiseOperandRendersAsInteger` so a shift's stale enum never pulls the sibling up. (Defect 2)
4. **`TryCoerceEnumOperand`:** add a branch — a value rendering as int flowing into an enum side takes `EnumIntegerCast`. Central door for conditional/switch/coalesce arms. (Defect 3)
5. **`BitwiseChainRenderedType`** (via new `ChainOperandRenderedInteger`): map a bare-enum chain operand to its underlying integer, so the outer `(E)` return cast on defect 1's `(E)((int)e<<n | (int)other)` is retained.

DOWN-coercion runs first and returns early in `BinaryBody`/`CompareText`, so the extended `TryCoerceEnumOperand` fires only in arm contexts (no double-handling).

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `EnumCastPrinterTests`: 53 passed | `EnumCastPrinterTests`: 62 passed (9 new) |
| Decompiler fast suite (`-trait- "Speed=Slow"`) | 3413, 0 failed | 3422, 0 failed |
| Reduced fixture validity | Pass (3 defect fixtures compile via `AssertCompiles`) | Pass |
| Reduced fixture fidelity | IL unchanged — inserted casts are identity reinterprets | IL unchanged |
| Real witness | 3 fixtures render invalid C# (CS0019/CS0019/CS1503) | 3 fixtures render valid C# |

IL fidelity: `member -S "IL"` on `EnumShiftOrEnumSibling` shows `ldarg.0; ldarg.1; ldc.i4.s 31; and; shl; ldarg.2; or; ret` — no `conv` opcodes. Every cast this fix inserts (`(int)e`, `(int)other`, `(CfgPriority)`) is a no-op reinterpret emitting zero IL, so recompiled opcodes are unchanged. The slow Fidelity-area gate is environmentally flaky on the dev machine and is deferred to CI.

Before/After renders were acquired verbatim via `dotnet-inspect member ... -S "Decompiled Source"` at base and head; the three Before shapes were independently confirmed to fail compilation (CS0019, CS0019, CS1503) and the three After shapes to compile.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.EnumCastPrinterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Speed=Slow"
```
