### PR TITLE
Expression-body single multi-line switch-expression returns (#3088)

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
@@ -33,4 +33,26 @@ public sealed class CSharpExpressionBodyTests
     [InlineData("Foo();\nBar();")]
     public void FromSingleStatement_RejectsNonExpressionForms(string body)
         => Assert.Null(CSharpExpressionBody.FromSingleStatement(body));
+
+    // ── Multi-line single-return extraction (issue #3088) ──────────────────
+
+    [Fact]
+    public void MultilineReturnExpressionLines_SplitsSwitchReturn()
+    {
+        var lines = CSharpExpressionBody.MultilineReturnExpressionLines(
+            "return shape switch\n{\n    Dot d => d.Radius,\n    _ => -1,\n};");
+        Assert.NotNull(lines);
+        Assert.Equal(
+            ["shape switch", "{", "    Dot d => d.Radius,", "    _ => -1,", "}"],
+            lines);
+    }
+
+    [Theory]
+    [InlineData("return value.Length;")]          // single line — FromSingleStatement owns it
+    [InlineData("result = 0;\nreturn x switch\n{\n    _ => 1,\n};")]  // has a leading statement, but the string still starts non-`return`
+    [InlineData("x switch\n{\n    _ => 1,\n};")]   // no `return`
+    [InlineData("return\nx;")]                      // bare `return` (no space)
+    [InlineData("return x switch\n{\n    _ => 1,\n}")] // no terminating ';'
+    public void MultilineReturnExpressionLines_RejectsNonMultilineReturnForms(string body)
+        => Assert.Null(CSharpExpressionBody.MultilineReturnExpressionLines(body));
 }

--- a/src/ILInspector.CSharp.Tests/CSharpMemberLayoutTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpMemberLayoutTests.cs
@@ -4,10 +4,10 @@ namespace ILInspector.CSharp.Tests;
 
 public sealed class CSharpMemberLayoutTests
 {
-    static string Render(string head, string? body, int indent, bool wrapExpressionBodyArrow = false)
+    static string Render(string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleReturnExpression = false)
     {
         var sb = new StringBuilder();
-        CSharpMemberLayout.Append(sb, head, body, indent, wrapExpressionBodyArrow);
+        CSharpMemberLayout.Append(sb, head, body, indent, wrapExpressionBodyArrow, bodyIsSingleReturnExpression);
         return sb.ToString().Replace("\r\n", "\n");
     }
 
@@ -70,6 +70,57 @@ public sealed class CSharpMemberLayoutTests
         => Assert.Equal(
             "        set\n            => _x = value;\n",
             Render("set", "_x = value;", indent: 8, wrapExpressionBodyArrow: true));
+
+    // Issue #3088: a body that is exactly one multi-line `return <switch>;`
+    // renders expression-bodied, with the switch block re-indented under the
+    // member. The caller proves the single-return shape (the typed signal);
+    // the layout owns the presentation.
+    const string SwitchReturnBody =
+        "return shape switch\n{\n    Dot d => d.Radius,\n    _ => -1,\n};";
+
+    [Fact]
+    public void Append_MultilineSwitchReturn_RendersExpressionBodied_SameLineArrow()
+        => Assert.Equal(
+            "    int Area(Shape shape) => shape switch\n"
+            + "    {\n"
+            + "        Dot d => d.Radius,\n"
+            + "        _ => -1,\n"
+            + "    };\n",
+            Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, bodyIsSingleReturnExpression: true));
+
+    [Fact]
+    public void Append_MultilineSwitchReturn_WrapsArrowOnNextLine_WhenRequested()
+        => Assert.Equal(
+            "    int Area(Shape shape)\n"
+            + "        => shape switch\n"
+            + "        {\n"
+            + "            Dot d => d.Radius,\n"
+            + "            _ => -1,\n"
+            + "        };\n",
+            Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, wrapExpressionBodyArrow: true, bodyIsSingleReturnExpression: true));
+
+    [Fact]
+    public void Append_MultilineSwitchReturn_InNestedAccessor_RendersExpressionBodied()
+        => Assert.Equal(
+            "        get => shape switch\n"
+            + "        {\n"
+            + "            Dot d => d.Radius,\n"
+            + "            _ => -1,\n"
+            + "        };\n",
+            Render("get", SwitchReturnBody, indent: 8, bodyIsSingleReturnExpression: true));
+
+    [Fact]
+    public void Append_MultilineSwitchReturn_StaysBlock_WhenSignalNotSet()
+        => Assert.Equal(
+            "    int Area(Shape shape)\n"
+            + "    {\n"
+            + "        return shape switch\n"
+            + "        {\n"
+            + "            Dot d => d.Radius,\n"
+            + "            _ => -1,\n"
+            + "        };\n"
+            + "    }\n",
+            Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, bodyIsSingleReturnExpression: false));
 
     [Fact]
     public void AppendIndentedBody_PreservesBlankLinesAndTrimsTrailing()

--- a/src/ILInspector.CSharp/CSharpExpressionBody.cs
+++ b/src/ILInspector.CSharp/CSharpExpressionBody.cs
@@ -29,6 +29,45 @@ public static class CSharpExpressionBody
         return IsStatementExpression(line) ? line : null;
     }
 
