### PR TITLE
Fold tuple element names into the type view and separate display from identity (#2996)

### DIFF
--- a/docs/design/type-spelling-identity-display.md
+++ b/docs/design/type-spelling-identity-display.md
@@ -1,0 +1,453 @@
+# Type spelling: identity vs. display
+
+> Design write-up for the API-shape change that lets presentation refinements
+> (tuple element names, `dynamic`, NRT annotations) reach the display without
+> contaminating member **identity**. Motivated by folding
+> `[TupleElementNamesAttribute]` into Metadata's type view (issue
+> [#2996](https://github.com/richlander/dotnet-inspect/issues/2996), Step 3),
+> which surfaced a conflation that predates tuples.
+
+## The question that started this
+
+Rendering named tuples as C# `(int count, string name)` instead of
+`System.ValueTuple<int, string>` is a **settled, fixture-backed outcome** (22
+passing display tests; the encoding is total, local, and taste-free). Wiring it
+in broke one test — `MetadataFindingsTests.RealAssemblySelfCompare_IsExact` —
+with an `ArgumentOutOfRangeException` inside the member-**identity** layer.
+
+That failure is not a tuple bug. It is the symptom of a model deficiency: the
+API shape stores every type as **one opaque display string**, and that same
+string is what member identity re-parses to build its correspondence digest.
+Every presentation refinement therefore leaks into identity.
+
+## Current shape (the conflation)
+
+A type is spelled exactly once, as a rendered string, in these slots:
+
+- `ApiParameter.Type` (and `TypeWithModifier`)
+- `ApiSignature.ReturnType`, `ApiMember.ReturnType`, `ApiMember.Signature`
+- field / property / event type strings
+
+All of them come from `TypeNode.Render()`
+(`src/ILInspector.Metadata/TypeNode.cs`), which applies **presentation
+refinements**:
+
+- NRT annotation: `string` → `string?` (lines 217/239/312/410…)
+- `dynamic`: `object` → `dynamic` (line 196)
+- proposed: tuple syntax + element names, `System.ValueTuple<int,string>` →
+  `(int count, string name)`
+
+That one string then feeds **member identity**
+(`src/ILInspector.Metadata/ApiMemberIdentity.cs`), the producer of the Member
+Index digest / correspondence key. Identity does **not** have a structural
+model to read; it re-derives structure by string-parsing the display spelling
+and laundering presentation back out:
+
+- Primary path: `signature.ParameterTypesSummary` →
+  `ApiParameter.TypeWithModifier` (a `Render()` string), then
+  `NormalizeCanonicalParameters` → `NormalizeDynamicToObject`.
+- Fallback path (JSON-round-tripped surface; `SignatureModel` is `[JsonIgnore]`):
+  re-parse `member.Signature` via `LegacyCanonicalMemberName`,
+  `ExtractCanonicalParameterList`, `ExtractCanonicalIndexerParameterList`,
+  `AbbreviateSignature`, each also passed through `NormalizeDynamicToObject`.
+
+### Why this is a root-cause conflation, not a tuple edge case
+
+**One slot, two consumers with opposite requirements.** Display wants the
+refined spelling; identity wants a presentation-independent structural spelling.
+Because they share a slot, each new refinement forces a per-feature identity-side
+scrub — or breaks identity outright:
+
+1. **`dynamic`** was patched with `NormalizeDynamicToObject` — a string scrub
+   that works only because `dynamic`/`object` is a paren-free token substitution.
+2. **NRT `?`** renders into `Type` but has **no** scrub. Identity is therefore
+   already *latently annotation-sensitive*: two builds of the same assembly under
+   different nullable context produce different fingerprints, even though
+   nullability is erased at runtime and cannot distinguish overloads. This is a
+   pre-existing leak that simply hasn't bitten a self-compare (annotations are
+   stable within one build).
+3. **Tuples** cannot use the scrub pattern at all:
+   - `(int count, string name)` adds parentheses, element **names**, and reverses
+     the `TRest` flattening — far past what a token substitution can undo.
+   - Element names in the digest would make identity **name-sensitive**: renaming
+     a tuple element would change a member's identity, which is wrong (names are
+     erased at runtime; you cannot overload on them).
+   - A tuple **return type** puts `(` at string position 0.
+     `LegacyCanonicalMemberName` computes `signature.IndexOf('(')` (0) then
+     `signature.LastIndexOf(memberName, parenStart - 1)` =
+     `LastIndexOf(name, -1)` → `ArgumentOutOfRangeException`. Every string parser
+     here assumes the first `(` is the parameter list; before tuples, no rendered
+     type ever contained `(` (generics use `<>`, arrays `[]`, fnptr
+     `delegate*<>`).
+
+The pattern is unmistakable: presentation is baked into the identity-bearing
+string, and identity has accreted feature-by-feature string surgery to remove it.
+Tuples are the case where surgery is no longer viable, forcing the architectural
+fix.
+
+## Design principle
+
+From `AGENTS.md`: *"Treat identifiers … and presentation as separate concerns.
+Do not infer one from display text when a typed identity exists."* Metadata owns
+the type facts and should produce **both** spellings from the structure it
+already holds; identity should consume the structural spelling **directly** and
+never re-parse display.
+
+## The two spellings
+
+| Spelling | Example | Properties | Producer |
+| --- | --- | --- | --- |
+| **Display** | `(int count, string name)`, `dynamic`, `string?` | presentation-refined; what humans/agents read | `TypeNode.Render()` (unchanged) |
+| **Canonical** | `System.ValueTuple<int, string>`, `object`, `string` | presentation-independent, name-insensitive, annotation-insensitive | `TypeNode.RenderCanonical()` (new) |
+
+`TypeNode` is the fact owner and already holds every discriminator
+(`IsDynamic`, `IsNullableAnnotated`, tuple elements + `TupleElementName`).
+`RenderCanonical()` ignores those three refinements and emits the structural
+spelling. This **centralizes the split at the fact owner** and lets identity
+**retire** the accreted string scrubs.
+
+## Where the canonical spelling lives (the real decision)
+
+Identity has two entry points — the live `SignatureModel` (transient,
+`[JsonIgnore]`) and the persisted `member.Signature`/`ReturnType` strings (used
+after JSON round-trip). The canonical spelling must be available to **both**,
+which means it must survive JSON. Three options:
+
+### Option A — Canonical fields on the typed model
+
+Add persisted canonical spellings alongside the display ones:
+
+- `ApiParameter.CanonicalType` next to `Type`
+- canonical return next to `ApiSignature.ReturnType` / `ApiMember.ReturnType`
+- canonical field / property / event type next to the display string
+
+Produced at extraction by rendering the `TypeNode` twice (`Render()` +
+`RenderCanonical()`). Identity's `ParameterTypesSummary`-equivalent composes from
+`CanonicalType`; display keeps `Type`. The identity **fallback** path reads the
+persisted canonical fields — **no string re-parsing, no
+`NormalizeDynamicToObject`** on the live path.
+
+- **Pros:** identity becomes a *stored structural fact*. Kills the string parsers
+  and the dynamic scrub at the root. Name/annotation-insensitive by construction.
+  Reusable for every future shape fact. Survives JSON.
+- **Cons:** schema addition on `ApiParameter`/`ApiSignature`/`ApiMember`; the
+  second render must be threaded through every type-bearing extraction site
+  (return/param/field/property/event); older serialized surfaces lack the field.
+
+**Compatibility guarantee (pinned invariant).** For every existing member, the
+canonical spelling must equal the *current post-`NormalizeDynamicToObject`
+identity spelling byte-for-byte*, so no published Member Index selector changes.
+This constrains what the **Member Index projection** may erase (the XML-doc
+projection differs — it erases NRT; see the multi-projection table in the
+[Recommendation](#recommendation) and the round-2 reconciliation):
+
+- **`dynamic`→`object`:** erased. Already the scrub's behavior — zero digest
+  change.
+- **Tuple syntax + names:** erased to `System.ValueTuple<…>`. Zero churn because
+  no prior baseline ever rendered tuple *display* into identity — these members
+  used the `ValueTuple<…>` spelling before, which is exactly what canonical
+  restores. This is the change's actual win, and it is name-insensitive by
+  construction.
+- **NRT `?`: NOT erased in this change.** Today's identity spelling *includes*
+  `?` (there is no nullable scrub). Erasing it would change the digest of every
+  NRT-annotated member — a pin violation, not a free win. Canonical therefore
+  *preserves* `?` exactly as today. Closing the latent NRT leak is a separate,
+  explicitly **versioned** identity-contract change (deferred; see
+  [Deferred](#deferred-nrt-in-identity)), not smuggled in here.
+- **Modifiers (`out`/`in`/`params`):** preserved. These come from `[Out]` /
+  `[ParamArray]` attributes and are prepended by `TypeWithModifier`, but the CLR
+  type tree models `out`/`in`/`ref` identically as byref (`&`) and knows nothing
+  of `params`. So canonical is composed as **`CanonicalTypeWithModifier`** =
+  structural type (byref stripped) + the *same* extracted `Modifier` today's
+  identity uses — mirroring the existing `type.StartsWith("ref ")` surgery in
+  `ApiSurfaceExtractor.cs` (~960). The refinement erasure is orthogonal to the
+  modifier.
+
+`RealAssemblySelfCompare_IsExact` plus a `modreq`/`modopt`/fnptr/array/byref/
+pointer/nested-generic/`+`-nested corpus canary is the pin.
+
+**Migration.** When the persisted identity key is absent (older JSON), fall back
+to the current string-parse path, kept as a versioned compatibility shim. The
+shim must be **hardened to never throw** on tuple *display* text (guard the
+`IndexOf('(')`/`LastIndexOf(name, parenStart-1)` path so a leading `(` degrades
+rather than crashing) and must not attempt to recover `ValueTuple<…>` from
+`(…)` display. New surfaces never take the shim.
+
+### Option B — One persisted `ApiMember.CanonicalSignature` string
+
+Compute the whole identity canonical string once at extraction and persist it;
+identity reads it directly.
+
+- **Pros:** simplest consumer.
+- **Cons:** denormalizes declaring-type/kind into the member; still a string, so
+  less reusable than a per-type canonical projection; duplicates identity's
+  digest-format knowledge into the extractor (two places to keep in sync).
+
+### Option C — Persist a structured type node per slot
+
+Replace the opaque string with a typed type-tree in the serialized surface;
+display and identity each render from the structure.
+
+- **Pros:** most principled; every future shape fact flows for free.
+- **Cons:** large JSON schema change and blast radius; over-scoped now.
+  Option A is the incremental step toward it — the canonical spelling is exactly
+  the identity projection a typed node would compute.
+
+## Recommendation
+
+**Hybrid A+B, multi-projection (revised after two review rounds):** a
+`RenderCanonical()` structural **seam** on `TypeNode` (the fact owner) that each
+identity **projection** composes with its *own* presentation-erasure policy; the
+finished keys are computed at extraction while `SignatureModel` is live and
+**persisted whole** on `ApiMember`.
+
+The second review round established that there is **no single canonical
+spelling**. Identity is not one key — it is several, each with a *different*
+erasure contract. Baking one "canonical" string and reusing it for all of them is
+unsound (it breaks XML-doc lookup). So `RenderCanonical()` produces the
+structural, presentation-free spelling (tuples→`ValueTuple<…>`,
+`dynamic`→`object`), and each projection layers its own policy on top:
+
+| Projection | Persisted on `ApiMember` | Tuple names | `dynamic` | NRT `?` | Byref/return syntax |
+| --- | --- | --- | --- | --- | --- |
+| **Member Index digest** (primary identity) | yes | erased | →`object` | **preserved** (pin — identity includes `?` today) | `ref readonly` preserved |
+| **XML-doc member id** | yes | erased | →`System.Object` | **erased** (XML-doc ids never encode NRT) | byref `@`, generic `{…}` |
+| **Extension-instance correspondence** soft key | yes | erased | →`object` | preserved (matches current) | per current `NormalizeCorrespondenceType` |
+
+Steps:
+
+1. Add `TypeNode.RenderCanonical()` — the structural, name-insensitive spelling.
+   This is the single fact-owner **seam**, not a finished key. Modifiers are
+   composed separately as `CanonicalTypeWithModifier` = byref-stripped structural
+   type + the *same* extracted `Modifier` today's `TypeWithModifier` uses. A
+   **canonical return formatter** mirrors `FormatMethodReturnType` so
+   `ref readonly` (inserted from the return param's `modreq`/`InAttribute`, not
+   the type node) survives — a plain `RenderCanonical()` sees only `ref X`.
+2. Compute **all three** finished keys — Member Index digest, XML-doc id, and the
+   extension-instance projection key — during extraction from the live
+   `SignatureModel`, each with its own erasure policy from the table, and persist
+   them as top-level `ApiMember` properties. Today all three are computed *late*
+   (`GetCanonicalSignature`/`TryGetExtensionInstanceProjection` run at diff time
+   from the member's display strings via `Anchor?.CanonicalSignature`, not
+   persisted); moving them to extraction is the actual structural change.
+3. Every identity/correspondence consumer reads the persisted key, never a
+   rendered display string. This explicitly includes the extension-instance soft
+   key built in `MetadataFindings.CreateMemberFindingKey` — otherwise a tuple
+   leaks into the soft key and element renames break diff pairing.
+4. **All** raw-signature parsers — `LegacyCanonicalMemberName`,
+   `ExtractMemberNameWithGeneric`, `ExtractCanonicalParameterList`,
+   `ExtractCanonicalIndexerParameterList`, `AbbreviateSignature` — demote to a
+   hardened fallback used **only** for pre-key serialized surfaces. Every one that
+   does `IndexOf('(')` then `LastIndexOf(name, parenStart-1)` must guard the
+   leading-`(` case to degrade rather than throw, and none may attempt to recover
+   `ValueTuple<…>` from `(…)` display text.
+
+This fixes the root conflation, deletes the scrubs from the live path, keeps each
+key computed exactly once (no round-trip skew), and preserves every existing
+selector under the pinned corpus invariant. Tuples land purely as a **display**
+refinement (`Render()`), never reaching any key. Option C (a typed type-tree in
+the surface) remains the principled long-term shape; this hybrid is the
+incremental step and leaves `RenderCanonical()` as the projection a typed node
+would later compute.
+
+## How each distinction flows after the change
+
+| Distinction | Slot | Producer | Consumer |
+| --- | --- | --- | --- |
+| Display type (tuple syntax, `dynamic`, NRT `?`) | `ApiParameter.Type`, return/field/property strings | `TypeNode.Render()` | `member` command, Markdown/JSON output |
+| Identity keys (structural) | three persisted `ApiMember` keys (digest / XML-doc / extension) | `RenderCanonical()` seam + per-projection policy, composed live at extraction | `ApiMemberIdentity`, correspondence, diff pairing, XML-doc lookup |
+| Tuple element **names** | display render only | `TypeNode` (`TupleElementName`) | display only — never any key |
+| NRT `?` | display + Member Index key (preserved), XML-doc key (erased) | `TypeNode` (`IsNullableAnnotated`) + per-projection policy | see table above; **diff delta**, see caveat below |
+
+## Validation / invariants
+
+- **Pinned:** `RealAssemblySelfCompare_IsExact` stays exact — the persisted
+  identity key equals the prior identity spelling across the whole corpus,
+  including `modreq`/`modopt`/fnptr/array/byref/pointer/nested-generic/`+`-nested
+  and `out`/`in`/`params` members (the modifier and shape canary).
+- **New:** renaming a tuple element does **not** change any identity key
+  (name-insensitivity), including the extension-instance soft key — but the rename
+  **does** appear as a diff delta (display `Signature` is still compared).
+- **New:** a tuple **return type** member yields a valid identity key (no crash)
+  and a `(...)` display; the hardened fallback also never throws on tuple display.
+- **New:** every key (Member Index digest, XML-doc id, extension-instance soft
+  key, conversion-`~ReturnType`) is composed from `RenderCanonical()` with its own
+  policy — a tuple or `dynamic` in any of them no longer leaks.
+- **New:** `ref readonly` returns keep `readonly` in the canonical key (canonical
+  return formatter), so no correspondence churn.
+- Existing 22 tuple display tests are unaffected (display is `Render()`,
+  untouched).
+
+## In-scope consumer switches (do not miss these)
+
+Every identity/correspondence path that today reads a **display** string must
+compose from `RenderCanonical()` (with its projection's policy) instead, or it
+inherits the leak:
+
+- `ApiMemberIdentity` primary digest (`ParameterTypesSummary` → `TypeWithModifier`)
+  — NRT preserved.
+- `TryGetExtensionInstanceProjection` — reads `Parameters[0].TypeWithModifier` and
+  `ReturnType`; invoked *late* from `MetadataFindings.CreateMemberFindingKey`, so
+  its key **must be persisted at extraction** or the tuple leaks into the soft key
+  and element renames break pairing (both reviewers, round 2, blocking).
+- `TryGetXmlDocMemberIdentity` / `NormalizeXmlDocParameterType` — **NRT erased**,
+  XML-doc `@`/`{…}` syntax; has an NRT strip today but **no** tuple parser. Its
+  persisted projection differs from the Member Index projection (NRT erased vs
+  preserved) — they are not the same string.
+- Conversion-operator `~ReturnType` suffix (`NormalizeDynamicToObject(ReturnType)`).
+- `NormalizeCorrespondenceType` and any Finding soft/correspondence keys.
+
+## Broader opportunity: structure over display
+
+This conflation is not unique to member identity. Across the Metadata layer,
+multiple consumers recover a **structural** fact by string-matching a **display**
+spelling — the same anti-pattern, each independently fragile to any presentation
+refinement (NRT `?`, `dynamic`, tuples):
+
+- `EcosystemIntegrationScanner` — `signature.ReturnType == "…IServiceCollection"`,
+  `.StartsWith("Aspire.Hosting.ApplicationModel.IResourceBuilder<")`.
+- `OpenTelemetryScanner` — `ReturnType == "bool"`,
+  `== "OpenTelemetry.Trace.TracerProviderBuilder"`, etc.
+- `MethodClassificationScanner` — pointer return detected via
+  `ReturnType.Contains('*')`.
+- `NormalizeXmlDocParameterType` — an entire mini type-parser (arrays `[]`,
+  pointers `*`, generic `{…}`, attribute stripping, dynamic scrub) reconstructing
+  structure from the display string; reused by the CLI `XmlDocFileParser`.
+
+The fix these share is the same one identity needs: a durable, presentation-
+independent **structural type view**, asked structural questions directly instead
+of pattern-matched as text.
+
+**The codebase already contains the reference *discipline*** (not a droppable
+implementation). `ILInspector.Analysis`'s `TypeRef`
+(`src/ILInspector.Analysis/TypeRef.cs`) is a structurally-equal type model whose
+own contract states *"Display names are for humans; equality is structural"*. It
+carries `ElementType` / `TypeArguments` / `ContainsPointer()` and excludes
+advisory provenance (`TrustedFrameworkAssembly`, spoof flags) from structural
+identity — exactly the separation of concerns this design argues for. Analysis
+consumers (`OpaqueUnsafe`, `LibraryBodyIndex`) ask `TypeRef` structural questions
+and never string-match. **Metadata is the outlier:** it builds a `TypeNode` tree,
+flattens it to a display string, discards the structure, then makes every
+downstream consumer re-parse.
+
+**Important caveat (round 2):** `TypeRef` cannot simply move below Metadata. It
+carries Analysis-specific trust bits and its decoder *rejects* function pointers
+and custom modifiers (`TypeRefDecoder` → `Unsupported`) — precisely the
+`fnptr`/`modreq`/`modopt` shapes this design's pin **must** preserve. So the north
+star is to give `TypeNode` a durable structural projection sharing `TypeRef`'s
+*discipline*, not to hoist `TypeRef` itself; a real `TypeNode`↔`TypeRef`
+convergence is a larger, separate effort with its own layering and coverage work.
+
+**Scope discipline for this change.** The tuple slice does *not* unify all of the
+above. It (a) establishes the `RenderCanonical()` structural seam on `TypeNode`
+and the persisted multi-projection-key pattern in a reusable way, and (b)
+migrates only the identity/correspondence/XML-doc consumers listed above. The
+scanners operate on `GuardedSignatureText` display strings independent of
+`ApiSurface` (so they do not crash on tuples today) and, together with a
+`TypeNode`↔`TypeRef` convergence, are explicit **follow-ups** this design enables
+but does not perform — each a separate PR with its own compatibility surface.
+
+## Deferred: NRT in identity
+
+Erasing NRT `?` from the identity key is *semantically* correct (nullability is
+runtime-erased; you cannot overload on it) but is a **digest-changing** contract
+break, so it is out of scope here. It ships, if at all, as an explicitly
+versioned identity-contract v2 with a documented, bounded churn set — never
+bundled into the tuple change. Until then canonical preserves `?` exactly.
+
+**Correction (round 2).** An earlier draft claimed a nullability change "remains a
+diff delta the diff command surfaces (correspondence pairs the member; the delta
+reports the change)." That is **not** how the engine behaves today. The primary
+member key is `handle.CanonicalSignature ?? handle.Identity` and the *only* soft
+key is the extension-instance projection (`MetadataFindings.CreateMemberFindingKey`)
+— there is **no NRT-agnostic soft key**. Because canonical preserves `?`, an NRT
+change alters the primary key and nothing bridges it, so the member is reported as
+a paired **Add + Remove**, not a single "nullability changed" delta (the change is
+still *visible*, just not gracefully paired). Achieving the graceful paired delta
+would require a new NRT-agnostic soft key (a `RenderCanonical()` projection with
+`?` erased) — that is part of the deferred v2, not a property of the current
+design.
+
+## Non-goals / boundaries
+
+- Not changing what tuples render as in display (settled, fixture-backed).
+- Not introducing a typed type-tree in the serialized surface (Option C) —
+  future.
+- Not closing the NRT-in-identity leak in this change (deferred, versioned); NRT
+  changes currently surface as Add/Remove, not paired deltas.
+- Metadata-layer only. No decompiler / `ILInspector.CSharp` changes; product
+  paths stay SRM-only, Roslyn-free, NativeAOT-friendly.
+- Ecosystem scanners (`EcosystemIntegrationScanner`, `OpenTelemetryScanner`, …)
+  that exact-match `ReturnType == "bool"` etc. would become annotation-robust by
+  reading a structural view — noted as follow-up, not required here.
+
+## Review reconciliation
+
+Two adversarial review rounds, each by two models off the author's Claude Opus
+4.8 (GPT-5.5, Gemini 3.1 Pro), per the roster. Round 1 reviewed bare Option A;
+round 2 reviewed the revised hybrid. Findings and resolutions:
+
+### Round 1 (Option A)
+
+- **[Both, blocking] Missed identity consumers.** `TryGetExtensionInstanceProjection`
+  and the XML-doc identity path read display strings; XML-doc cannot parse tuple
+  `(…)` into `System.ValueTuple{…}`. → Promoted to explicit in-scope consumer
+  switches.
+- **[GPT, blocking] NRT vs byte-exact pin contradiction.** Today's identity
+  includes `?`, so erasing it churns digests. → Canonical *preserves* NRT;
+  leak-closure deferred to a versioned v2.
+- **[Gemini, blocking] `out`/`in`/`params` divergence.** `TypeWithModifier`
+  prepends attribute-derived modifiers the CLR type tree collapses to `ref`/none.
+  → Canonical composed as `CanonicalTypeWithModifier`, preserving the modifier.
+- **[Both, blocking] Fallback crashes on tuple display.** → Shim hardened.
+- **[Both, design] Prefer persisting the finished key over parallel canonical type
+  strings.** → Adopted the hybrid A+B.
+- **[Gemini, validated] Correspondence vs delta** is the correct distinction.
+
+### Round 2 (revised hybrid)
+
+- **[Both, blocking] Extension-instance key leaks tuples.** The hybrid rejected
+  persisting canonical *types* on `ApiParameter`, but `TryGetExtensionInstanceProjection`
+  runs *late* on `ApiMember` (`CreateMemberFindingKey`) from display strings — so
+  a tuple leaks into the soft key and element renames break pairing, violating the
+  design's own invariant. Code-verified: primary key is
+  `handle.CanonicalSignature ?? handle.Identity`; the sole soft key is this
+  projection. → The extension-instance key is now **persisted at extraction** too,
+  alongside the digest and XML-doc id.
+- **[GPT, blocking] No single canonical spelling.** The XML-doc id must *erase*
+  NRT (`M(string?)`→`M:T.M(System.String)`) while the Member Index digest must
+  *preserve* it — one spelling for both breaks XML-doc lookup for every nullable
+  API. → Recommendation restructured into an explicit **multi-projection** model:
+  `RenderCanonical()` is a structural *seam*; each key applies its own erasure
+  policy (table in the recommendation).
+- **[GPT, blocking] `ref readonly` returns.** `FormatMethodReturnType` inserts
+  `readonly` from the return param's `modreq`/`InAttribute`, which a bare
+  `RenderCanonical()` on the type node loses → correspondence churn. Code-verified
+  in `ApiSurfaceExtractor.FormatMethodReturnType`. Gemini missed this (only
+  considered plain `ref`). → Added a canonical return formatter mirroring it.
+- **[GPT, blocking] Fallback hardening incomplete.** `ExtractMemberNameWithGeneric`
+  has the same `IndexOf('(')`/`LastIndexOf(name, parenStart-1)` throw as
+  `LegacyCanonicalMemberName`. → Hardening now covers **all** raw-signature
+  parsers.
+- **[Gemini, correction] NRT diff-delta overclaim.** Corrected above — NRT changes
+  currently surface as Add/Remove, not paired deltas, until a v2 NRT-agnostic soft
+  key exists.
+- **[GPT, non-blocking] `TypeRef` overstated.** It carries Analysis trust bits and
+  its decoder *rejects* fnptr/modopt — the exact shapes the pin preserves. →
+  Broader-opportunity section now says share `TypeRef`'s *discipline*, not hoist
+  `TypeRef` itself.
+- **[Gemini, validated] Scanners are safely deferrable** — they run on
+  `GuardedSignatureText`, independent of `ApiSurface`, so they do not crash on
+  tuples today. Modifier composition (A2) and per-kind key byte-match (B)
+  confirmed sound by both.
+
+## Residual open questions
+
+1. Is a single-assembly self-compare a sufficient pin, or is a cross-build canary
+   needed to prove the shape/modifier canonical is byte-stable?
+2. Exact whitespace of each projection must be pinned (today
+   `NormalizeCanonicalCommas` strips `", "`→`","`); the persisted keys must match
+   byte-for-byte.
+3. Should the deferred NRT-in-identity v2 land (with its NRT-agnostic soft key for
+   graceful paired deltas), or is annotation-sensitive identity acceptable
+   indefinitely?

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -436,7 +436,7 @@ public static class ApiMemberIdentity
             // "this[...]" signature text instead, which IS preserved across JSON
             // round-trips.
             var indexerParameters = member.SignatureModel is { Parameters.Count: > 0 } propertySignature
-                ? NormalizeCanonicalParameters(propertySignature.ParameterTypesSummary)
+                ? NormalizeCanonicalParameters(propertySignature.CanonicalParameterTypesSummary)
                 : NormalizeDynamicToObject(ExtractCanonicalIndexerParameterList(member.Signature));
             canonicalSignature = $"{kindCode}:{declaringType}.{member.Name}{indexerParameters}";
             return true;
@@ -455,14 +455,14 @@ public static class ApiMemberIdentity
                   ? member.Name
                   : signature.MemberName!);
         memberName = NormalizeCanonicalCommas(memberName);
-        var canonical = $"{kindCode}:{declaringType}.{memberName}{NormalizeCanonicalParameters(signature.ParameterTypesSummary)}";
+        var canonical = $"{kindCode}:{declaringType}.{memberName}{NormalizeCanonicalParameters(signature.CanonicalParameterTypesSummary)}";
         // Conversion operators overload on return type, so the parameter list alone
         // is an ambiguous identity (every System.Decimal.op_Explicit(Decimal) collides).
         // Append a product-owned return-type suffix. It intentionally uses the
         // same "~ReturnType" delimiter as XML doc identity so conversion anchors
         // and XML lookups do not grow divergent spellings for the same fact.
-        if (IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(signature.ReturnType))
-            canonical += $"~{NormalizeCanonicalCommas(NormalizeDynamicToObject(signature.ReturnType!))}";
+        if (IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(signature.EffectiveCanonicalReturnType))
+            canonical += $"~{NormalizeCanonicalCommas(NormalizeDynamicToObject(signature.EffectiveCanonicalReturnType!))}";
         canonicalSignature = canonical;
         return true;
     }
@@ -490,7 +490,7 @@ public static class ApiMemberIdentity
             return false;
         }
         if (signature.Parameters.Any(parameter =>
-                string.IsNullOrWhiteSpace(parameter.TypeWithModifier)))
+                string.IsNullOrWhiteSpace(parameter.CanonicalTypeWithModifier)))
         {
             identityKey = "";
             variant = "";
@@ -498,11 +498,11 @@ public static class ApiMemberIdentity
         }
 
         string receiver = isExtension
