### PR TITLE
Raise short-circuit &&/|| from bool-constant-arm ternaries (#3071)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2264,12 +2264,14 @@ public class RaisingPassTests
         // `cond ? false : boolExpr` lowers to a select whose false arm is the
         // literal 0; the pass recovers it as `false` and types the slot bool, so
         // the bool-returning method no longer returns an int slot (CS0029).
+        // ShortCircuitTernaryPass then canonicalizes the recovered
+        // `cond ? false : boolExpr` to `!cond && boolExpr`.
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.SelectBoolReturn), source);
 
         Assert.Contains("bool S_0", output);
         Assert.DoesNotContain("int S_0", output);
-        Assert.Contains("false", output);
+        Assert.Contains("x <= 0 && x.GetHashCode() > 0", output);
         Assert.DoesNotContain("? 0", output);
         Assert.DoesNotContain(": 0", output);
     }
@@ -2293,7 +2295,9 @@ public class RaisingPassTests
     {
         // A bool computed into a stack slot and stored through ref bool is still a
         // bool consumer. Without this, the slot stays int and the ref bool store is
-        // `target = S_0` (CS0029).
+        // `target = S_0` (CS0029). The recovered `flag ? false : other` is left as a
+        // ternary: its surviving operand is a bare parameter load, which csc would
+        // emit branchless, so ShortCircuitTernaryPass declines it to stay opcode-exact.
         var boolType = TypeRef.CoreLib("System", "Boolean");
         var intType = TypeRef.CoreLib("System", "Int32");
         var sbyteType = TypeRef.CoreLib("System", "SByte");
@@ -2318,7 +2322,7 @@ public class RaisingPassTests
         string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
 
         Assert.Contains("bool S_0", output);
-        Assert.Contains("? false :", output);
+        Assert.Contains("flag ? false : other", output);
         Assert.DoesNotContain("int S_0", output);
         Assert.Contains("target = S_0;", output);
     }
@@ -3976,7 +3980,7 @@ public class RaisingPassTests
         Assert.DoesNotContain("goto", output);
         Assert.DoesNotContain(function.Descendants.OfType<ConditionalBranch>(), _ => true);
         Assert.Contains("if (node is Call c)", output);
-        Assert.Contains("return c.Callee.RequiresUnsafe ? true : SignatureRequiresUnsafe(c.Callee);", output);
+        Assert.Contains("return c.Callee.RequiresUnsafe || SignatureRequiresUnsafe(c.Callee);", output);
     }
 
     [Fact]
@@ -4069,7 +4073,9 @@ public class RaisingPassTests
         // terminator, so the dispatch cannot inline it as a leaf and the whole
         // method stays flat goto soup (issue #912). The pass folds each diamond to
         // `return c ? a : b`, making the arm a terminator so the dispatch fully
-        // raises — no surviving goto, and the folded ternary present.
+        // raises — no surviving goto. ShortCircuitTernaryPass then canonicalizes the
+        // recovered when-true-false diamond arm (`(y < 16) ? false : (y <= 31)`) to
+        // the `&&` it spells (`y >= 16 && y <= 31`).
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.SlotDiamondDispatch));
         Assert.NotNull(function);
@@ -4077,7 +4083,7 @@ public class RaisingPassTests
         string output = CSharpPrinter.Print(function!).Output!;
 
         Assert.DoesNotContain("goto", output);
-        Assert.Contains("?", output);   // a folded conditional arm survives
+        Assert.Contains("return y >= 16 && y <= 31;", output);   // a folded diamond arm survives as a short-circuit terminator
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ShortCircuitTernaryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ShortCircuitTernaryPassTests.cs
@@ -10,6 +10,7 @@ public class ShortCircuitTernaryPassTests
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef s_double = TypeRef.CoreLib("System", "Double");
     static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef s_truth = TypeRef.CoreLib("Synthetic", "TruthOver");
 
     static Constant Bool(bool value) => new(value, s_bool);
 
@@ -41,24 +42,73 @@ public class ShortCircuitTernaryPassTests
         => new(ComparisonKind.Equal, false,
                new LoadArgument(0, "a", s_string), new LoadArgument(1, "b", s_string));
 