+    /// <summary>
+    /// The expression of a <em>multi-line</em> single-<c>return</c> body — the
+    /// raised switch-expression return (issue #3088) — as its lines, with the
+    /// leading <c>return </c> and trailing <c>;</c> removed and every line's
+    /// trailing whitespace trimmed. The first entry is the value/arrow line
+    /// (<c>&lt;value&gt; switch</c>); the rest are the block lines (<c>{</c>,
+    /// one arm per line, <c>}</c>) at their body-relative (column-zero) indent,
+    /// which the layout re-indents under the member. Returns <see langword="null"/>
+    /// for a single-line body (that is <see cref="FromSingleStatement"/>'s job) or
+    /// anything not shaped as <c>return &lt;expr&gt;;</c>.
+    /// </summary>
+    /// <remarks>
+    /// This never asserts, on its own, that the body is a single statement — a
+    /// flat string cannot prove that soundly. Callers must gate it on the typed
+    /// <c>BodyIsSingleReturnExpression</c> signal the printer proves structurally.
+    /// </remarks>
+    public static IReadOnlyList<string>? MultilineReturnExpressionLines(string body)
+    {
+        var trimmed = body.Trim();
+        if (!trimmed.EndsWith(';'))
+            return null;
+        int newline = trimmed.IndexOf('\n');
+        if (newline < 0)
+            return null;   // single line — FromSingleStatement owns it
+
+        var firstLine = trimmed[..newline].TrimStart();
+        if (!firstLine.StartsWith("return ", StringComparison.Ordinal))
+            return null;
+        var valueLine = firstLine["return ".Length..].Trim();
+        if (valueLine.Length == 0)
+            return null;
+
+        var rest = trimmed[(newline + 1)..^1];   // drop the terminating ';'
+        var lines = new List<string> { valueLine };
+        foreach (var line in rest.Split('\n'))
+            lines.Add(line.TrimEnd());
+        return lines;
+    }
+
     static bool IsStatementExpression(string expression)
     {
         if (expression.StartsWith("await ", StringComparison.Ordinal))

--- a/src/ILInspector.CSharp/CSharpMemberLayout.cs
+++ b/src/ILInspector.CSharp/CSharpMemberLayout.cs
@@ -27,7 +27,17 @@ public static class CSharpMemberLayout
     /// Otherwise a brace block with the body content one level (four spaces)
     /// deeper. Blank lines in the body are preserved.
     /// </summary>
-    public static void Append(StringBuilder sb, string head, string? body, int indent, bool wrapExpressionBodyArrow = false)
+    /// <param name="bodyIsSingleReturnExpression">
+    /// When <see langword="true"/> the caller has proven, from the typed
+    /// <c>DecompilerResult.BodyIsSingleReturnExpression</c> signal, that
+    /// <paramref name="body"/> is exactly one <c>return &lt;expr&gt;;</c>
+    /// statement whose expression spans several lines (a raised switch
+    /// expression). Such a body renders expression-bodied — <c>head =&gt; &lt;value&gt;
+    /// switch { … };</c> — with the switch block re-indented under the member
+    /// (issue #3088). Only ever set for a multi-line body; single-line bodies
+    /// stay on the <see cref="CSharpExpressionBody.FromSingleStatement"/> path.
+    /// </param>
+    public static void Append(StringBuilder sb, string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleReturnExpression = false)
     {
         ArgumentNullException.ThrowIfNull(sb);
         ArgumentNullException.ThrowIfNull(head);
@@ -36,6 +46,12 @@ public static class CSharpMemberLayout
         if (body is null)
         {
             sb.AppendLine($"{pad}{head};");
+            return;
+        }
+        if (bodyIsSingleReturnExpression
+            && CSharpExpressionBody.MultilineReturnExpressionLines(body) is { } expressionLines)
+        {
+            AppendMultilineExpressionBody(sb, head, expressionLines, indent, wrapExpressionBodyArrow);
             return;
         }
         if (CSharpExpressionBody.FromSingleStatement(body) is { } expression)
@@ -55,6 +71,48 @@ public static class CSharpMemberLayout
         sb.AppendLine($"{pad}{{");
         AppendIndentedBody(sb, body, indent + 4);
         sb.AppendLine($"{pad}}}");
+    }
+
+    /// <summary>
+    /// Renders a multi-line single-<c>return</c> expression body (a raised switch
+    /// expression). The value/arrow line sits after the arrow — on
+    /// <paramref name="head"/>'s line, or, when
+    /// <paramref name="wrapExpressionBodyArrow"/> is set, one level deeper on its
+    /// own line — and the block lines re-indent so the switch <c>{</c> aligns with
+    /// the token that opens the expression: the member indent for the same-line
+    /// arrow, or the arrow's indent for the wrapped arrow. The final line gains the
+    /// statement terminator (<c>};</c>). Blank lines are preserved.
+    /// </summary>
+    static void AppendMultilineExpressionBody(
+        StringBuilder sb, string head, IReadOnlyList<string> expressionLines, int indent, bool wrapExpressionBodyArrow)
+    {
+        string pad = new(' ', indent);
+        string valueLine = expressionLines[0];
+        if (wrapExpressionBodyArrow)
+        {
+            sb.AppendLine($"{pad}{head}");
+            sb.AppendLine($"{pad}    => {valueLine}");
+        }
+        else
+        {
+            sb.AppendLine($"{pad}{head} => {valueLine}");
+        }
+
+        string continuationPad = new(' ', wrapExpressionBodyArrow ? indent + 4 : indent);
+        for (int i = 1; i < expressionLines.Count; i++)
+        {
+            string line = expressionLines[i];
+            bool last = i == expressionLines.Count - 1;
+            if (line.Length == 0)
+            {
+                sb.AppendLine();
+                continue;
+            }
+            sb.Append(continuationPad).Append(line);
+            if (last)
+                sb.Append(';');
+            sb.AppendLine();
+        }
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
@@ -44,6 +44,7 @@ public sealed class DynamicCompilationSiteInventoryTests
             ["UnboxValueReadPassTests.cs"] = (1, "Product-output validity: compiles the normalized unbox value-read source (cast vs Unsafe.Unbox) per case."),
             ["IrImporterTests.cs"] = (1, "Product-output validity: compiles synthesized source feeding the IR importer."),
             ["MemberBodyProducerUnionTests.cs"] = (1, "Product-output validity: recompiles member-body producer output per rule set."),
+            ["MemberBodyProducerExpressionBodyTests.cs"] = (1, "Product-output validity: decompiles a compiled single-switch-return member and asserts the expression-bodied rendering (#3088)."),
             ["LadderRung6GateTests.cs"] = (1, "Product-output validity: compiles synthesized rung-6 gate source."),
             ["LadderRung9GateTests.cs"] = (1, "Product-output validity: compiles synthesized rung-9 gate source with feature parse options."),
 
@@ -86,9 +87,12 @@ public sealed class DynamicCompilationSiteInventoryTests
     //     comparison lambdas to assert their expression-tree node identity.
     //   #3067 adds SplittableExpressionWrapTests.cs (1 site): recompiles the
     //     printer's wrapped &&/|| chain output.
-    //   Combined: 33 files, 41 sites.
-    const int ExpectedDynamicFiles = 33;
-    const int ExpectedDynamicSites = 41;
+    //   #3088 adds MemberBodyProducerExpressionBodyTests.cs (1 site): decompiles
+    //     a compiled single-switch-return member and asserts the expression-bodied
+    //     rendering.
+    //   Combined: 34 files, 42 sites.
+    const int ExpectedDynamicFiles = 34;
+    const int ExpectedDynamicSites = 42;
 
     // Migrated away from Dynamic in this change; must not reappear in the scan.
     static readonly string[] MigratedFiles = ["CompileBackTypeIdentityTests.cs"];

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using ILInspector.Decompiler;
+using ILInspector.Metadata;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #3088: a method (or accessor) whose entire body is a single
+// `return <switch-expression>;` renders as an expression-bodied member
+// (`head => <scrutinee> switch { ... };`) instead of a brace block. The
+// signal is computed structurally in the printer (BodyIsSingleReturnExpression)
+// from the raised IR and threaded to the CSharp layout layer, which owns the
+// block-vs-expression-body decision and re-indents the switch block under the
+// member. These fixtures compile real C#, decompile the full member, and assert
+// the end-to-end shape — including the close negative where a preceding
+// statement forces the block form to remain.
+[Trait("Area", "RoundTrip")]
+public class MemberBodyProducerExpressionBodyTests
+{
+    [Fact]
+    public void SingleSwitchReturn_RendersExpressionBodied()
+    {
+        using var assembly = Compile("""
+            public class Fx
+            {
+                public static int Area(object shape) => shape switch
+                {
+                    string s => s.Length,
+                    int[] a => a.Length,
+                    _ => 0,
+                };
+            }
+            """);
+
+        string source = ComposeType(assembly.Path, "Fx");
+
+        // Expression-bodied member: arrow on the header line, switch block
+        // re-indented under the member (member at indent 4, arms at indent 8,
+        // closing `};` back at indent 4).
+        Assert.Contains(
+            """
+                public static int Area(object shape) => shape switch
+                {
+                    string V_0 => V_0.Length,
+                    int[] V_1 => V_1.Length,
+                    _ => 0,
+                };
+            """.ReplaceLineEndings("\n").Trim('\n'),
+            source);
+
+        // The old block form must be gone.
+        Assert.DoesNotContain("return shape switch", source);
+        Assert.DoesNotContain("return V_0 switch", source);
+    }
+
+    [Fact]
+    public void SwitchReturnAfterAnotherStatement_StaysBlock()
+    {
+        using var assembly = Compile("""
+            public class Fx
+            {
+                public static int TwoStatements(object shape, out bool matched)
+                {
+                    matched = shape is string;
+                    return shape switch
+                    {
+                        string s => s.Length,
+                        int[] a => a.Length,
+                        _ => 0,
+                    };
+                }
+            }
+            """);
+
+        string source = ComposeType(assembly.Path, "Fx");
+
+        // A method with a statement preceding the switch return is not a single
+        // return expression, so it must keep the brace-block body (arrow header
+        // is absent; the body opens with `{` on the next line).
+        Assert.Contains("public static int TwoStatements(object shape, out bool matched)\n    {", source);
+        Assert.DoesNotContain("TwoStatements(object shape, out bool matched) =>", source);
+    }
+
+    static string ComposeType(string path, string fullName)
+    {
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(surface.Types, t => t.FullName == fullName);
+        var source = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
+        Assert.NotNull(source);
+        return source!.ReplaceLineEndings("\n");
+    }
+
+    static TempAssembly Compile(string source)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-exprbody-{Guid.NewGuid():N}.dll");
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            Path.GetFileNameWithoutExtension(path),
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return new TempAssembly(path);
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+        => RoslynTestReferences.TrustedPlatform;
+
+    sealed class TempAssembly(string path) : IDisposable
+    {
+        public string Path { get; } = path;
+
+        public void Dispose()
+        {
+            try { File.Delete(Path); }
+            catch { }
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -265,6 +265,17 @@ public sealed record DecompilerResult(
     public bool ContainsAwaitExpression { get; init; }
 
     /// <summary>
+    /// True when the whole body is exactly one <c>return &lt;switch-expression&gt;;</c>
+    /// statement — a multi-line switch-expression return with nothing else in the
+    /// body. The member layer (<see cref="ILInspector.CSharp.CSharpMemberLayout"/>)
+    /// consumes this typed structural fact to render the member expression-bodied
+    /// (<c>head =&gt; &lt;value&gt; switch { … };</c>) instead of a brace block
+    /// (issue #3088). It is a body-shape fact the printer proves from the emitted
+    /// statement tree, so consumers never re-parse the rendered text to recover it.
+    /// </summary>
+    public bool BodyIsSingleReturnExpression { get; init; }
+
+    /// <summary>
     /// A telemetry-free record of what the decompilation observed — its fidelity
     /// outcome, the symbol source it used, and its diagnostics — for a host to
     /// convert into its own diagnostics. Null for projections that do not build
@@ -301,6 +312,7 @@ public sealed record DecompilerResult(
             && RequiresAsyncBodyModifier == other.RequiresAsyncBodyModifier
             && RequiresUnsafeBodyModifier == other.RequiresUnsafeBodyModifier
             && ContainsAwaitExpression == other.ContainsAwaitExpression
+            && BodyIsSingleReturnExpression == other.BodyIsSingleReturnExpression
             && EqualityComparer<DecompilerTrace?>.Default.Equals(Trace, other.Trace);
 
     public override int GetHashCode()
@@ -314,6 +326,7 @@ public sealed record DecompilerResult(
         hash.Add(RequiresAsyncBodyModifier);
         hash.Add(RequiresUnsafeBodyModifier);
         hash.Add(ContainsAwaitExpression);
+        hash.Add(BodyIsSingleReturnExpression);
         hash.Add(Trace);
         return hash.ToHashCode();
     }

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -840,9 +840,10 @@ public static class MemberBodyProducer
 
                     string? constructorChain = null;
                     bool requiresUnsafeContext = false;
+                    bool bodyIsSingleReturnExpression = false;
                     string? body = member.IsAbstract
                         ? null
-                        : DecompileBody(pipelineSource, memberHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresUnsafeContext, printerOptions);
+                        : DecompileBody(pipelineSource, memberHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
 
                     // An explicit interface property implementation surfaces
                     // as its accessor method (Iface.get_X). Render the
@@ -866,9 +867,9 @@ public static class MemberBodyProducer
                             CSharpMemberLayout.Append(sb, "set", body, 8, WrapExpressionBodyArrow(printerOptions));
                             sb.AppendLine("    }");
                         }
-                        else if (CSharpExpressionBody.FromSingleStatement(body) is not null)
+                        else if (bodyIsSingleReturnExpression || CSharpExpressionBody.FromSingleStatement(body) is not null)
                         {
-                            CSharpMemberLayout.Append(sb, head, body, 4, WrapExpressionBodyArrow(printerOptions));
+                            CSharpMemberLayout.Append(sb, head, body, 4, WrapExpressionBodyArrow(printerOptions), bodyIsSingleReturnExpression);
                         }
                         else
                         {
@@ -891,7 +892,7 @@ public static class MemberBodyProducer
                     var declaration = bodyShape is null
                         ? DefaultDeclarationFormatter.FormatMember(type, member)
                         : DefaultDeclarationFormatter.FormatMemberWithBody(type, member, bodyShape);
-                    AppendMember(sb, declaration, body, WrapExpressionBodyArrow(printerOptions), constructorChain);
+                    AppendMember(sb, declaration, body, WrapExpressionBodyArrow(printerOptions), constructorChain, bodyIsSingleReturnExpression);
                     break;
                 }
 
@@ -1120,12 +1121,12 @@ public static class MemberBodyProducer
         return null;
     }
 
-    static void AppendMember(StringBuilder sb, string signature, string? body, bool wrapExpressionBodyArrow, string? constructorChain = null)
+    static void AppendMember(StringBuilder sb, string signature, string? body, bool wrapExpressionBodyArrow, string? constructorChain = null, bool bodyIsSingleReturnExpression = false)
     {
         // An explicit base(...)/this(...) chain renders as a signature
         // initializer (the printer lifted it out of the body).
         string head = constructorChain is null ? signature : $"{signature} : {constructorChain}";
-        CSharpMemberLayout.Append(sb, head, body, 4, wrapExpressionBodyArrow);
+        CSharpMemberLayout.Append(sb, head, body, 4, wrapExpressionBodyArrow, bodyIsSingleReturnExpression);
     }
 
     static string TypeParameterDisplayName(TypeParameter typeParameter)
@@ -1187,16 +1188,16 @@ public static class MemberBodyProducer
         var getterHandle = ResolveAccessorHandle(reader, typeHandle, member.GetterToken, $"get_{member.Name}");
         var setterHandle = ResolveAccessorHandle(reader, typeHandle, member.SetterToken, $"set_{member.Name}");
 
-        var accessors = new List<(string Keyword, string? Body, bool RequiresUnsafeContext)>();
+        var accessors = new List<(string Keyword, string? Body, bool RequiresUnsafeContext, bool SingleReturnExpression)>();
         if (accessorList >= 0)
         {
             string list = signature[accessorList..];
             if (list.Contains("get;", StringComparison.Ordinal))
-                accessors.Add(("get", DecompileAccessor(pipelineSource, getterHandle, typeFullName, $"get_{member.Name}", bodyNamespaces, out var getRequiresUnsafe, printerOptions), getRequiresUnsafe));
+                accessors.Add(("get", DecompileAccessor(pipelineSource, getterHandle, typeFullName, $"get_{member.Name}", bodyNamespaces, out var getRequiresUnsafe, out var getSingleReturn, printerOptions), getRequiresUnsafe, getSingleReturn));
             if (list.Contains("set;", StringComparison.Ordinal))
-                accessors.Add(("set", DecompileAccessor(pipelineSource, setterHandle, typeFullName, $"set_{member.Name}", bodyNamespaces, out var setRequiresUnsafe, printerOptions), setRequiresUnsafe));
+                accessors.Add(("set", DecompileAccessor(pipelineSource, setterHandle, typeFullName, $"set_{member.Name}", bodyNamespaces, out var setRequiresUnsafe, out var setSingleReturn, printerOptions), setRequiresUnsafe, setSingleReturn));
             if (list.Contains("init;", StringComparison.Ordinal))
-                accessors.Add(("init", DecompileAccessor(pipelineSource, setterHandle, typeFullName, $"set_{member.Name}", bodyNamespaces, out var initRequiresUnsafe, printerOptions), initRequiresUnsafe));
+                accessors.Add(("init", DecompileAccessor(pipelineSource, setterHandle, typeFullName, $"set_{member.Name}", bodyNamespaces, out var initRequiresUnsafe, out var initSingleReturn, printerOptions), initRequiresUnsafe, initSingleReturn));
         }
 
         if (!requiresUnsafeContext && accessors.Any(a => a.RequiresUnsafeContext))
@@ -1228,10 +1229,13 @@ public static class MemberBodyProducer
         // Expression bodies per the style oracle
         // (csharp_style_expression_bodied_properties/accessors = true):
         // a lone getter returning one expression is 'head => expr;', and any
-        // single-statement accessor is 'get/set => ...;'.
-        if (accessors is [("get", { } loneGet, _)] && CSharpExpressionBody.FromSingleStatement(loneGet) is not null)
+        // single-statement accessor is 'get/set => ...;'. A lone getter whose
+        // body is one multi-line 'return <switch>;' also folds to an expression
+        // body (issue #3088), gated on the printer's typed single-return signal.
+        if (accessors is [("get", { } loneGet, _, var loneGetSingleReturn)]
+            && (loneGetSingleReturn || CSharpExpressionBody.FromSingleStatement(loneGet) is not null))
         {
-            CSharpMemberLayout.Append(sb, head, loneGet, 4, WrapExpressionBodyArrow(printerOptions));
+            CSharpMemberLayout.Append(sb, head, loneGet, 4, WrapExpressionBodyArrow(printerOptions), loneGetSingleReturn);
             return;
         }
 
@@ -1239,9 +1243,9 @@ public static class MemberBodyProducer
         sb.AppendLine("    {");
         for (int i = 0; i < accessors.Count; i++)
         {
-            var (keyword, body, _) = accessors[i];
+            var (keyword, body, _, singleReturn) = accessors[i];
             if (i > 0) sb.AppendLine();
-            CSharpMemberLayout.Append(sb, keyword, body, 8, WrapExpressionBodyArrow(printerOptions));
+            CSharpMemberLayout.Append(sb, keyword, body, 8, WrapExpressionBodyArrow(printerOptions), singleReturn);
         }
         sb.AppendLine("    }");
     }
@@ -1298,7 +1302,7 @@ public static class MemberBodyProducer
         Pipeline.MetadataSource pipelineSource, MethodDefinitionHandle? memberHandle,
         string typeFullName, ApiMember member, int overloadIndex,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext,
-        Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleReturnExpression, Pipeline.PrinterOptions? printerOptions)
     {
         // Prefer the member's own metadata handle — the canonical same-reader
         // addressing (see docs/design/member-body-substrate.md). The caller has
@@ -1309,7 +1313,7 @@ public static class MemberBodyProducer
         if (memberHandle is { } methodHandle)
             return DecompileFunction(pipelineSource,
                 Pipeline.IrImporter.Import(pipelineSource, methodHandle),
-                bodyNamespaces, out constructorChain, out requiresUnsafeContext, printerOptions);
+                bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
 
         // Public-only overload counting, except explicit interface
         // implementations (non-public by nature) — matching the API surface
@@ -1318,7 +1322,7 @@ public static class MemberBodyProducer
             publicOnly: member.Kind != "explicit-interface-implementation"
                 && !(member.Kind == "constructor" && member.DeclaringOverloadIndex is not null)
                 && member.Accessibility is null,
-            bodyNamespaces, out constructorChain, out requiresUnsafeContext, printerOptions);
+            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
     }
 
     /// <summary>
@@ -1389,7 +1393,7 @@ public static class MemberBodyProducer
         Pipeline.MetadataSource pipelineSource, MethodDefinitionHandle? accessorHandle,
         string typeFullName, string accessorName,
         SortedSet<string> bodyNamespaces, out bool requiresUnsafeContext,
-        Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleReturnExpression, Pipeline.PrinterOptions? printerOptions)
         // Prefer the accessor's own handle (fixes indexer get_Item/set_Item
         // drift, where name+index:0 always selects the first indexer's
         // accessor). Fall back to the by-name path — accessors are non-public
@@ -1398,9 +1402,9 @@ public static class MemberBodyProducer
         => accessorHandle is { } handle
             ? DecompileFunction(pipelineSource,
                 Pipeline.IrImporter.Import(pipelineSource, handle),
-                bodyNamespaces, out _, out requiresUnsafeContext, printerOptions)
+                bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions)
             : DecompileMethod(pipelineSource, typeFullName, accessorName, overloadIndex: 0,
-            publicOnly: false, bodyNamespaces, out _, out requiresUnsafeContext, printerOptions);
+            publicOnly: false, bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
 
     /// <summary>
     /// Imports one method to typed IR, runs the raising passes, and prints the
@@ -1413,10 +1417,10 @@ public static class MemberBodyProducer
     static string? DecompileMethod(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string methodName, int overloadIndex,
         bool publicOnly, SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext,
-        Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleReturnExpression, Pipeline.PrinterOptions? printerOptions)
         => DecompileFunction(pipelineSource,
             Pipeline.IrImporter.Import(pipelineSource, typeFullName, methodName, overloadIndex, publicOnly),
-            bodyNamespaces, out constructorChain, out requiresUnsafeContext, printerOptions);
+            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
 
     /// <summary>
     /// Runs the raising passes and prints an already-imported function. A null
@@ -1427,10 +1431,11 @@ public static class MemberBodyProducer
     static string? DecompileFunction(
         Pipeline.MetadataSource pipelineSource, Pipeline.IrFunction? function,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext,
-        Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleReturnExpression, Pipeline.PrinterOptions? printerOptions)
     {
         constructorChain = null;
         requiresUnsafeContext = false;
+        bodyIsSingleReturnExpression = false;
         if (function is null)
             return null;
         CollectNamespaces(function, bodyNamespaces);
@@ -1439,6 +1444,7 @@ public static class MemberBodyProducer
             typesProvablyDisjoint: pipelineSource.AreProvablyDisjoint);
         constructorChain = result.ConstructorChain;
         requiresUnsafeContext = result.RequiresUnsafeBodyModifier;
+        bodyIsSingleReturnExpression = result.BodyIsSingleReturnExpression;
         return result.Output?.TrimEnd() ?? DiagnosticComment(result);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -239,8 +239,37 @@ public sealed partial class CSharpPrinter
             RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
             RequiresUnsafeBodyModifier = function.Descendants.Prepend(function).Any(NeedsUnsafeContext),
             ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
+            BodyIsSingleReturnExpression = BodyIsSingleReturnExpression(function),
             Metadata = new DecompilerResultMetadata(EffectiveDecompilerOptions(), [.. _decisions]),
         };
