### PR TITLE
Add shared per-site "type is apparent" analysis (#3192)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeApparencyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeApparencyTests.cs
@@ -1,0 +1,67 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Direct coverage of the shared per-site "type is apparent" predicate
+/// (<see cref="CSharpPrinter.TypeIsApparent"/>) that the target-typed-<c>new</c>
+/// shortener consumes and a future opt-in <c>var</c> lens will consume. Each apparent
+/// shape is paired with a close negative so the predicate stays conservative: it must
+/// report apparent only when the right-hand side spells the declared type exactly.
+/// </summary>
+public class TypeApparencyTests
+{
+    static readonly TypeRef VoidType = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef IntType = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef ListOfInt = TypeRef.Definition("synthetic", "N", "MyList");
+    static readonly TypeRef OtherType = TypeRef.Definition("synthetic", "N", "Other");
+
+    static NewObject Creation(TypeRef type)
+        => new(new MethodRef(type, ".ctor", VoidType, [], HasThis: true), []);
+
+    [Fact]
+    public void ObjectCreation_OfExactType_IsApparent()
+        => Assert.True(CSharpPrinter.TypeIsApparent(ListOfInt, Creation(ListOfInt)));
+
+    [Fact]
+    public void ObjectCreation_OfDifferentType_IsNotApparent()
+        => Assert.False(CSharpPrinter.TypeIsApparent(OtherType, Creation(ListOfInt)));
+
+    [Fact]
+    public void ArrayCreation_OfMatchingElementType_IsApparent()
+        => Assert.True(CSharpPrinter.TypeIsApparent(
+            TypeRef.SzArray(IntType),
+            new NewArray(IntType, new Constant(4, IntType))));
+
+    [Fact]
+    public void ArrayCreation_ComparedAgainstBareElementType_IsNotApparent()
+        // `new int[n]` names `int[]`, not `int`: a declaration typed `int` is not
+        // apparent from an array creation.
+        => Assert.False(CSharpPrinter.TypeIsApparent(
+            IntType,
+            new NewArray(IntType, new Constant(4, IntType))));
+
+    [Fact]
+    public void ExplicitCast_ToExactType_IsApparent()
+        => Assert.True(CSharpPrinter.TypeIsApparent(
+            ListOfInt,
+            new CastClass(ListOfInt, new LoadArgument(0, "x", OtherType))));
+
+    [Fact]
+    public void ExplicitCast_ToDifferentType_IsNotApparent()
+        => Assert.False(CSharpPrinter.TypeIsApparent(
+            OtherType,
+            new CastClass(ListOfInt, new LoadArgument(0, "x", OtherType))));
+
+    [Fact]
+    public void PlainValueRead_IsNotApparent()
+        // A parameter/local read (or any non-type-naming expression) leaves the type
+        // implicit — conservatively not apparent.
+        => Assert.False(CSharpPrinter.TypeIsApparent(ListOfInt, new LoadArgument(0, "x", ListOfInt)));
+
+    [Fact]
+    public void DefaultValue_IsNotApparent_ConservativeByDesign()
+        // `default(T)` names the type, but a target-typed `default` renders bare; the
+        // v1 predicate declines it rather than risk a `var x = default;` that loses T.
+        => Assert.False(CSharpPrinter.TypeIsApparent(IntType, new DefaultValue(IntType)));
+}

--- a/src/ILInspector.Decompiler.Tests/TypeApparencyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeApparencyTests.cs
@@ -64,4 +64,11 @@ public class TypeApparencyTests
         // `default(T)` names the type, but a target-typed `default` renders bare; the
         // v1 predicate declines it rather than risk a `var x = default;` that loses T.
         => Assert.False(CSharpPrinter.TypeIsApparent(IntType, new DefaultValue(IntType)));
+
+    [Fact]
+    public void ValueTypeCast_ViaUnboxAny_IsNotApparent_DocumentedV1Boundary()
+        // A value-type cast (`(int)obj`) is genuinely apparent in C# but is modeled by
+        // UnboxAny, not CastClass. v1 declines it — a documented extension point for the
+        // `var` slice, not a defect (declining is output-safe). This locks the boundary.
+        => Assert.False(CSharpPrinter.TypeIsApparent(IntType, new UnboxAny(IntType, new LoadArgument(0, "obj", OtherType))));
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -4204,13 +4204,37 @@ public sealed partial class CSharpPrinter
             || MultiDimArrayCreationText(creation) is not null
             || IsSystemObjectType(creation.Constructor.DeclaringType)
             || !IsTargetTypedNewEligible(target)
-            || !target.Equals(creation.Constructor.DeclaringType))
+            || !TypeIsApparent(target, creation))
         {
             return null;
         }
 
         return $"new({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
     }
