### PR TITLE
Add closed-set Corpus container in ILInspector.Metadata (#3180, Layer 2)

### DIFF
--- a/src/ILInspector.Metadata/Corpus.cs
+++ b/src/ILInspector.Metadata/Corpus.cs
@@ -1,0 +1,237 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// One assembly in a <see cref="Corpus"/>: a resolved local file path plus opaque provenance the
+/// producer supplied. The metadata layer treats <see cref="Source"/>, <see cref="Version"/>, and
+/// <see cref="Tfm"/> as display-only strings — it performs no package resolution and never reaches a
+/// feed. How the assembly was chosen (explicit path, package selection, dependency closure, …) is a
+/// higher-layer concern; the corpus only knows "these are the assemblies to operate within."
+/// </summary>
+public sealed record CorpusMember
+{
+    /// <summary>Local path to the assembly file to search.</summary>
+    public required string AssemblyPath { get; init; }
+
+    /// <summary>Where the assembly came from (package name, framework, "local"), as the producer labelled it.</summary>
+    public string? Source { get; init; }
+
+    /// <summary>Version of <see cref="Source"/>, when the producer pinned one.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>Target framework moniker the assembly was selected for, when known.</summary>
+    public string? Tfm { get; init; }
+}
+
+/// <summary>
+/// A type match from <see cref="Corpus.SearchTypes"/>: the metadata facts about the matched type
+/// plus the <see cref="CorpusMember"/> provenance that supplied it, so consumers render source and
+/// version without re-deriving them.
+/// </summary>
+public sealed record CorpusTypeMatch
+{
+    /// <summary>The input pattern that matched this type.</summary>
+    public required string Pattern { get; init; }
+
+    /// <summary>The type's simple (unqualified) name.</summary>
+    public required string TypeName { get; init; }
+
+    /// <summary>Namespace of the type, when it has one.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Full name of the type (<c>Namespace.Name</c>, or <c>Name</c> when global).</summary>
+    public required string FullName { get; init; }
+
+    /// <summary>Type kind: class, struct, interface, enum, delegate.</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>The assembly file name without extension that declared the type.</summary>
+    public required string Assembly { get; init; }
+
+    /// <summary>Provenance <see cref="CorpusMember.Source"/> of the declaring assembly.</summary>
+    public string? Source { get; init; }
+
+    /// <summary>Provenance <see cref="CorpusMember.Version"/> of the declaring assembly.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>Provenance <see cref="CorpusMember.Tfm"/> of the declaring assembly.</summary>
+    public string? Tfm { get; init; }
+
+    /// <summary>True when <see cref="Pattern"/> was a glob (contained <c>*</c> or <c>?</c>).</summary>
+    public bool IsGlob { get; init; }
+}
+
+/// <summary>
+/// A member match from <see cref="Corpus.SearchMembers"/>: the metadata-layer
+/// <see cref="MemberSearchResult"/> paired with the <see cref="CorpusMember"/> provenance that
+/// supplied it. Composition (rather than field duplication) keeps the member fields authoritative on
+/// <see cref="MemberSearchResult"/> while the corpus attaches the source/version it alone knows.
+/// </summary>
+public sealed record CorpusMemberMatch
+{
+    /// <summary>The metadata-layer member match.</summary>
+    public required MemberSearchResult Member { get; init; }
+
+    /// <summary>Provenance <see cref="CorpusMember.Source"/> of the declaring assembly.</summary>
+    public string? Source { get; init; }
+
+    /// <summary>Provenance <see cref="CorpusMember.Version"/> of the declaring assembly.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>Provenance <see cref="CorpusMember.Tfm"/> of the declaring assembly.</summary>
+    public string? Tfm { get; init; }
+}
+
+/// <summary>
+/// Result of <see cref="Corpus.SearchTypes"/>: matches plus the assembly paths whose metadata could
+/// not be read. Skipped paths are surfaced rather than dropped so an all-unreadable corpus cannot
+/// masquerade as a clean "no matches" success.
+/// </summary>
+public sealed record CorpusTypeSearchOutcome(
+    IReadOnlyList<CorpusTypeMatch> Results,
+    IReadOnlyList<string> SkippedAssemblies);
+
+/// <summary>
+/// Result of <see cref="Corpus.SearchMembers"/>: matches plus the assembly paths whose metadata could
+/// not be read.
+/// </summary>
+public sealed record CorpusMemberSearchOutcome(
+    IReadOnlyList<CorpusMemberMatch> Results,
+    IReadOnlyList<string> SkippedAssemblies);
+
+/// <summary>
+/// A resolved, finite, closed set of assemblies to operate <em>within</em>. This is the
+/// metadata-layer "corpus" primitive: an immutable list of <see cref="CorpusMember"/> plus offline,
+/// deterministic type- and member-search over exactly that set. It never resolves packages or
+/// reaches a feed — populating the set is a separate, higher-layer step, and once populated a corpus
+/// is authoritative and network-free. Search reuses the same building blocks as open-set type search
+/// (<see cref="AssemblyReader.ExtractApiSurface(string, bool, bool)"/> and <see cref="TypeMatcher"/>)
+/// so results rank identically; the corpus adds only the closed-set scoping and per-member provenance.
+/// </summary>
+public sealed class Corpus
+{
+    private readonly List<CorpusMember> _members;
+
+    /// <summary>Creates a corpus over the given members. The set is snapshotted; later mutation of the source has no effect.</summary>
+    public Corpus(IEnumerable<CorpusMember> members)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+        _members = [.. members];
+    }
+
+    /// <summary>The assemblies in this corpus, in the order supplied.</summary>
+    public IReadOnlyList<CorpusMember> Members => _members;
+
+    /// <summary>Number of assemblies in the corpus.</summary>
+    public int Count => _members.Count;
+
+    /// <summary>
+    /// Finds types in the corpus whose full or simple name matches any pattern. Exact patterns use
+    /// the shared namespace/arity-aware <see cref="TypeMatcher.MatchesTypeFilter"/>; patterns with
+    /// <c>*</c>/<c>?</c> are globs. A type is emitted once per pattern it matches.
+    /// </summary>
+    /// <param name="patterns">Type-name patterns.</param>
+    /// <param name="includeAll">When true, non-public types are included; otherwise public only.</param>
+    /// <param name="limit">Optional cap on total results collected across the corpus.</param>
+    public CorpusTypeSearchOutcome SearchTypes(
+        IReadOnlyList<string> patterns,
+        bool includeAll = false,
+        int? limit = null)
+    {
+        ArgumentNullException.ThrowIfNull(patterns);
+
+        var results = new List<CorpusTypeMatch>();
+        var skipped = new List<string>();
+
+        if (patterns.Count == 0)
+            return new CorpusTypeSearchOutcome(results, skipped);
+
+        foreach (var member in _members)
+        {
+            if (limit is int cap && results.Count >= cap)
+                break;
+
+            var surface = AssemblyReader.ExtractApiSurface(member.AssemblyPath, includeAll, typesOnly: true);
+            if (surface is null)
+            {
+                skipped.Add(member.AssemblyPath);
+                continue;
+            }
+
+            var assemblyName = Path.GetFileNameWithoutExtension(member.AssemblyPath);
+
+            foreach (var type in surface.Types)
+            {
+                foreach (var pattern in patterns)
+                {
+                    if (limit is int innerCap && results.Count >= innerCap)
+                        return new CorpusTypeSearchOutcome(results, skipped);
+
+                    var isGlob = pattern.Contains('*') || pattern.Contains('?');
+                    if (!TypeMatcher.MatchesTypeFilter(type.FullName, pattern))
+                        continue;
+
+                    results.Add(new CorpusTypeMatch
+                    {
+                        Pattern = pattern,
+                        TypeName = type.Name,
+                        Namespace = type.Namespace,
+                        FullName = type.FullName,
+                        Kind = type.Kind,
+                        Assembly = assemblyName,
+                        Source = member.Source,
+                        Version = member.Version,
+                        Tfm = member.Tfm,
+                        IsGlob = isGlob,
+                    });
+                }
+            }
+        }
+
+        return new CorpusTypeSearchOutcome(results, skipped);
+    }
+
+    /// <summary>
+    /// Finds members in the corpus whose name matches any pattern, reusing <see cref="MemberSearch"/>
+    /// per member so each match carries the provenance of the specific assembly that supplied it.
+    /// </summary>
+    /// <param name="patterns">Member-name patterns (exact case-insensitive, or glob with <c>*</c>/<c>?</c>).</param>
+    /// <param name="includeAll">When true, non-public members are included; otherwise public only.</param>
+    /// <param name="limit">Optional cap on total results collected across the corpus.</param>
+    public CorpusMemberSearchOutcome SearchMembers(
+        IReadOnlyList<string> patterns,
+        bool includeAll = false,
+        int? limit = null)
+    {
+        ArgumentNullException.ThrowIfNull(patterns);
+
+        var results = new List<CorpusMemberMatch>();
+        var skipped = new List<string>();
+
+        if (patterns.Count == 0)
+            return new CorpusMemberSearchOutcome(results, skipped);
+
+        foreach (var member in _members)
+        {
+            if (limit is int cap && results.Count >= cap)
+                break;
+
+            var remaining = limit is int lim ? lim - results.Count : (int?)null;
+            var outcome = MemberSearch.Search([member.AssemblyPath], patterns, includeAll, remaining);
+
+            skipped.AddRange(outcome.SkippedAssemblies);
+
+            foreach (var hit in outcome.Results)
+            {
+                results.Add(new CorpusMemberMatch
+                {
+                    Member = hit,
+                    Source = member.Source,
+                    Version = member.Version,
+                    Tfm = member.Tfm,
+                });
+            }
+        }
+
+        return new CorpusMemberSearchOutcome(results, skipped);
+    }
+}

