### PR TITLE
Decline FoldGuardReturn folds that eagerly deref a chain-buried by-ref (#3114)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FoldGuardReturnFidelityTests.cs
@@ -63,6 +63,15 @@ public class FoldGuardReturnFidelityTests
     static LoadIndirect ByRefBoolDeref()
         => new(s_bool, new LoadArgument(1, "y", TypeRef.ByRef(s_bool)));
 
+    // A bool-returning call — a side-effecting barrier csc will not collapse past.
+    static Call BoolCall()
+        => new(new MethodRef(s_holder, "Call", s_bool, [], HasThis: false), isVirtual: false, []);
+
+    // A bool-returning call taking one bool argument (a by-ref deref confined to a
+    // call argument stays guarded and folds faithfully).
+    static Call BoolCallWith(IrExpression argument)
+        => new(new MethodRef(s_holder, "Sink", s_bool, [s_bool], HasThis: false), isVirtual: false, [argument]);
+
     // A raw pointer bool dereference: can access-violate, so csc keeps the branch and
     // the raise stays opcode-exact — the negative boundary of the by-ref guard.
     static LoadIndirect PointerBoolDeref()
@@ -231,6 +240,102 @@ public class FoldGuardReturnFidelityTests
     {
         // if (start <= 0) return refBool; return true;  →  start > 0 || refBool.
         AssertDeclined(StartLessEqualZero(), ByRefBoolDeref(), Bool(true));
+    }
+
+    // ---- Decline: a by-ref buried in a SAME-KIND logical chain (or under a reducible
+    // bool wrapper) that the printer flattens into the emitted operator. #3127's
+    // RendersAsBranchlessBarePlace only inspects the top-level operand and misses these;
+    // LiftEagerlyDerefsByRef descends the flattened chain (#3114 follow-up). ----
+
+    [Fact]
+    public void ByRefBeforeCallInAndChain_Case3_Declines()
+    {
+        // if (start <= 0) return (*r && Call()); return false;  →  start > 0 && (*r && Call())
+        // flattens to `start > 0 && *r && Call()`; the call-free `start > 0 & *r` PREFIX
+        // collapses branchless before the call barrier, so *r is dereferenced eagerly (NRE
+        // divergence on a null by-ref). Integer condition, so the decline is attributable
+        // to the operand chain descent, not the negate gate.
+        AssertDeclined(StartLessEqualZero(), new LogicalBinary(LogicalKind.And, ByRefBoolDeref(), BoolCall()), Bool(false));
+    }
+
+    [Fact]
+    public void ByRefAfterCallInAndChain_Case3_Declines()
+    {
+        // if (start <= 0) return (Call() && *r); return false;  →  flattens to
+        // `start > 0 && Call() && *r`. The trailing `&& *r` (bare by-ref right operand)
+        // collapses branchless, dereferencing *r whenever the guarded prefix is false —
+        // a by-ref anywhere in the same-kind chain is a hazard, not only before the call.
+        AssertDeclined(StartLessEqualZero(), new LogicalBinary(LogicalKind.And, BoolCall(), ByRefBoolDeref()), Bool(false));
+    }
+
+    [Fact]
+    public void ByRefInOrChain_Case2_OuterOr_Declines()
+    {
+        // if (start <= 0) return (*r || Call()); return true;  →  start > 0 || (*r || Call())
+        // flattens to `start > 0 || *r || Call()`; the `start > 0 | *r` prefix collapses
+        // branchless. The Or lift makes the same-kind Or chain the hazard.
+        AssertDeclined(StartLessEqualZero(), new LogicalBinary(LogicalKind.Or, ByRefBoolDeref(), BoolCall()), Bool(true));
+    }
+
+    [Fact]
+    public void ByRefInAndChainUnderEqualsTrueWrapper_Case3_Declines()
+    {
+        // SYNTHETIC/defensive: csc constant-folds `(*r && Call()) == true` to `*r && Call()`
+        // (no `ceq`), so this exact shape is not csc-reachable, but the fixpoint is pre-order
+        // and could present the un-reduced `== true` before FoldBoolConstantComparison strips
+        // it. Peeling the reducible wrapper BEFORE the same-kind flatten still reaches the
+        // buried by-ref.
+        var chain = new LogicalBinary(LogicalKind.And, ByRefBoolDeref(), BoolCall());
+        var wrapped = new Comparison(ComparisonKind.Equal, false, chain, Bool(true));
+        AssertDeclined(StartLessEqualZero(), wrapped, Bool(false));
+    }
+
+    // ---- Accept: a by-ref confined to a COMPOUND operand that keeps its branch still
+    // folds — the negative boundary of the chain descent. ----
+
+    [Fact]
+    public void ByRefInDifferentKindLogicalOperand_Case3_StillFolds()
+    {
+        // if (start <= 0) return (*r || Call()); return false;  →  start > 0 && (*r || Call()).
+        // The Or operand is a different kind from the And lift, so the printer does NOT
+        // flatten it; csc keeps the branch and *r stays guarded.
+        var (kind, _, right) = FoldOne(StartLessEqualZero(), new LogicalBinary(LogicalKind.Or, ByRefBoolDeref(), BoolCall()), Bool(false));
+        Assert.Equal(LogicalKind.And, kind);
+        Assert.Equal(LogicalKind.Or, Assert.IsType<LogicalBinary>(right).Kind);
+    }
+
+    [Fact]
+    public void ByRefInBitwiseAndOperand_Case3_StillFolds()
+    {
+        // if (start <= 0) return (local & *r); return false;  →  start > 0 && (local & *r).
+        // A bitwise `&` (Binary, not LogicalBinary) is a compound operand csc keeps the
+        // branch for; the by-ref stays guarded.
+        var bitwise = new Binary(BinaryKind.And, isChecked: false, isUnsigned: false, new LoadLocal(0, s_bool), ByRefBoolDeref());
+        var (kind, _, right) = FoldOne(StartLessEqualZero(), bitwise, Bool(false));
+        Assert.Equal(LogicalKind.And, kind);
+        Assert.IsType<Binary>(right);
+    }
+
+    [Fact]
+    public void ByRefInComparisonOperand_Case3_StillFolds()
+    {
+        // if (start <= 0) return (*r == local); return false;  →  start > 0 && (*r == local).
+        // A comparison is compound (not a reducible bool-constant comparison), so csc keeps
+        // the branch and the by-ref stays guarded.
+        var comparison = new Comparison(ComparisonKind.Equal, false, ByRefBoolDeref(), new LoadLocal(0, s_bool));
+        var (kind, _, right) = FoldOne(StartLessEqualZero(), comparison, Bool(false));
+        Assert.Equal(LogicalKind.And, kind);
+        Assert.IsType<Comparison>(right);
+    }
+
+    [Fact]
+    public void ByRefBehindCallArgument_Case3_StillFolds()
+    {
+        // if (start <= 0) return Sink(*r); return false;  →  start > 0 && Sink(*r).
+        // A call keeps the branch, so a by-ref confined to its argument stays guarded.
+        var (kind, _, right) = FoldOne(StartLessEqualZero(), BoolCallWith(ByRefBoolDeref()), Bool(false));
+        Assert.Equal(LogicalKind.And, kind);
+        Assert.IsType<Call>(right);
     }
 
     // ---- The both-opposite-constant identity/negation fold is a separate

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -505,20 +505,34 @@ public sealed class BooleanFoldingPass : IIrPass
             //   thenConstant == false: And(!c, tailValue)  negates; operand = tailValue
             bool negatesCondition;
             IrExpression survivingOperand;
+            // The branchless-collapse hazard depends on the OUTER logical kind the fold
+            // emits: the printer flattens only a same-kind chain, so a by-ref buried under
+            // a `||` operand of an `&&` lift (or vice versa) stays a guarded compound and
+            // folds faithfully. tailConstant lifts thenValue under `tailFlag ? Or : And`;
+            // thenConstant lifts tailValue under `thenConstant ? Or : And`.
+            LogicalKind outerKind;
             if (tailConstant is { } tailFlag)
             {
                 negatesCondition = tailFlag;
                 survivingOperand = thenValue;
+                outerKind = tailFlag ? LogicalKind.Or : LogicalKind.And;
             }
             else
             {
                 negatesCondition = thenConstant == false;
                 survivingOperand = tailValue;
+                outerKind = thenConstant == true ? LogicalKind.Or : LogicalKind.And;
             }
 
             if (ShortCircuitFidelity.IsUserDefinedTruthiness(guard.Condition)
                 || (negatesCondition && !ShortCircuitFidelity.NegationIsOpcodeExact(guard.Condition))
-                || ShortCircuitFidelity.RendersAsBranchlessBarePlace(survivingOperand))
+                || ShortCircuitFidelity.RendersAsBranchlessBarePlace(survivingOperand)
+                // RendersAsBranchlessBarePlace only inspects the top-level operand; a by-ref
+                // deref buried in a same-kind logical chain (or under a reducible bool
+                // wrapper) becomes a collapsible operand of the flattened chain and would be
+                // dereferenced eagerly — a NullReferenceException divergence (#3114 follow-up
+                // to #3127, which missed this chain-buried case).
+                || ShortCircuitFidelity.LiftEagerlyDerefsByRef(survivingOperand, outerKind))
             {
                 return false;
             }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ShortCircuitFidelity.cs
