### PR TITLE
Corpus producer + serializable manifest in DotnetInspector.Services (#3180, layer 3)

### DIFF
--- a/src/DotnetInspector.Services.Tests/CorpusManifestTests.cs
+++ b/src/DotnetInspector.Services.Tests/CorpusManifestTests.cs
@@ -61,23 +61,38 @@ public class CorpusManifestTests
     }
 
     [Fact]
-    public void FromJson_EmptyEntries_Throws()
+    public void FromJson_EmptyEntries_ParsesAsEmptyManifest()
     {
+        // An empty entry list is valid data and must round-trip; refusing to *operate* on an empty
+        // corpus is enforced at the population boundary, not during parsing.
         const string json = """
         { "schemaVersion": 1, "entries": [] }
         """;
 
-        Assert.Throws<System.Text.Json.JsonException>(() => CorpusManifest.FromJson(json));
+        var manifest = CorpusManifest.FromJson(json);
+
+        Assert.Empty(manifest.Entries);
     }
 
     [Fact]
-    public void FromJson_MissingEntries_Throws()
+    public void FromJson_MissingEntries_ParsesAsEmptyManifest()
     {
         const string json = """
         { "schemaVersion": 1 }
         """;
 
-        Assert.Throws<System.Text.Json.JsonException>(() => CorpusManifest.FromJson(json));
+        var manifest = CorpusManifest.FromJson(json);
+
+        Assert.Empty(manifest.Entries);
+    }
+
+    [Fact]
+    public void EmptyManifest_JsonRoundTripsSymmetrically()
+    {
+        var roundTripped = CorpusManifest.FromJson(new CorpusManifest().ToJson());
+
+        Assert.Empty(roundTripped.Entries);
+        Assert.Equal(CorpusManifest.CurrentSchemaVersion, roundTripped.SchemaVersion);
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/CorpusManifestTests.cs
+++ b/src/DotnetInspector.Services.Tests/CorpusManifestTests.cs
@@ -1,0 +1,62 @@
+namespace DotnetInspector.Services.Tests;
+
+public class CorpusManifestTests
+{
+    [Fact]
+    public void JsonRoundTrip_PreservesSchemaAndEntries()
+    {
+        var manifest = new CorpusManifest
+        {
+            Entries =
+            [
+                new CorpusManifestEntry(AssemblySetSourceKind.Package, "Newtonsoft.Json", "13.0.3", "net8.0"),
+                new CorpusManifestEntry(AssemblySetSourceKind.PlatformFramework, "Microsoft.NETCore.App", "10.0.0"),
+                new CorpusManifestEntry(AssemblySetSourceKind.Assembly, @"C:\pkgs\Local.dll"),
+            ],
+        };
+
+        var json = manifest.ToJson();
+        var roundTripped = CorpusManifest.FromJson(json);
+
+        Assert.Equal(CorpusManifest.CurrentSchemaVersion, roundTripped.SchemaVersion);
+        Assert.Equal(manifest.Entries, roundTripped.Entries);
+    }
+
+    [Fact]
+    public void ToJson_SerializesEnumAsNameAndOmitsNulls()
+    {
+        var manifest = new CorpusManifest
+        {
+            Entries = [new CorpusManifestEntry(AssemblySetSourceKind.Package, "Serilog", "3.1.1")],
+        };
+
+        var json = manifest.ToJson();
+
+        Assert.Contains("\"schemaVersion\"", json);
+        Assert.Contains("\"Package\"", json);
+        // Tfm was null and must be omitted rather than serialized as an explicit null.
+        Assert.DoesNotContain("\"tfm\"", json);
+    }
+
+    [Fact]
+    public void FromJson_UnsupportedSchemaVersion_Throws()
+    {
+        const string json = """
+        { "schemaVersion": 99, "entries": [] }
+        """;
+
+        Assert.Throws<NotSupportedException>(() => CorpusManifest.FromJson(json));
+    }
+
+    [Fact]
+    public void FromJson_NullDocument_Throws()
+    {
+        Assert.Throws<System.Text.Json.JsonException>(() => CorpusManifest.FromJson("null"));
+    }
+
+    [Fact]
+    public void FromJson_EmptyString_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => CorpusManifest.FromJson(string.Empty));
+    }
+}

--- a/src/DotnetInspector.Services.Tests/CorpusManifestTests.cs
+++ b/src/DotnetInspector.Services.Tests/CorpusManifestTests.cs
@@ -59,4 +59,40 @@ public class CorpusManifestTests
     {
         Assert.Throws<ArgumentException>(() => CorpusManifest.FromJson(string.Empty));
     }
+
+    [Fact]
+    public void FromJson_EmptyEntries_Throws()
+    {
+        const string json = """
+        { "schemaVersion": 1, "entries": [] }
+        """;
+
+        Assert.Throws<System.Text.Json.JsonException>(() => CorpusManifest.FromJson(json));
+    }
+
+    [Fact]
+    public void FromJson_MissingEntries_Throws()
+    {
+        const string json = """
+        { "schemaVersion": 1 }
+        """;
+
+        Assert.Throws<System.Text.Json.JsonException>(() => CorpusManifest.FromJson(json));
+    }
+
+    [Fact]
+    public void Entries_DefensivelyCopiesAndExposesReadOnlyView()
+    {
+        var source = new List<CorpusManifestEntry>
+        {
+            new(AssemblySetSourceKind.Package, "P", "1.0.0"),
+        };
+
+        var manifest = new CorpusManifest { Entries = source };
+        source.Clear(); // mutating the original must not affect the manifest
+
+        Assert.Single(manifest.Entries);
+        Assert.IsNotType<List<CorpusManifestEntry>>(manifest.Entries);
+        Assert.Throws<NotSupportedException>(() => ((IList<CorpusManifestEntry>)manifest.Entries).Clear());
+    }
 }

