### PR TITLE
Surface applied byte-divergent style lenses as an Applied Taste section

### DIFF
--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -9,11 +9,21 @@ Every raise PR must keep Before, After, and Fully raised. Before and After must
 each show a concrete C# example. After records this PR's output; Fully raised
 records the intended endpoint.
 
-Under Before and After, record two independent verdicts on the shown C# so the
+Under Before and After, record independent verdicts on the shown C# so the
 assessment sits next to the code it judges:
 
 - Valid: does it compile and bind (True/False)?
 - Correct: does it preserve the original observable behavior (True/False)?
+- IL fidelity: does it recompile to the original opcodes (True/False), or is it
+  not currently checkable? This is the camp the #3127 trap hides in: a render
+  can be Valid and Correct yet no longer opcode-faithful. It is judged by the
+  compile-back harness or the `diff` command, never by `member`.
+- Taste applied: which configurable, opcode-neutral style choices the render
+  applied, from `-S "Applied Taste"`. A byte-divergent style lens listed there
+  is exactly why IL fidelity can be False while Valid/Correct are True — surface
+  it here instead of leaving the reader to infer it from prose.
+- Commit: the exact digest the render was acquired at (base for Before, head for
+  After), so each block is reproducible.
 
 Add optional prose only to explain a verdict. Keeping both Before and After
 makes this a before→after comparison, not a snapshot of only the raised output:
@@ -30,6 +40,8 @@ same `{Type} {MethodSelector} {scope}`:
   lower-level, authoritative anchor.
 - Before: `-S "Decompiled Source"` at the base commit (the pre-change output).
 - After: `-S "Decompiled Source"` at this PR's head (the post-change output).
+- Applied Taste: `-S "Applied Taste"` at the same commit as each render, to
+  populate the "Taste applied" verdict (lists any byte-divergent style lenses).
 
 Only Fully raised is authored by hand — it is the intended endpoint, not a
 current render.
@@ -57,6 +69,28 @@ For focused invalid-Full / burndown row fixes, prefer
 > Should we accept this change?
 
 **Conclusion:** **PASS/REVIEW/BLOCKED** — {one sentence with the decisive reason}.
+
+### Benchmark target
+
+<!--
+State the exact inspected artifact and the full dotnet-inspect command once, so
+the Before/After renders below are unambiguous and reproducible. The build of
+dotnet-inspect itself is implied by Before (base) vs After (head), so it is not
+restated here.
+
+- Benchmark target: the corpus library and its version (package `{lib}@{ver}`)
+  or repo + commit digest (`{owner}/{repo}@{sha}`).
+- dotnet-inspect command: the exact member invocation used for the renders
+  below (the same selector for Before and After).
+-->
+
+Benchmark target: `{lib}@{ver}`
+
+dotnet-inspect command:
+
+```bash
+dotnet-inspect member {Type} {MethodSelector} {scope} -S "Decompiled Source"
+```
 
 ### Original source
 
@@ -87,6 +121,9 @@ Original source.
 
 - Valid: {True/False}
 - Correct: {True/False}
+- IL fidelity: {True/False/not currently checkable}
+- Taste applied: {None / list the byte-divergent style lenses from `-S "Applied Taste"`}
+- Commit: {base commit digest}
 
 {optional prose to elaborate on the verdict}
 
@@ -103,6 +140,9 @@ the method signature line here too, for the same reason.
 
 - Valid: {True/False}
 - Correct: {True/False}
+- IL fidelity: {True/False/not currently checkable}
+- Taste applied: {None / list the byte-divergent style lenses from `-S "Applied Taste"`}
+- Commit: {head commit digest}
 
 {optional prose to elaborate on the verdict}
 

