### PR TITLE
Fold multi-line single expression-statement bodies (#3084)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -168,12 +168,14 @@ shipped default.
 
 A body that is exactly one statement folds on the simple single-line path (a
 lone `return <expr>;`, a `throw`, or a statement-expression). A body that is one
-*multi-line* single expression folds too: a wrapped switch return (issue #3088)
-or any other wrapped single `return <expr>;`, such as a fluent chain
-(issue #3084). The arrow trails the signature line with the expression's opening
-token after it, and the continuation lines re-indent one level under the
-member — the natural multi-line extension of the single-line `head => expr;`
-form.
+*multi-line* single statement folds too: a wrapped switch return (issue #3088),
+any other wrapped single `return <expr>;` such as a fluent chain (issue #3084),
+or a void member whose one statement is a wrapped expression statement — a fluent
+call chain with the result discarded (issue #3084). The arrow trails the
+signature line with the statement's opening token after it (the value after a
+stripped `return`, or the whole first line otherwise), and the continuation
+lines re-indent one level under the member — the natural multi-line extension of
+the single-line `head => expr;` form.
 
 ```csharp
 public static string Pipeline(StringBuilder builder)
@@ -188,13 +190,33 @@ public static string Pipeline(StringBuilder builder) => builder
     .Append("alphabet")
     .Append("bravissimo")
     .ToString();
+
+public static void Drain(StringBuilder builder)
+{
+    builder
+        .Append("alphabet")
+        .Append("bravissimo")
+        .Clear();
+}
+// folds to (no `return` to strip — the whole first line trails the arrow):
+public static void Drain(StringBuilder builder) => builder
+    .Append("alphabet")
+    .Append("bravissimo")
+    .Clear();
 ```
 
 The fold is gated on a typed structural signal the printer proves from the
-emitted statement tree — the body is exactly one top-level `return` with no
-lifted declarations, label, constructor chain, field initializer, async
-modifier, or unsupported fallback — never a re-parse of the rendered text. A
-member with any statement preceding the return keeps its brace block.
+emitted statement tree — the body is exactly one top-level statement (a `return`
+with a value, or an expression statement) with no lifted declarations, label,
+constructor chain, field initializer, async modifier, or unsupported fallback —
+never a re-parse of the rendered text. A `return` branch additionally requires
+its printed form to begin with a bare `return` so a value the printer lifted
+into a leading declaration (a `stackalloc`-to-pointer return) is not mistaken for
+a foldable expression. A member with any statement preceding the folded one keeps
+its brace block. (The extractor is shape-agnostic about the leading keyword, so a
+wrapped `throw <expr>;` would fold identically should one ever print multi-line;
+the printer does not currently produce multi-line throws, so that path is latent,
+not reachable.)
 
 ### Line wrapping
 

--- a/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
@@ -34,12 +34,12 @@ public sealed class CSharpExpressionBodyTests
     public void FromSingleStatement_RejectsNonExpressionForms(string body)
         => Assert.Null(CSharpExpressionBody.FromSingleStatement(body));
 
-    // ── Multi-line single-return extraction (issue #3088) ──────────────────
+    // ── Multi-line single-statement expression extraction (issues #3088, #3084) ─
 
     [Fact]
-    public void MultilineReturnExpressionLines_SplitsSwitchReturn()
+    public void MultilineExpressionBodyLines_SplitsSwitchReturn()
     {
-        var lines = CSharpExpressionBody.MultilineReturnExpressionLines(
+        var lines = CSharpExpressionBody.MultilineExpressionBodyLines(
             "return shape switch\n{\n    Dot d => d.Radius,\n    _ => -1,\n};");
         Assert.NotNull(lines);
         Assert.Equal(
@@ -48,12 +48,12 @@ public sealed class CSharpExpressionBodyTests
     }
 
     [Fact]
-    public void MultilineReturnExpressionLines_SplitsFluentChainReturn()
+    public void MultilineExpressionBodyLines_SplitsFluentChainReturn()
     {
         // Issue #3084: extraction is not switch-specific. A wrapped fluent chain
         // return yields its receiver as the value line and each chained call as a
         // continuation line at its body-relative indent.
-        var lines = CSharpExpressionBody.MultilineReturnExpressionLines(
+        var lines = CSharpExpressionBody.MultilineExpressionBodyLines(
             "return builder\n    .Append(\"a\")\n    .Append(\"b\")\n    .ToString();");
         Assert.NotNull(lines);
         Assert.Equal(
@@ -62,9 +62,9 @@ public sealed class CSharpExpressionBodyTests
     }
 
     [Fact]
-    public void MultilineReturnExpressionLines_SplitsWrappedTernaryReturn()
+    public void MultilineExpressionBodyLines_SplitsWrappedTernaryReturn()
     {
-        var lines = CSharpExpressionBody.MultilineReturnExpressionLines(
+        var lines = CSharpExpressionBody.MultilineExpressionBodyLines(
             "return condition\n    ? first\n    : second;");
         Assert.NotNull(lines);
         Assert.Equal(
@@ -72,12 +72,41 @@ public sealed class CSharpExpressionBodyTests
             lines);
     }
 
+    [Fact]
+    public void MultilineExpressionBodyLines_SplitsVoidFluentExpressionStatement()
+    {
+        // Issue #3084 (this slice): a void fluent call chain printed as a single
+        // expression statement has no `return` keyword, so the whole first line is
+        // the arrow value and the chained calls follow as continuations.
+        var lines = CSharpExpressionBody.MultilineExpressionBodyLines(
+            "builder\n    .Append(\"a\")\n    .Append(\"b\")\n    .Clear();");
+        Assert.NotNull(lines);
+        Assert.Equal(
+            ["builder", "    .Append(\"a\")", "    .Append(\"b\")", "    .Clear()"],
+            lines);
+    }
+
+    [Fact]
+    public void MultilineExpressionBodyLines_IsShapeAgnosticForThrow()
+    {
+        // The extractor keeps any non-`return` first line whole, so a wrapped
+        // `throw <expr>;` would fold to `=> throw <expr>;` should one ever print
+        // multi-line. (The printer does not currently produce multi-line throws,
+        // so this is latent, not reachable — see BodyIsSingleExpressionBody.)
+        var lines = CSharpExpressionBody.MultilineExpressionBodyLines(
+            "throw Build(\n    first,\n    second);");
+        Assert.NotNull(lines);
+        Assert.Equal(
+            ["throw Build(", "    first,", "    second)"],
+            lines);
+    }
+
     [Theory]
     [InlineData("return value.Length;")]          // single line — FromSingleStatement owns it
-    [InlineData("result = 0;\nreturn x switch\n{\n    _ => 1,\n};")]  // has a leading statement, but the string still starts non-`return`
-    [InlineData("x switch\n{\n    _ => 1,\n};")]   // no `return`
-    [InlineData("return\nx;")]                      // bare `return` (no space)
+    [InlineData("builder.Append(x);")]            // single-line expr statement — FromSingleStatement owns it
+    [InlineData("")]                               // empty
     [InlineData("return x switch\n{\n    _ => 1,\n}")] // no terminating ';'
-    public void MultilineReturnExpressionLines_RejectsNonMultilineReturnForms(string body)
-        => Assert.Null(CSharpExpressionBody.MultilineReturnExpressionLines(body));
+    [InlineData("builder\n    .Append(x)")]        // no terminating ';'
+    public void MultilineExpressionBodyLines_RejectsNonMultilineStatementForms(string body)
+        => Assert.Null(CSharpExpressionBody.MultilineExpressionBodyLines(body));
 }

--- a/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
@@ -107,6 +107,7 @@ public sealed class CSharpExpressionBodyTests
     [InlineData("")]                               // empty
     [InlineData("return x switch\n{\n    _ => 1,\n}")] // no terminating ';'
     [InlineData("builder\n    .Append(x)")]        // no terminating ';'
+    [InlineData("unsafe\n{\n    NativeMemory.Free(p);\n}")] // unsafe wrapper — ends in '}', not ';'
     public void MultilineExpressionBodyLines_RejectsNonMultilineStatementForms(string body)
         => Assert.Null(CSharpExpressionBody.MultilineExpressionBodyLines(body));
 }

--- a/src/ILInspector.CSharp.Tests/CSharpMemberLayoutTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpMemberLayoutTests.cs
@@ -4,10 +4,10 @@ namespace ILInspector.CSharp.Tests;
 
 public sealed class CSharpMemberLayoutTests
 {
-    static string Render(string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleReturnExpression = false)
+    static string Render(string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleExpressionBody = false)
     {
         var sb = new StringBuilder();
-        CSharpMemberLayout.Append(sb, head, body, indent, wrapExpressionBodyArrow, bodyIsSingleReturnExpression);
+        CSharpMemberLayout.Append(sb, head, body, indent, wrapExpressionBodyArrow, bodyIsSingleExpressionBody);
         return sb.ToString().Replace("\r\n", "\n");
     }
 
@@ -86,7 +86,7 @@ public sealed class CSharpMemberLayoutTests
             + "        Dot d => d.Radius,\n"
             + "        _ => -1,\n"
             + "    };\n",
-            Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, bodyIsSingleReturnExpression: true));
+            Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, bodyIsSingleExpressionBody: true));
 
     [Fact]
     public void Append_MultilineSwitchReturn_WrapsArrowOnNextLine_WhenRequested()
@@ -97,7 +97,7 @@ public sealed class CSharpMemberLayoutTests
             + "            Dot d => d.Radius,\n"
             + "            _ => -1,\n"
             + "        };\n",
-            Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, wrapExpressionBodyArrow: true, bodyIsSingleReturnExpression: true));
+            Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, wrapExpressionBodyArrow: true, bodyIsSingleExpressionBody: true));
 
     [Fact]
     public void Append_MultilineSwitchReturn_InNestedAccessor_RendersExpressionBodied()
@@ -107,7 +107,7 @@ public sealed class CSharpMemberLayoutTests
             + "            Dot d => d.Radius,\n"
             + "            _ => -1,\n"
             + "        };\n",
-            Render("get", SwitchReturnBody, indent: 8, bodyIsSingleReturnExpression: true));
+            Render("get", SwitchReturnBody, indent: 8, bodyIsSingleExpressionBody: true));
 
     [Fact]
     public void Append_MultilineSwitchReturn_StaysBlock_WhenSignalNotSet()