+
+    /// <summary>
+    /// True when the printed body is exactly one top-level
+    /// <c>return &lt;switch-expression&gt;;</c> statement — a multi-line
+    /// switch-expression return with nothing else in the body. The member layer
+    /// renders such a body as an expression-bodied member (issue #3088). The
+    /// check is structural (the emitted top-level statement list plus the lifts
+    /// the printer already tracked), never a re-parse of the rendered text, and
+    /// stays deliberately narrow: only the switch-expression return values that
+    /// render as a self-contained <c>&lt;value&gt; switch { … }</c> qualify, so a
+    /// return whose printed form spans several statements (a
+    /// <c>stackalloc</c>-to-pointer return) is excluded.
+    /// </summary>
+    bool BodyIsSingleReturnExpression(IrFunction function)
+        => !_emittedDeclarations
+            && !_topLevelHasLabel
+            && _constructorChain is null
+            && _fieldInitializers.Count == 0
+            && !function.RequiresAsyncBodyModifier
+            && !NeedsUnsupportedFallbackReturn(function)
+            && _topLevelStatements is
+            [
+                Return
+                {
+                    Value: SwitchExpression or PatternSwitchExpression
+                        or UnionSwitchExpression or TupleSwitchExpression
+                }
+            ];
 
     DecompilerOptions EffectiveDecompilerOptions()
         => new()
