### PR TITLE
Fold direct/inline guarded heterogeneous arms via #3082 disjointness oracle

### DIFF
--- a/src/ILInspector.Decompiler.Tests/HeterogeneousArmSample.cs
+++ b/src/ILInspector.Decompiler.Tests/HeterogeneousArmSample.cs
@@ -10,7 +10,10 @@ namespace ILInspector.Decompiler.Tests;
 /// <c>return</c>. <see cref="ILInspector.Decompiler.Pipeline.PatternSwitchExpressionPass"/>
 /// raises the whole cascade back into a single switch expression.
 ///
-/// <see cref="Area"/> is the mixed intro-chain-plus-inline shape. Isolated from
+/// <see cref="Area"/> is the mixed intro-chain-plus-inline shape (all-unguarded).
+/// <see cref="GuardedArea"/> adds a <c>when</c>-guarded first arm — the #3028
+/// follow-up that folds a refutable heterogeneous arm through the type-
+/// disjointness oracle. Isolated from
 /// <see cref="CfgSampleClass"/> so it does not perturb the fidelity gate's pinned
 /// population.
 /// </summary>
@@ -40,6 +43,20 @@ public static class HeterogeneousArmSample
     public static int Area(Shape shape) => shape switch
     {
         Dot d => d.Radius,
+        Bar b => b.Length,
+        Box x => x.Side,
+        _ => -1,
+    };
+
+    // Heterogeneous cascade whose FIRST arm is `when`-guarded over a type (Dot)
+    // disjoint from every later arm (Bar, Box). csc lowers the guarded arm to an
+    // `if (d is null) { REST } else { MATCHED }` dispatch whose default is a shared
+    // trailing return; a Dot that fails the guard is routed to that default. The
+    // fold is faithful ONLY because Dot is provably disjoint from Bar and Box, so
+    // it exercises the disjointness oracle on the direct/inline surface.
+    public static int GuardedArea(Shape shape, int min) => shape switch
+    {
+        Dot d when d.Radius > min => d.Radius,
         Bar b => b.Length,
         Box x => x.Side,
         _ => -1,

--- a/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
@@ -509,6 +509,61 @@ public class PatternSwitchExpressionPassTests
         Assert.False(switchExpression.Arms[1].HasGuard);
     }
 
+    // Builds a direct-place cascade whose FIRST arm is an UNGUARDED then-only intro
+    // arm (`a = place as Leaf; if (!a) { REST } return 1;`) whose REST nests a
+    // guarded then-only intro arm as the LAST arm — `b = place as Twig; if (!b)
+    // return -1; if (G(b)) return 2;`. A Twig that fails its guard runs off the end
+    // of the REST block and reaches the ENCLOSING Leaf arm's value (`return 1`), NOT
+    // the trailing default. Leaf and Twig are disjoint, so the disjointness gate
+    // alone would admit the fold; only the fall-through check must decline it.
+    static IrFunction DirectGuardedLastArmFallsToPriorArm()
+    {
+        IrExpression Place() => new LoadArgument(0, "node", Node);
+        IrExpression Guard() => new Call(new MethodRef(Twig, "Ok", Bool, [Twig], HasThis: false), isVirtual: false, [new LoadLocal(1, Twig)]);
+
+        // REST (inside the Leaf arm's `then`): a guarded Twig intro arm whose guard
+        // failure falls off the end of this block into the Leaf arm's value.
+        var guardThen = new Block();
+        guardThen.Add(new Return(new Constant(2, Int32)));
+        var rest = new Block();
+        rest.Add(new StoreLocal(1, Twig, new IsInstance(Twig, Place())));
+        rest.Add(new IfStatement(new LogicalNot(new LoadLocal(1, Twig)), Return(-1), null));
+        rest.Add(new IfStatement(Guard(), guardThen, null));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, Leaf, new IsInstance(Leaf, Place())));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Leaf)), rest, null));
+        block.Add(new Return(new Constant(1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Twig), container);
+
+        static Block Return(int value)
+        {
+            var b = new Block();
+            b.Add(new Return(new Constant(value, Int32)));
+            return b;
+        }
+    }
+
+    [Fact]
+    public void Synthetic_GuardedLastArmFallsToPriorArm_DoesNotRaise()
+    {
+        // #3102 review (GPT, Finding 1): a guarded intro arm nested as the LAST arm
+        // of a prior unguarded arm's then-only REST. Its guard FAILURE runs off the
+        // end of the REST block into the PRIOR arm's value (`return 1`), not the
+        // default. Folding to `Leaf => 1, Twig when G => 2, _ => -1` diverts that
+        // failure to `_ => -1` — divergent (original returns 1). Leaf and Twig ARE
+        // provably disjoint, so the disjointness gate would admit it; the fold must
+        // still be declined because the matched body's fall-through is not the
+        // default in a then-only REST (fallThroughIsDefault == false).
+        var proves = DirectGuardedLastArmFallsToPriorArm();
+        RunPass(proves, (a, b) => !a.Equals(b));
+        Assert.Empty(proves.Descendants.OfType<PatternSwitchExpression>());
+    }
+
     // Builds a direct-place cascade (intro head + one inline sibling) whose inline
     // arm value takes the address of the scrutinee place — the by-ref mutation
     // vector. `argAddress` selects an argument scrutinee (`&arg`) versus a local

