### PR TITLE
Add PreferBranchlessBoolean style lens (#3138)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -286,6 +286,33 @@ d` collapse (IDE0075) is a separate future knob, so a literal-arm ternary such a
 the opt-in raised path, after the default pipeline, and the IL-anchored Annotated
 view never applies it (it must stay byte-faithful for line/IL alignment).
 
+The second lens is `PrinterOptions.PreferBranchlessBoolean`
+(`dotnet_inspect_style_prefer_branchless_boolean`). It targets the *same* declined
+guarded return, but renders the compact short-circuit "bool hack" — the exact form
+the default's short-circuit fold produced before #3114 guarded it — instead of the
+ternary:
+
+```csharp
+// shipped default (byte-faithful — the flat guard is what recompiles exactly):
+if (a) { return false; }
+return b;
+// with PreferBranchlessBoolean (behavior-faithful, byte-divergent):
+return !a && b;
+```
+
+The four constant-arm shapes fold to `a && b`, `!a || b`, `a || b`, and `!a && b`
+respectively. Unlike the ternary, this form is **not oracle-endorsed** —
+dotnet/runtime's `.editorconfig` would never recommend it — so it is a user
+*compactness/branchless* preference, opt-in only, and it is **never** part of a
+"full taste" aggregate. It is exposed under a tool-owned
+`dotnet_inspect_style_*` key rather than a `dotnet_style_*` key to make that
+distinction explicit. Two hazards stay declined because they are about *behavior*,
+not just bytes: a user-defined-truthiness condition (lifting it rebinds to a
+user-defined `&&`/`||`, changing the result) and a managed by-ref surviving
+operand (csc's branchless lowering would eagerly dereference a location the branch
+had guarded). When both lenses are enabled the oracle-endorsed ternary wins the
+shared shape.
+
 ## Names
 
 Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL view — the two views stay name-aligned by construction. With a PDB, source names are used. Synthesizing readable names (`size`, `array`, `item`) where no PDB exists is an open design question: it is the largest remaining cosmetic gap against source, but it would break view alignment unless opt-in.
@@ -295,8 +322,8 @@ Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL
 The oracle settles a single shipped default per equivalence class, but a few
 class-3 no-anchor spellings are also exposed as opt-in knobs (see
 [`this` member qualification](#this-member-qualification) and
-[Line wrapping](#line-wrapping)), as is the first byte-divergent
-[style lens](#style-lenses-behavior-faithful-byte-divergent). A tool-owned config
+[Line wrapping](#line-wrapping)), as are the byte-divergent
+[style lenses](#style-lenses-behavior-faithful-byte-divergent). A tool-owned config
 file selects them without a per-run flag.
 
 `dotnet-inspect` discovers a `.dotnet-inspectconfig` file by walking up from the
@@ -325,10 +352,11 @@ dotnet_style_prefer_conditional_expression_over_return = true
   `root = true` drives no behavior on its own; it is the conventional, explicit
   way to mark a repository-root config as the boundary.
 - Recognized keys map to `PrinterOptions`: the two `this`-qualification keys
-  above (byte-preserving class-3 spellings) and
-  `dotnet_style_prefer_conditional_expression_over_return` (the first
-  byte-divergent [style lens](#style-lenses-behavior-faithful-byte-divergent)).
-  The set grows as more knobs ship.
+  above (byte-preserving class-3 spellings),
+  `dotnet_style_prefer_conditional_expression_over_return` (the oracle-endorsed
+  ternary [style lens](#style-lenses-behavior-faithful-byte-divergent)), and
+  `dotnet_inspect_style_prefer_branchless_boolean` (the non-oracle-endorsed
+  branchless lens, under a tool-owned key). The set grows as more knobs ship.
 - Unknown keys, malformed lines, and non-boolean values are reported as a
   `Warning:` on stderr and skipped — the rest of the file still applies. A bad
   config never fails the run silently.

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -307,11 +307,17 @@ dotnet/runtime's `.editorconfig` would never recommend it — so it is a user
 "full taste" aggregate. It is exposed under a tool-owned
 `dotnet_inspect_style_*` key rather than a `dotnet_style_*` key to make that
 distinction explicit. Two hazards stay declined because they are about *behavior*,
-not just bytes: a user-defined-truthiness condition (lifting it rebinds to a
-user-defined `&&`/`||`, changing the result) and a managed by-ref surviving
+not just bytes: a user-defined-truthiness condition and a managed by-ref surviving
 operand (csc's branchless lowering would eagerly dereference a location the branch
-had guarded). When both lenses are enabled the oracle-endorsed ternary wins the
-shared shape.
+had guarded). The lens declines *every* user-defined-truthiness condition
+wholesale — anywhere in the condition subtree, including one wrapped in a negation.
+Such a condition never yields the compact bool-hack this lens targets: lifting it
+is either invalid (the printer strips `op_True`/`op_False` to a bare user-typed
+receiver, so `t && b` fails to compile), behavior-divergent (were a user `&`/`|`
+present, it would rebind to that operator's semantics), or valid but not branchless
+(a negation spelled as the ternary `(t ? false : true)` re-embeds a branch).
+Over-declining is always valid and faithful. When both lenses are enabled the
+oracle-endorsed ternary wins the shared shape.
 
 ## Names
 

--- a/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanLensTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanLensTests.cs
@@ -116,6 +116,22 @@ public sealed class PreferBranchlessBooleanLensTests
     }
 
     [Fact]
+    public void NegatedUserTruthinessGuard_LensDeclines_StaysFlat()
+    {
+        // A user-truthiness condition wrapped in a negation (`if (t) {} else { ... }`
+        // raises to `LogicalNot(op_True(t))`). The direct-call guard alone would miss
+        // it: Conditions.Negate unwraps the LogicalNot to the bare `op_True` call the
+        // printer strips to `t`, so lifting this NEGATING shape emits the uncompilable
+        // `t || b` (Truthy has no user `|`). The subtree scan must catch it and the
+        // lens must decline, leaving the flat guard exactly as the default.
+        var defaultText = Render(nameof(PreferBranchlessBooleanSpecimen.NegatedUserTruthinessGuard));
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.NegatedUserTruthinessGuard), LensOptions);
+        Assert.Equal(defaultText, lensText);
+        Assert.Contains("return b;", lensText);
+        Assert.DoesNotContain("||", lensText);
+    }
+
+    [Fact]
     public void ByRefOperandGuard_LensDeclines_StaysFlat()
     {
         // The surviving operand is a managed by-ref dereference; csc's branchless

--- a/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanLensTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanLensTests.cs
@@ -132,6 +132,22 @@ public sealed class PreferBranchlessBooleanLensTests
     }
 
     [Fact]
+    public void WrappedTruthinessNonNegatingGuard_LensDeclines_StaysFlat()
+    {
+        // Non-negating counterpart of the negated case: `if (t) {} else { return b; }`
+        // with a `false` tail keeps the condition `LogicalNot(op_True(t))` as-is, so
+        // the fold `(t ? false : true) && b` is VALID. The lens still declines it: a
+        // negation spelled as a ternary is not the compact short-circuit form this
+        // lens produces, and it stays out of every user-truthiness condition
+        // wholesale. Declining is always valid and faithful.
+        var defaultText = Render(nameof(PreferBranchlessBooleanSpecimen.WrappedTruthinessNonNegatingGuard));
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.WrappedTruthinessNonNegatingGuard), LensOptions);
+        Assert.Equal(defaultText, lensText);
+        Assert.Contains("return b;", lensText);
+        Assert.DoesNotContain("&&", lensText);
+    }
+
+    [Fact]
     public void ByRefOperandGuard_LensDeclines_StaysFlat()
     {
         // The surviving operand is a managed by-ref dereference; csc's branchless

--- a/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanLensTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanLensTests.cs
@@ -1,0 +1,180 @@
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The opt-in tier-3 style lens
+/// <see cref="PrinterOptions.PreferBranchlessBoolean"/> (#3138): re-renders a flat
+/// guarded boolean return with a constant arm the default view leaves as
+/// <c>if (c) return A; return B;</c> (because the short-circuit fold is not
+/// opcode-faithful for a bare-load operand — #3114) into the compact short-circuit
+/// "bool hack".
+///
+/// The knob is byte-divergent (csc recompiles the short-circuit form branchless)
+/// but unconditionally behavior-preserving: it keeps the same condition, surviving
+/// operand, and short-circuit order. These tests pin BOTH the structural rewrite
+/// AND, via <see cref="BoolPairs"/>, executed runtime equivalence over every
+/// boolean input. They also pin the two BEHAVIOR guards the lens keeps
+/// (user-defined truthiness and a managed by-ref operand) and the deterministic
+/// ternary-wins precedence when both lenses are enabled.
+/// </summary>
+[Trait("Area", "RoundTrip")]
+public sealed class PreferBranchlessBooleanLensTests
+{
+    static string AssemblyPath => typeof(PreferBranchlessBooleanLensTests).Assembly.Location;
+
+    static readonly PrinterOptions LensOptions = new() { PreferBranchlessBoolean = true };
+
+    static ApiType Specimen()
+    {
+        using var pe = new PEReader(File.OpenRead(AssemblyPath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        return Assert.Single(api.Types, t => t.FullName == typeof(PreferBranchlessBooleanSpecimen).FullName);
+    }
+
+    static string Render(string memberName, PrinterOptions? options = null)
+    {
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == memberName);
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null, printerOptions: options);
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.NotNull(rendered.Text);
+        return rendered.Text!;
+    }
+
+    [Fact]
+    public void AndTailGuard_DefaultFlat_LensFoldsToAnd()
+    {
+        var defaultText = Render(nameof(PreferBranchlessBooleanSpecimen.AndTailGuard));
+        Assert.Contains("return false;", defaultText);
+        Assert.DoesNotContain("&&", defaultText);
+
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.AndTailGuard), LensOptions);
+        Assert.Contains("=> a && b;", lensText);
+        Assert.DoesNotContain("if (", lensText);
+    }
+
+    [Fact]
+    public void OrTailGuard_LensFoldsToNegatedOr()
+    {
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.OrTailGuard), LensOptions);
+        Assert.Contains("=> !a || b;", lensText);
+        Assert.DoesNotContain("if (", lensText);
+    }
+
+    [Fact]
+    public void OrThenGuard_LensFoldsToOr()
+    {
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.OrThenGuard), LensOptions);
+        Assert.Contains("=> a || b;", lensText);
+        Assert.DoesNotContain("if (", lensText);
+    }
+
+    [Fact]
+    public void AndThenGuard_LensFoldsToNegatedAnd()
+    {
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.AndThenGuard), LensOptions);
+        Assert.Contains("=> !a && b;", lensText);
+        Assert.DoesNotContain("if (", lensText);
+    }
+
+    [Fact]
+    public void BothVariable_LensNoOp_NoConstantArmToLift()
+    {
+        // No constant arm, so there is no operator to lift the condition into: the
+        // branchless "bool hack" does not apply and the lens leaves the flat guard
+        // byte-identical to the default (unlike the ternary lens, which would fold).
+        var defaultText = Render(nameof(PreferBranchlessBooleanSpecimen.BothVariable));
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.BothVariable), LensOptions);
+        Assert.Equal(defaultText, lensText);
+        Assert.Contains("if (", lensText);
+    }
+
+    [Fact]
+    public void Plain_LensNoOp_ByteIdenticalToDefault()
+    {
+        var defaultText = Render(nameof(PreferBranchlessBooleanSpecimen.Plain));
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.Plain), LensOptions);
+        Assert.Equal(defaultText, lensText);
+    }
+
+    [Fact]
+    public void UserTruthinessGuard_LensDeclines_StaysFlat()
+    {
+        // Lifting a user-truthiness condition into `t && b` rebinds to a
+        // user-defined `&` that does not exist and changes the runtime result, so
+        // the lens must decline and leave the flat guard exactly as the default.
+        var defaultText = Render(nameof(PreferBranchlessBooleanSpecimen.UserTruthinessGuard));
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.UserTruthinessGuard), LensOptions);
+        Assert.Equal(defaultText, lensText);
+        Assert.Contains("return false;", lensText);
+        Assert.DoesNotContain("&&", lensText);
+    }
+
+    [Fact]
+    public void ByRefOperandGuard_LensDeclines_StaysFlat()
+    {
+        // The surviving operand is a managed by-ref dereference; csc's branchless
+        // lowering would eagerly dereference it on the guarded path (null-by-ref NRE
+        // divergence), so the lens must decline and leave the flat guard.
+        var defaultText = Render(nameof(PreferBranchlessBooleanSpecimen.ByRefOperandGuard));
+        var lensText = Render(nameof(PreferBranchlessBooleanSpecimen.ByRefOperandGuard), LensOptions);
+        Assert.Equal(defaultText, lensText);
+        Assert.Contains("return p;", lensText);
+        Assert.DoesNotContain("||", lensText);
+    }
+
+    [Fact]
+    public void TernaryWins_WhenBothLensesEnabled()
+    {
+        // Deterministic precedence: the oracle-endorsed ternary consumes the shape
+        // first, so the non-endorsed branchless form never fires. OrThenGuard is a
+        // case where the two lenses DIFFER (`a || b` vs `a ? true : b`).
+        var both = new PrinterOptions
+        {
+            PreferConditionalExpressionReturn = true,
+            PreferBranchlessBoolean = true,
+        };
+        var text = Render(nameof(PreferBranchlessBooleanSpecimen.OrThenGuard), both);
+        Assert.Contains("=> a ? true : b;", text);
+        Assert.DoesNotContain("||", text);
+    }
+
+    // Executed behavioral-equivalence gate for the tier-3 lens: the specimen
+    // methods run their compiled (source) semantics; the short-circuit form is the
+    // lens's rendering. Proving `method(inputs) == (bool hack over inputs)` for
+    // every boolean input pins that the rewrite preserves behavior — the contract
+    // this tier trades byte-fidelity for.
+    [Theory]
+    [MemberData(nameof(BoolPairs))]
+    public void AndTailGuard_ShortCircuitIsBehaviorEquivalent(bool a, bool b)
+        => Assert.Equal(a && b, PreferBranchlessBooleanSpecimen.AndTailGuard(a, b));
+
+    [Theory]
+    [MemberData(nameof(BoolPairs))]
+    public void OrTailGuard_ShortCircuitIsBehaviorEquivalent(bool a, bool b)
+        => Assert.Equal(!a || b, PreferBranchlessBooleanSpecimen.OrTailGuard(a, b));
+
+    [Theory]
+    [MemberData(nameof(BoolPairs))]
+    public void OrThenGuard_ShortCircuitIsBehaviorEquivalent(bool a, bool b)
+        => Assert.Equal(a || b, PreferBranchlessBooleanSpecimen.OrThenGuard(a, b));
+
+    [Theory]
+    [MemberData(nameof(BoolPairs))]
+    public void AndThenGuard_ShortCircuitIsBehaviorEquivalent(bool a, bool b)
+        => Assert.Equal(!a && b, PreferBranchlessBooleanSpecimen.AndThenGuard(a, b));
+
+    public static TheoryData<bool, bool> BoolPairs()
+    {
+        var data = new TheoryData<bool, bool>();
+        foreach (var a in new[] { false, true })
+        foreach (var b in new[] { false, true })
+            data.Add(a, b);
+        return data;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanSpecimen.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanSpecimen.cs
@@ -1,0 +1,123 @@
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Guarded-boolean-return shapes for the opt-in
+/// <see cref="ILInspector.Decompiler.Pipeline.PrinterOptions.PreferBranchlessBoolean"/>
+/// style lens (#3138). Each fold method compiles to an
+/// <c>if (c) return A; return B;</c> pair with a <see cref="bool"/> constant arm —
+/// the shape the default view leaves flat because the short-circuit fold is not
+/// opcode-faithful when the surviving operand is a bare load csc would collapse to
+/// a branchless <c>&amp;</c>/<c>|</c> (#3114). The lens re-offers those as the
+/// compact short-circuit "bool hack".
+///
+/// The four fold shapes (surviving operand is the bare parameter, so the default
+/// declines every one):
+/// <list type="bullet">
+/// <item><see cref="AndTailGuard"/>: <c>if (a) return b; return false;</c> → <c>a &amp;&amp; b</c></item>
+/// <item><see cref="OrTailGuard"/>: <c>if (a) return b; return true;</c> → <c>!a || b</c></item>
+/// <item><see cref="OrThenGuard"/>: <c>if (a) return true; return b;</c> → <c>a || b</c></item>
+/// <item><see cref="AndThenGuard"/>: <c>if (a) return false; return b;</c> → <c>!a &amp;&amp; b</c></item>
+/// </list>
+/// </summary>
+public static class PreferBranchlessBooleanSpecimen
+{
+    // if (a) return b; return false; ≡ a && b. Surviving operand `b` is a bare arg,
+    // so the default declines the branchless fold and leaves this flat.
+    public static bool AndTailGuard(bool a, bool b)
+    {
+        if (a)
+        {
+            return b;
+        }
+
+        return false;
+    }
+
+    // if (a) return b; return true; ≡ !a || b. Negated condition + bare surviving
+    // operand; default leaves it flat.
+    public static bool OrTailGuard(bool a, bool b)
+    {
+        if (a)
+        {
+            return b;
+        }
+
+        return true;
+    }
+
+    // if (a) return true; return b; ≡ a || b. Bare surviving operand; default flat.
+    public static bool OrThenGuard(bool a, bool b)
+    {
+        if (a)
+        {
+            return true;
+        }
+
+        return b;
+    }
+
+    // if (a) return false; return b; ≡ !a && b. Negated condition + bare surviving
+    // operand; default flat.
+    public static bool AndThenGuard(bool a, bool b)
+    {
+        if (a)
+        {
+            return false;
+        }
+
+        return b;
+    }
+
+    // Both arms variable (no constant): the branchless "bool hack" does not apply
+    // (there is no operator to lift the condition into), so the lens is a no-op and
+    // leaves this flat. (The ternary lens would fold it; this one must not.)
+    public static bool BothVariable(bool a, bool b, bool c)
+    {
+        if (a)
+        {
+            return b;
+        }
+
+        return c;
+    }
+
+    // No guarded return at all: the lens finds nothing and its output is
+    // byte-identical to the default.
+    public static bool Plain(bool a, bool b) => a & b;
+
+    // User-defined truthiness in the condition: the lens must DECLINE (stay flat),
+    // because lifting `t` into `t && b` rebinds to a user-defined `&` that does not
+    // exist and changes the runtime result (CS0019 / behavior divergence).
+    public static bool UserTruthinessGuard(Truthy t, bool b)
+    {
+        if (t)
+        {
+            return b;
+        }
+
+        return false;
+    }
+
+    // Surviving operand is a managed by-ref dereference: csc's branchless lowering
+    // would eagerly dereference `p` on the path the branch had guarded (null-by-ref
+    // NRE divergence), so the lens must DECLINE and leave the flat guard.
+    public static bool ByRefOperandGuard(bool a, ref bool p)
+    {
+        if (a)
+        {
+            return p;
+        }
+
+        return false;
+    }
+
+    // A struct usable in boolean context via operator true/false, but with NO
+    // user-defined `&`/`|`, so any short-circuit lift of a `Truthy` condition is
+    // uncompilable.
+    public readonly struct Truthy
+    {
+        public static bool operator true(Truthy _) => true;
+
+        public static bool operator false(Truthy _) => false;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanSpecimen.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanSpecimen.cs
@@ -130,6 +130,28 @@ public static class PreferBranchlessBooleanSpecimen
         return true;
     }
 
+    // User-defined truthiness under a negation, NON-negating fold shape: same
+    // `if (t) {} else { return b; }` head but a `false` tail. The condition
+    // `LogicalNot(op_True(t))` is used as-is (no Conditions.Negate), so the printer
+    // spells it as the bool-typed ternary `(t ? false : true)` and the fold
+    // `(t ? false : true) && b` is technically VALID. The lens still DECLINES it:
+    // that output is not a clean branchless short-circuit (it re-embeds a ternary),
+    // and the lens deliberately stays out of every user-defined-truthiness condition
+    // because none of them yield the compact bool-hack this lens targets. Declining
+    // is always valid and faithful.
+    public static bool WrappedTruthinessNonNegatingGuard(Truthy t, bool b)
+    {
+        if (t)
+        {
+        }
+        else
+        {
+            return b;
+        }
+
+        return false;
+    }
+
     // A struct usable in boolean context via operator true/false, but with NO
     // user-defined `&`/`|`, so any short-circuit lift of a `Truthy` condition is
     // uncompilable.

--- a/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanSpecimen.cs
+++ b/src/ILInspector.Decompiler.Tests/PreferBranchlessBooleanSpecimen.cs
@@ -111,6 +111,25 @@ public static class PreferBranchlessBooleanSpecimen
         return false;
     }
 
+    // User-defined truthiness under a negation: `if (t) {} else { return b; }`
+    // raises to a guarded return whose condition is `LogicalNot(op_True(t))`. With a
+    // `true` tail this is a NEGATING fold shape (`!c || b`): Conditions.Negate
+    // unwraps the LogicalNot to the bare `op_True` call the printer strips to `t`,
+    // so the direct-call guard would miss it and the lens would emit the
+    // uncompilable `t || b` (Truthy has no user `|`). The lens must DECLINE.
+    public static bool NegatedUserTruthinessGuard(Truthy t, bool b)
+    {
+        if (t)
+        {
+        }
+        else
+        {
+            return b;
+        }
+
+        return true;
+    }
+
     // A struct usable in boolean context via operator true/false, but with NO
     // user-defined `&`/`|`, so any short-circuit lift of a `Truthy` condition is
     // uncompilable.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -97,9 +97,13 @@ public sealed partial class CSharpPrinter
             IrPasses.Run(function, IrPasses.Default, context);
             // Opt-in tier-3 style lens (#3138), byte-divergent by design: runs
             // only when requested, after the byte-faithful default pipeline has
-            // left the guarded bool return flat.
+            // left the guarded bool return flat. The oracle-endorsed ternary runs
+            // first so that, when both lenses are enabled, it wins the shared shape
+            // (it consumes the guarded return, leaving the branchless pass a no-op).
             if (options?.PreferConditionalExpressionReturn == true)
                 new PreferConditionalReturnPass().Run(function, context);
+            if (options?.PreferBranchlessBoolean == true)
+                new PreferBranchlessBooleanPass().Run(function, context);
         }
         catch (Exception ex)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -93,6 +93,32 @@ public sealed record PrinterOptions
     /// </summary>
     public bool PreferConditionalExpressionReturn { get; init; }
 
