### PR TITLE
Fully raise outer type-pattern dispatch to nested switch expression (#3113)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
@@ -181,6 +181,38 @@ public class CrossAssemblyMethodFactsTests
         Assert.True(call.Callee.IsSpecialNameInferred);
     }
 
+    [Fact]
+    public void CrossAssemblyRefStruct_RecoveredIntoByRefLikeTypes()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath);
+
+        // GPT review round 5 (#3124): a `ref struct` defined in a REFERENCED
+        // assembly resolves to a ValueType shape but carries no same-assembly
+        // by-ref-like fact, so the value-type-arm gate would raise `T t` over it —
+        // invalid C# (CS8121). The [IsByRefLike] fact is now resolved through the
+        // cross-assembly resolver and recovered into ByRefLikeTypes; the
+        // same-assembly value struct (ExternalNumber) stays out.
+        var refStructUser = ImportFunction(source, nameof(CrossAssemblyFixtureMethods.UseExternalRefStruct));
+        Assert.Contains(refStructUser.ByRefLikeTypes, t => t.Name == "ExternalRefStruct");
+
+        var structUser = ImportFunction(source, nameof(CrossAssemblyFixtureMethods.UseExternalStruct));
+        Assert.DoesNotContain(structUser.ByRefLikeTypes, t => t.Name == "ExternalNumber");
+    }
+
+    [Fact]
+    public void MissingCrossAssemblyRefStructMetadata_KeepsByRefLikeUnknown()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath, null, TestAssemblyReferenceResolvers.None);
+
+        // With the defining assembly outside the reference closure the fact cannot
+        // be resolved, so the referenced ref struct is absent from ByRefLikeTypes —
+        // fail visible, not a wrong-positive.
+        var refStructUser = ImportFunction(source, nameof(CrossAssemblyFixtureMethods.UseExternalRefStruct));
+        Assert.DoesNotContain(refStructUser.ByRefLikeTypes, t => t.Name == "ExternalRefStruct");
+    }
+
     static string Print(MetadataSource source, string methodName)
     {
         var function = ImportFunction(source, methodName);
@@ -273,6 +305,11 @@ public class CrossAssemblyMethodFactsTests
                             => new(left.Value + right.Value);
                     }
 