--- a/src/ILInspector.Decompiler.Tests/StyleLensDecisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleLensDecisionTests.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The applied-lens evidence: when an opt-in byte-divergent style lens (#3138)
+/// actually rewrites a render, <see cref="CSharpPrinter.PrintRaised(IrFunction,
+/// System.Func{MethodRef, IrFunction?}, PrinterOptions?, System.Func{TypeRef,
+/// TypeRef, bool})"/> records a <see cref="DecompilerDecision"/> in the
+/// <see cref="DecompilerDecisionCategories.StyleLens"/> category. That decision is
+/// the surface a host reports as "a byte-divergent lens was applied here" — the
+/// #3127 signal that two "valid/correct" verdicts are not opcode-faithful —
+/// without reverse-engineering the rendered text. The default (lens-off) render
+/// records no such decision.
+/// </summary>
+[Trait("Area", "RoundTrip")]
+public sealed class StyleLensDecisionTests
+{
+    static string AssemblyPath => typeof(StyleLensDecisionTests).Assembly.Location;
+
+    static DecompilerResult Decompile(string typeName, string method, PrinterOptions? options = null)
+    {
+        using var source = MetadataSource.Open(AssemblyPath);
+        var function = IrImporter.Import(source, typeName, method);
+        Assert.NotNull(function);
+        return CSharpPrinter.PrintRaised(
+            function!,
+            importMethodBody: methodRef => IrImporter.Import(source, methodRef),
+            options,
+            source.AreProvablyDisjoint);
+    }
+
+    [Fact]
+    public void ConditionalReturnLens_WhenApplied_RecordsByteDivergentDecision()
+    {
+        var result = Decompile(
+            typeof(PreferConditionalReturnSpecimen).FullName!,
+            nameof(PreferConditionalReturnSpecimen.NeitherOr),
+            new PrinterOptions { PreferConditionalExpressionReturn = true });
+
+        var decision = Assert.Single(
+            result.Decisions,
+            d => d.RuleId == "style-lens.prefer-conditional-return");
+        Assert.Equal(DecompilerDecisionCategories.StyleLens, decision.Category);
+    }
+
+    [Fact]
+    public void ConditionalReturnLens_Default_RecordsNoStyleLensDecision()
+    {
+        var result = Decompile(
+            typeof(PreferConditionalReturnSpecimen).FullName!,
+            nameof(PreferConditionalReturnSpecimen.NeitherOr));
+
+        Assert.DoesNotContain(
+            result.Decisions,
+            d => d.Category == DecompilerDecisionCategories.StyleLens);
+    }
+
+    [Fact]
+    public void BranchlessBooleanLens_WhenApplied_RecordsByteDivergentDecision()
+    {
+        var result = Decompile(
+            typeof(PreferBranchlessBooleanSpecimen).FullName!,
+            nameof(PreferBranchlessBooleanSpecimen.AndTailGuard),
+            new PrinterOptions { PreferBranchlessBoolean = true });
+
+        var decision = Assert.Single(
+            result.Decisions,
+            d => d.RuleId == "style-lens.prefer-branchless-boolean");
+        Assert.Equal(DecompilerDecisionCategories.StyleLens, decision.Category);
+    }
+
+    [Fact]
+    public void BranchlessBooleanLens_Default_RecordsNoStyleLensDecision()
+    {
+        var result = Decompile(
+            typeof(PreferBranchlessBooleanSpecimen).FullName!,
+            nameof(PreferBranchlessBooleanSpecimen.AndTailGuard));
+
+        Assert.DoesNotContain(
+            result.Decisions,
+            d => d.Category == DecompilerDecisionCategories.StyleLens);
+    }
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -119,6 +119,31 @@ public sealed record DecompilerDecision(
     public string? NewValue { get; init; }
 }
 
+/// <summary>
+/// Stable <see cref="DecompilerDecision.Category"/> values. A category records
+/// the fidelity contract the choice was made under, so a host can tell a
+/// byte-identical spelling apart from a render that no longer recompiles to the
+/// original opcodes. Never renumber or reuse.
+/// </summary>
+public static class DecompilerDecisionCategories
+{
+    /// <summary>
+    /// A byte-preserving choice: the selected spelling/layout recompiles to the
+    /// identical IL (a class-3 no-anchor pick or a whitespace-only wrap). The
+    /// render stays opcode-faithful.
+    /// </summary>
+    public const string Taste = "taste";
+
+    /// <summary>
+    /// An opt-in, behavior-preserving but <b>byte-divergent</b> style lens
+    /// (#3138): the render computes the identical result but no longer reproduces
+    /// the original opcodes, so it must not feed the compile-back fidelity gates.
+    /// This is the signal a reader needs to know the two "valid/correct" verdicts
+    /// are not opcode-faithful (the #3127 trap).
+    /// </summary>
+    public const string StyleLens = "style-lens";
+}
+
 public sealed record DecompilerResultMetadata(
     DecompilerOptions EffectiveOptions,
     IReadOnlyList<DecompilerDecision> Decisions)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -91,6 +91,7 @@ public sealed partial class CSharpPrinter
         PrinterOptions? options = null,
         Func<TypeRef, TypeRef, bool>? typesProvablyDisjoint = null)
     {
+        var appliedLenses = new List<DecompilerDecision>();
         try
         {
             var context = RaiseContext(importMethodBody, typesProvablyDisjoint);
@@ -100,16 +101,62 @@ public sealed partial class CSharpPrinter
             // left the guarded bool return flat. The oracle-endorsed ternary runs
             // first so that, when both lenses are enabled, it wins the shared shape
             // (it consumes the guarded return, leaving the branchless pass a no-op).
+            // When a lens actually rewrites, record a byte-divergent applied-lens
+            // decision so a host can surface that the render is no longer
+            // opcode-faithful (the #3127 signal) instead of inferring it from prose.
             if (options?.PreferConditionalExpressionReturn == true)
-                new PreferConditionalReturnPass().Run(function, context);
+            {
+                var pass = new PreferConditionalReturnPass();
+                pass.Run(function, context);
+                if (pass.Rewrites > 0)
+                    appliedLenses.Add(new DecompilerDecision(
+                        "style-lens.prefer-conditional-return",
+                        DecompilerDecisionCategories.StyleLens,
+                        function.Name,
+                        "Rewrote a guarded boolean return as a conditional expression "
+                            + "(dotnet_style_prefer_conditional_expression_over_return, IDE0046). "
+                            + "Behavior-preserving but byte-divergent: the render no longer "
+                            + "reproduces the original branch opcodes.")
+                    {
+                        OldValue = "if (c) return A; return B;",
+                        NewValue = "return c ? A : B;",
+                    });
+            }
             if (options?.PreferBranchlessBoolean == true)
-                new PreferBranchlessBooleanPass().Run(function, context);
+            {
+                var pass = new PreferBranchlessBooleanPass();
+                pass.Run(function, context);
+                if (pass.Rewrites > 0)
+                    appliedLenses.Add(new DecompilerDecision(
+                        "style-lens.prefer-branchless-boolean",
+                        DecompilerDecisionCategories.StyleLens,
+                        function.Name,
+                        "Folded a guarded boolean return into the compact short-circuit "
+                            + "\"bool hack\" (dotnet_inspect_style_prefer_branchless_boolean; not "
+                            + "oracle-endorsed). Behavior-preserving but byte-divergent: the render "
+                            + "no longer reproduces the original branch opcodes.")
+                    {
+                        OldValue = "if (c) return false; return B;",
+                        NewValue = "return !c && B;",
+                    });
+            }
         }
         catch (Exception ex)
         {
             return DecompilerResult.Failure(DiagnosticIds.InternalError, $"{ex.GetType().Name}: {ex.Message}");
         }
-        return Print(function, options);
+        var result = Print(function, options);
+        if (appliedLenses.Count > 0 && result.Output is not null)
+        {
+            result = result with
+            {
+                Metadata = result.Metadata with
+                {
+                    Decisions = [.. result.Metadata.Decisions, .. appliedLenses],
+                },
+            };
+        }
+        return result;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PreferBranchlessBooleanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PreferBranchlessBooleanPass.cs
@@ -51,12 +51,21 @@ public sealed class PreferBranchlessBooleanPass : IIrPass
 {
     public string Name => "prefer-branchless-boolean";
 
+    /// <summary>
+    /// Number of guarded returns this pass actually folded into the compact
+    /// short-circuit "bool hack". Non-zero means the byte-divergent lens changed
+    /// the render, so <see cref="CSharpPrinter"/> records an applied-lens decision
+    /// the host can surface.
+    /// </summary>
+    public int Rewrites { get; private set; }
+
     public void Run(IrFunction function, PassContext context)
     {
         // Fixpoint: folding an inner guarded return can expose an outer one whose
         // tail is now the freshly minted short-circuit return.
         while (RewriteOnce(function, context.Stepper))
         {
+            Rewrites++;
         }
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PreferConditionalReturnPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PreferConditionalReturnPass.cs
@@ -29,12 +29,21 @@ public sealed class PreferConditionalReturnPass : IIrPass
 {
     public string Name => "prefer-conditional-return";
 
+    /// <summary>
+    /// Number of guarded returns this pass actually rewrote into a conditional
+    /// expression. Non-zero means the byte-divergent lens changed the render, so
+    /// <see cref="CSharpPrinter.PrintRaised(IrFunction, Func{MethodRef, IrFunction?}, PrinterOptions?, Func{TypeRef, TypeRef, bool})"/>
+    /// records an applied-lens decision the host can surface.
+    /// </summary>
+    public int Rewrites { get; private set; }
+
     public void Run(IrFunction function, PassContext context)
     {
         // Fixpoint: collapsing an inner guarded return can expose an outer one
         // whose tail is now the freshly minted `return c ? A : B;`.
         while (RewriteOnce(function, context.Stepper))
         {
+            Rewrites++;
         }
     }
 

--- a/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
+++ b/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
@@ -1,0 +1,64 @@
+using DotnetInspector.Output;
+using ILInspector.Decompiler;
+
+namespace DotnetInspector.Tests;
+
+public class AppliedTasteSectionTests
+{
+    [Fact]
+    public void BuildRows_StyleLensDecision_IsByteDivergent()
+    {
+        var decision = new DecompilerDecision(
+            "style-lens.prefer-conditional-return",
+            DecompilerDecisionCategories.StyleLens,
+            "NeitherOr",
+            "Rewrote a guarded boolean return as a conditional expression.");
+
+        var row = Assert.Single(ApiOutputFormatter.BuildAppliedTasteRows([decision]));
+
+        Assert.Equal("style-lens.prefer-conditional-return", row.Rule);
+        Assert.Equal("byte-divergent", row.Fidelity);
+        Assert.Equal("NeitherOr", row.Subject);
+        Assert.Equal(decision.Detail, row.Detail);
+    }
+
+    [Fact]
+    public void BuildRows_TasteDecision_IsBytePreserving()
+    {
+        var decision = new DecompilerDecision(
+            "expression.wrap-splittable-chain",
+            DecompilerDecisionCategories.Taste,
+            "M",
+            "Wrapped a splittable call chain across lines.");
+
+        var row = Assert.Single(ApiOutputFormatter.BuildAppliedTasteRows([decision]));
+
+        Assert.Equal("byte-preserving", row.Fidelity);
+    }
+
+    [Fact]
+    public void BuildRows_ExcludesAlwaysOnFrameworkImport()
+    {
+        // The framework-import rewrite is always-on and universally expected, not
+        // a configurable taste choice: it must never surface on the taste surface.
+        var frameworkImport = new DecompilerDecision(
+            "type-name.framework-imported",
+            DecompilerDecisionCategories.Taste,
+            "MakeList",
+            "Imported List<T>.");
+        var lens = new DecompilerDecision(
+            "style-lens.prefer-branchless-boolean",
+            DecompilerDecisionCategories.StyleLens,
+            "MakeList",
+            "Folded a guarded boolean return.");
+
+        var rows = ApiOutputFormatter.BuildAppliedTasteRows([frameworkImport, lens]);
+
+        var row = Assert.Single(rows);
+        Assert.Equal("style-lens.prefer-branchless-boolean", row.Rule);
+    }
+
+    [Fact]
+    public void BuildRows_NoDecisions_YieldsEmpty()
+        => Assert.Empty(ApiOutputFormatter.BuildAppliedTasteRows([]));
+}

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4213,7 +4213,7 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("## Applied Taste", output);
-        Assert.Contains("No configurable style choices were applied to this member.", output);
+        Assert.Contains("No recorded style choices were applied to this member.", output);
         Assert.DoesNotContain("byte-divergent", output);
     }
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4201,6 +4201,47 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SelectedOverload_SelectAppliedTaste_DefaultRenderReportsNoChoices()
+    {
+        // The byte-divergent style lenses are opt-in (off by shipped default), so a
+        // default member render applies no configurable style choice: the explicitly
+        // selected Applied Taste section renders its empty-state note, not a row.
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(FactsTableFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(FactsTableFixture.BoxInt), "-S", "Applied Taste", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Applied Taste", output);
+        Assert.Contains("No configurable style choices were applied to this member.", output);
+        Assert.DoesNotContain("byte-divergent", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedOverload_DiscoverSchema_ListsAppliedTaste()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(FactsTableFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(FactsTableFixture.BoxInt), "-D", "--schema");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("| Applied Taste | section (opt-in) |", output);
+    }
+
+    [Fact]
+    public async Task Member_AppliedTaste_IsExplicitOnly_NotShownAtDetailed()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(FactsTableFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(FactsTableFixture.BoxInt), "-v:d", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.DoesNotContain("Applied Taste", output);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_SelectFacts_IncludesResearchHeaderFacts()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -490,6 +490,7 @@ public static class MemberCommand
         SectionNames.CustomAttributes,
         SectionNames.DecompiledSource,
         SectionNames.FidelityCauses,
+        SectionNames.AppliedTaste,
         SectionNames.AnnotatedSource,
         SectionNames.OriginalSource,
         SectionNames.SourceDiff,

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -18,7 +18,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class MemberCodeProvider
 {
-    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool CostOverlay, bool SemanticsOverlay, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Facts = false, bool FidelityCauses = false, string? ProjectAssetsPath = null, string? TargetFramework = null);
+    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool CostOverlay, bool SemanticsOverlay, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Facts = false, bool FidelityCauses = false, bool AppliedTaste = false, string? ProjectAssetsPath = null, string? TargetFramework = null);
 
     /// <summary>
     /// Code content for one member. C# sections retain the complete decompiler
@@ -37,6 +37,7 @@ internal static class MemberCodeProvider
         IReadOnlyList<(string Name, string? Value)>? Attributes,
         IReadOnlyList<ILInspector.Research.ResearchViews.FactRow>? Facts = null,
         FindingInspection<Decompiler.DecompilerFidelityCause>? FidelityCauses = null,
+        IReadOnlyList<Decompiler.DecompilerDecision>? AppliedTaste = null,
         bool RequiresAsyncBodyModifier = false);
 
     internal static List<(ApiMember Member, Item Code)> Collect(
@@ -119,18 +120,20 @@ internal static class MemberCodeProvider
             Decompiler.DecompilerResult? decompiledResult = null;
             Decompiler.DecompilerResult? projectionResult = null;
             IrFunction? raisedFunction = null;
-            if ((request.DecompiledSource || request.FidelityCauses) && pipelineSource is not null)
+            if ((request.DecompiledSource || request.FidelityCauses || request.AppliedTaste) && pipelineSource is not null)
             {
-                // The style options (renderOptions) affect only the printed C#
-                // string, which is surfaced solely by the Decompiled Source
-                // section. A fidelity-only projection reads the raised IR and
-                // recompile diagnostics (both style-invariant) and discards the
-                // printed string, so it must not consume the config -- pass the
-                // shipped defaults there. This keeps "config consumed" exactly
-                // equal to "styled source produced", which is the signal the
-                // config-warning latch keys off (a non-null DecompiledResult
-                // Output) at the formatter emit site.
-                var projectionRenderOptions = request.DecompiledSource ? renderOptions : null;
+                // The style options (renderOptions) affect the printed C# string
+                // (Decompiled Source) and the set of configurable render choices
+                // that fire (Applied Taste) -- notably the opt-in byte-divergent
+                // lenses, whose applied-lens decisions only exist when the render
+                // runs with those options. Both consume the config. A fidelity-only
+                // projection reads the raised IR and recompile diagnostics (both
+                // style-invariant) and discards the printed string, so it must not
+                // consume the config -- pass the shipped defaults there. The
+                // config-warning latch still keys off a surfaced Decompiled Source
+                // Output (below), so an Applied-Taste-only run that renders no
+                // styled source stays silent.
+                var projectionRenderOptions = request.DecompiledSource || request.AppliedTaste ? renderOptions : null;
                 projectionResult = TrimOutput(RenderDecompiledSource(
                     pipelineSource,
                     lookupType,
@@ -151,6 +154,10 @@ internal static class MemberCodeProvider
 
             if (request.DecompiledSource)
                 decompiledResult = projectionResult;
+
+            IReadOnlyList<Decompiler.DecompilerDecision>? appliedTaste = null;
+            if (request.AppliedTaste)
+                appliedTaste = projectionResult?.Decisions ?? [];
 
             FindingInspection<Decompiler.DecompilerFidelityCause>? fidelityCauses = null;
             if (request.FidelityCauses)
@@ -270,6 +277,7 @@ internal static class MemberCodeProvider
                 attributes,
                 facts,
                 fidelityCauses,
+                appliedTaste,
                 requiresAsyncBodyModifier)));
         }
 
@@ -314,7 +322,7 @@ internal static class MemberCodeProvider
     /// </summary>
     static Decompiler.Pipeline.MetadataSource? OpenPipelineSource(Request request, string dllPath, string? pdbPath)
     {
-        if (!request.DecompiledSource && !request.AnnotatedSource && !request.CostOverlay && !request.SemanticsOverlay && !request.Facts && !request.FidelityCauses)
+        if (!request.DecompiledSource && !request.AnnotatedSource && !request.CostOverlay && !request.SemanticsOverlay && !request.Facts && !request.FidelityCauses && !request.AppliedTaste)
             return null;
         try
         {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1210,6 +1210,7 @@ public static class ApiOutputFormatter
             UnsafeOperations: requestedSections.Contains(SectionNames.UnsafeOperations),
             Facts: requestedSections.Contains(SectionNames.Facts),
             FidelityCauses: requestedSections.Contains(SectionNames.FidelityCauses),
+            AppliedTaste: requestedSections.Contains(SectionNames.AppliedTaste),
             ProjectAssetsPath: options?.ProjectAssetsPath,
             TargetFramework: options?.Tfm);
 
@@ -1428,7 +1429,7 @@ public static class ApiOutputFormatter
             }
         }
 
-        if (request.DecompiledSource || request.AnnotatedSource || request.CostOverlay || request.SemanticsOverlay || request.IL || request.Attributes || request.Facts || request.FidelityCauses)
+        if (request.DecompiledSource || request.AnnotatedSource || request.CostOverlay || request.SemanticsOverlay || request.IL || request.Attributes || request.Facts || request.FidelityCauses || request.AppliedTaste)
             RequestTelemetry.Breadcrumb("method-body-load", singleMethod?.Name ?? type.Name);
 
         foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath, options?.IncludeAll ?? false, options?.RenderOptions))
@@ -1455,6 +1456,12 @@ public static class ApiOutputFormatter
             if (code.FidelityCauses is not null)
             {
                 memberCode.FidelityCauseRows = BuildFidelityCauseRows(code.FidelityCauses);
+                hasCode = true;
+            }
+
+            if (code.AppliedTaste is not null)
+            {
+                memberCode.AppliedTasteRows = BuildAppliedTasteRows(code.AppliedTaste);
                 hasCode = true;
             }
 
@@ -1606,6 +1613,24 @@ public static class ApiOutputFormatter
                     failed.Error.Reason)
             ],
         };