--- a/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
@@ -148,6 +148,36 @@ public class PatternSwitchExpressionPassTests
         Assert.Contains("_ => -1,", output);
     }
 
+    [Fact]
+    public void GuardedHeterogeneousArm_RaisesOnlyWhenProvablyDisjoint()
+    {
+        // The direct/inline surface (#3028) extended to a refutable arm: the FIRST
+        // arm is `when`-guarded (`Dot d when d.Radius > min`) over a type disjoint
+        // from every later arm. csc lowers the guarded arm to an `if (d is null)
+        // { REST } else { MATCHED }` dispatch whose default is a shared trailing
+        // return; a Dot that fails the guard is routed to that default. Folding is
+        // faithful ONLY because Dot is provably disjoint from Bar and Box, so it
+        // depends on the type-disjointness oracle (#3082's AreProvablyDisjoint):
+        // Raised wires the assembly's real oracle and the guarded arm folds.
+        var function = Raised(typeof(HeterogeneousArmSample), nameof(HeterogeneousArmSample.GuardedArea));
+
+        var switchExpression = Assert.Single(function.Descendants.OfType<PatternSwitchExpression>());
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.True(switchExpression.HasDefault);
+        Assert.Equal(3, switchExpression.Arms.Count);
+        Assert.True(switchExpression.Arms[0].HasGuard);
+        Assert.Contains("Dot", switchExpression.Arms[0].PatternType.ToDisplayString());
+        Assert.False(switchExpression.Arms[1].HasGuard);
+        Assert.False(switchExpression.Arms[2].HasGuard);
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+        Assert.Contains("return shape switch", output);
+        Assert.Contains("Dot d when d.Radius > min => d.Radius,", output);
+        Assert.Contains("Bar b => b.Length,", output);
+        Assert.Contains("Box x => x.Side,", output);
+        Assert.Contains("_ => -1,", output);
+    }
+
     // ── Synthetic shape + negative guards ──────────────────────────────────
 
     // Minimal recognized shape (post-#3003 structuring): `sv = <place>; k = sv
@@ -395,20 +425,88 @@ public class PatternSwitchExpressionPassTests
     }
 
     [Fact]