+                    public ref struct ExternalRefStruct
+                    {
+                        public int Value;
+                    }
+
                     [CompilerGenerated]
                     public static class Generated__DisplayClass0_0
                     {
@@ -327,6 +364,19 @@ public class CrossAssemblyMethodFactsTests
 
                         public static ExternalNumber UseRealOperator(ExternalNumber left, ExternalNumber right)
                             => left + right;
+
+                        public static int UseExternalRefStruct()
+                        {
+                            ExternalRefStruct value = default;
+                            value.Value = 3;
+                            return value.Value;
+                        }
+
+                        public static int UseExternalStruct()
+                        {
+                            ExternalNumber value = new(3);
+                            return value.Value;
+                        }
 
                         public static int UseProperty(PropertyLibrary library)
                             => library.Count;
@@ -389,6 +439,8 @@ public class CrossAssemblyMethodFactsTests
         public const string UseOperatorLikeAddition = nameof(UseOperatorLikeAddition);
         public const string UseOperatorLikeImplicit = nameof(UseOperatorLikeImplicit);
         public const string UseRealOperator = nameof(UseRealOperator);
+        public const string UseExternalRefStruct = nameof(UseExternalRefStruct);
+        public const string UseExternalStruct = nameof(UseExternalStruct);
         public const string UseProperty = nameof(UseProperty);
         public const string UseUri = nameof(UseUri);
         public const string UseExternalInlineArray = nameof(UseExternalInlineArray);

--- a/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
@@ -27,8 +27,10 @@ namespace ILInspector.Decompiler.Tests;
 ///
 /// The compiler-backed positive is the witness itself. The synthetic negatives
 /// pin the new discriminators: a value-type arm whose unbox type disagrees with
-/// its isinst test, a guard whose failure diverges from the default, and a
-/// diamond whose matched arm does not reach the shared default.
+/// its isinst test, a guard whose failure diverges from the default, a diamond
+/// whose matched arm does not reach the shared default, a nullable test type
+/// (illegal as a declaration pattern), and a bound-slot type that disagrees with
+/// the pattern type (the last two from GPT review of #3124).
 /// </summary>
 [Trait("Area", "Pass")]
 public class OuterTypePatternDispatchRaisingTests
@@ -102,7 +104,9 @@ public class OuterTypePatternDispatchRaisingTests
         IrExpression noMatchDefault,
         IrExpression guardFailDefault,
         IrExpression leafValue,
-        bool elseDeadTail = false)
+        bool elseDeadTail = false,
+        TypeRef? unboxType = null,
+        TypeRef? bindType = null)
     {
         IrExpression Win() => new Call(
             new MethodRef(Node, "Win", Bool, [Int32], HasThis: false),
@@ -125,7 +129,7 @@ public class OuterTypePatternDispatchRaisingTests
 
         var then = new Block();
         then.Add(vtDispatch);
-        then.Add(new StoreLocal(1, Int32, new UnboxAny(Int32, new LoadLocal(9, Node))));
+        then.Add(new StoreLocal(1, bindType ?? Int32, new UnboxAny(unboxType ?? Int32, new LoadLocal(9, Node))));
         then.Add(guard);
         then.Add(new Return(Win()));
 
@@ -222,6 +226,48 @@ public class OuterTypePatternDispatchRaisingTests
             guardFailDefault: Default(),
             leafValue: new Constant(true, Bool),
             elseDeadTail: true);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    [Fact]
+    public void Synthetic_NullableValueTypeTest_DoesNotRaise()
+    {
+        // GPT review (#3124): a `Nullable<int>` isinst+unbox arm is consistent —
+        // test, unbox, and bind types all agree — but `int?` is illegal as a
+        // C# declaration-pattern type (CS8116), so raising it would emit invalid
+        // C# under a `Full` label. IsValueTypeArm must decline any nullable test
+        // type; the cascade stays if/return.
+        var nullableInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Nullable`1"), ImmutableArray.Create(Int32));
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: nullableInt,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool),
+            unboxType: nullableInt,
+            bindType: nullableInt);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    [Fact]
+    public void Synthetic_BindTypeDiffersFromTest_DoesNotRaise()
+    {
+        // GPT review (#3124): isinst+unbox both name `int`, but the bound slot is
+        // declared `bool`. Raising declares an `int` pattern var for a `bool` slot
+        // (CS0029), so the pattern type must equal the bound local's declared type.
+        // IsValueTypeArm declines when they disagree; the cascade stays if/return.
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: Int32,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool),
+            unboxType: Int32,
+            bindType: Bool);
 
         RunPass(function);
 

--- a/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
@@ -232,6 +232,41 @@ public class OuterTypePatternDispatchRaisingTests
         Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
     }
 
+    public static IEnumerable<object[]> UnspellablePatternTypes()
+    {
+        // A bare `Nullable`1` definition (open, no type argument): CS0723 as a pattern.
+        yield return [TypeRef.CoreLib("System", "Nullable`1")];
+        // A pointer type: not a pattern type (`int*` is a syntax error in a pattern).
+        yield return [TypeRef.Pointer(Int32)];
+        // A function-pointer type: CS8521 as a pattern.
+        yield return [TypeRef.FunctionPointer(Int32, ImmutableArray<TypeRef>.Empty, "")];
+    }
+
+    [Theory]
+    [MemberData(nameof(UnspellablePatternTypes))]
+    public void Synthetic_UnspellableValueTypePattern_DoesNotRaise(TypeRef testType)
+    {
+        // GPT review (#3124): the value-type arm accepted any non-`Nullable<T>`
+        // test type, so a bare `Nullable`1` definition, a pointer, or a
+        // function pointer raised to a switch arm (`Nullable =>`, `int* =>`,
+        // `delegate*<int> =>`) — none of which is a legal C# declaration pattern.
+        // IsSpellableValueTypePattern admits only concrete non-nullable value-type
+        // definitions/instances, so each of these declines and the cascade stays
+        // if/return. Test, unbox, and bind types agree, isolating the pattern-kind
+        // gate from the unbox/bind checks.
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: testType,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool),
+            unboxType: testType,
+            bindType: testType);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
     [Fact]
     public void Synthetic_NullableValueTypeTest_DoesNotRaise()
     {

--- a/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
@@ -1,0 +1,230 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Issue #3113: <see cref="PatternSwitchExpressionPass"/> raises the outer
+/// type-pattern dispatch of <see cref="ScatteredReturnDispatchSample.Dispatch"/>
+/// — the #2978 witness — all the way back to its original nested
+/// <c>switch</c> expression. #3094 raised only the inner <c>s.Length</c>
+/// comparison-chain arm; this closes the outer dispatch, which needs three new
+/// recognizer capabilities the compiler emits here:
+/// <list type="bullet">
+/// <item>a <em>diamond intro arm</em> — the matched value lives in the <c>if</c>'s
+///   <c>else</c> and the remaining arms in its <c>then</c> (csc's shape when an
+///   arm value spans multiple blocks, here the nested switch expression);</item>
+/// <item>a <em>value-type arm</em> — <c>if (!(o is int)) return default; i =
+///   (int)o;</c>, an isinst test then a separate unbox.any bind with no isinst
+///   intro local;</item>
+/// <item>a <em>flipped-comparison guard</em> — a <c>when i &gt; 0</c> whose
+///   failure lowers to <c>if (i &lt;= 0) return default;</c>, recovered by
+///   negating the relational.</item>
+/// </list>
+/// The shared default <c>_ =&gt; Fail(out x)</c> is a method call reached by
+/// several identical <c>return Fail(out x)</c> paths, so folding also needs
+/// structural call identity (SameSinkValue), not just re-evaluable-place identity.
+///
+/// The compiler-backed positive is the witness itself. The synthetic negatives
+/// pin the new discriminators: a value-type arm whose unbox type disagrees with
+/// its isinst test, a guard whose failure diverges from the default, and a
+/// diamond whose matched arm does not reach the shared default.
+/// </summary>
+[Trait("Area", "Pass")]
+public class OuterTypePatternDispatchRaisingTests
+{
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Node = TypeRef.CoreLib("Synthetic", "Node");
+    static readonly TypeRef Leaf = TypeRef.CoreLib("Synthetic", "Leaf");
+
+    static IrFunction Raised(System.Type fixtureType, string methodName)
+    {
+        using var source = MetadataSource.Open(fixtureType.Assembly.Location);
+        var function = IrImporter.Import(source, fixtureType.FullName!, methodName);
+        Assert.NotNull(function);
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method => IrImporter.Import(source, method),
+            typesProvablyDisjoint: source.AreProvablyDisjoint);
+        IrPasses.Run(function!, IrPasses.Default, context);
+        function!.CheckInvariant();
+        return function;
+    }
+
+    static void RunPass(IrFunction function) => new PatternSwitchExpressionPass().Run(function, PassContext.None);
+
+    // ── Compiler-backed positive: the #2978 witness ─────────────────────────
+
+    [Fact]
+    public void Witness_FullyRaisesToNestedSwitchExpression()
+    {
+        var function = Raised(typeof(ScatteredReturnDispatchSample), nameof(ScatteredReturnDispatchSample.Dispatch));
+
+        // Outer type-pattern dispatch is a single pattern switch expression; no
+        // if/statement residue survives.
+        var patternSwitch = Assert.Single(function.Descendants.OfType<PatternSwitchExpression>());
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.True(patternSwitch.HasDefault);
+        Assert.Equal(2, patternSwitch.Arms.Count);
+
+        // Arm 0: `string s` — unguarded reference arm whose value is the inner
+        // (value-constant) switch expression raised by #3094.
+        Assert.Contains("string", patternSwitch.Arms[0].PatternType.ToDisplayString());
+        Assert.False(patternSwitch.Arms[0].HasGuard);
+        Assert.Single(function.Descendants.OfType<SwitchExpression>());
+
+        // Arm 1: `int i when i > 0` — the guarded value-type arm.
+        Assert.Contains("int", patternSwitch.Arms[1].PatternType.ToDisplayString());
+        Assert.True(patternSwitch.Arms[1].HasGuard);
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+        Assert.Contains("return o switch", output);
+        Assert.Contains("string s => s.Length switch { 0 => Fail(out x), 1 => Win(1, out x), _ => Fail(out x) },", output);
+        Assert.Contains("int i when i > 0 => Win(i, out x),", output);
+        Assert.Contains("_ => Fail(out x),", output);
+    }
+
+    // ── Synthetic builder mirroring the witness's outer dispatch ────────────
+
+    // Builds the witness's outer temp-form cascade:
+    //   V9 = <switch value>;
+    //   L0 = V9 as Leaf;
+    //   if (!L0) { if (!(V9 is <unboxType-as-testType>)) return <default>;
+    //              L1 = (int)V9;
+    //              if (L1 <= 0) return <guardFailDefault>;
+    //              return Win(L1); }
+    //   else     { return <leafValue> <plus optional dead tail> }
+    // The Leaf arm is the diamond intro arm; the int arm is the value-type arm
+    // with a flipped `L1 <= 0` guard. Knobs break exactly one invariant.
+    static IrFunction DiamondValueTypeCascade(
+        TypeRef valueTypeTest,
+        IrExpression noMatchDefault,
+        IrExpression guardFailDefault,
+        IrExpression leafValue,
+        bool elseDeadTail = false)
+    {
+        IrExpression Win() => new Call(
+            new MethodRef(Node, "Win", Bool, [Int32], HasThis: false),
+            isVirtual: false,
+            [new LoadLocal(1, Int32)]);
+
+        var vtDispatchThen = new Block();
+        vtDispatchThen.Add(new Return(noMatchDefault));
+        var vtDispatch = new IfStatement(
+            new LogicalNot(new IsInstance(valueTypeTest, new LoadLocal(9, Node))),
+            vtDispatchThen,
+            null);
+
+        var guardThen = new Block();
+        guardThen.Add(new Return(guardFailDefault));
+        var guard = new IfStatement(
+            new Comparison(ComparisonKind.LessThanOrEqual, isUnsigned: false, new LoadLocal(1, Int32), new Constant(0, Int32)),
+            guardThen,
+            null);
+
+        var then = new Block();
+        then.Add(vtDispatch);
+        then.Add(new StoreLocal(1, Int32, new UnboxAny(Int32, new LoadLocal(9, Node))));
+        then.Add(guard);
+        then.Add(new Return(Win()));
+
+        var elseBlock = new Block();
+        elseBlock.Add(new Return(leafValue));
+        if (elseDeadTail)
+            elseBlock.Add(new Return(new Constant(true, Bool)));
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(9, Node, new LoadArgument(0, "o", Node)));
+        block.Add(new StoreLocal(0, Leaf, new IsInstance(Leaf, new LoadLocal(9, Node))));
+        block.Add(new IfStatement(new LogicalNot(new LoadLocal(0, Leaf)), then, elseBlock));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Bool, [new Parameter("o", Node)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Node, signature, ImmutableArray.Create(Leaf, Int32, Bool, Node, Node, Node, Node, Node, Node, Node), container);
+    }
+
+    static Call Default() => new(new MethodRef(Node, "Fail", Bool, [], HasThis: false), isVirtual: false, []);
+
+    [Fact]
+    public void Synthetic_DiamondValueTypeGuard_Raises()
+    {
+        // All invariants intact: the value-type unbox matches its isinst test, the
+        // guard failure returns the same call as the default, and the diamond's
+        // else reaches the default. Folds to a two-arm switch expression.
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: Int32,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool));
+
+        RunPass(function);
+
+        var patternSwitch = Assert.Single(function.Descendants.OfType<PatternSwitchExpression>());
+        Assert.Equal(2, patternSwitch.Arms.Count);
+        Assert.True(patternSwitch.HasDefault);
+        Assert.Contains("Leaf", patternSwitch.Arms[0].PatternType.ToDisplayString());
+        Assert.False(patternSwitch.Arms[0].HasGuard);
+        Assert.Contains("int", patternSwitch.Arms[1].PatternType.ToDisplayString());
+        Assert.True(patternSwitch.Arms[1].HasGuard);
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+    }
+
+    [Fact]
+    public void Synthetic_ValueTypeUnboxTypeDiffersFromTest_DoesNotRaise()
+    {
+        // The value-type arm's isinst tests `Leaf` but the unbox binds `int`. A
+        // switch arm's pattern is one type; a test/unbox type disagreement is not
+        // a value-type pattern bind, so IsValueTypeArm declines and the cascade
+        // stays if/return.
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: Leaf,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool));
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    [Fact]
+    public void Synthetic_GuardFailDivergesFromDefault_DoesNotRaise()
+    {
+        // The value-type arm's `when` guard failure returns `Other()`, a different
+        // call than the shared `Fail()` default. In a switch expression a failed
+        // guard falls to the default arm, so a divergent guard-fail value means
+        // the fold is not faithful — SameSinkValue distinguishes the two calls and
+        // the cascade is left as-is.
+        var other = new Call(new MethodRef(Node, "Other", Bool, [], HasThis: false), isVirtual: false, []);
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: Int32,
+            noMatchDefault: Default(),
+            guardFailDefault: other,
+            leafValue: new Constant(true, Bool));
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    [Fact]
+    public void Synthetic_DiamondElseDoesNotReachDefault_DoesNotRaise()
+    {
+        // The diamond's `else` (the Leaf arm value) is followed by a second
+        // statement, so the matched body does not reach the shared default tail.
+        // The arm value must be a single reachable run; an unreached tail means
+        // this is not the diamond arm shape, so decline.
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: Int32,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool),
+            elseDeadTail: true);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
@@ -29,8 +29,13 @@ namespace ILInspector.Decompiler.Tests;
 /// pin the new discriminators: a value-type arm whose unbox type disagrees with
 /// its isinst test, a guard whose failure diverges from the default, a diamond
 /// whose matched arm does not reach the shared default, a nullable test type
-/// (illegal as a declaration pattern), and a bound-slot type that disagrees with
-/// the pattern type (the last two from GPT review of #3124).
+/// (illegal as a declaration pattern), a bound-slot type that disagrees with the
+/// pattern type, un-spellable test types (pointer/function-pointer/bare
+/// <c>Nullable`1</c>/<c>void</c>/static class), and a framework ref struct
+/// (<c>Span&lt;int&gt;</c>) which resolves to a value-type shape but is illegal
+/// as a boxed pattern. A synthetic positive pins that a generic-parameter arm
+/// (<c>isinst T; unbox.any T</c>, which csc does emit) still raises. The last
+/// group is from GPT review of #3124.
 /// </summary>
 [Trait("Area", "Pass")]
 public class OuterTypePatternDispatchRaisingTests
@@ -240,6 +245,10 @@ public class OuterTypePatternDispatchRaisingTests
         yield return [TypeRef.Pointer(Int32)];
         // A function-pointer type: CS8521 as a pattern.
         yield return [TypeRef.FunctionPointer(Int32, ImmutableArray<TypeRef>.Empty, "")];
+        // System.Void: not a matchable value type (CS1547).
+        yield return [TypeRef.CoreLib("System", "Void")];
+        // A static/reference class definition (no value-type shape): CS0723/CS8121 as a pattern.
+        yield return [TypeRef.CoreLib("System", "Math")];
     }
 
     [Theory]
