### PR TITLE
Inline fully-raised side-effect-free accumulator temporaries (#3009 sub-part 2)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -269,6 +269,17 @@ public class CfgSampleClass
     // bool op — neither operand is an integer, so no `? 1 : 0` materialization.
     public static bool AndTwoBools(bool a, bool b) => a & b;
 
+    static int IncrementReorderSink(int a, bool b) => b ? 1 : 2;
+
+    // Named arguments evaluate in source order (`b: x > 0` first, then `a: x++`),
+    // so csc spills the comparison across the post-increment before the call.
+    // The comparison `x > 0` is a pure composite ExpressionInliningPass may now
+    // defer (issue #3009), but deferring it past the reconstructed `x++` would
+    // read the *incremented* value and change the result. The pass tracks the
+    // increment target as a mutation, so `x > 0` stays put and still evaluates
+    // before `x++` (issue #3133 adversarial review).
+    public static int IncrementReorderGuard(int x) => IncrementReorderSink(b: x > 0, a: x++);
+
     // Adversarial: the bool operand mixes with a `uint` sibling. The materialized
     // `(b ? 1 : 0)` is a signed int, so `int | uint` would be CS0266 (widens to
     // long) unless the mixed-sign reconciliation casts it: `(uint)(... ? 1 : 0) | c`.

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -172,6 +172,91 @@ public class ExpressionInliningPassTests
         function.CheckInvariant();
     }
 
+    // The interference check must recognize compound assignments, not just plain
+    // stores and increments. A `??=` (`NullCoalescingAssignment`) reconstructed
+    // before the late inlining run mutates its local; a pure composite reading
+    // that local must not be deferred past it. Here the slot holds `x + 1` and
+    // the for-loop initializer is `x ??= 5`, whose write sits before the slot's
+    // load in the condition (issue #3133 adversarial review — GPT/Gemini `??=`).
+    [Fact]
+    public void PureCompositeReadingLocal_IsNotInlinedPastNullCoalescingAssignment()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadLocal(0, Int32),
+            new Constant(1, Int32))));
+        block.Add(new ForLoop(
+            new NullCoalescingAssignment(0, Int32, new Constant(5, Int32)),
+            new Comparison(
+                ComparisonKind.LessThan,
+                isUnsigned: false,
+                new LoadStackSlot(0, Int32),
+                new Constant(10, Int32)),
+            new IncrementDecrement(new LoadLocal(1, Int32), isIncrement: true, isPrefix: false),
+            new Block(1)));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32, Int32],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Contains(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
+    }
+
+    // Same hazard via a tuple deconstruction that reassigns an existing local
+    // (`IsDeclared: false`). The slot holds `x + 1`; the for-loop initializer
+    // deconstructs into `x`, so the deferred composite would read the mutated
+    // value. `DeconstructionAssignment` local targets must count as writes
+    // (issue #3133 adversarial review — Gemini deconstruction case).
+    [Fact]
+    public void PureCompositeReadingLocal_IsNotInlinedPastDeconstructionAssignment()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadLocal(0, Int32),
+            new Constant(1, Int32))));
+        block.Add(new ForLoop(
+            new DeconstructionAssignment(
+                [0],
+                [Int32],
+                new Constant(0, Int32),
+                [false]),
+            new Comparison(
+                ComparisonKind.LessThan,
+                isUnsigned: false,
+                new LoadStackSlot(0, Int32),
+                new Constant(10, Int32)),
+            new IncrementDecrement(new LoadLocal(1, Int32), isIncrement: true, isPrefix: false),
+            new Block(1)));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32, Int32],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Contains(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
+    }
+
     [Fact]
     public void CachedDelegateArgument_InlinesToSingleCall()
     {

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -131,6 +131,47 @@ public class ExpressionInliningPassTests
         function.CheckInvariant();
     }
 
+    // Counterpart to the reorder guards: the interference check is precise, not a
+    // blanket ban. A slot holds `x > 0`; the increment `x++` happens strictly
+    // AFTER the slot's single load, so deferring the comparison into the call is
+    // safe. The value must still inline — a coarse function-wide mutation scan
+    // would drop it (issue #3133 adversarial review — Gemini over-blocking case).
+    [Fact]
+    public void PureCompositeReadingArgument_InlinesWhenIncrementFollowsTheLoad()
+    {
+        var use = new MethodRef(Holder, "Use", Void, [Int32, Bool], HasThis: false);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Comparison(
+            ComparisonKind.GreaterThan,
+            isUnsigned: false,
+            new LoadArgument(0, "x", Int32),
+            new Constant(0, Int32))));
+        block.Add(new ExpressionStatement(new Call(
+            use,
+            isVirtual: false,
+            [
+                new LoadArgument(1, "y", Int32),
+                new LoadStackSlot(0, Bool),
+            ])));
+        block.Add(new ExpressionStatement(
+            new IncrementDecrement(new LoadArgument(0, "x", Int32), isIncrement: true, isPrefix: false)));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("x", Int32), new Parameter("y", Int32)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
+    }
+
     [Fact]
     public void CachedDelegateArgument_InlinesToSingleCall()
     {

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -89,6 +89,48 @@ public class ExpressionInliningPassTests
         function.CheckInvariant();
     }
 
