### PR TITLE
Unify member table experience and carry durable identity into JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ dotnet-inspect library System.Text.Json -S Signals
 dotnet-inspect package System.Text.Json --path @readme --content --frontmatter
 dotnet-inspect package Newtonsoft.Json -S "Package Info" --fields Version --value
 dotnet-inspect type Command --project ./src/App
-dotnet-inspect member Command --project ./src/App --show-index
+dotnet-inspect member Command --project ./src/App -S "Member Index"
 dotnet-inspect project ./src/App -S Skills --jsonl
 dotnet-inspect project ./src/App -S Skills --paths
 dotnet-inspect project ./src/App -S Skills --print --row 1
@@ -362,7 +362,7 @@ dotnet-inspect package System.Text.Json@8.0.0..8.0.5 --versions
 dotnet-inspect type JsonSerializer --package System.Text.Json@8.0.0..8.0.5 --at '#4'
 dotnet-inspect member JsonSerializer Serialize --package System.Text.Json@8.0.0..8.0.5 --at 8.0.5
 dotnet-inspect type Command --project ./src/App
-dotnet-inspect member Command --project ./src/App --show-index
+dotnet-inspect member Command --project ./src/App -S "Member Index"
 dotnet-inspect project ./src/App -S Skills
 dotnet-inspect project ./src/App -S Skills --print --row 1
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print-all

--- a/docs/workflows/discovery/project-context-search.md
+++ b/docs/workflows/discovery/project-context-search.md
@@ -96,7 +96,7 @@ System.CommandLine.Command
 ### 2b. Inspect members
 
 ```bash
-dotnet-inspect member Command --project /tmp/find-project-workflow/FindDemo/FindDemo.csproj --show-index -n 12
+dotnet-inspect member Command --project /tmp/find-project-workflow/FindDemo/FindDemo.csproj -S "Member Index" -n 12
 ```
 
 ```expect

--- a/docs/workflows/getting-started/lap-around.md
+++ b/docs/workflows/getting-started/lap-around.md
@@ -170,10 +170,10 @@ Kind: class
 Methods: 36
 ```
 
