### PR TITLE
Generalize StyleOptionDescriptor to carry a value domain (#3169 substrate)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -541,7 +541,7 @@ dotnet_style_prefer_conditional_expression_over_return = true
   and the ternary lens — everything the runtime `.editorconfig`/IDE oracle
   prefers) so a user need not copy each `dotnet_style_*` line. It deliberately
   excludes the non-endorsed branchless lens, so the guarded-boolean-return
-  conflict group resolves to the ternary deterministically. It applies in file
+  axis resolves to the ternary deterministically. It applies in file
   order like any other key, so a later explicit per-knob line overrides it
   (last-write-wins) — `full_taste = true` then
   `dotnet_style_qualification_for_field = false` is "full taste minus one knob".
@@ -591,44 +591,55 @@ The recognized knobs are described once, in the library, by
 `StyleOptionCatalog` (`ILInspector.Decompiler.Pipeline`). Each
 `StyleOptionDescriptor` carries a knob's stable id, human-facing title and
 summary, its tier (`Formatting`, `Spelling`, `Lens`, or `Synthesis`), whether it
-is `ByteDivergent`, whether it is `OracleEndorsed` (declared) and `CorpusEndorsed`
-(revealed), its `.dotnet-inspectconfig`
-key (`null` for API-only formatting/synthesis knobs), a `ConflictGroup` for
-mutually-exclusive knobs, and NativeAOT-safe `Get`/`With` delegates that read and
-set the knob on a `PrinterOptions` without reflection.
+is `ByteDivergent`, and the **value domain** it ranges over — its ordered list of
+`StyleOptionValue`s. Most knobs are two-state (a `false`/`true` domain); the
+guarded-boolean-return knob is a single multi-value axis
+(`flat` / `conditional-expression` / `branchless`). Each `StyleOptionValue`
+carries its stable token, optional title, whether that value is `OracleEndorsed`
+(declared) and `CorpusEndorsed` (revealed),
+its `.dotnet-inspectconfig` key (`null` for the off/default value and for API-only
+formatting/synthesis knobs), and NativeAOT-safe `IsSelected`/`SetSelected`
+delegates that read and drive that value's backing state without reflection. The
+descriptor reads and single-selects the whole axis through
+`GetValue`/`WithValue`.
 
-`OracleEndorsed` records **declared**-oracle endorsement specifically — the knob
+`OracleEndorsed` records **declared**-oracle endorsement specifically — the value
 has a `.editorconfig` rule behind it. `CorpusEndorsed` records **revealed**
 endorsement — the runtime's own source corpus reveals a dominant practice for the