--- a/src/DotnetInspector.Services.Tests/CorpusProducerTests.cs
+++ b/src/DotnetInspector.Services.Tests/CorpusProducerTests.cs
@@ -189,7 +189,7 @@ public class CorpusProducerTests
 
         Assert.Equal(2, manifest.Entries.Count);
         Assert.Equal(new CorpusManifestEntry(AssemblySetSourceKind.Package, "Pkg", "1.0.0", "net8.0"), manifest.Entries[0]);
-        Assert.Equal(new CorpusManifestEntry(AssemblySetSourceKind.Assembly, @"C:\loose\Local.dll"), manifest.Entries[1]);
+        Assert.Equal(new CorpusManifestEntry(AssemblySetSourceKind.Assembly, Path.GetFullPath(@"C:\loose\Local.dll")), manifest.Entries[1]);
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/CorpusProducerTests.cs
+++ b/src/DotnetInspector.Services.Tests/CorpusProducerTests.cs
@@ -1,0 +1,189 @@
+using System.IO.Compression;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Services.Tests;
+
+public class CorpusProducerTests
+{
+    private static readonly string SelfAssembly = typeof(CorpusProducerTests).Assembly.Location;
+
+    [Fact]
+    public async Task PopulateAsync_LocalPackage_ProducesCorpusMemberAndManifestEntry()
+    {
+        var packageDir = Directory.CreateTempSubdirectory("corpus-producer-populate").FullName;
+        var packagePath = Path.Combine(packageDir, "TestPackage.1.0.0.nupkg");
+
+        try
+        {
+            using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                archive.CreateEntryFromFile(SelfAssembly, "lib/net10.0/TestPackage.dll");
+            }
+
+            using var httpClient = new HttpClient();
+            using var populated = await CorpusProducer.PopulateAsync(
+                httpClient,
+                new AssemblySetRequest
+                {
+                    Packages = [packagePath],
+                    Tfm = "net10.0",
+                    TempDirPrefix = "corpus-producer-test",
+                });
+
+            var member = Assert.Single(populated.Corpus.Members);
+            Assert.Equal("TestPackage", member.Source);
+            Assert.Equal("1.0.0", member.Version);
+            Assert.Equal("net10.0", member.Tfm);
+            Assert.True(File.Exists(member.AssemblyPath));
+
+            var entry = Assert.Single(populated.Manifest.Entries);
+            Assert.Equal(new CorpusManifestEntry(AssemblySetSourceKind.Package, "TestPackage", "1.0.0", "net10.0"), entry);
+            Assert.Empty(populated.Diagnostics);
+
+            // The produced corpus searches offline over exactly the resolved assembly.
+            var typeSearch = populated.Corpus.SearchTypes([typeof(CorpusProducerTests).FullName!]);
+            Assert.Empty(typeSearch.SkippedAssemblies);
+            var match = Assert.Single(typeSearch.Results);
+            Assert.Equal("TestPackage", match.Source);
+        }
+        finally
+        {
+            Directory.Delete(packageDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PopulateAsync_PackageWithManyAssemblies_DedupesManifestButKeepsEveryMember()
+    {
+        var packageDir = Directory.CreateTempSubdirectory("corpus-producer-dedup").FullName;
+        var packagePath = Path.Combine(packageDir, "MultiSurface.2.0.0.nupkg");
+
+        try
+        {
+            using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                archive.CreateEntryFromFile(SelfAssembly, "lib/net10.0/Alpha.dll");
+                archive.CreateEntryFromFile(SelfAssembly, "lib/net10.0/Zeta.dll");
+            }
+
+            using var httpClient = new HttpClient();
+            using var populated = await CorpusProducer.PopulateAsync(
+                httpClient,
+                new AssemblySetRequest { Packages = [packagePath], Tfm = "net10.0" });
+
+            Assert.Equal(2, populated.Corpus.Count);
+            Assert.All(populated.Corpus.Members, m => Assert.Equal("MultiSurface", m.Source));
+
+            // Two assemblies, one logical origin.
+            var entry = Assert.Single(populated.Manifest.Entries);
+            Assert.Equal(AssemblySetSourceKind.Package, entry.Kind);
+            Assert.Equal("MultiSurface", entry.Id);
+            Assert.Equal("2.0.0", entry.Version);
+        }
+        finally
+        {
+            Directory.Delete(packageDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PopulateAsync_DisposeReleasesOwnedExtractionDirectory()
+    {
+        var packageDir = Directory.CreateTempSubdirectory("corpus-producer-dispose").FullName;
+        var packagePath = Path.Combine(packageDir, "Disposable.1.0.0.nupkg");
+
+        try
+        {
+            using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                archive.CreateEntryFromFile(SelfAssembly, "lib/net10.0/Disposable.dll");
+            }
+
+            using var httpClient = new HttpClient();
+            var populated = await CorpusProducer.PopulateAsync(
+                httpClient,
+                new AssemblySetRequest
+                {
+                    Packages = [packagePath],
+                    Tfm = "net10.0",
+                    TempDirPrefix = "corpus-producer-dispose-test",
+                });
+
+            var memberPath = Assert.Single(populated.Corpus.Members).AssemblyPath;
+            Assert.True(File.Exists(memberPath));
+
+            populated.Dispose();
+
+            Assert.False(File.Exists(memberPath));
+            // Dispose is idempotent.
+            populated.Dispose();
+        }
+        finally
+        {
+            Directory.Delete(packageDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ToManifest_NormalizesPathBoundSourceToReloadableAssemblyEntry()
+    {
+        var directory = Directory.CreateTempSubdirectory("corpus-producer-dir").FullName;
+        var copiedAssembly = Path.Combine(directory, "Copied.dll");
+        File.Copy(SelfAssembly, copiedAssembly);
+
+        try
+        {
+            using var httpClient = new HttpClient();
+            using var set = await AssemblySetResolver.CollectAsync(
+                httpClient,
+                new AssemblySetRequest { Directories = [directory] });
+
+            var manifest = CorpusProducer.ToManifest(set);
+
+            var entry = Assert.Single(manifest.Entries);
+            Assert.Equal(AssemblySetSourceKind.Assembly, entry.Kind);
+            Assert.Equal(copiedAssembly, entry.Id);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PopulateFromManifestAsync_AssemblyEntry_ReloadsEquivalentCorpus()
+    {
+        var manifest = new CorpusManifest
+        {
+            Entries = [new CorpusManifestEntry(AssemblySetSourceKind.Assembly, SelfAssembly)],
+        };
+
+        using var httpClient = new HttpClient();
+        using var populated = await CorpusProducer.PopulateFromManifestAsync(httpClient, manifest);
+
+        var member = Assert.Single(populated.Corpus.Members);
+        Assert.Equal(SelfAssembly, member.AssemblyPath);
+
+        // Rebuilt manifest describes the reloaded corpus and matches the input entry.
+        var rebuilt = Assert.Single(populated.Manifest.Entries);
+        Assert.Equal(manifest.Entries[0], rebuilt);
+    }
+
+    [Fact]
+    public void ToManifest_MixedSources_PreservesFirstAppearanceOrderAndDedupes()
+    {
+        var entries = new[]
+        {
+            new AssemblySetEntry(@"C:\ext\A.dll", "Pkg", "1.0.0", AssemblySetSourceKind.Package, "net8.0"),
+            new AssemblySetEntry(@"C:\ext\B.dll", "Pkg", "1.0.0", AssemblySetSourceKind.Package, "net8.0"),
+            new AssemblySetEntry(@"C:\loose\Local.dll", "Local.dll", null, AssemblySetSourceKind.Assembly),
+            new AssemblySetEntry(@"C:\ext\A.dll", "Pkg", "1.0.0", AssemblySetSourceKind.Package, "net8.0"),
+        };
+
+        var manifest = CorpusProducer.ToManifest(entries);
+
+        Assert.Equal(2, manifest.Entries.Count);
+        Assert.Equal(new CorpusManifestEntry(AssemblySetSourceKind.Package, "Pkg", "1.0.0", "net8.0"), manifest.Entries[0]);
+        Assert.Equal(new CorpusManifestEntry(AssemblySetSourceKind.Assembly, @"C:\loose\Local.dll"), manifest.Entries[1]);
+    }
+}

--- a/src/DotnetInspector.Services.Tests/CorpusProducerTests.cs
+++ b/src/DotnetInspector.Services.Tests/CorpusProducerTests.cs
@@ -40,6 +40,11 @@ public class CorpusProducerTests
             Assert.Equal(new CorpusManifestEntry(AssemblySetSourceKind.Package, "TestPackage", "1.0.0", "net10.0"), entry);
             Assert.Empty(populated.Diagnostics);
 
+            // Diagnostics is a genuine read-only view, not a downcastable backing list.
+            Assert.Throws<NotSupportedException>(() =>
+                ((IList<AssemblySetDiagnostic>)populated.Diagnostics).Add(
+                    new AssemblySetDiagnostic(AssemblySetDiagnosticSeverity.Warning, "x")));
+
             // The produced corpus searches offline over exactly the resolved assembly.
             var typeSearch = populated.Corpus.SearchTypes([typeof(CorpusProducerTests).FullName!]);
             Assert.Empty(typeSearch.SkippedAssemblies);
@@ -185,5 +190,72 @@ public class CorpusProducerTests
         Assert.Equal(2, manifest.Entries.Count);
         Assert.Equal(new CorpusManifestEntry(AssemblySetSourceKind.Package, "Pkg", "1.0.0", "net8.0"), manifest.Entries[0]);
         Assert.Equal(new CorpusManifestEntry(AssemblySetSourceKind.Assembly, @"C:\loose\Local.dll"), manifest.Entries[1]);
+    }
+
+    [Fact]
+    public void ToManifest_PlatformFrameworkCollapses_ButPlatformAssembliesStayDistinctByPath()
+    {
+        // Mirrors AssemblySetResolver output: a whole framework's assemblies all carry the framework name
+        // in Source (correctly collapsible), while individually resolved platform assemblies ALSO carry the
+        // framework name in Source rather than the requested assembly name (so collapsing by Source would
+        // wrongly merge them into one un-reloadable entry).
+        var entries = new[]
+        {
+            new AssemblySetEntry(@"C:\packs\App\System.Runtime.dll", "Microsoft.NETCore.App", "10.0.0", AssemblySetSourceKind.PlatformFramework),
+            new AssemblySetEntry(@"C:\packs\App\System.Collections.dll", "Microsoft.NETCore.App", "10.0.0", AssemblySetSourceKind.PlatformFramework),
+            new AssemblySetEntry(@"C:\packs\App\System.Text.Json.dll", "Microsoft.NETCore.App", "10.0.0", AssemblySetSourceKind.PlatformAssembly),
+            new AssemblySetEntry(@"C:\packs\App\System.Linq.dll", "Microsoft.NETCore.App", "10.0.0", AssemblySetSourceKind.PlatformAssembly),
+        };
+
+        var manifest = CorpusProducer.ToManifest(entries);
+
+        // Framework -> exactly one reload-by-name entry.
+        Assert.Single(
+            manifest.Entries,
+            e => e.Kind == AssemblySetSourceKind.PlatformFramework && e.Id == "Microsoft.NETCore.App");
+
+        // Platform assemblies stay distinct, captured by full path (not merged into the framework name).
+        var assemblyEntries = manifest.Entries.Where(e => e.Kind == AssemblySetSourceKind.Assembly).ToArray();
+        Assert.Equal(2, assemblyEntries.Length);
+        Assert.Contains(assemblyEntries, e => e.Id == Path.GetFullPath(@"C:\packs\App\System.Text.Json.dll"));
+        Assert.Contains(assemblyEntries, e => e.Id == Path.GetFullPath(@"C:\packs\App\System.Linq.dll"));
+        Assert.Equal(3, manifest.Entries.Count);
+    }
+
+    [Fact]
+    public void ToManifest_PathBoundEntry_IsNormalizedToFullPath()
+    {
+        var relative = Path.Combine("sub", "Rel.dll");
+        var entries = new[]
+        {
+            new AssemblySetEntry(relative, "Rel.dll", null, AssemblySetSourceKind.Assembly),
+        };
+
+        var entry = Assert.Single(CorpusProducer.ToManifest(entries).Entries);
+
+        Assert.Equal(AssemblySetSourceKind.Assembly, entry.Kind);
+        Assert.True(Path.IsPathFullyQualified(entry.Id));
+        Assert.Equal(Path.GetFullPath(relative), entry.Id);
+    }
+
+    [Fact]
+    public void ToManifest_Entries_AreReadOnlyAndNotDowncastableToMutableList()
+    {
+        var manifest = CorpusProducer.ToManifest(new[]
+        {
+            new AssemblySetEntry(@"C:\loose\A.dll", "A.dll", null, AssemblySetSourceKind.Assembly),
+        });
+
+        Assert.IsNotType<List<CorpusManifestEntry>>(manifest.Entries);
+        Assert.Throws<NotSupportedException>(() => ((IList<CorpusManifestEntry>)manifest.Entries).Clear());
+    }
+
+    [Fact]
+    public async Task PopulateFromManifestAsync_EmptyManifest_Throws()
+    {
+        using var httpClient = new HttpClient();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            CorpusProducer.PopulateFromManifestAsync(httpClient, new CorpusManifest()));
     }
 }

--- a/src/DotnetInspector.Services.Tests/CorpusProducerTests.cs
+++ b/src/DotnetInspector.Services.Tests/CorpusProducerTests.cs
@@ -258,4 +258,18 @@ public class CorpusProducerTests
         await Assert.ThrowsAsync<ArgumentException>(() =>
             CorpusProducer.PopulateFromManifestAsync(httpClient, new CorpusManifest()));
     }
+
+    [Fact]
+    public async Task PopulateAsync_ResolvesNoAssemblies_ThrowsRatherThanReturningEmptyCorpus()
+    {
+        var missingDirectory = Path.Combine(Path.GetTempPath(), $"corpus-missing-{Guid.NewGuid():N}");
+        using var httpClient = new HttpClient();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            CorpusProducer.PopulateAsync(
+                httpClient,
+                new AssemblySetRequest { Directories = [missingDirectory] }));
+
+        Assert.Contains("resolved no assemblies", ex.Message);
+    }
 }

--- a/src/DotnetInspector.Services/CorpusManifest.cs
+++ b/src/DotnetInspector.Services/CorpusManifest.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// One logical origin in a <see cref="CorpusManifest"/>: the pinned recipe for reproducing a slice of
+/// a corpus, not an individual assembly file. A package that expands to many assemblies collapses to a
+/// single entry; a path-bound source (loose assembly, project, directory) is normalized to a
+/// reload-by-path <see cref="AssemblySetSourceKind.Assembly"/> entry so every entry is re-populatable.
+/// </summary>
+/// <param name="Kind">How the entry is re-populated (package, platform framework, loose assembly, …).</param>
+/// <param name="Id">
+/// The re-population identity for <see cref="Kind"/>: a package name, a platform framework/assembly
+/// name, or — for path-bound kinds — the assembly's local file path.
+/// </param>
+/// <param name="Version">The pinned version, when the producer resolved one (informational for platform kinds).</param>
+/// <param name="Tfm">The target framework moniker the entry was selected for, when known.</param>
+public sealed record CorpusManifestEntry(
+    AssemblySetSourceKind Kind,
+    string Id,
+    string? Version = null,
+    string? Tfm = null);
+
+/// <summary>
+/// A serializable, offline-durable description of a corpus: the ordered set of logical entries needed
+/// to repopulate it. This is the shareable/primary state a corpus round-trips through — serialize it to
+/// persist or share, deserialize and re-populate to obtain an equivalent live <see cref="ILInspector.Metadata.Corpus"/>.
+/// The manifest itself performs no resolution or I/O; repopulation is a separate, explicit step in
+/// <see cref="CorpusProducer"/>.
+/// </summary>
+public sealed record CorpusManifest
+{
+    /// <summary>The current manifest schema version emitted by this build.</summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>Schema version of this manifest, so older documents can be detected on load.</summary>
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+
+    /// <summary>The logical entries, in the order they should be repopulated.</summary>
+    public IReadOnlyList<CorpusManifestEntry> Entries { get; init; } = [];
+
+    /// <summary>Serializes this manifest to indented JSON using the AOT-safe source-generated context.</summary>
+    public string ToJson() =>
+        JsonSerializer.Serialize(this, CorpusManifestJsonContext.Default.CorpusManifest);
+
+    /// <summary>
+    /// Deserializes a manifest from JSON produced by <see cref="ToJson"/>. Throws when the payload is
+    /// null/empty JSON or carries an unsupported <see cref="SchemaVersion"/>, so a malformed document
+    /// cannot silently reload as an empty corpus.
+    /// </summary>
+    public static CorpusManifest FromJson(string json)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(json);
+
+        var manifest = JsonSerializer.Deserialize(json, CorpusManifestJsonContext.Default.CorpusManifest)
+            ?? throw new JsonException("Corpus manifest JSON deserialized to null.");
+
+        if (manifest.SchemaVersion != CurrentSchemaVersion)
+        {
+            throw new NotSupportedException(
+                $"Unsupported corpus manifest schema version {manifest.SchemaVersion}; expected {CurrentSchemaVersion}.");
+        }
+
+        return manifest;
+    }
+}
+
+/// <summary>
+/// Source-generated <see cref="JsonSerializerContext"/> for <see cref="CorpusManifest"/>. Using the
+/// generator (rather than reflection-based serialization) keeps manifest round-tripping compatible with
+/// the NativeAOT-published CLI.
+/// </summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    UseStringEnumConverter = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(CorpusManifest))]
+public sealed partial class CorpusManifestJsonContext : JsonSerializerContext
+{
+}

--- a/src/DotnetInspector.Services/CorpusManifest.cs
+++ b/src/DotnetInspector.Services/CorpusManifest.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -11,8 +12,9 @@ namespace DotnetInspector.Services;
 /// </summary>
 /// <param name="Kind">How the entry is re-populated (package, platform framework, loose assembly, …).</param>
 /// <param name="Id">
-/// The re-population identity for <see cref="Kind"/>: a package name, a platform framework/assembly
-/// name, or — for path-bound kinds — the assembly's local file path.
+/// The re-population identity for <see cref="Kind"/>: a package name for packages, a framework name for
+/// a whole platform framework, or — for path-bound kinds (loose assembly, project, directory, and a
+/// single platform assembly) — the assembly's full local file path.
 /// </param>
 /// <param name="Version">The pinned version, when the producer resolved one (informational for platform kinds).</param>
 /// <param name="Tfm">The target framework moniker the entry was selected for, when known.</param>
@@ -37,8 +39,23 @@ public sealed record CorpusManifest
     /// <summary>Schema version of this manifest, so older documents can be detected on load.</summary>
     public int SchemaVersion { get; init; } = CurrentSchemaVersion;
 
-    /// <summary>The logical entries, in the order they should be repopulated.</summary>
-    public IReadOnlyList<CorpusManifestEntry> Entries { get; init; } = [];
+    /// <summary>
+    /// The logical entries, in the order they should be repopulated. Assignment defensively copies into
+    /// a genuine read-only collection so a caller cannot downcast the exposed list and mutate the recipe
+    /// (which would break the invariant that a manifest describes its corpus).
+    /// </summary>
+    public IReadOnlyList<CorpusManifestEntry> Entries
+    {
+        get => _entries;
+        init => _entries = value is null
+            ? EmptyEntries
+            : new ReadOnlyCollection<CorpusManifestEntry>([.. value]);
+    }
+
+    private readonly IReadOnlyList<CorpusManifestEntry> _entries = EmptyEntries;
+
+    private static readonly ReadOnlyCollection<CorpusManifestEntry> EmptyEntries =
+        new([]);
 
     /// <summary>Serializes this manifest to indented JSON using the AOT-safe source-generated context.</summary>
     public string ToJson() =>
@@ -46,8 +63,8 @@ public sealed record CorpusManifest
 
     /// <summary>
     /// Deserializes a manifest from JSON produced by <see cref="ToJson"/>. Throws when the payload is
-    /// null/empty JSON or carries an unsupported <see cref="SchemaVersion"/>, so a malformed document
-    /// cannot silently reload as an empty corpus.
+    /// null/empty JSON, carries an unsupported <see cref="SchemaVersion"/>, or contains no entries, so a
+    /// malformed or empty document cannot silently reload as an empty corpus.
     /// </summary>
     public static CorpusManifest FromJson(string json)
     {
@@ -60,6 +77,12 @@ public sealed record CorpusManifest
         {
             throw new NotSupportedException(
                 $"Unsupported corpus manifest schema version {manifest.SchemaVersion}; expected {CurrentSchemaVersion}.");
+        }
+
+        if (manifest.Entries.Count == 0)
+        {
+            throw new JsonException(
+                "Corpus manifest contains no entries; a manifest that describes no assemblies cannot be loaded.");
         }
 
         return manifest;

--- a/src/DotnetInspector.Services/CorpusManifest.cs
+++ b/src/DotnetInspector.Services/CorpusManifest.cs
@@ -63,8 +63,9 @@ public sealed record CorpusManifest
 
     /// <summary>
     /// Deserializes a manifest from JSON produced by <see cref="ToJson"/>. Throws when the payload is
-    /// null/empty JSON, carries an unsupported <see cref="SchemaVersion"/>, or contains no entries, so a
-    /// malformed or empty document cannot silently reload as an empty corpus.
+    /// null/empty JSON string, or carries an unsupported <see cref="SchemaVersion"/>. An empty entry list
+    /// is preserved as valid data so serialization round-trips symmetrically; refusing to operate on an
+    /// empty corpus is enforced at the population boundary (<see cref="CorpusProducer"/>), not here.
     /// </summary>
     public static CorpusManifest FromJson(string json)
     {
@@ -77,12 +78,6 @@ public sealed record CorpusManifest
         {
             throw new NotSupportedException(
                 $"Unsupported corpus manifest schema version {manifest.SchemaVersion}; expected {CurrentSchemaVersion}.");
-        }
-
-        if (manifest.Entries.Count == 0)
-        {
-            throw new JsonException(
-                "Corpus manifest contains no entries; a manifest that describes no assemblies cannot be loaded.");
         }
 
         return manifest;

--- a/src/DotnetInspector.Services/CorpusProducer.cs
+++ b/src/DotnetInspector.Services/CorpusProducer.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using DotnetInspector.Packages;
 using ILInspector.Metadata;
 
@@ -23,7 +24,7 @@ public sealed class PopulatedCorpus : IDisposable
         _sets = sets;
         Corpus = corpus;
         Manifest = manifest;
-        Diagnostics = diagnostics;
+        Diagnostics = new ReadOnlyCollection<AssemblySetDiagnostic>([.. diagnostics]);
     }
 
     /// <summary>The resolved, closed set of assemblies to operate within.</summary>
@@ -41,8 +42,11 @@ public sealed class PopulatedCorpus : IDisposable
         if (_disposed)
             return;
 
+        // Best-effort per set: one failing Dispose must not strand the others' extraction directories.
         foreach (var set in _sets)
-            set.Dispose();
+        {
+            try { set.Dispose(); } catch { }
+        }
 
         _disposed = true;
     }
@@ -85,11 +89,13 @@ public static class CorpusProducer
     }
 
     /// <summary>