-    public void Synthetic_InlineGuardFallsThrough_DoesNotRaise()
+    public void Synthetic_InlineGuardFallsThroughFinalArm_Raises()
     {
-        // #3028 PR A scopes the newly recognized heterogeneous surface (a direct
-        // scrutinee or any inline-positive arm) to UNGUARDED arms only. A guarded
-        // arm whose failure short-circuits to the default folds faithfully only
-        // when no later arm can match the same value, which needs a
-        // type-disjointness oracle this SRM-only pass does not have. Even the safe
-        // fall-through inline guard is therefore deferred to a follow-up; only the
-        // unguarded new-surface shape folds under PR A.
+        // A guarded inline arm in the safe fall-through form (`if (G) { return V; }`)
+        // that is the LAST arm folds without any disjointness proof: its guard
+        // failure routes to the default in the lowered cascade AND in a switch
+        // expression (there is no later arm to catch it), so the fold is faithful.
+        // RefutableArmsDisjointFromLaterArms only constrains a refutable NON-last
+        // arm, so this raises even with no oracle wired — exercising that the
+        // "non-last" qualifier is load-bearing.
         var function = DirectIntroGuardedInline(new LoadArgument(0, "node", Node), shortCircuitToDefault: false);
 
         RunPass(function);
 
-        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+        var switchExpression = Assert.Single(function.Descendants.OfType<PatternSwitchExpression>());
+        Assert.Equal(2, switchExpression.Arms.Count);
+        Assert.True(switchExpression.HasDefault);
+        Assert.False(switchExpression.Arms[0].HasGuard);
+        Assert.True(switchExpression.Arms[1].HasGuard);
+    }
+
+    // Builds a direct-place (temp-less) cascade whose FIRST arm is a `when`-guarded
+    // intro arm in csc's if/else lowering — `k0 = place as Leaf; if (!k0) { REST }
+    // else { if (Ok(k0)) return 1; } return <default>;` — followed by a later
+    // inline Twig arm in REST. The guarded Leaf arm PRECEDES the Twig arm, so a
+    // Leaf that fails its guard routes to the default in the lowering but would
+    // fall to the Twig arm in a switch: faithful only if Leaf and Twig are disjoint.
+    static IrFunction DirectGuardedIfElseCascade()
+    {
+        IrExpression Place() => new LoadArgument(0, "node", Node);
+        IrExpression Guard() => new Call(new MethodRef(Leaf, "Ok", Bool, [Leaf], HasThis: false), isVirtual: false, [new LoadLocal(0, Leaf)]);
+
+        // MATCHED (else): positive guard, fall-through to the shared default.
+        var guardThen = new Block();
+        guardThen.Add(new Return(new Constant(1, Int32)));
+        var matched = new Block();
+        matched.Add(new IfStatement(Guard(), guardThen, null));
+
+        // REST (then): inline Twig arm + trailing default.
+        var twigThen = new Block();
+        twigThen.Add(new Return(new Constant(2, Int32)));
+        var rest = new Block();
+        rest.Add(new IfStatement(new IsPattern(Place(), Twig, 1), twigThen, null));
+        rest.Add(new Return(new Constant(-1, Int32)));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, Leaf, new IsInstance(Leaf, Place())));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Leaf)), rest, matched));
+        block.Add(new Return(new Constant(-1, Int32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("node", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Twig), container);
+    }
+
+    [Fact]
+    public void Synthetic_DirectGuardedNonLastArm_RaisesOnlyWhenProvablyDisjoint()
+    {
+        // The #3028 load-bearing case on the direct/inline surface: a `when`-guarded
+        // intro arm (csc's if/else lowering) that PRECEDES a later arm. A Leaf that
+        // fails its guard routes to the default in the cascade but would fall to the
+        // Twig arm in a switch — faithful only if Leaf and Twig cannot both match.
+        // The oracle must PROVE disjointness; absent or negative never folds.
+
+        // No oracle wired → decline.
+        var noOracle = DirectGuardedIfElseCascade();
+        RunPass(noOracle);
+        Assert.Empty(noOracle.Descendants.OfType<PatternSwitchExpression>());
+
+        // Oracle that cannot prove disjointness → decline.
+        var refuses = DirectGuardedIfElseCascade();
+        RunPass(refuses, (_, _) => false);
+        Assert.Empty(refuses.Descendants.OfType<PatternSwitchExpression>());
+
+        // Oracle proving the two distinct arm types disjoint → raise.
+        var proves = DirectGuardedIfElseCascade();
+        RunPass(proves, (a, b) => !a.Equals(b));
+        var switchExpression = Assert.Single(proves.Descendants.OfType<PatternSwitchExpression>());
+        Assert.Equal(2, switchExpression.Arms.Count);
+        Assert.True(switchExpression.HasDefault);
+        Assert.True(switchExpression.Arms[0].HasGuard);
+        Assert.False(switchExpression.Arms[1].HasGuard);
     }
 
     // Builds a direct-place cascade (intro head + one inline sibling) whose inline
@@ -637,17 +735,20 @@ public class PatternSwitchExpressionPassTests
     [Fact]
     public void Synthetic_DirectSubpatternOverlapsLaterArm_DoesNotRaise()
     {
-        // #3028 review round 2 (GPT): the unguarded-surface gate must also reject
-        // property-subpattern arms on the new surface. An `Outer { Inner: Leaf }`
-        // arm whose inner match fails routes to the default just like a failed
-        // guard; folding it (with a later overlapping `Outer` arm) would make that
-        // failure fall through to the `Outer` arm instead — divergent. The gate
-        // declines any guarded OR subpattern arm on the direct/inline surface.
-        var function = DirectSubpatternPlusInline(new LoadArgument(0, "node", Outer));
+        // A property-subpattern arm (`Outer { Inner: Leaf }`) whose inner match
+        // fails routes to the default just like a failed guard; folding it with a
+        // later arm of the SAME outer type (`Outer`) would make that failure fall
+        // through to the `Outer` arm instead — divergent. The two arms share the
+        // outer type `Outer`, so they are NOT disjoint: even an oracle that proves
+        // every DISTINCT pair disjoint declines here, because `Outer` is not
+        // disjoint from `Outer`.
+        var noOracle = DirectSubpatternPlusInline(new LoadArgument(0, "node", Outer));
+        RunPass(noOracle);
+        Assert.Empty(noOracle.Descendants.OfType<PatternSwitchExpression>());
 
-        RunPass(function);
-
-        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+        var distinctPairsDisjoint = DirectSubpatternPlusInline(new LoadArgument(0, "node", Outer));
+        RunPass(distinctPairsDisjoint, (a, b) => !a.Equals(b));
+        Assert.Empty(distinctPairsDisjoint.Descendants.OfType<PatternSwitchExpression>());
     }
 
     // ── #3082 soundness gates on the temp-form intro cascade ───────────────

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -137,32 +137,21 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             return false;
 
         var arms = new List<ArmData>();
-        if (!TryParseChain(region, 0, scrutinee, defaultValue, arms) || arms.Count < minArms)
+        if (!TryParseChain(region, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: false) || arms.Count < minArms)
             return false;
 
-        // PR A (#3028) scopes the newly recognized heterogeneous surface — a
-        // direct (temp-less) scrutinee, or any inline-positive sibling arm — to
-        // plain, unguarded type-pattern arms. A guarded arm, or a property-
-        // subpattern arm (`Outer { Inner: T }`), routes its guard/subpattern
-        // FAILURE straight to the trailing default; in the folded switch that
-        // failure instead falls through to the later arms. Reproducing the
-        // original routing is faithful only when no later arm can match the same
-        // value, which needs a type-disjointness oracle this SRM-only,
-        // no-inspected-assembly-loading pass does not have. The pre-existing
-        // temp-form intro cascade (#3022) keeps its guarded and subpattern arms
-        // under the compiler's proven mutual exclusivity; guarded/subpattern
-        // heterogeneous arms are deferred to a follow-up carrying a real oracle.
-        bool isNewSurface = scrutinee.TempLocal is null || arms.Any(a => a.IsInline);
-        if (isNewSurface && arms.Any(a => a.Guard is not null || a.Subpattern is not null))
-            return false;
-
-        // [#3082 finding 1] The guarded / property-subpattern arms that survive
-        // here are the temp-form intro cascade (#3022) the compiler proved
-        // mutually exclusive. A refutable non-last arm routes its refinement
-        // FAILURE to the trailing default in the lowered cascade, but to the NEXT
-        // arm in a switch expression. Reproducing that routing is faithful only
-        // when no later arm's type can also match the same value — require a
-        // provable-disjointness proof from the oracle and decline without one.
+        // A refutable (guarded or property-subpattern) non-last arm routes its
+        // refinement FAILURE to the trailing default in the lowered cascade, but
+        // to the NEXT arm in a switch expression. Reproducing that routing is
+        // faithful only when no later arm's type can also match the same value —
+        // require a provable-disjointness proof from the oracle and decline
+        // without one. This holds on every surface: the temp-form intro cascade
+        // (#3022), whose arms the compiler already proved mutually exclusive, and
+        // the direct/inline heterogeneous surface (#3028), where a guarded intro
+        // arm (`Dot d when g`) or subpattern arm is folded ONLY when the oracle
+        // proves it disjoint from every later arm. (An unguarded arm always
+        // matches its type and never falls through, so it carries no obligation
+        // here; #3065's compiler-lowered head guarantees the CS8510 ordering.)
         if (!RefutableArmsDisjointFromLaterArms(arms, disjoint))
             return false;
 
@@ -236,19 +225,31 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     }
 
     // A chain of arms whose collective no-match fall-through reaches the default.