+    // A user-defined-truthiness condition: the `operator true` call the compiler
+    // inserts for a user type used in boolean context. The printer strips it to the
+    // bare user-typed receiver `a`, so lifting `a` into `||`/`&&` would rebind the
+    // user-defined conditional operator (op_BitwiseOr/op_BitwiseAnd + op_True) and
+    // reselect the overload — the pass declines it for both forms.
+    static Call UserTruthiness()
+        => new(new MethodRef(s_truth, "op_True", s_bool, [s_truth], HasThis: false),
+               isVirtual: false, [new LoadArgument(0, "a", s_truth)]);
+
+    // A managed by-ref (`in`/`ref`/`out`) bool dereference: LoadIndirect over an
+    // argument typed `ref bool`. csc treats a managed by-ref as non-null and
+    // side-effect-free, so `c && refBool` collapses to a branchless `&` — the pass
+    // must decline it just like a bare local.
+    static LoadIndirect ByRefBoolDeref()
+        => new(s_bool, new LoadArgument(1, "y", TypeRef.ByRef(s_bool)));
+
+    // A raw pointer (`bool*`) dereference: LoadIndirect over an argument typed
+    // `bool*`. A pointer read can access-violate, so csc keeps the branch for
+    // `c && *p` — the pass raises it (opcode-exact), unlike the managed by-ref.
+    static LoadIndirect PointerBoolDeref()
+        => new(s_bool, new LoadArgument(1, "p", TypeRef.Pointer(s_bool)));
+
     [Fact]
     public void TrueThenValue_BecomesShortCircuitOr()
     {
+        // A-form `flag ? true : y`  →  `flag || y`. A bare bool condition spells as a
+        // primitive bool, so lifting it into `||`-operand position binds the
+        // primitive operator (no user-operator rebind) and is opcode-exact.
         var result = RunOn(new Conditional(Flag(), Bool(true), Y()));
 
         var logical = Assert.IsType<LogicalBinary>(result);
         Assert.Equal(LogicalKind.Or, logical.Kind);
-        Assert.IsType<LoadArgument>(logical.Left);   // condition unchanged
-        Assert.IsType<Comparison>(logical.Right);     // the surviving arm
+        Assert.IsType<LoadArgument>(logical.Left);    // condition unchanged
+        Assert.IsType<Comparison>(logical.Right);    // the surviving arm
+    }
+
+    [Fact]
+    public void UserTruthinessCondition_AForm_IsNotRewritten()
+    {
+        // A-form `a ? true : y` where `a` is a user type evaluated through
+        // `operator true` would become `a || y`. The printer strips the op_True call
+        // to the bare user-typed receiver `a`, so `a || y` rebinds to the
+        // user-defined conditional `|` (which requires op_True/op_False), reselecting
+        // the overload and changing the call tokens and runtime result — decline.
+        var result = RunOn(new Conditional(UserTruthiness(), Bool(true), Y()));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void UserTruthinessCondition_BForm_IsNotRewritten()
+    {
+        // Same rebind hazard in the B-form: `a ? false : y` → `!a && y` would rebind
+        // the user-defined conditional `&`. (The B-form also declines it through the
+        // integer-comparison negate gate, but the truthiness gate is the reason.)
+        var result = RunOn(new Conditional(UserTruthiness(), Bool(false), Y()));
+
+        Assert.IsType<Conditional>(result);
     }
 
     [Fact]
     public void BoolCondition_BForm_IsNotRewritten()
     {
-        // B-form `flag ? false : y` would become `!flag && y`. Negating a
-        // non-comparison condition is not the proven integer dual, and the printer
-        // can fold a negated condition to a different operator/branch polarity, so
-        // the B-form fires only for a confirmed-integer comparison — decline here.
+        // B-form `flag ? false : y` would become `!flag && y`. A bare bool is not a
+        // comparison, so negating it is not the proven integer dual and the printer
+        // can fold the negation to a different branch — the B-form declines it. (The
+        // A-form leaves a bare bool condition alone: `flag || y` is opcode-exact.)
         var result = RunOn(new Conditional(Flag(), Bool(false), Y()));
 
         Assert.IsType<Conditional>(result);
@@ -174,6 +224,43 @@ public class ShortCircuitTernaryPassTests
         var result = RunOn(new Conditional(StartLessEqualZero(), Bool(false), new LoadArgument(1, "other", s_bool)));
 
         Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void ByRefDereferenceOperand_BForm_IsNotRewritten()
+    {
+        // `c ? false : refBool` would become `!c && refBool`. csc treats a managed
+        // by-ref (`in`/`ref`/`out`) as non-null and side-effect-free, so it collapses
+        // that to a branchless `&` and eagerly dereferences the location the branch
+        // had guarded (an observable NullReferenceException divergence on a null
+        // by-ref). Decline so the raise never trades branch IL for branchless.
+        var result = RunOn(new Conditional(StartLessEqualZero(), Bool(false), ByRefBoolDeref()));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void ByRefDereferenceOperand_AForm_IsNotRewritten()
+    {
+        // Same branchless hazard for the A-form: `c ? true : refBool` would become
+        // `c || refBool`, which csc collapses to a branchless `|`.
+        var result = RunOn(new Conditional(StartLessEqualZero(), Bool(true), ByRefBoolDeref()));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void PointerDereferenceOperand_StillRewrites()
+    {
+        // `c ? false : *p` → `!c && *p`. A raw pointer read can access-violate, so
+        // csc keeps the branch for `c && *p` — raising it is opcode-exact. This is
+        // the negative boundary of the by-ref guard: the guard fires for a managed
+        // by-ref (which collapses branchless), not for a pointer dereference.
+        var result = RunOn(new Conditional(StartLessEqualZero(), Bool(false), PointerBoolDeref()));
+
+        var logical = Assert.IsType<LogicalBinary>(result);
+        Assert.Equal(LogicalKind.And, logical.Kind);
+        Assert.IsType<LoadIndirect>(logical.Right);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ShortCircuitTernaryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ShortCircuitTernaryPassTests.cs
@@ -9,6 +9,7 @@ public class ShortCircuitTernaryPassTests
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef s_double = TypeRef.CoreLib("System", "Double");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
 
     static Constant Bool(bool value) => new(value, s_bool);
 
@@ -33,6 +34,13 @@ public class ShortCircuitTernaryPassTests
         => new(ComparisonKind.LessThan, false,
                new LoadArgument(0, "a", s_double), new LoadArgument(1, "b", s_double));
 
+    // A reference (string) equality condition. Negating it takes the Equal→NotEqual
+    // dual, which the printer spells with the inverse operator (op_Equality →
+    // op_Inequality) — a different call token — so the B-form declines it.
+    static Comparison StringEquals()
+        => new(ComparisonKind.Equal, false,
+               new LoadArgument(0, "a", s_string), new LoadArgument(1, "b", s_string));
+
     [Fact]
     public void TrueThenValue_BecomesShortCircuitOr()
     {
@@ -45,14 +53,15 @@ public class ShortCircuitTernaryPassTests
     }
 
     [Fact]
-    public void FalseThenValue_BecomesNegatedShortCircuitAnd()
+    public void BoolCondition_BForm_IsNotRewritten()
     {
+        // B-form `flag ? false : y` would become `!flag && y`. Negating a
+        // non-comparison condition is not the proven integer dual, and the printer
+        // can fold a negated condition to a different operator/branch polarity, so
+        // the B-form fires only for a confirmed-integer comparison — decline here.
         var result = RunOn(new Conditional(Flag(), Bool(false), Y()));
 
-        var logical = Assert.IsType<LogicalBinary>(result);
-        Assert.Equal(LogicalKind.And, logical.Kind);
-        Assert.IsType<LogicalNot>(logical.Left);      // condition negated
-        Assert.IsType<Comparison>(logical.Right);
+        Assert.IsType<Conditional>(result);
     }
 
     [Fact]
@@ -111,11 +120,48 @@ public class ShortCircuitTernaryPassTests
     }
 
     [Fact]
+    public void ReferenceEqualityCondition_BForm_IsNotRewritten()
+    {
+        // `(a == b) ? false : y` would become `!(a == b) && y`. Negating a reference
+        // equality takes the Equal→NotEqual dual, which the printer spells with the
+        // inverse operator (op_Equality → op_Inequality) — a different call token —
+        // so decline to keep the rewrite opcode-exact.
+        var result = RunOn(new Conditional(StringEquals(), Bool(false), Y()));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void ReferenceEqualityCondition_AForm_StillRewrites()
+    {
+        // `(a == b) ? true : y` → `(a == b) || y`. The A-form leaves the condition
+        // untouched (no dual), so the operator token is preserved — safe to rewrite.
+        var result = RunOn(new Conditional(StringEquals(), Bool(true), Y()));
+
+        var logical = Assert.IsType<LogicalBinary>(result);
+        Assert.Equal(LogicalKind.Or, logical.Kind);
+        Assert.IsType<Comparison>(logical.Left);   // condition unchanged
+    }
+
+    [Fact]
+    public void BareStackSlotOperand_IsNotRewritten()
+    {
+        // Integer-comparison condition (passes the B-form negate gate) so this
+        // isolates the operand guard: a residual stack slot renders as a bare
+        // synthetic local, so csc collapses `c && S_0` to a branchless `&` just
+        // like a named local — decline.
+        var result = RunOn(new Conditional(StartLessEqualZero(), Bool(false), new LoadStackSlot(0, s_bool)));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
     public void BareLocalOperand_IsNotRewritten()
     {
-        // csc collapses `!c && local` to a branchless `&`; leave the ternary so the
-        // raise never trades branch IL for branchless.
-        var result = RunOn(new Conditional(Flag(), Bool(false), new LoadLocal(1, s_bool)));
+        // csc collapses `c && local` to a branchless `&`; leave the ternary so the
+        // raise never trades branch IL for branchless. (Integer condition so the
+        // decline is attributable to the operand guard, not the negate gate.)
+        var result = RunOn(new Conditional(StartLessEqualZero(), Bool(false), new LoadLocal(1, s_bool)));
 
         Assert.IsType<Conditional>(result);
     }
@@ -124,8 +170,8 @@ public class ShortCircuitTernaryPassTests
     public void BareArgumentOperand_IsNotRewritten()
     {
         // Same branchless hazard for a bare parameter load in the exact B-form
-        // (`c ? false : other` would become `!c & other`).
-        var result = RunOn(new Conditional(Flag(), Bool(false), new LoadArgument(1, "other", s_bool)));
+        // (`c ? false : other` would become `c & other`).
+        var result = RunOn(new Conditional(StartLessEqualZero(), Bool(false), new LoadArgument(1, "other", s_bool)));
 
         Assert.IsType<Conditional>(result);
     }

--- a/src/ILInspector.Decompiler.Tests/ShortCircuitTernaryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ShortCircuitTernaryPassTests.cs
@@ -1,0 +1,163 @@
+using ILInspector.Decompiler.Pipeline;
+using System.Collections.Immutable;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "Pass")]
+public class ShortCircuitTernaryPassTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+
+    static Constant Bool(bool value) => new(value, s_bool);
+
+    // A computed (non-constant, non-bare-load) bool operand for the surviving
+    // short-circuit arm: a comparison. csc keeps the branch for a computed
+    // operand, so raising the ternary is opcode-exact. A bare local/argument load
+    // is the one operand csc would collapse to a branchless `&`/`|`, so those are
+    // covered by the decline negatives below, not here.
+    static Comparison Y()
+        => new(ComparisonKind.GreaterThan, false, new LoadLocal(2, s_int), new Constant(0, s_int));
+
+    // A plain bool condition (negation wraps it in LogicalNot).
+    static LoadArgument Flag() => new(0, "flag", s_bool);
+
+    // A comparison condition (negation takes the IL dual, <= becomes >).
+    static Comparison StartLessEqualZero()
+        => new(ComparisonKind.LessThanOrEqual, false, new LoadArgument(0, "start", s_int), new Constant(0, s_int));
+
+    [Fact]
+    public void TrueThenValue_BecomesShortCircuitOr()
+    {
+        var result = RunOn(new Conditional(Flag(), Bool(true), Y()));
+
+        var logical = Assert.IsType<LogicalBinary>(result);
+        Assert.Equal(LogicalKind.Or, logical.Kind);
+        Assert.IsType<LoadArgument>(logical.Left);   // condition unchanged
+        Assert.IsType<Comparison>(logical.Right);     // the surviving arm
+    }
+
+    [Fact]
+    public void FalseThenValue_BecomesNegatedShortCircuitAnd()
+    {
+        var result = RunOn(new Conditional(Flag(), Bool(false), Y()));
+
+        var logical = Assert.IsType<LogicalBinary>(result);
+        Assert.Equal(LogicalKind.And, logical.Kind);
+        Assert.IsType<LogicalNot>(logical.Left);      // condition negated
+        Assert.IsType<Comparison>(logical.Right);
+    }
+
+    [Fact]
+    public void ValueThenTrue_WhenFalseConstant_IsNotRewritten()
+    {
+        // C-form `c ? y : true`. csc lays this out with the opposite branch polarity
+        // than `!c || y`, so re-forming the operator is not opcode-exact — decline.
+        var result = RunOn(new Conditional(Flag(), Y(), Bool(true)));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void ValueThenFalse_WhenFalseConstant_IsNotRewritten()
+    {
+        // D-form `c ? y : false`. Same branch-polarity mismatch against `c && y`.
+        var result = RunOn(new Conditional(Flag(), Y(), Bool(false)));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void WitnessShape_NegatesComparisonToItsDual()
+    {
+        // `start <= 0 ? false : y`  →  `start > 0 && y` (the flagship witness).
+        var result = RunOn(new Conditional(StartLessEqualZero(), Bool(false), Y()));
+
+        var logical = Assert.IsType<LogicalBinary>(result);
+        Assert.Equal(LogicalKind.And, logical.Kind);
+        var comparison = Assert.IsType<Comparison>(logical.Left);
+        Assert.Equal(ComparisonKind.GreaterThan, comparison.Kind);
+        Assert.IsType<Comparison>(logical.Right);
+    }
+
+    [Fact]
+    public void BareLocalOperand_IsNotRewritten()
+    {
+        // csc collapses `!c && local` to a branchless `&`; leave the ternary so the
+        // raise never trades branch IL for branchless.
+        var result = RunOn(new Conditional(Flag(), Bool(false), new LoadLocal(1, s_bool)));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void BareArgumentOperand_IsNotRewritten()
+    {
+        // Same branchless hazard for a bare parameter load in the exact B-form
+        // (`c ? false : other` would become `!c & other`).
+        var result = RunOn(new Conditional(Flag(), Bool(false), new LoadArgument(1, "other", s_bool)));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void BothArmsConstant_IsNotRewritten()
+    {
+        // `c ? true : false` is an identity, owned by other folds — leave it.
+        var result = RunOn(new Conditional(Flag(), Bool(true), Bool(false)));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void BothArmsConstantInverted_IsNotRewritten()
+    {
+        var result = RunOn(new Conditional(Flag(), Bool(false), Bool(true)));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void NonConstantArms_AreNotRewritten()
+    {
+        var result = RunOn(new Conditional(Flag(), new LoadLocal(0, s_bool), Y()));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void NonBooleanConstantArm_IsNotRewritten()
+    {
+        // `c ? 1 : x` is an int-valued select, not a short-circuit boolean.
+        var conditional = new Conditional(Flag(), new Constant(1, s_int), new LoadLocal(1, s_int));
+        var function = Wrap(conditional, s_int, [s_int, s_int]);
+
+        new ShortCircuitTernaryPass().Run(function, PassContext.None);
+
+        var ret = Assert.IsType<Return>(function.Body.Blocks[0].Children[0]);
+        Assert.IsType<Conditional>(ret.Value);
+        function.CheckInvariant();
+    }
+
+    static IrExpression RunOn(Conditional conditional)
+    {
+        var function = Wrap(conditional, s_bool, [s_bool, s_bool, s_int]);
+
+        new ShortCircuitTernaryPass().Run(function, PassContext.None);
+
+        var ret = Assert.IsType<Return>(function.Body.Blocks[0].Children[0]);
+        function.CheckInvariant();
+        return ret.Value!;
+    }
+
+    static IrFunction Wrap(IrExpression value, TypeRef returnType, ImmutableArray<TypeRef> locals)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(value));
+        container.Add(block);
+        var signature = new MethodSignature(
+            returnType, [new Parameter("start", s_int)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, locals, container);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ShortCircuitTernaryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ShortCircuitTernaryPassTests.cs
@@ -8,6 +8,7 @@ public class ShortCircuitTernaryPassTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef s_double = TypeRef.CoreLib("System", "Double");
 
     static Constant Bool(bool value) => new(value, s_bool);
 
@@ -25,6 +26,12 @@ public class ShortCircuitTernaryPassTests
     // A comparison condition (negation takes the IL dual, <= becomes >).
     static Comparison StartLessEqualZero()
         => new(ComparisonKind.LessThanOrEqual, false, new LoadArgument(0, "start", s_int), new Constant(0, s_int));
+
+    // A float comparison condition. Negating it flips the ordered/unordered sense,
+    // which the printer cannot spell, so the B-form declines it.
+    static Comparison FloatCompare()
+        => new(ComparisonKind.LessThan, false,
+               new LoadArgument(0, "a", s_double), new LoadArgument(1, "b", s_double));
 
     [Fact]
     public void TrueThenValue_BecomesShortCircuitOr()
@@ -78,6 +85,29 @@ public class ShortCircuitTernaryPassTests
         var comparison = Assert.IsType<Comparison>(logical.Left);
         Assert.Equal(ComparisonKind.GreaterThan, comparison.Kind);
         Assert.IsType<Comparison>(logical.Right);
+    }
+
+    [Fact]
+    public void FloatComparisonCondition_BForm_IsNotRewritten()
+    {
+        // `(a < b) ? false : y` would become `!(a < b) && y`. Negating a float
+        // comparison flips its ordered/unordered sense (blt.s → blt.un.s), which
+        // the printer cannot spell — decline so the rewrite stays opcode-exact.
+        var result = RunOn(new Conditional(FloatCompare(), Bool(false), Y()));
+
+        Assert.IsType<Conditional>(result);
+    }
+
+    [Fact]
+    public void FloatComparisonCondition_AForm_StillRewrites()
+    {
+        // `(a < b) ? true : y` → `(a < b) || y`. The A-form does not negate the
+        // condition, so there is no ordered/unordered flip; float conditions are safe.
+        var result = RunOn(new Conditional(FloatCompare(), Bool(true), Y()));
+
+        var logical = Assert.IsType<LogicalBinary>(result);
+        Assert.Equal(LogicalKind.Or, logical.Kind);
+        Assert.IsType<Comparison>(logical.Left);   // condition unchanged
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -421,6 +421,13 @@ public static class IrPasses
         // by the importer's overload-safe count. Before coercion insertion so the
         // trailing defaults are still bare constants, never wrapped sink values.
         new OptionalArgumentElisionPass(),
+        // Re-form a short-circuit && / || from a when-true-constant bool ternary
+        // (c ? false : y → !c && y; c ? true : y → c || y). Opcode-exact for these
+        // two forms only; runs last, after every ternary-consuming pass (tuple-binary
+        // and switch-expression raises) so it never starves them of the
+        // `c ? … : false` diamond shape, and before coercion insertion so the
+        // reshaped bool value is coerced at its sink.
+        new ShortCircuitTernaryPass(),
         new CoercionInsertionPass(),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -105,6 +105,8 @@ internal static class NativePasses
     public static FluentChainRecompositionPass FluentChainRecomposition => new();
     [Native(NativeCategory.EmitArtifact, "trailing arguments the compiler baked in for omitted C# optional parameters (a constant equal to the parameter's default) elided back to the shorter call the source wrote")]
     public static OptionalArgumentElisionPass OptionalArgumentElision => new();
+    [Native(NativeCategory.EmitArtifact, "a when-true-constant bool ternary (the slot-diamond spelling of a short-circuit && / ||, e.g. c ? false : y) re-formed into the LogicalBinary operator the compiler lowered to branches")]
+    public static ShortCircuitTernaryPass ShortCircuitTernary => new();
 
     // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
     [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
@@ -22,17 +22,24 @@ namespace ILInspector.Decompiler.Pipeline;
 /// IL; the corpus compile-back gates guard the exact forms continuously).
 ///
 /// <para>Even for the two exact forms the rewrite is declined when the surviving
-/// operand is a bare local or parameter load: csc collapses <c>a &amp;&amp; b</c> /
-/// <c>a || b</c> to a branchless <c>&amp;</c>/<c>|</c> for that one operand shape, so
-/// raising the ternary would trade branch IL for branchless (see
-/// <see cref="IsBareLocalOrArgumentLoad"/>). Every computed or memory-loaded
+/// operand is a bare local, parameter, or stack-slot load: csc collapses
+/// <c>a &amp;&amp; b</c> / <c>a || b</c> to a branchless <c>&amp;</c>/<c>|</c> for those
+/// operand shapes, so raising the ternary would trade branch IL for branchless
+/// (see <see cref="IsBareLocalOrArgumentLoad"/>). Every computed or memory-loaded
 /// operand (field/element load, comparison, call, negation, nested logical
-/// operator) keeps the branch and is opcode-exact
-/// (<see cref="Conditions.Negate"/> re-forms <c>!c</c> as the comparison dual csc
-/// already branches on, e.g. <c>start &lt;= 0</c> ↔ <c>start &gt; 0</c>). The one
-/// exception is a float comparison condition in the B-form: negating it flips the
-/// ordered/unordered sense, which the printer cannot spell, so that shape is
-/// declined (<see cref="IsFloatComparison"/>).</para>
+/// operator) keeps the branch.</para>
+///
+/// <para>The B-form additionally negates the condition, and negation is only
+/// proven opcode-exact for a primitive-integer comparison, whose dual is the same
+/// integer branch (e.g. <c>start &lt;= 0</c> ↔ <c>start &gt; 0</c>, both
+/// <c>ble.s</c>). Every other condition's negation the printer can fold to a
+/// different operator token or branch polarity — a float dual flips the
+/// ordered/unordered sense, an <c>==</c>/<c>!=</c> dual or negated operator call
+/// flips to the inverse operator, and an <c>is</c>/<c>is null</c>/<c>!= 0</c>
+/// truthiness test inverts to its opposite — so the B-form fires only for a
+/// confirmed-integer comparison condition and declines the rest
+/// (<see cref="NegateIsIntegerComparisonDual"/>). The A-form (no negate) renders
+/// the condition verbatim and accepts any condition shape.</para>
 ///
 /// It fires only when the when-true arm is a bool constant and the when-false arm
 /// is a non-constant bool expression; a both-constant <c>c ? true : false</c> is
@@ -62,15 +69,14 @@ public sealed class ShortCircuitTernaryPass : IIrPass
             if (!TryClassify(conditional, out var kind, out bool negate))
                 continue;
 
-            // The B-form (`c ? false : y` → `!c && y`) negates the condition.
-            // Negating a float comparison keeps the value NaN-correct only by
-            // toggling its ordered/unordered sense (Conditions.Negate flips the
-            // unordered flag), but the C# printer spells both senses with the same
-            // relational operator, so recompiling the negated float comparison
-            // trades csc's ordered branch (blt.s) for the unordered one
-            // (blt.un.s). Decline so the rewrite stays opcode-exact; the A-form
-            // (no negate) and integer/reference comparisons are unaffected.
-            if (negate && IsFloatComparison(conditional.Condition))
+            // The B-form (`c ? false : y` → `!c && y`) negates the condition. The
+            // ONLY negation the pipeline is proven to spell back to the same branch
+            // opcodes is a primitive-integer comparison's dual (e.g. `start <= 0` →
+            // `start > 0`, both `ble.s`). Every other negation the printer can fold
+            // to a different operator token or branch polarity, so the B-form fires
+            // only for a confirmed-integer comparison; the A-form (no negate)
+            // renders the condition verbatim and is unaffected.
+            if (negate && !NegateIsIntegerComparisonDual(conditional.Condition))
                 continue;
 
             // The surviving operand is always the when-false arm. Decline when csc
@@ -126,29 +132,51 @@ public sealed class ShortCircuitTernaryPass : IIrPass
     /// <summary>
     /// csc emits a branchless <c>&amp;</c>/<c>|</c> (not a short-circuit branch) for
     /// <c>a &amp;&amp; b</c>/<c>a || b</c> only when the non-short-circuiting operand is
-    /// a bare local or parameter load — the one shape whose evaluation it can prove
-    /// is side-effect-free and cannot throw. Every other operand (field/element
-    /// load, comparison, call, negation, nested logical operator) keeps the branch,
-    /// so raising its ternary is opcode-exact. This mirrors Roslyn's branchless
-    /// eligibility (local/parameter/constant operands; a constant operand cannot
-    /// occur here because the pass requires the non-short-circuiting arm to be
-    /// non-constant). Confirmed against real csc-emitted IL: a bare-load operand
-    /// compiles branchless, every computed/memory-loaded operand keeps the branch.
+    /// a bare local, parameter, or stack-slot load — the operand shapes whose
+    /// evaluation it can prove is side-effect-free and cannot throw. (A residual
+    /// stack slot renders as a bare synthetic local, so csc collapses it the same
+    /// way.) Every other operand (field/element load, comparison, call, negation,
+    /// nested logical operator) keeps the branch, so raising its ternary is
+    /// opcode-exact. This mirrors Roslyn's branchless eligibility
+    /// (local/parameter/constant operands; a constant operand cannot occur here
+    /// because the pass requires the non-short-circuiting arm to be non-constant).
+    /// Confirmed against real csc-emitted IL: a bare-load operand compiles
+    /// branchless, every computed/memory-loaded operand keeps the branch.
     /// </summary>
     static bool IsBareLocalOrArgumentLoad(IrExpression operand)
-        => operand is LoadLocal or LoadArgument;
+        => operand is LoadLocal or LoadArgument or LoadStackSlot;
 
     /// <summary>
-    /// A comparison over IEEE-754 <c>float</c>/<c>double</c> operands. Its C#
-    /// printed form (a single relational operator) cannot distinguish the ordered
-    /// and unordered senses, so a negated float comparison does not round-trip to
-    /// the same branch opcode (<c>blt.s</c> vs <c>blt.un.s</c>). The B-form decline
-    /// in <see cref="RewriteOne"/> uses this to keep the rewrite opcode-exact.
+    /// Whether negating <paramref name="condition"/> re-forms to something that
+    /// recompiles to the same branch opcodes. The pipeline's <see cref="Conditions.Negate"/>
+    /// plus the printer's negation folds are only proven opcode-exact for a
+    /// confirmed primitive-integer comparison, whose dual is the same integer
+    /// branch (e.g. <c>start &lt;= 0</c> → <c>start &gt; 0</c>, both <c>ble.s</c>).
+    /// Every other negation the printer can fold to a different operator token or
+    /// branch polarity, so the B-form declines it:
+    /// <list type="bullet">
+    /// <item>a <see cref="Comparison"/> over float operands takes a dual that
+    /// flips the ordered/unordered sense (<c>blt.s</c> vs <c>blt.un.s</c>);</item>
+    /// <item>an <c>Equal</c>/<c>NotEqual</c> <see cref="Comparison"/> over a
+    /// non-integer operand (string/object/enum/struct), and a negated
+    /// comparison/equality operator <em>call</em> (<c>op_Equality</c>,
+    /// <c>op_LessThan</c>, …), flip to the inverse operator and — for a
+    /// user-defined operator — a different call token;</item>
+    /// <item>a truthiness test (<c>is</c>/<c>is null</c>/<c>!= 0</c>) inverts to
+    /// its own opposite spelling.</item>
+    /// </list>
+    /// Declining hands those back to the base pipeline's faithful rendering. The
+    /// integer family is read the same way <c>InvertComparison</c> reads it.
     /// </summary>
-    static bool IsFloatComparison(IrExpression condition)
-        => condition is Comparison comparison
-           && (TypeFamilies.Of(comparison.Left.ResultType) == StackFamily.F
-               || TypeFamilies.Of(comparison.Right.ResultType) == StackFamily.F);
+    static bool NegateIsIntegerComparisonDual(IrExpression condition)
+    {
+        if (condition is not Comparison comparison)
+            return false;
+
+        StackFamily? family = TypeFamilies.Of(comparison.Left.ResultType)
+                              ?? TypeFamilies.Of(comparison.Right.ResultType);
+        return family is StackFamily.I4 or StackFamily.I8 or StackFamily.I;
+    }
 
     static bool IsBool(TypeRef? type)
         => type is { Namespace: "System", Name: "Boolean" };

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
@@ -29,7 +29,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// operand (field/element load, comparison, call, negation, nested logical
 /// operator) keeps the branch and is opcode-exact
 /// (<see cref="Conditions.Negate"/> re-forms <c>!c</c> as the comparison dual csc
-/// already branches on, e.g. <c>start &lt;= 0</c> ↔ <c>start &gt; 0</c>).</para>
+/// already branches on, e.g. <c>start &lt;= 0</c> ↔ <c>start &gt; 0</c>). The one
+/// exception is a float comparison condition in the B-form: negating it flips the
+/// ordered/unordered sense, which the printer cannot spell, so that shape is
+/// declined (<see cref="IsFloatComparison"/>).</para>
 ///
 /// It fires only when the when-true arm is a bool constant and the when-false arm
 /// is a non-constant bool expression; a both-constant <c>c ? true : false</c> is
@@ -57,6 +60,17 @@ public sealed class ShortCircuitTernaryPass : IIrPass
         foreach (var conditional in function.Descendants.OfType<Conditional>().ToList())
         {
             if (!TryClassify(conditional, out var kind, out bool negate))
+                continue;
+
+            // The B-form (`c ? false : y` → `!c && y`) negates the condition.
+            // Negating a float comparison keeps the value NaN-correct only by
+            // toggling its ordered/unordered sense (Conditions.Negate flips the
+            // unordered flag), but the C# printer spells both senses with the same
+            // relational operator, so recompiling the negated float comparison
+            // trades csc's ordered branch (blt.s) for the unordered one
+            // (blt.un.s). Decline so the rewrite stays opcode-exact; the A-form
+            // (no negate) and integer/reference comparisons are unaffected.
+            if (negate && IsFloatComparison(conditional.Condition))
                 continue;
 
             // The surviving operand is always the when-false arm. Decline when csc
@@ -123,6 +137,18 @@ public sealed class ShortCircuitTernaryPass : IIrPass
     /// </summary>
     static bool IsBareLocalOrArgumentLoad(IrExpression operand)
         => operand is LoadLocal or LoadArgument;
+
+    /// <summary>
+    /// A comparison over IEEE-754 <c>float</c>/<c>double</c> operands. Its C#
+    /// printed form (a single relational operator) cannot distinguish the ordered
+    /// and unordered senses, so a negated float comparison does not round-trip to
+    /// the same branch opcode (<c>blt.s</c> vs <c>blt.un.s</c>). The B-form decline
+    /// in <see cref="RewriteOne"/> uses this to keep the rewrite opcode-exact.
+    /// </summary>
+    static bool IsFloatComparison(IrExpression condition)
+        => condition is Comparison comparison
+           && (TypeFamilies.Of(comparison.Left.ResultType) == StackFamily.F
+               || TypeFamilies.Of(comparison.Right.ResultType) == StackFamily.F);
 
     static bool IsBool(TypeRef? type)
         => type is { Namespace: "System", Name: "Boolean" };

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
@@ -22,24 +22,30 @@ namespace ILInspector.Decompiler.Pipeline;
 /// IL; the corpus compile-back gates guard the exact forms continuously).
 ///
 /// <para>Even for the two exact forms the rewrite is declined when the surviving
-/// operand is a bare local, parameter, or stack-slot load: csc collapses
-/// <c>a &amp;&amp; b</c> / <c>a || b</c> to a branchless <c>&amp;</c>/<c>|</c> for those
-/// operand shapes, so raising the ternary would trade branch IL for branchless
-/// (see <see cref="IsBareLocalOrArgumentLoad"/>). Every computed or memory-loaded
-/// operand (field/element load, comparison, call, negation, nested logical
-/// operator) keeps the branch.</para>
+/// operand renders as a bare, non-faulting place: a local, parameter, or
+/// stack-slot load, or a managed by-ref (<c>in</c>/<c>ref</c>/<c>out</c>)
+/// dereference. csc collapses <c>a &amp;&amp; b</c> / <c>a || b</c> to a branchless
+/// <c>&amp;</c>/<c>|</c> for those operand shapes, so raising the ternary would
+/// trade branch IL for branchless (see <see cref="RendersAsBranchlessBarePlace"/>).
+/// Every faulting or side-effecting operand — field/element load, comparison,
+/// call, and even a raw pointer dereference <c>*p</c> — keeps the branch and is
+/// raised.</para>
 ///
-/// <para>The B-form additionally negates the condition, and negation is only
-/// proven opcode-exact for a primitive-integer comparison, whose dual is the same
-/// integer branch (e.g. <c>start &lt;= 0</c> ↔ <c>start &gt; 0</c>, both
-/// <c>ble.s</c>). Every other condition's negation the printer can fold to a
-/// different operator token or branch polarity — a float dual flips the
-/// ordered/unordered sense, an <c>==</c>/<c>!=</c> dual or negated operator call
-/// flips to the inverse operator, and an <c>is</c>/<c>is null</c>/<c>!= 0</c>
-/// truthiness test inverts to its opposite — so the B-form fires only for a
-/// confirmed-integer comparison condition and declines the rest
-/// (<see cref="NegateIsIntegerComparisonDual"/>). The A-form (no negate) renders
-/// the condition verbatim and accepts any condition shape.</para>
+/// <para>The condition is lifted into the left operand of the spelled operator, so
+/// both forms decline a user-defined-truthiness condition — an <c>operator true</c>/
+/// <c>operator false</c> evaluation the compiler inserts for a user type used in
+/// boolean context. The printer strips such a call to its bare user-typed receiver,
+/// so <c>c || y</c> / <c>!c &amp;&amp; y</c> would rebind to the user-defined conditional
+/// <c>|</c>/<c>&amp;</c>, reselecting the overload and diverging in call tokens and
+/// runtime result (<see cref="IsUserDefinedTruthiness"/>). A primitive-bool condition
+/// — comparison, bool property/field/local/method, nested logical operator — binds
+/// the primitive operator. The B-form additionally negates the condition, and
+/// negation is only proven opcode-exact for a primitive-integer comparison, whose
+/// dual is the same integer branch (e.g. <c>start &lt;= 0</c> ↔ <c>start &gt; 0</c>,
+/// both <c>ble.s</c>). A float dual flips the ordered/unordered sense and a reference
+/// <c>==</c>/<c>!=</c> dual flips the operator token, so the B-form fires only for a
+/// confirmed-integer comparison (<see cref="NegateIsIntegerComparisonDual"/>); the
+/// A-form (no negate) renders any primitive-bool condition verbatim.</para>
 ///
 /// It fires only when the when-true arm is a bool constant and the when-false arm
 /// is a non-constant bool expression; a both-constant <c>c ? true : false</c> is
@@ -69,20 +75,32 @@ public sealed class ShortCircuitTernaryPass : IIrPass
             if (!TryClassify(conditional, out var kind, out bool negate))
                 continue;
 
-            // The B-form (`c ? false : y` → `!c && y`) negates the condition. The
-            // ONLY negation the pipeline is proven to spell back to the same branch
-            // opcodes is a primitive-integer comparison's dual (e.g. `start <= 0` →
-            // `start > 0`, both `ble.s`). Every other negation the printer can fold
-            // to a different operator token or branch polarity, so the B-form fires
-            // only for a confirmed-integer comparison; the A-form (no negate)
-            // renders the condition verbatim and is unaffected.
+            // Both forms lift the condition into the LEFT operand of the spelled
+            // `||`/`&&`. A user-defined-truthiness condition — an `operator true`/
+            // `operator false` evaluation the compiler inserts for a user type used
+            // in boolean context — renders as its bare user-typed receiver (the same
+            // strip the printer applies), so `c || y` / `!c && y` would rebind to the
+            // user-defined conditional `|`/`&`, reselecting the overload and diverging
+            // in call tokens and runtime result. A primitive-bool condition
+            // (comparison, bool property/field/local/method, nested logical operator)
+            // binds the primitive operator, so decline only the truthiness lift.
+            if (IsUserDefinedTruthiness(conditional.Condition))
+                continue;
+
+            // The B-form (`c ? false : y` → `!c && y`) additionally negates the
+            // condition. The ONLY negation the pipeline is proven to spell back to
+            // the same branch opcodes is a primitive-integer comparison's dual (e.g.
+            // `start <= 0` → `start > 0`, both `ble.s`); a float/reference comparison
+            // dual flips the ordered/unordered sense or the operator token, so the
+            // B-form declines everything but a confirmed-integer comparison. The
+            // A-form (no negate) renders the condition verbatim.
             if (negate && !NegateIsIntegerComparisonDual(conditional.Condition))
                 continue;
 
             // The surviving operand is always the when-false arm. Decline when csc
             // would emit a branchless `&`/`|` for the spelled operator: raising the
             // ternary would trade branch IL for branchless.
-            if (IsBareLocalOrArgumentLoad((IrExpression)conditional.WhenFalse))
+            if (RendersAsBranchlessBarePlace((IrExpression)conditional.WhenFalse))
                 continue;
 
             var children = conditional.DetachChildren();
@@ -131,20 +149,41 @@ public sealed class ShortCircuitTernaryPass : IIrPass
 
     /// <summary>
     /// csc emits a branchless <c>&amp;</c>/<c>|</c> (not a short-circuit branch) for
-    /// <c>a &amp;&amp; b</c>/<c>a || b</c> only when the non-short-circuiting operand is
-    /// a bare local, parameter, or stack-slot load — the operand shapes whose
-    /// evaluation it can prove is side-effect-free and cannot throw. (A residual
-    /// stack slot renders as a bare synthetic local, so csc collapses it the same
-    /// way.) Every other operand (field/element load, comparison, call, negation,
-    /// nested logical operator) keeps the branch, so raising its ternary is
-    /// opcode-exact. This mirrors Roslyn's branchless eligibility
-    /// (local/parameter/constant operands; a constant operand cannot occur here
-    /// because the pass requires the non-short-circuiting arm to be non-constant).
-    /// Confirmed against real csc-emitted IL: a bare-load operand compiles
-    /// branchless, every computed/memory-loaded operand keeps the branch.
+    /// <c>a &amp;&amp; b</c>/<c>a || b</c> only when the non-short-circuiting operand
+    /// renders as a bare, non-faulting place: a local, parameter, or stack-slot
+    /// load, or a <em>managed by-ref</em> dereference (an <c>in</c>/<c>ref</c>/<c>out</c>
+    /// parameter or <c>ref</c> local, which csc treats as non-null and side-effect
+    /// -free, spelling as the bare referent). A residual stack slot renders as a bare
+    /// synthetic local, so csc collapses it the same way. Raising those would trade
+    /// branch IL for branchless (and, for the by-ref case, eagerly dereference a
+    /// location the branch had guarded — an observable <c>NullReferenceException</c>
+    /// divergence on a null by-ref). Every other operand keeps the branch and is
+    /// safe to raise: a field/static/element load or call (can fault or has side
+    /// effects), a comparison (even over bare locals), a nested logical operator,
+    /// and — confirmed against real csc-emitted IL — a raw <em>pointer</em>
+    /// dereference <c>*p</c> (which can access-violate, so csc keeps the branch).
+    /// The operand map was verified opcode-by-opcode: only the bare-load and
+    /// managed-by-ref shapes compile branchless; all others keep the branch.
     /// </summary>
-    static bool IsBareLocalOrArgumentLoad(IrExpression operand)
-        => operand is LoadLocal or LoadArgument or LoadStackSlot;
+    static bool RendersAsBranchlessBarePlace(IrExpression operand)
+        => operand is LoadLocal or LoadArgument or LoadStackSlot
+           || operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+
+    /// <summary>
+    /// Whether <paramref name="condition"/> is a user-defined-truthiness evaluation
+    /// — a call to <c>operator true</c>/<c>operator false</c> the compiler inserts
+    /// when a user type is used in boolean context. The printer strips such a call
+    /// to its bare user-typed receiver (it renders <c>op_True(a)</c>/<c>op_False(a)</c>
+    /// as <c>a</c>), so lifting it into a short-circuit operand — <c>a || y</c> /
+    /// <c>!a &amp;&amp; y</c> — would rebind to the user-defined conditional <c>|</c>/<c>&amp;</c>,
+    /// reselecting the overload and changing the call tokens and runtime result. Only
+    /// a type carrying <c>op_True</c>/<c>op_False</c> can bind a user-defined
+    /// <c>||</c>/<c>&amp;&amp;</c>, so this is the complete rebind set; a primitive-bool
+    /// condition (comparison, bool property/field/local/method, nested logical
+    /// operator) binds the primitive operator and is safe to lift.
+    /// </summary>
+    static bool IsUserDefinedTruthiness(IrExpression condition)
+        => condition is Call { Callee.Name: "op_True" or "op_False" };
 
     /// <summary>
     /// Whether negating <paramref name="condition"/> re-forms to something that

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
@@ -1,0 +1,129 @@
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Normalizes a boolean conditional (ternary) whose <em>when-true</em> arm is a
+/// bool constant into the short-circuit operator it spells. csc lowers
+/// <c>a &amp;&amp; b</c> / <c>a || b</c> to a branch diamond that the slot-diamond and
+/// boolean folds raise back to a ternary with a constant when-true arm:
+/// <list type="bullet">
+/// <item><c>c ? true : y</c> → <c>c || y</c></item>
+/// <item><c>c ? false : y</c> → <c>!c &amp;&amp; y</c></item>
+/// </list>
+/// Only these two forms are opcode-exact. csc lays out <c>c ? true : y</c> and
+/// <c>c ? false : y</c> with the same branch (condition true ⇒ take the constant,
+/// fall through ⇒ evaluate <c>y</c>) that it emits for <c>c || y</c> / <c>!c &amp;&amp; y</c>,
+/// so the rewrite recompiles to identical IL. The mirror forms with a constant
+/// <em>when-false</em> arm (<c>c ? y : true</c>, <c>c ? y : false</c>) are
+/// deliberately left alone: csc lays them out with the opposite branch polarity
+/// than <c>!c || y</c> / <c>c &amp;&amp; y</c>, so re-forming the operator would trade
+/// one branch shape for another (confirmed divergent against real csc-emitted
+/// IL; the corpus compile-back gates guard the exact forms continuously).
+///
+/// <para>Even for the two exact forms the rewrite is declined when the surviving
+/// operand is a bare local or parameter load: csc collapses <c>a &amp;&amp; b</c> /
+/// <c>a || b</c> to a branchless <c>&amp;</c>/<c>|</c> for that one operand shape, so
+/// raising the ternary would trade branch IL for branchless (see
+/// <see cref="IsBareLocalOrArgumentLoad"/>). Every computed or memory-loaded
+/// operand (field/element load, comparison, call, negation, nested logical
+/// operator) keeps the branch and is opcode-exact
+/// (<see cref="Conditions.Negate"/> re-forms <c>!c</c> as the comparison dual csc
+/// already branches on, e.g. <c>start &lt;= 0</c> ↔ <c>start &gt; 0</c>).</para>
+///
+/// It fires only when the when-true arm is a bool constant and the when-false arm
+/// is a non-constant bool expression; a both-constant <c>c ? true : false</c> is
+/// an identity/negation other folds own, and is left untouched.
+///
+/// <para>Runs late — after every ternary-consuming pass (the tuple-binary and
+/// switch-expression raises, which need the <c>c ? … : false</c> diamond shape) —
+/// so it never starves a downstream consumer. It reconstructs a short-circuit
+/// operator the compiler lowered to branches, so it is a decompiler-native
+/// <see cref="NativeCategory.EmitArtifact"/> pass, not a Roslyn un-lowering.</para>
+/// </summary>
+public sealed class ShortCircuitTernaryPass : IIrPass
+{
+    public string Name => "short-circuit-ternary";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (RewriteOne(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool RewriteOne(IrFunction function, Stepper stepper)
+    {
+        foreach (var conditional in function.Descendants.OfType<Conditional>().ToList())
+        {
+            if (!TryClassify(conditional, out var kind, out bool negate))
+                continue;
+
+            // The surviving operand is always the when-false arm. Decline when csc
+            // would emit a branchless `&`/`|` for the spelled operator: raising the
+            // ternary would trade branch IL for branchless.
+            if (IsBareLocalOrArgumentLoad((IrExpression)conditional.WhenFalse))
+                continue;
+
+            var children = conditional.DetachChildren();
+            var condition = (IrExpression)children[0];
+            var operand = (IrExpression)children[2];
+            var left = negate ? Conditions.Negate(condition) : condition;
+
+            stepper.StepOver("normalize constant-arm ternary to short-circuit &&/||", conditional);
+            conditional.ReplaceWith(new LogicalBinary(kind, left, operand));
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// A ternary whose when-true arm is a bool constant and whose when-false arm is
+    /// a non-constant bool expression (the surviving short-circuit operand).
+    /// <paramref name="negate"/> is whether the condition must be inverted.
+    /// </summary>
+    static bool TryClassify(Conditional c, out LogicalKind kind, out bool negate)
+    {
+        kind = default;
+        negate = false;
+
+        if (!IsBool(c.ResultType))
+            return false;
+
+        switch (c)
+        {
+            // c ? true : y  →  c || y
+            case { WhenTrue: Constant { Value: true }, WhenFalse: var y } when y is not Constant:
+                kind = LogicalKind.Or;
+                negate = false;
+                return true;
+
+            // c ? false : y  →  !c && y
+            case { WhenTrue: Constant { Value: false }, WhenFalse: var y } when y is not Constant:
+                kind = LogicalKind.And;
+                negate = true;
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// csc emits a branchless <c>&amp;</c>/<c>|</c> (not a short-circuit branch) for
+    /// <c>a &amp;&amp; b</c>/<c>a || b</c> only when the non-short-circuiting operand is
+    /// a bare local or parameter load — the one shape whose evaluation it can prove
+    /// is side-effect-free and cannot throw. Every other operand (field/element
+    /// load, comparison, call, negation, nested logical operator) keeps the branch,
+    /// so raising its ternary is opcode-exact. This mirrors Roslyn's branchless
+    /// eligibility (local/parameter/constant operands; a constant operand cannot
+    /// occur here because the pass requires the non-short-circuiting arm to be
+    /// non-constant). Confirmed against real csc-emitted IL: a bare-load operand
+    /// compiles branchless, every computed/memory-loaded operand keeps the branch.
+    /// </summary>
+    static bool IsBareLocalOrArgumentLoad(IrExpression operand)
+        => operand is LoadLocal or LoadArgument;
+
+    static bool IsBool(TypeRef? type)
+        => type is { Namespace: "System", Name: "Boolean" };
+}


### PR DESCRIPTION
- Advances #3071
- Changes decompiled C# so a short-circuit `&&`/`||` the compiler lowered to a
  branch diamond re-forms as the operator it spelled, instead of a
  bool-constant-arm ternary
- Card revision: `64db03216fd380ebd539c3bfb4f83d2b673c21d0`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the new `ShortCircuitTernaryPass` re-forms only the two
opcode-exact bool-constant-in-`when-true` ternary forms (`c ? true : y` → `c || y`,
`c ? false : y` → `!c && y`), declines every branch-polarity- and branchless-hazard
shape, and the PR-quick corpus is neutral with zero pass bugs.

### Original source

<!-- src/ILInspector.CSharp/CSharpDeclarationWriter.cs — the real witness -->

```csharp
static string EscapeReservedKeywordIdentifiers(string text)
{
    var sb = new StringBuilder(text.Length);
    for (int i = 0; i < text.Length;)
    {
        if (IsIdentifierStart(text[i]))
        {
            int start = i++;
            while (i < text.Length && IsIdentifierPart(text[i]))
                i++;
            string token = text[start..i];
            bool alreadyEscaped = start > 0 && text[start - 1] == '@';
            sb.Append(!alreadyEscaped && CSharpKeywords.RequiresDeclarationEscape(token) ? EscapeIdentifier(token) : token);
            continue;
        }
        sb.Append(text[i++]);
    }
    return sb.ToString();
}
```

### Before

<!-- base decompiler (origin/main) decompiling the shipped ILInspector.CSharp.dll -->

```csharp
string EscapeReservedKeywordIdentifiers(string text)
{
    StringBuilder sb = new(text.Length);
    int i = 0;
    while (i < text.Length)
    {
        if (IsIdentifierStart(text[i]))
        {
            start = i++;
            while (i < text.Length && IsIdentifierPart(text[i]))
            {
                i++;
            }
            V_5 = start;
            token = text.Substring(V_5, i - V_5);
            S_2 = !((start <= 0 ? false : (text[start - 1] == '@')) || !CSharpKeywords.RequiresDeclarationEscape(token)) ? EscapeIdentifier(token) : token;
            sb.Append(S_2);
        }
        else
        {
            sb.Append(text[i++]);
        }
    }
    return sb.ToString();
}
```

- Valid: True
- Correct: True

The surviving nested residue is the bool-constant-arm ternary
`start <= 0 ? false : (text[start - 1] == '@')`. It is valid and behavior-preserving,
just a lower-quality spelling of the short-circuit `&&` the source wrote.

### After

<!-- this PR's decompiler decompiling the same ILInspector.CSharp.dll -->

```csharp
string EscapeReservedKeywordIdentifiers(string text)
{
    StringBuilder sb = new(text.Length);
    int i = 0;
    while (i < text.Length)
    {
        if (IsIdentifierStart(text[i]))
        {
            start = i++;
            while (i < text.Length && IsIdentifierPart(text[i]))
            {
                i++;
            }
            V_5 = start;
            token = text.Substring(V_5, i - V_5);
            S_2 = !((start > 0 && text[start - 1] == '@') || !CSharpKeywords.RequiresDeclarationEscape(token)) ? EscapeIdentifier(token) : token;
            sb.Append(S_2);
        }
        else
        {
            sb.Append(text[i++]);
        }
    }
    return sb.ToString();
}
```

- Valid: True
- Correct: True

The nested ternary is re-formed to `start > 0 && text[start - 1] == '@'`, byte-for-byte
the `&&` sub-expression the original source wrote. `Conditions.Negate` recovers `!c` as
the comparison dual csc already branches on (`start <= 0` ↔ `start > 0`).

### Fully raised

```csharp
static string EscapeReservedKeywordIdentifiers(string text)
{
    var sb = new StringBuilder(text.Length);
    for (int i = 0; i < text.Length;)
    {
        if (IsIdentifierStart(text[i]))
        {
            int start = i++;
            while (i < text.Length && IsIdentifierPart(text[i]))
                i++;
            string token = text[start..i];
            bool alreadyEscaped = start > 0 && text[start - 1] == '@';
            sb.Append(!alreadyEscaped && CSharpKeywords.RequiresDeclarationEscape(token) ? EscapeIdentifier(token) : token);
            continue;
        }
        sb.Append(text[i++]);
    }
    return sb.ToString();
}
```

- Required tracking issue: #3071 — remaining slices to reach the fully raised
  endpoint: the range-indexer raise `token = text[start..i]` (#3070 / PR #3085),
  a De Morgan re-form of `!(a || !b)` → `!a && b`, `alreadyEscaped` local
  re-hoist, and the printer sink hoist that drops the `S_2` temp.

## Evidence

| Check | Baseline (origin/main) | Head (this PR) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | n/a (pass is new) | `ShortCircuitTernaryPassTests`: 21 passed |
| Raising regression tests | `RaisingPassTests`: 109 passed | `RaisingPassTests`: 109 passed |
| Coverage classification | `LoweringCoverageTests`: 6 passed | `LoweringCoverageTests`: 6 passed |
| Decompiler fast suite | 3424, 56 failed | 3424, 56 failed |
| Real witness | `CSharpDeclarationWriter::EscapeReservedKeywordIdentifiers` renders `start <= 0 ? false : …` | renders `start > 0 && …` |

The 56 fast-suite failures are pre-existing and environmental on this machine
(Roslyn compile-back gates hitting CS0009 on native shared-framework DLLs:
`ReturnToSenderFixtureCatalogTests` 31, `FidelityCheckGeneratedFilterTests` 15,
`TypeSourceCheckTests` 4, `LadderRung6GateTests` 3; plus one missing partial-build
fixture, one `RecompileFail`, and one CRLF case). The FAIL name set is byte-identical
between Baseline and Head — zero in the `ShortCircuit`/`Raising` area — and all are
CI-green.

### Opcode-exactness

The two forms this pass fires on are opcode-exact on recompile; the C/D mirror
forms, branchless-collapse operands, and rebinding conditions are not, and are
declined. This was mapped empirically with csc canaries (`OptimizationLevel.Release`,
SRM byte-compare / IL opcode compare):

- Branch-polarity: `c ? true : y` / `c ? false : y` (const in `when-true`) recompile
  byte-identical to `c || y` / `!c && y`. The mirror `c ? y : true` / `c ? y : false`
  use the opposite branch polarity even with computed operands → declined.
- Branchless operand: csc collapses `a && b`/`a || b` to a branchless `&`/`|` only
  when the surviving operand is a bare place (local/parameter/stack-slot load) or a
  managed by-ref deref (`in`/`ref`/`out`, treated non-null and side-effect-free) —
  both declined (`RendersAsBranchlessBarePlace`); the by-ref case would also eagerly
  deref a branch-guarded location (NRE divergence on a null by-ref). A raw pointer
  deref `*p` can access-violate, so csc keeps the branch → still raised.
- Condition truthiness: a user-defined `operator true`/`operator false` condition is
  declined (`IsUserDefinedTruthiness`) — the printer strips it to its bare user-typed
  receiver, so `c || y` / `!c && y` would rebind to the user-defined conditional
  `|`/`&` (which requires op_True/op_False), reselecting the overload and diverging
  in call tokens and runtime result. A primitive-bool condition binds the primitive
  operator and is raised.
- Negation (B-form only): the negating form fires only for a confirmed
  primitive-integer comparison, whose dual is the same integer branch (`start <= 0` ↔
  `start > 0`, both `ble.s`); a float dual flips ordered/unordered and a reference
  `==`/`!=` dual flips the operator token, so both are declined
  (`NegateIsIntegerComparisonDual`).

The branchless by-ref and condition-truthiness guards were added in round-2
adversarial review (commit `8719a435`). The same three hazards in the *standalone*
guarded-return path are re-formed by a different, pre-existing pass
(`BooleanFoldingPass.FoldGuardReturn`) and are out of scope here — filed as #3114.

The Speed=Slow compile-back gate that would assert this in CI is excluded from
`ci.yml` and cannot run locally (CS0009 on native shared-framework DLLs pulled into
the Roslyn reference set), so exactness here rests on the canary plus the neutral
corpus card below.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the PR-quick corpus is neutral on every tracked metric
with zero pass bugs.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly; 15 assemblies, 1,500
methods (SPC + pinned NuGet packages + dotnet-inspect managed assemblies). Local A/B
with a matched-environment base snapshot (base and head decompilers over an identical
input set), `--compile-cap 0 --corpus-fidelity-cap 0`.

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 16.53% | 16.53% | 0 pp |
| Conditional-branch residue (-) | 3.00% | 3.00% | 0 pp |
| Forward-merge stops (-) | 2.07% | 2.07% | 0 pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — corpus sensor matched baseline tolerances; no changed
> rows. The witness gain is outside this pinned set (`ILInspector.CSharp.dll` is not
> a PR-quick corpus assembly) and is shown by the witness A/B above.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ShortCircuitTernaryPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.RaisingPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```