-            ? signature.Parameters[0].TypeWithModifier
+            ? signature.Parameters[0].CanonicalTypeWithModifier
             : type.FullName;
         if (string.IsNullOrWhiteSpace(receiver)
             || string.IsNullOrWhiteSpace(member.Name)
-            || string.IsNullOrWhiteSpace(signature.ReturnType))
+            || string.IsNullOrWhiteSpace(signature.EffectiveCanonicalReturnType))
         {
             identityKey = "";
             variant = "";
@@ -517,10 +517,10 @@ public static class ApiMemberIdentity
             NormalizeCorrespondenceType(receiver),
             member.Name,
             signature.TypeParameters.Count.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            NormalizeCorrespondenceType(signature.ReturnType),
+            NormalizeCorrespondenceType(signature.EffectiveCanonicalReturnType!),
         };
         facets.AddRange(parameters.Select(parameter =>
-            NormalizeCorrespondenceType(parameter.TypeWithModifier)));
+            NormalizeCorrespondenceType(parameter.CanonicalTypeWithModifier)));
 
         identityKey = string.Concat(facets.Select(facet => $"{facet.Length}:{facet}"));
         variant = isExtension ? "extension" : "instance";
@@ -589,6 +589,41 @@ public static class ApiMemberIdentity
             char.IsLetterOrDigit(c) || c is '_' or '.' or '`' or '+' or '/';
     }
 
