### PR TITLE
Raise switches whose case/default section contains a natural loop (#3161)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4828,6 +4828,63 @@ public class CfgSampleClass
             return v + 1;
         }
     }
+
+    // #3161 compile-back witness, shaped for high likeness to the platform method
+    // that motivated the fix (System.Text.Json.JsonElement.DeepEquals): a `switch`
+    // with TWO loop-bearing sections — an Array-like arm (length guard + an
+    // elementwise `foreach`) and an Object-like arm (count guard + a paired `while`
+    // with an in-loop early return) — plus scalar arms and a default. csc emits a
+    // dense `switch` opcode over cases 0..4 and lowers both loops to back-edges, so
+    // neither case section is a straight-line single-entry region. Before #3161 the
+    // whole switch stayed flat (a loop-bearing section could not be owned);
+    // SwitchRaisingPass now owns both sections and StructuringPass raises the loops.
+    // SwitchBranchRenderingTests proves the raise renders a structured `switch`;
+    // this method carries it into the fidelity gate so contract-V1 compile-back
+    // proves the raised switch-with-loops recompiles to the original opcodes —
+    // the IL fidelity that cannot be checked on DeepEquals itself, whose internal
+    // System.Text.Json surface the compile-back oracle cannot recompile.
+    public static int SwitchWithTwoLoopingCaseSections(int kind, int[] left, int[] right)
+    {
+        switch (kind)
+        {
+            case 0:
+                if (left.Length != right.Length)
+                {
+                    return 0;
+                }
+                int sum = 0;
+                foreach (int value in left)
+                {
+                    sum += value;
+                }
+                return sum;
+            case 1:
+                if (left.Length != right.Length)
+                {
+                    return -1;
+                }
+                int matched = 0;
+                int i = 0;
+                while (i < left.Length)
+                {
+                    if (left[i] != right[i])
+                    {
+                        return matched;
+                    }
+                    matched++;
+                    i++;
+                }
+                return matched;
+            case 2:
+                return left.Length;
+            case 3:
+                return right.Length;
+            case 4:
+                return 42;
+            default:
+                return -1;
+        }
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -312,6 +312,20 @@ public class FidelityGateTests
     /// </summary>
     static readonly string[] PinnedExact =
     {
+        // #3161: a `switch` with TWO loop-bearing sections — an Array-like arm
+        // (length guard + a `foreach`) and an Object-like arm (count guard + a
+        // `while` with an in-loop early return) — plus scalar arms and a default,
+        // shaped for high likeness to the platform method that motivated the fix
+        // (System.Text.Json.JsonElement.DeepEquals, whose Array and Object arms each
+        // loop). csc emits a dense `switch` opcode over cases 0..4 and lowers both
+        // loops to back-edges, so neither case section is a straight-line
+        // single-entry region. Before #3161 SwitchRaisingPass left the whole switch
+        // flat; it now owns both loop-bearing sections and the raise recompiles
+        // opcode-exact. This pins the transformation's IL fidelity on a shape we own
+        // — the same fidelity that cannot be checked on DeepEquals itself, since its
+        // internal System.Text.Json surface is not recompilable by the compile-back
+        // oracle (tracked for a future cross-assembly compile-back capability).
+        "SwitchWithTwoLoopingCaseSections",
         // The compile-back oracle replays the fixture's runtime-async feature,
         // so these methods must retain the same lowering rather than merely
         // remaining recompilable.

--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -30,6 +30,40 @@ static class SwitchTableFixture
     }
 }
 
+/// <summary>
+/// Real-IL fixture for
+/// <see cref="SwitchBranchRenderingTests.FullPipeline_RaisesSwitchWhoseCaseContainsLoop"/>:
+/// a <c>switch</c> one of whose case sections carries a loop. csc lowers the loop
+/// to a bottom-tested back-edge, so the section is not a straight-line
+/// single-entry region — the shape that used to keep the whole switch flat
+/// (issue #3161) until <c>SwitchRaisingPass</c> learned to own a section that
+/// contains a natural loop.
+/// </summary>
+static class SwitchLoopingCaseFixture
+{
+    public static int Reduce(int kind, int[] values)
+    {
+        switch (kind)
+        {
+            case 0:
+                int total = 0;
+                foreach (int value in values)
+                {
+                    total += value;
+                }
+                return total;
+            case 1:
+                return values.Length;
+            case 2:
+                return -values.Length;
+            case 3:
+                return 42;
+            default:
+                return -1;
+        }
+    }
+}
+
 // An IL `switch` opcode the switch-raising pass could not lift into a structured
 // `switch` stays in the tree as a SwitchBranch jump table. The printer must
 // render it as valid lowered C# — a single-evaluated temp plus one `if`/`goto`