@@ -120,7 +120,7 @@ public sealed class CSharpMemberLayoutTests
             + "            _ => -1,\n"
             + "        };\n"
             + "    }\n",
-            Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, bodyIsSingleReturnExpression: false));
+            Render("int Area(Shape shape)", SwitchReturnBody, indent: 4, bodyIsSingleExpressionBody: false));
 
     // Issue #3084: the same single-return expression-body fold is not
     // switch-specific — any multi-line single `return <expr>;` (here a wrapped
@@ -136,7 +136,7 @@ public sealed class CSharpMemberLayoutTests
             + "        .Append(\"a\")\n"
             + "        .Append(\"b\")\n"
             + "        .ToString();\n",
-            Render("string Build(StringBuilder builder)", FluentChainReturnBody, indent: 4, bodyIsSingleReturnExpression: true));
+            Render("string Build(StringBuilder builder)", FluentChainReturnBody, indent: 4, bodyIsSingleExpressionBody: true));
 
     [Fact]
     public void Append_MultilineFluentReturn_WrapsArrowOnNextLine_WhenRequested()
@@ -146,7 +146,7 @@ public sealed class CSharpMemberLayoutTests
             + "            .Append(\"a\")\n"
             + "            .Append(\"b\")\n"
             + "            .ToString();\n",
-            Render("string Build(StringBuilder builder)", FluentChainReturnBody, indent: 4, wrapExpressionBodyArrow: true, bodyIsSingleReturnExpression: true));
+            Render("string Build(StringBuilder builder)", FluentChainReturnBody, indent: 4, wrapExpressionBodyArrow: true, bodyIsSingleExpressionBody: true));
 
     [Fact]
     public void Append_MultilineFluentReturn_StaysBlock_WhenSignalNotSet()
@@ -158,7 +158,36 @@ public sealed class CSharpMemberLayoutTests
             + "            .Append(\"b\")\n"
             + "            .ToString();\n"
             + "    }\n",
-            Render("string Build(StringBuilder builder)", FluentChainReturnBody, indent: 4, bodyIsSingleReturnExpression: false));
+            Render("string Build(StringBuilder builder)", FluentChainReturnBody, indent: 4, bodyIsSingleExpressionBody: false));
+
+    // Issue #3084 (this slice): the fold is not return-specific either — a void
+    // member whose only statement is a multi-line expression statement (a wrapped
+    // fluent chain, no `return`) renders expression-bodied too, the whole first
+    // line trailing the arrow and each chained call re-indented one level under
+    // the member.
+    const string FluentChainStatementBody =
+        "builder\n    .Append(\"a\")\n    .Append(\"b\")\n    .Clear();";
+
+    [Fact]
+    public void Append_MultilineFluentStatement_RendersExpressionBodied_SameLineArrow()
+        => Assert.Equal(
+            "    void Build(StringBuilder builder) => builder\n"
+            + "        .Append(\"a\")\n"
+            + "        .Append(\"b\")\n"
+            + "        .Clear();\n",
+            Render("void Build(StringBuilder builder)", FluentChainStatementBody, indent: 4, bodyIsSingleExpressionBody: true));
+
+    [Fact]
+    public void Append_MultilineFluentStatement_StaysBlock_WhenSignalNotSet()
+        => Assert.Equal(
+            "    void Build(StringBuilder builder)\n"
+            + "    {\n"
+            + "        builder\n"
+            + "            .Append(\"a\")\n"
+            + "            .Append(\"b\")\n"
+            + "            .Clear();\n"
+            + "    }\n",
+            Render("void Build(StringBuilder builder)", FluentChainStatementBody, indent: 4, bodyIsSingleExpressionBody: false));
 
     [Fact]
     public void AppendIndentedBody_PreservesBlankLinesAndTrimsTrailing()