+    /// <summary>
+    /// Locates the index of the parameter-list opening parenthesis in a member display
+    /// signature, skipping a leading balanced parenthesized group that represents a C#
+    /// tuple return type (e.g. <c>(int count, string name) Parse(...)</c>). A tuple return
+    /// puts <c>(</c> at position 0, which is never the parameter list; returns -1 when no
+    /// parameter-list parenthesis follows. Ordinary signatures (no leading tuple) resolve
+    /// to the first <c>(</c> exactly as before, preserving existing digests.
+    /// </summary>
+    static int IndexOfParameterListParen(string signature)
+    {
+        var searchFrom = 0;
+        if (signature.Length > 0 && signature[0] == '(')
+        {
+            var depth = 0;
+            for (var i = 0; i < signature.Length; i++)
+            {
+                if (signature[i] == '(')
+                {
+                    depth++;
+                }
+                else if (signature[i] == ')')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        searchFrom = i + 1;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return signature.IndexOf('(', searchFrom);
+    }
+
     // Preserve the v1 Member Index digest contract for members that already have
     // compatibility signature text. The legacy parser had edge-case behavior
     // around method names inside generic parameter names, and published stable
@@ -598,8 +633,8 @@ public static class ApiMemberIdentity
         if (string.IsNullOrEmpty(signature))
             return null;
 
-        var parenStart = signature.IndexOf('(');
-        if (parenStart < 0)
+        var parenStart = IndexOfParameterListParen(signature);
+        if (parenStart <= 0)
             return null;
 
         var nameIndex = signature.LastIndexOf(memberName, parenStart - 1, StringComparison.Ordinal);
@@ -636,8 +671,8 @@ public static class ApiMemberIdentity
 
     static string ExtractMemberNameWithGeneric(string signature, string memberName)
     {
-        var parenStart = signature.IndexOf('(');
-        if (parenStart < 0)
+        var parenStart = IndexOfParameterListParen(signature);
+        if (parenStart <= 0)
             return memberName;
 
         var nameIndex = signature.LastIndexOf(memberName, parenStart - 1, StringComparison.Ordinal);
@@ -821,10 +856,10 @@ public static class ApiMemberIdentity
             .ToDictionary(p => p.Name, p => p.Index, StringComparer.Ordinal);
         var methodParameterMap = GetMethodGenericParameterMap(signature.MemberName);
         var parameters = signature.Parameters
-            .Select(parameter => NormalizeXmlDocParameterType(parameter.TypeWithModifier, typeParameterMap, methodParameterMap))
+            .Select(parameter => NormalizeXmlDocParameterType(parameter.CanonicalTypeWithModifier, typeParameterMap, methodParameterMap))
             .ToList();
-        var returnType = IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(signature.ReturnType)
-            ? NormalizeXmlDocParameterType(signature.ReturnType!, typeParameterMap, methodParameterMap)
+        var returnType = IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(signature.EffectiveCanonicalReturnType)
+            ? NormalizeXmlDocParameterType(signature.EffectiveCanonicalReturnType!, typeParameterMap, methodParameterMap)
             : null;
         identity = new XmlDocMemberIdentity(lookupKey, parameters, returnType);
         return true;

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -188,18 +188,23 @@ public static class ApiMemberIdentity
 
     static bool HasCanonicalDivergence(ApiMember member, ApiSignature signature)
     {
-        // A tuple parameter is part of member identity, so its erased spelling must be
-        // persisted. A tuple return type only affects identity for conversion operators
-        // (which overload on return type); for every other member the return type is not
-        // part of the digest, so a return-only divergence needs no persistence.
+        // Persist canonical identity for any member whose display signature carries C#
+        // tuple syntax the text fallback cannot re-canonicalize after a JSON round-trip
+        // (SignatureModel is not serialized). Two divergence sources both require it:
+        //   * A tuple PARAMETER is part of the identity digest; its erased spelling and
+        //     element names must not leak in and cannot be recovered from display text.
+        //   * A tuple RETURN type is only part of the digest for conversion operators, but
+        //     even for other members its '(...)' parentheses would derail the fallback's
+        //     first-'(' parameter-list detection, corrupting the round-tripped identity.
+        //     The persisted digest is computed live and correctly omits the non-conversion
+        //     return type, so short-circuiting to it keeps live and round-trip in lockstep.
         if (signature.Parameters.Any(parameter =>
                 !string.Equals(parameter.EffectiveCanonicalType, parameter.Type, StringComparison.Ordinal)))
         {
             return true;
         }
 
-        return IsConversionOperator(member.Name)
-            && !string.Equals(signature.EffectiveCanonicalReturnType, signature.ReturnType, StringComparison.Ordinal);
+        return !string.Equals(signature.EffectiveCanonicalReturnType, signature.ReturnType, StringComparison.Ordinal);
     }
 
     public static string GetMemberSignatureSortKey(ApiMember member)

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -162,6 +162,46 @@ public static class ApiMemberIdentity
     public static ApiMemberHandle CreateHandle(ApiType type, ApiMember member)
         => new(type, member, GetMemberAnchor(type, member));
 
+    /// <summary>
+    /// Persists <see cref="ApiMember.CanonicalSignature"/> for every member whose canonical
+    /// (identity) spelling diverges from its display <see cref="ApiMember.Signature"/> — i.e.
+    /// members carrying C# tuple syntax, whose element names and <c>(...)</c> spelling must
+    /// not leak into identity and cannot be recovered from the display text after a JSON
+    /// round-trip (<see cref="ApiMember.SignatureModel"/> is not serialized). Computed here,
+    /// while the structural model is live, so a round-tripped surface pairs with the same
+    /// members read live. Non-divergent (non-tuple) members are left untouched, keeping
+    /// their serialized form and digests unchanged.
+    /// </summary>
+    public static void PopulateCanonicalIdentities(ApiSurface surface)
+    {
+        foreach (var type in surface.Types)
+        {
+            foreach (var member in type.Members)
+            {
+                if (member.SignatureModel is not { } signature || !HasCanonicalDivergence(member, signature))
+                    continue;
+
+                member.CanonicalSignature = GetCanonicalSignature(type, member);
+            }
+        }
+    }
+
+    static bool HasCanonicalDivergence(ApiMember member, ApiSignature signature)
+    {
+        // A tuple parameter is part of member identity, so its erased spelling must be
+        // persisted. A tuple return type only affects identity for conversion operators
+        // (which overload on return type); for every other member the return type is not
+        // part of the digest, so a return-only divergence needs no persistence.
+        if (signature.Parameters.Any(parameter =>
+                !string.Equals(parameter.EffectiveCanonicalType, parameter.Type, StringComparison.Ordinal)))
+        {
+            return true;
+        }
+
+        return IsConversionOperator(member.Name)
+            && !string.Equals(signature.EffectiveCanonicalReturnType, signature.ReturnType, StringComparison.Ordinal);
+    }
+
     public static string GetMemberSignatureSortKey(ApiMember member)
     {
         var signature = member.Signature ?? "";
@@ -358,6 +398,13 @@ public static class ApiMemberIdentity
 
     public static string GetCanonicalSignature(ApiType type, ApiMember member)
     {
+        // A persisted canonical identity (present for tuple-bearing members whose display
+        // signature cannot be re-canonicalized from text after a JSON round-trip) is
+        // authoritative: it was computed at extraction from the live structural model and
+        // guarantees round-tripped surfaces pair with the same members read live.
+        if (!string.IsNullOrEmpty(member.CanonicalSignature))
+            return member.CanonicalSignature!;
+
         if (TryGetCanonicalSignature(type, member, out var canonicalSignature))
             return canonicalSignature;
 
@@ -401,6 +448,14 @@ public static class ApiMemberIdentity
 
     public static bool TryGetCanonicalSignature(ApiType type, ApiMember member, out string canonicalSignature)
     {
+        // See GetCanonicalSignature: a persisted canonical identity is authoritative and
+        // survives the JSON round-trip that discards SignatureModel.
+        if (!string.IsNullOrEmpty(member.CanonicalSignature))
+        {
+            canonicalSignature = member.CanonicalSignature!;
+            return true;
+        }
+
         var declaringType = string.IsNullOrWhiteSpace(member.DeclaringType)
             ? MetadataTypeNameFormatter.FormatFullName(type)
             : member.DeclaringType!;

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -206,6 +206,7 @@ public readonly record struct TypeParameterConstraint(string Value, bool IsTypeN
 public class ApiSignature
 {
     public string? ReturnType { get; set; }
+    public string? CanonicalReturnType { get; set; }
     public List<string> ReturnAttributes { get; set; } = [];
     public string? MemberName { get; set; }
     public bool IsRequired { get; set; }
@@ -218,6 +219,24 @@ public class ApiSignature
     public string ParameterTypesSummary => Parameters.Count == 0
         ? ""
         : $"({string.Join(", ", Parameters.Select(parameter => parameter.TypeWithModifier))})";
+
+    /// <summary>
+    /// The presentation-independent parameter list used for member identity: identical
+    /// to <see cref="ParameterTypesSummary"/> except that tuple element names and C#
+    /// tuple syntax are erased (<c>System.ValueTuple&lt;int, string&gt;</c> rather than
+    /// <c>(int count, string name)</c>). For members with no tuple parameters this equals
+    /// <see cref="ParameterTypesSummary"/> character-for-character.
+    /// </summary>
+    public string CanonicalParameterTypesSummary => Parameters.Count == 0
+        ? ""
+        : $"({string.Join(", ", Parameters.Select(parameter => parameter.CanonicalTypeWithModifier))})";
+
+    /// <summary>
+    /// The canonical (tuple-erased) return-type spelling used for identity; falls back to
+    /// <see cref="ReturnType"/> when a canonical spelling was not recorded.
+    /// </summary>
+    public string? EffectiveCanonicalReturnType =>
+        string.IsNullOrEmpty(CanonicalReturnType) ? ReturnType : CanonicalReturnType;
 
     public List<(string name, string type, bool hasDefault)> ParameterInfoSummary => Parameters
         .Select(parameter => (parameter.Name, parameter.TypeWithModifier, parameter.HasDefault))
@@ -234,6 +253,7 @@ public class ApiParameter
     public List<string> Attributes { get; set; } = [];
     public string Name { get; set; } = "";
     public string Type { get; set; } = "";
+    public string? CanonicalType { get; set; }
     public string? Modifier { get; set; }
     public bool HasDefault { get; set; }
     public string? DefaultValueText { get; set; }
@@ -241,6 +261,20 @@ public class ApiParameter
     public string TypeWithModifier => string.IsNullOrEmpty(Modifier)
         ? Type
         : $"{Modifier} {Type}";
+
+    /// <summary>
+    /// The canonical (tuple-erased) parameter type; falls back to <see cref="Type"/> when a
+    /// canonical spelling was not recorded, so a non-tuple parameter's canonical spelling
+    /// equals its display spelling.
+    /// </summary>
+    public string EffectiveCanonicalType =>
+        string.IsNullOrEmpty(CanonicalType) ? Type : CanonicalType!;
+
+    /// <summary>Canonical type composed with its by-ref/params modifier, mirroring
+    /// <see cref="TypeWithModifier"/> but tuple-erased for identity.</summary>
+    public string CanonicalTypeWithModifier => string.IsNullOrEmpty(Modifier)
+        ? EffectiveCanonicalType
+        : $"{Modifier} {EffectiveCanonicalType}";
 }
 
 public class ApiAccessor

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -396,6 +396,20 @@ public class ApiMember
     public string? ReturnType { get; set; }
     public string? Signature { get; set; }
 
+    /// <summary>
+    /// The persisted, presentation-independent canonical member identity — the Member Index
+    /// digest input (e.g. <c>M:N.C.Parse(System.ValueTuple&lt;int,string&gt;)</c>). Populated
+    /// at extraction only when it diverges from what parsing the display
+    /// <see cref="Signature"/> would yield — i.e. for members whose signature contains C#
+    /// tuple syntax, whose element names and <c>(...)</c> spelling must not leak into
+    /// identity and cannot be recovered from the display text after a JSON round-trip
+    /// (<see cref="SignatureModel"/> is <see cref="JsonIgnoreAttribute"/>). Null in the
+    /// common case, where the canonical spelling equals the display-derived one, so
+    /// serialized surfaces for non-tuple members are unchanged.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CanonicalSignature { get; set; }
+
     [JsonIgnore]
     public ApiSignature? SignatureModel { get; set; }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -623,6 +623,8 @@ public static class ApiSurfaceExtractor
             }
         }
 
+        ApiMemberIdentity.PopulateCanonicalIdentities(surface);
+
         return surface;
     }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -471,11 +471,17 @@ public static class ApiSurfaceExtractor
                 eventNullableBytes ??= NullabilityReader.GetParameterNullableBytes(reader, adder.GetParameters(), 1);
                 if (eventNullableBytes is { Length: > 0 } && eventNullableBytes[0] == 2 && !eventType.EndsWith("?", StringComparison.Ordinal))
                     eventType += "?";
-                // A `dynamic` event handler (e.g. EventHandler<dynamic>) is always a
-                // generic instantiation, so re-decode the TypeSpec through the TypeNode
-                // tree to recover the dynamic view. Non-dynamic events are untouched.
+                // A `dynamic` event handler (e.g. EventHandler<dynamic>) or a
+                // named-tuple handler (EventHandler<(int a, int b)>) is always a
+                // generic instantiation, so re-decode the TypeSpec through the
+                // TypeNode tree to recover the dynamic / tuple view. Plain events
+                // are untouched.
+                var eventTupleNames = TupleElementNamesReader.GetTupleElementNames(reader, evt.GetCustomAttributes());
+                var eventDynamicFlags = evt.Type.Kind == HandleKind.TypeSpecification
+                    ? DynamicReader.GetDynamicFlags(reader, evt.GetCustomAttributes())
+                    : null;
                 if (evt.Type.Kind == HandleKind.TypeSpecification
-                    && DynamicReader.GetDynamicFlags(reader, evt.GetCustomAttributes()) is { } eventDynamicFlags)
+                    && (eventDynamicFlags is not null || eventTupleNames is not null))
                 {
                     var eventNode = GuardedProviderDecode.TypeSpec(
                         reader,
@@ -491,6 +497,7 @@ public static class ApiSurfaceExtractor
                         eventNode.ApplyNullability(eventNullableBytes, ref eventPos, 0);
                         eventPos = 0;
                         eventNode.ApplyDynamic(eventDynamicFlags, ref eventPos);
+                        eventNode.ApplyTupleNames(eventTupleNames);
                         eventType = eventNode.Render();
                     }
                 }
@@ -773,6 +780,8 @@ public static class ApiSurfaceExtractor
         var fieldDynamicFlags = DynamicReader.GetDynamicFlags(reader, field.GetCustomAttributes());
         pos = 0;
         fieldNode.ApplyDynamic(fieldDynamicFlags, ref pos);
+        fieldNode.ApplyTupleNames(
+            TupleElementNamesReader.GetTupleElementNames(reader, field.GetCustomAttributes()));
         return (fieldNode.Render(), fieldNode.IsDegraded);
     }
 
@@ -959,6 +968,8 @@ public static class ApiSurfaceExtractor
         var returnDynamicFlags = DynamicReader.GetParameterDynamicFlags(reader, paramHandles, 0);
         pos = 0;
         treeSignature.ReturnType.ApplyDynamic(returnDynamicFlags, ref pos);
+        treeSignature.ReturnType.ApplyTupleNames(
+            TupleElementNamesReader.GetParameterTupleElementNames(reader, paramHandles, 0));
 
         // Build parameter list with nullability
         var paramTypes = treeSignature.ParameterTypes;
@@ -974,7 +985,10 @@ public static class ApiSurfaceExtractor
             var paramDynamicFlags = DynamicReader.GetParameterDynamicFlags(reader, paramHandles, i + 1);
             pos = 0;
             paramTypes[i].ApplyDynamic(paramDynamicFlags, ref pos);
+            paramTypes[i].ApplyTupleNames(
+                TupleElementNamesReader.GetParameterTupleElementNames(reader, paramHandles, i + 1));
             string type = paramTypes[i].Render();
+            string canonicalType = paramTypes[i].RenderCanonical();
 
             // Parameter handles may include return parameter at SequenceNumber 0
             // Actual parameters have SequenceNumber 1, 2, 3...
@@ -985,6 +999,7 @@ public static class ApiSurfaceExtractor
             if (isByRef)
             {
                 type = type["ref ".Length..];
+                canonicalType = canonicalType["ref ".Length..];
                 refKind ??= "ref";
             }
             else
@@ -1008,6 +1023,7 @@ public static class ApiSurfaceExtractor
                 Attributes = attributes,
                 Name = paramName,
                 Type = type,
+                CanonicalType = canonicalType,
                 Modifier = modifier,
                 HasDefault = hasDefault,
                 DefaultValueText = DefaultValueText(reader, defaultValue, type, hasDefault, AcceptsNullDefault(paramTypes[i]))
@@ -1016,6 +1032,7 @@ public static class ApiSurfaceExtractor
 
         string paramStr2 = string.Join(", ", parameters);
         var returnType = FormatMethodReturnType(reader, treeSignature.ReturnType, paramHandles);
+        var canonicalReturnType = FormatCanonicalMethodReturnType(reader, treeSignature.ReturnType, paramHandles);
         var returnAttributes = ReturnParameterAttributes(reader, paramHandles);
         var methodTypeParameters = GenericParameters(reader, method.GetGenericParameters(), context, nullableDefault, includeVariance: false);
         var methodName = context.MethodParameters.Count > 0
@@ -1024,6 +1041,7 @@ public static class ApiSurfaceExtractor
         return ($"{returnType} {methodName}({paramStr2})", new ApiSignature
         {
             ReturnType = returnType,
+            CanonicalReturnType = canonicalReturnType,
             ReturnAttributes = returnAttributes,
             MemberName = methodName,
             TypeParameters = methodTypeParameters,
@@ -1053,6 +1071,24 @@ public static class ApiSurfaceExtractor
     private static string FormatMethodReturnType(MetadataReader reader, TypeNode returnType, ParameterHandleCollection paramHandles)
     {
         var rendered = returnType.Render();
+        if (!rendered.StartsWith("ref ", StringComparison.Ordinal)
+            || !IsReadOnlyByRefReturn(reader, returnType, paramHandles))
+        {
+            return rendered;
+        }
+
+        return $"ref readonly {rendered["ref ".Length..]}";
+    }
+
+    /// <summary>
+    /// Canonical (tuple-erased) counterpart to <see cref="FormatMethodReturnType"/>. Mirrors
+    /// its <c>ref readonly</c> synthesis so the canonical return spelling preserves by-ref
+    /// return modifiers used by member identity, differing from the display spelling only in
+    /// tuple rendering.
+    /// </summary>
+    private static string FormatCanonicalMethodReturnType(MetadataReader reader, TypeNode returnType, ParameterHandleCollection paramHandles)
+    {
+        var rendered = returnType.RenderCanonical();
         if (!rendered.StartsWith("ref ", StringComparison.Ordinal)
             || !IsReadOnlyByRefReturn(reader, returnType, paramHandles))
         {
@@ -1597,6 +1633,8 @@ public static class ApiSurfaceExtractor
         var propDynamicFlags = DynamicReader.GetDynamicFlags(reader, prop.GetCustomAttributes());
         pos = 0;
         treeSignature.ReturnType.ApplyDynamic(propDynamicFlags, ref pos);
+        treeSignature.ReturnType.ApplyTupleNames(
+            TupleElementNamesReader.GetTupleElementNames(reader, prop.GetCustomAttributes()));
 
         // Determine accessor visibility
         MethodAttributes getterAccess = 0;
@@ -1696,7 +1734,10 @@ public static class ApiSurfaceExtractor
             var paramDynamicFlags = DynamicReader.GetParameterDynamicFlags(reader, paramHandles, i + 1);
             pos = 0;
             paramTypes[i].ApplyDynamic(paramDynamicFlags, ref pos);
+            paramTypes[i].ApplyTupleNames(
+                TupleElementNamesReader.GetParameterTupleElementNames(reader, paramHandles, i + 1));
             var paramType = paramTypes[i].Render();
+            var canonicalParamType = paramTypes[i].RenderCanonical();
             var (paramName, isParams, refKind, hasDefault, defaultValue, attributes) = GetParameterInfo(reader, paramHandles, i + 1);
             paramName ??= $"arg{i}";
 
@@ -1704,6 +1745,7 @@ public static class ApiSurfaceExtractor
             if (isByRef)
             {
                 paramType = paramType["ref ".Length..];
+                canonicalParamType = canonicalParamType["ref ".Length..];
                 refKind ??= "ref";
             }
             else
@@ -1726,6 +1768,7 @@ public static class ApiSurfaceExtractor
                 Attributes = attributes,
                 Name = paramName,
                 Type = paramType,
+                CanonicalType = canonicalParamType,
                 Modifier = modifier,
                 HasDefault = hasDefault,
                 DefaultValueText = DefaultValueText(reader, defaultValue, paramType, hasDefault, AcceptsNullDefault(paramTypes[i]))
@@ -1733,9 +1776,11 @@ public static class ApiSurfaceExtractor
         }
 
         var returnType = FormatMethodReturnType(reader, treeSignature.ReturnType, paramHandles);
+        var canonicalReturnType = FormatCanonicalMethodReturnType(reader, treeSignature.ReturnType, paramHandles);
         var model = new ApiSignature
         {
             ReturnType = returnType,
+            CanonicalReturnType = canonicalReturnType,
             MemberName = indexerParameters.Count > 0 ? "this[]" : name,
             IsRequired = isRequired,
             Parameters = parameterModels,

--- a/src/ILInspector.Metadata/TupleElementNamesReader.cs
+++ b/src/ILInspector.Metadata/TupleElementNamesReader.cs
@@ -1,0 +1,68 @@
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Reads <c>TupleElementNamesAttribute</c> element names from custom-attribute
+/// collections. The names record the C# element names of a <c>System.ValueTuple</c>
+/// instantiation authored with named elements (e.g. the <c>count</c>/<c>name</c>
+/// in <c>(int count, string name)</c>), so the type view can render tuple syntax
+/// with names instead of a bare <c>System.ValueTuple&lt;int, string&gt;</c>.
+/// </summary>
+/// <remarks>
+/// The attribute stores a single <c>string[]</c> argument: a flat, breadth-first
+/// stream of element names across every tuple in the type (a tuple's own element
+/// names first, then its nested tuples), with <c>null</c> for unnamed positions
+/// and trailing <c>null</c> padding per tuple for its 8+ arity "Rest" nesting.
+/// A fully unnamed tuple emits no attribute at all. The consuming walk lives in
+/// <see cref="TypeNode.ApplyTupleNames"/>, which mirrors this ordering.
+/// </remarks>
+public static class TupleElementNamesReader
+{
+    /// <summary>
+    /// Gets the TupleElementNamesAttribute names array (null entries for unnamed
+    /// positions) from custom attributes. Returns null when the attribute is
+    /// absent or its <c>string[]</c> argument is itself null.
+    /// </summary>
+    public static string?[]? GetTupleElementNames(MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var attrHandle in attributes)
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            var attrTypeName = AttributeReader.GetAttributeTypeName(reader, attr.Constructor);
+            if (attrTypeName != KnownAttributeNames.TupleElementNamesAttribute) continue;
+
+            var blob = reader.GetBlobReader(attr.Value);
+            if (blob.RemainingBytes < 2) return null;
+            blob.ReadUInt16(); // prolog
+
+            if (blob.RemainingBytes < 4) return null;
+            uint count = blob.ReadUInt32();
+            if (count == 0xFFFF_FFFF) return null; // null array
+            // Each serialized string is at least one byte (length or 0xFF null marker).
+            if (count > (uint)blob.RemainingBytes) return null;
+
+            var names = new string?[count];
+            for (uint i = 0; i < count; i++)
+                names[i] = blob.ReadSerializedString();
+            return names;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Gets TupleElementNamesAttribute names for a specific parameter by sequence
+    /// number. Sequence 0 = return type, 1+ = parameters.
+    /// </summary>
+    public static string?[]? GetParameterTupleElementNames(
+        MetadataReader reader, ParameterHandleCollection paramHandles, int sequenceNumber)
+    {
+        foreach (var handle in paramHandles)
+        {
+            var param = reader.GetParameter(handle);
+            if (param.SequenceNumber == sequenceNumber)
+                return GetTupleElementNames(reader, param.GetCustomAttributes());
+        }
+        return null;
+    }
+}

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -125,12 +125,22 @@ internal abstract class TypeNode
             var args = current.Arguments;
             // A well-formed C# tuple of arity > 7 is ValueTuple<T1..T7, TRest>
             // where TRest is itself a ValueTuple holding the remaining elements.
-            if (args.Length == 8 && args[7] is GenericTypeNode { BaseName: ValueTupleBaseName } rest)
+            if (args.Length == 8)
             {
-                for (int i = 0; i < 7; i++)
-                    elements.Add(args[i]);
-                current = rest;
-                continue;
+                if (args[7] is GenericTypeNode { BaseName: ValueTupleBaseName } rest)
+                {
+                    for (int i = 0; i < 7; i++)
+                        elements.Add(args[i]);
+                    current = rest;
+                    continue;
+                }
+
+                // An 8-argument ValueTuple whose 8th ("Rest") argument is not itself a
+                // ValueTuple cannot arise from C# tuple syntax (TRest must be a ValueTuple).
+                // Treat it as an ordinary generic instantiation so it keeps its
+                // System.ValueTuple<...> spelling and never collides with a genuine
+                // eight-element tuple.
+                return null;
             }
             elements.AddRange(args);
             break;

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -26,8 +26,33 @@ internal abstract class TypeNode
     /// </summary>
     public bool IsDynamic { get; set; }
 
-    /// <summary>Renders this type to a C# type string with nullability annotations.</summary>
-    public abstract string Render();
+    /// <summary>
+    /// The C# element name for this node when it is a positional element of an
+    /// enclosing <c>System.ValueTuple</c> instantiation authored with a named
+    /// element (e.g. <c>count</c> in <c>(int count, string name)</c>). Null when
+    /// the element is unnamed or this node is not a tuple element. Set by
+    /// <see cref="ApplyTupleNames"/>.
+    /// </summary>
+    public string? TupleElementName { get; set; }
+
+    /// <summary>Renders this type to a C# display string with nullability annotations,
+    /// including C# tuple syntax (<c>(int count, string name)</c>) for
+    /// <c>System.ValueTuple</c> instantiations.</summary>
+    public string Render() => Render(canonicalTuples: false);
+
+    /// <summary>
+    /// Renders the structural, presentation-independent spelling used for member
+    /// identity and correspondence: <c>System.ValueTuple&lt;int, string&gt;</c> rather
+    /// than tuple syntax, and element names erased. Every other facet (nullability,
+    /// <c>dynamic</c>, modifiers) is identical to <see cref="Render()"/>, so a non-tuple
+    /// member's canonical spelling equals its display spelling byte-for-byte.
+    /// </summary>
+    public string RenderCanonical() => Render(canonicalTuples: true);
+
+    /// <summary>Core renderer. When <paramref name="canonicalTuples"/> is true, a
+    /// <c>System.ValueTuple</c> instantiation renders in generic form with no element
+    /// names; otherwise it renders as C# tuple syntax.</summary>
+    public abstract string Render(bool canonicalTuples);
 
     public virtual bool HasRequiredModifier(string ns, string name) => false;
 
@@ -75,6 +100,106 @@ internal abstract class TypeNode
     /// <summary>Whether a rendered type name denotes <c>System.Object</c>.</summary>
     private protected static bool IsObjectName(string name) =>
         name is "object" or "System.Object";
+
+    /// <summary>The fully qualified base name of a <c>System.ValueTuple</c> instantiation.</summary>
+    private const string ValueTupleBaseName = "System.ValueTuple";
+
+    /// <summary>
+    /// When <paramref name="node"/> is a C# tuple — a <c>System.ValueTuple</c>
+    /// instantiation of flattened arity &gt;= 2 — returns its logical element
+    /// nodes in source order, absorbing the 8th "Rest" argument's nested
+    /// <c>ValueTuple</c> chain (<c>ValueTuple&lt;T1..T7, ValueTuple&lt;T8..&gt;&gt;</c>
+    /// flattens to <c>(T1..Tn)</c>). Returns null otherwise. A 1-arity
+    /// <c>ValueTuple&lt;T&gt;</c> is intentionally not a tuple: C# <c>(T)</c> is
+    /// parenthesization, not a one-element tuple, so it keeps generic spelling.
+    /// </summary>
+    internal static List<TypeNode>? TryGetTupleElements(TypeNode node)
+    {
+        if (node is not GenericTypeNode { BaseName: ValueTupleBaseName } tuple)
+            return null;
+
+        var elements = new List<TypeNode>();
+        var current = tuple;
+        while (true)
+        {
+            var args = current.Arguments;
+            // A well-formed C# tuple of arity > 7 is ValueTuple<T1..T7, TRest>
+            // where TRest is itself a ValueTuple holding the remaining elements.
+            if (args.Length == 8 && args[7] is GenericTypeNode { BaseName: ValueTupleBaseName } rest)
+            {
+                for (int i = 0; i < 7; i++)
+                    elements.Add(args[i]);
+                current = rest;
+                continue;
+            }
+            elements.AddRange(args);
+            break;
+        }
+        return elements.Count >= 2 ? elements : null;
+    }
+
+    /// <summary>
+    /// The count of trailing null padding entries a tuple of the given flattened
+    /// arity contributes to a <c>TupleElementNamesAttribute</c> names stream,
+    /// accounting for its nested "Rest" <c>ValueTuple</c> containers:
+    /// <c>f(n) = (n-7) + f(n-7)</c> for <c>n &gt; 7</c>, else 0. Empirically
+    /// verified against the Roslyn encoding across arities 7..29.
+    /// </summary>
+    private static int TupleNamePadding(int arity)
+        => arity <= 7 ? 0 : (arity - 7) + TupleNamePadding(arity - 7);
+
+    /// <summary>
+    /// Applies <c>TupleElementNamesAttribute</c> element names to the tuple
+    /// positions in this type tree. The names are a flat stream ordered
+    /// per tuple — a tuple's own element names first, then recursing into each
+    /// element — with trailing null padding per tuple for its 8+ arity "Rest"
+    /// nesting (see <see cref="TupleNamePadding"/>). Only tuple element positions
+    /// consume the stream; non-tuple structure (arrays, generics, by-ref, etc.)
+    /// consumes nothing. A null stream (attribute absent) leaves every tuple
+    /// unnamed; unnamed tuples still render with positional <c>(...)</c> syntax.
+    /// </summary>
+    public void ApplyTupleNames(string?[]? names)
+    {
+        if (names is null) return;
+        int position = 0;
+        DecodeTupleNames(this, names, ref position);
+    }
+
+    private static void DecodeTupleNames(TypeNode node, string?[] names, ref int position)
+    {
+        if (TryGetTupleElements(node) is { } elements)
+        {
+            foreach (var element in elements)
+            {
+                element.TupleElementName = position < names.Length ? names[position] : null;
+                position++;
+            }
+            position += TupleNamePadding(elements.Count);
+            foreach (var element in elements)
+                DecodeTupleNames(element, names, ref position);
+        }
+        else
+        {
+            foreach (var child in TypeChildren(node))
+                DecodeTupleNames(child, names, ref position);
+        }
+    }
+
+    /// <summary>
+    /// The immediate type-node children of a non-tuple node, in preorder, used to
+    /// find tuples nested inside non-tuple structure (e.g. <c>Func&lt;(int a,int b)&gt;</c>).
+    /// </summary>
+    private static IEnumerable<TypeNode> TypeChildren(TypeNode node) => node switch
+    {
+        GenericTypeNode generic => generic.Arguments,
+        SZArrayTypeNode array => [array.ElementType],
+        MDArrayTypeNode array => [array.ElementType],
+        PointerTypeNode pointer => [pointer.ElementType],
+        ByRefTypeNode byRef => [byRef.ElementType],
+        FunctionPointerTypeNode fnptr => fnptr.ChildTypes,
+        PassthroughTypeNode passthrough => [passthrough.Inner],
+        _ => [],
+    };
 }
 
 /// <summary>A visible fail-closed substitute for a rejected signature type.</summary>
@@ -83,7 +208,7 @@ internal sealed class DegradedTypeNode : TypeNode
     public override bool IsReferenceType => true;
     public override bool IsDegraded => true;
 
-    public override string Render() => IsDynamic
+    public override string Render(bool canonicalTuples) => IsDynamic
         ? (IsNullableAnnotated ? "dynamic?" : "dynamic")
         : (IsNullableAnnotated ? "object?" : "object");
 
@@ -102,7 +227,7 @@ internal sealed class PrimitiveTypeNode(string name, bool isReferenceType) : Typ
 {
     public override bool IsReferenceType => isReferenceType;
 
-    public override string Render()
+    public override string Render(bool canonicalTuples)
     {
         string effective = IsDynamic ? "dynamic" : name;
         return IsReferenceType && IsNullableAnnotated ? $"{effective}?" : effective;
@@ -124,7 +249,7 @@ internal sealed class NamedTypeNode(string name, bool isReferenceType) : TypeNod
     public string Name => name;
     public override bool IsReferenceType => isReferenceType;
 
-    public override string Render()
+    public override string Render(bool canonicalTuples)
     {
         string effective = IsDynamic ? "dynamic" : name;
         return IsReferenceType && IsNullableAnnotated ? $"{effective}?" : effective;
@@ -148,12 +273,28 @@ internal sealed class GenericTypeNode(
     string nestedSuffix = "",
     bool degradedGenericType = false) : TypeNode
 {
+    public string BaseName => baseName;
+    public ImmutableArray<TypeNode> Arguments => arguments;
     public override bool IsReferenceType => isReferenceType;
     public override bool IsDegraded => degradedGenericType || arguments.Any(argument => argument.IsDegraded);
 
-    public override string Render()
+    public override string Render(bool canonicalTuples)
     {
-        var argsStr = string.Join(", ", arguments.Select(a => a.Render()));
+        // A System.ValueTuple instantiation spells as C# tuple syntax
+        // (int count, string name) rather than System.ValueTuple<int, string>,
+        // flattening 8+ arity "Rest" nesting and applying any element names.
+        // The canonical (identity) spelling keeps the generic form and drops names.
+        if (!canonicalTuples && TryGetTupleElements(this) is { } elements)
+        {
+            var parts = elements.Select(element =>
+                element.TupleElementName is { Length: > 0 } elementName
+                    ? $"{element.Render()} {elementName}"
+                    : element.Render());
+            var tuple = $"({string.Join(", ", parts)})";
+            return IsReferenceType && IsNullableAnnotated ? $"{tuple}?" : tuple;
+        }
+
+        var argsStr = string.Join(", ", arguments.Select(a => a.Render(canonicalTuples)));
         var result = $"{baseName}<{argsStr}>{nestedSuffix}";
         return IsReferenceType && IsNullableAnnotated ? $"{result}?" : result;
     }
@@ -178,12 +319,13 @@ internal sealed class GenericTypeNode(
 /// <summary>Single-dimensional arrays (string[], int[], etc.).</summary>
 internal sealed class SZArrayTypeNode(TypeNode elementType) : TypeNode
 {
+    public TypeNode ElementType => elementType;
     public override bool IsReferenceType => true;
     public override bool IsDegraded => elementType.IsDegraded;
 
-    public override string Render()
+    public override string Render(bool canonicalTuples)
     {
-        var result = $"{elementType.Render()}[]";
+        var result = $"{elementType.Render(canonicalTuples)}[]";
         return IsNullableAnnotated ? $"{result}?" : result;
     }
 
@@ -204,12 +346,13 @@ internal sealed class SZArrayTypeNode(TypeNode elementType) : TypeNode
 /// <summary>Multi-dimensional arrays (int[,], etc.).</summary>
 internal sealed class MDArrayTypeNode(TypeNode elementType, int rank) : TypeNode
 {
+    public TypeNode ElementType => elementType;
     public override bool IsReferenceType => true;
     public override bool IsDegraded => elementType.IsDegraded;
 
-    public override string Render()
+    public override string Render(bool canonicalTuples)
     {
-        var result = $"{elementType.Render()}[{new string(',', rank - 1)}]";
+        var result = $"{elementType.Render(canonicalTuples)}[{new string(',', rank - 1)}]";
         return IsNullableAnnotated ? $"{result}?" : result;
     }
 
@@ -230,10 +373,11 @@ internal sealed class MDArrayTypeNode(TypeNode elementType, int rank) : TypeNode
 /// <summary>Pointer types (int*, void*, etc.).</summary>
 internal sealed class PointerTypeNode(TypeNode elementType) : TypeNode
 {
+    public TypeNode ElementType => elementType;
     public override bool IsReferenceType => false;
     public override bool IsDegraded => elementType.IsDegraded;
 
-    public override string Render() => $"{elementType.Render()}*";
+    public override string Render(bool canonicalTuples) => $"{elementType.Render(canonicalTuples)}*";
 
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
@@ -251,10 +395,11 @@ internal sealed class PointerTypeNode(TypeNode elementType) : TypeNode
 /// <summary>By-reference types (ref T, out T, in T). Does not consume a nullability byte.</summary>
 internal sealed class ByRefTypeNode(TypeNode elementType) : TypeNode
 {
+    public TypeNode ElementType => elementType;
     public override bool IsReferenceType => false;
     public override bool IsDegraded => elementType.IsDegraded;
 
-    public override string Render() => $"ref {elementType.Render()}";
+    public override string Render(bool canonicalTuples) => $"ref {elementType.Render(canonicalTuples)}";
 
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
@@ -279,7 +424,7 @@ internal sealed class GenericParameterNode(string name) : TypeNode
 {
     public override bool IsReferenceType => false; // unknown; annotation still applies
 
-    public override string Render() => IsNullableAnnotated ? $"{name}?" : name;
+    public override string Render(bool canonicalTuples) => IsNullableAnnotated ? $"{name}?" : name;
 
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
@@ -294,13 +439,14 @@ internal sealed class GenericParameterNode(string name) : TypeNode
 /// <summary>Function pointer types (delegate*&lt;...&gt;).</summary>
 internal sealed class FunctionPointerTypeNode(MethodSignature<TypeNode> signature) : TypeNode
 {
+    public IEnumerable<TypeNode> ChildTypes => signature.ParameterTypes.Prepend(signature.ReturnType);
     public override bool IsReferenceType => false;
     public override bool IsDegraded => signature.ReturnType.IsDegraded
         || signature.ParameterTypes.Any(parameter => parameter.IsDegraded);
 
-    public override string Render()
+    public override string Render(bool canonicalTuples)
     {
-        var types = signature.ParameterTypes.Select(t => t.Render()).Append(signature.ReturnType.Render());
+        var types = signature.ParameterTypes.Select(t => t.Render(canonicalTuples)).Append(signature.ReturnType.Render(canonicalTuples));
         string arguments = string.Join(", ", types);
         string convention = ConventionText(signature.Header.CallingConvention);
         return convention.Length == 0
@@ -338,10 +484,11 @@ internal sealed class FunctionPointerTypeNode(MethodSignature<TypeNode> signatur
 /// <summary>Modified or pinned types—pass through to the underlying type.</summary>
 internal class PassthroughTypeNode(TypeNode inner) : TypeNode
 {
+    public TypeNode Inner => inner;
     public override bool IsReferenceType => inner.IsReferenceType;
     public override bool IsDegraded => inner.IsDegraded;
 
-    public override string Render() => inner.Render();
+    public override string Render(bool canonicalTuples) => inner.Render(canonicalTuples);
 
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {

--- a/tests/ILInspector.Metadata.Tests/TupleIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TupleIdentityTests.cs
@@ -201,6 +201,35 @@ public sealed class TupleIdentityTests
         Assert.Equal(live, ApiMemberIdentity.GetCanonicalSignature(rtType, rtOp));
     }
 
+    [Theory]
+    [InlineData(nameof(TupleSampleClass.NamedReturn))]
+    [InlineData(nameof(TupleSampleClass.UnnamedReturn))]
+    [InlineData(nameof(TupleSampleClass.NestedTuple))]
+    [InlineData(nameof(TupleSampleClass.MidNested))]
+    [InlineData(nameof(TupleSampleClass.TupleInsideFunc))]
+    [InlineData(nameof(TupleSampleClass.TupleArray))]
+    public void RoundTrip_TupleReturningMethod_CanonicalIdentityMatchesLive(string name)
+    {
+        // A tuple in the RETURN type is not part of a non-conversion method's identity
+        // digest, but its '(...)' parentheses would derail the display-text fallback's
+        // first-'(' parameter-list detection after a JSON round-trip (corrupting the
+        // identity to e.g. "NamedReturn(int,string name))"). HasCanonicalDivergence must
+        // therefore persist a CanonicalSignature for these members too, so live and
+        // round-tripped surfaces produce identical digests.
+        var member = Method(name);
+        Assert.False(string.IsNullOrEmpty(member.CanonicalSignature));
+        var live = ApiMemberIdentity.GetCanonicalSignature(SampleType, member);
+        Assert.EndsWith($"{name}()", live);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(Surface);
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<ApiSurface>(json)!;
+        var rtType = roundTripped.Types.First(t => t.Name == nameof(TupleSampleClass));
+        var rtMember = rtType.Members.First(m => m.Name == name && m.Kind == "method");
+
+        Assert.Null(rtMember.SignatureModel);
+        Assert.Equal(live, ApiMemberIdentity.GetCanonicalSignature(rtType, rtMember));
+    }
+
     // --- Invalid ValueTuple`8 (non-tuple Rest) must not masquerade as a tuple -
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/TupleIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TupleIdentityTests.cs
@@ -147,4 +147,83 @@ public sealed class TupleIdentityTests
         Assert.Equal("ref readonly int", member.SignatureModel!.ReturnType);
         Assert.Equal("ref readonly int", member.SignatureModel!.EffectiveCanonicalReturnType);
     }
+
+    // --- JSON round-trip identity parity (persisted CanonicalSignature) -------
+
+    [Fact]
+    public void RoundTrip_TupleParam_CanonicalIdentityMatchesLive()
+    {
+        // SignatureModel is [JsonIgnore]; a persisted CanonicalSignature is what lets a
+        // tuple member's identity survive serialization. Without it, the fallback would
+        // parse tuple DISPLAY syntax and diverge from the live digest.
+        var member = Method(nameof(TupleSampleClass.NamedParam));
+        Assert.False(string.IsNullOrEmpty(member.CanonicalSignature));
+
+        var live = ApiMemberIdentity.GetCanonicalSignature(SampleType, member);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(Surface);
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<ApiSurface>(json)!;
+        var rtType = roundTripped.Types.First(t => t.Name == nameof(TupleSampleClass));
+        var rtMember = rtType.Members.First(m =>
+            m.Name == nameof(TupleSampleClass.NamedParam) && m.Kind == "method");
+
+        Assert.Null(rtMember.SignatureModel);
+        Assert.Equal(live, ApiMemberIdentity.GetCanonicalSignature(rtType, rtMember));
+        Assert.Contains("System.ValueTuple<int,int>", ApiMemberIdentity.GetCanonicalSignature(rtType, rtMember));
+    }
+
+    [Fact]
+    public void RoundTrip_NonTupleMember_NoCanonicalSignaturePersisted()
+    {
+        // Churn guard: a non-tuple member's canonical spelling equals its display spelling,
+        // so no CanonicalSignature is persisted and its serialized form is unchanged.
+        var member = Method(nameof(TupleSampleClass.NoTuple));
+        Assert.Null(member.CanonicalSignature);
+    }
+
+    [Fact]
+    public void RoundTrip_TupleReturningConversionOperator_CanonicalIdentityMatchesLive()
+    {
+        // Conversion operators overload on return type, so a tuple return is part of
+        // identity. The fallback string path cannot reverse (int a, int b) back to
+        // System.ValueTuple; the persisted CanonicalSignature must carry it.
+        var op = SampleType.Members.First(m => m.Name == "op_Implicit");
+        Assert.False(string.IsNullOrEmpty(op.CanonicalSignature));
+        var live = ApiMemberIdentity.GetCanonicalSignature(SampleType, op);
+        Assert.Contains("~System.ValueTuple<int,int>", live);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(Surface);
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<ApiSurface>(json)!;
+        var rtType = roundTripped.Types.First(t => t.Name == nameof(TupleSampleClass));
+        var rtOp = rtType.Members.First(m => m.Name == "op_Implicit");
+
+        Assert.Null(rtOp.SignatureModel);
+        Assert.Equal(live, ApiMemberIdentity.GetCanonicalSignature(rtType, rtOp));
+    }
+
+    // --- Invalid ValueTuple`8 (non-tuple Rest) must not masquerade as a tuple -
+
+    [Fact]
+    public void InvalidRestValueTuple_KeepsGenericSpelling()
+    {
+        var member = Method(nameof(TupleSampleClass.InvalidRestValueTupleParam));
+        Assert.Contains("System.ValueTuple<int, int, int, int, int, int, int, int>", member.Signature);
+    }
+
+    [Fact]
+    public void InvalidRestValueTuple_DoesNotCollideWithGenuineEightTuple()
+    {
+        var genuine = Method(nameof(TupleSampleClass.GenuineEightTupleParam));
+        var invalid = Method(nameof(TupleSampleClass.InvalidRestValueTupleParam));
+
+        // Genuine eight-tuple renders as C# tuple syntax; the invalid Rest keeps generics.
+        Assert.Contains("(int, int, int, int, int, int, int, int)", genuine.Signature);
+        Assert.DoesNotContain("System.ValueTuple", genuine.Signature);
+        Assert.DoesNotContain("(int, int, int, int, int, int, int, int)", invalid.Signature);
+
+        // Their identities are distinct too.
+        Assert.NotEqual(
+            ApiMemberIdentity.GetCanonicalSignature(SampleType, genuine),
+            ApiMemberIdentity.GetCanonicalSignature(SampleType, invalid));
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/TupleIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TupleIdentityTests.cs
@@ -1,0 +1,150 @@
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+#nullable enable
+
+/// <summary>
+/// Canary tests for the tuple / member-identity separation: the C# tuple
+/// <em>display</em> spelling (<c>(int count, string name)</c>) must never leak
+/// into the <em>identity</em> spelling used by the Member Index digest,
+/// XML-doc lookup, and extension/instance correspondence, which must remain the
+/// presentation-independent <c>System.ValueTuple&lt;...&gt;</c> form with element
+/// names erased. Other facets (nullability, <c>ref readonly</c>) must survive
+/// canonicalization unchanged.
+/// </summary>
+public sealed class TupleIdentityTests
+{
+    private static readonly ApiSurface Surface;
+
+    static TupleIdentityTests()
+    {
+        var assemblyPath = typeof(TupleIdentityTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        Surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+    }
+
+    private static ApiType SampleType =>
+        Surface.Types.First(t => t.Name == nameof(TupleSampleClass));
+
+    private static ApiMember Method(string name) =>
+        SampleType.Members.First(m => m.Name == name && m.Kind == "method");
+
+    private static string Canonical(string methodName) =>
+        ApiMemberIdentity.GetCanonicalSignature(SampleType, Method(methodName));
+
+    // --- TypeNode.RenderCanonical: structural, name-insensitive spelling -----
+
+    private static GenericTypeNode Tuple(params TypeNode[] args) =>
+        new("System.ValueTuple", isReferenceType: false, [.. args]);
+
+    private static PrimitiveTypeNode Int() => new("int", isReferenceType: false);
+    private static PrimitiveTypeNode Str() => new("string", isReferenceType: true);
+
+    [Fact]
+    public void RenderCanonical_NamedTuple_DropsSyntaxAndNames()
+    {
+        var node = Tuple(Int(), Str());
+        node.ApplyTupleNames(["count", "name"]);
+        Assert.Equal("System.ValueTuple<int, string>", node.RenderCanonical());
+    }
+
+    [Fact]
+    public void RenderCanonical_IsElementNameInsensitive()
+    {
+        var named = Tuple(Int(), Str());
+        named.ApplyTupleNames(["count", "name"]);
+        var renamed = Tuple(Int(), Str());
+        renamed.ApplyTupleNames(["total", "label"]);
+        var unnamed = Tuple(Int(), Str());
+        unnamed.ApplyTupleNames(null);
+
+        Assert.Equal(named.RenderCanonical(), renamed.RenderCanonical());
+        Assert.Equal(named.RenderCanonical(), unnamed.RenderCanonical());
+    }
+
+    [Fact]
+    public void RenderCanonical_PreservesNullability()
+    {
+        // A canonical spelling erases tuple presentation but nothing else: the
+        // NRT annotation that distinguishes string from string? must survive.
+        var node = Str();
+        int pos = 0;
+        node.ApplyNullability([2], ref pos, 0);
+        Assert.Equal("string?", node.Render());
+        Assert.Equal("string?", node.RenderCanonical());
+    }
+
+    [Fact]
+    public void RenderCanonical_NonTuple_EqualsDisplay()
+    {
+        var node = new GenericTypeNode(
+            "System.Collections.Generic.List", isReferenceType: true, [Int()]);
+        Assert.Equal(node.Render(), node.RenderCanonical());
+    }
+
+    [Fact]
+    public void RenderCanonical_NestedTuple_FullyStructural()
+    {
+        var inner = Tuple(Int(), Int());
+        var node = Tuple(inner, Str());
+        node.ApplyTupleNames(["pair", "c", "a", "b"]);
+        Assert.Equal(
+            "System.ValueTuple<System.ValueTuple<int, int>, string>",
+            node.RenderCanonical());
+    }
+
+    // --- Member Index digest (GetCanonicalSignature) -------------------------
+
+    [Fact]
+    public void Canonical_TupleReturn_DoesNotCrash()
+    {
+        // A tuple return puts '(' at signature position 0; the identity parsers
+        // must not assume the first '(' opens the parameter list.
+        var canonical = Canonical(nameof(TupleSampleClass.NamedReturn));
+        Assert.Contains("NamedReturn", canonical);
+        Assert.DoesNotContain("count", canonical);
+    }
+
+    [Fact]
+    public void Canonical_TupleParam_ErasesNamesToValueTuple()
+    {
+        var canonical = Canonical(nameof(TupleSampleClass.NamedParam));
+        Assert.Contains("System.ValueTuple<int,int>", canonical);
+        Assert.DoesNotContain("point", canonical);
+        Assert.DoesNotContain("(int x", canonical);
+    }
+
+    [Fact]
+    public void Canonical_TupleParam_IsElementNameInsensitive()
+    {
+        // NamedParam((int x, int y)) and NamedParamAlt((int a, int b)) differ only
+        // in tuple element names; their canonical parameter lists must be identical.
+        var a = Canonical(nameof(TupleSampleClass.NamedParam));
+        var b = Canonical(nameof(TupleSampleClass.NamedParamAlt));
+        Assert.EndsWith("(System.ValueTuple<int,int>)", a);
+        Assert.EndsWith("(System.ValueTuple<int,int>)", b);
+    }
+
+    [Fact]
+    public void Canonical_PreservesNullability_DistinctDigests()
+    {
+        // string vs string? is a real API difference and must remain a distinct
+        // Member Index identity: canonicalization erases tuples, not nullability.
+        var nonNull = Canonical(nameof(TupleSampleClass.NonNullRef));
+        var nullable = Canonical(nameof(TupleSampleClass.NullRef));
+        Assert.NotEqual(nonNull, nullable);
+    }
+
+    // --- Canonical return spelling preserves ref readonly --------------------
+
+    [Fact]
+    public void CanonicalReturn_PreservesRefReadonly()
+    {
+        var member = Method(nameof(TupleSampleClass.RefReadonlyReturn));
+        Assert.Equal("ref readonly int", member.SignatureModel!.ReturnType);
+        Assert.Equal("ref readonly int", member.SignatureModel!.EffectiveCanonicalReturnType);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/TupleTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TupleTypeViewTests.cs
@@ -260,4 +260,17 @@ public class TupleSampleClass
     public string? NullRef(string? s) => s;
     private int _slot;
     public ref readonly int RefReadonlyReturn() => ref _slot;
+
+    // A genuine eight-element C# tuple lowers to ValueTuple<T1..T7, ValueTuple<T8>>.
+    public void GenuineEightTupleParam((int, int, int, int, int, int, int, int) t) { }
+
+    // An explicit ValueTuple`8 whose 8th ("Rest") argument is NOT a ValueTuple. This is a
+    // valid generic instantiation but not a C# tuple, so it must keep generic spelling and
+    // never collide with the genuine eight-tuple above.
+    public void InvalidRestValueTupleParam(
+        System.ValueTuple<int, int, int, int, int, int, int, int> t) { }
+
+    // A conversion operator returning a tuple: conversion operators overload on return type,
+    // so the tuple return is part of member identity and must canonicalize across round-trips.
+    public static implicit operator (int a, int b)(TupleSampleClass f) => default;
 }

--- a/tests/ILInspector.Metadata.Tests/TupleTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TupleTypeViewTests.cs
@@ -1,0 +1,263 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+#nullable enable
+
+/// <summary>
+/// Tests for <c>TupleElementNamesAttribute</c> reading and C# tuple-syntax
+/// rendering in API signatures. Uses the test assembly itself (whose fixture
+/// types below are compiled by Roslyn, the authoritative encoder of the
+/// tuple-element-names array) as the subject, so the decoder is validated
+/// against real compiler-emitted metadata rather than synthetic input.
+/// </summary>
+public sealed class TupleTypeViewTests
+{
+    private static readonly ApiSurface Surface;
+
+    static TupleTypeViewTests()
+    {
+        var assemblyPath = typeof(TupleTypeViewTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        Surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+    }
+
+    private static ApiType GetType(string name) =>
+        Surface.Types.First(t => t.Name == name);
+
+    private static ApiMember GetMethod(string methodName) =>
+        GetType(nameof(TupleSampleClass)).Members.First(m => m.Name == methodName && m.Kind == "method");
+
+    private static ApiMember GetProperty(string propName) =>
+        GetType(nameof(TupleSampleClass)).Members.First(m => m.Name == propName && m.Kind == "property");
+
+    private static ApiMember GetField(string fieldName) =>
+        GetType(nameof(TupleSampleClass)).Members.First(m => m.Name == fieldName && m.Kind == "field");
+
+    // --- Direct TypeNode unit tests (constructed nodes, no metadata) ---------
+
+    private static GenericTypeNode Tuple(params TypeNode[] args) =>
+        new("System.ValueTuple", isReferenceType: false, [.. args]);
+
+    private static PrimitiveTypeNode Int() => new("int", isReferenceType: false);
+    private static PrimitiveTypeNode Str() => new("string", isReferenceType: true);
+
+    [Fact]
+    public void TwoTuple_Named_RendersElementNames()
+    {
+        var node = Tuple(Int(), Str());
+        node.ApplyTupleNames(["count", "name"]);
+        Assert.Equal("(int count, string name)", node.Render());
+    }
+
+    [Fact]
+    public void TwoTuple_NoNames_RendersPositional()
+    {
+        var node = Tuple(Int(), Str());
+        node.ApplyTupleNames(null);
+        Assert.Equal("(int, string)", node.Render());
+    }
+
+    [Fact]
+    public void TwoTuple_PartialNames_RendersMixed()
+    {
+        var node = Tuple(Int(), Str());
+        node.ApplyTupleNames([null, "name"]);
+        Assert.Equal("(int, string name)", node.Render());
+    }
+
+    [Fact]
+    public void OneArityValueTuple_StaysGeneric()
+    {
+        // C# (T) is parenthesization, not a one-tuple, so ValueTuple<int> keeps
+        // its generic spelling and must never render as "(int)".
+        var node = Tuple(Int());
+        node.ApplyTupleNames(null);
+        Assert.Equal("System.ValueTuple<int>", node.Render());
+    }
+
+    [Fact]
+    public void NestedTuple_NamesFlowBreadthFirst()
+    {
+        // ((int a, int b) pair, string c): outer element names first, then inner.
+        var inner = Tuple(Int(), Int());
+        var node = Tuple(inner, Str());
+        node.ApplyTupleNames(["pair", "c", "a", "b"]);
+        Assert.Equal("((int a, int b) pair, string c)", node.Render());
+    }
+
+    [Fact]
+    public void TupleInsideGeneric_NamesApply_NoSlotForContainer()
+    {
+        // List<(int x, int y)>: the container consumes no name slot.
+        var tuple = Tuple(Int(), Int());
+        var node = new GenericTypeNode("System.Collections.Generic.List", isReferenceType: true, [tuple]);
+        node.ApplyTupleNames(["x", "y"]);
+        Assert.Equal("System.Collections.Generic.List<(int x, int y)>", node.Render());
+    }
+
+    // --- End-to-end: signatures extracted from Roslyn-compiled fixtures ------
+
+    [Fact]
+    public void Method_NamedTupleReturn()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.NamedReturn));
+        Assert.StartsWith("(int count, string name) ", member.Signature);
+    }
+
+    [Fact]
+    public void Method_NamedTupleParam()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.NamedParam));
+        Assert.Contains("(int x, int y) point", member.Signature);
+    }
+
+    [Fact]
+    public void Method_UnnamedTuple_RendersPositional()
+    {
+        // No TupleElementNamesAttribute is emitted; still spelled with (...) syntax.
+        var member = GetMethod(nameof(TupleSampleClass.UnnamedReturn));
+        Assert.StartsWith("(int, string) ", member.Signature);
+        Assert.DoesNotContain("ValueTuple", member.Signature);
+    }
+
+    [Fact]
+    public void Method_PartialNames()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.PartialNames));
+        Assert.StartsWith("(int, string second) ", member.Signature);
+    }
+
+    [Fact]
+    public void Method_NestedTuple()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.NestedTuple));
+        Assert.StartsWith("((int a, int b) pair, string c) ", member.Signature);
+    }
+
+    [Fact]
+    public void Method_MidNestedTuple()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.MidNested));
+        Assert.StartsWith("(int a, (int b, int c) inner, int d) ", member.Signature);
+    }
+
+    [Fact]
+    public void Method_TupleInsideFunc()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.TupleInsideFunc));
+        Assert.Contains("Func<(int fa, string fb)>", member.Signature);
+    }
+
+    [Fact]
+    public void Method_TupleArray()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.TupleArray));
+        Assert.StartsWith("(int ea, string eb)[] ", member.Signature);
+    }
+
+    [Fact]
+    public void Method_DictionaryTupleKey()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.DictionaryTupleKey));
+        Assert.Contains("Dictionary<(int ka, int kb), string>", member.Signature);
+    }
+
+    [Fact]
+    public void Method_RefTupleParam()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.RefTuple));
+        Assert.Contains("ref (int a, int b) value", member.Signature);
+    }
+
+    [Fact]
+    public void Method_BigTuple_NineElements_NamesAlign()
+    {
+        // A 9-tuple lowers to ValueTuple<T1..T7, ValueTuple<T8,T9>>; the flat name
+        // stream is [a1..a9, null, null]. Names must land on the flattened
+        // elements and the trailing null padding must be skipped, not misapplied.
+        var member = GetMethod(nameof(TupleSampleClass.BigTuple));
+        Assert.StartsWith(
+            "(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9) ",
+            member.Signature);
+    }
+
+    [Fact]
+    public void Field_NamedTuple()
+    {
+        var member = GetField(nameof(TupleSampleClass.NamedTupleField));
+        Assert.Equal("(int id, string label)", member.ReturnType);
+    }
+
+    [Fact]
+    public void Property_NamedTuple()
+    {
+        var member = GetProperty(nameof(TupleSampleClass.NamedTupleProp));
+        Assert.Contains("(int width, int height)", member.Signature);
+    }
+
+    [Fact]
+    public void Event_NamedTupleHandler()
+    {
+        var member = GetType(nameof(TupleSampleClass)).Members
+            .First(m => m.Name == nameof(TupleSampleClass.TupleEvent) && m.Kind == "event");
+        Assert.Contains("Action<(int code, string message)>", member.Signature);
+        Assert.DoesNotContain("ValueTuple", member.Signature);
+    }
+
+    // --- Negative controls: non-tuple members are unaffected -----------------
+
+    [Fact]
+    public void Method_NoTuple_Unaffected()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.NoTuple));
+        Assert.StartsWith("int ", member.Signature);
+        Assert.DoesNotContain("(int", member.Signature);
+    }
+
+    [Fact]
+    public void Method_GenericNonTuple_Unaffected()
+    {
+        var member = GetMethod(nameof(TupleSampleClass.GenericNonTuple));
+        Assert.Contains("Dictionary<string, int>", member.Signature);
+        Assert.DoesNotContain("(int", member.Signature);
+    }
+}
+
+// ===== Test fixture types with a spread of tuple shapes =====
+
+/// <summary>Sample class exercising TupleElementNamesAttribute decoding.</summary>
+public class TupleSampleClass
+{
+    public (int id, string label) NamedTupleField = default;
+
+    public (int width, int height) NamedTupleProp { get; set; }
+
+    public (int count, string name) NamedReturn() => default;
+    public void NamedParam((int x, int y) point) { }
+    public (int, string) UnnamedReturn() => default;
+    public (int, string second) PartialNames() => default;
+    public ((int a, int b) pair, string c) NestedTuple() => default;
+    public (int a, (int b, int c) inner, int d) MidNested() => default;
+    public Func<(int fa, string fb)> TupleInsideFunc() => default!;
+    public (int ea, string eb)[] TupleArray() => default!;
+    public Dictionary<(int ka, int kb), string> DictionaryTupleKey() => default!;
+    public void RefTuple(ref (int a, int b) value) { value = default; }
+
+    public (int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9) BigTuple() => default;
+
+    public int NoTuple() => 0;
+    public Dictionary<string, int> GenericNonTuple() => default!;
+
+    public event Action<(int code, string message)> TupleEvent = null!;
+
+    // --- Identity/canonical-spelling fixtures --------------------------------
+    public void NamedParamAlt((int a, int b) q) { }
+    public string NonNullRef(string s) => s;
+    public string? NullRef(string? s) => s;
+    private int _slot;
+    public ref readonly int RefReadonlyReturn() => ref _slot;
+}


