### PR TITLE
Adopt Markout native change rendering in HarnessReportDiff; bump Markout 0.25.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Markout" Version="0.24.0" />
+    <PackageVersion Include="Markout" Version="0.25.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/tests/HarnessReportDiff.Tests/ComparisonRendererTests.cs
+++ b/tests/HarnessReportDiff.Tests/ComparisonRendererTests.cs
@@ -1,0 +1,78 @@
+using DotnetInspector.HarnessReportDiff;
+using DotnetInspector.HarnessReports;
+
+namespace HarnessReportDiff.Tests;
+
+public class ComparisonRendererTests
+{
+    [Fact]
+    public void Markdown_RendersNativeArrowGlyphAndGoalLabel_ForComparableMetrics()
+    {
+        var comparison = HarnessReportComparer.Compare(
+            Report(new ResidueEvidence(0), Metric("exact", MetricGoal.Higher, 10), Metric("fail", MetricGoal.Lower, 3)),
+            Report(new ResidueEvidence(0), Metric("exact", MetricGoal.Higher, 12), Metric("fail", MetricGoal.Lower, 5)));
+
+        string markdown = ComparisonRenderer.Render(comparison, "markdown");
+
+        // Native change cell: arrow between the two rate displays, plus the improvement/regression glyph.
+        Assert.Contains("10 (50.00%) → 12 (60.00%) ✓", markdown);
+        Assert.Contains("3 (15.00%) → 5 (25.00%) ✗", markdown);
+        // Goal label glyphs replace the old hand-mapped (+)/(−).
+        Assert.Contains("exact ↑", markdown);
+        Assert.Contains("fail ↓", markdown);
+        // The hand-rolled goal symbols and verdict-word column are gone.
+        Assert.DoesNotContain("(+)", markdown);
+        Assert.DoesNotContain("Metric (goal)", markdown);
+        Assert.DoesNotContain("Improved", markdown);
+        Assert.DoesNotContain("Regressed", markdown);
+    }
+
+    [Fact]
+    public void Markdown_OmitsPolarityGlyph_ForIncomparableMetric()
+    {
+        var comparison = HarnessReportComparer.Compare(
+            Report(new ResidueEvidence(0), Metric("exact", MetricGoal.Higher, 10, "sample-a")),
+            Report(new ResidueEvidence(0), Metric("exact", MetricGoal.Higher, 12, "sample-b")));
+
+        string markdown = ComparisonRenderer.Render(comparison, "markdown");
+
+        // Values still render with the goal-direction label, but no ✓/✗ verdict glyph and an n/a delta.
+        Assert.Contains("exact ↑", markdown);
+        Assert.Contains("10 (50.00%) → 12 (60.00%)", markdown);
+        Assert.Contains("| n/a |", markdown);
+        Assert.DoesNotContain("✓", markdown);
+        Assert.DoesNotContain("✗", markdown);
+    }
+
+    [Fact]
+    public void Tsv_EmitsTypedGoalColumnAndVerdictEnum()
+    {
+        var comparison = HarnessReportComparer.Compare(
+            Report(new ResidueEvidence(0), Metric("exact", MetricGoal.Higher, 10)),
+            Report(new ResidueEvidence(0), Metric("exact", MetricGoal.Higher, 12)));
+
+        string tsv = ComparisonRenderer.Render(comparison, "tsv");
+
+        Assert.Contains("section\titem\tgoal\tbefore\tafter\tdelta\tverdict\tdetail", tsv);
+        Assert.Contains("Metric\texact\tHigher\t10 (50.00%)\t12 (60.00%)\t+2 / +10.00 pp\tImproved\t", tsv);
+    }
+
+    [Fact]
+    public void Jsonl_CarriesGoalAndVerdictFields()
+    {
+        var comparison = HarnessReportComparer.Compare(
+            Report(new ResidueEvidence(0), Metric("fail", MetricGoal.Lower, 3)),
+            Report(new ResidueEvidence(0), Metric("fail", MetricGoal.Lower, 5)));
+
+        string jsonl = ComparisonRenderer.Render(comparison, "jsonl");
+
+        Assert.Contains("\"goal\":\"Lower\"", jsonl);
+        Assert.Contains("\"verdict\":\"Regressed\"", jsonl);
+    }
+
+    static ComparableMetric Metric(string id, MetricGoal goal, long count, string population = "same")
+        => new(id, id, goal, new MetricValue(count, 20), population);
+
+    static StructuredHarnessReport Report(ResidueEvidence residue, params ComparableMetric[] metrics)
+        => new(1, "test", "test report", "same", metrics, residue);
+}

