### PR TITLE
Guard FoldGuardReturn short-circuit folds for opcode fidelity (#3114)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -23,13 +23,15 @@ public class FidelityGateTests
     /// decompiler docket. Each is a tracked defect or a benign over-render; the gate
     /// tolerates these but fails if a NEW method joins the set. Shrink this list as
     /// fixes land. Tracked defects include StaleFieldRead (issue #605) and
-    /// benign codegen choices (BothPositive, NeitherOr).
+    /// benign codegen choices (BothPositive). NeitherOr left the docket when
+    /// #3114 taught FoldGuardReturn to decline the negated `a && b` guard fold
+    /// (`if (a && b) return false; return c;`) whose recompile diverged.
     /// GotoCommonExit is the step-2 common-exit fold: the decompiler inlines the
     /// shared return tail into each arm, recompiling to cleaner direct-return IL
     /// than the original goto-and-merge shape — a benign equivalent restructuring.
     /// SelectBoolReturn is a benign branch-polarity inversion in a bool-select
     /// ternary (orig <c>bgt</c> vs recmp <c>ble</c>), the same class as
-    /// BothPositive/NeitherOr; it was previously hidden in the recompile-fail
+    /// BothPositive; it was previously hidden in the recompile-fail
     /// bucket because its <c>System.GC.KeepAlive</c> call recompiled the short
     /// <c>GC</c> name with no <c>using System;</c> in the skeleton, and the
     /// harness now emits that using.
@@ -58,7 +60,6 @@ public class FidelityGateTests
         // hidden index temp for the same `return [a, b, 42];` source idiom.
         "CollectionListLiteral",
         "GotoCommonExit",
-        "NeitherOr",
         // This hand-written await-enumerator loop recompiles through the same
         // runtime-async shape but schedules the receiver load after the
         // enumerator-local initialization rather than before it.

--- a/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
@@ -1,0 +1,299 @@
+using ILInspector.Decompiler.Pipeline;
+using System.Collections.Immutable;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Guards on <c>BooleanFoldingPass.FoldGuardReturn</c> for the mixed constant-arm
+/// shape <c>if (c) return A; return B;</c> where exactly one arm is a bool constant.
+/// That fold re-forms a short-circuit <c>&amp;&amp;</c>/<c>||</c> by lifting the condition
+/// into the operator's left operand (optionally negated) and keeping the other arm
+/// as the surviving right operand — the same lift <see cref="ShortCircuitTernaryPass"/>
+/// performs for the nested constant-arm ternary — so it must carry the same
+/// opcode-fidelity guards (shared through <c>ShortCircuitFidelity</c>) or it emits C#
+/// whose recompilation diverges in branch opcodes, operator tokens, or runtime
+/// behavior (#3114). Compiler-shape evidence for the five hazards is the repro table
+/// on #3114 (`--dump` at base `e15f41c4`); the corpus compile-back gates guard the
+/// exact forms continuously. These fixtures pin the pass-level decline/accept.
+/// </summary>
+[Trait("Area", "Pass")]
+public class FoldGuardReturnFidelityTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef s_double = TypeRef.CoreLib("System", "Double");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef s_truth = TypeRef.CoreLib("Synthetic", "TruthOver");
+    static readonly TypeRef s_holder = TypeRef.CoreLib("Synthetic", "Holder");
+
+    static Constant Bool(bool value) => new(value, s_bool);
+
+    // A computed (non-bare-load) bool operand: a comparison. csc keeps the branch for
+    // a computed operand, so raising the short-circuit operator is opcode-exact.
+    static Comparison Y()
+        => new(ComparisonKind.GreaterThan, false, new LoadLocal(2, s_int), new Constant(0, s_int));
+
+    // A bare bool argument condition (negation is not the proven integer dual).
+    static LoadArgument Flag() => new(0, "flag", s_bool);
+
+    // An integer comparison condition; its negation is the proven same-branch dual
+    // (`start <= 0` → `start > 0`, both `ble.s`).
+    static Comparison StartLessEqualZero()
+        => new(ComparisonKind.LessThanOrEqual, false, new LoadArgument(0, "start", s_int), new Constant(0, s_int));
+
+    // A float comparison condition; negating it flips the ordered/unordered sense.
+    static Comparison FloatCompare()
+        => new(ComparisonKind.LessThan, false,
+               new LoadArgument(0, "a", s_double), new LoadArgument(1, "b", s_double));
+
+    // A reference (string) equality condition; negating it flips op_Equality →
+    // op_Inequality (a different call token).
+    static Comparison StringEquals()
+        => new(ComparisonKind.Equal, false,
+               new LoadArgument(0, "a", s_string), new LoadArgument(1, "b", s_string));
+
+    // A user-defined-truthiness condition: the `operator true` call csc inserts for a
+    // user type in boolean context. Lifting it rebinds the user-defined `|`/`&`.
+    static Call UserTruthiness()
+        => new(new MethodRef(s_truth, "op_True", s_bool, [s_truth], HasThis: false),
+               isVirtual: false, [new LoadArgument(0, "a", s_truth)]);
+
+    // A managed by-ref bool dereference: csc collapses `c && refBool` to a branchless
+    // `&`, eagerly dereferencing a location the branch had guarded.
+    static LoadIndirect ByRefBoolDeref()
+        => new(s_bool, new LoadArgument(1, "y", TypeRef.ByRef(s_bool)));
+
+    // A raw pointer bool dereference: can access-violate, so csc keeps the branch and
+    // the raise stays opcode-exact — the negative boundary of the by-ref guard.
+    static LoadIndirect PointerBoolDeref()
+        => new(s_bool, new LoadArgument(1, "p", TypeRef.Pointer(s_bool)));
+
+    // A bare reference (string) branch condition — the `brtrue`/`brfalse` over a
+    // reference the printer spells `value is not null`. Negating it flips only branch
+    // polarity (`is null`), so the negating fold stays opcode-exact. This is the
+    // `String.IsNullOrEmpty` witness shape carried since before #3114.
+    static LoadArgument ReferenceValue()
+        => new(0, "value", s_string);
+
+    // An explicit `x != null` reference test; its negation is the exact `x == null`
+    // (a branch-polarity flip), not an operator-token change.
+    static Comparison ReferenceNotNull()
+        => new(ComparisonKind.NotEqual, false,
+               new LoadArgument(0, "value", s_string), new Constant(null, s_string));
+
+    // ---- Accept: opcode-exact folds still fire ----
+
+    [Fact]
+    public void IntegerComparisonNegate_Case3_FoldsToAnd()
+    {
+        // if (start <= 0) return false; return y;  ≡  return start > 0 && y;
+        var (kind, left, right) = FoldOne(StartLessEqualZero(), Bool(false), Y());
+        Assert.Equal(LogicalKind.And, kind);
+        Assert.Equal(ComparisonKind.GreaterThan, Assert.IsType<Comparison>(left).Kind);
+        Assert.IsType<Comparison>(right);
+    }
+
+    [Fact]
+    public void PrimitiveBoolCondition_NoNegate_Case3_FoldsToOr()
+    {
+        // if (flag) return true; return y;  ≡  return flag || y;  (A-form, no negate)
+        var (kind, left, right) = FoldOne(Flag(), Bool(true), Y());
+        Assert.Equal(LogicalKind.Or, kind);
+        Assert.IsType<LoadArgument>(left);   // condition unchanged
+        Assert.IsType<Comparison>(right);
+    }
+
+    [Fact]
+    public void IntegerComparison_Case2_NegateFoldsToOr()
+    {
+        // if (start <= 0) return y; return true;  ≡  return start > 0 || y;
+        var (kind, left, right) = FoldOne(StartLessEqualZero(), Y(), Bool(true));
+        Assert.Equal(LogicalKind.Or, kind);
+        Assert.Equal(ComparisonKind.GreaterThan, Assert.IsType<Comparison>(left).Kind);
+        Assert.IsType<Comparison>(right);
+    }
+
+    [Fact]
+    public void IntegerComparison_Case2_NoNegateFoldsToAnd()
+    {
+        // if (start <= 0) return y; return false;  ≡  return start <= 0 && y;
+        var (kind, left, right) = FoldOne(StartLessEqualZero(), Y(), Bool(false));
+        Assert.Equal(LogicalKind.And, kind);
+        Assert.Equal(ComparisonKind.LessThanOrEqual, Assert.IsType<Comparison>(left).Kind);
+        Assert.IsType<Comparison>(right);
+    }
+
+    [Fact]
+    public void PointerDereferenceOperand_StillFolds()
+    {
+        // if (start <= 0) return false; return *p;  ≡  return start > 0 && *p;
+        // A pointer read can access-violate, so csc keeps the branch — raising is exact.
+        var (kind, _, right) = FoldOne(StartLessEqualZero(), Bool(false), PointerBoolDeref());
+        Assert.Equal(LogicalKind.And, kind);
+        Assert.IsType<LoadIndirect>(right);
+    }
+
+    [Fact]
+    public void ReferenceNullBranchNegate_Case2_FoldsToOr()
+    {
+        // if (value is not null) return y; return true;  ≡  return value is null || y;
+        // The bare reference branch negates to a branch-polarity flip (is null), which
+        // re-lowers to the opposite brtrue/brfalse — opcode-exact. This is the
+        // `String.IsNullOrEmpty` shape (`value is null || value.Length == 0`).
+        var (kind, left, right) = FoldOne(ReferenceValue(), Y(), Bool(true));
+        Assert.Equal(LogicalKind.Or, kind);
+        Assert.IsType<LogicalNot>(left);   // Negate wraps the bare reference load
+        Assert.IsType<Comparison>(right);
+    }
+
+    [Fact]
+    public void ExplicitNullTestNegate_Case3_FoldsToAnd()
+    {
+        // if (value != null) return false; return y;  ≡  return value == null && y;
+        // An explicit reference null test inverts to its opposite null test, not an
+        // operator-token change — opcode-exact.
+        var (kind, left, right) = FoldOne(ReferenceNotNull(), Bool(false), Y());
+        Assert.Equal(LogicalKind.And, kind);
+        Assert.Equal(ComparisonKind.Equal, Assert.IsType<Comparison>(left).Kind);
+        Assert.IsType<Comparison>(right);
+    }
+
+    // ---- Decline: hazardous folds are left flat ----
+
+    [Fact]
+    public void FloatComparisonNegate_Case3_Declines()
+    {
+        // if (a < b) return false; return y;  →  !(a < b) && y flips ordered/unordered.
+        AssertDeclined(FloatCompare(), Bool(false), Y());
+    }
+
+    [Fact]
+    public void ReferenceEqualityNegate_Case3_Declines()
+    {
+        // if (a == b) return false; return y;  →  a != b && y flips op_Equality token.
+        AssertDeclined(StringEquals(), Bool(false), Y());
+    }
+
+    [Fact]
+    public void FloatComparisonNegate_Case2_Declines()
+    {
+        // if (a < b) return y; return true;  →  !(a < b) || y flips ordered/unordered.
+        AssertDeclined(FloatCompare(), Y(), Bool(true));
+    }
+
+    [Fact]
+    public void UserTruthiness_Case3_TrueThen_Declines()
+    {
+        // if (op_True(a)) return true; return y;  →  a || y rebinds user-defined `|`.
+        AssertDeclined(UserTruthiness(), Bool(true), Y());
+    }
+
+    [Fact]
+    public void UserTruthiness_Case3_FalseThen_Declines()
+    {
+        // if (op_True(a)) return false; return y;  →  !a && y rebinds user-defined `&`.
+        AssertDeclined(UserTruthiness(), Bool(false), Y());
+    }
+
+    [Fact]
+    public void BoolConditionNegate_Case3_Declines()
+    {
+        // if (flag) return false; return y;  →  !flag && y. A bare bool is not a
+        // comparison, so its negation is not the proven integer dual — decline.
+        AssertDeclined(Flag(), Bool(false), Y());
+    }
+
+    [Fact]
+    public void BareLocalOperand_Case3_Declines()
+    {
+        // if (start <= 0) return false; return localBool;  →  start > 0 && localBool.
+        // csc collapses `c && local` to a branchless `&` — decline. (Integer condition,
+        // so the decline is attributable to the operand guard, not the negate gate.)
+        AssertDeclined(StartLessEqualZero(), Bool(false), new LoadLocal(1, s_bool));
+    }
+
+    [Fact]
+    public void BareArgumentOperand_Case3_Declines()
+    {
+        AssertDeclined(StartLessEqualZero(), Bool(false), new LoadArgument(1, "other", s_bool));
+    }
+
+    [Fact]
+    public void ByRefDereferenceOperand_Case3_Declines()
+    {
+        // csc collapses `c && refBool` to a branchless `&` and eagerly dereferences a
+        // location the branch had guarded (NRE divergence on a null by-ref).
+        AssertDeclined(StartLessEqualZero(), Bool(false), ByRefBoolDeref());
+    }
+
+    [Fact]
+    public void ByRefDereferenceOperand_Case2_Declines()
+    {
+        // if (start <= 0) return refBool; return true;  →  start > 0 || refBool.
+        AssertDeclined(StartLessEqualZero(), ByRefBoolDeref(), Bool(true));
+    }
+
+    // ---- The both-opposite-constant identity/negation fold is a separate
+    // readability raise (no operator lift, no surviving operand) and stays ungated. ----
+
+    [Fact]
+    public void BothOppositeConstants_StillFoldsToCondition()
+    {
+        // if (flag) return true; return false;  ≡  return flag;
+        var block = Run(Flag(), Bool(true), Bool(false));
+        var ret = Assert.IsType<Return>(Assert.Single(block.Children));
+        Assert.IsType<LoadArgument>(ret.Value);
+    }
+
+    [Fact]
+    public void BothOppositeConstants_FloatCondition_StillFolds()
+    {
+        // if (a < b) return false; return true;  ≡  return !(a < b). The both-constant
+        // negation is out of #3114's scope (owned by the identity/negation fold), so it
+        // still collapses the guard rather than staying flat.
+        var block = Run(FloatCompare(), Bool(false), Bool(true));
+        Assert.IsType<Return>(Assert.Single(block.Children));
+    }
+
+    // ---- Harness ----
+
+    static (LogicalKind Kind, IrExpression Left, IrExpression Right) FoldOne(
+        IrExpression condition, IrExpression thenValue, IrExpression tailValue)
+    {
+        var block = Run(condition, thenValue, tailValue);
+        var ret = Assert.IsType<Return>(Assert.Single(block.Children));
+        var logical = Assert.IsType<LogicalBinary>(ret.Value);
+        return (logical.Kind, logical.Left, logical.Right);
+    }
+
+    static void AssertDeclined(IrExpression condition, IrExpression thenValue, IrExpression tailValue)
+    {
+        var block = Run(condition, thenValue, tailValue);
+        Assert.Equal(2, block.Children.Count);
+        Assert.IsType<IfStatement>(block.Children[0]);
+        Assert.IsType<Return>(block.Children[1]);
+    }
+
+    // Builds `if (condition) return thenValue; return tailValue;`, runs the pass, and
+    // returns the containing block for inspection.
+    static Block Run(IrExpression condition, IrExpression thenValue, IrExpression tailValue)
+    {
+        var then = new Block(0);
+        then.Add(new Return(thenValue));
+        var guard = new IfStatement(condition, then, null);
+
+        var block = new Block(0);
+        block.Add(guard);
+        block.Add(new Return(tailValue));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(
+            s_bool, [new Parameter("start", s_int)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", s_holder, signature, [s_bool, s_bool, s_int], body);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        return block;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -23,7 +23,7 @@ public class LoweredFidelityGateTests
     /// Methods whose lowered C# still differs under compile-back fidelity contract V1 — the open
     /// lowered docket. The gate tolerates these but fails if a NEW method joins the set.
     /// Beyond the shared sugared docket (BothPositive, GotoCommonExit,
-    /// NeitherOr, SelectBoolReturn), the lowered view adds ReverseCopy:
+    /// SelectBoolReturn), the lowered view adds ReverseCopy:
     /// lowering deliberately skips
     /// IncrementDecrementPass, so the dup-based ++/-- idiom round-trips as an explicit temp
     /// rather than the folded operator — a benign by-design divergence for this view.
@@ -52,7 +52,6 @@ public class LoweredFidelityGateTests
         // Span<T> indices for the same source idiom.
         "CollectionListLiteral",
         "GotoCommonExit",
-        "NeitherOr",
         "ManualAwaitEnumeratorLoop",
         "ReverseCopy",
         // RuntimeInlineArrayForeach is the runtime-style inline-array enumerator

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -485,6 +485,45 @@ public sealed class BooleanFoldingPass : IIrPass
         if (tailConstant is null && thenConstant is null)
             return false;  // general ternary returns are a separate decision
 
+        // Cases 2 and 3 (exactly one arm is a bool constant) re-form a short-circuit
+        // &&/|| that lifts the condition into the operator's LEFT operand — optionally
+        // negated — and keeps the other arm as the surviving right operand. That is the
+        // same lift ShortCircuitTernaryPass performs for the nested constant-arm ternary
+        // (#3107), so it needs the same opcode-fidelity guards or it can emit C# whose
+        // recompilation diverges in branch opcodes, operator tokens, or runtime behavior
+        // (#3114). The both-opposite-constant case below (`return c;`/`return !c;`) is a
+        // separate branch-materialization readability raise — no operator lift, no
+        // surviving operand — and is intentionally not gated here.
+        bool bothOppositeConstants =
+            thenConstant is { } t && tailConstant is { } t2 && t != t2;
+        if (!bothOppositeConstants)
+        {
+            // negate/operand map (mirrors the fold shapes chosen below):
+            //   tailConstant == true : Or(!c, thenValue)   negates; operand = thenValue
+            //   tailConstant == false: And(c, thenValue)              operand = thenValue
+            //   thenConstant == true : Or(c, tailValue)               operand = tailValue
+            //   thenConstant == false: And(!c, tailValue)  negates; operand = tailValue
+            bool negatesCondition;
+            IrExpression survivingOperand;
+            if (tailConstant is { } tailFlag)
+            {
+                negatesCondition = tailFlag;
+                survivingOperand = thenValue;
+            }
+            else
+            {
+                negatesCondition = thenConstant == false;
+                survivingOperand = tailValue;
+            }
+
+            if (ShortCircuitFidelity.IsUserDefinedTruthiness(guard.Condition)
+                || (negatesCondition && !ShortCircuitFidelity.NegationIsOpcodeExact(guard.Condition))
+                || ShortCircuitFidelity.RendersAsBranchlessBarePlace(survivingOperand))
+            {
+                return false;
+            }
+        }
+
         var condition = guard.Condition;
         condition.Detach();
         IrExpression folded;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
@@ -1,0 +1,143 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// The opcode-fidelity guards shared by every pass that re-forms a short-circuit
+/// <c>&amp;&amp;</c>/<c>||</c> by lifting a condition into the operator's left operand and
+/// keeping one arm as the surviving right operand. csc lowers <c>a &amp;&amp; b</c>/<c>a || b</c>
+/// to a branch diamond, so raising a diamond back to the operator is opcode-exact
+/// only when the condition binds the primitive operator (not a user-defined
+/// truthiness rebind), the negation — when the form negates the condition — is a
+/// proven integer-comparison dual, and the surviving operand does not render as a
+/// bare place csc would collapse to a branchless <c>&amp;</c>/<c>|</c>.
+///
+/// <para>Both <see cref="ShortCircuitTernaryPass"/> (the nested constant-arm ternary,
+/// #3107) and <see cref="BooleanFoldingPass"/>'s guarded-return fold (#3114) perform
+/// the same lift, so they share these predicates rather than mirroring them, keeping
+/// the validated fidelity contract in one place.</para>
+/// </summary>
+static class ShortCircuitFidelity
+{
+    /// <summary>
+    /// csc emits a branchless <c>&amp;</c>/<c>|</c> (not a short-circuit branch) for
+    /// <c>a &amp;&amp; b</c>/<c>a || b</c> only when the non-short-circuiting operand
+    /// renders as a bare, non-faulting place: a local, parameter, or stack-slot
+    /// load, or a <em>managed by-ref</em> dereference (an <c>in</c>/<c>ref</c>/<c>out</c>
+    /// parameter or <c>ref</c> local, which csc treats as non-null and side-effect
+    /// -free, spelling as the bare referent). A residual stack slot renders as a bare
+    /// synthetic local, so csc collapses it the same way. Raising those would trade
+    /// branch IL for branchless (and, for the by-ref case, eagerly dereference a
+    /// location the branch had guarded — an observable <c>NullReferenceException</c>
+    /// divergence on a null by-ref). Every other operand keeps the branch and is
+    /// safe to raise: a field/static/element load or call (can fault or has side
+    /// effects), a comparison (even over bare locals), a nested logical operator,
+    /// and — confirmed against real csc-emitted IL — a raw <em>pointer</em>
+    /// dereference <c>*p</c> (which can access-violate, so csc keeps the branch).
+    /// The operand map was verified opcode-by-opcode: only the bare-load and
+    /// managed-by-ref shapes compile branchless; all others keep the branch.
+    /// </summary>
+    public static bool RendersAsBranchlessBarePlace(IrExpression operand)
+        => operand is LoadLocal or LoadArgument or LoadStackSlot
+           || operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+
+    /// <summary>
+    /// Whether <paramref name="condition"/> is a user-defined-truthiness evaluation
+    /// — a call to <c>operator true</c>/<c>operator false</c> the compiler inserts
+    /// when a user type is used in boolean context. The printer strips such a call
+    /// to its bare user-typed receiver (it renders <c>op_True(a)</c>/<c>op_False(a)</c>
+    /// as <c>a</c>), so lifting it into a short-circuit operand — <c>a || y</c> /
+    /// <c>!a &amp;&amp; y</c> — would rebind to the user-defined conditional <c>|</c>/<c>&amp;</c>,
+    /// reselecting the overload and changing the call tokens and runtime result. Only
+    /// a type carrying <c>op_True</c>/<c>op_False</c> can bind a user-defined
+    /// <c>||</c>/<c>&amp;&amp;</c>, so this is the complete rebind set; a primitive-bool
+    /// condition (comparison, bool property/field/local/method, nested logical
+    /// operator) binds the primitive operator and is safe to lift.
+    /// </summary>
+    public static bool IsUserDefinedTruthiness(IrExpression condition)
+        => condition is Call { Callee.Name: "op_True" or "op_False" };
+
+    /// <summary>
+    /// Whether negating <paramref name="condition"/> re-forms to something that
+    /// recompiles to the same branch opcodes. The pipeline's <see cref="Conditions.Negate"/>
+    /// plus the printer's negation folds are only proven opcode-exact for a
+    /// confirmed primitive-integer comparison, whose dual is the same integer
+    /// branch (e.g. <c>start &lt;= 0</c> → <c>start &gt; 0</c>, both <c>ble.s</c>).
+    /// Every other negation the printer can fold to a different operator token or
+    /// branch polarity, so the negating form declines it:
+    /// <list type="bullet">
+    /// <item>a <see cref="Comparison"/> over float operands takes a dual that
+    /// flips the ordered/unordered sense (<c>blt.s</c> vs <c>blt.un.s</c>);</item>
+    /// <item>an <c>Equal</c>/<c>NotEqual</c> <see cref="Comparison"/> over a
+    /// non-integer operand (string/object/enum/struct), and a negated
+    /// comparison/equality operator <em>call</em> (<c>op_Equality</c>,
+    /// <c>op_LessThan</c>, …), flip to the inverse operator and — for a
+    /// user-defined operator — a different call token;</item>
+    /// <item>a truthiness test (<c>is</c>/<c>is null</c>/<c>!= 0</c>) inverts to
+    /// its own opposite spelling.</item>
+    /// </list>
+    /// Declining hands those back to the base pipeline's faithful rendering. The
+    /// integer family is read the same way <c>InvertComparison</c> reads it.
+    /// </summary>
+    public static bool NegateIsIntegerComparisonDual(IrExpression condition)
+    {
+        if (condition is not Comparison comparison)
+            return false;
+
+        StackFamily? family = TypeFamilies.Of(comparison.Left.ResultType)
+                              ?? TypeFamilies.Of(comparison.Right.ResultType);
+        return family is StackFamily.I4 or StackFamily.I8 or StackFamily.I;
+    }
+
+    /// <summary>
+    /// Whether negating <paramref name="condition"/> is opcode-exact for the
+    /// guarded-return fold. This is deliberately broader than
+    /// <see cref="NegateIsIntegerComparisonDual"/>: besides a primitive-integer
+    /// comparison dual, the guarded-return form has folded a <em>reference
+    /// null-branch</em> since before #3114 — a <c>brtrue</c>/<c>brfalse</c> over a
+    /// reference whose negation flips only branch polarity, spelled <c>is null</c>
+    /// ↔ <c>is not null</c> (the <c>String.IsNullOrEmpty</c> witness
+    /// <c>value is null || value.Length == 0</c>). A polarity flip re-lowers to the
+    /// opposite <c>brtrue</c>/<c>brfalse</c> on the same operand, so it is exact.
+    ///
+    /// <para>The nested ternary pass (#3107) intentionally keeps the narrower
+    /// integer-only gate; broadening it is separate follow-up, so this predicate
+    /// lives beside — not in place of — <see cref="NegateIsIntegerComparisonDual"/>.
+    /// The hazards stay declined: a float comparison (ordered/unordered flip), a
+    /// non-integer <c>==</c>/<c>!=</c> comparison or comparison-operator
+    /// <em>call</em> (operator-token flip), and a bare bool are none of the
+    /// accepted shapes.</para>
+    /// </summary>
+    public static bool NegationIsOpcodeExact(IrExpression condition)
+        => NegateIsIntegerComparisonDual(condition) || IsReferenceNullBranch(condition);
+
+    /// <summary>
+    /// Whether <paramref name="condition"/> is a reference null-branch, whose
+    /// negation is only a branch-polarity flip. Covers an explicit
+    /// <c>x == null</c>/<c>x != null</c> test, an <c>isinst</c> type test, and a
+    /// bare reference branch operand — recognised the same way the printer's
+    /// truthiness spelling recognises a reference: a generic instance (provably a
+    /// reference), a signature <see cref="ValueTypeHint.ReferenceType"/> hint, or a
+    /// corelib object/string/array (<see cref="StackFamily.O"/>). A cross-assembly
+    /// user type with no reference hint stays unrecognised and declines,
+    /// conservatively handing that shape back to the faithful branch rendering.
+    /// </summary>
+    static bool IsReferenceNullBranch(IrExpression condition)
+    {
+        if (condition is Comparison { Kind: ComparisonKind.Equal or ComparisonKind.NotEqual } comparison
+            && (comparison.Left is Constant { Value: null } || comparison.Right is Constant { Value: null }))
+        {
+            return true;
+        }
+
+        if (condition is IsInstance)
+            return true;
+
+        TypeRef? type = condition.ResultType;
+        if (type is null)
+            return false;
+        if (type.Kind == TypeRefKind.GenericInstance)
+            return true;
+        if (type.DeclaredValueTypeHint == ValueTypeHint.ReferenceType)
+            return true;
+        return TypeFamilies.Of(type) == StackFamily.O;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitTernaryPass.cs
@@ -26,7 +26,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// stack-slot load, or a managed by-ref (<c>in</c>/<c>ref</c>/<c>out</c>)
 /// dereference. csc collapses <c>a &amp;&amp; b</c> / <c>a || b</c> to a branchless
 /// <c>&amp;</c>/<c>|</c> for those operand shapes, so raising the ternary would
-/// trade branch IL for branchless (see <see cref="RendersAsBranchlessBarePlace"/>).
+/// trade branch IL for branchless (see <see cref="ShortCircuitFidelity.RendersAsBranchlessBarePlace"/>).
 /// Every faulting or side-effecting operand — field/element load, comparison,
 /// call, and even a raw pointer dereference <c>*p</c> — keeps the branch and is
 /// raised.</para>
@@ -37,14 +37,14 @@ namespace ILInspector.Decompiler.Pipeline;
 /// boolean context. The printer strips such a call to its bare user-typed receiver,
 /// so <c>c || y</c> / <c>!c &amp;&amp; y</c> would rebind to the user-defined conditional
 /// <c>|</c>/<c>&amp;</c>, reselecting the overload and diverging in call tokens and
-/// runtime result (<see cref="IsUserDefinedTruthiness"/>). A primitive-bool condition
+/// runtime result (<see cref="ShortCircuitFidelity.IsUserDefinedTruthiness"/>). A primitive-bool condition
 /// — comparison, bool property/field/local/method, nested logical operator — binds
 /// the primitive operator. The B-form additionally negates the condition, and
 /// negation is only proven opcode-exact for a primitive-integer comparison, whose
 /// dual is the same integer branch (e.g. <c>start &lt;= 0</c> ↔ <c>start &gt; 0</c>,
 /// both <c>ble.s</c>). A float dual flips the ordered/unordered sense and a reference
 /// <c>==</c>/<c>!=</c> dual flips the operator token, so the B-form fires only for a
-/// confirmed-integer comparison (<see cref="NegateIsIntegerComparisonDual"/>); the
+/// confirmed-integer comparison (<see cref="ShortCircuitFidelity.NegateIsIntegerComparisonDual"/>); the
 /// A-form (no negate) renders any primitive-bool condition verbatim.</para>
 ///
 /// It fires only when the when-true arm is a bool constant and the when-false arm
@@ -84,7 +84,7 @@ public sealed class ShortCircuitTernaryPass : IIrPass
             // in call tokens and runtime result. A primitive-bool condition
             // (comparison, bool property/field/local/method, nested logical operator)
             // binds the primitive operator, so decline only the truthiness lift.
-            if (IsUserDefinedTruthiness(conditional.Condition))
+            if (ShortCircuitFidelity.IsUserDefinedTruthiness(conditional.Condition))
                 continue;
 
             // The B-form (`c ? false : y` → `!c && y`) additionally negates the
@@ -94,13 +94,13 @@ public sealed class ShortCircuitTernaryPass : IIrPass
             // dual flips the ordered/unordered sense or the operator token, so the
             // B-form declines everything but a confirmed-integer comparison. The
             // A-form (no negate) renders the condition verbatim.
-            if (negate && !NegateIsIntegerComparisonDual(conditional.Condition))
+            if (negate && !ShortCircuitFidelity.NegateIsIntegerComparisonDual(conditional.Condition))
                 continue;
 
             // The surviving operand is always the when-false arm. Decline when csc
             // would emit a branchless `&`/`|` for the spelled operator: raising the
             // ternary would trade branch IL for branchless.
-            if (RendersAsBranchlessBarePlace((IrExpression)conditional.WhenFalse))
+            if (ShortCircuitFidelity.RendersAsBranchlessBarePlace((IrExpression)conditional.WhenFalse))
                 continue;
 
             var children = conditional.DetachChildren();
@@ -145,76 +145,6 @@ public sealed class ShortCircuitTernaryPass : IIrPass
             default:
                 return false;
         }
-    }
-
-    /// <summary>
-    /// csc emits a branchless <c>&amp;</c>/<c>|</c> (not a short-circuit branch) for
-    /// <c>a &amp;&amp; b</c>/<c>a || b</c> only when the non-short-circuiting operand
-    /// renders as a bare, non-faulting place: a local, parameter, or stack-slot
-    /// load, or a <em>managed by-ref</em> dereference (an <c>in</c>/<c>ref</c>/<c>out</c>
-    /// parameter or <c>ref</c> local, which csc treats as non-null and side-effect
-    /// -free, spelling as the bare referent). A residual stack slot renders as a bare
-    /// synthetic local, so csc collapses it the same way. Raising those would trade
-    /// branch IL for branchless (and, for the by-ref case, eagerly dereference a
-    /// location the branch had guarded — an observable <c>NullReferenceException</c>
-    /// divergence on a null by-ref). Every other operand keeps the branch and is
-    /// safe to raise: a field/static/element load or call (can fault or has side
-    /// effects), a comparison (even over bare locals), a nested logical operator,
-    /// and — confirmed against real csc-emitted IL — a raw <em>pointer</em>
-    /// dereference <c>*p</c> (which can access-violate, so csc keeps the branch).
-    /// The operand map was verified opcode-by-opcode: only the bare-load and
-    /// managed-by-ref shapes compile branchless; all others keep the branch.
-    /// </summary>
-    static bool RendersAsBranchlessBarePlace(IrExpression operand)
-        => operand is LoadLocal or LoadArgument or LoadStackSlot
-           || operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
-
-    /// <summary>
-    /// Whether <paramref name="condition"/> is a user-defined-truthiness evaluation
-    /// — a call to <c>operator true</c>/<c>operator false</c> the compiler inserts
-    /// when a user type is used in boolean context. The printer strips such a call
-    /// to its bare user-typed receiver (it renders <c>op_True(a)</c>/<c>op_False(a)</c>
-    /// as <c>a</c>), so lifting it into a short-circuit operand — <c>a || y</c> /
-    /// <c>!a &amp;&amp; y</c> — would rebind to the user-defined conditional <c>|</c>/<c>&amp;</c>,
-    /// reselecting the overload and changing the call tokens and runtime result. Only
-    /// a type carrying <c>op_True</c>/<c>op_False</c> can bind a user-defined
-    /// <c>||</c>/<c>&amp;&amp;</c>, so this is the complete rebind set; a primitive-bool
-    /// condition (comparison, bool property/field/local/method, nested logical
-    /// operator) binds the primitive operator and is safe to lift.
-    /// </summary>
-    static bool IsUserDefinedTruthiness(IrExpression condition)
-        => condition is Call { Callee.Name: "op_True" or "op_False" };
-
-    /// <summary>
-    /// Whether negating <paramref name="condition"/> re-forms to something that
-    /// recompiles to the same branch opcodes. The pipeline's <see cref="Conditions.Negate"/>
-    /// plus the printer's negation folds are only proven opcode-exact for a
-    /// confirmed primitive-integer comparison, whose dual is the same integer
-    /// branch (e.g. <c>start &lt;= 0</c> → <c>start &gt; 0</c>, both <c>ble.s</c>).
-    /// Every other negation the printer can fold to a different operator token or
-    /// branch polarity, so the B-form declines it:
-    /// <list type="bullet">
-    /// <item>a <see cref="Comparison"/> over float operands takes a dual that
-    /// flips the ordered/unordered sense (<c>blt.s</c> vs <c>blt.un.s</c>);</item>
-    /// <item>an <c>Equal</c>/<c>NotEqual</c> <see cref="Comparison"/> over a
-    /// non-integer operand (string/object/enum/struct), and a negated
-    /// comparison/equality operator <em>call</em> (<c>op_Equality</c>,
-    /// <c>op_LessThan</c>, …), flip to the inverse operator and — for a
-    /// user-defined operator — a different call token;</item>
-    /// <item>a truthiness test (<c>is</c>/<c>is null</c>/<c>!= 0</c>) inverts to
-    /// its own opposite spelling.</item>
-    /// </list>
-    /// Declining hands those back to the base pipeline's faithful rendering. The
-    /// integer family is read the same way <c>InvertComparison</c> reads it.
-    /// </summary>
-    static bool NegateIsIntegerComparisonDual(IrExpression condition)
-    {
-        if (condition is not Comparison comparison)
-            return false;
-
-        StackFamily? family = TypeFamilies.Of(comparison.Left.ResultType)
-                              ?? TypeFamilies.Of(comparison.Right.ResultType);
-        return family is StackFamily.I4 or StackFamily.I8 or StackFamily.I;
     }
 
     static bool IsBool(TypeRef? type)


### PR DESCRIPTION
- Fixes #3114
- Changes `BooleanFoldingPass.FoldGuardReturn` to carry the same opcode-fidelity guards as `ShortCircuitTernaryPass`, so a guarded return with a bool-constant arm no longer re-forms a short-circuit `&&`/`||` whose recompilation diverges.
- Card revision: `3ee230ad`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — `FoldGuardReturn` performs the same condition-lift as `ShortCircuitTernaryPass` (#3107) but lacked its three fidelity guards, so it could emit C# whose recompilation diverges in branch opcodes, operator tokens, or runtime behavior; this shares the validated predicates and applies them, declining exactly the hazardous folds while preserving every opcode-exact one.

### Original source

```csharp
public static bool NeitherOr(bool a, bool b, bool c)
{
    if (a && b)
        return false;
    return c;
}
```

### Before

Acquired with `dotnet-inspect member … NeitherOr -S "Decompiled Source"` at base `origin/main` (`da030adf`):

```csharp
public static bool NeitherOr(bool a, bool b, bool c) => !(a & b) && c;
```

- Valid: True
- Correct: True

Behavior is preserved, but this **re-forms a short-circuit that negates the `a & b` condition**, and the negated form recompiles to a different branch structure than the original `if (a && b) …` diamond — an opcode-fidelity divergence (`NeitherOr` was on the fidelity docket for exactly this reason).

### After

Acquired with the same command at this PR's head:

```csharp
public static bool NeitherOr(bool a, bool b, bool c)
{
    if (a & b)
    {
        return false;
    }
    return c;
}
```

- Valid: True
- Correct: True

The negating fold is declined, so the guarded return stays flat and recompiles opcode-exact. `NeitherOr` therefore leaves the fidelity docket.

### Fully raised

The After is in the intended state: this is a hazardous negating fold, so declining it (leaving the honest, opcode-exact `if/return`) **is** the correct endpoint — raising it would reintroduce the divergence.

## Approach

- Extract the three validated predicates into a shared `ShortCircuitFidelity` helper (the issue's preferred share-over-mirror). `ShortCircuitTernaryPass` now delegates to it (its 21 unit tests confirm the refactor is behavior-preserving).
- Apply the guards in `FoldGuardReturn` **before** it mutates the tree: decline on user-defined truthiness, on a negating fold whose negation is not opcode-exact, or on a surviving operand csc would collapse branchless.
- **Negate gate is broadened for the guarded-return form only** to `NegationIsOpcodeExact` = integer-comparison dual **or** reference null-branch. The issue's prescribed integer-only gate is incomplete here: `FoldGuardReturn` has folded a reference null-branch since before #3114 — the `String.IsNullOrEmpty` witness `value is null || value.Length == 0` — whose negation is only a branch-polarity flip and is opcode-exact. `ShortCircuitTernaryPass` keeps the narrower integer-only gate; broadening it is separate follow-up.

`String.IsNullOrEmpty` at head (regression check — the good fold is preserved):

```csharp
public static bool IsNullOrEmpty(string? value) => value is null || value.Length == 0;
```

## Evidence

- **Pass-level:** new `FoldGuardReturnFidelityTests` (19) pin accept/decline for every hazard (float dual, string `op_Equality` token flip, user truthiness, bare-place branchless collapse, by-ref NRE) and every accept (integer dual, reference null-branch, explicit null test, pointer deref). `ShortCircuitTernaryPassTests` (21) and `IrImporterTests` (65, incl. the `IsNullOrEmpty`/`List.Contains` real-artifact folds) stay green.
- **Fast decompiler suite:** 3507 tests, 0 failures.
- **Fidelity gate (real-artifact):** ran `FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket` on base (`1be371f2`) and this branch. The current diff set is **identical except `NeitherOr`**, which base reports and this branch does not — the change removes one docketed divergence and adds **zero** new ones. `NeitherOr` is dropped from the raised docket so the gate now guards against its regression.

### Environment note

The slow gates currently also report pre-existing **environmental** failures on this machine (compile-back resolves corelib to `System.Private.CoreLib`/`7cec85d7…` while originals reference `System.Runtime`/`b03f5f7f…`), which flood the diff set with ~74 unrelated methods (lambdas, iterators, local functions, expression trees). These reproduce identically on base and are unrelated to this change.

## Compatibility / non-action boundary

- Only the negating/operator-lift cases 2 and 3 are gated. The both-opposite-constant readability raise (`return c;`/`return !c;`) has no operator lift and is intentionally left ungated.
- `ShortCircuitTernaryPass` runtime behavior is unchanged (pure delegation refactor).
- The lowered fidelity docket is left unchanged (its view does not run the same raising and was not re-measured here).
