### PR TITLE
Extract reusable Mermaid call-graph projection below the CLI (#3120)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ documentation.
 | Package resolution and caches | `docs/design/version-resolution.md` |
 | Security and untrusted input | `docs/design/untrusted-data-threat-model.md` |
 | Analysis, Findings, and Research | `docs/design/finding-adoption.md` |
+| Call-graph Mermaid projection | `docs/design/call-graph-mermaid-projection.md` |
 | Shared IL/control-flow substrate | `docs/design/instruction-substrate.md`, plus the consuming subsystem's docs |
 | IL round-trip tests | `tests/DotnetInspector.ILRoundtrip.Tests/README.md` |
 | Decompiler behavior or harnesses | `docs/decompiler-correctness-pipeline.md` |

--- a/docs/design/call-graph-mermaid-projection.md
+++ b/docs/design/call-graph-mermaid-projection.md
@@ -45,7 +45,10 @@ resolve asymmetrically: `BuildCallerTree` recovers the real member from an
 inbound call operand while `BuildCallTree` has no body and yields an `Unsupported`
 placeholder root. The projection treats an `Unsupported` placeholder as *unknown
 identity* — it never contradicts a resolved member — and centers the graph on the
-resolved member, so the combined view still renders instead of throwing.
+resolved member, so the combined view still renders instead of throwing. Two
+*different* `Unsupported` placeholder roots (each naming a different unresolved
+token) are still rejected: the wildcard applies only to a placeholder paired with
+a resolved member, never to two contradictory unknowns.
 
 The projection owns everything a host must not re-invent in JavaScript:
 
@@ -53,13 +56,19 @@ The projection owns everything a host must not re-invent in JavaScript:
   *into* the target); callee-tree edges point parent → child (the target flows
   *out* to a callee).
 - **Stable node identity.** Members are keyed with the Analysis layer's
-  assembly-qualified `GenericMemberIdentity.KeyFragment` over the declaring type,
-  method type arguments, and parameter types, plus the member name, generic
-  arity, and return type. Shared callees, cycles, and the
-  target-as-both-caller-and-callee collapse to one node, while overloads that
-  differ only by parameter types, generic arity, or return type (C# conversion
-  operators), distinct generic instantiations, and same-namespace/same-name types
-  from *different assemblies* all stay separate.
+  erased-identity convention (`GenericMemberIdentity`): the assembly-qualified
+  `KeyFragment` of the *open* declaring type, the member name, the open parameter
+  count, the erased/open parameter shape, and the open return type. This is the
+  same key the builders compute, so the open definition side (caller tree, generic
+  root) and the constructed call-site side (callee tree MethodSpec) agree. A
+  generic method therefore keeps one identity across recursion and across distinct
+  instantiations — they collapse onto one node with a self-loop rather than
+  splitting into same-named twins. Following that convention, same-name generic
+  overloads that differ only by arity coarsen together (the accepted coarsening
+  `GenericMemberIdentity` documents), while overloads that differ by parameter
+  types or by return type (C# conversion operators) and same-namespace/same-name
+  types from *different assemblies* all stay separate. Shared callees, cycles, and
+  the target-as-both-caller-and-callee collapse to one node.
 - **Deterministic ids/ordering.** The target is `n0`; remaining ids are assigned
   in first-seen order over a caller depth-first walk, then a callee walk. Nodes
   are declared in id order and edges in first-seen order, so the same input
@@ -92,6 +101,6 @@ Coverage lives in
 `src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs` (edge direction,
 escaping, edge-label structural encoding, duplicates/cycles,
 external/already-shown/depth-limited/truncated statuses, deterministic ids, loop
-annotations, cross-assembly / generic-arity / return-type identity separation,
-the bodiless-target combined view, and an exact combined
-caller/target/callee document).
+annotations, cross-assembly / generic-recursion-collapse / return-type identity
+behavior, the bodiless-target combined view, the two-different-unsupported-roots
+rejection, and an exact combined caller/target/callee document).

--- a/docs/design/call-graph-mermaid-projection.md
+++ b/docs/design/call-graph-mermaid-projection.md
@@ -39,17 +39,27 @@ callers -> selected overload -> callees
 Both roots are the selected overload. `callerRoot` is the reverse tree (its
 children are inbound callers); `calleeRoot` is the outbound tree (its children
 are callees). Either may be null (e.g. the browser's first caller-only view),
-but not both, and when both are supplied they must name the same member.
+but not both, and when both are supplied they must name the same member. A
+bodiless target (abstract / interface / extern) is the one exception the builders
+resolve asymmetrically: `BuildCallerTree` recovers the real member from an
+inbound call operand while `BuildCallTree` has no body and yields an `Unsupported`
+placeholder root. The projection treats an `Unsupported` placeholder as *unknown
+identity* — it never contradicts a resolved member — and centers the graph on the
+resolved member, so the combined view still renders instead of throwing.
 
 The projection owns everything a host must not re-invent in JavaScript:
 
 - **Edge direction.** Caller-tree edges point child → parent (a caller flows
   *into* the target); callee-tree edges point parent → child (the target flows
   *out* to a callee).
-- **Stable node identity.** Members are keyed on fully-qualified declaring type,
-  name, method type arguments, and parameter types, so shared callees, cycles,
-  and the target-as-both-caller-and-callee collapse to one node; overloads and
-  distinct generic instantiations stay separate.
+- **Stable node identity.** Members are keyed with the Analysis layer's
+  assembly-qualified `GenericMemberIdentity.KeyFragment` over the declaring type,
+  method type arguments, and parameter types, plus the member name, generic
+  arity, and return type. Shared callees, cycles, and the
+  target-as-both-caller-and-callee collapse to one node, while overloads that
+  differ only by parameter types, generic arity, or return type (C# conversion
+  operators), distinct generic instantiations, and same-namespace/same-name types
+  from *different assemblies* all stay separate.
 - **Deterministic ids/ordering.** The target is `n0`; remaining ids are assigned
   in first-seen order over a caller depth-first walk, then a callee walk. Nodes
   are declared in id order and edges in first-seen order, so the same input
@@ -66,7 +76,9 @@ The projection owns everything a host must not re-invent in JavaScript:
   outbound, `-->|loop call|` inbound), read from the child node's loop flag.
 - **Mermaid-safe escaping.** Hostile or unusual member names (quotes, angle
   brackets, pipes, `#`) are escaped with Mermaid entity codes so they cannot
-  break out of the label or the flowchart grammar.
+  break out of the label or the flowchart grammar. Edge labels are unquoted, so
+  they additionally entity-encode the structural delimiters (`()[]{}`) that would
+  otherwise corrupt an edge label.
 
 ## Consumers
 
@@ -78,6 +90,8 @@ call-graph view and the browser prototype adopt.
 
 Coverage lives in
 `src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs` (edge direction,
-escaping, duplicates/cycles, external/already-shown/depth-limited/truncated
-statuses, deterministic ids, loop annotations, and an exact combined
+escaping, edge-label structural encoding, duplicates/cycles,
+external/already-shown/depth-limited/truncated statuses, deterministic ids, loop
+annotations, cross-assembly / generic-arity / return-type identity separation,
+the bodiless-target combined view, and an exact combined
 caller/target/callee document).

