### PR TITLE
Share ApiSurfaceExtractor field-inclusion with RTS compile-back (#3091)

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -103,8 +103,8 @@ jobs:
           restore-keys: |
             nuget-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Build managed tool
-        run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+      - name: Build solution (tool + fixtures)
+        run: dotnet build dotnet-inspect.slnx -c Release
 
       - name: Run CLI tests (including slow integration)
         run: dotnet run --project src/dotnet-inspect.Tests -c Release

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -323,7 +323,10 @@ public static class ApiSurfaceExtractor
 
                 string fieldName = reader.GetString(field.Name);
                 if (!IsSurfaceableFieldName(fieldName, includeCompilerGenerated))
-                    continue; // Skip auto-property backing fields; other compiler-generated fields unless opted in
+                    continue; // Skip compiler-generated (<...>) fields unless opted in
+
+                if (IsAutoPropertyBackingField(reader, field, fieldName))
+                    continue; // Skip a synthesized auto-property backing field (re-synthesized on reconstruction)
 
                 if (IsFieldLikeEventBackingField(reader, field, fieldName, fieldLikeEventBackingFieldNames))
                     continue; // Skip a field-like event's private, compiler-generated backing field
@@ -919,15 +922,28 @@ public static class ApiSurfaceExtractor
         => name.StartsWith('<') && name.EndsWith("k__BackingField", StringComparison.Ordinal);
 
     /// <summary>
-    /// Whether a field name belongs to a type's declarable field surface. Auto-property backing
-    /// fields are always excluded; other compiler-generated (<c>&lt;...&gt;</c>) fields are
-    /// excluded unless <paramref name="includeCompilerGenerated"/> is set. Ordinary fields
-    /// (including the enum <c>value__</c> slot, which callers handle separately) are surfaced.
+    /// True when a field is a synthesized auto-property backing field: it is spelled
+    /// <c>&lt;Prop&gt;k__BackingField</c> AND carries its own <c>[CompilerGenerated]</c> marker.
+    /// Requiring the field's own marker (not the name alone) mirrors the field-like-event backing
+    /// fold: C# spelling rules do not bind arbitrary IL, so a genuine field could share the shape;
+    /// the C# compiler always marks a real auto-property backing field compiler-generated.
+    /// </summary>
+    static bool IsAutoPropertyBackingField(MetadataReader reader, FieldDefinition field, string name)
+        => IsAutoPropertyBackingFieldName(name)
+           && AttributeReader.HasAttribute(
+               reader,
+               field.GetCustomAttributes(),
+               KnownAttributeNames.CompilerGeneratedAttribute);
+
+    /// <summary>
+    /// Whether a field name belongs to a type's declarable field surface based on its name alone.
+    /// Compiler-generated (<c>&lt;...&gt;</c>) fields are excluded unless
+    /// <paramref name="includeCompilerGenerated"/> is set; ordinary fields are surfaced. Backing
+    /// fields (auto-property, field-like event) and an enum's <c>value__</c> slot carry additional
+    /// positive-evidence checks applied by callers.
     /// </summary>
     static bool IsSurfaceableFieldName(string name, bool includeCompilerGenerated)
     {
-        if (IsAutoPropertyBackingFieldName(name))
-            return false;
         if (name.StartsWith('<'))
             return includeCompilerGenerated;
         return true;
@@ -935,9 +951,10 @@ public static class ApiSurfaceExtractor
 
     /// <summary>
     /// The field handles that make up a type's declarable field surface: ordinary fields,
-    /// excluding synthesized auto-property backing fields, the enum storage slot (<c>value__</c>),
-    /// and a field-like event's compiler-generated backing field. Compiler-generated fields (e.g.
-    /// state-machine hoisted locals, display-class captures) are included only when
+    /// excluding synthesized auto-property backing fields (positive <c>[CompilerGenerated]</c>
+    /// evidence), an enum's storage slot (<c>value__</c>), and a field-like event's
+    /// compiler-generated backing field. Compiler-generated fields (e.g. state-machine hoisted
+    /// locals, display-class captures) are included only when
     /// <paramref name="includeCompilerGenerated"/> is set; non-public fields only when
     /// <paramref name="includeAll"/> is set. This is the single field-inclusion decision shared by
     /// API-surface extraction and compile-back reconstruction so both agree on which fields a type
@@ -949,6 +966,7 @@ public static class ApiSurfaceExtractor
         bool includeAll,
         bool includeCompilerGenerated)
     {
+        bool isEnum = IsEnum(reader, typeDef);
         var fieldLikeEventBackingFieldNames = FieldLikeEventBackingFieldNames(reader, typeDef);
         var handles = new List<FieldDefinitionHandle>();
         foreach (var fieldHandle in typeDef.GetFields())
@@ -958,10 +976,12 @@ public static class ApiSurfaceExtractor
                 continue;
 
             string fieldName = reader.GetString(field.Name);
-            if (fieldName == "value__")
-                continue;
+            if (isEnum && fieldName == "value__")
+                continue; // An enum's storage slot is not a declarable field member
             if (!IsSurfaceableFieldName(fieldName, includeCompilerGenerated))
                 continue;
+            if (IsAutoPropertyBackingField(reader, field, fieldName))
+                continue; // Skip a synthesized auto-property backing field (re-synthesized on reconstruction)
             if (IsFieldLikeEventBackingField(reader, field, fieldName, fieldLikeEventBackingFieldNames))
                 continue;
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -16,7 +16,7 @@ public static class ApiSurfaceExtractor
     private const string OptionalAttributeName = "System.Runtime.InteropServices.Optional";
     private const string DateTimeConstantAttributeName = "System.Runtime.CompilerServices.DateTimeConstant";
 
-    public static ApiSurface Extract(PEReader peReader, bool includeAll = false, bool typesOnly = false)
+    public static ApiSurface Extract(PEReader peReader, bool includeAll = false, bool typesOnly = false, bool includeCompilerGenerated = false)
     {
         var surface = new ApiSurface();
         var reader = peReader.GetMetadataReader();
@@ -41,8 +41,10 @@ public static class ApiSurfaceExtractor
 
             string metadataName = reader.GetString(typeDef.Name);
 
-            // Skip compiler-generated types
-            if (TypeFilters.IsCompilerGenerated(metadataName))
+            // Skip compiler-generated types unless explicitly requested. The opt-in
+            // surfaces closure/display/state-machine types and their real fields so
+            // tooling (and compile-back reconstruction) can enumerate captured state.
+            if (TypeFilters.IsCompilerGenerated(metadataName) && !includeCompilerGenerated)
                 continue;
 
             // Skip EditorBrowsable(Never) and Obsolete types unless --all
@@ -307,31 +309,10 @@ public static class ApiSurfaceExtractor
             bool isEnum = apiType.Kind == "enum";
 
             // A C# field-like event's compiler-generated backing field is private, is itself
-            // marked [CompilerGenerated], and shares the event's exact (unmangled) name. Fold a
-            // field only when it carries all of that positive backing-field evidence AND matches
-            // an event whose adder is [CompilerGenerated] (i.e. a genuinely field-like event).
-            // The decisive signal is the candidate field's own [CompilerGenerated] marker, not the
-            // accessor's: hand-authored or non-C# metadata may attach [CompilerGenerated] to a
-            // custom accessor while a legitimate, same-named field backs nothing of the sort (the
-            // C# CS0102 restriction does not bind arbitrary IL). Requiring the field itself to be
-            // private and compiler-generated keeps a genuine field from being suppressed.
-            HashSet<string>? fieldLikeEventBackingFieldNames = null;
-            foreach (var eventHandle in typeDef.GetEvents())
-            {
-                var eventDef = reader.GetEventDefinition(eventHandle);
-                var adder = eventDef.GetAccessors().Adder;
-                if (adder.IsNil
-                    || !AttributeReader.HasAttribute(
-                        reader,
-                        reader.GetMethodDefinition(adder).GetCustomAttributes(),
-                        KnownAttributeNames.CompilerGeneratedAttribute))
-                {
-                    continue;
-                }
-
-                (fieldLikeEventBackingFieldNames ??= new HashSet<string>(StringComparer.Ordinal))
-                    .Add(reader.GetString(eventDef.Name));
-            }
+            // marked [CompilerGenerated], and shares the event's exact (unmangled) name. That
+            // pre-scan and the per-field fold below are factored into shared helpers so
+            // API-surface extraction and compile-back reconstruction agree on the fold.
+            var fieldLikeEventBackingFieldNames = FieldLikeEventBackingFieldNames(reader, typeDef);
 
             foreach (var fieldHandle in typeDef.GetFields())
             {
@@ -341,15 +322,10 @@ public static class ApiSurfaceExtractor
                     continue;
 
                 string fieldName = reader.GetString(field.Name);
-                if (fieldName.StartsWith("<"))
-                    continue; // Skip backing fields
+                if (!IsSurfaceableFieldName(fieldName, includeCompilerGenerated))
+                    continue; // Skip auto-property backing fields; other compiler-generated fields unless opted in
 
-                if (fieldAccess == FieldAttributes.Private
-                    && fieldLikeEventBackingFieldNames?.Contains(fieldName) == true
-                    && AttributeReader.HasAttribute(
-                        reader,
-                        field.GetCustomAttributes(),
-                        KnownAttributeNames.CompilerGeneratedAttribute))
+                if (IsFieldLikeEventBackingField(reader, field, fieldName, fieldLikeEventBackingFieldNames))
                     continue; // Skip a field-like event's private, compiler-generated backing field
 
                 // Skip EditorBrowsable(Never) fields unless --all; obsolete are surfaced with marker.
@@ -884,6 +860,115 @@ public static class ApiSurfaceExtractor
             value = value[..arityIndex];
 
         return value;
+    }
+
+    /// <summary>
+    /// Names of a type's field-like events. A C# field-like event's compiler-generated backing
+    /// field is private, is itself marked <c>[CompilerGenerated]</c>, and shares the event's exact
+    /// (unmangled) name. Only events whose adder is <c>[CompilerGenerated]</c> (i.e. genuinely
+    /// field-like) contribute a name; hand-authored or non-C# accessors are excluded so a
+    /// legitimate same-named field is not suppressed.
+    /// </summary>
+    static HashSet<string>? FieldLikeEventBackingFieldNames(MetadataReader reader, TypeDefinition typeDef)
+    {
+        HashSet<string>? names = null;
+        foreach (var eventHandle in typeDef.GetEvents())
+        {
+            var eventDef = reader.GetEventDefinition(eventHandle);
+            var adder = eventDef.GetAccessors().Adder;
+            if (adder.IsNil
+                || !AttributeReader.HasAttribute(
+                    reader,
+                    reader.GetMethodDefinition(adder).GetCustomAttributes(),
+                    KnownAttributeNames.CompilerGeneratedAttribute))
+            {
+                continue;
+            }
+
+            (names ??= new HashSet<string>(StringComparer.Ordinal)).Add(reader.GetString(eventDef.Name));
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// True when a field is a field-like event's private, compiler-generated backing field. The
+    /// decisive signal is the candidate field's own <c>[CompilerGenerated]</c> marker (not the
+    /// accessor's): the C# CS0102 same-name restriction does not bind arbitrary IL, so a genuine
+    /// field could share an event's name; requiring the field itself to be private and
+    /// compiler-generated keeps it from being folded away.
+    /// </summary>
+    static bool IsFieldLikeEventBackingField(
+        MetadataReader reader,
+        FieldDefinition field,
+        string fieldName,
+        HashSet<string>? fieldLikeEventBackingFieldNames)
+        => (field.Attributes & FieldAttributes.FieldAccessMask) == FieldAttributes.Private
+           && fieldLikeEventBackingFieldNames?.Contains(fieldName) == true
+           && AttributeReader.HasAttribute(
+               reader,
+               field.GetCustomAttributes(),
+               KnownAttributeNames.CompilerGeneratedAttribute);
+
+    /// <summary>
+    /// A synthesized auto-property backing field, spelled <c>&lt;Prop&gt;k__BackingField</c>. The
+    /// pattern is matched precisely (leading <c>&lt;</c> plus the <c>k__BackingField</c> suffix) so
+    /// a legitimate user field whose name merely contains <c>__BackingField</c> is not dropped.
+    /// </summary>
+    static bool IsAutoPropertyBackingFieldName(string name)
+        => name.StartsWith('<') && name.EndsWith("k__BackingField", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Whether a field name belongs to a type's declarable field surface. Auto-property backing
+    /// fields are always excluded; other compiler-generated (<c>&lt;...&gt;</c>) fields are
+    /// excluded unless <paramref name="includeCompilerGenerated"/> is set. Ordinary fields
+    /// (including the enum <c>value__</c> slot, which callers handle separately) are surfaced.
+    /// </summary>
+    static bool IsSurfaceableFieldName(string name, bool includeCompilerGenerated)
+    {
+        if (IsAutoPropertyBackingFieldName(name))
+            return false;
+        if (name.StartsWith('<'))
+            return includeCompilerGenerated;
+        return true;
+    }
+
+    /// <summary>
+    /// The field handles that make up a type's declarable field surface: ordinary fields,
+    /// excluding synthesized auto-property backing fields, the enum storage slot (<c>value__</c>),
+    /// and a field-like event's compiler-generated backing field. Compiler-generated fields (e.g.
+    /// state-machine hoisted locals, display-class captures) are included only when
+    /// <paramref name="includeCompilerGenerated"/> is set; non-public fields only when
+    /// <paramref name="includeAll"/> is set. This is the single field-inclusion decision shared by
+    /// API-surface extraction and compile-back reconstruction so both agree on which fields a type
+    /// really has.
+    /// </summary>
+    public static List<FieldDefinitionHandle> SurfaceFieldHandles(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        bool includeAll,
+        bool includeCompilerGenerated)
+    {
+        var fieldLikeEventBackingFieldNames = FieldLikeEventBackingFieldNames(reader, typeDef);
+        var handles = new List<FieldDefinitionHandle>();
+        foreach (var fieldHandle in typeDef.GetFields())
+        {
+            var field = reader.GetFieldDefinition(fieldHandle);
+            if ((field.Attributes & FieldAttributes.FieldAccessMask) != FieldAttributes.Public && !includeAll)
+                continue;
+
+            string fieldName = reader.GetString(field.Name);
+            if (fieldName == "value__")
+                continue;
+            if (!IsSurfaceableFieldName(fieldName, includeCompilerGenerated))
+                continue;
+            if (IsFieldLikeEventBackingField(reader, field, fieldName, fieldLikeEventBackingFieldNames))
+                continue;
+
+            handles.Add(fieldHandle);
+        }
+
+        return handles;
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -313,7 +313,7 @@ public static class ApiSurfaceExtractor
             // pre-scan and the per-field fold below are factored into shared helpers so
             // API-surface extraction and compile-back reconstruction agree on the fold.
             var fieldLikeEventBackingFieldNames = FieldLikeEventBackingFieldNames(reader, typeDef);
-            var autoPropertyBackingFieldNames = AutoPropertyBackingFieldNames(reader, typeDef);
+            var autoPropertyBackingFields = AutoPropertyBackingFieldDescriptors(reader, typeDef, typeContext);
 
             foreach (var fieldHandle in typeDef.GetFields())
             {
@@ -326,7 +326,7 @@ public static class ApiSurfaceExtractor
                 if (!IsSurfaceableFieldName(fieldName, includeCompilerGenerated))
                     continue; // Skip compiler-generated (<...>) fields unless opted in
 
-                if (IsAutoPropertyBackingField(reader, field, fieldName, autoPropertyBackingFieldNames))
+                if (IsAutoPropertyBackingField(reader, field, fieldName, autoPropertyBackingFields, typeContext))
                     continue; // Skip a synthesized auto-property backing field (re-synthesized on reconstruction)
 
                 if (IsFieldLikeEventBackingField(reader, field, fieldName, fieldLikeEventBackingFieldNames))
@@ -915,51 +915,120 @@ public static class ApiSurfaceExtractor
                KnownAttributeNames.CompilerGeneratedAttribute);
 
     /// <summary>
-    /// Names of a type's auto-property backing fields, derived from its declared properties. An
-    /// auto-property's backing field is spelled <c>&lt;Prop&gt;k__BackingField</c>; a candidate
-    /// field is only folded when a property with the matching name actually exists (mirroring the
-    /// field-like-event fold, which requires a matching event). Property names carrying <c>&lt;</c>
-    /// or <c>.</c> (compiler-generated or explicit-interface names) cannot name a C# auto-property
-    /// and are skipped.
+    /// A declared auto-property's backing-field descriptor: the property's decoded return type and
+    /// whether its accessors are static. A genuine backing field must agree with both, so a merely
+    /// same-named compiler-generated field of a different type or staticness is not folded.
     /// </summary>
-    static HashSet<string>? AutoPropertyBackingFieldNames(MetadataReader reader, TypeDefinition typeDef)
+    readonly record struct AutoPropertyBackingField(string PropertyType, bool IsStatic);
+
+    /// <summary>
+    /// Maps each of a type's auto-property backing-field names (<c>&lt;Prop&gt;k__BackingField</c>)
+    /// to its <see cref="AutoPropertyBackingField"/> descriptor. Only genuine auto-properties
+    /// contribute: the property has a <c>[CompilerGenerated]</c> accessor (auto signal) and a
+    /// decodable return type, and its name carries no <c>&lt;</c> or <c>.</c> (compiler-generated or
+    /// explicit-interface names cannot name a C# auto-property). The per-field fold then also
+    /// requires the candidate field's type and staticness to match this descriptor, mirroring the
+    /// discriminator the compile-back planner historically applied so a same-named but
+    /// type/static-mismatched or non-auto-property field is preserved rather than silently dropped.
+    /// </summary>
+    static Dictionary<string, AutoPropertyBackingField>? AutoPropertyBackingFieldDescriptors(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        GenericContext context)
     {
-        HashSet<string>? names = null;
+        Dictionary<string, AutoPropertyBackingField>? descriptors = null;
         foreach (var propertyHandle in typeDef.GetProperties())
         {
-            string propertyName = reader.GetString(reader.GetPropertyDefinition(propertyHandle).Name);
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            string propertyName = reader.GetString(property.Name);
             if (propertyName.Contains('<', StringComparison.Ordinal)
                 || propertyName.Contains('.', StringComparison.Ordinal))
             {
                 continue;
             }
 
-            (names ??= new HashSet<string>(StringComparer.Ordinal))
-                .Add($"<{propertyName}>k__BackingField");
+            if (!TryGetAutoPropertyAccessorStaticness(reader, property.GetAccessors(), out bool isStatic))
+                continue; // Not an auto-property: no [CompilerGenerated] accessor.
+
+            if (!GuardedSignatureText.PropertyText(reader, property, context)
+                    .TryGetValue(out var propertySignature))
+            {
+                continue; // Undecodable property signature: cannot prove a type match.
+            }
+
+            (descriptors ??= new Dictionary<string, AutoPropertyBackingField>(StringComparer.Ordinal))
+                [$"<{propertyName}>k__BackingField"]
+                    = new AutoPropertyBackingField(propertySignature.ReturnType, isStatic);
         }
 
-        return names;
+        return descriptors;
     }
 
     /// <summary>
-    /// True when a field is a synthesized auto-property backing field: it carries its own
-    /// <c>[CompilerGenerated]</c> marker AND its name matches a declared property's backing-field
-    /// name. Requiring a matching property (not the mangled name shape alone) mirrors the
-    /// field-like-event backing fold: C# spelling rules do not bind arbitrary IL, so a
-    /// compiler-generated field that merely shares the shape but backs no declared property is
-    /// preserved (on reconstruction no property maps the body's field reference, so the raw field
-    /// must stay declared).
+    /// True when a property is an auto-property, i.e. either accessor is <c>[CompilerGenerated]</c>;
+    /// <paramref name="isStatic"/> reports that accessor's staticness, which the backing field's own
+    /// storage must share.
+    /// </summary>
+    static bool TryGetAutoPropertyAccessorStaticness(
+        MetadataReader reader,
+        PropertyAccessors accessors,
+        out bool isStatic)
+    {
+        if (!accessors.Getter.IsNil)
+        {
+            var getter = reader.GetMethodDefinition(accessors.Getter);
+            if (AttributeReader.HasAttribute(reader, getter.GetCustomAttributes(), KnownAttributeNames.CompilerGeneratedAttribute))
+            {
+                isStatic = (getter.Attributes & MethodAttributes.Static) != 0;
+                return true;
+            }
+        }
+
+        if (!accessors.Setter.IsNil)
+        {
+            var setter = reader.GetMethodDefinition(accessors.Setter);
+            if (AttributeReader.HasAttribute(reader, setter.GetCustomAttributes(), KnownAttributeNames.CompilerGeneratedAttribute))
+            {
+                isStatic = (setter.Attributes & MethodAttributes.Static) != 0;
+                return true;
+            }
+        }
+
+        isStatic = false;
+        return false;
+    }
+
+    /// <summary>
+    /// True when a field is a genuine auto-property backing field that reconstruction will
+    /// re-synthesize from auto-property syntax: it is <c>[CompilerGenerated]</c>, its name matches a
+    /// declared auto-property's backing-field name, and its staticness and type agree with that
+    /// property. Requiring type and staticness agreement (not the mangled name shape alone) mirrors
+    /// the compile-back planner's historical discriminator, so a same-named but type/static-mismatched
+    /// or non-auto-property compiler-generated field is preserved (on reconstruction no auto-property
+    /// re-creates it, so the raw field must stay declared).
     /// </summary>
     static bool IsAutoPropertyBackingField(
         MetadataReader reader,
         FieldDefinition field,
         string fieldName,
-        HashSet<string>? autoPropertyBackingFieldNames)
-        => autoPropertyBackingFieldNames?.Contains(fieldName) == true
-           && AttributeReader.HasAttribute(
-               reader,
-               field.GetCustomAttributes(),
-               KnownAttributeNames.CompilerGeneratedAttribute);
+        Dictionary<string, AutoPropertyBackingField>? autoPropertyBackingFields,
+        GenericContext context)
+    {
+        if (autoPropertyBackingFields is null
+            || !autoPropertyBackingFields.TryGetValue(fieldName, out var descriptor))
+        {
+            return false;
+        }
+
+        if (!AttributeReader.HasAttribute(reader, field.GetCustomAttributes(), KnownAttributeNames.CompilerGeneratedAttribute))
+            return false;
+
+        if (((field.Attributes & FieldAttributes.Static) != 0) != descriptor.IsStatic)
+            return false;
+
+        return GuardedSignatureText.FieldText(reader, field, context).TryGetValue(out var fieldType)
+            && fieldType == descriptor.PropertyType;
+    }
 
     /// <summary>
     /// Whether a field name belongs to a type's declarable field surface based on its name alone.
@@ -993,8 +1062,9 @@ public static class ApiSurfaceExtractor
         bool includeCompilerGenerated)
     {
         bool isEnum = IsEnum(reader, typeDef);
+        var context = GenericContext.ForType(reader, typeDef);
         var fieldLikeEventBackingFieldNames = FieldLikeEventBackingFieldNames(reader, typeDef);
-        var autoPropertyBackingFieldNames = AutoPropertyBackingFieldNames(reader, typeDef);
+        var autoPropertyBackingFields = AutoPropertyBackingFieldDescriptors(reader, typeDef, context);
         var handles = new List<FieldDefinitionHandle>();
         foreach (var fieldHandle in typeDef.GetFields())
         {
@@ -1007,7 +1077,7 @@ public static class ApiSurfaceExtractor
                 continue; // An enum's storage slot is not a declarable field member
             if (!IsSurfaceableFieldName(fieldName, includeCompilerGenerated))
                 continue;
-            if (IsAutoPropertyBackingField(reader, field, fieldName, autoPropertyBackingFieldNames))
+            if (IsAutoPropertyBackingField(reader, field, fieldName, autoPropertyBackingFields, context))
                 continue; // Skip a synthesized auto-property backing field (re-synthesized on reconstruction)
             if (IsFieldLikeEventBackingField(reader, field, fieldName, fieldLikeEventBackingFieldNames))
                 continue;

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -313,6 +313,7 @@ public static class ApiSurfaceExtractor
             // pre-scan and the per-field fold below are factored into shared helpers so
             // API-surface extraction and compile-back reconstruction agree on the fold.
             var fieldLikeEventBackingFieldNames = FieldLikeEventBackingFieldNames(reader, typeDef);
+            var autoPropertyBackingFieldNames = AutoPropertyBackingFieldNames(reader, typeDef);
 
             foreach (var fieldHandle in typeDef.GetFields())
             {
@@ -325,7 +326,7 @@ public static class ApiSurfaceExtractor
                 if (!IsSurfaceableFieldName(fieldName, includeCompilerGenerated))
                     continue; // Skip compiler-generated (<...>) fields unless opted in
 
-                if (IsAutoPropertyBackingField(reader, field, fieldName))
+                if (IsAutoPropertyBackingField(reader, field, fieldName, autoPropertyBackingFieldNames))
                     continue; // Skip a synthesized auto-property backing field (re-synthesized on reconstruction)
 
                 if (IsFieldLikeEventBackingField(reader, field, fieldName, fieldLikeEventBackingFieldNames))
@@ -914,22 +915,47 @@ public static class ApiSurfaceExtractor
                KnownAttributeNames.CompilerGeneratedAttribute);
 
     /// <summary>
-    /// A synthesized auto-property backing field, spelled <c>&lt;Prop&gt;k__BackingField</c>. The
-    /// pattern is matched precisely (leading <c>&lt;</c> plus the <c>k__BackingField</c> suffix) so
-    /// a legitimate user field whose name merely contains <c>__BackingField</c> is not dropped.
+    /// Names of a type's auto-property backing fields, derived from its declared properties. An
+    /// auto-property's backing field is spelled <c>&lt;Prop&gt;k__BackingField</c>; a candidate
+    /// field is only folded when a property with the matching name actually exists (mirroring the
+    /// field-like-event fold, which requires a matching event). Property names carrying <c>&lt;</c>
+    /// or <c>.</c> (compiler-generated or explicit-interface names) cannot name a C# auto-property
+    /// and are skipped.
     /// </summary>
-    static bool IsAutoPropertyBackingFieldName(string name)
-        => name.StartsWith('<') && name.EndsWith("k__BackingField", StringComparison.Ordinal);
+    static HashSet<string>? AutoPropertyBackingFieldNames(MetadataReader reader, TypeDefinition typeDef)
+    {
+        HashSet<string>? names = null;
+        foreach (var propertyHandle in typeDef.GetProperties())
+        {
+            string propertyName = reader.GetString(reader.GetPropertyDefinition(propertyHandle).Name);
+            if (propertyName.Contains('<', StringComparison.Ordinal)
+                || propertyName.Contains('.', StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            (names ??= new HashSet<string>(StringComparer.Ordinal))
+                .Add($"<{propertyName}>k__BackingField");
+        }
+
+        return names;
+    }
 
     /// <summary>
-    /// True when a field is a synthesized auto-property backing field: it is spelled
-    /// <c>&lt;Prop&gt;k__BackingField</c> AND carries its own <c>[CompilerGenerated]</c> marker.
-    /// Requiring the field's own marker (not the name alone) mirrors the field-like-event backing
-    /// fold: C# spelling rules do not bind arbitrary IL, so a genuine field could share the shape;
-    /// the C# compiler always marks a real auto-property backing field compiler-generated.
+    /// True when a field is a synthesized auto-property backing field: it carries its own
+    /// <c>[CompilerGenerated]</c> marker AND its name matches a declared property's backing-field
+    /// name. Requiring a matching property (not the mangled name shape alone) mirrors the
+    /// field-like-event backing fold: C# spelling rules do not bind arbitrary IL, so a
+    /// compiler-generated field that merely shares the shape but backs no declared property is
+    /// preserved (on reconstruction no property maps the body's field reference, so the raw field
+    /// must stay declared).
     /// </summary>
-    static bool IsAutoPropertyBackingField(MetadataReader reader, FieldDefinition field, string name)
-        => IsAutoPropertyBackingFieldName(name)
+    static bool IsAutoPropertyBackingField(
+        MetadataReader reader,
+        FieldDefinition field,
+        string fieldName,
+        HashSet<string>? autoPropertyBackingFieldNames)
+        => autoPropertyBackingFieldNames?.Contains(fieldName) == true
            && AttributeReader.HasAttribute(
                reader,
                field.GetCustomAttributes(),
@@ -968,6 +994,7 @@ public static class ApiSurfaceExtractor
     {
         bool isEnum = IsEnum(reader, typeDef);
         var fieldLikeEventBackingFieldNames = FieldLikeEventBackingFieldNames(reader, typeDef);
+        var autoPropertyBackingFieldNames = AutoPropertyBackingFieldNames(reader, typeDef);
         var handles = new List<FieldDefinitionHandle>();
         foreach (var fieldHandle in typeDef.GetFields())
         {
@@ -980,7 +1007,7 @@ public static class ApiSurfaceExtractor
                 continue; // An enum's storage slot is not a declarable field member
             if (!IsSurfaceableFieldName(fieldName, includeCompilerGenerated))
                 continue;
-            if (IsAutoPropertyBackingField(reader, field, fieldName))
+            if (IsAutoPropertyBackingField(reader, field, fieldName, autoPropertyBackingFieldNames))
                 continue; // Skip a synthesized auto-property backing field (re-synthesized on reconstruction)
             if (IsFieldLikeEventBackingField(reader, field, fieldName, fieldLikeEventBackingFieldNames))
                 continue;

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1028,28 +1028,45 @@ public class ApiSurfaceExtractorTests
             var typeDef = reader.TypeDefinitions
                 .Select(reader.GetTypeDefinition)
                 .Single(t => reader.GetString(t.Name) == "FieldSurfaceSample");
+            var enumDef = reader.TypeDefinitions
+                .Select(reader.GetTypeDefinition)
+                .Single(t => reader.GetString(t.Name) == "FieldSurfaceEnum");
 
             var off = SurfaceFieldNames(reader, typeDef, includeCompilerGenerated: false);
             var on = SurfaceFieldNames(reader, typeDef, includeCompilerGenerated: true);
 
-            // Ordinary fields are always surfaced, including a user field whose name merely
-            // contains "__BackingField" (only the exact <Prop>k__BackingField shape is synthetic).
-            Assert.Contains("Plain", off);
-            Assert.Contains("count__BackingField", off);
-            Assert.Contains("Plain", on);
-            Assert.Contains("count__BackingField", on);
-
-            // Synthesized fields are excluded regardless of the opt-in.
             foreach (var set in new[] { off, on })
             {
-                Assert.DoesNotContain("<Value>k__BackingField", set); // auto-property backing
-                Assert.DoesNotContain("value__", set);                // enum storage slot name
-                Assert.DoesNotContain("Evt", set);                    // field-like event backing
+                // Ordinary fields are always surfaced, including a user field whose name merely
+                // contains "__BackingField" (only the exact <Prop>k__BackingField shape is
+                // synthetic) and a non-enum type's `value__` field (the storage-slot exclusion is
+                // gated on enums, so on a plain class `value__` is an ordinary field).
+                Assert.Contains("Plain", set);
+                Assert.Contains("count__BackingField", set);
+                Assert.Contains("value__", set);
+
+                // A field-like event's private [CompilerGenerated] backing field is always folded.
+                Assert.DoesNotContain("Evt", set);
+
+                // A real auto-property backing field carries its own [CompilerGenerated] marker and
+                // is dropped everywhere, even under the opt-in.
+                Assert.DoesNotContain("<Value>k__BackingField", set);
             }
 
-            // A compiler-generated (<...>) field is gated behind the opt-in.
+            // Positive-evidence discriminator: a hand-authored <Orphan>k__BackingField with the
+            // backing-field name but NO [CompilerGenerated] marker is not a real backing field, so
+            // it is treated as an ordinary compiler-generated (<...>) field — gated by the opt-in,
+            // not folded by name. A plain state-machine hoisted local behaves the same way.
+            Assert.DoesNotContain("<Orphan>k__BackingField", off);
+            Assert.Contains("<Orphan>k__BackingField", on);
             Assert.DoesNotContain("<hoisted>5__1", off);
             Assert.Contains("<hoisted>5__1", on);
+
+            // On a genuine enum, `value__` is the storage slot and is excluded; literal members
+            // still surface.
+            var enumOff = SurfaceFieldNames(reader, enumDef, includeCompilerGenerated: false);
+            Assert.DoesNotContain("value__", enumOff);
+            Assert.Contains("Red", enumOff);
         }
         finally
         {
@@ -1064,10 +1081,12 @@ public class ApiSurfaceExtractorTests
             .Select(h => reader.GetString(reader.GetFieldDefinition(h).Name))
             .ToHashSet(StringComparer.Ordinal);
 
-    // Emits (via Reflection.Emit) a type whose fields exercise every branch of the field-inclusion
+    // Emits (via Reflection.Emit) types that exercise every branch of the field-inclusion
     // primitive: an ordinary field, a user field that merely contains "__BackingField", a real
-    // auto-property backing field, the enum storage-slot name, a compiler-generated hoisted local,
-    // and a field-like event's private [CompilerGenerated] backing field. Returns the saved path.
+    // [CompilerGenerated] auto-property backing field, a same-named lookalike WITHOUT the marker,
+    // a non-enum `value__` field, a compiler-generated hoisted local, and a field-like event's
+    // private [CompilerGenerated] backing field — plus a genuine enum whose `value__` is the
+    // storage slot. Returns the saved path.
     static string EmitFieldSurfaceSample()
     {
         var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
@@ -1076,15 +1095,23 @@ public class ApiSurfaceExtractorTests
         var tb = module.DefineType("FieldSurfaceSample",
             System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
 
-        tb.DefineField("Plain", typeof(int), System.Reflection.FieldAttributes.Public);
-        tb.DefineField("count__BackingField", typeof(int), System.Reflection.FieldAttributes.Public);
-        tb.DefineField("<Value>k__BackingField", typeof(int), System.Reflection.FieldAttributes.Private);
-        tb.DefineField("value__", typeof(int), System.Reflection.FieldAttributes.Public);
-        tb.DefineField("<hoisted>5__1", typeof(int), System.Reflection.FieldAttributes.Public);
-
         var cgCtor = typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)
             .GetConstructor(Type.EmptyTypes)!;
         var cgAttr = new System.Reflection.Emit.CustomAttributeBuilder(cgCtor, Array.Empty<object>());
+
+        tb.DefineField("Plain", typeof(int), System.Reflection.FieldAttributes.Public);
+        tb.DefineField("count__BackingField", typeof(int), System.Reflection.FieldAttributes.Public);
+
+        // A real auto-property backing field: <Prop>k__BackingField AND [CompilerGenerated].
+        var realBacking = tb.DefineField(
+            "<Value>k__BackingField", typeof(int), System.Reflection.FieldAttributes.Private);
+        realBacking.SetCustomAttribute(cgAttr);
+
+        // A same-named lookalike without the [CompilerGenerated] marker: not a backing field.
+        tb.DefineField("<Orphan>k__BackingField", typeof(int), System.Reflection.FieldAttributes.Private);
+
+        tb.DefineField("value__", typeof(int), System.Reflection.FieldAttributes.Public);
+        tb.DefineField("<hoisted>5__1", typeof(int), System.Reflection.FieldAttributes.Public);
 
         // Field-like event: a private [CompilerGenerated] field sharing the event name, with
         // [CompilerGenerated] add/remove accessors.
@@ -1105,6 +1132,12 @@ public class ApiSurfaceExtractorTests
         eventBuilder.SetRemoveOnMethod(remove);
 
         tb.CreateType();
+
+        // A genuine enum: its `value__` storage slot must be excluded; literals surface.
+        var eb = module.DefineEnum(
+            "FieldSurfaceEnum", System.Reflection.TypeAttributes.Public, typeof(int));
+        eb.DefineLiteral("Red", 0);
+        eb.CreateType();
 
         string path = Path.Combine(Path.GetTempPath(), $"field-surface-{Guid.NewGuid():N}.dll");
         ab.Save(path);

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1065,6 +1065,22 @@ public class ApiSurfaceExtractorTests
             Assert.DoesNotContain("<hoisted>5__1", off);
             Assert.Contains("<hoisted>5__1", on);
 
+            // Even with a matching property name, a candidate is folded only when its type and
+            // staticness agree with the property and the accessor is [CompilerGenerated]. A type
+            // mismatch (`string` field vs `int` property), a staticness mismatch (static field vs
+            // instance property), and a non-auto property (hand-authored accessor) each decline the
+            // fold, so the compiler-generated field is preserved rather than silently dropped.
+            foreach (var preserved in new[]
+                     {
+                         "<Mismatch>k__BackingField",
+                         "<Slot>k__BackingField",
+                         "<Manual>k__BackingField",
+                     })
+            {
+                Assert.DoesNotContain(preserved, off);
+                Assert.Contains(preserved, on);
+            }
+
             // On a genuine enum, `value__` is the storage slot and is excluded; literal members
             // still surface.
             var enumOff = SurfaceFieldNames(reader, enumDef, includeCompilerGenerated: false);
@@ -1086,11 +1102,11 @@ public class ApiSurfaceExtractorTests
 
     // Emits (via Reflection.Emit) types that exercise every branch of the field-inclusion
     // primitive: an ordinary field, a user field that merely contains "__BackingField", a genuine
-    // auto-property backing field ([CompilerGenerated] AND matched by a declared `Value` property),
-    // a [CompilerGenerated] backing-name lookalike with NO backing property, a non-enum `value__`
-    // field, a compiler-generated hoisted local, and a field-like event's private
-    // [CompilerGenerated] backing field — plus a genuine enum whose `value__` is the storage slot.
-    // Returns the saved path.
+    // auto-property backing field ([CompilerGenerated], type/staticness-matched, [CompilerGenerated]
+    // accessor), same-named lookalikes that decline the fold (type mismatch, staticness mismatch,
+    // non-auto property, and no backing property), a non-enum `value__` field, a compiler-generated
+    // hoisted local, and a field-like event's private [CompilerGenerated] backing field — plus a
+    // genuine enum whose `value__` is the storage slot. Returns the saved path.
     static string EmitFieldSurfaceSample()
     {
         var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
@@ -1103,25 +1119,75 @@ public class ApiSurfaceExtractorTests
             .GetConstructor(Type.EmptyTypes)!;
         var cgAttr = new System.Reflection.Emit.CustomAttributeBuilder(cgCtor, Array.Empty<object>());
 
+        // Defines a `<PropertyName>k__BackingField` field (always [CompilerGenerated]) alongside a
+        // matching property, letting a caller vary each fold discriminator independently: whether
+        // the accessor is [CompilerGenerated] (auto-property signal), and whether the field's type
+        // and staticness match the property. Only when every discriminator agrees is the field a
+        // genuine auto-property backing field.
+        void DefineBackingFieldLookalike(
+            string propertyName,
+            Type propertyType,
+            Type fieldType,
+            bool accessorCompilerGenerated,
+            bool fieldStatic,
+            bool accessorStatic)
+        {
+            var fieldAttrs = System.Reflection.FieldAttributes.Private;
+            if (fieldStatic)
+                fieldAttrs |= System.Reflection.FieldAttributes.Static;
+            var backing = tb.DefineField($"<{propertyName}>k__BackingField", fieldType, fieldAttrs);
+            backing.SetCustomAttribute(cgAttr);
+
+            var getterAttrs = System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.SpecialName
+                | System.Reflection.MethodAttributes.HideBySig;
+            if (accessorStatic)
+                getterAttrs |= System.Reflection.MethodAttributes.Static;
+            var getter = tb.DefineMethod($"get_{propertyName}", getterAttrs, propertyType, Type.EmptyTypes);
+            var il = getter.GetILGenerator();
+            il.Emit(propertyType.IsValueType
+                ? System.Reflection.Emit.OpCodes.Ldc_I4_0
+                : System.Reflection.Emit.OpCodes.Ldnull);
+            il.Emit(System.Reflection.Emit.OpCodes.Ret);
+            if (accessorCompilerGenerated)
+                getter.SetCustomAttribute(cgAttr);
+
+            var prop = tb.DefineProperty(
+                propertyName, System.Reflection.PropertyAttributes.None, propertyType, null);
+            prop.SetGetMethod(getter);
+        }
+
         tb.DefineField("Plain", typeof(int), System.Reflection.FieldAttributes.Public);
         tb.DefineField("count__BackingField", typeof(int), System.Reflection.FieldAttributes.Public);
 
-        // A genuine auto-property backing field: [CompilerGenerated] <Value>k__BackingField backed
-        // by a declared property `Value` of the same name.
-        var realBacking = tb.DefineField(
-            "<Value>k__BackingField", typeof(int), System.Reflection.FieldAttributes.Private);
-        realBacking.SetCustomAttribute(cgAttr);
-        var getValue = tb.DefineMethod("get_Value",
-            System.Reflection.MethodAttributes.Public
-            | System.Reflection.MethodAttributes.SpecialName
-            | System.Reflection.MethodAttributes.HideBySig,
-            typeof(int), Type.EmptyTypes);
-        var getValueIl = getValue.GetILGenerator();
-        getValueIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_0);
-        getValueIl.Emit(System.Reflection.Emit.OpCodes.Ret);
-        var valueProp = tb.DefineProperty(
-            "Value", System.Reflection.PropertyAttributes.None, typeof(int), null);
-        valueProp.SetGetMethod(getValue);
+        // A genuine auto-property backing field: [CompilerGenerated] <Value>k__BackingField whose
+        // type (int) and staticness (instance) match a declared auto-property `Value` with a
+        // [CompilerGenerated] accessor. Every discriminator agrees, so it is folded.
+        DefineBackingFieldLookalike(
+            "Value", typeof(int), typeof(int),
+            accessorCompilerGenerated: true, fieldStatic: false, accessorStatic: false);
+
+        // Type mismatch: <Mismatch>k__BackingField is a [CompilerGenerated] `string` field while the
+        // matching auto-property `Mismatch` is `int`. A field of a different type cannot be that
+        // property's backing field, so it is preserved (old RTS compared field/property types).
+        DefineBackingFieldLookalike(
+            "Mismatch", typeof(int), typeof(string),
+            accessorCompilerGenerated: true, fieldStatic: false, accessorStatic: false);
+
+        // Staticness mismatch: <Slot>k__BackingField is a [CompilerGenerated] static field while the
+        // matching auto-property `Slot` is an instance property. Staticness disagreement means it is
+        // not that property's backing field, so it is preserved.
+        DefineBackingFieldLookalike(
+            "Slot", typeof(int), typeof(int),
+            accessorCompilerGenerated: true, fieldStatic: true, accessorStatic: false);
+
+        // Non-auto property: a hand-authored (non-[CompilerGenerated]) property `Manual` plus an
+        // unrelated [CompilerGenerated] <Manual>k__BackingField. Because the property is not an
+        // auto-property, the field backs nothing the compiler re-synthesizes, so it must be
+        // preserved (its data would otherwise be silently lost).
+        DefineBackingFieldLookalike(
+            "Manual", typeof(int), typeof(int),
+            accessorCompilerGenerated: false, fieldStatic: false, accessorStatic: false);
 
         // A [CompilerGenerated] field with the mangled backing-field name shape but NO declared
         // property `Orphan`: it backs no auto-property, so it must be preserved.

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using ILInspector.CSharp;
 using ILInspector.Metadata;
@@ -971,6 +972,145 @@ public class ApiSurfaceExtractorTests
         }
     }
 
+    [Fact]
+    public void Extract_ExcludesCompilerGeneratedTypesByDefault()
+    {
+        // The test assembly itself is a real csc artifact: SampleClosureHost's capturing lambda
+        // forces the compiler to emit a nested `<>c__DisplayClass`. By default (opt-in off) no
+        // compiler-generated type is surfaced, even under --all.
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        Assert.DoesNotContain(surface.Types, t => (t.MetadataName ?? "").Contains("DisplayClass"));
+    }
+
+    [Fact]
+    public void Extract_SurfacesCompilerGeneratedTypesAndRealFieldsWhenOptedIn()
+    {
+        // With the opt-in, compiler-generated types are surfaced together with their genuine
+        // fields (the display class carries the captured state), but synthesized auto-property
+        // backing fields stay excluded everywhere — even under the opt-in.
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(
+            peReader, includeAll: true, includeCompilerGenerated: true);
+
+        // A display class from a real capturing lambda is surfaced with at least one field member.
+        Assert.Contains(
+            surface.Types,
+            t => (t.MetadataName ?? "").Contains("DisplayClass")
+                 && t.Members.Any(m => m.Kind == "field"));
+
+        // Auto-property backing fields (<Prop>k__BackingField) are never surfaced as fields, even
+        // once compiler-generated members are opted in.
+        Assert.DoesNotContain(
+            surface.Types.SelectMany(t => t.Members),
+            m => m.Kind == "field" && m.Name.EndsWith("k__BackingField", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SurfaceFieldHandles_ExcludesSynthesizedFieldsAndGatesCompilerGeneratedFields()
+    {
+        // Direct unit test of the shared field-inclusion primitive over a hand-authored type with
+        // precisely-named fields. Synthetic metadata is appropriate here: the primitive is a pure
+        // name/attribute filter, so exact field names isolate exactly what it decides.
+        string dllPath = EmitFieldSurfaceSample();
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            var typeDef = reader.TypeDefinitions
+                .Select(reader.GetTypeDefinition)
+                .Single(t => reader.GetString(t.Name) == "FieldSurfaceSample");
+
+            var off = SurfaceFieldNames(reader, typeDef, includeCompilerGenerated: false);
+            var on = SurfaceFieldNames(reader, typeDef, includeCompilerGenerated: true);
+
+            // Ordinary fields are always surfaced, including a user field whose name merely
+            // contains "__BackingField" (only the exact <Prop>k__BackingField shape is synthetic).
+            Assert.Contains("Plain", off);
+            Assert.Contains("count__BackingField", off);
+            Assert.Contains("Plain", on);
+            Assert.Contains("count__BackingField", on);
+
+            // Synthesized fields are excluded regardless of the opt-in.
+            foreach (var set in new[] { off, on })
+            {
+                Assert.DoesNotContain("<Value>k__BackingField", set); // auto-property backing
+                Assert.DoesNotContain("value__", set);                // enum storage slot name
+                Assert.DoesNotContain("Evt", set);                    // field-like event backing
+            }
+
+            // A compiler-generated (<...>) field is gated behind the opt-in.
+            Assert.DoesNotContain("<hoisted>5__1", off);
+            Assert.Contains("<hoisted>5__1", on);
+        }
+        finally
+        {
+            try { File.Delete(dllPath); } catch { /* best-effort */ }
+        }
+    }
+
+    static HashSet<string> SurfaceFieldNames(
+        MetadataReader reader, TypeDefinition typeDef, bool includeCompilerGenerated)
+        => ApiSurfaceExtractor
+            .SurfaceFieldHandles(reader, typeDef, includeAll: true, includeCompilerGenerated)
+            .Select(h => reader.GetString(reader.GetFieldDefinition(h).Name))
+            .ToHashSet(StringComparer.Ordinal);
+
+    // Emits (via Reflection.Emit) a type whose fields exercise every branch of the field-inclusion
+    // primitive: an ordinary field, a user field that merely contains "__BackingField", a real
+    // auto-property backing field, the enum storage-slot name, a compiler-generated hoisted local,
+    // and a field-like event's private [CompilerGenerated] backing field. Returns the saved path.
+    static string EmitFieldSurfaceSample()
+    {
+        var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("FieldSurfaceEmit"), typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("FieldSurfaceEmit");
+        var tb = module.DefineType("FieldSurfaceSample",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+
+        tb.DefineField("Plain", typeof(int), System.Reflection.FieldAttributes.Public);
+        tb.DefineField("count__BackingField", typeof(int), System.Reflection.FieldAttributes.Public);
+        tb.DefineField("<Value>k__BackingField", typeof(int), System.Reflection.FieldAttributes.Private);
+        tb.DefineField("value__", typeof(int), System.Reflection.FieldAttributes.Public);
+        tb.DefineField("<hoisted>5__1", typeof(int), System.Reflection.FieldAttributes.Public);
+
+        var cgCtor = typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)
+            .GetConstructor(Type.EmptyTypes)!;
+        var cgAttr = new System.Reflection.Emit.CustomAttributeBuilder(cgCtor, Array.Empty<object>());
+
+        // Field-like event: a private [CompilerGenerated] field sharing the event name, with
+        // [CompilerGenerated] add/remove accessors.
+        var evtField = tb.DefineField("Evt", typeof(Action), System.Reflection.FieldAttributes.Private);
+        evtField.SetCustomAttribute(cgAttr);
+        const System.Reflection.MethodAttributes accessorAttrs =
+            System.Reflection.MethodAttributes.Private
+            | System.Reflection.MethodAttributes.SpecialName
+            | System.Reflection.MethodAttributes.HideBySig;
+        var add = tb.DefineMethod("add_Evt", accessorAttrs, typeof(void), new[] { typeof(Action) });
+        add.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        add.SetCustomAttribute(cgAttr);
+        var remove = tb.DefineMethod("remove_Evt", accessorAttrs, typeof(void), new[] { typeof(Action) });
+        remove.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        remove.SetCustomAttribute(cgAttr);
+        var eventBuilder = tb.DefineEvent("Evt", System.Reflection.EventAttributes.None, typeof(Action));
+        eventBuilder.SetAddOnMethod(add);
+        eventBuilder.SetRemoveOnMethod(remove);
+
+        tb.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"field-surface-{Guid.NewGuid():N}.dll");
+        ab.Save(path);
+        return path;
+    }
+
     static IReadOnlyList<ApiMember> ExtractClashTypeMembers(string dllPath)
     {
         using var stream = File.OpenRead(dllPath);
@@ -1027,6 +1167,21 @@ public class ApiSurfaceExtractorTests
         return path;
     }
 
+}
+
+/// <summary>
+/// Fixture: a capturing lambda that forces csc to emit a compiler-generated display class with
+/// fields for the captured state, plus an auto-property whose backing field must stay excluded.
+/// </summary>
+public class SampleClosureHost
+{
+    public int AutoValue { get; set; }
+
+    public System.Func<int> Capture(int seed)
+    {
+        int local = seed * 2;
+        return () => seed + local;
+    }
 }
 
 /// <summary>

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1048,15 +1048,18 @@ public class ApiSurfaceExtractorTests
                 // A field-like event's private [CompilerGenerated] backing field is always folded.
                 Assert.DoesNotContain("Evt", set);
 
-                // A real auto-property backing field carries its own [CompilerGenerated] marker and
-                // is dropped everywhere, even under the opt-in.
+                // A genuine auto-property backing field — [CompilerGenerated] AND matched by a
+                // declared property of the same name (`Value`) — is dropped everywhere, even under
+                // the opt-in.
                 Assert.DoesNotContain("<Value>k__BackingField", set);
             }
 
-            // Positive-evidence discriminator: a hand-authored <Orphan>k__BackingField with the
-            // backing-field name but NO [CompilerGenerated] marker is not a real backing field, so
-            // it is treated as an ordinary compiler-generated (<...>) field — gated by the opt-in,
-            // not folded by name. A plain state-machine hoisted local behaves the same way.
+            // Positive-evidence discriminator: <Orphan>k__BackingField is [CompilerGenerated] and
+            // has the mangled backing-field name shape, but NO property named `Orphan` is declared,
+            // so it backs no auto-property. It is preserved (surfaced as an ordinary
+            // compiler-generated <...> field under the opt-in), matching the old RTS field surface:
+            // the compiler-generated marker and mangled name alone are not enough; a matching
+            // property is required to fold. A plain hoisted local behaves the same way.
             Assert.DoesNotContain("<Orphan>k__BackingField", off);
             Assert.Contains("<Orphan>k__BackingField", on);
             Assert.DoesNotContain("<hoisted>5__1", off);
@@ -1082,11 +1085,12 @@ public class ApiSurfaceExtractorTests
             .ToHashSet(StringComparer.Ordinal);
 
     // Emits (via Reflection.Emit) types that exercise every branch of the field-inclusion
-    // primitive: an ordinary field, a user field that merely contains "__BackingField", a real
-    // [CompilerGenerated] auto-property backing field, a same-named lookalike WITHOUT the marker,
-    // a non-enum `value__` field, a compiler-generated hoisted local, and a field-like event's
-    // private [CompilerGenerated] backing field — plus a genuine enum whose `value__` is the
-    // storage slot. Returns the saved path.
+    // primitive: an ordinary field, a user field that merely contains "__BackingField", a genuine
+    // auto-property backing field ([CompilerGenerated] AND matched by a declared `Value` property),
+    // a [CompilerGenerated] backing-name lookalike with NO backing property, a non-enum `value__`
+    // field, a compiler-generated hoisted local, and a field-like event's private
+    // [CompilerGenerated] backing field — plus a genuine enum whose `value__` is the storage slot.
+    // Returns the saved path.
     static string EmitFieldSurfaceSample()
     {
         var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
@@ -1102,13 +1106,28 @@ public class ApiSurfaceExtractorTests
         tb.DefineField("Plain", typeof(int), System.Reflection.FieldAttributes.Public);
         tb.DefineField("count__BackingField", typeof(int), System.Reflection.FieldAttributes.Public);
 
-        // A real auto-property backing field: <Prop>k__BackingField AND [CompilerGenerated].
+        // A genuine auto-property backing field: [CompilerGenerated] <Value>k__BackingField backed
+        // by a declared property `Value` of the same name.
         var realBacking = tb.DefineField(
             "<Value>k__BackingField", typeof(int), System.Reflection.FieldAttributes.Private);
         realBacking.SetCustomAttribute(cgAttr);
+        var getValue = tb.DefineMethod("get_Value",
+            System.Reflection.MethodAttributes.Public
+            | System.Reflection.MethodAttributes.SpecialName
+            | System.Reflection.MethodAttributes.HideBySig,
+            typeof(int), Type.EmptyTypes);
+        var getValueIl = getValue.GetILGenerator();
+        getValueIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_0);
+        getValueIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var valueProp = tb.DefineProperty(
+            "Value", System.Reflection.PropertyAttributes.None, typeof(int), null);
+        valueProp.SetGetMethod(getValue);
 
-        // A same-named lookalike without the [CompilerGenerated] marker: not a backing field.
-        tb.DefineField("<Orphan>k__BackingField", typeof(int), System.Reflection.FieldAttributes.Private);
+        // A [CompilerGenerated] field with the mangled backing-field name shape but NO declared
+        // property `Orphan`: it backs no auto-property, so it must be preserved.
+        var orphanBacking = tb.DefineField(
+            "<Orphan>k__BackingField", typeof(int), System.Reflection.FieldAttributes.Private);
+        orphanBacking.SetCustomAttribute(cgAttr);
 
         tb.DefineField("value__", typeof(int), System.Reflection.FieldAttributes.Public);
         tb.DefineField("<hoisted>5__1", typeof(int), System.Reflection.FieldAttributes.Public);

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -9999,6 +9999,9 @@ public class CommandExecutionTests
     [Fact]
     public async Task PInvokeMethods_DeclaringTypeAndSignature_RenderAsCodeSpansWithFunctionPointerPunctuation()
     {
+        Assert.SkipUnless(
+            OperatingSystem.IsWindows(),
+            "Interop.User32.EnumWindows P/Invokes exist only in the Windows build of System.Diagnostics.Process.");
         var (exit, output, error) = await RunAppAsync(
             "library", "--platform", "System.Diagnostics.Process",
             "--section", "P/Invoke Methods", "-v:d", "--tips", "q");
@@ -10017,6 +10020,9 @@ public class CommandExecutionTests
     [Fact]
     public async Task PInvokeMethods_MachineOutput_KeepsRawValuesWithoutCodeMarkup()
     {
+        Assert.SkipUnless(
+            OperatingSystem.IsWindows(),
+            "Interop.User32.EnumWindows P/Invokes exist only in the Windows build of System.Diagnostics.Process.");
         var (exit, output, error) = await RunAppAsync(
             "library", "--platform", "System.Diagnostics.Process",
             "--section", "P/Invoke Methods", "--jsonl");

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2850,43 +2850,6 @@ public static class CompileBackSourceComposer
         return false;
     }
 
-    // Backing field metadata names (`<Name>k__BackingField`) for every auto-property on the
-    // type whose skeleton the member surface re-emits. The compiler re-synthesizes each such
-    // backing field, so the raw field must be suppressed to avoid a stray duplicate (issue #3036).
-    static HashSet<string> AutoPropertyBackingFieldNames(MetadataReader reader, TypeDefinition typeDef)
-    {
-        var names = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var propertyHandle in typeDef.GetProperties())
-        {
-            var property = reader.GetPropertyDefinition(propertyHandle);
-            string propertyName = reader.GetString(property.Name);
-            if (propertyName.Contains('<', StringComparison.Ordinal)
-                || propertyName.Contains('.', StringComparison.Ordinal))
-                continue;
-
-            string returnTypeDisplay;
-            try
-            {
-                var declaration = MetadataDeclarationQuery.GetProperty(reader, typeDef, property);
-                if (declaration.Signature.ReturnType is not { } propertyReturnType)
-                    continue;
-                returnTypeDisplay = CompileBackTypeSignature.Display(propertyReturnType).DisplayName;
-            }
-            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
-            {
-                continue;
-            }
-
-            var accessors = property.GetAccessors();
-            bool isAuto = (!accessors.Getter.IsNil && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnTypeDisplay))
-                || (!accessors.Setter.IsNil && IsAutoPropertySetter(reader, typeDef, property, accessors.Setter, returnTypeDisplay));
-            if (isAuto)
-                names.Add($"<{propertyName}>k__BackingField");
-        }
-
-        return names;
-    }
-
     static bool IsAutoProperty(
         MetadataReader reader,
         TypeDefinition typeDef,
@@ -4090,13 +4053,15 @@ public static class CompileBackSourceComposer
                 || requirement.IncludeMemberSurface;
             var accessorMethods = new HashSet<MethodDefinitionHandle>();
             var typeContext = GenericContext.ForType(reader, typeDef);
-            // The compiler re-synthesizes the backing field for each auto-property skeleton this
-            // surface emits, so the raw `<Name>k__BackingField` must not also be emitted as a
-            // field. Its unspeakable name is sanitized to a legal identifier (e.g.
-            // `__Name_k__BackingField`), which would otherwise compile as a stray duplicate field
-            // sitting next to the reconstructed auto-property (issue #3036).
-            var autoPropertyBackingFields = AutoPropertyBackingFieldNames(reader, typeDef);
-            foreach (var fieldHandle in typeDef.GetFields())
+            // The product owns the field-inclusion decision (ApiSurfaceExtractor.SurfaceFieldHandles):
+            // it drops synthesized auto-property backing fields (`<Name>k__BackingField`, which the
+            // compiler re-synthesizes for each reconstructed auto-property, issue #3036), the enum
+            // `value__` slot, and a field-like event's compiler-generated backing field (issue
+            // #3083), while surfacing the closure/state-machine captures reconstruction needs
+            // (includeCompilerGenerated). RTS keeps only the reconstruction-side gates below
+            // (unspeakable names, signature decode, fixed buffers, pointer surface, dedup).
+            foreach (var fieldHandle in ApiSurfaceExtractor.SurfaceFieldHandles(
+                reader, typeDef, includeAll: true, includeCompilerGenerated: true))
             {
                 var field = reader.GetFieldDefinition(fieldHandle);
                 string fieldName = reader.GetString(field.Name);
@@ -4104,8 +4069,6 @@ public static class CompileBackSourceComposer
                 {
                     continue;
                 }
-                if (autoPropertyBackingFields.Contains(fieldName))
-                    continue;
                 if (members.Any(member => member.Kind == CompileBackMemberKind.Field && member.Identity.Method == Identifier(fieldName)))
                     continue;
 


### PR DESCRIPTION
- Advances #3091
- Changes RTS closure member-surface to consume the product's field-inclusion
  primitive; adds an opt-in product capability. One intended net behavior change
  (a field-like event's backing field is now folded, not emitted as a stray field).
- Evidence revision: `91a96a02`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — RTS hand-rolled its own member-surface field
enumeration, duplicating the product's field-inclusion rules and diverging from
the merged #3083 field-like-event fold; this routes RTS through a shared,
product-owned `ApiSurfaceExtractor.SurfaceFieldHandles` primitive so the two
agree, proven by 47/47 product tests (incl. a real csc display-class canary) and
a byte-identical decompiler fast-suite FAIL set base-vs-head.

Before (RTS member surface for a field-like-event target):

```text
event Action Changed { add; remove; }
Action Changed;          // <- stray backing field emitted -> CS0102/CS0229
```

After:

```text
event Action Changed { add; remove; }   // backing field folded (product-owned)
```

## Scope and safety

- **Root cause:** RTS's `AddClosureMemberSurface` iterated `typeDef.GetFields()`
  and re-derived which fields to keep (its own `AutoPropertyBackingFieldNames`),
  a second implementation of a product decision — exactly what the harness-boundary
  rule warns against. It also predated #3083, so it still emitted a field-like
  event's backing field as a stray field.
- **Fix shape:** Product/shared change. `ApiSurfaceExtractor` gains an opt-in
  `includeCompilerGenerated` (default off) and a public `SurfaceFieldHandles`
  primitive that centralizes the field-inclusion decision (drop synthesized
  auto-property backing fields, the enum `value__` slot, and a field-like event's
  compiler-generated backing field; gate other `<...>` compiler-generated fields
  behind the opt-in). RTS consumes `SurfaceFieldHandles(includeAll: true,
  includeCompilerGenerated: true)` and keeps only reconstruction-side gates
  (unspeakable-name skip, signature decode, fixed buffers, pointer surface, dedup).
- **Product impact:** `ApiSurfaceExtractor.Extract` is byte-identical when the new
  opt-in is off (its default); every existing caller is unaffected. The opt-in is
  new surface, exercised only by RTS via `SurfaceFieldHandles` (RTS does not depend
  on the `Extract` flag).
- **Scope boundary:** Staged, fields-first. A surfaced compiler-generated type
  currently shows its fields + `.ctor` but not its `<...>` lambda methods; broader
  compiler-generated member coverage is a follow-up. The opt-in is off by default,
  so this has zero impact on existing behavior.
- **RTS boundary:** Preserved and strengthened. Enumeration (which fields exist)
  is now product-owned; reconstruction (how to spell/decode them: const value,
  fixed-buffer signature, pointer gating, body policy) stays in RTS. RTS gains no
  new C# knowledge.

## Evidence

| Check | Result |
| --- | --- |
| Product build (`ILInspector.Metadata`) | Pass, 0 warnings |
| Harness build (`DecompilerHarness`) | Pass, 0 warnings |
| Focused product tests | `DotnetInspector.Tests.ApiSurfaceExtractorTests` 47/47 |
| Decompiler fast suite | FAIL set **byte-identical** base (`0025d5d0`) vs head (56=56, 0 added/removed) |
| Targeted compile-back / RTS A/B | Deferred to CI — see note |

**Real witness (product):** the test assembly's own `SampleClosureHost` capturing
lambda emits a genuine csc `<>c__DisplayClass`; `Extract(includeCompilerGenerated:
false)` excludes it, `Extract(includeCompilerGenerated: true)` surfaces it with its
captured-state field members, while an auto-property `<AutoValue>k__BackingField`
stays excluded under both.

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS (fidelity numbers deferred to CI)** — the intended net
change (folding a field-like event's backing field) removes a stray-field
CS0102/CS0229 *floor*, which can only make compile-back better or equal, never
worse; all other field surfaces are unchanged by construction (`SurfaceFieldHandles`
reproduces RTS's prior inclusion for real csc artifacts).

Local recompile-fidelity and RTS A/B cards are **not reproducible on this machine**:
Roslyn recompile pulls native shared-framework DLLs (`aspnetcorev2_inprocess.dll`,
`coreclr.dll`, …) into references and fails wholesale with CS0009 (`PE image
doesn't contain managed metadata`). This is a known environmental limitation on the
dev box; the decompiler fast-suite FAIL set is identical base-vs-head (the 31
`ReturnToSenderFixtureCatalogTests` reds are pre-existing CS0009, not caused by this
change). Recompile-Exact / RTS A/B coverage comes from `deep-inspect.yml`'s `test`
lane (no `Speed=Slow` filter), which I'll trigger before merge.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Compiler-generated `<...>` methods on a surfaced CG type | Left as frontier | Staged fields-first; opt-in is off by default so no impact. Follow-up. |
| Local recompile-Exact / RTS A/B | Deferred to CI | Environmental CS0009 on native shared-framework DLLs; not a code issue. |

## Validation

```powershell
dotnet build src/ILInspector.Metadata/ILInspector.Metadata.csproj -c Release --configfile nuget.config
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config
dotnet build src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release --configfile nuget.config
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -class DotnetInspector.Tests.ApiSurfaceExtractorTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Speed=Slow"
```

## Review

Two-model adversarial review (per AGENTS.md roster) pending on fixed head `91a96a02`.

| Reviewer | Result | Notes |
| --- | --- | --- |
| _pending_ | | |
| _pending_ | | |