+
+    /// <summary>
+    /// Whether the declared type of a declaration/creation site is <em>apparent</em>
+    /// from the initializer's syntax — the notion dotnet/runtime's editorconfig keys
+    /// <c>csharp_style_var_when_type_is_apparent</c> and
+    /// <c>csharp_style_implicit_object_creation_when_type_is_apparent</c> both hinge
+    /// on. A type is apparent when the right-hand side names it directly: object
+    /// creation of exactly that type (<c>new T(...)</c>), a single-dimension array
+    /// creation of that type (<c>new T[n]</c>), or an explicit reference cast to it
+    /// (<c>(T)x</c>). Deliberately conservative — forms whose rendered spelling need
+    /// not name the type (numeric conversions, a target-typed <c>default</c>) are not
+    /// treated as apparent here, so a future opt-in <c>var</c> lens never spells
+    /// <c>var</c> where the type would silently vanish. Pure over the typed IR
+    /// (SRM-only, Roslyn-free); the target-typed-<c>new</c> shortener
+    /// (<see cref="TargetTypedNewText"/>) consumes it today, and the planned <c>var</c>
+    /// lens will consult the same predicate so both spelling axes agree per site.
+    /// </summary>
+    internal static bool TypeIsApparent(TypeRef declaredType, IrExpression initializer) => initializer switch
+    {
+        NewObject creation => declaredType.Equals(creation.Constructor.DeclaringType),
+        NewArray array => declaredType.Equals(TypeRef.SzArray(array.ElementType)),
+        CastClass cast => declaredType.Equals(cast.Type),
+        _ => false,
+    };
 
     /// <summary>
     /// The bare <c>System.Object</c> type, by name — assembly-agnostic so a facade or
@@ -5323,6 +5347,11 @@ public sealed partial class CSharpPrinter
         => ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal);
 
     string DeclarationTypeText(TypeRef type, IrExpression initializer)
+        // An anonymous type has no spellable name, so `var` is mandatory here — not a
+        // taste call. Every other declaration keeps its explicit type on the byte-stable
+        // default. Where the type is apparent (`TypeIsApparent(type, initializer)`), a
+        // future opt-in `var` lens will spell `var`; that decision routes through the
+        // same predicate the target-typed-`new` shortener uses so both axes agree.
         => initializer is AnonymousObject anonymous && type.Equals(anonymous.Type)
             ? "var"
             : TypeText(type);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -4220,13 +4220,25 @@ public sealed partial class CSharpPrinter
     /// on. A type is apparent when the right-hand side names it directly: object
     /// creation of exactly that type (<c>new T(...)</c>), a single-dimension array
     /// creation of that type (<c>new T[n]</c>), or an explicit reference cast to it
