### PR TITLE
Add PreferConditionalExpressionReturn style lens (#3138)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -251,6 +251,41 @@ and declines otherwise:
   fidelity concern. The from-end open form (`s[^n..]`), which the compiler spills
   distinctly, is recovered.
 
+## Style lenses (behavior-faithful, byte-divergent)
+
+The knobs above are all **byte-preserving**: every one selects a spelling that
+recompiles to the identical IL (a class-3 no-anchor choice) or changes only
+whitespace, so the default and the knob-on output are members of the same
+compile-back equivalence class. A **style lens** is a different, explicitly
+opt-in contract (#3138): it trades byte fidelity for a source-style preference
+the oracle endorses but the fidelity-first default cannot take. A lens is
+**behavior-preserving** — its output computes the identical result for every
+input — but **not** opcode-faithful, so its output must never feed the
+compile-back fidelity gates, and it is off by default.
+
+The first lens is `PrinterOptions.PreferConditionalExpressionReturn`
+(`dotnet_style_prefer_conditional_expression_over_return`, IDE0046). A guarded
+boolean return the default leaves flat because no short-circuit fold of it is
+opcode-faithful (see the short-circuit fidelity guard, #3114) is re-rendered as
+the conditional expression:
+
+```csharp
+// shipped default (byte-faithful — the flat guard is what recompiles exactly):
+if (a & b) { return false; }
+return c;
+// with PreferConditionalExpressionReturn (behavior-faithful, byte-divergent):
+return a & b ? false : c;
+```
+
+The ternary is the *canonical* desugaring of the guard — same condition, same
+arms, same evaluation order — so the rewrite is unconditionally
+behavior-preserving; that is what lets the lens re-offer a fold the default had
+to decline. It deliberately stops at IDE0046: the further `c ? true : d` → `c ||
+d` collapse (IDE0075) is a separate future knob, so a literal-arm ternary such as
+`a ? true : b` is kept as written rather than simplified. The lens runs only on
+the opt-in raised path, after the default pipeline, and the IL-anchored Annotated
+view never applies it (it must stay byte-faithful for line/IL alignment).
+
 ## Names
 
 Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL view — the two views stay name-aligned by construction. With a PDB, source names are used. Synthesizing readable names (`size`, `array`, `item`) where no PDB exists is an open design question: it is the largest remaining cosmetic gap against source, but it would break view alignment unless opt-in.
@@ -260,8 +295,9 @@ Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL
 The oracle settles a single shipped default per equivalence class, but a few
 class-3 no-anchor spellings are also exposed as opt-in knobs (see
 [`this` member qualification](#this-member-qualification) and
-[Line wrapping](#line-wrapping)). A tool-owned config file selects them without a
-per-run flag.
+[Line wrapping](#line-wrapping)), as is the first byte-divergent
+[style lens](#style-lenses-behavior-faithful-byte-divergent). A tool-owned config
+file selects them without a per-run flag.
 
 `dotnet-inspect` discovers a `.dotnet-inspectconfig` file by walking up from the
 current working directory to the filesystem root; the **nearest** file wins (no
@@ -278,6 +314,7 @@ The file is flat `key = value`, using the same key and value vocabulary as an
 root = true
 dotnet_style_qualification_for_field = true
 dotnet_style_qualification_for_property = true
+dotnet_style_prefer_conditional_expression_over_return = true
 ```
 
 - `#` and `;` comment lines and `[section]` headers are ignored.
@@ -287,8 +324,11 @@ dotnet_style_qualification_for_property = true
   `.editorconfig` does not warn). Discovery already stops at the nearest file, so
   `root = true` drives no behavior on its own; it is the conventional, explicit
   way to mark a repository-root config as the boundary.
-- Recognized keys map to `PrinterOptions`; today the two `this`-qualification
-  keys above are recognized, and the set grows as more class-3 knobs ship.
+- Recognized keys map to `PrinterOptions`: the two `this`-qualification keys
+  above (byte-preserving class-3 spellings) and
+  `dotnet_style_prefer_conditional_expression_over_return` (the first
+  byte-divergent [style lens](#style-lenses-behavior-faithful-byte-divergent)).
+  The set grows as more knobs ship.
 - Unknown keys, malformed lines, and non-boolean values are reported as a
   `Warning:` on stderr and skipped — the rest of the file still applies. A bad
   config never fails the run silently.

--- a/src/ILInspector.Decompiler.Tests/PreferConditionalReturnLensTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferConditionalReturnLensTests.cs
@@ -106,6 +106,33 @@ public sealed class PreferConditionalReturnLensTests
         Assert.DoesNotContain("?", lensText);
     }
 
+    [Fact]
+    public void AndShapedGuard_LensSpellsShortCircuit_AndStaysValid()
+    {
+        // `if (c) return value; return false;` -> conditional `c ? value : false`,
+        // which the printer idiomatically renders as `c && value`. Behavior-faithful
+        // and valid C# for a primitive-bool condition.
+        var defaultText = Render(nameof(PreferConditionalReturnSpecimen.AndShapedGuard));
+        Assert.Contains("return false;", defaultText);
+
+        var lensText = Render(nameof(PreferConditionalReturnSpecimen.AndShapedGuard), LensOptions);
+        Assert.Contains("c && value", lensText);
+        Assert.DoesNotContain("if (", lensText);
+    }
+
+    [Fact]
+    public void UserTruthinessGuard_LensDeclines_StaysFlatAndValid()
+    {
+        // The condition is a user-defined operator-true call with no user `&`, so a
+        // short-circuit lift would be uncompilable. The lens must decline and leave
+        // the flat guard exactly as the default renders it.
+        var defaultText = Render(nameof(PreferConditionalReturnSpecimen.UserTruthinessGuard));
+        var lensText = Render(nameof(PreferConditionalReturnSpecimen.UserTruthinessGuard), LensOptions);
+        Assert.Equal(defaultText, lensText);
+        Assert.Contains("return false;", lensText);
+        Assert.DoesNotContain("&&", lensText);
+    }
+
     // Executed behavioral-equivalence gate for the tier-3 lens: the specimen
     // methods run their compiled (source) semantics; the ternary is the lens's
     // rendering. Proving `method(inputs) == (ternary over inputs)` for every

--- a/src/ILInspector.Decompiler.Tests/PreferConditionalReturnLensTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferConditionalReturnLensTests.cs
@@ -1,0 +1,133 @@
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The opt-in tier-3 style lens
+/// <see cref="PrinterOptions.PreferConditionalExpressionReturn"/> (#3138):
+/// re-renders a flat guarded boolean return the default view leaves as
+/// <c>if (c) return A; return B;</c> (because no short-circuit fold is
+/// opcode-faithful — #3114) into the IDE0046 conditional expression
+/// <c>return c ? A : B;</c>.
+///
+/// The knob is byte-divergent (the ternary recompiles to a different branch
+/// stream) but unconditionally behavior-preserving: the ternary is the canonical
+/// desugaring of the guarded return. These tests pin BOTH properties — the
+/// structural rewrite AND, via <see cref="Equivalence"/>, executed runtime
+/// equivalence over every boolean input.
+/// </summary>
+[Trait("Area", "RoundTrip")]
+public sealed class PreferConditionalReturnLensTests
+{
+    static string AssemblyPath => typeof(PreferConditionalReturnLensTests).Assembly.Location;
+
+    static readonly PrinterOptions LensOptions = new() { PreferConditionalExpressionReturn = true };
+
+    static ApiType Specimen()
+    {
+        using var pe = new PEReader(File.OpenRead(AssemblyPath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        return Assert.Single(api.Types, t => t.FullName == typeof(PreferConditionalReturnSpecimen).FullName);
+    }
+
+    static string Render(string memberName, PrinterOptions? options = null)
+    {
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == memberName);
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null, printerOptions: options);
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.NotNull(rendered.Text);
+        return rendered.Text!;
+    }
+
+    [Fact]
+    public void NeitherOr_DefaultLeavesGuardedReturnFlat()
+    {
+        var text = Render(nameof(PreferConditionalReturnSpecimen.NeitherOr));
+        Assert.Contains("return false;", text);
+        Assert.Contains("return c;", text);
+        Assert.DoesNotContain("?", text);
+    }
+
+    [Fact]
+    public void NeitherOr_LensRewritesToConditionalExpression()
+    {
+        var text = Render(nameof(PreferConditionalReturnSpecimen.NeitherOr), LensOptions);
+        // csc compiled `a && b` to the branchless `a & b`; the ternary keeps it.
+        Assert.Contains("a & b ? false : c", text);
+        // The flat guarded pair is gone.
+        Assert.DoesNotContain("if (", text);
+        Assert.DoesNotContain("return false;", text);
+    }
+
+    [Fact]
+    public void GuardBothVariable_DefaultLeavesGuardedReturnFlat()
+    {
+        var text = Render(nameof(PreferConditionalReturnSpecimen.GuardBothVariable));
+        Assert.Contains("return b;", text);
+        Assert.Contains("return c;", text);
+        Assert.DoesNotContain("?", text);
+    }
+
+    [Fact]
+    public void GuardBothVariable_LensRewritesToConditionalExpression()
+    {
+        var text = Render(nameof(PreferConditionalReturnSpecimen.GuardBothVariable), LensOptions);
+        Assert.Contains("a ? b : c", text);
+        Assert.DoesNotContain("if (", text);
+    }
+
+    [Fact]
+    public void OrShapedGuard_LensKeepsLiteralArm_NotSimplifiedToOr()
+    {
+        // The default leaves this flat (no opcode-faithful fold); the lens rewrites
+        // it to the IDE0046 form `a ? true : b` and does NOT further collapse to
+        // `a || b` (that IDE0075 simplification is a separate, deferred knob).
+        var defaultText = Render(nameof(PreferConditionalReturnSpecimen.OrShapedGuard));
+        Assert.Contains("return true;", defaultText);
+        Assert.DoesNotContain("?", defaultText);
+
+        var lensText = Render(nameof(PreferConditionalReturnSpecimen.OrShapedGuard), LensOptions);
+        Assert.Contains("a ? true : b", lensText);
+        Assert.DoesNotContain("||", lensText);
+    }
+
+    [Fact]
+    public void And_LensNoOp_ByteIdenticalToDefault()
+    {
+        // No guarded return: the lens finds nothing and leaves the output alone.
+        var defaultText = Render(nameof(PreferConditionalReturnSpecimen.And));
+        var lensText = Render(nameof(PreferConditionalReturnSpecimen.And), LensOptions);
+        Assert.Equal(defaultText, lensText);
+        Assert.DoesNotContain("?", lensText);
+    }
+
+    // Executed behavioral-equivalence gate for the tier-3 lens: the specimen
+    // methods run their compiled (source) semantics; the ternary is the lens's
+    // rendering. Proving `method(inputs) == (ternary over inputs)` for every
+    // boolean input pins that the lens rewrite preserves behavior — the contract
+    // this tier trades byte-fidelity for.
+    [Theory]
+    [MemberData(nameof(BoolTriples))]
+    public void NeitherOr_TernaryIsBehaviorEquivalent(bool a, bool b, bool c)
+        => Assert.Equal((a && b) ? false : c, PreferConditionalReturnSpecimen.NeitherOr(a, b, c));
+
+    [Theory]
+    [MemberData(nameof(BoolTriples))]
+    public void GuardBothVariable_TernaryIsBehaviorEquivalent(bool a, bool b, bool c)
+        => Assert.Equal(a ? b : c, PreferConditionalReturnSpecimen.GuardBothVariable(a, b, c));
+
+    public static TheoryData<bool, bool, bool> BoolTriples()
+    {
+        var data = new TheoryData<bool, bool, bool>();
+        foreach (var a in new[] { false, true })
+        foreach (var b in new[] { false, true })
+        foreach (var c in new[] { false, true })
+            data.Add(a, b, c);
+        return data;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/PreferConditionalReturnSpecimen.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferConditionalReturnSpecimen.cs
@@ -1,0 +1,57 @@
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Guarded-boolean-return shapes for the opt-in
+/// <see cref="ILInspector.Decompiler.Pipeline.PrinterOptions.PreferConditionalExpressionReturn"/>
+/// style lens (#3138). Each method compiles to an <c>if (c) return A; return B;</c>
+/// pair with <see cref="bool"/> arms — the shape the default view leaves flat
+/// because no short-circuit fold of it is opcode-faithful (#3114). The lens
+/// re-offers those as <c>return c ? A : B;</c>. <see cref="And"/> is the no-op
+/// negative — no guarded return at all, so the lens leaves it byte-identical.
+/// </summary>
+public static class PreferConditionalReturnSpecimen
+{
+    // Declined single-constant-arm case: `if (a && b) return false; return c;`.
+    // The default declines the `(a && b) && c` fold (short-circuit is not
+    // opcode-faithful here), so it renders flat. Lens: `return (a && b) ? false : c;`.
+    public static bool NeitherOr(bool a, bool b, bool c)
+    {
+        if (a && b)
+        {
+            return false;
+        }
+
+        return c;
+    }
+
+    // Both arms variable: the default treats a general (non-constant-arm) bool
+    // ternary return as a separate decision and leaves it flat. Lens: `return a ? b : c;`.
+    public static bool GuardBothVariable(bool a, bool b, bool c)
+    {
+        if (a)
+        {
+            return b;
+        }
+
+        return c;
+    }
+
+    // Counter-shape for the IDE0075 boundary: `if (a) return true; return b;`.
+    // The default leaves this flat too (no short-circuit fold is opcode-faithful),
+    // so the lens rewrites it — but to the honest IDE0046 form `a ? true : b`, NOT
+    // the further `a || b` simplification. That `? true :` -> `||` collapse is
+    // IDE0075, a separate (deferred) knob, so this lens keeps the literal arm.
+    public static bool OrShapedGuard(bool a, bool b)
+    {
+        if (a)
+        {
+            return true;
+        }
+
+        return b;
+    }
+
+    // Pure no-op negative: no guarded return at all, so the lens finds nothing and
+    // its output is byte-identical to the default.
+    public static bool And(bool a, bool b) => a & b;
+}

--- a/src/ILInspector.Decompiler.Tests/PreferConditionalReturnSpecimen.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferConditionalReturnSpecimen.cs
@@ -54,4 +54,41 @@ public static class PreferConditionalReturnSpecimen
     // Pure no-op negative: no guarded return at all, so the lens finds nothing and
     // its output is byte-identical to the default.
     public static bool And(bool a, bool b) => a & b;
+
+    // Constant-false-arm shape: `if (c) return value; return false;`. The lens
+    // produces the conditional `c ? value : false`, which the printer idiomatically
+    // spells as the short-circuit `c && value` (behavior-faithful; valid for a
+    // primitive-bool condition).
+    public static bool AndShapedGuard(bool c, bool value)
+    {
+        if (c)
+        {
+            return value;
+        }
+
+        return false;
+    }
+
+    // User-defined truthiness in the condition: the lens must DECLINE (stay flat),
+    // because collapsing `c ? value : false` to `c && value` would rebind to a
+    // user-defined `&` that does not exist (CS0019).
+    public static bool UserTruthinessGuard(Truthy c, bool value)
+    {
+        if (c)
+        {
+            return value;
+        }
+
+        return false;
+    }
+
+    // A struct usable in boolean context via operator true/false, but with NO
+    // user-defined `&`/`|` — so any short-circuit lift of a `Truthy` condition is
+    // uncompilable.
+    public readonly struct Truthy
+    {
+        public static bool operator true(Truthy _) => true;
+
+        public static bool operator false(Truthy _) => false;
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -93,7 +93,13 @@ public sealed partial class CSharpPrinter
     {
         try
         {
-            IrPasses.Run(function, IrPasses.Default, RaiseContext(importMethodBody, typesProvablyDisjoint));
+            var context = RaiseContext(importMethodBody, typesProvablyDisjoint);
+            IrPasses.Run(function, IrPasses.Default, context);
+            // Opt-in tier-3 style lens (#3138), byte-divergent by design: runs
+            // only when requested, after the byte-faithful default pipeline has
+            // left the guarded bool return flat.
+            if (options?.PreferConditionalExpressionReturn == true)
+                new PreferConditionalReturnPass().Run(function, context);
         }
         catch (Exception ex)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -75,6 +75,24 @@ public sealed record PrinterOptions
     /// </summary>
     public bool QualifyPropertyAccess { get; init; }
 
+    /// <summary>
+    /// When set, a guarded boolean return the default view must render as a flat
+    /// <c>if (c) return A; return B;</c> — because no short-circuit fold is
+    /// opcode-faithful for that shape (see <c>ShortCircuitFidelity</c> / #3114) —
+    /// is instead rendered as the conditional expression <c>return c ? A : B;</c>.
+    /// This is the runtime <c>.editorconfig</c> IDE0046-preferred spelling
+    /// (<c>dotnet_style_prefer_conditional_expression_over_return</c>).
+    ///
+    /// Unlike every other knob on this record, this one is <b>byte-divergent</b>:
+    /// the ternary recompiles to a different branch stream than the original (a
+    /// polarity flip and block reorder), so it is <b>not</b> opcode-faithful. It
+    /// is the first opt-in <b>style lens</b> (#3138): the rewrite is the canonical
+    /// desugaring of the guarded return, so it is unconditionally
+    /// <b>behavior-preserving</b>, but the output must not be fed the compile-back
+    /// fidelity gates. Off by default; the default view stays byte-faithful.
+    /// </summary>
+    public bool PreferConditionalExpressionReturn { get; init; }
+
     /// <summary>The shipped defaults — every knob off.</summary>
     public static PrinterOptions Default { get; } = new();
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -771,7 +771,7 @@ public sealed class BooleanFoldingPass : IIrPass
         return true;
     }
 
-    static bool ConsumesBranchTarget(
+    internal static bool ConsumesBranchTarget(
         IrFunction function,
         IrNode anchor,
         IrNode firstConsumed,

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PreferConditionalReturnPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PreferConditionalReturnPass.cs
@@ -78,9 +78,23 @@ public sealed class PreferConditionalReturnPass : IIrPass
         if (BooleanFoldingPass.ConsumesBranchTarget(function, guard, thenReturn, tailReturn))
             return false;
 
+        // A user-defined-truthiness condition (`operator true`/`operator false`)
+        // is DECLINED, mirroring the default's FoldGuardReturn guard. The printer
+        // strips such a condition to its bare user-typed receiver and, when the
+        // false arm is the constant `false`, spells the conditional as a
+        // short-circuit `c && A` (SpellsAsLogicalAnd) — which rebinds to a
+        // user-defined `&` that need not exist, emitting uncompilable C# (CS0019).
+        // The flat guard is the valid, faithful rendering for that exotic shape.
+        if (ShortCircuitFidelity.IsUserDefinedTruthiness(guard.Condition))
+            return false;
+
         // `if (c) return A; return B;` ≡ `return c ? A : B;` — same condition
         // polarity, same arms, same evaluation order (IDE0046 keeps the guard
-        // condition as-is, unlike the polarity-swapped FoldTernaryReturn).
+        // condition as-is, unlike the polarity-swapped FoldTernaryReturn). The
+        // printer idiomatically spells the constant-false-arm case `c ? A : false`
+        // as the short-circuit `c && A`, matching how it renders every other
+        // boolean Conditional — that is behavior-faithful (short-circuit
+        // preserved) and, for a primitive-bool condition, always valid C#.
         var condition = guard.Condition;
         condition.Detach();
         thenValue.Detach();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PreferConditionalReturnPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PreferConditionalReturnPass.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Opt-in <b>style lens</b> (#3138), off the default pipeline and gated by
+/// <see cref="PrinterOptions.PreferConditionalExpressionReturn"/>: rewrites a
+/// flat guarded boolean return
+/// <c>if (c) return A; return B;</c> into the conditional expression
+/// <c>return c ? A : B;</c> — the runtime <c>.editorconfig</c> IDE0046 preferred
+/// spelling (<c>dotnet_style_prefer_conditional_expression_over_return</c>).
+///
+/// It runs only on the opt-in raised path, AFTER the default pipeline has
+/// deliberately left the shape flat: no short-circuit <c>&amp;&amp;</c>/<c>||</c>
+/// fold of a bool guarded return is opcode-faithful, so
+/// <see cref="BooleanFoldingPass"/> declines it (#3114 /
+/// <c>ShortCircuitFidelity</c>) and the flat <c>if</c>/<c>return</c> pair is what
+/// survives to render.
+///
+/// The ternary is the CANONICAL desugaring of the guarded return: same condition,
+/// same arms, same short-circuit evaluation order, so the rewrite is
+/// unconditionally <b>behavior-preserving</b>. It is <b>not</b> opcode-faithful —
+/// the recompiled branch stream flips polarity and reorders blocks — so this pass
+/// must never run on a byte-faithful path (default / lowered) and its output must
+/// not feed the compile-back fidelity gates. That contract is what makes it a
+/// tier-3 style lens rather than a raising pass.
+/// </summary>
+public sealed class PreferConditionalReturnPass : IIrPass
+{
+    public string Name => "prefer-conditional-return";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        // Fixpoint: collapsing an inner guarded return can expose an outer one
+        // whose tail is now the freshly minted `return c ? A : B;`.
+        while (RewriteOnce(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool RewriteOnce(IrFunction function, Stepper stepper)
+    {
+        foreach (var node in function.Descendants.ToList())
+        {
+            if (node.Parent is null || node is not IfStatement guard)
+                continue;
+            if (TryRewriteGuardReturn(function, guard, stepper))
+                return true;
+        }
+
+        return false;
+    }
+
+    // Mirrors FoldGuardReturn's guarded-return match exactly (else-less if whose
+    // Then is a single Return, immediately followed by a sibling Return, both
+    // arms System.Boolean, neither Return a live branch target). The default
+    // pass declines the FIDELITY-erasing short-circuit fold of this shape; the
+    // ternary is its behavior-equivalent tier-3 rendering.
+    static bool TryRewriteGuardReturn(IrFunction function, IfStatement guard, Stepper stepper)
+    {
+        if (guard.HasElse || guard.Parent is not Block container)
+            return false;
+        if (guard.Then.Children.Count != 1
+            || guard.Then.Children[0] is not Return { Value: { } thenValue } thenReturn)
+        {
+            return false;
+        }
+        if (guard.ChildIndex + 1 >= container.Children.Count
+            || container.Children[guard.ChildIndex + 1] is not Return { Value: { } tailValue } tailReturn)
+        {
+            return false;
+        }
+        if (thenValue.ResultType is not { Namespace: "System", Name: "Boolean" }
+            || tailValue.ResultType is not { Namespace: "System", Name: "Boolean" })
+        {
+            return false;
+        }
+        if (BooleanFoldingPass.ConsumesBranchTarget(function, guard, thenReturn, tailReturn))
+            return false;
+
+        // `if (c) return A; return B;` ≡ `return c ? A : B;` — same condition
+        // polarity, same arms, same evaluation order (IDE0046 keeps the guard
+        // condition as-is, unlike the polarity-swapped FoldTernaryReturn).
+        var condition = guard.Condition;
+        condition.Detach();
+        thenValue.Detach();
+        tailValue.Detach();
+
+        var ternary = new Conditional(condition, thenValue, tailValue)
+        {
+            MergedType = TypeRef.CoreLib("System", "Boolean"),
+        };
+
+        tailReturn.Detach();
+        stepper.StepOver("rewrite guarded return into conditional expression", guard);
+        var mergedReturn = new Return(ternary);
+        mergedReturn.InheritSourceOffset(guard);
+        guard.ReplaceWith(mergedReturn);
+        return true;
+    }
+}

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -46,6 +46,29 @@ public class RenderStyleConfigTests
     }
 
     [Fact]
+    public void Parse_PreferConditionalReturnKey_MapsToLensKnob()
+    {
+        var result = RenderStyleConfig.Parse(
+            "dotnet_style_prefer_conditional_expression_over_return = true",
+            origin: "cfg");
+
+        Assert.True(result.Options.PreferConditionalExpressionReturn);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_PreferConditionalReturn_DefaultsOffAndToleratesSeverity()
+    {
+        Assert.False(RenderStyleConfig.Parse("", origin: null).Options.PreferConditionalExpressionReturn);
+
+        var withSeverity = RenderStyleConfig.Parse(
+            "dotnet_style_prefer_conditional_expression_over_return = true:suggestion",
+            origin: null);
+        Assert.True(withSeverity.Options.PreferConditionalExpressionReturn);
+        Assert.Empty(withSeverity.Warnings);
+    }
+
+    [Fact]
     public void Parse_FalseValue_LeavesKnobOff()
     {
         var result = RenderStyleConfig.Parse("dotnet_style_qualification_for_field = false", origin: null);

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -38,11 +38,15 @@ internal static class RenderStyleConfig
     /// <summary>The tool-owned style file name discovered by walking up from the working directory.</summary>
     public const string FileName = ".dotnet-inspectconfig";
 
-    // v1 recognizes exactly the two class-3 this.-qualification knobs, which are
-    // the only shipped spelling knobs with an exact editorconfig key. More keys
-    // are added here as further class-3 knobs land.
+    // v1 recognizes the two class-3 this.-qualification knobs (byte-preserving
+    // spelling choices) plus the opt-in ternary style lens
+    // (dotnet_style_prefer_conditional_expression_over_return). The latter is the
+    // first BYTE-DIVERGENT key: it is behavior-preserving but not opcode-faithful
+    // (#3138), so it is a deliberate style lens, not a class-3 spelling knob. More
+    // keys are added here as further knobs land.
     private const string FieldKey = "dotnet_style_qualification_for_field";
     private const string PropertyKey = "dotnet_style_qualification_for_property";
+    private const string PreferConditionalReturnKey = "dotnet_style_prefer_conditional_expression_over_return";
 
     // The editorconfig boundary marker. Discovery is nearest-wins, so the nearest
     // file is already a hard boundary (nothing above it is read); 'root' is
@@ -118,6 +122,7 @@ internal static class RenderStyleConfig
     {
         bool qualifyField = false;
         bool qualifyProperty = false;
+        bool preferConditionalReturn = false;
         List<string>? warnings = null;
 
         void Warn(string message) => (warnings ??= []).Add(message);
@@ -167,6 +172,12 @@ internal static class RenderStyleConfig
                     else
                         Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
                     break;
+                case PreferConditionalReturnKey:
+                    if (TryParseBool(value, out var t))
+                        preferConditionalReturn = t;
+                    else
+                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
+                    break;
                 case RootKey:
                     // editorconfig boundary marker. Discovery is nearest-wins, so
                     // the nearest file is already a hard boundary; 'root' drives no
@@ -185,6 +196,7 @@ internal static class RenderStyleConfig
         {
             QualifyFieldAccess = qualifyField,
             QualifyPropertyAccess = qualifyProperty,
+            PreferConditionalExpressionReturn = preferConditionalReturn,
         };
 
         return new RenderStyleResolution(options, origin, (IReadOnlyList<string>?)warnings ?? []);


### PR DESCRIPTION
## What

First opt-in **style lens** (#3138): a new tier of render option that is **behavior-faithful but byte-divergent**, distinct from the existing byte-preserving class-3 spelling knobs.

The lens `PrinterOptions.PreferConditionalExpressionReturn` (config key `dotnet_style_prefer_conditional_expression_over_return`, IDE0046) re-renders a guarded boolean return the **default** view must leave flat — because no short-circuit fold of that shape is opcode-faithful (#3114) — as the conditional expression:

```csharp
// shipped default (byte-faithful):
if (a & b) { return false; }
return c;
// with the lens (behavior-faithful, byte-divergent):
return a & b ? false : c;
```

## Why it's safe

The ternary is the **canonical desugaring** of the guarded return — same condition, same arms, same short-circuit evaluation order — so the rewrite is **unconditionally behavior-preserving**. That is exactly what lets the lens re-offer a fold #3114 had to decline for opcode fidelity. It is **not** opcode-faithful, so:

- Off by default; the default/lowered byte-faithful paths are untouched.
- Runs only on the opt-in raised path, after the default pipeline.
- The IL-anchored **Annotated** view never applies it (stays line/IL aligned).
- Its output must never feed the compile-back fidelity gates (it doesn't — the gates only run Default/Lowered).

Deliberately stops at IDE0046: the further `c ? true : d` → `c || d` collapse (IDE0075 / "bool hack") is a separate future knob, so a literal-arm ternary like `a ? true : b` is kept as-is.

## Changes

- **`PrinterOptions.PreferConditionalExpressionReturn`** — new byte-divergent knob (documented as such).
- **`PreferConditionalReturnPass`** — matches the flat bool guard-return surviving the default pipeline (mirrors `FoldGuardReturn`'s match; reuses its `ConsumesBranchTarget` guard) and rewrites to `return c ? A : B;`.
- **`CSharpPrinter.PrintRaised`** — runs the pass only when the knob is set, after `IrPasses.Default`, reusing the existing `RaiseContext`. No `PassContext`/`RaiseContext` signature churn.
- **`RenderStyleConfig`** — maps the new `.dotnet-inspectconfig` key.
- **`docs/decompiler-taste.md`** — new "Style lenses" section + config-key/example updates.

## Evidence

- New focused tests (`PreferConditionalReturnLensTests`): default-flat vs lens-ternary structural checks, IDE0075-not-applied, a no-op negative, and an **executed truth-table behavioral-equivalence gate** over all boolean inputs.
- New `RenderStyleConfigTests` coverage for the config key.
- Fast decompiler suite: **3557 / 0 failures**; default output byte-unchanged.
- CLI end-to-end verified: with the config key set, `member ... -S "Decompiled Source"` renders `=> a & b ? false : c;`; without it, the flat guard.

## Review

New heuristic/behavior → needs 2-model adversarial review (Gemini + GPT) per AGENTS.md before merge.