-    // Two arm shapes are recognized and may be mixed:
-    //   * Intro-chain arm: `intro Lk = isinst Tk(SV); if (!Lk) { REST } MATCHED`
-    //     where MATCHED (this arm's guard + value) trails the dispatch test as
+    // Three arm shapes are recognized and may be mixed:
+    //   * Intro-chain arm (then-only): `intro Lk = isinst Tk(SV); if (!Lk) { REST }
+    //     MATCHED` where MATCHED (this arm's guard + value) trails the dispatch as
     //     sibling statements and REST (the remaining arms, ultimately a bare
-    //     `return <default>`) nests inside the test's `then` branch. The dispatch
-    //     test carries no `else`: its `then` always returns, so csc drops it.
+    //     `return <default>`) nests in the test's `then`. csc emits this when the
+    //     arm always returns, so the dispatch needs no `else`.
+    //   * Intro-chain arm (if/else): `intro Lk = isinst Tk(SV); if (!Lk) { REST }
+    //     else { MATCHED }` with the `<default>` a shared statement after the
+    //     dispatch. csc emits this when MATCHED can fall through — a `when` guard
+    //     or property subpattern whose failure must reach the default — so both
+    //     REST (then) and MATCHED (else) fall off their block into that shared
+    //     default.
     //   * Inline-positive arm: `if (SV is Tk x) { MATCHED }` whose no-match falls
     //     straight through to the following sibling statement (the next arm, or the
     //     bare `return <default>`).