+    // A pure value (no effect, cannot throw) is still unsound to defer past a
+    // write to a place it READS. A slot holds `x + 1`; a for-loop follows whose
+    // initializer assigns `x = 10`. The slot's single load sits in the loop
+    // condition, which is not the first-evaluated leaf (the initializer runs
+    // first), so purity alone would inline `x + 1` into the condition and read
+    // the overwritten `x`. The interference check keeps the slot alive
+    // (issue #3133 adversarial review — GPT for-loop-initializer case).
+    [Fact]
+    public void PureCompositeReadingReassignedLocal_IsNotInlinedPastForLoopInitializer()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadLocal(0, Int32),
+            new Constant(1, Int32))));
+        block.Add(new ForLoop(
+            new StoreLocal(0, Int32, new Constant(10, Int32)),
+            new Comparison(
+                ComparisonKind.LessThan,
+                isUnsigned: false,
+                new LoadStackSlot(0, Int32),
+                new Constant(5, Int32)),
+            new IncrementDecrement(new LoadLocal(0, Int32), isIncrement: true, isPrefix: false),
+            new Block(1)));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Contains(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
+    }
+
     [Fact]
     public void CachedDelegateArgument_InlinesToSingleCall()
     {

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -13,6 +13,7 @@ public class ExpressionInliningPassTests
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef Action = TypeRef.CoreLib("System", "Action");
     static readonly TypeRef String = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
 
     static string PrintRaised(string methodName)
     {
@@ -29,6 +30,65 @@ public class ExpressionInliningPassTests
     // The collapsed cache leaves the chain spilled across reused stack slots
     // (`S_0 = xs; S_1 = x => ...; S_0 = Where(S_0, S_1); ...`). Live-range
     // inlining folds those temps into the call arguments, leaving one statement.
+    // A pure composite (a comparison) spilled across a post-increment must not
+    // be deferred past the `x++`: doing so would evaluate `x > 0` on the mutated
+    // value. ExpressionInliningPass records the increment's target as a mutation,
+    // so the comparison keeps its position and evaluates before the increment
+    // (issue #3133 adversarial review of the #3009 purity broadening).
+    [Fact]
+    public void CompositeReadingIncrementedArgument_DoesNotReorderPastIncrement()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.IncrementReorderGuard));
+
+        int comparison = output.IndexOf("x > 0", StringComparison.Ordinal);
+        int increment = output.IndexOf("x++", StringComparison.Ordinal);
+        Assert.True(comparison >= 0, $"expected `x > 0` in output, got: {output}");
+        Assert.True(increment >= 0, $"expected `x++` in output, got: {output}");
+        Assert.True(comparison < increment,
+            $"`x > 0` must evaluate before `x++`; the comparison was reordered past the increment: {output}");
+    }
+
+    // Direct-IR proof for the late slots-only path the compiled fixture above
+    // cannot reach (csc spills the reordered argument to a local, which the early
+    // full run protects by pass ordering). A slot holds the pure comparison
+    // `x > 0`; a post-increment of `x` sits before the slot's single load, which
+    // is not the first-evaluated leaf. Without tracking the increment as a
+    // mutation the pass would deem the comparison pure and defer it past `x++`,
+    // reading the incremented value. The slot must survive (issue #3133).
+    [Fact]
+    public void SlotCompositeReadingIncrementedArgument_IsNotInlinedPastIncrement()
+    {
+        var use = new MethodRef(Holder, "Use", Void, [Int32, Bool], HasThis: false);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Comparison(
+            ComparisonKind.GreaterThan,
+            isUnsigned: false,
+            new LoadArgument(0, "x", Int32),
+            new Constant(0, Int32))));
+        block.Add(new ExpressionStatement(new Call(
+            use,
+            isVirtual: false,
+            [
+                new IncrementDecrement(new LoadArgument(0, "x", Int32), isIncrement: true, isPrefix: false),
+                new LoadStackSlot(0, Bool),
+            ])));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("x", Int32)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Contains(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
+    }
+
     [Fact]
     public void CachedDelegateArgument_InlinesToSingleCall()
     {

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -257,6 +257,131 @@ public class ExpressionInliningPassTests
         function.CheckInvariant();
     }
 