--- a/tools/HarnessReportDiff/Program.cs
+++ b/tools/HarnessReportDiff/Program.cs
@@ -2,6 +2,7 @@ using DotnetInspector.HarnessReportDiff;
 using DotnetInspector.HarnessReports;
 using Markout;
 using Markout.Formatting;
+using System.Globalization;
 using System.Text.Json;
 
 if (args.Length < 2)
@@ -33,18 +34,41 @@ for (int i = 2; i < args.Length; i++)
 try
 {
     var comparison = HarnessReportComparer.Compare(HarnessReportReader.Read(beforePath), HarnessReportReader.Read(afterPath));
-    var output = new StringWriter();
-    if (format == "markdown")
+    Console.Write(ComparisonRenderer.Render(comparison, format));
+    return failOnRegression && comparison.HasRegressions ? 1 : 0;
+}
+catch (Exception ex) when (ex is IOException
+    or JsonException
+    or InvalidOperationException
+    or UnauthorizedAccessException
+    or ArgumentException)
+{
+    Console.Error.WriteLine(ex.Message);
+    return 2;
+}
+
+/// <summary>
+/// Renders a <see cref="HarnessComparison"/> to text in the requested format. The Markdown card flows
+/// through Markout's native change rendering (arrow, polarity glyph, goal label); the tsv/jsonl paths
+/// emit one flat, string-valued row shape with a <c>section</c> discriminator.
+/// </summary>
+public static class ComparisonRenderer
+{
+    public static string Render(HarnessComparison comparison, string format)
     {
-        MarkoutSerializer.Serialize(
-            ComparisonView.Create(comparison),
-            output,
-            new MarkdownFormatter(),
-            ComparisonViewContext.Default,
-            new MarkoutWriterOptions());
-    }
-    else
-    {
+        ArgumentNullException.ThrowIfNull(comparison);
+        var output = new StringWriter();
+        if (format == "markdown")
+        {
+            MarkoutSerializer.Serialize(
+                ComparisonView.Create(comparison),
+                output,
+                new MarkdownFormatter(),
+                ComparisonViewContext.Default,
+                new MarkoutWriterOptions());
+            return output.ToString();
+        }
+
         var options = format switch
         {
             "tsv" => new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv },
@@ -57,26 +81,16 @@ try
             new TableFormatter(showHeader: true),
             ComparisonViewContext.Default,
             options);
+        string rendered = output.ToString();
+        if (format == "jsonl")
+        {
+            rendered = string.Join(
+                Environment.NewLine,
+                rendered.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                + Environment.NewLine;
+        }
+        return rendered;
     }
-    string rendered = output.ToString();
-    if (format == "jsonl")
-    {
-        rendered = string.Join(
-            Environment.NewLine,
-            rendered.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries))
-            + Environment.NewLine;
-    }
-    Console.Write(rendered);
-    return failOnRegression && comparison.HasRegressions ? 1 : 0;
-}
-catch (Exception ex) when (ex is IOException
-    or JsonException
-    or InvalidOperationException
-    or UnauthorizedAccessException
-    or ArgumentException)
-{
-    Console.Error.WriteLine(ex.Message);
-    return 2;
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
@@ -92,7 +106,8 @@ sealed class ComparisonView
     public List<FullyRaisedRow>? FullyRaised { get; init; }
 
     [MarkoutSection(Name = "Metrics")]
-    public List<MetricRow>? Metrics { get; init; }
+    [MarkoutLabelHeader("Metric")]
+    public List<MultiSourceRow>? Metrics { get; init; }
 
     [MarkoutSection(Name = "Warnings", EmptyText = "None")]
     public List<WarningRow>? Warnings { get; init; }
@@ -107,8 +122,40 @@ sealed class ComparisonView
         FullyRaised = comparison.FullyRaised is { } fullyRaised
             ? [new(fullyRaised.Before, fullyRaised.After, fullyRaised.Basis, fullyRaised.Verdict.ToString())]
             : null,
-        Metrics = [.. comparison.Metrics.Select(MetricRow.Create)],
+        Metrics = comparison.Metrics.Count == 0 ? null : [.. comparison.Metrics.Select(MetricMovementRow)],
         Warnings = comparison.Warnings.Count == 0 ? null : [.. comparison.Warnings.Select(warning => new WarningRow(warning))],
+    };
+
+    // Render each metric as a Markout change row: the arrow, the ✓/✗ polarity glyph, and the goal
+    // (↑/↓) label glyph are all derived natively from the two MetricValue cells plus the mapped Goal —
+    // no hand-built change string, goal symbol, or verdict word. The typed MetricVerdict still drives
+    // the exit-code gate (HarnessComparison.HasRegressions); it is not inferred from this display.
+    static MultiSourceRow MetricMovementRow(MetricComparison metric)
+    {
+        // An incomparable population must not imply a good/bad change: neutralize the value-cell goal to
+        // Context so no ✓/✗ is derived, while the label still shows the metric's inherent direction.
+        Goal cellGoal = metric.Verdict == MetricVerdict.Incomparable
+            ? Goal.Context
+            : MapGoal(metric.Goal);
+        return new MultiSourceRow(
+            metric.Label,
+            new Source(
+                "Change",
+                new Change<MetricValueCell>(new MetricValueCell(metric.Before), new MetricValueCell(metric.After)),
+                new MarkoutCellFormat { Goal = cellGoal }),
+            new Source("Delta", new MetricText(metric.Delta)))
+        {
+            Goal = MapGoal(metric.Goal),
+        };
+    }
+
+    // Hold and Context carry no display polarity (their any-change semantics live in the verdict/gate,
+    // not the glyph), so both map to Markout's neutral Context.
+    static Goal MapGoal(MetricGoal goal) => goal switch
+    {
+        MetricGoal.Higher => Goal.Higher,
+        MetricGoal.Lower => Goal.Lower,
+        _ => Goal.Context,
     };
 }
 
