### PR TITLE
Surface config warnings for Applied-Taste-only runs

### DIFF
--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -491,6 +491,10 @@ public class RenderStyleConfigTests
         Assert.Null(withDefault.DecompiledResult);
         Assert.NotNull(withConfig.FidelityCauses);
         Assert.NotNull(withDefault.FidelityCauses);
+        // A fidelity-only projection consumes no config, so it never marks the
+        // warning latch regardless of whether a config was resolved.
+        Assert.False(withConfig.StyledProjectionProduced);
+        Assert.False(withDefault.StyledProjectionProduced);
     }
 
     [Fact]
@@ -506,6 +510,28 @@ public class RenderStyleConfigTests
 
         Assert.NotNull(code.DecompiledResult?.Output);
         Assert.Contains("this._count", code.DecompiledResult!.Output);
+        Assert.True(code.StyledProjectionProduced);
+    }
+
+    // The Applied-Taste-only path (#3158): `member <M> -S "Applied Taste"` without
+    // Decompiled Source still renders the styled projection to extract the applied
+    // decisions, so the config IS consumed -- but DecompiledResult stays null. The
+    // old latch keyed off DecompiledResult and silently swallowed a bad config
+    // here; StyledProjectionProduced is the independent signal that fixes it.
+    [Fact]
+    public void AppliedTasteOnlyRequest_MarksStyledProjectionProduced_ThoughNoDecompiledResult()
+    {
+        var appliedTasteOnly = new MemberCodeProvider.Request(
+            DecompiledSource: false, AnnotatedSource: false, CostOverlay: false,
+            SemanticsOverlay: false, IL: false, Attributes: false, Calls: false,
+            Callers: false, CallGraph: false, UnsafeOperations: false,
+            AppliedTaste: true);
+
+        var code = CollectSpecimenCompute(
+            appliedTasteOnly, PrinterOptions.Default with { QualifyFieldAccess = true });
+
+        Assert.Null(code.DecompiledResult);
+        Assert.True(code.StyledProjectionProduced);
     }
 
     // MAI review finding (head a25e01d9): `member <Type> --directory <dir>
@@ -580,6 +606,36 @@ public class RenderStyleConfigTests
         var (_, code) = Assert.Single(results);
         Assert.NotNull(code.DecompiledResult);
         Assert.Null(code.DecompiledResult!.Output);
+        // The printer never ran (no IL body), so no config was consumed: the latch
+        // stays unmarked even though Decompiled Source was requested.
+        Assert.False(code.StyledProjectionProduced);
+    }
+
+    // The bodyless-method invariant must also hold for an Applied-Taste-only run:
+    // no printed body means no config consumption, so no warning, matching the
+    // Decompiled Source behavior above.
+    [Fact]
+    public void AppliedTasteOnly_NoBodyMethod_DoesNotMarkStyledProjection()
+    {
+        var appliedTasteOnly = new MemberCodeProvider.Request(
+            DecompiledSource: false, AnnotatedSource: false, CostOverlay: false,
+            SemanticsOverlay: false, IL: false, Attributes: false, Calls: false,
+            Callers: false, CallGraph: false, UnsafeOperations: false,
+            AppliedTaste: true);
+
+        string assemblyPath = typeof(SamplePInvokeClass).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(SamplePInvokeClass).FullName);
+        var methods = type.Members
+            .Where(m => m.Name == nameof(SamplePInvokeClass.GetCurrentProcessId)).ToList();
+
+        var results = MemberCodeProvider.Collect(
+            type, methods, assemblyPath, overloadIndex: 0, appliedTasteOnly,
+            renderOptions: PrinterOptions.Default with { QualifyFieldAccess = true });
+
+        var (_, code) = Assert.Single(results);
+        Assert.False(code.StyledProjectionProduced);
     }
 
     private static MemberCodeProvider.Item CollectSpecimenCompute(

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -38,7 +38,13 @@ internal static class MemberCodeProvider
         IReadOnlyList<ILInspector.Research.ResearchViews.FactRow>? Facts = null,
         FindingInspection<Decompiler.DecompilerFidelityCause>? FidelityCauses = null,
         IReadOnlyList<Decompiler.DecompilerDecision>? AppliedTaste = null,
-        bool RequiresAsyncBodyModifier = false);
+        bool RequiresAsyncBodyModifier = false,
+        // True when a config-consuming styled projection (Decompiled Source or
+        // Applied Taste, never the style-invariant fidelity-only read) actually
+        // printed a body. The resolved-config warnings should surface whenever
+        // this holds, even for an Applied-Taste-only run that renders no Decompiled
+        // Source section, so a bad .dotnet-inspectconfig never fails silently.
+        bool StyledProjectionProduced = false);
 
     internal static List<(ApiMember Member, Item Code)> Collect(
         ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex,
@@ -120,6 +126,7 @@ internal static class MemberCodeProvider
             Decompiler.DecompilerResult? decompiledResult = null;
             Decompiler.DecompilerResult? projectionResult = null;
             IrFunction? raisedFunction = null;
+            bool styledProjectionProduced = false;
             if ((request.DecompiledSource || request.FidelityCauses || request.AppliedTaste) && pipelineSource is not null)
             {
                 // The style options (renderOptions) affect the printed C# string
@@ -129,10 +136,10 @@ internal static class MemberCodeProvider
                 // runs with those options. Both consume the config. A fidelity-only
                 // projection reads the raised IR and recompile diagnostics (both
                 // style-invariant) and discards the printed string, so it must not
-                // consume the config -- pass the shipped defaults there. The
-                // config-warning latch still keys off a surfaced Decompiled Source
-                // Output (below), so an Applied-Taste-only run that renders no
-                // styled source stays silent.
+                // consume the config -- pass the shipped defaults there.
+                // styledProjectionProduced (below) drives the config-warning latch,
+                // so an Applied-Taste-only run that consumes the config surfaces its
+                // warnings even without a Decompiled Source section.
                 var projectionRenderOptions = request.DecompiledSource || request.AppliedTaste ? renderOptions : null;
                 projectionResult = TrimOutput(RenderDecompiledSource(
                     pipelineSource,
@@ -150,6 +157,14 @@ internal static class MemberCodeProvider
                         pipelineSource.Symbols,
                         projectionResult.Diagnostics)
                 };
+                // Both Decompiled Source and Applied Taste render with the resolved
+                // style options (config consumed); a fidelity-only projection passes
+                // the shipped defaults and does not. Record that a config-consuming
+                // projection printed a body so the warning latch (below) fires for
+                // an Applied-Taste-only run too, not just Decompiled Source.
+                styledProjectionProduced =
+                    (request.DecompiledSource || request.AppliedTaste)
+                    && projectionResult.Output is not null;
             }
 
             if (request.DecompiledSource)
@@ -278,7 +293,8 @@ internal static class MemberCodeProvider
                 facts,
                 fidelityCauses,
                 appliedTaste,
-                requiresAsyncBodyModifier)));
+                requiresAsyncBodyModifier,
+                styledProjectionProduced)));
         }
 
         return results;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1443,14 +1443,14 @@ public static class ApiOutputFormatter
 
             hasCode |= PopulateCSharpSections(memberCode, type, member, code);
 