-For code, use `--show-index` (or `-S "Member Index"`) to see addressing hints, then drill into a specific overload:
+For code, use `-S "Member Index"` to see the full addressing table (the durable `~digest` selector is also shown in the default member table's Digest column), then drill into a specific overload:
 
 ```bash
-dotnet-inspect member --package Microsoft.Extensions.Options OptionsFactory --show-index
+dotnet-inspect member --package Microsoft.Extensions.Options OptionsFactory -S "Member Index"
 ```
 
 ```expect

--- a/docs/workflows/getting-started/type-and-member-addressability.md
+++ b/docs/workflows/getting-started/type-and-member-addressability.md
@@ -228,14 +228,14 @@ Methods: 103
 
 ## Member select mode
 
-> Goal: `--show-index` renders the Member Index section with addressing tokens for detailed member pages.
+> Goal: `-S "Member Index"` renders the Member Index section with addressing tokens for detailed member pages.
 
 ```prompt
 Show me the members of Command with selection tokens.
 ```
 
 ```bash
-dotnet-inspect member System.CommandLine@2.0.3 Command --show-index
+dotnet-inspect member System.CommandLine@2.0.3 Command -S "Member Index"
 ```
 
 ```expect

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -397,15 +397,24 @@ public class ApiMember
     public string? Signature { get; set; }
 
     /// <summary>
+    /// Durable 10-char digest for this overload — the same value shown in the Markdown
+    /// Digest column and the <c>Name~digest</c> stable selector. Lets JSON consumers
+    /// address the exact overload without parsing the display table. Populated for the
+    /// type/member JSON output; null (and omitted) when identity was not projected.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Digest { get; set; }
+
+    /// <summary>
     /// The persisted, presentation-independent canonical member identity — the Member Index
     /// digest input (e.g. <c>M:N.C.Parse(System.ValueTuple&lt;int,string&gt;)</c>). Populated
-    /// at extraction only when it diverges from what parsing the display
+    /// at extraction when it diverges from what parsing the display
     /// <see cref="Signature"/> would yield — i.e. for members whose signature contains C#
     /// tuple syntax, whose element names and <c>(...)</c> spelling must not leak into
     /// identity and cannot be recovered from the display text after a JSON round-trip
-    /// (<see cref="SignatureModel"/> is <see cref="JsonIgnoreAttribute"/>). Null in the
-    /// common case, where the canonical spelling equals the display-derived one, so
-    /// serialized surfaces for non-tuple members are unchanged.
+    /// (<see cref="SignatureModel"/> is <see cref="JsonIgnoreAttribute"/>) — and also filled
+    /// in for the type/member JSON output so consumers get durable identity without a side
+    /// call. Omitted when null.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? CanonicalSignature { get; set; }

--- a/src/ILInspector.Metadata/MemberTargetResolver.cs
+++ b/src/ILInspector.Metadata/MemberTargetResolver.cs
@@ -266,7 +266,7 @@ public static class MemberTargetResolver
             if (matches.Count == 0)
             {
                 return Failure(MemberTargetDiagnosticKind.DigestNotFound,
-                    $"Error: No overload of {selector.Name} matches digest '{digest}'. Use -S \"Member Index\" to list digests.",
+                    $"Error: No overload of {selector.Name} matches digest '{digest}'. Use one of the stable {selector.Name}~<digest> selectors.",
                     candidates);
             }
 
@@ -295,7 +295,7 @@ public static class MemberTargetResolver
             if (candidates.Count > 1)
             {
                 return Failure(MemberTargetDiagnosticKind.AmbiguousMember,
-                    $"Error: Member selector '{selector.RequestedText}' is ambiguous. Use {selector.Name}:1 through {selector.Name}:{candidates.Count}, or run -S \"Member Index\" to list stable ~digest selectors.",
+                    $"Error: Member selector '{selector.RequestedText}' is ambiguous. Use one of the stable {selector.Name}~<digest> selectors, or {selector.Name}:1 through {selector.Name}:{candidates.Count}.",
                     candidates);
             }
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1802,6 +1802,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_MethodsTable_OmitsDecodeColumn()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializer", "-m", "Serialize", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Serialize", output);
+        // The Decode degradation marker is never a default table column; it surfaces on stderr.
+        Assert.DoesNotContain("Decode", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Router_ConstructorSelector_NormalizesCtorAlias()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1708,7 +1708,7 @@ public class CommandExecutionTests
     public async Task Member_FullyQualifiedPlatformMember_UsesPlatformMemberFindIfMiss()
     {
         var (exit, output, error) = await RunAppAsync(
-            "member", "System.String.IndexOf", "--table", "--show-index", "--tips", "q");
+            "member", "System.String.IndexOf", "--table", "-S", "Member Index", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Contains("IndexOf:1", output);
@@ -1811,6 +1811,100 @@ public class CommandExecutionTests
         Assert.Contains("Serialize", output);
         // The Decode degradation marker is never a default table column; it surfaces on stderr.
         Assert.DoesNotContain("Decode", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_MethodsTable_ShowsAlwaysOnDigestColumn()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializer", "-m", "Serialize", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        // The durable ~digest handle is always shown as a Digest column in the default member table.
+        Assert.Contains("| Name | Digest | Signature | Description |", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_CompactSummaryTables_OmitDecodeColumn()
+    {
+        // The compact per-kind summary tables (Constructors, Properties, Fields, Method
+        // Groups) also drop the empty Decode degradation column; degradation surfaces on stderr.
+        var (exit, output, error) = await RunAppAsync(
+            "System.Text.Json.JsonSerializerOptions", "-m", "8", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Constructors", output);
+        Assert.Contains("## Properties", output);
+        Assert.DoesNotContain("Decode", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_Json_CarriesDigestAndCanonicalSignature()
+    {
+        // The agent-facing JSON must expose the durable overload handle (digest) and the
+        // doc-ID canonical signature, not just the human-facing Markdown Digest column.
+        var (exit, output, error) = await RunAppAsync(
+            "System.Text.Json.JsonSerializer.Serialize:1", "--json", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("\"digest\": \"1dc14dd1fb\"", output);
+        Assert.Contains("\"canonical_signature\": \"M:System.Text.Json.JsonSerializer.Serialize", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_JsonLimit_SelectsSameOverloadDigestAsTable()
+    {
+        // -m N over --json applies the same display ordering as the Markdown table, so the
+        // selected overload's digest matches across the two experiences.
+        var table = await RunAppAsync(
+            "System.Text.Json.JsonSerializer.Serialize", "-m", "1", "--tips", "q");
+        var json = await RunAppAsync(
+            "System.Text.Json.JsonSerializer.Serialize", "-m", "1", "--json", "--tips", "q");
+
+        Assert.Equal(0, table.Exit);
+        Assert.Equal(0, json.Exit);
+        var tableDigest = System.Text.RegularExpressions.Regex.Match(table.Output, "`([0-9a-f]{10})`");
+        Assert.True(tableDigest.Success, "Expected a ~digest in the Methods table Digest column.");
+        Assert.Contains($"\"digest\": \"{tableDigest.Groups[1].Value}\"", json.Output);
+    }
+
+    [Fact]
+    public async Task Member_Limit_SelectsSameOverloadInTableAndMemberIndex()
+    {
+        // The default member table and the Member Index apply -m N over the same ordering,
+        // so a one-member limit selects the same overload (same ~digest) in both views.
+        var table = await RunAppAsync(
+            "System.Text.Json.JsonSerializer.Serialize", "-m", "1", "--tips", "q");
+        var index = await RunAppAsync(
+            "System.Text.Json.JsonSerializer.Serialize", "-m", "1", "-S", "Member Index", "--tips", "q");
+
+        Assert.Equal(0, table.Exit);
+        Assert.Equal(0, index.Exit);
+        Assert.Empty(table.Error);
+        Assert.Empty(index.Error);
+
+        var digest = System.Text.RegularExpressions.Regex.Match(table.Output, "`([0-9a-f]{10})`");
+        Assert.True(digest.Success, "Expected a ~digest in the Methods table Digest column.");
+        // The Member Index Stable selector for the same overload is Name~<digest>.
+        Assert.Contains($"~{digest.Groups[1].Value}", index.Output);
+    }
+
+    [Fact]
+    public async Task Member_OverloadDetail_ShowsDigestAndCanonicalSignature()
+    {
+        // Drilling into a single overload (even via the non-durable positional :N) must surface
+        // the durable Digest and the Canonical Signature so the reference can be upgraded.
+        var (exit, output, error) = await RunAppAsync(
+            "System.Text.Json.JsonSerializer.Serialize:6", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Signature", output);
+        Assert.Contains("| Signature | Digest | Canonical Signature | Description |", output);
+        Assert.Contains("M:System.Text.Json.JsonSerializer.Serialize", output);
         Assert.Empty(error);
     }
 
@@ -1976,7 +2070,7 @@ public class CommandExecutionTests
     public async Task Member_BareSimpleTypeMiss_UsesPlatformFindIfMiss()
     {
         var (exit, output, error) = await RunAppAsync(
-            "member", "Regex", "-m", "Match", "--show-index", "--rows", "-n", "4", "--tips", "q");
+            "member", "Regex", "-m", "Match", "-S", "Member Index", "--rows", "-n", "4", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Contains("# System.Text.RegularExpressions.Regex", output);
@@ -2950,7 +3044,7 @@ public class CommandExecutionTests
             PlatformAssembly = "System.Text.Json",
             TypeName = "JsonSerializer",
             Discover = ["Member Index"],
-            ShowMemberIndex = true,
+            Select = ["Member Index"],
             Schema = true
         };
 
@@ -2958,7 +3052,7 @@ public class CommandExecutionTests
             () => MemberCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
-        // --show-index is now a compatibility alias for the dedicated Member Index section.
+        // Selecting the dedicated Member Index section renders its selector/identity columns.
         Assert.Contains("| Stable | column |", output);
         Assert.Contains("| Canonical Signature | column |", output);
     }
@@ -3009,7 +3103,7 @@ public class CommandExecutionTests
             PlatformAssembly = "System.Text.Json",
             TypeName = "JsonSerializer",
             Discover = ["Member Index"],
-            ShowMemberIndex = true,
+            Select = ["Member Index"],
             Verbosity = Verbosity.Normal
         };
 
@@ -3017,7 +3111,7 @@ public class CommandExecutionTests
             () => MemberCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
-        // With --show-index the dedicated Member Index section renders.
+        // Selecting the Member Index section renders it at Normal verbosity too.
         Assert.Contains("| Stable | column |", output);
         Assert.Contains("| Canonical Signature | column |", output);
     }
@@ -3491,7 +3585,7 @@ public class CommandExecutionTests
             PlatformAssembly = "System.Text.Json",
             TypeName = "JsonSerializer",
             MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "SerializeToNode" },
-            ShowMemberIndex = true
+            Select = ["Member Index"]
         };
 
         var (exit, output, _) = await ConsoleCapture.RunAsync(
@@ -3515,7 +3609,7 @@ public class CommandExecutionTests
             PlatformAssembly = "System.Text.Json",
             TypeName = "JsonSerializerOptions",
             MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GetConverter" },
-            ShowMemberIndex = true
+            Select = ["Member Index"]
         };
 
         var (exit, output, _) = await ConsoleCapture.RunAsync(
@@ -3527,13 +3621,13 @@ public class CommandExecutionTests
         Assert.Contains("`GetConverter`", output);
         Assert.DoesNotContain("## Signature", output);
 
-        options = options with { Select = ["Methods"], ShowMemberIndex = false };
+        options = options with { Select = ["Methods"] };
         (exit, output, _) = await ConsoleCapture.RunAsync(
             () => MemberCommand.ExecuteAsync(options));
 
         Assert.Equal(0, exit);
         Assert.Contains("## Methods", output);
-        Assert.Contains("| Name | Signature |", output);
+        Assert.Contains("| Name | Digest | Signature |", output);
         Assert.DoesNotContain("## Signature", output);
     }
 
@@ -3664,8 +3758,8 @@ public class CommandExecutionTests
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("section 'Call Graph' requires a single selected overload", error);
-        Assert.Contains("Use Overloaded:1 through Overloaded:2", error);
-        Assert.Contains("-S \"Member Index\"", error);
+        Assert.Contains("Overloaded~<digest>", error);
+        Assert.Contains("Overloaded:1 through Overloaded:2", error);
         Assert.DoesNotContain("Select value 'Call Graph' not found", error);
     }
 
@@ -3694,7 +3788,8 @@ public class CommandExecutionTests
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("section 'Callers' requires a single selected overload", error);
-        Assert.Contains("Use Overloaded:1 through Overloaded:2", error);
+        Assert.Contains("Overloaded~<digest>", error);
+        Assert.Contains("Overloaded:1 through Overloaded:2", error);
     }
 
     [Fact]
@@ -3722,7 +3817,8 @@ public class CommandExecutionTests
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("section 'Callers' requires a single selected overload", error);
-        Assert.Contains("Use Overloaded:1 through Overloaded:2", error);
+        Assert.Contains("Overloaded~<digest>", error);
+        Assert.Contains("Overloaded:1 through Overloaded:2", error);
     }
 
     [Fact]
@@ -4498,7 +4594,7 @@ public class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "member", "JsonSerializer", "--package", "System.Text.Json",
-            "-m", "Serialize", "--show-index", "--table");
+            "-m", "Serialize", "-S", "Member Index", "--table");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -4899,7 +4995,7 @@ public class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "member", "String", "--platform", "System.Private.CoreLib",
-            "-S", "Explicit Interface Implementations", "--show-index", "--tips", "q", "--rows", "-n", "4");
+            "-S", "Explicit Interface Implementations,Member Index", "--tips", "q", "--rows", "-n", "4");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -4934,7 +5030,7 @@ public class CommandExecutionTests
 
         (exit, output, error) = await RunAppAsync(
             "member", "String", "--platform", "System.Private.CoreLib",
-            "-S", "Extension Methods", "--show-index", "--tips", "q", "--rows", "-n", "4");
+            "-S", "Extension Methods,Member Index", "--tips", "q", "--rows", "-n", "4");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -8700,7 +8796,7 @@ public class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "member", typeof(MemberGenericSelectorFixture).FullName!, "--library", TestAssemblyPath,
-            "GenericChoice<T>", "--show-index", "--table");
+            "GenericChoice<T>", "-S", "Member Index", "--table");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1000,6 +1000,68 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void PopulateMemberSections_CollectsDegradedSignaturesForStderrWarning()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Worker",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Kind = "method",
+                    Name = "Run",
+                    Signature = "object Run()",
+                    SignatureModel = new ApiSignature { ReturnType = "object", MemberName = "Run" },
+                    SignatureDecodeStatus = SignatureDecodeStatus.Degraded
+                },
+                new ApiMember
+                {
+                    Kind = "method",
+                    Name = "Ok",
+                    Signature = "void Ok()",
+                    SignatureModel = new ApiSignature { ReturnType = "void", MemberName = "Ok" }
+                }
+            ]
+        };
+        var view = new TypeView();
+
+        ApiOutputFormatter.PopulateMemberSections(
+            view, new MethodsView(), new OperatorsView(), new ExplicitInterfaceImplementationsView(),
+            new ExtensionMethodsView(), new EventsView(), type, new MemberOptions());
+
+        // Only the degraded member is recorded; the healthy member is not.
+        var degraded = Assert.Single(view.DegradedSignatureMembers!);
+        Assert.Contains("Run", degraded);
+        Assert.DoesNotContain("Ok", degraded);
+
+        var writer = new StringWriter();
+        ApiOutputFormatter.WriteSignatureDecodeWarning(view, writer);
+        var warning = writer.ToString();
+        Assert.Contains("could not be fully decoded", warning);
+        Assert.Contains("Run", warning);
+    }
+
+    [Fact]
+    public void WriteSignatureDecodeWarning_EmitsNothingWhenNoMemberDegraded()
+    {
+        var writer = new StringWriter();
+        ApiOutputFormatter.WriteSignatureDecodeWarning(new TypeView(), writer);
+        Assert.Empty(writer.ToString());
+    }
+
+    [Fact]
+    public void MemberRow_HasNoDecodeColumnInDefaultMemberTables()
+    {
+        // The Decode degradation marker is reported via stderr, never as a table column.
+        Assert.DoesNotContain(
+            typeof(MemberRow).GetProperties(),
+            p => p.Name == "Decode");
+    }
+
+    [Fact]
     public void BuildTypeRenderManifest_CapturesActualMemberTable()
     {
         var type = new ApiType

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -969,15 +969,15 @@ public class OutputFormatterTests
         Assert.True(TypeView.SignatureDecodeIsEmpty(null));
         Assert.True(TypeView.SignatureDecodeIsEmpty(
         [
-            new MemberSignatureRow("void A()", null, null),
-            new MemberSignatureRow("void B()", "", null),
+            new MemberSignatureRow("void A()", "aaaa", "M:A", null, null),
+            new MemberSignatureRow("void B()", "bbbb", "M:B", "", null),
         ]));
 
         // A degraded member must keep the Decode column so the failure marker stays visible.
         Assert.False(TypeView.SignatureDecodeIsEmpty(
         [
-            new MemberSignatureRow("void A()", null, null),
-            new MemberSignatureRow("void B()", "degraded", null),
+            new MemberSignatureRow("void A()", "aaaa", "M:A", null, null),
+            new MemberSignatureRow("void B()", "bbbb", "M:B", "degraded", null),
         ]));
     }
 

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -36,7 +36,6 @@ public class MemberOptionsParserTests
         var compactOption = new Option<bool>("--compact");
         var unsafeOption = new Option<bool>("--unsafe");
         var indexOption = new Option<int?>("--index");