@@ -299,6 +328,25 @@ public sealed partial class CSharpPrinter
     /// <summary>Field initializers (<c>this.f = value</c> stores preceding the base call) lifted out of a constructor body to the field declarations, keyed in source order.</summary>
     readonly List<(string Field, string Value)> _fieldInitializers = [];
     readonly HashSet<IrNode> _fieldInitStores = [];
+
+    /// <summary>
+    /// True once <see cref="PrintBody"/> has emitted at least one up-front local
+    /// declaration (before the body statements). A body with declarations is not
+    /// a single-return expression, so it disqualifies the
+    /// <see cref="DecompilerResult.BodyIsSingleReturnExpression"/> signal.
+    /// </summary>
+    bool _emittedDeclarations;
+
+    /// <summary>
+    /// The top-level statements <see cref="AppendContainer"/> actually emitted
+    /// (chain/field-initializer lifts and the trimmed trailing <c>return;</c>
+    /// excluded), plus whether any top-level label was emitted. Together they let
+    /// <see cref="Result"/> recognize the single <c>return &lt;switch&gt;;</c> body
+    /// that <see cref="DecompilerResult.BodyIsSingleReturnExpression"/> reports —
+    /// a structural fact, not a re-parse of the rendered text.
+    /// </summary>
+    readonly List<IrNode> _topLevelStatements = [];
+    bool _topLevelHasLabel;
 
     /// <summary>Pinned local slots a <see cref="Fixed"/> statement owns: declared by the fixed header (skipped up front) and read as a pointer of the fixed's element type.</summary>
     readonly HashSet<int> _fixedLocals = [];