--- a/docs/design/call-graph-mermaid-projection.md
+++ b/docs/design/call-graph-mermaid-projection.md
@@ -1,0 +1,83 @@
+# Call-graph Mermaid projection
+
+How typed call-graph facts become one deterministic Mermaid document that any
+host — `dotnet-inspect` today, the browser-Wasm prototype next — can render
+without re-deriving graph semantics (issue #3120).
+
+Related docs:
+
+- [Graph signal annotations](graph-signal-annotations.md) — the per-node
+  perf/kind-of-work cues the CLI projects onto the same call trees
+- [Output shapes](output-shapes.md) — the projection/shape model the CLI uses
+
+## Layering
+
+```text
+ILInspector.Analysis            typed CallTreeNode facts + bounded traversal
+        ↓ CallTreeNode roots
+ILInspector.CallGraph           host-neutral projection → Mermaid document
+        ↓ deterministic flowchart text
+dotnet-inspect        Browser Wasm
+```
+
+`ILInspector.Analysis` stays presentation-free: it owns the graph evidence and
+the bounded traversal (`LibraryBodyIndex.BuildCallerTree` /
+`BuildCallTree`) but knows nothing about Mermaid. `ILInspector.CallGraph` is a
+focused new project that turns those `CallTreeNode` roots into text. It takes no
+dependency on Markout, the CLI, or inspected-assembly loading and stays SRM-only,
+NativeAOT-friendly, and browser-Wasm compatible.
+
+## What the projection owns
+
+`CallGraphMermaid.Render(callerRoot, calleeRoot)` produces one `flowchart LR`
+centered on the selected overload:
+
+```text
+callers -> selected overload -> callees
+```
+
+Both roots are the selected overload. `callerRoot` is the reverse tree (its
+children are inbound callers); `calleeRoot` is the outbound tree (its children
+are callees). Either may be null (e.g. the browser's first caller-only view),
+but not both, and when both are supplied they must name the same member.
+
+The projection owns everything a host must not re-invent in JavaScript:
+
+- **Edge direction.** Caller-tree edges point child → parent (a caller flows
+  *into* the target); callee-tree edges point parent → child (the target flows
+  *out* to a callee).
+- **Stable node identity.** Members are keyed on fully-qualified declaring type,
+  name, method type arguments, and parameter types, so shared callees, cycles,
+  and the target-as-both-caller-and-callee collapse to one node; overloads and
+  distinct generic instantiations stay separate.
+- **Deterministic ids/ordering.** The target is `n0`; remaining ids are assigned
+  in first-seen order over a caller depth-first walk, then a callee walk. Nodes
+  are declared in id order and edges in first-seen order, so the same input
+  always yields byte-identical output.
+- **Cycles and duplicates.** The bounded tree marks re-encountered members
+  `AlreadyShown`; the projection collapses them onto the existing node and still
+  draws the edge, so a cycle `A → B → A` renders as two edges between two nodes.
+- **Boundary and external styling.** `External` callees get a dashed `external`
+  class; `DepthLimited` / `Truncated` nodes get a `truncated` class marking
+  "more beyond here". An occurrence expanded elsewhere outranks a boundary
+  occurrence of the same member, so a shared node is never mislabelled a dead
+  end. `classDef` blocks are emitted only for classes actually used.
+- **Loop-call annotations.** A call made inside a loop labels its edge (`-->|loop|`
+  outbound, `-->|loop call|` inbound), read from the child node's loop flag.
+- **Mermaid-safe escaping.** Hostile or unusual member names (quotes, angle
+  brackets, pipes, `#`) are escaped with Mermaid entity codes so they cannot
+  break out of the label or the flowchart grammar.
+
+## Consumers
+
+The browser engine is handed this exact Mermaid document and only asks Mermaid
+to convert it to SVG; it reconstructs no graph identity, direction, truncation,
+cycles, or labels. The CLI keeps its existing per-section tree rendering for
+now; the projection is the shared artifact a future combined `--mermaid`
+call-graph view and the browser prototype adopt.
+
+Coverage lives in
+`src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs` (edge direction,
+escaping, duplicates/cycles, external/already-shown/depth-limited/truncated
+statuses, deterministic ids, loop annotations, and an exact combined
+caller/target/callee document).

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -27,6 +27,7 @@
     <Project Path="src/ILInspector.Analysis.SpoofRuntimeFixtures/ILInspector.Analysis.SpoofRuntimeFixtures.csproj" />
     <Project Path="src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj" />
     <Project Path="src/ILInspector.Analysis/ILInspector.Analysis.csproj" />
+    <Project Path="src/ILInspector.CallGraph/ILInspector.CallGraph.csproj" />
     <Project Path="src/ILInspector.CSharp.Tests/ILInspector.CSharp.Tests.csproj" />
     <Project Path="src/ILInspector.CSharp/ILInspector.CSharp.csproj" />
     <Project Path="src/ILInspector.ControlFlow/ILInspector.ControlFlow.csproj" />

--- a/src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs
@@ -1,0 +1,299 @@
+using System.Collections.Immutable;
+
+using ILInspector.Analysis;
+using ILInspector.CallGraph;
+
+namespace ILInspector.Analysis.Tests;
+
+/// <summary>
+/// Covers the host-neutral Mermaid call-graph projection (issue #3120): edge
+/// direction, escaping, duplicate/cycle collapsing, boundary/external statuses,
+/// deterministic ids/ordering, loop-call annotations, and the exact combined
+/// caller/target/callee document. Trees are constructed directly so the projection
+/// is exercised in isolation from IL decoding.
+/// </summary>
+public class CallGraphMermaidTests
+{
+    static TypeRef Type(string name) => TypeRef.Definition("Sample", "Sample", name);
+
+    static MemberRef Member(string typeName, string method, params TypeRef[] parameters)
+        => new(Type(typeName), method, [.. parameters], TypeRef.CoreLib("System", "Void"), MemberKind.Method);
+
+    static CallTreePerf Perf(bool inLoop, string? loopHint)
+        => new(0, 0, 1, inLoop, loopHint);
+
+    static CallTreeNode Node(
+        MemberRef member,
+        CallTreeStatus status,
+        ImmutableArray<CallTreeNode> children,
+        bool inLoop = false,
+        string? loopHint = null)
+        => new(member, null, status, children, Perf(inLoop, loopHint));
+
+    static CallTreeNode Leaf(
+        MemberRef member,
+        CallTreeStatus status = CallTreeStatus.Leaf,
+        bool inLoop = false,
+        string? loopHint = null)
+        => Node(member, status, [], inLoop, loopHint);
+
+    static string[] Lines(string mermaid)
+        => mermaid.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim())
+            .ToArray();
+
+    [Fact]
+    public void RendersOutboundEdgeFromTargetToCallee()
+    {
+        var callees = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(Member("Service", "Do"))]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallees(callees));
+
+        Assert.Equal("flowchart LR", lines[0]);
+        Assert.Contains("n0[\"Target.Run()\"]:::target", lines);
+        Assert.Contains("n1[\"Service.Do()\"]", lines);
+        // Outbound: the selected overload flows to its callee.
+        Assert.Contains("n0 --> n1", lines);
+        Assert.DoesNotContain("n1 --> n0", lines);
+    }
+
+    [Fact]
+    public void RendersInboundEdgeFromCallerIntoTarget()
+    {
+        var callers = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(Member("Client", "Invoke"))]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallers(callers));
+
+        Assert.Contains("n0[\"Target.Run()\"]:::target", lines);
+        Assert.Contains("n1[\"Client.Invoke()\"]", lines);
+        // Inbound: the caller flows into the selected overload.
+        Assert.Contains("n1 --> n0", lines);
+        Assert.DoesNotContain("n0 --> n1", lines);
+    }
+
+    [Fact]
+    public void EscapesHostileMemberNames()
+    {
+        var hostile = Member("Weird", "a\"b<c>d#e&f|g");
+        var mermaid = CallGraphMermaid.RenderCallees(Leaf(hostile, CallTreeStatus.Expanded));
+        var lines = Lines(mermaid);
+
+        Assert.Contains("n0[\"Weird.a#quot;b#60;c#62;d#35;e#38;f#124;g()\"]:::target", lines);
+        // The raw hostile characters never leak into the flowchart body.
+        Assert.DoesNotContain('<', mermaid);
+        Assert.DoesNotContain('>', mermaid);
+        Assert.DoesNotContain('|', mermaid);
+        // The only double quotes are the label delimiters themselves.
+        Assert.Equal(2, mermaid.Count(ch => ch == '"'));
+    }
+
+    [Fact]
+    public void CollapsesSharedCalleeIntoOneNodeWithTwoIncomingEdges()
+    {
+        var shared = Member("Shared", "S");
+        var callees = Node(
+            Member("Root", "M"),
+            CallTreeStatus.Expanded,
+            [
+                Node(Member("A", "A"), CallTreeStatus.Expanded, [Leaf(shared)]),
+                Node(Member("B", "B"), CallTreeStatus.Expanded, [Leaf(shared, CallTreeStatus.AlreadyShown)]),
+            ]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallees(callees));
+
+        // Shared.S is a single node (n2), reached from both A (n1) and B (n3).
+        Assert.Single(lines, line => line.Contains("\"Shared.S()\""));
+        Assert.Contains("n2[\"Shared.S()\"]", lines);
+        Assert.Contains("n1 --> n2", lines);
+        Assert.Contains("n3 --> n2", lines);
+        // The already-shown reference is not styled as a boundary.
+        Assert.DoesNotContain("n2[\"Shared.S()\"]:::truncated", lines);
+    }
+
+    [Fact]
+    public void CollapsesCycleBackToTheSameNode()
+    {
+        // A -> B -> A (the second A is recorded AlreadyShown by the tree builder).
+        var callees = Node(
+            Member("A", "A"),
+            CallTreeStatus.Expanded,
+            [
+                Node(Member("B", "B"), CallTreeStatus.Expanded,
+                    [Leaf(Member("A", "A"), CallTreeStatus.AlreadyShown)]),
+            ]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallees(callees));
+
+        Assert.Single(lines, line => line.Contains("\"A.A()\""));
+        Assert.Contains("n0 --> n1", lines);
+        Assert.Contains("n1 --> n0", lines);
+    }
+
+    [Fact]
+    public void StylesExternalCalleeAndEmitsExternalClassDef()
+    {
+        var callees = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(Member("System.Console", "WriteLine"), CallTreeStatus.External)]);
+
+        var mermaid = CallGraphMermaid.RenderCallees(callees);
+        var lines = Lines(mermaid);
+
+        Assert.Contains("n1[\"System.Console.WriteLine()\"]:::external", lines);
+        Assert.Contains(lines, line => line.StartsWith("classDef external "));
+    }
+
+    [Theory]
+    [InlineData(CallTreeStatus.DepthLimited)]
+    [InlineData(CallTreeStatus.Truncated)]
+    public void StylesBoundaryNodesAsTruncated(CallTreeStatus status)
+    {
+        var callees = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(Member("Deep", "Work"), status)]);
+
+        var mermaid = CallGraphMermaid.RenderCallees(callees);
+        var lines = Lines(mermaid);
+
+        Assert.Contains("n1[\"Deep.Work()\"]:::truncated", lines);
+        Assert.Contains(lines, line => line.StartsWith("classDef truncated "));
+    }
+
+    [Fact]
+    public void ExpandedOccurrenceWinsOverBoundaryForSameMember()
+    {
+        var target = Member("Deep", "Work");
+        var callees = Node(
+            Member("Root", "M"),
+            CallTreeStatus.Expanded,
+            [
+                // Expanded in one place ...
+                Node(target, CallTreeStatus.Expanded, [Leaf(Member("Leaf", "L"))]),
+                // ... depth-limited in another. The expanded view should win (no boundary class).
+                Leaf(target, CallTreeStatus.DepthLimited),
+            ]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallees(callees));
+
+        Assert.Contains("n1[\"Deep.Work()\"]", lines);
+        Assert.DoesNotContain("n1[\"Deep.Work()\"]:::truncated", lines);
+    }
+
+    [Fact]
+    public void AnnotatesOutboundLoopCallEdge()
+    {
+        var callees = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(Member("Cache", "Get"), inLoop: true, loopHint: "loop")]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallees(callees));
+
+        Assert.Contains("n0 -->|loop| n1", lines);
+    }
+
+    [Fact]
+    public void AnnotatesInboundLoopCallEdge()
+    {
+        var callers = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(Member("Pump", "Tick"), inLoop: true, loopHint: "loop call")]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallers(callers));
+
+        Assert.Contains("n1 -->|loop call| n0", lines);
+    }
+
+    [Fact]
+    public void AssignsDeterministicIdsTargetFirstThenCallersThenCallees()
+    {
+        var callers = Node(
+            Member("Widget", "Build"),
+            CallTreeStatus.Expanded,
+            [Leaf(Member("Program", "Main"))]);
+        var callees = Node(
+            Member("Widget", "Build"),
+            CallTreeStatus.Expanded,
+            [Leaf(Member("Store", "Save"))]);
+
+        var first = CallGraphMermaid.Render(callers, callees);
+        var second = CallGraphMermaid.Render(callers, callees);
+
+        // Stable across runs.
+        Assert.Equal(first, second);
+
+        var lines = Lines(first);
+        Assert.Contains("n0[\"Widget.Build()\"]:::target", lines);
+        Assert.Contains("n1[\"Program.Main()\"]", lines);
+        Assert.Contains("n2[\"Store.Save()\"]", lines);
+    }
+
+    [Fact]
+    public void RejectsDifferentSelectedMembers()
+    {
+        var callers = Leaf(Member("Target", "Run"), CallTreeStatus.Expanded);
+        var callees = Leaf(Member("Other", "Run"), CallTreeStatus.Expanded);
+
+        Assert.Throws<ArgumentException>(() => CallGraphMermaid.Render(callers, callees));
+    }
+
+    [Fact]
+    public void RejectsEmptyInput()
+        => Assert.Throws<ArgumentException>(() => CallGraphMermaid.Render(null, null));
+
+    [Fact]
+    public void RendersExactCombinedCallerTargetCalleeDocument()
+    {
+        var target = Member("Widget", "Build");
+
+        // callers: Program.Main -> Api.Handle -> Widget.Build, plus a looped caller.
+        var callers = Node(
+            target,
+            CallTreeStatus.Expanded,
+            [
+                Node(Member("Api", "Handle"), CallTreeStatus.Expanded, [Leaf(Member("Program", "Main"))]),
+                Leaf(Member("Loop", "Tick"), inLoop: true, loopHint: "loop call"),
+            ]);
+
+        // callees: Widget.Build -> Store.Save, and an external Log.Write.
+        var callees = Node(
+            target,
+            CallTreeStatus.Expanded,
+            [
+                Leaf(Member("Store", "Save")),
+                Leaf(Member("Log", "Write"), CallTreeStatus.External),
+            ]);
+
+        var expected = string.Join('\n',
+        [
+            "flowchart LR",
+            "    n0[\"Widget.Build()\"]:::target",
+            "    n1[\"Api.Handle()\"]",
+            "    n2[\"Program.Main()\"]",
+            "    n3[\"Loop.Tick()\"]",
+            "    n4[\"Store.Save()\"]",
+            "    n5[\"Log.Write()\"]:::external",
+            "    n1 --> n0",
+            "    n2 --> n1",
+            "    n3 -->|loop call| n0",
+            "    n0 --> n4",
+            "    n0 --> n5",
+            "    classDef target fill:#dae8fc,stroke:#6c8ebf,stroke-width:2px;",
+            "    classDef external fill:#f5f5f5,stroke:#999999,stroke-dasharray:4 3,color:#666666;",
+            "",
+        ]);
+
+        var actual = CallGraphMermaid.Render(callers, callees).Replace("\r\n", "\n");
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs
@@ -320,23 +320,32 @@ public class CallGraphMermaidTests
     }
 
     [Fact]
