### PR TITLE
Model revealed-preference corpus-endorsement axis (#3179)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -599,14 +599,14 @@ set the knob on a `PrinterOptions` without reflection.
 
 `OracleEndorsed` records **declared**-oracle endorsement specifically — the knob
 has a `.editorconfig` rule behind it. `CorpusEndorsed` records **revealed**
-endorsement — a knob the declared oracle is silent on but the runtime's own
-source corpus reveals a dominant practice for. The two flags are independent (a
-knob may be endorsed by both facets, one, or neither), and each
-`CorpusEndorsed = true` is a deliberate, documented judgment, never a
-silently-inferred or measured-heat claim. Today exactly one knob is
-revealed-endorsed — `wrap-splittable-expressions`, because runtime code wraps
-long boolean chains in line with its 120-column practice. The other
-formatting/synthesis knobs are left un-endorsed on both axes: wrapping the
+endorsement — the runtime's own source corpus reveals a dominant practice for the
+knob (typically where the declared oracle is silent, though the two facets are
+independent). The two flags are independent (a knob may be endorsed by both
+facets, one, or neither), and each `CorpusEndorsed = true` is a deliberate,
+documented judgment, never a silently-inferred or measured-heat claim. Today
+exactly one knob is revealed-endorsed — `wrap-splittable-expressions`, because
+runtime code wraps long boolean chains in line with its 120-column practice. The
+other formatting/synthesis knobs are left un-endorsed on both axes: wrapping the
 expression-body arrow actually *diverges* from the corpus (the runtime keeps `=>`
 on the same line, which the shipped default already does), and a synthesized
 local name is our own invention, not a corpus spelling. The catalog exposes the

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -591,19 +591,28 @@ The recognized knobs are described once, in the library, by
 `StyleOptionCatalog` (`ILInspector.Decompiler.Pipeline`). Each
 `StyleOptionDescriptor` carries a knob's stable id, human-facing title and
 summary, its tier (`Formatting`, `Spelling`, `Lens`, or `Synthesis`), whether it
-is `ByteDivergent`, whether it is `OracleEndorsed`, its `.dotnet-inspectconfig`
+is `ByteDivergent`, whether it is `OracleEndorsed` (declared) and `CorpusEndorsed`
+(revealed), its `.dotnet-inspectconfig`
 key (`null` for API-only formatting/synthesis knobs), a `ConflictGroup` for
 mutually-exclusive knobs, and NativeAOT-safe `Get`/`With` delegates that read and
 set the knob on a `PrinterOptions` without reflection.
 
 `OracleEndorsed` records **declared**-oracle endorsement specifically — the knob
-has a `.editorconfig` rule behind it. A knob being non-endorsed (the `Formatting`
-and `Synthesis` knobs) therefore means the *declared* oracle is silent, not that
-the runtime corpus is: runtime code visibly wraps long boolean chains, has
-expression-body arrow habits, and uses readable local names. Capturing that
-*revealed* endorsement as a distinct axis — so a future "house style" aggregate
-could enable declared ∪ revealed while "full taste" stays declared-only — is
-tracked in [#3179](https://github.com/richlander/dotnet-inspect/issues/3179).
+has a `.editorconfig` rule behind it. `CorpusEndorsed` records **revealed**
+endorsement — a knob the declared oracle is silent on but the runtime's own
+source corpus reveals a dominant practice for. The two flags are independent (a
+knob may be endorsed by both facets, one, or neither), and each
+`CorpusEndorsed = true` is a deliberate, documented judgment, never a
+silently-inferred or measured-heat claim. Today exactly one knob is
+revealed-endorsed — `wrap-splittable-expressions`, because runtime code wraps
+long boolean chains in line with its 120-column practice. The other
+formatting/synthesis knobs are left un-endorsed on both axes: wrapping the
+expression-body arrow actually *diverges* from the corpus (the runtime keeps `=>`
+on the same line, which the shipped default already does), and a synthesized
+local name is our own invention, not a corpus spelling. The catalog exposes the
+revealed subset as `CorpusEndorsedOptions`; a future "house style" aggregate would
+fold declared ∪ revealed while "full taste" stays declared-only
+([#3179](https://github.com/richlander/dotnet-inspect/issues/3179)).
 
 This makes the option surface discoverable and drift-proof for every host, not
 just the CLI: the config resolver derives its recognized keys from the catalog,

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -238,4 +238,66 @@ public class StyleOptionCatalogTests
         foreach (var o in Options)
             Assert.Equal(!o.OracleEndorsed, o.Get(result));
     }
+
+    // ---- corpus (revealed-preference) endorsement axis (#3179) ----
+
+    [Fact]
+    public void CorpusEndorsedOptions_IsExactlyTheCorpusEndorsedDescriptors()
+    {
+        Assert.Equal(
+            Options.Where(o => o.CorpusEndorsed).ToArray(),
+            StyleOptionCatalog.CorpusEndorsedOptions.ToArray());
+        Assert.All(StyleOptionCatalog.CorpusEndorsedOptions, o => Assert.True(o.CorpusEndorsed));
+    }
+
+    [Fact]
+    public void CorpusEndorsedOptions_AreExactlyTheWrapSplittableKnob()
+    {
+        // Pin the first revealed-preference classification to literal ids,
+        // independent of the CorpusEndorsed flag the production filter reads. The
+        // runtime corpus wraps long boolean chains (matching its 120-column
+        // practice); the other formatting/synthesis knobs are deliberately left
+        // un-endorsed pending evidence, so mismarking one fails here.
+        var actual = StyleOptionCatalog.CorpusEndorsedOptions
+            .Select(o => o.Id)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(new[] { "wrap-splittable-expressions" }, actual);
+    }
+
+    [Fact]
+    public void TheTwoEndorsementFacets_AreIndependentFlags()
+    {
+        // The two axes are orthogonal by contract. In today's catalog no knob is
+        // endorsed by both facets (the subsets are disjoint), but this asserts the
+        // flags are read independently, not that one implies the other.
+        var declaredButNotRevealed = Options.Where(o => o.OracleEndorsed && !o.CorpusEndorsed).ToArray();
+        var revealedButNotDeclared = Options.Where(o => o.CorpusEndorsed && !o.OracleEndorsed).ToArray();
+
+        Assert.NotEmpty(declaredButNotRevealed); // e.g. the this.-qualifications
+        Assert.NotEmpty(revealedButNotDeclared); // e.g. wrap-splittable-expressions
+    }
+
+    [Fact]
+    public void BranchlessLens_IsEndorsedByNeitherFacet()
+    {
+        // The idiosyncratic "bool hack" is the canonical neither-facet knob: no
+        // .editorconfig rule and no revealed corpus practice.
+        var branchless = Options.Single(o => o.Id == "prefer-branchless-boolean");
+        Assert.False(branchless.OracleEndorsed);
+        Assert.False(branchless.CorpusEndorsed);
+    }
+
+    [Fact]
+    public void WrapExpressionBodyArrow_IsEndorsedByNeitherFacet()
+    {
+        // Wrapping the expression-body arrow is a user preference, not the corpus's
+        // practice: the runtime keeps => on the same line, so the shipped default
+        // (arrow.Get == false) already matches the corpus and enabling the knob
+        // diverges from it. So it is neither declared- nor revealed-endorsed.
+        var arrow = Options.Single(o => o.Id == "wrap-expression-body-arrow");
+        Assert.False(arrow.OracleEndorsed);
+        Assert.False(arrow.CorpusEndorsed);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -85,15 +85,15 @@ public sealed record StyleOptionDescriptor
 
     /// <summary>
     /// <see langword="true"/> when the runtime's own <b>source corpus</b> reveals a
-    /// dominant practice endorsing this knob even where <see cref="OracleEndorsed"/>
-    /// is <see langword="false"/> — a declared-silent but revealed-endorsed shape
-    /// (see <c>docs/decompiler-taste.md</c>, the two oracle facets). Each
-    /// <see langword="true"/> is a deliberate, documented judgment, never a
-    /// silently-inferred or measured-heat claim. Independent of
-    /// <see cref="OracleEndorsed"/>: a knob may be endorsed by neither facet (an
-    /// idiosyncratic preference like the branchless "bool hack" or wrapping the
-    /// expression-body arrow, which the corpus does not do), by the declared facet,
-    /// or by the revealed facet.
+    /// dominant practice endorsing this knob — typically where
+    /// <see cref="OracleEndorsed"/> is <see langword="false"/> (the declared oracle
+    /// is silent), though the two facets are independent and a knob could in
+    /// principle be endorsed by both (see <c>docs/decompiler-taste.md</c>, the two
+    /// oracle facets). Each <see langword="true"/> is a deliberate, documented
+    /// judgment, never a silently-inferred or measured-heat claim. A knob may be
+    /// endorsed by neither facet (an idiosyncratic preference like the branchless
+    /// "bool hack", or wrapping the expression-body arrow, which the corpus does
+    /// not do), by the declared facet, by the revealed facet, or by both.
     /// </summary>
     public required bool CorpusEndorsed { get; init; }
 
@@ -299,14 +299,13 @@ public static class StyleOptionCatalog
     }
 
     /// <summary>
-    /// The revealed-endorsed subset of <see cref="Options"/> — knobs the declared
-    /// oracle is silent on (<see cref="StyleOptionDescriptor.OracleEndorsed"/> is
-    /// <see langword="false"/>) but the runtime's own source corpus reveals a
-    /// dominant practice for (<see cref="StyleOptionDescriptor.CorpusEndorsed"/> is
-    /// <see langword="true"/>). This is the material a future "house style"
-    /// aggregate would fold in on top of "full taste". The two flags are
-    /// independent by contract (a knob could in principle be endorsed by both
-    /// facets); in today's catalog no knob is, so this subset and
+    /// The revealed-endorsed subset of <see cref="Options"/> — knobs whose
+    /// <see cref="StyleOptionDescriptor.CorpusEndorsed"/> is <see langword="true"/>
+    /// because the runtime's own source corpus reveals a dominant practice for them.
+    /// This is the material a future "house style" aggregate would fold in on top of
+    /// "full taste". The two flags are independent by contract (a knob could in
+    /// principle be endorsed by both facets); in today's catalog every
+    /// revealed-endorsed knob happens to be declared-silent, so this subset and
     /// <see cref="OracleEndorsedOptions"/> happen to be disjoint. A host should not
     /// rely on that disjointness — treat the two accessors as independent.
     ///

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -74,12 +74,28 @@ public sealed record StyleOptionDescriptor
     public required bool ByteDivergent { get; init; }
 
     /// <summary>
-    /// <see langword="true"/> when the runtime <c>.editorconfig</c>/IDE oracle
-    /// endorses this spelling (so it is eligible for a future "full taste"
-    /// aggregate). <see langword="false"/> for idiosyncratic user preferences such
-    /// as the branchless "bool hack".
+    /// <see langword="true"/> when the <b>declared</b> oracle — the runtime
+    /// <c>.editorconfig</c> and enabled IDE fixers — endorses this spelling (so it
+    /// is part of the "full taste" aggregate). <see langword="false"/> for a knob
+    /// the declared oracle is silent on, including idiosyncratic user preferences
+    /// such as the branchless "bool hack". Orthogonal to <see cref="CorpusEndorsed"/>:
+    /// a declared-silent knob may still be revealed-endorsed by the corpus.
     /// </summary>
     public required bool OracleEndorsed { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the runtime's own <b>source corpus</b> reveals a
+    /// dominant practice endorsing this knob even where <see cref="OracleEndorsed"/>
+    /// is <see langword="false"/> — a declared-silent but revealed-endorsed shape
+    /// (see <c>docs/decompiler-taste.md</c>, the two oracle facets). Each
+    /// <see langword="true"/> is a deliberate, documented judgment, never a
+    /// silently-inferred or measured-heat claim. Independent of
+    /// <see cref="OracleEndorsed"/>: a knob may be endorsed by neither facet (an
+    /// idiosyncratic preference like the branchless "bool hack" or wrapping the
+    /// expression-body arrow, which the corpus does not do), by the declared facet,
+    /// or by the revealed facet.
+    /// </summary>
+    public required bool CorpusEndorsed { get; init; }
 
     /// <summary>
     /// The <c>.dotnet-inspectconfig</c> key that selects this knob, or
@@ -134,6 +150,7 @@ public static class StyleOptionCatalog
             ByteDivergent = false,
             OracleEndorsed = false,
             ConfigKey = null,
+            CorpusEndorsed = false,
             Get = static o => o.ReadableLocalNames,
             With = static (o, v) => o with { ReadableLocalNames = v },
         },
@@ -146,6 +163,7 @@ public static class StyleOptionCatalog
             ByteDivergent = false,
             OracleEndorsed = false,
             ConfigKey = null,
+            CorpusEndorsed = true,
             Get = static o => o.WrapSplittableExpressions,
             With = static (o, v) => o with { WrapSplittableExpressions = v },
         },
@@ -158,6 +176,7 @@ public static class StyleOptionCatalog
             ByteDivergent = false,
             OracleEndorsed = false,
             ConfigKey = null,
+            CorpusEndorsed = false,
             Get = static o => o.WrapExpressionBodyArrow,
             With = static (o, v) => o with { WrapExpressionBodyArrow = v },
         },
@@ -170,6 +189,7 @@ public static class StyleOptionCatalog
             ByteDivergent = false,
             OracleEndorsed = true,
             ConfigKey = "dotnet_style_qualification_for_field",
+            CorpusEndorsed = false,
             Get = static o => o.QualifyFieldAccess,
             With = static (o, v) => o with { QualifyFieldAccess = v },
         },
