### PR TITLE
Cache SearchValues<char> for per-call IndexOfAny character sets

### DIFF
--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Reflection.Metadata;
 using System.Security.Cryptography;
 using System.Text.Json;
@@ -518,6 +519,10 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
         return true;
     }
 
+    // Delimiters that mark a NuGet version range rather than a single version;
+    // cached to avoid allocating the delimiter array on every call.
+    static readonly SearchValues<char> s_versionRangeDelimiters = SearchValues.Create("[](),");
+
     static string? DependencyExactVersion(string? version)
     {
         if (string.IsNullOrWhiteSpace(version))
@@ -535,7 +540,7 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 return range[0].Trim();
         }
 
-        return version.IndexOfAny(['[', ']', '(', ')', ',']) < 0 ? version : null;
+        return version.AsSpan().ContainsAny(s_versionRangeDelimiters) ? null : version;
     }
 
     static IEnumerable<string> ProbeNuGetPackageVersionDlls(string packageDir, string? tfm, bool preferImplementationAssemblies)

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -605,9 +606,14 @@ public static class AttributeReader
         _ => null,
     };
 
+    // A type name containing a backtick (arity), '[' (array/generic), or ','
+    // (assembly-qualified) cannot be spelled as a plain typeof(); cached to
+    // avoid allocating the delimiter array on every render.
+    static readonly SearchValues<char> s_typeArgumentDelimiters = SearchValues.Create("`[,");
+
     static string? RenderTypeArgument(string typeName)
     {
-        if (typeName.IndexOfAny(['`', '[', ',']) >= 0)
+        if (typeName.AsSpan().ContainsAny(s_typeArgumentDelimiters))
             return null;
         string escapedType = MetadataDeclarationQuery.EscapeCompatibilityTypeKeywords(
             typeName.Replace('+', '.'));

--- a/src/ILInspector.Metadata/ResourceExtractor.cs
+++ b/src/ILInspector.Metadata/ResourceExtractor.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
@@ -12,7 +13,12 @@ static class ResourceExtractor
         string DestinationPath,
         string DestinationFullPath);
 
-    static readonly char[] s_portableInvalidFileNameCharacters = ['<', '>', '"', '|', '?', '*'];
+    // The portable set ('<' '>' '"' '|' '?' '*') is unioned with the platform's
+    // invalid file-name characters so component validation stays deterministic
+    // across operating systems. Caching in SearchValues also avoids the fresh
+    // array that Path.GetInvalidFileNameChars() allocates on every call.
+    static readonly SearchValues<char> s_invalidFileNameCharacters =
+        SearchValues.Create([.. Path.GetInvalidFileNameChars(), '<', '>', '"', '|', '?', '*']);
 
     public static List<string> ExtractAll(PEReader peReader, string outputDirectory)
     {
@@ -199,8 +205,7 @@ static class ResourceExtractor
         {
             if (component.Length == 0
                 || component is "." or ".."
-                || component.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
-                || component.IndexOfAny(s_portableInvalidFileNameCharacters) >= 0
+                || component.AsSpan().ContainsAny(s_invalidFileNameCharacters)
                 || component.Contains(':')
                 || component.EndsWith(' ')
                 || component.EndsWith('.')

--- a/src/dotnet-inspect/Commands/CacheCommand.cs
+++ b/src/dotnet-inspect/Commands/CacheCommand.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text.Json;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
@@ -147,10 +148,15 @@ public class CacheCommand
         }
     }
 
+    // Path separators a session name must not contain; cached to avoid
+    // allocating the separator array on every validation.
+    private static readonly SearchValues<char> s_sessionNameSeparators =
+        SearchValues.Create([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, Path.VolumeSeparatorChar]);
+
     private static bool IsSafeSessionName(string sessionName) =>
         !string.IsNullOrWhiteSpace(sessionName)
         && !sessionName.Contains("..", StringComparison.Ordinal)
-        && sessionName.IndexOfAny([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, Path.VolumeSeparatorChar]) < 0;
+        && !sessionName.AsSpan().ContainsAny(s_sessionNameSeparators);
 
     private static bool IsUnderTempDirectory(string path)
     {


### PR DESCRIPTION
## What

Replace four `IndexOfAny([...])` / `Path.GetInvalidFileNameChars()` call sites that allocated a fresh `char[]` on **every** invocation with cached `static readonly SearchValues<char>` fields, scanned via `ReadOnlySpan<char>.ContainsAny`. This matches the existing `SearchValues` precedent in `DocCommentParser`.

All four changes are behavior-preserving; the theme is allocation elimination, not new behavior.

| Site | Before | Win |
| --- | --- | --- |
| `ResourceExtractor.GetSafePathComponents` | `component.IndexOfAny(Path.GetInvalidFileNameChars())` **per loop iteration** + a second `IndexOfAny` over the portable set | `Path.GetInvalidFileNameChars()` clones its array on every call; now one cached `SearchValues` union, one scan |
| `AttributeReader.RenderTypeArgument` | `typeName.IndexOfAny(['`', '[', ','])` | inline `char[]` per render → cached field |
| `AssemblyDependencyResolver.DependencyExactVersion` | `version.IndexOfAny(['[', ']', '(', ')', ','])` | inline `char[]` per call → cached field |
| `CacheCommand.IsSafeSessionName` | `IndexOfAny([DirectorySeparatorChar, AltDirectorySeparatorChar, VolumeSeparatorChar])` | inline `char[]` per validation → cached field (cold path; included for consistency) |

### ResourceExtractor note

The cached `SearchValues` unions the platform's invalid file-name characters with the portable set (`< > " | ? *`). This preserves the prior two-check semantics exactly (`IndexOfAny(A) || IndexOfAny(B)` == `ContainsAny(A ∪ B)`) and keeps resource-name validation deterministic across operating systems. It also removes the per-iteration `Path.GetInvalidFileNameChars()` allocation on a security-sensitive (untrusted resource name) path.

## Deliberately excluded

- `FactPrimitiveCatalog.NamespaceSeparators` — already a `static` field (no per-call allocation), so it does not fit the allocation-elimination theme. Converting it would be a throughput bet requiring a benchmark.
- `SharedOptions.ListSeparators` — used with `string.Split(char[], …)`, which has no `SearchValues<char>` overload.
- Single-char `is 'x' or 'y'` classifier chains — scalar membership; `SearchValues` only pays off when scanning a span.

## Evidence

Behavior-preserving refactor validated on Windows (SDK 11.0.100-preview.6):

- `ILInspector.Metadata.Tests`: **794/794** (covers `ResourceExtractor` incl. `ExtractAll_RejectsUnsafeResourceNames` with `wild*.txt`/`question?.txt`/`pipe|.txt`/`value:stream`, and `AttributeReader`)
- `DotnetInspector.Services.Tests`: **297/297** (covers `AssemblyDependencyResolver`)
- `CacheCommandTests`: **8/8** (session-name validation)
- `dotnet build dotnet-inspect.slnx -c Release`: 0 errors

Allocation elimination is verifiable structurally. No throughput/vectorization claim is made — that would require a benchmark per the repo evidence rules.

## Risk

Low: mechanical, behavior-preserving hoists of char-set membership checks to cached `SearchValues<char>`. SRM-only, NativeAOT-friendly (`SearchValues` is AOT-safe), no new dependencies.
