### PR TITLE
Guard FoldGuardReturn's short-circuit fold against invalid/divergent C# (#3114)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
@@ -143,6 +143,47 @@ public class FoldGuardReturnFidelityTests
         AssertDeclined(CondCompare(), Bool(false), ByRefBoolDeref(), [Int32]);
     }
 
+    // === correctness declines: the wrapped forms the fold's own downstream
+    // transforms would strip back to a bare hazard (adversarial review, #3119) ===
+
+    [Fact]
+    public void NegatedTruthinessCondition_TailConstant_IsNotFolded()
+    {
+        // `if (!t) return computed; return true;` lifts the condition through
+        // Conditions.Negate on the `||` arm, which unwraps the LogicalNot and re-exposes
+        // the bare `op_True(t)` — the printer then strips it to `return t || computed;`,
+        // which binds the user-defined `|` (typed TruthOver, not bool): non-compiling.
+        // The look-through peel must see the truthiness call under the negation.
+        AssertDeclined(new LogicalNot(UserTruthiness()), Computed(), Bool(true), [Int32]);
+    }
+
+    [Fact]
+    public void ByRefDereferenceUnderEqualsTrueComparison_IsNotFolded()
+    {
+        // `if (c) return *r == true; return false;` folds to `c && (*r == true)`, then
+        // BooleanFoldingPass's fixpoint reduces `*r == true` to the bare `*r` — the same
+        // branchless eager-deref divergence the raw-operand guard catches. The peel must
+        // see the by-ref deref under the identity comparison the pass will strip.
+        var byRefEqualsTrue = new Comparison(
+            ComparisonKind.Equal, isUnsigned: false, ByRefBoolDeref(), Bool(true));
+        AssertDeclined(CondCompare(), byRefEqualsTrue, Bool(false), [Int32]);
+    }
+
+    [Fact]
+    public void ByRefDereferenceUnderEqualsFalseComparison_StillFolds()
+    {
+        // `if (c) return *r == false; return false;` folds to `c && (*r == false)`, which
+        // the fixpoint reduces to `c && !*r`. The negating form keeps a `!` (and, per the
+        // merged round-2 boundary, a branch), so the surviving operand is not a bare
+        // deref and the readable fold is kept — the peel declines ONLY the bare-producing
+        // identity forms (`== true` / `!= false`), not `== false` / `!= true`.
+        var byRefEqualsFalse = new Comparison(
+            ComparisonKind.Equal, isUnsigned: false, ByRefBoolDeref(), Bool(false));
+        var result = RunGuard(CondCompare(), byRefEqualsFalse, Bool(false), [Int32]);
+
+        Assert.IsType<LogicalBinary>(result);
+    }
+
     static IrExpression RunGuard(
         IrExpression condition, IrExpression thenValue, IrExpression tailValue, ImmutableArray<TypeRef> locals)
     {

--- a/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
@@ -233,11 +233,16 @@ public class FoldGuardReturnFidelityTests
     // becomes a bare operand of the emitted OUTER-kind chain is eagerly dereferenced
     // (NRE divergence) and is declined — but one confined to a compound operand that
     // keeps its branch (a bitwise `&`, a different-kind logical, a call argument) folds
-    // faithfully. The reachable-from-csc shapes below (bitwise `a & r`, different-kind
-    // `*r || a`, `*r > 0`, `*r.b`, and the call-barrier chain `*r && Call()`) were each
-    // verified against SDK-csc /optimize IL plus a null-by-ref runtime probe; the pure
-    // same-kind `LogicalBinary` cases are synthetic predicate tests (csc pre-lowers a
-    // bare-operand `a && *r` to bitwise), noted per test. ===
+    // faithfully. The csc-REACHABLE shapes below were each verified against SDK-csc
+    // /optimize IL plus a null-by-ref runtime probe: the bitwise `a & r`, the comparison
+    // `*r > 0`, the by-ref field `r.b`, and the call-barrier same-kind chain `*r && Call()`
+    // (a call keeps csc from collapsing the `&&`). The `LogicalBinary` cases built over
+    // BARE operands (`a && *r`, `*r || a`) and the `== true`-wrapped cases are SYNTHETIC
+    // predicate tests: csc lowers a bare-operand `&&`/`||` to a bitwise `Binary` (so those
+    // sources import as the `a & r` case, not `LogicalBinary`) and constant-folds
+    // `x == true`. A csc-reachable `LogicalBinary` needs a compound (call) operand
+    // (`*r && Call()`, `*r || Call()`); the reachable analog of a wrapped chain is the
+    // `!`-negated `!(*r && Call())`. Synthetic status noted per test. ===
 
     [Fact]
     public void ByRefUnderLogicalAndOperand_TailConstant_IsNotFolded()
@@ -272,14 +277,16 @@ public class FoldGuardReturnFidelityTests
     [Fact]
     public void ByRefInLogicalAndChainUnderEqualsTrueWrapper_TailConstant_IsNotFolded()
     {
-        // #3119 round-5 finding 1: a same-kind chain hidden under a reducible `== true`
-        // wrapper. `if (c) return (*r && Call()) == true; return false;` → the fold lifts
-        // `(*r && Call()) == true`; FoldBoolConstantComparison then strips `== true`,
-        // leaving `c && *r && Call()`, whose call-free `c && *r` prefix collapses
-        // branchless (eager by-ref deref — same NRE divergence as the unwrapped chain).
-        // The peel must run BEFORE the same-kind flatten so the buried by-ref is reached;
-        // flattening first would treat the whole `== true` comparison as an opaque compound
-        // and wrongly fold. (The unwrapped chain is `ByRefBeforeCallInLogicalAndOperand`.)
+        // #3119 round-5 finding 1 / round-6: SYNTHETIC defensive predicate test. csc
+        // constant-folds `(*r && Call()) == true` to `*r && Call()` (verified: the wrapped
+        // and unwrapped sources emit byte-identical IL, no `ceq`), so this `== true` node
+        // is NOT csc-reachable. The csc-REACHABLE analog that drives the same peel-then-
+        // recurse path is the `!`-negated chain `!(*r && Call())` (csc keeps the `&&`
+        // branch and appends a `ceq`), which the parity-agnostic peel conservatively
+        // declines for the same reason as a bare `!*r`. This pins that the peel runs BEFORE
+        // the same-kind flatten: IF a reducible wrapper around a same-kind chain reaches
+        // the fold, its buried by-ref is still reached (flattening first would treat the
+        // wrapper as an opaque compound and miss it).
         var call = new Call(
             new MethodRef(Holder, "Call", Boolean, [], HasThis: false), isVirtual: false, []);
         var chain = new LogicalBinary(LogicalKind.And, ByRefBoolDeref(), call);
@@ -290,11 +297,11 @@ public class FoldGuardReturnFidelityTests
     [Fact]
     public void LocalOnlyLogicalAndChainUnderEqualsTrueWrapper_TailConstant_StillFolds()
     {
-        // Negative for finding 1: the same `== true`-wrapped same-kind chain WITHOUT a
-        // by-ref folds. `if (c) return (a && Call()) == true; return false;` reduces to
-        // `c && a && Call()`; the branchless `c & a` prefix is a valid readability raise
-        // (a local never faults), so the guarded-return fold keeps it. The peel-then-
-        // flatten reaches the local `a` but the by-ref hazard predicate ignores it.
+        // Negative for the peel-then-recurse: the same synthetic wrapped same-kind chain
+        // WITHOUT a by-ref still folds. The peel reaches the local `a`, but the by-ref
+        // hazard predicate only fires on a by-ref deref, so a local operand is a valid
+        // readability raise (a local never faults) and the guarded-return fold keeps it.
+        // (Synthetic like the sibling: csc constant-folds `== true`.)
         var call = new Call(
             new MethodRef(Holder, "Call", Boolean, [], HasThis: false), isVirtual: false, []);
         var chain = new LogicalBinary(LogicalKind.And, new LoadLocal(1, Boolean), call);
@@ -307,10 +314,12 @@ public class FoldGuardReturnFidelityTests
     [Fact]
     public void ByRefInSameKindLogicalOperand_TailTrue_OuterOr_IsNotFolded()
     {
-        // The lift is `||`-kind here (`if (c) return *r || a; return true;` → `!c || (*r
-        // || a)`). Now the inner `||` matches the outer `||`, flattens to `!c || *r || a`,
-        // and collapses branchless — the by-ref is eager. The SAME operand folds under an
-        // `&&` lift (next test); the hazard is outer-kind-relative.
+        // SYNTHETIC same-kind (`Or`) chain under an `Or` lift. A bare `*r || a` lowers to a
+        // bitwise `Binary.Or` (faithful, folds), so the csc-reachable same-kind hazard
+        // needs a call barrier: `*r || Call()` → `!c || (*r || Call())` flattens to
+        // `!c || *r || Call()`, whose `!c || *r` prefix collapses branchless (eager by-ref).
+        // This pins the outer-kind-relative decline on the `LogicalBinary(Or)` shape; the
+        // SAME shape folds under an `&&` lift (next test).
         var operand = new LogicalBinary(LogicalKind.Or, ByRefBoolDeref(), new LoadLocal(1, Boolean));
         AssertDeclined(CondCompare(), operand, Bool(true), [Int32, Boolean]);
     }
@@ -318,11 +327,13 @@ public class FoldGuardReturnFidelityTests
     [Fact]
     public void ByRefInDifferentKindLogicalOperand_TailConstant_StillFolds()
     {
-        // #3119 round-4 finding 2: `if (c) return *r || a; return false;` → `c && (*r ||
-        // a)`. The inner `||` differs from the `&&` lift, so the printer keeps it a
+        // #3119 round-4/round-6: a different-kind `LogicalBinary(Or)` operand under an
+        // `&&` lift folds. The `||` differs from the `&&` lift, so the printer keeps it a
         // parenthesized compound the outer `&&` branch guards — the by-ref is read only
-        // when c is true, exactly as in the original (verified: IL byte-identical to the
-        // guarded original, null-by-ref does NOT throw). A faithful, foldable raise.
+        // when c is true. (SYNTHETIC IR: a bare `*r || a` lowers to a bitwise `Binary.Or`,
+        // = the `ByRefUnderBitwiseAndOperand` case which was verified byte-identical; the
+        // csc-reachable different-kind `LogicalBinary` needs a call operand, `*r || Call()`.
+        // The predicate's fold decision is identical for either.)
         var operand = new LogicalBinary(LogicalKind.Or, ByRefBoolDeref(), new LoadLocal(1, Boolean));
         var result = RunGuard(CondCompare(), operand, Bool(false), [Int32, Boolean]);
 
@@ -354,6 +365,38 @@ public class FoldGuardReturnFidelityTests
         var operand = new Call(
             new MethodRef(Holder, "Use", Boolean, [Boolean], HasThis: false),
             isVirtual: false, [ByRefBoolDeref()]);
+        var result = RunGuard(CondCompare(), operand, Bool(false), [Int32]);
+
+        Assert.IsType<LogicalBinary>(result);
+    }
+
+    [Fact]
+    public void ByRefInComparisonOperand_TailConstant_StillFolds()
+    {
+        // `if (c) return *r > 0; return false;` (int by-ref) → `c && (*r > 0)`. The by-ref
+        // deref is confined to a comparison, a compound operand csc keeps the `c` branch
+        // for, so it is read only when c is true (verified round-4: IL byte-identical to
+        // the guarded original, null-by-ref does NOT throw). This pins that the guard does
+        // NOT decline a by-ref nested in a comparison — a regression guard against the
+        // round-3 subtree scan, which wrongly declined any by-ref anywhere in the operand.
+        var byRefInt = new LoadIndirect(Int32, new LoadArgument(1, "r", TypeRef.ByRef(Int32)));
+        var operand = new Comparison(ComparisonKind.GreaterThan, isUnsigned: false, byRefInt, new Constant(0, Int32));
+        var result = RunGuard(CondCompare(), operand, Bool(false), [Int32]);
+
+        Assert.IsType<LogicalBinary>(result);
+    }
+
+    [Fact]
+    public void ByRefStructFieldOperand_TailConstant_StillFolds()
+    {
+        // `if (c) return r.b; return false;` (by-ref struct `r`, bool field `b`) →
+        // `c && r.b`. The field access reads through the by-ref address with `ldfld` — it
+        // is not a bare `ldind` bool deref, so it is a compound operand csc keeps the `c`
+        // branch for and stays foldable (verified round-4: IL byte-identical, no null-by-
+        // ref throw). Pins non-decline for a by-ref struct field access.
+        var structRef = TypeRef.CoreLib("Synthetic", "S");
+        var field = new FieldRef(structRef, "b", Boolean);
+        var operand = new LoadField(field, new LoadArgument(1, "r", TypeRef.ByRef(structRef)));
         var result = RunGuard(CondCompare(), operand, Bool(false), [Int32]);
 
         Assert.IsType<LogicalBinary>(result);

--- a/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
@@ -144,7 +144,12 @@ public class FoldGuardReturnFidelityTests
     }
 
     // === correctness declines: the wrapped forms the fold's own downstream
-    // transforms would strip back to a bare hazard (adversarial review, #3119) ===
+    // transforms would strip or invert back to a bare hazard (adversarial review,
+    // #3119). The peel is a CONSERVATIVE, negation-parity-agnostic over-approximation:
+    // it follows a hazard through any chain of logical negations and bool-constant
+    // comparisons (both directions), so it also declines the branch-preserving `!x`
+    // forms (`== false` / `!= true`). Declining an extra readable raise is sound;
+    // modeling parity exactly would re-implement FoldBoolConstantComparison + Negate. ===
 
     [Fact]
     public void NegatedTruthinessCondition_TailConstant_IsNotFolded()
@@ -155,6 +160,31 @@ public class FoldGuardReturnFidelityTests
         // which binds the user-defined `|` (typed TruthOver, not bool): non-compiling.
         // The look-through peel must see the truthiness call under the negation.
         AssertDeclined(new LogicalNot(UserTruthiness()), Computed(), Bool(true), [Int32]);
+    }
+
+    [Fact]
+    public void TruthinessUnderEqualsTrueComparison_TailConstant_IsNotFolded()
+    {
+        // `if (t == true) return computed; return false;` reduces `op_True(t) == true`
+        // to the bare `op_True(t)`, which the printer strips to `return t && computed;` —
+        // the user-defined `&` rebind, non-compiling. The peel must see the truthiness
+        // call under the identity comparison the fixpoint strips.
+        var truthEqualsTrue = new Comparison(
+            ComparisonKind.Equal, isUnsigned: false, UserTruthiness(), Bool(true));
+        AssertDeclined(truthEqualsTrue, Computed(), Bool(false), [Int32]);
+    }
+
+    [Fact]
+    public void TruthinessUnderEqualsFalseComparison_TailConstant_IsNotFolded()
+    {
+        // `if (t == false) return computed; return true;` lifts through Conditions.Negate
+        // on the `||` arm, which inverts `op_True(t) == false` to `op_True(t) != false`;
+        // the fixpoint reduces that to the bare `op_True(t)` → `t || computed`, the same
+        // rebind. Both comparison directions must be peeled because the arm decides the
+        // negation.
+        var truthEqualsFalse = new Comparison(
+            ComparisonKind.Equal, isUnsigned: false, UserTruthiness(), Bool(false));
+        AssertDeclined(truthEqualsFalse, Computed(), Bool(true), [Int32]);
     }
 
     [Fact]
@@ -170,18 +200,31 @@ public class FoldGuardReturnFidelityTests
     }
 
     [Fact]
-    public void ByRefDereferenceUnderEqualsFalseComparison_StillFolds()
+    public void ByRefDereferenceUnderDoubleNegatedComparison_IsNotFolded()
     {
-        // `if (c) return *r == false; return false;` folds to `c && (*r == false)`, which
-        // the fixpoint reduces to `c && !*r`. The negating form keeps a `!` (and, per the
-        // merged round-2 boundary, a branch), so the surviving operand is not a bare
-        // deref and the readable fold is kept — the peel declines ONLY the bare-producing
-        // identity forms (`== true` / `!= false`), not `== false` / `!= true`.
+        // `if (c) return (*r == false) == false; return false;`: the outer Negate inverts
+        // the inner comparison and the fixpoint reduces the whole chain back to the bare
+        // `*r` — a branchless eager deref. A single identity peel stops at the outer
+        // negating comparison; following the non-constant side through the full chain is
+        // what reaches the hidden by-ref deref (adversarial review, #3119).
+        var innerEqualsFalse = new Comparison(
+            ComparisonKind.Equal, isUnsigned: false, ByRefBoolDeref(), Bool(false));
+        var doubleNegated = new Comparison(
+            ComparisonKind.Equal, isUnsigned: false, innerEqualsFalse, Bool(false));
+        AssertDeclined(CondCompare(), doubleNegated, Bool(false), [Int32]);
+    }
+
+    [Fact]
+    public void ByRefDereferenceUnderEqualsFalseComparison_IsNotFolded()
+    {
+        // `if (c) return *r == false; return false;` reduces to `c && !*r`. The `!*r`
+        // keeps a branch, so folding here would be sound — but the conservative,
+        // parity-agnostic peel declines it anyway rather than re-simulate the reduction
+        // to distinguish the bare `*r` (hazard) from `!*r` (safe). An extra decline of a
+        // rare, readable by-ref raise is sound.
         var byRefEqualsFalse = new Comparison(
             ComparisonKind.Equal, isUnsigned: false, ByRefBoolDeref(), Bool(false));
-        var result = RunGuard(CondCompare(), byRefEqualsFalse, Bool(false), [Int32]);
-
-        Assert.IsType<LogicalBinary>(result);
+        AssertDeclined(CondCompare(), byRefEqualsFalse, Bool(false), [Int32]);
     }
 
     static IrExpression RunGuard(

--- a/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
@@ -1,0 +1,190 @@
+using System.Collections.Immutable;
+
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// #3114: <c>BooleanFoldingPass.FoldGuardReturn</c> re-forms <c>if (c) return A;
+/// return B;</c> (with a bool-constant arm) into a short-circuit. Most re-forms are
+/// opcode-divergent but VALID readability raises (a block-reordered guard clause, a
+/// both-constant <c>return c</c>) and keep folding; only two shapes produce output
+/// the correctness bar rejects and are declined: a user-defined-truthiness condition
+/// (yields non-compiling C#) and a managed by-ref surviving operand (a branchless
+/// deref that faults where the branch had guarded).
+/// </summary>
+[Trait("Area", "Pass")]
+public class FoldGuardReturnFidelityTests
+{
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Truth = TypeRef.CoreLib("Synthetic", "TruthOver");
+
+    static Constant Bool(bool value) => new(value, Boolean);
+
+    // An integer comparison condition (the common guard test).
+    static Comparison CondCompare()
+        => new(ComparisonKind.GreaterThan, isUnsigned: false, new LoadArgument(0, "s", Int32), new Constant(0, Int32));
+
+    // A computed (non-constant, non-bare-place) bool operand: a comparison. csc keeps
+    // the branch for a computed operand, so the tailConstant fold is opcode-exact.
+    static Comparison Computed()
+        => new(ComparisonKind.GreaterThan, isUnsigned: false, new LoadLocal(1, Int32), new Constant(0, Int32));
+
+    // A user-defined-truthiness condition: the `operator true` call the compiler
+    // inserts for a user type in boolean context.
+    static Call UserTruthiness()
+        => new(new MethodRef(Truth, "op_True", Boolean, [Truth], HasThis: false),
+               isVirtual: false, [new LoadArgument(0, "t", Truth)]);
+
+    // A managed by-ref (`in`/`ref`/`out`) bool dereference.
+    static LoadIndirect ByRefBoolDeref()
+        => new(Boolean, new LoadArgument(1, "r", TypeRef.ByRef(Boolean)));
+
+    // A raw pointer (`bool*`) dereference.
+    static LoadIndirect PointerBoolDeref()
+        => new(Boolean, new LoadArgument(1, "p", TypeRef.Pointer(Boolean)));
+
+    // === accepted readability raises: STILL fold ===
+
+    [Fact]
+    public void TailConstant_ComputedOperand_StillFolds()
+    {
+        // `if (c) return computed; return false;` → `c && computed`. The exact inverse
+        // of csc's `&&` lowering: keeps folding.
+        var result = RunGuard(CondCompare(), Computed(), Bool(false), [Int32, Int32]);
+
+        var logical = Assert.IsType<LogicalBinary>(result);
+        Assert.Equal(LogicalKind.And, logical.Kind);
+    }
+
+    [Fact]
+    public void ThenConstant_GuardClause_StillFolds()
+    {
+        // `if (c) return false; return X;` → `!c && X`. Opcode-divergent (block
+        // reorder) but valid and readable — an accepted readability raise per #3114.
+        var result = RunGuard(CondCompare(), Bool(false), Computed(), [Int32, Int32]);
+
+        var logical = Assert.IsType<LogicalBinary>(result);
+        Assert.Equal(LogicalKind.And, logical.Kind);
+    }
+
+    [Fact]
+    public void BothConstant_StillFolds()
+    {
+        // `if (c) return true; return false;` → `return c`. Opcode-divergent (csc keeps
+        // the branch; `c` is `cgt`) but valid — accepted readability raise.
+        var result = RunGuard(CondCompare(), Bool(true), Bool(false), [Int32]);
+
+        Assert.IsType<Comparison>(result);
+    }
+
+    [Fact]
+    public void TailConstant_BareLocalOperand_StillFolds()
+    {
+        // `if (c) return local; return false;` → `c && local`. csc would emit a
+        // branchless `&` (opcode-divergent), but that is a plain readability raise
+        // richlander chose to keep — only the managed by-ref deref is declined.
+        var result = RunGuard(CondCompare(), new LoadLocal(1, Boolean), Bool(false), [Int32, Boolean]);
+
+        Assert.IsType<LogicalBinary>(result);
+    }
+
+    [Fact]
+    public void TailConstant_PointerDereferenceOperand_StillFolds()
+    {
+        // `if (c) return *p; return false;` → `c && *p`. A pointer read can
+        // access-violate, so csc keeps the branch — folding is safe.
+        var result = RunGuard(CondCompare(), PointerBoolDeref(), Bool(false), [Int32]);
+
+        Assert.IsType<LogicalBinary>(result);
+    }
+
+    // === correctness declines: leave the faithful guarded return ===
+
+    [Fact]
+    public void TruthinessCondition_TailConstant_IsNotFolded()
+    {
+        // `if (t) return computed; return false;` would become `t && computed`, which
+        // binds the user-defined `&` (typed TruthOver, not bool) — non-compiling.
+        AssertDeclined(UserTruthiness(), Computed(), Bool(false), [Int32]);
+    }
+
+    [Fact]
+    public void TruthinessCondition_ThenConstant_IsNotFolded()
+    {
+        // `if (t) return false; return X;` would become `!t && X` — same rebind.
+        AssertDeclined(UserTruthiness(), Bool(false), Computed(), [Int32]);
+    }
+
+    [Fact]
+    public void TruthinessCondition_BothConstant_IsNotFolded()
+    {
+        // `if (t) return true; return false;` would become `return t`, which needs a
+        // nonexistent TruthOver→bool conversion — non-compiling.
+        AssertDeclined(UserTruthiness(), Bool(true), Bool(false), []);
+    }
+
+    [Fact]
+    public void ByRefDereferenceOperand_TailConstant_IsNotFolded()
+    {
+        // `if (c) return *r; return false;` would become `c && *r`, which csc
+        // collapses to a branchless `&` that eagerly dereferences a managed by-ref the
+        // branch had guarded — a NullReferenceException divergence.
+        AssertDeclined(CondCompare(), ByRefBoolDeref(), Bool(false), [Int32]);
+    }
+
+    [Fact]
+    public void ByRefDereferenceOperand_ThenConstant_IsNotFolded()
+    {
+        // `if (c) return false; return *r;` would become `!c && *r` — same eager-deref
+        // divergence on the surviving operand.
+        AssertDeclined(CondCompare(), Bool(false), ByRefBoolDeref(), [Int32]);
+    }
+
+    static IrExpression RunGuard(
+        IrExpression condition, IrExpression thenValue, IrExpression tailValue, ImmutableArray<TypeRef> locals)
+    {
+        var function = BuildGuard(condition, thenValue, tailValue, locals);
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        var ret = Assert.IsType<Return>(Assert.Single(function.Body.Blocks[0].Children));
+        return ret.Value!;
+    }
+
+    static void AssertDeclined(
+        IrExpression condition, IrExpression thenValue, IrExpression tailValue, ImmutableArray<TypeRef> locals)
+    {
+        var function = BuildGuard(condition, thenValue, tailValue, locals);
+        var block = function.Body.Blocks[0];
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Equal(2, block.Children.Count);
+        Assert.IsType<IfStatement>(block.Children[0]);
+        Assert.IsType<Return>(block.Children[1]);
+    }
+
+    static IrFunction BuildGuard(
+        IrExpression condition, IrExpression thenValue, IrExpression tailValue, ImmutableArray<TypeRef> locals)
+    {
+        var then = new Block(0);
+        then.Add(new Return(thenValue));
+        var guard = new IfStatement(condition, then, null);
+
+        var block = new Block(0);
+        block.Add(guard);
+        block.Add(new Return(tailValue));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(
+                Boolean, [new Parameter("s", Int32)], HasThis: false, GenericParameterCount: 0),
+            locals,
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
@@ -227,22 +227,29 @@ public class FoldGuardReturnFidelityTests
         AssertDeclined(CondCompare(), byRefEqualsFalse, Bool(false), [Int32]);
     }
 
-    // === by-ref nested in a composition (adversarial review rounds 3–4, #3119).
+    // === by-ref nested in a composition (adversarial review rounds 3–5, #3119).
     // csc collapses `c && OP` to a branchless `c & OP` only when OP renders as a bare
     // place; the printer flattens a same-kind logical chain, so a by-ref deref that
     // becomes a bare operand of the emitted OUTER-kind chain is eagerly dereferenced
     // (NRE divergence) and is declined — but one confined to a compound operand that
     // keeps its branch (a bitwise `&`, a different-kind logical, a call argument) folds
-    // faithfully. All five shapes below were verified against SDK-csc /optimize IL plus
-    // a null-by-ref runtime probe. ===
+    // faithfully. The reachable-from-csc shapes below (bitwise `a & r`, different-kind
+    // `*r || a`, `*r > 0`, `*r.b`, and the call-barrier chain `*r && Call()`) were each
+    // verified against SDK-csc /optimize IL plus a null-by-ref runtime probe; the pure
+    // same-kind `LogicalBinary` cases are synthetic predicate tests (csc pre-lowers a
+    // bare-operand `a && *r` to bitwise), noted per test. ===
 
     [Fact]
     public void ByRefUnderLogicalAndOperand_TailConstant_IsNotFolded()
     {
-        // `if (c) return a && *r; return false;` → `c && (a && *r)`. The inner `&&` is
-        // the SAME kind as the `&&` lift, so it flattens to `c && a && r` and recompiles
-        // branchless (`c & a & r`), eagerly dereferencing the guarded by-ref (verified:
-        // null-by-ref throws). The by-ref is a bare operand of the flattened And chain.
+        // Synthetic/defensive predicate shape: a same-kind `LogicalBinary(And, a, *r)`.
+        // csc pre-lowers the bare-operand source `a && *r` to a BITWISE `a & r` (see
+        // ByRefUnderBitwiseAndOperand, which folds faithfully), so this literal
+        // LogicalBinary is not what that source imports as — the reachable logical-chain
+        // hazard needs a call barrier that keeps the `&&` (ByRefBeforeCallInLogicalAnd-
+        // Operand, next test). This test pins the by-ref scan: IF a same-kind
+        // `LogicalBinary` reaches the guard, it flattens to `c && a && r`, whose call-free
+        // prefix would collapse branchless (eager by-ref deref), so it is declined.
         var operand = new LogicalBinary(LogicalKind.And, new LoadLocal(1, Boolean), ByRefBoolDeref());
         AssertDeclined(CondCompare(), operand, Bool(false), [Int32, Boolean]);
     }
@@ -260,6 +267,41 @@ public class FoldGuardReturnFidelityTests
             new MethodRef(Holder, "Call", Boolean, [], HasThis: false), isVirtual: false, []);
         var operand = new LogicalBinary(LogicalKind.And, ByRefBoolDeref(), call);
         AssertDeclined(CondCompare(), operand, Bool(false), [Int32]);
+    }
+
+    [Fact]
+    public void ByRefInLogicalAndChainUnderEqualsTrueWrapper_TailConstant_IsNotFolded()
+    {
+        // #3119 round-5 finding 1: a same-kind chain hidden under a reducible `== true`
+        // wrapper. `if (c) return (*r && Call()) == true; return false;` → the fold lifts
+        // `(*r && Call()) == true`; FoldBoolConstantComparison then strips `== true`,
+        // leaving `c && *r && Call()`, whose call-free `c && *r` prefix collapses
+        // branchless (eager by-ref deref — same NRE divergence as the unwrapped chain).
+        // The peel must run BEFORE the same-kind flatten so the buried by-ref is reached;
+        // flattening first would treat the whole `== true` comparison as an opaque compound
+        // and wrongly fold. (The unwrapped chain is `ByRefBeforeCallInLogicalAndOperand`.)
+        var call = new Call(
+            new MethodRef(Holder, "Call", Boolean, [], HasThis: false), isVirtual: false, []);
+        var chain = new LogicalBinary(LogicalKind.And, ByRefBoolDeref(), call);
+        var wrapped = new Comparison(ComparisonKind.Equal, isUnsigned: false, chain, Bool(true));
+        AssertDeclined(CondCompare(), wrapped, Bool(false), [Int32]);
+    }
+
+    [Fact]
+    public void LocalOnlyLogicalAndChainUnderEqualsTrueWrapper_TailConstant_StillFolds()
+    {
+        // Negative for finding 1: the same `== true`-wrapped same-kind chain WITHOUT a
+        // by-ref folds. `if (c) return (a && Call()) == true; return false;` reduces to
+        // `c && a && Call()`; the branchless `c & a` prefix is a valid readability raise
+        // (a local never faults), so the guarded-return fold keeps it. The peel-then-
+        // flatten reaches the local `a` but the by-ref hazard predicate ignores it.
+        var call = new Call(
+            new MethodRef(Holder, "Call", Boolean, [], HasThis: false), isVirtual: false, []);
+        var chain = new LogicalBinary(LogicalKind.And, new LoadLocal(1, Boolean), call);
+        var wrapped = new Comparison(ComparisonKind.Equal, isUnsigned: false, chain, Bool(true));
+        var result = RunGuard(CondCompare(), wrapped, Bool(false), [Int32, Boolean]);
+
+        Assert.IsType<LogicalBinary>(result);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
@@ -227,51 +227,88 @@ public class FoldGuardReturnFidelityTests
         AssertDeclined(CondCompare(), byRefEqualsFalse, Bool(false), [Int32]);
     }
 
-    // === correctness declines: a managed by-ref deref nested inside a raised
-    // logical/bitwise composition (adversarial review round 3, #3119). A leaf-only
-    // peel stops at the composition node and misses the deref; the subtree scan
-    // reaches it. csc branchless-collapses `c && OP` whenever OP is side-effect-free,
-    // so any by-ref deref in a call-free OP becomes an eager deref of a guarded
-    // location — the same NullReferenceException divergence as the bare operand. ===
+    // === by-ref nested in a composition (adversarial review rounds 3–4, #3119).
+    // csc collapses `c && OP` to a branchless `c & OP` only when OP renders as a bare
+    // place; the printer flattens a same-kind logical chain, so a by-ref deref that
+    // becomes a bare operand of the emitted OUTER-kind chain is eagerly dereferenced
+    // (NRE divergence) and is declined — but one confined to a compound operand that
+    // keeps its branch (a bitwise `&`, a different-kind logical, a call argument) folds
+    // faithfully. All five shapes below were verified against SDK-csc /optimize IL plus
+    // a null-by-ref runtime probe. ===
 
     [Fact]
     public void ByRefUnderLogicalAndOperand_TailConstant_IsNotFolded()
     {
-        // `if (c) return a && *r; return false;` → `c && (a && *r)`, which flattens and
-        // recompiles branchless (`c & a & r`), eagerly dereferencing the guarded by-ref.
-        // The old leaf-only peel stopped at the LogicalBinary and missed the nested deref.
+        // `if (c) return a && *r; return false;` → `c && (a && *r)`. The inner `&&` is
+        // the SAME kind as the `&&` lift, so it flattens to `c && a && r` and recompiles
+        // branchless (`c & a & r`), eagerly dereferencing the guarded by-ref (verified:
+        // null-by-ref throws). The by-ref is a bare operand of the flattened And chain.
         var operand = new LogicalBinary(LogicalKind.And, new LoadLocal(1, Boolean), ByRefBoolDeref());
         AssertDeclined(CondCompare(), operand, Bool(false), [Int32, Boolean]);
     }
 
     [Fact]
-    public void ByRefUnderLogicalOrOperand_TailConstant_IsNotFolded()
+    public void ByRefBeforeCallInLogicalAndOperand_TailConstant_IsNotFolded()
     {
-        // `if (c) return *r || a; return false;` → `c && (*r || a)` → branchless
-        // `c & (r | a)`, the same eager deref with the by-ref on the `||` left.
-        var operand = new LogicalBinary(LogicalKind.Or, ByRefBoolDeref(), new LoadLocal(1, Boolean));
-        AssertDeclined(CondCompare(), operand, Bool(false), [Int32, Boolean]);
+        // #3119 round-4 finding 1: a trailing call does NOT guard an earlier by-ref.
+        // `if (c) return *r && Call(); return false;` → `c && (*r && Call())` flattens to
+        // `c && *r && Call()`; the call-free `c && *r` PREFIX collapses branchless
+        // (`c & *r`) before the call is reached, so the by-ref is dereferenced eagerly
+        // (verified: null-by-ref throws). The by-ref is a bare operand of the flattened
+        // And chain even though a call sits later in that chain.
+        var call = new Call(
+            new MethodRef(Holder, "Call", Boolean, [], HasThis: false), isVirtual: false, []);
+        var operand = new LogicalBinary(LogicalKind.And, ByRefBoolDeref(), call);
+        AssertDeclined(CondCompare(), operand, Bool(false), [Int32]);
     }
 
     [Fact]
-    public void ByRefUnderBitwiseAndOperand_TailConstant_IsNotFolded()
+    public void ByRefInSameKindLogicalOperand_TailTrue_OuterOr_IsNotFolded()
     {
-        // The real csc shape: source `if (c) return a && r; return false;` imports with
-        // the inner `a && r` already lowered to a bitwise `a & r` (both operands simple).
-        // Lifting `c && (a & r)` recompiles branchless → eager by-ref deref. The subtree
-        // scan reaches the deref under the bitwise node.
+        // The lift is `||`-kind here (`if (c) return *r || a; return true;` → `!c || (*r
+        // || a)`). Now the inner `||` matches the outer `||`, flattens to `!c || *r || a`,
+        // and collapses branchless — the by-ref is eager. The SAME operand folds under an
+        // `&&` lift (next test); the hazard is outer-kind-relative.
+        var operand = new LogicalBinary(LogicalKind.Or, ByRefBoolDeref(), new LoadLocal(1, Boolean));
+        AssertDeclined(CondCompare(), operand, Bool(true), [Int32, Boolean]);
+    }
+
+    [Fact]
+    public void ByRefInDifferentKindLogicalOperand_TailConstant_StillFolds()
+    {
+        // #3119 round-4 finding 2: `if (c) return *r || a; return false;` → `c && (*r ||
+        // a)`. The inner `||` differs from the `&&` lift, so the printer keeps it a
+        // parenthesized compound the outer `&&` branch guards — the by-ref is read only
+        // when c is true, exactly as in the original (verified: IL byte-identical to the
+        // guarded original, null-by-ref does NOT throw). A faithful, foldable raise.
+        var operand = new LogicalBinary(LogicalKind.Or, ByRefBoolDeref(), new LoadLocal(1, Boolean));
+        var result = RunGuard(CondCompare(), operand, Bool(false), [Int32, Boolean]);
+
+        Assert.IsType<LogicalBinary>(result);
+    }
+
+    [Fact]
+    public void ByRefUnderBitwiseAndOperand_TailConstant_StillFolds()
+    {
+        // #3119 round-4 finding 2: the real csc shape. Source `if (c) return a && r;
+        // return false;` imports with the inner `a && r` already lowered to a bitwise
+        // `a & r`. A bitwise composition is a compound operand csc keeps the `c` branch
+        // for, so `c && (a & r)` recompiles to IL byte-identical to the guarded original
+        // (verified: null-by-ref does NOT throw). My round-3 fix wrongly declined this;
+        // the by-ref is not a bare operand of the And chain.
         var operand = new Binary(BinaryKind.And, isChecked: false, isUnsigned: false,
             new LoadLocal(1, Boolean), ByRefBoolDeref());
-        AssertDeclined(CondCompare(), operand, Bool(false), [Int32, Boolean]);
+        var result = RunGuard(CondCompare(), operand, Bool(false), [Int32, Boolean]);
+
+        Assert.IsType<LogicalBinary>(result);
     }
 
     [Fact]
     public void ByRefBehindCallOperand_TailConstant_StillFolds()
     {
-        // `if (c) return Use(*r); return false;` → `c && Use(*r)`. The call is a
-        // side-effect barrier csc will not hoist past the lift, so it keeps the branch
-        // and the by-ref deref stays guarded — a faithful, foldable readability raise.
-        // The scan must NOT over-decline a by-ref that only appears inside a call.
+        // `if (c) return Use(*r); return false;` → `c && Use(*r)`. The by-ref is a call
+        // argument, so it lives inside the compound call operand the `c` branch guards —
+        // it is not a bare operand of the And chain, and folding stays faithful.
         var operand = new Call(
             new MethodRef(Holder, "Use", Boolean, [Boolean], HasThis: false),
             isVirtual: false, [ByRefBoolDeref()]);

--- a/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
@@ -227,6 +227,59 @@ public class FoldGuardReturnFidelityTests
         AssertDeclined(CondCompare(), byRefEqualsFalse, Bool(false), [Int32]);
     }
 
+    // === correctness declines: a managed by-ref deref nested inside a raised
+    // logical/bitwise composition (adversarial review round 3, #3119). A leaf-only
+    // peel stops at the composition node and misses the deref; the subtree scan
+    // reaches it. csc branchless-collapses `c && OP` whenever OP is side-effect-free,
+    // so any by-ref deref in a call-free OP becomes an eager deref of a guarded
+    // location — the same NullReferenceException divergence as the bare operand. ===
+
+    [Fact]
+    public void ByRefUnderLogicalAndOperand_TailConstant_IsNotFolded()
+    {
+        // `if (c) return a && *r; return false;` → `c && (a && *r)`, which flattens and
+        // recompiles branchless (`c & a & r`), eagerly dereferencing the guarded by-ref.
+        // The old leaf-only peel stopped at the LogicalBinary and missed the nested deref.
+        var operand = new LogicalBinary(LogicalKind.And, new LoadLocal(1, Boolean), ByRefBoolDeref());
+        AssertDeclined(CondCompare(), operand, Bool(false), [Int32, Boolean]);
+    }
+
+    [Fact]
+    public void ByRefUnderLogicalOrOperand_TailConstant_IsNotFolded()
+    {
+        // `if (c) return *r || a; return false;` → `c && (*r || a)` → branchless
+        // `c & (r | a)`, the same eager deref with the by-ref on the `||` left.
+        var operand = new LogicalBinary(LogicalKind.Or, ByRefBoolDeref(), new LoadLocal(1, Boolean));
+        AssertDeclined(CondCompare(), operand, Bool(false), [Int32, Boolean]);
+    }
+
+    [Fact]
+    public void ByRefUnderBitwiseAndOperand_TailConstant_IsNotFolded()
+    {
+        // The real csc shape: source `if (c) return a && r; return false;` imports with
+        // the inner `a && r` already lowered to a bitwise `a & r` (both operands simple).
+        // Lifting `c && (a & r)` recompiles branchless → eager by-ref deref. The subtree
+        // scan reaches the deref under the bitwise node.
+        var operand = new Binary(BinaryKind.And, isChecked: false, isUnsigned: false,
+            new LoadLocal(1, Boolean), ByRefBoolDeref());
+        AssertDeclined(CondCompare(), operand, Bool(false), [Int32, Boolean]);
+    }
+
+    [Fact]
+    public void ByRefBehindCallOperand_TailConstant_StillFolds()
+    {
+        // `if (c) return Use(*r); return false;` → `c && Use(*r)`. The call is a
+        // side-effect barrier csc will not hoist past the lift, so it keeps the branch
+        // and the by-ref deref stays guarded — a faithful, foldable readability raise.
+        // The scan must NOT over-decline a by-ref that only appears inside a call.
+        var operand = new Call(
+            new MethodRef(Holder, "Use", Boolean, [Boolean], HasThis: false),
+            isVirtual: false, [ByRefBoolDeref()]);
+        var result = RunGuard(CondCompare(), operand, Bool(false), [Int32]);
+
+        Assert.IsType<LogicalBinary>(result);
+    }
+
     static IrExpression RunGuard(
         IrExpression condition, IrExpression thenValue, IrExpression tailValue, ImmutableArray<TypeRef> locals)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -498,20 +498,40 @@ public sealed class BooleanFoldingPass : IIrPass
         if (ShortCircuitFidelity.IsUserDefinedTruthiness(guard.Condition))
             return false;
 
-        // 2. When the surviving (short-circuited) operand is a managed by-ref
-        //    dereference, csc collapses the spelled `&&`/`||` to a branchless `&`/`|`
-        //    that eagerly dereferences a location the branch had guarded — an
-        //    observable NullReferenceException divergence. The both-constant arm lifts
-        //    no operand; the tailConstant arm lifts `thenValue`, the thenConstant arm
-        //    lifts `tailValue`. (A bare local or pointer deref stays a readability
-        //    raise and is left to fold.)
+        // 2. When the surviving (short-circuited) operand would eagerly dereference a
+        //    managed by-ref, csc collapses the spelled `&&`/`||` to a branchless `&`/`|`
+        //    that dereferences a location the branch had guarded — an observable
+        //    NullReferenceException divergence. The hazard depends on the OUTER logical
+        //    kind the fold emits: the printer flattens only a same-kind chain, so a
+        //    by-ref under a `||` operand of an `&&` lift (or vice versa) stays a guarded
+        //    compound and folds faithfully. The both-constant arm lifts no operand; the
+        //    tailConstant arm lifts `thenValue` under `tailBool ? Or : And`, the
+        //    thenConstant arm lifts `tailValue` under `thenConstant ? Or : And`. (A bare
+        //    local or pointer deref stays a readability raise and is left to fold.)
         bool bothOppositeConstants =
             thenConstant is { } thenC && tailConstant is { } tailC && thenC != tailC;
-        IrExpression? survivingOperand = bothOppositeConstants ? null
-            : tailConstant is not null ? thenValue
-            : tailValue;
-        if (survivingOperand is not null && ShortCircuitFidelity.IsManagedByRefDeref(survivingOperand))
+        IrExpression? survivingOperand;
+        LogicalKind outerKind;
+        if (bothOppositeConstants)
+        {
+            survivingOperand = null;
+            outerKind = default;
+        }
+        else if (tailConstant is { } tailBool0)
+        {
+            survivingOperand = thenValue;
+            outerKind = tailBool0 ? LogicalKind.Or : LogicalKind.And;
+        }
+        else
+        {
+            survivingOperand = tailValue;
+            outerKind = thenConstant!.Value ? LogicalKind.Or : LogicalKind.And;
+        }
+        if (survivingOperand is not null
+            && ShortCircuitFidelity.LiftEagerlyDerefsByRef(survivingOperand, outerKind))
+        {
             return false;
+        }
 
         var condition = guard.Condition;
         condition.Detach();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -485,6 +485,34 @@ public sealed class BooleanFoldingPass : IIrPass
         if (tailConstant is null && thenConstant is null)
             return false;  // general ternary returns are a separate decision
 
+        // #3114: decline the two folds whose output the correctness bar rejects, so
+        // the faithful guarded return stands. (The opcode-divergent but VALID and
+        // readable re-forms — a block-reordered guard clause and the both-constant
+        // `return c` — are accepted readability raises and still fold.)
+        //
+        // 1. A user-defined-truthiness condition (`operator true`/`operator false`)
+        //    prints as its bare receiver, so returning or lifting it yields C# that
+        //    does not bind: `return t` needs a nonexistent user→bool conversion, and
+        //    `t && A` binds the user-defined `&` (result typed as the user type, not
+        //    bool). Declined in every arm.
+        if (ShortCircuitFidelity.IsUserDefinedTruthiness(guard.Condition))
+            return false;
+
+        // 2. When the surviving (short-circuited) operand is a managed by-ref
+        //    dereference, csc collapses the spelled `&&`/`||` to a branchless `&`/`|`
+        //    that eagerly dereferences a location the branch had guarded — an
+        //    observable NullReferenceException divergence. The both-constant arm lifts
+        //    no operand; the tailConstant arm lifts `thenValue`, the thenConstant arm
+        //    lifts `tailValue`. (A bare local or pointer deref stays a readability
+        //    raise and is left to fold.)
+        bool bothOppositeConstants =
+            thenConstant is { } thenC && tailConstant is { } tailC && thenC != tailC;
+        IrExpression? survivingOperand = bothOppositeConstants ? null
+            : tailConstant is not null ? thenValue
+            : tailValue;
+        if (survivingOperand is not null && ShortCircuitFidelity.IsManagedByRefDeref(survivingOperand))
+            return false;
+
         var condition = guard.Condition;
         condition.Detach();
         IrExpression folded;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
@@ -1,0 +1,43 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Fidelity predicates shared by the two short-circuit re-forms —
+/// <see cref="ShortCircuitTernaryPass"/> (constant-arm ternary) and
+/// <see cref="BooleanFoldingPass"/>'s guarded-return fold. Both lift a lowered
+/// branch shape into a spelled <c>&amp;&amp;</c>/<c>||</c>; these identify the
+/// condition and operand shapes where that lift would change the bound C#
+/// semantics or produce output that does not compile. Sharing keeps the two
+/// passes' hazard sets from drifting apart.
+/// </summary>
+internal static class ShortCircuitFidelity
+{
+    /// <summary>
+    /// Whether <paramref name="condition"/> is a user-defined-truthiness evaluation
+    /// — a call to <c>operator true</c>/<c>operator false</c> the compiler inserts
+    /// when a user type is used in boolean context. The printer strips such a call
+    /// to its bare user-typed receiver (it renders <c>op_True(a)</c>/<c>op_False(a)</c>
+    /// as <c>a</c>), so lifting or returning the receiver rebinds to a user-defined
+    /// or nonexistent operator: <c>a || y</c>/<c>a &amp;&amp; y</c> bind the
+    /// user-defined conditional <c>|</c>/<c>&amp;</c> (result typed as the user type,
+    /// not <c>bool</c>), and a bare <c>return a</c> needs a user→bool conversion that
+    /// does not exist. Only a type carrying <c>op_True</c>/<c>op_False</c> reaches
+    /// here, so this is the complete rebind set; a primitive-bool condition
+    /// (comparison, bool property/field/local/method, nested logical operator) binds
+    /// the primitive operator and is safe to lift.
+    /// </summary>
+    internal static bool IsUserDefinedTruthiness(IrExpression condition)
+        => condition is Call { Callee.Name: "op_True" or "op_False" };
+
+    /// <summary>
+    /// Whether <paramref name="operand"/> is a managed by-ref (<c>in</c>/<c>ref</c>/
+    /// <c>out</c>) dereference. csc treats a managed by-ref as non-null and
+    /// side-effect-free, so a spelled <c>a &amp;&amp; *r</c>/<c>a || *r</c> collapses
+    /// to a branchless <c>&amp;</c>/<c>|</c> that eagerly dereferences a location the
+    /// branch had guarded — an observable <see cref="System.NullReferenceException"/>
+    /// divergence on a null by-ref. A raw <em>pointer</em> dereference <c>*p</c> is
+    /// deliberately excluded: a pointer read can access-violate, so csc keeps the
+    /// branch and lifting it is safe.
+    /// </summary>
+    internal static bool IsManagedByRefDeref(IrExpression operand)
+        => operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
@@ -56,9 +56,11 @@ internal static class ShortCircuitFidelity
     /// flattened <paramref name="outerKind"/> chain: a bare <c>*r</c>, a <c>*r == true</c>
     /// wrapper the fixpoint reduces back to a bare <c>*r</c>, or one under a same-kind
     /// logical composition (<c>a &amp;&amp; *r</c>, <c>*r &amp;&amp; Call()</c> when
-    /// <paramref name="outerKind"/> is <c>And</c>). It is NOT a hazard when the by-ref
-    /// dereference is confined to a compound operand that keeps the branch: a bitwise
-    /// composition (<c>a &amp; *r</c>), a different-kind logical sub-expression
+    /// <paramref name="outerKind"/> is <c>And</c>) — including a same-kind chain itself
+    /// hidden under such a reducible wrapper (<c>(*r &amp;&amp; Call()) == true</c>), which
+    /// is why the peel runs BEFORE the same-kind flatten and recurses. It is NOT a hazard
+    /// when the by-ref dereference is confined to a compound operand that keeps the branch:
+    /// a bitwise composition (<c>a &amp; *r</c>), a different-kind logical sub-expression
     /// (<c>*r || a</c> under an <c>And</c> lift), a comparison (<c>*r &gt; 0</c>), a by-ref
     /// struct field (<c>r.b</c>), or a call argument (<c>SomeCall(*r)</c>) — all recompile
     /// with the guard intact and stay foldable. The shared, parity-agnostic
@@ -81,39 +83,19 @@ internal static class ShortCircuitFidelity
     /// </summary>
     internal static bool LiftEagerlyDerefsByRef(IrExpression operand, LogicalKind outerKind)
     {
-        foreach (var chainOperand in FlattenLogicalChain(operand, outerKind))
+        // Peel BEFORE classifying the node: a same-kind chain hidden under a reducible
+        // `== true`/`!= false` wrapper (which FoldBoolConstantComparison later strips,
+        // splicing the chain into the surrounding `outerKind` chain — e.g.
+        // `(*r && Call()) == true` reduces to `*r && Call()`) must be flattened so its
+        // by-ref operands are reached. Peeling only after flattening treats such a
+        // wrapper as an opaque compound and misses the buried by-ref.
+        var peeled = PeelReducibleBoolWrappers(operand);
+        if (peeled is LogicalBinary logical && logical.Kind == outerKind)
         {
-            if (PeelReducibleBoolWrappers(chainOperand)
-                is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef })
-            {
-                return true;
-            }
+            return LiftEagerlyDerefsByRef(logical.Left, outerKind)
+                || LiftEagerlyDerefsByRef(logical.Right, outerKind);
         }
-        return false;
-    }
-
-    /// <summary>
-    /// The operands of the maximal logical chain of <paramref name="outerKind"/>
-    /// (<c>&amp;&amp;</c> or <c>||</c>) rooted at <paramref name="expression"/> — the
-    /// operands the printer's same-kind flattening would splice into the surrounding
-    /// <c>c <paramref name="outerKind"/> …</c> chain. A <see cref="LogicalBinary"/> of the
-    /// same kind is descended into; anything else (a different-kind logical, a bitwise
-    /// composition, a comparison, a call, a bare place) is a single opaque operand that
-    /// keeps its own branch and is yielded whole.
-    /// </summary>
-    static IEnumerable<IrExpression> FlattenLogicalChain(IrExpression expression, LogicalKind outerKind)
-    {
-        if (expression is LogicalBinary logical && logical.Kind == outerKind)
-        {
-            foreach (var operand in FlattenLogicalChain(logical.Left, outerKind))
-                yield return operand;
-            foreach (var operand in FlattenLogicalChain(logical.Right, outerKind))
-                yield return operand;
-        }
-        else
-        {
-            yield return expression;
-        }
+        return peeled is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
     }
 
     /// <summary>
@@ -138,8 +120,9 @@ internal static class ShortCircuitFidelity
     /// fragile second implementation this intentionally avoids. (For the ternary re-form
     /// the comparison reduction has already run upstream, so only the negation peel is
     /// live there. It also serves <see cref="LiftEagerlyDerefsByRef"/>, which peels each
-    /// flattened chain operand so a by-ref deref hidden under a <c>== true</c>/<c>!</c>
-    /// wrapper is still reached.)
+    /// operand BEFORE the same-kind flatten so a by-ref deref hidden under a
+    /// <c>== true</c>/<c>!</c> wrapper — even one wrapping a whole same-kind chain — is
+    /// still reached.)
     /// </summary>
     static IrExpression PeelReducibleBoolWrappers(IrExpression expression)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
@@ -14,81 +14,93 @@ internal static class ShortCircuitFidelity
     /// <summary>
     /// Whether <paramref name="condition"/> is a user-defined-truthiness evaluation
     /// — a call to <c>operator true</c>/<c>operator false</c> the compiler inserts
-    /// when a user type is used in boolean context, optionally under one or more
-    /// logical negations. The printer strips such a call to its bare user-typed
-    /// receiver (it renders <c>op_True(a)</c>/<c>op_False(a)</c> — and their negations
-    /// — as <c>a</c>/inverted <c>a</c>), so lifting or returning the receiver rebinds
-    /// to a user-defined or nonexistent operator: <c>a || y</c>/<c>a &amp;&amp; y</c>
-    /// bind the user-defined conditional <c>|</c>/<c>&amp;</c> (result typed as the
-    /// user type, not <c>bool</c>), and a bare <c>return a</c> needs a user→bool
-    /// conversion that does not exist.
+    /// when a user type is used in boolean context, possibly wrapped by the negations
+    /// and bool-constant comparisons the fold's own fixpoint peels away (see
+    /// <see cref="PeelReducibleBoolWrappers"/>). The printer strips such a call to its
+    /// bare user-typed receiver (it renders <c>op_True(a)</c>/<c>op_False(a)</c> as
+    /// <c>a</c>), so lifting or returning the receiver rebinds to a user-defined or
+    /// nonexistent operator: <c>a || y</c>/<c>a &amp;&amp; y</c> bind the user-defined
+    /// conditional <c>|</c>/<c>&amp;</c> (result typed as the user type, not
+    /// <c>bool</c>), and a bare <c>return a</c> needs a user→bool conversion that does
+    /// not exist.
     ///
-    /// The leading-negation peel is load-bearing: the guarded-return fold lifts the
-    /// condition through <see cref="Conditions.Negate"/> on its <c>||</c>/negated
-    /// <c>&amp;&amp;</c> arms, which unwraps a <c>LogicalNot</c> and re-exposes the
-    /// bare truthiness call — so a <c>!op_True(a)</c> condition would otherwise slip
-    /// past a match on the raw shape.
-    ///
-    /// Only a type carrying <c>op_True</c>/<c>op_False</c> reaches here, so this is the
-    /// complete rebind set; a primitive-bool condition (comparison, bool
-    /// property/field/local/method, nested logical operator) binds the primitive
-    /// operator and is safe to lift.
+    /// Only a type carrying <c>op_True</c>/<c>op_False</c> reaches the leaf, so this is
+    /// the complete rebind set; a primitive-bool condition (comparison against a non-
+    /// truthiness value, bool property/field/local/method, nested logical operator)
+    /// binds the primitive operator and is safe to lift.
     /// </summary>
     internal static bool IsUserDefinedTruthiness(IrExpression condition)
-    {
-        var inner = condition;
-        while (inner is LogicalNot { Operand: { } negated })
-            inner = negated;
-        return inner is Call { Callee.Name: "op_True" or "op_False" };
-    }
+        => PeelReducibleBoolWrappers(condition) is Call { Callee.Name: "op_True" or "op_False" };
 
     /// <summary>
-    /// Whether <paramref name="operand"/> is (or, after the bool-constant-comparison
-    /// reduction the lift's own pass will apply, becomes) a managed by-ref
-    /// (<c>in</c>/<c>ref</c>/<c>out</c>) dereference. csc treats a managed by-ref as
-    /// non-null and side-effect-free, so a spelled <c>a &amp;&amp; *r</c>/<c>a || *r</c>
-    /// collapses to a branchless <c>&amp;</c>/<c>|</c> that eagerly dereferences a
-    /// location the branch had guarded — an observable
-    /// <see cref="System.NullReferenceException"/> divergence on a null by-ref.
-    ///
-    /// The identity-comparison peel is load-bearing for the guarded-return fold: it
-    /// lifts the surviving operand <em>before</em> <see cref="BooleanFoldingPass"/>'s
-    /// fixpoint reduces an identity bool-constant comparison (<c>x == true</c> /
-    /// <c>x != false</c>) to the bare <c>x</c>. Peeling exactly those forms — the ones
-    /// that strip to a bare operand, not the <c>== false</c> / <c>!= true</c> forms
-    /// that keep a negation (and a branch) — reaches a by-ref deref hiding under
-    /// <c>(*r) == true</c>. (For the ternary re-form this reduction has already run,
-    /// so the peel is inert there.)
-    ///
-    /// A raw <em>pointer</em> dereference <c>*p</c> is deliberately excluded: a pointer
-    /// read can access-violate, so csc keeps the branch and lifting it is safe.
+    /// Whether <paramref name="operand"/> is (or, after the fold's own fixpoint peels
+    /// the wrappers in <see cref="PeelReducibleBoolWrappers"/>, becomes) a managed
+    /// by-ref (<c>in</c>/<c>ref</c>/<c>out</c>) dereference. csc treats a managed
+    /// by-ref as non-null and side-effect-free, so a spelled <c>a &amp;&amp; *r</c>/
+    /// <c>a || *r</c> collapses to a branchless <c>&amp;</c>/<c>|</c> that eagerly
+    /// dereferences a location the branch had guarded — an observable
+    /// <see cref="System.NullReferenceException"/> divergence on a null by-ref. A raw
+    /// <em>pointer</em> dereference <c>*p</c> is deliberately excluded: a pointer read
+    /// can access-violate, so csc keeps the branch and lifting it is safe.
     /// </summary>
     internal static bool IsManagedByRefDeref(IrExpression operand)
+        => PeelReducibleBoolWrappers(operand) is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+
+    /// <summary>
+    /// Follow the reducible operand through the wrappers that
+    /// <see cref="BooleanFoldingPass"/>'s fixpoint strips or inverts <em>after</em> its
+    /// guarded-return fold has already lifted the expression: leading logical negations
+    /// (the fold lifts a condition through <see cref="Conditions.Negate"/> on its
+    /// <c>||</c>/negated-<c>&amp;&amp;</c> arms), and bool-constant comparisons
+    /// (<c>x == true</c>/<c>x == false</c>/<c>x != true</c>/<c>x != false</c>) that
+    /// <c>FoldBoolConstantComparison</c> reduces to <c>x</c> or <c>!x</c>. It follows the
+    /// non-constant side of each comparison so a hazard nested under any chain of these
+    /// wrappers is still reached — e.g. the double negation <c>(*r == false) == false</c>
+    /// whose outer <see cref="Conditions.Negate"/> inverts the inner comparison and
+    /// reduces back to the bare <c>*r</c>, or <c>op_True(t) == false</c> whose inversion
+    /// re-exposes the bare truthiness call.
+    ///
+    /// This is a deliberate CONSERVATIVE over-approximation: it ignores negation parity,
+    /// so it treats <c>!x</c> forms (which keep a branch — e.g. the safe
+    /// <c>c &amp;&amp; !*r</c>, or a valid inverted-truthiness <c>(t ? false : true)</c>)
+    /// the same as the bare hazard and may decline a valid, branch-preserving raise.
+    /// Declining an extra readable raise is sound; emitting a rebound or eager-deref one
+    /// is not. Modeling parity exactly would require re-simulating
+    /// <c>FoldBoolConstantComparison</c> and <see cref="Conditions.Negate"/> here — a
+    /// fragile second implementation this intentionally avoids. (For the ternary re-form
+    /// the comparison reduction has already run upstream, so only the negation peel is
+    /// live there.)
+    /// </summary>
+    static IrExpression PeelReducibleBoolWrappers(IrExpression expression)
     {
-        var inner = operand;
-        while (StripBareBoolComparison(inner) is { } bare)
-            inner = bare;
-        return inner is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+        var inner = expression;
+        while (true)
+        {
+            if (inner is LogicalNot { Operand: { } negated })
+                inner = negated;
+            else if (BoolConstantComparisonOperand(inner) is { } operand)
+                inner = operand;
+            else
+                return inner;
+        }
     }
 
     /// <summary>
-    /// The bare left operand that <see cref="BooleanFoldingPass"/>'s
-    /// <c>FoldBoolConstantComparison</c> reduces an identity bool test to — <c>x</c>
-    /// from <c>x == true</c> or <c>x != false</c> (a bool-typed left compared to a
-    /// right-hand bool <c>0</c>/<c>1</c> constant). Returns null for the negating
-    /// forms (<c>x == false</c> / <c>x != true</c>, which fold to <c>!x</c> and keep a
-    /// branch) and for any non-identity shape.
+    /// The non-constant operand of a bool-constant comparison
+    /// <c>FoldBoolConstantComparison</c> reduces — the bool-typed left side of
+    /// <c>x == true</c>/<c>x == false</c>/<c>x != true</c>/<c>x != false</c> (a
+    /// right-hand bool <c>0</c>/<c>1</c> constant), regardless of comparison direction.
+    /// Both directions are followed because the guarded-return fold's
+    /// <see cref="Conditions.Negate"/> can invert the comparison on its arm before the
+    /// reduction runs. Returns null for any non-reducible shape.
     /// </summary>
-    static IrExpression? StripBareBoolComparison(IrExpression expression)
+    static IrExpression? BoolConstantComparisonOperand(IrExpression expression)
     {
         if (expression is not Comparison { Kind: ComparisonKind.Equal or ComparisonKind.NotEqual } comparison)
             return null;
         if (comparison.Left.ResultType is not { Namespace: "System", Name: "Boolean" })
             return null;
-        if (BoolConstantValue(comparison.Right) is not { } constant)
-            return null;
-        bool keepIdentity = constant == (comparison.Kind == ComparisonKind.Equal);
-        return keepIdentity ? comparison.Left : null;
+        return BoolConstantValue(comparison.Right) is not null ? comparison.Left : null;
     }
 
     static bool? BoolConstantValue(IrExpression expression) => expression switch

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
@@ -33,18 +33,49 @@ internal static class ShortCircuitFidelity
         => PeelReducibleBoolWrappers(condition) is Call { Callee.Name: "op_True" or "op_False" };
 
     /// <summary>
-    /// Whether <paramref name="operand"/> is (or, after the fold's own fixpoint peels
-    /// the wrappers in <see cref="PeelReducibleBoolWrappers"/>, becomes) a managed
-    /// by-ref (<c>in</c>/<c>ref</c>/<c>out</c>) dereference. csc treats a managed
-    /// by-ref as non-null and side-effect-free, so a spelled <c>a &amp;&amp; *r</c>/
-    /// <c>a || *r</c> collapses to a branchless <c>&amp;</c>/<c>|</c> that eagerly
-    /// dereferences a location the branch had guarded — an observable
-    /// <see cref="System.NullReferenceException"/> divergence on a null by-ref. A raw
-    /// <em>pointer</em> dereference <c>*p</c> is deliberately excluded: a pointer read
+    /// Whether lifting <paramref name="operand"/> behind a spelled <c>&amp;&amp;</c>/
+    /// <c>||</c> would eagerly dereference a managed by-ref
+    /// (<c>in</c>/<c>ref</c>/<c>out</c>) the branch had guarded. csc treats a managed
+    /// by-ref as non-null and side-effect-free, so it collapses <c>c &amp;&amp; OP</c>
+    /// to a branchless <c>c &amp; OP</c> whenever <c>OP</c> is entirely side-effect-free
+    /// (has no call). That collapse re-evaluates every by-ref dereference in <c>OP</c>
+    /// unconditionally — an observable <see cref="System.NullReferenceException"/>
+    /// divergence on a null by-ref that the compiler's branch had short-circuited.
+    ///
+    /// So the hazard is present exactly when <c>OP</c> contains a managed by-ref
+    /// dereference AND contains no call: a bare <c>*r</c>, a bool-constant comparison
+    /// (<c>*r == true</c>) or negation (<c>!*r</c>) over one, or — the case the earlier
+    /// leaf-only peel missed — one nested inside a raised logical/bitwise composition
+    /// (<c>a &amp;&amp; *r</c>, <c>a &amp; *r</c>, <c>r | a</c>; csc branchless-collapses
+    /// the inner <c>a &amp;&amp; r</c> to <c>a &amp; r</c>, and the outer lift then
+    /// collapses that whole operand). Conversely a call anywhere in <c>OP</c> is a
+    /// side-effect barrier csc will not hoist past the lift, so it keeps the branch and
+    /// guards the whole operand — <c>c &amp;&amp; SomeCall(*r)</c> stays faithful and is
+    /// deliberately kept foldable. A raw <em>pointer</em> dereference <c>*p</c> is
+    /// excluded (its address kind is not <see cref="TypeRefKind.ByRef"/>): a pointer read
     /// can access-violate, so csc keeps the branch and lifting it is safe.
     /// </summary>
     internal static bool IsManagedByRefDeref(IrExpression operand)
-        => PeelReducibleBoolWrappers(operand) is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+        => ContainsManagedByRefDereference(operand) && !ContainsCall(operand);
+
+    /// <summary>
+    /// Whether the <paramref name="operand"/> subtree contains a managed by-ref
+    /// (<c>in</c>/<c>ref</c>/<c>out</c>) dereference. A raw pointer dereference is
+    /// excluded — only <see cref="TypeRefKind.ByRef"/> addresses qualify.
+    /// </summary>
+    static bool ContainsManagedByRefDereference(IrExpression operand)
+        => operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef }
+            || operand.Descendants.OfType<LoadIndirect>().Any(load => load.Address.ResultType is { Kind: TypeRefKind.ByRef });
+
+    /// <summary>
+    /// Whether the <paramref name="operand"/> subtree contains a call — the
+    /// side-effect barrier csc will not hoist past a lifted short-circuit, so it keeps
+    /// the compiler's branch and every by-ref dereference the call transitively guards
+    /// stays guarded.
+    /// </summary>
+    static bool ContainsCall(IrExpression operand)
+        => operand is Call or CallIndirect
+            || operand.Descendants.Any(node => node is Call or CallIndirect);
 
     /// <summary>
     /// Follow the reducible operand through the wrappers that