-    bool TryParseChain(IReadOnlyList<IrNode> stmts, int index, Scrutinee scrutinee, IrExpression defaultValue, List<ArmData> arms)
+    // <paramref name="fallThroughIsDefault"/> is set when running off the end of
+    // <paramref name="stmts"/> lands on the default (a `then`/`else` block whose
+    // enclosing dispatch is trailed by the default); at the top level, and inside a
+    // then-only `then` (whose fall-through reaches the sibling MATCHED, not the
+    // default), it is false and the list must end in an explicit `return <default>`.
+    bool TryParseChain(IReadOnlyList<IrNode> stmts, int index, Scrutinee scrutinee, IrExpression defaultValue, List<ArmData> arms, bool fallThroughIsDefault)
     {
+        // Ran off the end: faithful only when fall-through lands on the default.
         if (index >= stmts.Count)
-            return false;
+            return fallThroughIsDefault;
 
         // Bottom of the chain: a bare `return <default>`.
         if (index == stmts.Count - 1 && stmts[index] is Return { Value: { } tailValue } && DefaultEquals(tailValue, defaultValue))
@@ -273,21 +274,41 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             int? inlineIndex = ReferencesLocalIn(inlineGuard, inlineLocal) || ReferenceOwnership.SubtreeReferencesLocal(inlineValue, inlineLocal)
                 ? inlineLocal
                 : null;
-            // Inline arms are the newly recognized heterogeneous surface; PR A
-            // (#3028) folds them only unguarded (the guard gate in TryFold rejects
-            // a guarded new-surface fold). Tag the arm inline so that gate applies.
+            // Inline arms are the direct/inline heterogeneous surface (#3028). A
+            // guarded inline arm routes its guard failure to the following sibling
+            // (the fall-through shape enforced above), exactly as a switch `when`
+            // does; RefutableArmsDisjointFromLaterArms in TryFold still requires
+            // its type disjoint from every later arm before folding.
             arms.Add(new ArmData(inlineType, inlineLocal, inlineIndex, Subpattern: null, inlineGuard, inlineValue, IsInline: true));
-            return TryParseChain(stmts, index + 1, scrutinee, defaultValue, arms);
+            return TryParseChain(stmts, index + 1, scrutinee, defaultValue, arms, fallThroughIsDefault);
         }
 
         if (!IsArmIntro(stmts[index], scrutinee, out int patternLocal, out var patternType, out _))
             return false;