@@ -247,12 +256,12 @@ public class OuterTypePatternDispatchRaisingTests
     public void Synthetic_UnspellableValueTypePattern_DoesNotRaise(TypeRef testType)
     {
         // GPT review (#3124): the value-type arm accepted any non-`Nullable<T>`
-        // test type, so a bare `Nullable`1` definition, a pointer, or a
-        // function pointer raised to a switch arm (`Nullable =>`, `int* =>`,
-        // `delegate*<int> =>`) — none of which is a legal C# declaration pattern.
-        // IsSpellableValueTypePattern admits only concrete non-nullable value-type
-        // definitions/instances, so each of these declines and the cascade stays
-        // if/return. Test, unbox, and bind types agree, isolating the pattern-kind
+        // test type, so a bare `Nullable`1` definition, a pointer, a function
+        // pointer, `System.Void`, or a static/reference class raised to a switch
+        // arm — none of which is a legal C# declaration pattern. A test type must
+        // now prove it is a known non-nullable value type (or a generic
+        // parameter), so each of these declines and the cascade stays if/return.
+        // Test, unbox, and bind types agree, isolating the pattern-eligibility
         // gate from the unbox/bind checks.
         var function = DiamondValueTypeCascade(
             valueTypeTest: testType,
@@ -261,6 +270,62 @@ public class OuterTypePatternDispatchRaisingTests
             leafValue: new Constant(true, Bool),
             unboxType: testType,
             bindType: testType);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    public static IEnumerable<object[]> GenericParameterPatternTypes()
+    {
+        yield return [TypeRef.GenericParameter(0, "T")];
+        yield return [TypeRef.MethodGenericParameter(0, "T")];
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericParameterPatternTypes))]
+    public void Synthetic_GenericParameterValueTypeArm_Raises(TypeRef testType)
+    {
+        // GPT review (#3124): csc emits `isinst T; unbox.any T; stloc T` for an
+        // unconstrained (or struct-constrained) generic parameter, and `T t` is a
+        // legal C# declaration pattern. An over-strict kind whitelist wrongly
+        // declined these; IsSpellableValueTypePattern now admits generic
+        // parameters directly, so the value-type arm raises — matching the shape
+        // the compiler itself produces.
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: testType,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool),
+            unboxType: testType,
+            bindType: testType);
+
+        RunPass(function);
+
+        var patternSwitch = Assert.Single(function.Descendants.OfType<PatternSwitchExpression>());
+        Assert.Equal(2, patternSwitch.Arms.Count);
+        Assert.True(patternSwitch.HasDefault);
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+    }
+
+    [Fact]
+    public void Synthetic_FrameworkRefStructWithValueShape_DoesNotRaise()
+    {
+        // GPT review (#3124): a ref struct (`Span<int>`) resolves to a value-type
+        // shape but is illegal as a boxed pattern (CS8121) and is never a
+        // compiler-produced value-type arm — a ref struct cannot be boxed. Even
+        // stamped with a value-type hint (so the general value-type gate would
+        // admit it), IsFrameworkRefStruct rejects `Span`/`ReadOnlySpan` by name,
+        // so the cascade stays if/return rather than raising invalid `Full` C#.
+        var spanDef = TypeRef.CoreLib("System", "Span`1").WithValueTypeHint(ValueTypeHint.ValueType);
+        var span = TypeRef.GenericInstance(spanDef, ImmutableArray.Create(Int32));
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: span,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool),
+            unboxType: span,
+            bindType: span);
 
         RunPass(function);
 

--- a/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
@@ -31,11 +31,12 @@ namespace ILInspector.Decompiler.Tests;
 /// whose matched arm does not reach the shared default, a nullable test type
 /// (illegal as a declaration pattern), a bound-slot type that disagrees with the
 /// pattern type, un-spellable test types (pointer/function-pointer/bare
-/// <c>Nullable`1</c>/<c>void</c>/static class), and a framework ref struct
-/// (<c>Span&lt;int&gt;</c>) which resolves to a value-type shape but is illegal
-/// as a boxed pattern. A synthetic positive pins that a generic-parameter arm
-/// (<c>isinst T; unbox.any T</c>, which csc does emit) still raises. The last
-/// group is from GPT review of #3124.
+/// <c>Nullable`1</c>/<c>void</c>/static class), a stack-only value type
+/// (<c>Span&lt;int&gt;</c>, <c>TypedReference</c>) which resolves to a value-type
+/// shape but is illegal as a boxed pattern, and a user-defined <c>ref struct</c>
+/// caught through the imported <c>[IsByRefLike]</c> fact. A synthetic positive
+/// pins that a generic-parameter arm (<c>isinst T; unbox.any T</c>, which csc
+/// does emit) still raises. The last group is from GPT review of #3124.
 /// </summary>
 [Trait("Area", "Pass")]
 public class OuterTypePatternDispatchRaisingTests
@@ -315,7 +316,7 @@ public class OuterTypePatternDispatchRaisingTests
         // shape but is illegal as a boxed pattern (CS8121) and is never a
         // compiler-produced value-type arm — a ref struct cannot be boxed. Even
         // stamped with a value-type hint (so the general value-type gate would
-        // admit it), IsFrameworkRefStruct rejects `Span`/`ReadOnlySpan` by name,
+        // admit it), IsStackOnlyValueType rejects `Span`/`ReadOnlySpan` by name,
         // so the cascade stays if/return rather than raising invalid `Full` C#.
         var spanDef = TypeRef.CoreLib("System", "Span`1").WithValueTypeHint(ValueTypeHint.ValueType);
         var span = TypeRef.GenericInstance(spanDef, ImmutableArray.Create(Int32));
@@ -326,6 +327,56 @@ public class OuterTypePatternDispatchRaisingTests
             leafValue: new Constant(true, Bool),
             unboxType: span,
             bindType: span);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    [Fact]
+    public void Synthetic_TypedReferenceValueTypeArm_DoesNotRaise()
+    {
+        // GPT review round 4 (#3124): `System.TypedReference` sits in the corelib
+        // value-type list, so the general value-type gate admits it, yet it is a
+        // stack-only by-ref-like type — illegal as a boxed pattern (CS8121) and
+        // never a compiler-produced value-type arm. IsStackOnlyValueType rejects
+        // it by name (its by-ref-like nature lives on the cross-assembly corelib
+        // definition, not the TypeRef), so the cascade stays if/return.
+        var typedRef = TypeRef.CoreLib("System", "TypedReference");
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: typedRef,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool),
+            unboxType: typedRef,
+            bindType: typedRef);
+
+        RunPass(function);
+
+        Assert.Empty(function.Descendants.OfType<PatternSwitchExpression>());
+    }
+
+    [Fact]
+    public void Synthetic_UserRefStructValueTypeArm_DoesNotRaise()
+    {
+        // GPT review round 4 (#3124): a user-defined `ref struct` in the inspected
+        // assembly resolves to a ValueType shape (indistinguishable from an
+        // ordinary struct by shape alone), so the general value-type gate admits
+        // it. A ref struct cannot be boxed, so the value-type arm over one is
+        // never compiler-produced and `T t` over it is illegal (CS8121). The
+        // `[IsByRefLike]` fact is recovered at import into `function.ByRefLikeTypes`
+        // (populated here to mirror that import); IsByRefLike consults it and
+        // declines, so the cascade stays if/return. State unreachable via csc — a
+        // synthetic fixture is the appropriate proof for this defensive gate.
+        var userRefStruct = TypeRef.CoreLib("Synthetic", "UserRefStruct").WithValueTypeHint(ValueTypeHint.ValueType);
+        var function = DiamondValueTypeCascade(
+            valueTypeTest: userRefStruct,
+            noMatchDefault: Default(),
+            guardFailDefault: Default(),
+            leafValue: new Constant(true, Bool),
+            unboxType: userRefStruct,
+            bindType: userRefStruct);
+        function.ByRefLikeTypes = ImmutableHashSet.Create(userRefStruct);
 
         RunPass(function);
 

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
@@ -44,17 +44,19 @@ public class ScatteredReturnDispatchStructuringTests
     {
         string output = Print(nameof(ScatteredReturnDispatchSample.Dispatch));
 
-        // The failing int arm (i <= 0) now returns the duplicated default instead
-        // of falling off the end — the CS0177 fix.
-        int guard = output.IndexOf("if (i <= 0)", StringComparison.Ordinal);
-        Assert.True(guard >= 0, output);
-        Assert.Contains("return Fail(out x);", output[guard..]);
+        // Issue #3113: the scattered dispatch is now fully raised past the
+        // statement form into the original nested switch expression. The #2978
+        // CS0177 guarantee (every path returns, out x assigned on the failing
+        // i <= 0 case) is subsumed: the shared default is the `_ => Fail(out x)`
+        // arm, so no path falls off the end. StructuringPass still duplicates the
+        // scattered default as a prerequisite for this raise.
+        Assert.Contains("int i when i > 0 => Win(i, out x)", output);
+        Assert.Contains("_ => Fail(out x)", output);
 
-        // Every path returns: the method body ends with an unconditional return.
-        Assert.EndsWith("return Win(i, out x);", output);
-
-        // The default is duplicated into each guard rather than dropped: no goto
-        // label survives and the raised body has no fall-through terminator.
+        // The whole body is a single switch-expression return: every arm produces
+        // a value, so no fall-through terminator and no goto survive.
+        Assert.StartsWith("return o switch", output);
+        Assert.EndsWith("};", output);
         Assert.DoesNotContain("goto", output);
     }
 

--- a/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
@@ -30,6 +30,8 @@ public class SubstratePredicateCensusTests
             "FieldRef equality paired with pass-owned receiver/index-shape checks for null-coalescing assignment.",
         [new("NullCoalescingAssignmentPass.cs", "SameReceiver")] =
             "Pass-local receiver admissibility: null static receiver or PlaceIdentity.SameVariable only.",
+        [new("PatternSwitchExpressionPass.cs", "SameSinkValue")] =
+            "Switch-expression default convergence check: composes PlaceIdentity.SameOperand with conservative recursive Call structural equality (MethodRef record equality + args), sound because exactly one default path runs so identical Fail(out x) returns fold to one `_ =>` arm; declines on any unlisted node kind.",
         [new("UnionSwitchExpressionPass.cs", "SameTailExpression")] =
             "Union switch store-tail folding compares a pass-owned duplicated tail shape; this is not a reusable re-evaluable-place atom and declines on unlisted expression kinds.",
         [new("UnionSwitchExpressionPass.cs", "SameTailExpressions")] =

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -40,6 +40,7 @@ internal sealed class CrossAssemblyTypeResolver
     readonly MetadataContext _context;
     readonly ConcurrentDictionary<TypeRef, ValueTypeHint> _valueTypeCache = new();
     readonly ConcurrentDictionary<TypeRef, MetadataFactState> _inlineArrayCache = new();
+    readonly ConcurrentDictionary<TypeRef, MetadataFactState> _byRefLikeCache = new();
     readonly ConcurrentDictionary<MethodRef, ResolvedMethodFacts?> _methodFactCache = new();
     readonly ConcurrentDictionary<(TypeRef Type, TypeRef Interface), MetadataFactState> _interfaceCache = new();
 
@@ -560,6 +561,35 @@ internal sealed class CrossAssemblyTypeResolver
         return fact;
     }
 
