### PR TITLE
Add this.-qualification knobs for methods and events (#3097)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -138,18 +138,36 @@ Anything the count cannot prove safe stays explicit.
 
 `this.field` and `field`, and `this.Prop` and `Prop`, compile to the identical
 IL — a `this`-rooted instance member load is `ldarg.0; ldfld` / `ldarg.0; call
-get_Prop` either way, so the `this.` prefix has no IL consequence. This is a
-class-3 no-anchor spelling with **no binding hazard** (unlike target-typed
-`new()` or argument elision): the prefix cannot rebind the member, it can only be
-redundant. The shipped default renders the bare name, qualifying only where the
-bare name would not bind to the member — a local/parameter shadow or a
-member/type-name collision — matching how the runtime writes member access.
+get_Prop` either way, so the `this.` prefix has no IL consequence. The same holds
+for an instance method call (`this.M()` and `M()` both emit `ldarg.0;
+call/callvirt`), a method group over `this` (`this.M` and `M` both emit `ldarg.0;
+ldftn`), and an event subscription (`this.E += h` and `E += h` both emit
+`ldarg.0; ... call add_E`). This is a class-3 no-anchor spelling with **no binding
+hazard** (unlike target-typed `new()` or argument elision): the prefix cannot
+rebind the member, it can only be redundant. The shipped default renders the bare
+name, qualifying only where the bare name would not bind to the member — a
+local/parameter shadow or a member/type-name collision — matching how the runtime
+writes member access.
 
 The always-qualified spelling is available as an opt-in, off by default so
 default output stays byte-for-byte stable:
 
 - `PrinterOptions.QualifyFieldAccess` mirrors `dotnet_style_qualification_for_field`.
 - `PrinterOptions.QualifyPropertyAccess` mirrors `dotnet_style_qualification_for_property`.
+- `PrinterOptions.QualifyMethodAccess` mirrors `dotnet_style_qualification_for_method`
+  (instance method calls and method groups over `this`).
+- `PrinterOptions.QualifyEventAccess` mirrors `dotnet_style_qualification_for_event`
+  (event `+=`/`-=` subscriptions).
+
+The four knobs are independent — each qualifies only the member kind it governs.
+Two consequences are worth calling out:
+
+- A genuine non-virtual `base.M()` call is **never** rewritten to `this.M()`, even
+  with method qualification on: the `base` call deliberately skips virtual
+  dispatch, so `this.M()` would re-enable it and change behavior.
+- Event subscriptions are governed by `QualifyEventAccess`, not
+  `QualifyPropertyAccess` (they share a printer helper internally but are decoupled
+  at the knob), matching the separate `_event`/`_property` editorconfig keys.
 
 ```csharp
 public int Compute() => _count + Extra;          // shipped default: bare
@@ -278,6 +296,8 @@ The file is flat `key = value`, using the same key and value vocabulary as an
 root = true
 dotnet_style_qualification_for_field = true
 dotnet_style_qualification_for_property = true
+dotnet_style_qualification_for_method = true
+dotnet_style_qualification_for_event = true
 ```
 
 - `#` and `;` comment lines and `[section]` headers are ignored.
@@ -287,8 +307,9 @@ dotnet_style_qualification_for_property = true
   `.editorconfig` does not warn). Discovery already stops at the nearest file, so
   `root = true` drives no behavior on its own; it is the conventional, explicit
   way to mark a repository-root config as the boundary.
-- Recognized keys map to `PrinterOptions`; today the two `this`-qualification
-  keys above are recognized, and the set grows as more class-3 knobs ship.
+- Recognized keys map to `PrinterOptions`; today the four `this`-qualification
+  keys above (field, property, method, event) are recognized, and the set grows
+  as more class-3 knobs ship.
 - Unknown keys, malformed lines, and non-boolean values are reported as a
   `Warning:` on stderr and skipped — the rest of the file still applies. A bad
   config never fails the run silently.

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -10,11 +10,14 @@ namespace ILInspector.Decompiler.Tests;
 /// <summary>
 /// The opt-in <c>this.</c>-qualification knobs
 /// (<see cref="PrinterOptions.QualifyFieldAccess"/> /