@@ -40,6 +40,65 @@ static class ShortCircuitFidelity
            || operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
 
     /// <summary>
+    /// The <em>soundness</em> extension of <see cref="RendersAsBranchlessBarePlace"/>
+    /// for the case that predicate misses: a managed by-ref dereference that is not the
+    /// surviving operand itself but is buried inside a same-kind logical chain the
+    /// printer flattens into the emitted operator.
+    ///
+    /// <para>csc collapses <c>L &amp;&amp; R</c> to a branchless <c>L &amp; R</c> (and
+    /// <c>L || R</c> to <c>L | R</c>) exactly when <c>R</c> renders as a bare place — a
+    /// local/argument/field load or a managed by-ref dereference, which csc treats as
+    /// non-null and side-effect-free. A <em>compound</em> right operand (a bitwise
+    /// <c>&amp;</c>/<c>|</c>, a different-kind logical sub-expression, a comparison, or a
+    /// call) keeps the branch, so a by-ref dereference confined to one stays guarded and
+    /// is safe to fold. But the printer flattens a maximal same-kind logical chain, so
+    /// when the fold emits <c>c <paramref name="outerKind"/> OP</c> and <c>OP</c> is a
+    /// same-kind chain, every operand of that chain becomes a collapsible right operand
+    /// of the flattened chain. A by-ref dereference reachable as one of those flattened
+    /// operands is therefore dereferenced unconditionally — an observable
+    /// <see cref="System.NullReferenceException"/> divergence on a null by-ref where the
+    /// branch had guarded it (e.g. <c>c &amp;&amp; (*r &amp;&amp; Call())</c> flattens to
+    /// <c>c &amp;&amp; *r &amp;&amp; Call()</c>; the call-free <c>c &amp; *r</c> prefix
+    /// collapses branchless before the call barrier is reached).
+    /// <see cref="RendersAsBranchlessBarePlace"/> only inspects the top-level operand, so
+    /// it does not see a by-ref buried in such a chain; this predicate descends it.</para>
+    ///
+    /// <para>The reducible bool wrappers of <see cref="PeelReducibleBoolWrappers"/> are
+    /// peeled BEFORE the same-kind flatten so a by-ref hidden under a leading <c>!</c>
+    /// (<c>!(*r &amp;&amp; Call())</c>) or a bool-constant comparison
+    /// (<c>(*r &amp;&amp; Call()) == true</c>) that <c>FoldBoolConstantComparison</c> would
+    /// splice into the surrounding chain is still reached. Peeling only ignores negation
+    /// parity, so it conservatively over-declines a branch-preserving <c>!*r</c> too —
+    /// sound, because declining an extra valid readability raise never changes behavior
+    /// while folding an unfaithful one does. A raw <em>pointer</em> dereference <c>*p</c>
+    /// is excluded (its address kind is not <see cref="TypeRefKind.ByRef"/>): a pointer
+    /// read can access-violate, so csc keeps the branch and lifting it is safe.</para>
+    ///
+    /// <para>Verified against SDK-csc <c>/optimize</c> IL + a null-by-ref runtime probe:
+    /// the by-ref-before-call same-kind chain and the bare operand each diverge from
+    /// their guarded original (null-by-ref throws), while the bitwise
+    /// (<c>a &amp; *r</c>), different-kind logical (<c>*r || Call()</c> under an
+    /// <c>&amp;&amp;</c> lift), comparison (<c>*r &gt; 0</c>), by-ref field (<c>r.b</c>),
+    /// and call-argument (<c>Call(*r)</c>) folds compile to byte-identical IL and do not
+    /// throw (#3114 follow-up to #3127).</para>
+    /// </summary>
+    public static bool LiftEagerlyDerefsByRef(IrExpression operand, LogicalKind outerKind)
+    {
+        // Peel BEFORE classifying the node: a same-kind chain hidden under a reducible
+        // `== true`/`!= false` wrapper (which FoldBoolConstantComparison later strips,
+        // splicing the chain into the surrounding `outerKind` chain) must be flattened
+        // so its by-ref operands are reached. Peeling only after flattening treats such
+        // a wrapper as an opaque compound and misses the buried by-ref.
+        var peeled = PeelReducibleBoolWrappers(operand);
+        if (peeled is LogicalBinary logical && logical.Kind == outerKind)
+        {
+            return LiftEagerlyDerefsByRef(logical.Left, outerKind)
+                || LiftEagerlyDerefsByRef(logical.Right, outerKind);
+        }
+        return peeled is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef };
+    }
+
+    /// <summary>
     /// Whether <paramref name="condition"/> is a user-defined-truthiness evaluation
     /// — a call to <c>operator true</c>/<c>operator false</c> the compiler inserts
     /// when a user type is used in boolean context. The printer strips such a call