+    /// <summary>
+    /// Whether a cross-assembly type carries <c>[IsByRefLike]</c> — a
+    /// <c>ref struct</c> in a referenced assembly. Same-assembly ref structs are
+    /// resolved directly from the inspected assembly's type definitions; this
+    /// resolves the referenced-assembly case. <see cref="MetadataFactState.Unknown"/>
+    /// when the defining assembly is outside the reference closure.
+    /// </summary>
+    public MetadataFactState IsByRefLike(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        if (definition is null)
+            return MetadataFactState.Unknown;
+        if (_byRefLikeCache.TryGetValue(definition, out var cached))
+            return cached;
+
+        var fact = MetadataFactState.Unknown;
+        try
+        {
+            if (Locate(definition) is { } location)
+                fact = ReadByRefLikeFact(location);
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+        }
+
+        _byRefLikeCache[definition] = fact;
+        return fact;
+    }
+
     TypeLocation? Locate(TypeRef type)
     {
         string name = type.Name.Replace('+', '.');
@@ -641,6 +671,19 @@ internal sealed class CrossAssemblyTypeResolver
 
         var typeDef = assembly.Reader.GetTypeDefinition(handle);
         return MethodDefinitionFacts.HasInlineArrayAttribute(assembly.Reader, typeDef)
+            ? MetadataFactState.Yes
+            : MetadataFactState.No;
+    }
+
+    MetadataFactState ReadByRefLikeFact(TypeLocation location)
+    {
+        if (_context.Open(location) is not { } assembly)
+            return MetadataFactState.Unknown;
+        if (!assembly.TryGetType(location.FullTypeName, out var handle))
+            return MetadataFactState.Unknown;
+
+        var typeDef = assembly.Reader.GetTypeDefinition(handle);
+        return MethodDefinitionFacts.HasByRefLikeAttribute(assembly.Reader, typeDef)
             ? MetadataFactState.Yes
             : MetadataFactState.No;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -653,7 +653,9 @@ public static class IrImporter
             shapes[type] = shape;
             if (source.IsUnionType(type))
                 unionTypes.Add(type);
-            if (source.IsByRefLikeType(type))
+            // Only a value type can be a ref struct; skip the cross-assembly
+            // [IsByRefLike] resolution for reference/enum/unknown shapes.
+            if (shape == TypeShape.ValueType && source.IsByRefLikeType(type))
                 byRefLikeTypes.Add(type);
             if (shape == TypeShape.Enum && source.ResolveEnumMembers(type) is { } members)
             {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -622,6 +622,7 @@ public static class IrImporter
         Dictionary<TypeRef, TypeRef>? enumUnderlyingTypes = null;
         var collectionInitializerTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
         var unionTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
+        var byRefLikeTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
 
         void Consider(TypeRef? type)
         {
@@ -652,6 +653,8 @@ public static class IrImporter
             shapes[type] = shape;
             if (source.IsUnionType(type))
                 unionTypes.Add(type);
+            if (source.IsByRefLikeType(type))
+                byRefLikeTypes.Add(type);
             if (shape == TypeShape.Enum && source.ResolveEnumMembers(type) is { } members)
             {
                 enums ??= [];
@@ -702,6 +705,8 @@ public static class IrImporter
             function.CollectionInitializerTypes = collectionInitializerTypes.ToImmutable();
         if (unionTypes.Count > 0)
             function.UnionTypes = unionTypes.ToImmutable();
+        if (byRefLikeTypes.Count > 0)
+            function.ByRefLikeTypes = byRefLikeTypes.ToImmutable();
     }
 
     /// <summary>Block leaders: entry, branch and leave targets, instructions following a terminator, and every exception-region boundary.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -414,6 +414,16 @@ public sealed class IrFunction : IrNode
     public IReadOnlySet<TypeRef> UnionTypes { get; set; }
         = ImmutableHashSet<TypeRef>.Empty;
 
+    /// <summary>
+    /// Same-assembly types proven to carry <c>IsByRefLikeAttribute</c> — that is,
+    /// user-defined <c>ref struct</c>s. Consumed where a value-type declaration
+    /// pattern would otherwise be raised: a ref struct cannot be boxed, so an
+    /// <c>isinst</c>/<c>unbox.any</c> arm over one is never compiler-produced and
+    /// a <c>T t</c> pattern over it is illegal (CS8121).
+    /// </summary>
+    public IReadOnlySet<TypeRef> ByRefLikeTypes { get; set; }
+        = ImmutableHashSet<TypeRef>.Empty;
+
     public override IEnumerable<TypeRef> DirectTypes
         => Signature.Parameters.Select(p => p.Type)
             .Append(Signature.ReturnType)

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -385,9 +385,16 @@ public sealed class MetadataSource : IDisposable
 
     internal bool IsByRefLikeType(TypeRef type)
     {
+        if (NamedDefinition(type) is not { } definition || string.IsNullOrEmpty(definition.Assembly))
+            return false;
         EnsureTypeMaps();
-        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
-        return definition is not null && _byRefLikeTypes!.Contains(definition);
+        // Same-assembly ref structs are authoritative in the enumerated set; a
+        // same-assembly type absent from it is not a ref struct. Only a
+        // cross-assembly (referenced) definition needs the resolver, which reads
+        // [IsByRefLike] from the defining assembly's metadata.
+        if (definition.Assembly == (Reader.IsAssembly ? TypeRefDecoder.CanonicalSelf(Reader) : ""))
+            return _byRefLikeTypes!.Contains(definition);
+        return CrossAssembly.IsByRefLike(definition) == MetadataFactState.Yes;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -255,6 +255,7 @@ public sealed class MetadataSource : IDisposable
     HashSet<TypeRef>? _genericDefinitions;
     Dictionary<TypeRef, ImmutableArray<TypeRef>>? _interfaceImpls;
     HashSet<TypeRef>? _unionTypes;
+    HashSet<TypeRef>? _byRefLikeTypes;
     HashSet<TypeRef>? _delegates;
 
     /// <summary>
@@ -382,6 +383,13 @@ public sealed class MetadataSource : IDisposable
         return definition is not null && _unionTypes!.Contains(definition);
     }
 
+    internal bool IsByRefLikeType(TypeRef type)
+    {
+        EnsureTypeMaps();
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is not null && _byRefLikeTypes!.Contains(definition);
+    }
+
     /// <summary>
     /// The named members of a same-assembly enum, as value → name (every
     /// underlying integer width normalized to <see cref="long"/>). Null for a
@@ -421,6 +429,7 @@ public sealed class MetadataSource : IDisposable
         var genericDefinitions = new HashSet<TypeRef>();
         var interfaceImpls = new Dictionary<TypeRef, ImmutableArray<TypeRef>>();
         var unionTypes = new HashSet<TypeRef>();
+        var byRefLikeTypes = new HashSet<TypeRef>();
         var delegates = new HashSet<TypeRef>();
         foreach (var handle in Reader.TypeDefinitions)
         {
@@ -448,6 +457,8 @@ public sealed class MetadataSource : IDisposable
             if (MethodDefinitionFacts.HasUnionAttribute(Reader, typeDef)
                 && impls.Any(IsUnionInterface))
                 unionTypes.Add(key);
+            if (MethodDefinitionFacts.HasByRefLikeAttribute(Reader, typeDef))
+                byRefLikeTypes.Add(key);
             interfaceImpls[key] = impls;
             if (shape == TypeShape.Enum)
             {
@@ -463,6 +474,7 @@ public sealed class MetadataSource : IDisposable
         _genericDefinitions = genericDefinitions;
         _interfaceImpls = interfaceImpls;
         _unionTypes = unionTypes;
+        _byRefLikeTypes = byRefLikeTypes;
         _delegates = delegates;
         _shapes = shapes;   // assign last: ResolveShape gates on _shapes
         }

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -49,6 +49,12 @@ internal static class MethodDefinitionFacts
     internal static bool HasUnionAttribute(MetadataReader reader, TypeDefinition type)
         => HasAttribute(reader, type.GetCustomAttributes(), "System.Runtime.CompilerServices", "UnionAttribute");
 
+    // The compiler stamps [IsByRefLike] on every `ref struct`. A ref struct cannot
+    // be boxed, so an `isinst`/`unbox.any` value-type arm over one is never
+    // compiler-produced and a `T t` declaration pattern over it is illegal (CS8121).
+    internal static bool HasByRefLikeAttribute(MetadataReader reader, TypeDefinition type)
+        => HasAttribute(reader, type.GetCustomAttributes(), "System.Runtime.CompilerServices", "IsByRefLikeAttribute");
+
     // The compiler stamps ExtensionAttribute on an extension method (and on its
     // declaring class and module). The method-level mark is the precise signal.
     internal static bool HasExtensionAttribute(MetadataReader reader, MethodDefinition method)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -137,6 +137,7 @@ public sealed class LocalFunctionRaisingPass : IIrPass
                 function.EnumMembers = MergeMap(function.EnumMembers, body.EnumMembers);
                 function.EnumUnderlyingTypes = MergeMap(function.EnumUnderlyingTypes, body.EnumUnderlyingTypes);
                 function.UnionTypes = MergeSet(function.UnionTypes, body.UnionTypes);
+                function.ByRefLikeTypes = MergeSet(function.ByRefLikeTypes, body.ByRefLikeTypes);
                 environment?.Elide();
             }
         }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -27,12 +27,6 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 {
     public string Name => "pattern-switch-expression";
 
-    // The processed function's type shapes, set at the start of each Run. Used by
-    // IsSpellableValueTypePattern to prove a value-type arm's test type is a legal,
-    // non-nullable value-type declaration pattern (structs/enums vs. static classes,
-    // interfaces, and other reference types are indistinguishable by TypeRef alone).
-    IReadOnlyDictionary<TypeRef, TypeShape> _shapes = new Dictionary<TypeRef, TypeShape>();
-
     sealed record ArmData(TypeRef PatternType, int PatternLocal, int? LocalIndex, PropertySubpattern? Subpattern, IrExpression? Guard, IrExpression Value, bool IsInline);
 
     /// <summary>
@@ -56,7 +50,6 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        _shapes = function.TypeShapes;
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
             if (container.Blocks is [var block] && TryMatch(function, block, context.TypesProvablyDisjoint, out int startIndex, out var switchExpression))
@@ -144,7 +137,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             return false;
 
         var arms = new List<ArmData>();
-        if (!TryParseChain(region, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: false) || arms.Count < minArms)
+        if (!TryParseChain(function, region, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: false) || arms.Count < minArms)
             return false;
 
         // A refutable (guarded or property-subpattern) non-last arm routes its
@@ -259,7 +252,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     // enclosing dispatch is trailed by the default); at the top level, and inside a
     // then-only `then` (whose fall-through reaches the sibling MATCHED, not the
     // default), it is false and the list must end in an explicit `return <default>`.
-    bool TryParseChain(IReadOnlyList<IrNode> stmts, int index, Scrutinee scrutinee, IrExpression defaultValue, List<ArmData> arms, bool fallThroughIsDefault)
+    bool TryParseChain(IrFunction function, IReadOnlyList<IrNode> stmts, int index, Scrutinee scrutinee, IrExpression defaultValue, List<ArmData> arms, bool fallThroughIsDefault)
     {
         // Ran off the end: faithful only when fall-through lands on the default.
         if (index >= stmts.Count)
@@ -294,7 +287,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             // does; RefutableArmsDisjointFromLaterArms in TryFold still requires
             // its type disjoint from every later arm before folding.
             arms.Add(new ArmData(inlineType, inlineLocal, inlineIndex, Subpattern: null, inlineGuard, inlineValue, IsInline: true));
-            return TryParseChain(stmts, index + 1, scrutinee, defaultValue, arms, fallThroughIsDefault);
+            return TryParseChain(function, stmts, index + 1, scrutinee, defaultValue, arms, fallThroughIsDefault);
         }
 
         if (!IsArmIntro(stmts[index], scrutinee, out int patternLocal, out var patternType, out _))
@@ -304,7 +297,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             // `unbox.any` after the boolean `isinst` test, so — unlike a reference arm —
             // it has no `StoreLocal Lk = isinst` intro. Its no-match returns the default,
             // so it is necessarily the last matched arm before the default.
-            if (IsValueTypeArm(stmts, index, scrutinee, defaultValue, out int vtLocal, out var vtType, out int vtBodyStart))
+            if (IsValueTypeArm(function, stmts, index, scrutinee, defaultValue, out int vtLocal, out var vtType, out int vtBodyStart))
             {
                 if (!TryParseMatchedBody(stmts, vtBodyStart, vtType, vtLocal, defaultValue, out var vtArm, out int vtNext, out bool vtFallsThrough))
                     return false;
@@ -338,7 +331,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
                     return false;
                 arms.Add(elseArm);
                 // REST nests in `then`; its fall-through reaches the shared default.
-                return TryParseChain(dispatch.Then.Children, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: true);
+                return TryParseChain(function, dispatch.Then.Children, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: true);
             }
 
             // Diamond-return form (#3113): MATCHED (`else`) returns its arm value
@@ -355,7 +348,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
                 || !ReachesDefaultTail(dispatch.Else!.Children, diaNext, defaultValue))
                 return false;
             arms.Add(diaArm);
-            return TryParseChain(ConcatContinuation(dispatch.Then.Children, stmts, index + 2), 0, scrutinee, defaultValue, arms, fallThroughIsDefault);
+            return TryParseChain(function, ConcatContinuation(dispatch.Then.Children, stmts, index + 2), 0, scrutinee, defaultValue, arms, fallThroughIsDefault);
         }
 
         // Then-only form: MATCHED body = the sibling statements after the dispatch.
@@ -382,7 +375,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         arms.Add(arm);
         // REST nests in `then`; its fall-through reaches the sibling MATCHED (not
         // the default), so it must reach the default explicitly.
-        return TryParseChain(dispatch.Then.Children, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: false);
+        return TryParseChain(function, dispatch.Then.Children, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: false);
     }
 
     // Whether control arriving at <paramref name="index"/> reaches the default:
@@ -636,6 +629,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     // (`isinst int; unbox.any int; stloc bool` would declare an `int` pattern var for a `bool`
     // slot — CS0029).
     bool IsValueTypeArm(
+        IrFunction function,
         IReadOnlyList<IrNode> stmts,
         int index,
         Scrutinee scrutinee,
@@ -654,7 +648,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
                 Then.Children: [Return { Value: { } noMatch }]
             }
             && scrutinee.Matches(testOperand)
-            && IsSpellableValueTypePattern(testType)
+            && IsSpellableValueTypePattern(function, testType)
             && DefaultEquals(noMatch, defaultValue)
             && index + 1 < stmts.Count
             && stmts[index + 1] is StoreLocal { Value: UnboxAny { Type: { } unboxType, Operand: { } unboxOperand } } bind
@@ -671,37 +665,34 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     }
 
     // Whether a value-type arm's test type is spellable as a C# declaration pattern `T x`.
-    // csc emits a value-type arm's isinst+unbox for a concrete non-nullable value type or for
+    // csc emits a value-type arm's isinst+unbox for a boxable non-nullable value type or for
     // an unconstrained generic parameter (`isinst T; unbox.any T; stloc T` — and `T t` is a
-    // legal declaration pattern). Generic parameters are admitted directly; framework ref
-    // structs are rejected by name (see IsFrameworkRefStruct); every other kind must prove it
-    // is a known non-nullable value type via its resolved shape, which rejects reference types
-    // (interfaces, delegates, static classes — CS0723/CS8121), `System.Void` (CS1547),
-    // `Nullable<T>` (CS8116), the un-spellable kinds (pointer, function pointer, by-ref,
-    // pinned, unsupported, array), and any type whose value-ness cannot be established.
-    // Declining any of these leaves the cascade in its valid statement form rather than raising
-    // invalid `Full` C#.
-    //
-    // Residual: a user-defined ref struct also resolves to a ValueType shape but carries no
-    // by-ref-like fact in the SRM-only TypeShape model, so it is indistinguishable from an
-    // ordinary struct here. It is reachable only by hostile, non-compiler IL — a ref struct
-    // cannot be boxed, so csc never emits `isinst`/`unbox.any` over one — and closing it would
-    // require plumbing by-ref-like metadata into the pipeline, out of scope for this pass.
-    bool IsSpellableValueTypePattern(TypeRef type)
+    // legal declaration pattern). Generic parameters are admitted directly. Ref structs are
+    // rejected — they resolve to a ValueType shape but cannot be boxed (CS8121), so are never a
+    // compiler-produced value-type arm: framework/stack-only corelib ref structs by name (see
+    // IsStackOnlyValueType) and user-defined ones through the function's by-ref-like fact set.
+    // Every other kind must prove it is a known non-nullable value type via its resolved shape,
+    // which rejects reference types (interfaces, delegates, static classes — CS0723/CS8121),
+    // `System.Void` (CS1547), `Nullable<T>` (CS8116), the un-spellable kinds (pointer, function
+    // pointer, by-ref, pinned, unsupported, array), and any type whose value-ness cannot be
+    // established. Declining any of these leaves the cascade in its valid statement form rather
+    // than raising invalid `Full` C#.
+    static bool IsSpellableValueTypePattern(IrFunction function, TypeRef type)
     {
         if (type.Kind is TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter)
             return true;
-        if (IsFrameworkRefStruct(type))
+        if (IsStackOnlyValueType(type) || IsByRefLike(function, type))
             return false;
-        return TypeFamilies.IsKnownNonNullableValueType(type, _shapes);
+        return TypeFamilies.IsKnownNonNullableValueType(type, function.TypeShapes);
     }
 