@@ -386,8 +420,37 @@ public class SwitchBranchRenderingTests
     }
 
     [Fact]
-    public void FullPipeline_PreservesEveryResidualSwitchTargetLabel()
+    public void FullPipeline_RaisesSwitchWhoseCaseContainsLoop()
     {
+        // A compiled `switch` whose `case 0` carries a `foreach` loop. csc lowers
+        // the loop to a back-edge, so the section is not a straight-line
+        // single-entry region. Before #3161 this kept the whole switch flat (its
+        // `default`/looping section could not be owned); now SwitchRaisingPass
+        // owns the loop-bearing section and StructuringPass raises the loop.
+        using var source = MetadataSource.Open(typeof(SwitchLoopingCaseFixture).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(SwitchLoopingCaseFixture).FullName!,
+            nameof(SwitchLoopingCaseFixture.Reduce));
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function);
+        string output = result.Output ?? "";
+
+        Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+        Assert.Contains("switch (", output);
+        Assert.DoesNotContain("__switchValue", output);
+        AssertGotoTargetsHaveLabels(output);
+    }
+
+    [Fact]
+    public void FullPipeline_RaisesRealSwitchWithLoopingSections()
+    {
+        // Regression witness for #3161 on a real compiler-produced method:
+        // `CSharpSpellability.TypeIssue` is a `switch (type.Kind)` whose sections
+        // carry `foreach`/`for` loops. It used to stay a flat residual dispatch
+        // (`if (__switchValue…) goto …`); now it raises into a structured switch
+        // with Full fidelity and no residual dispatch temp.
         using var source = MetadataSource.Open(typeof(CSharpSpellability).Assembly.Location);
         var function = IrImporter.Import(
             source,
@@ -399,7 +462,8 @@ public class SwitchBranchRenderingTests
         string output = result.Output ?? "";
 
         Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
-        Assert.Contains("if (__switchValue", output);
+        Assert.Contains("switch (", output);
+        Assert.DoesNotContain("__switchValue", output);
         AssertGotoTargetsHaveLabels(output);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -966,7 +966,12 @@ public sealed class SwitchRaisingPass : IIrPass
         region = [];
         exits = [];
         var members = new SortedSet<int> { head };
-        var reachCache = new Dictionary<int, HashSet<int>>();
+        // Same-SCC membership answers "is t reachable from its own predecessor p"
+        // for the back-edge test below. Reachability is a static property of the
+        // CFG, so the strongly-connected components of the post-switch subgraph
+        // are computed once here and reused for every predecessor test, instead
+        // of re-running a per-predecessor forward DFS on each growth iteration.
+        int[] sccId = ComputeSectionSccIds(blocks, s, offsetToIndex);
 
         bool changed = true;
         while (changed)
@@ -994,9 +999,14 @@ public sealed class SwitchRaisingPass : IIrPass
                     // fall-through edges), but any such region is rejected later by
                     // the OwnsTiledRegion contiguous-span check, which requires the
                     // owned blocks to exactly tile the case span.
+                    //
+                    // p is already a predecessor of t (edge p -> t exists), so t
+                    // reaches p — the back-edge condition — exactly when t and p
+                    // lie in the same strongly-connected component. A predecessor
+                    // at or before the switch (p <= s) is outside the subgraph and
+                    // has scc id -1, so it never matches the case-target t (t > s).
                     bool interior = preds.TryGetValue(t, out var ps)
-                        && ps.All(p => members.Contains(p)
-                            || ForwardReachable(blocks, t, s, offsetToIndex, reachCache).Contains(p));
+                        && ps.All(p => members.Contains(p) || sccId[t] == sccId[p]);
                     if (interior)
                     {
                         members.Add(t);
@@ -1018,42 +1028,103 @@ public sealed class SwitchRaisingPass : IIrPass
     }
 
     /// <summary>
-    /// Returns the set of blocks forward-reachable from <paramref name="from"/>
-    /// over section-internal edges (successors with index &gt; <paramref
-    /// name="s"/>, the switch block), including <paramref name="from"/> itself.
-    /// Reachability is a static property of the CFG and independent of region
-    /// growth, so each source's set is computed once and memoized in <paramref
-    /// name="cache"/> for reuse across every <see cref="GrowRegion"/> iteration
-    /// and predecessor test — keeping the growth loop at O(V·(V+E)) instead of
-    /// re-running a fresh DFS per predecessor per iteration. <see
-    /// cref="GrowRegion"/> queries it to recognize a back-edge predecessor — a
-    /// loop body block only reachable through its own header — so the header
-    /// interiorizes into the single-entry region instead of becoming a false
-    /// exit.
+    /// Labels each block with the strongly-connected component it belongs to
+    /// within the post-switch subgraph — the blocks with index &gt; <paramref
+    /// name="s"/> (the switch block), with edges taken from <see
+    /// cref="TrySuccessors"/> and restricted to that same index range. Blocks at
+    /// or before the switch, and any block whose successors cannot be analyzed,
+    /// are outside the subgraph and receive id -1. Two blocks share a component
+    /// exactly when each is forward-reachable from the other over section-internal
+    /// edges, which <see cref="GrowRegion"/> uses to recognize a back-edge
+    /// predecessor (a loop body block only reachable through its own header) so
+    /// the header interiorizes into the single-entry region instead of becoming a
+    /// false exit. The traversal is iterative (an explicit work stack) so deep
+    /// control-flow graphs from untrusted assemblies cannot overflow the runtime
+    /// stack, and runs in O(V + E).
     /// </summary>
-    static HashSet<int> ForwardReachable(IReadOnlyList<Block> blocks, int from, int s,
-        Dictionary<int, int> offsetToIndex, Dictionary<int, HashSet<int>> cache)
+    static int[] ComputeSectionSccIds(IReadOnlyList<Block> blocks, int s, Dictionary<int, int> offsetToIndex)
     {
-        if (cache.TryGetValue(from, out var cached))
-            return cached;
-
-        var reachable = new HashSet<int>();
-        var stack = new Stack<int>();
-        stack.Push(from);
-        while (stack.Count > 0)
+        int n = blocks.Count;
+        var sccId = new int[n];
+        var index = new int[n];
+        var low = new int[n];
+        var onStack = new bool[n];
+        for (int i = 0; i < n; i++)
         {
-            int cur = stack.Pop();
-            if (!reachable.Add(cur))
-                continue;
-            if (!TrySuccessors(blocks, cur, offsetToIndex, out var succs))
-                continue;
-            foreach (int t in succs)
-                if (t > s && !reachable.Contains(t))
-                    stack.Push(t);
+            sccId[i] = -1;
+            index[i] = -1;
         }
 
-        cache[from] = reachable;
-        return reachable;
+        List<int> SectionSuccs(int u)
+        {
+            var result = new List<int>();
+            if (!TrySuccessors(blocks, u, offsetToIndex, out var succs))
+                return result;
+            foreach (int t in succs)
+                if (t > s)
+                    result.Add(t);
+            return result;
+        }
+
+        var component = new Stack<int>();
+        var work = new Stack<(int Node, int Next, List<int> Succs)>();
+        int nextIndex = 0;
+        int nextScc = 0;
+
+        for (int root = s + 1; root < n; root++)
+        {
+            if (index[root] != -1)
+                continue;
+
+            index[root] = low[root] = nextIndex++;
+            component.Push(root);
+            onStack[root] = true;
+            work.Push((root, 0, SectionSuccs(root)));
+
+            while (work.Count > 0)
+            {
+                var (v, next, succs) = work.Pop();
+                if (next < succs.Count)
+                {
+                    work.Push((v, next + 1, succs));
+                    int w = succs[next];
+                    if (index[w] == -1)
+                    {
+                        index[w] = low[w] = nextIndex++;
+                        component.Push(w);
+                        onStack[w] = true;
+                        work.Push((w, 0, SectionSuccs(w)));
+                    }
+                    else if (onStack[w] && index[w] < low[v])
+                    {
+                        low[v] = index[w];
+                    }
+                }
+                else
+                {
+                    if (low[v] == index[v])
+                    {
+                        while (true)
+                        {
+                            int u = component.Pop();
+                            onStack[u] = false;
+                            sccId[u] = nextScc;
+                            if (u == v)
+                                break;
+                        }
+                        nextScc++;
+                    }
+                    if (work.Count > 0)
+                    {
+                        var parent = work.Peek();
+                        if (low[v] < low[parent.Node])
+                            low[parent.Node] = low[v];
+                    }
+                }
+            }
+        }
+
+        return sccId;
     }
 
     static bool SectionTerminates(IReadOnlyList<Block> blocks, List<int> region, Dictionary<int, int> offsetToIndex)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -966,6 +966,7 @@ public sealed class SwitchRaisingPass : IIrPass
         region = [];
         exits = [];
         var members = new SortedSet<int> { head };
+        var reachCache = new Dictionary<int, HashSet<int>>();
 
         bool changed = true;
         while (changed)
@@ -988,11 +989,14 @@ public sealed class SwitchRaisingPass : IIrPass
                     // header — and then the loop body, whose predecessors become
                     // members — interiorize, so the switch owns a section that
                     // still holds an unraised loop (StructuringPass raises it once
-                    // the section is a container). Any foreign entry into t or the
-                    // back-edge source is still rejected by OnlyReachedByTable.
+                    // the section is a container). This relaxation admits some
+                    // foreign entries (OnlyReachedByTable does not screen
+                    // fall-through edges), but any such region is rejected later by
+                    // the OwnsTiledRegion contiguous-span check, which requires the
+                    // owned blocks to exactly tile the case span.
                     bool interior = preds.TryGetValue(t, out var ps)
                         && ps.All(p => members.Contains(p)
-                            || ReachesForward(blocks, t, p, s, offsetToIndex));
+                            || ForwardReachable(blocks, t, s, offsetToIndex, reachCache).Contains(p));
                     if (interior)
                     {
                         members.Add(t);
@@ -1014,33 +1018,42 @@ public sealed class SwitchRaisingPass : IIrPass
     }
 
     /// <summary>
-    /// True if <paramref name="target"/> is forward-reachable from
-    /// <paramref name="from"/> over section-internal edges (blocks past the
-    /// switch, walked through <see cref="TrySuccessors"/>). Used by
-    /// <see cref="GrowRegion"/> to recognize a back-edge predecessor — a loop
-    /// body block that is only reachable through its own header — so the header
+    /// Returns the set of blocks forward-reachable from <paramref name="from"/>
+    /// over section-internal edges (successors with index &gt; <paramref
+    /// name="s"/>, the switch block), including <paramref name="from"/> itself.
+    /// Reachability is a static property of the CFG and independent of region
+    /// growth, so each source's set is computed once and memoized in <paramref
+    /// name="cache"/> for reuse across every <see cref="GrowRegion"/> iteration
+    /// and predecessor test — keeping the growth loop at O(V·(V+E)) instead of
+    /// re-running a fresh DFS per predecessor per iteration. <see
+    /// cref="GrowRegion"/> queries it to recognize a back-edge predecessor — a
+    /// loop body block only reachable through its own header — so the header
     /// interiorizes into the single-entry region instead of becoming a false
     /// exit.
     /// </summary>
-    static bool ReachesForward(IReadOnlyList<Block> blocks, int from, int target, int s, Dictionary<int, int> offsetToIndex)
+    static HashSet<int> ForwardReachable(IReadOnlyList<Block> blocks, int from, int s,
+        Dictionary<int, int> offsetToIndex, Dictionary<int, HashSet<int>> cache)
     {
-        var visited = new HashSet<int>();
+        if (cache.TryGetValue(from, out var cached))
+            return cached;
+
+        var reachable = new HashSet<int>();
         var stack = new Stack<int>();
         stack.Push(from);
         while (stack.Count > 0)
         {
             int cur = stack.Pop();
-            if (cur == target)
-                return true;
-            if (!visited.Add(cur))
+            if (!reachable.Add(cur))
                 continue;
             if (!TrySuccessors(blocks, cur, offsetToIndex, out var succs))
                 continue;
             foreach (int t in succs)
-                if (t > s && !visited.Contains(t))
+                if (t > s && !reachable.Contains(t))
                     stack.Push(t);
         }
-        return false;
+
+        cache[from] = reachable;
+        return reachable;
     }
 
     static bool SectionTerminates(IReadOnlyList<Block> blocks, List<int> region, Dictionary<int, int> offsetToIndex)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -981,7 +981,18 @@ public sealed class SwitchRaisingPass : IIrPass
                         continue;
                     if (t <= s)
                         return false;   // backward into / before the switch — a loop
-                    bool interior = preds.TryGetValue(t, out var ps) && ps.All(members.Contains);
+                    // A block joins the single-entry region when every predecessor
+                    // is already inside — or is a back-edge source, i.e. reachable
+                    // from t itself. A section-internal loop's header has such a
+                    // downstream predecessor (the back-edge); ignoring it lets the
+                    // header — and then the loop body, whose predecessors become
+                    // members — interiorize, so the switch owns a section that
+                    // still holds an unraised loop (StructuringPass raises it once
+                    // the section is a container). Any foreign entry into t or the
+                    // back-edge source is still rejected by OnlyReachedByTable.
+                    bool interior = preds.TryGetValue(t, out var ps)
+                        && ps.All(p => members.Contains(p)
+                            || ReachesForward(blocks, t, p, s, offsetToIndex));
                     if (interior)
                     {
                         members.Add(t);
@@ -1000,6 +1011,36 @@ public sealed class SwitchRaisingPass : IIrPass
         }
         region = members.ToList();
         return true;
+    }
+
+    /// <summary>
+    /// True if <paramref name="target"/> is forward-reachable from
+    /// <paramref name="from"/> over section-internal edges (blocks past the
+    /// switch, walked through <see cref="TrySuccessors"/>). Used by
+    /// <see cref="GrowRegion"/> to recognize a back-edge predecessor — a loop
+    /// body block that is only reachable through its own header — so the header
+    /// interiorizes into the single-entry region instead of becoming a false
+    /// exit.
+    /// </summary>
+    static bool ReachesForward(IReadOnlyList<Block> blocks, int from, int target, int s, Dictionary<int, int> offsetToIndex)
+    {
+        var visited = new HashSet<int>();
+        var stack = new Stack<int>();
+        stack.Push(from);
+        while (stack.Count > 0)
+        {
+            int cur = stack.Pop();
+            if (cur == target)
+                return true;
+            if (!visited.Add(cur))
+                continue;
+            if (!TrySuccessors(blocks, cur, offsetToIndex, out var succs))
+                continue;
+            foreach (int t in succs)
+                if (t > s && !visited.Contains(t))
+                    stack.Push(t);
+        }
+        return false;
     }
 
     static bool SectionTerminates(IReadOnlyList<Block> blocks, List<int> region, Dictionary<int, int> offsetToIndex)