### PR DESCRIPTION
## What

Fold `[TupleElementNamesAttribute]` into Metadata's type view so `System.ValueTuple`
instantiations render as C# tuple syntax (`(int count, string name)`), and separate
that **display** spelling from the presentation-independent **identity** spelling used
by member correspondence. Part of #2996.

## Why

Rendering named tuples surfaced a latent conflation: the rendered display string
**doubled as the member identity fingerprint**. Concretely:

- Identity parsers assumed the first `(` opens the parameter list, so a **tuple return
  type** (which puts `(` at signature position 0) crashed
  `MetadataFindingsTests.RealAssemblySelfCompare_IsExact` with
  `ArgumentOutOfRangeException`.
- Tuple **element names** would have churned Member Index digests, XML-doc ids, and
  extension/instance correspondence keys — renaming a tuple element is not an API change,
  but it would have registered as one.

The same anti-pattern (structural facts re-derived from rendered display strings) already
made identity latently annotation-sensitive for NRT `?`. This PR fixes tuples structurally
rather than scrubbing display text.

## How

A canonical (presentation-independent) spelling that differs from display **only** in tuple
rendering, so every non-tuple member's canonical spelling equals its display spelling
character-for-character (byte-for-byte digest preservation by construction):

- `TypeNode.RenderCanonical()` renders the structural form
  (`System.ValueTuple<int, string>`, element names erased). Threaded via a
  `Render(bool canonicalTuples)` seam; only `GenericTypeNode` branches on it.