@@ -54,22 +85,21 @@ internal static class ShortCircuitFidelity
     /// <c>||</c>/negated-<c>&amp;&amp;</c> arms), and bool-constant comparisons
     /// (<c>x == true</c>/<c>x == false</c>/<c>x != true</c>/<c>x != false</c>) that
     /// <c>FoldBoolConstantComparison</c> reduces to <c>x</c> or <c>!x</c>. It follows the
-    /// non-constant side of each comparison so a hazard nested under any chain of these
-    /// wrappers is still reached — e.g. the double negation <c>(*r == false) == false</c>
-    /// whose outer <see cref="Conditions.Negate"/> inverts the inner comparison and
-    /// reduces back to the bare <c>*r</c>, or <c>op_True(t) == false</c> whose inversion
-    /// re-exposes the bare truthiness call.
+    /// non-constant side of each comparison so a truthiness call nested under any chain of
+    /// these wrappers is still reached — e.g. <c>op_True(t) == false</c> whose outer
+    /// <see cref="Conditions.Negate"/> inverts the inner comparison and reduces back to
+    /// the bare truthiness call, or the double negation <c>(op_True(t) == false) == false</c>.
     ///
     /// This is a deliberate CONSERVATIVE over-approximation: it ignores negation parity,
-    /// so it treats <c>!x</c> forms (which keep a branch — e.g. the safe
-    /// <c>c &amp;&amp; !*r</c>, or a valid inverted-truthiness <c>(t ? false : true)</c>)
-    /// the same as the bare hazard and may decline a valid, branch-preserving raise.
-    /// Declining an extra readable raise is sound; emitting a rebound or eager-deref one
-    /// is not. Modeling parity exactly would require re-simulating
+    /// so it treats <c>!x</c> forms (which keep a branch — e.g. a valid inverted-truthiness
+    /// <c>(t ? false : true)</c>) the same as the bare hazard and may decline a valid,
+    /// branch-preserving raise. Declining an extra readable raise is sound; emitting a
+    /// rebound one is not. Modeling parity exactly would require re-simulating
     /// <c>FoldBoolConstantComparison</c> and <see cref="Conditions.Negate"/> here — a
     /// fragile second implementation this intentionally avoids. (For the ternary re-form
     /// the comparison reduction has already run upstream, so only the negation peel is