-        var selectOption = new Option<bool>("--show-index");
         var kindOption = new Option<string[]>("-k") { AllowMultipleArgumentsPerToken = true };
         kindOption.Aliases.Add("--kind");
         var binOption = new Option<string[]>("--bin") { AllowMultipleArgumentsPerToken = true };
@@ -61,7 +60,6 @@ public class MemberOptionsParserTests
         opts.AddTableOptionsTo(memberCommand);
         memberCommand.Options.Add(unsafeOption);
         memberCommand.Options.Add(indexOption);
-        memberCommand.Options.Add(selectOption);
         memberCommand.Options.Add(kindOption);
         memberCommand.Options.Add(binOption);
         memberCommand.Options.Add(callerProjectOption);
@@ -80,7 +78,7 @@ public class MemberOptionsParserTests
         var args = new MemberOptionsParser.MemberCommandArgs(
             argsArg, packageOption, assemblyOption, platformOption, frameworkOption, tfmOption,
             allOption, memberOption, ctorOption, compactOption, opts.NoHeaders,
-            unsafeOption, indexOption, selectOption, kindOption,
+            unsafeOption, indexOption, kindOption,
             binOption, callerProjectOption, callerPackageOption, repoOption, atOption);
 
         return (root, opts, args);

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -183,7 +183,6 @@ public static class ApiCommandDefinitions
         var compactOption = new Option<bool>("--compact") { Description = "Output as minified JSON (use with --json)" };
         var unsafeOption = new Option<bool>("--unsafe") { Description = "Filter members to unsafe signatures (pointers)" };
         var indexOption = new Option<int?>("--index") { Description = "Select member overload by index (or use Name:N shorthand)" };