+    // A catch clause binds the caught exception into a local (folded into the
+    // header as `VariableIndex`), which csc can place in a slot a prior value
+    // read. The slot holds `x + 1` reading local 0; the following try's catch
+    // rebinds local 0. The slot's single load sits in the catch body — not the
+    // first-evaluated leaf (the try body runs first) — so purity alone would
+    // inline `x + 1` into the handler and read the caught exception. The catch
+    // binding must count as a write (issue #3133 adversarial review — GPT catch
+    // case).
+    [Fact]
+    public void PureCompositeReadingLocal_IsNotInlinedPastCatchBinding()
+    {
+        var use = new MethodRef(Holder, "Use", Void, [Int32], HasThis: false);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadLocal(0, Int32),
+            new Constant(1, Int32))));
+
+        var tryBody = new BlockContainer();
+        var tryBlock = new Block(1);
+        tryBlock.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new Constant(0, Int32)])));
+        tryBody.Add(tryBlock);
+
+        var catchBody = new BlockContainer();
+        var catchBlock = new Block(2);
+        catchBlock.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(0, Int32)])));
+        catchBody.Add(catchBlock);
+        var clause = new CatchClause(ExceptionType, catchBody) { VariableIndex = 0 };
+
+        block.Add(new TryCatch(tryBody, [clause]));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Contains(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
+    }
+
+    // A foreach header rebinds its iteration local each pass; csc can reuse a
+    // slot for it that a prior value read. The slot holds `x + 1` reading local
+    // 0; the following foreach iterates into local 0. The slot's single load
+    // sits in the loop body — not the first-evaluated leaf (the collection runs
+    // first) — so purity alone would inline `x + 1` into the body and read the
+    // iteration value. The foreach binding must count as a write (issue #3133
+    // adversarial review — Gemini foreach case).
+    [Fact]
+    public void PureCompositeReadingLocal_IsNotInlinedPastForeachBinding()
+    {
+        var use = new MethodRef(Holder, "Use", Void, [Int32], HasThis: false);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadLocal(0, Int32),
+            new Constant(1, Int32))));
+
+        var foreachBody = new Block(1);
+        foreachBody.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(0, Int32)])));
+        block.Add(new ForeachStatement(0, Int32, new LoadArgument(0, "xs", Object), foreachBody));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("xs", Object)], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Contains(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
+    }
+
+    // Correct-by-construction guard for the interference check. Every IR node
+    // that binds a local or argument names its place through a `LocalIndex` /
+    // `VariableIndex` property; ExpressionInliningPass.Writes must recognize each
+    // so a deferred pure value is never moved past a binding of a place it reads.
+    // A newly added binding node fails this pin until it is handled in Writes
+    // (issue #3133 adversarial review kept surfacing missing writers).
+    [Fact]
+    public void Writes_CoversEveryLocalOrArgumentBindingNode()
+    {
+        string[] bindingIndexNames = ["LocalIndex", "VariableIndex"];
+        var discovered = typeof(IrNode).Assembly.GetTypes()
+            .Where(t => t.IsPublic
+                && t.Namespace == typeof(IrNode).Namespace
+                && t.GetProperties().Any(p => bindingIndexNames.Contains(p.Name)
+                    && (p.PropertyType == typeof(int) || p.PropertyType == typeof(int?))))
+            .Select(t => t.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        string[] expected =
+        [
+            "CatchClause",
+            "DeconstructionTarget",
+            "Fixed",
+            "ForeachStatement",
+            "IsPattern",
+            "NullCoalescingAssignment",
+            "PatternSwitchExpressionArm",
+            "PropertySubpattern",
+            "RecursivePropertyDeclarationPattern",
+            "UnionSwitchExpressionArm",
+            "UsingStatement",
+        ];
+
+        Assert.Equal(expected, discovered);
+    }
+
     [Fact]
     public void CachedDelegateArgument_InlinesToSingleCall()
     {

--- a/src/ILInspector.Decompiler.Tests/FlagsEnumAccumulatorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FlagsEnumAccumulatorTests.cs
@@ -54,4 +54,21 @@ public class FlagsEnumAccumulatorTests
         Assert.DoesNotContain("(long)512", output);
         Assert.Contains("FlagCaps64.Protocol", output);
     }
+
+    // #3009 sub-part 2: with the accumulator fully raised, the remaining ternary
+    // slot (`FlagCaps64 S_1 = interactive ? ... : ...;`) is a side-effect-free,
+    // non-throwing value, so ExpressionInliningPass inlines it into its single
+    // use in the OR chain. No spilled slot local survives; the whole method
+    // collapses to one fully-raised expression.
+    [Fact]
+    public void FlagsEnumAccumulator_InlinesTernarySlot_NoSlotLocalSurvives()
+    {
+        var output = Render(nameof(FlagsEnumAccumulatorSamples.Accumulate));
+
+        // No spilled stack-slot local of any type survives the inline.
+        Assert.DoesNotContain("S_1", output);
+        Assert.DoesNotContain("FlagCaps64 S_", output);
+        // The ternary now appears inline as an operand of the OR chain.
+        Assert.Contains("interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2308,6 +2308,11 @@ public class RaisingPassTests
         block.Add(new StoreIndirect(sbyteType,
             new LoadArgument(2, "target", TypeRef.ByRef(boolType)),
             new LoadStackSlot(0, intType)));
+        // A second consumer keeps the slot materialized (two loads), so this test
+        // pins slot typing rather than being subsumed by single-use inlining.
+        block.Add(new StoreIndirect(sbyteType,
+            new LoadArgument(2, "target", TypeRef.ByRef(boolType)),
+            new LoadStackSlot(0, intType)));
         var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
             [new Parameter("flag", boolType), new Parameter("other", boolType), new Parameter("target", TypeRef.ByRef(boolType))],
             HasThis: false,
@@ -2392,6 +2397,12 @@ public class RaisingPassTests
             new Constant(null, objectType),
             new LoadArgument(2, "value", stringType))
         { MergedType = objectType }));
