### PR TITLE
Fix Windows-local test failures: CRLF stdout splitting and path-separator assertion (#3018)

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3192,7 +3192,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var lines = output.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
         Assert.Equal(2, lines.Length);
         Assert.Contains(lines, line => line.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", StringComparison.Ordinal));
         Assert.Contains(lines, line => line.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", StringComparison.Ordinal));
@@ -8666,7 +8666,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var lines = output.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
         Assert.Equal(2, lines.Length);
         Assert.Contains(lines, line => line.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", StringComparison.Ordinal));
         Assert.Contains(lines, line => line.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", StringComparison.Ordinal));
@@ -9960,7 +9960,7 @@ public class CommandExecutionTests
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
-            Assert.Equal(["skills/SKILL.md", "skills/two/SKILL.md"], output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            Assert.Equal(["skills/SKILL.md", "skills/two/SKILL.md"], output.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries));
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/PackageVersionTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionTests.cs
@@ -87,7 +87,7 @@ public class PackageVersionTests
         Assert.Equal(0, exit);
         Assert.Equal(
             ["8.0.0", "8.0.1", "8.0.2", "8.0.3", "8.0.4", "8.0.5"],
-            output.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            output.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries));
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
@@ -315,15 +315,17 @@ public sealed class MetadataSourceFindingsTests
             .Select(static finding => finding.Payload)
             .ToArray();
 
+        // CanonicalPath is separator-agnostic (always forward slashes); OriginalPath
+        // carries the OS separator and so fails these suffix checks on Windows (#3018).
         var authored = Assert.Single(mappings, mapping =>
-            mapping.OriginalPath.EndsWith(
+            mapping.CanonicalPath.EndsWith(
                 "tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs",
                 StringComparison.Ordinal));
         Assert.False(authored.IsPrimaryDocument);
         var primary = Assert.Single(mappings, static mapping => mapping.IsPrimaryDocument);
         Assert.EndsWith(
             "Generated/MetadataSourceFindings.g.cs",
-            primary.OriginalPath,
+            primary.CanonicalPath,
             StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
## Summary

Fixes the Windows-local test failures tracked in #3018. Two of the three root
causes were live test-robustness bugs (fixed here); the third was already
resolved on `main`.

- **Root cause A — CRLF stdout splitting (fixed).** `dotnet-inspect.Tests` split
  captured CLI stdout on `'\n'`; on Windows the CLI emits CRLF, so each token
  kept a trailing `'\r'` and exact/`EndsWith` assertions failed. Normalized with
  `output.ReplaceLineEndings("\n").Split('\n', …)` — a convention already used
  elsewhere in the suite — in the four affected assertions:
  - `PackageVersionTests.Versions_WithRange_ListsTheInclusiveAddressVector`
  - `CommandExecutionTests.Type_SourceFiles_Bare_EmitsUrlColumn`
  - `CommandExecutionTests.Package_SourceFilesSection_Bare_EmitsUrlColumn`
  - `CommandExecutionTests.Project_SkillsPaths_EmitsSkillPaths`
- **Root cause B — forward-slash path assertion (fixed).**
  `MetadataSourceFindingsTests.MemberSourceProducer_UsesFirstVisibleDocumentWhenRootIsOmitted`
  asserted `OriginalPath.EndsWith("tests/…/*.cs")`; `OriginalPath` carries the OS
  separator (backslash on Windows). Assert against the separator-agnostic
  `CanonicalPath` (always forward slashes) instead.
- **Root cause C — native-DLL CS0009 (already fixed on `main`).** The harness
  compile-back paths (`FidelityCheck.EvaluateTargets` /
  `ReturnToSender.CompileBackTargets`) previously included the native
  `aspnetcorev2_inprocess.dll` in the Roslyn reference set, failing every
  recompile with CS0009. This was resolved by #3142 (`ManagedReferenceFilter`),
  which postdates the issue's base `c04c2345`. No change needed here — verified
  below.

## Scope / risk

Test-only change (`src/dotnet-inspect.Tests`, `tests/ILInspector.Metadata.Tests`);
no `src/` product paths touched. Both edits are no-ops on Linux (output is already
`\n`; `CanonicalPath` equals the forward-slash `OriginalPath` for the local test
build), so Linux CI behavior is unchanged. Mechanical, low-risk — no adversarial
review required.

## Validation

Windows 10.0.26200, SDK `11.0.100-preview.6.26359.118` (matches the issue's env):

- A — the 4 CLI tests: `Total: 4, Failed: 0`.
- B — `dotnet run --project tests\ILInspector.Metadata.Tests -c Release -- -class "…MetadataSourceFindingsTests"`: `Total: 18, Failed: 0`.
- C — representative harness compile-back gates
  (`NullCoalescingAssignmentPassTests.LazyFieldGetter_RecompilesOpcodeExact`,
  `RuntimeAsyncAwaiterPassTests.CompiledYield_{CompileBack,ReturnToSender}ShellCarriesAsyncModifier`,
  `LadderRung6GateTests.Rung6FunctionPointerInvocation_RecompilesThroughFidelityHarness`):
  `Total: 4, Failed: 0`.

Closes #3018.