-        var selectOption = new Option<bool>("--show-index") { Description = "Show the Member Index section with copyable selectors and canonical signatures" };
         var binOption = new Option<string[]>("--bin")
         {
             Description = "Scan output directory(s) for inbound callers of the selected member (Callers section). Can repeat.",
@@ -230,7 +229,6 @@ public static class ApiCommandDefinitions
         opts.AddTableOptionsTo(memberCommand);
         memberCommand.Options.Add(unsafeOption);
         memberCommand.Options.Add(indexOption);
-        memberCommand.Options.Add(selectOption);
         memberCommand.Options.Add(binOption);
         memberCommand.Options.Add(callerProjectOption);
         memberCommand.Options.Add(callerPackageOption);
@@ -251,7 +249,7 @@ public static class ApiCommandDefinitions
             argsArg, packageOption, assemblyOption, platformOption, frameworkOption, tfmOption,
             allOption, memberOption, ctorOption,
             compactOption, opts.NoHeaders,
-            unsafeOption, indexOption, selectOption, kindOption,
+            unsafeOption, indexOption, kindOption,
             binOption, callerProjectOption, callerPackageOption, repoOption, atOption);
 
         memberCommand.SetAction(async (parseResult, ct) =>

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -30,7 +30,6 @@ public static class MemberOptionsParser
         Option<bool> NoHeaderOption,
         Option<bool> UnsafeOption,
         Option<int?> IndexOption,
-        Option<bool> SelectOption,
         Option<string[]> KindOption,
         Option<string[]> BinOption,
         Option<string[]> ProjectOption,
@@ -244,11 +243,8 @@ public static class MemberOptionsParser
         var kindFilter = SharedParsers.ParseKindFilter(kindValues);
         kindFilter.UnionWith(memberKindFilter);
 
-        var showMemberIndex = parseResult.GetValue(args.SelectOption);
         var select = opts.ParseSelect(parseResult);
         bool hasExplicitSelect = select is { Length: > 0 };
-        if (showMemberIndex)
-            select = [.. select ?? [], SectionNames.MemberIndex];
         var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
         if (!PerformanceTriageOptions.TryValidate(performanceTriage, out var triageShapeError))
             return new VersionError(triageShapeError);
@@ -297,7 +293,6 @@ public static class MemberOptionsParser
             OverloadIndex = parseResult.GetValue(args.IndexOption) ?? shorthandIndex,
             MemberDigest = memberDigest,
             MemberGenericArity = memberGenericArity,
-            ShowMemberIndex = showMemberIndex,
             CallerScopeDirectories = parseResult.GetValue(args.BinOption) ?? [],
             CallerScopeProjects = projectSourcePath is null
                 ? projectValues

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1545,7 +1545,12 @@ public class ApiCommand
             members = members.Where(m => m.IsUnsafe).ToList();
 
         if (options.Limit.HasValue && members.Count > options.Limit.Value)
-            members = members.Take(options.Limit.Value).ToList();
+            members = members
+                .OrderBy(m => ApiOutputFormatter.GetMemberSortOrder(m.Kind))
+                .ThenBy(m => m.Name, StringComparer.Ordinal)
+                .ThenBy(ApiOutputFormatter.GetMemberSignatureSortKey, StringComparer.Ordinal)
+                .Take(options.Limit.Value)
+                .ToList();
 
         // -S/--select scopes JSON to the requested sections, mirroring the markdown view.
         if (options.IncludeSections is { Count: > 0 } sections)
@@ -1574,6 +1579,16 @@ public class ApiCommand
             };
         }
 
