### PR TITLE
Enable Nightshift for this repo: orientation skill + charter

### DIFF
--- a/.github/skills/nightshift/SKILL.md
+++ b/.github/skills/nightshift/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: nightshift
+description: >-
+  The Nightshift orientation: what Nightshift is (Turnstile, Nightshift,
+  Octoshift), the unit of work (an "order" = one landable PR), the five roles and
+  what each owns, and how they coordinate through state rather than chat. Start
+  here, then run `nightshift skill <role>` for your role's operating skill. Use
+  this when asked what Nightshift is, how the roles fit together, or to get
+  oriented before joining a shift.
+---
+
+# Nightshift
+
+Nightshift drives many units of work to completion in parallel by shifting the
+mechanical oversight onto the night-shift coordinator — so the people who set
+direction don't spend their attention on it. Work is built and reviewed to a clean
+bar on a **night shift**, while direction-setting and the merge decision stay
+deliberate acts on the **day shift**. It is a **loose harness**: it sits above many
+coding-agent harnesses and coordinates them through shared state — leases, orders,
+directives — never their inner loops. **Loosely overlaid; strictly gated.**
+
+You are reading the orientation. When you know your role, get its operating skill:
+
+```bash
+nightshift skill <role>   # planner | coordinator | worker | builder | reviewer
+```
+
+Run `nightshift skill` with no argument to reprint this orientation. (`planner` and
+`coordinator` share one skill; a Planner is a Coordinator scoped to registering work.)
+
+## The three layers
+
+- **Turnstile** — a credential-free coordination kernel (kv, leases, watch) over a
+  local Unix socket. No GitHub, no network, no auth.
+- **Nightshift** — the shift mechanics on top of Turnstile: plans, orders, the ready
+  set, claims, and landing.
+- **Octoshift** — the optional bridge that watches GitHub merges and drives landing
+  back into Nightshift.
+
+## The unit of work
+
+The unit of work is an **order**: one **landable PR**, the atomic unit of both claim
+and merge, bound to at most one GitHub issue. A **plan** (`orders.json`) is a DAG of
+orders for a feature; `after` edges express which orders must land before others can
+start. An order is claimed by one worker, built and reviewed to a clean adversarial
+verdict, opened as a PR and cleared by the coordinator, merged, and **landed** — at
+which point its dependents open.
+
+## The five roles
+
+**Roles are responsibilities, not people.** A role names *what* work is done and its
+boundaries — build versus review, who writes to GitHub, which model runs — not how
+many processes call `nightshift`. Any role can be filled by a person or an agent, and
+one session can fill several. Most sessions on a machine are workers.
+
+| Role | Owns | Skill |
+|---|---|---|
+| **Product Manager** | The expanding shape of the product: new issues, taste, where features must be re-shaped or composed. Sets direction. | — |
+| **Planner** | Turns intent (often issues) into orders and registers them with nightshift. | `nightshift skill planner` |
+| **Coordinator** | Runs the shift: registers plans, keeps the ready set live, owns the GitHub surface (push, PRs, the one clearance note), first-level escalation, lands merged orders. | `nightshift skill coordinator` |
+| **Worker** | Claims one order and takes it to a reviewed branch (handed back for the coordinator to push) — building it *and* reviewing it, usually via subagents. | `nightshift skill worker` |
+| **PR Lander** | Holds merge authority; keeps sequenced PRs flowing. | — |
+
+The **Worker** builds and reviews by spawning subagents (an optimization that
+preserves its context window and supplies model diversity). Those two
+responsibilities each have their own skill a worker points a subagent at:
+
+- **Builder** — build one order into commits on its branch: `nightshift skill builder`
+- **Reviewer** — review one order's diff read-only and report inward: `nightshift skill reviewer`
+
+## How the roles work together
+
+Because roles can be distinct sessions — or distinct machines — they **do not talk
+directly**. They coordinate through Nightshift/Turnstile state: an escalation a worker
+raises surfaces to the coordinator as state, read off the board like every other
+signal. Every instruction a worker needs arrives as the **return value of a gate call**
+(`next`, `check`), never as chat.
+
+The life of one order:
+
+1. A Product Manager files an issue; the Planner turns it into orders and registers
+   them (`add`/`plan`).
+2. The Coordinator seeds the specs and the ready set. A Worker claims a ready order
+   with `next`.
+3. The Worker **builds** it (a builder subagent on model A) and **reviews** it (a
+   reviewer subagent on model B ≠ A), fixing and re-reviewing until **two clean reviews
+   from two different models** on the same final head.
+4. The Worker hands the branch back and `release`s it done, with the review attestation.
+5. The Coordinator pushes the branch, opens/updates the PR, and posts the **one**
+   clearance note.
+6. The PR Lander merges. The Coordinator **lands** the order, and its dependents open.
+
+## The invariants that hold regardless of the split
+
+- **A Worker is always a separate instance** from the Coordinator/Planner. The
+  coordinator never claims, builds, reviews, or spawns workers — workers `join` and
+  `next` on their own.
+- **The builder never reviews its own work.** Building produces a committed branch;
+  grading your own homework is not a review.
+- **Every change clears the gate:** two clean reviews from two **different** models on
+  the final head — governance and docs PRs included.
+- **Only the coordinator writes to GitHub** — every push, PR, and the single clearance
+  note. Build and review roles run with no write access to origin.
+
+## The CLI contract
+
+Every agent-facing verb signals two ways at once: an **exit code** (branch on it
+without parsing stdout) and a **human-readable token on the first line of stdout**
+(`WORK` / `NOWORK` / `OK` / `HALT` / `DRAINING` / `QUERY` / `FENCE_STALE` and
+siblings). Your role skill tells you which verb you wait on and how to wait without
+stalling or polling.
+
+## Where to go next
+
+- Your role's operating skill: `nightshift skill worker` (or `planner`,
+  `coordinator`, `builder`, `reviewer`).
+- Design docs live under `docs/design/` — `nightshift-vision.md`, `nightshift-spec.md`,
+  `workflow.md`, `turnstile.md`, `octoshift.md`.