-    /// live there.)
+    /// live there. The by-ref hazard no longer routes through this peel — see
+    /// <see cref="IsManagedByRefDeref"/>, which scans the whole operand subtree.)
     /// </summary>
     static IrExpression PeelReducibleBoolWrappers(IrExpression expression)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
@@ -14,30 +14,87 @@ internal static class ShortCircuitFidelity
     /// <summary>
     /// Whether <paramref name="condition"/> is a user-defined-truthiness evaluation
     /// — a call to <c>operator true</c>/<c>operator false</c> the compiler inserts
-    /// when a user type is used in boolean context. The printer strips such a call
-    /// to its bare user-typed receiver (it renders <c>op_True(a)</c>/<c>op_False(a)</c>
-    /// as <c>a</c>), so lifting or returning the receiver rebinds to a user-defined
-    /// or nonexistent operator: <c>a || y</c>/<c>a &amp;&amp; y</c> bind the
-    /// user-defined conditional <c>|</c>/<c>&amp;</c> (result typed as the user type,
-    /// not <c>bool</c>), and a bare <c>return a</c> needs a user→bool conversion that
-    /// does not exist. Only a type carrying <c>op_True</c>/<c>op_False</c> reaches
-    /// here, so this is the complete rebind set; a primitive-bool condition
-    /// (comparison, bool property/field/local/method, nested logical operator) binds
-    /// the primitive operator and is safe to lift.
+    /// when a user type is used in boolean context, optionally under one or more
+    /// logical negations. The printer strips such a call to its bare user-typed
+    /// receiver (it renders <c>op_True(a)</c>/<c>op_False(a)</c> — and their negations
+    /// — as <c>a</c>/inverted <c>a</c>), so lifting or returning the receiver rebinds
+    /// to a user-defined or nonexistent operator: <c>a || y</c>/<c>a &amp;&amp; y</c>
+    /// bind the user-defined conditional <c>|</c>/<c>&amp;</c> (result typed as the
+    /// user type, not <c>bool</c>), and a bare <c>return a</c> needs a user→bool
+    /// conversion that does not exist.
+    ///
+    /// The leading-negation peel is load-bearing: the guarded-return fold lifts the
+    /// condition through <see cref="Conditions.Negate"/> on its <c>||</c>/negated
+    /// <c>&amp;&amp;</c> arms, which unwraps a <c>LogicalNot</c> and re-exposes the
+    /// bare truthiness call — so a <c>!op_True(a)</c> condition would otherwise slip
+    /// past a match on the raw shape.
+    ///
+    /// Only a type carrying <c>op_True</c>/<c>op_False</c> reaches here, so this is the
+    /// complete rebind set; a primitive-bool condition (comparison, bool
+    /// property/field/local/method, nested logical operator) binds the primitive
+    /// operator and is safe to lift.
     /// </summary>
     internal static bool IsUserDefinedTruthiness(IrExpression condition)