@@ -118,24 +165,41 @@ sealed record ReportRow(string Side, string Kind, string Description);
 [MarkoutSerializable]
 sealed record FullyRaisedRow(string Before, string After, string Basis, string Verdict);
 
-[MarkoutSerializable]
-sealed record MetricRow(
-    [property: MarkoutPropertyName("Metric (goal)")] string Metric,
-    string Change,
-    string Delta,
-    string Verdict)
+// A MetricValue rendered as a Markout cell: mirrors MetricValue.Display ("count" or "count (pct%)") and
+// exposes the goal magnitude (rate when a total is present, else the raw count) so Change<T> can derive
+// the polarity glyph. Mirrors the QualityRate pattern in CorpusSensor.cs.
+readonly record struct MetricValueCell(long Count, long? Total) : IMarkoutCell, IGoalMagnitude
 {
-    public static MetricRow Create(MetricComparison metric)
+    public MetricValueCell(MetricValue value)
+        : this(value.Count, value.Total)
     {
-        string goal = metric.Goal switch
-        {
-            MetricGoal.Higher => "+",
-            MetricGoal.Lower => "−",
-            MetricGoal.Hold => "=",
-            _ => "context",
-        };
-        return new($"{metric.Label} ({goal})", $"{metric.Before.Display} → {metric.After.Display}", metric.Delta, metric.Verdict.ToString());
     }
+
+    double IGoalMagnitude.GoalMagnitude => Total is > 0 ? (double)Count / Total.Value : Count;
+
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+        => writer.Write(Total is > 0
+            ? $"{Count.ToString("N0", CultureInfo.InvariantCulture)} ({100.0 * Count / Total.Value:0.00}%)"
+            : Count.ToString("N0", CultureInfo.InvariantCulture));
+
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+    {
+        fields.Add(new MarkoutField(SideKey(side, "count"), Count.ToString(CultureInfo.InvariantCulture)));
+        if (Total is > 0)
+            fields.Add(new MarkoutField(SideKey(side, "total"), Total.Value.ToString(CultureInfo.InvariantCulture)));
+    }
+
+    static string SideKey(string? side, string key) => side is null ? key : side + "_" + key;
+}
+
+// A precomputed delta string (count, optionally with a percentage-point rate) rendered verbatim. The
+// rate delta is information Markout's numeric delta cannot express, so it is carried here.
+readonly record struct MetricText(string Text) : IMarkoutCell
+{
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format) => writer.Write(Text);
+
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+        => fields.Add(new MarkoutField(side ?? "value", Text));
 }
 
 [MarkoutSerializable]