-            // The resolved config is consumed only when styled C# is actually
-            // printed. Collect returns a decompiled result only for a selected
-            // overload (never callers-only aggregation or a fidelity-only
-            // projection), and even then its Output is null when the method has no
-            // IL body (e.g. a P/Invoke) -- the printer never ran, so no styling
-            // occurred. Key the warning latch off a produced Output so a member
-            // run that requests but does not render styled source stays silent.
-            if (code.DecompiledResult?.Output is not null)
+            // The resolved config is consumed whenever a styled projection prints a
+            // body -- Decompiled Source or Applied Taste (both render with the
+            // config), but never a callers-only aggregation, a fidelity-only
+            // projection (style-invariant), or a bodyless method whose printer never
+            // ran. Key the warning latch off that produced styled projection so an
+            // Applied-Taste-only run still surfaces a bad .dotnet-inspectconfig,
+            // while a run that consumes no config stays silent.
+            if (code.StyledProjectionProduced)
                 options?.RenderConfigWarnings?.EmitOnce();
 
             if (code.FidelityCauses is not null)


### PR DESCRIPTION
## Summary

**A bad `.dotnet-inspectconfig` must never fail silently.** The config-warning
latch keyed off a produced Decompiled Source `Output`, but an
**Applied-Taste-only** run consumes the same resolved config while leaving
`DecompiledResult` null — so its warnings were suppressed.

## Fix

- `MemberCodeProvider.Item` gains a `StyledProjectionProduced` signal, set when a
  config-consuming styled projection (**Decompiled Source or Applied Taste**,
  never the style-invariant fidelity-only read) actually printed a body.
- `ApiOutputFormatter` keys the warning latch off that signal instead of
  `DecompiledResult.Output`.

This preserves silence for runs that consume no config (callers-only aggregation,
fidelity-only projection, bodyless P/Invoke whose printer never ran).

## Evidence

Real-run, bad-key config (`nonsense_bogus_key`):

| Run | Config | stderr |
| --- | --- | --- |
| `-S "Applied Taste"` | bad key | `Warning: .dotnet-inspectconfig: line 2: unknown key 'nonsense_bogus_key' (ignored)` ✅ (was silent) |
| `-S "Decompiled Source"` | bad key | warning ✅ (no regression) |
| `-S "Applied Taste"` | clean | silent ✅ (no false positive) |

Tests: `RenderStyleConfigTests` 43/43 (augmented fidelity-only, Decompiled Source,
bodyless P/Invoke invariants with the new signal; added Applied-Taste-only positive
and bodyless-P/Invoke negative cases). Full solution builds (only pre-existing
Metadata.Tests warnings).

## Notes

Stacked on #3172 (`record-this-qualification-decisions`); base will retarget to
`main` after that merges. Draft pending adversarial review.