@@ -422,7 +470,10 @@ public sealed partial class CSharpPrinter
         foreach (var declaration in CollectDeclarations(function))
             sb.AppendLine(declaration);
         if (sb.Length > 0)
+        {
+            _emittedDeclarations = true;
             sb.AppendLine();
+        }
 
         AppendContainer(sb, function.Body, 0, topLevel: true);
         if (NeedsUnsupportedFallbackReturn(function))
@@ -475,6 +526,8 @@ public sealed partial class CSharpPrinter
             {
                 AppendLabel(sb, pad, block.StartOffset);
                 labelPendingStatement = true;
+                if (topLevel)
+                    _topLevelHasLabel = true;
             }
             // The trailing 'return;' trims, current-style — unless it is a
             // labeled block's only statement, where trimming would strand
@@ -491,6 +544,8 @@ public sealed partial class CSharpPrinter
                 emit.Add(statement);
             }
 
+            if (topLevel)
+                _topLevelStatements.AddRange(emit);
             if (emit.Any(n => !RendersAsCommentOnly(n)))
                 labelPendingStatement = false;
             AppendStatements(sb, emit, indent);

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -169,6 +169,70 @@ public class ApiOutputFormatterTests
         Assert.DoesNotContain(DiagnosticIds.EmptyOutput, source);
     }
 