-        => condition is Call { Callee.Name: "op_True" or "op_False" };
+    {
+        var inner = condition;
+        while (inner is LogicalNot { Operand: { } negated })
+            inner = negated;
+        return inner is Call { Callee.Name: "op_True" or "op_False" };
+    }
 
     /// <summary>
-    /// Whether <paramref name="operand"/> is a managed by-ref (<c>in</c>/<c>ref</c>/
-    /// <c>out</c>) dereference. csc treats a managed by-ref as non-null and
-    /// side-effect-free, so a spelled <c>a &amp;&amp; *r</c>/<c>a || *r</c> collapses
-    /// to a branchless <c>&amp;</c>/<c>|</c> that eagerly dereferences a location the
-    /// branch had guarded — an observable <see cref="System.NullReferenceException"/>
-    /// divergence on a null by-ref. A raw <em>pointer</em> dereference <c>*p</c> is
-    /// deliberately excluded: a pointer read can access-violate, so csc keeps the
-    /// branch and lifting it is safe.
+    /// Whether <paramref name="operand"/> is (or, after the bool-constant-comparison
+    /// reduction the lift's own pass will apply, becomes) a managed by-ref
+    /// (<c>in</c>/<c>ref</c>/<c>out</c>) dereference. csc treats a managed by-ref as
+    /// non-null and side-effect-free, so a spelled <c>a &amp;&amp; *r</c>/<c>a || *r</c>
+    /// collapses to a branchless <c>&amp;</c>/<c>|</c> that eagerly dereferences a
+    /// location the branch had guarded — an observable
+    /// <see cref="System.NullReferenceException"/> divergence on a null by-ref.
+    ///
+    /// The identity-comparison peel is load-bearing for the guarded-return fold: it
+    /// lifts the surviving operand <em>before</em> <see cref="BooleanFoldingPass"/>'s
+    /// fixpoint reduces an identity bool-constant comparison (<c>x == true</c> /
+    /// <c>x != false</c>) to the bare <c>x</c>. Peeling exactly those forms — the ones
+    /// that strip to a bare operand, not the <c>== false</c> / <c>!= true</c> forms
+    /// that keep a negation (and a branch) — reaches a by-ref deref hiding under
+    /// <c>(*r) == true</c>. (For the ternary re-form this reduction has already run,
+    /// so the peel is inert there.)
+    ///
+    /// A raw <em>pointer</em> dereference <c>*p</c> is deliberately excluded: a pointer
+    /// read can access-violate, so csc keeps the branch and lifting it is safe.
     /// </summary>
     internal static bool IsManagedByRefDeref(IrExpression operand)
