### PR TITLE
Render class finalizers as ~Type() destructor syntax (#3157)

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -43,6 +43,64 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void FinalizerMember_RendersDestructorSyntaxWithoutModifiers()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Handle", Kind = "class" };
+        var finalizer = new ApiMember
+        {
+            Name = "Finalize",
+            // Roslyn emits the finalizer with an explicit .override MethodImpl, so
+            // it surfaces as an explicit-interface-implementation kind; IsFinalizer
+            // is the metadata fact that drives the ~Type() spelling.
+            Kind = "explicit-interface-implementation",
+            Signature = "void Finalize()",
+            IsVirtual = true,
+            IsFinalizer = true,
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, finalizer);
+
+        Assert.Equal("~Handle()", declaration);
+    }
+
+    [Fact]
+    public void UnsafeFinalizerMember_KeepsUnsafeModifierOnly()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Handle", Kind = "class" };
+        var finalizer = new ApiMember
+        {
+            Name = "Finalize",
+            Kind = "explicit-interface-implementation",
+            Signature = "void Finalize()",
+            IsVirtual = true,
+            IsFinalizer = true,
+            IsUnsafe = true,
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, finalizer);
+
+        Assert.Equal("unsafe ~Handle()", declaration);
+    }
+
+    [Fact]
+    public void FinalizerMember_OnGenericType_DropsTypeArity()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Box`1", Kind = "class" };
+        var finalizer = new ApiMember
+        {
+            Name = "Finalize",
+            Kind = "explicit-interface-implementation",
+            Signature = "void Finalize()",
+            IsVirtual = true,
+            IsFinalizer = true,
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, finalizer);
+
+        Assert.Equal("~Box()", declaration);
+    }
+
+    [Fact]
     public void ShortWithUsingsMemberUnit_GeneratesImportsAndShortensTypes()
     {
         var type = CreateSampleType();

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -101,6 +101,31 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void FinalizerMember_WithSuppressFinalizerSpelling_KeepsLiteralFinalize()
+    {
+        // Issue #3157 (fidelity hardening): the '~Type()' spelling assumes the
+        // recompiled destructor re-emits the mandatory 'base.Finalize()'. When the
+        // decompiled body did NOT recover the canonical destructor scaffold, the
+        // full-body path suppresses the destructor spelling so recompiling keeps
+        // the observed body instead of silently re-injecting the base call.
+        var type = new ApiType { Namespace = "Samples", Name = "Handle", Kind = "class" };
+        var finalizer = new ApiMember
+        {
+            Name = "Finalize",
+            Kind = "explicit-interface-implementation",
+            Signature = "void Finalize()",
+            IsVirtual = true,
+            IsFinalizer = true,
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            type, finalizer, new CSharpDeclarationOptions { SuppressFinalizerSpelling = true });
+
+        Assert.Equal("void Finalize()", declaration);
+        Assert.DoesNotContain("~Handle", declaration);
+    }
+
+    [Fact]
     public void ShortWithUsingsMemberUnit_GeneratesImportsAndShortensTypes()
     {
         var type = CreateSampleType();

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -324,6 +324,10 @@ internal static class CSharpDeclarationWriter
         {
             signature = $"{FormatConstructorTypeName(type.Name)}()";
         }
+        else if (member.IsFinalizer)
+        {
+            signature = $"~{FormatConstructorTypeName(type.Name)}()";
+        }
         else if (member.Kind == "constructor")
         {
             var typeName = FormatConstructorTypeName(type.Name);
@@ -374,6 +378,13 @@ internal static class CSharpDeclarationWriter
         if (member.Name == ".cctor")
         {
             modifiers.Add("static");
+            if (member.IsUnsafe || options.ForceUnsafe)
+                modifiers.Add("unsafe");
+        }
+        else if (member.IsFinalizer)
+        {
+            // A finalizer (`~Type()`) carries no accessibility or override
+            // modifiers — only `unsafe` is legal on it.
             if (member.IsUnsafe || options.ForceUnsafe)
                 modifiers.Add("unsafe");
         }

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -30,6 +30,15 @@ internal sealed record CSharpDeclarationOptions
     public bool IncludeObsoleteAttribute { get; init; } = true;
     public bool OmitInterfaceMemberModifiers { get; init; }
     public bool OmitPropertyAccessors { get; init; }
+
+    /// <summary>
+    /// When true, a finalizer member (<see cref="ApiMember.IsFinalizer"/>) is
+    /// rendered as the literal <c>void Finalize()</c> method rather than the
+    /// <c>~Type()</c> destructor syntax. Set on body-bearing renders whose body
+    /// was not recovered as a canonical destructor, so the emitted source does
+    /// not silently re-inject the compiler's mandatory <c>base.Finalize()</c>.
+    /// </summary>
+    public bool SuppressFinalizerSpelling { get; init; }
 }
 
 internal sealed record CSharpRenderedDeclaration(
@@ -324,7 +333,7 @@ internal static class CSharpDeclarationWriter
         {
             signature = $"{FormatConstructorTypeName(type.Name)}()";
         }
-        else if (member.IsFinalizer)
+        else if (member.IsFinalizer && !options.SuppressFinalizerSpelling)
         {
             signature = $"~{FormatConstructorTypeName(type.Name)}()";
         }
@@ -381,7 +390,7 @@ internal static class CSharpDeclarationWriter
             if (member.IsUnsafe || options.ForceUnsafe)
                 modifiers.Add("unsafe");
         }
-        else if (member.IsFinalizer)
+        else if (member.IsFinalizer && !options.SuppressFinalizerSpelling)
         {
             // A finalizer (`~Type()`) carries no accessibility or override
             // modifiers — only `unsafe` is legal on it.

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -85,7 +85,8 @@ public sealed class CSharpFormatter
             _declarationOptions with
             {
                 ForceAsync = _declarationOptions.ForceAsync || body.RequiresAsyncModifier,
-                ForceUnsafe = _declarationOptions.ForceUnsafe || body.RequiresUnsafeModifier
+                ForceUnsafe = _declarationOptions.ForceUnsafe || body.RequiresUnsafeModifier,
+                SuppressFinalizerSpelling = body.SuppressDestructorSyntax
             },
             methodParameters);
     }

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -23,6 +23,17 @@ public abstract record CSharpMemberBody
     /// unsafe signature already represented by <see cref="ApiMember.IsUnsafe"/>.
     /// </summary>
     public bool RequiresUnsafeModifier { get; init; }
+
+    /// <summary>
+    /// True when a finalizer member (<see cref="ApiMember.IsFinalizer"/>) must
+    /// be rendered as the literal <c>void Finalize()</c> method rather than the
+    /// <c>~Type()</c> destructor syntax, because the body was <em>not</em>
+    /// recovered as a canonical destructor (<c>IrFunction.IsDestructor</c>).
+    /// A body-only fact: recompiling <c>~Type() { … }</c> re-injects the
+    /// mandatory <c>base.Finalize()</c> the compiler forbids writing, so the
+    /// destructor spelling is only faithful when that scaffold was recovered.
+    /// </summary>
+    public bool SuppressDestructorSyntax { get; init; }
 }
 
 public enum CSharpConstructorInitializerKind

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -580,6 +580,7 @@ public sealed class CSharpTypePrinter
             IsAbstract = member.IsAbstract,
             IsOverride = member.IsOverride,
             IsSealed = member.IsSealed,
+            IsFinalizer = member.IsFinalizer,
             IsReadOnly = member.IsReadOnly,
             IsConst = member.IsConst,
             IsUnsafe = member.IsUnsafe,

--- a/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
@@ -54,6 +54,10 @@ public class DestructorRecoveryPassTests
         Assert.DoesNotContain(
             function.Descendants.OfType<Call>(),
             call => call.Callee.Name == "Finalize");
+
+        // The destructor fact surfaces on the printed result so full-body
+        // consumers can gate the '~Type()' spelling on it (issue #3157).
+        Assert.True(CSharpPrinter.Print(function).BodyIsDestructor);
     }
 
     [Fact]
@@ -72,6 +76,11 @@ public class DestructorRecoveryPassTests
         Assert.Contains(
             function.Descendants.OfType<Call>(),
             call => call.Callee.Name == "Finalize");
+
+        // A non-canonical Finalize override reports BodyIsDestructor=false, so the
+        // full-body consumer keeps the literal 'void Finalize()' rather than the
+        // '~Type()' spelling that would re-inject base.Finalize() on recompile.
+        Assert.False(CSharpPrinter.Print(function).BodyIsDestructor);
     }
 
     static IrFunction BuildManualFinalize(bool includeExecutableTrailingStatement)

--- a/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
@@ -83,7 +83,23 @@ public class DestructorRecoveryPassTests
         Assert.False(CSharpPrinter.Print(function).BodyIsDestructor);
     }
 
-    static IrFunction BuildManualFinalize(bool includeExecutableTrailingStatement)
+    [Fact]
+    public void FinalizeOverride_WithGenericArity_StandsDown()
+    {
+        // A finalizer is never generic. An IL method that explicitly overrides
+        // object.Finalize while declaring its own type parameters must keep the
+        // literal form — folding it to '~Type()' would erase '<T>'.
+        var function = BuildManualFinalize(includeExecutableTrailingStatement: false, genericParameterCount: 1);
+
+        new DestructorRecoveryPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.False(function.IsDestructor);
+        Assert.Single(function.Descendants.OfType<TryFinally>());
+        Assert.False(CSharpPrinter.Print(function).BodyIsDestructor);
+    }
+
+    static IrFunction BuildManualFinalize(bool includeExecutableTrailingStatement, int genericParameterCount = 0)
     {
         var body = new BlockContainer();
         var block = new Block(0);
@@ -98,7 +114,7 @@ public class DestructorRecoveryPassTests
         return new IrFunction(
             "Finalize",
             Holder,
-            new MethodSignature(Void, [], HasThis: true, GenericParameterCount: 0),
+            new MethodSignature(Void, [], HasThis: true, GenericParameterCount: genericParameterCount),
             [],
             body);
     }

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
@@ -222,6 +222,67 @@ public class MemberBodyProducerExpressionBodyTests
         Assert.Contains("return (int*)__stackalloc;", source);
     }
 
+    [Fact]
+    public void Finalizer_RendersDestructorSyntaxExpressionBodied()
+    {
+        // Issue #3157: a C# finalizer (`~Type()`) lowers to an `object.Finalize`
+        // override that Roslyn emits with an explicit `.override` MethodImpl, so it
+        // otherwise surfaces as a modifier-less `void Finalize()`. The metadata
+        // `IsFinalizer` fact drives the destructor spelling, and the single-statement
+        // body folds to an expression-bodied destructor.
+        using var assembly = Compile("""
+            public class Handle
+            {
+                private int _n;
+                ~Handle() { _n = 0; }
+            }
+            """);
+
+        string source = ComposeType(assembly.Path, "Handle");
+
+        Assert.Contains("~Handle() => _n = 0;", source);
+        Assert.DoesNotContain("void Finalize", source);
+        Assert.DoesNotContain("Finalize()", source);
+    }
+
+    [Fact]
+    public void Finalizer_WithBlockBody_RendersDestructorBraceBlock()
+    {
+        using var assembly = Compile("""
+            public class Handle
+            {
+                private int _n;
+                ~Handle() { _n = 0; _n = 1; }
+            }
+            """);
+
+        string source = ComposeType(assembly.Path, "Handle");
+
+        Assert.Contains("~Handle()\n    {", source);
+        Assert.DoesNotContain("void Finalize", source);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceFinalize_IsNotTreatedAsDestructor()
+    {
+        // Close negative: an explicit interface implementation of a method that
+        // happens to be named `Finalize` is NOT the object.Finalize override. Its
+        // metadata name is dot-qualified (`IThing.Finalize`), so it must keep the
+        // `void IThing.Finalize()` spelling and never fold to `~Impl()`.
+        using var assembly = Compile("""
+            public interface IThing { void Finalize(); }
+            public class Impl : IThing
+            {
+                void IThing.Finalize() { }
+            }
+            """);
+
+        string source = ComposeType(assembly.Path, "Impl");
+
+        Assert.Contains("void IThing.Finalize()", source);
+        Assert.DoesNotContain("~Impl", source);
+    }
+
     static string ComposeType(string path, string fullName)
     {
         using var pe = new PEReader(File.OpenRead(path));

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -322,6 +322,17 @@ public sealed record DecompilerResult(
     public bool BodyIsSingleExpressionBody { get; init; }
 
     /// <summary>
+    /// True when the printed body was recovered as a canonical C# destructor —
+    /// a <c>Finalize</c> override whose <c>try { … } finally { base.Finalize(); }</c>
+    /// scaffold the destructor pass stripped (<c>IrFunction.IsDestructor</c>).
+    /// A body-shape fact: full-body consumers render the header as <c>~Type()</c>
+    /// only when this is set, so a finalizer whose body did not match the
+    /// scaffold keeps the literal <c>void Finalize()</c> rather than silently
+    /// re-injecting the compiler's mandatory base call on recompile.
+    /// </summary>
+    public bool BodyIsDestructor { get; init; }
+
+    /// <summary>
     /// A telemetry-free record of what the decompilation observed — its fidelity
     /// outcome, the symbol source it used, and its diagnostics — for a host to
     /// convert into its own diagnostics. Null for projections that do not build
@@ -359,6 +370,7 @@ public sealed record DecompilerResult(
             && RequiresUnsafeBodyModifier == other.RequiresUnsafeBodyModifier
             && ContainsAwaitExpression == other.ContainsAwaitExpression
             && BodyIsSingleExpressionBody == other.BodyIsSingleExpressionBody
+            && BodyIsDestructor == other.BodyIsDestructor
             && EqualityComparer<DecompilerTrace?>.Default.Equals(Trace, other.Trace);
 
     public override int GetHashCode()
@@ -373,6 +385,7 @@ public sealed record DecompilerResult(
         hash.Add(RequiresUnsafeBodyModifier);
         hash.Add(ContainsAwaitExpression);
         hash.Add(BodyIsSingleExpressionBody);
+        hash.Add(BodyIsDestructor);
         hash.Add(Trace);
         return hash.ToHashCode();
     }

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -841,9 +841,10 @@ public static class MemberBodyProducer
                     string? constructorChain = null;
                     bool requiresUnsafeContext = false;
                     bool bodyIsSingleExpressionBody = false;
+                    bool bodyIsDestructor = false;
                     string? body = member.IsAbstract
                         ? null
-                        : DecompileBody(pipelineSource, memberHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
+                        : DecompileBody(pipelineSource, memberHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, out bodyIsDestructor, printerOptions);
 
                     // An explicit interface property implementation surfaces
                     // as its accessor method (Iface.get_X). Render the
@@ -887,7 +888,13 @@ public static class MemberBodyProducer
                         {
                             RequiresAsyncModifier = memberHandle is { } asyncHandle
                                 && TypeShellProducer.RequiresAsyncBodyModifier(reader, asyncHandle),
-                            RequiresUnsafeModifier = requiresUnsafeContext
+                            RequiresUnsafeModifier = requiresUnsafeContext,
+                            // Only spell '~Type()' when the destructor pass actually
+                            // recovered the canonical try/finally { base.Finalize(); }
+                            // scaffold. A Finalize override whose body did not match
+                            // keeps the literal 'void Finalize()' so recompiling does
+                            // not silently re-inject the mandatory base call.
+                            SuppressDestructorSyntax = member.IsFinalizer && !bodyIsDestructor
                         };
                     var declaration = bodyShape is null
                         ? DefaultDeclarationFormatter.FormatMember(type, member)
@@ -1303,7 +1310,7 @@ public static class MemberBodyProducer
         Pipeline.MetadataSource pipelineSource, MethodDefinitionHandle? memberHandle,
         string typeFullName, ApiMember member, int overloadIndex,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext,
-        out bool bodyIsSingleExpressionBody, Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleExpressionBody, out bool bodyIsDestructor, Pipeline.PrinterOptions? printerOptions)
     {
         // Prefer the member's own metadata handle — the canonical same-reader
         // addressing (see docs/design/member-body-substrate.md). The caller has
@@ -1314,7 +1321,7 @@ public static class MemberBodyProducer
         if (memberHandle is { } methodHandle)
             return DecompileFunction(pipelineSource,
                 Pipeline.IrImporter.Import(pipelineSource, methodHandle),
-                bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
+                bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, out bodyIsDestructor, printerOptions);
 
         // Public-only overload counting, except explicit interface
         // implementations (non-public by nature) — matching the API surface
@@ -1323,7 +1330,7 @@ public static class MemberBodyProducer
             publicOnly: member.Kind != "explicit-interface-implementation"
                 && !(member.Kind == "constructor" && member.DeclaringOverloadIndex is not null)
                 && member.Accessibility is null,
-            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
+            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, out bodyIsDestructor, printerOptions);
     }
 
     /// <summary>
@@ -1403,9 +1410,9 @@ public static class MemberBodyProducer
         => accessorHandle is { } handle
             ? DecompileFunction(pipelineSource,
                 Pipeline.IrImporter.Import(pipelineSource, handle),
-                bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions)
+                bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleExpressionBody, out _, printerOptions)
             : DecompileMethod(pipelineSource, typeFullName, accessorName, overloadIndex: 0,
-            publicOnly: false, bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
+            publicOnly: false, bodyNamespaces, out _, out requiresUnsafeContext, out bodyIsSingleExpressionBody, out _, printerOptions);
 
     /// <summary>
     /// Imports one method to typed IR, runs the raising passes, and prints the
@@ -1418,10 +1425,10 @@ public static class MemberBodyProducer
     static string? DecompileMethod(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string methodName, int overloadIndex,
         bool publicOnly, SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext,
-        out bool bodyIsSingleExpressionBody, Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleExpressionBody, out bool bodyIsDestructor, Pipeline.PrinterOptions? printerOptions)
         => DecompileFunction(pipelineSource,
             Pipeline.IrImporter.Import(pipelineSource, typeFullName, methodName, overloadIndex, publicOnly),
-            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, printerOptions);
+            bodyNamespaces, out constructorChain, out requiresUnsafeContext, out bodyIsSingleExpressionBody, out bodyIsDestructor, printerOptions);
 
     /// <summary>
     /// Runs the raising passes and prints an already-imported function. A null
@@ -1432,11 +1439,12 @@ public static class MemberBodyProducer
     static string? DecompileFunction(
         Pipeline.MetadataSource pipelineSource, Pipeline.IrFunction? function,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext,
-        out bool bodyIsSingleExpressionBody, Pipeline.PrinterOptions? printerOptions)
+        out bool bodyIsSingleExpressionBody, out bool bodyIsDestructor, Pipeline.PrinterOptions? printerOptions)
     {
         constructorChain = null;
         requiresUnsafeContext = false;
         bodyIsSingleExpressionBody = false;
+        bodyIsDestructor = false;
         if (function is null)
             return null;
         CollectNamespaces(function, bodyNamespaces);
@@ -1446,6 +1454,7 @@ public static class MemberBodyProducer
         constructorChain = result.ConstructorChain;
         requiresUnsafeContext = result.RequiresUnsafeBodyModifier;
         bodyIsSingleExpressionBody = result.BodyIsSingleExpressionBody;
+        bodyIsDestructor = result.BodyIsDestructor;
         return result.Output?.TrimEnd() ?? DiagnosticComment(result);
     }
 

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -167,6 +167,12 @@ public static class MemberBodyProducer
             {
                 RequiresAsyncModifier = projection.RequiresAsyncBodyModifier,
                 RequiresUnsafeModifier = projection.RequiresUnsafeBodyModifier,
+                // Member-agnostic destructor gate: suppress '~Type()' whenever the
+                // body was not recovered as a canonical destructor (issue #3157).
+                // Harmless for non-finalizers (the writer only consults this when
+                // the member is a finalizer); correct for a finalizer consumer of
+                // this shared substrate whose body did not match the scaffold.
+                SuppressDestructorSyntax = !projection.BodyIsDestructor,
             };
             return new MemberBodyProductionResult(
                 MemberBodyProductionStatus.Complete,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -297,6 +297,7 @@ public sealed partial class CSharpPrinter
             RequiresUnsafeBodyModifier = function.Descendants.Prepend(function).Any(NeedsUnsafeContext),
             ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
             BodyIsSingleExpressionBody = BodyIsSingleExpressionBody(function, output),
+            BodyIsDestructor = function.IsDestructor,
             Metadata = new DecompilerResultMetadata(EffectiveDecompilerOptions(), [.. _decisions]),
         };
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DestructorRecoveryPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DestructorRecoveryPass.cs
@@ -15,11 +15,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// the original IL, so the recovery is opcode-exact.
 ///
 /// <para>Runs after structuring so the EH region is a <see cref="TryFinally"/>.
-/// Conservative: the method must be a parameterless instance <c>void Finalize</c>
-/// whose body is that try/finally, followed at most by the implicit void
-/// return, with a finally of nothing but the base call; anything else (a
-/// prologue before the try, executable trailing work, extra finally work) keeps
-/// the literal form.</para>
+/// Conservative: the method must be a parameterless, non-generic instance
+/// <c>void Finalize</c> whose body is that try/finally, followed at most by the
+/// implicit void return, with a finally of nothing but the base call; anything
+/// else (a prologue before the try, executable trailing work, extra finally
+/// work, or a generic arity that <c>~Type()</c> could not spell) keeps the
+/// literal form.</para>
 /// </summary>
 public sealed class DestructorRecoveryPass : IIrPass
 {
@@ -30,6 +31,7 @@ public sealed class DestructorRecoveryPass : IIrPass
         if (function.Name != "Finalize"
             || !function.Signature.HasThis
             || function.Signature.Parameters.Length != 0
+            || function.Signature.GenericParameterCount != 0
             || !IsVoid(function.Signature.ReturnType))
         {
             return;

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -454,6 +454,17 @@ public class ApiMember
     public bool IsAbstract { get; set; }
     public bool IsOverride { get; set; }
     public bool IsSealed { get; set; }
+
+    /// <summary>
+    /// True when this method is a class finalizer — the <c>object.Finalize</c>
+    /// override the C# <c>~Type()</c> destructor syntax compiles to. Roslyn emits
+    /// it with an explicit <c>.override</c> MethodImpl, so it otherwise surfaces
+    /// as a modifier-less <c>void Finalize()</c>; this flag lets the C# writer
+    /// spell it <c>~Type()</c> instead. A metadata fact (the overridden slot),
+    /// separate from the C# spelling the writer owns.
+    /// </summary>
+    public bool IsFinalizer { get; set; }
+
     public bool IsReadOnly { get; set; }
     public bool IsConst { get; set; }
     public bool IsUnsafe { get; set; }

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -457,11 +457,12 @@ public class ApiMember
 
     /// <summary>
     /// True when this method is a class finalizer — the <c>object.Finalize</c>
-    /// override the C# <c>~Type()</c> destructor syntax compiles to. Roslyn emits
-    /// it with an explicit <c>.override</c> MethodImpl, so it otherwise surfaces
-    /// as a modifier-less <c>void Finalize()</c>; this flag lets the C# writer
-    /// spell it <c>~Type()</c> instead. A metadata fact (the overridden slot),
-    /// separate from the C# spelling the writer owns.
+    /// override the C# <c>~Type()</c> destructor syntax compiles to. Detected
+    /// from the method's explicit <c>.override</c> MethodImpl targeting
+    /// <c>System.Object::Finalize</c>, so it is judged by the overridden slot
+    /// rather than by name or signature shape. Lets the C# writer spell it
+    /// <c>~Type()</c> instead of the bare <c>void Finalize()</c>. A metadata fact
+    /// (the overridden slot), separate from the C# spelling the writer owns.
     /// </summary>
     public bool IsFinalizer { get; set; }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -870,11 +870,10 @@ public static class ApiSurfaceExtractor
                 // assembly cannot be resolved from metadata alone (SRM-only, no
                 // inspected-assembly loading), so we cannot check its object is
                 // the real root. Require the reference to resolve through a
-                // recognized core library instead — an adversarial `System.Object`
-                // defined in an arbitrary assembly is thereby rejected. A build
-                // that fully impersonates a core-library assembly name is a
-                // deeper supply-chain concern out of scope for this cosmetic
-                // spelling decision.
+                // recognized core library — matched by both assembly name and
+                // its strong-name public-key token — so that an adversarial
+                // `System.Object` defined in an arbitrary or name-impersonating
+                // assembly is rejected.
                 return string.Equals(reader.GetString(typeRef.Namespace), "System", StringComparison.Ordinal)
                     && string.Equals(reader.GetString(typeRef.Name), "Object", StringComparison.Ordinal)
                     && ResolvesThroughCoreLibrary(reader, typeRef.ResolutionScope);
@@ -894,32 +893,67 @@ public static class ApiSurfaceExtractor
     }
 
     // The reference assemblies and runtime cores that define the real
-    // System.Object. A TypeReference to `System.Object` that resolves through
-    // any other assembly is an adversarial or accidental lookalike, not the
-    // runtime finalizer slot.
-    private static readonly HashSet<string> CoreLibraryAssemblyNames =
+    // System.Object, paired with the strong-name public-key token each is
+    // signed with. A TypeReference to `System.Object` that resolves through
+    // any other assembly — or through an assembly that impersonates one of
+    // these names without carrying its public-key token — is an adversarial or
+    // accidental lookalike, not the runtime finalizer slot.
+    private static readonly Dictionary<string, byte[]> CoreLibraryPublicKeyTokens =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            "System.Runtime",
-            "System.Private.CoreLib",
-            "mscorlib",
-            "netstandard",
+            ["System.Runtime"] = new byte[] { 0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a },
+            ["System.Private.CoreLib"] = new byte[] { 0x7c, 0xec, 0x85, 0xd7, 0xbe, 0xa7, 0x79, 0x8e },
+            ["mscorlib"] = new byte[] { 0xb7, 0x7a, 0x5c, 0x56, 0x19, 0x34, 0xe0, 0x89 },
+            ["netstandard"] = new byte[] { 0xcc, 0x7b, 0x13, 0xff, 0xcd, 0x2d, 0xdd, 0x51 },
         };
 
     /// <summary>
     /// True when <paramref name="resolutionScope"/> is an
-    /// <see cref="AssemblyReference"/> to a recognized core library — the
-    /// resolution scope a real cross-assembly <c>System.Object</c> reference
-    /// carries. Nested (<see cref="TypeReference"/>), module, and nil scopes are
+    /// <see cref="AssemblyReference"/> to a recognized core library — matched by
+    /// both assembly name and strong-name public-key token — the resolution
+    /// scope a real cross-assembly <c>System.Object</c> reference carries.
+    /// Nested (<see cref="TypeReference"/>), module, and nil scopes are
     /// rejected: <c>System.Object</c> is never a nested type, and a same-module
-    /// object is a <see cref="TypeDefinition"/> handled elsewhere.
+    /// object is a <see cref="TypeDefinition"/> handled elsewhere. An assembly
+    /// that impersonates a core-library name but lacks (or forges) its
+    /// public-key token is rejected.
     /// </summary>
     private static bool ResolvesThroughCoreLibrary(MetadataReader reader, EntityHandle resolutionScope)
     {
         if (resolutionScope.Kind != HandleKind.AssemblyReference)
             return false;
         var assemblyRef = reader.GetAssemblyReference((AssemblyReferenceHandle)resolutionScope);
-        return CoreLibraryAssemblyNames.Contains(reader.GetString(assemblyRef.Name));
+        if (!CoreLibraryPublicKeyTokens.TryGetValue(reader.GetString(assemblyRef.Name), out byte[]? expectedToken))
+            return false;
+        return TokenMatches(reader, assemblyRef, expectedToken);
+    }
+
+    /// <summary>
+    /// True when the strong-name public-key token of <paramref name="assemblyRef"/>
+    /// equals <paramref name="expectedToken"/>. An assembly reference stores
+    /// either the full public key (when <see cref="AssemblyFlags.PublicKey"/> is
+    /// set) or the already-computed 8-byte token; the token is the low 8 bytes
+    /// of the SHA-1 hash of the public key, in reverse order.
+    /// </summary>
+    private static bool TokenMatches(MetadataReader reader, System.Reflection.Metadata.AssemblyReference assemblyRef, byte[] expectedToken)
+    {
+        if (assemblyRef.PublicKeyOrToken.IsNil)
+            return false;
+        byte[] blob = reader.GetBlobBytes(assemblyRef.PublicKeyOrToken);
+        byte[] token;
+        if ((assemblyRef.Flags & AssemblyFlags.PublicKey) != 0)
+        {
+            byte[] hash = System.Security.Cryptography.SHA1.HashData(blob);
+            token = new byte[8];
+            for (int i = 0; i < 8; i++)
+                token[i] = hash[hash.Length - 1 - i];
+        }
+        else
+        {
+            token = blob;
+        }
+
+        return token.AsSpan().SequenceEqual(expectedToken);
     }
 
     private static bool IsOperatorMethodName(string methodName) =>

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -193,16 +193,20 @@ public static class ApiSurfaceExtractor
                 // `System.Object::Finalize`, so we detect it by that target
                 // rather than by name/signature shape. Keying on the overridden
                 // slot (not the name `Finalize`, the reused virtual slot, or the
-                // decoded signature) is what excludes the false positives a
-                // shape heuristic admits: a generic `Finalize<T>()` override, an
+                // decoded signature) excludes the false positives a shape
+                // heuristic admits: an implicit generic `Finalize<T>()`, an
                 // override of an unrelated base/interface `Finalize()` slot, and
                 // an explicit `IFoo.Finalize()` implementation (whose MethodImpl
                 // targets the interface, not object). A method whose signature
                 // failed to decode is likewise judged by its MethodImpl target
                 // alone, so a degraded decode cannot masquerade as a finalizer.
+                // A finalizer is never generic, so we still reject a method that
+                // explicitly `.override`s object.Finalize while declaring its own
+                // type parameters — rendering it `~Type()` would erase `<T>`.
                 // VB-style implicit `object.Finalize` overrides carry no
                 // MethodImpl and fall back to the literal `void Finalize()`.
                 var isFinalizer = apiType.Kind == "class"
+                    && method.GetGenericParameters().Count == 0
                     && objectFinalizeOverrides.Contains(methodHandle);
 
                 var member = new ApiMember
@@ -866,7 +870,13 @@ public static class ApiSurfaceExtractor
                     && string.Equals(reader.GetString(typeRef.Name), "Object", StringComparison.Ordinal);
             case HandleKind.TypeDefinition:
                 var typeDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeHandle);
-                return string.Equals(reader.GetString(typeDef.Namespace), "System", StringComparison.Ordinal)
+                // The genuine root object is the only `System.Object` with no
+                // base type. An adversarial assembly can define its own
+                // `System.Object` that extends the real one (a non-root fake);
+                // requiring a nil base type rejects it while still accepting the
+                // real object when inspecting the assembly that defines it.
+                return typeDef.BaseType.IsNil
+                    && string.Equals(reader.GetString(typeDef.Namespace), "System", StringComparison.Ordinal)
                     && string.Equals(reader.GetString(typeDef.Name), "Object", StringComparison.Ordinal);
             default:
                 return false;

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -893,29 +893,38 @@ public static class ApiSurfaceExtractor
     }
 
     // The reference assemblies and runtime cores that define the real
-    // System.Object, paired with the strong-name public-key token each is
-    // signed with. A TypeReference to `System.Object` that resolves through
-    // any other assembly — or through an assembly that impersonates one of
-    // these names without carrying its public-key token — is an adversarial or
-    // accidental lookalike, not the runtime finalizer slot.
-    private static readonly Dictionary<string, byte[]> CoreLibraryPublicKeyTokens =
+    // System.Object, paired with the strong-name public-key token(s) each is
+    // legitimately signed with. `mscorlib` shipped under several Microsoft
+    // tokens across historical profiles (desktop .NET Framework, Silverlight/
+    // PCL/Windows Phone, and the .NET Compact Framework), so a name maps to a
+    // set of accepted tokens. A TypeReference to `System.Object` that resolves
+    // through any other assembly — or through an assembly that impersonates one
+    // of these names without carrying a matching Microsoft public-key token —
+    // is an adversarial or accidental lookalike, not the runtime finalizer slot.
+    private static readonly Dictionary<string, byte[][]> CoreLibraryPublicKeyTokens =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            ["System.Runtime"] = new byte[] { 0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a },
-            ["System.Private.CoreLib"] = new byte[] { 0x7c, 0xec, 0x85, 0xd7, 0xbe, 0xa7, 0x79, 0x8e },
-            ["mscorlib"] = new byte[] { 0xb7, 0x7a, 0x5c, 0x56, 0x19, 0x34, 0xe0, 0x89 },
-            ["netstandard"] = new byte[] { 0xcc, 0x7b, 0x13, 0xff, 0xcd, 0x2d, 0xdd, 0x51 },
+            ["System.Runtime"] = new[] { new byte[] { 0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a } },
+            ["System.Private.CoreLib"] = new[] { new byte[] { 0x7c, 0xec, 0x85, 0xd7, 0xbe, 0xa7, 0x79, 0x8e } },
+            ["mscorlib"] = new[]
+            {
+                new byte[] { 0xb7, 0x7a, 0x5c, 0x56, 0x19, 0x34, 0xe0, 0x89 }, // .NET Framework (desktop)
+                new byte[] { 0x7c, 0xec, 0x85, 0xd7, 0xbe, 0xa7, 0x79, 0x8e }, // Silverlight / PCL / Windows Phone
+                new byte[] { 0x96, 0x9d, 0xb8, 0x05, 0x3d, 0x33, 0x22, 0xac }, // .NET Compact Framework
+            },
+            ["netstandard"] = new[] { new byte[] { 0xcc, 0x7b, 0x13, 0xff, 0xcd, 0x2d, 0xdd, 0x51 } },
         };
 
     /// <summary>
     /// True when <paramref name="resolutionScope"/> is an
     /// <see cref="AssemblyReference"/> to a recognized core library — matched by
-    /// both assembly name and strong-name public-key token — the resolution
-    /// scope a real cross-assembly <c>System.Object</c> reference carries.
-    /// Nested (<see cref="TypeReference"/>), module, and nil scopes are
-    /// rejected: <c>System.Object</c> is never a nested type, and a same-module
-    /// object is a <see cref="TypeDefinition"/> handled elsewhere. An assembly
-    /// that impersonates a core-library name but lacks (or forges) its
+    /// both assembly name and one of that library's legitimate strong-name
+    /// public-key tokens — the resolution scope a real cross-assembly
+    /// <c>System.Object</c> reference carries. Nested
+    /// (<see cref="TypeReference"/>), module, and nil scopes are rejected:
+    /// <c>System.Object</c> is never a nested type, and a same-module object is
+    /// a <see cref="TypeDefinition"/> handled elsewhere. An assembly that
+    /// impersonates a core-library name but lacks (or forges) a matching
     /// public-key token is rejected.
     /// </summary>
     private static bool ResolvesThroughCoreLibrary(MetadataReader reader, EntityHandle resolutionScope)
@@ -923,37 +932,46 @@ public static class ApiSurfaceExtractor
         if (resolutionScope.Kind != HandleKind.AssemblyReference)
             return false;
         var assemblyRef = reader.GetAssemblyReference((AssemblyReferenceHandle)resolutionScope);
-        if (!CoreLibraryPublicKeyTokens.TryGetValue(reader.GetString(assemblyRef.Name), out byte[]? expectedToken))
+        if (!CoreLibraryPublicKeyTokens.TryGetValue(reader.GetString(assemblyRef.Name), out byte[][]? expectedTokens))
             return false;
-        return TokenMatches(reader, assemblyRef, expectedToken);
+        if (!TryComputeToken(reader, assemblyRef, out byte[] token))
+            return false;
+        foreach (byte[] expected in expectedTokens)
+        {
+            if (token.AsSpan().SequenceEqual(expected))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>
-    /// True when the strong-name public-key token of <paramref name="assemblyRef"/>
-    /// equals <paramref name="expectedToken"/>. An assembly reference stores
-    /// either the full public key (when <see cref="AssemblyFlags.PublicKey"/> is
-    /// set) or the already-computed 8-byte token; the token is the low 8 bytes
-    /// of the SHA-1 hash of the public key, in reverse order.
+    /// Computes the 8-byte strong-name public-key token of
+    /// <paramref name="assemblyRef"/>. An assembly reference stores either the
+    /// full public key (when <see cref="AssemblyFlags.PublicKey"/> is set) or
+    /// the already-computed token; the token is the low 8 bytes of the SHA-1
+    /// hash of the public key, in reverse order. Returns false for a nil or
+    /// wrong-length token blob.
     /// </summary>
-    private static bool TokenMatches(MetadataReader reader, System.Reflection.Metadata.AssemblyReference assemblyRef, byte[] expectedToken)
+    private static bool TryComputeToken(MetadataReader reader, System.Reflection.Metadata.AssemblyReference assemblyRef, out byte[] token)
     {
+        token = [];
         if (assemblyRef.PublicKeyOrToken.IsNil)
             return false;
         byte[] blob = reader.GetBlobBytes(assemblyRef.PublicKeyOrToken);
-        byte[] token;
         if ((assemblyRef.Flags & AssemblyFlags.PublicKey) != 0)
         {
             byte[] hash = System.Security.Cryptography.SHA1.HashData(blob);
             token = new byte[8];
             for (int i = 0; i < 8; i++)
                 token[i] = hash[hash.Length - 1 - i];
-        }
-        else
-        {
-            token = blob;
+            return true;
         }
 
-        return token.AsSpan().SequenceEqual(expectedToken);
+        if (blob.Length != 8)
+            return false;
+        token = blob;
+        return true;
     }
 
     private static bool IsOperatorMethodName(string methodName) =>

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -866,8 +866,18 @@ public static class ApiSurfaceExtractor
         {
             case HandleKind.TypeReference:
                 var typeRef = reader.GetTypeReference((TypeReferenceHandle)typeHandle);
+                // Cross-assembly reference (the normal Roslyn case): the target
+                // assembly cannot be resolved from metadata alone (SRM-only, no
+                // inspected-assembly loading), so we cannot check its object is
+                // the real root. Require the reference to resolve through a
+                // recognized core library instead — an adversarial `System.Object`
+                // defined in an arbitrary assembly is thereby rejected. A build
+                // that fully impersonates a core-library assembly name is a
+                // deeper supply-chain concern out of scope for this cosmetic
+                // spelling decision.
                 return string.Equals(reader.GetString(typeRef.Namespace), "System", StringComparison.Ordinal)
-                    && string.Equals(reader.GetString(typeRef.Name), "Object", StringComparison.Ordinal);
+                    && string.Equals(reader.GetString(typeRef.Name), "Object", StringComparison.Ordinal)
+                    && ResolvesThroughCoreLibrary(reader, typeRef.ResolutionScope);
             case HandleKind.TypeDefinition:
                 var typeDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeHandle);
                 // The genuine root object is the only `System.Object` with no
@@ -881,6 +891,35 @@ public static class ApiSurfaceExtractor
             default:
                 return false;
         }
+    }
+
+    // The reference assemblies and runtime cores that define the real
+    // System.Object. A TypeReference to `System.Object` that resolves through
+    // any other assembly is an adversarial or accidental lookalike, not the
+    // runtime finalizer slot.
+    private static readonly HashSet<string> CoreLibraryAssemblyNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "System.Runtime",
+            "System.Private.CoreLib",
+            "mscorlib",
+            "netstandard",
+        };
+
+    /// <summary>
+    /// True when <paramref name="resolutionScope"/> is an
+    /// <see cref="AssemblyReference"/> to a recognized core library — the
+    /// resolution scope a real cross-assembly <c>System.Object</c> reference
+    /// carries. Nested (<see cref="TypeReference"/>), module, and nil scopes are
+    /// rejected: <c>System.Object</c> is never a nested type, and a same-module
+    /// object is a <see cref="TypeDefinition"/> handled elsewhere.
+    /// </summary>
+    private static bool ResolvesThroughCoreLibrary(MetadataReader reader, EntityHandle resolutionScope)
+    {
+        if (resolutionScope.Kind != HandleKind.AssemblyReference)
+            return false;
+        var assemblyRef = reader.GetAssemblyReference((AssemblyReferenceHandle)resolutionScope);
+        return CoreLibraryAssemblyNames.Contains(reader.GetString(assemblyRef.Name));
     }
 
     private static bool IsOperatorMethodName(string methodName) =>

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -181,6 +181,22 @@ public static class ApiSurfaceExtractor
                 var isVirtual = (methodAttributes & MethodAttributes.Virtual) != 0;
                 var isNewSlot = (methodAttributes & MethodAttributes.NewSlot) != 0;
                 var isOverride = isVirtual && !isNewSlot && !isExplicitInterfaceImplementation;
+
+                // A class finalizer is the `object.Finalize` override — a
+                // parameterless void `Finalize` that reuses (does not new-slot)
+                // the base virtual slot. Roslyn emits it with an explicit
+                // `.override` MethodImpl, so it lands in explicitImplementationBodies
+                // above; detect it by shape so the C# writer can spell `~Type()`.
+                // The exact name `Finalize` (no dot-qualified interface prefix)
+                // and the reused slot exclude an explicit `IFoo.Finalize()` impl.
+                var isFinalizer = apiType.Kind == "class"
+                    && methodName == "Finalize"
+                    && (methodAttributes & MethodAttributes.Static) == 0
+                    && isVirtual
+                    && !isNewSlot
+                    && (signature.Model?.Parameters is null or { Count: 0 })
+                    && signature.Model?.ReturnType is null or "void";
+
                 var member = new ApiMember
                 {
                     Name = methodName,
@@ -196,6 +212,7 @@ public static class ApiSurfaceExtractor
                     IsAbstract = (methodAttributes & MethodAttributes.Abstract) != 0,
                     IsOverride = isOverride,
                     IsSealed = isOverride && (methodAttributes & MethodAttributes.Final) != 0,
+                    IsFinalizer = isFinalizer,
                     Signature = signature.Text,
                     SignatureModel = signature.Model,
                     SignatureDecodeStatus = signature.IsDegraded

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -147,6 +147,11 @@ public static class ApiSurfaceExtractor
 
             var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
 
+            // Methods whose explicit `.override` MethodImpl targets
+            // `System.Object::Finalize` — i.e. genuine class finalizers, the
+            // slot the C# `~Type()` destructor compiles to.
+            var objectFinalizeOverrides = GetObjectFinalizeOverrides(reader, typeDef);
+
             // Methods
             foreach (var methodHandle in typeDef.GetMethods())
             {
@@ -182,20 +187,23 @@ public static class ApiSurfaceExtractor
                 var isNewSlot = (methodAttributes & MethodAttributes.NewSlot) != 0;
                 var isOverride = isVirtual && !isNewSlot && !isExplicitInterfaceImplementation;
 
-                // A class finalizer is the `object.Finalize` override — a
-                // parameterless void `Finalize` that reuses (does not new-slot)
-                // the base virtual slot. Roslyn emits it with an explicit
-                // `.override` MethodImpl, so it lands in explicitImplementationBodies
-                // above; detect it by shape so the C# writer can spell `~Type()`.
-                // The exact name `Finalize` (no dot-qualified interface prefix)
-                // and the reused slot exclude an explicit `IFoo.Finalize()` impl.
+                // A class finalizer is the `object.Finalize` override the C#
+                // `~Type()` destructor compiles to. Roslyn emits it with an
+                // explicit `.override` MethodImpl targeting
+                // `System.Object::Finalize`, so we detect it by that target
+                // rather than by name/signature shape. Keying on the overridden
+                // slot (not the name `Finalize`, the reused virtual slot, or the
+                // decoded signature) is what excludes the false positives a
+                // shape heuristic admits: a generic `Finalize<T>()` override, an
+                // override of an unrelated base/interface `Finalize()` slot, and
+                // an explicit `IFoo.Finalize()` implementation (whose MethodImpl
+                // targets the interface, not object). A method whose signature
+                // failed to decode is likewise judged by its MethodImpl target
+                // alone, so a degraded decode cannot masquerade as a finalizer.
+                // VB-style implicit `object.Finalize` overrides carry no
+                // MethodImpl and fall back to the literal `void Finalize()`.
                 var isFinalizer = apiType.Kind == "class"
-                    && methodName == "Finalize"
-                    && (methodAttributes & MethodAttributes.Static) == 0
-                    && isVirtual
-                    && !isNewSlot
-                    && (signature.Model?.Parameters is null or { Count: 0 })
-                    && signature.Model?.ReturnType is null or "void";
+                    && objectFinalizeOverrides.Contains(methodHandle);
 
                 var member = new ApiMember
                 {
@@ -796,6 +804,73 @@ public static class ApiSurfaceExtractor
         }
 
         return handles;
+    }
+
+    /// <summary>
+    /// The set of methods on <paramref name="typeDef"/> whose explicit
+    /// <c>.override</c> MethodImpl targets <c>System.Object::Finalize</c> — the
+    /// slot a C# <c>~Type()</c> destructor compiles to. Keying on the overridden
+    /// declaration (not the method's own name/slot/signature) is what lets the
+    /// C# writer spell <c>~Type()</c> for real finalizers while excluding a
+    /// same-named override of an unrelated <c>Finalize</c> slot or an explicit
+    /// interface implementation.
+    /// </summary>
+    private static HashSet<MethodDefinitionHandle> GetObjectFinalizeOverrides(
+        MetadataReader reader, TypeDefinition typeDef)
+    {
+        HashSet<MethodDefinitionHandle> handles = [];
+        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody.Kind != HandleKind.MethodDefinition)
+                continue;
+            if (ReferencesObjectFinalize(reader, implementation.MethodDeclaration))
+                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
+        }
+
+        return handles;
+    }
+
+    /// <summary>
+    /// True when <paramref name="methodDeclaration"/> (the target of a
+    /// <c>.override</c> MethodImpl) names <c>Finalize</c> on <c>System.Object</c>.
+    /// The target is a <see cref="MemberReferenceHandle"/> in the common case
+    /// (object lives in another assembly) and a <see cref="MethodDefinitionHandle"/>
+    /// only when inspecting the assembly that defines <c>System.Object</c>.
+    /// </summary>
+    private static bool ReferencesObjectFinalize(MetadataReader reader, EntityHandle methodDeclaration)
+    {
+        switch (methodDeclaration.Kind)
+        {
+            case HandleKind.MemberReference:
+                var memberRef = reader.GetMemberReference((MemberReferenceHandle)methodDeclaration);
+                return string.Equals(reader.GetString(memberRef.Name), "Finalize", StringComparison.Ordinal)
+                    && IsSystemObjectType(reader, memberRef.Parent);
+            case HandleKind.MethodDefinition:
+                var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)methodDeclaration);
+                return string.Equals(reader.GetString(methodDef.Name), "Finalize", StringComparison.Ordinal)
+                    && IsSystemObjectType(reader, methodDef.GetDeclaringType());
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>True when <paramref name="typeHandle"/> resolves to <c>System.Object</c>.</summary>
+    private static bool IsSystemObjectType(MetadataReader reader, EntityHandle typeHandle)
+    {
+        switch (typeHandle.Kind)
+        {
+            case HandleKind.TypeReference:
+                var typeRef = reader.GetTypeReference((TypeReferenceHandle)typeHandle);
+                return string.Equals(reader.GetString(typeRef.Namespace), "System", StringComparison.Ordinal)
+                    && string.Equals(reader.GetString(typeRef.Name), "Object", StringComparison.Ordinal);
+            case HandleKind.TypeDefinition:
+                var typeDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeHandle);
+                return string.Equals(reader.GetString(typeDef.Namespace), "System", StringComparison.Ordinal)
+                    && string.Equals(reader.GetString(typeDef.Name), "Object", StringComparison.Ordinal);
+            default:
+                return false;
+        }
     }
 
     private static bool IsOperatorMethodName(string methodName) =>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2288,7 +2288,13 @@ public static class ApiOutputFormatter
         var bodyShape = new CSharpBlockBody(lowered)
         {
             RequiresAsyncModifier = requiresAsyncBodyModifier,
-            RequiresUnsafeModifier = result.RequiresUnsafeBodyModifier
+            RequiresUnsafeModifier = result.RequiresUnsafeBodyModifier,
+            // Only spell '~Type()' when the destructor pass recovered the
+            // canonical try/finally { base.Finalize(); } scaffold (issue #3157).
+            // A Finalize override whose body did not match keeps the literal
+            // 'void Finalize()' so recompiling this selected-member source does
+            // not silently re-inject the compiler's mandatory base.Finalize().
+            SuppressDestructorSyntax = member.IsFinalizer && !result.BodyIsDestructor
         };
         var formatter = includeCustomAttributes ? AnnotatedCSharpFormatter : DefaultCSharpFormatter;
         var declaration = formatter.FormatMemberWithBody(


### PR DESCRIPTION
Fixes #3157.

A C# finalizer (`~Type()`) compiles to an `object.Finalize` override that Roslyn
emits with an explicit `.override` MethodImpl. The extractor's explicit-body
collection therefore classified it as an explicit-interface-implementation, and
the C# declaration writer spelled the bare slot `void Finalize()` instead of the
`~Type()` destructor syntax. The body raise (stripping the `try/finally { base.Finalize(); }`)
was already handled by `DestructorRecoveryPass`; only the member **head** was wrong.

This adds a metadata fact `ApiMember.IsFinalizer` (a non-static, parameterless,
void, reused-slot virtual method named `Finalize` on a class), set in the
extractor. The C# writer then spells `~Type()` and drops the illegal
accessibility/override modifiers, keeping only `unsafe`. Metadata owns the slot
fact; CSharp owns the spelling.

The exact name `Finalize` (not dot-qualified) plus the reused (non-new) slot
excludes an explicit `IFoo.Finalize()` implementation and implicit interface
impls (which new-slot) — covered by a negative test.

## Original source (IL anchor)

SourceLink C# is unavailable for the local fixture, so the authoritative anchor
is the `IL` section (`member FinDemo.Handle Finalize -S "IL"`) — the finalizer's
`try { _n = 0; } finally { base.Finalize(); }` slot:

```text
IL_0000: ldarg.0
IL_0001: ldc.i4.0
IL_0002: stfld        FinDemo.Handle::_n
IL_0007: leave.s      IL_0010
IL_0009: ldarg.0
IL_000A: call         System.Object::Finalize()
IL_000F: endfinally
IL_0010: ret
```

## Before (base 76d73685, `-S "Decompiled Source"`)

```csharp
public class Handle
{
    private int _n;

