### PR TITLE
Parenthesize right-nested same-kind && / || chains (#3126)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -82,6 +82,97 @@ public class PrinterPrecedenceTests
         Assert.DoesNotContain("a ? b : c ? d", output);
     }
 
+    // ---- #3126: right-associative same-kind && / || chains keep their parens ----
+    // C# `&&`/`||` are left-associative, so a right-nested same-kind chain
+    // `a && (b && c)` must keep its parens: dropping them reparses as the
+    // left-nested `(a && b) && c`, which csc lays out with a different branch
+    // structure — the reprint would recompile to a divergent opcode stream. (Not
+    // reachable as a top-level ternary from C# source — csc folds a constant-arm
+    // ternary to `&&`/`||` at compile time — so the printer is exercised over the
+    // hand-built right-nested IR the boolean folds reconstruct.)
+
+    [Fact]
+    public void LogicalAnd_RightNestedSameKind_StaysParenthesized()
+    {
+        // a && (b && c) — right-nested `&&`.
+        var chain = new LogicalBinary(
+            LogicalKind.And,
+            new LoadArgument(0, "a", s_bool),
+            new LogicalBinary(
+                LogicalKind.And,
+                new LoadArgument(1, "b", s_bool),
+                new LoadArgument(2, "c", s_bool)));
+
+        var output = PrintReturn(
+            chain, s_bool,
+            [new Parameter("a", s_bool), new Parameter("b", s_bool), new Parameter("c", s_bool)]);
+
+        Assert.Contains("return a && (b && c);", output);
+    }
+
+    [Fact]
+    public void LogicalOr_RightNestedSameKind_StaysParenthesized()
+    {
+        // a || (b || c) — right-nested `||`.
+        var chain = new LogicalBinary(
+            LogicalKind.Or,
+            new LoadArgument(0, "a", s_bool),
+            new LogicalBinary(
+                LogicalKind.Or,
+                new LoadArgument(1, "b", s_bool),
+                new LoadArgument(2, "c", s_bool)));
+
+        var output = PrintReturn(
+            chain, s_bool,
+            [new Parameter("a", s_bool), new Parameter("b", s_bool), new Parameter("c", s_bool)]);
+
+        Assert.Contains("return a || (b || c);", output);
+    }
+
+    [Fact]
+    public void LogicalAnd_LeftNestedSameKind_StaysFlat()
+    {
+        // (a && b) && c — left-nested `&&`. C# `&&` is left-associative, so this
+        // is opcode-identical to the flat `a && b && c` and must NOT gain parens
+        // (regression guard against over-parenthesizing the common left-nested
+        // chain, which is what most compiled `&&` lowerings produce).
+        var chain = new LogicalBinary(
+            LogicalKind.And,
+            new LogicalBinary(
+                LogicalKind.And,
+                new LoadArgument(0, "a", s_bool),
+                new LoadArgument(1, "b", s_bool)),
+            new LoadArgument(2, "c", s_bool));
+
+        var output = PrintReturn(
+            chain, s_bool,
+            [new Parameter("a", s_bool), new Parameter("b", s_bool), new Parameter("c", s_bool)]);
+
+        Assert.Contains("return a && b && c;", output);
+        Assert.DoesNotContain("(a && b)", output);
+    }
+
+    [Fact]
+    public void LogicalAnd_RightNestedDifferentKind_StaysParenthesized()
+    {
+        // a && (b || c) — a different-kind chain already parenthesizes on either
+        // side (unchanged by #3126); this pins that the right-operand rule did not
+        // regress the mixed-kind case.
+        var chain = new LogicalBinary(
+            LogicalKind.And,
+            new LoadArgument(0, "a", s_bool),
+            new LogicalBinary(
+                LogicalKind.Or,
+                new LoadArgument(1, "b", s_bool),
+                new LoadArgument(2, "c", s_bool)));
+
+        var output = PrintReturn(
+            chain, s_bool,
+            [new Parameter("a", s_bool), new Parameter("b", s_bool), new Parameter("c", s_bool)]);
+
+        Assert.Contains("return a && (b || c);", output);
+    }
+
     // Issue #2916: a ref-typed conditional whose arms are both genuine
     // ref-producers renders as a ref ternary (`ref a : ref b`, see Deref's
     // Conditional case). One arm is an `Unbox` — a managed pointer into a box.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3648,8 +3648,10 @@ public sealed partial class CSharpPrinter
 
     /// <summary>
     /// Short-circuit composition prints comparisons and nots bare (they bind