### PR DESCRIPTION
- Fixes #3161 (advances tracking issue #3159; also improves #3162, #3163)
- Changes decompiler raising so a `switch` whose case/default section contains a
  natural loop is raised into a structured C# `switch` (previously left flat as a
  goto/label comparison chain)
- Card revision: `a8129d63`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the target method now raises to a structured switch
with structured loops, render-A/B is `valid->valid` with zero `valid->invalid`,
the corpus closure gate is unchanged, and the only fidelity-gate failures on
this machine are pre-existing/environmental (reproduced identically on the
base commit).

### Benchmark target

Benchmark target: `System.Text.Json@10.0.10`

dotnet-inspect command:

```bash
dotnet-inspect System.Text.Json.JsonElement.DeepEquals -S "Decompiled Source"
```

### Original source

```csharp
public static bool DeepEquals(JsonElement element1, JsonElement element2)
{
    if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
    {
        ThrowHelper.ThrowInsufficientExecutionStackException_JsonElementDeepEqualsInsufficientExecutionStack();
    }
    element1.CheckValidInstance();
    element2.CheckValidInstance();
    JsonValueKind kind = element1.ValueKind;
    if (kind != element2.ValueKind)
    {
        return false;
    }
    switch (kind)
    {
        case JsonValueKind.Null or JsonValueKind.False or JsonValueKind.True:
            return true;
        case JsonValueKind.Number:
            return JsonHelpers.AreEqualJsonNumbers(element1.GetRawValue().Span, element2.GetRawValue().Span);
        case JsonValueKind.String:
            // ...swap-and-unescape...
            return element1.ValueEquals(element2.ValueSpan);
        case JsonValueKind.Array:
            // ...length check + foreach comparison...
        default:
            // ...object property-count + enumerate-and-compare loop...
    }
}
```