-knob (typically where the declared oracle is silent, though the two facets are
-independent). The two flags are independent (a knob may be endorsed by both
+value (typically where the declared oracle is silent, though the two facets are
+independent). The two flags are independent (a value may be endorsed by both
 facets, one, or neither), and each `CorpusEndorsed = true` is a deliberate,
 documented judgment, never a silently-inferred or measured-heat claim. Today
 exactly one knob is revealed-endorsed — `wrap-splittable-expressions`, because
 runtime code wraps long boolean chains in line with its 120-column practice. The
 other formatting/synthesis knobs are left un-endorsed on both axes: wrapping the
 expression-body arrow actually *diverges* from the corpus (the runtime keeps `=>`
-on the same line, which the shipped default already does), and a synthesized
-local name is our own invention, not a corpus spelling. The catalog exposes the
-revealed subset as `CorpusEndorsedOptions`; a future "house style" aggregate would
-fold declared ∪ revealed while "full taste" stays declared-only
+on the same line, which the shipped default already does), and a synthesized local
+name is our own invention, not a corpus spelling. The catalog exposes the revealed
+subset as `CorpusEndorsedOptions`; a future "house style" aggregate would fold
+declared ∪ revealed while "full taste" stays declared-only
 ([#3179](https://github.com/richlander/dotnet-inspect/issues/3179)).
 
 This makes the option surface discoverable and drift-proof for every host, not
-just the CLI: the config resolver derives its recognized keys from the catalog,
-a Wasm UI can enumerate the knobs (grouping the mutually-exclusive lenses by
-`ConflictGroup` and toggling each through `Get`/`With`), and the "full taste"
-aggregate is exactly the `OracleEndorsed` subset. The catalog exposes that subset
-as `OracleEndorsedOptions` and applies it with `ApplyFullTaste(PrinterOptions,
-enabled)`; the CLI surfaces it as the `dotnet_inspect_style_full_taste` config
-key. Because that subset enables only the oracle-endorsed ternary, the aggregate
-never trips the `guarded-boolean-return` conflict group the two guarded-boolean
-lenses share. A picker offers at most one member of that group (the printer still
-resolves any overlap deterministically, preferring the oracle-endorsed ternary).
-Every opt-in knob is a boolean toggle — including the
-expression-body arrow wrap (`WrapExpressionBodyArrow`) — so the catalog is
-exhaustive; a future non-boolean knob would need a descriptor shape that carries
-its value domain.
+just the CLI: the config resolver derives its recognized keys from every value's
+`ConfigKey`, a Wasm UI can enumerate the knobs (presenting each axis's `Values` as
+a mutually-exclusive choice and driving it through `GetValue`/`WithValue`), and the
+"full taste" aggregate is exactly the endorsed value of each participating axis.
+The catalog exposes the participating knobs as `OracleEndorsedOptions` and applies
+the aggregate with `ApplyFullTaste(PrinterOptions, enabled)` — selecting each
+axis's `EndorsedValue`; the CLI surfaces it as the
+`dotnet_inspect_style_full_taste` config key. Because a multi-value axis is
+single-select by construction — `GetValue` reports the first selected value in
+`Values` order, so the oracle-endorsed `conditional-expression` wins over
+`branchless` when both are set, exactly as the printer resolves it — the aggregate
+selects the ternary and the axis never resolves ambiguously.
+
+Every opt-in knob's value domain is carried by the descriptor directly: the
+two-state knobs (including the expression-body arrow wrap, `WrapExpressionBodyArrow`)
+have a `false`/`true` domain, and the guarded-boolean-return family is one
+three-token axis rather than two coupled booleans. The catalog is exhaustive: a
+test-only drift guard asserts every backing `PrinterOptions` boolean is reachable
+through some descriptor value, so a new knob cannot land without a catalog entry.
 
 ## Verification and soundness
 

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -9,30 +9,52 @@ namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
 /// The library-owned <see cref="StyleOptionCatalog"/> is the single source of
-/// truth for the opt-in boolean <see cref="PrinterOptions"/> knobs — their
-/// identity, tier/contract, oracle endorsement, config key, mutual-exclusivity,
-/// and NativeAOT-safe accessors. These tests pin that contract so a host (the CLI
-/// resolver, a Wasm UI, the future "full taste" aggregate) can rely on it, and so
-/// the catalog cannot silently drift from the <see cref="PrinterOptions"/> surface.
+/// truth for the opt-in <see cref="PrinterOptions"/> knobs — their identity,
+/// tier/contract, value domain, oracle endorsement, config keys, and
+/// NativeAOT-safe accessors. These tests pin that contract so a host (the CLI
+/// resolver, a Wasm UI, the "full taste" aggregate) can rely on it, and so the
+/// catalog cannot silently drift from the <see cref="PrinterOptions"/> surface.
+/// Most knobs are two-state (boolean) toggles; the guarded-boolean-return knob is
+/// a single multi-value axis whose value domain the descriptor carries directly.
 /// </summary>
 public class StyleOptionCatalogTests
 {
     private static IReadOnlyList<StyleOptionDescriptor> Options => StyleOptionCatalog.Options;
 
-    // Every public instance boolean property on PrinterOptions is a knob a host may
-    // want to discover and toggle. Reflection here is a test-only drift guard (never
-    // a product path): if a new boolean knob lands without a catalog entry, this
-    // fails and forces the catalog — the single source of truth — to be updated.
+    private const string GuardedReturnId = "guarded-boolean-return-style";
+
+    // Every public instance boolean property on PrinterOptions is backing state a
+    // host may want to discover and drive through the catalog. Reflection here is a
+    // test-only drift guard (never a product path): if a new boolean knob lands
+    // without a catalog value that reaches it, the coverage test below fails and
+    // forces the catalog — the single source of truth — to be updated.
     private static IReadOnlyList<PropertyInfo> BooleanKnobProperties =>
         typeof(PrinterOptions)
             .GetProperties(BindingFlags.Public | BindingFlags.Instance)
             .Where(p => p.PropertyType == typeof(bool))
             .ToArray();
 
+    private static IReadOnlyList<StyleOptionValue> AllValues =>
+        Options.SelectMany(o => o.Values).ToArray();
+
+    private static ISet<string> ChangedBoolProps(PrinterOptions before, PrinterOptions after) =>
+        BooleanKnobProperties
+            .Where(p => (bool)p.GetValue(before)! != (bool)p.GetValue(after)!)
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
     [Fact]
-    public void EveryBooleanPrinterOption_HasExactlyOneCatalogEntry()
+    public void EveryBackingBooleanProperty_IsReachableThroughSomeCatalogValue()
     {
-        Assert.Equal(BooleanKnobProperties.Count, Options.Count);
+        // Drift guard: selecting each value (from the shipped default) must, taken
+        // together, be able to drive every backing PrinterOptions boolean. A new
+        // boolean knob with no catalog value to set it fails here.
+        var reached = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var value in AllValues)
+            reached.UnionWith(ChangedBoolProps(PrinterOptions.Default, value.SetSelected(PrinterOptions.Default, true)));
+
+        var expected = BooleanKnobProperties.Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+        Assert.Equal(expected, reached);
     }
 
     [Fact]
@@ -53,40 +75,82 @@ public class StyleOptionCatalogTests
     }
 
     [Fact]
+    public void Values_AreNonEmpty_WithUniqueTokens_AndAValidDefault()
+    {
+        Assert.All(Options, o =>
+        {
+            Assert.NotEmpty(o.Values);
+            var tokens = o.Values.Select(v => v.Token).ToArray();
+            Assert.All(tokens, t => Assert.False(string.IsNullOrWhiteSpace(t)));
+            Assert.Equal(tokens.Length, tokens.Distinct(StringComparer.Ordinal).Count());
+            // The declared default must be a real token on the axis, and it must be
+            // the value in effect on the shipped default options.
+            Assert.Contains(o.DefaultValue, tokens);
+            Assert.Equal(o.DefaultValue, o.GetValue(PrinterOptions.Default));
+        });
+    }
+
+    [Fact]
     public void ConfigKeys_WherePresent_AreUnique()
     {
-        var keys = Options.Select(o => o.ConfigKey).Where(k => k is not null).ToArray();
+        var keys = AllValues.Select(v => v.ConfigKey).Where(k => k is not null).ToArray();
         Assert.Equal(keys.Length, keys.Distinct(StringComparer.Ordinal).Count());
     }
 
     [Fact]
-    public void GetWith_RoundTripsEachKnob_OffByDefault()
+    public void GetValueWithValue_RoundTripsEachValue_FromTheDefault()
     {
         foreach (var o in Options)
         {
-            Assert.False(o.Get(PrinterOptions.Default), $"{o.Id} should be off in the shipped default");
+            Assert.Equal(o.DefaultValue, o.GetValue(PrinterOptions.Default));
 
-            var enabled = o.With(PrinterOptions.Default, true);
-            Assert.True(o.Get(enabled), $"{o.Id} should read back true after With(true)");
+            foreach (var value in o.Values)
+            {
+                var selected = o.WithValue(PrinterOptions.Default, value.Token);
+                Assert.Equal(value.Token, o.GetValue(selected));
 
-            var disabled = o.With(enabled, false);
-            Assert.False(o.Get(disabled), $"{o.Id} should read back false after With(false)");
+                // Returning to the default token clears the axis again.
+                var cleared = o.WithValue(selected, o.DefaultValue);
+                Assert.Equal(o.DefaultValue, o.GetValue(cleared));
+            }
         }
     }
 
     [Fact]
-    public void With_TogglesExactlyOneKnob_LeavingOthersUntouched()
+    public void WithValue_SetsOneAxis_LeavingEveryOtherAxisAtItsDefault()
     {
-        // Enabling one knob must not flip any other knob's Get — proof that the
-        // delegates are isolated and target distinct PrinterOptions properties.
+        // Single-selecting a non-default value on one descriptor must not move any
+        // other descriptor off its default — proof the delegates target disjoint
+        // backing state.
         foreach (var subject in Options)
         {
-            var enabled = subject.With(PrinterOptions.Default, true);
+            var nonDefault = subject.Values.First(v => !string.Equals(v.Token, subject.DefaultValue, StringComparison.Ordinal));
+            var mutated = subject.WithValue(PrinterOptions.Default, nonDefault.Token);
+
             foreach (var other in Options)
             {
-                var expected = ReferenceEquals(other, subject);
-                Assert.Equal(expected, other.Get(enabled));
+                if (ReferenceEquals(other, subject))
+                    continue;
+
+                Assert.Equal(other.DefaultValue, other.GetValue(mutated));
             }
+        }
+    }
+
+    [Fact]
+    public void ConfigKeyFalse_TogglesAnAxisOffWithoutTouchingSiblings()
+    {
+        // A boolean knob's key = false is the per-value SetSelected(false) path: it
+        // clears its own backing state and nothing else. Proven on the four
+        // qualification knobs (each is a two-state axis with a config key).
+        foreach (var o in Options.Where(o => o.Values.Count == 2 && o.ConfigKey is not null))
+        {
+            var onValue = o.Values.Single(v => v.ConfigKey is not null);
+            var enabled = onValue.SetSelected(PrinterOptions.Default, true);
+            Assert.Equal(onValue.Token, o.GetValue(enabled));
+
+            var disabled = onValue.SetSelected(enabled, false);
+            Assert.Equal(o.DefaultValue, o.GetValue(disabled));
         }
     }
 
@@ -97,54 +161,62 @@ public class StyleOptionCatalogTests
     }
 
     [Fact]
-    public void GuardedBooleanReturnGroup_IsExactlyTheTwoLenses()
+    public void GuardedBooleanReturn_IsOneTriStateLensAxis()
     {
-        var grouped = Options
-            .Where(o => o.ConflictGroup == StyleOptionCatalog.GuardedBooleanReturnGroup)
-            .Select(o => o.Id)
-            .OrderBy(id => id, StringComparer.Ordinal)
-            .ToArray();
+        var guarded = Options.Single(o => o.Id == GuardedReturnId);
+        Assert.Equal(StyleOptionTier.Lens, guarded.Tier);
+        Assert.True(guarded.ByteDivergent);
 
-        Assert.Equal(new[] { "prefer-branchless-boolean", "prefer-conditional-expression-return" }, grouped);
-        // Both members of a conflict group are byte-divergent lenses.
-        Assert.All(
-            Options.Where(o => o.ConflictGroup == StyleOptionCatalog.GuardedBooleanReturnGroup),
-            o => Assert.Equal(StyleOptionTier.Lens, o.Tier));
+        var tokens = guarded.Values.Select(v => v.Token).ToArray();
+        Assert.Equal(new[] { "flat", "conditional-expression", "branchless" }, tokens);
+        // The byte-faithful flat spelling is the default (no lens applied).
+        Assert.Equal("flat", guarded.DefaultValue);
     }
 
     [Fact]
