### PR TITLE
Add library-owned StyleOptionCatalog as the style-knob source of truth

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -445,6 +445,9 @@ dotnet_style_prefer_conditional_expression_over_return = true
   ternary [style lens](#style-lenses-behavior-faithful-byte-divergent)), and
   `dotnet_inspect_style_prefer_branchless_boolean` (the non-oracle-endorsed
   branchless lens, under a tool-owned key). The set grows as more knobs ship.
+- The recognized keys are not hand-maintained in the resolver: they come from the
+  library-owned `StyleOptionCatalog` (see [Option catalog](#option-catalog)), so
+  the CLI vocabulary and the option surface cannot drift.
 - Unknown keys, malformed lines, and non-boolean values are reported as a
   `Warning:` on stderr and skipped — the rest of the file still applies. A bad
   config never fails the run silently.
@@ -481,6 +484,28 @@ of the assembly and the options it is handed, so the config surface never change
 what the library computes for a given `PrinterOptions`. The knobs affect the
 primary decompiled-source view; the Annotated Source and IR-stage views stay on
 the shipped default so they remain aligned with the IL.
+
+### Option catalog
+
+The recognized knobs are described once, in the library, by
+`StyleOptionCatalog` (`ILInspector.Decompiler.Pipeline`). Each
+`StyleOptionDescriptor` carries a knob's stable id, human-facing title and
+summary, its tier (`Formatting`, `Spelling`, `Lens`, or `Synthesis`), whether it
+is `ByteDivergent`, whether it is `OracleEndorsed`, its `.dotnet-inspectconfig`
+key (`null` for API-only formatting/synthesis knobs), a `ConflictGroup` for
+mutually-exclusive knobs, and NativeAOT-safe `Get`/`With` delegates that read and
+set the knob on a `PrinterOptions` without reflection.
+
+This makes the option surface discoverable and drift-proof for every host, not
+just the CLI: the config resolver derives its recognized keys from the catalog,
+a Wasm UI can enumerate the knobs (grouping the mutually-exclusive lenses by
+`ConflictGroup` and toggling each through `Get`/`With`), and the future "full
+taste" aggregate is exactly the `OracleEndorsed` subset. The two guarded-boolean
+lenses share the `guarded-boolean-return` conflict group, so a picker offers at
+most one (the printer still resolves any overlap deterministically, preferring the
+oracle-endorsed ternary). The single non-boolean knob
+(`ExpressionBodyArrowPlacement`) is not yet modeled in the catalog, which
+currently describes boolean toggles.
 
 ## Verification and soundness
 

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The library-owned <see cref="StyleOptionCatalog"/> is the single source of
+/// truth for the opt-in boolean <see cref="PrinterOptions"/> knobs — their
+/// identity, tier/contract, oracle endorsement, config key, mutual-exclusivity,
+/// and NativeAOT-safe accessors. These tests pin that contract so a host (the CLI
+/// resolver, a Wasm UI, the future "full taste" aggregate) can rely on it, and so
+/// the catalog cannot silently drift from the <see cref="PrinterOptions"/> surface.
+/// </summary>
+public class StyleOptionCatalogTests
+{
+    private static IReadOnlyList<StyleOptionDescriptor> Options => StyleOptionCatalog.Options;
+
+    // Every public instance boolean property on PrinterOptions is a knob a host may
+    // want to discover and toggle. Reflection here is a test-only drift guard (never
+    // a product path): if a new boolean knob lands without a catalog entry, this
+    // fails and forces the catalog — the single source of truth — to be updated.
+    private static IReadOnlyList<PropertyInfo> BooleanKnobProperties =>
+        typeof(PrinterOptions)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.PropertyType == typeof(bool))
+            .ToArray();
+
+    [Fact]
+    public void EveryBooleanPrinterOption_HasExactlyOneCatalogEntry()
+    {
+        Assert.Equal(BooleanKnobProperties.Count, Options.Count);
+    }
+
+    [Fact]
+    public void Ids_AreNonEmpty_AndUnique()
+    {
+        Assert.All(Options, o => Assert.False(string.IsNullOrWhiteSpace(o.Id)));
+        Assert.Equal(Options.Count, Options.Select(o => o.Id).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void TitlesAndSummaries_AreNonEmpty()
+    {
+        Assert.All(Options, o =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(o.Title));
+            Assert.False(string.IsNullOrWhiteSpace(o.Summary));
+        });
+    }
+
+    [Fact]
+    public void ConfigKeys_WherePresent_AreUnique()
+    {
+        var keys = Options.Select(o => o.ConfigKey).Where(k => k is not null).ToArray();
+        Assert.Equal(keys.Length, keys.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void GetWith_RoundTripsEachKnob_OffByDefault()
+    {
+        foreach (var o in Options)
+        {
+            Assert.False(o.Get(PrinterOptions.Default), $"{o.Id} should be off in the shipped default");
+
+            var enabled = o.With(PrinterOptions.Default, true);
+            Assert.True(o.Get(enabled), $"{o.Id} should read back true after With(true)");
+
+            var disabled = o.With(enabled, false);
+            Assert.False(o.Get(disabled), $"{o.Id} should read back false after With(false)");
+        }
+    }
+
+    [Fact]
+    public void With_TogglesExactlyOneKnob_LeavingOthersUntouched()
+    {
+        // Enabling one knob must not flip any other knob's Get — proof that the
+        // delegates are isolated and target distinct PrinterOptions properties.
+        foreach (var subject in Options)
+        {
+            var enabled = subject.With(PrinterOptions.Default, true);
+            foreach (var other in Options)
+            {
+                var expected = ReferenceEquals(other, subject);
+                Assert.Equal(expected, other.Get(enabled));
+            }
+        }
+    }
+
+    [Fact]
+    public void ByteDivergent_IsExactlyTheLensTier()
+    {
+        Assert.All(Options, o => Assert.Equal(o.Tier == StyleOptionTier.Lens, o.ByteDivergent));
+    }
+
+    [Fact]
+    public void GuardedBooleanReturnGroup_IsExactlyTheTwoLenses()
+    {
+        var grouped = Options
+            .Where(o => o.ConflictGroup == StyleOptionCatalog.GuardedBooleanReturnGroup)
+            .Select(o => o.Id)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(new[] { "prefer-branchless-boolean", "prefer-conditional-expression-return" }, grouped);
+        // Both members of a conflict group are byte-divergent lenses.
+        Assert.All(
+            Options.Where(o => o.ConflictGroup == StyleOptionCatalog.GuardedBooleanReturnGroup),
+            o => Assert.Equal(StyleOptionTier.Lens, o.Tier));
+    }
+
+    [Fact]
+    public void OracleEndorsedSet_ExcludesTheBranchlessLens()
+    {
+        var endorsed = Options.Where(o => o.OracleEndorsed).Select(o => o.Id).ToArray();
+        Assert.Contains("prefer-conditional-expression-return", endorsed);
+        Assert.DoesNotContain("prefer-branchless-boolean", endorsed);
+        // The branchless lens uses a tool-owned key, never a dotnet_style_* one.
+        var branchless = Options.Single(o => o.Id == "prefer-branchless-boolean");
+        Assert.StartsWith("dotnet_inspect_style_", branchless.ConfigKey);
+    }
+
+    [Fact]
+    public void OracleEndorsedKnobsWithAConfigKey_UseTheEditorconfigVocabulary()
+    {
+        foreach (var o in Options.Where(o => o.OracleEndorsed && o.ConfigKey is not null))
+            Assert.StartsWith("dotnet_style_", o.ConfigKey);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -1,0 +1,226 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// The family a <see cref="StyleOptionDescriptor"/> belongs to, ordered from the
+/// most conservative contract to the least. The tier fixes the fidelity contract
+/// the knob's output honors; <see cref="StyleOptionDescriptor.ByteDivergent"/> is
+/// the machine-checkable consequence.
+/// </summary>
+public enum StyleOptionTier
+{
+    /// <summary>
+    /// Layout only (whitespace/line breaks). Token- and byte-identical to the
+    /// shipped default; no IL consequence. Below the class-3 spelling line.
+    /// </summary>
+    Formatting,
+
+    /// <summary>
+    /// A class-3 no-anchor token choice (e.g. <c>this.</c> qualification). Equally
+    /// faithful to the default — the round-trip fixed point holds for either
+    /// spelling — and byte-preserving (IL-identical).
+    /// </summary>
+    Spelling,
+
+    /// <summary>
+    /// A byte-divergent style lens (#3138): behavior-faithful but not
+    /// opcode-faithful, so its output must never feed the compile-back fidelity
+    /// gates. The only tier whose <see cref="StyleOptionDescriptor.ByteDivergent"/>
+    /// is <see langword="true"/>.
+    /// </summary>
+    Lens,
+
+    /// <summary>
+    /// Name synthesis (readable local names). A separate axis from the
+    /// fidelity-neutral knobs because it trades a fidelity property
+    /// (Annotated-IL name alignment), even though the emitted IL is unchanged.
+    /// </summary>
+    Synthesis,
+}
+
+/// <summary>
+/// The single, library-owned source of truth describing one opt-in
+/// <see cref="PrinterOptions"/> knob: its identity, human-facing text, tier and
+/// contract, oracle endorsement, config key, mutual-exclusivity group, and
+/// NativeAOT-safe accessors to read and set it on a <see cref="PrinterOptions"/>.
+///
+/// <para>The accessors are explicit delegates (never reflection) so the catalog is
+/// enumerable from any host — including a Wasm build — without breaking the
+/// product's NativeAOT constraint. A UI can list every option, group the
+/// mutually-exclusive ones by <see cref="ConflictGroup"/>, filter the
+/// oracle-endorsed set for a future "full taste" aggregate, and toggle each knob
+/// through <see cref="Get"/>/<see cref="With"/> without knowing the concrete
+/// property.</para>
+/// </summary>
+public sealed record StyleOptionDescriptor
+{
+    /// <summary>Stable, kebab-case identifier for programmatic reference (never localized).</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Short human-facing label for a picker (e.g. a checkbox caption).</summary>
+    public required string Title { get; init; }
+
+    /// <summary>One-sentence description of what enabling the knob does.</summary>
+    public required string Summary { get; init; }
+
+    /// <summary>The family and fidelity contract this knob belongs to.</summary>
+    public required StyleOptionTier Tier { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the knob's output recompiles to different bytes
+    /// than the shipped default (behavior-faithful but not opcode-faithful). Only
+    /// the <see cref="StyleOptionTier.Lens"/> knobs are byte-divergent; enabling
+    /// any of them promotes the whole render out of the compile-back fidelity gates.
+    /// </summary>
+    public required bool ByteDivergent { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the runtime <c>.editorconfig</c>/IDE oracle
+    /// endorses this spelling (so it is eligible for a future "full taste"
+    /// aggregate). <see langword="false"/> for idiosyncratic user preferences such
+    /// as the branchless "bool hack".
+    /// </summary>
+    public required bool OracleEndorsed { get; init; }
+
+    /// <summary>
+    /// The <c>.dotnet-inspectconfig</c> key that selects this knob, or
+    /// <see langword="null"/> when the knob has no config key (it is settable only
+    /// through the API, e.g. a formatting knob). Oracle-endorsed keys use the
+    /// editorconfig <c>dotnet_style_*</c> vocabulary; the non-endorsed branchless
+    /// lens uses a tool-owned <c>dotnet_inspect_style_*</c> key.
+    /// </summary>
+    public string? ConfigKey { get; init; }
+
+    /// <summary>
+    /// Identifier of a mutual-exclusivity group, or <see langword="null"/> when the
+    /// knob conflicts with nothing. Knobs that share a group rewrite the same shape,
+    /// so a host should let at most one be enabled at a time (the printer still
+    /// resolves any overlap deterministically, but a picker should not offer both).
+    /// </summary>
+    public string? ConflictGroup { get; init; }
+
+    /// <summary>Reads the knob's current value from a <see cref="PrinterOptions"/>.</summary>
+    public required Func<PrinterOptions, bool> Get { get; init; }
+
+    /// <summary>Returns a copy of <paramref name="options"/> with this knob set to the given value.</summary>
+    public required Func<PrinterOptions, bool, PrinterOptions> With { get; init; }
+}
+
+/// <summary>
+/// The catalog of every opt-in boolean <see cref="PrinterOptions"/> knob, exposed
+/// as the shared source of truth for hosts (CLI config resolution, a Wasm UI, the
+/// future "full taste" aggregate) so option metadata lives in exactly one place
+/// and cannot drift between the library and its consumers.
+/// </summary>
+public static class StyleOptionCatalog
+{
+    /// <summary>Mutual-exclusivity group for the guarded-boolean-return style lenses (ternary vs. branchless).</summary>
+    public const string GuardedBooleanReturnGroup = "guarded-boolean-return";
+
+    /// <summary>
+    /// Every opt-in boolean knob, in a stable presentation order (formatting and
+    /// spelling first, then the byte-divergent lenses). The single enum knob
+    /// (<see cref="ExpressionBodyArrowPlacement"/>) is intentionally not modeled
+    /// here yet, since this catalog describes boolean toggles.
+    /// </summary>
+    public static IReadOnlyList<StyleOptionDescriptor> Options { get; } =
+    [
+        new StyleOptionDescriptor
+        {
+            Id = "readable-local-names",
+            Title = "Readable local names",
+            Summary = "Synthesize a readable name for a local that has no PDB source name instead of V_index.",
+            Tier = StyleOptionTier.Synthesis,
+            ByteDivergent = false,
+            OracleEndorsed = false,
+            ConfigKey = null,
+            Get = static o => o.ReadableLocalNames,
+            With = static (o, v) => o with { ReadableLocalNames = v },
+        },
+        new StyleOptionDescriptor
+        {
+            Id = "wrap-splittable-expressions",
+            Title = "Wrap long boolean chains",
+            Summary = "Break a long short-circuit &&/|| chain across lines instead of one very wide line (whitespace only).",
+            Tier = StyleOptionTier.Formatting,
+            ByteDivergent = false,
+            OracleEndorsed = false,
+            ConfigKey = null,
+            Get = static o => o.WrapSplittableExpressions,
+            With = static (o, v) => o with { WrapSplittableExpressions = v },
+        },
+        new StyleOptionDescriptor
+        {
+            Id = "qualify-field-access",
+            Title = "Qualify field access with this.",
+            Summary = "Render this. on an instance field even where the bare name is unambiguous (IL-identical).",
+            Tier = StyleOptionTier.Spelling,
+            ByteDivergent = false,
+            OracleEndorsed = true,
+            ConfigKey = "dotnet_style_qualification_for_field",
+            Get = static o => o.QualifyFieldAccess,
+            With = static (o, v) => o with { QualifyFieldAccess = v },
+        },
+        new StyleOptionDescriptor
+        {
+            Id = "qualify-property-access",
+            Title = "Qualify property access with this.",
+            Summary = "Render this. on an instance property even where the bare name is unambiguous (IL-identical).",
+            Tier = StyleOptionTier.Spelling,
+            ByteDivergent = false,
+            OracleEndorsed = true,
+            ConfigKey = "dotnet_style_qualification_for_property",
+            Get = static o => o.QualifyPropertyAccess,
+            With = static (o, v) => o with { QualifyPropertyAccess = v },
+        },
+        new StyleOptionDescriptor
+        {
+            Id = "qualify-method-access",
+            Title = "Qualify method access with this.",
+            Summary = "Render this. on an instance method call even where the bare name is unambiguous (IL-identical).",
+            Tier = StyleOptionTier.Spelling,
+            ByteDivergent = false,
+            OracleEndorsed = true,
+            ConfigKey = "dotnet_style_qualification_for_method",
+            Get = static o => o.QualifyMethodAccess,
+            With = static (o, v) => o with { QualifyMethodAccess = v },
+        },
+        new StyleOptionDescriptor
+        {
+            Id = "qualify-event-access",
+            Title = "Qualify event access with this.",
+            Summary = "Render this. on an instance event even where the bare name is unambiguous (IL-identical).",
+            Tier = StyleOptionTier.Spelling,
+            ByteDivergent = false,
+            OracleEndorsed = true,
+            ConfigKey = "dotnet_style_qualification_for_event",
+            Get = static o => o.QualifyEventAccess,
+            With = static (o, v) => o with { QualifyEventAccess = v },
+        },
+        new StyleOptionDescriptor
+        {
+            Id = "prefer-conditional-expression-return",
+            Title = "Prefer conditional expression return",
+            Summary = "Render a declined guarded boolean return as the ternary return c ? A : B; (oracle-preferred, byte-divergent).",
+            Tier = StyleOptionTier.Lens,
+            ByteDivergent = true,
+            OracleEndorsed = true,
+            ConfigKey = "dotnet_style_prefer_conditional_expression_over_return",
+            ConflictGroup = GuardedBooleanReturnGroup,
+            Get = static o => o.PreferConditionalExpressionReturn,
+            With = static (o, v) => o with { PreferConditionalExpressionReturn = v },
+        },
+        new StyleOptionDescriptor
+        {
+            Id = "prefer-branchless-boolean",
+            Title = "Prefer branchless boolean",
+            Summary = "Render a declined guarded boolean return as the compact short-circuit \"bool hack\" (not oracle-endorsed, byte-divergent).",
+            Tier = StyleOptionTier.Lens,
+            ByteDivergent = true,
+            OracleEndorsed = false,
+            ConfigKey = "dotnet_inspect_style_prefer_branchless_boolean",
+            ConflictGroup = GuardedBooleanReturnGroup,
+            Get = static o => o.PreferBranchlessBoolean,
+            With = static (o, v) => o with { PreferBranchlessBoolean = v },
+        },
+    ];
+}

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -672,6 +672,36 @@ public class RenderStyleConfigTests
         return result.Output!;
     }
 
+    // ---- catalog is the source of truth ----
+
+    [Fact]
+    public void EveryCatalogConfigKey_IsHonoredByParse()
+    {
+        // The resolver is data-driven from StyleOptionCatalog, so every catalog
+        // knob that declares a config key must round-trip through Parse with no
+        // warning and set exactly its own option.
+        foreach (var knob in StyleOptionCatalog.Options.Where(o => o.ConfigKey is not null))
+        {
+            var result = RenderStyleConfig.Parse($"{knob.ConfigKey} = true", origin: "cfg");
+
+            Assert.Empty(result.Warnings);
+            Assert.True(knob.Get(result.Options), $"'{knob.ConfigKey}' should set {knob.Id}");
+        }
+    }
+
+    [Fact]
+    public void ApiOnlyCatalogKnobs_HaveNoConfigKey()
+    {
+        // Knobs with no config key (formatting/synthesis) are API-only and must not
+        // be reachable through the file vocabulary; a made-up key still warns.
+        var apiOnly = StyleOptionCatalog.Options.Where(o => o.ConfigKey is null).ToArray();
+        Assert.Contains(apiOnly, o => o.Id == "readable-local-names");
+
+        var result = RenderStyleConfig.Parse("readable_local_names = true", origin: "cfg");
+        Assert.False(result.Options.ReadableLocalNames);
+        Assert.Contains(result.Warnings, w => w.Contains("unknown key"));
+    }
+
     private static string CreateTempDirectory()
     {
         var path = Path.Combine(Path.GetTempPath(), "dotnet-inspectconfig-tests", Path.GetRandomFileName());

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using ILInspector.Decompiler.Pipeline;
 
 namespace DotnetInspector.Services;
@@ -38,22 +41,17 @@ internal static class RenderStyleConfig
     /// <summary>The tool-owned style file name discovered by walking up from the working directory.</summary>
     public const string FileName = ".dotnet-inspectconfig";
 
-    // Recognizes the class-3 this.-qualification knobs (byte-preserving spelling
-    // choices with an exact editorconfig key) plus the opt-in style lenses. The
-    // lenses are the first BYTE-DIVERGENT keys: behavior-preserving but not
-    // opcode-faithful (#3138), so they are deliberate style lenses, not class-3
-    // spelling knobs. More keys are added here as further knobs land.
-    private const string FieldKey = "dotnet_style_qualification_for_field";
-    private const string PropertyKey = "dotnet_style_qualification_for_property";
-    private const string MethodKey = "dotnet_style_qualification_for_method";
-    private const string EventKey = "dotnet_style_qualification_for_event";
-    private const string PreferConditionalReturnKey = "dotnet_style_prefer_conditional_expression_over_return";
-
-    // The branchless "bool hack" lens (#3138) is NOT oracle-endorsed — no real
-    // .editorconfig key encourages it — so it is exposed under a tool-owned
-    // namespace rather than a dotnet_style_* key, making clear it is a
-    // dotnet-inspect compactness preference, not an editorconfig concept.
-    private const string PreferBranchlessBooleanKey = "dotnet_inspect_style_prefer_branchless_boolean";
+    // The recognized style keys and how they set PrinterOptions come from the
+    // library-owned StyleOptionCatalog — the single source of truth — so this
+    // resolver never drifts from the option surface. Every catalog knob with a
+    // config key is honored here (the four byte-preserving this.-qualification
+    // spellings, the oracle-endorsed conditional-expression lens, and the
+    // tool-owned branchless "bool hack" lens); knobs with no config key are
+    // API-only and simply do not appear in the file vocabulary.
+    private static readonly IReadOnlyDictionary<string, StyleOptionDescriptor> KnobsByKey =
+        StyleOptionCatalog.Options
+            .Where(o => o.ConfigKey is not null)
+            .ToDictionary(o => o.ConfigKey!, StringComparer.Ordinal);
 
     // The editorconfig boundary marker. Discovery is nearest-wins, so the nearest
     // file is already a hard boundary (nothing above it is read); 'root' is
@@ -127,12 +125,7 @@ internal static class RenderStyleConfig
     /// </summary>
     public static RenderStyleResolution Parse(string text, string? origin)
     {
-        bool qualifyField = false;
-        bool qualifyProperty = false;
-        bool qualifyMethod = false;
-        bool qualifyEvent = false;
-        bool preferConditionalReturn = false;
-        bool preferBranchlessBoolean = false;
+        var options = PrinterOptions.Default;
         List<string>? warnings = null;
 
         void Warn(string message) => (warnings ??= []).Add(message);
@@ -170,42 +163,6 @@ internal static class RenderStyleConfig
 
             switch (key)
             {
-                case FieldKey:
-                    if (TryParseBool(value, out var f))
-                        qualifyField = f;
-                    else
-                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
-                    break;
-                case PropertyKey:
-                    if (TryParseBool(value, out var p))
-                        qualifyProperty = p;
-                    else
-                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
-                    break;
-                case MethodKey:
-                    if (TryParseBool(value, out var m))
-                        qualifyMethod = m;
-                    else
-                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
-                    break;
-                case EventKey:
-                    if (TryParseBool(value, out var e))
-                        qualifyEvent = e;
-                    else
-                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
-                    break;
-                case PreferConditionalReturnKey:
-                    if (TryParseBool(value, out var t))
-                        preferConditionalReturn = t;
-                    else
-                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
-                    break;
-                case PreferBranchlessBooleanKey:
-                    if (TryParseBool(value, out var b))
-                        preferBranchlessBoolean = b;
-                    else
-                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
-                    break;
                 case RootKey:
                     // editorconfig boundary marker. Discovery is nearest-wins, so
                     // the nearest file is already a hard boundary; 'root' drives no
@@ -215,20 +172,21 @@ internal static class RenderStyleConfig
                         Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
                     break;
                 default:
-                    Warn($"line {i + 1}: unknown key '{key}' (ignored)");
+                    if (KnobsByKey.TryGetValue(key, out var knob))
+                    {
+                        if (TryParseBool(value, out var on))
+                            options = knob.With(options, on);
+                        else
+                            Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
+                    }
+                    else
+                    {
+                        Warn($"line {i + 1}: unknown key '{key}' (ignored)");
+                    }
+
                     break;
             }
         }
-
-        var options = PrinterOptions.Default with
-        {
-            QualifyFieldAccess = qualifyField,
-            QualifyPropertyAccess = qualifyProperty,
-            QualifyMethodAccess = qualifyMethod,
-            QualifyEventAccess = qualifyEvent,
-            PreferConditionalExpressionReturn = preferConditionalReturn,
-            PreferBranchlessBoolean = preferBranchlessBoolean,
-        };
 
         return new RenderStyleResolution(options, origin, (IReadOnlyList<string>?)warnings ?? []);
     }


### PR DESCRIPTION
## What

Introduces `StyleOptionCatalog` (`ILInspector.Decompiler.Pipeline`) — a public, library-owned `IReadOnlyList<StyleOptionDescriptor>` that is the single source of truth for the opt-in boolean `PrinterOptions` knobs, and makes the CLI's `RenderStyleConfig` resolver consume it instead of a hand-maintained key→property switch.

Unblocks a Wasm-built UI (and any other host) discovering the options, knowing which are byte-divergent, and knowing which are mutually exclusive. Also lays the metadata foundation the future "full taste" aggregate (#3138) consumes (the `OracleEndorsed` subset).

## Design

Each `StyleOptionDescriptor` carries:
- `Id` (stable kebab-case), `Title`, `Summary`
- `Tier` (`Formatting` / `Spelling` / `Lens` / `Synthesis`) + `ByteDivergent` (true only for the two lenses)
- `OracleEndorsed` (membership test for "full taste")
- `ConfigKey` (editorconfig `dotnet_style_*` or tool-owned `dotnet_inspect_style_*`; `null` for API-only formatting/synthesis knobs)
- `ConflictGroup` (mutually-exclusive group; the ternary + branchless lenses share `guarded-boolean-return`)
- NativeAOT-safe `Get`/`With` delegates — no reflection, so the catalog is enumerable from a Wasm host without breaking the product's NativeAOT constraint.

`RenderStyleConfig` now derives its recognized keys from the catalog, so the CLI vocabulary and the option surface cannot drift. The refactor is **behavior-preserving**: `root`-key handling, `value:severity` tolerance, and per-key warnings are unchanged.

## Scope boundary

The single non-boolean knob (`ExpressionBodyArrowPlacement`) is intentionally **not** modeled yet — the catalog describes boolean toggles. A general non-bool shape can be added when a second enum knob justifies it.

## Evidence

- New `StyleOptionCatalogTests` (10): drift guard (catalog count == PrinterOptions bool-property count via test-only reflection), id/config-key uniqueness, get/with round-trip + isolation (each `With` toggles exactly one knob), `ByteDivergent` ⇔ `Lens` tier, conflict group == the two lenses, oracle set excludes branchless, key vocabulary.
- New resolver integration tests (2): every catalog config key round-trips through `RenderStyleConfig.Parse`; API-only knobs have no config key and still warn as unknown.
- `RenderStyleConfigTests` green (41/0) — refactor behavior-preserving.
- Fast decompiler suite 3664/0; full `dotnet-inspect.Tests` clean except one pre-existing environmental flake (`PlatformResolverTests.GetPacksDirectory_ReturnsValidPath`, a packs-path assertion that passes in isolation and is untouched by this change).
- `docs/decompiler-taste.md` updated (new "Option catalog" subsection); markdownlint clean.

Adversarial review to follow (new public API + parser refactor).