--- a/src/ILInspector.CSharp/CSharpExpressionBody.cs
+++ b/src/ILInspector.CSharp/CSharpExpressionBody.cs
@@ -30,24 +30,34 @@ public static class CSharpExpressionBody
     }
 
     /// <summary>
-    /// The expression of a <em>multi-line</em> single-<c>return</c> body — a raised
-    /// switch-expression return (issue #3088), a wrapped fluent chain, or any other
-    /// wrapped single expression (issue #3084) — as its lines, with the leading
-    /// <c>return </c> and trailing <c>;</c> removed and every line's trailing
-    /// whitespace trimmed. The first entry is the value/arrow line (the token that
-    /// opens the expression, such as <c>&lt;value&gt; switch</c> or the chain's
-    /// receiver); the rest are the continuation lines at their body-relative
-    /// (column-zero) indent, which the layout re-indents under the member. Returns
-    /// <see langword="null"/> for a single-line body (that is
-    /// <see cref="FromSingleStatement"/>'s job) or anything not shaped as
-    /// <c>return &lt;expr&gt;;</c>.
+    /// The expression of a <em>multi-line</em> single-statement body — a raised
+    /// switch-expression return (issue #3088), a wrapped fluent chain in
+    /// <c>return</c> or void expression-statement position, or any other wrapped
+    /// single expression (issue #3084) — as its lines, with the leading
+    /// <c>return </c> (when present) and trailing <c>;</c> removed and every
+    /// line's trailing whitespace trimmed. The first entry is the value/arrow line
+    /// (the token that opens the expression, such as <c>&lt;value&gt; switch</c>,
+    /// the chain's receiver, or a leading <c>throw</c>); the rest are the
+    /// continuation lines at their body-relative (column-zero) indent, which the
+    /// layout re-indents under the member. Returns <see langword="null"/> for a
+    /// single-line body (that is <see cref="FromSingleStatement"/>'s job) or
+    /// anything not shaped as a single <c>&lt;expr&gt;;</c> statement.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// The helper is deliberately shape-agnostic about the statement keyword: it
+    /// strips a leading <c>return </c> when present and otherwise keeps the whole
+    /// first line as the arrow value, so a void expression statement folds to
+    /// <c>=&gt; &lt;expr&gt;;</c> and a wrapped <c>throw &lt;expr&gt;;</c> (should
+    /// one ever print multi-line) folds to <c>=&gt; throw &lt;expr&gt;;</c>.
+    /// </para>
+    /// <para>
     /// This never asserts, on its own, that the body is a single statement — a
     /// flat string cannot prove that soundly. Callers must gate it on the typed
-    /// <c>BodyIsSingleReturnExpression</c> signal the printer proves structurally.
+    /// <c>BodyIsSingleExpressionBody</c> signal the printer proves structurally.
+    /// </para>
     /// </remarks>
-    public static IReadOnlyList<string>? MultilineReturnExpressionLines(string body)
+    public static IReadOnlyList<string>? MultilineExpressionBodyLines(string body)
     {
         var trimmed = body.Trim();
         if (!trimmed.EndsWith(';'))
@@ -57,9 +67,9 @@ public static class CSharpExpressionBody
             return null;   // single line — FromSingleStatement owns it
 
         var firstLine = trimmed[..newline].TrimStart();
-        if (!firstLine.StartsWith("return ", StringComparison.Ordinal))
-            return null;
-        var valueLine = firstLine["return ".Length..].Trim();
+        var valueLine = firstLine.StartsWith("return ", StringComparison.Ordinal)
+            ? firstLine["return ".Length..].Trim()
+            : firstLine;
         if (valueLine.Length == 0)
             return null;
 

--- a/src/ILInspector.CSharp/CSharpMemberLayout.cs
+++ b/src/ILInspector.CSharp/CSharpMemberLayout.cs
@@ -27,18 +27,19 @@ public static class CSharpMemberLayout
     /// Otherwise a brace block with the body content one level (four spaces)
     /// deeper. Blank lines in the body are preserved.
     /// </summary>
-    /// <param name="bodyIsSingleReturnExpression">
+    /// <param name="bodyIsSingleExpressionBody">
     /// When <see langword="true"/> the caller has proven, from the typed
-    /// <c>DecompilerResult.BodyIsSingleReturnExpression</c> signal, that
-    /// <paramref name="body"/> is exactly one <c>return &lt;expr&gt;;</c>
-    /// statement whose expression spans several lines (a raised switch
-    /// expression, a wrapped fluent chain, or any other wrapped single
-    /// expression). Such a body renders expression-bodied — <c>head =&gt; &lt;value&gt;</c>
-    /// with the continuation lines re-indented under the member (issues #3088 and
-    /// #3084). Only ever set for a multi-line body; single-line bodies stay on the
+    /// <c>DecompilerResult.BodyIsSingleExpressionBody</c> signal, that
+    /// <paramref name="body"/> is exactly one multi-line single-statement
+    /// expression — a <c>return &lt;expr&gt;;</c> or a void <c>&lt;expr&gt;;</c>
+    /// statement (a raised switch expression, a wrapped fluent chain, or any
+    /// other wrapped single expression). Such a body renders expression-bodied —
+    /// <c>head =&gt; &lt;value&gt;</c> with the continuation lines re-indented under
+    /// the member (issues #3088 and #3084). Only ever set for a multi-line body;
+    /// single-line bodies stay on the
     /// <see cref="CSharpExpressionBody.FromSingleStatement"/> path.
     /// </param>
-    public static void Append(StringBuilder sb, string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleReturnExpression = false)
+    public static void Append(StringBuilder sb, string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleExpressionBody = false)
     {
         ArgumentNullException.ThrowIfNull(sb);
         ArgumentNullException.ThrowIfNull(head);
@@ -49,8 +50,8 @@ public static class CSharpMemberLayout
             sb.AppendLine($"{pad}{head};");
             return;
         }
-        if (bodyIsSingleReturnExpression
-            && CSharpExpressionBody.MultilineReturnExpressionLines(body) is { } expressionLines)
+        if (bodyIsSingleExpressionBody
+            && CSharpExpressionBody.MultilineExpressionBodyLines(body) is { } expressionLines)
         {
             AppendMultilineExpressionBody(sb, head, expressionLines, indent, wrapExpressionBodyArrow);
             return;

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
@@ -10,7 +10,7 @@ namespace ILInspector.Decompiler.Tests;
 // Issue #3088: a method (or accessor) whose entire body is a single
 // `return <switch-expression>;` renders as an expression-bodied member
 // (`head => <scrutinee> switch { ... };`) instead of a brace block. The
-// signal is computed structurally in the printer (BodyIsSingleReturnExpression)
+// signal is computed structurally in the printer (BodyIsSingleExpressionBody)
 // from the raised IR and threaded to the CSharp layout layer, which owns the
 // block-vs-expression-body decision and re-indents the switch block under the
 // member. These fixtures compile real C#, decompile the full member, and assert
@@ -136,6 +136,56 @@ public class MemberBodyProducerExpressionBodyTests
     }
 
     [Fact]
+    public void SingleVoidFluentExpressionStatement_RendersExpressionBodied()
+    {
+        // Issue #3084 (this slice): a void method whose whole body is one
+        // expression statement — a fluent call chain wide enough to wrap — folds
+        // to an expression-bodied member too. There is no `return`, so the arrow
+        // trails the signature with the chain receiver after it and the chained
+        // calls follow one level deeper.
+        using var assembly = Compile("""
+            public class Fx
+            {
+                public static void Build(System.Text.StringBuilder builder)
+                {
+                    builder.Append("alphabet").Append("bravissimo").Append("charlateral").Append("deltatango").Append("echolocation").Append("foxtrotter");
+                }
+            }
+            """);
+
+        string source = ComposeType(assembly.Path, "Fx");
+
+        Assert.Contains("public static void Build(StringBuilder builder) => builder", source);
+        Assert.Contains("\n        .Append(\"alphabet\")", source);
+        Assert.Contains("\n        .Append(\"foxtrotter\");", source);
+        // The old block form (a brace block wrapping the lone statement) is gone.
+        Assert.DoesNotContain("Build(StringBuilder builder)\n    {", source);
+    }
+
+    [Fact]
+    public void VoidFluentExpressionStatementAfterAnotherStatement_StaysBlock()
+    {
+        // Close negative: a statement preceding the fluent chain makes the body
+        // two statements, not a single expression body, so it keeps the
+        // brace-block form.
+        using var assembly = Compile("""
+            public class Fx
+            {
+                public static void Build(System.Text.StringBuilder builder)
+                {
+                    builder.Clear();
+                    builder.Append("alphabet").Append("bravissimo").Append("charlateral").Append("deltatango").Append("echolocation").Append("foxtrotter");
+                }
+            }
+            """);
+
+        string source = ComposeType(assembly.Path, "Fx");
+
+        Assert.Contains("public static void Build(StringBuilder builder)\n    {", source);
+        Assert.DoesNotContain("Build(StringBuilder builder) =>", source);
+    }
+
+    [Fact]
     public void SingleStackallocPointerReturn_StaysBlock()
     {
         // GPT review of #3141: a lone `return stackalloc ...;` whose value the
@@ -143,8 +193,8 @@ public class MemberBodyProducerExpressionBodyTests
         // block) is still one top-level Return, and its output is multi-line, so
         // it satisfied the earlier flag guard. But its printed body does not
         // begin with a bare `return `, so it is not a foldable expression body.
-        // The text guard keeps BodyIsSingleReturnExpression off, matching what
-        // MultilineReturnExpressionLines would accept, and the member stays a
+        // The text guard keeps BodyIsSingleExpressionBody off, matching what
+        // MultilineExpressionBodyLines would accept, and the member stays a
         // brace block. (Output was already correct via downstream re-gating;
         // this locks the member framing so a future guard relaxation cannot
         // silently fold a multi-statement expansion.)

--- a/src/ILInspector.Decompiler.Tests/MultiLineExpressionBodyRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MultiLineExpressionBodyRenderTests.cs
@@ -44,4 +44,29 @@ public sealed class MultiLineExpressionBodyRenderTests
             "        .ToString();",
             rendered.Text!.Replace("\r\n", "\n"));
     }