@@ -154,40 +218,32 @@ sealed class ComparisonTableView
     {
         var rows = new List<ComparisonTableRow>
         {
-            new("Report", "Before", "", "", "", "", $"{comparison.Before.Kind}: {comparison.Before.Description}"),
-            new("Report", "After", "", "", "", "", $"{comparison.After.Kind}: {comparison.After.Description}"),
+            new("Report", "Before", "", "", "", "", "", $"{comparison.Before.Kind}: {comparison.Before.Description}"),
+            new("Report", "After", "", "", "", "", "", $"{comparison.After.Kind}: {comparison.After.Description}"),
         };
         if (comparison.FullyRaised is { } endpoint)
         {
             rows.Add(new(
                 "Endpoint",
                 "Fully raised",
+                "",
                 endpoint.Before,
                 endpoint.After,
                 "",
                 endpoint.Verdict.ToString(),
                 endpoint.Basis));
         }
-        rows.AddRange(comparison.Metrics.Select(metric =>
-        {
-            string goal = metric.Goal switch
-            {
-                MetricGoal.Higher => "+",
-                MetricGoal.Lower => "−",
-                MetricGoal.Hold => "=",
-                _ => "context",
-            };
-            return new ComparisonTableRow(
-                "Metric",
-                $"{metric.Label} ({goal})",
-                metric.Before.Display,
-                metric.After.Display,
-                metric.Delta,
-                metric.Verdict.ToString(),
-                "");
-        }));
+        rows.AddRange(comparison.Metrics.Select(metric => new ComparisonTableRow(
+            "Metric",
+            metric.Label,
+            metric.Goal.ToString(),
+            metric.Before.Display,
+            metric.After.Display,
+            metric.Delta,
+            metric.Verdict.ToString(),
+            "")));
         rows.AddRange(comparison.Warnings.Select(warning =>
-            new ComparisonTableRow("Warning", "Warning", "", "", "", "", warning)));
+            new ComparisonTableRow("Warning", "Warning", "", "", "", "", "", warning)));
         return new ComparisonTableView { Rows = rows };
     }
 }
