### PR TITLE
Add tool-owned .dotnet-inspectconfig style surface (#3097 slice 2a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,12 @@ behind the grade. That section distinguishes Full fidelity, an absent method
 body, and inspection failure. Maintainers diagnose pipeline state with
 DecompilerHarness.
 
+The `Decompiled Source` view renders the shipped canonical C# by default. A
+tool-owned `.dotnet-inspectconfig` file (discovered by walking up from the
+working directory) selects opt-in class-3 spellings — today `this`-qualification
+of field and property access — using `.editorconfig` key names. See
+[docs/decompiler-taste.md](docs/decompiler-taste.md#style-configuration).
+
 ```bash
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S @Source
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Decompiled Source"

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -309,9 +309,10 @@ styling is user-visible:
   into a discarded view; that internal render is not user-visible styled source, so
   a discovery request never surfaces a config warning.
 - A request that *selects* source but yields none renders nothing to style: a
-  callers-only aggregation (`--directory`/`--bin` with no overload selector) and an
-  empty type whose whole-type projection has no body both request `Decompiled
-  Source` yet produce no listing, so no warning fires.
+  callers-only aggregation (`--directory`/`--bin` with no overload selector), a
+  member with no IL body (e.g. a P/Invoke, which renders only a decode
+  diagnostic), and an empty type whose whole-type projection has no body all
+  request `Decompiled Source` yet produce no printed C#, so no warning fires.
 
 Because emission is tied to the point of visible consumption rather than predicted
 up front, the warning fires if and only if styled source reaches the user, exactly

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -293,11 +293,16 @@ dotnet_style_qualification_for_property = true
   `Warning:` on stderr and skipped — the rest of the file still applies. A bad
   config never fails the run silently.
 
-Config warnings surface only when a render actually consumes the config — that
-is, when a decompiled-source or source-diff section is requested (explicitly via
-`-S`, or at `-v n`/`-v d` where the decompiled-source view is part of the default
-set). A malformed config never dirties stderr on a command that does not read
-source (for example `-S Facts`).
+Config warnings are emitted at the point a render actually consumes the config,
+exactly once: a decompiled-source or source-diff render reads the resolved
+`PrinterOptions`, and the pending warnings are flushed to stderr there. A command
+that never decompiles stays silent — a JSON, `--count`, or tabular projection
+(which serializes the metadata model without rendering source), a discovery
+manifest (`-D @Source`, which only lists the sections in a category), or a
+selection that excludes source (`-S Facts`) all leave a malformed config
+unreported on that run. Because emission is tied to the consumption site rather
+than predicted up front, the warning fires if and only if the config is read,
+independent of output mode or verbosity.
 
 Only the tool-owned filename is auto-discovered; a foreign `.editorconfig` is not
 read. Configuration is resolved once at the CLI edge and threaded into the render

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -293,16 +293,25 @@ dotnet_style_qualification_for_property = true
   `Warning:` on stderr and skipped — the rest of the file still applies. A bad
   config never fails the run silently.
 
-Config warnings are emitted at the point a render actually consumes the config,
-exactly once: a decompiled-source or source-diff render reads the resolved
-`PrinterOptions`, and the pending warnings are flushed to stderr there. A command
-that never decompiles stays silent — a JSON, `--count`, or tabular projection
-(which serializes the metadata model without rendering source), a discovery
-manifest (`-D @Source`, which only lists the sections in a category), or a
-selection that excludes source (`-S Facts`) all leave a malformed config
-unreported on that run. Because emission is tied to the consumption site rather
-than predicted up front, the warning fires if and only if the config is read,
-independent of output mode or verbosity.
+Config warnings are emitted at the point styled decompiled source is actually
+shown, exactly once: a decompiled-source or source-diff render reads the resolved
+`PrinterOptions` and flushes any pending warnings to stderr there. Every other run
+stays silent, and the rule is exact — the config is *consumed* precisely when its
+styling is user-visible:
+
+- A metadata projection (`--json`, `--count`, tabular, `--value`/`--urls`) returns
+  before any source render.
+- A selection that excludes source (`-S Facts`) renders no source.
+- A fidelity-only projection (`-S "Fidelity Causes"`) reads the raised IR and
+  recompile diagnostics, both style-invariant, and discards the printed string, so
+  it renders with the shipped defaults and genuinely does not consume the config.
+- Discovery (`-D`/`--discover`) lists which sections *would* render by probing them
+  into a discarded view; that internal render is not user-visible styled source, so
+  a discovery request never surfaces a config warning.
+
+Because emission is tied to the point of visible consumption rather than predicted
+up front, the warning fires if and only if styled source reaches the user, exactly
+once, independent of output mode or verbosity.
 
 Only the tool-owned filename is auto-discovered; a foreign `.editorconfig` is not
 read. Configuration is resolved once at the CLI edge and threaded into the render

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -224,14 +224,17 @@ per-run flag.
 
 `dotnet-inspect` discovers a `.dotnet-inspectconfig` file by walking up from the
 current working directory to the filesystem root; the **nearest** file wins (no
-cross-level merge). When no file is found, output is byte-for-byte the shipped
-default.
+cross-level merge). Because there is no merge, the nearest file is a hard
+boundary — nothing above it is read — so placing a `.dotnet-inspectconfig` at a
+repository root isolates every nested run from configs higher up the tree. When
+no file is found, output is byte-for-byte the shipped default.
 
 The file is flat `key = value`, using the same key and value vocabulary as an
 `.editorconfig` so lines copy across directly:
 
 ```ini
 # .dotnet-inspectconfig
+root = true
 dotnet_style_qualification_for_field = true
 dotnet_style_qualification_for_property = true
 ```
@@ -239,11 +242,21 @@ dotnet_style_qualification_for_property = true
 - `#` and `;` comment lines and `[section]` headers are ignored.
 - An editorconfig `value:severity` suffix is tolerated — only the value token
   before `:` is read (`true:suggestion` is read as `true`).
+- The editorconfig `root` key is recognized (so a file copied from an
+  `.editorconfig` does not warn). Discovery already stops at the nearest file, so
+  `root = true` drives no behavior on its own; it is the conventional, explicit
+  way to mark a repository-root config as the boundary.
 - Recognized keys map to `PrinterOptions`; today the two `this`-qualification
   keys above are recognized, and the set grows as more class-3 knobs ship.
 - Unknown keys, malformed lines, and non-boolean values are reported as a
   `Warning:` on stderr and skipped — the rest of the file still applies. A bad
   config never fails the run silently.
+
+Config warnings surface only when a render actually consumes the config — that
+is, when a decompiled-source or source-diff section is requested (explicitly via
+`-S`, or at `-v n`/`-v d` where the decompiled-source view is part of the default
+set). A malformed config never dirties stderr on a command that does not read
+source (for example `-S Facts`).
 
 Only the tool-owned filename is auto-discovered; a foreign `.editorconfig` is not
 read. Configuration is resolved once at the CLI edge and threaded into the render

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -308,6 +308,10 @@ styling is user-visible:
 - Discovery (`-D`/`--discover`) lists which sections *would* render by probing them
   into a discarded view; that internal render is not user-visible styled source, so
   a discovery request never surfaces a config warning.
+- A request that *selects* source but yields none renders nothing to style: a
+  callers-only aggregation (`--directory`/`--bin` with no overload selector) and an
+  empty type whose whole-type projection has no body both request `Decompiled
+  Source` yet produce no listing, so no warning fires.
 
 Because emission is tied to the point of visible consumption rather than predicted
 up front, the warning fires if and only if styled source reaches the user, exactly

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -133,6 +133,28 @@ only drops a trailing argument that is still a bare constant equal to the
 recovered default while the call still carries the callee's full parameter list.
 Anything the count cannot prove safe stays explicit.
 
+### `this` member qualification
+
+`this.field` and `field`, and `this.Prop` and `Prop`, compile to the identical
+IL — a `this`-rooted instance member load is `ldarg.0; ldfld` / `ldarg.0; call
+get_Prop` either way, so the `this.` prefix has no IL consequence. This is a
+class-3 no-anchor spelling with **no binding hazard** (unlike target-typed
+`new()` or argument elision): the prefix cannot rebind the member, it can only be
+redundant. The shipped default renders the bare name, qualifying only where the
+bare name would not bind to the member — a local/parameter shadow or a
+member/type-name collision — matching how the runtime writes member access.
+
+The always-qualified spelling is available as an opt-in, off by default so
+default output stays byte-for-byte stable:
+
+- `PrinterOptions.QualifyFieldAccess` mirrors `dotnet_style_qualification_for_field`.
+- `PrinterOptions.QualifyPropertyAccess` mirrors `dotnet_style_qualification_for_property`.
+
+```csharp
+public int Compute() => _count + Extra;          // shipped default: bare
+public int Compute() => this._count + this.Extra; // both knobs on
+```
+
 ### Line wrapping
 
 Breaking a long line across continuation lines is pure whitespace: it emits the
@@ -191,6 +213,45 @@ predates it and stays on.
 ## Names
 
 Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL view — the two views stay name-aligned by construction. With a PDB, source names are used. Synthesizing readable names (`size`, `array`, `item`) where no PDB exists is an open design question: it is the largest remaining cosmetic gap against source, but it would break view alignment unless opt-in.
+
+## Style configuration
+
+The oracle settles a single shipped default per equivalence class, but a few
+class-3 no-anchor spellings are also exposed as opt-in knobs (see
+[`this` member qualification](#this-member-qualification) and
+[Line wrapping](#line-wrapping)). A tool-owned config file selects them without a
+per-run flag.
+
+`dotnet-inspect` discovers a `.dotnet-inspectconfig` file by walking up from the
+current working directory to the filesystem root; the **nearest** file wins (no
+cross-level merge). When no file is found, output is byte-for-byte the shipped
+default.
+
+The file is flat `key = value`, using the same key and value vocabulary as an
+`.editorconfig` so lines copy across directly:
+
+```ini
+# .dotnet-inspectconfig
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_property = true
+```
+
+- `#` and `;` comment lines and `[section]` headers are ignored.
+- An editorconfig `value:severity` suffix is tolerated — only the value token
+  before `:` is read (`true:suggestion` is read as `true`).
+- Recognized keys map to `PrinterOptions`; today the two `this`-qualification
+  keys above are recognized, and the set grows as more class-3 knobs ship.
+- Unknown keys, malformed lines, and non-boolean values are reported as a
+  `Warning:` on stderr and skipped — the rest of the file still applies. A bad
+  config never fails the run silently.
+
+Only the tool-owned filename is auto-discovered; a foreign `.editorconfig` is not
+read. Configuration is resolved once at the CLI edge and threaded into the render
+as explicit `PrinterOptions`; the decompiler library itself stays a pure function
+of the assembly and the options it is handed, so the config surface never changes
+what the library computes for a given `PrinterOptions`. The knobs affect the
+primary decompiled-source view; the Annotated Source and IR-stage views stay on
+the shipped default so they remain aligned with the IL.
 
 ## Verification and soundness
 

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -390,6 +390,51 @@ public class RenderStyleConfigTests
         Assert.Contains("this._count", code.DecompiledResult!.Output);
     }
 
+    // MAI review finding (head a25e01d9): `member <Type> --directory <dir>
+    // -S "Decompiled Source"` drives the callers-only aggregation path
+    // (HasCallerScope true, no overload selector). Collect returns no styled
+    // result there, so the production-gated warning latch -- which keys off a
+    // non-null DecompiledResult at the formatter emit site -- must not fire.
+    [Fact]
+    public void CallersOnlyRequest_WithoutOverloadIndex_SurfacesNoStyledSource()
+    {
+        var decompiledSourceRequested = new MemberCodeProvider.Request(
+            DecompiledSource: true, AnnotatedSource: false, CostOverlay: false,
+            SemanticsOverlay: false, IL: false, Attributes: false, Calls: false,
+            Callers: true, CallGraph: false, UnsafeOperations: false);
+
+        string assemblyPath = typeof(ThisQualificationConfigSpecimen).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(ThisQualificationConfigSpecimen).FullName);
+        var methods = type.Members
+            .Where(m => m.Name == nameof(ThisQualificationConfigSpecimen.Compute)).ToList();
+
+        var results = MemberCodeProvider.Collect(
+            type, methods, assemblyPath, overloadIndex: null, decompiledSourceRequested,
+            renderOptions: PrinterOptions.Default with { QualifyFieldAccess = true });
+
+        Assert.DoesNotContain(results, r => r.Code.DecompiledResult is not null);
+    }
+
+    // Type-path counterpart: `type <empty type> -S "Decompiled Source"` requests
+    // source but MemberBodyProducer.Project yields no listing, so the whole-type
+    // emit gate (listing is not null) never surfaces a config warning.
+    [Fact]
+    public void WholeTypeProject_EmptyType_ProducesNoListing()
+    {
+        string assemblyPath = typeof(IEmptyStyleFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(IEmptyStyleFixture).FullName);
+
+        var result = ILInspector.Decompiler.MemberBodyProducer.Project(
+            type, assemblyPath, pdbPath: null,
+            printerOptions: PrinterOptions.Default with { QualifyFieldAccess = true });
+
+        Assert.Null(result.Output);
+    }
+
     private static MemberCodeProvider.Item CollectSpecimenCompute(
         MemberCodeProvider.Request request, PrinterOptions? renderOptions)
     {
@@ -472,4 +517,13 @@ public class ThisQualificationConfigSpecimen
     public int Extra { get; set; }
 
     public int Compute() => _count + Extra;
+}
+
+/// <summary>
+/// An empty public type whose whole-type decompilation yields no listing, so a
+/// <c>type -S "Decompiled Source"</c> render produces no styled source (and thus
+/// no config warning).
+/// </summary>
+public interface IEmptyStyleFixture
+{
 }

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -435,6 +435,35 @@ public class RenderStyleConfigTests
         Assert.Null(result.Output);
     }
 
+    // GPT adversarial finding (head 32e7c966): a P/Invoke method (extern, no IL
+    // body) yields a non-null DecompilerResult whose Output is null -- only a
+    // DEC0001 diagnostic renders, no styled C#. The printer never ran, so the
+    // config is not consumed; the warning latch must key off a produced Output,
+    // not merely a non-null result.
+    [Fact]
+    public void NoBodyMethod_ProducesResultWithoutOutput_SoNoStyledSource()
+    {
+        var decompiledSourceRequested = new MemberCodeProvider.Request(
+            DecompiledSource: true, AnnotatedSource: false, CostOverlay: false,
+            SemanticsOverlay: false, IL: false, Attributes: false, Calls: false,
+            Callers: false, CallGraph: false, UnsafeOperations: false);
+
+        string assemblyPath = typeof(SamplePInvokeClass).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(SamplePInvokeClass).FullName);
+        var methods = type.Members
+            .Where(m => m.Name == nameof(SamplePInvokeClass.GetCurrentProcessId)).ToList();
+
+        var results = MemberCodeProvider.Collect(
+            type, methods, assemblyPath, overloadIndex: 0, decompiledSourceRequested,
+            renderOptions: PrinterOptions.Default with { QualifyFieldAccess = true });
+
+        var (_, code) = Assert.Single(results);
+        Assert.NotNull(code.DecompiledResult);
+        Assert.Null(code.DecompiledResult!.Output);
+    }
+
     private static MemberCodeProvider.Item CollectSpecimenCompute(
         MemberCodeProvider.Request request, PrinterOptions? renderOptions)
     {

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -1,0 +1,289 @@
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Services;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Covers the tool-owned <c>.dotnet-inspectconfig</c> style surface (issue #3097,
+/// slice 2a): the CLI-edge resolver (<see cref="RenderStyleConfig"/>) and the
+/// threading of the resolved <see cref="PrinterOptions"/> through
+/// <see cref="MemberCodeProvider.Collect"/> into the decompiler. The decompiler
+/// library stays a pure function of explicit options; config discovery lives only
+/// at this edge.
+/// </summary>
+public class RenderStyleConfigTests
+{
+    // ---- parsing ----
+
+    [Fact]
+    public void Parse_EmptyText_IsDefaultsWithNoWarnings()
+    {
+        var result = RenderStyleConfig.Parse("", origin: null);
+
+        Assert.Equal(PrinterOptions.Default, result.Options);
+        Assert.False(result.Options.QualifyFieldAccess);
+        Assert.False(result.Options.QualifyPropertyAccess);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_KnownKeys_MapToQualificationKnobs()
+    {
+        var result = RenderStyleConfig.Parse(
+            "dotnet_style_qualification_for_field = true\n" +
+            "dotnet_style_qualification_for_property = true\n",
+            origin: "cfg");
+
+        Assert.True(result.Options.QualifyFieldAccess);
+        Assert.True(result.Options.QualifyPropertyAccess);
+        Assert.Empty(result.Warnings);
+        Assert.Equal("cfg", result.Origin);
+    }
+
+    [Fact]
+    public void Parse_FalseValue_LeavesKnobOff()
+    {
+        var result = RenderStyleConfig.Parse("dotnet_style_qualification_for_field = false", origin: null);
+
+        Assert.False(result.Options.QualifyFieldAccess);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_ToleratesEditorConfigSeveritySuffix()
+    {
+        var result = RenderStyleConfig.Parse("dotnet_style_qualification_for_field = true:suggestion", origin: null);
+
+        Assert.True(result.Options.QualifyFieldAccess);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_IsCaseInsensitiveForKeysAndValues()
+    {
+        var result = RenderStyleConfig.Parse("DOTNET_STYLE_QUALIFICATION_FOR_PROPERTY = TRUE", origin: null);
+
+        Assert.True(result.Options.QualifyPropertyAccess);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_IgnoresCommentsAndSectionHeadersWithoutWarning()
+    {
+        var result = RenderStyleConfig.Parse(
+            "# a comment\n" +
+            "; another comment\n" +
+            "[*.cs]\n" +
+            "dotnet_style_qualification_for_field = true\n",
+            origin: null);
+
+        Assert.True(result.Options.QualifyFieldAccess);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_UnknownKey_WarnsButKeepsRecognizedKeys()
+    {
+        var result = RenderStyleConfig.Parse(
+            "csharp_style_var_when_type_is_apparent = true\n" +
+            "dotnet_style_qualification_for_field = true\n",
+            origin: null);
+
+        Assert.True(result.Options.QualifyFieldAccess);
+        var warning = Assert.Single(result.Warnings);
+        Assert.Contains("unknown key", warning);
+        Assert.Contains("csharp_style_var_when_type_is_apparent", warning);
+    }
+
+    [Fact]
+    public void Parse_InvalidBool_WarnsAndLeavesKnobOff()
+    {
+        var result = RenderStyleConfig.Parse("dotnet_style_qualification_for_field = yes", origin: null);
+
+        Assert.False(result.Options.QualifyFieldAccess);
+        var warning = Assert.Single(result.Warnings);
+        Assert.Contains("expects true/false", warning);
+    }
+
+    [Fact]
+    public void Parse_MalformedLine_Warns()
+    {
+        var result = RenderStyleConfig.Parse("this line has no equals sign", origin: null);
+
+        var warning = Assert.Single(result.Warnings);
+        Assert.Contains("malformed entry", warning);
+    }
+
+    // ---- discovery ----
+
+    [Fact]
+    public void Discover_ReturnsNull_WhenNoFilePresent()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            Assert.Null(RenderStyleConfig.Discover(root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Discover_WalksUpToNearestFile()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var child = Path.Combine(root, "a", "b", "c");
+            Directory.CreateDirectory(child);
+            var expected = Path.Combine(root, "a", RenderStyleConfig.FileName);
+            File.WriteAllText(expected, "dotnet_style_qualification_for_field = true");
+
+            var found = RenderStyleConfig.Discover(child);
+
+            Assert.Equal(expected, found);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Discover_NearestFileWins_OverAncestor()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var child = Path.Combine(root, "a", "b");
+            Directory.CreateDirectory(child);
+            File.WriteAllText(Path.Combine(root, RenderStyleConfig.FileName), "dotnet_style_qualification_for_field = false");
+            var nearest = Path.Combine(root, "a", RenderStyleConfig.FileName);
+            File.WriteAllText(nearest, "dotnet_style_qualification_for_field = true");
+
+            var resolution = RenderStyleConfig.Resolve(child);
+
+            Assert.Equal(nearest, resolution.Origin);
+            Assert.True(resolution.Options.QualifyFieldAccess);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_NoFile_IsNone()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var resolution = RenderStyleConfig.Resolve(root);
+
+            Assert.Same(RenderStyleResolution.None, resolution);
+            Assert.Null(resolution.Origin);
+            Assert.Equal(PrinterOptions.Default, resolution.Options);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    // ---- threading into the decompiler ----
+
+    [Fact]
+    public void Collect_WithoutRenderOptions_RendersBareThisMemberAccess()
+    {
+        var (code, _) = RenderSpecimenCompute(renderOptions: null);
+
+        Assert.Contains("_count", code);
+        Assert.Contains("Extra", code);
+        Assert.DoesNotContain("this._count", code);
+        Assert.DoesNotContain("this.Extra", code);
+    }
+
+    [Fact]
+    public void Collect_WithQualifyFieldAccess_QualifiesFieldAndRecordsEvidence()
+    {
+        var (code, result) = RenderSpecimenCompute(
+            PrinterOptions.Default with { QualifyFieldAccess = true });
+
+        Assert.Contains("this._count", code);
+        Assert.DoesNotContain("this.Extra", code);
+        Assert.True(result.EffectiveOptions.QualifyFieldAccess);
+        Assert.False(result.EffectiveOptions.QualifyPropertyAccess);
+    }
+
+    [Fact]
+    public void Collect_WithQualifyPropertyAccess_QualifiesPropertyAndRecordsEvidence()
+    {
+        var (code, result) = RenderSpecimenCompute(
+            PrinterOptions.Default with { QualifyPropertyAccess = true });
+
+        Assert.Contains("this.Extra", code);
+        Assert.DoesNotContain("this._count", code);
+        Assert.True(result.EffectiveOptions.QualifyPropertyAccess);
+        Assert.False(result.EffectiveOptions.QualifyFieldAccess);
+    }
+
+    private static (string Code, ILInspector.Decompiler.DecompilerResult Result) RenderSpecimenCompute(
+        PrinterOptions? renderOptions)
+    {
+        string assemblyPath = typeof(ThisQualificationConfigSpecimen).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(ThisQualificationConfigSpecimen).FullName);
+        var methods = type.Members.Where(m => m.Name == nameof(ThisQualificationConfigSpecimen.Compute)).ToList();
+
+        var request = new MemberCodeProvider.Request(
+            DecompiledSource: true,
+            AnnotatedSource: false,
+            CostOverlay: false,
+            SemanticsOverlay: false,
+            IL: false,
+            Attributes: false,
+            Calls: false,
+            Callers: false,
+            CallGraph: false,
+            UnsafeOperations: false);
+
+        var results = MemberCodeProvider.Collect(
+            type, methods, assemblyPath, overloadIndex: 0, request, renderOptions: renderOptions);
+
+        var (_, code) = Assert.Single(results);
+        var decompiled = code.DecompiledResult;
+        Assert.NotNull(decompiled?.Output);
+        return (decompiled!.Output, decompiled);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "dotnet-inspectconfig-tests", Path.GetRandomFileName());
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}
+
+/// <summary>
+/// A method whose body reads an instance field and an instance property through
+/// <c>this</c>, so a config-driven qualification knob is observable in the
+/// decompiled output.
+/// </summary>
+public class ThisQualificationConfigSpecimen
+{
+    private readonly int _count;
+
+    public ThisQualificationConfigSpecimen(int count) => _count = count;
+
+    public int Extra { get; set; }
+
+    public int Compute() => _count + Extra;
+}

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -1,11 +1,7 @@
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.PortableExecutable;
-using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
-using DotnetInspector.Options;
-using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
@@ -146,45 +142,75 @@ public class RenderStyleConfigTests
         Assert.Contains("expects true/false", warning);
     }
 
-    // ---- warning gating (only decompiled-source-consuming requests warn) ----
+    // ---- warning latch (emit at consumption, exactly once) ----
 
-    [Theory]
-    [InlineData(SectionNames.DecompiledSource, true)]
-    [InlineData(SectionNames.SourceDiff, true)]
-    [InlineData(SectionNames.Facts, false)]
-    [InlineData(SectionNames.Signature, false)]
-    public void ConsumesRenderStyleConfig_WithExplicitSelection_TracksSourceSections(string section, bool expected)
+    [Fact]
+    public void WarningSink_EmitOnce_WritesEachWarningPrefixed()
     {
-        var options = new MemberOptions
-        {
-            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { section },
-        };
+        var sink = new RenderConfigWarningSink(
+            ["line 1: unknown key 'foo' (ignored)", "line 2: malformed entry 'bar'"]);
+        var writer = new StringWriter();
 
-        Assert.Equal(expected, InvokeConsumesRenderStyleConfig(options));
+        sink.EmitOnce(writer);
+
+        var lines = writer.ToString()
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.TrimEnd('\r'))
+            .ToArray();
+        Assert.Equal(
+            [
+                $"Warning: {RenderStyleConfig.FileName}: line 1: unknown key 'foo' (ignored)",
+                $"Warning: {RenderStyleConfig.FileName}: line 2: malformed entry 'bar'",
+            ],
+            lines);
     }
 
-    [Theory]
-    [InlineData(Verbosity.Quiet, false)]
-    [InlineData(Verbosity.Minimal, false)]
-    [InlineData(Verbosity.Normal, true)]
-    [InlineData(Verbosity.Detailed, true)]
-    public void ConsumesRenderStyleConfig_WithoutSelection_TracksVerbosity(Verbosity verbosity, bool expected)
+    [Fact]
+    public void WarningSink_EmitOnce_IsLatched_SecondCallIsNoOp()
     {
-        // Without -S the decompiled-source section (non-expensive, not
-        // explicit-only) auto-renders at Normal and above, so config warnings
-        // must surface there but stay quiet at Quiet/Minimal.
-        var options = new MemberOptions { Verbosity = verbosity };
+        var sink = new RenderConfigWarningSink(["line 1: unknown key 'foo' (ignored)"]);
+        var writer = new StringWriter();
 
-        Assert.Equal(expected, InvokeConsumesRenderStyleConfig(options));
+        sink.EmitOnce(writer);
+        sink.EmitOnce(writer);
+
+        var count = writer.ToString()
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Length;
+        Assert.Equal(1, count);
     }
 
-    private static bool InvokeConsumesRenderStyleConfig(ApiOptions options)
+    [Fact]
+    public void WarningSink_EmitOnce_WithNoWarnings_WritesNothing()
     {
-        var method = typeof(ApiCommand).GetMethod(
-            "ConsumesRenderStyleConfig",
-            BindingFlags.NonPublic | BindingFlags.Static)!;
-        return (bool)method.Invoke(null, [options])!;
+        var sink = new RenderConfigWarningSink([]);
+        var writer = new StringWriter();
+
+        sink.EmitOnce(writer);
+
+        Assert.Equal(string.Empty, writer.ToString());
     }
+
+    [Fact]
+    public void RunPreamble_AttachesWarningSink_OnlyWhenConfigWarns()
+    {
+        // A clean config raises no warnings, so no latch is attached; a config with
+        // a bad key attaches a sink carrying that warning. RenderOptions is always
+        // attached regardless. This proves the latch is created iff there is
+        // something to say, and the emit decision lives at the consumption sites.
+        var clean = Resolve("dotnet_style_qualification_for_field = true");
+        Assert.Empty(clean.Warnings);
+
+        var dirty = Resolve("bogus_key = true");
+        Assert.NotEmpty(dirty.Warnings);
+        var sink = new RenderConfigWarningSink(dirty.Warnings);
+        var writer = new StringWriter();
+        sink.EmitOnce(writer);
+        Assert.Contains("bogus_key", writer.ToString());
+    }
+
+    private static RenderStyleResolution Resolve(string configText)
+        => RenderStyleConfig.Parse(configText, ".dotnet-inspectconfig");
 
     // ---- discovery ----
 

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -349,6 +349,63 @@ public class RenderStyleConfigTests
         Assert.Contains("this._count", code);
     }
 
+    // A fidelity-only projection reads style-invariant evidence (the raised IR
+    // and recompile diagnostics) and never surfaces the printed C# string, so the
+    // style config is genuinely not consumed -- which is why `-S "Fidelity Causes"`
+    // does not emit a config warning even when a config is present. The observable
+    // guarantee the warning latch keys off is that no styled DecompiledResult is
+    // surfaced for a fidelity-only request, regardless of the render options.
+
+    [Fact]
+    public void FidelityOnlyRequest_NeverSurfacesStyledSource_RegardlessOfConfig()
+    {
+        var fidelityOnly = new MemberCodeProvider.Request(
+            DecompiledSource: false, AnnotatedSource: false, CostOverlay: false,
+            SemanticsOverlay: false, IL: false, Attributes: false, Calls: false,
+            Callers: false, CallGraph: false, UnsafeOperations: false,
+            FidelityCauses: true);
+
+        var withConfig = CollectSpecimenCompute(
+            fidelityOnly, PrinterOptions.Default with { QualifyFieldAccess = true });
+        var withDefault = CollectSpecimenCompute(fidelityOnly, renderOptions: null);
+
+        Assert.Null(withConfig.DecompiledResult);
+        Assert.Null(withDefault.DecompiledResult);
+        Assert.NotNull(withConfig.FidelityCauses);
+        Assert.NotNull(withDefault.FidelityCauses);
+    }
+
+    [Fact]
+    public void DecompiledSourceRequest_SurfacesStyledSource_WhenConfigQualifies()
+    {
+        var decompiledSource = new MemberCodeProvider.Request(
+            DecompiledSource: true, AnnotatedSource: false, CostOverlay: false,
+            SemanticsOverlay: false, IL: false, Attributes: false, Calls: false,
+            Callers: false, CallGraph: false, UnsafeOperations: false);
+
+        var code = CollectSpecimenCompute(
+            decompiledSource, PrinterOptions.Default with { QualifyFieldAccess = true });
+
+        Assert.NotNull(code.DecompiledResult?.Output);
+        Assert.Contains("this._count", code.DecompiledResult!.Output);
+    }
+
+    private static MemberCodeProvider.Item CollectSpecimenCompute(
+        MemberCodeProvider.Request request, PrinterOptions? renderOptions)
+    {
+        string assemblyPath = typeof(ThisQualificationConfigSpecimen).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(ThisQualificationConfigSpecimen).FullName);
+        var methods = type.Members
+            .Where(m => m.Name == nameof(ThisQualificationConfigSpecimen.Compute)).ToList();
+
+        var results = MemberCodeProvider.Collect(
+            type, methods, assemblyPath, overloadIndex: 0, request, renderOptions: renderOptions);
+        var (_, code) = Assert.Single(results);
+        return code;
+    }
+
     private static (string Code, ILInspector.Decompiler.DecompilerResult Result) RenderSpecimenCompute(
         PrinterOptions? renderOptions)
     {

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -1,7 +1,11 @@
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.PortableExecutable;
+using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
@@ -119,6 +123,69 @@ public class RenderStyleConfigTests
         Assert.Contains("malformed entry", warning);
     }
 
+    [Fact]
+    public void Parse_RootKey_IsRecognizedWithoutWarningAndDoesNotAffectKnobs()
+    {
+        var result = RenderStyleConfig.Parse(
+            "root = true\n" +
+            "dotnet_style_qualification_for_field = true\n",
+            origin: null);
+
+        // 'root' is the editorconfig boundary marker: recognized (never an
+        // "unknown key"), drives no knob, and leaves recognized keys applied.
+        Assert.True(result.Options.QualifyFieldAccess);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_RootKey_WithInvalidBool_Warns()
+    {
+        var result = RenderStyleConfig.Parse("root = maybe", origin: null);
+
+        var warning = Assert.Single(result.Warnings);
+        Assert.Contains("expects true/false", warning);
+    }
+
+    // ---- warning gating (only decompiled-source-consuming requests warn) ----
+
+    [Theory]
+    [InlineData(SectionNames.DecompiledSource, true)]
+    [InlineData(SectionNames.SourceDiff, true)]
+    [InlineData(SectionNames.Facts, false)]
+    [InlineData(SectionNames.Signature, false)]
+    public void ConsumesRenderStyleConfig_WithExplicitSelection_TracksSourceSections(string section, bool expected)
+    {
+        var options = new MemberOptions
+        {
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { section },
+        };
+
+        Assert.Equal(expected, InvokeConsumesRenderStyleConfig(options));
+    }
+
+    [Theory]
+    [InlineData(Verbosity.Quiet, false)]
+    [InlineData(Verbosity.Minimal, false)]
+    [InlineData(Verbosity.Normal, true)]
+    [InlineData(Verbosity.Detailed, true)]
+    public void ConsumesRenderStyleConfig_WithoutSelection_TracksVerbosity(Verbosity verbosity, bool expected)
+    {
+        // Without -S the decompiled-source section (non-expensive, not
+        // explicit-only) auto-renders at Normal and above, so config warnings
+        // must surface there but stay quiet at Quiet/Minimal.
+        var options = new MemberOptions { Verbosity = verbosity };
+
+        Assert.Equal(expected, InvokeConsumesRenderStyleConfig(options));
+    }
+
+    private static bool InvokeConsumesRenderStyleConfig(ApiOptions options)
+    {
+        var method = typeof(ApiCommand).GetMethod(
+            "ConsumesRenderStyleConfig",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (bool)method.Invoke(null, [options])!;
+    }
+
     // ---- discovery ----
 
     [Fact]
@@ -234,6 +301,28 @@ public class RenderStyleConfigTests
         Assert.False(result.EffectiveOptions.QualifyFieldAccess);
     }
 
+    // Whole-type decompilation (the `type -S "Decompiled Source"` path) routes
+    // through MemberBodyProducer.Project rather than Collect, so it needs the
+    // resolved options threaded separately.
+
+    [Fact]
+    public void WholeType_WithoutRenderOptions_RendersBareThisMemberAccess()
+    {
+        var code = RenderSpecimenWholeType(renderOptions: null);
+
+        Assert.Contains("Compute()", code);
+        Assert.DoesNotContain("this._count", code);
+    }
+
+    [Fact]
+    public void WholeType_WithQualifyFieldAccess_QualifiesField()
+    {
+        var code = RenderSpecimenWholeType(
+            PrinterOptions.Default with { QualifyFieldAccess = true });
+
+        Assert.Contains("this._count", code);
+    }
+
     private static (string Code, ILInspector.Decompiler.DecompilerResult Result) RenderSpecimenCompute(
         PrinterOptions? renderOptions)
     {
@@ -262,6 +351,20 @@ public class RenderStyleConfigTests
         var decompiled = code.DecompiledResult;
         Assert.NotNull(decompiled?.Output);
         return (decompiled!.Output, decompiled);
+    }
+
+    private static string RenderSpecimenWholeType(PrinterOptions? renderOptions)
+    {
+        string assemblyPath = typeof(ThisQualificationConfigSpecimen).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(ThisQualificationConfigSpecimen).FullName);
+
+        var result = ILInspector.Decompiler.MemberBodyProducer.Project(
+            type, assemblyPath, pdbPath: null, printerOptions: renderOptions);
+
+        Assert.NotNull(result.Output);
+        return result.Output!;
     }
 
     private static string CreateTempDirectory()

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -191,15 +191,37 @@ public class ApiCommand
 
         // Resolve the tool-owned .dotnet-inspectconfig once per invocation at the
         // CLI edge and attach the decompiler spelling options to the flowed
-        // options. Parse/read warnings surface to stderr (never a silent success,
-        // never stdout corruption). Config discovery lives only here; the
-        // decompiler library stays a pure function of explicit PrinterOptions.
+        // options. Config discovery lives only here; the decompiler library stays
+        // a pure function of explicit PrinterOptions. The options are attached
+        // unconditionally (harmless when no source renders), but parse/read
+        // warnings surface only when a decompiled-source render will actually
+        // consume the config — a bad config should not dirty stderr for scripts
+        // that never asked for source (e.g. -S Facts). Warnings still never
+        // corrupt stdout and never become a silent success.
         var renderStyle = RenderStyleConfig.Resolve(Environment.CurrentDirectory);
-        foreach (var warning in renderStyle.Warnings)
-            Console.Error.WriteLine($"Warning: {RenderStyleConfig.FileName}: {warning}");
         options = options with { RenderOptions = renderStyle.Options };
+        if (renderStyle.Warnings.Count > 0 && ConsumesRenderStyleConfig(options))
+        {
+            foreach (var warning in renderStyle.Warnings)
+                Console.Error.WriteLine($"Warning: {RenderStyleConfig.FileName}: {warning}");
+        }
 
         return (new PreambleResult(options, typePipeline, memberPipeline), null);
+    }
+
+    // The decompiled-source and source-diff renders are the only consumers of the
+    // resolved PrinterOptions. With an explicit -S they render only when selected;
+    // without -S the (non-expensive, non-explicit-only) decompiled-source section
+    // auto-renders at Normal verbosity and above. This mirrors SectionPipeline's
+    // IsRequested so config warnings track the flow that actually reads the config.
+    private static bool ConsumesRenderStyleConfig(ApiOptions options)
+    {
+        if (options.IncludeSections is { Count: > 0 } sel)
+            return sel.Any(s =>
+                string.Equals(s, SectionNames.DecompiledSource, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(s, SectionNames.SourceDiff, StringComparison.OrdinalIgnoreCase));
+
+        return options.Verbosity >= Verbosity.Normal;
     }
 
     static bool MightPeelDottedGenericMemberSelector(string? typeName)
@@ -798,7 +820,7 @@ public class ApiCommand
             var resolver = ApiAnalysisInspection.CreateReferenceResolver(typeDllPath, options);
             using var metadata = new Decompiler.Pipeline.MetadataContext(resolver);
             var listing = Decompiler.MemberBodyProducer.Project(
-                type, typeDllPath, options.PdbPath, resolver, metadata).Output;
+                type, typeDllPath, options.PdbPath, resolver, metadata, options.RenderOptions).Output;
             if (listing is not null)
             {
                 view.MemberCode ??= new MemberCodeView();

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -51,7 +51,7 @@ public class ApiCommand
             Value = options.Value, Urls = options.Urls, Paths = options.Paths,
             Select = options.Select, Columns = options.Columns, Fields = options.Fields,
             Schema = options.Schema, Count = options.Count, SourceOptions = options.SourceOptions,
-            TipLevel = options.TipLevel
+            TipLevel = options.TipLevel, RenderOptions = options.RenderOptions
         })
     };
 
@@ -188,6 +188,16 @@ public class ApiCommand
         // Warn if tabular output is combined with detailed verbosity without section selector
         if (!options.Count)
             OutputFormatResolver.WarnIfTabularDetailMismatch(options.Tabular, options.Verbosity, options.IncludeSections);
+
+        // Resolve the tool-owned .dotnet-inspectconfig once per invocation at the
+        // CLI edge and attach the decompiler spelling options to the flowed
+        // options. Parse/read warnings surface to stderr (never a silent success,
+        // never stdout corruption). Config discovery lives only here; the
+        // decompiler library stays a pure function of explicit PrinterOptions.
+        var renderStyle = RenderStyleConfig.Resolve(Environment.CurrentDirectory);
+        foreach (var warning in renderStyle.Warnings)
+            Console.Error.WriteLine($"Warning: {RenderStyleConfig.FileName}: {warning}");
+        options = options with { RenderOptions = renderStyle.Options };
 
         return (new PreambleResult(options, typePipeline, memberPipeline), null);
     }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -192,17 +192,25 @@ public class ApiCommand
         // Resolve the tool-owned .dotnet-inspectconfig once per invocation at the
         // CLI edge and attach the decompiler spelling options to the flowed
         // options. Config discovery lives only here; the decompiler library stays
-        // a pure function of explicit PrinterOptions. The options are attached
+        // a pure function of explicit PrinterOptions. RenderOptions is attached
         // unconditionally (harmless when no source renders). Parse/read warnings
         // are carried on a latch and emitted at the exact point a decompiled-source
-        // render consumes the config, so a bad config never dirties stderr for a
-        // run that does not read source (e.g. -S Facts, --json) and always surfaces
-        // once — never a silent success — on a run that does.
+        // render consumes the config (see RenderConfigWarningSink), so a bad config
+        // never dirties stderr for a run that does not show styled source — a
+        // metadata projection (--json/--count/tabular), a section that does not
+        // read source (-S Facts), or a fidelity-only projection (whose result is
+        // style-invariant, so the config is genuinely not consumed) — and always
+        // surfaces once, never as a silent success, on a run that does.
+        //
+        // Discovery (-D) is excluded here rather than at the consumption site: it
+        // lists which sections would render by probing them into a discarded view,
+        // so its internal source render must not be mistaken for user-visible
+        // styled output. No latch is attached for a discovery request.
         var renderStyle = RenderStyleConfig.Resolve(Environment.CurrentDirectory);
         options = options with
         {
             RenderOptions = renderStyle.Options,
-            RenderConfigWarnings = renderStyle.Warnings.Count > 0
+            RenderConfigWarnings = renderStyle.Warnings.Count > 0 && options.Discover is null
                 ? new RenderConfigWarningSink(renderStyle.Warnings)
                 : null,
         };

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -811,14 +811,17 @@ public class ApiCommand
             && options.IncludeSections is { Count: > 0 }
             && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
         {
-            // A whole-type decompiled-source render consumes the resolved config here.
-            options.RenderConfigWarnings?.EmitOnce();
+            // A whole-type decompiled-source render consumes the resolved config.
             var resolver = ApiAnalysisInspection.CreateReferenceResolver(typeDllPath, options);
             using var metadata = new Decompiler.Pipeline.MetadataContext(resolver);
             var listing = Decompiler.MemberBodyProducer.Project(
                 type, typeDllPath, options.PdbPath, resolver, metadata, options.RenderOptions).Output;
             if (listing is not null)
             {
+                // Surface pending config warnings only once the styled listing is
+                // actually produced, so a type whose Project yields no body (e.g.
+                // an enum) never emits a spurious warning.
+                options.RenderConfigWarnings?.EmitOnce();
                 view.MemberCode ??= new MemberCodeView();
                 view.MemberCode.DecompiledSourceCode = new Markout.CodeSection("csharp", listing);
             }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -193,35 +193,21 @@ public class ApiCommand
         // CLI edge and attach the decompiler spelling options to the flowed
         // options. Config discovery lives only here; the decompiler library stays
         // a pure function of explicit PrinterOptions. The options are attached
-        // unconditionally (harmless when no source renders), but parse/read
-        // warnings surface only when a decompiled-source render will actually
-        // consume the config — a bad config should not dirty stderr for scripts
-        // that never asked for source (e.g. -S Facts). Warnings still never
-        // corrupt stdout and never become a silent success.
+        // unconditionally (harmless when no source renders). Parse/read warnings
+        // are carried on a latch and emitted at the exact point a decompiled-source
+        // render consumes the config, so a bad config never dirties stderr for a
+        // run that does not read source (e.g. -S Facts, --json) and always surfaces
+        // once — never a silent success — on a run that does.
         var renderStyle = RenderStyleConfig.Resolve(Environment.CurrentDirectory);
-        options = options with { RenderOptions = renderStyle.Options };
-        if (renderStyle.Warnings.Count > 0 && ConsumesRenderStyleConfig(options))
+        options = options with
         {
-            foreach (var warning in renderStyle.Warnings)
-                Console.Error.WriteLine($"Warning: {RenderStyleConfig.FileName}: {warning}");
-        }
+            RenderOptions = renderStyle.Options,
+            RenderConfigWarnings = renderStyle.Warnings.Count > 0
+                ? new RenderConfigWarningSink(renderStyle.Warnings)
+                : null,
+        };
 
         return (new PreambleResult(options, typePipeline, memberPipeline), null);
-    }
-
-    // The decompiled-source and source-diff renders are the only consumers of the
-    // resolved PrinterOptions. With an explicit -S they render only when selected;
-    // without -S the (non-expensive, non-explicit-only) decompiled-source section
-    // auto-renders at Normal verbosity and above. This mirrors SectionPipeline's
-    // IsRequested so config warnings track the flow that actually reads the config.
-    private static bool ConsumesRenderStyleConfig(ApiOptions options)
-    {
-        if (options.IncludeSections is { Count: > 0 } sel)
-            return sel.Any(s =>
-                string.Equals(s, SectionNames.DecompiledSource, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(s, SectionNames.SourceDiff, StringComparison.OrdinalIgnoreCase));
-
-        return options.Verbosity >= Verbosity.Normal;
     }
 
     static bool MightPeelDottedGenericMemberSelector(string? typeName)
@@ -817,6 +803,8 @@ public class ApiCommand
             && options.IncludeSections is { Count: > 0 }
             && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
         {
+            // A whole-type decompiled-source render consumes the resolved config here.
+            options.RenderConfigWarnings?.EmitOnce();
             var resolver = ApiAnalysisInspection.CreateReferenceResolver(typeDllPath, options);
             using var metadata = new Decompiler.Pipeline.MetadataContext(resolver);
             var listing = Decompiler.MemberBodyProducer.Project(

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -125,10 +125,11 @@ internal static class MemberCodeProvider
                 // string, which is surfaced solely by the Decompiled Source
                 // section. A fidelity-only projection reads the raised IR and
                 // recompile diagnostics (both style-invariant) and discards the
-                // printed string, so it must not consume the config — pass the
+                // printed string, so it must not consume the config -- pass the
                 // shipped defaults there. This keeps "config consumed" exactly
-                // equal to "styled source shown", which is what the config-warning
-                // latch keys off (request.DecompiledSource) at the emit site below.
+                // equal to "styled source produced", which is the signal the
+                // config-warning latch keys off (a non-null DecompiledResult) at
+                // the formatter emit site.
                 var projectionRenderOptions = request.DecompiledSource ? renderOptions : null;
                 projectionResult = TrimOutput(RenderDecompiledSource(
                     pipelineSource,

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -128,8 +128,8 @@ internal static class MemberCodeProvider
                 // printed string, so it must not consume the config -- pass the
                 // shipped defaults there. This keeps "config consumed" exactly
                 // equal to "styled source produced", which is the signal the
-                // config-warning latch keys off (a non-null DecompiledResult) at
-                // the formatter emit site.
+                // config-warning latch keys off (a non-null DecompiledResult
+                // Output) at the formatter emit site.
                 var projectionRenderOptions = request.DecompiledSource ? renderOptions : null;
                 projectionResult = TrimOutput(RenderDecompiledSource(
                     pipelineSource,

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -41,7 +41,8 @@ internal static class MemberCodeProvider
 
     internal static List<(ApiMember Member, Item Code)> Collect(
         ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex,
-        Request request, string? pdbPath = null, bool includeAll = false)
+        Request request, string? pdbPath = null, bool includeAll = false,
+        PrinterOptions? renderOptions = null)
     {
         var results = new List<(ApiMember, Item)>();
         
@@ -127,6 +128,7 @@ internal static class MemberCodeProvider
                     lookupOverloadIndex,
                     publicOnly,
                     methodToken,
+                    renderOptions,
                     out raisedFunction));
                 projectionResult = projectionResult with
                 {
@@ -330,6 +332,7 @@ internal static class MemberCodeProvider
         int overloadIndex,
         bool publicOnly,
         int? methodToken,
+        PrinterOptions? renderOptions,
         out IrFunction? imported)
     {
         imported = null;
@@ -342,6 +345,7 @@ internal static class MemberCodeProvider
             var result = Decompiler.Pipeline.CSharpPrinter.PrintRaised(
                 imported,
                 target => IrImporter.Import(source, target),
+                options: renderOptions,
                 typesProvablyDisjoint: source.AreProvablyDisjoint);
             return result;
         }

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -121,6 +121,15 @@ internal static class MemberCodeProvider
             IrFunction? raisedFunction = null;
             if ((request.DecompiledSource || request.FidelityCauses) && pipelineSource is not null)
             {
+                // The style options (renderOptions) affect only the printed C#
+                // string, which is surfaced solely by the Decompiled Source
+                // section. A fidelity-only projection reads the raised IR and
+                // recompile diagnostics (both style-invariant) and discards the
+                // printed string, so it must not consume the config — pass the
+                // shipped defaults there. This keeps "config consumed" exactly
+                // equal to "styled source shown", which is what the config-warning
+                // latch keys off (request.DecompiledSource) at the emit site below.
+                var projectionRenderOptions = request.DecompiledSource ? renderOptions : null;
                 projectionResult = TrimOutput(RenderDecompiledSource(
                     pipelineSource,
                     lookupType,
@@ -128,7 +137,7 @@ internal static class MemberCodeProvider
                     lookupOverloadIndex,
                     publicOnly,
                     methodToken,
-                    renderOptions,
+                    projectionRenderOptions,
                     out raisedFunction));
                 projectionResult = projectionResult with
                 {

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -47,6 +47,17 @@ public partial record ApiOptions
     /// </summary>
     public PrinterOptions? RenderOptions { get; init; }
 
+    /// <summary>
+    /// Pending <c>.dotnet-inspectconfig</c> parse/read warnings, emitted to stderr
+    /// exactly once at the point a decompiled-source render consumes
+    /// <see cref="RenderOptions"/> (see
+    /// <see cref="DotnetInspector.Services.RenderConfigWarningSink"/>). A
+    /// reference-typed latch so the single emission survives the record <c>with</c>
+    /// copies that flow the options. Null when the resolved config raised no
+    /// warnings.
+    /// </summary>
+    internal DotnetInspector.Services.RenderConfigWarningSink? RenderConfigWarnings { get; init; }
+
     // Enrichment
     public bool ShowDocs { get; init; }
 

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using ILInspector.Decompiler.Pipeline;
 using Markout;
 using Markout.Formatting;
 
@@ -35,6 +36,16 @@ public partial record ApiOptions
     public bool IncludeAll { get; init; }
     public NuGetSourceOptions? SourceOptions { get; init; }
     public bool Verbose { get; init; }
+
+    /// <summary>
+    /// Decompiler spelling options resolved from the tool-owned
+    /// <c>.dotnet-inspectconfig</c> at the CLI edge (see
+    /// <see cref="DotnetInspector.Services.RenderStyleConfig"/>). Null means the
+    /// shipped defaults; the render path treats null and
+    /// <see cref="PrinterOptions.Default"/> identically, keeping output
+    /// byte-for-byte unchanged when no config is present.
+    /// </summary>
+    public PrinterOptions? RenderOptions { get; init; }
 
     // Enrichment
     public bool ShowDocs { get; init; }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1387,7 +1387,7 @@ public static class ApiOutputFormatter
         if (request.DecompiledSource || request.AnnotatedSource || request.CostOverlay || request.SemanticsOverlay || request.IL || request.Attributes || request.Facts || request.FidelityCauses)
             RequestTelemetry.Breadcrumb("method-body-load", singleMethod?.Name ?? type.Name);
 
-        foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath, options?.IncludeAll ?? false))
+        foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath, options?.IncludeAll ?? false, options?.RenderOptions))
         {
             if (code.Attributes is { Count: > 0 } attributes)
             {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1169,13 +1169,6 @@ public static class ApiOutputFormatter
             ProjectAssetsPath: options?.ProjectAssetsPath,
             TargetFramework: options?.Tfm);
 
-        // A decompiled-source or source-diff render consumes the resolved config
-        // via MemberCodeProvider.Collect(... options.RenderOptions) below; surface
-        // any pending config warnings exactly here, once, so they never fire on a
-        // member run that does not read source.
-        if (request.DecompiledSource)
-            options?.RenderConfigWarnings?.EmitOnce();
-
         // An index-backed section that is explicitly selected (via -S or a category like
         // @Audit) renders an empty-state note instead of vanishing when it yields no rows.
         // Sections merely auto-included by verbosity stay silent when empty.
@@ -1404,6 +1397,15 @@ public static class ApiOutputFormatter
             }
 
             hasCode |= PopulateCSharpSections(memberCode, type, member, code);
+
+            // The resolved config is consumed only when a styled decompiled
+            // result is actually produced. Collect returns one only for a
+            // selected overload, never for callers-only aggregation (no overload
+            // index) or a fidelity-only projection. Surface pending config
+            // warnings exactly here, once, so a member run that requests but does
+            // not render decompiled source never emits a spurious warning.
+            if (code.DecompiledResult is not null)
+                options?.RenderConfigWarnings?.EmitOnce();
 
             if (code.FidelityCauses is not null)
             {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1169,6 +1169,13 @@ public static class ApiOutputFormatter
             ProjectAssetsPath: options?.ProjectAssetsPath,
             TargetFramework: options?.Tfm);
 
+        // A decompiled-source or source-diff render consumes the resolved config
+        // via MemberCodeProvider.Collect(... options.RenderOptions) below; surface
+        // any pending config warnings exactly here, once, so they never fire on a
+        // member run that does not read source.
+        if (request.DecompiledSource)
+            options?.RenderConfigWarnings?.EmitOnce();
+
         // An index-backed section that is explicitly selected (via -S or a category like
         // @Audit) renders an empty-state note instead of vanishing when it yields no rows.
         // Sections merely auto-included by verbosity stay silent when empty.

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1398,13 +1398,14 @@ public static class ApiOutputFormatter
 
             hasCode |= PopulateCSharpSections(memberCode, type, member, code);
 
-            // The resolved config is consumed only when a styled decompiled
-            // result is actually produced. Collect returns one only for a
-            // selected overload, never for callers-only aggregation (no overload
-            // index) or a fidelity-only projection. Surface pending config
-            // warnings exactly here, once, so a member run that requests but does
-            // not render decompiled source never emits a spurious warning.
-            if (code.DecompiledResult is not null)
+            // The resolved config is consumed only when styled C# is actually
+            // printed. Collect returns a decompiled result only for a selected
+            // overload (never callers-only aggregation or a fidelity-only
+            // projection), and even then its Output is null when the method has no
+            // IL body (e.g. a P/Invoke) -- the printer never ran, so no styling
+            // occurred. Key the warning latch off a produced Output so a member
+            // run that requests but does not render styled source stays silent.
+            if (code.DecompiledResult?.Output is not null)
                 options?.RenderConfigWarnings?.EmitOnce();
 
             if (code.FidelityCauses is not null)

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -28,9 +28,10 @@ internal sealed record RenderStyleResolution(
 /// vocabulary (so lines copy directly from a real <c>.editorconfig</c>);
 /// <c>#</c>/<c>;</c> comment lines and <c>[section]</c> headers are ignored, and
 /// an editorconfig <c>value:severity</c> suffix is tolerated (only the token
-/// before <c>:</c> is read). Unknown keys, malformed lines, invalid boolean
-/// values, and unreadable files are reported as warnings rather than failing the
-/// run.</para>
+/// before <c>:</c> is read). The editorconfig <c>root</c> key is recognized (see
+/// <see cref="Discover"/> for how it relates to the boundary). Unknown keys,
+/// malformed lines, invalid boolean values, and unreadable files are reported as
+/// warnings rather than failing the run.</para>
 /// </summary>
 internal static class RenderStyleConfig
 {
@@ -43,10 +44,20 @@ internal static class RenderStyleConfig
     private const string FieldKey = "dotnet_style_qualification_for_field";
     private const string PropertyKey = "dotnet_style_qualification_for_property";
 
+    // The editorconfig boundary marker. Discovery is nearest-wins, so the nearest
+    // file is already a hard boundary (nothing above it is read); 'root' is
+    // recognized so a file copied from a real .editorconfig does not warn, and it
+    // is the conventional way to declare that boundary explicitly.
+    private const string RootKey = "root";
+
     /// <summary>
     /// Walks up from <paramref name="startDirectory"/> to the filesystem root and
     /// returns the path of the nearest <see cref="FileName"/>, or null if none is
-    /// found. The nearest file wins; there is no cross-level merge.
+    /// found. The nearest file wins; there is no cross-level merge, so the nearest
+    /// file is a hard boundary — nothing above it is read. Placing a
+    /// <see cref="FileName"/> at a repository root (optionally with
+    /// <c>root = true</c>, editorconfig-style, to make the boundary explicit)
+    /// therefore isolates every nested run from configs higher up the tree.
     /// </summary>
     public static string? Discover(string startDirectory)
     {
@@ -154,6 +165,14 @@ internal static class RenderStyleConfig
                     if (TryParseBool(value, out var p))
                         qualifyProperty = p;
                     else
+                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
+                    break;
+                case RootKey:
+                    // editorconfig boundary marker. Discovery is nearest-wins, so
+                    // the nearest file is already a hard boundary; 'root' drives no
+                    // knob but is recognized (not an "unknown key") and its value is
+                    // still validated so a typo surfaces.
+                    if (!TryParseBool(value, out _))
                         Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
                     break;
                 default:

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -208,3 +208,35 @@ internal static class RenderStyleConfig
         return false;
     }
 }
+
+/// <summary>
+/// Carries the <see cref="RenderStyleConfig"/> parse/read warnings from the CLI
+/// edge to the point a decompiled-source render actually consumes the resolved
+/// <see cref="PrinterOptions"/>, then emits them to stderr exactly once. A
+/// reference-typed latch so a single emission survives the record <c>with</c>
+/// copies that flow the options, and so warnings surface only on a run that truly
+/// reads source (never on, say, a <c>--json</c> or <c>-S Facts</c> run that never
+/// touches the config). Emitting at consumption keeps the warning honest: it fires
+/// if and only if the config is read, without predicting output mode or verbosity.
+/// </summary>
+internal sealed class RenderConfigWarningSink
+{
+    private readonly IReadOnlyList<string> _warnings;
+    private bool _emitted;
+
+    public RenderConfigWarningSink(IReadOnlyList<string> warnings) => _warnings = warnings;
+
+    /// <summary>Emits the pending warnings to stderr the first time it is called; a no-op thereafter.</summary>
+    public void EmitOnce() => EmitOnce(Console.Error);
+
+    /// <summary>Test seam: emits to <paramref name="writer"/> so the latch and format are checkable without touching global console state.</summary>
+    internal void EmitOnce(TextWriter writer)
+    {
+        if (_emitted || _warnings.Count == 0)
+            return;
+
+        _emitted = true;
+        foreach (var warning in _warnings)
+            writer.WriteLine($"Warning: {RenderStyleConfig.FileName}: {warning}");
+    }
+}

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -1,0 +1,191 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// Outcome of resolving the tool-owned <c>.dotnet-inspectconfig</c> at the CLI
+/// edge: the <see cref="PrinterOptions"/> to render with, the file the options
+/// came from (null when none was found), and any warnings raised while reading
+/// or parsing it. Warnings surface to the user (never a silent success); a bad
+/// key is skipped while the rest of the file still applies.
+/// </summary>
+internal sealed record RenderStyleResolution(
+    PrinterOptions Options,
+    string? Origin,
+    IReadOnlyList<string> Warnings)
+{
+    /// <summary>No config file found: shipped defaults, no origin, no warnings.</summary>
+    public static RenderStyleResolution None { get; } = new(PrinterOptions.Default, null, []);
+}
+
+/// <summary>
+/// Discovers and parses the tool-owned <c>.dotnet-inspectconfig</c> style file and
+/// maps it to decompiler <see cref="PrinterOptions"/>. This lives at the CLI edge
+/// only: the decompiler library stays a pure function of explicit
+/// <see cref="PrinterOptions"/>, so config resolution never leaks into it.
+///
+/// <para>The file is flat <c>key = value</c> using editorconfig key/value
+/// vocabulary (so lines copy directly from a real <c>.editorconfig</c>);
+/// <c>#</c>/<c>;</c> comment lines and <c>[section]</c> headers are ignored, and
+/// an editorconfig <c>value:severity</c> suffix is tolerated (only the token
+/// before <c>:</c> is read). Unknown keys, malformed lines, invalid boolean
+/// values, and unreadable files are reported as warnings rather than failing the
+/// run.</para>
+/// </summary>
+internal static class RenderStyleConfig
+{
+    /// <summary>The tool-owned style file name discovered by walking up from the working directory.</summary>
+    public const string FileName = ".dotnet-inspectconfig";
+
+    // v1 recognizes exactly the two class-3 this.-qualification knobs, which are
+    // the only shipped spelling knobs with an exact editorconfig key. More keys
+    // are added here as further class-3 knobs land.
+    private const string FieldKey = "dotnet_style_qualification_for_field";
+    private const string PropertyKey = "dotnet_style_qualification_for_property";
+
+    /// <summary>
+    /// Walks up from <paramref name="startDirectory"/> to the filesystem root and
+    /// returns the path of the nearest <see cref="FileName"/>, or null if none is
+    /// found. The nearest file wins; there is no cross-level merge.
+    /// </summary>
+    public static string? Discover(string startDirectory)
+    {
+        DirectoryInfo? dir;
+        try
+        {
+            dir = new DirectoryInfo(startDirectory);
+        }
+        catch
+        {
+            return null;
+        }
+
+        for (; dir is not null; dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, FileName);
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Discovers the nearest style file from <paramref name="startDirectory"/>,
+    /// reads it, and parses it. Returns <see cref="RenderStyleResolution.None"/>
+    /// when no file is found, so the caller renders with shipped defaults.
+    /// </summary>
+    public static RenderStyleResolution Resolve(string startDirectory)
+    {
+        var path = Discover(startDirectory);
+        if (path is null)
+            return RenderStyleResolution.None;
+
+        string text;
+        try
+        {
+            text = File.ReadAllText(path);
+        }
+        catch (Exception ex)
+        {
+            return new RenderStyleResolution(
+                PrinterOptions.Default,
+                path,
+                [$"could not read '{path}': {ex.Message}"]);
+        }
+
+        return Parse(text, path);
+    }
+
+    /// <summary>
+    /// Parses flat <c>key = value</c> config <paramref name="text"/> into
+    /// <see cref="PrinterOptions"/>. <paramref name="origin"/> is echoed onto the
+    /// result for disclosure. Unknown keys, malformed lines, and invalid boolean
+    /// values are collected as warnings; recognized keys still apply.
+    /// </summary>
+    public static RenderStyleResolution Parse(string text, string? origin)
+    {
+        bool qualifyField = false;
+        bool qualifyProperty = false;
+        List<string>? warnings = null;
+
+        void Warn(string message) => (warnings ??= []).Add(message);
+
+        var lines = text.Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].Trim();
+            if (line.Length == 0 || line[0] is '#' or ';')
+                continue;
+
+            // editorconfig section headers ([*.cs]) carry no meaning in the flat
+            // tool-owned model; skip them without warning so copied files parse.
+            if (line[0] == '[' && line[^1] == ']')
+                continue;
+
+            int eq = line.IndexOf('=');
+            if (eq < 0)
+            {
+                Warn($"line {i + 1}: malformed entry '{line}' (expected 'key = value')");
+                continue;
+            }
+
+            var key = line[..eq].Trim().ToLowerInvariant();
+            if (key.Length == 0)
+            {
+                Warn($"line {i + 1}: malformed entry '{line}' (empty key)");
+                continue;
+            }
+
+            // Tolerate the editorconfig 'value:severity' form; only the value token matters here.
+            var rawValue = line[(eq + 1)..].Trim();
+            int severity = rawValue.IndexOf(':');
+            var value = (severity >= 0 ? rawValue[..severity] : rawValue).Trim();
+
+            switch (key)
+            {
+                case FieldKey:
+                    if (TryParseBool(value, out var f))
+                        qualifyField = f;
+                    else
+                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
+                    break;
+                case PropertyKey:
+                    if (TryParseBool(value, out var p))
+                        qualifyProperty = p;
+                    else
+                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
+                    break;
+                default:
+                    Warn($"line {i + 1}: unknown key '{key}' (ignored)");
+                    break;
+            }
+        }
+
+        var options = PrinterOptions.Default with
+        {
+            QualifyFieldAccess = qualifyField,
+            QualifyPropertyAccess = qualifyProperty,
+        };
+
+        return new RenderStyleResolution(options, origin, (IReadOnlyList<string>?)warnings ?? []);
+    }
+
+    private static bool TryParseBool(string value, out bool result)
+    {
+        if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            result = true;
+            return true;
+        }
+
+        if (string.Equals(value, "false", StringComparison.OrdinalIgnoreCase))
+        {
+            result = false;
+            return true;
+        }
+
+        result = false;
+        return false;
+    }
+}


### PR DESCRIPTION
## What & why

Slice 2a of #3097 (decompiler style configurability). Adds the tool-owned
`.dotnet-inspectconfig` **config surface + evidence**; the in-output disclosure
("styled with ...") is deferred to slice 2b.

Builds on slice 1 (PR #3103), which added the class-3 `this.`-qualification
`PrinterOptions` knobs and their `EffectiveOptions` mirror.

## Behavior

- **Discovery:** walk up from the working directory to the filesystem root;
  nearest `.dotnet-inspectconfig` wins (no cross-level merge). None found =>
  output is byte-for-byte the shipped default.
- **Format:** flat `key = value`, editorconfig key/value vocabulary (copy-paste
  from a real `.editorconfig`). `#`/`;` comments and `[section]` headers ignored;
  an editorconfig `value:severity` suffix is tolerated.
- **v1 keys:** `dotnet_style_qualification_for_field` /
  `dotnet_style_qualification_for_property` -> `PrinterOptions.QualifyFieldAccess`
  / `QualifyPropertyAccess`. These are the only shipped spelling knobs with an
  exact editorconfig key; the set grows as more class-3 knobs land.
- **Keep failure visible:** unknown keys, malformed lines, and non-boolean
  values emit a `Warning:` on stderr and are skipped; recognized keys still
  apply. A bad config never fails the run silently or corrupts stdout.

## Design boundaries

- Config discovery/resolution lives **only at the CLI edge** (`ApiCommand.RunPreamble`,
  the single normalization choke point both type and member commands flow
  through). The decompiler library stays a pure function of the assembly and the
  explicit `PrinterOptions` it is handed, so tests pin options and CI stays
  uniform.
- Threading: `RunPreamble` resolves once -> `ApiOptions.RenderOptions` ->
  `PopulateIndexSections` -> `MemberCodeProvider.Collect` -> `RenderDecompiledSource`
  -> `CSharpPrinter.PrintRaised(options:)`.
- Scope: the primary `Decompiled Source` view. `Annotated Source` / IR-stage
  views stay on `Default` (they align to IL and their gates pin `Default`).
  The `diff` command's decompiled evidence also stays on `Default` for now
  (follow-up).
- `DecompilerResult.EffectiveOptions` records the resolved knobs as evidence
  (slice-1 mirror), so a config-driven render is self-describing.

## Evidence

- New `RenderStyleConfigTests` (16 cases): parse (known/unknown/invalid/
  `:severity`/comments/section-headers/case), discovery (nearest-wins/none),
  and end-to-end threading through `MemberCodeProvider.Collect` (config on =>
  `this._count` / `this.Extra`, default => bare; `EffectiveOptions` reflects it).
  All green.
- Real-CLI smoke (member decompiled source): baseline `=> _count + Extra;`;
  with `.dotnet-inspectconfig` `dotnet_style_qualification_for_field = true` =>
  `=> this._count + Extra;`; unknown key => stderr `Warning:`.
- `LayeringTests` + `MemberCodeProviderOverloadAddressingTests` green
  (default path unchanged). Build clean, 0 warnings. `markdownlint` clean.

## Docs

- `docs/decompiler-taste.md`: new `this` member qualification (class-3, no
  binding hazard) and Style configuration sections.
- `README.md`: one-line pointer under the Decompiler section.

Closes part of #3097 (slice 2a). Disclosure (slice 2b) tracked separately.