+        block.Add(new StoreField(
+            new FieldRef(owner, "_fmt", stringType),
+            new LoadArgument(0, "this", owner),
+            new LoadStackSlot(0, stringType)));
+        // A second consumer keeps the slot materialized (two loads), so this test
+        // pins slot typing rather than being subsumed by single-use inlining.
         block.Add(new StoreField(
             new FieldRef(owner, "_fmt", stringType),
             new LoadArgument(0, "this", owner),

--- a/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
@@ -199,7 +199,12 @@ public class SelfQualifySyntheticShadow
 {
     public static int S_0() => 2;
 
-    public static int Uses(int a, int b) => S_0() + (a > b ? a : b);
+    public static int Side() => 5;
+
+    // The ternary condition calls a method, so it is impure and stays spilled to
+    // a synthetic S_0 slot (rather than inlining), keeping the name collision
+    // with the static S_0() call that this test exercises.
+    public static int Uses(int a, int b) => S_0() + (Side() > b ? a : b);
 }
 
 public class SelfQualifyGenericParamShadow

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -78,16 +78,6 @@ public sealed class ExpressionInliningPass : IIrPass
                 case StoreArgument argumentStore: argumentAddresses.Add(argumentStore.Index); break;
                 case LoadStackSlot load: Entry(true, load.Slot).Loads.Add(load); break;
                 case StoreStackSlot store when store.Parent is Block: Entry(true, store.Slot).Stores.Add(store); break;
-                // A reconstructed `x++`/`x--` mutates its target place. Record it
-                // as a write so a value that reads that place cannot be deemed
-                // pure and reordered past the increment (Gemini #3133 review):
-                // IncrementDecrementPass folds the `starg`/`stloc` away before the
-                // late slots-only run, so without this the store that would flag
-                // the place mutated no longer exists in the tree.
-                case IncrementDecrement { Target: LoadLocal incLocal }:
-                    locals[(false, incLocal.Index)] = Entry(false, incLocal.Index) with { AddressTaken = true }; break;
-                case IncrementDecrement { Target: LoadArgument incArg }:
-                    argumentAddresses.Add(incArg.Index); break;
             }
         }
 
@@ -140,8 +130,19 @@ public sealed class ExpressionInliningPass : IIrPass
                 continue;  // the local declaration carries a required cast/type witness
 
             bool pure = IsPure(store is StoreLocal sl ? sl.Value : ((StoreStackSlot)store).Value, locals, argumentAddresses, function);
-            if (!IsFirstEvaluatedLeaf(load, next) && !pure)
+            bool firstLeaf = IsFirstEvaluatedLeaf(load, next);
+            if (!firstLeaf && !pure)
                 continue;  // inlining would move the computation past whatever evaluates before the load
+            // Purity proves the value has no effect and cannot throw, but a value
+            // deferred to a NON-first-leaf load also moves past `next`'s prefix.
+            // If that prefix writes a place the value reads (a `StoreLocal`, or a
+            // reconstructed `x++`/`x--` whose `starg`/`stloc` was folded away), the
+            // deferred value would observe the mutated place. A pure value reads
+            // only arguments and locals (IsPure admits nothing else), so guard
+            // exactly those against a conflicting write anywhere in `next`
+            // (#3133 adversarial review — GPT for-loop-initializer case).
+            if (!firstLeaf && DefersPastConflictingWrite(store is StoreLocal s2 ? s2.Value : ((StoreStackSlot)store).Value, next))
+                continue;
 
             var value = (IrExpression)store.DetachChildren()[0];
 
