### PR TITLE
Expression-body multi-line single-return expressions (#3084)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -156,6 +156,46 @@ public int Compute() => _count + Extra;          // shipped default: bare
 public int Compute() => this._count + this.Extra; // both knobs on
 ```
 
+### Expression-bodied members
+
+Rendering a value-returning member as `head => <expr>;` instead of a brace block
+wrapping a lone `return <expr>;` is an IL-identical framing choice — the two
+forms are a language-guaranteed equivalence — so it sits below the three-class
+rule, alongside brace style and line wrapping. The oracle is `dotnet/runtime`'s
+`.editorconfig` (`csharp_style_expression_bodied_methods` /
+`_properties` / `_accessors = true`), so the expression-bodied form is the
+shipped default.
+
+A body that is exactly one statement folds on the simple single-line path (a
+lone `return <expr>;`, a `throw`, or a statement-expression). A body that is one
+*multi-line* single expression folds too: a wrapped switch return (issue #3088)
+or any other wrapped single `return <expr>;`, such as a fluent chain
+(issue #3084). The arrow trails the signature line with the expression's opening
+token after it, and the continuation lines re-indent one level under the
+member — the natural multi-line extension of the single-line `head => expr;`
+form.
+
+```csharp
+public static string Pipeline(StringBuilder builder)
+{
+    return builder
+        .Append("alphabet")
+        .Append("bravissimo")
+        .ToString();
+}
+// folds to:
+public static string Pipeline(StringBuilder builder) => builder
+    .Append("alphabet")
+    .Append("bravissimo")
+    .ToString();
+```
+
+The fold is gated on a typed structural signal the printer proves from the
+emitted statement tree — the body is exactly one top-level `return` with no
+lifted declarations, label, constructor chain, field initializer, async
+modifier, or unsupported fallback — never a re-parse of the rendered text. A
+member with any statement preceding the return keeps its brace block.
+
 ### Line wrapping
 
 Breaking a long line across continuation lines is pure whitespace: it emits the

--- a/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
@@ -47,6 +47,31 @@ public sealed class CSharpExpressionBodyTests
             lines);
     }
 
+    [Fact]
+    public void MultilineReturnExpressionLines_SplitsFluentChainReturn()
+    {
+        // Issue #3084: extraction is not switch-specific. A wrapped fluent chain
+        // return yields its receiver as the value line and each chained call as a
+        // continuation line at its body-relative indent.
+        var lines = CSharpExpressionBody.MultilineReturnExpressionLines(
+            "return builder\n    .Append(\"a\")\n    .Append(\"b\")\n    .ToString();");
+        Assert.NotNull(lines);
+        Assert.Equal(
+            ["builder", "    .Append(\"a\")", "    .Append(\"b\")", "    .ToString()"],
+            lines);
+    }
+
+    [Fact]
+    public void MultilineReturnExpressionLines_SplitsWrappedTernaryReturn()
+    {
+        var lines = CSharpExpressionBody.MultilineReturnExpressionLines(
+            "return condition\n    ? first\n    : second;");
+        Assert.NotNull(lines);
+        Assert.Equal(
+            ["condition", "    ? first", "    : second"],
+            lines);
+    }
+
     [Theory]
     [InlineData("return value.Length;")]          // single line — FromSingleStatement owns it
     [InlineData("result = 0;\nreturn x switch\n{\n    _ => 1,\n};")]  // has a leading statement, but the string still starts non-`return`

--- a/src/ILInspector.CSharp.Tests/CSharpMemberLayoutTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpMemberLayoutTests.cs
@@ -122,6 +122,44 @@ public sealed class CSharpMemberLayoutTests
             + "    }\n",
             Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, bodyIsSingleReturnExpression: false));
 
+    // Issue #3084: the same single-return expression-body fold is not
+    // switch-specific — any multi-line single `return <expr>;` (here a wrapped
+    // fluent chain) renders expression-bodied, the chain receiver trailing the
+    // arrow and each chained call re-indented one level under the member.
+    const string FluentChainReturnBody =
+        "return builder\n    .Append(\"a\")\n    .Append(\"b\")\n    .ToString();";
+
+    [Fact]
+    public void Append_MultilineFluentReturn_RendersExpressionBodied_SameLineArrow()
+        => Assert.Equal(
+            "    string Build(StringBuilder builder) => builder\n"
+            + "        .Append(\"a\")\n"
+            + "        .Append(\"b\")\n"
+            + "        .ToString();\n",
+            Render("string Build(StringBuilder builder)", FluentChainReturnBody, indent: 4, bodyIsSingleReturnExpression: true));
+
+    [Fact]
+    public void Append_MultilineFluentReturn_WrapsArrowOnNextLine_WhenRequested()
+        => Assert.Equal(
+            "    string Build(StringBuilder builder)\n"
+            + "        => builder\n"
+            + "            .Append(\"a\")\n"
+            + "            .Append(\"b\")\n"
+            + "            .ToString();\n",
+            Render("string Build(StringBuilder builder)", FluentChainReturnBody, indent: 4, wrapExpressionBodyArrow: true, bodyIsSingleReturnExpression: true));
+
+    [Fact]
+    public void Append_MultilineFluentReturn_StaysBlock_WhenSignalNotSet()
+        => Assert.Equal(
+            "    string Build(StringBuilder builder)\n"
+            + "    {\n"
+            + "        return builder\n"
+            + "            .Append(\"a\")\n"
+            + "            .Append(\"b\")\n"
+            + "            .ToString();\n"
+            + "    }\n",
+            Render("string Build(StringBuilder builder)", FluentChainReturnBody, indent: 4, bodyIsSingleReturnExpression: false));
+
     [Fact]
     public void AppendIndentedBody_PreservesBlankLinesAndTrimsTrailing()
     {

--- a/src/ILInspector.CSharp/CSharpExpressionBody.cs
+++ b/src/ILInspector.CSharp/CSharpExpressionBody.cs
@@ -30,15 +30,17 @@ public static class CSharpExpressionBody
     }
 
     /// <summary>
-    /// The expression of a <em>multi-line</em> single-<c>return</c> body — the
-    /// raised switch-expression return (issue #3088) — as its lines, with the
-    /// leading <c>return </c> and trailing <c>;</c> removed and every line's
-    /// trailing whitespace trimmed. The first entry is the value/arrow line
-    /// (<c>&lt;value&gt; switch</c>); the rest are the block lines (<c>{</c>,
-    /// one arm per line, <c>}</c>) at their body-relative (column-zero) indent,
-    /// which the layout re-indents under the member. Returns <see langword="null"/>
-    /// for a single-line body (that is <see cref="FromSingleStatement"/>'s job) or
-    /// anything not shaped as <c>return &lt;expr&gt;;</c>.
+    /// The expression of a <em>multi-line</em> single-<c>return</c> body — a raised
+    /// switch-expression return (issue #3088), a wrapped fluent chain, or any other
+    /// wrapped single expression (issue #3084) — as its lines, with the leading
+    /// <c>return </c> and trailing <c>;</c> removed and every line's trailing
+    /// whitespace trimmed. The first entry is the value/arrow line (the token that
+    /// opens the expression, such as <c>&lt;value&gt; switch</c> or the chain's
+    /// receiver); the rest are the continuation lines at their body-relative
+    /// (column-zero) indent, which the layout re-indents under the member. Returns
+    /// <see langword="null"/> for a single-line body (that is
+    /// <see cref="FromSingleStatement"/>'s job) or anything not shaped as
+    /// <c>return &lt;expr&gt;;</c>.
     /// </summary>
     /// <remarks>
     /// This never asserts, on its own, that the body is a single statement — a

--- a/src/ILInspector.CSharp/CSharpMemberLayout.cs
+++ b/src/ILInspector.CSharp/CSharpMemberLayout.cs
@@ -32,10 +32,11 @@ public static class CSharpMemberLayout
     /// <c>DecompilerResult.BodyIsSingleReturnExpression</c> signal, that
     /// <paramref name="body"/> is exactly one <c>return &lt;expr&gt;;</c>
     /// statement whose expression spans several lines (a raised switch
-    /// expression). Such a body renders expression-bodied — <c>head =&gt; &lt;value&gt;
-    /// switch { … };</c> — with the switch block re-indented under the member
-    /// (issue #3088). Only ever set for a multi-line body; single-line bodies
-    /// stay on the <see cref="CSharpExpressionBody.FromSingleStatement"/> path.
+    /// expression, a wrapped fluent chain, or any other wrapped single
+    /// expression). Such a body renders expression-bodied — <c>head =&gt; &lt;value&gt;</c>
+    /// with the continuation lines re-indented under the member (issues #3088 and
+    /// #3084). Only ever set for a multi-line body; single-line bodies stay on the
+    /// <see cref="CSharpExpressionBody.FromSingleStatement"/> path.
     /// </param>
     public static void Append(StringBuilder sb, string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleReturnExpression = false)
     {
@@ -75,13 +76,15 @@ public static class CSharpMemberLayout
 
     /// <summary>
     /// Renders a multi-line single-<c>return</c> expression body (a raised switch
+    /// expression, a wrapped fluent chain, or any other wrapped single
     /// expression). The value/arrow line sits after the arrow — on
     /// <paramref name="head"/>'s line, or, when
     /// <paramref name="wrapExpressionBodyArrow"/> is set, one level deeper on its
-    /// own line — and the block lines re-indent so the switch <c>{</c> aligns with
-    /// the token that opens the expression: the member indent for the same-line
-    /// arrow, or the arrow's indent for the wrapped arrow. The final line gains the
-    /// statement terminator (<c>};</c>). Blank lines are preserved.
+    /// own line — and the continuation lines re-indent so that whatever opens the
+    /// expression (a switch <c>{</c>, a chained <c>.Method(…)</c>) aligns with the
+    /// token after the arrow: the member indent for the same-line arrow, or the
+    /// arrow's indent for the wrapped arrow. The final line gains the statement
+    /// terminator (<c>;</c>). Blank lines are preserved.
     /// </summary>
     static void AppendMultilineExpressionBody(
         StringBuilder sb, string head, IReadOnlyList<string> expressionLines, int indent, bool wrapExpressionBodyArrow)

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
@@ -83,6 +83,58 @@ public class MemberBodyProducerExpressionBodyTests
         Assert.DoesNotContain("TwoStatements(object shape, out bool matched) =>", source);
     }
 
+    [Fact]
+    public void SingleWrappedFluentReturn_RendersExpressionBodied()
+    {
+        // Issue #3084: the single-return expression-body fold is not
+        // switch-specific. A method whose whole body is one `return <fluent
+        // chain>;` wide enough to wrap also folds to an expression-bodied
+        // member — the arrow trails the signature with the chain receiver after
+        // it, continuations one level deeper.
+        using var assembly = Compile("""
+            public class Fx
+            {
+                public static string Build(System.Text.StringBuilder builder)
+                {
+                    return builder.Append("alphabet").Append("bravissimo").Append("charlateral").Append("deltatango").Append("echolocation").Append("foxtrotter").ToString();
+                }
+            }
+            """);
+
+        string source = ComposeType(assembly.Path, "Fx");
+
+        Assert.Contains("public static string Build(StringBuilder builder) => builder", source);
+        Assert.Contains("\n        .Append(\"alphabet\")", source);
+        Assert.Contains("\n        .ToString();", source);
+        // The old block form (a brace block wrapping a lone `return`) is gone.
+        Assert.DoesNotContain("return builder", source);
+        Assert.DoesNotContain("Build(StringBuilder builder)\n    {", source);
+    }
+
+    [Fact]
+    public void WrappedFluentReturnAfterAnotherStatement_StaysBlock()
+    {
+        // Close negative: a statement preceding the wrapped return makes the
+        // body two statements, not a single return expression, so it keeps the
+        // brace-block body.
+        using var assembly = Compile("""
+            public class Fx
+            {
+                public static string Build(System.Text.StringBuilder builder)
+                {
+                    builder.Append("prefix");
+                    return builder.Append("alphabet").Append("bravissimo").Append("charlateral").Append("deltatango").Append("echolocation").Append("foxtrotter").ToString();
+                }
+            }
+            """);
+
+        string source = ComposeType(assembly.Path, "Fx");
+
+        Assert.Contains("public static string Build(StringBuilder builder)\n    {", source);
+        Assert.DoesNotContain("Build(StringBuilder builder) =>", source);
+        Assert.Contains("return builder", source);
+    }
+
     static string ComposeType(string path, string fullName)
     {
         using var pe = new PEReader(File.OpenRead(path));

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
@@ -135,6 +135,43 @@ public class MemberBodyProducerExpressionBodyTests
         Assert.Contains("return builder", source);
     }
 