--- a/.github/skills/nightshift/SKILL.md
+++ b/.github/skills/nightshift/SKILL.md
@@ -112,7 +112,8 @@ stalling or polling.
 
 ## Where to go next
 
-- Your role's operating skill: `nightshift skill worker` (or `planner`,
-  `coordinator`, `builder`, `reviewer`).
-- Design docs live under `docs/design/` — `nightshift-vision.md`, `nightshift-spec.md`,
-  `workflow.md`, `turnstile.md`, `octoshift.md`.
+- **Start a shift in this repo:** see [`NIGHTSHIFT.md`](../../../NIGHTSHIFT.md) at the repo root for
+  how to bring the coordination daemon up and which issues become orders here.
+- **Your role's operating skill:** `nightshift skill worker` (or `planner`, `coordinator`, `builder`,
+  `reviewer`).
+- **If any tool errors or behaves unexpectedly, stop and ask for help — do not try to fix the tools.**

--- a/.github/skills/nightshift/SKILL.md
+++ b/.github/skills/nightshift/SKILL.md
@@ -82,9 +82,9 @@ The life of one order:
    them (`add`/`plan`).
 2. The Coordinator seeds the specs and the ready set. A Worker claims a ready order
    with `next`.
-3. The Worker **builds** it (a builder subagent on model A) and **reviews** it (a
-   reviewer subagent on model B ≠ A), fixing and re-reviewing until **two clean reviews
-   from two different models** on the same final head.
+3. The Worker **builds** it (a builder subagent on model A) and **reviews** it (reviewer
+   subagents on two other models, B and C, neither the builder's A), fixing and
+   re-reviewing until **two clean reviews from two different models** on the same final head.
 4. The Worker hands the branch back and `release`s it done, with the review attestation.
 5. The Coordinator pushes the branch, opens/updates the PR, and posts the **one**
    clearance note.
@@ -100,7 +100,8 @@ The life of one order:
 - **Every change clears the gate:** two clean reviews from two **different** models on
   the final head — governance and docs PRs included.
 - **Only the coordinator writes to GitHub** — every push, PR, and the single clearance
-  note. Build and review roles run with no write access to origin.
+  note; the PR Lander's merge is the one exception. Build and review roles run with no
+  write access to origin.
 
 ## The CLI contract
 

--- a/NIGHTSHIFT.md
+++ b/NIGHTSHIFT.md
@@ -11,6 +11,31 @@ for the SDK, build/test commands, branching, the output-verbosity contract, evid
 adversarial review. This charter does not restate those — it only shapes *which issues become orders
 and how they are sliced*.
 
+## Starting the tools
+
+The `nightshift`, `turnstile`, and `octoshift` commands are **already installed as binaries on your
+PATH**. You do **not** build, rebuild, or redeploy them, and there is nothing to compile before a
+shift — ignore any instruction that tells you to.
+
+Bring up the coordination daemon **once per machine** — it holds the board, so leave it running:
+
+```bash
+turnstile serve --socket ~/.turnstile/turnstile.sock --db ~/.turnstile/turnstile.db
+```
+
+Point every `nightshift` and `turnstile` call at that socket (the default is
+`~/.turnstile/turnstile.sock`, so this only matters if you chose another path):
+
+```bash
+export TURNSTILE_SOCKET=~/.turnstile/turnstile.sock
+```
+
+With the daemon up, follow your role skill — `nightshift skill coordinator` to register the plan and
+open the ready set, `nightshift skill worker` to claim and build an order.
+
+**If any tool errors, hangs, crashes, or behaves in a way you do not expect, stop and ask the operator
+for help. Do not try to diagnose, patch, rebuild, restart, or work around the tools yourself.**
+
 ## Scope — which issues become work
 
 Candidates are **open issues in this repository** that describe a concrete change to one of the

--- a/NIGHTSHIFT.md
+++ b/NIGHTSHIFT.md
@@ -93,11 +93,14 @@ theme into orders:
 
 `AGENTS.md` already requires adversarial review from **two different models** for any non-trivial
 behavior change — this **is** Nightshift's two-clean gate, so the two do not stack: a worker's two
-clean reviews from two different models on the final head satisfy both. Simple, mechanical, or
-documentation-only orders that `AGENTS.md` exempts from adversarial review still clear Nightshift by
-that same standard — state why the order is low risk in its clearance note. Keep the repo's readiness
-convention: when all merge-blocking validation and required review are complete, the clearance note is
-`Ready to merge`.
+clean reviews from two different models on the final head satisfy both. Where the two bars differ,
+**Nightshift is the stricter one and it governs the shift.** `AGENTS.md` exempts simple, mechanical,
+or documentation-only changes from adversarial review; a Nightshift **order** does **not** inherit
+that exemption — **every order clears the two-clean gate on its final head, docs and design orders
+included.** Scale the review *effort* to the blast radius — a docs order is cleared by confirming its
+claims and links are accurate, a heuristic or shape change by attacking its correctness — but never
+waive the two-clean bar itself. Keep the repo's readiness convention: when all merge-blocking
+validation and required review are complete, the clearance note is `Ready to merge`.
 
 The mechanics of expressing an order and driving it to merge — the plan format, the two-clean review
 gate, landing — are standard Nightshift and belong to your skill.

--- a/NIGHTSHIFT.md
+++ b/NIGHTSHIFT.md
@@ -1,0 +1,78 @@
+# NIGHTSHIFT.md — this repository's charter
+
+This document is the Nightshift engineering charter for **dotnet-inspect**. It is written for a
+**planner** to import at the start of a shift and use to turn this repo's issues into **orders** that
+workers execute. Read the planner skill (`nightshift skill planner`) for *how* to plan; this charter
+carries only what is specific to this repo. Your authority is this charter **plus** whatever the
+operator told you this session — where both are silent, do not assume: post on the issue and wait.
+
+Repository-wide engineering requirements are in [`AGENTS.md`](AGENTS.md); it is the source of truth
+for the SDK, build/test commands, branching, the output-verbosity contract, evidence expectations, and
+adversarial review. This charter does not restate those — it only shapes *which issues become orders
+and how they are sliced*.
+
+## Scope — which issues become work
+
+Candidates are **open issues in this repository** that describe a concrete change to one of the
+product subsystems, the harnesses, the skills, or the design docs:
+
+- **Metadata** (`src/ILInspector.Metadata/**`, `src/ILInspector.MetadataPrimitives/**`) — SRM-level
+  metadata facts.
+- **Analysis** (`src/ILInspector.Analysis/**`, `src/ILInspector.CallGraph/**`,
+  `src/ILInspector.ControlFlow/**`, `src/ILInspector.Instructions/**`) — IL-body evidence.
+- **CSharp / decompiler** (`src/ILInspector.CSharp/**`, `src/ILInspector.Decompiler/**`) — C# spelling,
+  type views, and raising/structuring.
+- **Research / Findings** (`src/ILInspector.Research/**`, `src/ILInspector.Findings/**`) — evidence
+  composition.
+- **CLI and output** (`src/dotnet-inspect/**`) — command and presentation concerns.
+- **Shared services** (`src/DotnetInspector.*/**`), the **harnesses** (`tools/**`, `tests/**`), the
+  **skills** (`skills/**`, `.github/skills/**`), and the **docs** (`docs/**`, `README.md`).
+
+The **Product Manager tells you the theme at the start of each session** — plan the open issues that
+match that theme. Pure discussion, open design questions, and product-shape decisions with unresolved
+tradeoffs are **not** planned; they belong to the Product Manager (you may post to move them forward).
+
+## Turning issues into orders
+
+The order — its id, `paths`, `after` edges, and `standard` — is something **you produce** to drive the
+shift; it is not authored into the issue. Issues stay ordinary issues. To turn the ones that match the
+theme into orders:
+
+- **Size each order to about an hour**, and to a size that can be **adversarially reviewed at high
+  quality**. Many issues already fit and need no breakdown; split the ones that don't.
+- **Keep `paths` disjoint and layer-aligned.** Slice orders along the subsystem boundaries above so
+  concurrent workers never collide on the same files, and so each order stays inside one owner's layer.
+  Metadata owns metadata facts, Analysis owns IL-body evidence, CSharp owns C# spelling and type views,
+  Research composes evidence, and the CLI owns command and presentation concerns — do not let one order
+  reach across these to infer another layer's facts.
+- **Design-first for the hard ones.** If an issue is ambiguous, carries tradeoff decisions, has
+  significant cross-subsystem interactions, or introduces a new foundational capability, start with a
+  **docs-only design PR** under `docs/design/` before any implementation. Design PRs clear the same
+  adversarial gate as code — often it matters more, because a bad design produces bad code.
+- **Use the decompiler PR templates for decompiler work.** Raising, typing, structuring, fidelity,
+  validity, or corpus changes carry extra evidence requirements; set each such order's `standard` to
+  the relevant template and design doc:
+  - `docs/templates/decompiler-pr.md` — raising, structuring, validity, fidelity, or corpus behavior.
+  - `docs/templates/decompiler-burndown-fix-pr.md` — a focused invalid-`Full` or burndown row fix.
+  - `docs/templates/decompiler-compile-back-harness-pr.md` — compile-back harness or fidelity skeleton.
+  The `Area` / `Speed` decompiler test taxonomy in `docs/decompiler-correctness-pipeline.md` is how a
+  worker scopes evidence for these orders.
+- **Collapse strong overlap.** If two issues overlap heavily, merge them into a single order (or a
+  shared set of overlapping slices) rather than planning orders that will collide on the same files.
+- **Readiness is a gate.** An order needs a design solid enough to slice into `paths`-bounded pieces
+  against a concrete `standard`. When an issue is still a sketch — unsettled scope, no agreed shape,
+  unresolved tradeoffs — **do not plan it.** Post on the issue naming the specific design it still
+  needs, and leave it for the Product Manager to shape.
+
+## How this composes with the repo's review gate
+
+`AGENTS.md` already requires adversarial review from **two different models** for any non-trivial
+behavior change — this **is** Nightshift's two-clean gate, so the two do not stack: a worker's two
+clean reviews from two different models on the final head satisfy both. Simple, mechanical, or
+documentation-only orders that `AGENTS.md` exempts from adversarial review still clear Nightshift by
+that same standard — state why the order is low risk in its clearance note. Keep the repo's readiness
+convention: when all merge-blocking validation and required review are complete, the clearance note is
+`Ready to merge`.
+
+The mechanics of expressing an order and driving it to merge — the plan format, the two-clean review
+gate, landing — are standard Nightshift and belong to your skill.


### PR DESCRIPTION
## What

Enables Nightshift in this repo with two docs-only artifacts:

1. **`.github/skills/nightshift/SKILL.md`** — the Nightshift orientation skill (Turnstile / Nightshift / Octoshift, the *order* = one landable PR unit of work, the five roles, and `nightshift skill <role>` for each role's operating skill). Placed under `.github/skills/` (Copilot-discovered, repo-local, and the same convention the `nightshift` repo uses) — **not** the product `skills/` tree, whose `SKILL.md` files are embedded into the shipped `dotnet-inspect` tool.
2. **`NIGHTSHIFT.md`** — the repo's planning charter: which open issues become orders (per subsystem), how to slice them (~1h, layer-aligned, disjoint `paths`, design-first docs PRs for hard issues, decompiler PR templates as an order's `standard`, a readiness gate). It defers engineering rules to `AGENTS.md` and notes the repo's existing two-model adversarial review already **is** Nightshift's two-clean gate.

## Evidence / risk

Documentation-only. Both files pass `markdownlint-cli`; all in-file references (AGENTS.md, the three decompiler PR templates, the correctness pipeline doc, subsystem paths) resolve. No product build/test impact; low risk, so no adversarial review per AGENTS.md.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>