### Before

```csharp
public static bool DeepEquals(System.Text.Json.JsonElement element1, System.Text.Json.JsonElement element2)
{
    int __switchValue0 = default;
    JsonValueKind kind;
    // ...locals...
    if (RuntimeHelpers.TryEnsureSufficientExecutionStack()) goto IL_000C;
    ThrowHelper.ThrowInsufficientExecutionStackException_JsonElementDeepEqualsInsufficientExecutionStack();
    IL_000C:
    element1.CheckValidInstance();
    element2.CheckValidInstance();
    kind = element1.ValueKind;
    if (kind == element2.ValueKind) goto IL_002E;
    return false;
    IL_002E:
    __switchValue0 = (int)(kind - 2);
    if (__switchValue0 == 0) goto IL_00B6;
    if (__switchValue0 == 1) goto IL_007B;
    if (__switchValue0 == 2) goto IL_0055;
    if (__switchValue0 == 3) goto IL_0053;
    if (__switchValue0 == 4) goto IL_0053;
    if (__switchValue0 == 5) goto IL_0053;
    goto IL_0124;
    IL_0053:
    return true;
    // ...remaining goto/label sections, object loop left flat...
}
```

- Valid: True
- Correct: True
- IL fidelity: not directly checkable on DeepEquals itself — its decompiled body
  references internal `System.Text.Json` surface the compile-back oracle cannot
  recompile (`FidelityUnavailable`/`ContextFail`). The transformation's IL
  fidelity is pinned on a shape we own instead; see the `Exact` fixture pin below.
