### PR TITLE
Omit is_finalizer:false from JSON; lock finalizer out of async (#3157 follow-up)

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -168,6 +168,32 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void FinalizerMember_NeverGetsAsyncModifier_EvenWhenForced()
+    {
+        // Defensive guard (adversarial review of #3168): a finalizer must never
+        // acquire the 'async' modifier. Even under ForceAsync and an async-eligible
+        // Kind (explicit-interface-implementation), 'async ~Handle()' is not legal
+        // C#. The '!member.IsFinalizer' clause on the async gate locks this shut
+        // independently of the Kind classification, so a future Kind change cannot
+        // re-open it.
+        var type = new ApiType { Namespace = "Samples", Name = "Handle", Kind = "class" };
+        var finalizer = new ApiMember
+        {
+            Name = "Finalize",
+            Kind = "explicit-interface-implementation",
+            Signature = "void Finalize()",
+            IsVirtual = true,
+            IsFinalizer = true,
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            type, finalizer, new CSharpDeclarationOptions { ForceAsync = true });
+
+        Assert.Equal("~Handle()", declaration);
+        Assert.DoesNotContain("async", declaration);
+    }
+
+    [Fact]
     public void ShortWithUsingsMemberUnit_GeneratesImportsAndShortensTypes()
     {
         var type = CreateSampleType();

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -435,6 +435,7 @@ internal static class CSharpDeclarationWriter
         }
 
         if ((options.ForceAsync || member.IsAsync)
+            && !member.IsFinalizer
             && member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
             modifiers.Add("async");
 

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -463,7 +463,11 @@ public class ApiMember
     /// rather than by name or signature shape. Lets the C# writer spell it
     /// <c>~Type()</c> instead of the bare <c>void Finalize()</c>. A metadata fact
     /// (the overridden slot), separate from the C# spelling the writer owns.
+    /// Emitted only when true: the finalizer identity is already carried by the
+    /// dedicated <c>Kind = "finalizer"</c>, so serializing <c>is_finalizer: false</c>
+    /// on every other member would be redundant schema noise.
     /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsFinalizer { get; set; }
 
     public bool IsReadOnly { get; set; }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -520,6 +520,35 @@ public class ApiOutputFormatterTests
         Assert.Equal("", row.ReturnType);
     }
 
+    [Fact]
+    public void ApiTypeJson_OmitsIsFinalizerOnNonFinalizers_KeepsItTrueOnFinalizer()
+    {
+        // Regression guard (adversarial review of #3168): the finalizer identity
+        // is already carried by the dedicated Kind = "finalizer". Serializing
+        // is_finalizer: false on every other member is redundant schema noise.
+        // The ApiType JSON contexts default to WhenWritingNull (not
+        // WhenWritingDefault), so without a property-level [JsonIgnore] the
+        // false bool leaks onto every member. Assert it is omitted for a plain
+        // member and still present (true) for the finalizer.
+        var type = new ApiType
+        {
+            Name = "Handle",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember { Name = "Work", Kind = "method", Signature = "void Work()" },
+                new ApiMember { Name = "Finalize", Kind = "finalizer", Signature = "void Finalize()", IsFinalizer = true },
+            ]
+        };
+
+        string json = System.Text.Json.JsonSerializer.Serialize(type, ApiTypeJsonContext.Default.ApiType);
+
+        // The non-finalizer member must not carry the redundant false bool...
+        Assert.DoesNotContain("\"is_finalizer\": false", json, System.StringComparison.Ordinal);
+        // ...while the finalizer keeps its true marker.
+        Assert.Contains("\"is_finalizer\": true", json, System.StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]


### PR DESCRIPTION
## Summary

Two follow-ups from my adversarial review of #3168, stacked on the finalizer-section work (#3186). Both are small, mechanical hardening changes that keep the finalizer feature honest at its output boundaries.

- **JSON schema noise (fix):** `ApiMember.IsFinalizer` was serializing `is_finalizer: false` on *every* member. The `ApiType` JSON contexts (`ApiTypeJsonContext`, `ApiJsonContext`) default to `WhenWritingNull` — not `WhenWritingDefault` — so the `false` bool leaked. Added a property-level `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]` so it is emitted **only when true**. The finalizer identity is already carried by the dedicated `Kind = "finalizer"`, so `is_finalizer: false` was pure redundancy. Round-trips safely (absent → `false`).
- **Defensive async lock:** A finalizer must never acquire `async` (`async ~Type()` is not legal C#). At #3186 the finalizer `Kind` already falls outside the async-eligible set, so this is not currently reachable — but I added `&& !member.IsFinalizer` to the async gate so a future `Kind` reclassification cannot silently re-open it.

## Behavioral claim

- `--json` / structured output no longer emits `is_finalizer: false`; finalizers still emit `is_finalizer: true`.
- The C# writer never prepends `async` to a finalizer, independent of `Kind`.

## Evidence

- `ApiOutputFormatterTests.ApiTypeJson_OmitsIsFinalizerOnNonFinalizers_KeepsItTrueOnFinalizer` — serializes an `ApiType` via `ApiTypeJsonContext` (the `WhenWritingNull` path where the bug manifested); asserts `is_finalizer: false` absent, `is_finalizer: true` present.
- `CSharpDeclarationWriterTests.FinalizerMember_NeverGetsAsyncModifier_EvenWhenForced` — `ForceAsync = true` + async-eligible `Kind` (`explicit-interface-implementation`) + `IsFinalizer = true` renders `~Handle()` with no `async`.
- Suites green: `CSharpDeclarationWriterTests` 44/44, `ApiOutputFormatterTests` 31 (1 unrelated ilasm skip), `ILInspector.Metadata.Tests` 794/794.

## Scope / boundary

- Product paths remain SRM-only, NativeAOT-friendly, Roslyn-free. No inspected-assembly loading added.
- The **VB implicit-`object.Finalize`-override false-negative** finding from the same review is **out of scope** and tracked in #3196 (a correct fix needs base-slot-chain resolution to `System.Object`, often cross-assembly/SRM-unresolvable, and re-opens the round-1 false-positive surface).

## Stacking

Stacked on #3186 (`fix/finalizer-section`) → #3168 (`fix/issue-3157-finalizer`) → `main`. Must rebase/retarget onto `main` after #3186 and #3168 merge.