-/// <see cref="PrinterOptions.QualifyPropertyAccess"/>). These are class-3 spelling
-/// choices with no IL anchor: <c>this.field</c>/<c>this.Prop</c> emit the same
-/// <c>ldarg.0; ldfld</c> / <c>ldarg.0; call get_Prop</c> as the bare name. Off by
-/// default — an unshadowed instance member stays bare — so the default render is
-/// byte-identical to before the knobs existed.
+/// <see cref="PrinterOptions.QualifyPropertyAccess"/> /
+/// <see cref="PrinterOptions.QualifyMethodAccess"/> /
+/// <see cref="PrinterOptions.QualifyEventAccess"/>). These are class-3 spelling
+/// choices with no IL anchor: <c>this.field</c>/<c>this.Prop</c>/<c>this.M()</c>/
+/// <c>this.E += h</c> emit the same <c>ldarg.0; ...</c> sequence as the bare name.
+/// Off by default — an unshadowed instance member stays bare — so the default
+/// render is byte-identical to before the knobs existed. A genuine
+/// <c>base.M()</c> call is never rewritten (that would re-enable virtual dispatch).
 /// </summary>
 [Trait("Area", "RoundTrip")]
 public sealed class ThisQualificationTests
@@ -31,6 +34,18 @@ public sealed class ThisQualificationTests
     static string Render(string memberName, PrinterOptions? options = null)
     {
         var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == memberName);
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null, printerOptions: options);
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.NotNull(rendered.Text);
+        return rendered.Text!;
+    }
+
+    static string RenderMember(System.Type declaringType, string memberName, PrinterOptions? options = null)
+    {
+        using var pe = new PEReader(File.OpenRead(AssemblyPath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == declaringType.FullName);
         var member = Assert.Single(type.Members, m => m.Name == memberName);
         var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null, printerOptions: options);
         Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
@@ -118,6 +133,102 @@ public sealed class ThisQualificationTests
         Assert.True(PrintSynthetic(new PrinterOptions { QualifyPropertyAccess = true }).EffectiveOptions.QualifyPropertyAccess);
         Assert.False(PrintSynthetic(PrinterOptions.Default).EffectiveOptions.QualifyPropertyAccess);
     }
+
+    [Fact]
+    public void MethodCall_DefaultsToBareName()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.CallMethod));
+        Assert.Contains("ReadField()", text);
+        Assert.DoesNotContain("this.ReadField()", text);
+    }
+
+    [Fact]
+    public void MethodCall_QualifiesWithThis_WhenRequested()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.CallMethod),
+            new PrinterOptions { QualifyMethodAccess = true });
+        Assert.Contains("this.ReadField()", text);
+    }
+
+    [Fact]
+    public void MethodGroup_DefaultsToBareName()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.MethodGroup));
+        Assert.Contains("ReadField", text);
+        Assert.DoesNotContain("this.ReadField", text);
+    }
+
+    [Fact]
+    public void MethodGroup_QualifiesWithThis_WhenRequested()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.MethodGroup),
+            new PrinterOptions { QualifyMethodAccess = true });
+        Assert.Contains("this.ReadField", text);
+    }
+
+    [Fact]
+    public void EventSubscription_DefaultsToBareName()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.Subscribe));
+        Assert.Contains("Changed +=", text);
+        Assert.DoesNotContain("this.Changed", text);
+    }
+
+    [Fact]
+    public void EventSubscription_QualifiesWithThis_WhenRequested()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.Subscribe),
+            new PrinterOptions { QualifyEventAccess = true });
+        Assert.Contains("this.Changed +=", text);
+    }
+
+    // The method and event knobs are independent from the field/property knobs
+    // and from each other: enabling one must not qualify a member the other
+    // governs. (Events and properties in particular share the printer's
+    // PropertyTarget helper, so this pins their decoupling.)
+    [Fact]
+    public void PropertyKnob_DoesNotQualifyEvents()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.Subscribe),
+            new PrinterOptions { QualifyPropertyAccess = true });
+        Assert.DoesNotContain("this.Changed", text);
+    }
+
+    [Fact]
+    public void EventKnob_DoesNotQualifyMethods()
+    {
+        var text = Render(nameof(ThisQualificationSpecimen.CallMethod),
+            new PrinterOptions { QualifyEventAccess = true });
+        Assert.DoesNotContain("this.ReadField", text);
+    }
+
+    // A genuine non-virtual base call (base.M()) deliberately skips virtual
+    // dispatch; the qualify-method knob must leave it as base.M() and never
+    // rewrite it to this.M() (which would re-enable dispatch -- here, unbounded
+    // recursion).
+    [Fact]
+    public void BaseCall_StaysBase_WhenMethodQualificationRequested()
+    {
+        var text = RenderMember(typeof(ThisQualificationDerived),
+            nameof(ThisQualificationDerived.Value),
+            new PrinterOptions { QualifyMethodAccess = true });
+        Assert.Contains("base.Value()", text);
+        Assert.DoesNotContain("this.Value()", text);
+    }
+
+    [Fact]
+    public void EffectiveOptions_RecordsMethodKnob()
+    {
+        Assert.True(PrintSynthetic(new PrinterOptions { QualifyMethodAccess = true }).EffectiveOptions.QualifyMethodAccess);
+        Assert.False(PrintSynthetic(PrinterOptions.Default).EffectiveOptions.QualifyMethodAccess);
+    }
+
+    [Fact]
+    public void EffectiveOptions_RecordsEventKnob()
+    {
+        Assert.True(PrintSynthetic(new PrinterOptions { QualifyEventAccess = true }).EffectiveOptions.QualifyEventAccess);
+        Assert.False(PrintSynthetic(PrinterOptions.Default).EffectiveOptions.QualifyEventAccess);
+    }
 }
 
 // A real compiled type: an unshadowed instance field and instance property, each