- `ApiParameter`/`ApiSignature` carry canonical facets (`CanonicalType`,
  `CanonicalTypeWithModifier`, `CanonicalReturnType`, `CanonicalParameterTypesSummary`),
  populated at extraction. A canonical return formatter mirrors `ref readonly` synthesis.
- Member identity, XML-doc identity, and extension/instance correspondence now read the
  canonical facets instead of display strings. Nullability and `ref readonly` are preserved;
  tuples and element names never enter identity.
- Raw-signature fallback parsers (`LegacyCanonicalMemberName`, `ExtractMemberNameWithGeneric`)
  skip a leading balanced tuple group before locating the parameter list, so a tuple-return
  member degrades instead of throwing on the JSON round-trip path.

Design recorded in `docs/design/type-spelling-identity-display.md` (two adversarial design
review rounds reconciled).

## Evidence

- `TupleTypeViewTests` (display): 22 cases over Roslyn-compiled fixtures — named/unnamed/partial,
  nested, big (9-tuple flattening), tuple-in-generic/array/func, ref tuple, field/property/event.
- `TupleIdentityTests` (new): `RenderCanonical` name-insensitivity + NRT preservation +
  non-tuple==display; canonical digest erases tuple param names to `System.ValueTuple<...>`,
  keeps `string` vs `string?` distinct, preserves `ref readonly`, and does not crash on a tuple
  return.
- `RealAssemblySelfCompare_IsExact` restored to green.
- Metadata suite: **783/783**. CLI suite: 1989 total, only the 2 pre-existing Darwin P/Invoke
  content fails remain (unrelated to this change).

## Compatibility

Non-tuple members: canonical == display, so Member Index digests, XML-doc ids, and
correspondence keys are unchanged. Round-trip identity parity for **new** JSON that persists
tuple *display* in `member.Signature` degrades safely (no crash); full round-trip canonical
parity for tuple members is a documented follow-up.