@@ -140,4 +199,58 @@ static class ShortCircuitFidelity
             return true;
         return TypeFamilies.Of(type) == StackFamily.O;
     }
+
+    /// <summary>
+    /// Follow the reducible operand through the wrappers <see cref="BooleanFoldingPass"/>'s
+    /// fixpoint strips or inverts <em>after</em> its guarded-return fold has lifted the
+    /// expression: leading logical negations, and bool-constant comparisons
+    /// (<c>x == true</c>/<c>x == false</c>/<c>x != true</c>/<c>x != false</c>) that
+    /// <c>FoldBoolConstantComparison</c> reduces to <c>x</c> or <c>!x</c>. It follows the
+    /// non-constant side of each comparison so a chain nested under any run of these
+    /// wrappers is still reached. Used by <see cref="LiftEagerlyDerefsByRef"/>, which peels
+    /// each operand before the same-kind flatten so a by-ref deref hidden under a
+    /// <c>== true</c>/<c>!</c> wrapper — even one wrapping a whole same-kind chain — is still
+    /// reached. This is a deliberate CONSERVATIVE over-approximation: it ignores negation
+    /// parity, so it may decline a valid branch-preserving raise; modeling parity exactly
+    /// would re-implement <c>FoldBoolConstantComparison</c>/<see cref="Conditions.Negate"/>
+    /// here — a fragile second implementation this avoids.
+    /// </summary>
+    static IrExpression PeelReducibleBoolWrappers(IrExpression expression)
+    {
+        var inner = expression;
+        while (true)
+        {
+            if (inner is LogicalNot { Operand: { } negated })
+                inner = negated;
+            else if (BoolConstantComparisonOperand(inner) is { } operand)
+                inner = operand;
+            else
+                return inner;
+        }
+    }
+
+    /// <summary>
+    /// The non-constant operand of a bool-constant comparison
+    /// <c>FoldBoolConstantComparison</c> reduces — the bool-typed left side of
+    /// <c>x == true</c>/<c>x == false</c>/<c>x != true</c>/<c>x != false</c> (a right-hand
+    /// bool <c>0</c>/<c>1</c> constant), regardless of comparison direction. Both
+    /// directions are followed because the guarded-return fold's
+    /// <see cref="Conditions.Negate"/> can invert the comparison on its arm before the
+    /// reduction runs. Returns null for any non-reducible shape.
+    /// </summary>
+    static IrExpression? BoolConstantComparisonOperand(IrExpression expression)
+    {
+        if (expression is not Comparison { Kind: ComparisonKind.Equal or ComparisonKind.NotEqual } comparison)
+            return null;
+        if (comparison.Left.ResultType is not { Namespace: "System", Name: "Boolean" })
+            return null;
+        return BoolConstantValue(comparison.Right) is not null ? comparison.Left : null;
+    }
+
+    static bool? BoolConstantValue(IrExpression expression) => expression switch
+    {
+        Constant { Value: bool value } => value,
+        Constant { Value: int value } when value is 0 or 1 => value == 1,
+        _ => null,
+    };
 }