-    /// Builds the serializable manifest describing resolved assembly entries. Package and platform
-    /// sources collapse to one logical entry each (many assemblies share a package name/version/TFM);
-    /// path-bound sources (loose assembly, project, directory) are normalized to reload-by-path
-    /// <see cref="AssemblySetSourceKind.Assembly"/> entries so the manifest is always repopulatable.
-    /// Entry order follows first appearance.
+    /// Builds the serializable manifest describing resolved assembly entries. A package or whole platform
+    /// framework collapses to one logical entry (its many assemblies share one package/framework
+    /// name+version+TFM). Every other source — loose assembly, project, directory, and an individually
+    /// resolved platform assembly — is normalized to a reload-by-<em>path</em>
+    /// <see cref="AssemblySetSourceKind.Assembly"/> entry (Id = the assembly's full path) so the manifest
+    /// is always repopulatable and working-directory independent. Entry order follows first appearance;
+    /// duplicates are removed.
     /// </summary>
     public static CorpusManifest ToManifest(IEnumerable<AssemblySetEntry> entries)
     {
@@ -102,7 +108,7 @@ public static class CorpusProducer
         {
             var manifestEntry = IsLogicalOrigin(entry.SourceKind)
                 ? new CorpusManifestEntry(entry.SourceKind, entry.Source, entry.Version, entry.Tfm)
-                : new CorpusManifestEntry(AssemblySetSourceKind.Assembly, entry.Path, entry.Version, entry.Tfm);
+                : new CorpusManifestEntry(AssemblySetSourceKind.Assembly, Path.GetFullPath(entry.Path), entry.Version, entry.Tfm);
 
             if (seen.Add((manifestEntry.Kind, manifestEntry.Id, manifestEntry.Version, manifestEntry.Tfm)))
                 manifestEntries.Add(manifestEntry);
@@ -152,6 +158,13 @@ public static class CorpusProducer
         ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(manifest);
 
+        if (manifest.Entries.Count == 0)
+        {
+            throw new ArgumentException(
+                "Corpus manifest has no entries; cannot populate a corpus from an empty manifest.",
+                nameof(manifest));
+        }
+
         var sets = new List<AssemblySet>();
         var entries = new List<AssemblySetEntry>();
         var diagnostics = new List<AssemblySetDiagnostic>();
@@ -172,16 +185,21 @@ public static class CorpusProducer
         catch
         {
             foreach (var set in sets)
-                set.Dispose();
+            {
+                try { set.Dispose(); } catch { }
+            }
             throw;
         }
     }
 
     private static bool IsLogicalOrigin(AssemblySetSourceKind kind) => kind switch
     {
+        // A package and a whole platform framework each fan out to many assemblies that share one
+        // logical name+version+TFM, so they collapse to a single re-populatable entry. Every other kind
+        // (including a single platform assembly, whose Source records its framework rather than the
+        // requested assembly) is captured individually by path.
         AssemblySetSourceKind.Package => true,
         AssemblySetSourceKind.PlatformFramework => true,
-        AssemblySetSourceKind.PlatformAssembly => true,
         _ => false,
     };
 

--- a/src/DotnetInspector.Services/CorpusProducer.cs
+++ b/src/DotnetInspector.Services/CorpusProducer.cs
@@ -1,0 +1,214 @@
+using DotnetInspector.Packages;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// A live <see cref="ILInspector.Metadata.Corpus"/> together with the temporary extraction directories
+/// backing it and the serializable <see cref="CorpusManifest"/> that describes it. Disposing releases
+/// every owned extraction directory, so callers should keep it alive for as long as they operate within
+/// the corpus and dispose it exactly once when done.
+/// </summary>
+public sealed class PopulatedCorpus : IDisposable
+{
+    private readonly IReadOnlyList<AssemblySet> _sets;
+    private bool _disposed;
+
+    internal PopulatedCorpus(
+        IReadOnlyList<AssemblySet> sets,
+        Corpus corpus,
+        CorpusManifest manifest,
+        IReadOnlyList<AssemblySetDiagnostic> diagnostics)
+    {
+        _sets = sets;
+        Corpus = corpus;
+        Manifest = manifest;
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>The resolved, closed set of assemblies to operate within.</summary>
+    public Corpus Corpus { get; }
+
+    /// <summary>The serializable recipe that describes <see cref="Corpus"/> and can repopulate an equivalent set.</summary>
+    public CorpusManifest Manifest { get; }
+
+    /// <summary>Diagnostics gathered while populating (missing directories, unusable packages, …).</summary>
+    public IReadOnlyList<AssemblySetDiagnostic> Diagnostics { get; }
+
+    /// <summary>Removes every temporary extraction directory owned by this corpus.</summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        foreach (var set in _sets)
+            set.Dispose();
+
+        _disposed = true;
+    }
+}
+
+/// <summary>
+/// Turns the acquisition layer's <see cref="AssemblySet"/> into the metadata layer's closed-set
+/// <see cref="Corpus"/> and its serializable <see cref="CorpusManifest"/>. This is the seam that makes
+/// <see cref="AssemblySetResolver"/> a corpus <em>producer</em>: acquisition (packages, platforms,
+/// projects, downloads) stays here, while the resulting corpus carries no feed reference and operates
+/// entirely offline.
+/// </summary>
+public static class CorpusProducer
+{
+    /// <summary>Maps a resolved <see cref="AssemblySet"/> to a closed-set <see cref="Corpus"/>.</summary>
+    public static Corpus ToCorpus(AssemblySet set)
+    {
+        ArgumentNullException.ThrowIfNull(set);
+        return ToCorpus(set.Assemblies);
+    }
+
+    /// <summary>Maps resolved assembly entries to a closed-set <see cref="Corpus"/>, one member per entry.</summary>
+    public static Corpus ToCorpus(IEnumerable<AssemblySetEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        return new Corpus(entries.Select(static entry => new CorpusMember
+        {
+            AssemblyPath = entry.Path,
+            Source = entry.Source,
+            Version = entry.Version,
+            Tfm = entry.Tfm,
+        }));
+    }
+
+    /// <summary>Builds the serializable manifest describing a resolved <see cref="AssemblySet"/>.</summary>
+    public static CorpusManifest ToManifest(AssemblySet set)
+    {
+        ArgumentNullException.ThrowIfNull(set);
+        return ToManifest(set.Assemblies);
+    }
+
+    /// <summary>
+    /// Builds the serializable manifest describing resolved assembly entries. Package and platform
+    /// sources collapse to one logical entry each (many assemblies share a package name/version/TFM);
+    /// path-bound sources (loose assembly, project, directory) are normalized to reload-by-path
+    /// <see cref="AssemblySetSourceKind.Assembly"/> entries so the manifest is always repopulatable.
+    /// Entry order follows first appearance.
+    /// </summary>
+    public static CorpusManifest ToManifest(IEnumerable<AssemblySetEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        var manifestEntries = new List<CorpusManifestEntry>();
+        var seen = new HashSet<(AssemblySetSourceKind Kind, string Id, string? Version, string? Tfm)>();
+
+        foreach (var entry in entries)
+        {
+            var manifestEntry = IsLogicalOrigin(entry.SourceKind)
+                ? new CorpusManifestEntry(entry.SourceKind, entry.Source, entry.Version, entry.Tfm)
+                : new CorpusManifestEntry(AssemblySetSourceKind.Assembly, entry.Path, entry.Version, entry.Tfm);
+
+            if (seen.Add((manifestEntry.Kind, manifestEntry.Id, manifestEntry.Version, manifestEntry.Tfm)))
+                manifestEntries.Add(manifestEntry);
+        }
+
+        return new CorpusManifest { Entries = manifestEntries };
+    }
+
+    /// <summary>
+    /// Resolves a request into a live corpus. The single explicit network/extraction step for a corpus:
+    /// the returned <see cref="PopulatedCorpus"/> owns the extraction directories and, once returned,
+    /// searches over it are offline.
+    /// </summary>
+    public static async Task<PopulatedCorpus> PopulateAsync(
+        HttpClient httpClient,
+        AssemblySetRequest request,
+        Action<string>? log = null)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var set = await AssemblySetResolver.CollectAsync(httpClient, request, log).ConfigureAwait(false);
+        try
+        {
+            return new PopulatedCorpus([set], ToCorpus(set), ToManifest(set), set.Diagnostics);
+        }
+        catch
+        {
+            set.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Repopulates a live corpus from a previously serialized manifest, resolving each entry with its own
+    /// pinned TFM. The returned <see cref="PopulatedCorpus.Manifest"/> is rebuilt from what actually
+    /// resolved, so it always describes the returned corpus. Aggregated diagnostics surface any entry
+    /// that could not be resolved rather than silently shrinking the set.
+    /// </summary>
+    public static async Task<PopulatedCorpus> PopulateFromManifestAsync(
+        HttpClient httpClient,
+        CorpusManifest manifest,
+        NuGetSourceOptions? sourceOptions = null,
+        string tempDirPrefix = "inspect-corpus",
+        Action<string>? log = null)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        var sets = new List<AssemblySet>();
+        var entries = new List<AssemblySetEntry>();
+        var diagnostics = new List<AssemblySetDiagnostic>();
+
+        try
+        {
+            foreach (var entry in manifest.Entries)
+            {
+                var request = BuildEntryRequest(entry, sourceOptions, tempDirPrefix);
+                var set = await AssemblySetResolver.CollectAsync(httpClient, request, log).ConfigureAwait(false);
+                sets.Add(set);
+                entries.AddRange(set.Assemblies);
+                diagnostics.AddRange(set.Diagnostics);
+            }
+
+            return new PopulatedCorpus(sets, ToCorpus(entries), ToManifest(entries), diagnostics);
+        }
+        catch
+        {
+            foreach (var set in sets)
+                set.Dispose();
+            throw;
+        }
+    }
+
+    private static bool IsLogicalOrigin(AssemblySetSourceKind kind) => kind switch
+    {
+        AssemblySetSourceKind.Package => true,
+        AssemblySetSourceKind.PlatformFramework => true,
+        AssemblySetSourceKind.PlatformAssembly => true,
+        _ => false,
+    };
+
+    private static AssemblySetRequest BuildEntryRequest(
+        CorpusManifestEntry entry,
+        NuGetSourceOptions? sourceOptions,
+        string tempDirPrefix)
+    {
+        var request = new AssemblySetRequest
+        {
+            Tfm = entry.Tfm,
+            SourceOptions = sourceOptions,
+            TempDirPrefix = tempDirPrefix,
+        };
+
+        return entry.Kind switch
+        {
+            AssemblySetSourceKind.Package => request with { Packages = [PackageSpec(entry)] },
+            AssemblySetSourceKind.PlatformFramework => request with { PlatformFrameworks = [entry.Id] },
+            AssemblySetSourceKind.PlatformAssembly => request with { PlatformAssemblies = [entry.Id] },
+            AssemblySetSourceKind.Assembly => request with { Assemblies = [entry.Id] },
+            AssemblySetSourceKind.Project => request with { Projects = [entry.Id] },
+            AssemblySetSourceKind.Directory => request with { Directories = [entry.Id] },
+            _ => throw new NotSupportedException($"Unsupported corpus manifest entry kind: {entry.Kind}."),
+        };
+    }
+
+    private static string PackageSpec(CorpusManifestEntry entry) =>
+        string.IsNullOrEmpty(entry.Version) ? entry.Id : $"{entry.Id}@{entry.Version}";
+}

--- a/src/DotnetInspector.Services/CorpusProducer.cs
+++ b/src/DotnetInspector.Services/CorpusProducer.cs
@@ -120,7 +120,9 @@ public static class CorpusProducer
     /// <summary>
     /// Resolves a request into a live corpus. The single explicit network/extraction step for a corpus:
     /// the returned <see cref="PopulatedCorpus"/> owns the extraction directories and, once returned,
-    /// searches over it are offline.
+    /// searches over it are offline. Throws <see cref="InvalidOperationException"/> (surfacing any
+    /// diagnostics) when the request resolves no assemblies, so an all-failed acquisition cannot return a
+    /// success-shaped empty corpus.
     /// </summary>
     public static async Task<PopulatedCorpus> PopulateAsync(
         HttpClient httpClient,
@@ -133,6 +135,9 @@ public static class CorpusProducer
         var set = await AssemblySetResolver.CollectAsync(httpClient, request, log).ConfigureAwait(false);
         try
         {
+            if (set.Assemblies.Count == 0)
+                throw new InvalidOperationException(DescribeEmptyResolution(set.Diagnostics));
+
             return new PopulatedCorpus([set], ToCorpus(set), ToManifest(set), set.Diagnostics);
         }
         catch
@@ -146,7 +151,8 @@ public static class CorpusProducer
     /// Repopulates a live corpus from a previously serialized manifest, resolving each entry with its own
     /// pinned TFM. The returned <see cref="PopulatedCorpus.Manifest"/> is rebuilt from what actually
     /// resolved, so it always describes the returned corpus. Aggregated diagnostics surface any entry
-    /// that could not be resolved rather than silently shrinking the set.
+    /// that could not be resolved rather than silently shrinking the set; if nothing resolves at all the
+    /// method throws <see cref="InvalidOperationException"/> rather than returning an empty corpus.
     /// </summary>
     public static async Task<PopulatedCorpus> PopulateFromManifestAsync(
         HttpClient httpClient,
@@ -180,6 +186,9 @@ public static class CorpusProducer
                 diagnostics.AddRange(set.Diagnostics);
             }
 
+            if (entries.Count == 0)
+                throw new InvalidOperationException(DescribeEmptyResolution(diagnostics));
+
             return new PopulatedCorpus(sets, ToCorpus(entries), ToManifest(entries), diagnostics);
         }
         catch
@@ -190,6 +199,15 @@ public static class CorpusProducer
             }
             throw;
         }
