### PR TITLE
Add opt-in this.-qualification printer knobs (class-3 spelling)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection.PortableExecutable;
 
 using ILInspector.Decompiler;
@@ -85,6 +86,37 @@ public sealed class ThisQualificationTests
         var text = Render(nameof(ThisQualificationSpecimen.ReadField),
             new PrinterOptions { QualifyPropertyAccess = true });
         Assert.DoesNotContain("this._value", text);
+    }
+
+    // A knob that changes rendered output must also be recorded in the product
+    // evidence (DecompilerResult.EffectiveOptions), matching ReadableLocalNames /
+    // WrapSplittableExpressions — otherwise a host cannot tell an on render from an
+    // off one without reverse-engineering the text.
+    static DecompilerResult PrintSynthetic(PrinterOptions options)
+    {
+        var holder = TypeRef.Definition("synthetic", "", "Holder");
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var block = new Block(0);
+        block.Add(new Return(new LoadArgument(0, "value", int32)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(int32, ImmutableArray<Parameter>.Empty, HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", holder, signature, [], container);
+        return CSharpPrinter.Print(function, options);
+    }
+
+    [Fact]
+    public void EffectiveOptions_RecordsFieldKnob()
+    {
+        Assert.True(PrintSynthetic(new PrinterOptions { QualifyFieldAccess = true }).EffectiveOptions.QualifyFieldAccess);
+        Assert.False(PrintSynthetic(PrinterOptions.Default).EffectiveOptions.QualifyFieldAccess);
+    }
+
+    [Fact]
+    public void EffectiveOptions_RecordsPropertyKnob()
+    {
+        Assert.True(PrintSynthetic(new PrinterOptions { QualifyPropertyAccess = true }).EffectiveOptions.QualifyPropertyAccess);
+        Assert.False(PrintSynthetic(PrinterOptions.Default).EffectiveOptions.QualifyPropertyAccess);
     }
 }
 

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -1,0 +1,106 @@
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The opt-in <c>this.</c>-qualification knobs
+/// (<see cref="PrinterOptions.QualifyFieldAccess"/> /
+/// <see cref="PrinterOptions.QualifyPropertyAccess"/>). These are class-3 spelling
+/// choices with no IL anchor: <c>this.field</c>/<c>this.Prop</c> emit the same
+/// <c>ldarg.0; ldfld</c> / <c>ldarg.0; call get_Prop</c> as the bare name. Off by
+/// default — an unshadowed instance member stays bare — so the default render is
+/// byte-identical to before the knobs existed.
+/// </summary>
+[Trait("Area", "RoundTrip")]
+public sealed class ThisQualificationTests
+{
+    static string AssemblyPath => typeof(ThisQualificationTests).Assembly.Location;
+
+    static ApiType Specimen()
+    {
+        using var pe = new PEReader(File.OpenRead(AssemblyPath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        return Assert.Single(api.Types, t => t.FullName == typeof(ThisQualificationSpecimen).FullName);
+    }
+
+    static string Render(string memberName, PrinterOptions? options = null)
+    {
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == memberName);
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null, printerOptions: options);
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.NotNull(rendered.Text);
+        return rendered.Text!;
+    }
+
+    [Fact]
+    public void FieldAccess_DefaultsToBareName()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.ReadField));
+        Assert.Contains("_value", text);
+        Assert.DoesNotContain("this._value", text);
+    }
+
+    [Fact]
+    public void FieldAccess_QualifiesWithThis_WhenRequested()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.ReadField),
+            new PrinterOptions { QualifyFieldAccess = true });
+        Assert.Contains("this._value", text);
+    }
+
+    [Fact]
+    public void PropertyAccess_DefaultsToBareName()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.ReadProperty));
+        Assert.Contains("Count", text);
+        Assert.DoesNotContain("this.Count", text);
+    }
+
+    [Fact]
+    public void PropertyAccess_QualifiesWithThis_WhenRequested()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.ReadProperty),
+            new PrinterOptions { QualifyPropertyAccess = true });
+        Assert.Contains("this.Count", text);
+    }
+
+    // The two knobs are independent: the field knob must not qualify a property
+    // read, and the property knob must not qualify a field read.
+    [Fact]
+    public void FieldKnob_DoesNotQualifyProperties()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.ReadProperty),
+            new PrinterOptions { QualifyFieldAccess = true });
+        Assert.DoesNotContain("this.Count", text);
+    }
+
+    [Fact]
+    public void PropertyKnob_DoesNotQualifyFields()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.ReadField),
+            new PrinterOptions { QualifyPropertyAccess = true });
+        Assert.DoesNotContain("this._value", text);
+    }
+}
+
+// A real compiled type: an unshadowed instance field and instance property, each
+// read through `this` by a public method, so the field/property access flows
+// through FieldTarget / PropertyTarget with a `LoadArgument{Index:0,Name:"this"}`
+// receiver — the exact sites the qualification knobs gate.
+public sealed class ThisQualificationSpecimen
+{
+    int _value;
+
+    public ThisQualificationSpecimen(int seed) => _value = seed;
+
+    public int Count { get; set; }
+
+    public int ReadField() => _value;
+
+    public int ReadProperty() => Count;
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -70,6 +70,22 @@ public sealed record DecompilerOptions
     /// </summary>
     public bool WrapSplittableExpressions { get; init; }
 
+    /// <summary>
+    /// Instance fields accessed through <c>this</c> may render the explicit
+    /// <c>this.</c> qualifier even where the bare name is unambiguous. Off by
+    /// default; an IL-identical spelling choice. Mirrors
+    /// <c>dotnet_style_qualification_for_field</c>.
+    /// </summary>
+    public bool QualifyFieldAccess { get; init; }
+
+    /// <summary>
+    /// Instance properties accessed through <c>this</c> may render the explicit
+    /// <c>this.</c> qualifier even where the bare name is unambiguous. Off by
+    /// default; an IL-identical spelling choice. Mirrors
+    /// <c>dotnet_style_qualification_for_property</c>.
+    /// </summary>
+    public bool QualifyPropertyAccess { get; init; }
+
     public static DecompilerOptions Default { get; } = new();
 }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -48,7 +48,7 @@ public sealed partial class CSharpPrinter
             // bare name binds to it, not the field (e.g. int Foo(int _x) =>
             // this._x + _x). Qualify with this. to reach the field; an
             // unshadowed instance field stays bare per the taste convention.
