### PR TITLE
Record this.-qualification knobs as byte-preserving Applied Taste decisions

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -230,10 +230,12 @@ array element type and rank, by-ref/pointer decoration, generic-parameter slot,
 function-pointer return type / calling convention / parameter ref-kinds, plus the
 full assembly-qualified namespace) so `M(List<int>)` and `M(List<string>)`,
 `M(NsA.Widget)` and `M(NsB.Widget)`, or `M(delegate*<int>)` and
-`M(delegate*<string>)`, stay two rows rather than collapsing into one. The key
-uses generic *arity*, not the specific type arguments, so two instantiations of
-one generic method — `this.G<int>()` and `this.G<string>()` — collapse into a
-single row (they are one source member).
+`M(delegate*<string>)`, stay two rows rather than collapsing into one. For a
+generic method the key uses the DEFINITION signature (its type parameter left as
+`!!0`) plus arity, not the MethodSpec-substituted parameters, so two
+instantiations of one generic method — `this.Echo<int>(1)` and
+`this.Echo<string>("s")` of `Echo<T>(T)` — collapse into a single row (they are
+one source member) even when a parameter mentions the type parameter.
 Qualifications inside a locals-bearing lambda body, which renders through an
 isolated nested printer, are not currently surfaced as taste rows.
 

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -182,9 +182,18 @@ that disambiguates a shadow or type-name collision would appear with the knob of
 too, so it is never attributed to the knob as a taste choice. Recording therefore
 applies only to a genuine instance receiver — a static or extension method whose
 first parameter is spelled `@this` (IL name `this`) reaches the same site but has
-no implicit receiver, so it records nothing. Method qualification is the most
-guarded because a bare method name binds through more rules than a field or
-property; it records a decision only when every one of these holds:
+no implicit receiver, so it records nothing.
+
+All four knobs also require the member to be declared on the **enclosing type at
+its own instantiation** before recording. A base-declared member reached through
+`this` — a field hidden by a `new` field of the same name (whose `base.X` load a
+pre-existing emit gap mis-spells `this.X`, but `this.X` binds to the *derived*
+field), or a merely-inherited field/property/event — is not a byte-preserving
+self-type opt-in, so it records nothing. This uniformly under-records a legitimate
+`this.` on an inherited member; a false-negative is safe, a false-positive is not.
+Method qualification is the most guarded because a bare method name binds through
+more rules than a field or property; it records a decision only when every one of
+these holds:
 
 - **enclosing type at its own instantiation.** The callee's declaring type must
   be the enclosing type at its exact instantiation, not merely the same generic
@@ -207,14 +216,24 @@ property; it records a decision only when every one of these holds:
   before `CSharpNaming.SourceMethodName` strips its `<...>` decoration (a lifted
   local function otherwise arrives spelled as a plain identifier and would slip
   past the check).
+- **not a generic method group.** A method *group* over a generic instance method
+  (`this.Make<int>` bound to a `Func<int>`) is not recorded: `MethodGroupText`
+  renders only the bare name, dropping the type arguments (a pre-existing emit gap
+  the call and `&`-of paths avoid), so the emitted `this.Make` fails delegate
+  return-type inference (CS0411) and does not round-trip. A generic method *call*
+  (`this.Make<int>()`) still records normally.
 
 Same-named overloads are recorded as distinct decisions; the dedup discriminator
-is a structurally complete per-overload key (generic instantiation, array element
-type and rank, by-ref/pointer decoration, generic-parameter slot, function-pointer
-return type / calling convention / parameter ref-kinds, plus the full
-assembly-qualified namespace) so `M(List<int>)` and `M(List<string>)`,
+is a structurally complete per-overload key (generic arity — so `M()` and `M<T>()`
+stay two rows despite sharing an empty parameter list — generic instantiation,
+array element type and rank, by-ref/pointer decoration, generic-parameter slot,
+function-pointer return type / calling convention / parameter ref-kinds, plus the
+full assembly-qualified namespace) so `M(List<int>)` and `M(List<string>)`,
 `M(NsA.Widget)` and `M(NsB.Widget)`, or `M(delegate*<int>)` and
-`M(delegate*<string>)`, stay two rows rather than collapsing into one.
+`M(delegate*<string>)`, stay two rows rather than collapsing into one. The key
+uses generic *arity*, not the specific type arguments, so two instantiations of
+one generic method — `this.G<int>()` and `this.G<string>()` — collapse into a
+single row (they are one source member).
 Qualifications inside a locals-bearing lambda body, which renders through an
 isolated nested printer, are not currently surfaced as taste rows.
 

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -186,13 +186,19 @@ no implicit receiver, so it records nothing. Method qualification is the most
 guarded because a bare method name binds through more rules than a field or
 property; it records a decision only when every one of these holds:
 
-- **same-type callee.** The callee's declaring type must be the enclosing type.
-  A cross-type callee reached here is either an inherited base method (whose
-  bare/`this.` form would rebind — the non-virtual case already renders `base.M`)
-  or an **explicit interface implementation** invoked through `this`, which does
-  not bind via `this.` at all (it requires a cast). Neither is a `this.` opt-in.
-  This deliberately under-records a legitimate `this.BaseMethod()`; a
-  false-negative is safe, a false-positive is not.
+- **enclosing type at its own instantiation.** The callee's declaring type must
+  be the enclosing type at its exact instantiation, not merely the same generic
+  definition. A callee that is not the exact self-type is one of: an inherited
+  base method (whose bare/`this.` form would rebind — the non-virtual case
+  already renders `base.M`); an **explicit interface implementation** invoked
+  through `this`, which does not bind via `this.` at all (it requires a cast); or
+  a **different instantiation** of the enclosing generic type — e.g.
+  `((I<object>)this).M()` from within `I<T>`, where bare/`this.` `M()` binds to
+  `I<T>::M`, not `I<object>::M`, so the qualifier is not byte-preserving.
+  Definition-only equality is too loose for the last case, so the guard reuses
+  the exact-instantiation test the static-call qualifier uses. This deliberately
+  under-records a legitimate `this.BaseMethod()`; a false-negative is safe, a
+  false-positive is not.
 - **not shadowed.** A name shadowed by an in-scope local, parameter, or nested
   lambda binder makes the `this.` mandatory disambiguation, not a choice.
 - **speakable target.** A compiler-generated group target — an unspeakable
@@ -204,11 +210,24 @@ property; it records a decision only when every one of these holds:
 
 Same-named overloads are recorded as distinct decisions; the dedup discriminator
 is a structurally complete per-overload key (generic instantiation, array element
-type and rank, by-ref/pointer decoration, generic-parameter slot, plus the full
-assembly-qualified namespace) so `M(List<int>)` and `M(List<string>)`, or
-`M(NsA.Widget)` and `M(NsB.Widget)`, stay two rows rather than collapsing into
-one. Qualifications inside a locals-bearing lambda body, which renders through an
+type and rank, by-ref/pointer decoration, generic-parameter slot, function-pointer
+return type / calling convention / parameter ref-kinds, plus the full
+assembly-qualified namespace) so `M(List<int>)` and `M(List<string>)`,
+`M(NsA.Widget)` and `M(NsB.Widget)`, or `M(delegate*<int>)` and
+`M(delegate*<string>)`, stay two rows rather than collapsing into one.
+Qualifications inside a locals-bearing lambda body, which renders through an
 isolated nested printer, are not currently surfaced as taste rows.