+    }
+
+    private static string DescribeEmptyResolution(IReadOnlyList<AssemblySetDiagnostic> diagnostics)
+    {
+        var message = "Populating the corpus resolved no assemblies.";
+        if (diagnostics.Count == 0)
+            return message;
+
+        return message + " " + string.Join("; ", diagnostics.Select(static d => $"{d.Severity}: {d.Message}"));
     }
 
     private static bool IsLogicalOrigin(AssemblySetSourceKind kind) => kind switch


### PR DESCRIPTION
## Layer 3 of the closed-set corpus stack (#3180)

**Stacked on #3190 (Layer 2).** Base branch: `feature/issue-3180-corpus-container`. Review only the top commits; the diff against `main` will include Layers 1–2 until those merge.

### What this adds
Population/acquisition support for the Metadata-layer `Corpus`, kept in `DotnetInspector.Services` so the low-level Metadata corpus stays SRM-only with no feed reference:

- **`CorpusManifest` / `CorpusManifestEntry(Kind, Id, Version?, Tfm?)`** — a serializable, AOT-safe (source-gen JSON: enum-by-name, camelCase, omit-null, schema-version guard) reload recipe. `ToJson`/`FromJson` round-trip.
- **`CorpusProducer`** — `ToCorpus`, `ToManifest`, `PopulateAsync(request)`, `PopulateFromManifestAsync(manifest)`. `AssemblySetResolver` acts as a *producer* here, not the corpus owner.
- **`PopulatedCorpus : IDisposable`** — owns extraction dirs with idempotent, best-effort disposal.