-        => operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+    {
+        var inner = operand;
+        while (StripBareBoolComparison(inner) is { } bare)
+            inner = bare;
+        return inner is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+    }
+
+    /// <summary>
+    /// The bare left operand that <see cref="BooleanFoldingPass"/>'s
+    /// <c>FoldBoolConstantComparison</c> reduces an identity bool test to — <c>x</c>
+    /// from <c>x == true</c> or <c>x != false</c> (a bool-typed left compared to a
+    /// right-hand bool <c>0</c>/<c>1</c> constant). Returns null for the negating
+    /// forms (<c>x == false</c> / <c>x != true</c>, which fold to <c>!x</c> and keep a
+    /// branch) and for any non-identity shape.
+    /// </summary>
+    static IrExpression? StripBareBoolComparison(IrExpression expression)
+    {
+        if (expression is not Comparison { Kind: ComparisonKind.Equal or ComparisonKind.NotEqual } comparison)
+            return null;
+        if (comparison.Left.ResultType is not { Namespace: "System", Name: "Boolean" })
+            return null;
+        if (BoolConstantValue(comparison.Right) is not { } constant)
+            return null;
+        bool keepIdentity = constant == (comparison.Kind == ComparisonKind.Equal);
+        return keepIdentity ? comparison.Left : null;
+    }
+
+    static bool? BoolConstantValue(IrExpression expression) => expression switch
+    {
+        Constant { Value: bool value } => value,
+        Constant { Value: int value } when value is 0 or 1 => value == 1,
+        _ => null,
+    };
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
@@ -33,49 +33,88 @@ internal static class ShortCircuitFidelity
         => PeelReducibleBoolWrappers(condition) is Call { Callee.Name: "op_True" or "op_False" };
 
     /// <summary>