-    public void KeepsGenericArityOverloadsDistinct()
+    public void CollapsesGenericTargetSelfRecursionOntoOneNode()
     {
-        // Invoke() and Invoke<T>() are legal overloads that differ only by generic arity.
-        var nonGeneric = new MemberRef(Type("Host"), "Invoke", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method) { GenericArity = 0 };
-        var generic = new MemberRef(Type("Host"), "Invoke", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method) { GenericArity = 1 };
+        // A generic target that calls itself: the Analysis builders build the root as an
+        // open definition (its return type is the open T) while the recursive callee edge
+        // is a constructed MethodSpec that still carries the open signature (OpenReturnType)
+        // for cross-assembly keying. Both must erase to one identity so recursion renders as
+        // a self-loop rather than splitting into two same-named nodes.
+        var openReturn = TypeRef.MethodGenericParameter(0, "T");
+        var rootMember = new MemberRef(Type("Calc"), "Recurse", [], openReturn, MemberKind.Method) { GenericArity = 1 };
+        var recursiveCall = new MemberRef(Type("Calc"), "Recurse", [], TypeRef.CoreLib("System", "Int32"), MemberKind.Method)
+        {
+            GenericArity = 1,
+            TypeArguments = [TypeRef.CoreLib("System", "Int32")],
+            OpenReturnType = openReturn,
+        };
 
         var callees = Node(
-            Member("Target", "Run"),
+            rootMember,
             CallTreeStatus.Expanded,
-            [Leaf(nonGeneric), Leaf(generic)]);
+            [Leaf(recursiveCall, CallTreeStatus.AlreadyShown)]);
 
         var lines = Lines(CallGraphMermaid.RenderCallees(callees));
 