+
+    internal static List<AppliedTasteRow> BuildAppliedTasteRows(
+        IReadOnlyList<Decompiler.DecompilerDecision> decisions)
+        =>
+        [
+            .. decisions
+                // The framework-import rewrite (List<T> for the mangled metadata
+                // name) is always-on and universally expected, not a configurable
+                // taste choice -- keep it off the taste surface.
+                .Where(static d => d.RuleId != "type-name.framework-imported")
+                .Select(static d => new AppliedTasteRow(
+                    d.RuleId,
+                    d.Category == Decompiler.DecompilerDecisionCategories.StyleLens
+                        ? "byte-divergent"
+                        : "byte-preserving",
+                    d.Subject,
+                    d.Detail))
+        ];
 
     static string FormatFidelityLocation(Decompiler.DecompilerFidelityLocation location)
         => location.Kind switch

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1618,6 +1618,12 @@ public static class ApiOutputFormatter
         IReadOnlyList<Decompiler.DecompilerDecision> decisions)
         =>
         [
+            // Projects the configurable choices the decompiler RECORDED as
+            // decisions -- currently the byte-divergent style lenses and the
+            // opt-in chain-wrap. Some byte-preserving knobs (this.-qualification)
+            // do not yet record a decision, so they will not appear here until
+            // issue #3156 lands; the empty-state wording is scoped to "recorded"
+            // choices to avoid over-claiming completeness.
             .. decisions
                 // The framework-import rewrite (List<T> for the mangled metadata
                 // name) is always-on and universally expected, not a configurable

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -511,6 +511,7 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.MethodAttributes>(HasSingleMethodLikeMember)
             .Add<ApiMemberSectionDescriptors.DecompiledSource>(HasSingleMethodLikeMember)
             .Add<ApiMemberDetailSectionDescriptors.FidelityCauses>(HasSingleMethodLikeMember)
+            .Add<ApiMemberDetailSectionDescriptors.AppliedTaste>(HasSingleMethodLikeMember)
             .Add<ApiMemberDetailSectionDescriptors.AnnotatedSource>(HasSingleMethodLikeMember)
             .Add<ApiMemberSectionDescriptors.OriginalSource>(HasSingleMethodLikeMember)
             .Add<ApiMemberDetailSectionDescriptors.SourceDiff>(HasSingleMethodLikeMember)
@@ -564,6 +565,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<MethodAttributes>()
             .Add<DecompiledSource>()
             .Add<FidelityCauses>()
+            .Add<AppliedTaste>()
             .Add<AnnotatedSource>()
             .Add<CostOverlay>()
             .Add<SemanticsOverlay>()
@@ -644,6 +646,17 @@ public static class ApiMemberDetailSectionDescriptors
     public sealed class FidelityCauses : ISectionDescriptor<ApiType>
     {
         public static string Name => SectionNames.FidelityCauses;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static bool ProbeEffectiveness => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+    }
+
+    public sealed class AppliedTaste : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.AppliedTaste;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static bool ProbeEffectiveness => false;

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -84,6 +84,9 @@ public static class SectionNames
     /// <summary>Section for typed causes that prevent Full decompiler fidelity.</summary>
     public const string FidelityCauses = "Fidelity Causes";
 
+    /// <summary>Section for the configurable, opcode-neutral style choices applied while rendering this member.</summary>
+    public const string AppliedTaste = "Applied Taste";
+
     /// <summary>Section for the decompiled C# method body with hidden-fact annotations and interleaved IL.</summary>
     public const string AnnotatedSource = "Annotated Source";
 

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -84,7 +84,7 @@ public static class SectionNames
     /// <summary>Section for typed causes that prevent Full decompiler fidelity.</summary>
     public const string FidelityCauses = "Fidelity Causes";
 
-    /// <summary>Section for the configurable, opcode-neutral style choices applied while rendering this member.</summary>
+    /// <summary>Section listing the configurable style choices the decompiler recorded while rendering this member, each tagged byte-preserving or byte-divergent. Primarily surfaces the opt-in byte-divergent style lenses (the #3127 signal). Some byte-preserving knobs (e.g. this.-qualification) are not yet recorded; see issue #3156.</summary>
     public const string AppliedTaste = "Applied Taste";
 
     /// <summary>Section for the decompiled C# method body with hidden-fact annotations and interleaved IL.</summary>

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -710,7 +710,7 @@ public class MemberCodeView
     [MarkoutSection(Name = SectionNames.FidelityCauses)]
     public List<FidelityCauseRow>? FidelityCauseRows { get; set; }
 
-    [MarkoutSection(Name = SectionNames.AppliedTaste, EmptyText = "No configurable style choices were applied to this member.")]
+    [MarkoutSection(Name = SectionNames.AppliedTaste, EmptyText = "No recorded style choices were applied to this member.")]
     public List<AppliedTasteRow>? AppliedTasteRows { get; set; }
 
     [MarkoutSection(Name = "Annotated Source")]

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -690,6 +690,13 @@ public sealed record FidelityCauseRow(
     string? Discriminator,
     string? Reason);
 
+[MarkoutSerializable]
+public sealed record AppliedTasteRow(
+    string Rule,
+    string Fidelity,
+    string? Subject,
+    string? Detail);
+
 /// <summary>
 /// Code sections for member command output (Decompiled Source, Annotated Source, Original Source, IL).
 /// Serialized separately after the main TypeView.
@@ -702,6 +709,9 @@ public class MemberCodeView
 
     [MarkoutSection(Name = SectionNames.FidelityCauses)]
     public List<FidelityCauseRow>? FidelityCauseRows { get; set; }
+
+    [MarkoutSection(Name = SectionNames.AppliedTaste, EmptyText = "No configurable style choices were applied to this member.")]
+    public List<AppliedTasteRow>? AppliedTasteRows { get; set; }
 
     [MarkoutSection(Name = "Annotated Source")]
     public CodeSection AnnotatedSourceCode { get; set; }
@@ -804,6 +814,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(UnsafeOperationRow))]
 [MarkoutContext(typeof(FactRow))]
 [MarkoutContext(typeof(FidelityCauseRow))]
