### PR TITLE
Add "full taste" style aggregate enabling the oracle-endorsed subset

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -521,6 +521,15 @@ dotnet_style_prefer_conditional_expression_over_return = true
   ternary [style lens](#style-lenses-behavior-faithful-byte-divergent)), and
   `dotnet_inspect_style_prefer_branchless_boolean` (the non-oracle-endorsed
   branchless lens, under a tool-owned key). The set grows as more knobs ship.
+- `dotnet_inspect_style_full_taste = true` is a tool-owned **aggregate** key: it
+  enables the whole oracle-endorsed subset at once (the four `this`-qualifications
+  and the ternary lens — everything the runtime `.editorconfig`/IDE oracle
+  prefers) so a user need not copy each `dotnet_style_*` line. It deliberately
+  excludes the non-endorsed branchless lens, so the guarded-boolean-return
+  conflict group resolves to the ternary deterministically. It applies in file
+  order like any other key, so a later explicit per-knob line overrides it
+  (last-write-wins) — `full_taste = true` then
+  `dotnet_style_qualification_for_field = false` is "full taste minus one knob".
 - The recognized keys are not hand-maintained in the resolver: they come from the
   library-owned `StyleOptionCatalog` (see [Option catalog](#option-catalog)), so
   the CLI vocabulary and the option surface cannot drift.
@@ -575,11 +584,15 @@ set the knob on a `PrinterOptions` without reflection.
 This makes the option surface discoverable and drift-proof for every host, not
 just the CLI: the config resolver derives its recognized keys from the catalog,
 a Wasm UI can enumerate the knobs (grouping the mutually-exclusive lenses by
-`ConflictGroup` and toggling each through `Get`/`With`), and the future "full
-taste" aggregate is exactly the `OracleEndorsed` subset. The two guarded-boolean
-lenses share the `guarded-boolean-return` conflict group, so a picker offers at
-most one (the printer still resolves any overlap deterministically, preferring the
-oracle-endorsed ternary). Every opt-in knob is a boolean toggle — including the
+`ConflictGroup` and toggling each through `Get`/`With`), and the "full taste"
+aggregate is exactly the `OracleEndorsed` subset. The catalog exposes that subset
+as `OracleEndorsedOptions` and applies it with `ApplyFullTaste(PrinterOptions,
+enabled)`; the CLI surfaces it as the `dotnet_inspect_style_full_taste` config
+key. Because that subset enables only the oracle-endorsed ternary, the aggregate
+never trips the `guarded-boolean-return` conflict group the two guarded-boolean
+lenses share. A picker offers at most one member of that group (the printer still
+resolves any overlap deterministically, preferring the oracle-endorsed ternary).
+Every opt-in knob is a boolean toggle — including the
 expression-body arrow wrap (`WrapExpressionBodyArrow`) — so the catalog is
 exhaustive; a future non-boolean knob would need a descriptor shape that carries
 its value domain.

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -146,4 +146,53 @@ public class StyleOptionCatalogTests
         Assert.False(arrow.Get(PrinterOptions.Default));
         Assert.True(arrow.Get(arrow.With(PrinterOptions.Default, true)));
     }
+
+    [Fact]
+    public void OracleEndorsedOptions_IsExactlyTheOracleEndorsedDescriptors()
+    {
+        // The "full taste" member list is precisely the oracle-endorsed filter over
+        // Options — same instances, same order — and nothing else.
+        Assert.Equal(
+            Options.Where(o => o.OracleEndorsed).ToArray(),
+            StyleOptionCatalog.OracleEndorsedOptions.ToArray());
+        Assert.All(StyleOptionCatalog.OracleEndorsedOptions, o => Assert.True(o.OracleEndorsed));
+    }
+
+    [Fact]
+    public void ApplyFullTaste_EnablesExactlyTheOracleEndorsedSubset()
+    {
+        var full = StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default);
+
+        foreach (var o in Options)
+            Assert.Equal(o.OracleEndorsed, o.Get(full));
+    }
+
+    [Fact]
+    public void ApplyFullTaste_ResolvesGuardedBooleanReturnGroup_ToTheTernary()
+    {
+        // The aggregate picks the oracle-endorsed ternary and never the branchless
+        // "bool hack", so the conflict group resolves deterministically by
+        // construction — the two are never both on.
+        var full = StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default);
+
+        var ternary = Options.Single(o => o.Id == "prefer-conditional-expression-return");
+        var branchless = Options.Single(o => o.Id == "prefer-branchless-boolean");
+        Assert.True(ternary.Get(full));
+        Assert.False(branchless.Get(full));
+    }
+
+    [Fact]
+    public void ApplyFullTaste_False_DisablesExactlyTheOracleEndorsedSubset()
+    {
+        // Turn every knob on, then apply the aggregate with enabled: false — only
+        // the oracle-endorsed subset is turned back off; non-endorsed knobs stay on.
+        var allOn = PrinterOptions.Default;
+        foreach (var o in Options)
+            allOn = o.With(allOn, true);
+
+        var result = StyleOptionCatalog.ApplyFullTaste(allOn, enabled: false);
+
+        foreach (var o in Options)
+            Assert.Equal(!o.OracleEndorsed, o.Get(result));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -159,6 +159,49 @@ public class StyleOptionCatalogTests
     }
 
     [Fact]