### Manifest reload semantics
Only `Package` and `PlatformFramework` entries are collapsed to a logical origin (they can be re-resolved by name/version). Everything else — `Assembly`, `PlatformAssembly`, `Project`, `Directory` — normalizes to a reload-by-path `Assembly` entry with `Path.GetFullPath(...)`. `ToCorpus` provenance is unchanged; only the manifest (reload recipe) collapses.

### Empty-corpus contract
Parsing is faithful: `FromJson` accepts an empty entry list (valid data, round-trips with `ToJson`; still rejects a null document and unsupported schema version). The "no success-shaped empty output" rule is enforced at the **population boundary** — `PopulateAsync`/`PopulateFromManifestAsync` throw `InvalidOperationException` (surfacing resolver diagnostics) when resolution yields zero assemblies; `PopulateFromManifestAsync` throws `ArgumentException` up front for an empty *input* manifest.

### Validation
- Full solution builds clean (Release).
- `DotnetInspector.Services.Tests`: **317 pass, 0 fail** (18 corpus tests). Offline — a local `.nupkg` exercises the full Package resolution path with no network; platform collapse is covered with synthetic resolver-shaped entries.

### Adversarial review (both non-Claude, isolated fixed-head review worktrees)
Two models reviewed each fixed head; both approved the final head `cfdeec59` with real-run evidence.