-            LoadArgument { Index: 0, Name: "this" } => QualifyThisMember(field.Name, field.Type) ? $"this.{fieldName}" : fieldName,
+            LoadArgument { Index: 0, Name: "this" } => _options.QualifyFieldAccess || QualifyThisMember(field.Name, field.Type) ? $"this.{fieldName}" : fieldName,
             _ => $"{ReceiverText(instance)}.{fieldName}",
         };
     }
@@ -99,7 +99,7 @@ public sealed partial class CSharpPrinter
             // Deconstruct(out int X, ...) whose body reads this.X). Qualify with
             // this. to reach the property; an unshadowed instance property stays
             // bare per the taste convention, matching FieldTarget.
-            LoadArgument { Index: 0, Name: "this" } => QualifyThisMember(name, AccessorValueType(accessor)) ? "this" : "",
+            LoadArgument { Index: 0, Name: "this" } => _options.QualifyPropertyAccess || QualifyThisMember(name, AccessorValueType(accessor)) ? "this" : "",
             _ => ReceiverText(instance),
         };
         // An instance property accessor with index arguments IS an indexer,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -249,6 +249,8 @@ public sealed partial class CSharpPrinter
             PreferFrameworkTypeImports = true,
             ExpressionBodyArrowPlacement = _options.ExpressionBodyArrowPlacement,
             WrapSplittableExpressions = _options.WrapSplittableExpressions,