    public Handle(int n) => _n = n;

    void Finalize() => _n = 0;

    public int Value => _n;
}
```

- Valid: False in intent — a bare `void Finalize()` compiles only with warning
  CS0465 and is **not** a finalizer.
- Correct: False — different observable behavior (no finalization slot).
- IL fidelity: False — recompiles to a plain method, not the `Finalize` override.
- Taste applied: none.
- Commit: 76d73685.

## After (head, `-S "Decompiled Source"`)

```csharp
public class Handle
{
    private int _n;

    public Handle(int n) => _n = n;

    ~Handle() => _n = 0;

    public int Value => _n;
}
```

- Valid: True.
- Correct: True — recompiles to the `object.Finalize` override slot.
- IL fidelity: True.
- Taste applied: none (finalizer spelling is a correctness fix, not a style lens).
- Commit: head of this branch.

## Fully raised

Same as After — this is the intended endpoint.

## Known limitation (pre-existing, out of scope)

The finalizer keeps `Kind = explicit-interface-implementation`, so in metadata
views it still lists under the "Explicit Interface Implementations" section and
the raw-metadata `--shape` tree still shows the slot as `void Finalize()`
(consistent with how that view shows `.ctor` for constructors). Re-categorizing
would change the member `Kind`/identity/digest with a wider blast radius; happy
to follow up separately. This PR fixes the decompiled C# render, which is what
#3157 reports.

## Validation

- Real CLI: `type FinDemo.Handle -S "Decompiled Source" --print` renders
  `~Handle() => _n = 0;` end to end.
- New tests: 3 unit (`CSharpDeclarationWriterTests`: finalizer syntax, unsafe-only
  modifier, generic type-arity drop) + 3 end-to-end
  (`MemberBodyProducerExpressionBodyTests`: expression-bodied finalizer, block
  finalizer, and negative `void IThing.Finalize()` explicit impl).
- Suites: CSharp.Tests 329, Metadata.Tests 794, MemberBodyProducerExpressionBodyTests 10,
  DestructorRecoveryPassTests 3 — all pass. Product `dotnet-inspect.Tests`: the
  only failures are the known pre-existing env reds (PerformanceTriage/ResourceTriage/
  caller-loop), identical base vs head.