+    [Fact]
+    public void SingleStackallocPointerReturn_StaysBlock()
+    {
+        // GPT review of #3141: a lone `return stackalloc ...;` whose value the
+        // printer expands into a lifted local declaration (inside an `unsafe`
+        // block) is still one top-level Return, and its output is multi-line, so
+        // it satisfied the earlier flag guard. But its printed body does not
+        // begin with a bare `return `, so it is not a foldable expression body.
+        // The text guard keeps BodyIsSingleReturnExpression off, matching what
+        // MultilineReturnExpressionLines would accept, and the member stays a
+        // brace block. (Output was already correct via downstream re-gating;
+        // this locks the member framing so a future guard relaxation cannot
+        // silently fold a multi-statement expansion.)
+        using var assembly = Compile("""
+            public unsafe class Fx
+            {
+                public static int* Grab()
+                {
+                    unsafe
+                    {
+                        int* p = stackalloc int[10];
+                        return p;
+                    }
+                }
+            }
+            """, allowUnsafe: true);
+
+        string source = ComposeType(assembly.Path, "Fx");
+
+        // Brace-block body (arrow header absent; body opens with `{`), with the
+        // lifted stackalloc declaration inside.
+        Assert.DoesNotContain("Grab() =>", source);
+        Assert.Contains("Grab()\n    {", source);
+        Assert.Contains("stackalloc byte[40]", source);
+        Assert.Contains("return (int*)__stackalloc;", source);
+    }
+
     static string ComposeType(string path, string fullName)
     {
         using var pe = new PEReader(File.OpenRead(path));
@@ -145,7 +182,7 @@ public class MemberBodyProducerExpressionBodyTests
         return source!.ReplaceLineEndings("\n");
     }
 
