### PR TITLE
Wrap long bitwise |/&/^ chains one operand per line (#3009 sub-part 3)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/BitwiseChainWrapTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BitwiseChainWrapTests.cs
@@ -1,0 +1,189 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #3009 sub-part 3: the opt-in PrinterOptions.WrapSplittableExpressions taste knob
+// also breaks a long associative bitwise |/&/^ chain one operand per continuation
+// line — but with the operator LEADING each broken line (the flags-accumulation
+// house style), the opposite placement from the short-circuit &&/|| wrapper.
+// Wrapping is whitespace-only: the broken body still compiles and carries the same
+// tokens as the inline form. Off by default.
+public sealed class BitwiseChainWrapTests
+{
+    static readonly TypeRef Holder = TypeRef.Definition("synthetic", "", "Holder");
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+
+    static readonly string[] Flags =
+    [
+        "firstCapabilityBit",
+        "secondCapabilityBit",
+        "thirdCapabilityBit",
+        "fourthCapabilityBit",
+        "fifthCapabilityBit",
+        "sixthCapabilityBit",
+    ];
+
+    static LoadArgument Flag(int index) => new(index, Flags[index], Int);
+
+    // firstCapabilityBit | ... | sixthCapabilityBit — a left-associative chain well
+    // past the 120-column wrap width once `return ...;` is added.
+    static Binary LongChain(BinaryKind kind = BinaryKind.Or)
+    {
+        IrExpression chain = Flag(0);
+        for (int i = 1; i < Flags.Length; i++)
+            chain = new Binary(kind, isChecked: false, isUnsigned: false, chain, Flag(i));
+        return (Binary)chain;
+    }
+
+    static string Render(IrExpression returnValue, PrinterOptions? options = null)
+        => CSharpPrinter.Print(Function(returnValue), options).Output!;
+
+    static DecompilerResult Result(IrExpression returnValue, PrinterOptions options)
+        => CSharpPrinter.Print(Function(returnValue), options);
+
+    static IrFunction Function(IrExpression returnValue)
+    {
+        var block = new Block(0);
+        block.Add(new Return(returnValue));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int, ImmutableArray<Parameter>.Empty, HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Holder, signature, [], container);
+    }
+
+    static readonly PrinterOptions Wrap = new() { WrapSplittableExpressions = true };
+
+    [Fact]
+    public void LongOrChain_WithOption_BreaksOneOperandPerLine_LeadingOperator()
+    {
+        string body = Render(LongChain(), Wrap);
+
+        // Head operand on the return line; every later operand on its own
+        // continuation-indented line with the operator LEADING it, the last operand
+        // closing with the statement semicolon.
+        Assert.Contains(
+            "return firstCapabilityBit\n"
+                + "    | secondCapabilityBit\n"
+                + "    | thirdCapabilityBit\n"
+                + "    | fourthCapabilityBit\n"
+                + "    | fifthCapabilityBit\n"
+                + "    | sixthCapabilityBit;",
+            body);
+        Assert.DoesNotContain("firstCapabilityBit | secondCapabilityBit", body);
+    }
+
+    [Fact]
+    public void LongAndChain_WithOption_BreaksOneOperandPerLine_LeadingOperator()
+    {
+        string body = Render(LongChain(BinaryKind.And), Wrap);
+
+        Assert.Contains(
+            "return firstCapabilityBit\n"
+                + "    & secondCapabilityBit\n"
+                + "    & thirdCapabilityBit\n"
+                + "    & fourthCapabilityBit\n"
+                + "    & fifthCapabilityBit\n"
+                + "    & sixthCapabilityBit;",
+            body);
+    }
+
+    [Fact]
+    public void LongChain_DefaultOptions_StaysInline()
+    {
+        string body = Render(LongChain());
+
+        Assert.Contains(
+            "return firstCapabilityBit | secondCapabilityBit | thirdCapabilityBit "
+                + "| fourthCapabilityBit | fifthCapabilityBit | sixthCapabilityBit;",
+            body);
+        Assert.DoesNotContain("\n    |", body);
+    }
+
+    [Fact]
+    public void ShortChain_WithOption_StaysInline()
+    {
+        // A two-operand chain is far under the wrap width, so it stays inline even
+        // with the option enabled.
+        var chain = new Binary(BinaryKind.Or, isChecked: false, isUnsigned: false, Flag(0), Flag(1));
+
+        string body = Render(chain, Wrap);
+
+        Assert.Contains("return firstCapabilityBit | secondCapabilityBit;", body);
+        Assert.DoesNotContain("\n    |", body);
+    }
+
+    // The broken form is whitespace-only: its whitespace-delimited token stream is
+    // identical to the inline chain's (same tokens, so identical IL).
+    [Fact]
+    public void WrappedChain_IsTokenIdenticalToInline()
+    {
+        string wrapped = Render(LongChain(), Wrap);
+        string inline = Render(LongChain());
+
+        Assert.Contains("\n    |", wrapped);
+        Assert.DoesNotContain("\n    |", inline);
+        Assert.Equal(Tokens(inline), Tokens(wrapped));
+    }
+
+    static string[] Tokens(string text)
+        => text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+
+    [Fact]
+    public void WrappedChain_EmitsTasteDecision()
+    {
+        DecompilerResult result = Result(LongChain(), Wrap);
+
+        Assert.Contains(
+            result.Decisions,
+            d => d is { RuleId: "expression.wrap-splittable-chain", Category: "taste" });
+        Assert.True(result.EffectiveOptions.WrapSplittableExpressions);
+    }
+
+    [Fact]
+    public void LongChain_DefaultOptions_EmitsNoWrapDecision()
+    {
+        DecompilerResult result = Result(LongChain(), PrinterOptions.Default);
+
+        Assert.DoesNotContain(
+            result.Decisions,
+            d => d.RuleId == "expression.wrap-splittable-chain");
+        Assert.False(result.EffectiveOptions.WrapSplittableExpressions);
+    }
+
+    [Fact]
+    public void WrappedChain_Compiles()
+    {
+        string body = Render(LongChain(), Wrap);
+
+        var errors = Recompile(body)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Wrapped chain must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<Diagnostic> Recompile(string body)
+    {
+        string parameters = string.Join(", ", Flags.Select(f => $"int {f}"));
+        string source = $$"""
+            using System;
+            static class __Gate
+            {
+                public static int M({{parameters}})
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RoslynTestReferences.TrustedPlatform,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        return compilation.GetDiagnostics();
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
@@ -35,6 +35,7 @@ public sealed class DynamicCompilationSiteInventoryTests
             ["FinallyDisposePrinterTests.cs"] = (1, "Product-output validity: compiles printer-produced finally/dispose source."),
             ["FluentChainFormattingTests.cs"] = (1, "Product-output validity: compiles printer-produced broken fluent-chain source."),
             ["SplittableExpressionWrapTests.cs"] = (1, "Product-output validity: compiles printer-produced wrapped &&/|| chain source."),
+            ["BitwiseChainWrapTests.cs"] = (1, "Product-output validity: compiles printer-produced wrapped bitwise |/&/^ chain source."),
             ["MemberNameCollisionRenderingTests.cs"] = (1, "Product-output validity: compiles rendered colliding-member source."),
             ["MixedSignComparisonTests.cs"] = (1, "Product-output validity: compiles synthesized mixed-sign comparison source."),
             ["MultiDimensionalArrayPrinterTests.cs"] = (1, "Product-output validity: compiles printer-produced multidim-array source."),
@@ -90,9 +91,11 @@ public sealed class DynamicCompilationSiteInventoryTests
     //   #3088 adds MemberBodyProducerExpressionBodyTests.cs (1 site): decompiles
     //     a compiled single-switch-return member and asserts the expression-bodied
     //     rendering.
-    //   Combined: 34 files, 42 sites.
-    const int ExpectedDynamicFiles = 34;
-    const int ExpectedDynamicSites = 42;
+    //   #3009 sub-part 3 adds BitwiseChainWrapTests.cs (1 site): recompiles the
+    //     printer's wrapped bitwise |/&/^ chain output.
+    //   Combined: 35 files, 43 sites.
+    const int ExpectedDynamicFiles = 35;
+    const int ExpectedDynamicSites = 43;
 
     // Migrated away from Dynamic in this change; must not reappear in the scan.
     static readonly string[] MigratedFiles = ["CompileBackTypeIdentityTests.cs"];

--- a/src/ILInspector.Decompiler.Tests/FlagsEnumAccumulatorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FlagsEnumAccumulatorTests.cs
@@ -11,15 +11,54 @@ namespace ILInspector.Decompiler.Tests;
 // to 'FlagCaps64' and 'long').
 public class FlagsEnumAccumulatorTests
 {
-    static string Render(string methodName)
+    static string Render(string methodName, PrinterOptions? options = null)
     {
         using var source = MetadataSource.Open(typeof(FlagsEnumAccumulatorSamples).Assembly.Location);
         var function = IrImporter.Import(source, typeof(FlagsEnumAccumulatorSamples).FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
         function!.CheckInvariant();
-        return CSharpPrinter.Print(function).Output!;
+        return CSharpPrinter.Print(function, options).Output!;
     }
+
+    // #3009 sub-part 3: with WrapSplittableExpressions on, the long fully-raised OR
+    // chain — here inside the `(int)` return cast — breaks one operand per line with
+    // the operator LEADING each continuation line. Off by default (covered by the
+    // sub-part 1/2 tests above, which render inline).
+    [Fact]
+    public void FlagsEnumAccumulator_WrapOption_BreaksOrChainWithLeadingOperator()
+    {
+        var output = Render(
+            nameof(FlagsEnumAccumulatorSamples.Accumulate),
+            new PrinterOptions { WrapSplittableExpressions = true });
+
+        Assert.Contains(
+            "return (int)(FlagCaps64.Protocol\n"
+                + "    | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)\n"
+                + "    | server & FlagCaps64.LoadLocal\n"
+                + "    | FlagCaps64.Secure\n"
+                + "    | server & FlagCaps64.MultiStatements\n"
+                + "    | FlagCaps64.MultiResults);",
+            output);
+    }
+
+    // Default options keep the whole accumulation on one line: the wrapping is a
+    // pure opt-in whitespace choice, token-identical to the inline form.
+    [Fact]
+    public void FlagsEnumAccumulator_DefaultOptions_StaysInline()
+    {
+        var inline = Render(nameof(FlagsEnumAccumulatorSamples.Accumulate));
+        var wrapped = Render(
+            nameof(FlagsEnumAccumulatorSamples.Accumulate),
+            new PrinterOptions { WrapSplittableExpressions = true });
+
+        Assert.DoesNotContain("\n    |", inline);
+        Assert.Contains("\n    |", wrapped);
+        Assert.Equal(Tokens(inline), Tokens(wrapped));
+    }
+
+    static string[] Tokens(string text)
+        => text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
 
     [Fact]
     public void FlagsEnumAccumulator_KeepsEnumTyping_NoBareLongOrEnum()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1929,7 +1929,8 @@ public sealed partial class CSharpPrinter
         if (Statement(node) is { } line)
         {
             if (!TryAppendFluentChain(sb, node, line, indent)
-                && !TryAppendSplittableExpression(sb, node, line, indent))
+                && !TryAppendSplittableExpression(sb, node, line, indent)
+                && !TryAppendBitwiseChain(sb, node, line, indent))
                 sb.Append(pad).AppendLine(line);
         }
     }
@@ -2293,6 +2294,60 @@ public sealed partial class CSharpPrinter
             $"Wrapped a long short-circuit {(root.Kind == LogicalKind.And ? "&&" : "||")} chain across continuation lines.");
         sb.AppendLine(broken);
         return true;
+    }
+
+    /// <summary>
+    /// The bitwise analog of <see cref="TryAppendSplittableExpression"/>: breaks a
+    /// long top-level <c>|</c>/<c>&amp;</c>/<c>^</c> chain one operand per line, the
+    /// operator <em>leading</em> each continuation line (the flags-accumulation
+    /// house style), when the opt-in <see cref="PrinterOptions.WrapSplittableExpressions"/>
+    /// taste is on. Unlike the short-circuit wrapper it splices the broken chain into
+    /// the already-rendered statement <paramref name="line"/> in place, so it handles
+    /// a bare chain (<c>return a | b | …</c>), an assignment, and a chain inside a
+    /// value-preserving cast (<c>return (int)(a | b | …)</c>) uniformly — the flat
+    /// chain text is located verbatim in the line and only its interior separators
+    /// are broken, so the wrapped form is a pure whitespace variant of the inline
+    /// form (same tokens, unchanged IL).
+    /// </summary>
+    bool TryAppendBitwiseChain(StringBuilder sb, IrNode node, string line, int indent)
+    {
+        if (!_options.WrapSplittableExpressions)
+            return false;
+        if (FindBitwiseChainRoot(node) is not { } root)
+            return false;
+        if (BitwiseChainLines(root, line, indent) is not { } broken)
+            return false;
+        AddDecision(
+            "expression.wrap-splittable-chain",
+            "taste",
+            _function.Name,
+            $"Wrapped a long bitwise {BinaryOperator(root)} chain across continuation lines.");
+        sb.AppendLine(broken);
+        return true;
+    }
+
+    /// <summary>
+    /// Yields the top-level associative bitwise <c>|</c>/<c>&amp;</c>/<c>^</c> chain
+    /// root of a statement whose value is such a chain — a <c>return</c> or a
+    /// (non-ref) local or stack-slot store — seeing through any value-preserving cast
+    /// wrappers (<c>return (int)(a | b | …)</c>, common when a fully-raised flags-enum
+    /// accumulation is returned as its underlying integer). Arithmetic
+    /// <c>+</c>/<c>-</c>/… are excluded: they are not the flags-accumulation idiom
+    /// this wraps, and subtraction is not associative for a one-operand-per-line
+    /// display. Returns null otherwise.
+    /// </summary>
+    Binary? FindBitwiseChainRoot(IrNode node)
+    {
+        IrExpression? value = node switch
+        {
+            Return { Value: { } returned } => returned,
+            StoreLocal { Type.Kind: not TypeRefKind.ByRef, Value: { } stored } => stored,
+            StoreStackSlot store when StackSlotTargetType(store) is { Kind: not TypeRefKind.ByRef } => store.Value,
+            _ => null,
+        };
+        while (value is Convert convert)
+            value = convert.Operand;
+        return value is Binary { Kind: BinaryKind.Or or BinaryKind.And or BinaryKind.Xor } binary ? binary : null;
     }
 
     /// <summary>
@@ -3746,6 +3801,88 @@ public sealed partial class CSharpPrinter
         {
             CollectLogicalChainOperands(logical.Left, kind, operands);
             CollectLogicalChainOperands(logical.Right, kind, operands);
+            return;
+        }
+        operands.Add(expression);
+    }
+
+    /// <summary>
+    /// Splices an associative bitwise <c>|</c>/<c>&amp;</c>/<c>^</c> chain rooted at
+    /// <paramref name="root"/> into the already-rendered statement
+    /// <paramref name="line"/> broken one operand per line — the first operand kept
+    /// where it sits, each later operand on its own continuation-indented line with
+    /// the operator <em>leading</em> the broken line (the flags-accumulation house
+    /// style, the opposite placement from the short-circuit <see cref="LogicalChainLines"/>
+    /// wrapper) — when the chain has at least <see cref="FluentChainMinSegments"/>
+    /// operands and the whole statement would exceed <see cref="FluentChainWrapWidth"/>.
+    /// Returns null (render inline) otherwise. Each operand's text is exactly the
+    /// <see cref="BinaryOperand"/> the flat <see cref="BinaryText"/> emits at the
+    /// chain's precedence, and the routine declines unless the per-operand join
+    /// reproduces that flat chain text and that text occurs exactly once in the line
+    /// — so any chain whose flat spelling is reshaped by the enum-coercion,
+    /// mixed-sign, or unchecked-constant special cases (all sibling-context
+    /// dependent) stays inline, and the splice is unambiguous. Only the interior
+    /// separators of the located chain are broken, so the wrapped form is
+    /// token-identical to the inline line — only whitespace differs and the IL is
+    /// unchanged. Gated on <see cref="PrinterOptions.WrapSplittableExpressions"/> by
+    /// the caller.
+    /// </summary>
+    string? BitwiseChainLines(Binary root, string line, int indent)
+    {
+        var operands = new List<IrExpression>();
+        CollectBitwiseChainOperands(root, root.Kind, operands);
+        if (operands.Count < FluentChainMinSegments)
+            return null;
+
+        string op = BinaryOperator(root);
+        var precedence = CSharpPrecedence.Of(root);
+        var texts = new List<string>(operands.Count);
+        for (int i = 0; i < operands.Count; i++)
+            texts.Add(BinaryOperand(operands[i], precedence, rightSide: i > 0));
+
+        // The broken form must be a pure whitespace variant of the flat chain:
+        // decline unless re-rendering the flattened operands reproduces the flat
+        // BinaryText exactly (guards the enum-coercion / mixed-sign / unchecked
+        // reshaping the flat renderer applies from sibling context).
+        string chainFlat = BinaryText(root);
+        if (string.Join($" {op} ", texts) != chainFlat)
+            return null;
+
+        // The flat chain must appear exactly once in the rendered statement so the
+        // in-place splice is unambiguous (it may sit inside a `return`, an
+        // assignment, or a value-preserving cast — all carried verbatim in the
+        // surrounding head/tail).
+        int idx = line.IndexOf(chainFlat, StringComparison.Ordinal);
+        if (idx < 0 || idx != line.LastIndexOf(chainFlat, StringComparison.Ordinal))
+            return null;
+
+        if (indent * 4 + line.Length <= FluentChainWrapWidth)
+            return null;
+
+        string pad = new(' ', indent * 4);
+        string continuation = pad + "    ";
+        string head = line[..idx];
+        string tail = line[(idx + chainFlat.Length)..];
+        var sb = new System.Text.StringBuilder();
+        sb.Append(pad).Append(head).Append(texts[0]);
+        for (int i = 1; i < texts.Count; i++)
+            sb.Append('\n').Append(continuation).Append(op).Append(' ').Append(texts[i]);
+        sb.Append(tail);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Flattens a same-kind associative bitwise chain into its operands in
+    /// left-to-right source order; a nested chain of a <em>different</em> bitwise
+    /// kind (or any non-<see cref="Binary"/>) is one operand and is not descended
+    /// into — matching how <see cref="BinaryOperand"/> parenthesizes it.
+    /// </summary>
+    static void CollectBitwiseChainOperands(IrExpression expression, BinaryKind kind, List<IrExpression> operands)
+    {
+        if (expression is Binary binary && binary.Kind == kind)
+        {
+            CollectBitwiseChainOperands(binary.Left, kind, operands);
+            CollectBitwiseChainOperands(binary.Right, kind, operands);
             return;
         }
         operands.Add(expression);


### PR DESCRIPTION
## What

Final sub-part of #3009. The opt-in `PrinterOptions.WrapSplittableExpressions` taste now also breaks a long associative bitwise `|`/`&`/`^` chain **one operand per continuation line, with the operator leading** each broken line (the flags-accumulation house style — the opposite placement from the short-circuit `&&`/`||` wrapper added in #3067).

With sub-parts 1 (#3073, enum slot typing) and 2 (#3133, slot inlining) merged, the fully-raised flags-enum accumulator now renders, with the option on, as:

```csharp
return (int)(FlagCaps64.Protocol
    | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)
    | server & FlagCaps64.LoadLocal
    | FlagCaps64.Secure
    | server & FlagCaps64.MultiStatements
    | FlagCaps64.MultiResults);
```

## How

`AppendStatement` gains a third `TryAppendBitwiseChain` fallback (after fluent- and short-circuit-chain wrapping). Unlike the short-circuit wrapper (which reconstructs a statement prefix), the bitwise wrapper **splices** the broken chain into the already-rendered statement `line` in place, so it handles a bare chain (`return a | b | …`), an assignment, and a chain inside a value-preserving cast (`return (int)(a | b | …)` — common when a fully-raised flags-enum accumulation is returned as its underlying integer) uniformly.

It declines (renders inline) unless:
- the per-operand re-render reproduces the flat `BinaryText(root)` exactly (guards the sibling-context-dependent enum-coercion / mixed-sign / unchecked special cases), **and**
- that flat chain text occurs exactly once in the line (unambiguous splice), **and**
- the whole statement exceeds `FluentChainWrapWidth` (120).

Only the interior separators of the located chain are broken, so the wrapped form is **token-identical** to the inline line — only whitespace differs, IL unchanged.

## Safety / blast radius

- **Off by default.** The default render path is byte-identical: `TryAppendBitwiseChain` returns immediately when `WrapSplittableExpressions` is false.
- Corpus + Validity gates (default options): 175/175 pass, no golden churn.

## Tests

- `BitwiseChainWrapTests` (new): leading-operator break for `|` and `&`, inline fallback below width / short chain / default options, token identity, taste decision emission, recompilation of the wrapped output.
- `FlagsEnumAccumulatorTests`: two end-to-end assertions — the wrapped multi-line form (the #3009 target) and default-options-stays-inline + token identity.
- Registered the new `CSharpCompilation.Create` site in the Dynamic census manifest (`DynamicCompilationSiteInventoryTests`).

## Validation

- Fast suite: 3642 pass, 1 fail — `ExpressionTreeLambdaTests.LookalikeExpressionAssembly_StaysFactoryCalls`, a pre-existing environmental failure when only the test csproj is built (missing fixture assemblies); confirmed identical on the stashed base.
- Corpus + Validity areas: 175/175.