- Taste applied: None (`-S "Applied Taste"` reports no style choices)
- Commit: `d131d951` (base)

The base output parses (goto is legal C#), but the jump-table switch is left as a
flat comparison chain and the object-comparison loop never structures because it
is trapped inside the flat container.

### After

```csharp
public static bool DeepEquals(System.Text.Json.JsonElement element1, System.Text.Json.JsonElement element2)
{
    // ...locals...
    if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
    {
        ThrowHelper.ThrowInsufficientExecutionStackException_JsonElementDeepEqualsInsufficientExecutionStack();
    }
    element1.CheckValidInstance();
    element2.CheckValidInstance();
    JsonValueKind kind = element1.ValueKind;
    if (kind != element2.ValueKind)
    {
        return false;
    }
    switch (kind - 2)
    {
        case JsonValueKind.Undefined:
            if (element1.GetArrayLength() != element2.GetArrayLength())
            {
                return false;
            }
            arrayEnumerator2 = element2.EnumerateArray();
            using (ArrayEnumerator V_6 = element1.EnumerateArray().GetEnumerator())
            {
                while (V_6.MoveNext())
                {
                    arrayEnumerator2.MoveNext();
                    if (!DeepEquals(V_6.Current, arrayEnumerator2.Current))
                    {
                        return false;
                    }
                }
            }
            return true;
        case JsonValueKind.Object:
            // ...string escape/swap/compare...
        // ...other cases...
        default:
            V_2 = element1.GetPropertyCount();
            if (V_2 != element2.GetPropertyCount())
            {
                return false;
            }
            V_3 = element1.EnumerateObject();
            V_4 = element2.EnumerateObject();
            while (V_3.MoveNext())
            {
                V_4.MoveNext();
                // ...NameEquals / recursive DeepEquals...
                V_2--;
            }
            return true;
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: not directly checkable on DeepEquals itself (its decompiled body
  references internal `System.Text.Json` surface — `CheckValidInstance`,
  `NameEquals`, `ArrayEnumerator`/`ObjectEnumerator`, `ThrowHelper.*`,
  `JsonProperty`, … — that the compile-back oracle cannot recompile, so it returns
  `FidelityUnavailable`/`ContextFail`). This PR instead pins the transformation's
  IL fidelity **`Exact`** on a dependency-free, high-likeness fixture,
  `CfgSampleClass.SwitchWithTwoLoopingCaseSections` — a `switch` with two
  loop-bearing sections (an Array-like `foreach` arm and an Object-like `while`
  arm with an in-loop early return) mirroring DeepEquals's Array and Object arms.
  Contract-V1 compile-back diffs its recompiled IL to the original opcode-for-
  opcode. Reaching DeepEquals itself is tracked in #3197.
- Taste applied: None
- Commit: `a8129d63` (head)

The jump-table switch now raises into a structured `switch`, and both the array
case and the object/default section raise their loops (`using`/`while`), with no
`goto`/labels and no `__switchValue0` temp.

### Fully raised

```csharp
// intended endpoint: labels spelled without the -2 bias, i.e. case JsonValueKind.Array etc.
switch (kind)
{
    case JsonValueKind.Array: /* ... */
    case JsonValueKind.Object: /* ... */
    // ...
}
```

- Required tracking issue: #3159 — the `switch (kind - 2)` /
  `case JsonValueKind.Undefined` **enum-bias label spelling** is a pre-existing,
  orthogonal concern (valid, byte-faithful, but misleadingly spelled). This PR
  raises the *structure*; the biased label spelling is unchanged by it (a switch
  with no bias, e.g. `CSharpSpellability.TypeIssue`, already prints correct
  labels after this change). Tracking the label-spelling slice under #3159.

### Checkable companion fixture (IL fidelity enabled)

DeepEquals above is the real-world *witness* for the fix, but it cannot be run
through the contract-V1 compile-back oracle: its decompiled body references
internal `System.Text.Json` surface the oracle cannot recompile, so IL fidelity
is **not directly checkable** on it (tracked in #3197). To get an *actionable* IL
fidelity verdict on the same transformation, this PR adds a dependency-free,
high-likeness fixture — `CfgSampleClass.SwitchWithTwoLoopingCaseSections` — shaped
to mirror DeepEquals's dual loop-bearing arms (an Array-like `foreach` arm with a
length guard, and an Object-like loop arm with a count guard and an in-loop early
return), plus scalar arms and a default. Its decompiled output
(`dotnet-inspect member CfgSampleClass SwitchWithTwoLoopingCaseSections --library
… -S "Decompiled Source"`) raises exactly like the DeepEquals endpoint above — a
structured `switch` with both loops raised, no `goto`/labels, no `__switchValue0`
temp:

```csharp
public static int SwitchWithTwoLoopingCaseSections(int kind, int[] left, int[] right)
{
    switch (kind)
    {
        case 0:
            if (left.Length != right.Length)
            {
                return 0;
            }
            int sum = 0;
            foreach (int value in left)
            {
                sum += value;
            }
            return sum;
        case 1:
            if (left.Length != right.Length)
            {
                return -1;
            }
            int matched = 0;
            for (int i = 0; i < left.Length; i++)
            {
                if (left[i] != right[i])
                {
                    return matched;
                }
                matched++;
            }
            return matched;
        case 2:
            return left.Length;
        case 3:
            return right.Length;
        case 4:
            return 42;
        default:
            return -1;
    }
}
```

- Valid: True
- Correct: True
- **IL fidelity: `Exact`** — contract-V1 compile-back recompiles this raised C# to
  the original opcodes byte-for-byte (both back-edges, both `beq` guards, and the
  dense `switch`), so it joins `PinnedExact` in `FidelityGateTests`. This is the
  IL fidelity that cannot be checked on DeepEquals itself.

So the two examples are complementary: DeepEquals proves the fix on the real
platform method (structure + validity), and this fixture proves the raise is
**opcode-faithful** on a shape we own.

## Evidence

| Check | Baseline (`d131d951`) | Head (`a8129d63`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests (`SwitchBranchRenderingTests`) | new regression tests red | Pass (2 new tests green) |
| Decompiler fast suite (`-trait- "Speed=Slow"`) | 3669, 0 failed (after test-baseline update) | 3669, 0 failed |
| Fidelity: `FidelityGateTests` | 5 total, **2 failed** | 5 total, **2 failed** (same tests, same methods) |
| Fidelity: `LoweredFidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket` | **FAIL**, same 6 methods | **FAIL**, same 6 methods |
| Fidelity: `ClusterCapture` + `NestedTargetLookup` + `PrinterPrecedence` + `DiffFixture` + `AuthoredRebuild` | — | 35 total, 0 failed |
| Render-A/B (`System.Text.Json`) | base emitted | 3975 evaluated; **2 changed, both `structural valid->valid`, 0 `valid->invalid`** |
| Real witness | `JsonElement::DeepEquals` flat/goto | `JsonElement::DeepEquals` raised to structured switch |

**Pre-existing baseline failures (all decisively proven unchanged by this PR):**
All three slow-gate fidelity failures were **reproduced identically on the base
commit `d131d951` with this change reverted** (revert `SwitchRaisingPass.cs`,
rebuild, re-run):

1. `FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket`
   (`ManualConstantOnlyComparisonFactory`, `StatementBodyLambdaInsideIf`)
2. `FidelityGateTests.PinnedFixesStayExact` (`TupleRest` →
   `RecompileFail: CS0246 'int' could not be found`)
3. `LoweredFidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket` — same 6
   methods on head and base (`EnumArgInInlineLocalFunction`,
   `EnumArgInLocalFunctionWithLocal`, `ManualConstantOnlyComparisonFactory`,
   `RecursiveLocalFunction`, `StaticLocalFunctionWithLocal`,
   `TwoLocalFunctionQuadrants`), identical full diff set.

These are compile-back toolchain failures on this machine (local-function /
expression-tree / tuple fixtures). **None of the failing methods contains a
dense jump-table switch with a looping section** — the only shape this change
touches. `SkeletonEmitTests.SkeletonRestatesGenericConstraints` (generic-
constraint restatement, orthogonal to raising) was not run to completion under
machine load; it does not exercise switch raising.

**Compile-back fidelity pin added by this PR.** Because DeepEquals itself is not
compile-back-checkable (internal `System.Text.Json` surface; tracked in #3197),
this PR pins the raise's IL fidelity on a dependency-free, high-likeness fixture,
`CfgSampleClass.SwitchWithTwoLoopingCaseSections` — a `switch` with two
loop-bearing sections (Array-like `foreach` + Object-like `while` with an in-loop
early return) mirroring DeepEquals's Array and Object arms. It recompiles
**`Exact`** and joins `PinnedExact`. Re-running `PinnedFixesStayExact` +
`NoNewFidelityDiffsBeyondKnownDocket` with the fixture confirms the new method is
`Exact` in the full-type reconstruction (absent from the diff set) and the
beyond-docket unexpected set is **unchanged from base**
(`{ManualConstantOnlyComparisonFactory, StatementBodyLambdaInsideIf}`); the two
facts still "fail" only on the pre-existing environmental items above.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
# render-A/B (standing evidence for a raise PR):
#   base: dotnet run --project tools/DecompilerHarness -c Release -- --emit-render-ab base.json --package System.Text.Json --workers 4   (at d131d951)
#   head: dotnet run --project tools/DecompilerHarness -c Release -- --render-ab base.json --package System.Text.Json --workers 4
```

## Readiness

Both former blockers have landed:

- **Corpus quality-diff-card** — PR-quick card posted (**Conclusion: PASS**: 0 pass
  bugs, pinned shapes intact, no valid→invalid regressions across the switch
  corpus).
- **Two-model adversarial review** (roster in `AGENTS.md`) — GPT + Gemini, both
  **clean** at the reviewed head, reconciled on this PR (GPT's region-growth
  perf finding fixed via the iterative-Tarjan SCC pass; soundness clean both).

The later test-only follow-up (`11eb7539`) adds the `Exact`-pinned companion
fixture and is low-risk (no product change), so it does not reopen review. **Ready
to merge.**