-        if (index + 1 >= stmts.Count || stmts[index + 1] is not IfStatement { HasElse: false } dispatch)
+        if (index + 1 >= stmts.Count || stmts[index + 1] is not IfStatement dispatch)
             return false;
         if (!IsNegatedLocalTest(dispatch.Condition, patternLocal))
             return false;
 
-        // MATCHED body = the sibling statements after the dispatch test.
+        if (dispatch.HasElse)
+        {
+            // If/else form (csc's lowering of a refutable intro arm): MATCHED is
+            // the `else`, REST the `then`, and both fall off their block into the
+            // shared default that trails the dispatch.
+            if (!DefaultReachedFrom(stmts, index + 2, defaultValue, fallThroughIsDefault))
+                return false;
+            if (!TryParseMatchedBody(dispatch.Else!.Children, 0, patternType, patternLocal, defaultValue, out var elseArm, out int elseNext))
+                return false;
+            // MATCHED's own fall-through (a guard/subpattern failure) runs off the
+            // `else` block into that same shared default.
+            if (!DefaultReachedFrom(dispatch.Else!.Children, elseNext, defaultValue, fallThroughIsDefault: true))
+                return false;
+            arms.Add(elseArm);
+            // REST nests in `then`; its fall-through reaches the shared default.
+            return TryParseChain(dispatch.Then.Children, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: true);
+        }
+
+        // Then-only form: MATCHED body = the sibling statements after the dispatch.
         if (!TryParseMatchedBody(stmts, index + 2, patternType, patternLocal, defaultValue, out var arm, out int matchedNext))
             return false;
         // Nothing may follow the matched body at this level except an optional
@@ -296,9 +317,17 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             return false;
 
         arms.Add(arm);
-        // REST: the remaining arms (or the bare default) nest in the `then` branch.
-        return TryParseChain(dispatch.Then.Children, 0, scrutinee, defaultValue, arms);
+        // REST nests in `then`; its fall-through reaches the sibling MATCHED (not
+        // the default), so it must reach the default explicitly.
+        return TryParseChain(dispatch.Then.Children, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: false);
     }
+
+    // Whether control arriving at <paramref name="index"/> reaches the default:
+    // either the list ends here on an explicit `return <default>`, or it runs off
+    // the end into an enclosing default (only when <paramref name="fallThroughIsDefault"/>).
+    static bool DefaultReachedFrom(IReadOnlyList<IrNode> stmts, int index, IrExpression defaultValue, bool fallThroughIsDefault)
+        => (index >= stmts.Count && fallThroughIsDefault)
+            || (index == stmts.Count - 1 && stmts[index] is Return { Value: { } value } && DefaultEquals(value, defaultValue));
 
     // Walks the cascade to its bottom to recover the default value: the value the
     // innermost no-match path yields. An intro-chain arm's no-match nests in its
@@ -328,12 +357,21 @@ public sealed class PatternSwitchExpressionPass : IIrPass
                 continue;
             }
 
-            // Intro-chain arm: no-match nests in the dispatch test's `then` branch.
+            // Intro-chain arm: no-match nests in the dispatch test's `then` branch
+            // (both the then-only and if/else forms). For the if/else form the
+            // shared default trails the dispatch, so take it directly when present.
             if (IsArmIntro(stmts[index], scrutinee, out int local, out _, out _)
                 && index + 1 < stmts.Count
-                && stmts[index + 1] is IfStatement { HasElse: false } dispatch
+                && stmts[index + 1] is IfStatement dispatch
                 && IsNegatedLocalTest(dispatch.Condition, local))
             {
+                if (dispatch.HasElse
+                    && index + 2 == stmts.Count - 1
+                    && stmts[index + 2] is Return { Value: { } shared })
+                {
+                    defaultValue = shared;
+                    return true;
+                }
                 stmts = dispatch.Then.Children;
                 index = 0;
                 continue;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -297,7 +297,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             // shared default that trails the dispatch.
             if (!DefaultReachedFrom(stmts, index + 2, defaultValue, fallThroughIsDefault))
                 return false;
-            if (!TryParseMatchedBody(dispatch.Else!.Children, 0, patternType, patternLocal, defaultValue, out var elseArm, out int elseNext))
+            if (!TryParseMatchedBody(dispatch.Else!.Children, 0, patternType, patternLocal, defaultValue, out var elseArm, out int elseNext, out _))
                 return false;
             // MATCHED's own fall-through (a guard/subpattern failure) runs off the
             // `else` block into that same shared default.
@@ -309,11 +309,24 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         }
 
         // Then-only form: MATCHED body = the sibling statements after the dispatch.