+    [Fact]
+    public void FormatSourceWithDeclaration_SingleSwitchReturn_RendersExpressionBodied()
+    {
+        // #3088: a member whose only statement is a multi-line
+        // `return <switch>;` renders expression-bodied. The block lines keep
+        // their column-zero body indent under the column-zero declaration.
+        var type = new ApiType { Namespace = "Samples", Name = "Shapes", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Area",
+            Kind = "method",
+            SignatureModel = new ApiSignature { MemberName = "Area", ReturnType = "System.Int32" }
+        };
+        var result = DecompilerResult.Success(
+            "return shape switch\n{\n    string s => s.Length,\n    int[] a => a.Length,\n    _ => 0,\n};") with
+        {
+            BodyIsSingleReturnExpression = true
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            member,
+            methodGenericParameters: null,
+            result,
+            preferExpressionBodied: true)
+            .ReplaceLineEndings("\n");
+
+        Assert.EndsWith(" => shape switch", Declaration(source));
+        Assert.Contains("\n{\n    string s => s.Length,\n    int[] a => a.Length,\n    _ => 0,\n};", source);
+        Assert.EndsWith("};", source.TrimEnd());
+        Assert.DoesNotContain("return shape switch", source);
+    }
+
+    [Fact]
+    public void FormatSourceWithDeclaration_SwitchReturn_StaysBlockWhenSignalNotSet()
+    {
+        // Same multi-line switch-return body, but the printer did not prove it a
+        // single-return expression (e.g. a statement precedes it), so it must
+        // keep the brace-block body.
+        var type = new ApiType { Namespace = "Samples", Name = "Shapes", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Area",
+            Kind = "method",
+            SignatureModel = new ApiSignature { MemberName = "Area", ReturnType = "System.Int32" }
+        };
+        var result = DecompilerResult.Success(
+            "return shape switch\n{\n    string s => s.Length,\n    int[] a => a.Length,\n    _ => 0,\n};") with
+        {
+            BodyIsSingleReturnExpression = false
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            member,
+            methodGenericParameters: null,
+            result,
+            preferExpressionBodied: true)
+            .ReplaceLineEndings("\n");
+
+        Assert.DoesNotContain("=>", Declaration(source));
+        Assert.Contains("return shape switch", source);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2236,6 +2236,27 @@ public static class ApiOutputFormatter
         if (!hasLeadingComments && preferExpressionBodied && CSharpExpressionBody.FromSingleStatement(body) is { } expressionBody)
             return $"{declaration} => {expressionBody};";
 
+        // A multi-line single-return switch expression renders expression-bodied
+        // too (issue #3088): `head => <value> switch { ... };`. The block lines
+        // sit at their body-relative (column-zero) indent, so at this member's
+        // column-zero declaration they need no re-indentation. Gate strictly on
+        // the printer's typed BodyIsSingleReturnExpression signal; the extraction
+        // helper is not sound on the flat string alone.
+        if (!hasLeadingComments && preferExpressionBodied && result.BodyIsSingleReturnExpression
+            && CSharpExpressionBody.MultilineReturnExpressionLines(body) is { Count: > 0 } multilineExpression)
+        {
+            var expression = new StringBuilder();
+            expression.Append(declaration).Append(" => ").Append(multilineExpression[0]);
+            for (int i = 1; i < multilineExpression.Count; i++)
+            {
+                expression.Append(Environment.NewLine);
+                expression.Append(multilineExpression[i]);
+                if (i == multilineExpression.Count - 1)
+                    expression.Append(';');
+            }
+            return expression.ToString();
+        }
+
         var formattedBodyLines = body.ReplaceLineEndings("\n").Split('\n');
         var lines = hasLeadingComments
             ? leadingBodyComments!.Concat(formattedBodyLines)


### PR DESCRIPTION
- Fixes/advances #3088
- Renders a method/accessor whose only statement is a multi-line `return <switch-expression>;` as an expression-bodied member.
- Card revision: `2423ab60`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a sole `return <switch>;` now renders `head => <value> switch { ... };` on both the whole-type and single-member rendering paths, gated on a typed structural signal from the printer (never string-sniffing).

### Original source

<!-- No SourceLink/PDB for the synthetic fixture; falling back to the authoritative IL section. -->

Original C# (compiled into the fixture, shown for context — SourceLink source is unavailable because the fixture carries no PDB):

```csharp
public static int Area(object shape) => shape switch
{
    string s => s.Length,
    int[] a => a.Length,
    _ => 0,
};
```

Authoritative `IL` (`member Shapes -m Area ... -S "IL"`):

```il
IL_0000: ldarg.0
IL_0001: isinst       System.String
IL_0006: stloc.0
IL_0007: ldloc.0
IL_0008: brtrue.s     IL_0016
IL_000A: ldarg.0
IL_000B: isinst       int[]
IL_0010: stloc.1
IL_0011: ldloc.1
IL_0012: brtrue.s     IL_0021
IL_0014: br.s         IL_0029
IL_0016: br.s         IL_0018
IL_0018: ldloc.0
IL_0019: callvirt     System.String::get_Length()
IL_001E: stloc.2
IL_001F: br.s         IL_002D
IL_0021: br.s         IL_0023
IL_0023: ldloc.1
IL_0024: ldlen
IL_0025: conv.i4
IL_0026: stloc.2
IL_0027: br.s         IL_002D
IL_0029: ldc.i4.0
IL_002A: stloc.2
IL_002B: br.s         IL_002D
IL_002D: ldloc.2
IL_002E: ret
```

### Before

`member Shapes -m Area ... -S "Decompiled Source"` at the base commit (`da030adf`):

```csharp
public static int Area(object shape)
{
    return shape switch
    {
        string V_0 => V_0.Length,
        int[] V_1 => V_1.Length,
        _ => 0,
    };
}
```

- Valid: True
- Correct: True

The raised switch expression is already correct; it is just block-bodied rather than the idiomatic expression-bodied member form.

### After

`member Shapes -m Area ... -S "Decompiled Source"` at this PR's head (`2423ab60`):

```csharp
public static int Area(object shape) => shape switch
{
    string V_0 => V_0.Length,
    int[] V_1 => V_1.Length,
    _ => 0,
};
```

- Valid: True
- Correct: True

The whole-`type` render matches (expression-bodied `Area`); a sibling multi-statement method (`TwoStatements`, which assigns an `out` param before the switch) correctly stays block-bodied.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| `ApiOutputFormatterTests` (member path) | n/a (new tests) | 24 total, 0 failed (1 skip: ilasm) |
| `ILInspector.CSharp.Tests` | 316, 0 failed | 316, 0 failed |
| Decompiler fast suite | 3499, 0 failed | 3499, 0 failed |
| Full `dotnet-inspect.Tests` | 2023, 1 failed | 2023, 1 failed |

The one full-suite failure, `PlatformResolverTests.GetPacksDirectory_ReturnsValidPath`, is pre-existing and environmental (packs-v2 cache path on this machine); it is unchanged by this PR (same test, same reason).

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — presentation-only. The raised IR and the printer's body string are unchanged (`return X switch {...};`); only the block-vs-expression-bodied member framing of an already-fully-raised switch differs, so lowering/branch residue and fidelity metrics are identical to baseline. The corpus quick gate is therefore not applicable to this change.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.ApiOutputFormatterTests
dotnet run --project src/ILInspector.CSharp.Tests -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