-    /// Whether lifting <paramref name="operand"/> behind a spelled <c>&amp;&amp;</c>/
-    /// <c>||</c> would eagerly dereference a managed by-ref
-    /// (<c>in</c>/<c>ref</c>/<c>out</c>) the branch had guarded. csc treats a managed
-    /// by-ref as non-null and side-effect-free, so it collapses <c>c &amp;&amp; OP</c>
-    /// to a branchless <c>c &amp; OP</c> whenever <c>OP</c> is entirely side-effect-free
-    /// (has no call). That collapse re-evaluates every by-ref dereference in <c>OP</c>
-    /// unconditionally — an observable <see cref="System.NullReferenceException"/>
-    /// divergence on a null by-ref that the compiler's branch had short-circuited.
+    /// Whether lifting <paramref name="operand"/> as the surviving short-circuit operand
+    /// of a spelled <c>c <paramref name="outerKind"/> OP</c> re-form would eagerly
+    /// dereference a managed by-ref (<c>in</c>/<c>ref</c>/<c>out</c>) the compiler's
+    /// branch had guarded — an observable <see cref="System.NullReferenceException"/>
+    /// divergence on a null by-ref.
     ///
-    /// So the hazard is present exactly when <c>OP</c> contains a managed by-ref
-    /// dereference AND contains no call: a bare <c>*r</c>, a bool-constant comparison
-    /// (<c>*r == true</c>) or negation (<c>!*r</c>) over one, or — the case the earlier
-    /// leaf-only peel missed — one nested inside a raised logical/bitwise composition
-    /// (<c>a &amp;&amp; *r</c>, <c>a &amp; *r</c>, <c>r | a</c>; csc branchless-collapses
-    /// the inner <c>a &amp;&amp; r</c> to <c>a &amp; r</c>, and the outer lift then
-    /// collapses that whole operand). Conversely a call anywhere in <c>OP</c> is a
-    /// side-effect barrier csc will not hoist past the lift, so it keeps the branch and
-    /// guards the whole operand — <c>c &amp;&amp; SomeCall(*r)</c> stays faithful and is
-    /// deliberately kept foldable. A raw <em>pointer</em> dereference <c>*p</c> is
-    /// excluded (its address kind is not <see cref="TypeRefKind.ByRef"/>): a pointer read
-    /// can access-violate, so csc keeps the branch and lifting it is safe.
+    /// csc collapses a short-circuit <c>L &amp;&amp; R</c> to a branchless <c>L &amp; R</c>
+    /// (and <c>L || R</c> to <c>L | R</c>) exactly when <c>R</c> renders as a bare place
+    /// — a local/argument/field load or a managed by-ref dereference, which csc treats as
+    /// non-null and side-effect-free. A <em>compound</em> right operand (a bitwise
+    /// <c>&amp;</c>/<c>|</c>, a different-kind logical sub-expression, a comparison, or a
+    /// call) keeps the branch, so a by-ref dereference buried inside one stays guarded.
+    /// The printer flattens a maximal same-kind logical chain, so <c>c <paramref
+    /// name="outerKind"/> OP</c> makes every operand of <c>OP</c>'s <paramref
+    /// name="outerKind"/>-chain a collapsible right operand of the emitted chain; a by-ref
+    /// dereference reachable as one of those flattened operands (through the reducible
+    /// bool wrappers of <see cref="PeelReducibleBoolWrappers"/>) is therefore dereferenced
+    /// unconditionally.
+    ///
+    /// So the hazard is exactly a by-ref dereference that appears as a bare operand of the
+    /// flattened <paramref name="outerKind"/> chain: a bare <c>*r</c>, a <c>*r == true</c>
+    /// wrapper the fixpoint reduces back to a bare <c>*r</c>, or one under a same-kind
+    /// logical composition (<c>a &amp;&amp; *r</c>, <c>*r &amp;&amp; Call()</c> when
+    /// <paramref name="outerKind"/> is <c>And</c>). It is NOT a hazard when the by-ref
+    /// dereference is confined to a compound operand that keeps the branch: a bitwise
+    /// composition (<c>a &amp; *r</c>), a different-kind logical sub-expression
+    /// (<c>*r || a</c> under an <c>And</c> lift), a comparison (<c>*r &gt; 0</c>), a by-ref
+    /// struct field (<c>r.b</c>), or a call argument (<c>SomeCall(*r)</c>) — all recompile
+    /// with the guard intact and stay foldable. The shared, parity-agnostic
+    /// <see cref="PeelReducibleBoolWrappers"/> also strips a leading <c>!</c> / <c>== false</c>,
+    /// so a <c>!*r</c>/<c>*r == false</c> operand — which keeps its branch and is faithful —
+    /// is conservatively declined too; declining an extra readable raise is sound, and
+    /// modeling the exact reduction parity would re-implement <c>FoldBoolConstantComparison</c>.
+    /// A raw <em>pointer</em> dereference <c>*p</c> is excluded (its address kind is not
+    /// <see cref="TypeRefKind.ByRef"/>): a pointer read can access-violate, so csc keeps
+    /// the branch and lifting it is safe.
+    ///
+    /// Verified against SDK-csc <c>/optimize</c> IL + a null-by-ref runtime probe: the
+    /// same-kind chain (<c>c &amp;&amp; a &amp;&amp; *r</c>), the by-ref-before-call
+    /// (<c>c &amp;&amp; *r &amp;&amp; Call()</c>), and the bare operand
+    /// (<c>c &amp;&amp; *r</c>) each diverge from their guarded original (null-by-ref
+    /// throws), while the bitwise (<c>c &amp;&amp; (a &amp; *r)</c>), different-kind
+    /// (<c>c &amp;&amp; (*r || a)</c>), comparison (<c>c &amp;&amp; *r &gt; 0</c>), field
+    /// (<c>c &amp;&amp; r.b</c>), and negation (<c>c &amp;&amp; !*r</c>) folds compile to
+    /// byte-identical IL and do not throw.
     /// </summary>
