### PR TITLE
Define cross-mechanism diff row currency contract + body-signal test (#2299)

### DIFF
--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -70,6 +70,75 @@ If the Finding producers later carry equivalent aligned hunk and typed display
 payloads, the semantic projections should be deleted rather than matched a
 third time.
 
+## Row currency contract
+
+Every diff row across MetadataDiff, ILDiff, Analysis/body-signal diff, C#Diff,
+and ResearchDiff must be reachable back to its owning API/member through stable
+member currency, then locatable inside its own mechanism through native row
+coordinates. The two obligations are separate: currency answers "which member,"
+native coordinates answer "which row within that member." This section states
+which layer supplies each obligation. It does not impose a universal
+`Before`/`After` handle: IL rows already carry side as row polarity
+(`Add`/`Remove`/`Context`), and forcing an explicit old/new pair onto that shape
+would duplicate the native model. See [Finding Coordinates](finding-coordinates.md)
+for the underlying subject / correspondence / provenance axes; this contract is
+the diff-row application of those axes.
+
+### Two carrier classes
+
+Rows fall into exactly one of two classes by whether the producing layer knows
+member identity:
+
+- **Anchor-carrying rows** live at member altitude and carry the stable member
+  currency directly. `ApiChange` (MetadataDiff) owns `MemberAnchor` through
+  `ApiChangeSubject`, exposing `CanonicalSignature`, `StableSelector`
+  (`Name~digest`), and the member digest as typed fields. Metadata is the layer
+  that owns member identity, so its rows are self-describing.
+- **Member-agnostic substrate rows** are produced by layers that intentionally
+  do not depend on Metadata, so they cannot and must not embed a `MemberAnchor`.
+  `IlDiffRow`/`CanonicalIlOperation` in `ILInspector.Instructions` and
+  `CSharpDiffRow` in `ILInspector.Decompiler` carry only their native
+  coordinates and a producer-owned `Message`. The caller that already resolved
+  the member — Research, via `ResearchSubjectKey` from
+  `ResearchMemberIdentity.SubjectFromAnchor` — supplies the stable currency by
+  wrapping. This caller-owned wrapping is deliberate; it keeps
+  `ILInspector.Instructions` and the C# printer free of a Metadata dependency
+  and NativeAOT/SRM-clean, and it is why no low-level substrate row grows a
+  `MemberAnchor` field.
+
+A row is never both. Adding member identity to a substrate row, or reconstructing
+it there from display text, would duplicate identity the wrapper already owns and
+violate the layer-ownership rule.
+
+### Native coordinates each mechanism preserves
+
+The wrapper preserves, not flattens, the native coordinates so a consumer can
+replay or locate the row after the member is known:
+
+| Mechanism | Anchor source | Native row coordinates |
+| --- | --- | --- |
+| MetadataDiff | `ApiChange` (`MemberAnchor` on `ApiChangeSubject`) | `ApiChangeSubjectKind`, old/new member handles, category |
+| ILDiff | wrapper (`ResearchSubjectKey`) | `HunkId`, `IlDiffKind` polarity, `CanonicalIlOperation`, IL offset (hint) |
+| Analysis/body-signal | wrapper (`ResearchSubjectKey`) | signal / shape, added/removed/changed kind, IL offset(s) as evidence |
+| C#Diff | wrapper (`ResearchSubjectKey`) | `ChangeId` / `CSharpDiffKind`, source-shape span, related IL offsets as evidence |
+
+IL offsets, operation-array ordinals, and source spans are local evidence and
+display hints, never the durable selector. The durable selector is always the
+`MemberAnchor`-derived `StableSelector` / canonical signature / digest carried by
+the anchor-carrying row or its wrapper.
+
+### ResearchDiff projection
+
+`ResearchChange` binds one member-agnostic native payload (`IlRow`, `CSharpRow`,
+`ApiChange`, and the analysis signal fields) to one `ResearchSubjectKey` whose
+`Id` is the anchor `StableSelector`, and to a cross-mechanism product `ChangeId`
+via `FindingDescriptor`. It never erases the lower-layer typed payload and never
+requires consumers to parse `Message`. Machine consumers query by `ChangeId`
+through `HasChange`, `HasChangePrefix`, and `HasChangeCategory`; product
+`ChangeId`s use fact concepts (`unsafe.stackalloc.added`, `il.hunk.changed`,
+`csharp.return-expression.changed`), not incidental detail fields. `Message`
+stays producer-owned presentation on either side of the join.
+
 ## Consumer contract
 
 Use `ImplementationDiff.CompareAssemblies` or `ImplementationDiff.Compare` when

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -86,53 +86,59 @@ the diff-row application of those axes.
 
 ### Two carrier classes
 
-Rows fall into exactly one of two classes by whether the producing layer knows
-member identity:
+Rows fall into exactly one of two classes by the altitude at which they are
+produced:
 
-- **Anchor-carrying rows** live at member altitude and carry the stable member
-  currency directly. `ApiChange` (MetadataDiff) owns `MemberAnchor` through
-  `ApiChangeSubject`, exposing `CanonicalSignature`, `StableSelector`
-  (`Name~digest`), and the member digest as typed fields. Metadata is the layer
-  that owns member identity, so its rows are self-describing.
-- **Member-agnostic substrate rows** are produced by layers that intentionally
-  do not depend on Metadata, so they cannot and must not embed a `MemberAnchor`.
-  `IlDiffRow`/`CanonicalIlOperation` in `ILInspector.Instructions` and
-  `CSharpDiffRow` in `ILInspector.Decompiler` carry only their native
-  coordinates and a producer-owned `Message`. The caller that already resolved
-  the member — Research, via `ResearchSubjectKey` from
-  `ResearchMemberIdentity.SubjectFromAnchor` — supplies the stable currency by
-  wrapping. This caller-owned wrapping is deliberate; it keeps
-  `ILInspector.Instructions` and the C# printer free of a Metadata dependency
-  and NativeAOT/SRM-clean, and it is why no low-level substrate row grows a
-  `MemberAnchor` field.
+- **Anchor-carrying rows** are produced after member alignment, so the row owns
+  the stable member currency directly. `ApiChange` (MetadataDiff) carries
+  `MemberAnchor` through `ApiChangeSubject`; `CSharpDiffRow` (C#Diff) carries
+  `MemberAnchor` plus its `StableMemberKey` on the row. Both expose
+  `CanonicalSignature`, `StableSelector` (`Name~digest`), and the member digest
+  as typed fields. `MemberAnchor` lives in `ILInspector.MetadataPrimitives`, a
+  lightweight primitive assembly, so carrying it does not pull in the heavy
+  Metadata layer.
+- **Body-substrate rows** are produced below member selection: they compare one
+  already-resolved body's operation or signal stream and hold no member
+  identity. `IlDiffRow`/`CanonicalIlOperation` in `ILInspector.Instructions`
+  carries only `HunkId`, `IlDiffKind` polarity, the operation, and a
+  producer-owned `Message`; analysis/body-signal facts sit at the same altitude.
+  The caller that already resolved the enclosing member supplies the stable
+  currency by wrapping — `IlAssemblyDiff.CompareMembers` returns an
+  `IlMemberDiffSubject`, and Research attaches a `ResearchSubjectKey` from
+  `ResearchMemberIdentity.SubjectFromMethod`. This is altitude, not a
+  Metadata-dependency ban: `ILInspector.Instructions` already references
+  `MetadataPrimitives`, so it *could* embed a `MemberAnchor`; it deliberately
+  does not, because a body substrate that diffs a single pre-resolved body pair
+  has no member to name and the enclosing member subject already owns that fact.
 
-A row is never both. Adding member identity to a substrate row, or reconstructing
-it there from display text, would duplicate identity the wrapper already owns and
-violate the layer-ownership rule.
+A row is never both. Adding member identity to a body-substrate row, or
+reconstructing it there from display text, would duplicate identity the wrapper
+already owns and violate the layer-ownership rule.
 
 ### Native coordinates each mechanism preserves
 
 The wrapper preserves, not flattens, the native coordinates so a consumer can
 replay or locate the row after the member is known:
 
-| Mechanism | Anchor source | Native row coordinates |
+| Mechanism | Currency carrier | Native row coordinates |
 | --- | --- | --- |
-| MetadataDiff | `ApiChange` (`MemberAnchor` on `ApiChangeSubject`) | `ApiChangeSubjectKind`, old/new member handles, category |
-| ILDiff | wrapper (`ResearchSubjectKey`) | `HunkId`, `IlDiffKind` polarity, `CanonicalIlOperation`, IL offset (hint) |
-| Analysis/body-signal | wrapper (`ResearchSubjectKey`) | signal / shape, added/removed/changed kind, IL offset(s) as evidence |
-| C#Diff | wrapper (`ResearchSubjectKey`) | `ChangeId` / `CSharpDiffKind`, source-shape span, related IL offsets as evidence |
+| MetadataDiff | row (`ApiChange` → `MemberAnchor` on `ApiChangeSubject`) | `ApiChangeSubjectKind`, old/new member handles, category |
+| C#Diff | row (`CSharpDiffRow` → `MemberAnchor` + `StableMemberKey`) | `ChangeId` / `CSharpDiffKind`, source line / `SourceCoordinate`, related IL offsets as evidence, fidelity |
+| ILDiff | wrapper (`ResearchSubjectKey` via `SubjectFromMethod`) | `HunkId`, `IlDiffKind` polarity, `CanonicalIlOperation`, IL offset (hint) |
+| Analysis/body-signal | wrapper (`ResearchSubjectKey` via `SubjectFromMethod`) | signal / shape, added/removed/changed kind, IL offset(s) as evidence |
 
 IL offsets, operation-array ordinals, and source spans are local evidence and
 display hints, never the durable selector. The durable selector is always the
 `MemberAnchor`-derived `StableSelector` / canonical signature / digest carried by
-the anchor-carrying row or its wrapper.
+the anchor-carrying row or supplied by the wrapper.
 
 ### ResearchDiff projection
 
-`ResearchChange` binds one member-agnostic native payload (`IlRow`, `CSharpRow`,
-`ApiChange`, and the analysis signal fields) to one `ResearchSubjectKey` whose
-`Id` is the anchor `StableSelector`, and to a cross-mechanism product `ChangeId`
-via `FindingDescriptor`. It never erases the lower-layer typed payload and never
+`ResearchChange` binds one native producer payload — `ApiChange` or
+`CSharpRow` (anchor-carrying) or `IlRow` and the analysis signal fields
+(body-substrate) — to one `ResearchSubjectKey` whose `Id` is the anchor
+`StableSelector`, and to a cross-mechanism product `ChangeId` via
+`FindingDescriptor`. It never erases the lower-layer typed payload and never
 requires consumers to parse `Message`. Machine consumers query by `ChangeId`
 through `HasChange`, `HasChangePrefix`, and `HasChangeCategory`; product
 `ChangeId`s use fact concepts (`unsafe.stackalloc.added`, `il.hunk.changed`,

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -771,6 +771,45 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_BodySignals_PreservesMemberCurrencyAndTypedEvidence()
+    {
+        // #2299 row-currency contract for the body-substrate class: a body-signal
+        // change carries no MemberAnchor on its own row, so Research must supply
+        // stable member currency (Subject.Id = Name~digest StableSelector) by
+        // wrapping, and keep the fact's typed evidence (Signal, IL offset) so a
+        // machine consumer never parses the producer-owned Message/Detail.
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchChangeMechanism.BodySignals));
+
+        var member = Assert.Single(
+            diff.MembersWhere(m => m.HasChange("unsafe.stackalloc.added")));
+        var change = Assert.Single(
+            diff.Changes,
+            c => c.Mechanism == ResearchChangeMechanism.BodySignals
+                && c.Descriptor.Id == "unsafe.stackalloc.added");
+
+        // Stable member currency: caller-supplied selector, in Name~digest form,
+        // agreeing with the grouped subject on both sides of the join.
+        Assert.Equal(ResearchSubjectKind.Member, change.Subject.Kind);
+        Assert.Equal(member.Subject.Id, change.Subject.Id);
+        Assert.Contains('~', change.Subject.Id);
+        Assert.False(string.IsNullOrEmpty(change.Subject.MemberName));
+
+        // Typed fact evidence, not display text.
+        Assert.Equal(ResearchChangeCategory.BodySignal, change.Category);
+        Assert.Equal(ResearchChangeKind.Added, change.Kind);
+        Assert.Equal("stackalloc", change.Signal);
+        Assert.NotNull(change.NewIlOffset);
+        Assert.Null(change.OldIlOffset);
+
+        // ChangeId derives from the typed Signal, so machine queries never parse
+        // the producer Message/Detail.
+        Assert.Equal($"unsafe.{change.Signal}.added", change.Descriptor.Id);
+    }
+
+    [Fact]
     public void CompareAssemblies_BodySignals_MemberTargetsKeepUnsafeRows()
     {
         var unfiltered = ResearchDiff.CompareAssemblies(


### PR DESCRIPTION
## Summary

Closes the two remaining slices on #2299 (the cross-mechanism row-currency contract), in the order requested: **docs first, then the analysis/body-signal test**.

### Docs — the currency carrier contract
Adds a **Row currency contract** section to `docs/design/implementation-diff.md` stating which diff rows carry `MemberAnchor` directly vs. which are body-substrate rows wrapped by Research:

- **Anchor-carrying rows** (produced after member alignment, own their currency): `ApiChange` (via `ApiChangeSubject`) and `CSharpDiffRow` (carries `MemberAnchor` + `StableMemberKey` directly).
- **Body-substrate rows** (below member selection, no member identity on the row): `IlDiffRow` and analysis/body-signal facts; Research supplies currency via `SubjectFromMethod`/`ResearchSubjectKey`.
- Clarifies the split is **altitude, not a Metadata-dependency ban** — `MemberAnchor` lives in the lightweight `MetadataPrimitives`, which `ILInspector.Instructions` already references.
- Records the native coordinates each mechanism preserves, that IL offsets/ordinals/spans are evidence not selectors, and that ResearchDiff projects cross-mechanism `ChangeId`s without erasing lower-layer payload or parsing `Message`. Cross-links `finding-coordinates.md`.

### Analysis — body-signal currency test
The prior closure audit asked for explicit tests that ResearchDiff preserves stable member identity **plus lower-layer typed evidence** for each mechanism without parsing `Message`. API/IL/C# were already covered; the **body-signal** mechanism was the gap. Adds `CompareAssemblies_BodySignals_PreservesMemberCurrencyAndTypedEvidence` asserting:
- `Subject.Id` is the caller-supplied `Name~digest` selector agreeing with the grouped subject;
- typed `Signal`/`NewIlOffset` evidence is present;
- the `ChangeId` derives from the typed `Signal`, so machine queries never parse `Message`/`Detail`.

## Evidence
- `markdownlint` clean on the changed doc.
- `dotnet run --project src/ILInspector.Research.Tests -c Release` — **114 passed, 0 failed** (new test included).

## Risk
Low. Documentation + one test that asserts existing behavior; no product code changed. No new heuristics or shapes → no adversarial review required.

## Follow-up
#2299 can then be closed, or kept open only if a standalone `BodySignalDiffRow` type is later desired (this PR records the design decision that body-signal currency is intentionally caller-supplied, so no such row is needed).