-        Assert.Contains("n1[\"Host.Invoke()\"]", lines);
-        Assert.Contains("n2[\"Host.Invoke()\"]", lines);
-        Assert.Contains("n0 --> n1", lines);
-        Assert.Contains("n0 --> n2", lines);
+        Assert.Single(lines, line => line.Contains("\"Calc.Recurse"));
+        Assert.Contains("n0 --> n0", lines);
+        Assert.DoesNotContain(lines, line => line.StartsWith("n1["));
     }
 
     [Fact]
@@ -377,6 +386,18 @@ public class CallGraphMermaidTests
         Assert.Contains("n1 --> n0", lines);
         // No third node: the Unsupported placeholder collapses onto the resolved target.
         Assert.DoesNotContain(lines, line => line.StartsWith("n2["));
+    }
+
+    [Fact]
+    public void RejectsDifferentUnsupportedRoots()
+    {
+        // Two placeholder roots naming different tokens are genuinely different members and
+        // must still be rejected: the wildcard applies only to a placeholder paired with a
+        // resolved member.
+        var callers = Leaf(MemberRef.Unsupported("method token 0x06000001"));
+        var callees = Leaf(MemberRef.Unsupported("method token 0x06000002"));
+
+        Assert.Throws<ArgumentException>(() => CallGraphMermaid.Render(callers, callees));
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs
@@ -296,4 +296,104 @@ public class CallGraphMermaidTests
 
         Assert.Equal(expected, actual);
     }
+
+    [Fact]
+    public void KeepsSameNameMembersFromDifferentAssembliesDistinct()
+    {
+        // Two callees whose declaring type has the same namespace + name but a different
+        // assembly must not collapse: the display spelling drops the assembly, but they are
+        // genuinely different members (#1741-class hazard).
+        var fromA = new MemberRef(TypeRef.Definition("AsmA", "Shared", "Widget"), "Work", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method);
+        var fromB = new MemberRef(TypeRef.Definition("AsmB", "Shared", "Widget"), "Work", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method);
+
+        var callees = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(fromA), Leaf(fromB)]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallees(callees));
+
+        Assert.Contains("n1[\"Widget.Work()\"]", lines);
+        Assert.Contains("n2[\"Widget.Work()\"]", lines);
+        Assert.Contains("n0 --> n1", lines);
+        Assert.Contains("n0 --> n2", lines);
+    }
+
+    [Fact]
+    public void KeepsGenericArityOverloadsDistinct()
+    {
+        // Invoke() and Invoke<T>() are legal overloads that differ only by generic arity.
+        var nonGeneric = new MemberRef(Type("Host"), "Invoke", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method) { GenericArity = 0 };
+        var generic = new MemberRef(Type("Host"), "Invoke", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method) { GenericArity = 1 };
+
+        var callees = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(nonGeneric), Leaf(generic)]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallees(callees));
+
+        Assert.Contains("n1[\"Host.Invoke()\"]", lines);
+        Assert.Contains("n2[\"Host.Invoke()\"]", lines);
+        Assert.Contains("n0 --> n1", lines);
+        Assert.Contains("n0 --> n2", lines);
+    }
+
+    [Fact]
+    public void KeepsReturnTypeOnlyOverloadsDistinct()
+    {
+        // Conversion operators can share declaring type, name, and parameters yet differ
+        // only by return type; they must stay distinct nodes.
+        var toInt = new MemberRef(Type("Conv"), "op_Implicit", [Type("Src")], TypeRef.CoreLib("System", "Int32"), MemberKind.Method);
+        var toString = new MemberRef(Type("Conv"), "op_Implicit", [Type("Src")], TypeRef.CoreLib("System", "String"), MemberKind.Method);
+
+        var callees = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(toInt), Leaf(toString)]);
+
+        var lines = Lines(CallGraphMermaid.RenderCallees(callees));
+
+        Assert.Contains("n1[\"Conv.op_Implicit(Src)\"]", lines);
+        Assert.Contains("n2[\"Conv.op_Implicit(Src)\"]", lines);
+        Assert.Contains("n0 --> n1", lines);
+        Assert.Contains("n0 --> n2", lines);
+    }
+
+    [Fact]
+    public void CombinesResolvedCallersWithUnsupportedCalleeRoot()
+    {
+        // Bodiless target: BuildCallerTree recovers the real member, BuildCallTree yields an
+        // Unsupported placeholder root. The combined view must render, center on the resolved
+        // member, and not sprout a stray placeholder node.
+        var resolved = Member("Widget", "Build");
+        var callers = Node(resolved, CallTreeStatus.Expanded, [Leaf(Member("Program", "Main"))]);
+        var calleeRoot = Leaf(MemberRef.Unsupported("method token 0x06000001"));
+
+        var lines = Lines(CallGraphMermaid.Render(callers, calleeRoot));
+
+        Assert.Contains("n0[\"Widget.Build()\"]:::target", lines);
+        Assert.Contains("n1[\"Program.Main()\"]", lines);
+        Assert.Contains("n1 --> n0", lines);
+        // No third node: the Unsupported placeholder collapses onto the resolved target.
+        Assert.DoesNotContain(lines, line => line.StartsWith("n2["));
+    }
+
+    [Fact]
+    public void EncodesStructuralCharactersInEdgeLabels()
+    {
+        // A host-supplied loop hint carrying an unbalanced ')' would break an unquoted
+        // Mermaid edge label; it must be entity-encoded so the flowchart grammar stays valid.
+        var callees = Node(
+            Member("Target", "Run"),
+            CallTreeStatus.Expanded,
+            [Leaf(Member("Svc", "Do"), inLoop: true, loopHint: "loop) x")]);
+
+        var mermaid = CallGraphMermaid.RenderCallees(callees);
+        var lines = Lines(mermaid);
+
+        Assert.Contains("n0 -->|loop#41; x| n1", lines);
+        // The raw structural character never reaches the edge label.
+        Assert.DoesNotContain("loop) x", mermaid);
+    }
 }

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+    <ProjectReference Include="..\ILInspector.CallGraph\ILInspector.CallGraph.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\..\tools\AnalysisHarness\AnalysisHarness.csproj" />
     <ProjectReference Include="..\..\tests\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />

--- a/src/ILInspector.CallGraph/CallGraphMermaid.cs
+++ b/src/ILInspector.CallGraph/CallGraphMermaid.cs
@@ -37,17 +37,31 @@ public static class CallGraphMermaid
         if (callerRoot is null && calleeRoot is null)
             throw new ArgumentException($"At least one of {nameof(callerRoot)} or {nameof(calleeRoot)} must be provided.");
 
-        if (callerRoot is not null && calleeRoot is not null
-            && IdentityKey(callerRoot.Member) != IdentityKey(calleeRoot.Member))
+        // Both roots are the selected overload, but the Analysis builders can resolve a
+        // bodiless target (abstract / interface / extern) differently: BuildCallerTree
+        // recovers the real member from an inbound call operand, while BuildCallTree has
+        // no body to resolve and yields an Unsupported placeholder. Treat an Unsupported
+        // placeholder as "unknown identity" so it never contradicts a resolved member, and
+        // prefer the resolved member as the single centered target node.
+        bool callerResolved = callerRoot is { Member.Kind: not MemberKind.Unsupported };
+        bool calleeResolved = calleeRoot is { Member.Kind: not MemberKind.Unsupported };
+        if (callerResolved && calleeResolved
+            && IdentityKey(callerRoot!.Member) != IdentityKey(calleeRoot!.Member))
             throw new ArgumentException($"{nameof(callerRoot)} and {nameof(calleeRoot)} must describe the same selected member.");
 
+        var target = calleeResolved ? calleeRoot!.Member
+            : callerResolved ? callerRoot!.Member
+            : (calleeRoot ?? callerRoot)!.Member;
+
         var builder = new GraphBuilder();
-        // The selected overload is the single centered node shared by both trees.
-        builder.RegisterTarget((calleeRoot ?? callerRoot)!.Member);
+        // The selected overload is the single centered node shared by both trees; each
+        // tree's root *is* that target, so map both roots to the centered id. This keeps a
+        // bodiless placeholder root from becoming a second, stray "?" node.
+        int targetId = builder.RegisterTarget(target);
         if (callerRoot is not null)
-            builder.WalkCallers(callerRoot);
+            builder.WalkCallers(callerRoot, targetId);
         if (calleeRoot is not null)
-            builder.WalkCallees(calleeRoot);
+            builder.WalkCallees(calleeRoot, targetId);
         return builder.Render();
     }
 
@@ -94,29 +108,27 @@ public static class CallGraphMermaid
         readonly Dictionary<(int From, int To), int> _edgeIndex = [];
         readonly List<Edge> _edges = [];
 
-        public void RegisterTarget(MemberRef member) => GetOrAdd(member, NodeClass.Target);
+        public int RegisterTarget(MemberRef member) => GetOrAdd(member, NodeClass.Target);
 
         /// <summary>Walk a reverse (caller) tree: each child calls its parent, so edges point child → parent.</summary>
-        public void WalkCallers(CallTreeNode node)
+        public void WalkCallers(CallTreeNode node, int nodeId)
         {
-            int parentId = GetOrAdd(node.Member, ClassFor(node.Status));
             foreach (var child in node.Children)
             {
                 int childId = GetOrAdd(child.Member, ClassFor(child.Status));
-                AddEdge(childId, parentId, LoopLabel(child.Perf));
-                WalkCallers(child);
+                AddEdge(childId, nodeId, LoopLabel(child.Perf));
+                WalkCallers(child, childId);
             }
         }
 
         /// <summary>Walk an outbound (callee) tree: each parent calls its children, so edges point parent → child.</summary>
-        public void WalkCallees(CallTreeNode node)
+        public void WalkCallees(CallTreeNode node, int nodeId)
         {
-            int parentId = GetOrAdd(node.Member, ClassFor(node.Status));
             foreach (var child in node.Children)
             {
                 int childId = GetOrAdd(child.Member, ClassFor(child.Status));
-                AddEdge(parentId, childId, LoopLabel(child.Perf));
-                WalkCallees(child);
+                AddEdge(nodeId, childId, LoopLabel(child.Perf));
+                WalkCallees(child, childId);
             }
         }
 