-        if (!TryParseMatchedBody(stmts, index + 2, patternType, patternLocal, defaultValue, out var arm, out int matchedNext))
+        if (!TryParseMatchedBody(stmts, index + 2, patternType, patternLocal, defaultValue, out var arm, out int matchedNext, out bool bodyFallsThrough))
             return false;
-        // Nothing may follow the matched body at this level except an optional
-        // trailing `return <default>` (an arm's own no-match fall-through).
-        if (!ReachesDefaultTail(stmts, matchedNext, defaultValue))
+        // An arm whose body ends in an unconditional return (unguarded, or the
+        // negated `if (!G) return <default>; return V;` guarded form) cannot reach
+        // `matchedNext`, so any structural tail there is unreachable. A body that
+        // FALLS THROUGH on refinement failure — the positive `if (G) return V;`
+        // guarded form, or a property-subpattern arm — must land on the default:
+        // an explicit trailing `return <default>`, or, when it runs off the end of
+        // this block, only if this block's own fall-through is the default. A
+        // then-only REST nested in a prior arm (fallThroughIsDefault == false)
+        // falls off its end into that PRIOR arm's matched value, not the default,
+        // so a falling-through matched body that runs off the end there must be
+        // declined; folding it would divert the guard failure to `_ => <default>`
+        // instead of the earlier arm's value (GPT #3102 review, Finding 1).
+        bool tailReachesDefault = bodyFallsThrough
+            ? DefaultReachedFrom(stmts, matchedNext, defaultValue, fallThroughIsDefault)
+            : ReachesDefaultTail(stmts, matchedNext, defaultValue);
+        if (!tailReachesDefault)
             return false;
 
         arms.Add(arm);
@@ -384,8 +397,14 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 
     // Parse the body run for a matched arm (value is `patternType`, bound to
     // `patternLocal`), starting at `stmts[index]`. Sets `arm` and `nextIndex`
-    // (the first statement after the arm; unconditional-return arms leave the
-    // caller to confirm the tail reaches the default).
+    // (the first statement after the arm). `bodyFallsThrough` reports whether the
+    // matched body can reach `nextIndex` on a refinement FAILURE — true only for
+    // the positive guarded form (`if (G) return V;`, whose guard failure drops to
+    // the next statement) and the property-subpattern form (whose null inner match
+    // drops past the `if`). The unguarded (`return V;`) and negated guarded
+    // (`if (!G) return <default>; return V;`) forms end in an unconditional return,
+    // so `nextIndex` is unreachable and the caller need not prove it is the
+    // default.
     bool TryParseMatchedBody(
         IReadOnlyList<IrNode> stmts,
         int index,
@@ -393,10 +412,12 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         int patternLocal,
         IrExpression defaultValue,
         out ArmData arm,
-        out int nextIndex)
+        out int nextIndex,
+        out bool bodyFallsThrough)
     {
         arm = null!;
         nextIndex = -1;
+        bodyFallsThrough = false;
         if (index >= stmts.Count)
             return false;
 
@@ -422,17 +443,22 @@ public sealed class PatternSwitchExpressionPass : IIrPass
                 : null;
             arm = new ArmData(patternType, patternLocal, outerLocal, subpattern, innerGuard, innerValue, IsInline: false);
             nextIndex = index + 2;
+            // A null inner match (`Lsub` is null) drops past the `if` to nextIndex.
+            bodyFallsThrough = true;
             return true;
         }
 
         // Bare type-pattern arm: a guarded (or unguarded) value run.