+    public void OracleEndorsedOptions_AreExactlyTheFourQualificationsAndTheTernary()
+    {
+        // Pin the intended "full taste" subset to literal ids, independent of the
+        // OracleEndorsed flag the production filter reads. Without this, mismarking
+        // a knob (e.g. a formatting knob) as OracleEndorsed would silently widen the
+        // aggregate while every flag-derived test still passed.
+        var expected = new[]
+        {
+            "prefer-conditional-expression-return",
+            "qualify-event-access",
+            "qualify-field-access",
+            "qualify-method-access",
+            "qualify-property-access",
+        };
+
+        var actual = StyleOptionCatalog.OracleEndorsedOptions
+            .Select(o => o.Id)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void OracleEndorsedSubset_HasAtMostOneMemberPerConflictGroup()
+    {
+        // The "deterministic by construction" property the aggregate relies on:
+        // enabling the whole oracle-endorsed subset can never turn on two members of
+        // the same conflict group. A generic invariant (not just the current
+        // guarded-boolean-return group) so a future endorsed knob that shared a
+        // group with another endorsed knob fails here instead of silently making the
+        // aggregate ambiguous.
+        var collisions = StyleOptionCatalog.OracleEndorsedOptions
+            .Where(o => o.ConflictGroup is not null)
+            .GroupBy(o => o.ConflictGroup, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToArray();
+
+        Assert.Empty(collisions);
+    }
+
+    [Fact]
     public void ApplyFullTaste_EnablesExactlyTheOracleEndorsedSubset()
     {
         var full = StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -236,4 +236,39 @@ public static class StyleOptionCatalog
             With = static (o, v) => o with { PreferBranchlessBoolean = v },
         },
     ];
+
+    /// <summary>
+    /// The oracle-endorsed subset of <see cref="Options"/> — the knobs whose
+    /// spelling the runtime <c>.editorconfig</c>/IDE oracle prefers — that the
+    /// "full taste" aggregate enables together. A host lists these as the members
+    /// a single "full taste" toggle turns on. Excludes idiosyncratic user
+    /// preferences (e.g. the branchless "bool hack" lens) and the fidelity-neutral
+    /// formatting/synthesis knobs the oracle takes no position on.
+    ///
+    /// <para>Declared after <see cref="Options"/> so its initializer reads the
+    /// fully-built list. Because only oracle-endorsed knobs are included, at most
+    /// one member of any <see cref="StyleOptionDescriptor.ConflictGroup"/> is
+    /// present (the ternary lens, never the branchless one), so the subset carries
+    /// no internal conflict.</para>
+    /// </summary>
+    public static IReadOnlyList<StyleOptionDescriptor> OracleEndorsedOptions { get; } =
+        [.. Options.Where(o => o.OracleEndorsed)];
+
+    /// <summary>
+    /// Returns a copy of <paramref name="options"/> with every
+    /// <see cref="OracleEndorsedOptions"/> knob set to <paramref name="enabled"/> —
+    /// the "full taste" aggregate. When <paramref name="enabled"/> is
+    /// <see langword="true"/> (the default) it turns the oracle-endorsed subset on;
+    /// <see langword="false"/> turns exactly that subset off. Non-endorsed knobs are
+    /// left untouched, and because the enabled subset shares no conflict group the
+    /// result is deterministic. Reflection-free and NativeAOT-safe: it only folds
+    /// the descriptors' explicit <see cref="StyleOptionDescriptor.With"/> delegates.
+    /// </summary>
+    public static PrinterOptions ApplyFullTaste(PrinterOptions options, bool enabled = true)
+    {
+        foreach (var knob in OracleEndorsedOptions)
+            options = knob.With(options, enabled);
+
+        return options;
+    }
 }

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -105,6 +105,72 @@ public class RenderStyleConfigTests
     }
 
     [Fact]