@@ -354,10 +355,29 @@ public sealed class ExpressionInliningPass : IIrPass
             _ => false,
         })];
 
+    // A pure value deferred to a non-first-leaf load must not read a place that
+    // `next` writes: enumerate the value's argument/local reads (IsPure admits no
+    // other place read) and block if `next` mutates one. Conservative over the
+    // whole statement — a write strictly after the load only costs a missed
+    // collapse, never correctness.
+    static bool DefersPastConflictingWrite(IrExpression value, IrNode next)
+    {
+        foreach (var node in value.Descendants.Prepend(value))
+        {
+            switch (node)
+            {
+                case LoadArgument argument when Writes(next, PlaceKind.Argument, argument.Index): return true;
+                case LoadLocal load when Writes(next, PlaceKind.Local, load.Index): return true;
+            }
+        }
+        return false;
+    }
+
     static bool Writes(IrNode statement, PlaceKind kind, int index)
         => statement.Descendants.Prepend(statement).Any(n => kind switch
         {
-            PlaceKind.Slot => n is StoreStackSlot s && s.Slot == index,
+            PlaceKind.Slot => (n is StoreStackSlot s && s.Slot == index)
+                || (n is IncrementDecrement { Target: LoadStackSlot isl } && isl.Slot == index),
             PlaceKind.Local => (n is StoreLocal l && l.Index == index)
                 || (n is IncrementDecrement { Target: LoadLocal il } && il.Index == index),
             PlaceKind.Argument => (n is StoreArgument a && a.Index == index)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -78,6 +78,16 @@ public sealed class ExpressionInliningPass : IIrPass
                 case StoreArgument argumentStore: argumentAddresses.Add(argumentStore.Index); break;
                 case LoadStackSlot load: Entry(true, load.Slot).Loads.Add(load); break;
                 case StoreStackSlot store when store.Parent is Block: Entry(true, store.Slot).Stores.Add(store); break;
+                // A reconstructed `x++`/`x--` mutates its target place. Record it
+                // as a write so a value that reads that place cannot be deemed
+                // pure and reordered past the increment (Gemini #3133 review):
+                // IncrementDecrementPass folds the `starg`/`stloc` away before the
+                // late slots-only run, so without this the store that would flag
+                // the place mutated no longer exists in the tree.
+                case IncrementDecrement { Target: LoadLocal incLocal }:
+                    locals[(false, incLocal.Index)] = Entry(false, incLocal.Index) with { AddressTaken = true }; break;
+                case IncrementDecrement { Target: LoadArgument incArg }:
+                    argumentAddresses.Add(incArg.Index); break;
             }
         }
 
@@ -348,8 +358,10 @@ public sealed class ExpressionInliningPass : IIrPass
         => statement.Descendants.Prepend(statement).Any(n => kind switch
         {
             PlaceKind.Slot => n is StoreStackSlot s && s.Slot == index,
-            PlaceKind.Local => n is StoreLocal l && l.Index == index,
-            PlaceKind.Argument => n is StoreArgument a && a.Index == index,
+            PlaceKind.Local => (n is StoreLocal l && l.Index == index)
+                || (n is IncrementDecrement { Target: LoadLocal il } && il.Index == index),
+            PlaceKind.Argument => (n is StoreArgument a && a.Index == index)
+                || (n is IncrementDecrement { Target: LoadArgument ia } && ia.Index == index),
             _ => false,
         });
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -135,12 +135,13 @@ public sealed class ExpressionInliningPass : IIrPass
                 continue;  // inlining would move the computation past whatever evaluates before the load
             // Purity proves the value has no effect and cannot throw, but a value
             // deferred to a NON-first-leaf load also moves past `next`'s prefix.
-            // If that prefix writes a place the value reads (a `StoreLocal`, or a
-            // reconstructed `x++`/`x--` whose `starg`/`stloc` was folded away), the
-            // deferred value would observe the mutated place. A pure value reads
-            // only arguments and locals (IsPure admits nothing else), so guard
-            // exactly those against a conflicting write anywhere in `next`
-            // (#3133 adversarial review — GPT for-loop-initializer case).
+            // If that prefix writes a place the value reads — a `StoreLocal`, a
+            // compound assignment (`??=` / tuple deconstruction), or a
+            // reconstructed `x++`/`x--` — the deferred value would observe the
+            // mutated place. A pure value reads only arguments and locals
+            // (IsPure admits nothing else), so guard exactly those against a
+            // conflicting write anywhere in `next` (#3133 adversarial review —
+            // GPT for-loop-initializer and `??=` cases).
             if (!firstLeaf && DefersPastConflictingWrite(store is StoreLocal s2 ? s2.Value : ((StoreStackSlot)store).Value, next))
                 continue;
 