+
+    [Fact]
+    public void WrappedSingleExpressionStatement_RendersStyleBExpressionBody()
+    {
+        // #3084 (this slice): a void member whose one statement is a wide
+        // expression statement (no `return`) folds to an expression-bodied member
+        // too — the whole first line trails the arrow, chained calls one level
+        // deeper. Block body and expression body are IL-identical.
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == nameof(MultiLineExpressionBodySamples.Drain));
+
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null);
+
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.Equal(
+            "    public static void Drain(StringBuilder builder) => builder\n" +
+            "        .Append(\"alphabet\")\n" +
+            "        .Append(\"bravissimo\")\n" +
+            "        .Append(\"charlateral\")\n" +
+            "        .Append(\"deltatango\")\n" +
+            "        .Append(\"echolocation\")\n" +
+            "        .Append(\"foxtrotter\")\n" +
+            "        .Clear();",
+            rendered.Text!.Replace("\r\n", "\n"));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/MultiLineExpressionBodySamples.cs
+++ b/src/ILInspector.Decompiler.Tests/MultiLineExpressionBodySamples.cs
@@ -19,4 +19,19 @@ public static class MultiLineExpressionBodySamples
             .Append("echolocation")
             .Append("foxtrotter")
             .ToString();
+
+    // #3084 (this slice) witness: a void method whose one statement is an
+    // expression statement (not a `return`) wide enough to wrap. The member
+    // layout must fold it to an expression-bodied member too — the whole first
+    // line trails the arrow with the chained calls one level deeper — even though
+    // there is no `return` keyword to strip.
+    public static void Drain(StringBuilder builder)
+        => builder
+            .Append("alphabet")
+            .Append("bravissimo")
+            .Append("charlateral")
+            .Append("deltatango")
+            .Append("echolocation")
+            .Append("foxtrotter")
+            .Clear();
 }

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -122,6 +122,28 @@ public class UnsafeEmitterTests
     }
 
     [Fact]