+[MarkoutContext(typeof(AppliedTasteRow))]
 [MarkoutContext(typeof(TypeSourceFileRow))]
 [MarkoutContext(typeof(MemberSourceLocationRow))]
 [MarkoutContext(typeof(TypeSummaryRow))]


### PR DESCRIPTION
## Conclusion

Follow-up to #3127. That PR relied on a reader parsing opcode-fidelity prose to notice that a **Valid: True / Correct: True** render had actually *diverged* from the original opcodes. The two byte-divergent style lenses that cause this recorded **nothing** when they fired, so the signal was invisible to the tool. This PR makes the tool emit that signal directly and updates the decompiler-PR template to show it.

## Product change (decompiler)

- `PreferConditionalReturnPass` / `PreferBranchlessBooleanPass` now expose a `Rewrites` count.
- The main `CSharpPrinter.PrintRaised` overload appends a `DecompilerDecision` in a new `"style-lens"` category when a lens actually rewrote the body.
- **Additive and opt-in:** with the lenses off (shipped default) no decision is recorded and rendered output is byte-for-byte unchanged. The line-mapped `PrintRaised` overload (annotated view) is left byte-faithful.

## CLI

- New **explicit-only** `Applied Taste` section projects `DecompilerResult.Decisions`, one row per configurable choice, with a **Fidelity** column (`byte-preserving` | `byte-divergent`).
- Excludes the always-on `type-name.framework-imported` rewrite (universally expected, not a taste choice).