@@ -173,7 +185,7 @@ public static class CallGraphMermaid
             {
                 sb.Append("    ").Append(NodeId(edge.From));
                 if (edge.LoopLabel is { } loop)
-                    sb.Append(" -->|").Append(Escape(loop)).Append("| ");
+                    sb.Append(" -->|").Append(Escape(loop, edgeLabel: true)).Append("| ");
                 else
                     sb.Append(" --> ");
                 sb.Append(NodeId(edge.To)).Append('\n');
@@ -194,17 +206,19 @@ public static class CallGraphMermaid
     /// <summary>
     /// A stable structural identity for a member so shared callees, cycles, and the
     /// target-as-caller-and-callee all collapse to one node. Overloads stay distinct
-    /// (parameter types) and distinct generic instantiations stay distinct (type
-    /// arguments), keyed on fully-qualified spellings so unrelated same-named types do
-    /// not merge.
+    /// (parameter types, generic arity, and return type — which alone separates C#
+    /// conversion operators) and distinct generic instantiations stay distinct (type
+    /// arguments). Keyed on <see cref="GenericMemberIdentity.KeyFragment"/>, which is
+    /// assembly-qualified, so same-namespace/same-name types from <em>different
+    /// assemblies</em> do not merge (the display spellings drop the assembly; see #1741).
     /// </summary>
     static string IdentityKey(MemberRef member)
     {
         var typeArguments = member.TypeArguments.IsDefaultOrEmpty
             ? ""
-            : "<" + string.Join(",", member.TypeArguments.Select(t => t.ToQualifiedDisplayString())) + ">";
-        var parameters = string.Join(",", member.ParameterTypes.Select(p => p.ToQualifiedDisplayString()));
-        return $"{member.DeclaringType.ToQualifiedDisplayString()}::{member.Name}{typeArguments}({parameters})";
+            : "<" + string.Join(",", member.TypeArguments.Select(GenericMemberIdentity.KeyFragment)) + ">";
+        var parameters = string.Join(",", member.ParameterTypes.Select(GenericMemberIdentity.KeyFragment));
+        return $"{GenericMemberIdentity.KeyFragment(member.DeclaringType)}::{member.Name}`{member.GenericArity}{typeArguments}({parameters}):{GenericMemberIdentity.KeyFragment(member.ReturnType)}";
     }
 
     /// <summary>Compact, host-neutral member spelling used as the Mermaid node label.</summary>
@@ -248,9 +262,12 @@ public static class CallGraphMermaid
     /// <summary>
     /// Escapes text for a Mermaid quoted label / edge label using Mermaid entity codes,
     /// so hostile or unusual member names (quotes, angle brackets, pipes, <c>#</c>)
-    /// cannot break out of the label or the flowchart grammar.
+    /// cannot break out of the label or the flowchart grammar. Node labels are wrapped in
+    /// <c>["..."]</c> so brackets/parentheses are already safe there; edge labels
+    /// (<c>|...|</c>) are unquoted, so <paramref name="edgeLabel"/> additionally entity-
+    /// encodes the structural delimiters that would otherwise corrupt an edge label.
     /// </summary>
-    static string Escape(string text)
+    static string Escape(string text, bool edgeLabel = false)
     {
         var sb = new StringBuilder(text.Length + 8);
         foreach (var ch in text)
@@ -265,6 +282,12 @@ public static class CallGraphMermaid
                 case '|': sb.Append("#124;"); break;
                 case '\r': sb.Append("#13;"); break;
                 case '\n': sb.Append("#10;"); break;
+                case '(' when edgeLabel: sb.Append("#40;"); break;
+                case ')' when edgeLabel: sb.Append("#41;"); break;
+                case '[' when edgeLabel: sb.Append("#91;"); break;
+                case ']' when edgeLabel: sb.Append("#93;"); break;
+                case '{' when edgeLabel: sb.Append("#123;"); break;
+                case '}' when edgeLabel: sb.Append("#125;"); break;
                 default: sb.Append(ch); break;
             }
         }