+    /// <summary>
+    /// When set, a guarded boolean return with a constant arm the default view
+    /// must render as a flat <c>if (c) return A; return B;</c> — because the
+    /// short-circuit fold is not opcode-faithful for that shape (see
+    /// <c>ShortCircuitFidelity</c> / #3114) — is instead rendered as the compact
+    /// short-circuit "bool hack" (<c>return c &amp;&amp; A;</c>,
+    /// <c>return c || X;</c>, <c>return !c &amp;&amp; X;</c>,
+    /// <c>return !c || A;</c>).
+    ///
+    /// Like <see cref="PreferConditionalExpressionReturn"/> this is a
+    /// <b>byte-divergent</b> opt-in <b>style lens</b> (#3138): the short-circuit
+    /// spelling keeps the same condition, surviving operand, and short-circuit
+    /// order, so it is unconditionally <b>behavior-preserving</b>, but it is not
+    /// opcode-faithful (a bare operand recompiles branchless, a negation flips
+    /// polarity), so its output must not feed the compile-back fidelity gates.
+    ///
+    /// Unlike the ternary lens this form is <b>not</b> oracle-endorsed
+    /// (dotnet/runtime's <c>.editorconfig</c> would never recommend it), so it is a
+    /// user compactness preference, opt-in only, and never part of a "full taste"
+    /// aggregate. When both this and
+    /// <see cref="PreferConditionalExpressionReturn"/> are set the oracle-endorsed
+    /// ternary wins (it consumes the shape first). Off by default; the default view
+    /// stays byte-faithful.
+    /// </summary>
+    public bool PreferBranchlessBoolean { get; init; }
+
     /// <summary>The shipped defaults — every knob off.</summary>
     public static PrinterOptions Default { get; } = new();
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PreferBranchlessBooleanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PreferBranchlessBooleanPass.cs
@@ -123,15 +123,22 @@ public sealed class PreferBranchlessBooleanPass : IIrPass
         IrExpression survivingOperand = tailConstant is not null ? thenValue : tailValue;
 
         // BEHAVIOR guards (kept from the default; NOT the opcode-only guards).