@@ -135,4 +246,29 @@ public sealed class ThisQualificationSpecimen
     public int ReadField() => _value;
 
     public int ReadProperty() => Count;
+
+    // Instance method call on the implicit this receiver.
+    public int CallMethod() => ReadField() + 1;
+
+    // Method group over the implicit this receiver.
+    public System.Func<int> MethodGroup() => ReadField;
+
+#pragma warning disable CS0067 // Changed is subscribed to via Subscribe; the fixture never raises it.
+    public event System.EventHandler? Changed;
+#pragma warning restore CS0067
+
+    // Event subscription (+=) on the implicit this receiver.
+    public void Subscribe(System.EventHandler handler) => Changed += handler;
+}
+
+// A base/derived pair so a genuine non-virtual base.Value() call is available:
+// the qualify-method knob must never rewrite it to this.Value().
+public class ThisQualificationBase
+{
+    public virtual int Value() => 1;
+}
+
+public sealed class ThisQualificationDerived : ThisQualificationBase
+{
+    public override int Value() => base.Value() + 1;
 }

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -216,6 +216,28 @@ public sealed class ThisQualificationTests
         Assert.DoesNotContain("this.Value()", text);
     }
 
+    // A method group over base.<virtual method> compiles to a NON-virtual
+    // `ldftn Base::M`; rendering it bare or `this.M` rebinds to the derived
+    // override with virtual dispatch (ldvirtftn), changing behavior. It must stay
+    // `base.M` both by default and under the qualify-method knob.
+    [Fact]
+    public void BaseMethodGroup_RendersBase_ByDefault()
+    {
+        var text = RenderMember(typeof(ThisQualificationDerived),
+            nameof(ThisQualificationDerived.BaseValueGroup));
+        Assert.Contains("base.Value", text);
+    }
+
+    [Fact]
+    public void BaseMethodGroup_StaysBase_WhenMethodQualificationRequested()
+    {
+        var text = RenderMember(typeof(ThisQualificationDerived),
+            nameof(ThisQualificationDerived.BaseValueGroup),
+            new PrinterOptions { QualifyMethodAccess = true });
+        Assert.Contains("base.Value", text);
+        Assert.DoesNotContain("this.Value", text);
+    }
+
     [Fact]
     public void EffectiveOptions_RecordsMethodKnob()
     {
@@ -271,4 +293,9 @@ public class ThisQualificationBase
 public sealed class ThisQualificationDerived : ThisQualificationBase
 {
     public override int Value() => base.Value() + 1;
+
+    // A method group over base.Value: csc emits a NON-virtual `ldftn Base::Value`,
+    // so it must render `base.Value` (bare or this.Value would rebind to the
+    // override with virtual dispatch and change behavior).
+    public System.Func<int> BaseValueGroup() => base.Value;
 }

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -238,6 +238,28 @@ public sealed class ThisQualificationTests
         Assert.DoesNotContain("this.Value", text);
     }
 