-    // Span<T>/ReadOnlySpan<T> resolve to a ValueType shape but are ref structs — illegal as a
-    // boxed pattern (CS8121) and never a compiler-produced value-type arm. Recognised by name
-    // because the `IsByRefLike` fact lives on the cross-assembly definition, not the TypeRef;
-    // matching `System` avoids user types of the same simple name. Mirrors the same-reason
-    // heuristic in LifetimeClassifier.IsRefStruct.
-    static bool IsFrameworkRefStruct(TypeRef type)
+    // The corelib value types that resolve to a ValueType shape (or the hardcoded value-type
+    // list) but are ref-struct / stack-only and cannot be boxed, so are illegal as a boxed
+    // declaration pattern (CS8121). Recognised by name because their `IsByRefLike` /
+    // intrinsic-stack-only nature lives on the cross-assembly corelib definition, not the
+    // TypeRef; matching `System` avoids user types of the same simple name. User-defined ref
+    // structs in the inspected assembly are caught by IsByRefLike instead.
+    static bool IsStackOnlyValueType(TypeRef type)
     {
         var (name, ns) = type.Kind is TypeRefKind.GenericInstance
             ? (type.ElementType?.Name, type.ElementType?.Namespace)
@@ -710,7 +701,18 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             return false;
         int tick = name.IndexOf('`');
         string simple = tick < 0 ? name : name[..tick];
-        return simple is "Span" or "ReadOnlySpan";
+        return simple is "Span" or "ReadOnlySpan" or "TypedReference" or "ArgIterator" or "RuntimeArgumentHandle";
+    }
+
+    // Whether the type (or a generic instance's definition) carries the compiler's
+    // `[IsByRefLike]` fact recovered at import into the function's by-ref-like set — a
+    // user-defined `ref struct` in the inspected assembly. A ref struct cannot be boxed, so
+    // `isinst`/`unbox.any` over one is never compiler-produced and `T t` over it is illegal
+    // (CS8121); such an arm is declined rather than raised to invalid `Full` C#.
+    static bool IsByRefLike(IrFunction function, TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is not null && function.ByRefLikeTypes.Contains(definition);
     }
 
     // The value a value-type arm dispatch (`if (!(scrutinee is Tvt)) return X`) yields

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -620,11 +620,14 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     // the `StoreLocal Lk = isinst` intro of a reference arm. Returns the bound local, the
     // pattern type, and the index of the first matched-body statement.
     //
-    // Declines two shapes only reachable from IL csc never emits, each of which would
-    // render invalid C# under a `Full` label: a `Nullable<T>` test type (a nullable value
-    // type is illegal as a declaration-pattern type — CS8116), and a bound local whose
-    // declared type disagrees with the pattern type (`isinst int; unbox.any int; stloc bool`
-    // would declare an `int` pattern var for a `bool` slot — CS0029).
+    // Declines shapes only reachable from IL csc never emits, each of which would render
+    // invalid C# under a `Full` label. The pattern type must be spellable as a C# value-type
+    // declaration pattern — a concrete non-nullable value type — so `IsSpellableValueTypePattern`
+    // rejects `Nullable<T>`/bare `Nullable`1` (CS8116/CS0723) and the un-spellable kinds
+    // (pointer, function pointer, by-ref, pinned, unsupported, array, open generic parameter).
+    // A bound local whose declared type disagrees with the pattern type is likewise declined
+    // (`isinst int; unbox.any int; stloc bool` would declare an `int` pattern var for a `bool`
+    // slot — CS0029).
     static bool IsValueTypeArm(
         IReadOnlyList<IrNode> stmts,
         int index,
@@ -644,7 +647,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
                 Then.Children: [Return { Value: { } noMatch }]
             }
             && scrutinee.Matches(testOperand)
-            && !TypeFamilies.IsNullableType(testType)
+            && IsSpellableValueTypePattern(testType)
             && DefaultEquals(noMatch, defaultValue)
             && index + 1 < stmts.Count
             && stmts[index + 1] is StoreLocal { Value: UnboxAny { Type: { } unboxType, Operand: { } unboxOperand } } bind
@@ -659,6 +662,18 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         }
         return false;
     }
+
+    // Whether a value-type arm's test type is spellable as a C# declaration pattern `T x`.
+    // csc emits a value-type arm's isinst+unbox only for a concrete non-nullable value type,
+    // so the whitelist admits a named definition or a (non-nullable) generic instance and
+    // rejects everything else: `Nullable<T>` and the bare `Nullable`1` definition (not a legal
+    // pattern type — CS8116/CS0723), and the un-spellable kinds (pointer, function pointer,
+    // by-ref, pinned, unsupported, array, and open generic parameters). Declining any of these
+    // leaves the cascade in its valid statement form rather than raising invalid `Full` C#.
+    static bool IsSpellableValueTypePattern(TypeRef type)
+        => type.Kind is TypeRefKind.Definition or TypeRefKind.GenericInstance
+            && !TypeFamilies.IsNullableType(type)
+            && type is not { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Nullable`1" };
 
     // The value a value-type arm dispatch (`if (!(scrutinee is Tvt)) return X`) yields
     // on no-match. Used by default discovery, which needs only the returned value X and

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -225,7 +225,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     }
 
     // A chain of arms whose collective no-match fall-through reaches the default.
-    // Three arm shapes are recognized and may be mixed:
+    // Five arm shapes are recognized and may be mixed:
     //   * Intro-chain arm (then-only): `intro Lk = isinst Tk(SV); if (!Lk) { REST }
     //     MATCHED` where MATCHED (this arm's guard + value) trails the dispatch as
     //     sibling statements and REST (the remaining arms, ultimately a bare
@@ -237,6 +237,13 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     //     or property subpattern whose failure must reach the default — so both
     //     REST (then) and MATCHED (else) fall off their block into that shared
     //     default.
+    //   * Diamond-return arm (if/else): the same two-armed shape, but MATCHED
+    //     (`else`) RETURNS its value outright and REST is `then` ++ the siblings
+    //     after the `if` (`then` falls through to them). csc emits this when the
+    //     matched value spans multiple blocks (e.g. a nested switch expression).
+    //   * Value-type arm: `if (!(SV is Tvt)) return <default>; Li = (Tvt)SV; MATCHED`
+    //     — a value-type pattern binds through a separate `unbox.any`, so it has no
+    //     isinst intro; its no-match returns the default, making it the last arm.
     //   * Inline-positive arm: `if (SV is Tk x) { MATCHED }` whose no-match falls
     //     straight through to the following sibling statement (the next arm, or the
     //     bare `return <default>`).
@@ -284,7 +291,26 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         }
 
         if (!IsArmIntro(stmts[index], scrutinee, out int patternLocal, out var patternType, out _))
+        {
+            // Value-type type-pattern arm: `if (!(scrut is Tvt)) return <default>;
+            // Li = (Tvt)scrut; MATCHED`. A value-type pattern binds through a separate
+            // `unbox.any` after the boolean `isinst` test, so — unlike a reference arm —
+            // it has no `StoreLocal Lk = isinst` intro. Its no-match returns the default,
+            // so it is necessarily the last matched arm before the default.
+            if (IsValueTypeArm(stmts, index, scrutinee, defaultValue, out int vtLocal, out var vtType, out int vtBodyStart))
+            {
+                if (!TryParseMatchedBody(stmts, vtBodyStart, vtType, vtLocal, defaultValue, out var vtArm, out int vtNext, out bool vtFallsThrough))
+                    return false;
+                bool vtTailReachesDefault = vtFallsThrough
+                    ? DefaultReachedFrom(stmts, vtNext, defaultValue, fallThroughIsDefault)
+                    : ReachesDefaultTail(stmts, vtNext, defaultValue);
+                if (!vtTailReachesDefault)
+                    return false;
+                arms.Add(vtArm);
+                return true;
+            }
             return false;
+        }
         if (index + 1 >= stmts.Count || stmts[index + 1] is not IfStatement dispatch)
             return false;
         if (!IsNegatedLocalTest(dispatch.Condition, patternLocal))
@@ -295,17 +321,34 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             // If/else form (csc's lowering of a refutable intro arm): MATCHED is
             // the `else`, REST the `then`, and both fall off their block into the
             // shared default that trails the dispatch.
-            if (!DefaultReachedFrom(stmts, index + 2, defaultValue, fallThroughIsDefault))
+            if (DefaultReachedFrom(stmts, index + 2, defaultValue, fallThroughIsDefault))
+            {
+                if (!TryParseMatchedBody(dispatch.Else!.Children, 0, patternType, patternLocal, defaultValue, out var elseArm, out int elseNext, out _))
+                    return false;
+                // MATCHED's own fall-through (a guard/subpattern failure) runs off the
+                // `else` block into that same shared default.
+                if (!DefaultReachedFrom(dispatch.Else!.Children, elseNext, defaultValue, fallThroughIsDefault: true))
+                    return false;
+                arms.Add(elseArm);
+                // REST nests in `then`; its fall-through reaches the shared default.
+                return TryParseChain(dispatch.Then.Children, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: true);
+            }
+
+            // Diamond-return form (#3113): MATCHED (`else`) returns its arm value
+            // outright, and REST is the `then` block followed by the siblings after
+            // the `if` (`then` falls through to them). csc emits this two-armed `if`
+            // — rather than dropping the `else` — when the matched value spans
+            // multiple basic blocks (e.g. a nested switch expression). The remaining
+            // arms' fall-through destiny is unchanged from this call, so thread
+            // `fallThroughIsDefault` into the virtual continuation. Require MATCHED to
+            // return outright (`!diaFallsThrough`) with nothing reachable after it, so
+            // this stays distinct from the shared-default if/else form handled above.
+            if (!TryParseMatchedBody(dispatch.Else!.Children, 0, patternType, patternLocal, defaultValue, out var diaArm, out int diaNext, out bool diaFallsThrough)
+                || diaFallsThrough
+                || !ReachesDefaultTail(dispatch.Else!.Children, diaNext, defaultValue))
                 return false;
-            if (!TryParseMatchedBody(dispatch.Else!.Children, 0, patternType, patternLocal, defaultValue, out var elseArm, out int elseNext, out _))
-                return false;
-            // MATCHED's own fall-through (a guard/subpattern failure) runs off the
-            // `else` block into that same shared default.
-            if (!DefaultReachedFrom(dispatch.Else!.Children, elseNext, defaultValue, fallThroughIsDefault: true))
-                return false;
-            arms.Add(elseArm);
-            // REST nests in `then`; its fall-through reaches the shared default.
-            return TryParseChain(dispatch.Then.Children, 0, scrutinee, defaultValue, arms, fallThroughIsDefault: true);
+            arms.Add(diaArm);
+            return TryParseChain(ConcatContinuation(dispatch.Then.Children, stmts, index + 2), 0, scrutinee, defaultValue, arms, fallThroughIsDefault);
         }
 
         // Then-only form: MATCHED body = the sibling statements after the dispatch.