-    internal static bool IsManagedByRefDeref(IrExpression operand)
-        => ContainsManagedByRefDereference(operand) && !ContainsCall(operand);
+    internal static bool LiftEagerlyDerefsByRef(IrExpression operand, LogicalKind outerKind)
+    {
+        foreach (var chainOperand in FlattenLogicalChain(operand, outerKind))
+        {
+            if (PeelReducibleBoolWrappers(chainOperand)
+                is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef })
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /// <summary>
-    /// Whether the <paramref name="operand"/> subtree contains a managed by-ref
-    /// (<c>in</c>/<c>ref</c>/<c>out</c>) dereference. A raw pointer dereference is
-    /// excluded — only <see cref="TypeRefKind.ByRef"/> addresses qualify.
+    /// The operands of the maximal logical chain of <paramref name="outerKind"/>
+    /// (<c>&amp;&amp;</c> or <c>||</c>) rooted at <paramref name="expression"/> — the
+    /// operands the printer's same-kind flattening would splice into the surrounding
+    /// <c>c <paramref name="outerKind"/> …</c> chain. A <see cref="LogicalBinary"/> of the
+    /// same kind is descended into; anything else (a different-kind logical, a bitwise
+    /// composition, a comparison, a call, a bare place) is a single opaque operand that
+    /// keeps its own branch and is yielded whole.
     /// </summary>
-    static bool ContainsManagedByRefDereference(IrExpression operand)
-        => operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef }
-            || operand.Descendants.OfType<LoadIndirect>().Any(load => load.Address.ResultType is { Kind: TypeRefKind.ByRef });
-
-    /// <summary>
-    /// Whether the <paramref name="operand"/> subtree contains a call — the
-    /// side-effect barrier csc will not hoist past a lifted short-circuit, so it keeps
-    /// the compiler's branch and every by-ref dereference the call transitively guards
-    /// stays guarded.
-    /// </summary>
-    static bool ContainsCall(IrExpression operand)
-        => operand is Call or CallIndirect
-            || operand.Descendants.Any(node => node is Call or CallIndirect);
+    static IEnumerable<IrExpression> FlattenLogicalChain(IrExpression expression, LogicalKind outerKind)
+    {
+        if (expression is LogicalBinary logical && logical.Kind == outerKind)
+        {
+            foreach (var operand in FlattenLogicalChain(logical.Left, outerKind))
+                yield return operand;
+            foreach (var operand in FlattenLogicalChain(logical.Right, outerKind))
+                yield return operand;
+        }
+        else
+        {
+            yield return expression;
+        }
+    }
 
     /// <summary>
     /// Follow the reducible operand through the wrappers that
@@ -98,8 +137,9 @@ internal static class ShortCircuitFidelity
     /// <c>FoldBoolConstantComparison</c> and <see cref="Conditions.Negate"/> here — a
     /// fragile second implementation this intentionally avoids. (For the ternary re-form
     /// the comparison reduction has already run upstream, so only the negation peel is