-    public void OracleEndorsedSet_ExcludesTheBranchlessLens()
+    public void GuardedBooleanReturn_EndorsesTheTernary_NotTheBranchless()
     {
-        var endorsed = Options.Where(o => o.OracleEndorsed).Select(o => o.Id).ToArray();
-        Assert.Contains("prefer-conditional-expression-return", endorsed);
-        Assert.DoesNotContain("prefer-branchless-boolean", endorsed);
-        // The branchless lens uses a tool-owned key, never a dotnet_style_* one.
-        var branchless = Options.Single(o => o.Id == "prefer-branchless-boolean");
+        var guarded = Options.Single(o => o.Id == GuardedReturnId);
+
+        var endorsed = guarded.EndorsedValue;
+        Assert.NotNull(endorsed);
+        Assert.Equal("conditional-expression", endorsed!.Token);
+        Assert.StartsWith("dotnet_style_", endorsed.ConfigKey);
+
+        var branchless = guarded.Values.Single(v => v.Token == "branchless");
+        Assert.False(branchless.OracleEndorsed);
+        // The branchless "bool hack" uses a tool-owned key, never a dotnet_style_* one.
         Assert.StartsWith("dotnet_inspect_style_", branchless.ConfigKey);
     }
 
     [Fact]
-    public void OracleEndorsedKnobsWithAConfigKey_UseTheEditorconfigVocabulary()
+    public void EndorsedValuesWithAConfigKey_UseTheEditorconfigVocabulary()
     {
-        foreach (var o in Options.Where(o => o.OracleEndorsed && o.ConfigKey is not null))
-            Assert.StartsWith("dotnet_style_", o.ConfigKey);
+        foreach (var o in Options)
+            if (o.EndorsedValue is { ConfigKey: not null } endorsed)
+                Assert.StartsWith("dotnet_style_", endorsed.ConfigKey);
+    }
+
+    [Fact]
+    public void AtMostOneValuePerAxis_IsOracleEndorsed()
+    {
+        Assert.All(Options, o => Assert.True(o.Values.Count(v => v.OracleEndorsed) <= 1));
     }
 
     [Fact]
     public void WrapExpressionBodyArrow_IsAnApiOnlyFormattingKnob()
     {
-        // The former ExpressionBodyArrowPlacement enum is now a boolean toggle, so
-        // it belongs in the catalog: a whitespace-only formatting choice with no
-        // config key and no oracle endorsement (the shipped default keeps the arrow
-        // on the same line; wrapping it is a user preference, not the oracle's).
+        // The former ExpressionBodyArrowPlacement enum is now a two-state toggle: a
+        // whitespace-only formatting choice with no config key and no oracle
+        // endorsement (the shipped default keeps the arrow on the same line;
+        // wrapping it is a user preference, not the oracle's).
         var arrow = Options.Single(o => o.Id == "wrap-expression-body-arrow");
         Assert.Equal(StyleOptionTier.Formatting, arrow.Tier);
         Assert.False(arrow.ByteDivergent);
         Assert.False(arrow.OracleEndorsed);
         Assert.Null(arrow.ConfigKey);
-        Assert.Null(arrow.ConflictGroup);
-        Assert.False(arrow.Get(PrinterOptions.Default));
-        Assert.True(arrow.Get(arrow.With(PrinterOptions.Default, true)));
+        Assert.Equal("false", arrow.GetValue(PrinterOptions.Default));
+        Assert.Equal("true", arrow.GetValue(arrow.WithValue(PrinterOptions.Default, "true")));
     }
 
     [Fact]
@@ -159,15 +231,15 @@ public class StyleOptionCatalogTests
     }
 
     [Fact]
-    public void OracleEndorsedOptions_AreExactlyTheFourQualificationsAndTheTernary()
+    public void OracleEndorsedOptions_AreExactlyTheFourQualificationsAndTheGuardedReturn()
     {
         // Pin the intended "full taste" subset to literal ids, independent of the
-        // OracleEndorsed flag the production filter reads. Without this, mismarking
-        // a knob (e.g. a formatting knob) as OracleEndorsed would silently widen the
-        // aggregate while every flag-derived test still passed.
+        // per-value OracleEndorsed flag the production filter reads. Without this,
+        // mismarking a knob would silently widen the aggregate while every
+        // flag-derived test still passed.
         var expected = new[]
         {
-            "prefer-conditional-expression-return",
+            "guarded-boolean-return-style",
             "qualify-event-access",
             "qualify-field-access",
             "qualify-method-access",
@@ -183,60 +255,42 @@ public class StyleOptionCatalogTests
     }
 
     [Fact]
-    public void OracleEndorsedSubset_HasAtMostOneMemberPerConflictGroup()
-    {
-        // The "deterministic by construction" property the aggregate relies on:
-        // enabling the whole oracle-endorsed subset can never turn on two members of
-        // the same conflict group. A generic invariant (not just the current
-        // guarded-boolean-return group) so a future endorsed knob that shared a
-        // group with another endorsed knob fails here instead of silently making the
-        // aggregate ambiguous.
-        var collisions = StyleOptionCatalog.OracleEndorsedOptions
-            .Where(o => o.ConflictGroup is not null)
-            .GroupBy(o => o.ConflictGroup, StringComparer.Ordinal)
-            .Where(g => g.Count() > 1)
-            .Select(g => g.Key)
-            .ToArray();
-
-        Assert.Empty(collisions);
-    }
-
-    [Fact]
-    public void ApplyFullTaste_EnablesExactlyTheOracleEndorsedSubset()
+    public void ApplyFullTaste_SelectsExactlyTheEndorsedValueOnEachAxis()
     {
         var full = StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default);
 
         foreach (var o in Options)
-            Assert.Equal(o.OracleEndorsed, o.Get(full));
+        {
+            var expected = o.EndorsedValue?.Token ?? o.DefaultValue;
+            Assert.Equal(expected, o.GetValue(full));
+        }
     }
 
     [Fact]
-    public void ApplyFullTaste_ResolvesGuardedBooleanReturnGroup_ToTheTernary()
+    public void ApplyFullTaste_ResolvesGuardedBooleanReturn_ToTheTernary()
     {
         // The aggregate picks the oracle-endorsed ternary and never the branchless
-        // "bool hack", so the conflict group resolves deterministically by
-        // construction — the two are never both on.
+        // "bool hack": the axis resolves deterministically to conditional-expression.
         var full = StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default);
 
-        var ternary = Options.Single(o => o.Id == "prefer-conditional-expression-return");
-        var branchless = Options.Single(o => o.Id == "prefer-branchless-boolean");
-        Assert.True(ternary.Get(full));
-        Assert.False(branchless.Get(full));
+        var guarded = Options.Single(o => o.Id == GuardedReturnId);
+        Assert.Equal("conditional-expression", guarded.GetValue(full));
+        Assert.True(full.PreferConditionalExpressionReturn);
+        Assert.False(full.PreferBranchlessBoolean);
     }
 
     [Fact]
-    public void ApplyFullTaste_False_DisablesExactlyTheOracleEndorsedSubset()
+    public void ApplyFullTaste_False_DeselectsExactlyTheEndorsedValues()
     {
-        // Turn every knob on, then apply the aggregate with enabled: false — only
-        // the oracle-endorsed subset is turned back off; non-endorsed knobs stay on.
-        var allOn = PrinterOptions.Default;
-        foreach (var o in Options)
-            allOn = o.With(allOn, true);
-
-        var result = StyleOptionCatalog.ApplyFullTaste(allOn, enabled: false);
+        // Turn full taste on, then apply it with enabled: false — every endorsed
+        // value is deselected and the aggregate leaves the render byte-faithful
+        // again (no endorsed value selected on any axis).
+        var full = StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default);
+        var off = StyleOptionCatalog.ApplyFullTaste(full, enabled: false);
 
         foreach (var o in Options)
-            Assert.Equal(!o.OracleEndorsed, o.Get(result));
+            if (o.EndorsedValue is { } endorsed)
+                Assert.False(endorsed.IsSelected(off), $"{o.Id}: endorsed value should be deselected");
     }
 
     // ---- corpus (revealed-preference) endorsement axis (#3179) ----
@@ -280,11 +334,13 @@ public class StyleOptionCatalogTests
     }
 
     [Fact]