+    // A closed static extension method group over this shares the base group's
+    // `ldarg.0; ldftn` shape but is NOT base.M: the callee is static and declared
+    // on the extension host, so base.Extend is CS0117. It must never enter the
+    // base arm -- bare by default, this.Extend under the qualify-method knob.
+    [Fact]
+    public void ExtensionMethodGroup_NeverRendersBase_ByDefault()
+    {
+        var text = RenderMember(typeof(ThisQualificationDerived),
+            nameof(ThisQualificationDerived.ExtensionGroup));
+        Assert.DoesNotContain("base.", text);
+    }
+
+    [Fact]
+    public void ExtensionMethodGroup_RendersThis_WhenMethodQualificationRequested()
+    {
+        var text = RenderMember(typeof(ThisQualificationDerived),
+            nameof(ThisQualificationDerived.ExtensionGroup),
+            new PrinterOptions { QualifyMethodAccess = true });
+        Assert.Contains("this.Extend", text);
+        Assert.DoesNotContain("base.", text);
+    }
+
     [Fact]
     public void EffectiveOptions_RecordsMethodKnob()
     {
@@ -298,4 +320,17 @@ public sealed class ThisQualificationDerived : ThisQualificationBase
     // so it must render `base.Value` (bare or this.Value would rebind to the
     // override with virtual dispatch and change behavior).
     public System.Func<int> BaseValueGroup() => base.Value;
+
+    // A method group over an extension method also emits `ldarg.0; ldftn`, but the
+    // callee is static (HasThis == false) and its declaring type is the extension
+    // host, not a base type. It must NOT render base.Extend (CS0117 on the base);
+    // under the qualify-method knob it stays this.Extend.
+    public System.Func<int> ExtensionGroup() => this.Extend;
+}
+
+// An extension on ThisQualificationDerived so `this.Extend` forms a closed
+// static-method group (ldarg.0; ldftn Extensions::Extend(Derived)).
+public static class ThisQualificationExtensions
+{
+    public static int Extend(this ThisQualificationDerived value) => 42;
 }

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -86,6 +86,22 @@ public sealed record DecompilerOptions
     /// </summary>
     public bool QualifyPropertyAccess { get; init; }
 
+    /// <summary>
+    /// Instance methods invoked through <c>this</c> may render the explicit
+    /// <c>this.</c> qualifier even where the bare name is unambiguous. Off by
+    /// default; an IL-identical spelling choice. Mirrors
+    /// <c>dotnet_style_qualification_for_method</c>.
+    /// </summary>
+    public bool QualifyMethodAccess { get; init; }
+
+    /// <summary>
+    /// Instance events subscribed through <c>this</c> may render the explicit
+    /// <c>this.</c> qualifier even where the bare name is unambiguous. Off by
+    /// default; an IL-identical spelling choice. Mirrors
+    /// <c>dotnet_style_qualification_for_event</c>.
+    /// </summary>
+    public bool QualifyEventAccess { get; init; }
+
     public static DecompilerOptions Default { get; } = new();
 }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -79,7 +79,7 @@ public sealed partial class CSharpPrinter
             : null;
     }
 
