### PR TITLE
Filter native DLLs from harness compile-back references; anchor event accessors

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -59,6 +59,8 @@
     <Compile Include="..\..\tools\DecompilerHarness\InverseLedger.cs" Link="InverseArchitecture\InverseLedger.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\HarnessLog.cs"
              Link="HarnessLog.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\ManagedReferenceFilter.cs"
+             Link="ManagedReferenceFilter.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\DecompilerHarnessReportViews.cs"
              Link="DecompilerHarnessReportViews.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusMetadata.cs"

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -4074,6 +4074,8 @@ static class FidelityCheck
                 return;
             if (!File.Exists(path))
                 return;
+            if (!ManagedReferenceFilter.IsManagedAssembly(path))
+                return;
             string simple = Path.GetFileNameWithoutExtension(path);
             if (seen.Contains(simple))
                 return; // first definition wins (prefer TPA over a dir copy)

--- a/tools/DecompilerHarness/ManagedReferenceFilter.cs
+++ b/tools/DecompilerHarness/ManagedReferenceFilter.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Filters compile-back reference candidates to managed PE images. Native DLLs
+/// (for example <c>aspnetcorev2_inprocess.dll</c>, <c>coreclr.dll</c>, or
+/// <c>msquic.dll</c>) ship in the Windows shared framework and pass
+/// <see cref="Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(string)"/>,
+/// but Roslyn rejects them at compile time with CS0009 ("PE image doesn't contain
+/// managed metadata"). Excluding them keeps the compile-back reference sets
+/// runnable on Windows, matching Linux CI where those native files are absent.
+/// </summary>
+internal static class ManagedReferenceFilter
+{
+    public static bool IsManagedAssembly(string path)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var pe = new PEReader(stream);
+            return pe.HasMetadata;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1735,19 +1735,7 @@ static class Program
         return new PackageAssemblyInputs(assemblies, tempDirs);
     }
 
-    static bool IsManaged(string path)
-    {
-        try
-        {
-            using var stream = File.OpenRead(path);
-            using var pe = new PEReader(stream);
-            return pe.HasMetadata;
-        }
-        catch
-        {
-            return false;
-        }
-    }
+    static bool IsManaged(string path) => ManagedReferenceFilter.IsManagedAssembly(path);
 
     static string TypeDisplayName(MetadataReader reader, TypeDefinition td)
     {

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1878,6 +1878,10 @@ static class ReturnToSender
                     result[getter] = anchor;
                 if (member.SetterToken is { } setter)
                     result[setter] = anchor;
+                if (member.AdderToken is { } adder)
+                    result[adder] = anchor;
+                if (member.RemoverToken is { } remover)
+                    result[remover] = anchor;
             }
         }
 