-        //  - A user-truthiness condition rebinds to a user-defined &&/|| operator,
-        //    changing the runtime result (and typically failing to compile).
+        //  - User-defined truthiness ANYWHERE in the condition rebinds to a
+        //    user-defined &&/|| operator, changing the runtime result (and
+        //    typically failing to compile). The direct-call check is not enough:
+        //    a wrapped condition such as `LogicalNot(op_True(t))` is unwrapped by
+        //    Conditions.Negate to reveal the bare op_True call the printer strips
+        //    to its user-typed receiver, so we scan the whole condition subtree.
+        //    The default's FoldGuardReturn is incidentally shielded from the
+        //    wrapped case by the opcode-fidelity negation guard this lens relaxes,
+        //    so the lens must guard it explicitly.
         //  - A surviving managed by-ref dereference is eagerly evaluated by csc's
         //    branchless lowering, dereferencing a location the branch had guarded
         //    (null-by-ref NRE divergence). Every other operand is behavior-safe:
         //    a bare local/arg/stack load has no side effect and cannot fault, and a
         //    field/element/call operand keeps the branch (csc does not go branchless
         //    for it), so short-circuit order is preserved either way.
-        if (ShortCircuitFidelity.IsUserDefinedTruthiness(guard.Condition)
+        if (InvolvesUserDefinedTruthiness(guard.Condition)
             || survivingOperand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef })
         {
             return false;
@@ -165,5 +172,26 @@ public sealed class PreferBranchlessBooleanPass : IIrPass
         foldedReturn.InheritSourceOffset(guard);
         guard.ReplaceWith(foldedReturn);
         return true;
+    }
+
+    // True when a user-defined-truthiness call (op_True/op_False) appears anywhere
+    // in the condition subtree — as the root, under a LogicalNot the negation would
+    // unwrap, or nested in a compound condition. Any such call is stripped by the
+    // printer to its bare user-typed receiver, so lifting the condition (or its
+    // negation) into a short-circuit operand would rebind to a user-defined
+    // &&/|| that need not exist (CS0019) and can change the runtime result. The
+    // scan is deliberately conservative: over-declining only leaves the shape flat,
+    // which is always valid and faithful.
+    static bool InvolvesUserDefinedTruthiness(IrExpression condition)
+    {
+        if (ShortCircuitFidelity.IsUserDefinedTruthiness(condition))
+            return true;
+        foreach (var node in condition.Descendants)
+        {
+            if (node is IrExpression expr && ShortCircuitFidelity.IsUserDefinedTruthiness(expr))
+                return true;
+        }
+
+        return false;
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PreferBranchlessBooleanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PreferBranchlessBooleanPass.cs
@@ -122,16 +122,25 @@ public sealed class PreferBranchlessBooleanPass : IIrPass
         //   thenConstant == false: And(!c, tailValue)  negates; operand = tailValue
         IrExpression survivingOperand = tailConstant is not null ? thenValue : tailValue;
 
-        // BEHAVIOR guards (kept from the default; NOT the opcode-only guards).
-        //  - User-defined truthiness ANYWHERE in the condition rebinds to a
-        //    user-defined &&/|| operator, changing the runtime result (and
-        //    typically failing to compile). The direct-call check is not enough:
-        //    a wrapped condition such as `LogicalNot(op_True(t))` is unwrapped by
-        //    Conditions.Negate to reveal the bare op_True call the printer strips
-        //    to its user-typed receiver, so we scan the whole condition subtree.
-        //    The default's FoldGuardReturn is incidentally shielded from the
-        //    wrapped case by the opcode-fidelity negation guard this lens relaxes,
-        //    so the lens must guard it explicitly.
+        // BEHAVIOR/SCOPE guards (kept from the default; NOT the opcode-only guards).
+        //  - User-defined truthiness ANYWHERE in the condition takes the shape out
+        //    of this lens's scope. Every fold of such a condition is one of:
+        //    (a) INVALID — the printer strips op_True/op_False to its bare user-typed
+        //        receiver, so `t && b` / `t || b` fails to compile (no user &/|,
+        //        CS0019); (b) BEHAVIOR-DIVERGENT — were a user `&`/`|` present, the
+        //        lift would rebind to its operator semantics instead of the guarded
+        //        control flow; or (c) VALID but NOT branchless — a negation spelled
+        //        as the ternary `(t ? false : true)` re-embeds a branch, which is not
+        //        the compact short-circuit form this lens exists to produce. So the
+        //        lens declines every user-truthiness condition wholesale. The direct
+        //        root check is not enough (a `LogicalNot(op_True(t))` unwraps to a
+        //        bare op_True under Conditions.Negate), so we scan the whole subtree.
+        //        Plain bools, comparisons, and nullable bools never emit
+        //        op_True/op_False, so this only ever declines the out-of-scope
+        //        truthiness family; over-declining is always valid and faithful.
+        //    The default's FoldGuardReturn is incidentally shielded from the wrapped
+        //    case by the opcode-fidelity negation guard this lens relaxes, so the
+        //    lens must guard it explicitly.
         //  - A surviving managed by-ref dereference is eagerly evaluated by csc's
         //    branchless lowering, dereferencing a location the branch had guarded
         //    (null-by-ref NRE divergence). Every other operand is behavior-safe:
@@ -176,12 +185,12 @@ public sealed class PreferBranchlessBooleanPass : IIrPass
 
     // True when a user-defined-truthiness call (op_True/op_False) appears anywhere
     // in the condition subtree — as the root, under a LogicalNot the negation would
-    // unwrap, or nested in a compound condition. Any such call is stripped by the
-    // printer to its bare user-typed receiver, so lifting the condition (or its
-    // negation) into a short-circuit operand would rebind to a user-defined
-    // &&/|| that need not exist (CS0019) and can change the runtime result. The
-    // scan is deliberately conservative: over-declining only leaves the shape flat,
-    // which is always valid and faithful.
+    // unwrap, or nested in a compound condition. Such a condition is out of this
+    // lens's scope: its fold is invalid, behavior-divergent, or a non-branchless
+    // ternary re-embed (see the call-site comment). The scan checks the condition
+    // itself AND its descendants because IrNode.Descendants is self-exclusive. It is
+    // deliberately conservative: over-declining only leaves the shape flat, which is
+    // always valid and faithful.
     static bool InvolvesUserDefinedTruthiness(IrExpression condition)
     {
         if (ShortCircuitFidelity.IsUserDefinedTruthiness(condition))

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PreferBranchlessBooleanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PreferBranchlessBooleanPass.cs
@@ -1,0 +1,169 @@
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Opt-in <b>style lens</b> (#3138), off the default pipeline and gated by
+/// <see cref="PrinterOptions.PreferBranchlessBoolean"/>: rewrites a flat guarded
+/// boolean return whose then- or tail-arm is a <c>bool</c> constant —
+/// <c>if (c) return A; return false;</c>, <c>if (c) return true; return X;</c>,
+/// and the negating duals — into the compact short-circuit "bool hack"
+/// (<c>return c &amp;&amp; A;</c>, <c>return c || X;</c>, <c>return !c &amp;&amp; X;</c>,
+/// <c>return !c || A;</c>). This is the exact fold
+/// <see cref="BooleanFoldingPass"/>'s <c>FoldGuardReturn</c> emitted <em>before</em>
+/// #3114 taught it to decline the shapes that are not opcode-faithful; the lens
+/// re-offers precisely those declined shapes.
+///
+/// Unlike the ternary lens (<see cref="PreferConditionalReturnPass"/>), this form
+/// is <b>not oracle-endorsed</b> — dotnet/runtime's <c>.editorconfig</c> never
+/// encourages <c>!(a &amp;&amp; b) &amp;&amp; c</c> over a readable ternary — so it is a
+/// user <em>compactness/branchless</em> preference, opt-in only, and never part of
+/// the "full taste" aggregate.
+///
+/// It runs only on the opt-in raised path, AFTER the default pipeline has
+/// deliberately left the guarded bool return flat because no short-circuit fold of
+/// that shape recompiles to the original branch opcodes (a bare-load operand csc
+/// collapses to a branchless <c>&amp;</c>/<c>|</c>, or a negation that flips
+/// ordered/unordered or operator tokens — see <see cref="ShortCircuitFidelity"/>).
+/// Those are <b>opcode</b> divergences, not behavior ones: the short-circuit
+/// spelling evaluates the same condition, keeps the same surviving operand, and
+/// preserves short-circuit order, so the rewrite is <b>behavior-preserving</b>.
+/// That is what makes it a tier-3 lens rather than a raising pass — its output is
+/// byte-divergent and must never feed the compile-back fidelity gates.
+///
+/// <para>Two hazards from the default's guards are genuinely about <em>behavior</em>
+/// (not just bytes) and are therefore KEPT here:</para>
+/// <list type="bullet">
+/// <item>A <b>user-defined-truthiness</b> condition
+/// (<see cref="ShortCircuitFidelity.IsUserDefinedTruthiness"/>): lifting it into a
+/// short-circuit operand rebinds to the user-defined <c>&amp;&amp;</c>/<c>||</c>,
+/// reselecting an overload and changing the runtime result (and often failing to
+/// compile).</item>
+/// <item>A surviving operand that is a <b>managed by-ref dereference</b>: csc
+/// compiles the short-circuit form branchless, eagerly dereferencing a location the
+/// original branch had guarded — an observable <c>NullReferenceException</c>
+/// divergence on a null by-ref. Every other bare-place operand (local, parameter,
+/// stack slot) is side-effect-free and non-faulting, so eager evaluation is
+/// behavior-safe and IS re-offered.</item>
+/// </list>
+/// </summary>
+public sealed class PreferBranchlessBooleanPass : IIrPass
+{
+    public string Name => "prefer-branchless-boolean";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        // Fixpoint: folding an inner guarded return can expose an outer one whose
+        // tail is now the freshly minted short-circuit return.
+        while (RewriteOnce(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool RewriteOnce(IrFunction function, Stepper stepper)
+    {
+        foreach (var node in function.Descendants.ToList())
+        {
+            if (node.Parent is null || node is not IfStatement guard)
+                continue;
+            if (TryRewriteGuardReturn(function, guard, stepper))
+                return true;
+        }
+
+        return false;
+    }
+
+    // Mirrors FoldGuardReturn's guarded-return match and short-circuit shape
+    // choice exactly (else-less if whose Then is a single Return, immediately
+    // followed by a sibling Return, both arms System.Boolean, exactly one arm a
+    // bool constant, neither Return a live branch target). The default pass
+    // declines the fidelity-erasing folds; this lens re-offers them under the
+    // behavior-only contract, keeping only the two BEHAVIOR hazards.
+    static bool TryRewriteGuardReturn(IrFunction function, IfStatement guard, Stepper stepper)
+    {
+        if (guard.HasElse || guard.Parent is not Block container)
+            return false;
+        if (guard.Then.Children.Count != 1
+            || guard.Then.Children[0] is not Return { Value: { } thenValue } thenReturn)
+        {
+            return false;
+        }
+        if (guard.ChildIndex + 1 >= container.Children.Count
+            || container.Children[guard.ChildIndex + 1] is not Return { Value: { } tailValue } tailReturn)
+        {
+            return false;
+        }
+        if (thenValue.ResultType is not { Namespace: "System", Name: "Boolean" }
+            || tailValue.ResultType is not { Namespace: "System", Name: "Boolean" })
+        {
+            return false;
+        }
+        if (BooleanFoldingPass.ConsumesBranchTarget(function, guard, thenReturn, tailReturn))
+            return false;
+
+        // Decide the shape COMPLETELY before any detach: bailing after a mutation
+        // leaves a mutilated IfStatement whose slots have shifted.
+        bool? tailConstant = tailValue is Constant { Value: bool tail } ? tail : null;
+        bool? thenConstant = thenValue is Constant { Value: bool then } ? then : null;
+
+        // The short-circuit "bool hack" only exists when exactly one arm is a bool
+        // constant (the other becomes the surviving operand). Both-variable arms are
+        // the ternary's domain (return c ? A : B;), and both-opposite-constants
+        // already fold to `return c;`/`return !c;` in the default pipeline, so
+        // neither survives to here as a fold candidate.
+        bool bothConstant = thenConstant is not null && tailConstant is not null;
+        if ((tailConstant is null && thenConstant is null) || bothConstant)
+            return false;
+
+        // negate/operand map (mirrors the fold shapes chosen below):
+        //   tailConstant == true : Or(!c, thenValue)   negates; operand = thenValue
+        //   tailConstant == false: And(c, thenValue)              operand = thenValue
+        //   thenConstant == true : Or(c, tailValue)               operand = tailValue
+        //   thenConstant == false: And(!c, tailValue)  negates; operand = tailValue
+        IrExpression survivingOperand = tailConstant is not null ? thenValue : tailValue;
+
+        // BEHAVIOR guards (kept from the default; NOT the opcode-only guards).
+        //  - A user-truthiness condition rebinds to a user-defined &&/|| operator,
+        //    changing the runtime result (and typically failing to compile).
+        //  - A surviving managed by-ref dereference is eagerly evaluated by csc's
+        //    branchless lowering, dereferencing a location the branch had guarded
+        //    (null-by-ref NRE divergence). Every other operand is behavior-safe:
+        //    a bare local/arg/stack load has no side effect and cannot fault, and a
+        //    field/element/call operand keeps the branch (csc does not go branchless
+        //    for it), so short-circuit order is preserved either way.
+        if (ShortCircuitFidelity.IsUserDefinedTruthiness(guard.Condition)
+            || survivingOperand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef })
+        {
+            return false;
+        }
+
+        var condition = guard.Condition;
+        condition.Detach();
+        IrExpression folded;
+        if (tailConstant is { } tailBool)
+        {
+            thenValue.Detach();
+            // if (c) return A; return true;  ≡ return !c || A;
+            // if (c) return A; return false; ≡ return c && A;
+            folded = tailBool
+                ? new LogicalBinary(LogicalKind.Or, Conditions.Negate(condition), thenValue)
+                : new LogicalBinary(LogicalKind.And, condition, thenValue);
+        }
+        else
+        {
+            tailValue.Detach();
+            // if (c) return true;  return X; ≡ return c || X;
+            // if (c) return false; return X; ≡ return !c && X;
+            folded = thenConstant == true
+                ? new LogicalBinary(LogicalKind.Or, condition, tailValue)
+                : new LogicalBinary(LogicalKind.And, Conditions.Negate(condition), tailValue);
+        }
+
+        tailReturn.Detach();
+        stepper.StepOver("rewrite guarded return into branchless short-circuit", guard);
+        var foldedReturn = new Return(folded);
+        foldedReturn.InheritSourceOffset(guard);
+        guard.ReplaceWith(foldedReturn);
+        return true;
+    }
+}

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -69,6 +69,29 @@ public class RenderStyleConfigTests
     }
 
     [Fact]
+    public void Parse_PreferBranchlessBooleanKey_MapsToLensKnob()
+    {
+        var result = RenderStyleConfig.Parse(
+            "dotnet_inspect_style_prefer_branchless_boolean = true",
+            origin: "cfg");
+
+        Assert.True(result.Options.PreferBranchlessBoolean);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_PreferBranchlessBoolean_DefaultsOffAndToleratesSeverity()
+    {
+        Assert.False(RenderStyleConfig.Parse("", origin: null).Options.PreferBranchlessBoolean);
+
+        var withSeverity = RenderStyleConfig.Parse(
+            "dotnet_inspect_style_prefer_branchless_boolean = true:suggestion",
+            origin: null);
+        Assert.True(withSeverity.Options.PreferBranchlessBoolean);
+        Assert.Empty(withSeverity.Warnings);
+    }
+
+    [Fact]
     public void Parse_FalseValue_LeavesKnobOff()
     {
         var result = RenderStyleConfig.Parse("dotnet_style_qualification_for_field = false", origin: null);

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -48,6 +48,12 @@ internal static class RenderStyleConfig
     private const string PropertyKey = "dotnet_style_qualification_for_property";
     private const string PreferConditionalReturnKey = "dotnet_style_prefer_conditional_expression_over_return";
 
+    // The branchless "bool hack" lens (#3138) is NOT oracle-endorsed — no real
+    // .editorconfig key encourages it — so it is exposed under a tool-owned
+    // namespace rather than a dotnet_style_* key, making clear it is a
+    // dotnet-inspect compactness preference, not an editorconfig concept.
+    private const string PreferBranchlessBooleanKey = "dotnet_inspect_style_prefer_branchless_boolean";
+
     // The editorconfig boundary marker. Discovery is nearest-wins, so the nearest
     // file is already a hard boundary (nothing above it is read); 'root' is
     // recognized so a file copied from a real .editorconfig does not warn, and it
@@ -123,6 +129,7 @@ internal static class RenderStyleConfig
         bool qualifyField = false;
         bool qualifyProperty = false;
         bool preferConditionalReturn = false;
+        bool preferBranchlessBoolean = false;
         List<string>? warnings = null;
 
         void Warn(string message) => (warnings ??= []).Add(message);
@@ -178,6 +185,12 @@ internal static class RenderStyleConfig
                     else
                         Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
                     break;
+                case PreferBranchlessBooleanKey:
+                    if (TryParseBool(value, out var b))
+                        preferBranchlessBoolean = b;
+                    else
+                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
+                    break;
                 case RootKey:
                     // editorconfig boundary marker. Discovery is nearest-wins, so
                     // the nearest file is already a hard boundary; 'root' drives no
@@ -197,6 +210,7 @@ internal static class RenderStyleConfig
             QualifyFieldAccess = qualifyField,
             QualifyPropertyAccess = qualifyProperty,
             PreferConditionalExpressionReturn = preferConditionalReturn,
+            PreferBranchlessBoolean = preferBranchlessBoolean,
         };
 
         return new RenderStyleResolution(options, origin, (IReadOnlyList<string>?)warnings ?? []);


### PR DESCRIPTION
## Summary

The **second** opt-in tier-3 style lens from the #3138 umbrella (behavior-faithful, byte-divergent), following the ternary lens (#3139). `PrinterOptions.PreferBranchlessBoolean` renders a guarded boolean return with a constant arm — which the default view must leave flat because the short-circuit fold is not opcode-faithful for a bare-load operand (#3114) — as the compact short-circuit "bool hack":

```csharp
// default (byte-faithful, the flat guard recompiles exactly):
if (a) { return false; }
return b;
// with PreferBranchlessBoolean (behavior-faithful, byte-divergent):
return !a && b;
```

The four constant-arm shapes fold to `a && b`, `!a || b`, `a || b`, `!a && b`. This re-offers **exactly** the fold `BooleanFoldingPass.FoldGuardReturn` emitted *before* #3114 guarded it — no new capability, a second lens payload.

## Contract: behavior hazards kept, opcode hazards relaxed

The default's `FoldGuardReturn` declines these shapes via three fidelity guards. The lens separates **behavior** hazards (kept) from pure **opcode** hazards (relaxed):

- **Kept — user-defined-truthiness condition**: lifting it into `t && b` rebinds to a user-defined `&&`/`||`, reselecting an overload and changing the runtime result (also typically CS0019). Declined, mirroring #3114/#3139.
- **Kept — managed by-ref surviving operand**: csc's branchless lowering eagerly dereferences a location the branch had guarded (null-by-ref NRE divergence). Declined.
- **Relaxed — negation opcode-exactness** (`NegationIsOpcodeExact`): `Conditions.Negate` is universally behavior-preserving (for floats it flips ordered/unordered to give the correct NaN dual; it is only *opcode*-divergent).
- **Relaxed — bare-place `&`/`|` collapse** (`RendersAsBranchlessBarePlace`): a bare local/arg/stack load is side-effect-free and non-faulting, so csc's branchless form is behavior-identical. (This is the poster case — it is what produces the branchless output the lens exists for.)

## Not oracle-endorsed

dotnet/runtime's `.editorconfig` would never recommend `!(a && b) && c`, so this is a user *compactness/branchless* preference. It is exposed under a **tool-owned** `dotnet_inspect_style_prefer_branchless_boolean` key (not a `dotnet_style_*` key) and is **never** part of a future "full taste" aggregate. When both lenses are enabled the oracle-endorsed **ternary wins** the shared shape (it runs first and consumes the guarded return, leaving this pass a no-op) — deterministic precedence.

## Scope / isolation

Runs only on the opt-in `PrintRaised` options overload, after the default pipeline. The IL-anchored Annotated view (`out statementLines`) and `PrintLowered` do not take options → stay byte-faithful and excluded from the compile-back fidelity gates by construction.

## Evidence

- **Specimen + tests** pin all four fold shapes (`a && b`, `!a || b`, `a || b`, `!a && b`), both behavior-guard declines (user-truthiness, by-ref stay flat), two no-op negatives (both-variable no constant arm; no guarded return), ternary-wins precedence, and an **executed truth-table behavioral-equivalence gate** over every boolean input.
- **Config**: `RenderStyleConfig` key-mapping + severity-tolerance tests.
- **CLI end-to-end**: `.dotnet-inspectconfig` with the key → `=> !a && b;`; without → flat guard.
- Decompiler fast suite **3594/0**; config tests **33/0**; full `slnx` build clean.

## Review

Requires 2-model adversarial review (new behavior/shape). Base `main` @ `70a3dc2e`, head `a66e255a`.