@@ -379,9 +380,12 @@ public sealed class ExpressionInliningPass : IIrPass
             PlaceKind.Slot => (n is StoreStackSlot s && s.Slot == index)
                 || (n is IncrementDecrement { Target: LoadStackSlot isl } && isl.Slot == index),
             PlaceKind.Local => (n is StoreLocal l && l.Index == index)
-                || (n is IncrementDecrement { Target: LoadLocal il } && il.Index == index),
+                || (n is IncrementDecrement { Target: LoadLocal il } && il.Index == index)
+                || (n is NullCoalescingAssignment nca && nca.LocalIndex == index)
+                || (n is DeconstructionAssignment dal && dal.Targets.Any(t => t.Kind == DeconstructionTargetKind.Local && t.LocalIndex == index)),
             PlaceKind.Argument => (n is StoreArgument a && a.Index == index)
-                || (n is IncrementDecrement { Target: LoadArgument ia } && ia.Index == index),
+                || (n is IncrementDecrement { Target: LoadArgument ia } && ia.Index == index)
+                || (n is DeconstructionAssignment daa && daa.Targets.Any(t => t.Kind == DeconstructionTargetKind.Argument && t.ArgumentIndex == index)),
             _ => false,
         });
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -470,6 +470,29 @@ public sealed class ExpressionInliningPass : IIrPass
         LoadArgument argument => !argumentAddresses.Contains(argument.Index)
             && !(function.Signature.HasThis && argument.Index == 0),
         LoadLocal load => !locals.TryGetValue((false, load.Index), out var entry) || !entry.AddressTaken,
+        // Side-effect-free, non-throwing composites: pure iff every operand is
+        // pure. Purity here must imply "cannot throw" as well as "no effect",
+        // because a pure value is deferred to its load site — moving a value
+        // that could throw past a prefix that could also throw (or have an
+        // effect) would change which exception surfaces. So division and
+        // remainder (DivideByZero/Overflow) and checked arithmetic/conversions
+        // (Overflow) are excluded; neg/not, bitwise/shift, unchecked
+        // arithmetic, comparisons, and conditionals never throw.
+        LogicalNot not => IsPure(not.Operand, locals, argumentAddresses, function),
+        Unary unary => IsPure(unary.Operand, locals, argumentAddresses, function),
+        Comparison comparison =>
+            IsPure(comparison.Left, locals, argumentAddresses, function)
+            && IsPure(comparison.Right, locals, argumentAddresses, function),
+        LogicalBinary logical =>
+            IsPure(logical.Left, locals, argumentAddresses, function)
+            && IsPure(logical.Right, locals, argumentAddresses, function),
+        Binary { Kind: not (BinaryKind.Divide or BinaryKind.Remainder), IsChecked: false } binary =>
+            IsPure(binary.Left, locals, argumentAddresses, function)
+            && IsPure(binary.Right, locals, argumentAddresses, function),
+        Conditional conditional =>
+            IsPure(conditional.Condition, locals, argumentAddresses, function)
+            && IsPure(conditional.WhenTrue, locals, argumentAddresses, function)
+            && IsPure(conditional.WhenFalse, locals, argumentAddresses, function),
         _ => false,
     };
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -135,13 +135,12 @@ public sealed class ExpressionInliningPass : IIrPass
                 continue;  // inlining would move the computation past whatever evaluates before the load
             // Purity proves the value has no effect and cannot throw, but a value
             // deferred to a NON-first-leaf load also moves past `next`'s prefix.
-            // If that prefix writes a place the value reads — a `StoreLocal`, a
-            // compound assignment (`??=` / tuple deconstruction), or a
-            // reconstructed `x++`/`x--` — the deferred value would observe the
-            // mutated place. A pure value reads only arguments and locals
-            // (IsPure admits nothing else), so guard exactly those against a
-            // conflicting write anywhere in `next` (#3133 adversarial review —
-            // GPT for-loop-initializer and `??=` cases).
+            // If that prefix writes a place the value reads, the deferred value
+            // would observe the mutated place. A pure value reads only arguments
+            // and locals (IsPure admits nothing else), so guard exactly those
+            // against any conflicting write anywhere in `next` — a store, a
+            // compound assignment, an increment, a `ref`/`out` escape, a catch or
+            // loop or pattern binding (#3133 adversarial review; see Writes).
             if (!firstLeaf && DefersPastConflictingWrite(store is StoreLocal s2 ? s2.Value : ((StoreStackSlot)store).Value, next))
                 continue;
 
