### PR TITLE
Fix RTS explicit-interface method reconstruction (#3112)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1367,6 +1367,52 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsExplicitInterfaceOpPrefixedNonOperatorMethod()
+    {
+        // Close positive case for the operator discriminator (#3112, adversarial review):
+        // a method whose metadata name merely starts with `op_` but is NOT a recognized
+        // operator (OperatorNames.FormatDisplayName returns it unchanged, and the printer
+        // renders it as a plain `int op_Custom()` member) must still reconstruct as an
+        // explicit implementation and round-trip Exact. The operator fallback must key off
+        // recognized-operator rendering, not the bare `op_` prefix, so it does not
+        // over-trigger here.
+        var assemblyPath = CompileFixture("""
+            public sealed class ExplicitOpNameFixture : IHasOpName
+            {
+                int IHasOpName.op_Custom()
+                {
+                    return 42;
+                }
+            }
+
+            public interface IHasOpName
+            {
+                int op_Custom();
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitOpNameFixture",
+                    "IHasOpName.op_Custom",
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("int IHasOpName.op_Custom()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IHasOpName_op_Custom", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_ExplicitInterfaceDefaultMethodFallsBackToPlainWithoutRecompileFail()
     {
         // Negative case (#3112, adversarial review): an explicit-interface implementation of a

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1279,6 +1279,49 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsStaticAbstractExplicitInterfaceMethod()
+    {
+        // Close positive case for the operator/DIM discriminators (#3112, adversarial review):
+        // an explicit implementation of a NON-operator static-abstract interface method must
+        // still reconstruct as an explicit implementation and round-trip Exact — the `op_`
+        // and default-interface-method fallbacks must not over-trigger on it.
+        var assemblyPath = CompileFixture("""
+            public sealed class ExplicitStaticFixture : IParseable
+            {
+                static int IParseable.Parse(string text)
+                {
+                    return text.Length;
+                }
+            }
+
+            public interface IParseable
+            {
+                static abstract int Parse(string text);
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitStaticFixture",
+                    "IParseable.Parse",
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("static int IParseable.Parse(string text)", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IParseable_Parse", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_ExplicitInterfaceOperatorFallsBackToPlainWithoutRecompileFail()
     {
         // Negative case (#3112, adversarial review): an explicit-interface implementation of a

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1458,6 +1458,55 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ExplicitStaticVirtualInterfaceMethodFallsBackToPlainWithoutRecompileFail()
+    {
+        // Negative case (#3112, adversarial review): an explicit-interface implementation of a
+        // C# 11 `static virtual` interface method (has a body, non-abstract) cannot be
+        // reconstructed by the explicit-method path — the interface member reconstructs bodyless
+        // and non-abstract, which is invalid because a non-abstract interface method requires a
+        // body (CS0501). The body/abstract discriminator must key off the declaration's Abstract
+        // flag directly: `static virtual` methods carry Virtual without NewSlot, so the narrower
+        // IsVirtualMethod helper (which requires NewSlot) would miss them and let them through.
+        // RTS must fall back to the plain sanitized shape (main's behavior) rather than regress
+        // the method-not-found ContextFail into a RecompileFail.
+        var assemblyPath = CompileFixture("""
+            public sealed class ExplicitStaticVirtualFixture : IStaticVirtual
+            {
+                static void IStaticVirtual.Test()
+                {
+                    System.Console.WriteLine("test");
+                }
+            }
+
+            public interface IStaticVirtual
+            {
+                static virtual void Test()
+                {
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitStaticVirtualFixture",
+                    "IStaticVirtual.Test",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("IStaticVirtual_Test", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("void IStaticVirtual.Test(", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_RoundTripsExplicitInterfaceIndexer()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1279,6 +1279,96 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ExplicitInterfaceOperatorFallsBackToPlainWithoutRecompileFail()
+    {
+        // Negative case (#3112, adversarial review): an explicit-interface implementation of a
+        // static-abstract operator cannot be reconstructed by the explicit-method path — the
+        // explicit target spelling would carry the raw `op_Addition` metadata name (via
+        // CSharpIdentifier.Sanitize) instead of C# `operator +` syntax, so it would not match
+        // the interface's `operator` member (CS0539). RTS must fall back to the plain sanitized
+        // shape (main's behavior) rather than regress the method-not-found ContextFail into a
+        // RecompileFail.
+        var assemblyPath = CompileFixture("""
+            public sealed class ExplicitOperatorFixture : INonGenericAdd
+            {
+                static INonGenericAdd INonGenericAdd.operator +(INonGenericAdd left, INonGenericAdd right)
+                {
+                    return left;
+                }
+            }
+
+            public interface INonGenericAdd
+            {
+                static abstract INonGenericAdd operator +(INonGenericAdd left, INonGenericAdd right);
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitOperatorFixture",
+                    "INonGenericAdd.op_Addition",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("INonGenericAdd_op_Addition", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("INonGenericAdd.op_Addition(", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExplicitInterfaceDefaultMethodFallsBackToPlainWithoutRecompileFail()
+    {
+        // Negative case (#3112, adversarial review): an explicit-interface implementation of a
+        // default interface method (virtual, non-abstract, has a body) cannot be reconstructed
+        // by the explicit-method path — the interface member reconstructs bodyless
+        // (StubBody.None) while remaining `virtual`, which is invalid because a non-abstract
+        // virtual interface method requires a body (CS0501). RTS must fall back to the plain
+        // sanitized shape (main's behavior) rather than regress the method-not-found ContextFail
+        // into a RecompileFail.
+        var assemblyPath = CompileFixture("""
+            public sealed class ExplicitDimFixture : IDefaultMethod
+            {
+                int IDefaultMethod.Compute()
+                {
+                    return 1;
+                }
+            }
+
+            public interface IDefaultMethod
+            {
+                int Compute() => 0;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitDimFixture",
+                    "IDefaultMethod.Compute",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("IDefaultMethod_Compute", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("int IDefaultMethod.Compute(", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_RoundTripsExplicitInterfaceIndexer()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1096,6 +1096,189 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsExplicitInterfaceMethod()
+    {
+        // #3112: a class method whose metadata name is an explicit-interface spelling
+        // (`IBase.Touch`) must reconstruct as an explicit-interface implementation with the
+        // interface declaring the member, not a plain `IBase_Touch` method (which recompiles
+        // under the wrong name and fails the fidelity lookup as ContextFail/method-not-found).
+        var assemblyPath = CompileFixture("""
+            using System;
+            public sealed class ExplicitMethodFixture : IBase
+            {
+                void IBase.Touch()
+                {
+                    Console.WriteLine("touched");
+                }
+            }
+
+            public interface IBase
+            {
+                void Touch();
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitMethodFixture",
+                    "IBase.Touch",
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("void IBase.Touch()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IBase_Touch", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RoundTripsNamespacedExplicitInterfaceMethodWithParameters()
+    {
+        // The corpus family (#3112) is dominated by namespaced interfaces (System.IConvertible,
+        // System.Collections.IEnumerable, ...) with real parameters and return values. Reconstruct
+        // the qualified interface spelling and round-trip the body exactly.
+        var assemblyPath = CompileFixture("""
+            namespace Sample
+            {
+                public sealed class ExplicitComputeFixture : IComputer
+                {
+                    int IComputer.Compute(int left, int right)
+                    {
+                        return left + right;
+                    }
+                }
+
+                public interface IComputer
+                {
+                    int Compute(int left, int right);
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Sample.ExplicitComputeFixture",
+                    "Sample.IComputer.Compute",
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("int Sample.IComputer.Compute(int left, int right)", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IComputer_Compute", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RoundTripsGenericExplicitInterfaceMethod()
+    {
+        // A generic method on a non-generic interface implemented explicitly keeps its method
+        // type parameters in the reconstructed `IBox.Wrap<T>(...)` header (constraints are
+        // inherited from the interface and must be omitted).
+        var assemblyPath = CompileFixture("""
+            public sealed class ExplicitGenericFixture : IBox
+            {
+                T IBox.Wrap<T>(T value)
+                {
+                    return value;
+                }
+            }
+
+            public interface IBox
+            {
+                T Wrap<T>(T value);
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitGenericFixture",
+                    "IBox.Wrap",
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("IBox.Wrap<T>(T value)", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IBox_Wrap", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_NestedExplicitInterfaceMethodFallsBackToPlainWithoutRecompileFail()
+    {
+        // Negative case for the explicit-interface method reconstruction (#3112): a nested
+        // interface (e.g. the corpus's `MutexSlim.IPendingLockToken`, `SqlMapper.ITypeHandler`)
+        // is only reached through its enclosing root and is not a standalone closure
+        // requirement, so its member declaration cannot be appended to a reconstructed
+        // interface shell. RTS must NOT emit an unbindable `Outer.IInner.Ping()` (which would
+        // turn a method-not-found ContextFail into a CS0539/CS0246 RecompileFail); it reverts
+        // to the plain sanitized shape, preserving the pre-fix ContextFail with no regression.
+        var assemblyPath = CompileFixture("""
+            namespace Sample
+            {
+                public sealed class NestedExplicitFixture : Outer.IInner
+                {
+                    void Outer.IInner.Ping()
+                    {
+                        System.Console.WriteLine("ping");
+                    }
+                }
+
+                public static class Outer
+                {
+                    public interface IInner
+                    {
+                        void Ping();
+                    }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Sample.NestedExplicitFixture",
+                    "Sample.Outer.IInner.Ping",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            // The target reverts to the plain sanitized shape rather than the explicit spelling.
+            Assert.Contains("Sample_Outer_IInner_Ping", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("void Sample.Outer.IInner.Ping(", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_RoundTripsExplicitInterfaceIndexer()
     {
         var assemblyPath = CompileFixture("""

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1337,14 +1337,20 @@ public static class CompileBackSourceComposer
             //    unchanged, matching the printer) stays on the normal path and can still
             //    reconstruct Exact.
             //  - Default interface methods (virtual, non-abstract): the interface member
-            //    reconstructs bodyless (StubBody.None) while remaining `virtual`, which is
-            //    invalid because a non-abstract virtual interface method requires a body
-            //    (CS0501).
+            //    reconstructs bodyless (StubBody.None) while remaining non-abstract, which is
+            //    invalid because a non-abstract interface method requires a body (CS0501).
+            //    Key off the declaration's Abstract flag directly rather than IsVirtualMethod:
+            //    a C# 11 `static virtual` interface method carries Virtual without NewSlot, so
+            //    IsVirtualMethod (which requires NewSlot) would miss it. Any non-abstract
+            //    interface declaration (default method, `static virtual`, or `sealed`) has a
+            //    body and cannot be reconstructed as a bodyless declaration here; only an
+            //    abstract declaration (including `static abstract`) can, so it stays on the
+            //    normal path and can still reconstruct Exact.
             if (OperatorNames.FormatDisplayName(declarationName) != declarationName)
             {
                 return false;
             }
-            if (IsVirtualMethod(declaration) && !IsAbstractMethod(declaration))
+            if ((declaration.Attributes & MethodAttributes.Abstract) == 0)
             {
                 return false;
             }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1329,15 +1329,18 @@ public static class CompileBackSourceComposer
             // Operators and non-abstract default interface methods cannot be reconstructed
             // faithfully here, so fall back to the plain sanitized shape (main's behavior)
             // rather than emit an unbindable explicit implementation:
-            //  - Operators: the explicit target spelling uses the raw `op_*` metadata name
-            //    (via CSharpIdentifier.Sanitize) instead of C# `operator` syntax, so it does
-            //    not match the interface's `operator` member (CS0539).
+            //  - Operators: the printer renders the interface member with C#
+            //    `operator`/`implicit`/`explicit` syntax (exactly when
+            //    OperatorNames.FormatDisplayName rewrites the metadata name), which the
+            //    explicit target spelling — the raw sanitized `op_*` name — cannot match
+            //    (CS0539). A non-operator `op_*`-named method (FormatDisplayName returns it
+            //    unchanged, matching the printer) stays on the normal path and can still
+            //    reconstruct Exact.
             //  - Default interface methods (virtual, non-abstract): the interface member
             //    reconstructs bodyless (StubBody.None) while remaining `virtual`, which is
             //    invalid because a non-abstract virtual interface method requires a body
             //    (CS0501).
-            if (declaration.Attributes.HasFlag(MethodAttributes.SpecialName)
-                && declarationName.StartsWith("op_", StringComparison.Ordinal))
+            if (OperatorNames.FormatDisplayName(declarationName) != declarationName)
             {
                 return false;
             }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1325,6 +1325,26 @@ public static class CompileBackSourceComposer
 
             var declarationHandle = (MethodDefinitionHandle)implementation.MethodDeclaration;
             var declaration = reader.GetMethodDefinition(declarationHandle);
+            string declarationName = reader.GetString(declaration.Name);
+            // Operators and non-abstract default interface methods cannot be reconstructed
+            // faithfully here, so fall back to the plain sanitized shape (main's behavior)
+            // rather than emit an unbindable explicit implementation:
+            //  - Operators: the explicit target spelling uses the raw `op_*` metadata name
+            //    (via CSharpIdentifier.Sanitize) instead of C# `operator` syntax, so it does
+            //    not match the interface's `operator` member (CS0539).
+            //  - Default interface methods (virtual, non-abstract): the interface member
+            //    reconstructs bodyless (StubBody.None) while remaining `virtual`, which is
+            //    invalid because a non-abstract virtual interface method requires a body
+            //    (CS0501).
+            if (declaration.Attributes.HasFlag(MethodAttributes.SpecialName)
+                && declarationName.StartsWith("op_", StringComparison.Ordinal))
+            {
+                return false;
+            }
+            if (IsVirtualMethod(declaration) && !IsAbstractMethod(declaration))
+            {
+                return false;
+            }
             var interfaceHandle = declaration.GetDeclaringType();
             var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
             var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1292,6 +1292,87 @@ public static class CompileBackSourceComposer
         }
     }
 
+    // The explicit-interface method analog of AddExplicitInterfacePropertyDeclaration:
+    // a class method target whose metadata name is an explicit-interface spelling
+    // (e.g. `System.Collections.IEnumerable.GetEnumerator`) is reconstructed as
+    // `IType.Member() { ... }`. That declaration only binds when the reconstructed
+    // interface shell actually declares the interface member, so append the interface's
+    // own method declaration (`void GetEnumerator();`) to the interface requirement.
+    // Without it Roslyn reports CS0539 (no member to implement) and, when RTS instead
+    // sanitizes the dotted name to a plain method, the recompiled method carries the
+    // wrong name and the fidelity lookup fails as ContextFail/method-not-found (#3112).
+    // Returns true when the interface's own method declaration is present on the
+    // reconstructed interface shell (either appended here or already required), so the
+    // caller can keep the target's explicit-interface spelling. Returns false when the
+    // declaration cannot be supplied — an unsupported interface-member signature, or an
+    // interface that is not a standalone requirement in the closure (e.g. a nested
+    // interface reached only through its enclosing root) — so the caller reverts the
+    // target to the plain sanitized shape instead of emitting an unbindable `IType.Member()`.
+    static bool AddExplicitInterfaceMethodDeclaration(
+        List<CompileBackTypeRequirement> requirements,
+        MetadataReader reader,
+        TypeDefinition targetType,
+        MethodDefinitionHandle targetMethod)
+    {
+        foreach (var implementationHandle in targetType.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody != targetMethod
+                || implementation.MethodDeclaration.Kind != HandleKind.MethodDefinition)
+            {
+                continue;
+            }
+
+            var declarationHandle = (MethodDefinitionHandle)implementation.MethodDeclaration;
+            var declaration = reader.GetMethodDefinition(declarationHandle);
+            var interfaceHandle = declaration.GetDeclaringType();
+            var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+            var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
+            var member = TypeProducer.MethodRequirement(
+                reader,
+                interfaceDef,
+                interfaceIdentity,
+                declarationHandle,
+                "explicit-interface-target-method");
+            if (member is null)
+                return false;
+
+            int requirementIndex = requirements.FindIndex(
+                requirement => requirement.Type.MetadataFullName == interfaceIdentity.MetadataFullName);
+            if (requirementIndex < 0)
+                return false;
+
+            var requirement = requirements[requirementIndex];
+            if (!requirement.RequiredMembers.Any(existing => TypeProducer.SameMemberShape(existing, member)))
+            {
+                requirements[requirementIndex] = requirement with
+                {
+                    RequiredMembers = requirement.RequiredMembers.Append(member).ToArray()
+                };
+            }
+            return true;
+        }
+        return false;
+    }
+
+    // Compatibility declaration text for an explicit-interface method target. The C#
+    // printer keeps method-shaped explicit-interface implementations on compatibility
+    // text (TryRenderSignatureModel only models plain methods), so RTS supplies the
+    // `<return> <IType.Member><type-params>(<params>)` spelling the printer escapes and
+    // emits. Parameter names/types mirror the reconstructed body's references.
+    static string ExplicitInterfaceMethodDeclarationSignature(
+        string explicitInterfaceMemberName,
+        CompileBackTypeSignature returnType,
+        IReadOnlyList<CompileBackTypeParameter> typeParameters,
+        IReadOnlyList<CompileBackParameter> parameters)
+    {
+        string typeParametersText = typeParameters.Count == 0
+            ? ""
+            : $"<{string.Join(", ", typeParameters.Select(parameter => parameter.Name))}>";
+        string parametersText = string.Join(", ", parameters.Select(RenderParameter));
+        return $"{returnType.DisplayName} {explicitInterfaceMemberName}{typeParametersText}({parametersText})";
+    }
+
     static ExplicitInterfaceEventInfo? ExplicitInterfaceEvent(
         MetadataReader reader,
         TypeDefinition targetType,
@@ -1649,6 +1730,28 @@ public static class CompileBackSourceComposer
                 ? constructorChain
                 : null;
 
+        var targetReturnType = isConstructor
+            ? null
+            : CompileBackTypeSignature.Display(MethodReturnType(reader, targetTypeDef, method));
+        var targetParameters = MethodParameters(reader, method, signature);
+        var targetTypeParameters = MethodTypeParameters(reader, method);
+        // A class method whose metadata name is an explicit-interface spelling
+        // (`IType.Member`) must be reconstructed as an explicit-interface implementation,
+        // not a plain method with the dotted name sanitized to `IType_Member`. The latter
+        // compiles but carries the wrong metadata name, so the fidelity lookup fails as
+        // ContextFail/method-not-found (#3112). Only supported non-generic interface
+        // targets resolve here; anything else keeps the pre-existing plain shape.
+        string? explicitInterfaceMemberName = isConstructor
+            ? null
+            : ExplicitInterfaceMemberName(reader, methodName);
+        string? explicitInterfaceDeclarationSignature = explicitInterfaceMemberName is null
+            ? null
+            : ExplicitInterfaceMethodDeclarationSignature(
+                explicitInterfaceMemberName,
+                targetReturnType!,
+                targetTypeParameters,
+                targetParameters);
+
         var targetMembers = isConstructor && primaryConstructor is not null
             ? primaryConstructor.FieldInitializers.ToList()
             :
@@ -1657,9 +1760,9 @@ public static class CompileBackSourceComposer
                 new CompileBackMethodIdentity(targetIdentity.FullName, targetMethodName, overload, signatureText),
                 isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
                 method.Attributes.HasFlag(MethodAttributes.Static),
-                MethodParameters(reader, method, signature),
-                isConstructor ? null : CompileBackTypeSignature.Display(MethodReturnType(reader, targetTypeDef, method)),
-                MethodTypeParameters(reader, method),
+                targetParameters,
+                targetReturnType,
+                targetTypeParameters,
                 CompileBackStubBodyKind.TargetBody,
                 targetBody,
                 [new CompileBackFact("metadata", isConstructor ? "target-constructor" : "target-method", reader.GetString(method.Name))],
@@ -1673,6 +1776,8 @@ public static class CompileBackSourceComposer
                     && (function.RequiresAsyncBodyModifier
                         || function.IsRuntimeAsync == MetadataFactState.Yes),
                 ConstructorInitializer: targetConstructorInitializer,
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName,
+                DeclarationSignature: explicitInterfaceDeclarationSignature,
                 RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function))
         ];
         bool includeRecordSurface = false;
@@ -1787,6 +1892,31 @@ public static class CompileBackSourceComposer
             AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
         }
 
+        if (explicitInterfaceMemberName is not null
+            && !AddExplicitInterfaceMethodDeclaration(requirements, reader, targetTypeDef, targetMethod))
+        {
+            // The interface member declaration could not be supplied (unsupported
+            // interface-member signature, or the interface is not a standalone closure
+            // requirement — e.g. a nested interface reached only through its enclosing
+            // root). Revert the target to the plain sanitized shape rather than emit
+            // `IType.Member()` against an interface that cannot declare it, which would
+            // turn a method-not-found ContextFail into a CS0539 RecompileFail.
+            // requirements[0].RequiredMembers wraps the still-mutable targetMembers list,
+            // so clearing the explicit-interface fields here reverts the rendered shape.
+            int targetIndex = targetMembers.FindIndex(member =>
+                member.Kind == CompileBackMemberKind.Method
+                && member.StubBody == CompileBackStubBodyKind.TargetBody
+                && member.ExplicitInterfaceMemberName == explicitInterfaceMemberName);
+            if (targetIndex >= 0)
+            {
+                targetMembers[targetIndex] = targetMembers[targetIndex] with
+                {
+                    ExplicitInterfaceMemberName = null,
+                    DeclarationSignature = null,
+                };
+            }
+        }
+
         var production = TypeProducer.Produce(reader, requirements, diagnostics);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
@@ -1822,10 +1952,12 @@ public static class CompileBackSourceComposer
             && member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet;
         bool isEvent = member.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove;
         bool isExplicitInterfaceEvent = member.ExplicitInterfaceMemberName is not null && isEvent;
+        bool isExplicitInterfaceMethod = member.ExplicitInterfaceMemberName is not null
+            && member.Kind is CompileBackMemberKind.Method;
         var apiMember = new ApiMember
         {
             Name = member.ExplicitInterfaceMemberName ?? member.Identity.Method,
-            Kind = isExplicitInterfaceProperty || isExplicitInterfaceEvent
+            Kind = isExplicitInterfaceProperty || isExplicitInterfaceEvent || isExplicitInterfaceMethod
                 ? "explicit-interface-implementation"
                 : member.Kind switch
                 {
@@ -3458,11 +3590,12 @@ public static class CompileBackSourceComposer
                 IsVirtual: IsVirtualMethod(accessor));
         }
 
-        static CompileBackMemberRequirement? MethodRequirement(
+        internal static CompileBackMemberRequirement? MethodRequirement(
             MetadataReader reader,
             TypeDefinition typeDef,
             CompileBackTypeIdentity typeIdentity,
-            MethodDefinitionHandle methodHandle)
+            MethodDefinitionHandle methodHandle,
+            string factId = "typed-closure-method")
         {
             var method = reader.GetMethodDefinition(methodHandle);
             string name = reader.GetString(method.Name);
@@ -3519,7 +3652,7 @@ public static class CompileBackSourceComposer
                     ? CompileBackStubBodyKind.None
                     : CompileBackStubBodyKind.Throw,
                 null,
-                [new CompileBackFact("metadata", isConstructor ? "typed-closure-constructor" : "typed-closure-method", name)],
+                [new CompileBackFact("metadata", isConstructor ? "typed-closure-constructor" : factId, name)],
                 isConstructor ? null : methodDeclaration?.Attributes,
                 isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                 IsAbstract: !isConstructor && IsAbstractMethod(method),


### PR DESCRIPTION
- Advances #3112
- Changes RTS explicit-interface **method** reconstruction (harness-only; product output unchanged)
- Evidence revision: `4809c7aa977a290bb22c765d09c4b64c4fb322fd`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — RTS reconstructed explicit-interface method targets
(`IType.Member`) as plain sanitized methods (`IType_Member`), so the recompiled
method carried the wrong metadata name and the fidelity lookup failed as
`ContextFail` / `method-not-found`; reconstructing them as real explicit-interface
implementations (mirroring the existing property/event handling) round-trips them
Exact, proven by focused round-trip tests. Shapes that cannot be reconstructed as a
bodyless explicit declaration (operators, default interface methods, `static virtual`,
generic/nested interfaces) fall back atomically to the pre-fix plain shape, so no
`RecompileFail` regression is introduced.

Before:

```text
compileBackStatus == ContextFail, detail == method-not-found
// class emits: public void IEnumerable_GetEnumerator() { ... }
// interface emits: interface IEnumerable { }   (member not declared)
```

After:

```text
STATUS = Exact
// class emits: IEnumerator IEnumerable.GetEnumerator() { ... }
// interface emits: interface IEnumerable { IEnumerator GetEnumerator(); }
```

## Scope and safety

- **Root cause:** For method targets, `ComposeMethod` set the member name via
  `Identifier(methodName)`, and `CSharpIdentifier.Sanitize` rewrites the dotted
  explicit-interface name (`System.Collections.IEnumerable.GetEnumerator`) to
  `System_Collections_IEnumerable_GetEnumerator`. The reconstruction compiled, but
  the recompiled metadata method name no longer matched the requested dotted name,
  so the post-recompile `FindMethodDefinition` lookup returned nothing —
  `ContextFail`/`method-not-found`. Properties and events already had
  explicit-interface handling; methods did not. This was the dominant cause of 126
  EVIL-corpus Invalid rows sharing `ContextFail` / `method-not-found` (all target
  names are explicit-interface spellings: `System.IConvertible.ToBoolean`,
  `System.Collections.IEnumerable.GetEnumerator`, ...).
- **Fix shape:** RTS orchestration only. Reconstruct the target as an
  explicit-interface implementation via a `DeclarationSignature` compatibility
  spelling (the C# printer keeps method-shaped explicit implementations on
  compatibility text - `TryRenderSignatureModel` only models plain methods), and
  append the interface's own method declaration to the reconstructed interface shell
  so the implementation binds (avoids CS0539). Mark the reconstructed `ApiMember` as
  `explicit-interface-implementation`. `MethodRequirement` gained an optional
  `factId` parameter so the interface-member fact is attributed
  (`explicit-interface-target-method`).
- **Product impact:** None. No product source/printer/API changes; the printer
  contract that keeps method-shaped explicit implementations on compatibility text is
  unchanged. All new code is under `tools/DecompilerHarness`.
- **Scope boundary (atomic + safe fallback):** The target is reconstructed as
  explicit **only** when the interface member declaration can actually be supplied as
  a bodyless declaration that binds. `AddExplicitInterfaceMethodDeclaration` returns
  `bool`; when it returns false the caller atomically reverts the target to the plain
  sanitized shape, preserving the pre-fix `ContextFail` rather than turning it into a
  `RecompileFail`. It returns false for:
  - **Operators** — the printer renders the interface member with C#
    `operator`/`implicit`/`explicit` syntax (exactly when
    `OperatorNames.FormatDisplayName` rewrites the metadata name), which the sanitized
    `op_*` target spelling cannot match (CS0539). A non-operator `op_*`-named method
    (`op_Custom`, which `FormatDisplayName` returns unchanged) stays on the normal path
    and reconstructs Exact.
  - **Non-abstract interface declarations** (default interface methods, C# 11
    `static virtual`, `sealed`) — these have a body and cannot be reconstructed as a
    bodyless declaration (CS0501). Detected by `(declaration.Attributes &
    MethodAttributes.Abstract) == 0`, which — unlike the narrower `IsVirtualMethod`
    helper — also catches `static virtual` (Virtual without NewSlot). Abstract
    declarations, including `static abstract`, keep the explicit path and reach Exact.
  - **Nested interfaces** reached only through an enclosing root (not standalone
    closure requirements, e.g. `MutexSlim.IPendingLockToken`) and **generic**
    interfaces — out of scope; keep the prior plain shape.
- **RTS boundary:** RTS only orchestrates closure reconstruction + Roslyn recompile +
  contract body comparison. C# spelling for explicit-interface members is supplied as
  compatibility declaration text, matching how the product's `ApiSurfaceExtractor`
  spells explicit-interface method signatures; RTS does not add new C# semantics.

## Evidence

| Check | Result |
| --- | --- |
| Product build (`dotnet-inspect.slnx -c Release`) | Pass (0 errors) |
| Harness build (`tools/DecompilerHarness`) | Pass (0 errors) |
| Focused explicit-interface tests | Pass (all positive → Exact, all negative → not RecompileFail) |
| Full RTS class (`ReturnToSenderPrototypeTests`) | 160 passed, 0 failed |
| Broad EVIL-corpus A/B | Not run in this environment (pinned corpus artifact unavailable on this Windows host); root cause + fix validated by focused round-trip tests |

Focused tests (`src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs`):

- `CompileBackTargets_RoundTripsExplicitInterfaceMethod` — simple `void IBase.Touch()` → Exact, asserts no `IBase_Touch`.
- `CompileBackTargets_RoundTripsNamespacedExplicitInterfaceMethodWithParameters` — `int Sample.IComputer.Compute(int, int)` → Exact.
- `CompileBackTargets_RoundTripsGenericExplicitInterfaceMethod` — `IBox.Wrap<T>(T)` → Exact.
- `CompileBackTargets_RoundTripsStaticAbstractExplicitInterfaceMethod` — `static int IParseable.Parse(string)` → Exact (close positive for the discriminators).
- `CompileBackTargets_RoundTripsExplicitInterfaceOpPrefixedNonOperatorMethod` — `int IHasOpName.op_Custom()` (non-operator) → Exact (operator check does not over-trigger).
- `CompileBackTargets_NestedExplicitInterfaceMethodFallsBackToPlainWithoutRecompileFail` — nested interface reverts to plain, asserts **not** `RecompileFail`.
- `CompileBackTargets_ExplicitInterfaceOperatorFallsBackToPlainWithoutRecompileFail` — `operator +` reverts to plain, **not** `RecompileFail`.
- `CompileBackTargets_ExplicitInterfaceDefaultMethodFallsBackToPlainWithoutRecompileFail` — DIM reverts to plain, **not** `RecompileFail`.
- `CompileBackTargets_ExplicitStaticVirtualInterfaceMethodFallsBackToPlainWithoutRecompileFail` — `static virtual` reverts to plain, **not** `RecompileFail`.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Explicit-interface methods on **top-level abstract** interfaces (incl. `static abstract`) | Fixed | Reconstruct as explicit + declare interface member → Exact |
| Explicit-interface **operators** | Fall back | Sanitized `op_*` spelling can't match the interface's `operator` member (CS0539); revert to plain (preserves `ContextFail`) |
| Explicit-interface **default methods / `static virtual` / `sealed`** | Fall back | Body-bearing declaration can't reconstruct bodyless (CS0501); revert to plain |
| Explicit-interface methods on **nested** interfaces | Left as frontier | Nested interface is not a standalone closure requirement; reverts to plain. Follow-up: seed the nested interface as a standalone requirement |
| Explicit-interface methods on **generic** interfaces | Not changed | Out of scope; keeps prior plain shape (unchanged Invalid, not worse) |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | **Clean** | First pass clean; found the `static virtual` regression on the operator/DIM head (reproduced + fixed in `4809c7aa`); re-review of `4809c7aa` clean (verified static-virtual falls back, `static abstract` still Exact, `sealed`/private DIMs fall back, operator-check ordering correct) |
| GPT-5.6 | **Clean** | Found operator/DIM RecompileFail (fixed in `5da22b9d`) and `op_` over-trigger (fixed in `1ee5015d`); re-review of `4809c7aa` clean, abstract-flag discriminator confirmed correct |

**Review conclusion:** **PASS** — two-model adversarial review (Gemini 3.1 Pro +
GPT-5.6) per AGENTS.md; both fixed-head (`4809c7aa`) reviews clean.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method "*Explicit*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests"
```