@@ -368,6 +411,13 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             {
                 index++;
                 continue;
+            }
+
+            // Value-type arm: its type-test failure returns the default directly.
+            if (IsValueTypeArmDefault(stmts[index], scrutinee, out var vtDefault))
+            {
+                defaultValue = vtDefault;
+                return true;
             }
 
             // Intro-chain arm: no-match nests in the dispatch test's `then` branch
@@ -462,14 +512,16 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         return true;
     }
 
-    // A value run in one of three shapes, all yielding (guard?, value):
+    // A value run in one of four shapes, all yielding (guard?, value):
     //   `return V;`                              -> unguarded
     //   `if (!G) return <default>; return V;`    -> guarded, negated form
+    //   `if (C)  return <default>; return V;`    -> guarded, flipped-comparison form
+    //                                               (guard = Conditions.Negate(C))
     //   `if (G) { return V; }`                   -> guarded, positive form
-    // `shortCircuitsToDefault` is true only for the negated form, whose guard
-    // failure returns the default immediately rather than falling through to the
-    // following statement — the caller uses it to reject short-circuiting shapes
-    // where fall-through order matters (inline sibling arms).
+    // `shortCircuitsToDefault` is true for both short-circuiting forms (negated and
+    // flipped-comparison), whose guard failure returns the default immediately rather
+    // than falling through to the following statement — the caller uses it to reject
+    // short-circuiting shapes where fall-through order matters (inline sibling arms).
     bool TryParseGuardedValue(
         IReadOnlyList<IrNode> stmts,
         int index,
@@ -511,6 +563,26 @@ public sealed class PatternSwitchExpressionPass : IIrPass
             return true;
         }
 
+        // Flipped-comparison negated form: `if (C) return <default>; return V;` where
+        // C is any non-`LogicalNot` condition (the `LogicalNot` shape is consumed
+        // above). csc lowers a `when G` whose failure branches to the default as
+        // `if (!G) goto default`, and `!G` frequently surfaces as a flipped relational
+        // (`when i > 0` -> `if (i <= 0) …`) rather than a syntactic negation. The arm's
+        // guard is the type-aware dual of C (Conditions.Negate is NaN-safe: it inverts
+        // an integer relational and wraps float/unknown in `!(…)`), computed over a
+        // detached clone so the original condition is left intact for fidelity.
+        if (guardIf.Condition is not LogicalNot
+            && guardIf.Then.Children is [Return { Value: { } flippedDefault }] && DefaultEquals(flippedDefault, defaultValue)
+            && index + 1 < stmts.Count
+            && stmts[index + 1] is Return { Value: { } flippedValue } && !DefaultEquals(flippedValue, defaultValue))
+        {
+            guard = Conditions.Negate((IrExpression)guardIf.Condition.Clone());
+            value = flippedValue;
+            consumed = 2;
+            shortCircuitsToDefault = true;
+            return true;
+        }
+
         // Positive form: `if (G) { return V; }`
         if (guardIf.Then.Children is [Return { Value: { } positiveValue }] && !DefaultEquals(positiveValue, defaultValue))
         {
@@ -538,6 +610,79 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         return false;
     }
 
+    static bool TestsScrutinee(IrNode node, Scrutinee scrutinee)
+        => IsArmIntro(node, scrutinee, out _, out _, out _)
+            || IsInlineArm(node, scrutinee, out _, out _, out _);
+
+    // A value-type type-pattern arm dispatch: `if (!(scrutinee is Tvt)) return <default>;`
+    // immediately followed by `Li = (Tvt)scrutinee` (an `unbox.any` bind). Value-type
+    // patterns test with `isinst` then bind through a separate `unbox.any`, so they lack
+    // the `StoreLocal Lk = isinst` intro of a reference arm. Returns the bound local, the
+    // pattern type, and the index of the first matched-body statement.
+    static bool IsValueTypeArm(
+        IReadOnlyList<IrNode> stmts,
+        int index,
+        Scrutinee scrutinee,
+        IrExpression defaultValue,
+        out int bindLocal,
+        out TypeRef patternType,
+        out int bodyStart)
+    {
+        bindLocal = -1;
+        patternType = null!;
+        bodyStart = -1;
+        if (stmts[index] is IfStatement
+            {
+                HasElse: false,
+                Condition: LogicalNot { Operand: IsInstance { Type: { } testType, Operand: { } testOperand } },
+                Then.Children: [Return { Value: { } noMatch }]
+            }
+            && scrutinee.Matches(testOperand)
+            && DefaultEquals(noMatch, defaultValue)
+            && index + 1 < stmts.Count
+            && stmts[index + 1] is StoreLocal { Value: UnboxAny { Type: { } unboxType, Operand: { } unboxOperand } } bind
+            && unboxType.Equals(testType)
+            && scrutinee.Matches(unboxOperand))
+        {
+            bindLocal = bind.Index;
+            patternType = testType;
+            bodyStart = index + 2;
+            return true;
+        }
+        return false;
+    }
+
+    // The value a value-type arm dispatch (`if (!(scrutinee is Tvt)) return X`) yields
+    // on no-match. Used by default discovery, which needs only the returned value X and
+    // not the subsequent `unbox.any` bind.
+    static bool IsValueTypeArmDefault(IrNode node, Scrutinee scrutinee, out IrExpression defaultValue)
+    {
+        defaultValue = null!;
+        if (node is IfStatement
+            {
+                HasElse: false,
+                Condition: LogicalNot { Operand: IsInstance { Operand: { } operand } },
+                Then.Children: [Return { Value: { } returned }]
+            }
+            && scrutinee.Matches(operand))
+        {
+            defaultValue = returned;
+            return true;
+        }
+        return false;
+    }
+
+    // The virtual continuation of a diamond-return arm: the dispatch `then` block's
+    // statements followed by the siblings after the `if` (from `outerStart`). The `then`
+    // falls through to those siblings, so together they form the remaining-arm chain.
+    static IReadOnlyList<IrNode> ConcatContinuation(IReadOnlyList<IrNode> nested, IReadOnlyList<IrNode> outer, int outerStart)
+    {
+        var continuation = new List<IrNode>(nested);
+        for (int i = outerStart; i < outer.Count; i++)
+            continuation.Add(outer[i]);
+        return continuation;
+    }
+
     // An inline-positive arm: `if (scrutinee is Tk x) { MATCHED }` with no `else`.
     // The matched body is the `then` block; the no-match path falls through to the
     // following sibling statement.
@@ -556,13 +701,6 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         }
         return false;
     }
-
-    // True when `node` is the first arm of a cascade over `scrutinee` — either an
-    // intro-chain arm or an inline-positive arm. Used to confirm a temp store is
-    // actually followed by a matching cascade before attempting the fold.
-    static bool TestsScrutinee(IrNode node, Scrutinee scrutinee)
-        => IsArmIntro(node, scrutinee, out _, out _, out _)
-            || IsInlineArm(node, scrutinee, out _, out _, out _);
 
     // Recovers a direct (temp-less) scrutinee from a leading intro-chain arm that
     // reads a re-evaluable place directly (`Lk = place as T; if (!Lk) …`). The
@@ -645,7 +783,41 @@ public sealed class PatternSwitchExpressionPass : IIrPass
         => expression is not null && ReferenceOwnership.SubtreeReferencesLocal(expression, local);
 
     static bool DefaultEquals(IrExpression? left, IrExpression? right)
-        => left is not null && right is not null && PlaceIdentity.SameOperand(left, right);
+        => left is not null && right is not null && SameSinkValue(left, right);
+
+    // Structural equality for a switch-expression default sink value. Augments
+    // PlaceIdentity.SameOperand (variables/constants only — the narrow re-evaluable
+    // place set) with conservative recursive Call equality, because a value-typed
+    // switch-expression default `_ => Fail(out x)` lowers to several identical
+    // `return Fail(out x)` no-match paths, and only their structural identity proves
+    // the fold faithful. Callee is a record (value equality over the full signature),
+    // so overloads sharing a name do not collide. Sound because a switch expression
+    // runs exactly one default path, so folding N identical calls into one `_ =>`
+    // arm preserves behavior; declines on any non-Call, non-operand node.
+    static bool SameSinkValue(IrExpression? left, IrExpression? right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+        if (left is null || right is null)
+            return false;
+        if (PlaceIdentity.SameOperand(left, right))
+            return true;
+        if (left is Call leftCall && right is Call rightCall)
+        {
+            if (leftCall.IsVirtual != rightCall.IsVirtual
+                || !Equals(leftCall.ConstrainedTo, rightCall.ConstrainedTo)
+                || !leftCall.Callee.Equals(rightCall.Callee)
+                || leftCall.Arguments.Count != rightCall.Arguments.Count)
+                return false;
+            for (int i = 0; i < leftCall.Arguments.Count; i++)
+            {
+                if (!SameSinkValue(leftCall.Arguments[i], rightCall.Arguments[i]))
+                    return false;
+            }
+            return true;
+        }
+        return false;
+    }
 
     static IEnumerable<int> PatternLocals(ArmData arm)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -619,6 +619,12 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     // patterns test with `isinst` then bind through a separate `unbox.any`, so they lack
     // the `StoreLocal Lk = isinst` intro of a reference arm. Returns the bound local, the
     // pattern type, and the index of the first matched-body statement.
+    //
+    // Declines two shapes only reachable from IL csc never emits, each of which would
+    // render invalid C# under a `Full` label: a `Nullable<T>` test type (a nullable value
+    // type is illegal as a declaration-pattern type — CS8116), and a bound local whose
+    // declared type disagrees with the pattern type (`isinst int; unbox.any int; stloc bool`
+    // would declare an `int` pattern var for a `bool` slot — CS0029).
     static bool IsValueTypeArm(
         IReadOnlyList<IrNode> stmts,
         int index,
@@ -638,10 +644,12 @@ public sealed class PatternSwitchExpressionPass : IIrPass
                 Then.Children: [Return { Value: { } noMatch }]
             }
             && scrutinee.Matches(testOperand)