+
+A method call the compiler lowered and the decompiler did **not** re-sugar — for
+example a `this.GetEnumerator()` left behind when a `foreach` over `this` is not
+raised back to `foreach` syntax — is still recorded when its qualifier is a valid,
+byte-preserving, same-member choice on the rendered lowered code. This is
+consistent with the decompiler rendering *what the IL does*: the row honestly
+annotates the `this.` the knob applied to the faithfully-rendered call, and the
+bare name binds to the same member. It is distinct from the suppressed cases
+above, where the emitted `this.M()` would not compile, would not bind bare, or
+would rebind to a different member. When the pattern *is* raised (the common
+case), no such call is printed and nothing is recorded.
 
 ### Expression-bodied members
 

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -174,6 +174,13 @@ public int Compute() => _count + Extra;          // shipped default: bare
 public int Compute() => this._count + this.Extra; // both knobs on
 ```
 
+When a knob adds `this.`, the printer records a byte-preserving taste decision
+(category `taste`, keyed by the knob's `StyleOptionCatalog` id, e.g.
+`qualify-field-access`) so the CLI **Applied Taste** section reports the opt-in
+spelling. Only knob-attributed qualification is recorded: a mandatory `this.`
+that disambiguates a shadow or type-name collision would appear with the knob off
+too, so it is never attributed to the knob as a taste choice.
+
 ### Expression-bodied members
 
 Rendering a value-returning member as `head => <expr>;` instead of a brace block

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -179,7 +179,16 @@ When a knob adds `this.`, the printer records a byte-preserving taste decision
 `qualify-field-access`) so the CLI **Applied Taste** section reports the opt-in
 spelling. Only knob-attributed qualification is recorded: a mandatory `this.`
 that disambiguates a shadow or type-name collision would appear with the knob off
-too, so it is never attributed to the knob as a taste choice.
+too, so it is never attributed to the knob as a taste choice. Recording therefore
+applies only to a genuine instance receiver — a static or extension method whose
+first parameter is spelled `@this` (IL name `this`) reaches the same site but has
+no implicit receiver, so it records nothing. Method qualification additionally
+skips a name shadowed by an in-scope local, parameter, or nested lambda binder
+(the `this.` is then mandatory) and a compiler-generated group target (an
+unspeakable `<M>b__N` lambda/local-function name, never authored); same-named
+overloads are recorded as distinct decisions. Qualifications inside a
+locals-bearing lambda body, which renders through an isolated nested printer, are
+not currently surfaced as taste rows.
 
 ### Expression-bodied members
 

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -182,13 +182,33 @@ that disambiguates a shadow or type-name collision would appear with the knob of
 too, so it is never attributed to the knob as a taste choice. Recording therefore
 applies only to a genuine instance receiver — a static or extension method whose
 first parameter is spelled `@this` (IL name `this`) reaches the same site but has
-no implicit receiver, so it records nothing. Method qualification additionally
-skips a name shadowed by an in-scope local, parameter, or nested lambda binder
-(the `this.` is then mandatory) and a compiler-generated group target (an
-unspeakable `<M>b__N` lambda/local-function name, never authored); same-named
-overloads are recorded as distinct decisions. Qualifications inside a
-locals-bearing lambda body, which renders through an isolated nested printer, are
-not currently surfaced as taste rows.
+no implicit receiver, so it records nothing. Method qualification is the most
+guarded because a bare method name binds through more rules than a field or
+property; it records a decision only when every one of these holds:
+
+- **same-type callee.** The callee's declaring type must be the enclosing type.
+  A cross-type callee reached here is either an inherited base method (whose
+  bare/`this.` form would rebind — the non-virtual case already renders `base.M`)
+  or an **explicit interface implementation** invoked through `this`, which does
+  not bind via `this.` at all (it requires a cast). Neither is a `this.` opt-in.
+  This deliberately under-records a legitimate `this.BaseMethod()`; a
+  false-negative is safe, a false-positive is not.
+- **not shadowed.** A name shadowed by an in-scope local, parameter, or nested
+  lambda binder makes the `this.` mandatory disambiguation, not a choice.
+- **speakable target.** A compiler-generated group target — an unspeakable
+  `<M>b__N` lambda or `<Outer>g__Local|N_M` local-function name — is never
+  authored. The unspeakable check runs against the **raw** IL metadata name,
+  before `CSharpNaming.SourceMethodName` strips its `<...>` decoration (a lifted
+  local function otherwise arrives spelled as a plain identifier and would slip
+  past the check).
+
+Same-named overloads are recorded as distinct decisions; the dedup discriminator
+is a structurally complete per-overload key (generic instantiation, array element
+type and rank, by-ref/pointer decoration, generic-parameter slot, plus the full
+assembly-qualified namespace) so `M(List<int>)` and `M(List<string>)`, or
+`M(NsA.Widget)` and `M(NsB.Widget)`, stay two rows rather than collapsing into
+one. Qualifications inside a locals-bearing lambda body, which renders through an
+isolated nested printer, are not currently surfaced as taste rows.
 
 ### Expression-bodied members
 

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
@@ -140,4 +140,62 @@ public sealed class ThisQualificationDecisionTests
         Assert.Contains("this._value", result.Output);
         Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-field-access");
     }
+
+    // Two same-named overloads qualified in one body are distinct members, so they
+    // must record two distinct decisions — the callee parameter types keep their
+    // dedup keys apart rather than collapsing them into a single "Overloaded" row.
+    [Fact]
+    public void OverloadedMethodCalls_WhenKnobSet_RecordDistinctDecisionsPerOverload()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.CallOverloads),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.Equal(2, result.Decisions.Count(d => d.RuleId == "qualify-method-access"));
+    }
+
+    // A local delegate shadows the instance method name, so this.ReadField() is
+    // mandatory disambiguation (bare ReadField binds to the delegate). The method
+    // sites lacked the shadow guard the field/property sites have; it must not be
+    // attributed to the qualify-method knob as an opt-in taste choice.
+    [Fact]
+    public void MethodShadowedByLocal_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.MethodShadowedByLocal),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
+
+    // A captured-this lambda is lifted to a compiler-generated instance method and
+    // referenced as a this.-qualified method group over an unspeakable <...>b__N
+    // name. That target is never user-authored, so the knob records no taste
+    // decision — in particular, no decision whose subject is an unspeakable name.
+    [Fact]
+    public void SyntheticMethodGroup_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.CapturedThisOnlyLambda),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.DoesNotContain(
+            result.Decisions,
+            d => d.RuleId == "qualify-method-access" && d.Subject.IndexOf('<') >= 0);
+    }
+
+    // Inside a static extension method whose first parameter is spelled `@this`
+    // (IL name "this"), @this.ReadField() reaches the this-receiver call site, but
+    // the enclosing method has no implicit receiver (HasThis is false), so the
+    // qualify-method knob records no taste decision.
+    [Fact]
+    public void StaticExtensionThisParam_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationSpecimenExtensions).FullName!,
+            nameof(ThisQualificationSpecimenExtensions.CallThroughThisParam),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
@@ -346,6 +346,22 @@ public sealed class ThisQualificationDecisionTests
         Assert.Single(result.Decisions, d => d.RuleId == "qualify-method-access");
     }
 
+    // Two instantiations of a generic method whose PARAMETER mentions T
+    // (Echo<int>(1) and Echo<string>("s") of Echo<T>(T)) are still one source
+    // member. Their callee ParameterTypes are substituted (int vs string), so a
+    // key built from them would split into two rows; keying on the DEFINITION
+    // signature (T as !!0) collapses them into one.
+    [Fact]
+    public void GenericMethodInstantiationsWithTypeParamArg_WhenKnobSet_RecordSingleDedupedDecision()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationGenericParam).FullName!,
+            nameof(ThisQualificationGenericParam.CallTwoInstantiations),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.Single(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
+
     // A method GROUP over a generic instance method (this.Make<int>) drops the type
     // argument in the emitted spelling (a pre-existing MethodGroupText gap). The
     // emitted this.Make fails delegate return-type inference (CS0411), so it is not

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
@@ -276,4 +276,89 @@ public sealed class ThisQualificationDecisionTests
 
         Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-method-access");
     }
+    // A derived type's OWN field (declared on the enclosing type at its own
+    // instantiation) qualified with this. is a genuine byte-preserving opt-in and
+    // records one decision.
+    [Fact]
+    public void OwnField_WithKnobEnabled_RecordsDecision()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationFieldDerived).FullName!,
+            nameof(ThisQualificationFieldDerived.ReadOwnField),
+            new PrinterOptions { QualifyFieldAccess = true });
+
+        Assert.Single(result.Decisions, d => d.RuleId == "qualify-field-access");
+    }
+
+    // A HIDDEN base field read via base.X targets the BASE field, but a pre-existing
+    // emit gap mis-spells it this.X. this.X binds to the DERIVED field, so it is not
+    // byte-preserving. The exact-instantiation guard records nothing.
+    [Fact]
+    public void HiddenBaseField_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationFieldDerived).FullName!,
+            nameof(ThisQualificationFieldDerived.ReadBaseField),
+            new PrinterOptions { QualifyFieldAccess = true });
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-field-access");
+    }
+
+    // A merely-inherited (unhidden) base field is safe to record, but the
+    // exact-instantiation guard uniformly under-records cross-type members. A
+    // false-negative is safe; the important guarantee is no false positive.
+    [Fact]
+    public void InheritedBaseField_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationFieldDerived).FullName!,
+            nameof(ThisQualificationFieldDerived.ReadInheritedField),
+            new PrinterOptions { QualifyFieldAccess = true });
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-field-access");
+    }
+
+    // M() and M<T>() differ only by arity and share an empty parameter list. The
+    // dedup discriminator must fold generic arity in, or the two collapse into one
+    // row and hide a taste application. Qualifying both must record two decisions.
+    [Fact]
+    public void ArityOverloadedMethodCalls_WhenKnobSet_RecordDistinctDecisions()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationArity).FullName!,
+            nameof(ThisQualificationArity.CallBothArities),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.Equal(2, result.Decisions.Count(d => d.RuleId == "qualify-method-access"));
+    }
+
+    // Two instantiations of the SAME generic method (G<int>, G<string>) are one
+    // source member. The discriminator keys on arity, not the specific type
+    // arguments, so both collapse into a single row.
+    [Fact]
+    public void GenericMethodInstantiations_WhenKnobSet_RecordSingleDedupedDecision()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationArity).FullName!,
+            nameof(ThisQualificationArity.CallTwoInstantiations),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.Single(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
+
+    // A method GROUP over a generic instance method (this.Make<int>) drops the type
+    // argument in the emitted spelling (a pre-existing MethodGroupText gap). The
+    // emitted this.Make fails delegate return-type inference (CS0411), so it is not
+    // byte-preserving; recording is suppressed for generic method groups.
+    [Fact]
+    public void GenericMethodGroup_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationGenericGroup).FullName!,
+            nameof(ThisQualificationGenericGroup.Build),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
 }
+

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
@@ -184,6 +184,52 @@ public sealed class ThisQualificationDecisionTests
             d => d.RuleId == "qualify-method-access" && d.Subject.IndexOf('<') >= 0);
     }
 
+    // Two overloads whose signatures differ only by generic type argument
+    // (List<int> vs List<string>) are still distinct members. The dedup
+    // discriminator must be structurally complete: a {Namespace}.{Name} key
+    // renders both parameter types as "System.Collections.Generic.List" and
+    // collapses the two into one row, hiding a real taste application.
+    [Fact]
+    public void GenericOverloadedMethodCalls_WhenKnobSet_RecordDistinctDecisionsPerOverload()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.CallGenericOverloads),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.Equal(2, result.Decisions.Count(d => d.RuleId == "qualify-method-access"));
+    }
+
+    // A local function capturing `this` is lifted to a compiler-generated instance
+    // method with an unspeakable RAW name (<...>g__Local|N_M). It is not a member
+    // and never carries a user `this.`; the knob records nothing. This guards the
+    // raw-name check: SourceMethodName strips the <...> to a bare `Local`, so a
+    // post-sanitization unspeakable check would wrongly record it.
+    [Fact]
+    public void CapturingLocalFunction_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.CallsCapturingLocalFunction),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
+
+    // An explicit interface implementation invoked through this reaches the call
+    // site with the interface as its declaring type (cross-type from the
+    // implementing class). Bare `FaceMethod()`/`this.FaceMethod()` does not bind —
+    // the member requires a cast — so it is never a `this.` opt-in. The cross-type
+    // guard records no taste decision.
+    [Fact]
+    public void ExplicitInterfaceCall_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationExplicitFace).FullName!,
+            nameof(ThisQualificationExplicitFace.CallExplicitInterface),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
+
     // Inside a static extension method whose first parameter is spelled `@this`
     // (IL name "this"), @this.ReadField() reaches the this-receiver call site, but
     // the enclosing method has no implicit receiver (HasThis is false), so the

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
@@ -230,6 +230,38 @@ public sealed class ThisQualificationDecisionTests
         Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-method-access");
     }
 
+    // A constructed generic self-call ((I<object>)this).M() from within I<T> shares
+    // only the DEFINITION with the enclosing type. Bare/this. M() binds to I<T>::M,
+    // not I<object>::M, so the qualifier is not byte-preserving. Definition-only
+    // equality would wrongly record it; the exact-instantiation guard records
+    // nothing.
+    [Fact]
+    public void ConstructedGenericSelfCall_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            typeof(IThisQualificationGeneric<>).FullName!,
+            nameof(IThisQualificationGeneric<object>.CallViaObjectInstantiation),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
+
+    // Two overloads differing only by a function pointer's return type
+    // (delegate*<int, int> vs delegate*<int, void>) are distinct members. The
+    // discriminator must key on the function pointer's return type / calling
+    // convention / parameter ref-kinds, not parameters alone, or the two collapse
+    // into one row and hide a taste application.
+    [Fact]
+    public void FunctionPointerReturnTypeOverloads_WhenKnobSet_RecordDistinctDecisions()
+    {
+        var result = Decompile(
+            typeof(ThisQualificationFnPtr).FullName!,
+            nameof(ThisQualificationFnPtr.CallBoth),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.Equal(2, result.Decisions.Count(d => d.RuleId == "qualify-method-access"));
+    }
+
     // Inside a static extension method whose first parameter is spelled `@this`
     // (IL name "this"), @this.ReadField() reaches the this-receiver call site, but
     // the enclosing method has no implicit receiver (HasThis is false), so the

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
@@ -1,0 +1,143 @@
+using System.Linq;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The recorded evidence for the opt-in <c>this.</c>-qualification knobs
+/// (<see cref="PrinterOptions.QualifyFieldAccess"/> and friends). These are
+/// class-3 spelling choices: byte-preserving (the bare and qualified spellings
+/// emit identical IL), so when a knob adds <c>this.</c> the printer records a
+/// <see cref="DecompilerDecisionCategories.Taste"/> decision the Applied Taste
+/// surface can report. The default (knob-off) render records nothing, and a
+/// mandatory shadow-disambiguation <c>this.</c> — one that would appear with the
+/// knob off too — is never attributed to the knob.
+/// </summary>
+[Trait("Area", "RoundTrip")]
+public sealed class ThisQualificationDecisionTests
+{
+    static string AssemblyPath => typeof(ThisQualificationDecisionTests).Assembly.Location;
+
+    static DecompilerResult Decompile(string typeName, string method, PrinterOptions? options = null)
+    {
+        using var source = MetadataSource.Open(AssemblyPath);
+        var function = IrImporter.Import(source, typeName, method);
+        Assert.NotNull(function);
+        return CSharpPrinter.PrintRaised(
+            function!,
+            importMethodBody: methodRef => IrImporter.Import(source, methodRef),
+            options,
+            source.AreProvablyDisjoint);
+    }
+
+    static DecompilerResult Decompile(string method, PrinterOptions? options = null)
+        => Decompile(typeof(ThisQualificationSpecimen).FullName!, method, options);
+
+    [Fact]
+    public void FieldQualification_WhenKnobSet_RecordsBytePreservingDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.ReadField),
+            new PrinterOptions { QualifyFieldAccess = true });
+
+        var decision = Assert.Single(result.Decisions, d => d.RuleId == "qualify-field-access");
+        Assert.Equal(DecompilerDecisionCategories.Taste, decision.Category);
+        Assert.Equal("_value", decision.OldValue);
+        Assert.Equal("this._value", decision.NewValue);
+    }
+
+    [Fact]
+    public void FieldQualification_Default_RecordsNoDecision()
+    {
+        var result = Decompile(nameof(ThisQualificationSpecimen.ReadField));
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-field-access");
+    }
+
+    [Fact]
+    public void FieldQualification_RepeatedAccess_RecordsSingleDedupedDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.SumFieldTwice),
+            new PrinterOptions { QualifyFieldAccess = true });
+
+        Assert.Single(result.Decisions, d => d.RuleId == "qualify-field-access");
+    }
+
+    [Fact]
+    public void PropertyQualification_WhenKnobSet_RecordsDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.ReadProperty),
+            new PrinterOptions { QualifyPropertyAccess = true });
+
+        var decision = Assert.Single(result.Decisions, d => d.RuleId == "qualify-property-access");
+        Assert.Equal(DecompilerDecisionCategories.Taste, decision.Category);
+    }
+
+    [Fact]
+    public void MethodCallQualification_WhenKnobSet_RecordsDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.CallMethod),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        var decision = Assert.Single(result.Decisions, d => d.RuleId == "qualify-method-access");
+        Assert.Equal(DecompilerDecisionCategories.Taste, decision.Category);
+    }
+
+    [Fact]
+    public void MethodGroupQualification_WhenKnobSet_RecordsDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.MethodGroup),
+            new PrinterOptions { QualifyMethodAccess = true });
+
+        Assert.Single(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
+
+    [Fact]
+    public void EventQualification_WhenKnobSet_RecordsDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.Subscribe),
+            new PrinterOptions { QualifyEventAccess = true });
+
+        var decision = Assert.Single(result.Decisions, d => d.RuleId == "qualify-event-access");
+        Assert.Equal(DecompilerDecisionCategories.Taste, decision.Category);
+    }
+
+    [Fact]
+    public void EventQualification_Default_RecordsNoDecision()
+    {
+        var result = Decompile(nameof(ThisQualificationSpecimen.Subscribe));
+
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-event-access");
+    }
+
+    // The design subtlety: a local shadows the field, so this._value is mandatory
+    // disambiguation the printer emits regardless of the knob. It must never be
+    // attributed to the qualify-field knob as an opt-in taste choice — not by
+    // default, and not even when the knob is also enabled.
+    [Fact]
+    public void MandatoryDisambiguation_Default_RecordsNoDecision()
+    {
+        var result = Decompile(nameof(ThisQualificationSpecimen.ReadShadowedField));
+
+        Assert.Contains("this._value", result.Output);
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-field-access");
+    }
+
+    [Fact]
+    public void MandatoryDisambiguation_WithKnobEnabled_RecordsNoDecision()
+    {
+        var result = Decompile(
+            nameof(ThisQualificationSpecimen.ReadShadowedField),
+            new PrinterOptions { QualifyFieldAccess = true });
+
+        Assert.Contains("this._value", result.Output);
+        Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-field-access");
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -304,6 +304,33 @@ public sealed class ThisQualificationSpecimen
     // Instance method call on the implicit this receiver.
     public int CallMethod() => ReadField() + 1;
 
+    // Two overloads reachable through the implicit this receiver. Qualifying both
+    // must record TWO distinct decisions: their shared display name alone must not
+    // dedup them into one row (the callee parameter types disambiguate the key).
+    public void Overloaded(int x) { }
+    public void Overloaded(string x) { }
+    public void CallOverloads()
+    {
+        this.Overloaded(1);
+        this.Overloaded("a");
+    }
+
+    // A local delegate shadows an instance method name, so the bare call binds to
+    // the delegate and reaching the method REQUIRES this.ReadField(). That this. is
+    // mandatory disambiguation, not the qualify-method knob, so it records no taste
+    // decision even when the knob is enabled.
+    public int MethodShadowedByLocal()
+    {
+        System.Func<int> ReadField = () => 3;
+        return this.ReadField() + ReadField();
+    }
+
+    // A lambda that captures only `this` is lifted to a compiler-generated instance
+    // method and referenced as a method group `this.<...>b__N`. That synthetic
+    // target is unspeakable (never user-authored), so the qualify-method knob
+    // records no taste decision for it.
+    public System.Func<int> CapturedThisOnlyLambda() => () => _value + 1;
+
     // Method group over the implicit this receiver.
     public System.Func<int> MethodGroup() => ReadField;
 
@@ -343,4 +370,15 @@ public sealed class ThisQualificationDerived : ThisQualificationBase
 public static class ThisQualificationExtensions
 {
     public static int Extend(this ThisQualificationDerived value) => 42;
+}
+
+// The extension's first parameter is spelled `@this`, so its IL parameter name is
+// "this" — the same LoadArgument{Index:0, Name:"this"} shape an instance method's
+// implicit receiver produces. But this is a STATIC method with no implicit
+// receiver: a this.-qualified member access inside it is a compile error, never a
+// taste choice, so the qualify-method knob records no decision here.
+public static class ThisQualificationSpecimenExtensions
+{
+    public static int CallThroughThisParam(this ThisQualificationSpecimen @this)
+        => @this.ReadField();
 }

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -429,3 +429,31 @@ public sealed class ThisQualificationExplicitFace : IThisQualificationFace
 
     public int CallExplicitInterface() => ((IThisQualificationFace)this).FaceMethod();
 }
+
+// A constructed generic self-call. From within I<T>, ((I<object>)this).M() emits
+// `callvirt I<object>::M`. I<object> shares I<T>'s DEFINITION but is a DIFFERENT
+// instantiation, so bare/`this.` M() would bind to I<T>::M, not I<object>::M — the
+// qualifier is NOT byte-preserving. Definition-only equality would wrongly treat
+// this as same-type; the exact-instantiation guard records nothing. (`out T` +
+// `class` makes the covariant cast to I<object> legal.)
+public interface IThisQualificationGeneric<out T> where T : class
+{
+    int M() => 1;
+    int CallViaObjectInstantiation() => ((IThisQualificationGeneric<object>)this).M();
+}
+
+// Two overloads whose signatures differ only by a function pointer's RETURN type
+// (delegate*<int, int> vs delegate*<int, void>). The dedup discriminator must key
+// on the function pointer's return type, calling convention, and parameter
+// ref-kinds — not parameters alone — or the two collapse into one row and hide a
+// taste application.
+public unsafe class ThisQualificationFnPtr
+{
+    public void Select(delegate*<int, int> p) { }
+    public void Select(delegate*<int, void> p) { }
+    public void CallBoth(delegate*<int, int> a, delegate*<int, void> b)
+    {
+        this.Select(a);
+        this.Select(b);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -507,6 +507,22 @@ public sealed class ThisQualificationArity
     }
 }
 
+// A generic method whose PARAMETER mentions its type parameter: Echo<T>(T). The
+// callee's ParameterTypes are substituted per MethodSpec (T -> int, T -> string),
+// so a key built from them would split this.Echo<int>(1) and this.Echo<string>("s")
+// into two rows for ONE source member. Keying on the DEFINITION signature (T left
+// as !!0) collapses them into a single row.
+public sealed class ThisQualificationGenericParam
+{
+    public T Echo<T>(T value) => value;
+
+    public void CallTwoInstantiations()
+    {
+        this.Echo<int>(1);
+        this.Echo<string>("s");
+    }
+}
+
 // A method GROUP over a generic instance method (this.Make<int> as a Func<int>).
 // MethodGroupText renders only the bare name, dropping the <int> (a pre-existing
 // emit gap; the group path never appends type arguments the way call and &-of

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -289,6 +289,16 @@ public sealed class ThisQualificationSpecimen
 
     public int ReadField() => _value;
 
+    // Reads the field twice: with the qualify-field knob on, both accesses emit
+    // this._value, but AddDecision dedups them into a single recorded decision.
+    public int SumFieldTwice() => _value + _value;
+
+    // A parameter shadows the field, so the bare name binds to the parameter and
+    // reaching the field REQUIRES this._value. That this. is mandatory
+    // disambiguation, not the qualify-field knob, so it records no taste decision
+    // even when the knob is enabled.
+    public int ReadShadowedField(int _value) => this._value + _value;
+
     public int ReadProperty() => Count;
 
     // Instance method call on the implicit this receiver.

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -457,3 +457,64 @@ public unsafe class ThisQualificationFnPtr
         this.Select(b);
     }
 }
+
+// A derived type that HIDES a base field with a `new` field of the same name, so
+// the class holds two distinct `X` fields. ReadOwnField reads the derived field
+// (declaring type == the enclosing type) and is a genuine this. opt-in. But
+// ReadBaseField reads base.X — the load targets the BASE field
+// (ldarg.0; ldfld Base::X). A pre-existing emit gap mis-spells that as this.X,
+// yet this.X binds to the DERIVED field, not base.X, so it is NOT byte-preserving
+// and must record nothing. ReadInheritedField reads a merely-inherited (unhidden)
+// base field; its this. is safe but the exact-instantiation guard under-records it
+// (a false-negative is safe).
+public class ThisQualificationFieldBase
+{
+    public int Hidden;
+    public int Inherited;
+}
+
+public sealed class ThisQualificationFieldDerived : ThisQualificationFieldBase
+{
+    public new int Hidden;
+
+    public int ReadOwnField() => Hidden;
+    public int ReadBaseField() => base.Hidden;
+    public int ReadInheritedField() => Inherited;
+}
+
+// Two overloads that differ only by ARITY: M() and M<T>() share an empty parameter
+// list, so a parameter-types-only dedup key collapses them into one row and hides
+// a taste application. Qualifying both must record TWO decisions. CallTwoInstantiations
+// qualifies the SAME generic method at two different instantiations (G<int>, G<string>);
+// those are one source member and must collapse into ONE row (arity, not the specific
+// type arguments, is the key).
+public sealed class ThisQualificationArity
+{
+    public void M() { }
+    public void M<T>() { }
+    public void G<T>() { }
+
+    public void CallBothArities()
+    {
+        this.M();
+        this.M<int>();
+    }
+
+    public void CallTwoInstantiations()
+    {
+        this.G<int>();
+        this.G<string>();
+    }
+}
+
+// A method GROUP over a generic instance method (this.Make<int> as a Func<int>).
+// MethodGroupText renders only the bare name, dropping the <int> (a pre-existing
+// emit gap; the group path never appends type arguments the way call and &-of
+// paths do). The emitted this.Make does not round-trip — delegate return-type
+// inference cannot recover T (CS0411) — so it must record nothing.
+public sealed class ThisQualificationGenericGroup
+{
+    public T Make<T>() => default!;
+
+    public System.Func<int> Build() => this.Make<int>;
+}

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -315,6 +315,33 @@ public sealed class ThisQualificationSpecimen
         this.Overloaded("a");
     }
 
+    // Two overloads whose signatures differ ONLY by generic type argument
+    // (List<int> vs List<string>). The dedup discriminator must distinguish them
+    // structurally: a name-only or {Namespace}.{Name} key renders both parameter
+    // types as the same "System.Collections.Generic.List", collapsing two genuine
+    // taste applications into one row and HIDING one. Qualifying both must record
+    // TWO distinct decisions.
+    public void GenericOverloaded(System.Collections.Generic.List<int> x) { }
+    public void GenericOverloaded(System.Collections.Generic.List<string> x) { }
+    public void CallGenericOverloads()
+    {
+        this.GenericOverloaded(new System.Collections.Generic.List<int>());
+        this.GenericOverloaded(new System.Collections.Generic.List<string>());
+    }
+
+    // A local function that captures `this` (reads _value) is lifted to a
+    // compiler-generated instance method whose RAW metadata name is
+    // <CallsCapturingLocalFunction>g__Local|N_M — unspeakable, and never a member
+    // you can write `this.` in front of. The knob must record nothing. The
+    // unspeakable check must run against the raw name: CSharpNaming.SourceMethodName
+    // strips the <...> to a bare `Local`, which would slip past a post-sanitization
+    // check.
+    public int CallsCapturingLocalFunction()
+    {
+        int Local() => _value + 1;
+        return Local();
+    }
+
     // A local delegate shadows an instance method name, so the bare call binds to
     // the delegate and reaching the method REQUIRES this.ReadField(). That this. is
     // mandatory disambiguation, not the qualify-method knob, so it records no taste
@@ -381,4 +408,24 @@ public static class ThisQualificationSpecimenExtensions
 {
     public static int CallThroughThisParam(this ThisQualificationSpecimen @this)
         => @this.ReadField();
+}
+
+// An explicit interface implementation: `int IThisQualificationFace.FaceMethod()`
+// can ONLY be reached through a cast (((IThisQualificationFace)this).FaceMethod()),
+// never through a bare `FaceMethod()` or `this.FaceMethod()` — the member does not
+// bind unqualified. csc emits `callvirt IThisQualificationFace::FaceMethod` on the
+// this receiver, whose declaring type is the interface (cross-type from the
+// implementing class). The qualify-method knob must record no taste decision: a
+// cross-type callee is never a `this.` opt-in. (The printer's pre-existing emit
+// still mis-spells this as this.FaceMethod(); only the false RECORD is suppressed.)
+public interface IThisQualificationFace
+{
+    int FaceMethod();
+}
+
+public sealed class ThisQualificationExplicitFace : IThisQualificationFace
+{
+    int IThisQualificationFace.FaceMethod() => 7;
+
+    public int CallExplicitInterface() => ((IThisQualificationFace)this).FaceMethod();
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -75,16 +75,22 @@ public sealed partial class CSharpPrinter
         TypeRef declaringType,
         ImmutableArray<TypeRef> parameterTypes)
     {
-        // Only a same-type instance-method call is a byte-preserving `this.` taste
-        // choice. A cross-type callee reached here is either an inherited base
-        // method (the non-virtual case already rendered base.M above; the virtual
-        // case would rebind under this./bare) or an explicit interface
-        // implementation invoked through this — which does not bind via `this.` at
-        // all and is only mis-rendered as this.M by a pre-existing emit gap.
-        // Neither is a user opt-in, so record nothing. This deliberately
-        // under-records a legitimate this.BaseMethod(); a false-negative is safe, a
+        // Only a call to the enclosing type AT ITS OWN INSTANTIATION is a
+        // byte-preserving `this.` taste choice. A callee reached here that is not
+        // the exact self-type is one of:
+        //  * an inherited base method (the non-virtual case already rendered
+        //    base.M above; the virtual case would rebind under this./bare);
+        //  * an explicit interface implementation invoked through this — which
+        //    does not bind via `this.` at all (it requires a cast) and is only
+        //    mis-rendered as this.M by a pre-existing emit gap;
+        //  * a DIFFERENT instantiation of the enclosing generic type, e.g.
+        //    ((I<object>)this).M() from within I<T> — bare/`this.` M() binds to
+        //    I<T>::M, not I<object>::M, so the qualifier is not byte-preserving.
+        // Definition-only equality (IsCrossType) is too loose for the last case,
+        // so gate on the exact-instantiation test. This deliberately under-records
+        // a legitimate this.BaseMethod(); a false-negative is safe, a
         // false-positive is not.
-        if (IsCrossType(declaringType))
+        if (!IsEnclosingTypeAtOwnInstantiation(declaringType))
             return;
         if (IsStaticCallNameShadowed(displayName) || IsUnspeakableName(rawName))
             return;
@@ -126,10 +132,23 @@ public sealed partial class CSharpPrinter
         TypeRefKind.Pinned => $"pinned {TypeKey(type.ElementType!)}",
         TypeRefKind.GenericParameter => $"!{type.GenericParameterIndex}",
         TypeRefKind.MethodGenericParameter => $"!!{type.GenericParameterIndex}",
-        TypeRefKind.FunctionPointer =>
-            $"fnptr({string.Join(",", type.TypeArguments.Select(TypeKey))})",
+        TypeRefKind.FunctionPointer => FunctionPointerKey(type),
         _ => $"{type.Assembly}:{type.Namespace}.{type.Name}",
     };
+
+    // A function-pointer type's identity includes its calling convention, return
+    // type, and each parameter's ref-kind and type — all part of overload identity.
+    // Keying on parameter types alone would collapse delegate*<int, void> vs
+    // delegate*<int, int>, or a managed vs unmanaged pointer, into one row.
+    static string FunctionPointerKey(TypeRef type)
+    {
+        var refKinds = type.FunctionPointerParameterRefKinds;
+        string parameters = string.Join(
+            ",",
+            type.TypeArguments.Select((p, i) =>
+                $"{(i < refKinds.Length ? refKinds[i].ToString() : "None")} {TypeKey(p)}"));
+        return $"fnptr[{type.CallingConvention}]({parameters})->{TypeKey(type.ElementType!)}";
+    }
 
     string FieldTarget(FieldRef field, IrExpression? instance)
     {
@@ -319,15 +338,20 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// True when a static-call target is the current type at its own
-    /// instantiation: the same non-generic type, or the enclosing generic type
-    /// instantiated with its own generic parameters in order
-    /// (<c>C&lt;T0, T1, …&gt;</c>). A different instantiation (<c>C&lt;string&gt;</c>)
-    /// or a method-type-parameter instantiation (<c>C&lt;!!0&gt;</c>) is a distinct
-    /// type whose static member must stay qualified — an unqualified call would
-    /// rebind to the enclosing instantiation and change which method runs.
+    /// True when a call target is the enclosing type at its OWN instantiation: the
+    /// same non-generic type, or the enclosing generic type instantiated with its
+    /// own generic parameters in order (<c>C&lt;T0, T1, …&gt;</c>). A different
+    /// instantiation (<c>C&lt;string&gt;</c>) or a method-type-parameter
+    /// instantiation (<c>C&lt;!!0&gt;</c>) is a DISTINCT type sharing only the
+    /// definition. Two spelling paths depend on the exact-instantiation test: a
+    /// static call must stay type-qualified (an unqualified call would rebind to
+    /// the enclosing instantiation and change which method runs), and a
+    /// this-qualification taste decision must not be recorded (bare/`this.` would
+    /// rebind to the enclosing instantiation, so the qualifier is not
+    /// byte-preserving). Definition equality alone (see <see cref="IsCrossType"/>)
+    /// is too loose for both.
     /// </summary>
-    bool IsCurrentStaticScope(TypeRef calleeDeclaringType)
+    bool IsEnclosingTypeAtOwnInstantiation(TypeRef calleeDeclaringType)
     {
         var scope = _function.DeclaringType;
         var scopeDefinition = scope is { Kind: TypeRefKind.GenericInstance, ElementType: { } sd } ? sd : scope;
@@ -497,7 +521,7 @@ public sealed partial class CSharpPrinter
             string sourceName = CSharpNaming.SourceMethodName(call.Callee.Name);
             string staticName = $"{sourceName}{typeArguments}";
             string staticArgs = Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
-            return IsCurrentStaticScope(call.Callee.DeclaringType) && !IsStaticCallNameShadowed(sourceName)
+            return IsEnclosingTypeAtOwnInstantiation(call.Callee.DeclaringType) && !IsStaticCallNameShadowed(sourceName)
                 ? $"{staticName}({staticArgs})"
                 : $"{TypeQualifierText(call.Callee.DeclaringType)}.{staticName}({staticArgs})";
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -73,6 +73,7 @@ public sealed partial class CSharpPrinter
         string displayName,
         string rawName,
         TypeRef declaringType,
+        int genericArity,
         ImmutableArray<TypeRef> parameterTypes)
     {
         // Only a call to the enclosing type AT ITS OWN INSTANTIATION is a
@@ -95,7 +96,7 @@ public sealed partial class CSharpPrinter
         if (IsStaticCallNameShadowed(displayName) || IsUnspeakableName(rawName))
             return;
         RecordThisQualificationDecision(
-            QualifyMethodOption, displayName, displayName, MethodOverloadDiscriminator(parameterTypes));
+            QualifyMethodOption, displayName, displayName, MethodOverloadDiscriminator(genericArity, parameterTypes));
     }
 
     // Compiler-generated members (captured-this lambdas, local-function group
@@ -110,16 +111,19 @@ public sealed partial class CSharpPrinter
     // A stable, structurally-complete per-overload key. Overloads share a display
     // name, so the decision subject alone would dedup two distinct methods into
     // one row. The key must distinguish every element the runtime treats as part
-    // of an overload's signature — generic instantiation (List<int> vs
-    // List<string>), array element type and rank, by-ref/pointer decoration, and
-    // generic-parameter slot — and must keep the full namespace + assembly
-    // (ToDisplayString strips the namespace, so it would collapse NsA.Widget and
-    // NsB.Widget). Under-distinguishing would merge distinct overloads and HIDE a
-    // real taste application, so this errs toward more distinctions, never fewer.
-    static string MethodOverloadDiscriminator(ImmutableArray<TypeRef> parameterTypes)
-        => parameterTypes.IsDefaultOrEmpty
-            ? ""
-            : string.Join(",", parameterTypes.Select(TypeKey));
+    // of an overload's signature — generic ARITY (M() vs M<T>() are distinct
+    // overloads with identical empty parameter lists), generic instantiation
+    // (List<int> vs List<string>), array element type and rank, by-ref/pointer
+    // decoration, and generic-parameter slot — and must keep the full namespace +
+    // assembly (ToDisplayString strips the namespace, so it would collapse
+    // NsA.Widget and NsB.Widget). Under-distinguishing would merge distinct
+    // overloads and HIDE a real taste application, so this errs toward more
+    // distinctions, never fewer. Arity (not the specific type arguments) keeps two
+    // instantiations of one generic method — this.M<int>() and this.M<string>() —
+    // in a single row, which is one member.
+    static string MethodOverloadDiscriminator(int genericArity, ImmutableArray<TypeRef> parameterTypes)
+        => $"`{genericArity}`:"
+            + (parameterTypes.IsDefaultOrEmpty ? "" : string.Join(",", parameterTypes.Select(TypeKey)));
 
     static string TypeKey(TypeRef type) => type.Kind switch
     {
@@ -207,7 +211,14 @@ public sealed partial class CSharpPrinter
         bool mandatory = QualifyThisMember(field.Name, field.Type);
         if (!_options.QualifyFieldAccess && !mandatory)
             return fieldName;
-        if (_options.QualifyFieldAccess && !mandatory)
+        // Record only a byte-preserving opt-in: the field must be declared on the
+        // enclosing type at its own instantiation. A base-declared field that is
+        // hidden by a `new` field of the same name reaches here spelled this.X (a
+        // pre-existing emit gap — the load targets base.X), but this.X binds to the
+        // DERIVED field, so recording it as byte-preserving would be a false
+        // positive. Gating on the exact-instantiation test also under-records a
+        // legitimate this. on a merely-inherited field; a false-negative is safe.
+        if (_options.QualifyFieldAccess && !mandatory && IsEnclosingTypeAtOwnInstantiation(field.DeclaringType))
             RecordThisQualificationDecision(QualifyFieldOption, field.Name, fieldName);
         return $"this.{fieldName}";
     }
@@ -272,7 +283,13 @@ public sealed partial class CSharpPrinter
         if (instance is not null && indexArguments.Count > 0)
             return $"{(receiver.Length == 0 ? "this" : receiver)}[{Arguments(indexArguments)}]";
         string escapedName = CSharpNaming.EscapeIdentifier(name);
-        if (thisQualifiedByKnob)
+        // Same byte-preserving gate as the field and method sites: a property or
+        // event declared on a base type (hidden or inherited) reached through this.
+        // is not a self-type opt-in, so it must not record. A virtual inherited
+        // accessor binds identically under this./bare and would be safe, but the
+        // exact-instantiation test uniformly under-records the cross-type cases; a
+        // false-negative is safe, a false-positive is not.
+        if (thisQualifiedByKnob && IsEnclosingTypeAtOwnInstantiation(accessor.DeclaringType))
             RecordThisQualificationDecision(isEvent ? QualifyEventOption : QualifyPropertyOption, name, escapedName);
         string dotted = receiver.Length == 0 ? escapedName : $"{receiver}.{escapedName}";
         return indexArguments.Count == 0 ? dotted : $"{dotted}[{Arguments(indexArguments)}]";
@@ -434,7 +451,16 @@ public sealed partial class CSharpPrinter
                 return $"base.{name}";
             if (_options.QualifyMethodAccess)
             {
-                RecordMethodQualificationIfTaste(name, method.Name, method.DeclaringType, method.ParameterTypes);
+                // A generic method GROUP (this.Make<int>) is deliberately not
+                // recorded: MethodGroupText renders only the bare name, dropping
+                // the type arguments (a pre-existing emit gap; AddressOfMethodText
+                // and CallText append them, this path does not). The emitted
+                // this.Make does not round-trip — delegate return-type inference
+                // cannot recover the type argument (CS0411) — so recording it as a
+                // byte-preserving opt-in would be a false positive. Suppressing is
+                // a safe under-record; fixing the emit is out of scope here.
+                if (method.TypeArguments.IsDefaultOrEmpty)
+                    RecordMethodQualificationIfTaste(name, method.Name, method.DeclaringType, 0, method.ParameterTypes);
                 return $"this.{name}";
             }
             return name;
@@ -551,7 +577,7 @@ public sealed partial class CSharpPrinter
             if (_options.QualifyMethodAccess)
             {
                 RecordMethodQualificationIfTaste(
-                    thisMethodName, call.Callee.Name, call.Callee.DeclaringType, call.Callee.ParameterTypes);
+                    thisMethodName, call.Callee.Name, call.Callee.DeclaringType, call.Callee.TypeArguments.Length, call.Callee.ParameterTypes);
                 return $"this.{thisMethodName}{typeArguments}({rest})";
             }
             return $"{thisMethodName}{typeArguments}({rest})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -74,7 +74,8 @@ public sealed partial class CSharpPrinter
         string rawName,
         TypeRef declaringType,
         int genericArity,
-        ImmutableArray<TypeRef> parameterTypes)
+        ImmutableArray<TypeRef> parameterTypes,
+        ImmutableArray<TypeRef> definitionParameterTypes = default)
     {
         // Only a call to the enclosing type AT ITS OWN INSTANTIATION is a
         // byte-preserving `this.` taste choice. A callee reached here that is not
@@ -95,8 +96,17 @@ public sealed partial class CSharpPrinter
             return;
         if (IsStaticCallNameShadowed(displayName) || IsUnspeakableName(rawName))
             return;
+        // A generic method call's ParameterTypes are already substituted against
+        // its MethodSpec (T -> int), so this.G<int>(x) and this.G<string>(x) of one
+        // G<T>(T) would key apart and record TWO rows for a single source member.
+        // Key on the DEFINITION signature (T left as !!0) so all instantiations of
+        // one method collapse into one row, while distinct non-generic overloads
+        // M(List<int>)/M(List<string>) still key apart on their concrete types.
+        var keyParameterTypes = genericArity > 0 && !definitionParameterTypes.IsDefaultOrEmpty
+            ? definitionParameterTypes
+            : parameterTypes;
         RecordThisQualificationDecision(
-            QualifyMethodOption, displayName, displayName, MethodOverloadDiscriminator(genericArity, parameterTypes));
+            QualifyMethodOption, displayName, displayName, MethodOverloadDiscriminator(genericArity, keyParameterTypes));
     }
 
     // Compiler-generated members (captured-this lambdas, local-function group
@@ -118,9 +128,10 @@ public sealed partial class CSharpPrinter
     // assembly (ToDisplayString strips the namespace, so it would collapse
     // NsA.Widget and NsB.Widget). Under-distinguishing would merge distinct
     // overloads and HIDE a real taste application, so this errs toward more
-    // distinctions, never fewer. Arity (not the specific type arguments) keeps two
-    // instantiations of one generic method — this.M<int>() and this.M<string>() —
-    // in a single row, which is one member.
+    // distinctions, never fewer. For a generic method the caller passes the
+    // DEFINITION parameter types (T as !!0), so the two instantiations
+    // this.M<int>() and this.M<string>() key identically and stay one row (one
+    // source member) even when a parameter mentions T.
     static string MethodOverloadDiscriminator(int genericArity, ImmutableArray<TypeRef> parameterTypes)
         => $"`{genericArity}`:"
             + (parameterTypes.IsDefaultOrEmpty ? "" : string.Join(",", parameterTypes.Select(TypeKey)));
@@ -577,7 +588,7 @@ public sealed partial class CSharpPrinter
             if (_options.QualifyMethodAccess)
             {
                 RecordMethodQualificationIfTaste(
-                    thisMethodName, call.Callee.Name, call.Callee.DeclaringType, call.Callee.TypeArguments.Length, call.Callee.ParameterTypes);
+                    thisMethodName, call.Callee.Name, call.Callee.DeclaringType, call.Callee.TypeArguments.Length, call.Callee.ParameterTypes, call.Callee.DefinitionParameterTypes);
                 return $"this.{thisMethodName}{typeArguments}({rest})";
             }
             return $"{thisMethodName}{typeArguments}({rest})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -22,10 +22,20 @@ public sealed partial class CSharpPrinter
     // Taste surface can report. Only the knob-attributed path calls this (the knob
     // is enabled AND the bare name already binds); a mandatory disambiguation
     // this. — one that would appear with the knob off too — is never recorded as a
-    // taste choice. AddDecision dedups on the full row, so repeated accesses to
-    // the same member collapse to a single decision.
-    void RecordThisQualificationDecision(StyleOptionDescriptor knob, string memberName, string bareName)
-        => AddDecision(
+    // taste choice. AddDecision dedups on the full row (plus dedupDiscriminator, so
+    // two same-named overloads stay distinct), so repeated accesses to one member
+    // collapse to a single decision.
+    void RecordThisQualificationDecision(StyleOptionDescriptor knob, string memberName, string bareName, string? dedupDiscriminator = null)
+    {
+        // A this. qualifier is only a byte-preserving taste choice when there is a
+        // genuine instance receiver. A static or extension method whose first
+        // parameter is spelled `this` (its IL parameter name is "this") reaches
+        // these sites as a LoadArgument{Index:0, Name:"this"}, but that is an
+        // explicit parameter, not an implicit receiver: qualifying it with this.
+        // would be a compile error, never an opt-in spelling, so record nothing.
+        if (!_function.Signature.HasThis)
+            return;
+        AddDecision(
             knob.Id,
             DecompilerDecisionCategories.Taste,
             memberName,
@@ -33,7 +43,43 @@ public sealed partial class CSharpPrinter
                 + "Byte-preserving: the bare name already binds to the member, so the "
                 + "qualifier is an opt-in spelling choice, not disambiguation.",
             oldValue: bareName,
-            newValue: $"this.{bareName}");
+            newValue: $"this.{bareName}",
+            dedupDiscriminator: dedupDiscriminator);
+    }
+
+    // A method this. qualifier is a recordable byte-preserving taste choice only
+    // when it is a genuine, user-authored opt-in — the method analogue of the
+    // QualifyThisMember guard the field/property/event sites already apply:
+    //  * the bare name must still bind to the method. IsStaticCallNameShadowed is
+    //    the scope-aware shadow check (it counts the enclosing method's locals and
+    //    parameters plus every nested lambda / local-function binder in scope), so
+    //    when a same-named binder would capture the bare call the this. is
+    //    mandatory disambiguation, not a choice, and records nothing;
+    //  * the target must be a speakable source method. A compiler-generated lambda
+    //    or local-function group target (an unspeakable <M>b__0-style name) is
+    //    never user-authored, so its this. is never a taste choice.
+    // The genuine-instance-receiver requirement is enforced by
+    // RecordThisQualificationDecision. Overloads share a name, so the callee
+    // parameter types disambiguate the dedup key.
+    void RecordMethodQualificationIfTaste(string name, ImmutableArray<TypeRef> parameterTypes)
+    {
+        if (IsStaticCallNameShadowed(name) || IsUnspeakableName(name))
+            return;
+        RecordThisQualificationDecision(QualifyMethodOption, name, name, MethodOverloadDiscriminator(parameterTypes));
+    }
+
+    // Compiler-generated members (captured-this lambdas, local-function group
+    // targets) carry unspeakable names bracketed with angle brackets, which a
+    // source identifier can never contain.
+    static bool IsUnspeakableName(string name)
+        => name.IndexOf('<') >= 0 || name.IndexOf('>') >= 0;
+
+    // A stable, side-effect-free per-overload key: overloads share a display name,
+    // so the decision subject alone would dedup two distinct methods into one row.
+    static string MethodOverloadDiscriminator(ImmutableArray<TypeRef> parameterTypes)
+        => parameterTypes.IsDefaultOrEmpty
+            ? ""
+            : string.Join(",", parameterTypes.Select(t => $"{t.Namespace}.{t.Name}"));
 
     string FieldTarget(FieldRef field, IrExpression? instance)
     {
@@ -314,7 +360,7 @@ public sealed partial class CSharpPrinter
                 return $"base.{name}";
             if (_options.QualifyMethodAccess)
             {
-                RecordThisQualificationDecision(QualifyMethodOption, name, name);
+                RecordMethodQualificationIfTaste(name, method.ParameterTypes);
                 return $"this.{name}";
             }
             return name;
@@ -430,7 +476,7 @@ public sealed partial class CSharpPrinter
                 return $"base.{thisMethodName}{typeArguments}({rest})";
             if (_options.QualifyMethodAccess)
             {
-                RecordThisQualificationDecision(QualifyMethodOption, thisMethodName, thisMethodName);
+                RecordMethodQualificationIfTaste(thisMethodName, call.Callee.ParameterTypes);
                 return $"this.{thisMethodName}{typeArguments}({rest})";
             }
             return $"{thisMethodName}{typeArguments}({rest})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -61,25 +61,75 @@ public sealed partial class CSharpPrinter
     // The genuine-instance-receiver requirement is enforced by
     // RecordThisQualificationDecision. Overloads share a name, so the callee
     // parameter types disambiguate the dedup key.
-    void RecordMethodQualificationIfTaste(string name, ImmutableArray<TypeRef> parameterTypes)
+    //  * displayName is the escaped C# spelling (post CSharpNaming.SourceMethodName)
+    //    used for the shadow check and the recorded row;
+    //  * rawName is the unsanitized IL metadata name, checked for unspeakability
+    //    BEFORE SourceMethodName strips its <...> decoration (otherwise a lifted
+    //    local function arrives already spelled as a plain identifier and slips
+    //    past the check);
+    //  * declaringType gates same-type membership: only a call whose callee is
+    //    declared on the enclosing type is a `this.` opt-in (see below).
+    void RecordMethodQualificationIfTaste(
+        string displayName,
+        string rawName,
+        TypeRef declaringType,
+        ImmutableArray<TypeRef> parameterTypes)
     {
-        if (IsStaticCallNameShadowed(name) || IsUnspeakableName(name))
+        // Only a same-type instance-method call is a byte-preserving `this.` taste
+        // choice. A cross-type callee reached here is either an inherited base
+        // method (the non-virtual case already rendered base.M above; the virtual
+        // case would rebind under this./bare) or an explicit interface
+        // implementation invoked through this — which does not bind via `this.` at
+        // all and is only mis-rendered as this.M by a pre-existing emit gap.
+        // Neither is a user opt-in, so record nothing. This deliberately
+        // under-records a legitimate this.BaseMethod(); a false-negative is safe, a
+        // false-positive is not.
+        if (IsCrossType(declaringType))
             return;
-        RecordThisQualificationDecision(QualifyMethodOption, name, name, MethodOverloadDiscriminator(parameterTypes));
+        if (IsStaticCallNameShadowed(displayName) || IsUnspeakableName(rawName))
+            return;
+        RecordThisQualificationDecision(
+            QualifyMethodOption, displayName, displayName, MethodOverloadDiscriminator(parameterTypes));
     }
 
     // Compiler-generated members (captured-this lambdas, local-function group
     // targets) carry unspeakable names bracketed with angle brackets, which a
-    // source identifier can never contain.
+    // source identifier can never contain. Feed this the RAW metadata name: a
+    // lifted local function's <Outer>g__Local|0_0 keeps its brackets there, but
+    // CSharpNaming.SourceMethodName has already stripped them from the display
+    // name.
     static bool IsUnspeakableName(string name)
         => name.IndexOf('<') >= 0 || name.IndexOf('>') >= 0;
 
-    // A stable, side-effect-free per-overload key: overloads share a display name,
-    // so the decision subject alone would dedup two distinct methods into one row.
+    // A stable, structurally-complete per-overload key. Overloads share a display
+    // name, so the decision subject alone would dedup two distinct methods into
+    // one row. The key must distinguish every element the runtime treats as part
+    // of an overload's signature — generic instantiation (List<int> vs
+    // List<string>), array element type and rank, by-ref/pointer decoration, and
+    // generic-parameter slot — and must keep the full namespace + assembly
+    // (ToDisplayString strips the namespace, so it would collapse NsA.Widget and
+    // NsB.Widget). Under-distinguishing would merge distinct overloads and HIDE a
+    // real taste application, so this errs toward more distinctions, never fewer.
     static string MethodOverloadDiscriminator(ImmutableArray<TypeRef> parameterTypes)
         => parameterTypes.IsDefaultOrEmpty
             ? ""
-            : string.Join(",", parameterTypes.Select(t => $"{t.Namespace}.{t.Name}"));
+            : string.Join(",", parameterTypes.Select(TypeKey));
+
+    static string TypeKey(TypeRef type) => type.Kind switch
+    {
+        TypeRefKind.GenericInstance =>
+            $"{TypeKey(type.ElementType!)}<{string.Join(",", type.TypeArguments.Select(TypeKey))}>",
+        TypeRefKind.SzArray => $"{TypeKey(type.ElementType!)}[]",
+        TypeRefKind.Array => $"{TypeKey(type.ElementType!)}[{type.Rank}]",
+        TypeRefKind.ByRef => $"ref {TypeKey(type.ElementType!)}",
+        TypeRefKind.Pointer => $"{TypeKey(type.ElementType!)}*",
+        TypeRefKind.Pinned => $"pinned {TypeKey(type.ElementType!)}",
+        TypeRefKind.GenericParameter => $"!{type.GenericParameterIndex}",
+        TypeRefKind.MethodGenericParameter => $"!!{type.GenericParameterIndex}",
+        TypeRefKind.FunctionPointer =>
+            $"fnptr({string.Join(",", type.TypeArguments.Select(TypeKey))})",
+        _ => $"{type.Assembly}:{type.Namespace}.{type.Name}",
+    };
 
     string FieldTarget(FieldRef field, IrExpression? instance)
     {
@@ -360,7 +410,7 @@ public sealed partial class CSharpPrinter
                 return $"base.{name}";
             if (_options.QualifyMethodAccess)
             {
-                RecordMethodQualificationIfTaste(name, method.ParameterTypes);
+                RecordMethodQualificationIfTaste(name, method.Name, method.DeclaringType, method.ParameterTypes);
                 return $"this.{name}";
             }
             return name;
@@ -476,7 +526,8 @@ public sealed partial class CSharpPrinter
                 return $"base.{thisMethodName}{typeArguments}({rest})";
             if (_options.QualifyMethodAccess)
             {
-                RecordMethodQualificationIfTaste(thisMethodName, call.Callee.ParameterTypes);
+                RecordMethodQualificationIfTaste(
+                    thisMethodName, call.Callee.Name, call.Callee.DeclaringType, call.Callee.ParameterTypes);
                 return $"this.{thisMethodName}{typeArguments}({rest})";
             }
             return $"{thisMethodName}{typeArguments}({rest})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -5,6 +5,36 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <summary>Rendering helpers for member access, calls, and call arguments.</summary>
 public sealed partial class CSharpPrinter
 {
+    // The library-owned catalog descriptors for the four this.-qualification
+    // knobs. Sourcing identity and config key from StyleOptionCatalog (#3160)
+    // keeps the recorded decision's RuleId and prose in lockstep with the single
+    // source of truth: a knob rename fails here at type init rather than drifting.
+    static readonly StyleOptionDescriptor QualifyFieldOption = QualificationKnob("qualify-field-access");
+    static readonly StyleOptionDescriptor QualifyPropertyOption = QualificationKnob("qualify-property-access");
+    static readonly StyleOptionDescriptor QualifyMethodOption = QualificationKnob("qualify-method-access");
+    static readonly StyleOptionDescriptor QualifyEventOption = QualificationKnob("qualify-event-access");
+
+    static StyleOptionDescriptor QualificationKnob(string id)
+        => StyleOptionCatalog.Options.Single(o => o.Id == id);
+
+    // A this.-qualification KNOB (not mandatory shadow disambiguation) added the
+    // this. qualifier, so record a byte-preserving taste decision the Applied
+    // Taste surface can report. Only the knob-attributed path calls this (the knob
+    // is enabled AND the bare name already binds); a mandatory disambiguation
+    // this. — one that would appear with the knob off too — is never recorded as a
+    // taste choice. AddDecision dedups on the full row, so repeated accesses to
+    // the same member collapse to a single decision.
+    void RecordThisQualificationDecision(StyleOptionDescriptor knob, string memberName, string bareName)
+        => AddDecision(
+            knob.Id,
+            DecompilerDecisionCategories.Taste,
+            memberName,
+            $"Qualified instance member '{memberName}' with 'this.' ({knob.ConfigKey}). "
+                + "Byte-preserving: the bare name already binds to the member, so the "
+                + "qualifier is an opt-in spelling choice, not disambiguation.",
+            oldValue: bareName,
+            newValue: $"this.{bareName}");
+
     string FieldTarget(FieldRef field, IrExpression? instance)
     {
         if (PointerMemberReceiver(instance) is { } pointerReceiver)
@@ -48,9 +78,23 @@ public sealed partial class CSharpPrinter
             // bare name binds to it, not the field (e.g. int Foo(int _x) =>
             // this._x + _x). Qualify with this. to reach the field; an
             // unshadowed instance field stays bare per the taste convention.
-            LoadArgument { Index: 0, Name: "this" } => _options.QualifyFieldAccess || QualifyThisMember(field.Name, field.Type) ? $"this.{fieldName}" : fieldName,
+            LoadArgument { Index: 0, Name: "this" } => FieldThisTarget(field, fieldName),
             _ => $"{ReceiverText(instance)}.{fieldName}",
         };
+    }
+
+    // The this-receiver plain-field branch of FieldTarget. Emits this. when the
+    // qualify-field knob is set OR a local shadows the field (mandatory), matching
+    // the prior inline predicate exactly, and records a decision only on the
+    // knob-attributed path (knob set AND no shadow forcing it).
+    string FieldThisTarget(FieldRef field, string fieldName)
+    {
+        bool mandatory = QualifyThisMember(field.Name, field.Type);
+        if (!_options.QualifyFieldAccess && !mandatory)
+            return fieldName;
+        if (_options.QualifyFieldAccess && !mandatory)
+            RecordThisQualificationDecision(QualifyFieldOption, field.Name, fieldName);
+        return $"this.{fieldName}";
     }
 
     string? PointerMemberReceiver(IrExpression? instance)
@@ -88,6 +132,7 @@ public sealed partial class CSharpPrinter
             return $"{pointerReceiver}->{CSharpNaming.EscapeIdentifier(name)}";
         }
 
+        bool thisQualifiedByKnob = false;
         string receiver = instance switch
         {
             // A NON-virtual this-receiver access to a base-declared member is
@@ -101,16 +146,34 @@ public sealed partial class CSharpPrinter
             // bare per the taste convention, matching FieldTarget. An event
             // subscription routes through here too, so it honors the separate
             // event qualification knob rather than the property one.
-            LoadArgument { Index: 0, Name: "this" } => (isEvent ? _options.QualifyEventAccess : _options.QualifyPropertyAccess) || QualifyThisMember(name, AccessorValueType(accessor)) ? "this" : "",
+            LoadArgument { Index: 0, Name: "this" } => ThisPropertyReceiver(name, accessor, isEvent, out thisQualifiedByKnob),
             _ => ReceiverText(instance),
         };
         // An instance property accessor with index arguments IS an indexer,
-        // whatever its metadata name (String's is Chars, not Item).
+        // whatever its metadata name (String's is Chars, not Item). An indexer
+        // always renders this[...] (never this.Item), so the qualify knob makes no
+        // textual difference there; this early return precedes the knob-attributed
+        // decision so an indexer never records one.
         if (instance is not null && indexArguments.Count > 0)
             return $"{(receiver.Length == 0 ? "this" : receiver)}[{Arguments(indexArguments)}]";
         string escapedName = CSharpNaming.EscapeIdentifier(name);
+        if (thisQualifiedByKnob)
+            RecordThisQualificationDecision(isEvent ? QualifyEventOption : QualifyPropertyOption, name, escapedName);
         string dotted = receiver.Length == 0 ? escapedName : $"{receiver}.{escapedName}";
         return indexArguments.Count == 0 ? dotted : $"{dotted}[{Arguments(indexArguments)}]";
+    }
+
+    // The this-receiver property/event branch of PropertyTarget: returns the
+    // receiver text ("this" when qualified, "" when bare) and reports through
+    // <paramref name="qualifiedByKnob"/> whether the qualify KNOB (not mandatory
+    // shadow disambiguation) selected the qualifier — the only case that is an
+    // opt-in taste choice worth recording.
+    string ThisPropertyReceiver(string name, MethodRef accessor, bool isEvent, out bool qualifiedByKnob)
+    {
+        bool knob = isEvent ? _options.QualifyEventAccess : _options.QualifyPropertyAccess;
+        bool mandatory = QualifyThisMember(name, AccessorValueType(accessor));
+        qualifiedByKnob = knob && !mandatory;
+        return knob || mandatory ? "this" : "";
     }
 
     bool QualifyThisMember(string memberName, TypeRef? valueType)
@@ -249,7 +312,12 @@ public sealed partial class CSharpPrinter
             // stay this.Ext (or bare) like any other extension group.
             if (method.HasThis && !isVirtual && IsCrossType(method.DeclaringType))
                 return $"base.{name}";
-            return _options.QualifyMethodAccess ? $"this.{name}" : name;
+            if (_options.QualifyMethodAccess)
+            {
+                RecordThisQualificationDecision(QualifyMethodOption, name, name);
+                return $"this.{name}";
+            }
+            return name;
         }
         if (PointerMethodReceiver(target) is { } pointerReceiver)
             return $"{pointerReceiver}->{name}";
@@ -360,8 +428,12 @@ public sealed partial class CSharpPrinter
             // re-enable virtual dispatch and change behavior).
             if (!call.IsVirtual && IsCrossType(call.Callee.DeclaringType))
                 return $"base.{thisMethodName}{typeArguments}({rest})";
-            string thisMethodQualifier = _options.QualifyMethodAccess ? "this." : "";
-            return $"{thisMethodQualifier}{thisMethodName}{typeArguments}({rest})";
+            if (_options.QualifyMethodAccess)
+            {
+                RecordThisQualificationDecision(QualifyMethodOption, thisMethodName, thisMethodName);
+                return $"this.{thisMethodName}{typeArguments}({rest})";
+            }
+            return $"{thisMethodName}{typeArguments}({rest})";
         }
         if (PointerMethodReceiver(receiver) is { } pointerReceiver)
             return $"{pointerReceiver}->{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -377,9 +377,9 @@ public sealed partial class CSharpPrinter
             QualifyEventAccess = _options.QualifyEventAccess,
         };
 
-    void AddDecision(string ruleId, string category, string subject, string detail, string? oldValue = null, string? newValue = null)
+    void AddDecision(string ruleId, string category, string subject, string detail, string? oldValue = null, string? newValue = null, string? dedupDiscriminator = null)
     {
-        string key = $"{ruleId}\0{category}\0{subject}\0{detail}\0{oldValue}\0{newValue}";
+        string key = $"{ruleId}\0{category}\0{subject}\0{detail}\0{oldValue}\0{newValue}\0{dedupDiscriminator}";
         if (_decisionKeys.Add(key))
         {
             _decisions.Add(new DecompilerDecision(ruleId, category, subject, detail)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -2184,6 +2184,7 @@ public static class IrImporter
                 return generic with
                 {
                     TypeArguments = methodArguments,
+                    DefinitionParameterTypes = generic.ParameterTypes,
                     ReturnType = generic.ReturnType.Instantiate([], methodArguments),
                     ParameterTypes = [.. generic.ParameterTypes.Select(p => p.Instantiate([], methodArguments))],
                 };

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -41,6 +41,17 @@ public sealed record MethodRef(
     public ImmutableArray<TypeRef> TypeArguments { get; init; } = [];
 
     /// <summary>
+    /// The generic method DEFINITION's parameter types, with its own type
+    /// parameters left as <c>!!N</c> placeholders (before the MethodSpec
+    /// substitution that produces <see cref="ParameterTypes"/>). Populated only
+    /// for a generic method instantiation; empty otherwise. Lets a consumer
+    /// identify the source member independent of the instantiation — two calls to
+    /// <c>G&lt;int&gt;</c> and <c>G&lt;string&gt;</c> of one <c>G&lt;T&gt;(T)</c>
+    /// share this signature though their <see cref="ParameterTypes"/> differ.
+    /// </summary>
+    public ImmutableArray<TypeRef> DefinitionParameterTypes { get; init; } = [];
+
+    /// <summary>
     /// Per-parameter call-site ref-kind (ref/out/in), aligned 1:1 with
     /// <see cref="ParameterTypes"/>. Populated for callees resolved as a
     /// MethodDef, from the parameter rows (IsReadOnlyAttribute / the Out flag),

--- a/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
+++ b/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
@@ -37,6 +37,29 @@ public class AppliedTasteSectionTests
     }
 
     [Fact]
+    public void BuildRows_ThisQualificationDecision_IsBytePreserving()
+    {
+        // The opt-in this.-qualification knobs (#3156) record byte-preserving
+        // taste decisions keyed by their StyleOptionCatalog id; they surface as
+        // ordinary byte-preserving rows, not filtered like the framework import.
+        var decision = new DecompilerDecision(
+            "qualify-field-access",
+            DecompilerDecisionCategories.Taste,
+            "ReadField",
+            "Qualified instance member 'ReadField' with 'this.'.")
+        {
+            OldValue = "_value",
+            NewValue = "this._value",
+        };
+
+        var row = Assert.Single(ApiOutputFormatter.BuildAppliedTasteRows([decision]));
+
+        Assert.Equal("qualify-field-access", row.Rule);
+        Assert.Equal("byte-preserving", row.Fidelity);
+        Assert.Equal("ReadField", row.Subject);
+    }
+
+    [Fact]
     public void BuildRows_ExcludesAlwaysOnFrameworkImport()
     {
         // The framework-import rewrite is always-on and universally expected, not

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1619,11 +1619,10 @@ public static class ApiOutputFormatter
         =>
         [
             // Projects the configurable choices the decompiler RECORDED as
-            // decisions -- currently the byte-divergent style lenses and the
-            // opt-in chain-wrap. Some byte-preserving knobs (this.-qualification)
-            // do not yet record a decision, so they will not appear here until
-            // issue #3156 lands; the empty-state wording is scoped to "recorded"
-            // choices to avoid over-claiming completeness.
+            // decisions -- the byte-divergent style lenses, the opt-in chain-wrap,
+            // and the byte-preserving this.-qualification knobs (#3156). Only
+            // knob-attributed qualification is recorded; a mandatory shadow
+            // disambiguation this. never appears here.
             .. decisions
                 // The framework-import rewrite (List<T> for the mangled metadata
                 // name) is always-on and universally expected, not a configurable


### PR DESCRIPTION
## Conclusion

Closes #3156. Follow-up to #3152, which added the explicit-only **Applied Taste** section but scoped it to *recorded* choices because the four `this.`-qualification knobs emitted `this.` without recording a `DecompilerDecision`. This PR records them, so an enabled qualify knob now surfaces a byte-preserving Applied Taste row instead of silently changing the render.

## Product change (decompiler)

At the four knob emission sites in `CSharpPrinter.Members.cs` (field, property/event, method call, method group), record a byte-preserving `DecompilerDecision` (category `taste`) via `AddDecision` — **only when the knob, not mandatory disambiguation, added the qualifier**.

### Design subtlety

`this.` is emitted for two reasons and only the first is a taste choice:

1. **Knob-driven** (`QualifyFieldAccess` etc.) — configurable, byte-preserving → **recorded**.
2. **Mandatory disambiguation** (`QualifyThisMember`: a local/parameter shadow or member/type-name collision) — required for correct binding, appears with the knob off too → **never recorded** as a taste choice.

So the sole recorded case is `knob && !mandatory`. **Indexers** always render `this[...]` regardless of the knob, so they record nothing (the indexer early-return precedes the decision). `AddDecision` dedups per member.

Identity and config key come from `StyleOptionCatalog` (#3160), so the decision's `RuleId` (e.g. `qualify-field-access`) and prose stay in lockstep with the single source of truth; a knob rename fails at type init rather than drifting.

## CLI

No behavior change needed: `BuildAppliedTasteRows` already classifies category `taste` as `byte-preserving`, and `MemberCodeProvider` already forwards the full `Decisions` list rendered with the configured options. Refreshed the now-stale `#3156` comment.

## Default-preserving

The knobs are off by shipped default → no decision recorded → byte output unchanged. Decompiler fast suite **3678 / 0**, so the refactor of the four sites is byte-identical across the corpus.

## Validation

- `ThisQualificationDecisionTests`: **10** (per-kind recording, dedup, and the mandatory-disambiguation-off/on negatives).
- `AppliedTasteSectionTests`: added a byte-preserving qualification row case (**5** total).
- Existing `ThisQualificationTests` **23/23** (refactor preserves output); decompiler fast suite **3678/0**; Applied Taste e2e **3/3**.
- `docs/decompiler-taste.md` note added; markdownlint clean.

## Review

Behavior-capable change → two-model adversarial review required before ready. **Draft: review pending.**