### PR DESCRIPTION
- Advances #3114 — focused correctness follow-up to merged #3127 (`be4291ee`)
- Supersedes #3119 (salvages its still-needed by-ref soundness delta)
- Changes `FoldGuardReturn` to also decline a short-circuit fold when the surviving operand hides a managed by-ref dereference inside a same-kind logical chain (or under a reducible bool wrapper), not only when the by-ref is the top-level bare operand
- Card revision: `e0d919c3`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — merged #3127 guarded only the top-level bare by-ref operand; a by-ref buried in the flattened same-kind chain still folds into an unconditional dereference that recompiles to a `NullReferenceException` divergence. This restores the decline for that chain-buried case while keeping #3127's opcode-fidelity policy verbatim.

### Original source

Authored fixture; no SourceLink source server, so the authoritative anchor is the raw IL. The `bgt.s` guard proves `r` (the by-ref) is dereferenced (`ldind.u1`) **only** when `start <= 0`; when `start > 0` control jumps straight to `return false` without touching `r`.

```il
IL_0000: ldarg.0
IL_0001: ldc.i4.0
IL_0002: bgt.s        IL_0010   // start > 0: skip the deref, return false
IL_0004: ldarg.1
IL_0005: ldind.u1               // *r — reached only when start <= 0
IL_0006: brfalse.s    IL_000E
IL_0008: call         WitnessNs.Hazard::Call()
IL_000D: ret
IL_000E: ldc.i4.0
IL_000F: ret
IL_0010: ldc.i4.0               // start > 0: return false, r untouched
IL_0011: ret
```

