### PR TITLE
Replace ExpressionBodyArrowPlacement enum with a boolean catalog knob

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -503,9 +503,10 @@ a Wasm UI can enumerate the knobs (grouping the mutually-exclusive lenses by
 taste" aggregate is exactly the `OracleEndorsed` subset. The two guarded-boolean
 lenses share the `guarded-boolean-return` conflict group, so a picker offers at
 most one (the printer still resolves any overlap deterministically, preferring the
-oracle-endorsed ternary). The single non-boolean knob
-(`ExpressionBodyArrowPlacement`) is not yet modeled in the catalog, which
-currently describes boolean toggles.
+oracle-endorsed ternary). Every opt-in knob is a boolean toggle — including the
+expression-body arrow wrap (`WrapExpressionBodyArrow`) — so the catalog is
+exhaustive; a future non-boolean knob would need a descriptor shape that carries
+its value domain.
 
 ## Verification and soundness
 

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
@@ -93,7 +93,7 @@ public sealed class MemberBodyProducerMemberRenderTests
             increment,
             AssemblyPath,
             pdbPath: null,
-            printerOptions: new PrinterOptions { ExpressionBodyArrowPlacement = ExpressionBodyArrowPlacement.NextLine });
+            printerOptions: new PrinterOptions { WrapExpressionBodyArrow = true });
 
         Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
         Assert.Equal("    public int Increment(int n)\n        => n + 1;", rendered.Text!.Replace("\r\n", "\n"));

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -129,4 +129,21 @@ public class StyleOptionCatalogTests
         foreach (var o in Options.Where(o => o.OracleEndorsed && o.ConfigKey is not null))
             Assert.StartsWith("dotnet_style_", o.ConfigKey);
     }
+
+    [Fact]
+    public void WrapExpressionBodyArrow_IsAnApiOnlyFormattingKnob()
+    {
+        // The former ExpressionBodyArrowPlacement enum is now a boolean toggle, so
+        // it belongs in the catalog: a whitespace-only formatting choice with no
+        // config key and no oracle endorsement (the shipped default keeps the arrow
+        // on the same line; wrapping it is a user preference, not the oracle's).
+        var arrow = Options.Single(o => o.Id == "wrap-expression-body-arrow");
+        Assert.Equal(StyleOptionTier.Formatting, arrow.Tier);
+        Assert.False(arrow.ByteDivergent);
+        Assert.False(arrow.OracleEndorsed);
+        Assert.Null(arrow.ConfigKey);
+        Assert.Null(arrow.ConflictGroup);
+        Assert.False(arrow.Get(PrinterOptions.Default));
+        Assert.True(arrow.Get(arrow.With(PrinterOptions.Default, true)));
+    }
 }

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -60,7 +60,7 @@ public sealed record DecompilerOptions
     /// Expression-bodied members keep the arrow on the declaration line by
     /// default; callers may opt into wrapping it onto the next line.
     /// </summary>
-    public ExpressionBodyArrowPlacement ExpressionBodyArrowPlacement { get; init; } = ExpressionBodyArrowPlacement.SameLine;
+    public bool WrapExpressionBodyArrow { get; init; }
 
     /// <summary>
     /// Long splittable expressions (short-circuit <c>&amp;&amp;</c>/<c>||</c>

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1252,7 +1252,7 @@ public static class MemberBodyProducer
     }
 
     static bool WrapExpressionBodyArrow(Pipeline.PrinterOptions? printerOptions)