## Template

`docs/templates/decompiler-pr.md`:

- **Benchmark target** (`{lib}@{ver}`) + full `dotnet-inspect` command block before *Original source*.
- **IL fidelity / Taste applied / Commit** rows added to the Before and After verdicts, so the #3127 trap is surfaced rather than inferred from prose.

## Validation

- Decompiler fast suite: **3606 passed / 0 failed**; `StyleLensDecisionTests` **4/4**.
- CLI suite: **2045** (1 pre-existing environmental failure `PlatformResolverTests.GetPacksDirectory_ReturnsValidPath`, unrelated SDK-path assertion).
- `AppliedTasteSectionTests` + CLI plumbing tests **7/7**; end-to-end verified (lens-fired byte-divergent row, empty default note, schema listing, explicit-only, framework-import excluded).
- Default-preserving: the lens is opt-in, so `appliedLenses` is empty by default and `result` is returned unchanged — the compile-back Fidelity gate (default options) is unaffected.
- markdownlint clean.

## Review

Two-model adversarial review per AGENTS.md. Both reviewers gave a final clean pass on head `2c5409eb` against base `origin/main` (`2114319f`, a true ancestor). Full reconciliation in [this comment](https://github.com/richlander/dotnet-inspect/pull/3152#issuecomment-5077212381).

- **GPT (gpt-5.6-sol):** no blocking findings; all 7 attack points confirmed safe except one non-blocking config-warning edge (deferred to #3158).
- **Gemini (gemini-3.1-pro-preview):** all 7 attack points confirmed safe; no blocking or non-blocking issues; "safe to merge."

### Findings

- **#1 / #2 — "reverted #3114/#3126 fidelity fixes":** base-mismatch artifact (reviewed head was behind main; four upstream commits appeared as this PR's deletions). Resolved by merging `origin/main` (merge commit `2b8ee245`, not force-push). Verified present on the corrected head: eager-by-ref guard `BooleanFoldingPass.cs:535`, right-nested parens `CSharpPrinter.cs:3764,3787`; 30 restored upstream fidelity tests pass. Both reviewers confirmed resolved.
- **#3 (GPT) — Applied Taste omits `this.`-qualification knobs:** accepted; PR scoped to the byte-divergent style-lens signal, qualification-decision recording deferred to **#3156**. Over-claiming wording corrected (empty state and section docs now scope to *recorded* choices). GPT confirmed the revised wording is coherent.
- **#4 (GPT) — config warnings suppressed on Applied-Taste-only runs:** non-blocking/by-design (Applied Taste is `ExplicitOnly`, meant to pair with Decompiled Source). Filed as follow-up **#3158**.

| # | Attack point | Verdict |
|---|---|---|
| 1 | Default-preserving (lenses off by default) | safe |
| 2 | Rewrite counters / fidelity | safe |
| 3 | Both lenses enabled (precedence) | safe |
| 4 | Config-warning suppression | non-blocking (#3158) |
| 5 | Default decision leakage | safe (only opt-in + filtered framework-import RuleIds) |
| 6 | Section plumbing (schema / empty state) | safe |
| 7 | Line-mapped overload stays byte-faithful | safe |

No blocking issues remain from either reviewer.