### Before

Base `d0d0ebc5` (merged #3127), `-S "Decompiled Source"`:

```csharp
public static bool ByRefBeforeCall(int start, ref bool r) => start <= 0 && r && Call();
```

- Valid: True
- Correct: False

The printer flattens the same-kind `&&` chain, so `r` becomes a bare operand of `start <= 0 && r && Call()`. csc recompiles the call-free prefix `start <= 0 && r` to a **branchless** `(start <= 0) & r` (a by-ref deref is a bare, side-effect-free place to csc), dereferencing `r` even when `start > 0`. On a null by-ref with `start > 0` the recompiled body throws where the original IL returned `false` — an observable divergence #3127's `RendersAsBranchlessBarePlace` missed because it never descends the operand.

### After

Head `e0d919c3`, `-S "Decompiled Source"`:

```csharp
public static bool ByRefBeforeCall(int start, ref bool r)
{
    if (start <= 0)
    {
        return r && Call();
    }
    return false;
}
```

- Valid: True
- Correct: True

The fold is declined, so the guard survives and `r` stays behind the `start <= 0` branch, recompiling faithfully.

### Fully raised

The After decompilation is in the fully raised state: for this shape the faithful endpoint is the branch-preserving form, because any short-circuit fold would reintroduce the eager by-ref dereference.

## Evidence

| Check | Baseline (`d0d0ebc5`) | Head (`e0d919c3`) |
| --- | --- | --- |
| Product build (`src/dotnet-inspect`) | Pass | Pass |
| Focused tests (`FoldGuardReturnFidelityTests`) | 19 passed | 27 passed (+8) |
| Related passes (`ShortCircuitTernaryPassTests`, `IrImporterTests`, `LoweringCoverageTests`) | Pass | 92 passed |
| Decompiler fast suite (`-trait- "Speed=Slow"`) | 3614, 2 failed (env) | 3614, 2 failed (env) |
| Real witness (`WitnessNs.Hazard::ByRefBeforeCall`) | folds to eager `start <= 0 && r && Call()` | declines; branch preserved |

The two fast-suite failures are pre-existing and environmental, unchanged by this PR:

- `StringSwitchRaisingTests.SmallStringSwitch_RendersSwitchOnString` — CRLF vs LF line-ending mismatch in the expected literal.
- `ExpressionTreeLambdaTests.LookalikeExpressionAssembly_StaysFactoryCalls` — `System.Linq.Expressions.dll` spoof fixture not built in the worktree.

Neither touches boolean folding.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the change only *narrows* an existing fold (adds a decline predicate). It introduces no new lowering, raising, or structuring, so it cannot add lowering residue, conditional-branch residue, or pass bugs. It can at most decline a fold for the exact chain-buried by-ref shape, which is the intended, correctness-preserving outcome. A full corpus gate was not run because there is no new raise to measure; the affected shape is exercised by the added fidelity unit tests and the real witness above.

## Scope

- Only a managed by-ref (`LoadIndirect` whose address is `TypeRefKind.ByRef`) is flagged. A raw pointer deref, a bitwise `&`/`|` (`Binary`) operand, a different-kind logical sub-expression, a comparison, and a by-ref confined to a call argument all keep their branch and still fold (covered by four accept tests).
- A chain-buried bare **local** remains an opcode-only (non-soundness) gap, pre-existing on main and out of scope here.
- CLI output is otherwise unchanged.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.FoldGuardReturnFidelityTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