--- a/src/ILInspector.Metadata/Corpus.cs
+++ b/src/ILInspector.Metadata/Corpus.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+
 namespace ILInspector.Metadata;
 
 /// <summary>
@@ -116,10 +118,15 @@ public sealed class Corpus
     {
         ArgumentNullException.ThrowIfNull(members);
         _members = [.. members];
+        Members = new ReadOnlyCollection<CorpusMember>(_members);
     }
 
-    /// <summary>The assemblies in this corpus, in the order supplied.</summary>
-    public IReadOnlyList<CorpusMember> Members => _members;
+    /// <summary>
+    /// The assemblies in this corpus, in the order supplied. Exposed as a genuine read-only view
+    /// (a <see cref="ReadOnlyCollection{T}"/>) so a consumer cannot downcast it back to the backing
+    /// list and mutate the closed set out from under the corpus.
+    /// </summary>
+    public IReadOnlyList<CorpusMember> Members { get; }
 
     /// <summary>Number of assemblies in the corpus.</summary>
     public int Count => _members.Count;

--- a/tests/ILInspector.Metadata.Tests/CorpusTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CorpusTests.cs
@@ -28,6 +28,16 @@ namespace ILInspector.Metadata.Tests
         }
 
         [Fact]
+        public void Members_is_a_read_only_view_that_cannot_be_downcast_and_mutated()
+        {
+            var corpus = SelfCorpus();
+
+            Assert.IsNotType<List<CorpusMember>>(corpus.Members);
+            Assert.Throws<NotSupportedException>(() => ((IList<CorpusMember>)corpus.Members).Clear());
+            Assert.Equal(1, corpus.Count);
+        }
+
+        [Fact]
         public void SearchTypes_exact_name_finds_type_with_kind_and_provenance()
         {
             var outcome = SelfCorpus().SearchTypes(["CorpusProbeTypeAlpha"]);

--- a/tests/ILInspector.Metadata.Tests/CorpusTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CorpusTests.cs
@@ -1,0 +1,200 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests
+{
+    public sealed class CorpusTests
+    {
+        private static string SelfAssembly => typeof(CorpusProbeTypeAlpha).Assembly.Location;
+
+        private static Corpus SelfCorpus(
+            string? source = "probe-pkg",
+            string? version = "9.9.9",
+            string? tfm = "net10.0")
+            => new([new CorpusMember { AssemblyPath = SelfAssembly, Source = source, Version = version, Tfm = tfm }]);
+
+        [Fact]
+        public void Constructor_snapshots_members_so_later_mutation_has_no_effect()
+        {
+            var list = new List<CorpusMember>
+            {
+                new() { AssemblyPath = SelfAssembly },
+            };
+            var corpus = new Corpus(list);
+
+            list.Clear();
+
+            Assert.Equal(1, corpus.Count);
+            Assert.Equal(SelfAssembly, Assert.Single(corpus.Members).AssemblyPath);
+        }
+
+        [Fact]
+        public void SearchTypes_exact_name_finds_type_with_kind_and_provenance()
+        {
+            var outcome = SelfCorpus().SearchTypes(["CorpusProbeTypeAlpha"]);
+
+            Assert.Empty(outcome.SkippedAssemblies);
+            var hit = Assert.Single(outcome.Results);
+            Assert.Equal(typeof(CorpusProbeTypeAlpha).FullName, hit.FullName);
+            Assert.Equal("CorpusProbeTypeAlpha", hit.TypeName);
+            Assert.Equal("class", hit.Kind);
+            Assert.Equal("probe-pkg", hit.Source);
+            Assert.Equal("9.9.9", hit.Version);
+            Assert.Equal("net10.0", hit.Tfm);
+            Assert.False(hit.IsGlob);
+            Assert.Equal(Path.GetFileNameWithoutExtension(SelfAssembly), hit.Assembly);
+        }
+
+        [Fact]
+        public void SearchTypes_glob_matches_multiple_public_types_but_not_non_public_by_default()
+        {
+            var outcome = SelfCorpus().SearchTypes(["CorpusProbeType*"]);
+
+            var names = outcome.Results.Select(r => r.FullName).ToHashSet();
+            Assert.Contains(typeof(CorpusProbeTypeAlpha).FullName!, names);
+            Assert.Contains(typeof(CorpusProbeTypeBeta).FullName!, names);
+            Assert.DoesNotContain("ILInspector.Metadata.Tests.CorpusProbeTypeHidden", names);
+            Assert.All(outcome.Results, r => Assert.True(r.IsGlob));
+        }
+
+        [Fact]
+        public void SearchTypes_includeAll_surfaces_non_public_type()
+        {
+            var withoutAll = SelfCorpus().SearchTypes(["CorpusProbeTypeHidden"]);
+            Assert.Empty(withoutAll.Results);
+
+            var withAll = SelfCorpus().SearchTypes(["CorpusProbeTypeHidden"], includeAll: true);
+            Assert.Contains(withAll.Results, r => r.TypeName == "CorpusProbeTypeHidden");
+        }
+
+        [Fact]
+        public void SearchTypes_empty_patterns_returns_empty_outcome()
+        {
+            var outcome = SelfCorpus().SearchTypes([]);
+
+            Assert.Empty(outcome.Results);
+            Assert.Empty(outcome.SkippedAssemblies);
+        }
+
+        [Fact]
+        public void SearchTypes_respects_result_limit()
+        {
+            var outcome = SelfCorpus().SearchTypes(["CorpusProbeType*"], limit: 1);
+
+            Assert.Single(outcome.Results);
+        }
+
+        [Fact]
+        public void SearchTypes_reports_unreadable_assembly_as_skipped_without_faking_success()
+        {
+            var missing = Path.Combine(Path.GetTempPath(), "corpus-types-does-not-exist-8b1c.dll");
+            var corpus = new Corpus([new CorpusMember { AssemblyPath = missing }]);
+
+            var outcome = corpus.SearchTypes(["CorpusProbeTypeAlpha"]);
+
+            Assert.Empty(outcome.Results);
+            Assert.Contains(missing, outcome.SkippedAssemblies);
+        }
+
+        [Fact]
+        public void SearchTypes_mixed_readable_and_unreadable_reports_both()
+        {
+            var missing = Path.Combine(Path.GetTempPath(), "corpus-types-mixed-2d7e.dll");
+            var corpus = new Corpus(
+            [
+                new CorpusMember { AssemblyPath = SelfAssembly, Source = "good" },
+                new CorpusMember { AssemblyPath = missing, Source = "bad" },
+            ]);
+
+            var outcome = corpus.SearchTypes(["CorpusProbeTypeAlpha"]);
+
+            Assert.Contains(outcome.Results, r => r.FullName == typeof(CorpusProbeTypeAlpha).FullName && r.Source == "good");
+            Assert.Contains(missing, outcome.SkippedAssemblies);
+        }
+
+        [Fact]
+        public void SearchMembers_finds_member_with_declaring_type_and_provenance()
+        {
+            var outcome = SelfCorpus().SearchMembers(["CorpusProbeMemberAlpha"]);
+
+            Assert.Empty(outcome.SkippedAssemblies);
+            var hit = Assert.Single(outcome.Results);
+            Assert.Equal("CorpusProbeMemberAlpha", hit.Member.MemberName);
+            Assert.Equal(typeof(CorpusProbeTypeAlpha).FullName, hit.Member.DeclaringType);
+            Assert.Equal("method", hit.Member.Kind);
+            Assert.Equal("probe-pkg", hit.Source);
+            Assert.Equal("9.9.9", hit.Version);
+            Assert.Equal("net10.0", hit.Tfm);
+        }
+
+        [Fact]
+        public void SearchMembers_includeAll_surfaces_non_public_member()
+        {
+            var withoutAll = SelfCorpus().SearchMembers(["CorpusProbeMemberHidden"]);
+            Assert.Empty(withoutAll.Results);
+
+            var withAll = SelfCorpus().SearchMembers(["CorpusProbeMemberHidden"], includeAll: true);
+            Assert.Contains(withAll.Results, r => r.Member.MemberName == "CorpusProbeMemberHidden");
+        }
+
+        [Fact]
+        public void SearchMembers_reports_unreadable_assembly_as_skipped_without_faking_success()
+        {
+            var missing = Path.Combine(Path.GetTempPath(), "corpus-members-does-not-exist-77aa.dll");
+            var corpus = new Corpus([new CorpusMember { AssemblyPath = missing }]);
+
+            var outcome = corpus.SearchMembers(["CorpusProbeMemberAlpha"]);
+
+            Assert.Empty(outcome.Results);
+            Assert.Contains(missing, outcome.SkippedAssemblies);
+        }
+
+        [Fact]
+        public void SearchMembers_respects_result_limit_across_the_set()
+        {
+            var outcome = SelfCorpus().SearchMembers(["CorpusProbeMember*"], limit: 1);
+
+            Assert.Single(outcome.Results);
+        }
+
+        [Fact]
+        public void SearchMembers_attaches_provenance_of_the_specific_member_that_supplied_the_hit()
+        {
+            var corpus = new Corpus(
+            [
+                new CorpusMember { AssemblyPath = SelfAssembly, Source = "pkg-a", Version = "1.0" },
+                new CorpusMember { AssemblyPath = SelfAssembly, Source = "pkg-b", Version = "2.0" },
+            ]);
+
+            var outcome = corpus.SearchMembers(["CorpusProbeMemberAlpha"]);
+
+            Assert.Contains(outcome.Results, r =>
+                r.Source == "pkg-a" && r.Version == "1.0" && r.Member.MemberName == "CorpusProbeMemberAlpha");
+            Assert.Contains(outcome.Results, r =>
+                r.Source == "pkg-b" && r.Version == "2.0" && r.Member.MemberName == "CorpusProbeMemberAlpha");
+        }
+
+        [Fact]
+        public void SearchMembers_empty_patterns_returns_empty_outcome()
+        {
+            var outcome = SelfCorpus().SearchMembers([]);
+
+            Assert.Empty(outcome.Results);
+            Assert.Empty(outcome.SkippedAssemblies);
+        }
+    }
+
+    public sealed class CorpusProbeTypeAlpha
+    {
+        public int CorpusProbeMemberAlpha() => 1;
+        private int CorpusProbeMemberHidden() => 2;
+    }
+
+    public sealed class CorpusProbeTypeBeta
+    {
+        public void CorpusProbeMemberBeta() { }
+    }
+
+    internal sealed class CorpusProbeTypeHidden
+    {
+    }
+}


### PR DESCRIPTION
## Summary

**Layer 2 of the stacked #3180 corpus work.** Adds the metadata-layer `Corpus` — the "operate within a closed set" object — on top of the `MemberSearch` primitive from #3183 (this PR's base).

A `Corpus` is an immutable, offline, network-free set of `CorpusMember` (a resolved local assembly path plus opaque `Source`/`Version`/`Tfm` provenance). It exposes:

- `SearchTypes` — type search within the set via `AssemblyReader.ExtractApiSurface` + `TypeMatcher.MatchesTypeFilter`, attaching per-member provenance.
- `SearchMembers` — reuses the Layer-1 `MemberSearch` primitive per member so each hit carries the provenance of the specific assembly that supplied it.

Both surface unreadable assemblies via `SkippedAssemblies` (keep-failure-visible) rather than masquerading as a clean "no matches" success. Closed mode falls out for free: the corpus holds no feed reference, so searching it is offline and deterministic.

### Design decision: membership granularity

At this layer a corpus is deliberately a **flat set of assemblies**. *How* those assemblies were chosen (explicit paths, package selection, dependency closure, version pinning) is a **producer** concern for the Services layer (Layer 3). This keeps the corpus SRM-only, NuGet-free, Roslyn-free, and NativeAOT-friendly, and resolves the issue's "membership granularity" question at the metadata boundary.

## Evidence

- 15 focused `CorpusTests` pass (provenance isolation across same-path members, limit semantics, skipped tracking, includeAll, duplicate-match behavior, snapshot immutability, read-only-view enforcement).
- Full Metadata suite: 818 total; the single failure is the pre-existing #3018 Windows-local path-separator test, unrelated to this change.

## Adversarial review (reconciled)

Two fixed-head reviews from different model families (per AGENTS.md roster; I authored as Claude, so both reviewers are non-Claude):

- **GPT-5.6** — one `major` finding: `Members` returned the backing `List<CorpusMember>` through `IReadOnlyList<CorpusMember>`, so a consumer could downcast and mutate the closed set. **Fixed** in `3feb058e` by exposing a genuine `ReadOnlyCollection<CorpusMember>` and adding a locking test. No blocking findings.
- **Gemini 3.1 Pro** — no issues; verified provenance mapping, limits, skipped tracking, duplicate emission, snapshot semantics, error visibility, and layering.

Both re-reviewed the fixed head `3feb058e` and reported **clean / blocking-free** (15/15 tests each).

## Stack

- #3183 — Layer 1 `MemberSearch` primitive (base of this PR)
- **this PR** — Layer 2 `Corpus` container
- Layer 3 (producer + serializable manifest in Services) and Layer 4 (CLI wiring) follow as further stacked PRs.

Draft until the full stack is reconciled.