-    /// (<c>(T)x</c>). Deliberately conservative — forms whose rendered spelling need
-    /// not name the type (numeric conversions, a target-typed <c>default</c>) are not
-    /// treated as apparent here, so a future opt-in <c>var</c> lens never spells
-    /// <c>var</c> where the type would silently vanish. Pure over the typed IR
-    /// (SRM-only, Roslyn-free); the target-typed-<c>new</c> shortener
-    /// (<see cref="TargetTypedNewText"/>) consumes it today, and the planned <c>var</c>
-    /// lens will consult the same predicate so both spelling axes agree per site.
+    /// (<c>(T)x</c>). Deliberately conservative — a form is treated as apparent only
+    /// when its <em>rendered</em> spelling is guaranteed to name the type, so a future
+    /// opt-in <c>var</c> lens never spells <c>var</c> where the type would silently
+    /// vanish. That is why numeric conversions and a target-typed <c>default</c> are
+    /// declined here.
+    /// <para>
+    /// Several further shapes are genuinely apparent in C# but are declined by this v1
+    /// because they are modeled by other IR nodes whose rendered form still needs
+    /// confirming before a consumer relies on them: a value-type cast
+    /// (<see cref="UnboxAny"/>, e.g. <c>(int)obj</c>), an object/collection initializer
+    /// (<see cref="ObjectInitializerExpression"/> wrapping the creation), and an
+    /// array/span literal (<see cref="ArrayLiteral"/>/<see cref="SpanLiteral"/>, e.g.
+    /// <c>new int[] { 1, 2 }</c>). They are extension points for the <c>var</c> slice,
+    /// not defects — declining is always output-safe.
+    /// </para>
+    /// Pure over the typed IR (SRM-only, Roslyn-free); the target-typed-<c>new</c>
+    /// shortener (<see cref="TargetTypedNewText"/>) consumes it today, and the planned
+    /// <c>var</c> lens will consult the same predicate so the two axes share one
+    /// apparency judgment.
     /// </summary>
     internal static bool TypeIsApparent(TypeRef declaredType, IrExpression initializer) => initializer switch
     {
@@ -5349,9 +5361,14 @@ public sealed partial class CSharpPrinter
     string DeclarationTypeText(TypeRef type, IrExpression initializer)
         // An anonymous type has no spellable name, so `var` is mandatory here — not a
         // taste call. Every other declaration keeps its explicit type on the byte-stable
-        // default. Where the type is apparent (`TypeIsApparent(type, initializer)`), a
-        // future opt-in `var` lens will spell `var`; that decision routes through the
-        // same predicate the target-typed-`new` shortener uses so both axes agree.
+        // default. A future opt-in `var` lens will consult `TypeIsApparent(type,
+        // initializer)` to decide whether to spell `var`. Note that `var` and the
+        // target-typed-`new` shortener are *mutually exclusive* spellings of the same
+        // apparent site, not simultaneous: dropping both ends of `List<int> x = new
+        // List<int>()` at once yields `var x = new()`, which is CS8754 (no target type
+        // for `new()`). The shared predicate is only the apparency input; that lens must
+        // own the either/or decision (keep the RHS type when spelling `var`, or keep the
+        // LHS type when shortening to `new()`).
         => initializer is AnonymousObject anonymous && type.Equals(anonymous.Type)
             ? "var"
             : TypeText(type);


### PR DESCRIPTION
## What

Introduces `TypeIsApparent(TypeRef declaredType, IrExpression initializer)` — a decompiler-owned, pure predicate that classifies whether a declaration/creation site names its type directly. This is the analysis substrate #3169 identifies as the real point of the `var` / target-typed-`new` taste family: both editorconfig axes (`csharp_style_var_when_type_is_apparent`, `csharp_style_implicit_object_creation_when_type_is_apparent`) hinge on the same notion, and we had no reusable model of it.

Closes #3192 (sub-issue of #3169). The catalog-shape prerequisite landed in #3189; this is the analysis prerequisite.

## Changes

- **New predicate** (`CSharpPrinter.cs`): `TypeIsApparent` reports apparent for object creation of the exact type (`new T(...)`), single-dimension array creation (`new T[n]`), and an explicit reference cast (`(T)x`). Deliberately conservative — numeric conversions and target-typed `default` are **not** apparent, so a future `var` lens can never spell `var` where the type would silently vanish.
- **Route the one live consumer through it**: the target-typed-`new` shortener's inline `target.Equals(constructedType)` clause is exactly the object-creation apparency case, now expressed via the shared predicate.
- **Mark the `var` seam**: `DeclarationTypeText` documents where the planned opt-in `var` lens will consult the same predicate, so both spelling axes agree per site. No `var` behavior is turned on.

## Why it's safe

- **No default-output change.** The `var` hook stays inert (no lens consumes it); `PrinterOptions.Default` remains fully explicit and byte-stable.
- **Target-typed-`new` refactor is byte-identical.** The predicate's `NewObject` branch is `declaredType.Equals(creation.Constructor.DeclaringType)` — the same clause it replaced. `TargetTypedNewText` only ever reaches that branch (it guards `value is NewObject creation` first), so output is unchanged.
- Product path stays **SRM-only, NativeAOT-friendly, Roslyn-free** — a pure switch over typed IR nodes.

## Non-goals (later slices of #3169)

- No `var` spelling change and no new catalog descriptor / editorconfig-key wiring.
- No broadening of target-typed-`new`'s applied scope.
- `default(T)`, numeric conversions, and factory-name apparency are documented extension points, not delivered here.

## Evidence

- **`TypeApparencyTests`** (new): 8 tests, each apparent shape paired with a close negative (different type, bare element type vs `T[]`, plain value read, `default(T)` declined).
- **`TargetTypedNewPassTests`** unchanged: all 11 pass → refactor byte-identical.
- Fast decompiler suite green: 3717 total, 0 failures after a full `dotnet-inspect.slnx` build (the single `ExpressionTreeLambdaTests.LookalikeExpressionAssembly_StaysFactoryCalls` miss is the known fixture-binary environmental case; it passes once the slnx fixture is built — verified).

## Adversarial review

Requested: new analysis predicate + a printer refactor on a byte-stable path → two non-Claude reviewers per `AGENTS.md`.