-    /// tighter than &amp;&amp;/||); same-kind chains associate without parens;
-    /// mixed kinds parenthesize.
+    /// tighter than &amp;&amp;/||); a same-kind chain associates without parens on the
+    /// left but parenthesizes on the right (C# &amp;&amp;/|| are left-associative, so a
+    /// right-nested same-kind chain <c>a &amp;&amp; (b &amp;&amp; c)</c> keeps its parens to stay
+    /// opcode-exact, #3126); mixed kinds parenthesize.
     /// </summary>
     string LogicalText(LogicalBinary logical)
     {
@@ -3657,24 +3659,30 @@ public sealed partial class CSharpPrinter
             return propertyPattern;
 
         string op = logical.Kind == LogicalKind.And ? "&&" : "||";
-        return $"{LogicalOperandText(logical.Left, logical.Kind)} {op} {LogicalOperandText(logical.Right, logical.Kind)}";
+        return $"{LogicalOperandText(logical.Left, logical.Kind, rightOperand: false)} {op} {LogicalOperandText(logical.Right, logical.Kind, rightOperand: true)}";
     }
 
     // A single operand of a short-circuit chain of the given kind. Sides are
     // condition positions: Condition() owns truthiness (a string operand spells
-    // 'is not null', never '!value') and the negation folds. Same-kind chains
-    // associate bare; a mixed-kind LogicalBinary parenthesizes. Any other side
+    // 'is not null', never '!value') and the negation folds. A same-kind chain on
+    // the LEFT associates bare — C# `&&`/`||` are left-associative, so
+    // `(a && b) && c` prints `a && b && c` and recompiles to the same left-nested
+    // IL. A same-kind chain on the RIGHT (<paramref name="rightOperand"/>) must
+    // parenthesize: `a && (b && c)` is right-associative and csc lays it out with a
+    // different branch structure than the flattened `a && b && c` (= `(a && b) && c`),
+    // so dropping the parens would recompile to a divergent opcode stream (#3126).
+    // A mixed-kind LogicalBinary parenthesizes on either side. Any other side
     // renders at the operator's demand — a ternary or `??` (or one hidden behind
     // a stale Coerce/Convert, the #2345/#2376 blind spot) is looser than
     // `&&`/`||` and must parenthesize, while comparisons and unary forms out-bind
     // it and stay bare (#2376 round-2: the enum/bool truthiness compositions
     // share the one precedence rule, not just BoolToInteger).