+    public void Parse_FullTasteKey_EnablesTheOracleEndorsedSubset()
+    {
+        // The "full taste" aggregate turns on the whole oracle-endorsed subset with
+        // one key — the four this.-qualifications and the ternary lens — and never
+        // the non-endorsed branchless "bool hack".
+        var result = RenderStyleConfig.Parse("dotnet_inspect_style_full_taste = true", origin: "cfg");
+
+        Assert.True(result.Options.QualifyFieldAccess);
+        Assert.True(result.Options.QualifyPropertyAccess);
+        Assert.True(result.Options.QualifyMethodAccess);
+        Assert.True(result.Options.QualifyEventAccess);
+        Assert.True(result.Options.PreferConditionalExpressionReturn);
+        Assert.False(result.Options.PreferBranchlessBoolean);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_FullTasteKey_DefaultsOffAndToleratesSeverity()
+    {
+        Assert.False(RenderStyleConfig.Parse("", origin: null).Options.QualifyFieldAccess);
+
+        var withSeverity = RenderStyleConfig.Parse(
+            "dotnet_inspect_style_full_taste = true:suggestion",
+            origin: null);
+        Assert.True(withSeverity.Options.QualifyFieldAccess);
+        Assert.True(withSeverity.Options.PreferConditionalExpressionReturn);
+        Assert.Empty(withSeverity.Warnings);
+    }
+
+    [Fact]
+    public void Parse_FullTasteFalse_IsRecognizedAndLeavesSubsetOff()
+    {
+        var result = RenderStyleConfig.Parse("dotnet_inspect_style_full_taste = false", origin: null);
+
+        Assert.False(result.Options.QualifyFieldAccess);
+        Assert.False(result.Options.PreferConditionalExpressionReturn);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_FullTasteThenExplicitOverride_LastWriteWins()
+    {
+        // A later explicit per-knob line overrides the aggregate (file order is
+        // last-write-wins), so a user can take "full taste" minus one knob.
+        var result = RenderStyleConfig.Parse(
+            "dotnet_inspect_style_full_taste = true\n" +
+            "dotnet_style_qualification_for_field = false\n",
+            origin: null);
+
+        Assert.False(result.Options.QualifyFieldAccess);
+        Assert.True(result.Options.QualifyPropertyAccess);
+        Assert.True(result.Options.PreferConditionalExpressionReturn);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_FullTasteKey_NonBoolValue_Warns()
+    {
+        var result = RenderStyleConfig.Parse("dotnet_inspect_style_full_taste = maybe", origin: null);
+
+        var warning = Assert.Single(result.Warnings);
+        Assert.Contains("expects true/false", warning);
+        Assert.False(result.Options.QualifyFieldAccess);
+    }
+
+    [Fact]
     public void Parse_ToleratesEditorConfigSeveritySuffix()
     {
         var result = RenderStyleConfig.Parse("dotnet_style_qualification_for_field = true:suggestion", origin: null);

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -59,6 +59,14 @@ internal static class RenderStyleConfig
     // is the conventional way to declare that boundary explicitly.
     private const string RootKey = "root";
 
+    // The tool-owned aggregate key. It maps to no single catalog descriptor;
+    // instead it enables (or, when false, disables) the whole oracle-endorsed
+    // subset at once via StyleOptionCatalog.ApplyFullTaste. It uses the
+    // tool-owned dotnet_inspect_style_* vocabulary because it is a convenience
+    // aggregate with no editorconfig equivalent. Applied in file order like every
+    // other key, so a later explicit per-knob line overrides it (last write wins).
+    private const string FullTasteKey = "dotnet_inspect_style_full_taste";
+
     /// <summary>
     /// Walks up from <paramref name="startDirectory"/> to the filesystem root and
     /// returns the path of the nearest <see cref="FileName"/>, or null if none is
@@ -169,6 +177,15 @@ internal static class RenderStyleConfig
                     // knob but is recognized (not an "unknown key") and its value is
                     // still validated so a typo surfaces.
                     if (!TryParseBool(value, out _))
+                        Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
+                    break;
+                case FullTasteKey:
+                    // The "full taste" aggregate: enable (or disable) the whole
+                    // oracle-endorsed subset at once. Deterministic — the enabled
+                    // subset shares no conflict group.
+                    if (TryParseBool(value, out var fullTaste))
+                        options = StyleOptionCatalog.ApplyFullTaste(options, fullTaste);
+                    else
                         Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
                     break;
                 default:


### PR DESCRIPTION
## What & why

Adds the **"full taste" aggregate** — a single opt-in that enables the *oracle-endorsed* subset of the style knobs together — the capstone of the #3138 opt-in style-lens arc. A user adopting the runtime `.editorconfig`'s preferred spellings no longer copies each `dotnet_style_*` line; one key does it. Fixes #3176.

## Behavior

**"Full taste" = the `OracleEndorsed` subset**, exactly:

- the four `this.`-qualifications (`dotnet_style_qualification_for_{field,property,method,event}`)
- the ternary lens (`dotnet_style_prefer_conditional_expression_over_return`)

It **excludes** the non-endorsed branchless "bool hack" lens. Because only oracle-endorsed knobs are enabled, the aggregate always picks the ternary and never the branchless lens, so the `guarded-boolean-return` conflict group resolves deterministically **by construction** — no intra-aggregate conflict.

## Surface

- **Library (`StyleOptionCatalog`)** — discoverable for CLI + Wasm hosts:
  - `OracleEndorsedOptions` — the filtered descriptor subset (the "full taste" member list a UI shows).
  - `ApplyFullTaste(PrinterOptions, bool enabled = true)` — folds the descriptors' explicit `With` delegates over that subset. Reflection-free, NativeAOT-safe.
- **CLI (`RenderStyleConfig`)** — tool-owned aggregate key `dotnet_inspect_style_full_taste`. Applies in file order (last-write-wins), so a later explicit per-knob line overrides it — "full taste minus one knob".

## Composition

Composes with **Applied Taste** (#3172/#3173) with no extra wiring: the aggregate sets ordinary `PrinterOptions` knobs, so the byte-preserving `this.`-qualification decisions flow through the existing reporting.

## Evidence

- Catalog tests **15/0** (added: subset identity, enable/disable-subset, conflict-group resolution).
- Config tests **48/0** (added: enable, disable, severity suffix, override precedence, non-bool warning).
- Fast decompiler suite **3699/0**. `markdownlint` clean on `docs/decompiler-taste.md`.
- Product paths stay reflection-free / NativeAOT-safe; behavior-safe default unchanged (all knobs off with no config).

## Non-actions

The fidelity-neutral formatting/synthesis knobs (readable local names, wrap-splittable, wrap-expression-body-arrow) are **not** part of "full taste" — the oracle takes no position on them.

Refs #3138, #3160, #3171.