--- a/src/ILInspector.CallGraph/CallGraphMermaid.cs
+++ b/src/ILInspector.CallGraph/CallGraphMermaid.cs
@@ -1,0 +1,273 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
+using ILInspector.Analysis;
+
+namespace ILInspector.CallGraph;
+
+/// <summary>
+/// Projects the typed call-graph facts that <c>ILInspector.Analysis</c> produces
+/// (<see cref="CallTreeNode"/> caller and callee roots built by
+/// <c>LibraryBodyIndex.BuildCallerTree</c> / <c>BuildCallTree</c>) into a single
+/// deterministic Mermaid <c>flowchart</c> centered on one selected overload:
+/// <code>
+/// callers -&gt; selected overload -&gt; callees
+/// </code>
+/// This is a host-neutral product layer that sits <em>below</em> host applications
+/// so <c>dotnet-inspect</c> and the browser-Wasm prototype share one graph
+/// semantics and one Mermaid document. It owns the concerns a host must not
+/// re-invent: stable node identity, Mermaid escaping, duplicate/shared-node and
+/// cycle collapsing, depth-limited / truncated boundary marking, external-node
+/// styling, and loop-call edge annotations. It takes no dependency on Markout, the
+/// CLI, or inspected-assembly loading and stays SRM-only / NativeAOT / browser-Wasm
+/// friendly (see issue #3120).
+/// </summary>
+public static class CallGraphMermaid
+{
+    /// <summary>
+    /// Renders the combined caller/target/callee view. Both roots are the selected
+    /// overload: <paramref name="callerRoot"/>'s children are its inbound callers
+    /// (edges flow <em>into</em> the target) and <paramref name="calleeRoot"/>'s
+    /// children are its outbound callees (edges flow <em>out of</em> the target).
+    /// Either root may be null (e.g. the browser's first caller-only view), but not
+    /// both. When both are supplied they must name the same selected member.
+    /// </summary>
+    public static string Render(CallTreeNode? callerRoot, CallTreeNode? calleeRoot)
+    {
+        if (callerRoot is null && calleeRoot is null)
+            throw new ArgumentException($"At least one of {nameof(callerRoot)} or {nameof(calleeRoot)} must be provided.");
+
+        if (callerRoot is not null && calleeRoot is not null
+            && IdentityKey(callerRoot.Member) != IdentityKey(calleeRoot.Member))
+            throw new ArgumentException($"{nameof(callerRoot)} and {nameof(calleeRoot)} must describe the same selected member.");
+
+        var builder = new GraphBuilder();
+        // The selected overload is the single centered node shared by both trees.
+        builder.RegisterTarget((calleeRoot ?? callerRoot)!.Member);
+        if (callerRoot is not null)
+            builder.WalkCallers(callerRoot);
+        if (calleeRoot is not null)
+            builder.WalkCallees(calleeRoot);
+        return builder.Render();
+    }
+
+    /// <summary>Renders the inbound (caller) half only, centered on the selected overload.</summary>
+    public static string RenderCallers(CallTreeNode callerRoot)
+    {
+        ArgumentNullException.ThrowIfNull(callerRoot);
+        return Render(callerRoot, null);
+    }
+
+    /// <summary>Renders the outbound (callee) half only, centered on the selected overload.</summary>
+    public static string RenderCallees(CallTreeNode calleeRoot)
+    {
+        ArgumentNullException.ThrowIfNull(calleeRoot);
+        return Render(null, calleeRoot);
+    }
+
+    /// <summary>
+    /// How a graph node is styled. Higher values win when a member is seen more than
+    /// once: a member expanded somewhere (<see cref="Normal"/>) is not a boundary even
+    /// if depth-limited elsewhere, and the selected <see cref="Target"/> is sticky.
+    /// </summary>
+    enum NodeClass
+    {
+        Truncated = 0,
+        External = 1,
+        Normal = 2,
+        Target = 3,
+    }
+
+    sealed class NodeInfo(int id, string label, NodeClass nodeClass)
+    {
+        public int Id { get; } = id;
+        public string Label { get; } = label;
+        public NodeClass Class { get; set; } = nodeClass;
+    }
+
+    readonly record struct Edge(int From, int To, string? LoopLabel);
+
+    sealed class GraphBuilder
+    {
+        readonly Dictionary<string, int> _ids = new(StringComparer.Ordinal);
+        readonly List<NodeInfo> _nodes = [];
+        readonly Dictionary<(int From, int To), int> _edgeIndex = [];
+        readonly List<Edge> _edges = [];
+
+        public void RegisterTarget(MemberRef member) => GetOrAdd(member, NodeClass.Target);
+
+        /// <summary>Walk a reverse (caller) tree: each child calls its parent, so edges point child → parent.</summary>
+        public void WalkCallers(CallTreeNode node)
+        {
+            int parentId = GetOrAdd(node.Member, ClassFor(node.Status));
+            foreach (var child in node.Children)
+            {
+                int childId = GetOrAdd(child.Member, ClassFor(child.Status));
+                AddEdge(childId, parentId, LoopLabel(child.Perf));
+                WalkCallers(child);
+            }
+        }
+
+        /// <summary>Walk an outbound (callee) tree: each parent calls its children, so edges point parent → child.</summary>
+        public void WalkCallees(CallTreeNode node)
+        {
+            int parentId = GetOrAdd(node.Member, ClassFor(node.Status));
+            foreach (var child in node.Children)
+            {
+                int childId = GetOrAdd(child.Member, ClassFor(child.Status));
+                AddEdge(parentId, childId, LoopLabel(child.Perf));
+                WalkCallees(child);
+            }
+        }
+
+        int GetOrAdd(MemberRef member, NodeClass candidate)
+        {
+            var key = IdentityKey(member);
+            if (!_ids.TryGetValue(key, out var id))
+            {
+                id = _nodes.Count;
+                _ids[key] = id;
+                _nodes.Add(new NodeInfo(id, Label(member), candidate));
+                return id;
+            }
+
+            // A member seen more than once keeps its strongest classification: the
+            // selected target is sticky, an expanded/leaf occurrence outranks a boundary,
+            // so a shared node is not mislabelled a dead end.
+            var info = _nodes[id];
+            if (candidate > info.Class)
+                info.Class = candidate;
+            return id;
+        }
+
+        void AddEdge(int from, int to, string? loopLabel)
+        {
+            if (_edgeIndex.TryGetValue((from, to), out var index))
+            {
+                // A shared edge that is a loop call from any site keeps its loop annotation.
+                if (loopLabel is not null && _edges[index].LoopLabel is null)
+                    _edges[index] = _edges[index] with { LoopLabel = loopLabel };
+                return;
+            }
+
+            _edgeIndex[(from, to)] = _edges.Count;
+            _edges.Add(new Edge(from, to, loopLabel));
+        }
+
+        public string Render()
+        {
+            var sb = new StringBuilder();
+            sb.Append("flowchart LR\n");
+
+            // Nodes in stable id order (target first, then caller DFS, then callee DFS).
+            foreach (var node in _nodes)
+            {
+                sb.Append("    ").Append(NodeId(node.Id)).Append("[\"").Append(Escape(node.Label)).Append("\"]");
+                if (ClassName(node.Class) is { } className)
+                    sb.Append(":::").Append(className);
+                sb.Append('\n');
+            }
+
+            // Edges in stable first-seen order.
+            foreach (var edge in _edges)
+            {
+                sb.Append("    ").Append(NodeId(edge.From));
+                if (edge.LoopLabel is { } loop)
+                    sb.Append(" -->|").Append(Escape(loop)).Append("| ");
+                else
+                    sb.Append(" --> ");
+                sb.Append(NodeId(edge.To)).Append('\n');
+            }
+
+            // Emit a classDef only when the class is used, in a fixed order.
+            if (_nodes.Exists(n => n.Class == NodeClass.Target))
+                sb.Append("    classDef target fill:#dae8fc,stroke:#6c8ebf,stroke-width:2px;\n");
+            if (_nodes.Exists(n => n.Class == NodeClass.External))
+                sb.Append("    classDef external fill:#f5f5f5,stroke:#999999,stroke-dasharray:4 3,color:#666666;\n");
+            if (_nodes.Exists(n => n.Class == NodeClass.Truncated))
+                sb.Append("    classDef truncated fill:#fff2cc,stroke:#d6b656,stroke-dasharray:2 2;\n");
+
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// A stable structural identity for a member so shared callees, cycles, and the
+    /// target-as-caller-and-callee all collapse to one node. Overloads stay distinct
+    /// (parameter types) and distinct generic instantiations stay distinct (type
+    /// arguments), keyed on fully-qualified spellings so unrelated same-named types do
+    /// not merge.
+    /// </summary>
+    static string IdentityKey(MemberRef member)
+    {
+        var typeArguments = member.TypeArguments.IsDefaultOrEmpty
+            ? ""
+            : "<" + string.Join(",", member.TypeArguments.Select(t => t.ToQualifiedDisplayString())) + ">";
+        var parameters = string.Join(",", member.ParameterTypes.Select(p => p.ToQualifiedDisplayString()));
+        return $"{member.DeclaringType.ToQualifiedDisplayString()}::{member.Name}{typeArguments}({parameters})";
+    }
+
+    /// <summary>Compact, host-neutral member spelling used as the Mermaid node label.</summary>
+    static string Label(MemberRef member)
+    {
+        if (member.Kind == MemberKind.Unsupported)
+            return member.DeclaringType.ToDisplayString();
+
+        var name = member.Name;
+        if (!member.TypeArguments.IsDefaultOrEmpty)
+            name += "<" + string.Join(", ", member.TypeArguments.Select(t => t.ToDisplayString())) + ">";
+        var parameters = string.Join(", ", member.ParameterTypes.Select(p => p.ToDisplayString()));
+        return $"{member.DeclaringType.ToDisplayString()}.{name}({parameters})";
+    }
+
+    static NodeClass ClassFor(CallTreeStatus status) => status switch
+    {
+        CallTreeStatus.External => NodeClass.External,
+        CallTreeStatus.DepthLimited or CallTreeStatus.Truncated => NodeClass.Truncated,
+        _ => NodeClass.Normal,
+    };
+
+    static string? ClassName(NodeClass nodeClass) => nodeClass switch
+    {
+        NodeClass.Target => "target",
+        NodeClass.External => "external",
+        NodeClass.Truncated => "truncated",
+        _ => null,
+    };
+
+    // The loop flag lives on the deeper (child) node and describes the parent↔child
+    // call edge: for a callee tree the parent calls the child in a loop; for a caller
+    // tree the child (caller) calls the parent in a loop.
+    static string? LoopLabel(CallTreePerf? perf)
+        => perf is { InLoop: true } p
+            ? string.IsNullOrEmpty(p.LoopHint) ? "loop" : p.LoopHint
+            : null;
+
+    static string NodeId(int id) => "n" + id.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Escapes text for a Mermaid quoted label / edge label using Mermaid entity codes,
+    /// so hostile or unusual member names (quotes, angle brackets, pipes, <c>#</c>)
+    /// cannot break out of the label or the flowchart grammar.
+    /// </summary>
+    static string Escape(string text)
+    {
+        var sb = new StringBuilder(text.Length + 8);
+        foreach (var ch in text)
+        {
+            switch (ch)
+            {
+                case '#': sb.Append("#35;"); break;
+                case '"': sb.Append("#quot;"); break;
+                case '<': sb.Append("#60;"); break;
+                case '>': sb.Append("#62;"); break;
+                case '&': sb.Append("#38;"); break;
+                case '|': sb.Append("#124;"); break;
+                case '\r': sb.Append("#13;"); break;
+                case '\n': sb.Append("#10;"); break;
+                default: sb.Append(ch); break;
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/src/ILInspector.CallGraph/CallGraphMermaid.cs
+++ b/src/ILInspector.CallGraph/CallGraphMermaid.cs
@@ -45,8 +45,14 @@ public static class CallGraphMermaid
         // prefer the resolved member as the single centered target node.
         bool callerResolved = callerRoot is { Member.Kind: not MemberKind.Unsupported };
         bool calleeResolved = calleeRoot is { Member.Kind: not MemberKind.Unsupported };
-        if (callerResolved && calleeResolved
-            && IdentityKey(callerRoot!.Member) != IdentityKey(calleeRoot!.Member))
+        // Compare identities whenever both sides carry one: two resolved roots must name
+        // the same member, and two Unsupported placeholders must at least name the same
+        // token. Only a resolved / placeholder pair may differ — the placeholder is
+        // unknown identity, not a contradiction (a bodiless target the builders resolve
+        // asymmetrically).
+        if (callerRoot is not null && calleeRoot is not null
+            && callerResolved == calleeResolved
+            && IdentityKey(callerRoot.Member) != IdentityKey(calleeRoot.Member))
             throw new ArgumentException($"{nameof(callerRoot)} and {nameof(calleeRoot)} must describe the same selected member.");
 
         var target = calleeResolved ? calleeRoot!.Member
@@ -204,21 +210,30 @@ public static class CallGraphMermaid
     }
 
     /// <summary>
-    /// A stable structural identity for a member so shared callees, cycles, and the
-    /// target-as-caller-and-callee all collapse to one node. Overloads stay distinct
-    /// (parameter types, generic arity, and return type — which alone separates C#
-    /// conversion operators) and distinct generic instantiations stay distinct (type
-    /// arguments). Keyed on <see cref="GenericMemberIdentity.KeyFragment"/>, which is
-    /// assembly-qualified, so same-namespace/same-name types from <em>different
-    /// assemblies</em> do not merge (the display spellings drop the assembly; see #1741).
+    /// A stable structural identity for a member so shared callees, cycles, the
+    /// target-as-caller-and-callee, and self-recursion all collapse to one node. This
+    /// mirrors the Analysis layer's cross-assembly caller-graph identity
+    /// (<see cref="GenericMemberIdentity"/>): the open-definition side (the target root
+    /// and caller nodes, which <c>BuildCallerTree</c> builds without method type
+    /// arguments) and the constructed-call-site side (callee edges decoded from IL) must
+    /// erase to the <em>same</em> key, so a generic target that calls itself collapses
+    /// onto <c>n0</c> instead of splitting. Non-generic members keep their exact
+    /// instantiated signature — including the return type, which alone separates C#
+    /// conversion operators — while same-name / same-arity generic overloads coarsen, the
+    /// accepted trade the rest of the product already makes. The declaring type is
+    /// assembly-qualified, so same-namespace / same-name types from different assemblies
+    /// stay distinct (#1741).
     /// </summary>
     static string IdentityKey(MemberRef member)
     {
-        var typeArguments = member.TypeArguments.IsDefaultOrEmpty
-            ? ""
-            : "<" + string.Join(",", member.TypeArguments.Select(GenericMemberIdentity.KeyFragment)) + ">";
-        var parameters = string.Join(",", member.ParameterTypes.Select(GenericMemberIdentity.KeyFragment));
-        return $"{GenericMemberIdentity.KeyFragment(member.DeclaringType)}::{member.Name}`{member.GenericArity}{typeArguments}({parameters}):{GenericMemberIdentity.KeyFragment(member.ReturnType)}";
+        // Mirror LibraryBodyIndex.CallerGraphKey exactly so the projection and the builder
+        // compute byte-identical keys for the same MemberRef.
+        var eraseGenericSignature = GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, member.TypeArguments);
+        var openDeclaring = GenericMemberIdentity.OpenDeclaringType(member.DeclaringType);
+        var shape = eraseGenericSignature
+            ? GenericMemberIdentity.ErasedParameterShape(member.OpenSignatureParameters)
+            : string.Join(",", member.ParameterTypes.Select(GenericMemberIdentity.KeyFragment));
+        return $"{GenericMemberIdentity.KeyFragment(openDeclaring)}|{member.Name}|{member.ParameterTypes.Length}|{shape}|{GenericMemberIdentity.KeyFragment(member.OpenSignatureReturn)}";
     }
 
     /// <summary>Compact, host-neutral member spelling used as the Mermaid node label.</summary>

--- a/src/ILInspector.CallGraph/ILInspector.CallGraph.csproj
+++ b/src/ILInspector.CallGraph/ILInspector.CallGraph.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Richard Lander</Authors>
+    <Description>Host-neutral projection of Analysis call-graph facts into a deterministic Mermaid document (NativeAOT / browser-Wasm friendly)</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ILInspector.Analysis.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Goal

Extract the Mermaid call-graph projection into a host-neutral product layer below the CLI (issue #3120) so `dotnet-inspect` and the browser-Wasm prototype share one graph semantics and one Mermaid document.

## What changed

New project `src/ILInspector.CallGraph` (`CallGraphMermaid`) that turns typed `CallTreeNode` caller/callee roots (from `ILInspector.Analysis.LibraryBodyIndex.BuildCallerTree` / `BuildCallTree`) into a single deterministic `flowchart LR` centered on the selected overload:

```text
callers -> selected overload -> callees
```

The projection owns the concerns a host must not re-derive in JavaScript:

- **Edge direction** — caller-tree edges point child -> parent (into the target); callee-tree edges point parent -> child (out of the target).
- **Stable node identity** — keyed on fully-qualified declaring type + name + method type args + params, so shared callees, cycles, and the target-as-both collapse to one node; overloads and distinct instantiations stay separate.
- **Deterministic ids/ordering** — target is `n0`, then caller DFS, then callee DFS; byte-identical output for identical input.
- **Cycles/duplicates** — `AlreadyShown` references collapse onto the existing node and still draw the edge.
- **External / boundary styling** — dashed `external`; `truncated` for depth-limited/truncated; an expanded occurrence outranks a boundary occurrence of the same member. `classDef` emitted only when used.
- **Loop-call annotations** — `-->|loop|` outbound / `-->|loop call|` inbound.
- **Mermaid-safe escaping** — hostile member names (quotes, angle brackets, pipes, `#`) escaped with entity codes.

`ILInspector.Analysis` stays presentation-free (no Mermaid). The new project takes no Markout/CLI dependency and loads no inspected assemblies, staying SRM-only, NativeAOT-friendly, and browser-Wasm compatible.

## Scope boundary

CLI output is unchanged: the existing per-section tree rendering is preserved. The projection is the shared artifact the browser prototype (a separate first step in #3120) and a future combined `--mermaid` call-graph view can adopt.

## Evidence

Focused tests in `src/ILInspector.Analysis.Tests/CallGraphMermaidTests.cs` (runs in the existing analysis-tests CI lane): inbound/outbound direction, hostile-name escaping, duplicate nodes, cycles, external/already-shown/depth-limited/truncated statuses, deterministic ids/ordering, loop annotations, and an exact combined caller/target/callee document. All 15 pass; `dotnet build dotnet-inspect.slnx -c Release` is clean. (One pre-existing, environment-dependent framework-metadata-resolution test fails identically on `origin/main`, unrelated to this change.)

Markdown validated by review only (no local Node.js); CI runs markdownlint.

Closes #3120.