-        => (printerOptions ?? Pipeline.PrinterOptions.Default).ExpressionBodyArrowPlacement == Pipeline.ExpressionBodyArrowPlacement.NextLine;
+        => (printerOptions ?? Pipeline.PrinterOptions.Default).WrapExpressionBodyArrow;
 
     /// <summary>
     /// The expression of a single-statement body suitable for '=>':

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -369,7 +369,7 @@ public sealed partial class CSharpPrinter
         {
             ReadableLocalNames = _options.ReadableLocalNames,
             PreferFrameworkTypeImports = true,
-            ExpressionBodyArrowPlacement = _options.ExpressionBodyArrowPlacement,
+            WrapExpressionBodyArrow = _options.WrapExpressionBodyArrow,
             WrapSplittableExpressions = _options.WrapSplittableExpressions,
             QualifyFieldAccess = _options.QualifyFieldAccess,
             QualifyPropertyAccess = _options.QualifyPropertyAccess,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -1,24 +1,6 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Placement of the <c>=&gt;</c> token for an expression-bodied member or accessor.
-/// </summary>
-public enum ExpressionBodyArrowPlacement
-{
-    /// <summary>
-    /// Keep the declaration head and the expression-body arrow on one line:
-    /// <c>head =&gt; expr;</c>.
-    /// </summary>
-    SameLine,
-
-    /// <summary>
-    /// Wrap the expression-body arrow onto the next line, indented one level
-    /// deeper than the declaration head.
-    /// </summary>
-    NextLine,
-}
-
-/// <summary>
 /// Opt-in render knobs for <see cref="CSharpPrinter"/>. Every field defaults to
 /// the shipped behavior, so <see cref="Default"/> reproduces today's output
 /// byte-for-byte — the fidelity gate, <c>--skip-pdb</c> deterministic reading,
@@ -38,11 +20,13 @@ public sealed record PrinterOptions
     public bool ReadableLocalNames { get; init; }
 
     /// <summary>
-    /// Selects whether an expression-bodied member or accessor keeps
-    /// <c>head =&gt; expr;</c> on one line (the shipped default) or wraps the
-    /// arrow onto the next line.
+    /// When set, an expression-bodied member or accessor wraps the <c>=&gt;</c>
+    /// arrow onto the next line (indented one level deeper than the declaration
+    /// head) instead of keeping <c>head =&gt; expr;</c> on one line. Off by
+    /// default (same line is the shipped default); a whitespace-only formatting
+    /// choice that leaves the tokens and IL unchanged.
     /// </summary>
-    public ExpressionBodyArrowPlacement ExpressionBodyArrowPlacement { get; init; } = ExpressionBodyArrowPlacement.SameLine;
+    public bool WrapExpressionBodyArrow { get; init; }
 
     /// <summary>
     /// When set, a long, splittable expression — today a short-circuit

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -118,9 +118,10 @@ public static class StyleOptionCatalog
 
     /// <summary>
     /// Every opt-in boolean knob, in a stable presentation order (formatting and
-    /// spelling first, then the byte-divergent lenses). The single enum knob
-    /// (<see cref="ExpressionBodyArrowPlacement"/>) is intentionally not modeled
-    /// here yet, since this catalog describes boolean toggles.
+    /// spelling first, then the byte-divergent lenses). Every opt-in
+    /// <see cref="PrinterOptions"/> knob is a boolean toggle, so this catalog is
+    /// exhaustive; a future non-boolean knob would need a descriptor shape that
+    /// carries its value domain.
     /// </summary>
     public static IReadOnlyList<StyleOptionDescriptor> Options { get; } =
     [
@@ -147,6 +148,18 @@ public static class StyleOptionCatalog
             ConfigKey = null,
             Get = static o => o.WrapSplittableExpressions,
             With = static (o, v) => o with { WrapSplittableExpressions = v },
+        },
+        new StyleOptionDescriptor
+        {
+            Id = "wrap-expression-body-arrow",
+            Title = "Wrap expression-body arrow",
+            Summary = "Wrap the => of an expression-bodied member or accessor onto the next line instead of keeping it on the declaration line (whitespace only).",
+            Tier = StyleOptionTier.Formatting,
+            ByteDivergent = false,
+            OracleEndorsed = false,
+            ConfigKey = null,
+            Get = static o => o.WrapExpressionBodyArrow,
+            With = static (o, v) => o with { WrapExpressionBodyArrow = v },
         },
         new StyleOptionDescriptor
         {


### PR DESCRIPTION
## What

The expression-body arrow placement was the **one** opt-in `PrinterOptions` knob that wasn't a boolean, so it was deliberately excluded from `StyleOptionCatalog` (#3160) and couldn't be discovered/toggled through the uniform catalog surface that hosts (the CLI resolver, a Wasm UI, the future "full taste" aggregate) depend on.

It has exactly two states — arrow on the same line (shipped default) or wrapped onto the next line — so this models it as a boolean and adds it to the catalog.

## Change

- Remove the `ExpressionBodyArrowPlacement` enum and the enum-typed `PrinterOptions` / `DecompilerOptions` properties; replace with a single `bool WrapExpressionBodyArrow`.
- **Convention-preserving polarity:** `false` = shipped default (same line), `true` = opt-in (wrap onto next line) — matching every other knob's "true engages the opt-in behavior". This flips the *spelling* but not the behavior: `PrinterOptions.Default` still renders the arrow on the same line, byte-for-byte.
- Add the knob to `StyleOptionCatalog` as an API-only **Formatting** toggle: no config key, not oracle-endorsed, not byte-divergent (whitespace-only; IL unchanged).
- Docs: `docs/decompiler-taste.md` now states the catalog is exhaustive (every opt-in knob is boolean); a future non-boolean knob would need a descriptor shape carrying its value domain.

## Why it's a clean swap

Every real consumer already funneled the enum through a bool — `MemberBodyProducer.WrapExpressionBodyArrow(...)` and the CSharp layer's `wrapArrow` parameter — so the enum only existed at the API boundary. `DecompilerOptions.EffectiveOptions` is an inspectable record, not serialized to any CLI output, so there is no output-shape change.

## Compatibility

Source-breaking for any external caller that set `ExpressionBodyArrowPlacement = …` (must become `WrapExpressionBodyArrow = true` for the former `NextLine`). All in-repo consumers are updated. Behavior and default output are unchanged.

## Evidence

- Build: 0 errors (3 pre-existing unrelated `Metadata.Tests` warnings).
- `StyleOptionCatalogTests` 11/0 (drift guard now balances 9 bool knobs ↔ 9 catalog entries; +1 focused test pins the new descriptor).
- `RenderStyleConfigTests` 41/0; `CSharpMemberLayoutTests` 20/0; `MemberBodyProducerMemberRenderTests` 13/0 (incl. the arrow-wrap render).
- Fast decompiler suite 3669/0.
- `markdownlint` clean.

Follow-on to #3138 / #3160. Adversarial review to follow (public API compatibility change).