@@ -196,6 +252,7 @@ sealed class ComparisonTableView
 sealed record ComparisonTableRow(
     string Section,
     string Item,
+    string Goal,
     string Before,
     string After,
     string Delta,
@@ -206,7 +263,6 @@ sealed record ComparisonTableRow(
 [MarkoutContext(typeof(ComparisonView))]
 [MarkoutContext(typeof(ReportRow))]
 [MarkoutContext(typeof(FullyRaisedRow))]
-[MarkoutContext(typeof(MetricRow))]
 [MarkoutContext(typeof(WarningRow))]
 [MarkoutContext(typeof(ComparisonTableView))]
 [MarkoutContext(typeof(ComparisonTableRow))]

--- a/tools/HarnessReportDiff/README.md
+++ b/tools/HarnessReportDiff/README.md
@@ -23,19 +23,25 @@ Existing DecompilerHarness corpus snapshots are also accepted directly.
 Use `--format tsv` or `--format jsonl` for structured rows. Add
 `--fail-on-regression` to exit 1 when a comparable metric moves opposite its
 declared goal. Invalid input or incompatible report kinds/schemas exit 2.
-TSV and JSONL use one flat row shape with a `section` discriminator; values
-remain strings so a count delta and a count-plus-rate delta do not change type.
+TSV and JSONL use one flat row shape with a `section` discriminator; every row
+carries a typed `goal` (`Higher`/`Lower`/`Hold`/`Context`) and `verdict`
+(`Improved`/`Neutral`/`Regressed`/`Incomparable`) column, and values remain
+strings so a count delta and a count-plus-rate delta do not change type.
 
-The default Markdown card uses `Metric (goal)` labels:
+The default Markdown card renders each metric through Markout's native change
+cell, so the direction and outcome are glyphs rather than words:
 
-- `(+)` means higher is better;
-- `(−)` means lower is better;
-- `(=)` means the value should remain fixed;
-- `(context)` means movement is informational.
+- the label carries a goal glyph — `↑` when higher is better, `↓` when lower is
+  better, and no glyph when the value should hold or is context-only;
+- the change cell shows `before → after` with a `✓` (improvement) or `✗`
+  (regression) polarity glyph derived from the goal;
+- the `Delta` column shows the signed count and, when a total is present, the
+  percentage-point rate change.
 
 Counts from different sampled method populations are marked `Incomparable`
-even when the sample sizes happen to match. Corpus snapshots supply their
-per-method identities for this check. Snapshots without method identities
+even when the sample sizes happen to match: their change cell renders the two
+values without a polarity glyph and the delta is `n/a`. Corpus snapshots supply
+their per-method identities for this check. Snapshots without method identities
 cannot establish either sample or aggregate comparability, even when their
 assembly names and method counts happen to match.
 


### PR DESCRIPTION
Closes #3144.

## What

`tools/HarnessReportDiff` rendered its comparison tables by hand — a
`before → after` change string, a precomputed delta string, a `+/−/=` goal
symbol duplicated across the Markdown and flat views, and a `Verdict` word.
This adopts Markout's native change-cell rendering (arrow, polarity glyph, goal
label derived from a `Change<T>` cell + `MarkoutCellFormat`) and drops the
hand-rolled machinery, and bumps Markout `0.24.0 → 0.25.0`.

### Markdown card
- Metrics render through `List<MultiSourceRow>`; each row uses a
  `Change<MetricValueCell>` cell so `before → after` and the ✓/✗ polarity glyph
  are native, and the row `Goal` produces the ↑/↓ label glyph.
- **Incomparable populations neutralize the cell goal to `Context`** so no
  misleading ✓/✗ is shown (the label still carries direction; delta stays `n/a`).
- The signed count **plus percentage-point rate** (which Markout's numeric
  delta cannot express) is retained in a dedicated `Delta` column.

### Flat tsv/jsonl
- Keeps the one flat, string-valued row shape; adds a typed `goal` column
  (`Higher`/`Lower`/`Hold`/`Context`) so the hand-mapped symbol is gone there
  too, and keeps the machine-useful `verdict` enum. Not consumed by CI/automation.

### Contract preserved
- The comparer is unchanged. The typed `MetricVerdict` still drives the
  `--fail-on-regression` gate (`HasRegressions`); verdict is **never inferred
  from display text**.

## Example

| Metric | Change | Delta |
| ------ | ------ | ----- |
| Fully raised ↑ | 1,249 (83.27%) → 1,252 (83.47%) ✓ | +3 / +0.20 pp |
| Detected lowering residue ↓ | 251 (16.73%) → 256 (17.07%) ✗ | +5 / +0.33 pp |

## Evidence
- Rendering extracted into a testable `ComparisonRenderer`; new tests cover
  markdown glyphs, incomparable no-glyph, and tsv/jsonl `goal`+`verdict` columns.
- Live-verified improvement (✓, exit 0), regression (✗, exit 1), and
  incomparable (no glyph, `n/a`) across markdown/tsv/jsonl.
- `HarnessReportDiff.Tests` 19/19; product CLI `dotnet-inspect.Tests` 2045/2045;
  CorpusSensor + history card 70/70 (Markout 0.25.0 bump). Markout diff
  0.24→0.25 is purely additive (0 breaking). README updated + markdownlint clean.

## Review
Product-output change → 2-model adversarial review (per AGENTS.md) to follow.