+        // Project the durable identity (Digest + Canonical Signature) onto each member so
+        // JSON consumers get the same overload handle the Markdown Digest column exposes.
+        // Computed against the resolved declaring type, matching the table's anchor.
+        foreach (var member in outputType.Members)
+        {
+            var anchor = ApiMemberIdentity.GetMemberAnchor(type, member);
+            member.Digest = anchor.Fingerprint;
+            member.CanonicalSignature = anchor.CanonicalSignature;
+        }
+
         if (options.CompactJson)
             Console.WriteLine(JsonSerializer.Serialize(outputType, ApiTypeCompactJsonContext.Default.ApiType));
         else
@@ -1581,8 +1596,7 @@ public class ApiCommand
     }
 
     private static bool ShouldRenderMemberIndex(ApiOptions options)
-        => options.IncludeSections?.Contains(SectionNames.MemberIndex) == true
-           || options is MemberOptions { ShowMemberIndex: true };
+        => options.IncludeSections?.Contains(SectionNames.MemberIndex) == true;
 
     private static bool ShouldRenderSourceLocations(ApiOptions options)
         => options.IncludeSections?.Contains(SectionNames.SourceLocations) == true;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -917,6 +917,7 @@ public class ApiCommand
                 sink.WriteLine(OutputFormatter.ApplyRowLimit(markdown, options.Rows));
             }
         }
