### PR TITLE
Relocate .dotnet-install manifest to .dotnet-install/ and add project

### DIFF
--- a/.dotnet-install/.dotnet-install.json
+++ b/.dotnet-install/.dotnet-install.json
@@ -1,5 +1,6 @@
 {
   "exe": "dotnet-inspect",
+  "project": "src/dotnet-inspect/dotnet-inspect.csproj",
   "update": {
     "type": "nuget",
     "package": "dotnet-inspect"


### PR DESCRIPTION
[dotnet-install](https://github.com/richlander/dotnet-install)'s repo gesture now reads `.dotnet-install/.dotnet-install.json` — the repo root is no longer scanned — so this moves the advertise manifest into that well-known directory (mirroring `.claude-plugin/` for skills).

It also adds an explicit **project** (`src/dotnet-inspect/dotnet-inspect.csproj`): this repo has many buildable `Exe` projects, so auto-discovery would be ambiguous without it.

Manifest:
```json
{
  "exe": "dotnet-inspect",
  "project": "src/dotnet-inspect/dotnet-inspect.csproj",
  "update": { "type": "nuget", "package": "dotnet-inspect" }
}
```