**Blocking (found independently by BOTH reviewers, both reproduced):** `PlatformAssembly` entries record the *resolved framework* in `Source`, not the requested assembly, so collapse-by-`Source` falsely merged distinct platform assemblies into one un-reloadable manifest entry. **Fixed** in `a0151fba`: only `Package`/`PlatformFramework` are logical-collapse origins; `PlatformAssembly` normalizes to reload-by-path.

**GPT majors (all fixed in `a0151fba`):**
- Path-bound Ids kept relative paths → break on cwd change → now `Path.GetFullPath`.
- `Entries`/`Diagnostics` exposed mutable backing `List<T>` → now defensively-copied `ReadOnlyCollection`.
- Empty/missing manifest entries → silent empty corpus → now guarded (see contract above).

**GPT follow-up major (fixed in `cfdeec59`):** produce/consume asymmetry — `PopulateAsync` could emit an empty manifest that the original `FromJson` rejected. Resolved by separating data parsing from the operation boundary (above).

**Gemini finding (fixed in `a0151fba`):** one failing `set.Dispose()` stranded the rest → best-effort per-set disposal. Gemini approved `a0151fba` clean, then confirmed the `cfdeec59` delta introduces no new defect (verified the zero-resolved guard runs inside the disposal-protected `try`, so no temp-dir leak).

Both fixed-head reviews are clean at `cfdeec59` (each: Release build clean, 20/20 targeted tests pass, no leaks, symmetric empty round-trip).

Commits: `c61b194c` (initial) → `a0151fba` (review fix 1) → `cfdeec59` (review fix 2).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