@@ -375,19 +374,53 @@ public sealed class ExpressionInliningPass : IIrPass
     }
 
     static bool Writes(IrNode statement, PlaceKind kind, int index)
-        => statement.Descendants.Prepend(statement).Any(n => kind switch
-        {
-            PlaceKind.Slot => (n is StoreStackSlot s && s.Slot == index)
-                || (n is IncrementDecrement { Target: LoadStackSlot isl } && isl.Slot == index),
-            PlaceKind.Local => (n is StoreLocal l && l.Index == index)
-                || (n is IncrementDecrement { Target: LoadLocal il } && il.Index == index)
-                || (n is NullCoalescingAssignment nca && nca.LocalIndex == index)
-                || (n is DeconstructionAssignment dal && dal.Targets.Any(t => t.Kind == DeconstructionTargetKind.Local && t.LocalIndex == index)),
-            PlaceKind.Argument => (n is StoreArgument a && a.Index == index)
-                || (n is IncrementDecrement { Target: LoadArgument ia } && ia.Index == index)
-                || (n is DeconstructionAssignment daa && daa.Targets.Any(t => t.Kind == DeconstructionTargetKind.Argument && t.ArgumentIndex == index)),
-            _ => false,
-        });
+        => statement.Descendants.Prepend(statement).Any(n => WritesNode(n, kind, index));
+
+    // True when a single node binds or mutates the given place. A deferred pure
+    // value reads only arguments and locals (IsPure admits nothing else), but the
+    // guard also covers slots for the live-range collapse.
+    //
+    // Completeness is the point here: an omitted writer would let a deferred pure
+    // value observe a mutated place (the #3133 adversarial review repeatedly
+    // surfaced missing writers — IncrementDecrement, `??=`, tuple deconstruction,
+    // catch bindings, foreach/using/fixed headers, and pattern bindings). Two
+    // structural facts bound the writer set so it stays complete:
+    //   * Every INDIRECT write to a local or argument — a `ref`/`out` call or
+    //     constructor argument, an `InitObject`, any store through an address — is
+    //     mediated by a `LoadLocalAddress`/`LoadArgumentAddress` node (see
+    //     DefiniteAssignment.IsVerifiedOutLocal). Detecting an escaped address
+    //     covers all of them without enumerating callee shapes.
+    //   * Every DIRECT binding writer names its place through a `LocalIndex` /
+    //     `VariableIndex` on the node itself. BindingWriterCoverageTests pins that
+    //     the node types carrying such a binding index are exactly those handled
+    //     below, so a newly added binding node fails that test until it is added
+    //     here.
+    static bool WritesNode(IrNode n, PlaceKind kind, int index) => kind switch
+    {
+        PlaceKind.Slot =>
+            (n is StoreStackSlot s && s.Slot == index)
+            || (n is IncrementDecrement { Target: LoadStackSlot isl } && isl.Slot == index),
+        PlaceKind.Local =>
+            (n is StoreLocal l && l.Index == index)
+            || (n is IncrementDecrement { Target: LoadLocal il } && il.Index == index)
+            || (n is LoadLocalAddress la && la.Index == index)
+            || (n is NullCoalescingAssignment nca && nca.LocalIndex == index)
+            || (n is DeconstructionAssignment dal && dal.Targets.Any(t => t.Kind == DeconstructionTargetKind.Local && t.LocalIndex == index))
+            || (n is CatchClause cc && cc.VariableIndex == index)
+            || (n is Fixed fx && fx.LocalIndex == index)
+            || (n is UsingStatement us && us.LocalIndex == index)
+            || (n is ForeachStatement fe && fe.LocalIndex == index)
+            || (n is IsPattern ip && ip.LocalIndex == index)
+            || (n is RecursivePropertyDeclarationPattern rp && rp.LocalIndex == index)
+            || (n is UnionSwitchExpressionArm ua && ua.LocalIndex == index)
+            || (n is PatternSwitchExpressionArm pa && (pa.LocalIndex == index || pa.Subpattern?.LocalIndex == index)),
+        PlaceKind.Argument =>
+            (n is StoreArgument a && a.Index == index)
+            || (n is IncrementDecrement { Target: LoadArgument ia } && ia.Index == index)
+            || (n is LoadArgumentAddress aa && aa.Index == index)
+            || (n is DeconstructionAssignment daa && daa.Targets.Any(t => t.Kind == DeconstructionTargetKind.Argument && t.ArgumentIndex == index)),
+        _ => false,
+    };
 
     static bool WritesStaticDelegateTarget(IrNode statement, IrExpression value)
         => value is DelegateCreation { Target: LoadField { Instance: null, Field: var field } }