-    string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true)
+    string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true, bool isEvent = false)
     {
         if (PointerMemberReceiver(instance) is { } pointerReceiver)
         {
@@ -98,8 +98,10 @@ public sealed partial class CSharpPrinter
             // bare read binds to it, not the property (e.g. the synthesized record
             // Deconstruct(out int X, ...) whose body reads this.X). Qualify with
             // this. to reach the property; an unshadowed instance property stays
-            // bare per the taste convention, matching FieldTarget.
-            LoadArgument { Index: 0, Name: "this" } => _options.QualifyPropertyAccess || QualifyThisMember(name, AccessorValueType(accessor)) ? "this" : "",
+            // bare per the taste convention, matching FieldTarget. An event
+            // subscription routes through here too, so it honors the separate
+            // event qualification knob rather than the property one.
+            LoadArgument { Index: 0, Name: "this" } => (isEvent ? _options.QualifyEventAccess : _options.QualifyPropertyAccess) || QualifyThisMember(name, AccessorValueType(accessor)) ? "this" : "",
             _ => ReceiverText(instance),
         };
         // An instance property accessor with index arguments IS an indexer,
@@ -235,7 +237,7 @@ public sealed partial class CSharpPrinter
         if (target is Constant { Value: null })
             return $"{TypeQualifierText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
-            return name;
+            return _options.QualifyMethodAccess ? $"this.{name}" : name;
         if (PointerMethodReceiver(target) is { } pointerReceiver)
             return $"{pointerReceiver}->{name}";
         return $"{ReceiverText(target)}.{name}";
@@ -338,11 +340,15 @@ public sealed partial class CSharpPrinter
             return $"(({TypeText(lambda.DelegateType)}){Operand(lambda)}).Invoke({rest})";
         if (receiver is LoadArgument { Index: 0, Name: "this" })
         {
+            string thisMethodName = CSharpNaming.SourceMethodName(call.Callee.Name);
             // Non-virtual this-receiver call to a base-declared method is
-            // C#'s base.M() — the call opcode deliberately skips dispatch.
-            return !call.IsVirtual && IsCrossType(call.Callee.DeclaringType)
-                ? $"base.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})"
-                : $"{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
+            // C#'s base.M() — the call opcode deliberately skips dispatch, so it
+            // stays base. even under the qualify-method knob (this.M() would
+            // re-enable virtual dispatch and change behavior).
+            if (!call.IsVirtual && IsCrossType(call.Callee.DeclaringType))
+                return $"base.{thisMethodName}{typeArguments}({rest})";
+            string thisMethodQualifier = _options.QualifyMethodAccess ? "this." : "";
+            return $"{thisMethodQualifier}{thisMethodName}{typeArguments}({rest})";
         }
         if (PointerMethodReceiver(receiver) is { } pointerReceiver)
             return $"{pointerReceiver}->{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -231,13 +231,22 @@ public sealed partial class CSharpPrinter
     /// method group (Type.Method); a this-receiver drops the qualifier to match
     /// instance-call spelling; any other receiver qualifies the name.
     /// </summary>
-    string MethodGroupText(MethodRef method, IrExpression target)
+    string MethodGroupText(MethodRef method, IrExpression target, bool isVirtual)
     {
         string name = CSharpNaming.SourceMethodName(method.Name);
         if (target is Constant { Value: null })
             return $"{TypeQualifierText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
+        {
+            // A non-virtual (ldftn) method group over this to a base-declared
+            // method is C#'s base.M — the ldftn deliberately captures the base
+            // slot. Bare M or this.M would rebind to the derived override and
+            // recompile to ldvirtftn (virtual dispatch), changing behavior; so it
+            // stays base even under the qualify-method knob, mirroring CallText.
+            if (!isVirtual && IsCrossType(method.DeclaringType))
+                return $"base.{name}";
             return _options.QualifyMethodAccess ? $"this.{name}" : name;
+        }
         if (PointerMethodReceiver(target) is { } pointerReceiver)
             return $"{pointerReceiver}->{name}";
         return $"{ReceiverText(target)}.{name}";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -238,12 +238,16 @@ public sealed partial class CSharpPrinter
             return $"{TypeQualifierText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
         {
-            // A non-virtual (ldftn) method group over this to a base-declared
-            // method is C#'s base.M — the ldftn deliberately captures the base
-            // slot. Bare M or this.M would rebind to the derived override and
-            // recompile to ldvirtftn (virtual dispatch), changing behavior; so it
-            // stays base even under the qualify-method knob, mirroring CallText.
-            if (!isVirtual && IsCrossType(method.DeclaringType))
+            // A non-virtual (ldftn) instance method group over this to a
+            // base-declared method is C#'s base.M — the ldftn deliberately
+            // captures the base slot. Bare M or this.M would rebind to the derived
+            // override and recompile to ldvirtftn (virtual dispatch), changing
+            // behavior; so it stays base even under the qualify-method knob,
+            // mirroring CallText. HasThis excludes closed static extension groups,
+            // which share the `ldarg.0; ldftn` shape but bind the receiver as their
+            // first argument — base.Ext would be CS0117 on the base type; they
+            // stay this.Ext (or bare) like any other extension group.
+            if (method.HasThis && !isVirtual && IsCrossType(method.DeclaringType))
                 return $"base.{name}";
             return _options.QualifyMethodAccess ? $"this.{name}" : name;
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2666,7 +2666,7 @@ public sealed partial class CSharpPrinter
         Call c when MultiDimArrayAccessText(c) is { } text => text,
         Call c => CallText(c),
         CallIndirect ci => $"{FunctionPointerOperand(ci.Pointer)}({Arguments(ci.Arguments, ci.ParameterTypes, CallIndirectRefKinds(ci), explicitIn: true)})",
-        DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
+        DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target, d.IsVirtual)})",
         InterpolatedStringExpression i => InterpolatedStringText(i),
         Lambda lam => LambdaText(lam),
         LocalFunctionInvocation inv => $"{CSharpNaming.EscapeIdentifier(inv.Name)}({Arguments(inv.Arguments)})",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -251,6 +251,8 @@ public sealed partial class CSharpPrinter
             WrapSplittableExpressions = _options.WrapSplittableExpressions,
             QualifyFieldAccess = _options.QualifyFieldAccess,
             QualifyPropertyAccess = _options.QualifyPropertyAccess,