+        ApiOutputFormatter.WriteSignatureDecodeWarning(view, Console.Error);
         return 0;
     }
 

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -18,9 +18,6 @@ public static class MemberCommand
 
     public static async Task<int> ExecuteAsync(MemberOptions options)
     {
-        if (options.ShowMemberIndex)
-            options = options with { Select = [.. options.Select ?? [], SectionNames.MemberIndex] };
-
         // Validate that member command has a type argument
         if (string.IsNullOrEmpty(options.TypeName))
         {
@@ -217,7 +214,7 @@ public static class MemberCommand
                         ? $"section '{singleOverloadSections[0]}' requires"
                         : $"sections {string.Join(", ", singleOverloadSections.Select(section => $"'{section}'"))} require";
                     Console.Error.WriteLine($"Error: {sectionLabel} a single selected overload for member '{memberName}'.");
-                    Console.Error.WriteLine($"Use {memberName}:1 through {memberName}:{overloads.Count}, or run -S \"Member Index\" to list stable ~digest selectors.");
+                    Console.Error.WriteLine($"Select one overload with {memberName}~<digest> (shown in the Digest column of the member listing), or positionally with {memberName}:1 through {memberName}:{overloads.Count}.");
                     return 1;
                 }
             }
@@ -387,7 +384,7 @@ public static class MemberCommand
                 }
 
                 if (overloadGroups.Any(g => g.Count() > 1))
-                    tips.Add(new(Name, $"{simpleName} {sourceFlag} --show-index", "show member selectors"));
+                    tips.Add(new(Name, $"{simpleName} {sourceFlag} -S \"Member Index\"", "full selector/identity table"));
 
                 tips.Add(new(TypeCommand.Name, $"{simpleName} {sourceFlag} --shape", "view type shape"));
                 tips.Add(new(Name, $"-m {simpleName}.{(exampleGroup?.Key ?? "Method")} {sourceFlag}", "dotted member syntax"));

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -308,7 +308,7 @@ public static class TypeCommand
                         }
 
                         if (overloadGroups.Any(g => g.Count() > 1))
-                            tips.Add(new(MemberCommand.Name, $"{simpleName} {sourceFlag} --show-index", "show member selectors"));
+                            tips.Add(new(MemberCommand.Name, $"{simpleName} {sourceFlag} -S \"Member Index\"", "full selector/identity table"));
 
                         tips.Add(new(Name, $"{simpleName} {sourceFlag} --shape", "view type shape"));
                         tips.Add(new(MemberCommand.Name, $"-m {simpleName}.{(exampleGroup?.Key ?? "Method")} {sourceFlag}", "dotted member syntax"));

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -203,7 +203,6 @@ public record MemberOptions : ApiOptions
     public int? OverloadIndex { get; init; }
     public string? MemberDigest { get; init; }
     public int? MemberGenericArity { get; init; }
-    public bool ShowMemberIndex { get; init; }
     public MethodSourceContext? MethodSource { get; init; }
 
     /// <summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -685,11 +685,13 @@ public static class ApiOutputFormatter
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         if (grouped.Count == 0) return (0, "");
 
-        // Flatten sorted for --limit application
+        // Flatten sorted for --limit application. This ordering must match the per-kind
+        // display ordering below so that -m N selects the same members that are shown.
         var allMembers = grouped
             .SelectMany(g => g.Value)
             .OrderBy(m => GetMemberSortOrder(m.Kind))
-            .ThenBy(m => m.Name)
+            .ThenBy(m => m.Name, StringComparer.Ordinal)
+            .ThenBy(GetMemberSignatureSortKey, StringComparer.Ordinal)
             .ToList();
 
         int truncated = 0;
@@ -739,9 +741,11 @@ public static class ApiOutputFormatter
                 }
 
                 var sigDisplay = FormatMemberDeclaration(type, m, abbreviate: abbreviate);
+                var digest = ApiMemberIdentity.GetMemberAnchor(type, m).Fingerprint;
                 return new MemberRow(
                     select,
                     OperatorNames.FormatDisplayName(m.Name),
+                    MarkoutInline.Code(digest),
                     MarkoutInline.Code(sigDisplay),
                     hasDocs ? (m.Documentation.Summary ?? "") : null);
             }).ToList();
@@ -818,6 +822,7 @@ public static class ApiOutputFormatter
 
         var member = type.Members[0];
         var sigDisplay = FormatMemberDeclaration(type, member, abbreviate: false);
+        var anchor = ApiMemberIdentity.GetMemberAnchor(type, member);
 
         var docsRequested = options.ShowDocs
             || options.Columns?.Any(c => c.Equals("Description", StringComparison.OrdinalIgnoreCase)) == true;
@@ -827,6 +832,8 @@ public static class ApiOutputFormatter
         [
             new MemberSignatureRow(
                 MarkoutInline.Code(sigDisplay),
+                MarkoutInline.Code(anchor.Fingerprint),
+                MarkoutInline.Code(anchor.CanonicalSignature),
                 SignatureDecodeMarker(member),
                 description)
         ];