-    static TempAssembly Compile(string source)
+    static TempAssembly Compile(string source, bool allowUnsafe = false)
     {
         var path = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-exprbody-{Guid.NewGuid():N}.dll");
         var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
@@ -153,7 +190,10 @@ public class MemberBodyProducerExpressionBodyTests
             Path.GetFileNameWithoutExtension(path),
             [tree],
             RuntimeReferences(),
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                allowUnsafe: allowUnsafe,
+                nullableContextOptions: NullableContextOptions.Enable));
 
         using var stream = File.Create(path);
         var result = compilation.Emit(stream);

--- a/src/ILInspector.Decompiler.Tests/MultiLineExpressionBodyRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MultiLineExpressionBodyRenderTests.cs
@@ -1,0 +1,47 @@
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #3084: a single-`return` member whose one expression wraps across lines renders
+// as an expression-bodied member rather than a brace block wrapping a lone
+// `return`. Block body and expression body are IL-identical; the oracle
+// (dotnet/runtime source and its .editorconfig) prefers the expression-bodied
+// form, and the arrow trails the signature line with the expression's opening
+// token after it — the same shape #3125 shipped for switch returns and the
+// natural multi-line extension of the single-line `head => expr;` default.
+[Trait("Area", "RoundTrip")]
+public sealed class MultiLineExpressionBodyRenderTests
+{
+    static string AssemblyPath => typeof(MultiLineExpressionBodyRenderTests).Assembly.Location;
+
+    static ApiType Specimen()
+    {
+        using var pe = new PEReader(File.OpenRead(AssemblyPath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        return Assert.Single(api.Types, t => t.FullName == typeof(MultiLineExpressionBodySamples).FullName);
+    }
+
+    [Fact]
+    public void WrappedSingleReturn_RendersStyleBExpressionBody()
+    {
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == nameof(MultiLineExpressionBodySamples.Pipeline));
+
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null);
+
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.Equal(
+            "    public static string Pipeline(StringBuilder builder) => builder\n" +
+            "        .Append(\"alphabet\")\n" +
+            "        .Append(\"bravissimo\")\n" +
+            "        .Append(\"charlateral\")\n" +
+            "        .Append(\"deltatango\")\n" +
+            "        .Append(\"echolocation\")\n" +
+            "        .Append(\"foxtrotter\")\n" +
+            "        .ToString();",
+            rendered.Text!.Replace("\r\n", "\n"));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/MultiLineExpressionBodySamples.cs
+++ b/src/ILInspector.Decompiler.Tests/MultiLineExpressionBodySamples.cs
@@ -1,0 +1,22 @@
+using System.Text;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #3084 witness: a single-`return` method whose one expression is wide enough to
+// wrap (the always-on fluent-chain wrapper breaks it one call per line). The
+// member layout must render the wrapped single expression as an
+// expression-bodied member (the arrow trails the signature line and the
+// expression's receiver follows it, continuations one level deeper), not a brace
+// block wrapping a lone `return`.
+public static class MultiLineExpressionBodySamples
+{
+    public static string Pipeline(StringBuilder builder)
+        => builder
+            .Append("alphabet")
+            .Append("bravissimo")
+            .Append("charlateral")
+            .Append("deltatango")
+            .Append("echolocation")
+            .Append("foxtrotter")
+            .ToString();
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -265,13 +265,16 @@ public sealed record DecompilerResult(
     public bool ContainsAwaitExpression { get; init; }
 
     /// <summary>
-    /// True when the whole body is exactly one <c>return &lt;switch-expression&gt;;</c>
-    /// statement — a multi-line switch-expression return with nothing else in the
-    /// body. The member layer (<see cref="ILInspector.CSharp.CSharpMemberLayout"/>)
-    /// consumes this typed structural fact to render the member expression-bodied
-    /// (<c>head =&gt; &lt;value&gt; switch { … };</c>) instead of a brace block
-    /// (issue #3088). It is a body-shape fact the printer proves from the emitted
-    /// statement tree, so consumers never re-parse the rendered text to recover it.
+    /// True when the whole body is exactly one multi-line
+    /// <c>return &lt;expression&gt;;</c> statement — a single wrapped expression with
+    /// nothing else in the body. The member layer
+    /// (<see cref="ILInspector.CSharp.CSharpMemberLayout"/>) consumes this typed
+    /// structural fact to render the member expression-bodied
+    /// (<c>head =&gt; &lt;expr&gt;;</c>) instead of a brace block wrapping a lone
+    /// <c>return</c> — a raised multi-line switch return (issue #3088) or any other
+    /// wrapped single expression such as a fluent chain (issue #3084). It is a
+    /// body-shape fact the printer proves from the emitted statement tree, so
+    /// consumers never re-parse the rendered text to recover it.
     /// </summary>
     public bool BodyIsSingleReturnExpression { get; init; }
 

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1230,8 +1230,9 @@ public static class MemberBodyProducer
         // (csharp_style_expression_bodied_properties/accessors = true):
         // a lone getter returning one expression is 'head => expr;', and any
         // single-statement accessor is 'get/set => ...;'. A lone getter whose
-        // body is one multi-line 'return <switch>;' also folds to an expression
-        // body (issue #3088), gated on the printer's typed single-return signal.
+        // body is one multi-line 'return <expr>;' also folds to an expression
+        // body (a raised switch return, issue #3088; a wrapped single expression,
+        // issue #3084), gated on the printer's typed single-return signal.
         if (accessors is [("get", { } loneGet, _, var loneGetSingleReturn)]
             && (loneGetSingleReturn || CSharpExpressionBody.FromSingleStatement(loneGet) is not null))
         {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -261,10 +261,16 @@ public sealed partial class CSharpPrinter
     /// is exactly one <see cref="Return"/> with no lifted declarations, its whole
     /// printed form is that one <c>return &lt;expr&gt;;</c> statement, so folding it
     /// to <c>head =&gt; &lt;expr&gt;;</c> is a language-guaranteed equivalence. The
-    /// only text-derived input is whether that single return actually wrapped:
-    /// a single-line return already folds on the
-    /// <see cref="CSharpExpressionBody.FromSingleStatement"/> path, so this signal
-    /// stays reserved for the multi-line case the flat helper cannot recover.
+    /// only text-derived input is whether that single return actually wrapped and
+    /// printed as a bare <c>return &lt;expr&gt;;</c>: a single-line return already
+    /// folds on the <see cref="CSharpExpressionBody.FromSingleStatement"/> path, so
+    /// this signal stays reserved for the multi-line case the flat helper cannot
+    /// recover. A rare single <see cref="Return"/> whose value the printer expands
+    /// into several statements (for example a <c>stackalloc</c>-to-pointer return
+    /// that lifts a local declaration inside an <c>unsafe</c> block) does not print
+    /// as a leading <c>return </c>, so the text guard keeps the flag off — matching
+    /// what <see cref="CSharpExpressionBody.MultilineReturnExpressionLines"/> would
+    /// accept, so the signal never claims a fold the member layer would reject.
     /// </summary>
     bool BodyIsSingleReturnExpression(IrFunction function, string output)
         => !_emittedDeclarations
@@ -274,7 +280,22 @@ public sealed partial class CSharpPrinter
             && !function.RequiresAsyncBodyModifier
             && !NeedsUnsupportedFallbackReturn(function)
             && _topLevelStatements is [Return { Value: not null }]
-            && output.AsSpan().Trim().Contains('\n');
+            && IsMultilineReturnExpressionText(output);
+
+    /// <summary>
+    /// True when <paramref name="output"/> is a multi-line body that begins with a
+    /// bare <c>return </c> — the exact text shape
+    /// <see cref="CSharpExpressionBody.MultilineReturnExpressionLines"/> extracts.
+    /// Keeps <see cref="BodyIsSingleReturnExpression"/> aligned with the downstream
+    /// extractor so the typed flag is never set for a single return the printer
+    /// expanded into multiple statements (which would not fold anyway).
+    /// </summary>
+    static bool IsMultilineReturnExpressionText(string output)
+    {
+        var trimmed = output.AsSpan().Trim();
+        return trimmed.Contains('\n')
+            && trimmed.StartsWith("return ", StringComparison.Ordinal);
+    }
 
     DecompilerOptions EffectiveDecompilerOptions()
         => new()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -245,37 +245,36 @@ public sealed partial class CSharpPrinter
             RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
             RequiresUnsafeBodyModifier = function.Descendants.Prepend(function).Any(NeedsUnsafeContext),
             ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
-            BodyIsSingleReturnExpression = BodyIsSingleReturnExpression(function),
+            BodyIsSingleReturnExpression = BodyIsSingleReturnExpression(function, output),
             Metadata = new DecompilerResultMetadata(EffectiveDecompilerOptions(), [.. _decisions]),
         };
 
     /// <summary>
     /// True when the printed body is exactly one top-level
-    /// <c>return &lt;switch-expression&gt;;</c> statement — a multi-line
-    /// switch-expression return with nothing else in the body. The member layer
-    /// renders such a body as an expression-bodied member (issue #3088). The
-    /// check is structural (the emitted top-level statement list plus the lifts
-    /// the printer already tracked), never a re-parse of the rendered text, and
-    /// stays deliberately narrow: only the switch-expression return values that
-    /// render as a self-contained <c>&lt;value&gt; switch { … }</c> qualify, so a
-    /// return whose printed form spans several statements (a
-    /// <c>stackalloc</c>-to-pointer return) is excluded.
+    /// <c>return &lt;expression&gt;;</c> statement whose expression spans several
+    /// lines — a single multi-line expression with nothing else in the body. The
+    /// member layer renders such a body as an expression-bodied member (a raised
+    /// multi-line switch return, issue #3088; a wrapped fluent chain or other
+    /// wrapped single expression, issue #3084). The single-statement shape is
+    /// structural (the emitted top-level statement list plus the lifts the printer
+    /// already tracked), never a re-parse of the rendered text: because the body
+    /// is exactly one <see cref="Return"/> with no lifted declarations, its whole
+    /// printed form is that one <c>return &lt;expr&gt;;</c> statement, so folding it
+    /// to <c>head =&gt; &lt;expr&gt;;</c> is a language-guaranteed equivalence. The
+    /// only text-derived input is whether that single return actually wrapped:
+    /// a single-line return already folds on the
+    /// <see cref="CSharpExpressionBody.FromSingleStatement"/> path, so this signal
+    /// stays reserved for the multi-line case the flat helper cannot recover.
     /// </summary>
-    bool BodyIsSingleReturnExpression(IrFunction function)
+    bool BodyIsSingleReturnExpression(IrFunction function, string output)
         => !_emittedDeclarations
             && !_topLevelHasLabel
             && _constructorChain is null
             && _fieldInitializers.Count == 0
             && !function.RequiresAsyncBodyModifier
             && !NeedsUnsupportedFallbackReturn(function)
-            && _topLevelStatements is
-            [
-                Return
-                {
-                    Value: SwitchExpression or PatternSwitchExpression
-                        or UnionSwitchExpression or TupleSwitchExpression
-                }
-            ];
+            && _topLevelStatements is [Return { Value: not null }]
+            && output.AsSpan().Trim().Contains('\n');
 
     DecompilerOptions EffectiveDecompilerOptions()
         => new()

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -233,6 +233,41 @@ public class ApiOutputFormatterTests
         Assert.Contains("return shape switch", source);
     }
 
+    [Fact]
+    public void FormatSourceWithDeclaration_SingleFluentReturn_RendersExpressionBodied()
+    {
+        // #3084: the single-return expression-body fold is not switch-specific.
+        // A member whose only statement is a multi-line `return <fluent chain>;`
+        // renders expression-bodied too — the chain receiver trails the arrow and
+        // the chained calls keep their column-zero body indent under the
+        // column-zero declaration.
+        var type = new ApiType { Namespace = "Samples", Name = "Builder", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Build",
+            Kind = "method",
+            SignatureModel = new ApiSignature { MemberName = "Build", ReturnType = "System.String" }
+        };
+        var result = DecompilerResult.Success(
+            "return builder\n    .Append(\"a\")\n    .Append(\"b\")\n    .ToString();") with
+        {
+            BodyIsSingleReturnExpression = true
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            member,
+            methodGenericParameters: null,
+            result,
+            preferExpressionBodied: true)
+            .ReplaceLineEndings("\n");
+
+        Assert.EndsWith(" => builder", Declaration(source));
+        Assert.Contains("\n    .Append(\"a\")\n    .Append(\"b\")\n    .ToString();", source);
+        Assert.EndsWith(".ToString();", source.TrimEnd());
+        Assert.DoesNotContain("return builder", source);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2236,12 +2236,14 @@ public static class ApiOutputFormatter
         if (!hasLeadingComments && preferExpressionBodied && CSharpExpressionBody.FromSingleStatement(body) is { } expressionBody)
             return $"{declaration} => {expressionBody};";
 
-        // A multi-line single-return switch expression renders expression-bodied
-        // too (issue #3088): `head => <value> switch { ... };`. The block lines
-        // sit at their body-relative (column-zero) indent, so at this member's
-        // column-zero declaration they need no re-indentation. Gate strictly on
-        // the printer's typed BodyIsSingleReturnExpression signal; the extraction
-        // helper is not sound on the flat string alone.
+        // A multi-line single-return expression renders expression-bodied too
+        // (a raised switch return, issue #3088; a wrapped fluent chain or other
+        // wrapped single expression, issue #3084): `head => <value>` with the
+        // continuation lines below. Those lines sit at their body-relative
+        // (column-zero) indent, so at this member's column-zero declaration they
+        // need no re-indentation. Gate strictly on the printer's typed
+        // BodyIsSingleReturnExpression signal; the extraction helper is not sound
+        // on the flat string alone.
         if (!hasLeadingComments && preferExpressionBodied && result.BodyIsSingleReturnExpression
             && CSharpExpressionBody.MultilineReturnExpressionLines(body) is { Count: > 0 } multilineExpression)
         {


### PR DESCRIPTION
- Fixes/advances #3084
- Renders any method/accessor whose only statement is a multi-line `return <expr>;` (a wrapped fluent chain, ternary, or the four switch-expression kinds) as an expression-bodied member.
- Card revision: `66812cc9`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — generalizes the single-return expression-body fold #3125 shipped for multi-line switch returns to *any* multi-line single `return <expr>;`, gated on the same typed structural signal (never string-sniffing). One broadened printer gate; all downstream threading was already general.

### Original source

The witness is a csc-compiled fixture (`MultiLineExpressionBodySamples.Pipeline`) with no PDB, so SourceLink C# is unavailable. The compiled-in C#, shown for context:

```csharp
public static string Pipeline(StringBuilder builder)
    => builder
        .Append("alphabet").Append("bravissimo").Append("charlateral")
        .Append("deltatango").Append("echolocation").Append("foxtrotter")
        .ToString();
```

### Before

`member MultiLineExpressionBodySamples Pipeline --library <tests.dll> -S "Decompiled Source"` at the base commit (`402ef9c7`, #3125):

```csharp
public static string Pipeline(System.Text.StringBuilder builder)
{
    return builder
        .Append("alphabet")
        .Append("bravissimo")
        .Append("charlateral")
        .Append("deltatango")
        .Append("echolocation")
        .Append("foxtrotter")
        .ToString();
}
```

- Valid: True
- Correct: True

The single expression is already fully raised; it is just block-bodied rather than the idiomatic expression-bodied form (#3125 only folded switch returns, not fluent chains).

### After

Same command at this PR's head (`66812cc9`):

```csharp
public static string Pipeline(System.Text.StringBuilder builder) => builder
    .Append("alphabet")
    .Append("bravissimo")
    .Append("charlateral")
    .Append("deltatango")
    .Append("echolocation")
    .Append("foxtrotter")
    .ToString();
```

- Valid: True
- Correct: True

The arrow trails the signature with the chain receiver after it and the calls re-indent one level under the member — reusing #3125's `AppendMultilineExpressionBody`. A sibling method with a statement before the return correctly stays block-bodied.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline (`402ef9c7`) | Head (`66812cc9`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| `MemberBodyProducerExpressionBodyTests` (e2e) | n/a (2 new tests) | 4 total, 0 failed |
| `MultiLineExpressionBodyRenderTests` (witness golden) | n/a (new) | 1 total, 0 failed |
| `ILInspector.CSharp.Tests` | 321, 0 failed | 321, 0 failed |
| Decompiler fast suite | 3568, 0 failed | 3574, 0 failed (+6 new) |
| Full `dotnet-inspect.Tests` | 2026, 1 failed | 2026, 1 failed |

The one full-suite failure, `PlatformResolverTests.GetPacksDirectory_ReturnsValidPath`, is pre-existing and environmental (packs-v2 cache path on this machine); it passes in isolation on both baseline and head and is unchanged by this PR (same test, same reason).

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — presentation-only, exactly as #3125. This PR only sets the `BodyIsSingleReturnExpression` flag consumed by the member-layout layer; it never changes the raised IR or the printer's body string (`return X;`). Only the block-vs-expression-bodied member framing of an already-fully-raised body differs, so lowering/branch residue and fidelity metrics are identical to baseline and the corpus quick gate is not applicable to this change.

## Validation

```bash
dotnet build src/dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.MemberBodyProducerExpressionBodyTests -class ILInspector.Decompiler.Tests.MultiLineExpressionBodyRenderTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.CSharp.Tests -c Release
```

## Scope boundary

Multi-line single `throw` and expression-statement bodies remain a deliberate follow-up; their single-line forms already fold via `FromSingleStatement`.