+            QualifyMethodAccess = _options.QualifyMethodAccess,
+            QualifyEventAccess = _options.QualifyEventAccess,
         };
 
     void AddDecision(string ruleId, string category, string subject, string detail, string? oldValue = null, string? newValue = null)
@@ -2290,7 +2292,7 @@ public sealed partial class CSharpPrinter
                 && SameLValue(load.Instance, s.Instance)
                 && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments),
             StorePropertyTargetType(s)),
-        EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CoerceText(e.Value, e.Accessor.ParameterTypes[0])};",
+        EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual, isEvent: true)} {(e.IsAdd ? "+=" : "-=")} {CoerceText(e.Value, e.Accessor.ParameterTypes[0])};",
         StoreElement s when InlineReceiverTempStoreValue(s) is { } value => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {value};",
         StoreElement s => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {InitializerText(s.Value, StoreElementTargetType(s), StoreElementNewTarget(s))};",
         StoreIndirect s => AssignmentText(

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -75,6 +75,25 @@ public sealed record PrinterOptions
     /// </summary>
     public bool QualifyPropertyAccess { get; init; }
 
+    /// <summary>
+    /// When set, an instance method invoked through <c>this</c> renders the explicit
+    /// <c>this.</c> qualifier even where the bare name is unambiguous. IL-identical —
+    /// <c>this.M()</c> and <c>M()</c> both emit <c>ldarg.0; call/callvirt</c>. A
+    /// genuine non-virtual base call still renders <c>base.M()</c> (qualifying it
+    /// with <c>this.</c> would re-enable virtual dispatch). Off by default. Mirrors
+    /// <c>dotnet_style_qualification_for_method</c>.
+    /// </summary>
+    public bool QualifyMethodAccess { get; init; }
+
+    /// <summary>
+    /// When set, an instance event subscribed through <c>this</c> renders the
+    /// explicit <c>this.</c> qualifier even where the bare name is unambiguous.
+    /// IL-identical — <c>this.E += h</c> and <c>E += h</c> both emit
+    /// <c>ldarg.0; call add_E</c>. Off by default. Mirrors
+    /// <c>dotnet_style_qualification_for_event</c>.
+    /// </summary>
+    public bool QualifyEventAccess { get; init; }
+
     /// <summary>The shipped defaults — every knob off.</summary>
     public static PrinterOptions Default { get; } = new();
 }

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -36,11 +36,15 @@ public class RenderStyleConfigTests
     {
         var result = RenderStyleConfig.Parse(
             "dotnet_style_qualification_for_field = true\n" +
-            "dotnet_style_qualification_for_property = true\n",
+            "dotnet_style_qualification_for_property = true\n" +
+            "dotnet_style_qualification_for_method = true\n" +
+            "dotnet_style_qualification_for_event = true\n",
             origin: "cfg");
 
         Assert.True(result.Options.QualifyFieldAccess);
         Assert.True(result.Options.QualifyPropertyAccess);
+        Assert.True(result.Options.QualifyMethodAccess);
+        Assert.True(result.Options.QualifyEventAccess);
         Assert.Empty(result.Warnings);
         Assert.Equal("cfg", result.Origin);
     }
@@ -327,6 +331,74 @@ public class RenderStyleConfigTests
         Assert.False(result.EffectiveOptions.QualifyFieldAccess);
     }
 
