### PR TITLE
Group corpus-scale count deltas with NumberFormat="N0" (#3170)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Markout" Version="0.25.0" />
+    <PackageVersion Include="Markout" Version="0.27.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -1306,6 +1306,39 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void QualityMetricChanges_GroupsThousandsInLargeDeltas()
+    {
+        // At corpus scale a folded delta must carry the same thousands grouping as its operands
+        // (Markout NumberFormat="N0", issue #3170): the scalar Change<int> count row groups both
+        // operands and the absolute delta, and the composite share row groups its delta-noun count.
+        var methods = ValidityMethods(("One", "valid"), ("Two", "valid"));
+        var baseline = Snapshot(
+            totalMethods: 88_000,
+            fullyRaisedMethods: 80_000,
+            fullyRaisedBasisPoints: 9_091,
+            pinnedMethods: methods,
+            validityCompileCap: 2,
+            fullMalformedMethods: 2_000,
+            semanticCheckedMethods: 2);
+        var current = Snapshot(
+            totalMethods: 88_000,
+            fullyRaisedMethods: 81_624,
+            fullyRaisedBasisPoints: 9_275,
+            pinnedMethods: methods,
+            validityCompileCap: 2,
+            fullMalformedMethods: 3_624,
+            semanticCheckedMethods: 2);
+
+        string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
+
+        // Scalar count row: grouped operands + grouped absolute delta.
+        Assert.Contains("2,000 → 3,624 (+1,624)", report);
+        // Composite share row (residue): grouped operands (shape) + grouped delta-noun count (knob).
+        Assert.Contains("8,000 (", report);
+        Assert.Contains("(-1,624 methods)", report);
+    }
+
+    [Fact]
     public void CurrentMeasuredDebt_ReportsNoneForCleanEnabledChecks()
     {
         var snapshot = Snapshot(

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -2510,7 +2510,7 @@ internal static class CorpusSensor
             new Source(
                 "Change",
                 new Change<int>(baseline, current),
-                new MarkoutCellFormat { Goal = goal, Delta = countDeltaKnown ? Markout.Delta.Absolute : Markout.Delta.None }));
+                new MarkoutCellFormat { Goal = goal, Delta = countDeltaKnown ? Markout.Delta.Absolute : Markout.Delta.None, NumberFormat = "N0" }));
 
     static MultiSourceRow ShareChangeRow(
         string metric,
@@ -2525,7 +2525,7 @@ internal static class CorpusSensor
             new Source(
                 "Change",
                 new Change<QualityRate>(new QualityRate(baseline, baselineTotal), new QualityRate(current, currentTotal)),
-                new MarkoutCellFormat { Goal = goal, DeltaNoun = countDeltaKnown ? "methods" : null }));
+                new MarkoutCellFormat { Goal = goal, DeltaNoun = countDeltaKnown ? "methods" : null, NumberFormat = "N0" }));
 
     static bool HaveSameMethodSample(
         IReadOnlyList<CorpusMethodSnapshot>? baselineMethods,


### PR DESCRIPTION
Consumes the markout 0.27.0 `MarkoutCellFormat.NumberFormat` knob so the folded count deltas in the corpus quality-metric change table carry thousands grouping, matching the operands that `QualityRate` already renders with `N0`.

## Changes

- Bump the `Markout` package pin `0.25.0` → `0.27.0`.
- Add `NumberFormat = "N0"` to both `CorpusSensor` change-row cells:
  - the scalar `Change<int>` "Full malformed" row — grouped operands **and** absolute delta (`2,000 → 3,624 (+1,624)`);
  - the `Change<QualityRate>` residue share row — grouped delta-noun `methods` count (`(-1,624 methods)`).
- Add a 4-digit regression test (`QualityMetricChanges_GroupsThousandsInLargeDeltas`) asserting grouped operands, absolute delta, and delta-noun count.

## Sweep of other `Change<T>` consumers (no change needed)

- `HarnessReportDiff` — `MetricValueCell` already self-formats with `N0`; its delta is a precomputed string.
- `IlDiffHarness` / `CSharpDiffHarness` — `Change<Segments>`; Markout's `Segments` cell renders via `CellText.Number` and ignores `NumberFormat`, so the knob is a no-op there.
- `MetricChange<T>` rows use the `WriteMetricChangeTable` API, which has no `MarkoutCellFormat`/format parameter.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — clean (0 errors).
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` — 3696 passed, 0 failed.

Closes #3170