+            QualifyFieldAccess = _options.QualifyFieldAccess,
+            QualifyPropertyAccess = _options.QualifyPropertyAccess,
         };
 
     void AddDecision(string ruleId, string category, string subject, string detail, string? oldValue = null, string? newValue = null)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -56,6 +56,25 @@ public sealed record PrinterOptions
     /// </summary>
     public bool WrapSplittableExpressions { get; init; }
 
+    /// <summary>
+    /// When set, an instance field accessed through <c>this</c> renders the explicit
+    /// <c>this.</c> qualifier even where the bare name is unambiguous (the shipped
+    /// default qualifies only to escape a local/parameter shadow or a member/type
+    /// name collision). IL-identical — <c>this.field</c> and <c>field</c> both emit
+    /// <c>ldarg.0; ldfld</c>, so the qualified form is a spelling choice with no
+    /// anchor. Off by default. Mirrors <c>dotnet_style_qualification_for_field</c>.
+    /// </summary>
+    public bool QualifyFieldAccess { get; init; }
+
+    /// <summary>
+    /// When set, an instance property accessed through <c>this</c> renders the
+    /// explicit <c>this.</c> qualifier even where the bare name is unambiguous.
+    /// IL-identical — <c>this.Prop</c> and <c>Prop</c> both emit
+    /// <c>ldarg.0; call get_Prop</c>. Off by default. Mirrors
+    /// <c>dotnet_style_qualification_for_property</c>.
+    /// </summary>
+    public bool QualifyPropertyAccess { get; init; }
+
     /// <summary>The shipped defaults — every knob off.</summary>
     public static PrinterOptions Default { get; } = new();
 }


### PR DESCRIPTION
## Summary

Slice 1 of #3097 (decompiler style configurability), **surface-independent core**. Adds two opt-in, default-off rendering knobs to `PrinterOptions` and gates the two `this.`-qualification sites on them:

- `QualifyFieldAccess` &rarr; `dotnet_style_qualification_for_field`
- `QualifyPropertyAccess` &rarr; `dotnet_style_qualification_for_property`

When set, an instance field/property accessed through `this` renders the explicit `this.` qualifier even where the bare name is unambiguous (the shipped default qualifies only to escape a local/parameter shadow or a member/type-name collision).

## Why this is safe

- **Default-preserving by construction.** The gate is `_options.Knob || QualifyThisMember(...)`. With `PrinterOptions.Default` (both knobs off) this short-circuits to the exact prior decision, so default output is byte-identical. `PrinterOptions.Default` stability is contractual (the fidelity gate and annotated-IL alignment depend on it).
- **No IL anchor (class 3).** For an unshadowed instance member, `this.field` == `field` (`ldarg.0; ldfld`) and `this.Prop` == `Prop` (`ldarg.0; call get_Prop`). Forcing the qualifier only triggers an *already-exercised* rendering shape (the shadow path) more often; it introduces no new shape.
- **No user surface yet.** There is no CLI flag or config reading; only tests construct these options. A `--editorconfig` flag was rejected as CLI tax. The config file + auto-discovery + disclosure discipline are **slice 2** (tracked on #3097).

## Scope boundary

`var`, predefined-type keyword (`int` vs `Int32`), target-typed `new`, expression-bodied vs block, and method/event `this.` qualification are intentionally **out of scope**: the first two are hazardous or cross-layer, the rest need their own conservative handling. Recorded on #3097.

## Validation

- Build: `dotnet build src\ILInspector.Decompiler.Tests\ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config` &rarr; **0 warnings, 0 errors**.
- New `ThisQualificationTests` (compiled specimen, real member IR): **6/6 pass** &mdash; default is bare for field and property; each knob qualifies only its own member kind; the knobs are independent.
- `MemberBodyProducerMemberRenderTests` (byte-identical per-member pins): **13/13 pass** &mdash; confirms no default drift.

## Files

- `PrinterOptions.cs` &mdash; two default-off `bool` knobs.
- `CSharpPrinter.Members.cs` &mdash; two one-line gate changes (`FieldTarget`, `PropertyTarget`).
- `ThisQualificationTests.cs` &mdash; new test + compiled specimen.