+    [Fact]
+    public void Collect_WithQualifyMethodAccess_QualifiesInstanceCallAndRecordsEvidence()
+    {
+        var (code, result) = RenderSpecimenMember(
+            nameof(ThisQualificationConfigSpecimen.Doubled),
+            PrinterOptions.Default with { QualifyMethodAccess = true });
+
+        Assert.Contains("this.Compute()", code);
+        Assert.True(result.EffectiveOptions.QualifyMethodAccess);
+        Assert.False(result.EffectiveOptions.QualifyEventAccess);
+    }
+
+    [Fact]
+    public void Collect_WithoutRenderOptions_RendersBareInstanceCall()
+    {
+        var (code, _) = RenderSpecimenMember(
+            nameof(ThisQualificationConfigSpecimen.Doubled), renderOptions: null);
+
+        Assert.Contains("Compute()", code);
+        Assert.DoesNotContain("this.Compute()", code);
+    }
+
+    [Fact]
+    public void Collect_WithQualifyMethodAccess_QualifiesThisMethodGroup()
+    {
+        var (code, _) = RenderSpecimenMember(
+            nameof(ThisQualificationConfigSpecimen.ComputeGetter),
+            PrinterOptions.Default with { QualifyMethodAccess = true });
+
+        Assert.Contains("this.Compute", code);
+    }
+
+    [Fact]
+    public void Collect_WithQualifyEventAccess_QualifiesEventAndRecordsEvidence()
+    {
+        var (code, result) = RenderSpecimenMember(
+            nameof(ThisQualificationConfigSpecimen.Subscribe),
+            PrinterOptions.Default with { QualifyEventAccess = true });
+
+        Assert.Contains("this.Pinged +=", code);
+        Assert.True(result.EffectiveOptions.QualifyEventAccess);
+        Assert.False(result.EffectiveOptions.QualifyMethodAccess);
+    }
+
+    [Fact]
+    public void Collect_WithoutRenderOptions_RendersBareEventSubscription()
+    {
+        var (code, _) = RenderSpecimenMember(
+            nameof(ThisQualificationConfigSpecimen.Subscribe), renderOptions: null);
+
+        Assert.Contains("Pinged +=", code);
+        Assert.DoesNotContain("this.Pinged", code);
+    }
+
+    // An event subscription and a property access both route through the printer's
+    // PropertyTarget helper, but they are governed by separate knobs: enabling
+    // property qualification must NOT qualify an event subscription (and the
+    // event knob, tested above, does).
+    [Fact]
+    public void Collect_WithQualifyPropertyAccess_DoesNotQualifyEventSubscription()
+    {
+        var (code, _) = RenderSpecimenMember(
+            nameof(ThisQualificationConfigSpecimen.Subscribe),
+            PrinterOptions.Default with { QualifyPropertyAccess = true });
+
+        Assert.DoesNotContain("this.Pinged", code);
+    }
+
     // Whole-type decompilation (the `type -S "Decompiled Source"` path) routes
     // through MemberBodyProducer.Project rather than Collect, so it needs the
     // resolved options threaded separately.
@@ -510,6 +582,36 @@ public class RenderStyleConfigTests
         return (decompiled!.Output, decompiled);
     }
 