### PR DESCRIPTION
- Advances #3009 (sub-part 2 of 3)
- Changes: fully-raised, side-effect-free accumulator temporaries now inline into their single use instead of spilling to a synthetic slot local.
- Card revision: `39b5797b`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — extending `ExpressionInliningPass.IsPure` to recurse over effect-free, non-throwing composites (conditionals, comparisons, bitwise/shift/unchecked arithmetic, neg/not, `&&`/`||`) lets the last spilled accumulator temporary inline; division/remainder and checked arithmetic/conversions stay excluded because a value that can throw must not be deferred past a prefix that can also throw.

### Original source

```csharp
public static int Accumulate(FlagCaps64 server, bool interactive)
{
    FlagCaps64 caps = FlagCaps64.Protocol
        | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)
        | (server & FlagCaps64.LoadLocal)
        | FlagCaps64.Secure
        | (server & FlagCaps64.MultiStatements)
        | FlagCaps64.MultiResults;
    return (int)caps;
}
```

### Before

<!-- base = origin/main @ 68ab5ae1 (sub-part 1 merged) -->

```csharp
public static int Accumulate(ILInspector.Decompiler.Tests.FlagCaps64 server, bool interactive)
{
    FlagCaps64 S_1 = interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None;
    return (int)(FlagCaps64.Protocol | S_1 | server & FlagCaps64.LoadLocal | FlagCaps64.Secure | server & FlagCaps64.MultiStatements | FlagCaps64.MultiResults);
}
```

- Valid: True
- Correct: True

The fully-raised enum accumulator (sub-part 1) still spills the ternary to a synthetic `S_1` slot local because `IsPure` classified `Conditional` as impure, forcing the slot to materialize.

### After

```csharp
public static int Accumulate(ILInspector.Decompiler.Tests.FlagCaps64 server, bool interactive) => (int)(FlagCaps64.Protocol | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None) | server & FlagCaps64.LoadLocal | FlagCaps64.Secure | server & FlagCaps64.MultiStatements | FlagCaps64.MultiResults);
```

- Valid: True
- Correct: True

The `S_1` temporary (a pure ternary) inlines into its single use in the OR chain, collapsing the method to one fully-raised expression. The remaining gap to *Fully raised* is only sub-part 3 (multi-line OR-chain wrapping), tracked in #3009.

### Fully raised

```csharp
public static int Accumulate(FlagCaps64 server, bool interactive)
    => (int)(FlagCaps64.Protocol
        | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)
        | (server & FlagCaps64.LoadLocal)
        | FlagCaps64.Secure
        | (server & FlagCaps64.MultiStatements)
        | FlagCaps64.MultiResults);
```

## Why it is sound

`IsPure` gates a transform that *defers* a value's evaluation to its single load site, moving it past whatever the consuming statement evaluates first. "Pure" here therefore means **no observable effect AND cannot throw**:

- A pure value neither observes nor produces effects, so reordering it past any prefix is invisible.
- If it could throw, deferring it past a prefix that can also throw (or has an effect) would change which exception surfaces — so `Divide`/`Remainder` (DivideByZero/Overflow), checked arithmetic, and checked conversions are excluded. `Convert` is excluded entirely (conservative).
- Leaf reads keep the existing guards: address-taken locals, escaped/`ref`/`out` argument addresses, and the struct-`this` receiver are never pure.

Recompilation is fidelity-neutral or positive: inlining removes a spurious `stloc`/`ldloc` pair and returns the value to the original stack shape the source spilled.

## Evidence

| Check | Command | Baseline | Head |
| --- | --- | --- | --- |
| Fast decompiler suite | `-trait- "Speed=Slow"` | 3372 pass | 3372 pass |
| Validity | `-trait "Area=Validity"` | 103 pass | 103 pass |
| Corpus (CoreLib sweep, floors) | `-trait "Area=Corpus"` | 61 pass | 61 pass |
| Fidelity (compile-back) | `-trait "Area=Fidelity"` | pending | pending — local gate running; CI `test (ubuntu)` is authoritative (local compile-back is env-flaky) |

Three focused tests (`SelfQualifyPrinterTests.SyntheticLocalShadowedStaticCall_StaysQualified`, `IrImporterTests.BooleanMaterialization_IndirectBoolStore_DeclaresBoolSlot`, `IrImporterTests.ReferenceConditionalStore_UsesConsumerSlotType`) newly inlined their single-use slot; each fixture was adjusted to keep the slot multi-use so it still pins its slot-typing/self-qualification behavior. New regression test `FlagsEnumAccumulator_InlinesTernarySlot_NoSlotLocalSurvives`.