@@ -182,6 +202,7 @@ public static class StyleOptionCatalog
             ByteDivergent = false,
             OracleEndorsed = true,
             ConfigKey = "dotnet_style_qualification_for_property",
+            CorpusEndorsed = false,
             Get = static o => o.QualifyPropertyAccess,
             With = static (o, v) => o with { QualifyPropertyAccess = v },
         },
@@ -194,6 +215,7 @@ public static class StyleOptionCatalog
             ByteDivergent = false,
             OracleEndorsed = true,
             ConfigKey = "dotnet_style_qualification_for_method",
+            CorpusEndorsed = false,
             Get = static o => o.QualifyMethodAccess,
             With = static (o, v) => o with { QualifyMethodAccess = v },
         },
@@ -206,6 +228,7 @@ public static class StyleOptionCatalog
             ByteDivergent = false,
             OracleEndorsed = true,
             ConfigKey = "dotnet_style_qualification_for_event",
+            CorpusEndorsed = false,
             Get = static o => o.QualifyEventAccess,
             With = static (o, v) => o with { QualifyEventAccess = v },
         },
@@ -219,6 +242,7 @@ public static class StyleOptionCatalog
             OracleEndorsed = true,
             ConfigKey = "dotnet_style_prefer_conditional_expression_over_return",
             ConflictGroup = GuardedBooleanReturnGroup,
