### PR TITLE
Fold CorpusSensor count delta into the Markout Change cell (#3143)

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -524,8 +524,9 @@ instead so the PR records the targeted checked population and RTS/current A/B
 evidence.
 
 Rate deltas in card prose use **percentage points** (`pp`): `+0.49 pp` means
-the rate increased from, for example, `82.17%` to `82.66%`. Counts still use raw
-signed count deltas in `Count delta`.
+the rate increased from, for example, `82.17%` to `82.66%`. The metric-change
+table folds the signed count delta into each `Change` cell — `(+3)` for count
+metrics and `(+3 methods)` for share metrics.
 
 For behaviour-preserving refactors, the existing #1174/#1166 real-world corpus
 sensor values are enough when you need the broader Deep Inspect signal:
@@ -559,15 +560,15 @@ The tool emits a block like:
 Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,907 methods
 Correctness coverage: validity sampled 350 / 87,907 (0.40%); fidelity sampled 6 / 87,907 (0.01%)
 
-| Metric (desired direction) | Baseline | PR | Count delta |
-| --- | ---: | ---: | ---: |
-| Fully raised (+) | 77,376 (88.02%) | 77,376 (88.02%) | 0 |
-| Conditional-branch residual (-) | 2,298 (2.61%) | 2,298 (2.61%) | 0 |
-| Forward-merge stops (-) | 2,290 (2.61%) | 2,290 (2.61%) | 0 |
-| Full malformed (-) | 165 | 165 | 0 |
-| Semantic defects (-) | 4/350 — sampled 350 / 87,907 (0.40%) | 4/350 — sampled 350 / 87,907 (0.40%) | 0 |
-| Fidelity diffs (-) | opcode-diff 1/6, operand-diff 0/6, unavailable 0/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | opcode-diff 1/6, operand-diff 0/6, unavailable 0/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | 0 |
-| Pass bugs (-) | 0 | 0 | 0 |
+| Metric (desired direction) | Baseline | PR |
+| --- | ---: | ---: |
+| Fully raised (+) | 77,376 (88.02%) | 77,376 (88.02%) |
+| Conditional-branch residual (-) | 2,298 (2.61%) | 2,298 (2.61%) |
+| Forward-merge stops (-) | 2,290 (2.61%) | 2,290 (2.61%) |
+| Full malformed (-) | 165 | 165 |
+| Semantic defects (-) | 4/350 — sampled 350 / 87,907 (0.40%) | 4/350 — sampled 350 / 87,907 (0.40%) |
+| Fidelity diffs (-) | opcode-diff 1/6, operand-diff 0/6, unavailable 0/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | opcode-diff 1/6, operand-diff 0/6, unavailable 0/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) |
+| Pass bugs (-) | 0 | 0 |
 
 Verdict: corpus sensor matched baseline tolerances.
 ```

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -214,12 +214,12 @@ Run: PR quick corpus, hash-stable 100 methods per assembly; {coverage summary}.
 
 Corpus: {assemblies}, {methods}. Baseline drift: {none or concise drift}.
 
-| Metric (goal) | Baseline | PR | Count delta |
-| --- | ---: | ---: | ---: |
-| Detected lowering residue (-) | {count/rate} | {count/rate} | {count} |
-| Conditional-branch residue (-) | {count/rate} | {count/rate} | {count} |
-| Forward-merge stops (-) | {count/rate} | {count/rate} | {count} |
-| Fully raised (+) | {count/rate} | {count/rate} | {count} |
+| Metric (goal) | Baseline | PR |
+| --- | ---: | ---: |
+| Detected lowering residue (-) | {count/rate} | {count/rate} |
+| Conditional-branch residue (-) | {count/rate} | {count/rate} |
+| Forward-merge stops (-) | {count/rate} | {count/rate} |
+| Fully raised (+) | {count/rate} | {count/rate} |
 
 > **Conclusion:** **PASS/ADVISORY/BLOCKED** — {one-line aggregate verdict}.
 

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -1048,9 +1048,9 @@ public class CorpusSensorComparisonTests
 
         Assert.Contains("Semantic defects (sampling differs)", semanticRow);
         Assert.DoesNotContain("✓", semanticRow);
-        Assert.EndsWith("| n/a |", semanticRow.TrimEnd());
+        Assert.EndsWith("| 1 (50.00%) → 0 (0.00%) |", semanticRow.TrimEnd());
         Assert.Contains("Full malformed (sampling differs)", malformedRow);
-        Assert.EndsWith("| n/a |", malformedRow.TrimEnd());
+        Assert.EndsWith("| 0 → 0 |", malformedRow.TrimEnd());
     }
 
     [Fact]
@@ -1078,7 +1078,7 @@ public class CorpusSensorComparisonTests
 
         Assert.Contains("Semantic defects (-)", semanticRow);
         Assert.Contains("✓", semanticRow);
-        Assert.EndsWith("| -1 |", semanticRow.TrimEnd());
+        Assert.EndsWith("| 1 (50.00%) → 0 (0.00%) (-1 methods) ✓ |", semanticRow.TrimEnd());
         Assert.DoesNotContain("sampling differs", report);
     }
 
@@ -1230,9 +1230,9 @@ public class CorpusSensorComparisonTests
         string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
 
         Assert.Contains("Fully raised (+)", report);
-        Assert.Contains("1 (50.00%) → 2 (100.00%) ✓", report);
+        Assert.Contains("1 (50.00%) → 2 (100.00%) (+1 methods) ✓", report);
         Assert.Contains("Detected lowering residue (-)", report);
-        Assert.Contains("0 (0.00%) → 0 (0.00%) |", report);
+        Assert.Contains("0 (0.00%) → 0 (0.00%) (0 methods) |", report);
         Assert.True(
             report.IndexOf("| Fully raised", StringComparison.Ordinal)
             > report.IndexOf("| Detected lowering residue", StringComparison.Ordinal));
@@ -1281,7 +1281,7 @@ public class CorpusSensorComparisonTests
 
         Assert.Contains("Detected lowering residue (population differs)", residue);
         Assert.DoesNotContain("✓", residue);
-        Assert.EndsWith("| n/a |", residue.TrimEnd());
+        Assert.EndsWith("| 1 (50.00%) → 0 (0.00%) |", residue.TrimEnd());
     }
 
     [Fact]
@@ -1302,7 +1302,7 @@ public class CorpusSensorComparisonTests
         string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
 
         Assert.Contains("Detected lowering residue (-)", report);
-        Assert.Contains("6 (6.45%) → 6 (6.45%) |", report);
+        Assert.Contains("6 (6.45%) → 6 (6.45%) (0 methods) |", report);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -2507,8 +2507,10 @@ internal static class CorpusSensor
         bool countDeltaKnown = true)
         => new(
             MetricLabel(metric, goal),
-            new Source("Change", new Change<int>(baseline, current), new MarkoutCellFormat { Goal = goal }),
-            new Source("Count delta", new QualityText(countDeltaKnown ? Delta(current - baseline) : "n/a")));
+            new Source(
+                "Change",
+                new Change<int>(baseline, current),
+                new MarkoutCellFormat { Goal = goal, Delta = countDeltaKnown ? Markout.Delta.Absolute : Markout.Delta.None }));
 
     static MultiSourceRow ShareChangeRow(
         string metric,
@@ -2520,8 +2522,10 @@ internal static class CorpusSensor
         bool countDeltaKnown = true)
         => new(
             MetricLabel(metric, goal),
-            new Source("Change", new Change<QualityRate>(new QualityRate(baseline, baselineTotal), new QualityRate(current, currentTotal)), new MarkoutCellFormat { Goal = goal }),
-            new Source("Count delta", new QualityText(countDeltaKnown ? Delta(current - baseline) : "n/a")));
+            new Source(
+                "Change",
+                new Change<QualityRate>(new QualityRate(baseline, baselineTotal), new QualityRate(current, currentTotal)),
+                new MarkoutCellFormat { Goal = goal, DeltaNoun = countDeltaKnown ? "methods" : null }));
 
     static bool HaveSameMethodSample(
         IReadOnlyList<CorpusMethodSnapshot>? baselineMethods,
@@ -2625,9 +2629,11 @@ internal static class CorpusSensor
     static string Delta(int value)
         => value > 0 ? $"+{Number(value)}" : Number(value);
 
-    readonly record struct QualityRate(int Count, int Total) : IMarkoutCell, IGoalMagnitude
+    readonly record struct QualityRate(int Count, int Total) : IMarkoutCell, IGoalMagnitude, IDeltaCountable
     {
         double IGoalMagnitude.GoalMagnitude => Total <= 0 ? double.NaN : RateBasisPoints(Count, Total) / 10_000.0;
+
+        double IDeltaCountable.DeltaCount => Count;
 
         public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
             => writer.Write(Total <= 0
@@ -2644,15 +2650,6 @@ internal static class CorpusSensor
 
         static string SideKey(string? side, string key)
             => side is null ? key : side + "_" + key;
-    }
-
-    readonly record struct QualityText(string Text) : IMarkoutCell
-    {
-        public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
-            => writer.Write(Text);
-
-        public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
-            => fields.Add(new MarkoutField(side ?? "value", Text));
     }
 
     static string DeltaPercentagePoints(int basisPoints)


### PR DESCRIPTION
Closes #3143.

## What

Removes the redundant **Count delta** column from the CorpusSensor
metric-change table (rendered inside the `--quality-diff-card`) by folding the
signed count delta into each Markout `Change` cell:

- **Scalar count rows** (`Change<int>` — Full malformed, RTS parity worse, Pass
  bugs) set `Delta = Delta.Absolute`, rendering a bare `(+N)`:
  `165 → 168 (+3) ✗`.
- **Composite share rows** (`Change<QualityRate>` — all the share metrics) add a
  new `IDeltaCountable` implementation on `QualityRate` (`DeltaCount => Count`)
  and set `DeltaNoun = "methods"`, rendering `1 (50.00%) → 2 (100.00%) (+1 methods) ✓`.

The now-unused `QualityText` cell type is deleted. The `Delta(int)` helper is
kept because it is still used by the prose gate/summary lines.

## Correctness of incomparable rows

`countDeltaKnown: false` is always paired with `Goal.Context` (incomparable
population/sample). Those rows already disclose incomparability two ways — a
label suffix (`(population differs)` / `(sampling differs)`) and a suppressed
verdict glyph — so folding drops the redundant explicit `n/a` while keeping the
signal visible. Folded incomparable rows emit **no** inline delta (scalar:
`Delta.None`; composite: `DeltaNoun = null`).

## Note on the issue premise

The issue stated `QualityRate` already implemented `IDeltaCountable` — it did
not. It also assumed `Delta.Absolute` would fold on the composite cell, but
Markout's composite branch ignores `format.Delta` and derives its numeric delta
from `IDeltaCountable` + `DeltaNoun`. That is why share rows carry a `methods`
noun (a bare `(+N)` is not achievable for composite cells) while count rows
stay bare. This asymmetry was confirmed with the maintainer.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release` — clean.
- `CorpusSensorComparisonTests` — 59/59 (updated to the folded strings, covering
  comparable `(+N)` / `(+N methods)`, zero-delta `(0)` / `(0 methods)`, and
  incomparable no-delta cases for both count and rate rows).
- Full fast Decompiler suite — 3654/3654.
- Changed Markdown passes `markdownlint`.
- Docs: updated the stale `Count delta` references in
  `docs/decompiler-quality.md` and `docs/templates/decompiler-pr.md`. (The
  illustrative card example in those docs predates #3137's `Change`-cell
  adoption and is broadly simplified; this PR only removes the now-defunct
  `Count delta` column, not a full example refresh.)

The CorpusSensor table is Markdown-only (no tsv/jsonl serialization), so
Markdown is the only affected output mode.