@@ -1052,6 +1059,18 @@ public static class ApiOutputFormatter
                 }
             }
         }
+
+        // The compact-summary tables no longer carry a Decode column, so surface any
+        // signature-decode degradation through the stderr warning instead.
+        var degradedSignatures = allEntries
+            .SelectMany(e => e.members)
+            .Where(m => m.SignatureDecodeStatus is SignatureDecodeStatus.Degraded)
+            .Select(m => FormatMemberDeclaration(type, m, abbreviate: false))
+            .ToList();
+        if (degradedSignatures.Count > 0)
+            view.DegradedSignatureMembers = (view.DegradedSignatureMembers ?? [])
+                .Concat(degradedSignatures)
+                .ToList();
 
         return (truncated, "members");
     }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -743,7 +743,6 @@ public static class ApiOutputFormatter
                     select,
                     OperatorNames.FormatDisplayName(m.Name),
                     MarkoutInline.Code(sigDisplay),
-                    SignatureDecodeMarker(m),
                     hasDocs ? (m.Documentation.Summary ?? "") : null);
             }).ToList();
 
@@ -799,6 +798,15 @@ public static class ApiOutputFormatter
                     break;
             }
         }
+
+        var degradedSignatures = allMembers
+            .Where(m => m.SignatureDecodeStatus is SignatureDecodeStatus.Degraded)
+            .Select(m => FormatMemberDeclaration(type, m, abbreviate: abbreviate))
+            .ToList();
+        if (degradedSignatures.Count > 0)
+            view.DegradedSignatureMembers = (view.DegradedSignatureMembers ?? [])
+                .Concat(degradedSignatures)
+                .ToList();
 
         return (truncated, "members");
     }
@@ -1046,6 +1054,23 @@ public static class ApiOutputFormatter
         }
 
         return (truncated, "members");
+    }
+
+    /// <summary>
+    /// Emits a stderr warning listing rendered members whose metadata signature blob could
+    /// not be fully decoded. The default member tables no longer carry a Decode column, so
+    /// this keeps signature-decode failures visible without cluttering successful output.
+    /// </summary>
+    internal static void WriteSignatureDecodeWarning(TypeView view, TextWriter error)
+    {
+        if (view.DegradedSignatureMembers is not { Count: > 0 } degraded)
+            return;
+
+        error.WriteLine(
+            $"Warning: {degraded.Count} member signature(s) could not be fully decoded from " +
+            "metadata; the displayed signature(s) may be incomplete or approximate:");
+        foreach (var signature in degraded)
+            error.WriteLine($"  - {signature}");
     }
 
     private static string? SignatureDecodeMarker(ApiMember member)

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -160,18 +160,22 @@ public class TypeView
 
     // Compact member summary sections (Minimal verbosity, matching old QuietMemberFormatter)
     [MarkoutSection(Name = "Constructors", IgnoreProperty = nameof(ConstructorSummaryRow.Overloads))]
+    [MarkoutIgnoreColumnWhen(nameof(ConstructorSummaryDecodeIsEmpty), nameof(ConstructorSummaryRow.Decode))]
     [JsonIgnore]
     public List<ConstructorSummaryRow>? ConstructorSummaryRows { get; set; }
 
     [MarkoutSection(Name = "Constructors")]
+    [MarkoutIgnoreColumnWhen(nameof(ConstructorSummaryDecodeIsEmpty), nameof(ConstructorSummaryRow.Decode))]
     [JsonIgnore]
     public List<ConstructorSummaryRow>? ConstructorSummaryRowsWithOverloads { get; set; }
 
     [MarkoutSection(Name = "Fields")]
+    [MarkoutIgnoreColumnWhen(nameof(FieldSummaryDecodeIsEmpty), nameof(FieldSummaryRow.Decode))]
     [JsonIgnore]
     public List<FieldSummaryRow>? FieldSummaryRows { get; set; }
 
     [MarkoutSection(Name = "Properties")]
+    [MarkoutIgnoreColumnWhen(nameof(PropertySummaryDecodeIsEmpty), nameof(PropertySummaryRow.Decode))]
     [JsonIgnore]
     public List<PropertySummaryRow>? PropertySummaryRows { get; set; }
 
@@ -233,6 +237,12 @@ public class TypeView
     // The Decode column carries a signature-decode degradation marker that is null for
     // well-formed metadata (the common case). Drop the column when no member is degraded.
     public static bool SignatureDecodeIsEmpty(List<MemberSignatureRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.Decode));
+
+    // Same treatment for the compact member-summary tables: the Decode degradation
+    // marker is null for well-formed metadata, so drop the column when nothing is degraded.
+    public static bool ConstructorSummaryDecodeIsEmpty(List<ConstructorSummaryRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.Decode));
+    public static bool PropertySummaryDecodeIsEmpty(List<PropertySummaryRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.Decode));
+    public static bool FieldSummaryDecodeIsEmpty(List<FieldSummaryRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.Decode));
 
     [MarkoutSection(Name = "Source Files", EmptyText = "No SourceLink source files found for this type.")]
     [JsonIgnore]