-    string LogicalOperandText(IrExpression side, LogicalKind kind)
+    string LogicalOperandText(IrExpression side, LogicalKind kind, bool rightOperand)
     {
         var demand = kind == LogicalKind.And ? Precedence.ConditionalAnd : Precedence.ConditionalOr;
         return side switch
         {
-            LogicalBinary nested when nested.Kind == kind => LogicalText(nested),
+            LogicalBinary nested when nested.Kind == kind && !rightOperand => LogicalText(nested),
             LogicalBinary nested => $"({LogicalText(nested)})",
             _ => RenderedCondition(side).At(demand),
         };
@@ -3705,7 +3713,7 @@ public sealed partial class CSharpPrinter
         string op = root.Kind == LogicalKind.And ? "&&" : "||";
         var texts = new List<string>(operands.Count);
         foreach (var operand in operands)
-            texts.Add(LogicalOperandText(operand, root.Kind));
+            texts.Add(LogicalOperandText(operand, root.Kind, rightOperand: false));
 
         // The broken form must be a pure whitespace variant of the flat chain:
         // decline unless re-rendering the flattened operands reproduces the flat
@@ -3738,7 +3746,11 @@ public sealed partial class CSharpPrinter
     /// Flattens a same-kind short-circuit chain into its operands in
     /// left-to-right source order; a nested chain of the <em>other</em> kind (or
     /// any non-<see cref="LogicalBinary"/>) is one operand and is not descended
-    /// into — matching how <see cref="LogicalOperandText"/> parenthesizes it.
+    /// into. This descends a same-kind chain on <em>both</em> sides, so for a
+    /// right-nested chain (which <see cref="LogicalOperandText"/> now parenthesizes
+    /// to stay opcode-exact) the flattened join no longer matches the flat
+    /// <see cref="LogicalText"/>; the caller's exact-match guard then declines the
+    /// multi-line wrap and renders the parenthesized inline form (#3126).
     /// </summary>
     static void CollectLogicalChainOperands(IrExpression expression, LogicalKind kind, List<IrExpression> operands)
     {


### PR DESCRIPTION
- Fixes #3126
- Changes the C# printer to keep the parentheses on a right-nested same-kind `&&`/`||` chain (`a && (b && c)`) instead of flattening it to `a && b && c`, so the reprint recompiles to the original opcode stream.
- Card revision: `41c11845`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the printer flattened right-nested same-kind short-circuit chains, silently re-associating them; adding the parens back is monotonic (parens around an already-valid bool subexpression can never fail to compile) and eliminates the opcode divergence.

### Corrected premise

Issue #3126 was filed from the #3114 round-5 review as a `ShortCircuitTernaryPass` opcode-fidelity gap. **That evidence was wrong.** csc constant-folds a constant-arm ternary (`c ? false : y` → `!c && y`, `c ? true : y` → `c || y`) at compile time, so no ternary diamond survives to `ShortCircuitTernaryPass` for these shapes. The divergence reproduces for hand-written non-ternary `&&` chains and for bare-bool conditions where that pass cannot fire. The real cause is the **printer** flattening a right-nested same-kind chain, which changes associativity: C# `&&`/`||` are left-associative, so `a && (b && c)` reprinted as `a && b && c` reparses as `(a && b) && c` and csc lays that out with a different branch structure (different IL bytes).

### Original source

```csharp
public static bool SB_callAndCall(bool c) => !c && (Call() && Call2());
```

### Before

```csharp
return !c && Call() && Call2();
```

- Valid: True
- Correct: True

Valid and behavior-preserving, but the flattened form re-associates to `(!c && Call()) && Call2()`; csc emits a different branch structure for it, so the reprint recompiles to a divergent opcode stream (fidelity below `Full`-exact).

### After

```csharp
return !c && (Call() && Call2());
```

- Valid: True
- Correct: True

The parens preserve the original right-nested associativity, so the reprint recompiles to the original opcode stream (opcode-exact).

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `PrinterPrecedenceTests`: 24 passed | `PrinterPrecedenceTests`: 24 passed (4 new #3126) |
| Synthetic fidelity corpus (38 methods, incl. real csc-compiled ternary-else `&&`/`||`) | 9 opcode diffs (29/38 exact) | 0 opcode diffs (38/38 exact) |
| Real-asm fidelity `ILInspector.Metadata.dll` (2292 methods) | 1736 exact / 336 opcode / 17 operand / 180 recompile-fail | 1736 / 336 / 17 / 180 (identical) |
| Real-asm fidelity `ILInspector.Analysis.dll` (978 methods) | 754 exact / 143 opcode / 13 operand / 64 recompile-fail | 754 / 143 / 13 / 64 (identical) |
| Decompiler fast suite | 2 pre-existing env reds | 2 pre-existing env reds (unchanged) |

The two pre-existing fast-suite reds are environmental and unchanged by this PR: `SmallStringSwitch_RendersSwitchOnString` (CRLF-vs-LF) and `LookalikeExpressionAssembly_StaysFactoryCalls` (missing fixture when building only the test project).

The right-nested same-kind shape does not occur in the two sampled real assemblies (real code is overwhelmingly left-nested from left-associative source), so the real-asm A/B is neutral — no regression. The value is demonstrated on the synthetic corpus, whose `RB_*` fixtures are **real csc-compiled** ternary-else `&&`/`||` methods, proving the shape is reachable from real input.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — neutral by construction. This is a printer-only change; the IR structure is unchanged, so lowering-residue / conditional-branch / forward-merge counts are identical base-vs-head. The meaningful signal is compile-back fidelity (synthetic 9→0, real-asm neutral), reported in the Evidence table above.

## Validation

```bash
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile ./nuget.config
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile ./nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.PrinterPrecedenceTests -trait- "Speed=Slow"
```