+            CorpusEndorsed = false,
             Get = static o => o.PreferConditionalExpressionReturn,
             With = static (o, v) => o with { PreferConditionalExpressionReturn = v },
         },
@@ -232,6 +256,7 @@ public static class StyleOptionCatalog
             OracleEndorsed = false,
             ConfigKey = "dotnet_inspect_style_prefer_branchless_boolean",
             ConflictGroup = GuardedBooleanReturnGroup,
+            CorpusEndorsed = false,
             Get = static o => o.PreferBranchlessBoolean,
             With = static (o, v) => o with { PreferBranchlessBoolean = v },
         },
@@ -243,7 +268,8 @@ public static class StyleOptionCatalog
     /// "full taste" aggregate enables together. A host lists these as the members
     /// a single "full taste" toggle turns on. Excludes idiosyncratic user
     /// preferences (e.g. the branchless "bool hack" lens) and the fidelity-neutral
-    /// formatting/synthesis knobs the oracle takes no position on.
+    /// formatting/synthesis knobs the <b>declared</b> oracle takes no position on
+    /// (some of which are <see cref="CorpusEndorsedOptions">revealed-endorsed</see>).
     ///
     /// <para>Declared after <see cref="Options"/> so its initializer reads the
     /// fully-built list. Because only oracle-endorsed knobs are included, at most
