### PR TITLE
Add closed-set member search primitive in ILInspector.Metadata (#3180)

### DIFF
--- a/src/ILInspector.Metadata/MemberSearch.cs
+++ b/src/ILInspector.Metadata/MemberSearch.cs
@@ -1,0 +1,172 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// A single member match produced by <see cref="MemberSearch"/>. The shape is
+/// presentation-independent and free of provenance beyond the assembly file name:
+/// callers attach package/source/version from their own resolution layer (e.g. the
+/// <c>AssemblySet</c> entry that supplied the path), mirroring how type search leaves
+/// <c>Source</c>/<c>SourceVersion</c> for the orchestrator to fill in.
+/// </summary>
+public sealed record MemberSearchResult
+{
+    /// <summary>The input pattern that matched this member.</summary>
+    public required string Pattern { get; init; }
+
+    /// <summary>The member's metadata name (e.g. <c>Parse</c>, <c>op_Addition</c>, <c>Item</c>).</summary>
+    public required string MemberName { get; init; }
+
+    /// <summary>Full name of the declaring type (<c>Namespace.Type</c>, or <c>Type</c> when global).</summary>
+    public required string DeclaringType { get; init; }
+
+    /// <summary>Namespace of the declaring type, when it has one.</summary>
+    public string? DeclaringNamespace { get; init; }
+
+    /// <summary>Member kind: method, property, field, event, constructor, operator, etc.</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>Display signature of the member, when the API surface captured one.</summary>
+    public string? Signature { get; init; }
+
+    /// <summary>Return/field/property type, when applicable.</summary>
+    public string? ReturnType { get; init; }
+
+    /// <summary>Durable 10-char overload digest, when the surface projected member identity.</summary>
+    public string? Digest { get; init; }
+
+    /// <summary>The assembly file name without extension that declared the member.</summary>
+    public required string Assembly { get; init; }
+
+    /// <summary>True when <see cref="Pattern"/> was a glob (contained <c>*</c> or <c>?</c>).</summary>
+    public bool IsGlob { get; init; }
+}
+
+/// <summary>
+/// Result of a <see cref="MemberSearch.Search(System.Collections.Generic.IEnumerable{string},
+/// System.Collections.Generic.IReadOnlyList{string}, bool, int?)"/> call: the matches and the
+/// assembly paths from which no API surface could be read. Skipped paths are reported rather than
+/// silently dropped so an all-unreadable set cannot masquerade as a clean "no matches" success.
+/// </summary>
+public sealed record MemberSearchOutcome(
+    IReadOnlyList<MemberSearchResult> Results,
+    IReadOnlyList<string> SkippedAssemblies);
+
+/// <summary>
+/// Closed-set member search: given a finite set of already-resolved assembly paths, find members
+/// whose name matches one or more patterns. This is the metadata-layer, offline "operate within a
+/// set" counterpart to type search — it reads local assemblies via
+/// <see cref="AssemblyReader.ExtractApiSurface(string, bool, bool)"/> and matches with the shared
+/// <see cref="TypeMatcher"/> name semantics (exact/case-insensitive or glob). It performs no
+/// package resolution or network access; populating the set is a separate, higher-layer concern.
+/// </summary>
+public static class MemberSearch
+{
+    /// <summary>
+    /// Searches the members of every assembly in <paramref name="assemblyPaths"/> for names matching
+    /// any pattern in <paramref name="patterns"/>. A member is emitted once per pattern it matches.
+    /// </summary>
+    /// <param name="assemblyPaths">The closed set of assembly file paths to search.</param>
+    /// <param name="patterns">Member-name patterns. Exact names match case-insensitively; patterns
+    /// containing <c>*</c> or <c>?</c> are treated as globs.</param>
+    /// <param name="includeAll">When true, non-public members are included; otherwise public only.</param>
+    /// <param name="limit">Optional cap on the number of results collected across the whole set.</param>
+    public static MemberSearchOutcome Search(
+        IEnumerable<string> assemblyPaths,
+        IReadOnlyList<string> patterns,
+        bool includeAll = false,
+        int? limit = null)
+    {
+        ArgumentNullException.ThrowIfNull(assemblyPaths);
+        ArgumentNullException.ThrowIfNull(patterns);
+
+        var results = new List<MemberSearchResult>();
+        var skipped = new List<string>();
+
+        if (patterns.Count == 0)
+            return new MemberSearchOutcome(results, skipped);
+
+        foreach (var path in assemblyPaths)
+        {
+            if (limit is int cap && results.Count >= cap)
+                break;
+
+            var surface = AssemblyReader.ExtractApiSurface(path, includeAll, typesOnly: false);
+            if (surface is null)
+            {
+                skipped.Add(path);
+                continue;
+            }
+
+            CollectFromSurface(surface, path, patterns, limit, results);
+        }
+
+        return new MemberSearchOutcome(results, skipped);
+    }
+
+    /// <summary>
+    /// Searches a single assembly's members. Returns an empty list when the assembly cannot be read
+    /// or has no metadata; callers that need to distinguish that case should use
+    /// <see cref="Search(IEnumerable{string}, IReadOnlyList{string}, bool, int?)"/> and inspect
+    /// <see cref="MemberSearchOutcome.SkippedAssemblies"/>.
+    /// </summary>
+    public static List<MemberSearchResult> SearchAssembly(
+        string assemblyPath,
+        IReadOnlyList<string> patterns,
+        bool includeAll = false)
+    {
+        ArgumentNullException.ThrowIfNull(patterns);
+
+        var results = new List<MemberSearchResult>();
+        if (patterns.Count == 0)
+            return results;
+
+        var surface = AssemblyReader.ExtractApiSurface(assemblyPath, includeAll, typesOnly: false);
+        if (surface is not null)
+            CollectFromSurface(surface, assemblyPath, patterns, limit: null, results);
+
+        return results;
+    }
+
+    private static void CollectFromSurface(
+        ApiSurface surface,
+        string assemblyPath,
+        IReadOnlyList<string> patterns,
+        int? limit,
+        List<MemberSearchResult> results)
+    {
+        var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
+
+        foreach (var type in surface.Types)
+        {
+            foreach (var member in type.Members)
+            {
+                foreach (var pattern in patterns)
+                {
+                    if (limit is int cap && results.Count >= cap)
+                        return;
+
+                    var isGlob = pattern.Contains('*') || pattern.Contains('?');
+                    var matched = isGlob
+                        ? TypeMatcher.MatchesGlob(member.Name, pattern)
+                        : TypeMatcher.MatchesMemberName(member.Name, pattern);
+
+                    if (!matched)
+                        continue;
+
+                    results.Add(new MemberSearchResult
+                    {
+                        Pattern = pattern,
+                        MemberName = member.Name,
+                        DeclaringType = type.FullName,
+                        DeclaringNamespace = type.Namespace,
+                        Kind = member.Kind,
+                        Signature = member.Signature,
+                        ReturnType = member.ReturnType,
+                        Digest = member.Digest,
+                        Assembly = assemblyName,
+                        IsGlob = isGlob,
+                    });
+                }
+            }
+        }
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MemberSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MemberSearchTests.cs
@@ -1,0 +1,123 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests
+{
+    public sealed class MemberSearchTests
+    {
+        private static string SelfAssembly => typeof(MemberSearchProbeAlphaFixture).Assembly.Location;
+
+        [Fact]
+        public void SearchAssembly_exact_name_finds_member_with_declaring_type_and_kind()
+        {
+            var results = MemberSearch.SearchAssembly(SelfAssembly, ["MemberSearchProbeAlpha"]);
+
+            var hit = Assert.Single(results);
+            Assert.Equal("MemberSearchProbeAlpha", hit.MemberName);
+            Assert.Equal(typeof(MemberSearchProbeAlphaFixture).FullName, hit.DeclaringType);
+            Assert.Equal("method", hit.Kind);
+            Assert.False(hit.IsGlob);
+            Assert.Equal("MemberSearchProbeAlpha", hit.Pattern);
+        }
+
+        [Fact]
+        public void SearchAssembly_is_case_insensitive_for_exact_names()
+        {
+            var results = MemberSearch.SearchAssembly(SelfAssembly, ["membersearchprobealpha"]);
+
+            Assert.Contains(results, r => r.MemberName == "MemberSearchProbeAlpha");
+        }
+
+        [Fact]
+        public void SearchAssembly_glob_matches_public_members_but_not_private_by_default()
+        {
+            var results = MemberSearch.SearchAssembly(SelfAssembly, ["MemberSearchProbe*"]);
+
+            var names = results.Select(r => r.MemberName).ToHashSet();
+            Assert.Contains("MemberSearchProbeAlpha", names);
+            Assert.Contains("MemberSearchProbeBeta", names);
+            Assert.DoesNotContain("MemberSearchProbeGammaHidden", names);
+            Assert.All(results.Where(r => r.MemberName.StartsWith("MemberSearchProbe")), r => Assert.True(r.IsGlob));
+        }
+
+        [Fact]
+        public void SearchAssembly_includeAll_surfaces_non_public_members()
+        {
+            var withoutAll = MemberSearch.SearchAssembly(SelfAssembly, ["MemberSearchProbeGammaHidden"]);
+            Assert.Empty(withoutAll);
+
+            var withAll = MemberSearch.SearchAssembly(SelfAssembly, ["MemberSearchProbeGammaHidden"], includeAll: true);
+            Assert.Contains(withAll, r => r.MemberName == "MemberSearchProbeGammaHidden");
+        }
+
+        [Fact]
+        public void SearchAssembly_no_match_returns_empty()
+        {
+            var results = MemberSearch.SearchAssembly(SelfAssembly, ["NoSuchMemberXyzzy1234"]);
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void Search_across_set_aggregates_and_records_assembly_name()
+        {
+            var outcome = MemberSearch.Search([SelfAssembly], ["MemberSearchProbeAlpha"]);
+
+            Assert.Empty(outcome.SkippedAssemblies);
+            var hit = Assert.Single(outcome.Results);
+            Assert.Equal(Path.GetFileNameWithoutExtension(SelfAssembly), hit.Assembly);
+        }
+
+        [Fact]
+        public void Search_reports_unreadable_assembly_as_skipped_without_faking_success()
+        {
+            var missing = Path.Combine(Path.GetTempPath(), "member-search-does-not-exist-4f2a.dll");
+
+            var outcome = MemberSearch.Search([missing], ["MemberSearchProbeAlpha"]);
+
+            Assert.Empty(outcome.Results);
+            Assert.Contains(missing, outcome.SkippedAssemblies);
+        }
+
+        [Fact]
+        public void Search_respects_result_limit()
+        {
+            var outcome = MemberSearch.Search([SelfAssembly], ["MemberSearchProbe*"], limit: 1);
+
+            Assert.Single(outcome.Results);
+        }
+
+        [Fact]
+        public void Search_empty_patterns_returns_empty_outcome()
+        {
+            var outcome = MemberSearch.Search([SelfAssembly], []);
+
+            Assert.Empty(outcome.Results);
+            Assert.Empty(outcome.SkippedAssemblies);
+        }
+
+        [Fact]
+        public void Search_same_member_name_in_two_types_returns_both()
+        {
+            var outcome = MemberSearch.Search([SelfAssembly], ["MemberSearchProbeShared"]);
+
+            Assert.Contains(outcome.Results, r =>
+                r.MemberName == "MemberSearchProbeShared"
+                && r.DeclaringType == typeof(MemberSearchProbeAlphaFixture).FullName);
+            Assert.Contains(outcome.Results, r =>
+                r.MemberName == "MemberSearchProbeShared"
+                && r.DeclaringType == typeof(MemberSearchProbeBetaFixture).FullName);
+        }
+    }
+
+    public sealed class MemberSearchProbeAlphaFixture
+    {
+        public int MemberSearchProbeAlpha() => 1;
+        public int MemberSearchProbeShared() => 2;
+        private int MemberSearchProbeGammaHidden() => 3;
+    }
+
+    public sealed class MemberSearchProbeBetaFixture
+    {
+        public void MemberSearchProbeBeta() { }
+        public int MemberSearchProbeShared() => 4;
+    }
+}


### PR DESCRIPTION
## What & why

First landable slice of the closed-set **corpus** work (#3180), homed per the
issue discussion: *operating within a set* is an `ILInspector.Metadata` concern
(SRM-only, no NuGet), while *population/acquisition* stays in
`DotnetInspector.Services`. This PR adds the concrete capability that was
missing on `main` — **member search within an already-resolved set of
assemblies** — as the metadata-layer counterpart to type search.

## Changes

- `src/ILInspector.Metadata/MemberSearch.cs`
  - `MemberSearch.Search(assemblyPaths, patterns, includeAll, limit)` → `MemberSearchOutcome`
  - `MemberSearch.SearchAssembly(assemblyPath, patterns, includeAll)` → `List<MemberSearchResult>`
  - Reuses `AssemblyReader.ExtractApiSurface` (enumeration) + `TypeMatcher`
    (exact/case-insensitive or glob) — **no new matching heuristic**, no
    package resolution, no network.
  - Unreadable / metadata-less assemblies are reported via
    `MemberSearchOutcome.SkippedAssemblies` rather than silently dropped
    (keep-failure-visible), so an all-unreadable set can't masquerade as a
    clean "no matches" success.
  - `includeAll` toggles non-public members; optional result `limit`.
- `tests/ILInspector.Metadata.Tests/MemberSearchTests.cs` — 10 focused tests
  (exact, case-insensitive, glob, public/non-public visibility, no-match,
  multi-assembly aggregation, skipped-assembly reporting, limit, empty
  patterns, same-name-in-two-types).

## Scope / risk

- **Additive.** No existing command or output behavior changes; nothing
  consumes `MemberSearch` yet. CLI/Services wiring and re-expressing type search
  through a corpus container are deliberate follow-ups.
- Product paths stay SRM-only / NativeAOT-friendly / Roslyn-free.

## Evidence

```text
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class "ILInspector.Metadata.Tests.MemberSearchTests"
=> Total: 10, Failed: 0
```

Full suite: `Total: 804, Failed: 1`. The single failure —
`MetadataSourceFindingsTests.MemberSourceProducer_UsesFirstVisibleDocumentWhenRootIsOmitted`
— is the **pre-existing, Windows-local** path-separator assertion tracked in
**#3018 (Root cause B)**; it reproduces identically on a pristine tree with
this PR's files removed, and is unrelated to this change.

## Follow-ups (not in this PR)

1. Corpus container type (holds the set; exposes `SearchTypes`/`SearchMembers`)
   once membership-granularity design settles.
2. `AssemblySetResolver` → corpus *producer*; serializable pinned manifest.
3. CLI wiring (`find`/`member` consume the corpus; type search re-expressed).

## Review

Draft. The broader corpus architecture is non-trivial and will need the
two-model adversarial review per `AGENTS.md`; this additive primitive is a
low-risk foundation. Feedback on the `MemberSearchResult` shape welcome before
CLI/Services wiring builds on it.

Refs #3180.