+    private static (string Code, ILInspector.Decompiler.DecompilerResult Result) RenderSpecimenMember(
+        string memberName, PrinterOptions? renderOptions)
+    {
+        string assemblyPath = typeof(ThisQualificationConfigSpecimen).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(ThisQualificationConfigSpecimen).FullName);
+        var methods = type.Members.Where(m => m.Name == memberName).ToList();
+
+        var request = new MemberCodeProvider.Request(
+            DecompiledSource: true,
+            AnnotatedSource: false,
+            CostOverlay: false,
+            SemanticsOverlay: false,
+            IL: false,
+            Attributes: false,
+            Calls: false,
+            Callers: false,
+            CallGraph: false,
+            UnsafeOperations: false);
+
+        var results = MemberCodeProvider.Collect(
+            type, methods, assemblyPath, overloadIndex: 0, request, renderOptions: renderOptions);
+
+        var (_, code) = Assert.Single(results);
+        var decompiled = code.DecompiledResult;
+        Assert.NotNull(decompiled?.Output);
+        return (decompiled!.Output, decompiled);
+    }
+
     private static string RenderSpecimenWholeType(PrinterOptions? renderOptions)
     {
         string assemblyPath = typeof(ThisQualificationConfigSpecimen).Assembly.Location;
@@ -546,6 +648,19 @@ public class ThisQualificationConfigSpecimen
     public int Extra { get; set; }
 
     public int Compute() => _count + Extra;
+
+    // Instance method call on the implicit this receiver.
+    public int Doubled() => Compute() * 2;
+
+    // Method group over the implicit this receiver.
+    public System.Func<int> ComputeGetter() => Compute;
+
+#pragma warning disable CS0067 // Pinged is subscribed to via Subscribe; the fixture never raises it.
+    public event System.EventHandler? Pinged;
+#pragma warning restore CS0067
+
+    // Event subscription (+=) on the implicit this receiver.
+    public void Subscribe(System.EventHandler handler) => Pinged += handler;
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -38,11 +38,13 @@ internal static class RenderStyleConfig
     /// <summary>The tool-owned style file name discovered by walking up from the working directory.</summary>
     public const string FileName = ".dotnet-inspectconfig";
 
-    // v1 recognizes exactly the two class-3 this.-qualification knobs, which are
-    // the only shipped spelling knobs with an exact editorconfig key. More keys
-    // are added here as further class-3 knobs land.
+    // Recognizes the class-3 this.-qualification knobs, which are the shipped
+    // spelling knobs with an exact editorconfig key. More keys are added here as
+    // further class-3 knobs land.
     private const string FieldKey = "dotnet_style_qualification_for_field";
     private const string PropertyKey = "dotnet_style_qualification_for_property";
+    private const string MethodKey = "dotnet_style_qualification_for_method";
+    private const string EventKey = "dotnet_style_qualification_for_event";
 
     // The editorconfig boundary marker. Discovery is nearest-wins, so the nearest
     // file is already a hard boundary (nothing above it is read); 'root' is
@@ -118,6 +120,8 @@ internal static class RenderStyleConfig
     {
         bool qualifyField = false;
         bool qualifyProperty = false;
+        bool qualifyMethod = false;
+        bool qualifyEvent = false;
         List<string>? warnings = null;
 
         void Warn(string message) => (warnings ??= []).Add(message);
@@ -167,6 +171,18 @@ internal static class RenderStyleConfig
                     else
                         Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
                     break;
+                case MethodKey:
+                    if (TryParseBool(value, out var m))
+                        qualifyMethod = m;
+                    else
+                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
+                    break;
+                case EventKey:
+                    if (TryParseBool(value, out var e))
+                        qualifyEvent = e;
+                    else
+                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
+                    break;
                 case RootKey:
                     // editorconfig boundary marker. Discovery is nearest-wins, so
                     // the nearest file is already a hard boundary; 'root' drives no
@@ -185,6 +201,8 @@ internal static class RenderStyleConfig
         {
             QualifyFieldAccess = qualifyField,
             QualifyPropertyAccess = qualifyProperty,
+            QualifyMethodAccess = qualifyMethod,
+            QualifyEventAccess = qualifyEvent,
         };
 
         return new RenderStyleResolution(options, origin, (IReadOnlyList<string>?)warnings ?? []);


### PR DESCRIPTION
## Summary

Slice 2b of the tool-owned decompiler style config (issue #3097). Extends the class-3 `this.`-qualification knob family with **method** and **event** qualification, mapped from their exact editorconfig keys through the existing CLI-edge `.dotnet-inspectconfig` resolver.

- `PrinterOptions.QualifyMethodAccess` ← `dotnet_style_qualification_for_method` — instance method calls (`CallText`) and method groups (`MethodGroupText`) over `this`.
- `PrinterOptions.QualifyEventAccess` ← `dotnet_style_qualification_for_event` — event `+=`/`-=` subscriptions (route through `PropertyTarget`).

Both default **off**, so default output is byte-for-byte unchanged. When set, they force `this.` on a same-type instance access that is already a `LoadArgument{this}` receiver — an IL-identical spelling with no binding hazard.

## Soundness

- A genuine non-virtual `base.M()` call is **never** rewritten to `this.M()` (that would re-enable virtual dispatch and change behavior — unbounded recursion in the fixture). The base arm short-circuits before the qualifier.
- Event subscriptions are now governed by `QualifyEventAccess` rather than `QualifyPropertyAccess`, **decoupling** the two knobs to match their separate editorconfig keys. Both share the `PropertyTarget` helper internally but read independent options. The just-shipped property knob is the only prior consumer, so no external behavior regresses.
- Both knobs are mirrored in `DecompilerResult.DecompilerOptions` and recorded via `EffectiveDecompilerOptions`, so a host can distinguish an on-render from an off-render without reverse-engineering the text.

## Evidence

- **Printer layer** (`ThisQualificationTests`, +10): method qualify / default-bare, method-group qualify / default-bare, event qualify / default-bare, `base.Value()` guard, cross-knob decoupling (property↛event, event↛method), `EffectiveOptions` records both knobs. 19/19 green.
- **Config seam** (`RenderStyleConfigTests`): key-mapping parse test (all four keys) + method/event qualification through the real `MemberCodeProvider.Collect` seam + property/event decoupling. 35/35 green.
- **CLI canary** (`.dotnet-inspectconfig` in CWD, real fixture DLL): method+event keys → `this.Compute()` / `this.Pinged += handler`; no config → bare; property-key-only → event stays bare (decoupling).
- Fast RoundTrip area: 19 `ThisQualificationTests` pass; the 31 failures are all pre-existing `ReturnToSenderFixtureCatalogTests` environmental compile-back reds (CI-green), identical to baseline.
- `docs/decompiler-taste.md` updated (two new keys + base-call caveat + event/property decoupling); markdownlint clean.

## Compatibility

Default output byte-for-byte unchanged (both knobs off gate every new branch). The only behavior change is intentional: `QualifyPropertyAccess=true` no longer qualifies events.

Part of #3097.