@@ -301,13 +311,17 @@ public class EventsView
 public class MethodGroupsView
 {
     [MarkoutSection(Name = "Method Groups", IgnoreProperty = nameof(MethodSummaryRow.Overloads))]
+    [MarkoutIgnoreColumnWhen(nameof(MethodSummaryDecodeIsEmpty), nameof(MethodSummaryRow.Decode))]
     public List<MethodSummaryRow>? Rows { get; set; }
 
     [MarkoutSection(Name = "Method Groups")]
+    [MarkoutIgnoreColumnWhen(nameof(MethodSummaryDecodeIsEmpty), nameof(MethodSummaryRow.Decode))]
     public List<MethodSummaryRow>? RowsWithOverloads { get; set; }
 
     [MarkoutIgnore]
     public bool HasRows => Rows is { Count: > 0 } || RowsWithOverloads is { Count: > 0 };
+
+    public static bool MethodSummaryDecodeIsEmpty(List<MethodSummaryRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.Decode));
 }
 
 [MarkoutSerializable(AutoFields = false)]
@@ -513,14 +527,15 @@ public record ApiInspectionFailureRow(
 public record MemberRow(
     [property: MarkoutSkipNull] string? Select,
     string Name,
+    string Digest,
     string Signature,
     string? Description)
 {
     /// <summary>
     /// Creates a MemberRow without Select column.
     /// </summary>
-    public MemberRow(string name, string signature, string? description)
-        : this(null, name, signature, description) { }
+    public MemberRow(string name, string digest, string signature, string? description)
+        : this(null, name, digest, signature, description) { }
 }
 
 [MarkoutSerializable]
@@ -547,6 +562,8 @@ public record MemberSourceLocationRow(
 [MarkoutSerializable]
 public record MemberSignatureRow(
     string Signature,
+    string Digest,
+    [property: MarkoutPropertyName("Canonical Signature")] string CanonicalSignature,
     [property: MarkoutSkipNull] string? Decode,
     [property: MarkoutSkipNull] string? Description);
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -251,6 +251,13 @@ public class TypeView
     [JsonIgnore]
     public MemberCodeView? MemberCode { get; set; }
 
+    // Signatures of rendered members whose metadata signature blob could not be fully
+    // decoded. Never rendered as a column; surfaced as a stderr warning after the table
+    // so degradation stays visible without polluting the default output with an empty column.
+    [MarkoutIgnore]
+    [JsonIgnore]
+    public List<string>? DegradedSignatureMembers { get; set; }
+
     private List<TypeSourceFileRow>? TypeSourceFiles()
     {
         List<TypeSourceFileRow> rows = [];
@@ -507,14 +514,13 @@ public record MemberRow(
     [property: MarkoutSkipNull] string? Select,
     string Name,
     string Signature,
-    [property: MarkoutSkipNull] string? Decode,
     string? Description)
 {
     /// <summary>
     /// Creates a MemberRow without Select column.
     /// </summary>
-    public MemberRow(string name, string signature, string? decode, string? description)
-        : this(null, name, signature, decode, description) { }
+    public MemberRow(string name, string signature, string? description)
+        : this(null, name, signature, description) { }
 }
 
 [MarkoutSerializable]


### PR DESCRIPTION
## Summary

Rationalizes several organically-evolved member-output behaviors surfaced by usability testing, and carries durable member identity into `--json`. Two commits:

1. **Replace empty Decode column with stderr degradation warning** (`0bf4aa54`) — the original complaint: the `Decode` column was empty in the common case. It's now dropped from the table and signature-decode degradation surfaces as an end-of-output stderr warning.
2. **Unify member table experience and carry durable identity into JSON** (`42134857`):
   - **Unified member table** — retire the `--show-index` flag; the Member Index section stays reachable via `-S "Member Index"`. The default member table always carries an inline `Digest` column; the canonical signature moves to member detail.
   - **Complete Decode cleanup** — remove the empty `Decode` column across the remaining compact summary tables (Constructors, Method Groups, Properties, Fields) and populate `DegradedSignatureMembers` on the compact path so degradation still warns.
   - **Durable-first diagnostics** — reword bad-digest, ambiguous-member, and section-requires-single messages to lead with the stable `Name~<digest>` selector and the inline Digest column instead of fragile positional `:N` and the old `-S "Member Index"` pointer.
   - **JSON identity** — add `Digest` + `CanonicalSignature` to `ApiMember` and fill them in for type/member `--json` output so consumers get durable identity without a side call. Align the JSON `-m N` overload selection with the Markdown display ordering so both return the same overload.

## Evidence

- Full solution builds clean (`dotnet build dotnet-inspect.slnx -c Release`).
- CLI suite: **2038 total, 0 failed, 12 skipped**.
- Metadata suite: **794/794**.
- Changed Markdown passes `markdownlint-cli`.
- Rebased onto latest `origin/main`; reconciled cleanly with its extraction-time `ApiMember.CanonicalSignature` work (the JSON fill-in stays consistent with `GetCanonicalSignature`'s persisted-value short-circuit).

## Compatibility / boundary

- The JSON fill-in is a scoped population at the output boundary, not source-of-truth materialization. Consolidating derived member identity into a small set of materialized shapes is tracked as follow-up in #3136.
- `Digest`/`CanonicalSignature` are omitted when null, so non-JSON and non-projected surfaces are unchanged.

## Follow-up (non-blocking)

- Architecture: materialize member identity (#3136).
- Low-severity findings still open: Source Locations detail omits Digest; Member Index leads with the positional Selector column.