@@ -271,4 +297,22 @@ public static class StyleOptionCatalog
 
         return options;
     }
+
+    /// <summary>
+    /// The revealed-endorsed subset of <see cref="Options"/> — knobs the declared
+    /// oracle is silent on (<see cref="StyleOptionDescriptor.OracleEndorsed"/> is
+    /// <see langword="false"/>) but the runtime's own source corpus reveals a
+    /// dominant practice for (<see cref="StyleOptionDescriptor.CorpusEndorsed"/> is
+    /// <see langword="true"/>). This is the material a future "house style"
+    /// aggregate would fold in on top of "full taste". The two flags are
+    /// independent by contract (a knob could in principle be endorsed by both
+    /// facets); in today's catalog no knob is, so this subset and
+    /// <see cref="OracleEndorsedOptions"/> happen to be disjoint. A host should not
+    /// rely on that disjointness — treat the two accessors as independent.
+    ///
+    /// <para>Declared after <see cref="Options"/> so its initializer reads the
+    /// fully-built list.</para>
+    /// </summary>
+    public static IReadOnlyList<StyleOptionDescriptor> CorpusEndorsedOptions { get; } =
+        [.. Options.Where(o => o.CorpusEndorsed)];
 }


### PR DESCRIPTION
## What & why

Adds a `CorpusEndorsed` boolean to `StyleOptionDescriptor` alongside the existing `OracleEndorsed` flag, modeling the **two oracle facets** the taste model relies on (named in the doc by #3181):

- **`OracleEndorsed` (declared)** — the runtime `.editorconfig`/IDE fixers endorse the spelling. Drives the "full taste" aggregate.
- **`CorpusEndorsed` (revealed)** — the declared oracle is silent, but the runtime's own source corpus reveals a dominant practice for the knob.

The two flags are **independent by contract**. This first, conservative pass marks exactly **one** knob revealed-endorsed: `wrap-splittable-expressions` (runtime wraps long boolean chains, matching its 120-column practice). Every other formatting/synthesis knob stays un-endorsed on both axes — notably the expression-body arrow wrap, which actually *diverges* from the corpus (runtime keeps `=>` on the same line), and readable-local-names, which is our own synthesis invention, not a corpus spelling.

Each `CorpusEndorsed = true` is a **deliberate, documented judgment**, never a silently-inferred or measured-heat claim (per AGENTS.md evidence discipline).

## Changes

- `StyleOptionCatalog`: `CorpusEndorsed` field + 9 classifications (only wrap-splittable = true) + `CorpusEndorsedOptions` accessor (declared after `Options`, mirroring `OracleEndorsedOptions`). Tightened `OracleEndorsed` doc to say **declared** and note orthogonality.
- Tests: pin `CorpusEndorsedOptions` to literal id `["wrap-splittable-expressions"]` (independent of the flag the production filter reads); assert the two facets are read independently; assert branchless and arrow-wrap are endorsed by neither facet.
- `docs/decompiler-taste.md`: reconciled the Option-catalog prose, which previously over-claimed arrow-habits and readable-names as corpus-legible; added `CorpusEndorsed` to the descriptor-field list.

## Scope / non-goals

Delivers **only** the classification model + accessor. The "house style" aggregate (declared ∪ revealed / `ApplyHouseStyle`), any config key for formatting knobs, and any measured-corpus signal are explicit follow-ups tracked in #3179.

## Evidence

- Reflection-free; no `PrinterOptions` change, so the drift guard (`EveryBooleanPrinterOption_HasExactlyOneCatalogEntry`, 9 bool props == 9 descriptors) is unaffected.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.StyleOptionCatalogTests"` → **22/0**.
- `npx markdownlint-cli docs/decompiler-taste.md` clean.

Adversarial review (2 models) to follow.