+    public void NewRulesModule_SingleUnsafeExpressionStatement_NotFlaggedExpressionBody()
+    {
+        // GPT review of #3146: a void member whose one statement needs an unsafe
+        // context wraps as `unsafe { <stmt>; }` under the new rules — a multi-line
+        // body ending in `}`, not `;`. The multi-line expression-body extractor
+        // rejects it (it requires a trailing `;`), so the typed
+        // BodyIsSingleExpressionBody signal must agree and stay false; otherwise a
+        // consumer trusting the flag without re-running the extractor would fold a
+        // body the extractor cannot supply. Output is a brace block either way;
+        // this locks the flag/extractor agreement (co-gating invariant).
+        var result = DecompileResult(
+            typeof(NewFixtures).Assembly.Location,
+            typeof(NewFixtures).FullName!,
+            nameof(NewFixtures.FreePointer));
+
+        Assert.NotNull(result.Output);
+        Assert.Contains("unsafe", result.Output);
+        Assert.EndsWith("}", result.Output!.TrimEnd());
+        Assert.False(result.BodyIsSingleExpressionBody);
+    }
+
+    [Fact]
     public void NewRulesModule_UnsafeCatchFilter_WrapsWholeTryCatch()
     {
         var int32 = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -265,18 +265,20 @@ public sealed record DecompilerResult(
     public bool ContainsAwaitExpression { get; init; }
 
     /// <summary>
-    /// True when the whole body is exactly one multi-line
-    /// <c>return &lt;expression&gt;;</c> statement — a single wrapped expression with
+    /// True when the whole body is exactly one multi-line single-statement
+    /// expression — a <c>return &lt;expression&gt;;</c> or a single void
+    /// <c>&lt;expression&gt;;</c> statement — a single wrapped expression with
     /// nothing else in the body. The member layer
     /// (<see cref="ILInspector.CSharp.CSharpMemberLayout"/>) consumes this typed
     /// structural fact to render the member expression-bodied
-    /// (<c>head =&gt; &lt;expr&gt;;</c>) instead of a brace block wrapping a lone
-    /// <c>return</c> — a raised multi-line switch return (issue #3088) or any other
-    /// wrapped single expression such as a fluent chain (issue #3084). It is a
-    /// body-shape fact the printer proves from the emitted statement tree, so
-    /// consumers never re-parse the rendered text to recover it.
+    /// (<c>head =&gt; &lt;expr&gt;;</c>) instead of a brace block wrapping the lone
+    /// statement — a raised multi-line switch return (issue #3088) or any other
+    /// wrapped single expression such as a fluent chain in return or void
+    /// expression-statement position (issue #3084). It is a body-shape fact the
+    /// printer proves from the emitted statement tree, so consumers never re-parse
+    /// the rendered text to recover it.
     /// </summary>
-    public bool BodyIsSingleReturnExpression { get; init; }
+    public bool BodyIsSingleExpressionBody { get; init; }
 
     /// <summary>
     /// A telemetry-free record of what the decompilation observed — its fidelity
@@ -315,7 +317,7 @@ public sealed record DecompilerResult(
             && RequiresAsyncBodyModifier == other.RequiresAsyncBodyModifier
             && RequiresUnsafeBodyModifier == other.RequiresUnsafeBodyModifier
             && ContainsAwaitExpression == other.ContainsAwaitExpression
-            && BodyIsSingleReturnExpression == other.BodyIsSingleReturnExpression
+            && BodyIsSingleExpressionBody == other.BodyIsSingleExpressionBody
             && EqualityComparer<DecompilerTrace?>.Default.Equals(Trace, other.Trace);
 
     public override int GetHashCode()
@@ -329,7 +331,7 @@ public sealed record DecompilerResult(
         hash.Add(RequiresAsyncBodyModifier);
         hash.Add(RequiresUnsafeBodyModifier);
         hash.Add(ContainsAwaitExpression);
-        hash.Add(BodyIsSingleReturnExpression);
+        hash.Add(BodyIsSingleExpressionBody);
         hash.Add(Trace);
         return hash.ToHashCode();
     }

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -840,10 +840,10 @@ public static class MemberBodyProducer
 
                     string? constructorChain = null;
                     bool requiresUnsafeContext = false;
-                    bool bodyIsSingleReturnExpression = false;
+                    bool bodyIsSingleExpressionBody = false;
                     string? body = member.IsAbstract
                         ? null
-                        : DecompileBody(pipelineSource, memberHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
+                        : DecompileBody(pipelineSource, memberHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
 
                     // An explicit interface property implementation surfaces
                     // as its accessor method (Iface.get_X). Render the
@@ -867,9 +867,9 @@ public static class MemberBodyProducer
                             CSharpMemberLayout.Append(sb, "set", body, 8, WrapExpressionBodyArrow(printerOptions));
                             sb.AppendLine("    }");
                         }
-                        else if (bodyIsSingleReturnExpression || CSharpExpressionBody.FromSingleStatement(body) is not null)
+                        else if (bodyIsSingleExpressionBody || CSharpExpressionBody.FromSingleStatement(body) is not null)
                         {
-                            CSharpMemberLayout.Append(sb, head, body, 4, WrapExpressionBodyArrow(printerOptions), bodyIsSingleReturnExpression);
+                            CSharpMemberLayout.Append(sb, head, body, 4, WrapExpressionBodyArrow(printerOptions), bodyIsSingleExpressionBody);
                         }
                         else
                         {
@@ -892,7 +892,7 @@ public static class MemberBodyProducer
                     var declaration = bodyShape is null
                         ? DefaultDeclarationFormatter.FormatMember(type, member)
                         : DefaultDeclarationFormatter.FormatMemberWithBody(type, member, bodyShape);
-                    AppendMember(sb, declaration, body, WrapExpressionBodyArrow(printerOptions), constructorChain, bodyIsSingleReturnExpression);
+                    AppendMember(sb, declaration, body, WrapExpressionBodyArrow(printerOptions), constructorChain, bodyIsSingleExpressionBody);
                     break;
                 }
 
@@ -1121,12 +1121,12 @@ public static class MemberBodyProducer
         return null;
     }
 
-    static void AppendMember(StringBuilder sb, string signature, string? body, bool wrapExpressionBodyArrow, string? constructorChain = null, bool bodyIsSingleReturnExpression = false)
+    static void AppendMember(StringBuilder sb, string signature, string? body, bool wrapExpressionBodyArrow, string? constructorChain = null, bool bodyIsSingleExpressionBody = false)
     {
         // An explicit base(...)/this(...) chain renders as a signature
         // initializer (the printer lifted it out of the body).
         string head = constructorChain is null ? signature : $"{signature} : {constructorChain}";
-        CSharpMemberLayout.Append(sb, head, body, 4, wrapExpressionBodyArrow, bodyIsSingleReturnExpression);
+        CSharpMemberLayout.Append(sb, head, body, 4, wrapExpressionBodyArrow, bodyIsSingleExpressionBody);
     }
 
     static string TypeParameterDisplayName(TypeParameter typeParameter)
@@ -1303,7 +1303,7 @@ public static class MemberBodyProducer
         Pipeline.MetadataSource pipelineSource, MethodDefinitionHandle? memberHandle,
         string typeFullName, ApiMember member, int overloadIndex,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext,
-        out bool bodyIsSingleReturnExpression, Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleExpressionBody, Pipeline.PrinterOptions? printerOptions)
     {
         // Prefer the member's own metadata handle — the canonical same-reader
         // addressing (see docs/design/member-body-substrate.md). The caller has
@@ -1314,7 +1314,7 @@ public static class MemberBodyProducer
         if (memberHandle is { } methodHandle)
             return DecompileFunction(pipelineSource,
                 Pipeline.IrImporter.Import(pipelineSource, methodHandle),
-                bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
+                bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
 
         // Public-only overload counting, except explicit interface
         // implementations (non-public by nature) — matching the API surface
@@ -1323,7 +1323,7 @@ public static class MemberBodyProducer
             publicOnly: member.Kind != "explicit-interface-implementation"
                 && !(member.Kind == "constructor" && member.DeclaringOverloadIndex is not null)
                 && member.Accessibility is null,
-            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
+            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
     }
 
     /// <summary>
@@ -1394,7 +1394,7 @@ public static class MemberBodyProducer
         Pipeline.MetadataSource pipelineSource, MethodDefinitionHandle? accessorHandle,
         string typeFullName, string accessorName,
         SortedSet<string> bodyNamespaces, out bool requiresUnsafeContext,
-        out bool bodyIsSingleReturnExpression, Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleExpressionBody, Pipeline.PrinterOptions? printerOptions)
         // Prefer the accessor's own handle (fixes indexer get_Item/set_Item
         // drift, where name+index:0 always selects the first indexer's
         // accessor). Fall back to the by-name path — accessors are non-public
@@ -1403,9 +1403,9 @@ public static class MemberBodyProducer
         => accessorHandle is { } handle
             ? DecompileFunction(pipelineSource,
                 Pipeline.IrImporter.Import(pipelineSource, handle),
-                bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions)
+                bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions)
             : DecompileMethod(pipelineSource, typeFullName, accessorName, overloadIndex: 0,
-            publicOnly: false, bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
+            publicOnly: false, bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
 
     /// <summary>
     /// Imports one method to typed IR, runs the raising passes, and prints the
@@ -1418,10 +1418,10 @@ public static class MemberBodyProducer
     static string? DecompileMethod(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string methodName, int overloadIndex,
         bool publicOnly, SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext,
-        out bool bodyIsSingleReturnExpression, Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleExpressionBody, Pipeline.PrinterOptions? printerOptions)
         => DecompileFunction(pipelineSource,
             Pipeline.IrImporter.Import(pipelineSource, typeFullName, methodName, overloadIndex, publicOnly),
-            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleReturnExpression, printerOptions);
+            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
 
     /// <summary>
     /// Runs the raising passes and prints an already-imported function. A null
@@ -1432,11 +1432,11 @@ public static class MemberBodyProducer
     static string? DecompileFunction(
         Pipeline.MetadataSource pipelineSource, Pipeline.IrFunction? function,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext,
-        out bool bodyIsSingleReturnExpression, Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleExpressionBody, Pipeline.PrinterOptions? printerOptions)
     {
         constructorChain = null;
         requiresUnsafeContext = false;
-        bodyIsSingleReturnExpression = false;
+        bodyIsSingleExpressionBody = false;
         if (function is null)
             return null;
         CollectNamespaces(function, bodyNamespaces);
@@ -1445,7 +1445,7 @@ public static class MemberBodyProducer
             typesProvablyDisjoint: pipelineSource.AreProvablyDisjoint);
         constructorChain = result.ConstructorChain;
         requiresUnsafeContext = result.RequiresUnsafeBodyModifier;
-        bodyIsSingleReturnExpression = result.BodyIsSingleReturnExpression;
+        bodyIsSingleExpressionBody = result.BodyIsSingleExpressionBody;
         return result.Output?.TrimEnd() ?? DiagnosticComment(result);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -249,56 +249,69 @@ public sealed partial class CSharpPrinter
             RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
             RequiresUnsafeBodyModifier = function.Descendants.Prepend(function).Any(NeedsUnsafeContext),
             ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
-            BodyIsSingleReturnExpression = BodyIsSingleReturnExpression(function, output),
+            BodyIsSingleExpressionBody = BodyIsSingleExpressionBody(function, output),
             Metadata = new DecompilerResultMetadata(EffectiveDecompilerOptions(), [.. _decisions]),
         };
 
     /// <summary>
-    /// True when the printed body is exactly one top-level
-    /// <c>return &lt;expression&gt;;</c> statement whose expression spans several
-    /// lines — a single multi-line expression with nothing else in the body. The
-    /// member layer renders such a body as an expression-bodied member (a raised
-    /// multi-line switch return, issue #3088; a wrapped fluent chain or other
-    /// wrapped single expression, issue #3084). The single-statement shape is
-    /// structural (the emitted top-level statement list plus the lifts the printer
-    /// already tracked), never a re-parse of the rendered text: because the body
-    /// is exactly one <see cref="Return"/> with no lifted declarations, its whole
-    /// printed form is that one <c>return &lt;expr&gt;;</c> statement, so folding it
-    /// to <c>head =&gt; &lt;expr&gt;;</c> is a language-guaranteed equivalence. The
-    /// only text-derived input is whether that single return actually wrapped and
-    /// printed as a bare <c>return &lt;expr&gt;;</c>: a single-line return already
-    /// folds on the <see cref="CSharpExpressionBody.FromSingleStatement"/> path, so
-    /// this signal stays reserved for the multi-line case the flat helper cannot
-    /// recover. A rare single <see cref="Return"/> whose value the printer expands
-    /// into several statements (for example a <c>stackalloc</c>-to-pointer return
-    /// that lifts a local declaration inside an <c>unsafe</c> block) does not print
-    /// as a leading <c>return </c>, so the text guard keeps the flag off — matching
-    /// what <see cref="CSharpExpressionBody.MultilineReturnExpressionLines"/> would
-    /// accept, so the signal never claims a fold the member layer would reject.
+    /// True when the printed body is exactly one top-level statement whose whole
+    /// printed form is a single multi-line expression — a
+    /// <c>return &lt;expression&gt;;</c> (a raised multi-line switch return, issue
+    /// #3088; a wrapped fluent chain or other wrapped single expression, issue
+    /// #3084) or a single void <c>&lt;expression&gt;;</c> statement (a wrapped
+    /// fluent call chain, issue #3084). The member layer renders such a body as an
+    /// expression-bodied member (<c>head =&gt; &lt;expr&gt;;</c>) instead of a
+    /// brace block. The single-statement shape is structural (the emitted
+    /// top-level statement list plus the lifts the printer already tracked), never
+    /// a re-parse of the rendered text: because the body is exactly one statement
+    /// with no lifted declarations, its whole printed form is that one
+    /// <c>&lt;expr&gt;;</c>, so folding it to <c>head =&gt; &lt;expr&gt;;</c> is a
+    /// language-guaranteed equivalence. The only text-derived input is whether
+    /// that statement actually wrapped: a single-line body already folds on the
+    /// <see cref="CSharpExpressionBody.FromSingleStatement"/> path, so this signal
+    /// stays reserved for the multi-line case the flat helper cannot recover.
     /// </summary>
-    bool BodyIsSingleReturnExpression(IrFunction function, string output)
+    bool BodyIsSingleExpressionBody(IrFunction function, string output)
         => !_emittedDeclarations
             && !_topLevelHasLabel
             && _constructorChain is null
             && _fieldInitializers.Count == 0
             && !function.RequiresAsyncBodyModifier
             && !NeedsUnsupportedFallbackReturn(function)
-            && _topLevelStatements is [Return { Value: not null }]
-            && IsMultilineReturnExpressionText(output);
+            && IsFoldableSingleStatement(_topLevelStatements, output);
 
     /// <summary>
-    /// True when <paramref name="output"/> is a multi-line body that begins with a
-    /// bare <c>return </c> — the exact text shape
-    /// <see cref="CSharpExpressionBody.MultilineReturnExpressionLines"/> extracts.
-    /// Keeps <see cref="BodyIsSingleReturnExpression"/> aligned with the downstream
-    /// extractor so the typed flag is never set for a single return the printer
-    /// expanded into multiple statements (which would not fold anyway).
+    /// True when <paramref name="statements"/> is exactly one foldable statement
+    /// and <paramref name="output"/> is its multi-line printed form. Keeps
+    /// <see cref="BodyIsSingleExpressionBody"/> aligned with the downstream
+    /// extractor (<see cref="CSharpExpressionBody.MultilineExpressionBodyLines"/>)
+    /// so the typed flag is never set for a statement the printer expanded into
+    /// several lines that would not fold:
+    /// <list type="bullet">
+    /// <item>A lone <see cref="Return"/> whose value the printer lifts into a
+    /// leading local declaration (a <c>stackalloc</c>-to-pointer return inside an
+    /// <c>unsafe</c> block) prints a decl first, not a bare <c>return </c>, so the
+    /// keyword prefix keeps the flag off.</item>
+    /// <item>A single <see cref="ExpressionStatement"/> has no leading-decl lift
+    /// path — its whole printed form is that one statement (wrapped by the fluent
+    /// or splittable renderer, whose first line is always the expression's own
+    /// opening token) — so the multi-line guard alone is sound; no keyword prefix
+    /// exists to check.</item>
+    /// </list>
     /// </summary>
-    static bool IsMultilineReturnExpressionText(string output)
+    static bool IsFoldableSingleStatement(IReadOnlyList<IrNode> statements, string output)
     {
+        if (statements is not [var only])
+            return false;
         var trimmed = output.AsSpan().Trim();
-        return trimmed.Contains('\n')
-            && trimmed.StartsWith("return ", StringComparison.Ordinal);
+        if (!trimmed.Contains('\n'))
+            return false;
+        return only switch
+        {
+            Return { Value: not null } => trimmed.StartsWith("return ", StringComparison.Ordinal),
+            ExpressionStatement => true,
+            _ => false,
+        };
     }
 
     DecompilerOptions EffectiveDecompilerOptions()
@@ -362,8 +375,8 @@ public sealed partial class CSharpPrinter
     /// <summary>
     /// True once <see cref="PrintBody"/> has emitted at least one up-front local
     /// declaration (before the body statements). A body with declarations is not
-    /// a single-return expression, so it disqualifies the
-    /// <see cref="DecompilerResult.BodyIsSingleReturnExpression"/> signal.
+    /// a single-expression body, so it disqualifies the
+    /// <see cref="DecompilerResult.BodyIsSingleExpressionBody"/> signal.
     /// </summary>
     bool _emittedDeclarations;
 
@@ -371,8 +384,8 @@ public sealed partial class CSharpPrinter
     /// The top-level statements <see cref="AppendContainer"/> actually emitted
     /// (chain/field-initializer lifts and the trimmed trailing <c>return;</c>
     /// excluded), plus whether any top-level label was emitted. Together they let
-    /// <see cref="Result"/> recognize the single <c>return &lt;switch&gt;;</c> body
-    /// that <see cref="DecompilerResult.BodyIsSingleReturnExpression"/> reports —
+    /// <see cref="Result"/> recognize the single-statement expression body
+    /// that <see cref="DecompilerResult.BodyIsSingleExpressionBody"/> reports —
     /// a structural fact, not a re-parse of the rendered text.
     /// </summary>
     readonly List<IrNode> _topLevelStatements = [];

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -286,17 +286,20 @@ public sealed partial class CSharpPrinter
     /// <see cref="BodyIsSingleExpressionBody"/> aligned with the downstream
     /// extractor (<see cref="CSharpExpressionBody.MultilineExpressionBodyLines"/>)
     /// so the typed flag is never set for a statement the printer expanded into
-    /// several lines that would not fold:
+    /// several lines that would not fold. The shared guards require a multi-line
+    /// body that terminates in <c>;</c> — the exact shape the extractor accepts:
     /// <list type="bullet">
     /// <item>A lone <see cref="Return"/> whose value the printer lifts into a
     /// leading local declaration (a <c>stackalloc</c>-to-pointer return inside an
     /// <c>unsafe</c> block) prints a decl first, not a bare <c>return </c>, so the
     /// keyword prefix keeps the flag off.</item>
     /// <item>A single <see cref="ExpressionStatement"/> has no leading-decl lift
-    /// path — its whole printed form is that one statement (wrapped by the fluent
-    /// or splittable renderer, whose first line is always the expression's own
-    /// opening token) — so the multi-line guard alone is sound; no keyword prefix
-    /// exists to check.</item>
+    /// path, so its whole printed form is that one statement — but under the new
+    /// memory-safety rules the printer may wrap a lone unsafe statement as
+    /// <c>unsafe { &lt;stmt&gt;; }</c>, whose printed form ends in <c>}</c>, not
+    /// <c>;</c>. The trailing-<c>;</c> guard keeps the flag off for that wrapper
+    /// (the extractor rejects it too), so no keyword prefix is needed to
+    /// discriminate the un-wrapped case.</item>
     /// </list>
     /// </summary>
     static bool IsFoldableSingleStatement(IReadOnlyList<IrNode> statements, string output)
@@ -304,7 +307,7 @@ public sealed partial class CSharpPrinter
         if (statements is not [var only])
             return false;
         var trimmed = output.AsSpan().Trim();
-        if (!trimmed.Contains('\n'))
+        if (!trimmed.Contains('\n') || trimmed[^1] != ';')
             return false;
         return only switch
         {

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -185,7 +185,7 @@ public class ApiOutputFormatterTests
         var result = DecompilerResult.Success(
             "return shape switch\n{\n    string s => s.Length,\n    int[] a => a.Length,\n    _ => 0,\n};") with
         {
-            BodyIsSingleReturnExpression = true
+            BodyIsSingleExpressionBody = true
         };
 
         var source = ApiOutputFormatter.FormatSourceWithDeclaration(
@@ -218,7 +218,7 @@ public class ApiOutputFormatterTests
         var result = DecompilerResult.Success(
             "return shape switch\n{\n    string s => s.Length,\n    int[] a => a.Length,\n    _ => 0,\n};") with
         {
-            BodyIsSingleReturnExpression = false
+            BodyIsSingleExpressionBody = false
         };
 
         var source = ApiOutputFormatter.FormatSourceWithDeclaration(
@@ -251,7 +251,7 @@ public class ApiOutputFormatterTests
         var result = DecompilerResult.Success(
             "return builder\n    .Append(\"a\")\n    .Append(\"b\")\n    .ToString();") with
         {
-            BodyIsSingleReturnExpression = true
+            BodyIsSingleExpressionBody = true
         };
 
         var source = ApiOutputFormatter.FormatSourceWithDeclaration(
@@ -266,6 +266,40 @@ public class ApiOutputFormatterTests
         Assert.Contains("\n    .Append(\"a\")\n    .Append(\"b\")\n    .ToString();", source);
         Assert.EndsWith(".ToString();", source.TrimEnd());
         Assert.DoesNotContain("return builder", source);
+    }
+
+    [Fact]
+    public void FormatSourceWithDeclaration_SingleVoidFluentExpressionStatement_RendersExpressionBodied()
+    {
+        // #3084 (this slice): the fold is not return-specific. A void member whose
+        // only statement is a multi-line expression statement (a wrapped fluent
+        // chain, no `return`) renders expression-bodied too — the whole first line
+        // trails the arrow and the chained calls keep their column-zero body indent
+        // under the column-zero declaration.
+        var type = new ApiType { Namespace = "Samples", Name = "Builder", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Build",
+            Kind = "method",
+            SignatureModel = new ApiSignature { MemberName = "Build", ReturnType = "System.Void" }
+        };
+        var result = DecompilerResult.Success(
+            "builder\n    .Append(\"a\")\n    .Append(\"b\")\n    .Clear();") with
+        {
+            BodyIsSingleExpressionBody = true
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            member,
+            methodGenericParameters: null,
+            result,
+            preferExpressionBodied: true)
+            .ReplaceLineEndings("\n");
+
+        Assert.EndsWith(" => builder", Declaration(source));
+        Assert.Contains("\n    .Append(\"a\")\n    .Append(\"b\")\n    .Clear();", source);
+        Assert.EndsWith(".Clear();", source.TrimEnd());
     }
 
     [Theory]

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2280,16 +2280,16 @@ public static class ApiOutputFormatter
         if (!hasLeadingComments && preferExpressionBodied && CSharpExpressionBody.FromSingleStatement(body) is { } expressionBody)
             return $"{declaration} => {expressionBody};";
 
-        // A multi-line single-return expression renders expression-bodied too
-        // (a raised switch return, issue #3088; a wrapped fluent chain or other
-        // wrapped single expression, issue #3084): `head => <value>` with the
-        // continuation lines below. Those lines sit at their body-relative
-        // (column-zero) indent, so at this member's column-zero declaration they
-        // need no re-indentation. Gate strictly on the printer's typed
-        // BodyIsSingleReturnExpression signal; the extraction helper is not sound
-        // on the flat string alone.
-        if (!hasLeadingComments && preferExpressionBodied && result.BodyIsSingleReturnExpression
-            && CSharpExpressionBody.MultilineReturnExpressionLines(body) is { Count: > 0 } multilineExpression)
+        // A multi-line single-statement expression body renders expression-bodied
+        // too (a raised switch return, issue #3088; a wrapped fluent chain in
+        // return or void expression-statement position, issue #3084):
+        // `head => <value>` with the continuation lines below. Those lines sit at
+        // their body-relative (column-zero) indent, so at this member's
+        // column-zero declaration they need no re-indentation. Gate strictly on
+        // the printer's typed BodyIsSingleExpressionBody signal; the extraction
+        // helper is not sound on the flat string alone.
+        if (!hasLeadingComments && preferExpressionBodied && result.BodyIsSingleExpressionBody
+            && CSharpExpressionBody.MultilineExpressionBodyLines(body) is { Count: > 0 } multilineExpression)
         {
             var expression = new StringBuilder();
             expression.Append(declaration).Append(" => ").Append(multilineExpression[0]);


### PR DESCRIPTION
- Advances #3084
- Changes a void member whose one statement is a multi-line expression statement (a wrapped fluent chain) to render `head => <expr>;` instead of a brace block
- Card revision: `684a9923`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — an expression statement has no leading-declaration lift path, so its whole printed form is that one statement; folding it to `head => <expr>;` is a language-guaranteed, IL-identical equivalence, gated on the same typed structural signal already used for returns.

This generalizes the multi-line single-statement fold shipped in #3141 (switch/fluent/other single `return <expr>;`) to the remaining reachable shape in #3084: a void member whose one statement is a wrapped expression statement. The extractor is made shape-agnostic about the leading keyword (it strips `return ` when present, otherwise keeps the whole first line), and the printer signal now accepts one `Return { Value: not null }` (requiring a bare `return ` prefix) **or** one `ExpressionStatement` (multi-line guard alone). Multi-line throws are covered by the shape-agnostic extractor but the printer never produces one today, so no dead printer branch was added.

Rename for accuracy (the fold is no longer return-only): `BodyIsSingleReturnExpression` → `BodyIsSingleExpressionBody`; `MultilineReturnExpressionLines` → `MultilineExpressionBodyLines`.

### Original source

```csharp
public static void Drain(System.Text.StringBuilder builder)
{
    builder.Append("alphabet").Append("bravissimo").Append("charlateral").Append("deltatango").Append("echolocation").Append("foxtrotter").Clear();
}
```

### Before

```csharp
public static void Drain(System.Text.StringBuilder builder)
{
    builder
        .Append("alphabet")
        .Append("bravissimo")
        .Append("charlateral")
        .Append("deltatango")
        .Append("echolocation")
        .Append("foxtrotter")
        .Clear();
}
```

- Valid: True
- Correct: True

The block form is valid and correct; it is just the lower-quality framing (a brace block wrapping a single statement the runtime's `.editorconfig` would render expression-bodied).

### After

```csharp
public static void Drain(System.Text.StringBuilder builder) => builder
    .Append("alphabet")
    .Append("bravissimo")
    .Append("charlateral")
    .Append("deltatango")
    .Append("echolocation")
    .Append("foxtrotter")
    .Clear();
```

- Valid: True
- Correct: True

The body string is byte-for-byte identical to Before; only the member framing changed (block → expression-bodied). Presentation-only, like #3141.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `MemberBodyProducerExpressionBodyTests` / `MultiLineExpressionBodyRenderTests`: pre-existing | `MemberBodyProducerExpressionBodyTests` 7 passed, `MultiLineExpressionBodyRenderTests` 2 passed |
| Decompiler fast suite | 3605, 0 failed | 3605, 0 failed |
| CSharp suite | 323, 0 failed | 325, 0 failed |
| dotnet-inspect suite | 2028, 0 failed (12 ilasm skips) | 2028, 0 failed (12 ilasm skips) |
| Real witness | `Widget::Drain` block-wrapped single statement | `Widget::Drain` expression-bodied (real `member --library` output above) |

No golden flips: the fast suite total is unchanged aside from the new tests; no existing corpus fixture had a multi-line void fluent statement body, so this is additive.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — presentation-only (member framing), like #3141: the decompiled body string is unchanged, so residue/fidelity/fully-raised are identical to baseline and the PR quick gate is not applicable. The only difference is the block-vs-expression-body member framing the CSharp layout layer owns.

## Validation

```bash
export PATH="$HOME/.local/share/dotnet:$PATH"
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.MemberBodyProducerExpressionBodyTests -class ILInspector.Decompiler.Tests.MultiLineExpressionBodyRenderTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.CSharp.Tests -c Release
dotnet run --project src/dotnet-inspect.Tests -c Release
```