-        if (!TryParseGuardedValue(stmts, index, defaultValue, out var guard, out var value, out int consumed, out _))
+        if (!TryParseGuardedValue(stmts, index, defaultValue, out var guard, out var value, out int consumed, out bool shortCircuitsToDefault))
             return false;
         int? localIndex = ReferencesLocalIn(guard, patternLocal) || ReferenceOwnership.SubtreeReferencesLocal(value, patternLocal)
             ? patternLocal
             : null;
         arm = new ArmData(patternType, patternLocal, localIndex, Subpattern: null, guard, value, IsInline: false);
         nextIndex = index + consumed;
+        // Only the positive guarded form (`if (G) return V;`) drops to nextIndex on
+        // guard failure; the unguarded and negated forms both end in a return.
+        bodyFallsThrough = guard is not null && !shortCircuitsToDefault;
         return true;
     }
 


### PR DESCRIPTION
- Advances #3028
- Changes: guarded heterogeneous arms on the direct/inline surface now fold to a `switch` expression, gated by #3082's type-disjointness oracle
- Card revision: `dc7b03d4`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a `when`-guarded direct/inline arm folds only when #3082's `AreProvablyDisjoint` proves it disjoint from every later arm, so the fold is faithful; without such a proof the pass declines and emits the pre-change if-cascade.

### Original source

```csharp
public static int GuardedArea(Shape shape, int min) => shape switch
{
    Dot d when d.Radius > min => d.Radius,
    Bar b => b.Length,
    Box x => x.Side,
    _ => -1,
};
```

### Before

```csharp
public static int GuardedArea(HeterogeneousArmSample.Shape shape, int min)
{
    Shape V_4 = shape;
    Dot d = V_4 as Dot;
    if (d is null)
    {
        if (V_4 is Bar b)
        {
            return b.Length;
        }
        if (V_4 is Box x)
        {
            return x.Side;
        }
    }
    else
    {
        if (d.Radius > min)
        {
            return d.Radius;
        }
    }
    return -1;
}
```

- Valid: True
- Correct: True

Faithful but unraised: the guarded first arm blocked the fold on the direct/inline surface (#3065/#3082 declined any guarded arm there).

### After

```csharp
public static int GuardedArea(HeterogeneousArmSample.Shape shape, int min)
{
    return shape switch
    {
        Dot d when d.Radius > min => d.Radius,
        Bar b => b.Length,
        Box x => x.Side,
        _ => -1,
    };
}
```

- Valid: True
- Correct: True

Faithful because `Dot` is provably disjoint from `Bar` and `Box`: a `Dot` that fails its guard routes to the default in both the cascade and the switch.

### Fully raised

The After decompilation is in the fully raised state.

## Change detail

Extends #3082's disjointness-gated fold from the temp-form intro cascade (#3022) to the direct/inline heterogeneous surface (#3028) for `when`-guarded arms, **reusing** #3082's `MetadataSource.AreProvablyDisjoint` and `RefutableArmsDisjointFromLaterArms` — no new oracle or seam.

- Remove the `isNewSurface && guard/subpattern => decline` gate in `TryFold`. #3082's `RefutableArmsDisjointFromLaterArms` already covers **all** arms and is the correct sole guard for a refutable non-last arm on every surface.
- Recognize csc's if/else lowering of a refutable direct intro arm (`k = place as T; if (!k) { REST } else { MATCHED }` with a shared trailing default) via a `fallThroughIsDefault` parameter, a `DefaultReachedFrom` helper, and `TryDiscoverDefault` HasElse handling. Then-only `then` blocks still require an explicit trailing default.

Does **not** close #3028: bare/multi-level property-subpattern arms do not structure to nested ifs upstream and remain a separate structuring frontier.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `PatternSwitchExpressionPassTests`: 22 passed | `PatternSwitchExpressionPassTests`: 25 passed |
| Decompiler fast suite | 3413, 0 failed | 3416, 0 failed |
| Real witness | `HeterogeneousArmSample.GuardedArea` unraised if-cascade | `HeterogeneousArmSample.GuardedArea` fully raised switch |

Head's +2 tests are `GuardedHeterogeneousArm_RaisesOnlyWhenProvablyDisjoint` and `Synthetic_DirectGuardedNonLastArm_RaisesOnlyWhenProvablyDisjoint`; `Synthetic_InlineGuardFallsThrough_DoesNotRaise` was converted to `...FinalArm_Raises`. No baseline failures.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.PatternSwitchExpressionPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```