@@ -2083,6 +2087,9 @@ static class ReturnToSender
 
         foreach (var dependency in resolver.ResolveAll())
         {
+            if (!ManagedReferenceFilter.IsManagedAssembly(dependency.Path))
+                continue;
+
             string simpleName = Path.GetFileNameWithoutExtension(dependency.Path);
             if (!seen.Add(simpleName))
                 continue;

--- a/tools/DecompilerHarness/TypeBindCheck.cs
+++ b/tools/DecompilerHarness/TypeBindCheck.cs
@@ -208,6 +208,8 @@ static class TypeBindCheck
         {
             if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                 return;
+            if (!ManagedReferenceFilter.IsManagedAssembly(path))
+                return;
             if (!seen.Add(Path.GetFileNameWithoutExtension(path)))
                 return;
             try { builder.Add(MetadataReference.CreateFromFile(path)); }

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -1202,6 +1202,8 @@ static class ValidityCheck
         {
             if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                 continue;
+            if (!ManagedReferenceFilter.IsManagedAssembly(path))
+                continue;
             try { builder.Add(MetadataReference.CreateFromFile(path)); }
             catch { }
         }


### PR DESCRIPTION
- Follow-up to #3117 (RTS product-surface migration)
- Changes harness-only behavior; product output is unchanged
- Evidence revision: `b41615c6`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — the compile-back reference collectors fed native
shared-framework DLLs to Roslyn (CS0009), which broke local Windows RTS runs
wholesale; filtering to managed PE images fixes it and exposed a latent
event-accessor anchor bug, both fixed here. Decisive evidence: the three
`ReturnToSender*` classes go **155 → 0** failures (239/239) locally.

Before (local Windows, three `ReturnToSender*` classes):

```text
Total: 239, Failed: 155
CS0009: ...aspnetcorev2_inprocess.dll ... PE image doesn't contain managed metadata
```

After:

```text
Total: 239, Failed: 0
```

## Scope and safety

- **Root cause:** `ReturnToSender.CompilationReferences`, `FidelityCheck`,
  `ValidityCheck`, and `TypeBindCheck` added every resolved dependency/TPA
  `.dll` — including native images (`aspnetcorev2_inprocess.dll`, `coreclr.dll`,
  `msquic.dll`) — to the Roslyn reference set. `MetadataReference.CreateFromFile`
  accepts them, but Roslyn rejects them at compile time with CS0009. These
  native files ship only in the Windows shared framework, so the failure never
  appeared on Linux CI.
- **Fix shape (reference):** extract the existing `Program.IsManaged`
  `PEReader.HasMetadata` check into a shared
  `ManagedReferenceFilter.IsManagedAssembly` and apply it at all four
  collectors. Managed reference/facade assemblies keep `HasMetadata == true`,
  so nothing referenceable is dropped; the filter is a **no-op on Linux CI**
  (those native files are absent) and only aligns local Windows with CI.
- **Fix shape (RTS anchor):** clearing CS0009 let recompiles succeed and
  surfaced a latent harness bug — `MemberAnchorsByMethodToken` registered
  `MetadataToken`/`GetterToken`/`SetterToken` but not `AdderToken`/`RemoverToken`,
  so event-accessor targets always got a null `MemberAnchor` and no round-trip
  comparison. Register the adder/remover tokens (mirroring getter/setter). The
  existing on-`main` test
  `CompileBackTargets_FullReconstructsPlainEventAccessorTarget` was latently red
  wherever recompile succeeds; it now passes with no test edit.
- **Product impact:** none. All changes are under `tools/DecompilerHarness`
  plus the test project's linked-file list.
- **RTS boundary:** RTS still only orchestrates closure + Roslyn + contract-V1
  body comparison; product/shared code owns C# source generation. This PR
  touches only reference-set hygiene and anchor bookkeeping.

## Evidence

| Check | Result |
| --- | --- |
| Harness build (`tools/DecompilerHarness`) | Pass |
| Test project build | Pass |
| `ReturnToSender{FixtureCatalog,Evidence,Prototype}Tests` | 239/239 pass (was 155 failing, all CS0009) |
| `TypeSourceCheckTests` (TypeBindCheck consumer) | 34/34 pass (was CS0009-red locally) |
| `FidelityGateTests` (FidelityCheck consumer) | No CS0009; 3/5 pass. 2 residual reds (`NoNewFidelityDiffsBeyondKnownDocket`, `PinnedFixesStayExact`) are pre-existing lambda-cache/assembly-identity env reds, CI-green |
| Real witness | `Holder.add_Changed` event accessor moved ContextFail(null anchor) → Exact contract match with round-trip comparison |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `FidelityGateTests` 2 residual reds | Left as pre-existing frontier | Not reference-related; documented CI-green env reds (lambda-cache ordinal / `System.Runtime` vs `System.Private.CoreLib` identity). By construction, removing non-managed PE files cannot change the IL of a *successful* recompile |
| deep-inspect decompiler slow gate 6h cap | Not addressed here | Separate CI-infra concern; unrelated to reference hygiene |

## Validation

```powershell
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config
dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- `
  -class ILInspector.Decompiler.Tests.ReturnToSenderFixtureCatalogTests `
  -class ILInspector.Decompiler.Tests.ReturnToSenderEvidenceTests `
  -class ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.TypeSourceCheckTests
```
