### PR TITLE
Add EVIL authored-corpus progress card (--history-card)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Markout" Version="0.22.0" />
+    <PackageVersion Include="Markout" Version="0.24.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusHistoryCardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusHistoryCardTests.cs
@@ -128,6 +128,17 @@ public class AuthoredCorpusHistoryCardTests
     }
 
     [Fact]
+    public void ParseHistory_RejectsNullRowInsteadOfSilentlyDroppingIt()
+    {
+        // A literal `null` line is well-formed JSON that deserializes to null;
+        // it must fail loudly rather than vanish (which would hide a row and
+        // silently corrupt the trend), unlike blank/whitespace lines.
+        Assert.Throws<JsonException>(
+            () => AuthoredCorpusHistoryCard.ParseHistory(
+                ["""{"date":"2026-08-01","validPct":57.0,"correct":1610,"invalid":5170,"invalidBreakdown":null}""", "null"]));
+    }
+
+    [Fact]
     public void ParseHistory_AcceptsAbsentBreakdownAsNotMeasured()
     {
         // Regression guard: a null breakdown remains a legitimate pre-#3096

--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusHistoryCardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusHistoryCardTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
@@ -104,5 +105,37 @@ public class AuthoredCorpusHistoryCardTests
         // The Runs trend table still lists every run.
         Assert.Contains("| 2026-07-20 | (baseline) |", card, StringComparison.Ordinal);
         Assert.Contains("| 2026-07-30 | deadbeef |", card, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ParseHistory_RejectsRowMissingRequiredMetricsInsteadOfFabricatingZeros()
+    {
+        // A row missing core measured fields must fail loudly rather than
+        // deserialize into an all-zero record that renders fabricated 0
+        // metrics and false movement glyphs.
+        Assert.Throws<JsonException>(
+            () => AuthoredCorpusHistoryCard.ParseHistory(["""{"date":"2026-08-01","commit":"cafef00d"}"""]));
+    }
+
+    [Fact]
+    public void ParseHistory_RejectsPartialInvalidBreakdownInsteadOfFabricatingZeros()
+    {
+        // A present-but-empty breakdown must not silently become {0,0,0};
+        // only an absent (null) breakdown is a valid "not measured" signal.
+        Assert.Throws<JsonException>(
+            () => AuthoredCorpusHistoryCard.ParseHistory(
+                ["""{"date":"2026-08-01","validPct":57.0,"correct":1610,"invalid":5170,"invalidBreakdown":{}}"""]));
+    }
+
+    [Fact]
+    public void ParseHistory_AcceptsAbsentBreakdownAsNotMeasured()
+    {
+        // Regression guard: a null breakdown remains a legitimate pre-#3096
+        // row and must still parse (rendered later as "—", never fabricated).
+        var runs = AuthoredCorpusHistoryCard.ParseHistory(
+            ["""{"date":"2026-08-01","validPct":57.0,"correct":1610,"invalid":5170,"invalidBreakdown":null}"""]);
+
+        Assert.Single(runs);
+        Assert.Null(runs[0].InvalidBreakdown);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusHistoryCardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusHistoryCardTests.cs
@@ -41,39 +41,45 @@ public class AuthoredCorpusHistoryCardTests
     }
 
     [Fact]
-    public void Render_MovementUsesPerMetricPolarity()
+    public void Render_MovementPivotsMetricsWithPerMetricGoalAndStepGlyphs()
     {
-        // Latest (250 product, 5180 invalid, 1600 correct, 57.4%) vs previous
-        // (306 product, 5259 invalid, 1539 correct, 56.2%): every headline metric
-        // improves, and lower-is-better metrics must read "improved" when they drop.
+        // Movement is the transpose of Runs: metrics are rows, runs are columns. Each row carries its
+        // Goal, so Markout appends the goal glyph (↑/↓) to the label and a per-step polarity glyph (✓/✗)
+        // to each column vs the previous populated one — replacing the old hand-computed Δ/Trend columns.
         string card = AuthoredCorpusHistoryCard.Render(Parse(), window: 0);
 
-        Assert.Contains("| Valid % | 56.2% | 57.4% | +1.2% | improved |", card, StringComparison.Ordinal);
-        Assert.Contains("| Correct | 1539 | 1600 | +61 | improved |", card, StringComparison.Ordinal);
-        Assert.Contains("| Invalid (raw) | 5259 | 5180 | −79 | improved |", card, StringComparison.Ordinal);
-        Assert.Contains("| Product defects | 306 | 250 | −56 | improved |", card, StringComparison.Ordinal);
+        Assert.Contains("| Metric | 2026-07-20 | 2026-07-24 | 2026-07-30 |", card, StringComparison.Ordinal);
+        // Higher-is-better: 56.6→56.2 down (✗), 56.2→57.4 up (✓).
+        Assert.Contains("| Valid % \u2191 | 56.6 | 56.2 \u2717 | 57.4 \u2713 |", card, StringComparison.Ordinal);
+        Assert.Contains("| Correct \u2191 | 1501 | 1539 \u2713 | 1600 \u2713 |", card, StringComparison.Ordinal);
+        // Lower-is-better: 5209→5259 up (✗), 5259→5180 down (✓).
+        Assert.Contains("| Invalid (raw) \u2193 | 5209 | 5259 \u2717 | 5180 \u2713 |", card, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Render_MovementIsNotApplicableWhenPreviousLacksProductSplit()
+    public void Render_MovementSkipsAbsentProductSplitWithoutFabricatingAStep()
     {
-        // Window of two spans the null-breakdown baseline and the first split run,
-        // so the product-defect delta cannot be computed and must read n/a rather
-        // than treating the missing split as zero.
-        string card = AuthoredCorpusHistoryCard.Render(Parse().Take(2).ToArray(), window: 2);
+        // The baseline run predates the invalid breakdown, so its product-defect cell is absent (—/-) and
+        // the first populated value carries no step glyph (no previous populated column to compare to);
+        // the next step (306→250, lower-is-better) is an improvement (✓).
+        string card = AuthoredCorpusHistoryCard.Render(Parse(), window: 0);
 
-        Assert.Contains("| Product defects | — | 306 | — | n/a |", card, StringComparison.Ordinal);
+        Assert.Contains("| Product defects \u2193 | - | 306 | 250 \u2713 |", card, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Render_WindowKeepsMostRecentRuns()
+    public void Render_MovementWindowBoundsThePivotButRunsStaysUnbounded()
     {
+        // Window bounds only the movement pivot to the most recent n runs; the Runs trend table always
+        // lists every recorded run.
         string card = AuthoredCorpusHistoryCard.Render(Parse(), window: 2);
 
-        Assert.DoesNotContain("2026-07-20", card, StringComparison.Ordinal);
-        Assert.Contains("2026-07-24", card, StringComparison.Ordinal);
-        Assert.Contains("2026-07-30", card, StringComparison.Ordinal);
-        Assert.Contains("Showing 2 of 3 recorded run(s).", card, StringComparison.Ordinal);
+        // Runs table keeps the oldest run...
+        Assert.Contains("| 2026-07-20 | (baseline) |", card, StringComparison.Ordinal);
+        // ...but the movement pivot spans only the last two runs.
+        Assert.Contains("| Metric | 2026-07-24 | 2026-07-30 |", card, StringComparison.Ordinal);
+        Assert.DoesNotContain("| Metric | 2026-07-20 |", card, StringComparison.Ordinal);
+        Assert.Contains("the last 2 are pivoted", card, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -81,6 +87,22 @@ public class AuthoredCorpusHistoryCardTests
     {
         string card = AuthoredCorpusHistoryCard.Render(Parse().Take(1).ToArray(), window: 0);
 
-        Assert.DoesNotContain("Movement", card, StringComparison.Ordinal);
+        Assert.DoesNotContain("## Movement", card, StringComparison.Ordinal);
+        Assert.Contains("Only one recorded run so far", card, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_WindowOfOneOverManyRunsDoesNotClaimOnlyOneRun()
+    {
+        // A movement window of 1 omits the pivot (a trend needs two), but there are still three
+        // recorded runs above — the note must explain the window, not misstate the run count.
+        string card = AuthoredCorpusHistoryCard.Render(Parse(), window: 1);
+
+        Assert.DoesNotContain("## Movement", card, StringComparison.Ordinal);
+        Assert.DoesNotContain("Only one recorded run", card, StringComparison.Ordinal);
+        Assert.Contains("Movement window is 1 run", card, StringComparison.Ordinal);
+        // The Runs trend table still lists every run.
+        Assert.Contains("| 2026-07-20 | (baseline) |", card, StringComparison.Ordinal);
+        Assert.Contains("| 2026-07-30 | deadbeef |", card, StringComparison.Ordinal);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusHistoryCardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusHistoryCardTests.cs
@@ -1,0 +1,86 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "Corpus")]
+public class AuthoredCorpusHistoryCardTests
+{
+    const string SampleHistory = """
+        {"date":"2026-07-20","commit":null,"poolMatched":26,"poolTotal":26,"evaluated":12000,"validPct":56.6,"correct":1501,"validDifferent":{"total":5290,"frontierIlExact":3097,"frontierIlDiff":2181},"invalid":5209,"invalidBreakdown":null,"unsupported":0,"drift":0,"honest":true,"sweepManifestSha256":null}
+        {"date":"2026-07-24","commit":"16c0687f","poolMatched":26,"poolTotal":26,"evaluated":12000,"validPct":56.2,"correct":1539,"validDifferent":{"total":5202,"frontierIlExact":3055,"frontierIlDiff":2137},"invalid":5259,"invalidBreakdown":{"productBodyDefect":306,"harnessShellReconstruction":4826,"unclassified":127},"unsupported":0,"drift":0,"honest":true,"sweepManifestSha256":"0a7eded85c3e1410"}
+        {"date":"2026-07-30","commit":"deadbeef","poolMatched":26,"poolTotal":26,"evaluated":12000,"validPct":57.4,"correct":1600,"validDifferent":{"total":5100,"frontierIlExact":3000,"frontierIlDiff":2100},"invalid":5180,"invalidBreakdown":{"productBodyDefect":250,"harnessShellReconstruction":4810,"unclassified":120},"unsupported":0,"drift":0,"honest":true,"sweepManifestSha256":"abc123"}
+        """;
+
+    static IReadOnlyList<HistoryRun> Parse()
+        => AuthoredCorpusHistoryCard.ParseHistory(SampleHistory.Split('\n'));
+
+    [Fact]
+    public void ParseHistory_ReadsTypedFieldsIncludingNullableBreakdown()
+    {
+        var runs = Parse();
+
+        Assert.Equal(3, runs.Count);
+        Assert.Null(runs[0].Commit);
+        Assert.Null(runs[0].InvalidBreakdown);
+        Assert.Equal("16c0687f", runs[1].Commit);
+        Assert.Equal(306, runs[1].InvalidBreakdown!.ProductBodyDefect);
+        Assert.Equal(4826, runs[1].InvalidBreakdown!.HarnessShellReconstruction);
+        Assert.Equal("0a7eded85c3e1410", runs[1].SweepManifestSha256);
+    }
+
+    [Fact]
+    public void Render_ProjectsRunsTableAndProvenanceColumns()
+    {
+        string card = AuthoredCorpusHistoryCard.Render(Parse(), window: 0);
+
+        Assert.Contains("# EVIL authored-corpus progress", card, StringComparison.Ordinal);
+        Assert.Contains("| Date | Commit | Valid % | Correct | Invalid (raw) | Product defects | Harness noise |", card, StringComparison.Ordinal);
+        // Null breakdown renders as an em dash, not a fabricated zero.
+        Assert.Contains("| 2026-07-20 | (baseline) | 56.6% | 1501 | 5209 | — | — |", card, StringComparison.Ordinal);
+        Assert.Contains("| 2026-07-30 | deadbeef | 57.4% | 1600 | 5180 | 250 | 4810 |", card, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_MovementUsesPerMetricPolarity()
+    {
+        // Latest (250 product, 5180 invalid, 1600 correct, 57.4%) vs previous
+        // (306 product, 5259 invalid, 1539 correct, 56.2%): every headline metric
+        // improves, and lower-is-better metrics must read "improved" when they drop.
+        string card = AuthoredCorpusHistoryCard.Render(Parse(), window: 0);
+
+        Assert.Contains("| Valid % | 56.2% | 57.4% | +1.2% | improved |", card, StringComparison.Ordinal);
+        Assert.Contains("| Correct | 1539 | 1600 | +61 | improved |", card, StringComparison.Ordinal);
+        Assert.Contains("| Invalid (raw) | 5259 | 5180 | −79 | improved |", card, StringComparison.Ordinal);
+        Assert.Contains("| Product defects | 306 | 250 | −56 | improved |", card, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_MovementIsNotApplicableWhenPreviousLacksProductSplit()
+    {
+        // Window of two spans the null-breakdown baseline and the first split run,
+        // so the product-defect delta cannot be computed and must read n/a rather
+        // than treating the missing split as zero.
+        string card = AuthoredCorpusHistoryCard.Render(Parse().Take(2).ToArray(), window: 2);
+
+        Assert.Contains("| Product defects | — | 306 | — | n/a |", card, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_WindowKeepsMostRecentRuns()
+    {
+        string card = AuthoredCorpusHistoryCard.Render(Parse(), window: 2);
+
+        Assert.DoesNotContain("2026-07-20", card, StringComparison.Ordinal);
+        Assert.Contains("2026-07-24", card, StringComparison.Ordinal);
+        Assert.Contains("2026-07-30", card, StringComparison.Ordinal);
+        Assert.Contains("Showing 2 of 3 recorded run(s).", card, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_SingleRunOmitsMovementTable()
+    {
+        string card = AuthoredCorpusHistoryCard.Render(Parse().Take(1).ToArray(), window: 0);
+
+        Assert.DoesNotContain("Movement", card, StringComparison.Ordinal);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -1047,7 +1047,7 @@ public class CorpusSensorComparisonTests
         string malformedRow = report.Split('\n').Single(line => line.Contains("Full malformed", StringComparison.Ordinal));
 
         Assert.Contains("Semantic defects (sampling differs)", semanticRow);
-        Assert.DoesNotContain("(good)", semanticRow);
+        Assert.DoesNotContain("✓", semanticRow);
         Assert.EndsWith("| n/a |", semanticRow.TrimEnd());
         Assert.Contains("Full malformed (sampling differs)", malformedRow);
         Assert.EndsWith("| n/a |", malformedRow.TrimEnd());
@@ -1077,7 +1077,7 @@ public class CorpusSensorComparisonTests
         string semanticRow = report.Split('\n').Single(line => line.Contains("Semantic defects", StringComparison.Ordinal));
 
         Assert.Contains("Semantic defects (-)", semanticRow);
-        Assert.Contains("(good)", semanticRow);
+        Assert.Contains("✓", semanticRow);
         Assert.EndsWith("| -1 |", semanticRow.TrimEnd());
         Assert.DoesNotContain("sampling differs", report);
     }
@@ -1162,7 +1162,7 @@ public class CorpusSensorComparisonTests
         Assert.Contains("Fidelity unavailable comparisons (sampling differs)", report);
         Assert.Contains("Fidelity exact (sampling differs)", report);
         Assert.DoesNotContain("Fidelity opcode diffs (-)", report);
-        Assert.DoesNotContain("(bad)", report);
+        Assert.DoesNotContain("✗", report);
     }
 
     [Fact]
@@ -1230,9 +1230,9 @@ public class CorpusSensorComparisonTests
         string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
 
         Assert.Contains("Fully raised (+)", report);
-        Assert.Contains("1 (50.00%) → 2 (100.00%) (good)", report);
+        Assert.Contains("1 (50.00%) → 2 (100.00%) ✓", report);
         Assert.Contains("Detected lowering residue (-)", report);
-        Assert.Contains("0 (0.00%) → 0 (0.00%) (neutral)", report);
+        Assert.Contains("0 (0.00%) → 0 (0.00%) |", report);
         Assert.True(
             report.IndexOf("| Fully raised", StringComparison.Ordinal)
             > report.IndexOf("| Detected lowering residue", StringComparison.Ordinal));
@@ -1280,7 +1280,7 @@ public class CorpusSensorComparisonTests
             line => line.Contains("Detected lowering residue", StringComparison.Ordinal));
 
         Assert.Contains("Detected lowering residue (population differs)", residue);
-        Assert.DoesNotContain("(good)", residue);
+        Assert.DoesNotContain("✓", residue);
         Assert.EndsWith("| n/a |", residue.TrimEnd());
     }
 
@@ -1302,7 +1302,7 @@ public class CorpusSensorComparisonTests
         string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
 
         Assert.Contains("Detected lowering residue (-)", report);
-        Assert.Contains("6 (6.45%) → 6 (6.45%) (neutral)", report);
+        Assert.Contains("6 (6.45%) → 6 (6.45%) |", report);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -141,6 +141,8 @@
              Link="TypeSourceCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\TypeBindCheck.cs"
              Link="TypeBindCheck.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\AuthoredCorpusHistoryCard.cs"
+             Link="AuthoredCorpusHistoryCard.cs" />
   </ItemGroup>
 
 </Project>

--- a/tools/DecompilerHarness/AuthoredCorpusHistoryCard.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusHistoryCard.cs
@@ -9,8 +9,9 @@ namespace ILInspector.DecompilerHarness;
 /// <summary>
 /// Renders a Markout progress card over the committed EVIL authored-corpus trend
 /// store (<c>tools/DecompilerHarness/corpus/evil-runs/history.jsonl</c>, one
-/// summarized run per line, newest-last). The card shows the last N runs as a
-/// trend table plus a latest-vs-previous movement table.
+/// summarized run per line, newest-last). The card shows every recorded run as a
+/// trend table plus a movement table that pivots the most recent runs onto
+/// per-metric rows with goal (↑/↓) and per-step (✓/✗) glyphs.
 ///
 /// The headline metric is <c>invalidBreakdown.productBodyDefect</c>, not raw
 /// <c>invalid</c>: per #3079/#3096 the raw invalid population is ~92% harness
@@ -21,8 +22,6 @@ static class AuthoredCorpusHistoryCard
 {
     internal const string DefaultHistoryRelativePath =
         "tools/DecompilerHarness/corpus/evil-runs/history.jsonl";
-
-    const int DefaultWindow = 5;
 
     public static int Run(string? historyPath, int window)
     {
@@ -73,16 +72,33 @@ static class AuthoredCorpusHistoryCard
     {
         ArgumentNullException.ThrowIfNull(runs);
 
-        int effectiveWindow = window <= 0 ? runs.Count : Math.Min(window, runs.Count);
-        var recent = runs.Skip(runs.Count - effectiveWindow).ToArray();
+        int movementCount = window <= 0 ? runs.Count : Math.Min(window, runs.Count);
+        var movementWindow = runs.Skip(runs.Count - movementCount).ToArray();
+        var movement = BuildMovement(movementWindow);
+
+        const string productSignalNote =
+            "Track product defects (target-body decompiler bugs), not raw invalid "
+            + "(~92% harness shell-reconstruction noise per #3079).";
+        string note;
+        if (movement is not null)
+        {
+            note = $"Runs lists every recorded run; the last {movementWindow.Length} are pivoted per metric "
+                + "below with goal (\u2191/\u2193) and per-step (\u2713/\u2717) glyphs. " + productSignalNote;
+        }
+        else if (runs.Count < 2)
+        {
+            note = "Only one recorded run so far; a trend needs at least two. " + productSignalNote;
+        }
+        else
+        {
+            note = "Movement window is 1 run; a trend needs at least two. " + productSignalNote;
+        }
 
         var view = new HistoryCardView
         {
-            Runs = [.. recent.Select(ToRunRow)],
-            Movement = BuildMovement(recent),
-            WindowNote = $"Showing {recent.Length} of {runs.Count} recorded run(s). "
-                + "Track product defects (target-body decompiler bugs), not raw invalid "
-                + "(~92% harness shell-reconstruction noise per #3079).",
+            Runs = [.. runs.Select(ToRunRow)],
+            Movement = movement,
+            WindowNote = note,
         };
 
         var output = new StringWriter();
@@ -105,74 +121,76 @@ static class AuthoredCorpusHistoryCard
             run.InvalidBreakdown is { } breakdown ? breakdown.ProductBodyDefect.ToString(CultureInfo.InvariantCulture) : "—",
             run.InvalidBreakdown is { } noise ? noise.HarnessShellReconstruction.ToString(CultureInfo.InvariantCulture) : "—");
 
-    static List<HistoryMovementRow>? BuildMovement(IReadOnlyList<HistoryRun> recent)
+    // Movement pivots the trend metrics: each metric is a row and each recent run a column, so a
+    // MultiSourceRow carries the row's Goal and lets Markout derive the goal glyph (↑/↓) on the label
+    // and a per-step polarity glyph (✓/✗) on each column vs the previous populated one — no hand-computed
+    // delta or trend word. It is the transpose (pivot) of the Runs table, bounded to the recent window.
+    static List<MultiSourceRow>? BuildMovement(IReadOnlyList<HistoryRun> window)
     {
-        if (recent.Count < 2)
+        if (window.Count < 2)
             return null;
 
-        HistoryRun previous = recent[^2];
-        HistoryRun latest = recent[^1];
-
+        string[] cols = ColumnKeys(window);
         return
         [
-            PercentMovement("Valid %", previous.ValidPct, latest.ValidPct, higherIsBetter: true),
-            CountMovement("Correct", previous.Correct, latest.Correct, higherIsBetter: true),
-            CountMovement("Invalid (raw)", previous.Invalid, latest.Invalid, higherIsBetter: false),
-            CountMovement(
-                "Product defects",
-                previous.InvalidBreakdown?.ProductBodyDefect,
-                latest.InvalidBreakdown?.ProductBodyDefect,
-                higherIsBetter: false),
+            ScalarRow("Valid %", Goal.Higher, window, cols, r => r.ValidPct),
+            ScalarRow("Correct", Goal.Higher, window, cols, r => r.Correct),
+            ScalarRow("Invalid (raw)", Goal.Lower, window, cols, r => r.Invalid),
+            ProductDefectRow(window, cols),
         ];
     }
 
-    static HistoryMovementRow PercentMovement(string metric, double previous, double latest, bool higherIsBetter)
+    static MultiSourceRow ScalarRow(
+        string label, Goal goal, IReadOnlyList<HistoryRun> window, string[] cols, Func<HistoryRun, double> value)
     {
-        double delta = latest - previous;
-        return new HistoryMovementRow(
-            metric,
-            FormatPct(previous),
-            FormatPct(latest),
-            SignedPct(delta),
-            Trend(delta, higherIsBetter));
+        var sources = new Source[window.Count];
+        for (int i = 0; i < window.Count; i++)
+            sources[i] = new Source(cols[i], value(window[i]));
+        return new MultiSourceRow(label, sources) { Goal = goal };
     }
 
-    static HistoryMovementRow CountMovement(string metric, int? previous, int? latest, bool higherIsBetter)
+    // Runs predating #3096 carry no invalid breakdown; render those columns as an absent cell so the
+    // product-defect signal stays honest (no fabricated zero) and Markout's pairwise chain skips them
+    // rather than charting a bogus step.
+    static MultiSourceRow ProductDefectRow(IReadOnlyList<HistoryRun> window, string[] cols)
     {
-        if (previous is not { } prev || latest is not { } cur)
+        var sources = new Source[window.Count];
+        for (int i = 0; i < window.Count; i++)
         {
-            return new HistoryMovementRow(
-                metric,
-                previous?.ToString(CultureInfo.InvariantCulture) ?? "—",
-                latest?.ToString(CultureInfo.InvariantCulture) ?? "—",
-                "—",
-                "n/a");
+            sources[i] = window[i].InvalidBreakdown is { } breakdown
+                ? new Source(cols[i], breakdown.ProductBodyDefect)
+                : new Source(cols[i], (IMarkoutCell?)null);
         }
 
-        int delta = cur - prev;
-        return new HistoryMovementRow(
-            metric,
-            prev.ToString(CultureInfo.InvariantCulture),
-            cur.ToString(CultureInfo.InvariantCulture),
-            SignedCount(delta),
-            Trend(delta, higherIsBetter));
+        return new MultiSourceRow("Product defects", sources) { Goal = Goal.Lower };
     }
 
-    static string Trend(double delta, bool higherIsBetter)
+    // Column keys are the run dates (the pivoted table's headers). Disambiguate a repeated date with its
+    // commit so each run stays a distinct column even when two runs share a day.
+    static string[] ColumnKeys(IReadOnlyList<HistoryRun> window)
     {
-        if (delta == 0)
-            return "unchanged";
-        bool better = higherIsBetter ? delta > 0 : delta < 0;
-        return better ? "improved" : "regressed";
+        var keys = new string[window.Count];
+        var seen = new Dictionary<string, int>();
+        for (int i = 0; i < window.Count; i++)
+        {
+            string key = window[i].Date ?? window[i].Commit ?? $"run{i + 1}";
+            if (seen.TryGetValue(key, out int count))
+            {
+                seen[key] = count + 1;
+                key = $"{key} #{window[i].Commit ?? (count + 1).ToString(CultureInfo.InvariantCulture)}";
+            }
+            else
+            {
+                seen[key] = 1;
+            }
+
+            keys[i] = key;
+        }
+
+        return keys;
     }
 
     static string FormatPct(double value) => value.ToString("F1", CultureInfo.InvariantCulture) + "%";
-
-    static string SignedPct(double delta)
-        => (delta > 0 ? "+" : delta < 0 ? "−" : "±") + Math.Abs(delta).ToString("F1", CultureInfo.InvariantCulture) + "%";
-
-    static string SignedCount(int delta)
-        => (delta > 0 ? "+" : delta < 0 ? "−" : "±") + Math.Abs(delta).ToString(CultureInfo.InvariantCulture);
 }
 
 internal sealed record HistoryRunValidDifferent(int Total, int FrontierIlExact, int FrontierIlDiff);
@@ -207,8 +225,9 @@ internal sealed class HistoryCardView
     [MarkoutSection(Name = "Runs")]
     public List<HistoryRunRow>? Runs { get; init; }
 
-    [MarkoutSection(Name = "Movement (latest vs previous)")]
-    public List<HistoryMovementRow>? Movement { get; init; }
+    [MarkoutSection(Name = "Movement")]
+    [MarkoutLabelHeader("Metric")]
+    public List<MultiSourceRow>? Movement { get; init; }
 }
 
 [MarkoutSerializable]
@@ -221,18 +240,9 @@ internal sealed record HistoryRunRow(
     [property: MarkoutPropertyName("Product defects")] string Product,
     [property: MarkoutPropertyName("Harness noise")] string Harness);
 
-[MarkoutSerializable]
-internal sealed record HistoryMovementRow(
-    string Metric,
-    string Previous,
-    string Latest,
-    [property: MarkoutPropertyName("Δ")] string Change,
-    string Trend);
-
 [MarkoutContextOptions(SuppressTableWarnings = true)]
 [MarkoutContext(typeof(HistoryCardView))]
 [MarkoutContext(typeof(HistoryRunRow))]
-[MarkoutContext(typeof(HistoryMovementRow))]
 internal sealed partial class AuthoredCorpusHistoryCardContext : MarkoutSerializerContext
 {
 }

--- a/tools/DecompilerHarness/AuthoredCorpusHistoryCard.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusHistoryCard.cs
@@ -61,8 +61,9 @@ static class AuthoredCorpusHistoryCard
         {
             if (string.IsNullOrWhiteSpace(line))
                 continue;
-            if (JsonSerializer.Deserialize<HistoryRun>(line, options) is { } run)
-                runs.Add(run);
+            var run = JsonSerializer.Deserialize<HistoryRun>(line, options)
+                ?? throw new JsonException($"History row is null (not a run object): {line.Trim()}");
+            runs.Add(run);
         }
 
         return runs;

--- a/tools/DecompilerHarness/AuthoredCorpusHistoryCard.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusHistoryCard.cs
@@ -1,0 +1,238 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Markout;
+using Markout.Formatting;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Renders a Markout progress card over the committed EVIL authored-corpus trend
+/// store (<c>tools/DecompilerHarness/corpus/evil-runs/history.jsonl</c>, one
+/// summarized run per line, newest-last). The card shows the last N runs as a
+/// trend table plus a latest-vs-previous movement table.
+///
+/// The headline metric is <c>invalidBreakdown.productBodyDefect</c>, not raw
+/// <c>invalid</c>: per #3079/#3096 the raw invalid population is ~92% harness
+/// shell-reconstruction noise that does not move on decompiler fixes, so the card
+/// surfaces the product sub-count as the signal that actually tracks progress.
+/// </summary>
+static class AuthoredCorpusHistoryCard
+{
+    internal const string DefaultHistoryRelativePath =
+        "tools/DecompilerHarness/corpus/evil-runs/history.jsonl";
+
+    const int DefaultWindow = 5;
+
+    public static int Run(string? historyPath, int window)
+    {
+        string path = historyPath ?? DefaultHistoryRelativePath;
+        if (!File.Exists(path))
+        {
+            Console.Error.WriteLine($"History file not found: {path}");
+            return 1;
+        }
+
+        IReadOnlyList<HistoryRun> runs;
+        try
+        {
+            runs = ParseHistory(File.ReadLines(path));
+        }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine($"History file is not valid JSONL: {ex.Message}");
+            return 1;
+        }
+
+        if (runs.Count == 0)
+        {
+            Console.Error.WriteLine($"History is empty or unparseable: {path}");
+            return 1;
+        }
+
+        Console.Write(Render(runs, window));
+        return 0;
+    }
+
+    internal static IReadOnlyList<HistoryRun> ParseHistory(IEnumerable<string> lines)
+    {
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        var runs = new List<HistoryRun>();
+        foreach (string line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            if (JsonSerializer.Deserialize<HistoryRun>(line, options) is { } run)
+                runs.Add(run);
+        }
+
+        return runs;
+    }
+
+    internal static string Render(IReadOnlyList<HistoryRun> runs, int window)
+    {
+        ArgumentNullException.ThrowIfNull(runs);
+
+        int effectiveWindow = window <= 0 ? runs.Count : Math.Min(window, runs.Count);
+        var recent = runs.Skip(runs.Count - effectiveWindow).ToArray();
+
+        var view = new HistoryCardView
+        {
+            Runs = [.. recent.Select(ToRunRow)],
+            Movement = BuildMovement(recent),
+            WindowNote = $"Showing {recent.Length} of {runs.Count} recorded run(s). "
+                + "Track product defects (target-body decompiler bugs), not raw invalid "
+                + "(~92% harness shell-reconstruction noise per #3079).",
+        };
+
+        var output = new StringWriter();
+        MarkoutSerializer.Serialize(
+            view,
+            output,
+            new MarkdownFormatter(),
+            AuthoredCorpusHistoryCardContext.Default,
+            new MarkoutWriterOptions());
+        return output.ToString();
+    }
+
+    static HistoryRunRow ToRunRow(HistoryRun run)
+        => new(
+            run.Date ?? "—",
+            run.Commit ?? "(baseline)",
+            FormatPct(run.ValidPct),
+            run.Correct,
+            run.Invalid,
+            run.InvalidBreakdown is { } breakdown ? breakdown.ProductBodyDefect.ToString(CultureInfo.InvariantCulture) : "—",
+            run.InvalidBreakdown is { } noise ? noise.HarnessShellReconstruction.ToString(CultureInfo.InvariantCulture) : "—");
+
+    static List<HistoryMovementRow>? BuildMovement(IReadOnlyList<HistoryRun> recent)
+    {
+        if (recent.Count < 2)
+            return null;
+
+        HistoryRun previous = recent[^2];
+        HistoryRun latest = recent[^1];
+
+        return
+        [
+            PercentMovement("Valid %", previous.ValidPct, latest.ValidPct, higherIsBetter: true),
+            CountMovement("Correct", previous.Correct, latest.Correct, higherIsBetter: true),
+            CountMovement("Invalid (raw)", previous.Invalid, latest.Invalid, higherIsBetter: false),
+            CountMovement(
+                "Product defects",
+                previous.InvalidBreakdown?.ProductBodyDefect,
+                latest.InvalidBreakdown?.ProductBodyDefect,
+                higherIsBetter: false),
+        ];
+    }
+
+    static HistoryMovementRow PercentMovement(string metric, double previous, double latest, bool higherIsBetter)
+    {
+        double delta = latest - previous;
+        return new HistoryMovementRow(
+            metric,
+            FormatPct(previous),
+            FormatPct(latest),
+            SignedPct(delta),
+            Trend(delta, higherIsBetter));
+    }
+
+    static HistoryMovementRow CountMovement(string metric, int? previous, int? latest, bool higherIsBetter)
+    {
+        if (previous is not { } prev || latest is not { } cur)
+        {
+            return new HistoryMovementRow(
+                metric,
+                previous?.ToString(CultureInfo.InvariantCulture) ?? "—",
+                latest?.ToString(CultureInfo.InvariantCulture) ?? "—",
+                "—",
+                "n/a");
+        }
+
+        int delta = cur - prev;
+        return new HistoryMovementRow(
+            metric,
+            prev.ToString(CultureInfo.InvariantCulture),
+            cur.ToString(CultureInfo.InvariantCulture),
+            SignedCount(delta),
+            Trend(delta, higherIsBetter));
+    }
+
+    static string Trend(double delta, bool higherIsBetter)
+    {
+        if (delta == 0)
+            return "unchanged";
+        bool better = higherIsBetter ? delta > 0 : delta < 0;
+        return better ? "improved" : "regressed";
+    }
+
+    static string FormatPct(double value) => value.ToString("F1", CultureInfo.InvariantCulture) + "%";
+
+    static string SignedPct(double delta)
+        => (delta > 0 ? "+" : delta < 0 ? "−" : "±") + Math.Abs(delta).ToString("F1", CultureInfo.InvariantCulture) + "%";
+
+    static string SignedCount(int delta)
+        => (delta > 0 ? "+" : delta < 0 ? "−" : "±") + Math.Abs(delta).ToString(CultureInfo.InvariantCulture);
+}
+
+internal sealed record HistoryRunValidDifferent(int Total, int FrontierIlExact, int FrontierIlDiff);
+
+internal sealed record HistoryRunInvalidBreakdown(int ProductBodyDefect, int HarnessShellReconstruction, int Unclassified);
+
+internal sealed record HistoryRun(
+    string? Date,
+    string? Commit,
+    int PoolMatched,
+    int PoolTotal,
+    int Evaluated,
+    double ValidPct,
+    int Correct,
+    HistoryRunValidDifferent? ValidDifferent,
+    int Invalid,
+    HistoryRunInvalidBreakdown? InvalidBreakdown,
+    int Unsupported,
+    int Drift,
+    bool Honest,
+    [property: JsonPropertyName("sweepManifestSha256")] string? SweepManifestSha256);
+
+[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(WindowNote), AutoFields = false)]
+internal sealed class HistoryCardView
+{
+    [MarkoutIgnore]
+    public string Title => "EVIL authored-corpus progress";
+
+    [MarkoutIgnore]
+    public string? WindowNote { get; init; }
+
+    [MarkoutSection(Name = "Runs")]
+    public List<HistoryRunRow>? Runs { get; init; }
+
+    [MarkoutSection(Name = "Movement (latest vs previous)")]
+    public List<HistoryMovementRow>? Movement { get; init; }
+}
+
+[MarkoutSerializable]
+internal sealed record HistoryRunRow(
+    string Date,
+    string Commit,
+    [property: MarkoutPropertyName("Valid %")] string Valid,
+    int Correct,
+    [property: MarkoutPropertyName("Invalid (raw)")] int Invalid,
+    [property: MarkoutPropertyName("Product defects")] string Product,
+    [property: MarkoutPropertyName("Harness noise")] string Harness);
+
+[MarkoutSerializable]
+internal sealed record HistoryMovementRow(
+    string Metric,
+    string Previous,
+    string Latest,
+    [property: MarkoutPropertyName("Δ")] string Change,
+    string Trend);
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(HistoryCardView))]
+[MarkoutContext(typeof(HistoryRunRow))]
+[MarkoutContext(typeof(HistoryMovementRow))]
+internal sealed partial class AuthoredCorpusHistoryCardContext : MarkoutSerializerContext
+{
+}

--- a/tools/DecompilerHarness/AuthoredCorpusHistoryCard.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusHistoryCard.cs
@@ -195,18 +195,21 @@ static class AuthoredCorpusHistoryCard
 
 internal sealed record HistoryRunValidDifferent(int Total, int FrontierIlExact, int FrontierIlDiff);
 
-internal sealed record HistoryRunInvalidBreakdown(int ProductBodyDefect, int HarnessShellReconstruction, int Unclassified);
+internal sealed record HistoryRunInvalidBreakdown(
+    [property: JsonRequired] int ProductBodyDefect,
+    [property: JsonRequired] int HarnessShellReconstruction,
+    [property: JsonRequired] int Unclassified);
 
 internal sealed record HistoryRun(
-    string? Date,
+    [property: JsonRequired] string? Date,
     string? Commit,
     int PoolMatched,
     int PoolTotal,
     int Evaluated,
-    double ValidPct,
-    int Correct,
+    [property: JsonRequired] double ValidPct,
+    [property: JsonRequired] int Correct,
     HistoryRunValidDifferent? ValidDifferent,
-    int Invalid,
+    [property: JsonRequired] int Invalid,
     HistoryRunInvalidBreakdown? InvalidBreakdown,
     int Unsupported,
     int Drift,

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -214,7 +214,7 @@ static class Program
                         break;
                     case "--history-card": historyCard = true; break;
                     case "--history-path": historyCardPath = NextArg(args, ref i, flag); break;
-                    case "--history-window": historyCardWindow = int.Parse(NextArg(args, ref i, flag)); break;
+                    case "--history-window": historyCardWindow = NextIntArg(args, ref i, flag); break;
                     case "--verify-authored-corpus":
                         verifyAuthoredCorpus = true;
                         verifyCorpusPath = NextArg(args, ref i, flag);
@@ -1776,6 +1776,14 @@ static class Program
         => i + 1 < args.Length
             ? args[++i]
             : throw new MissingArgumentException(flag);
+
+    static int NextIntArg(string[] args, ref int i, string flag)
+    {
+        string value = NextArg(args, ref i, flag);
+        return int.TryParse(value, out int result)
+            ? result
+            : throw new ArgumentException($"{flag} requires an integer value (got '{value}').");
+    }
 
     sealed class MissingArgumentException(string flag) : Exception
     {

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -75,6 +75,9 @@ static class Program
         string? harvestOutputPath = null;
         bool benchmarkAuthoredCorpus = false;
         string? benchmarkCorpusPath = null;
+        bool historyCard = false;
+        string? historyCardPath = null;
+        int historyCardWindow = 5;
         bool verifyAuthoredCorpus = false;
         string? verifyCorpusPath = null;
         bool failOnDrift = false;
@@ -209,6 +212,9 @@ static class Program
                         benchmarkAuthoredCorpus = true;
                         benchmarkCorpusPath = NextArg(args, ref i, flag);
                         break;
+                    case "--history-card": historyCard = true; break;
+                    case "--history-path": historyCardPath = NextArg(args, ref i, flag); break;
+                    case "--history-window": historyCardWindow = int.Parse(NextArg(args, ref i, flag)); break;
                     case "--verify-authored-corpus":
                         verifyAuthoredCorpus = true;
                         verifyCorpusPath = NextArg(args, ref i, flag);
@@ -342,6 +348,13 @@ static class Program
             if (inputs.Count > 0)
                 return Fail("--fixture-source-inventory reports the registered Built and Generated catalogs; do not pass assembly paths.");
             return FixtureSourceInventory(json);
+        }
+
+        if (historyCard)
+        {
+            if (inputs.Count > 0)
+                return Fail("--history-card renders the committed EVIL run-history trend store; do not pass assembly paths.");
+            return AuthoredCorpusHistoryCard.Run(historyCardPath, historyCardWindow);
         }
 
         if (generatedFixtures)
@@ -2025,6 +2038,17 @@ static class Program
           --fail-on-drift        with --verify-authored-corpus: fail-closed gate —
                                 exit non-zero unless every evaluated row is
                                 Verified (any Drifted or Unavailable row fails).
+          --history-card         render a Markout progress card over the committed
+                                EVIL run-history trend store: the last N runs as a
+                                trend table plus a latest-vs-previous movement
+                                table. Headline metric is product defects (#3079),
+                                not raw invalid (~92% harness noise). Reads no
+                                assemblies and runs no decompiler.
+          --history-path <file>  with --history-card: read a specific history.jsonl
+                                instead of the committed default
+                                (tools/DecompilerHarness/corpus/evil-runs/history.jsonl).
+          --history-window <n>   with --history-card: show the last n runs
+                                (default 5; <= 0 shows all).
           --fidelity-timings      with --fidelity-check: print phase timings for collect/render,
                                 skeleton emit, parse, compilation create, emit, and opcode compare
           --fidelity-zero-signal-guard <n>

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -77,7 +77,7 @@ static class Program
         string? benchmarkCorpusPath = null;
         bool historyCard = false;
         string? historyCardPath = null;
-        int historyCardWindow = 5;
+        int historyCardWindow = 3;
         bool verifyAuthoredCorpus = false;
         string? verifyCorpusPath = null;
         bool failOnDrift = false;
@@ -2039,16 +2039,18 @@ static class Program
                                 exit non-zero unless every evaluated row is
                                 Verified (any Drifted or Unavailable row fails).
           --history-card         render a Markout progress card over the committed
-                                EVIL run-history trend store: the last N runs as a
-                                trend table plus a latest-vs-previous movement
-                                table. Headline metric is product defects (#3079),
-                                not raw invalid (~92% harness noise). Reads no
-                                assemblies and runs no decompiler.
+                                EVIL run-history trend store: every run as a trend
+                                table plus a pivoted movement table over the last N
+                                runs with per-metric goal/step glyphs. Headline
+                                metric is product defects (#3079), not raw invalid
+                                (~92% harness noise). Reads no assemblies and runs
+                                no decompiler.
           --history-path <file>  with --history-card: read a specific history.jsonl
                                 instead of the committed default
                                 (tools/DecompilerHarness/corpus/evil-runs/history.jsonl).
-          --history-window <n>   with --history-card: show the last n runs
-                                (default 5; <= 0 shows all).
+          --history-window <n>   with --history-card: bound the movement pivot to the
+                                last n runs (default 3; <= 0 uses every run). The
+                                Runs trend table always lists every run.
           --fidelity-timings      with --fidelity-check: print phase timings for collect/render,
                                 skeleton emit, parse, compilation create, emit, and opcode compare
           --fidelity-zero-signal-guard <n>

--- a/tools/DecompilerHarness/corpus/evil-runs/README.md
+++ b/tools/DecompilerHarness/corpus/evil-runs/README.md
@@ -65,8 +65,8 @@ Each row contains these fields:
 
 ## Progress card
 
-Render a Markout progress card over this trend store — the last N runs as a
-trend table plus a latest-vs-previous movement table — with:
+Render a Markout progress card over this trend store — every recorded run as a
+trend table plus a pivoted movement table over the most recent runs — with:
 
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- --history-card
@@ -74,14 +74,22 @@ dotnet run --project tools/DecompilerHarness -c Release -- --history-card
 
 Options:
 
-- `--history-window <n>`: show the last `n` runs (default 5; `<= 0` shows all).
+- `--history-window <n>`: bound the movement pivot to the last `n` runs
+  (default 3; `<= 0` uses every run). The Runs trend table always lists every
+  run.
 - `--history-path <file>`: read a specific `history.jsonl` instead of the
   committed default.
 
 The card reads no assemblies and runs no decompiler. Its headline metric is
 `invalidBreakdown.productBodyDefect` (genuine target-body decompiler defects),
 not raw `invalid`: per #3079 the raw invalid population is dominated by harness
-shell-reconstruction noise that does not move on decompiler fixes. Runs that
-predate PR #3096 have no `invalidBreakdown`, so their product/harness columns
-and the product-defect movement row render as `—`/`n/a` rather than a
-fabricated zero.
+shell-reconstruction noise that does not move on decompiler fixes.
+
+The **Movement** table is the transpose (pivot) of **Runs**: each metric is a
+row and each recent run a column. Every metric row declares its optimization
+goal, so Markout renders the goal glyph (`↑` higher-is-better / `↓`
+lower-is-better) on the label and a per-step polarity glyph (`✓`/`✗`) on each
+column compared to the previous populated one — no hand-computed delta or trend
+word. Runs that predate PR #3096 have no `invalidBreakdown`, so their
+product/harness columns render as `—` and the product-defect pivot cell is
+absent (`-`) with no fabricated step, keeping the missing signal honest.

--- a/tools/DecompilerHarness/corpus/evil-runs/README.md
+++ b/tools/DecompilerHarness/corpus/evil-runs/README.md
@@ -62,3 +62,26 @@ Each row contains these fields:
 5. Record the UTC date, short SHA, and sweep-manifest SHA-256.
 6. Append one compact JSON object to `history.jsonl`.
 7. Validate every line parses before committing.
+
+## Progress card
+
+Render a Markout progress card over this trend store — the last N runs as a
+trend table plus a latest-vs-previous movement table — with:
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- --history-card
+```
+
+Options:
+
+- `--history-window <n>`: show the last `n` runs (default 5; `<= 0` shows all).
+- `--history-path <file>`: read a specific `history.jsonl` instead of the
+  committed default.
+
+The card reads no assemblies and runs no decompiler. Its headline metric is
+`invalidBreakdown.productBodyDefect` (genuine target-body decompiler defects),
+not raw `invalid`: per #3079 the raw invalid population is dominated by harness
+shell-reconstruction noise that does not move on decompiler fixes. Runs that
+predate PR #3096 have no `invalidBreakdown`, so their product/harness columns
+and the product-defect movement row render as `—`/`n/a` rather than a
+fabricated zero.


### PR DESCRIPTION
## What

Adds a `--history-card` harness mode that renders a Markout progress card over the committed EVIL run-history trend store (`tools/DecompilerHarness/corpus/evil-runs/history.jsonl`, from #3118): the last N runs as a trend table plus a latest-vs-previous movement table. Answers the "show progress on the last n measurements" ask on #3079.

Example (current committed history):

```text
# EVIL authored-corpus progress

Showing 3 of 3 recorded run(s). Track product defects (target-body decompiler bugs), not raw invalid (~92% harness shell-reconstruction noise per #3079).

## Runs

| Date | Commit | Valid % | Correct | Invalid (raw) | Product defects | Harness noise |
| ---- | ------ | ------- | ------- | ------------- | --------------- | ------------- |
| 2026-07-20 | (baseline) | 56.6% | 1501 | 5209 | — | — |
| 2026-07-23 | d6af0165 | 56.2% | 1537 | 5258 | — | — |
| 2026-07-24 | 16c0687f | 56.2% | 1539 | 5259 | 306 | 4826 |

## Movement (latest vs previous)

| Metric | Previous | Latest | Δ | Trend |
| ------ | -------- | ------ | - | ----- |
| Valid % | 56.2% | 56.2% | ±0.0% | unchanged |
| Correct | 1537 | 1539 | +2 | improved |
| Invalid (raw) | 5258 | 5259 | +1 | regressed |
| Product defects | — | 306 | — | n/a |
```

## Design

- **Headline metric is product defects, not raw invalid.** Per #3079/#3096 raw `invalid` is ~92% harness shell-reconstruction noise that does not move on decompiler fixes; the card surfaces `invalidBreakdown.productBodyDefect` as the signal that tracks progress.
- **Failure stays visible.** Runs predating #3096 have no `invalidBreakdown`; their product/harness columns and the product-defect movement row render as `—`/`n/a`, never a fabricated zero.
- **Per-metric polarity.** Movement marks lower-is-better metrics (invalid, product defects) `improved` when they drop and higher-is-better metrics (valid %, correct) `improved` when they rise.
- Reuses the existing Markout serializer/context pattern (`ReturnToSenderCatalogReport` shape). Reads no assemblies, runs no decompiler.

## Flags

- `--history-card` — render the card.
- `--history-window <n>` — last n runs (default 5; `<= 0` shows all).
- `--history-path <file>` — override the committed default.

## Evidence

- New file `AuthoredCorpusHistoryCard.cs`; parsing + rendering are pure and linked into `ILInspector.Decompiler.Tests`.
- `AuthoredCorpusHistoryCardTests` (6 tests, `Area=Corpus`) cover typed nullable-breakdown parsing, provenance columns, movement polarity, the `n/a` case when the previous run lacks a split, windowing, and single-run omission of the movement table. All pass.
- Real render over the committed `history.jsonl` verified (above); edge cases (missing file, assembly-path rejection, `--history-window 2`) verified manually.
- README updated and `markdownlint`-clean.

## Risk

Additive, presentation-only harness mode in a standalone file; cannot affect existing modes or any product decompiler path. Low risk. Happy to run the two-model adversarial pass if you'd prefer given the delta/polarity logic.

Refs #3079.