-    public void BranchlessLens_IsEndorsedByNeitherFacet()
+    public void BranchlessValue_IsEndorsedByNeitherFacet()
     {
-        // The idiosyncratic "bool hack" is the canonical neither-facet knob: no
-        // .editorconfig rule and no revealed corpus practice.
-        var branchless = Options.Single(o => o.Id == "prefer-branchless-boolean");
+        // The idiosyncratic "bool hack" is the canonical neither-facet value on the
+        // guarded-boolean-return axis: no .editorconfig rule and no revealed corpus
+        // practice.
+        var guarded = Options.Single(o => o.Id == GuardedReturnId);
+        var branchless = guarded.Values.Single(v => v.Token == "branchless");
         Assert.False(branchless.OracleEndorsed);
         Assert.False(branchless.CorpusEndorsed);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -38,280 +38,445 @@ public enum StyleOptionTier
 }
 
 /// <summary>
+/// One selectable value on a <see cref="StyleOptionDescriptor"/>'s axis: its
+/// stable token, optional human label, oracle endorsement, and the
+/// <c>.dotnet-inspectconfig</c> key (if any) that selects it. A boolean knob has
+/// two values (<c>false</c>/<c>true</c>); a multi-value knob such as the
+/// guarded-boolean-return family has three or more. The accessors are explicit,
+/// NativeAOT-safe delegates (never reflection) so any host can read and set the
+/// value on a <see cref="PrinterOptions"/> without knowing the concrete backing
+/// property or properties.
+/// </summary>
+public sealed record StyleOptionValue
+{
+    /// <summary>
+    /// Stable token identifying this value on the descriptor's axis
+    /// (kebab-case; <c>false</c>/<c>true</c> for a plain two-state toggle). Never
+    /// localized.
+    /// </summary>
+    public required string Token { get; init; }
+
+    /// <summary>Short human-facing label for a picker, or null to fall back to <see cref="Token"/>.</summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the runtime <c>.editorconfig</c>/IDE oracle
+    /// endorses this value (so it is the value a "full taste" aggregate selects on
+    /// this axis). At most one value per descriptor is oracle-endorsed. This is the
+    /// <b>declared</b> oracle facet; <see cref="CorpusEndorsed"/> is the orthogonal
+    /// <b>revealed</b> facet.
+    /// </summary>
+    public bool OracleEndorsed { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the runtime's own <b>source corpus</b> reveals a
+    /// dominant practice endorsing this value — the <b>revealed</b> oracle facet.
+    /// Independent of <see cref="OracleEndorsed"/> (the declared facet): a value may
+    /// be endorsed by neither facet (an idiosyncratic preference such as the
+    /// branchless "bool hack", or wrapping the expression-body arrow, which the
+    /// corpus does not do), by the declared facet, by the revealed facet, or by
+    /// both. Each <see langword="true"/> is a deliberate, documented judgment,
+    /// never a silently-inferred or measured-heat claim (see
+    /// <c>docs/decompiler-taste.md</c>, the two oracle facets).
+    /// </summary>
+    public bool CorpusEndorsed { get; init; }
+
+    /// <summary>
+    /// The <c>.dotnet-inspectconfig</c> key whose <c>= true</c> selects this value
+    /// (and whose <c>= false</c> deselects it), or <see langword="null"/> when the
+    /// value is not directly config-selectable — the default/off value of a knob,
+    /// or an API-only knob with no config vocabulary. Oracle-endorsed keys use the
+    /// editorconfig <c>dotnet_style_*</c> vocabulary; tool-owned values (e.g. the
+    /// branchless "bool hack") use a <c>dotnet_inspect_style_*</c> key.
+    /// </summary>
+    public string? ConfigKey { get; init; }
+
+    /// <summary>Reads whether this value is currently selected on a <see cref="PrinterOptions"/>.</summary>
+    public required Func<PrinterOptions, bool> IsSelected { get; init; }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="options"/> with this value's presence set
+    /// to the given flag. This is the per-key config setter: <c>key = true</c>
+    /// calls it with <see langword="true"/>, <c>key = false</c> with
+    /// <see langword="false"/>. It sets only this value's own backing state and
+    /// does not clear sibling values — the printer resolves any overlap
+    /// deterministically, exactly as it did when each value was an independent
+    /// boolean knob. Callers wanting single-select (clear siblings) semantics use
+    /// <see cref="StyleOptionDescriptor.WithValue"/>.
+    /// </summary>
+    public required Func<PrinterOptions, bool, PrinterOptions> SetSelected { get; init; }
+}
+
+/// <summary>
 /// The single, library-owned source of truth describing one opt-in
 /// <see cref="PrinterOptions"/> knob: its identity, human-facing text, tier and
-/// contract, oracle endorsement, config key, mutual-exclusivity group, and
-/// NativeAOT-safe accessors to read and set it on a <see cref="PrinterOptions"/>.
+/// contract, and the value domain it ranges over (its <see cref="Values"/>). A
+/// boolean knob is the two-value case (<c>false</c>/<c>true</c>); a multi-value
+/// knob — the guarded-boolean-return family — carries three tokens on one axis.
 ///
-/// <para>The accessors are explicit delegates (never reflection) so the catalog is
+/// <para>All accessors are explicit delegates (never reflection) so the catalog is
 /// enumerable from any host — including a Wasm build — without breaking the
-/// product's NativeAOT constraint. A UI can list every option, group the
-/// mutually-exclusive ones by <see cref="ConflictGroup"/>, filter the
-/// oracle-endorsed set for a future "full taste" aggregate, and toggle each knob
-/// through <see cref="Get"/>/<see cref="With"/> without knowing the concrete
-/// property.</para>
+/// product's NativeAOT constraint. A UI can list every option, present each
+/// axis's <see cref="Values"/> as a mutually-exclusive choice, filter the
+/// oracle-endorsed value of each axis for the "full taste" aggregate, and read or
+/// set the axis through <see cref="GetValue"/>/<see cref="WithValue"/> without
+/// knowing the concrete backing property.</para>
 /// </summary>
 public sealed record StyleOptionDescriptor
 {
     /// <summary>Stable, kebab-case identifier for programmatic reference (never localized).</summary>
     public required string Id { get; init; }
 
-    /// <summary>Short human-facing label for a picker (e.g. a checkbox caption).</summary>
+    /// <summary>Short human-facing label for a picker (e.g. a checkbox or dropdown caption).</summary>
     public required string Title { get; init; }
 
-    /// <summary>One-sentence description of what enabling the knob does.</summary>
+    /// <summary>One-sentence description of what the knob controls.</summary>
     public required string Summary { get; init; }
 
     /// <summary>The family and fidelity contract this knob belongs to.</summary>
     public required StyleOptionTier Tier { get; init; }
 
     /// <summary>
-    /// <see langword="true"/> when the knob's output recompiles to different bytes
-    /// than the shipped default (behavior-faithful but not opcode-faithful). Only
-    /// the <see cref="StyleOptionTier.Lens"/> knobs are byte-divergent; enabling
-    /// any of them promotes the whole render out of the compile-back fidelity gates.
+    /// <see langword="true"/> when the knob's non-default output recompiles to
+    /// different bytes than the shipped default (behavior-faithful but not
+    /// opcode-faithful). Only the <see cref="StyleOptionTier.Lens"/> knobs are
+    /// byte-divergent; selecting any non-default value of one promotes the whole
+    /// render out of the compile-back fidelity gates.
     /// </summary>
     public required bool ByteDivergent { get; init; }
 
     /// <summary>
-    /// <see langword="true"/> when the <b>declared</b> oracle — the runtime
-    /// <c>.editorconfig</c> and enabled IDE fixers — endorses this spelling (so it
-    /// is part of the "full taste" aggregate). <see langword="false"/> for a knob
-    /// the declared oracle is silent on, including idiosyncratic user preferences
-    /// such as the branchless "bool hack". Orthogonal to <see cref="CorpusEndorsed"/>:
-    /// a declared-silent knob may still be revealed-endorsed by the corpus.
+    /// The token of the shipped-default value — the value in effect on
+    /// <see cref="PrinterOptions.Default"/>. <see cref="GetValue"/> returns this
+    /// when no non-default value is selected.
     /// </summary>
-    public required bool OracleEndorsed { get; init; }
+    public required string DefaultValue { get; init; }
 
     /// <summary>
-    /// <see langword="true"/> when the runtime's own <b>source corpus</b> reveals a
-    /// dominant practice endorsing this knob — typically where
-    /// <see cref="OracleEndorsed"/> is <see langword="false"/> (the declared oracle
-    /// is silent), though the two facets are independent and a knob could in
-    /// principle be endorsed by both (see <c>docs/decompiler-taste.md</c>, the two
-    /// oracle facets). Each <see langword="true"/> is a deliberate, documented
-    /// judgment, never a silently-inferred or measured-heat claim. A knob may be
-    /// endorsed by neither facet (an idiosyncratic preference like the branchless
-    /// "bool hack", or wrapping the expression-body arrow, which the corpus does
-    /// not do), by the declared facet, by the revealed facet, or by both.
+    /// The value domain this knob ranges over, in presentation order. The first
+    /// entry is the default/off value; later entries are the selectable
+    /// alternatives. For a multi-value axis the order is also the resolution
+    /// precedence <see cref="GetValue"/> reports when more than one value is set at
+    /// once (the earlier, oracle-endorsed value wins — matching the printer).
     /// </summary>
-    public required bool CorpusEndorsed { get; init; }
+    public required IReadOnlyList<StyleOptionValue> Values { get; init; }
 
     /// <summary>
-    /// The <c>.dotnet-inspectconfig</c> key that selects this knob, or
-    /// <see langword="null"/> when the knob has no config key (it is settable only
-    /// through the API, e.g. a formatting knob). Oracle-endorsed keys use the
-    /// editorconfig <c>dotnet_style_*</c> vocabulary; the non-endorsed branchless
-    /// lens uses a tool-owned <c>dotnet_inspect_style_*</c> key.
+    /// The oracle-endorsed value on this axis (the one a "full taste" aggregate
+    /// selects), or <see langword="null"/> when the oracle takes no position on
+    /// this knob. At most one value is endorsed.
     /// </summary>
-    public string? ConfigKey { get; init; }
+    public StyleOptionValue? EndorsedValue => Values.SingleOrDefault(v => v.OracleEndorsed);
 
     /// <summary>
-    /// Identifier of a mutual-exclusivity group, or <see langword="null"/> when the
-    /// knob conflicts with nothing. Knobs that share a group rewrite the same shape,
-    /// so a host should let at most one be enabled at a time (the printer still
-    /// resolves any overlap deterministically, but a picker should not offer both).
+    /// <see langword="true"/> when some value on this axis is oracle-endorsed, so
+    /// the knob participates in the "full taste" aggregate.
     /// </summary>
-    public string? ConflictGroup { get; init; }
-
-    /// <summary>Reads the knob's current value from a <see cref="PrinterOptions"/>.</summary>
-    public required Func<PrinterOptions, bool> Get { get; init; }
-
-    /// <summary>Returns a copy of <paramref name="options"/> with this knob set to the given value.</summary>
-    public required Func<PrinterOptions, bool, PrinterOptions> With { get; init; }
-}
-
-/// <summary>
-/// The catalog of every opt-in boolean <see cref="PrinterOptions"/> knob, exposed
-/// as the shared source of truth for hosts (CLI config resolution, a Wasm UI, the
-/// future "full taste" aggregate) so option metadata lives in exactly one place
-/// and cannot drift between the library and its consumers.
-/// </summary>
-public static class StyleOptionCatalog
-{
-    /// <summary>Mutual-exclusivity group for the guarded-boolean-return style lenses (ternary vs. branchless).</summary>
-    public const string GuardedBooleanReturnGroup = "guarded-boolean-return";
+    public bool OracleEndorsed => EndorsedValue is not null;
 
     /// <summary>
-    /// Every opt-in boolean knob, in a stable presentation order (formatting and
-    /// spelling first, then the byte-divergent lenses). Every opt-in
-    /// <see cref="PrinterOptions"/> knob is a boolean toggle, so this catalog is
-    /// exhaustive; a future non-boolean knob would need a descriptor shape that
-    /// carries its value domain.
+    /// The corpus-endorsed (revealed) value on this axis, or <see langword="null"/>
+    /// when the runtime source corpus reveals no dominant practice for this knob.
+    /// At most one value is corpus-endorsed.
     /// </summary>
-    public static IReadOnlyList<StyleOptionDescriptor> Options { get; } =
-    [
-        new StyleOptionDescriptor
-        {
-            Id = "readable-local-names",
-            Title = "Readable local names",
-            Summary = "Synthesize a readable name for a local that has no PDB source name instead of V_index.",
-            Tier = StyleOptionTier.Synthesis,
-            ByteDivergent = false,
-            OracleEndorsed = false,
-            ConfigKey = null,
-            CorpusEndorsed = false,
-            Get = static o => o.ReadableLocalNames,
-            With = static (o, v) => o with { ReadableLocalNames = v },
-        },
-        new StyleOptionDescriptor
-        {
-            Id = "wrap-splittable-expressions",
-            Title = "Wrap long boolean chains",
-            Summary = "Break a long short-circuit &&/|| chain across lines instead of one very wide line (whitespace only).",
-            Tier = StyleOptionTier.Formatting,
-            ByteDivergent = false,
-            OracleEndorsed = false,
-            ConfigKey = null,
-            CorpusEndorsed = true,
-            Get = static o => o.WrapSplittableExpressions,
-            With = static (o, v) => o with { WrapSplittableExpressions = v },
-        },
-        new StyleOptionDescriptor
-        {
-            Id = "wrap-expression-body-arrow",
-            Title = "Wrap expression-body arrow",
-            Summary = "Wrap the => of an expression-bodied member or accessor onto the next line instead of keeping it on the declaration line (whitespace only).",
-            Tier = StyleOptionTier.Formatting,
-            ByteDivergent = false,
-            OracleEndorsed = false,
-            ConfigKey = null,
-            CorpusEndorsed = false,
-            Get = static o => o.WrapExpressionBodyArrow,
-            With = static (o, v) => o with { WrapExpressionBodyArrow = v },
-        },
-        new StyleOptionDescriptor
-        {
-            Id = "qualify-field-access",
-            Title = "Qualify field access with this.",
-            Summary = "Render this. on an instance field even where the bare name is unambiguous (IL-identical).",
-            Tier = StyleOptionTier.Spelling,
-            ByteDivergent = false,
-            OracleEndorsed = true,
-            ConfigKey = "dotnet_style_qualification_for_field",
-            CorpusEndorsed = false,
-            Get = static o => o.QualifyFieldAccess,
-            With = static (o, v) => o with { QualifyFieldAccess = v },
-        },
-        new StyleOptionDescriptor
-        {
-            Id = "qualify-property-access",
-            Title = "Qualify property access with this.",
-            Summary = "Render this. on an instance property even where the bare name is unambiguous (IL-identical).",
-            Tier = StyleOptionTier.Spelling,
-            ByteDivergent = false,
-            OracleEndorsed = true,
-            ConfigKey = "dotnet_style_qualification_for_property",
-            CorpusEndorsed = false,
-            Get = static o => o.QualifyPropertyAccess,
-            With = static (o, v) => o with { QualifyPropertyAccess = v },
-        },
-        new StyleOptionDescriptor
-        {
-            Id = "qualify-method-access",
-            Title = "Qualify method access with this.",
-            Summary = "Render this. on an instance method call even where the bare name is unambiguous (IL-identical).",
-            Tier = StyleOptionTier.Spelling,
-            ByteDivergent = false,
-            OracleEndorsed = true,
-            ConfigKey = "dotnet_style_qualification_for_method",
-            CorpusEndorsed = false,
-            Get = static o => o.QualifyMethodAccess,
-            With = static (o, v) => o with { QualifyMethodAccess = v },
-        },
-        new StyleOptionDescriptor
-        {
-            Id = "qualify-event-access",
-            Title = "Qualify event access with this.",
-            Summary = "Render this. on an instance event even where the bare name is unambiguous (IL-identical).",
-            Tier = StyleOptionTier.Spelling,
-            ByteDivergent = false,
-            OracleEndorsed = true,
-            ConfigKey = "dotnet_style_qualification_for_event",
-            CorpusEndorsed = false,
-            Get = static o => o.QualifyEventAccess,
-            With = static (o, v) => o with { QualifyEventAccess = v },
-        },
-        new StyleOptionDescriptor
-        {
-            Id = "prefer-conditional-expression-return",
-            Title = "Prefer conditional expression return",
-            Summary = "Render a declined guarded boolean return as the ternary return c ? A : B; (oracle-preferred, byte-divergent).",
-            Tier = StyleOptionTier.Lens,
-            ByteDivergent = true,
-            OracleEndorsed = true,
-            ConfigKey = "dotnet_style_prefer_conditional_expression_over_return",
-            ConflictGroup = GuardedBooleanReturnGroup,
-            CorpusEndorsed = false,
-            Get = static o => o.PreferConditionalExpressionReturn,
-            With = static (o, v) => o with { PreferConditionalExpressionReturn = v },
-        },
-        new StyleOptionDescriptor
-        {
-            Id = "prefer-branchless-boolean",
-            Title = "Prefer branchless boolean",
-            Summary = "Render a declined guarded boolean return as the compact short-circuit \"bool hack\" (not oracle-endorsed, byte-divergent).",
-            Tier = StyleOptionTier.Lens,
-            ByteDivergent = true,
-            OracleEndorsed = false,
-            ConfigKey = "dotnet_inspect_style_prefer_branchless_boolean",
-            ConflictGroup = GuardedBooleanReturnGroup,
-            CorpusEndorsed = false,
-            Get = static o => o.PreferBranchlessBoolean,
-            With = static (o, v) => o with { PreferBranchlessBoolean = v },
-        },
-    ];
+    public StyleOptionValue? CorpusEndorsedValue => Values.SingleOrDefault(v => v.CorpusEndorsed);
 
     /// <summary>
-    /// The oracle-endorsed subset of <see cref="Options"/> — the knobs whose
-    /// spelling the runtime <c>.editorconfig</c>/IDE oracle prefers — that the
-    /// "full taste" aggregate enables together. A host lists these as the members
-    /// a single "full taste" toggle turns on. Excludes idiosyncratic user
-    /// preferences (e.g. the branchless "bool hack" lens) and the fidelity-neutral
-    /// formatting/synthesis knobs the <b>declared</b> oracle takes no position on
-    /// (some of which are <see cref="CorpusEndorsedOptions">revealed-endorsed</see>).
-    ///
-    /// <para>Declared after <see cref="Options"/> so its initializer reads the
-    /// fully-built list. Because only oracle-endorsed knobs are included, at most
-    /// one member of any <see cref="StyleOptionDescriptor.ConflictGroup"/> is
-    /// present (the ternary lens, never the branchless one), so the subset carries
-    /// no internal conflict.</para>
+    /// <see langword="true"/> when some value on this axis is corpus-endorsed (the
+    /// revealed facet). Orthogonal to <see cref="OracleEndorsed"/>.
     /// </summary>
-    public static IReadOnlyList<StyleOptionDescriptor> OracleEndorsedOptions { get; } =
-        [.. Options.Where(o => o.OracleEndorsed)];
+    public bool CorpusEndorsed => CorpusEndorsedValue is not null;
 
     /// <summary>
-    /// Returns a copy of <paramref name="options"/> with every
-    /// <see cref="OracleEndorsedOptions"/> knob set to <paramref name="enabled"/> —
-    /// the "full taste" aggregate. When <paramref name="enabled"/> is
-    /// <see langword="true"/> (the default) it turns the oracle-endorsed subset on;
-    /// <see langword="false"/> turns exactly that subset off. Non-endorsed knobs are
-    /// left untouched, and because the enabled subset shares no conflict group the
-    /// result is deterministic. Reflection-free and NativeAOT-safe: it only folds
-    /// the descriptors' explicit <see cref="StyleOptionDescriptor.With"/> delegates.
+    /// The config key that turns a two-state (boolean) knob on, or
+    /// <see langword="null"/> for an API-only or multi-value knob (whose per-value
+    /// keys live on <see cref="Values"/>). Convenience for the common boolean case
+    /// so a host recording a two-state taste choice can name the key without
+    /// walking <see cref="Values"/>.
     /// </summary>
-    public static PrinterOptions ApplyFullTaste(PrinterOptions options, bool enabled = true)
+    public string? ConfigKey =>
+        Values.Count == 2 ? Values[1].ConfigKey : null;
+
+    /// <summary>
+    /// The token of the value currently selected on <paramref name="options"/> —
+    /// the first value in <see cref="Values"/> order whose
+    /// <see cref="StyleOptionValue.IsSelected"/> holds, or <see cref="DefaultValue"/>
+    /// when none does. The <see cref="Values"/> order makes this deterministic when
+    /// more than one value is set at once (the earlier value wins).
+    /// </summary>
+    public string GetValue(PrinterOptions options)
     {
-        foreach (var knob in OracleEndorsedOptions)
-            options = knob.With(options, enabled);
+        foreach (var value in Values)
+            if (value.IsSelected(options))
+                return value.Token;
+
+        return DefaultValue;
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="options"/> with this axis set to
+    /// <paramref name="token"/> and every other value on the axis cleared
+    /// (single-select). Selecting <see cref="DefaultValue"/> clears the whole axis.
+    /// Reflection-free: it only folds the values' explicit
+    /// <see cref="StyleOptionValue.SetSelected"/> delegates.
+    /// </summary>
+    public PrinterOptions WithValue(PrinterOptions options, string token)
+    {
+        foreach (var value in Values)
+            options = value.SetSelected(options, string.Equals(value.Token, token, StringComparison.Ordinal));
 
         return options;
     }
 
     /// <summary>
-    /// The revealed-endorsed subset of <see cref="Options"/> — knobs whose
-    /// <see cref="StyleOptionDescriptor.CorpusEndorsed"/> is <see langword="true"/>
-    /// because the runtime's own source corpus reveals a dominant practice for them.
-    /// This is the material a future "house style" aggregate would fold in on top of
-    /// "full taste". The two flags are independent by contract (a knob could in
-    /// principle be endorsed by both facets); in today's catalog every
-    /// revealed-endorsed knob happens to be declared-silent, so this subset and
-    /// <see cref="OracleEndorsedOptions"/> happen to be disjoint. A host should not
-    /// rely on that disjointness — treat the two accessors as independent.
+    /// Boolean convenience: <see langword="true"/> when any non-default value is
+    /// selected. Meaningful for the two-state knobs (and reports "some non-default
+    /// value is on" for a multi-value axis).
+    /// </summary>
+    public bool Get(PrinterOptions options) =>
+        !string.Equals(GetValue(options), DefaultValue, StringComparison.Ordinal);
+}
+
+/// <summary>
+/// The catalog of every opt-in <see cref="PrinterOptions"/> knob, exposed as the
+/// shared source of truth for hosts (CLI config resolution, a Wasm UI, the "full
+/// taste" aggregate) so option metadata lives in exactly one place and cannot
+/// drift between the library and its consumers. Most knobs are two-state
+/// (boolean) toggles; the guarded-boolean-return family is a single multi-value
+/// axis whose value domain the descriptor carries directly.
+/// </summary>
+public static class StyleOptionCatalog
+{
+    // Value tokens for the guarded-boolean-return family axis.
+    private const string GuardedReturnDefault = "flat";
+    private const string GuardedReturnConditional = "conditional-expression";
+    private const string GuardedReturnBranchless = "branchless";
+
+    /// <summary>
+    /// Every opt-in knob, in a stable presentation order (formatting and spelling
+    /// first, then the byte-divergent lens). Two-state knobs carry a
+    /// <c>false</c>/<c>true</c> value domain; the guarded-boolean-return knob is a
+    /// single multi-value axis (<c>flat</c> / <c>conditional-expression</c> /
+    /// <c>branchless</c>). The catalog is exhaustive: the drift-guard test asserts
+    /// every backing <see cref="PrinterOptions"/> property is reachable through
+    /// some descriptor value.
+    /// </summary>
+    public static IReadOnlyList<StyleOptionDescriptor> Options { get; } =
+    [
+        Boolean(
+            id: "readable-local-names",
+            title: "Readable local names",
+            summary: "Synthesize a readable name for a local that has no PDB source name instead of V_index.",
+            tier: StyleOptionTier.Synthesis,
+            byteDivergent: false,
+            oracleEndorsed: false,
+            configKey: null,
+            get: static o => o.ReadableLocalNames,
+            with: static (o, v) => o with { ReadableLocalNames = v }),
+        Boolean(
+            id: "wrap-splittable-expressions",
+            title: "Wrap long boolean chains",
+            summary: "Break a long short-circuit &&/|| chain across lines instead of one very wide line (whitespace only).",
+            tier: StyleOptionTier.Formatting,
+            byteDivergent: false,
+            oracleEndorsed: false,
+            configKey: null,
+            get: static o => o.WrapSplittableExpressions,
+            with: static (o, v) => o with { WrapSplittableExpressions = v },
+            corpusEndorsed: true),
+        Boolean(
+            id: "wrap-expression-body-arrow",
+            title: "Wrap expression-body arrow",
+            summary: "Wrap the => of an expression-bodied member or accessor onto the next line instead of keeping it on the declaration line (whitespace only).",
+            tier: StyleOptionTier.Formatting,
+            byteDivergent: false,
+            oracleEndorsed: false,
+            configKey: null,
+            get: static o => o.WrapExpressionBodyArrow,
+            with: static (o, v) => o with { WrapExpressionBodyArrow = v }),
+        Boolean(
+            id: "qualify-field-access",
+            title: "Qualify field access with this.",
+            summary: "Render this. on an instance field even where the bare name is unambiguous (IL-identical).",
+            tier: StyleOptionTier.Spelling,
+            byteDivergent: false,
+            oracleEndorsed: true,
+            configKey: "dotnet_style_qualification_for_field",
+            get: static o => o.QualifyFieldAccess,
+            with: static (o, v) => o with { QualifyFieldAccess = v }),
+        Boolean(
+            id: "qualify-property-access",
+            title: "Qualify property access with this.",
+            summary: "Render this. on an instance property even where the bare name is unambiguous (IL-identical).",
+            tier: StyleOptionTier.Spelling,
+            byteDivergent: false,
+            oracleEndorsed: true,
+            configKey: "dotnet_style_qualification_for_property",
+            get: static o => o.QualifyPropertyAccess,
+            with: static (o, v) => o with { QualifyPropertyAccess = v }),
+        Boolean(
+            id: "qualify-method-access",
+            title: "Qualify method access with this.",
+            summary: "Render this. on an instance method call even where the bare name is unambiguous (IL-identical).",
+            tier: StyleOptionTier.Spelling,
+            byteDivergent: false,
+            oracleEndorsed: true,
+            configKey: "dotnet_style_qualification_for_method",
+            get: static o => o.QualifyMethodAccess,
+            with: static (o, v) => o with { QualifyMethodAccess = v }),
+        Boolean(
+            id: "qualify-event-access",
+            title: "Qualify event access with this.",
+            summary: "Render this. on an instance event even where the bare name is unambiguous (IL-identical).",
+            tier: StyleOptionTier.Spelling,
+            byteDivergent: false,
+            oracleEndorsed: true,
+            configKey: "dotnet_style_qualification_for_event",
+            get: static o => o.QualifyEventAccess,
+            with: static (o, v) => o with { QualifyEventAccess = v }),
+        GuardedBooleanReturnStyle(),
+    ];
+
+    /// <summary>
+    /// The oracle-endorsed subset of <see cref="Options"/> — the knobs whose axis
+    /// carries a value the runtime <c>.editorconfig</c>/IDE oracle prefers — that
+    /// the "full taste" aggregate selects the endorsed value of. A host lists these
+    /// as the members a single "full taste" toggle turns on. Excludes knobs the
+    /// oracle takes no position on (the formatting/synthesis knobs and the
+    /// idiosyncratic branchless "bool hack" value).
+    ///
+    /// <para>Declared after <see cref="Options"/> so its initializer reads the
+    /// fully-built list. Because at most one value per axis is endorsed, the
+    /// aggregate selects at most one value per knob and so carries no internal
+    /// conflict.</para>
+    /// </summary>
+    public static IReadOnlyList<StyleOptionDescriptor> OracleEndorsedOptions { get; } =
+        [.. Options.Where(o => o.OracleEndorsed)];
+
+    /// <summary>
+    /// The corpus-endorsed (revealed-preference) subset of <see cref="Options"/> —
+    /// the knobs whose axis carries a value the runtime's own <b>source corpus</b>
+    /// reveals a dominant practice for. Orthogonal to
+    /// <see cref="OracleEndorsedOptions"/> (the declared facet): today's subsets
+    /// happen to be disjoint, but that is not a contract. Reserved for a future
+    /// "house style" aggregate (declared ∪ revealed), tracked in #3179; the "full
+    /// taste" aggregate stays declared-only.
     ///
     /// <para>Declared after <see cref="Options"/> so its initializer reads the
     /// fully-built list.</para>
     /// </summary>
     public static IReadOnlyList<StyleOptionDescriptor> CorpusEndorsedOptions { get; } =
         [.. Options.Where(o => o.CorpusEndorsed)];
+
+    /// <summary>
+    /// Returns a copy of <paramref name="options"/> with every
+    /// <see cref="OracleEndorsedOptions"/> knob's endorsed value selected (or, when
+    /// <paramref name="enabled"/> is <see langword="false"/>, deselected) — the
+    /// "full taste" aggregate. When <paramref name="enabled"/> is
+    /// <see langword="true"/> (the default) it turns the oracle-endorsed value of
+    /// each participating axis on; <see langword="false"/> turns exactly those
+    /// values off. Knobs the oracle takes no position on are left untouched, and
+    /// because at most one value per axis is endorsed the result is deterministic.
+    /// Reflection-free and NativeAOT-safe: it only folds the endorsed values'
+    /// explicit <see cref="StyleOptionValue.SetSelected"/> delegates.
+    /// </summary>
+    public static PrinterOptions ApplyFullTaste(PrinterOptions options, bool enabled = true)
+    {
+        foreach (var knob in OracleEndorsedOptions)
+            if (knob.EndorsedValue is { } endorsed)
+                options = endorsed.SetSelected(options, enabled);
+
+        return options;
+    }
+
+    // Builds a two-state (boolean) knob: a false/true value domain where the
+    // config key (when present) lives on the "true" value and its SetSelected both
+    // sets and clears the backing property, exactly matching how a plain boolean
+    // knob toggled before the value domain was generalized.
+    private static StyleOptionDescriptor Boolean(
+        string id,
+        string title,
+        string summary,
+        StyleOptionTier tier,
+        bool byteDivergent,
+        bool oracleEndorsed,
+        string? configKey,
+        Func<PrinterOptions, bool> get,
+        Func<PrinterOptions, bool, PrinterOptions> with,
+        bool corpusEndorsed = false)
+        => new()
+        {
+            Id = id,
+            Title = title,
+            Summary = summary,
+            Tier = tier,
+            ByteDivergent = byteDivergent,
+            DefaultValue = "false",
+            Values =
+            [
+                new StyleOptionValue
+                {
+                    Token = "false",
+                    IsSelected = o => !get(o),
+                    SetSelected = (o, on) => on ? with(o, false) : o,
+                },
+                new StyleOptionValue
+                {
+                    Token = "true",
+                    OracleEndorsed = oracleEndorsed,
+                    CorpusEndorsed = corpusEndorsed,
+                    ConfigKey = configKey,
+                    IsSelected = get,
+                    SetSelected = with,
+                },
+            ],
+        };
+
+    // The guarded-boolean-return family as one multi-value axis. Its two non-default
+    // values map onto the two independent byte-divergent lens properties, so config
+    // resolution and printer behavior are unchanged: each value's SetSelected sets
+    // only its own backing bool (last-write-wins per key), and GetValue reports the
+    // oracle-endorsed conditional-expression first when both happen to be set — the
+    // same "ternary wins" order the printer already applies.
+    private static StyleOptionDescriptor GuardedBooleanReturnStyle()
+        => new()
+        {
+            Id = "guarded-boolean-return-style",
+            Title = "Guarded boolean return style",
+            Summary = "How to render a declined guarded boolean return: the byte-faithful flat if/return (default), the oracle-preferred ternary return c ? A : B; (byte-divergent), or the compact short-circuit \"bool hack\" (byte-divergent, not oracle-endorsed).",
+            Tier = StyleOptionTier.Lens,
+            ByteDivergent = true,
+            DefaultValue = GuardedReturnDefault,
+            Values =
+            [
+                new StyleOptionValue
+                {
+                    Token = GuardedReturnDefault,
+                    Title = "Flat if/return (byte-faithful)",
+                    IsSelected = static o => !o.PreferConditionalExpressionReturn && !o.PreferBranchlessBoolean,
+                    // Selecting the default value clears the whole axis; deselecting
+                    // it is a no-op (a sibling selection clears it instead).
+                    SetSelected = static (o, on) =>
+                        on ? o with { PreferConditionalExpressionReturn = false, PreferBranchlessBoolean = false } : o,
+                },
+                new StyleOptionValue
+                {
+                    Token = GuardedReturnConditional,
+                    Title = "Conditional expression (ternary)",
+                    OracleEndorsed = true,
+                    ConfigKey = "dotnet_style_prefer_conditional_expression_over_return",
+                    IsSelected = static o => o.PreferConditionalExpressionReturn,
+                    SetSelected = static (o, on) => o with { PreferConditionalExpressionReturn = on },
+                },
+                new StyleOptionValue
+                {
+                    Token = GuardedReturnBranchless,
+                    Title = "Branchless \"bool hack\"",
+                    OracleEndorsed = false,
+                    ConfigKey = "dotnet_inspect_style_prefer_branchless_boolean",
+                    IsSelected = static o => o.PreferBranchlessBoolean,
+                    SetSelected = static (o, on) => o with { PreferBranchlessBoolean = on },
+                },
+            ],
+        };
 }

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -43,15 +43,20 @@ internal static class RenderStyleConfig
 
     // The recognized style keys and how they set PrinterOptions come from the
     // library-owned StyleOptionCatalog — the single source of truth — so this
-    // resolver never drifts from the option surface. Every catalog knob with a
+    // resolver never drifts from the option surface. Every catalog VALUE with a
     // config key is honored here (the four byte-preserving this.-qualification
-    // spellings, the oracle-endorsed conditional-expression lens, and the
-    // tool-owned branchless "bool hack" lens); knobs with no config key are
-    // API-only and simply do not appear in the file vocabulary.
-    private static readonly IReadOnlyDictionary<string, StyleOptionDescriptor> KnobsByKey =
+    // spellings, the oracle-endorsed conditional-expression lens value, and the
+    // tool-owned branchless "bool hack" value); values with no config key — the
+    // off/default value of a knob and any API-only knob — simply do not appear in
+    // the file vocabulary. A key = true selects its value; key = false deselects
+    // it (setting only that value's own backing state, so, exactly as before, two
+    // members of a multi-value axis set independently and the printer resolves any
+    // overlap deterministically).
+    private static readonly IReadOnlyDictionary<string, StyleOptionValue> KnobsByKey =
         StyleOptionCatalog.Options
-            .Where(o => o.ConfigKey is not null)
-            .ToDictionary(o => o.ConfigKey!, StringComparer.Ordinal);
+            .SelectMany(o => o.Values)
+            .Where(v => v.ConfigKey is not null)
+            .ToDictionary(v => v.ConfigKey!, StringComparer.Ordinal);
 
     // The editorconfig boundary marker. Discovery is nearest-wins, so the nearest
     // file is already a hard boundary (nothing above it is read); 'root' is
@@ -192,7 +197,7 @@ internal static class RenderStyleConfig
                     if (KnobsByKey.TryGetValue(key, out var knob))
                     {
                         if (TryParseBool(value, out var on))
-                            options = knob.With(options, on);
+                            options = knob.SetSelected(options, on);
                         else
                             Warn($"line {i + 1}: key '{key}' expects true/false, got '{value}' (ignored)");
                     }


### PR DESCRIPTION
## What & why

First slice of #3169. Generalizes `StyleOptionDescriptor` from a **boolean-only**
knob into one that carries an explicit **value domain**, the enabling substrate
the eventual `var` / target-typed-`new` taste family needs. Proven
non-speculatively by re-modeling the two coupled guarded-boolean-return lens
knobs as **one tri-state axis** (`flat` / `conditional-expression` /
`branchless`) instead of two independent booleans.

## Design (low-risk, zero behavior change)

- **`StyleOptionValue`** `{ Token, Title?, OracleEndorsed, CorpusEndorsed, ConfigKey?, IsSelected, SetSelected }`.
  Endorsement (both the declared `OracleEndorsed` and the revealed
  `CorpusEndorsed` facet added in #3182) and the config key move **per-value**.
- **`StyleOptionDescriptor`** gains `DefaultValue` / `Values` and
  `GetValue`/`WithValue` (single-select over the axis), keeping
  `Get`/`ConfigKey`/`OracleEndorsed`/`CorpusEndorsed`/`EndorsedValue` as computed
  back-compat. A `Boolean(...)` factory keeps the seven two-state knobs terse.
- The guarded-boolean-return family is **one 3-value axis over the same two
  backing `PrinterOptions` bools**: each value's `SetSelected` drives only its own
  bool (last-write-wins per key; the printer still resolves any overlap →
  ternary), and `GetValue` reports the oracle-endorsed `conditional-expression`
  first. So config resolution and printer output are **byte-identical**.
- **No `PrinterOptions` API change, no default-output change.** Dropped
  `ConflictGroup`/`GuardedBooleanReturnGroup` (subsumed by the single axis).
- `RenderStyleConfig` now resolves keys from **per-value** `ConfigKey`s via
  `SetSelected`; `ApplyFullTaste` selects each axis's `EndorsedValue`.

## Evidence

- `StyleOptionCatalogTests` **24/0** (19 rewritten for the value-domain model +
  the 5 corpus-facet tests from #3182, adapted to the per-value shape). The drift
  guard now asserts **every backing `PrinterOptions` bool is reachable through
  some catalog value** (stronger than the old 1:1 count).
- `RenderStyleConfigTests` **48/0, unchanged** — direct proof config behavior is
  byte-identical (single-key, both-key, `full_taste`, last-write-wins,
  warning paths all still pass without edits).
- Fast decompiler suite **3708/0** (`-trait- "Speed=Slow"`).
- `docs/decompiler-taste.md` Option-catalog section rewritten for the value
  domain; markdownlint clean.

## Scope boundary

Substrate only. The `var` family and its per-site apparency category dimension
(built-in / apparent / elsewhere) remain a future slice of #3169.

Rebased onto latest `main` (integrates #3182's `CorpusEndorsed` facet into the
per-value model).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 47752e34-b249-4ec5-82bb-9b28b29259e5