+            && !TypeFamilies.IsNullableType(testType)
             && DefaultEquals(noMatch, defaultValue)
             && index + 1 < stmts.Count
             && stmts[index + 1] is StoreLocal { Value: UnboxAny { Type: { } unboxType, Operand: { } unboxOperand } } bind
             && unboxType.Equals(testType)
+            && bind.Type.Equals(testType)
             && scrutinee.Matches(unboxOperand))
         {
             bindLocal = bind.Index;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PatternSwitchExpressionPass.cs
@@ -27,6 +27,12 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 {
     public string Name => "pattern-switch-expression";
 
+    // The processed function's type shapes, set at the start of each Run. Used by
+    // IsSpellableValueTypePattern to prove a value-type arm's test type is a legal,
+    // non-nullable value-type declaration pattern (structs/enums vs. static classes,
+    // interfaces, and other reference types are indistinguishable by TypeRef alone).
+    IReadOnlyDictionary<TypeRef, TypeShape> _shapes = new Dictionary<TypeRef, TypeShape>();
+
     sealed record ArmData(TypeRef PatternType, int PatternLocal, int? LocalIndex, PropertySubpattern? Subpattern, IrExpression? Guard, IrExpression Value, bool IsInline);
 
     /// <summary>
@@ -50,6 +56,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        _shapes = function.TypeShapes;
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
             if (container.Blocks is [var block] && TryMatch(function, block, context.TypesProvablyDisjoint, out int startIndex, out var switchExpression))
@@ -628,7 +635,7 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     // A bound local whose declared type disagrees with the pattern type is likewise declined
     // (`isinst int; unbox.any int; stloc bool` would declare an `int` pattern var for a `bool`
     // slot — CS0029).
-    static bool IsValueTypeArm(
+    bool IsValueTypeArm(
         IReadOnlyList<IrNode> stmts,
         int index,
         Scrutinee scrutinee,
@@ -664,16 +671,47 @@ public sealed class PatternSwitchExpressionPass : IIrPass
     }
 
     // Whether a value-type arm's test type is spellable as a C# declaration pattern `T x`.
-    // csc emits a value-type arm's isinst+unbox only for a concrete non-nullable value type,
-    // so the whitelist admits a named definition or a (non-nullable) generic instance and
-    // rejects everything else: `Nullable<T>` and the bare `Nullable`1` definition (not a legal
-    // pattern type — CS8116/CS0723), and the un-spellable kinds (pointer, function pointer,
-    // by-ref, pinned, unsupported, array, and open generic parameters). Declining any of these
-    // leaves the cascade in its valid statement form rather than raising invalid `Full` C#.
-    static bool IsSpellableValueTypePattern(TypeRef type)
-        => type.Kind is TypeRefKind.Definition or TypeRefKind.GenericInstance
-            && !TypeFamilies.IsNullableType(type)
-            && type is not { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Nullable`1" };
+    // csc emits a value-type arm's isinst+unbox for a concrete non-nullable value type or for
+    // an unconstrained generic parameter (`isinst T; unbox.any T; stloc T` — and `T t` is a
+    // legal declaration pattern). Generic parameters are admitted directly; framework ref
+    // structs are rejected by name (see IsFrameworkRefStruct); every other kind must prove it
+    // is a known non-nullable value type via its resolved shape, which rejects reference types
+    // (interfaces, delegates, static classes — CS0723/CS8121), `System.Void` (CS1547),
+    // `Nullable<T>` (CS8116), the un-spellable kinds (pointer, function pointer, by-ref,
+    // pinned, unsupported, array), and any type whose value-ness cannot be established.
+    // Declining any of these leaves the cascade in its valid statement form rather than raising
+    // invalid `Full` C#.
+    //
+    // Residual: a user-defined ref struct also resolves to a ValueType shape but carries no
+    // by-ref-like fact in the SRM-only TypeShape model, so it is indistinguishable from an
+    // ordinary struct here. It is reachable only by hostile, non-compiler IL — a ref struct
+    // cannot be boxed, so csc never emits `isinst`/`unbox.any` over one — and closing it would
+    // require plumbing by-ref-like metadata into the pipeline, out of scope for this pass.
+    bool IsSpellableValueTypePattern(TypeRef type)
+    {
+        if (type.Kind is TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter)
+            return true;
+        if (IsFrameworkRefStruct(type))
+            return false;
+        return TypeFamilies.IsKnownNonNullableValueType(type, _shapes);
+    }
+
+    // Span<T>/ReadOnlySpan<T> resolve to a ValueType shape but are ref structs — illegal as a
+    // boxed pattern (CS8121) and never a compiler-produced value-type arm. Recognised by name
+    // because the `IsByRefLike` fact lives on the cross-assembly definition, not the TypeRef;
+    // matching `System` avoids user types of the same simple name. Mirrors the same-reason
+    // heuristic in LifetimeClassifier.IsRefStruct.
+    static bool IsFrameworkRefStruct(TypeRef type)
+    {
+        var (name, ns) = type.Kind is TypeRefKind.GenericInstance
+            ? (type.ElementType?.Name, type.ElementType?.Namespace)
+            : (type.Name, type.Namespace);
+        if (ns != "System" || name is null)
+            return false;
+        int tick = name.IndexOf('`');
+        string simple = tick < 0 ? name : name[..tick];
+        return simple is "Span" or "ReadOnlySpan";
+    }
 
     // The value a value-type arm dispatch (`if (!(scrutinee is Tvt)) return X`) yields
     // on no-match. Used by default discovery, which needs only the returned value X and


### PR DESCRIPTION
- Fixes #3113
- Fully raises the outer type-pattern dispatch of `ScatteredReturnDispatchSample.Dispatch` to its original nested `switch` expression, completing the raise begun in #3094 (inner `s.Length` arm)
- Card revision: `cd76fd27f533af945c07e4eaf698f0787052dad6`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the witness now fully raises to its original nested `switch` expression with `Full` fidelity; the recognizer additions are gated by the existing soundness checks and the corpus shows only improvements (residue down, 0 pass bugs).

### Original source

```csharp
public static bool Dispatch(object o, out int x) => o switch
{
    string s => s.Length switch
    {
        0 => Fail(out x),
        1 => Win(1, out x),
        _ => Fail(out x)
    },
    int i when i > 0 => Win(i, out x),
    _ => Fail(out x)
};
```

### Before

```csharp
public static bool Dispatch(object o, out int x)
{
    int i;

    object V_3 = o;
    string s = V_3 as string;
    if (s is null)
    {
        if (V_3 is not int)
        {
            return Fail(out x);
        }
        i = (int)V_3;
    }
    else
    {
        return s.Length switch
        {
            0 => Fail(out x),
            1 => Win(1, out x),
            _ => Fail(out x),
        };
    }
    if (i <= 0)
    {
        return Fail(out x);
    }
    return Win(i, out x);
}
```

- Valid: True
- Correct: True

The inner `s.Length` arm was already raised by #3094; the outer type-pattern dispatch remained a valid, `Full`-fidelity `if/else` cascade over `V_3 as string` / `is not int` / `(int)V_3` with a trailing `i <= 0` guard.

### After

```csharp
public static bool Dispatch(object o, out int x)
{
    return o switch
    {
        string s => s.Length switch { 0 => Fail(out x), 1 => Win(1, out x), _ => Fail(out x) },
        int i when i > 0 => Win(i, out x),
        _ => Fail(out x),
    };
}
```

- Valid: True
- Correct: True

Matches the original source (the block body vs expression body and the single-line inner `switch` are cosmetic printer choices). Harness reports `fidelity: Full`.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline (`da030adf`) | Head (`cd76fd27`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | n/a (new file) | `OuterTypePatternDispatchRaisingTests`: 5 passed |
| Affected tests | `ScatteredReturnDispatchStructuringTests` + `SubstratePredicateCensusTests`: 4 passed | 4 passed (assertions updated to raised form) |
| Decompiler fast suite | 3502, 0 failed | 3502, 0 failed |
| Validity area | 103, 0 failed | 103, 0 failed |
| RoundTrip area | 336, 4 failed | 336, 4 failed |
| Real witness | `ScatteredReturnDispatchSample::Dispatch` statement form | fully raised, `Full` fidelity |

The 4 RoundTrip failures (`GeneratedFixtureCatalogTests.{CompilerLoweringFrontier_IsSelectableButNotInDefaultRun, ReturnToSenderRecordCatalog_CoversGeneratedRecordHelpers, MinimalCompileBackRungs_ReportExpectedOutcomesByFixtureId}`, `ReturnToSenderPrototypeTests.CompileBackTargets_FullReconstructsPlainEventAccessorTarget`) are pre-existing compile-back-infra failures: identical count and reason on base `da030adf`, unrelated to this change (event accessors / record helpers / fixture catalog, not type-pattern switch expressions).

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the pinned PR-quick gate matched baseline tolerances (0 pp on every rate) and the population residue counts fell, with 0 pass bugs.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly; validity/fidelity not run (rely on changed-method fidelity, which is `Full` for the witness).

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 17.67% | 17.67% | 0 pp |
| Conditional-branch residue (-) | 3.00% | 3.00% | 0 pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — pinned-subset gate matched baseline tolerances.

### Aggregate context

Corpus: 15 assemblies, 1,500 methods. Baseline drift: none.

| Metric (goal) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 251 (16.73%) | 249 (16.60%) | -2 |
| Conditional-branch residue (-) | 46 (3.07%) | 44 (2.93%) | -2 |
| Forward-merge stops (-) | 32 (2.13%) | 30 (2.00%) | -2 |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — every tracked residue population fell; no regressions.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.OuterTypePatternDispatchRaisingTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