-    /// live there. The by-ref hazard no longer routes through this peel — see
-    /// <see cref="IsManagedByRefDeref"/>, which scans the whole operand subtree.)
+    /// live there. It also serves <see cref="LiftEagerlyDerefsByRef"/>, which peels each
+    /// flattened chain operand so a by-ref deref hidden under a <c>== true</c>/<c>!</c>
+    /// wrapper is still reached.)
     /// </summary>
     static IrExpression PeelReducibleBoolWrappers(IrExpression expression)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
@@ -53,15 +53,20 @@ internal static class ShortCircuitFidelity
     /// unconditionally.
     ///
     /// So the hazard is exactly a by-ref dereference that appears as a bare operand of the
-    /// flattened <paramref name="outerKind"/> chain: a bare <c>*r</c>, a <c>*r == true</c>
-    /// wrapper the fixpoint reduces back to a bare <c>*r</c>, or one under a same-kind
-    /// logical composition (<c>a &amp;&amp; *r</c>, <c>*r &amp;&amp; Call()</c> when
-    /// <paramref name="outerKind"/> is <c>And</c>) — including a same-kind chain itself
-    /// hidden under such a reducible wrapper (<c>(*r &amp;&amp; Call()) == true</c>), which
-    /// is why the peel runs BEFORE the same-kind flatten and recurses. It is NOT a hazard
+    /// flattened <paramref name="outerKind"/> chain: a bare <c>*r</c>, or one buried in a
+    /// same-kind logical chain that a call barrier keeps csc from collapsing
+    /// (<c>*r &amp;&amp; Call()</c> when <paramref name="outerKind"/> is <c>And</c>; a bare
+    /// <c>a &amp;&amp; *r</c> is lowered to bitwise <c>a &amp; *r</c> and stays foldable).
+    /// The reducible-bool-wrapper peel runs BEFORE the same-kind flatten and recurses, so a
+    /// by-ref buried in such a chain that is itself hidden under a leading <c>!</c>
+    /// (reachably <c>!(*r &amp;&amp; Call())</c>, which csc keeps branchful and
+    /// <c>ceq</c>-negates — conservatively declined for the same parity-agnostic reason as a
+    /// bare <c>!*r</c>) or a bool-constant comparison (<c>(*r &amp;&amp; Call()) == true</c>,
+    /// which csc itself constant-folds, so a defensive rather than csc-reachable case) is
+    /// still reached. It is NOT a hazard
     /// when the by-ref dereference is confined to a compound operand that keeps the branch:
     /// a bitwise composition (<c>a &amp; *r</c>), a different-kind logical sub-expression
-    /// (<c>*r || a</c> under an <c>And</c> lift), a comparison (<c>*r &gt; 0</c>), a by-ref
+    /// (<c>*r || Call()</c> under an <c>And</c> lift), a comparison (<c>*r &gt; 0</c>), a by-ref
     /// struct field (<c>r.b</c>), or a call argument (<c>SomeCall(*r)</c>) — all recompile
     /// with the guard intact and stay foldable. The shared, parity-agnostic
     /// <see cref="PeelReducibleBoolWrappers"/> also strips a leading <c>!</c> / <c>== false</c>,
@@ -73,11 +78,11 @@ internal static class ShortCircuitFidelity
     /// the branch and lifting it is safe.
     ///
     /// Verified against SDK-csc <c>/optimize</c> IL + a null-by-ref runtime probe: the
-    /// same-kind chain (<c>c &amp;&amp; a &amp;&amp; *r</c>), the by-ref-before-call
-    /// (<c>c &amp;&amp; *r &amp;&amp; Call()</c>), and the bare operand
+    /// by-ref-before-call same-kind chain (<c>c &amp;&amp; (*r &amp;&amp; Call())</c>,
+    /// flattening to <c>c &amp;&amp; *r &amp;&amp; Call()</c>) and the bare operand
     /// (<c>c &amp;&amp; *r</c>) each diverge from their guarded original (null-by-ref
-    /// throws), while the bitwise (<c>c &amp;&amp; (a &amp; *r)</c>), different-kind
-    /// (<c>c &amp;&amp; (*r || a)</c>), comparison (<c>c &amp;&amp; *r &gt; 0</c>), field
+    /// throws), while the bitwise (<c>c &amp;&amp; (a &amp; *r)</c>), different-kind logical
+    /// (<c>c &amp;&amp; (*r || Call())</c>), comparison (<c>c &amp;&amp; *r &gt; 0</c>), field
     /// (<c>c &amp;&amp; r.b</c>), and negation (<c>c &amp;&amp; !*r</c>) folds compile to
     /// byte-identical IL and do not throw.
     /// </summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
@@ -99,8 +99,10 @@ public sealed class ShortCircuitTernaryPass : IIrPass
 
             // The surviving operand is always the when-false arm. Decline when csc
             // would emit a branchless `&`/`|` for the spelled operator: raising the
-            // ternary would trade branch IL for branchless.
-            if (RendersAsBranchlessBarePlace((IrExpression)conditional.WhenFalse))
+            // ternary would trade branch IL for branchless (and, for a by-ref deref
+            // reachable as a bare operand of the same-`kind` chain, eagerly dereference a
+            // guarded location — an NRE divergence).
+            if (RendersAsBranchlessBarePlace((IrExpression)conditional.WhenFalse, kind))
                 continue;
 
             var children = conditional.DetachChildren();
@@ -164,10 +166,17 @@ public sealed class ShortCircuitTernaryPass : IIrPass
     /// dereference <c>*p</c> (which can access-violate, so csc keeps the branch).
     /// The operand map was verified opcode-by-opcode: only the bare-load and
     /// managed-by-ref shapes compile branchless; all others keep the branch.
+    ///
+    /// The by-ref hazard is <paramref name="outerKind"/>-relative: the printer flattens
+    /// only a same-kind logical chain, so a by-ref dereference is eager only when it is a
+    /// bare operand of the emitted <paramref name="outerKind"/> chain — <see
+    /// cref="ShortCircuitFidelity.LiftEagerlyDerefsByRef"/> flattens against that kind.
+    /// A by-ref confined to a different-kind logical or a bitwise/call operand keeps its
+    /// own branch and stays raisable.
     /// </summary>
-    static bool RendersAsBranchlessBarePlace(IrExpression operand)
+    static bool RendersAsBranchlessBarePlace(IrExpression operand, LogicalKind outerKind)
         => operand is LoadLocal or LoadArgument or LoadStackSlot
-           || ShortCircuitFidelity.IsManagedByRefDeref(operand);
+           || ShortCircuitFidelity.LiftEagerlyDerefsByRef(operand, outerKind);
 
     /// <summary>
     /// Whether <paramref name="condition"/> is a user-defined-truthiness evaluation

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
@@ -167,7 +167,7 @@ public sealed class ShortCircuitTernaryPass : IIrPass
     /// </summary>
     static bool RendersAsBranchlessBarePlace(IrExpression operand)
         => operand is LoadLocal or LoadArgument or LoadStackSlot
-           || operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+           || ShortCircuitFidelity.IsManagedByRefDeref(operand);
 
     /// <summary>
     /// Whether <paramref name="condition"/> is a user-defined-truthiness evaluation
@@ -183,7 +183,7 @@ public sealed class ShortCircuitTernaryPass : IIrPass
     /// operator) binds the primitive operator and is safe to lift.
     /// </summary>
     static bool IsUserDefinedTruthiness(IrExpression condition)
-        => condition is Call { Callee.Name: "op_True" or "op_False" };
+        => ShortCircuitFidelity.IsUserDefinedTruthiness(condition);
 
     /// <summary>
     /// Whether negating <paramref name="condition"/> re-forms to something that


### PR DESCRIPTION
- Fixes #3114
- Changes `BooleanFoldingPass.FoldGuardReturn` to decline the two short-circuit re-forms that produce invalid or behavior-changing C#, so the faithful guarded return stands.
- Card revision: `9f29f1c0`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — declines exactly the two folds whose output the correctness bar rejects (user-defined-truthiness condition → invalid C#; managed by-ref surviving operand → NRE/eval divergence) while keeping every opcode-divergent-but-valid readability re-form; the pinned corpus is fully neutral.

`FoldGuardReturn` re-forms `if (c) return A; return B;` into a short-circuit `&&`/`||` whenever an arm is a bool constant. Sibling `ShortCircuitTernaryPass` (#3107) grew two correctness guards during adversarial review; `FoldGuardReturn` lifts the same lowered branch shape and carried the same two hazards. This factors both predicates into a shared `ShortCircuitFidelity` helper and applies them in `FoldGuardReturn` before any tree mutation, so the two passes' hazard sets cannot drift apart.

Scope is **correctness-only**: the opcode-divergent-but-valid re-forms (block-reordered guard clause, both-constant `return c`, bare-local/pointer operands) remain accepted readability raises and still fold.

### Witness 1 — user-defined truthiness (invalid C#)

Minimal repro (`TruthOver` defines `operator true`/`operator false` and a user-defined `&`):

```csharp
static bool TruthAnd(TruthOver t, int y) { if (t) return G(y); return false; }
```

#### Before

```csharp
return t && G(y);
```

- Valid: **False** — `t` is `TruthOver`, so `t && G(y)` binds the user-defined `&` and yields `TruthOver`, not `bool`; the `return` needs a nonexistent `TruthOver`→`bool` conversion (CS0029).
- Correct: **False** — does not compile.

#### After

```csharp
if (t)
{
    return G(y);
}
return false;
```

- Valid: **True**
- Correct: **True** — faithful guarded return; `if (t)` binds `operator true` exactly as the original.

### Witness 2 — managed by-ref surviving operand (recompile divergence)

```csharp
static bool ByRefOperand(int s, ref bool r) { if (s > 0) return r; return false; }
```

#### Before

```csharp
return s > 0 && r;
```

- Valid: **True**
- Correct: **False** — `r` is a managed by-ref deref, which csc treats as non-null and side-effect-free, so it recompiles `s > 0 && r` to a **branchless** `&` that dereferences `r` even when `s <= 0` — an observable `NullReferenceException`/eager-eval divergence from the original branch.

#### After

```csharp
if (s > 0)
{
    return r;
}
return false;
```

- Valid: **True**
- Correct: **True** — faithful guarded return; `r` is read only when `s > 0`.

### Fully raised

The After decompilations are in the fully raised state: declining these two folds is the intended endpoint, because the folded forms cannot be made both valid and behavior-preserving.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build (`dotnet-inspect.slnx -c Release`) | Pass | Pass |
| Focused tests | n/a (new file) | `FoldGuardReturnFidelityTests`: 11 passed |
| Refactor regression | `ShortCircuitTernaryPassTests`+`BooleanFolding*`+`IrImporterTests`+`LoweringCoverageTests`: 116 passed | 116 passed |
| Decompiler fast suite (`-trait- "Speed=Slow"`) | 3507, 56 failed | 3507, 56 failed |

The 56 fast-suite failures are pre-existing environmental reds on this machine, unchanged by this PR (identical name set): Roslyn compile-back gates hitting `CS0009` on native shared-framework DLLs (`ReturnToSenderFixtureCatalogTests` ×31, `FidelityCheckGeneratedFilterTests` ×15, `TypeSourceCheckTests` ×4, `LadderRung6GateTests` ×3, `NullCoalescingAssignmentPassTests`), one CRLF-vs-LF (`StringSwitchRaisingTests.SmallStringSwitch_RendersSwitchOnString`), and one partial-build missing fixture (`ExpressionTreeLambdaTests.LookalikeExpressionAssembly_StaysFactoryCalls`). Zero failures touch `FoldGuard`/`ShortCircuit`/`BooleanFolding`.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — matched-env PR-quick corpus A/B is fully neutral; a decline-only change cannot regress residue or introduce a pass bug.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly, `--compile-cap 0` (compile-back is env-broken on this machine; the metrics below are IL-derived and env-independent). 15 assemblies, 1,500 methods. Base snapshot generated from `origin/main` (60bc3f12) over the identical assembly set, so only the decompiler differs.

| Metric (goal) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 249 (16.60%) | 249 (16.60%) | 0 |
| Conditional-branch residue (-) | 44 (2.93%) | 44 (2.93%) | 0 |
| Forward-merge stops (-) | 30 (2.00%) | 30 (2.00%) | 0 |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — no corpus method hits the truthiness/by-ref guarded-return hazard; the declines fix the narrow invalid/divergent cases without any readability regression.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.FoldGuardReturnFidelityTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
