### PR TITLE
Render interface-declared this-receiver access with the erased ((I)this) cast (#3128)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationDecisionTests.cs
@@ -217,8 +217,9 @@ public sealed class ThisQualificationDecisionTests
     // An explicit interface implementation invoked through this reaches the call
     // site with the interface as its declaring type (cross-type from the
     // implementing class). Bare `FaceMethod()`/`this.FaceMethod()` does not bind —
-    // the member requires a cast — so it is never a `this.` opt-in. The cross-type
-    // guard records no taste decision.
+    // the member requires a cast — so it is never a `this.` opt-in. The #3128
+    // interface-cast arm renders `((I)this).FaceMethod()` before the knob arm, so
+    // no taste decision is recorded.
     [Fact]
     public void ExplicitInterfaceCall_WithKnobEnabled_RecordsNoDecision()
     {
@@ -234,7 +235,8 @@ public sealed class ThisQualificationDecisionTests
     // only the DEFINITION with the enclosing type. Bare/this. M() binds to I<T>::M,
     // not I<object>::M, so the qualifier is not byte-preserving. Definition-only
     // equality would wrongly record it; the exact-instantiation guard records
-    // nothing.
+    // nothing. The #3128 interface-cast arm renders it before the knob arm, so no
+    // taste decision is recorded either way.
     [Fact]
     public void ConstructedGenericSelfCall_WithKnobEnabled_RecordsNoDecision()
     {
@@ -244,6 +246,20 @@ public sealed class ThisQualificationDecisionTests
             new PrinterOptions { QualifyMethodAccess = true });
 
         Assert.DoesNotContain(result.Decisions, d => d.RuleId == "qualify-method-access");
+    }
+
+    // The #3128 emit: the call to a DIM at a DIFFERENT instantiation of the
+    // enclosing interface must keep the ((I<object>)this) cast — bare M() would
+    // rebind to I<T>::M. The cast is a validity/fidelity fix, present with the
+    // qualify-method knob off.
+    [Fact]
+    public void ConstructedGenericSelfCall_RendersInstantiationCast()
+    {
+        var result = Decompile(
+            typeof(IThisQualificationGeneric<>).FullName!,
+            nameof(IThisQualificationGeneric<object>.CallViaObjectInstantiation));
+
+        Assert.Contains("((IThisQualificationGeneric<object>)this).M()", result.Output);
     }
 
     // Two overloads differing only by a function pointer's return type

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -166,6 +166,55 @@ public sealed class ThisQualificationTests
         Assert.Contains("this.ReadField", text);
     }
 
+    // A default-interface-member call reached through `this` must render the
+    // erased `((I)this)` cast (#3128): the DIM is not a member of the implementing
+    // class, so bare `Value()` / `this.Value()` is CS1061. The default (knob-off)
+    // render was already invalid before this fix; it is now the faithful spelling
+    // that recompiles to `ldarg.0; callvirt IDimFace::Value()`.
+    [Fact]
+    public void DefaultInterfaceMemberCall_RendersInterfaceCast_ByDefault()
+    {
+        var text = RenderMember(typeof(DimConsumer), nameof(DimConsumer.DimCall));
+        Assert.Contains("((IDimFace)this).Value()", text);
+        Assert.DoesNotContain("this.Value()", text);
+    }
+
+    // The `((I)this)` cast is a validity fix, not a `this.`-qualification opt-in:
+    // it is present with the qualify-method knob off and unchanged with it on (the
+    // knob's `this.` arm never runs for an interface-declared callee).
+    [Fact]
+    public void DefaultInterfaceMemberCall_RendersInterfaceCast_UnderMethodQualification()
+    {
+        var text = RenderMember(typeof(DimConsumer), nameof(DimConsumer.DimCall),
+            new PrinterOptions { QualifyMethodAccess = true });
+        Assert.Contains("((IDimFace)this).Value()", text);
+        Assert.DoesNotContain("this.Value()", text);
+    }
+
+    // A DIM method group over `this` must likewise cast: `((IDimFace)this).Value`
+    // recompiles to `ldarg.0; dup; ldvirtftn IDimFace::Value; newobj Func`, where
+    // bare `Value` (CS1061) or `this.Value` would not bind.
+    [Fact]
+    public void DefaultInterfaceMemberGroup_RendersInterfaceCast_ByDefault()
+    {
+        var text = RenderMember(typeof(DimConsumer), nameof(DimConsumer.DimGroup));
+        Assert.Contains("((IDimFace)this).Value", text);
+        Assert.DoesNotContain("(Value)", text);
+    }
+
+    // An explicit interface implementation invoked through `this` reaches the call
+    // site with the interface as declaring type; the member does not bind on the
+    // implementing class, so it must render `((I)this).FaceMethod()` — the faithful
+    // spelling of the fixture's own source (#3128).
+    [Fact]
+    public void ExplicitInterfaceCall_RendersInterfaceCast()
+    {
+        var text = RenderMember(typeof(ThisQualificationExplicitFace),
+            nameof(ThisQualificationExplicitFace.CallExplicitInterface));
+        Assert.Contains("((IThisQualificationFace)this).FaceMethod()", text);
+        Assert.DoesNotContain("this.FaceMethod()", text);
+    }
+
     [Fact]
     public void EventSubscription_DefaultsToBareName()
     {
@@ -415,9 +464,9 @@ public static class ThisQualificationSpecimenExtensions
 // never through a bare `FaceMethod()` or `this.FaceMethod()` — the member does not
 // bind unqualified. csc emits `callvirt IThisQualificationFace::FaceMethod` on the
 // this receiver, whose declaring type is the interface (cross-type from the
-// implementing class). The qualify-method knob must record no taste decision: a
-// cross-type callee is never a `this.` opt-in. (The printer's pre-existing emit
-// still mis-spells this as this.FaceMethod(); only the false RECORD is suppressed.)
+// implementing class). The qualify-method knob records no taste decision: a
+// cross-type callee is never a `this.` opt-in. The printer re-inserts the erased
+// cast (#3128), so the emit is the faithful ((IThisQualificationFace)this).FaceMethod().
 public interface IThisQualificationFace
 {
     int FaceMethod();
@@ -533,4 +582,24 @@ public sealed class ThisQualificationGenericGroup
     public T Make<T>() => default!;
 
     public System.Func<int> Build() => this.Make<int>;
+}
+
+// A default interface member (DIM) reached from an implementing class. The DIM is
+// NOT a member of DimConsumer, so the source must write the ((IDimFace)this) cast;
+// a class→interface upcast emits no IL, so csc lowers ((IDimFace)this).Value() to
+// `ldarg.0; callvirt IDimFace::Value()` and the method group ((IDimFace)this).Value
+// to `ldarg.0; dup; ldvirtftn IDimFace::Value; newobj Func`. Both leave the IR
+// target a bare LoadArgument{0,"this"} with the callee declared on the interface,
+// so the printer must re-insert the erased cast — bare Value()/this.Value() is
+// CS1061 (#3128).
+public interface IDimFace
+{
+    int Value() => 7;
+}
+
+public sealed class DimConsumer : IDimFace
+{
+    public int DimCall() => ((IDimFace)this).Value();
+
+    public System.Func<int> DimGroup() => ((IDimFace)this).Value;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -397,6 +397,27 @@ public sealed partial class CSharpPrinter
         return true;
     }
 
+    /// <summary>
+    /// True when a <c>this</c>-receiver access to a member of
+    /// <paramref name="declaringType"/> is reached through an implicit
+    /// class→interface (or variant interface) upcast that emits no IL, so the
+    /// printer must re-insert the erased <c>((I)this)</c> cast. A default
+    /// interface member — and an explicit interface implementation — is not a
+    /// member of the implementing class, so bare <c>Member</c>/<c>this.Member</c>
+    /// fails to bind (CS1061); the callee's declaring interface is the only
+    /// receiver type that binds it. Requires a CONFIRMED interface declaring type
+    /// (absent from <see cref="IrFunction.InterfaceTypes"/> — e.g. a
+    /// cross-assembly type whose interface-ness cannot be proven — declines,
+    /// never guesses) that is not the enclosing type at its own instantiation: an
+    /// interface's own default member reached from inside that same interface
+    /// instantiation stays bare, while a different instantiation
+    /// (<c>I&lt;object&gt;</c> from within <c>I&lt;T&gt;</c>) still needs the cast
+    /// so the call does not rebind to the enclosing instantiation.
+    /// </summary>
+    bool IsInterfaceCastThisReceiver(TypeRef declaringType)
+        => _function.InterfaceTypes.Contains(NamedDefinition(declaringType))
+            && !IsEnclosingTypeAtOwnInstantiation(declaringType);
+
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
     string ReceiverText(IrExpression receiver) => receiver switch
     {
@@ -449,6 +470,14 @@ public sealed partial class CSharpPrinter
             return $"{TypeQualifierText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
         {
+            // A default-interface-member (or explicit interface impl) method group
+            // over this: the callee is declared on an interface `this` was
+            // implicitly upcast to (no IL), so the member is not a member of the
+            // implementing class. Re-insert the erased ((I)this) cast — bare/this.
+            // would be CS1061. Takes precedence over the base arm below (a virtual
+            // ldvirtftn over this would otherwise mis-read as base).
+            if (IsInterfaceCastThisReceiver(method.DeclaringType))
+                return $"(({TypeText(method.DeclaringType)})this).{name}";
             // A non-virtual (ldftn) instance method group over this to a
             // base-declared method is C#'s base.M — the ldftn deliberately
             // captures the base slot. Bare M or this.M would rebind to the derived
@@ -579,6 +608,13 @@ public sealed partial class CSharpPrinter
         if (receiver is LoadArgument { Index: 0, Name: "this" })
         {
             string thisMethodName = CSharpNaming.SourceMethodName(call.Callee.Name);
+            // A default-interface-member (or explicit interface impl) call over
+            // this: the callee is declared on an interface `this` was implicitly
+            // upcast to (no IL), so the member is not a member of the implementing
+            // class. Re-insert the erased ((I)this) cast — bare/this. would be
+            // CS1061. Takes precedence over the base arm below.
+            if (IsInterfaceCastThisReceiver(call.Callee.DeclaringType))
+                return $"(({TypeText(call.Callee.DeclaringType)})this).{thisMethodName}{typeArguments}({rest})";
             // Non-virtual this-receiver call to a base-declared method is
             // C#'s base.M() — the call opcode deliberately skips dispatch, so it
             // stays base. even under the qualify-method knob (this.M() would

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -623,6 +623,7 @@ public static class IrImporter
         var collectionInitializerTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
         var unionTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
         var byRefLikeTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
+        var interfaceTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
 
         void Consider(TypeRef? type)
         {
@@ -643,7 +644,8 @@ public static class IrImporter
                 type = type.ElementType;
             if (type is not { Kind: TypeRefKind.Definition } || !shapes.TryAdd(type, default))
                 return;
-            var shape = source.ClassifyResolvedType(type) switch
+            var kind = source.ClassifyResolvedType(type);
+            var shape = kind switch
             {
                 TypeShapeKind.Enum => TypeShape.Enum,
                 TypeShapeKind.Struct => TypeShape.ValueType,
@@ -651,6 +653,12 @@ public static class IrImporter
                 _ => TypeShape.Unknown,
             };
             shapes[type] = shape;
+            // Interface-ness is folded into TypeShape.Reference above, but the
+            // printer needs it apart from a class to re-insert the ((I)this) cast
+            // an implicit class→interface upcast erases. Record the confirmed
+            // definition only; an unresolved (Unknown) type is left absent.
+            if (kind == TypeShapeKind.Interface)
+                interfaceTypes.Add(type);
             if (source.IsUnionType(type))
                 unionTypes.Add(type);
             // Only a value type can be a ref struct; skip the cross-assembly
@@ -709,6 +717,8 @@ public static class IrImporter
             function.UnionTypes = unionTypes.ToImmutable();
         if (byRefLikeTypes.Count > 0)
             function.ByRefLikeTypes = byRefLikeTypes.ToImmutable();
+        if (interfaceTypes.Count > 0)
+            function.InterfaceTypes = interfaceTypes.ToImmutable();
     }
 
     /// <summary>Block leaders: entry, branch and leave targets, instructions following a terminator, and every exception-region boundary.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -435,6 +435,18 @@ public sealed class IrFunction : IrNode
     public IReadOnlySet<TypeRef> ByRefLikeTypes { get; set; }
         = ImmutableHashSet<TypeRef>.Empty;
 
+    /// <summary>
+    /// Definition-keyed types this function references that resolved to a C#
+    /// <c>interface</c>, materialized at import (the printer is metadata-free).
+    /// Definition-backed and cross-assembly-aware, but a type whose interface-ness
+    /// cannot be proven is <em>absent</em>, never guessed. Lets the printer
+    /// re-insert the <c>((I)this)</c> cast an implicit class→interface (or
+    /// variant) upcast erases from the IL, so a default-interface-member access
+    /// through <c>this</c> spells back to valid, opcode-faithful C#.
+    /// </summary>
+    public IReadOnlySet<TypeRef> InterfaceTypes { get; set; }
+        = ImmutableHashSet<TypeRef>.Empty;
+
     public override IEnumerable<TypeRef> DirectTypes
         => Signature.Parameters.Select(p => p.Type)
             .Append(Signature.ReturnType)


### PR DESCRIPTION
- Fixes #3128
- Renders a call or method-group to an interface-declared member reached through `this` with the erased `((I)this)` cast, so DIM and explicit-interface-implementation access compiles and stays opcode-faithful.
- Card revision: `f2568a98`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the printer now re-inserts the reference-conversion cast that IL erases, turning previously invalid (CS1061) or instantiation-infidelic renders into valid, opcode-faithful C#, with no effect on non-interface this-receiver calls.

A default-interface-member (DIM) or explicit-interface-implementation member reached through `this` is declared on an interface the class was implicitly upcast to. That class→interface upcast (and the variance upcast `I<T>`→`I<object>`) is an implicit reference conversion that emits **no IL**, so the IR target is a bare `LoadArgument{0,"this"}` with the callee declared on the interface. The old this-receiver arms in `CallText`/`MethodGroupText` spelled the member bare, but the member does not bind as a member of the implementing class.

The fix carries confirmed interface declaring types on `IrFunction.InterfaceTypes` (populated at import from `MetadataSource.ClassifyResolvedType`; **absent — never guessed — when interface-ness is unknown**, e.g. unresolved cross-assembly). A new printer discriminator `IsInterfaceCastThisReceiver` emits `((I)this)` when the callee's declaring type is a confirmed interface **and** not the enclosing type at its own instantiation. The arm is placed **first**, so every non-interface case falls through to the exact prior behavior.

### Benchmark target

Benchmark target: `ILInspector.Decompiler.Tests.dll` fixture specimens (`DimConsumer`, `ThisQualificationExplicitFace`, `IThisQualificationGeneric<T>`), which reproduce DIM, explicit-interface, and variance this-receiver access.

dotnet-inspect command:

```bash
dotnet-inspect member ILInspector.Decompiler.Tests.DimConsumer.DimCall --library ILInspector.Decompiler.Tests.dll -S "Decompiled Source" --all
```

### Original source

```csharp
public interface IDimFace { int Value() => 7; }

public sealed class DimConsumer : IDimFace
{
    public int DimCall() => ((IDimFace)this).Value();
    public System.Func<int> DimGroup() => ((IDimFace)this).Value;
}
```

IL anchor (`-S "IL"`) for `DimConsumer.DimCall`:

```il
IL_0000: ldarg.0
IL_0001: callvirt     ILInspector.Decompiler.Tests.IDimFace::Value()
IL_0006: ret
```

### Before

```csharp
public int DimCall() => Value();
public System.Func<int> DimGroup() => new Func<int>(Value);
public int CallExplicitInterface() => FaceMethod();
public virtual int CallViaObjectInstantiation() => M();
```

- Valid: **False** for the first three (`Value`/`FaceMethod` do not bind on the class → CS1061); `CallViaObjectInstantiation` compiles.
- Correct: **False** for `CallViaObjectInstantiation` — bare `M()` rebinds to the enclosing `I<T>::M` instead of `I<object>::M`.
- IL fidelity: **False** — the bare renders drop the interface receiver; `CallViaObjectInstantiation` binds a different instantiation.
- Taste applied: None.
- Commit: `d39bdf70`

### After

```csharp
public int DimCall() => ((IDimFace)this).Value();
public System.Func<int> DimGroup() => new Func<int>(((IDimFace)this).Value);
public int CallExplicitInterface() => ((IThisQualificationFace)this).FaceMethod();
public virtual int CallViaObjectInstantiation() => ((IThisQualificationGeneric<object>)this).M();
```

- Valid: **True** — all four compile and bind.
- Correct: **True** — the cast targets exactly the interface/instantiation the IL invokes.
- IL fidelity: **True** — the cast is an implicit reference conversion emitting no IL, so each render recompiles to the shown opcodes (`ldarg.0; callvirt IDimFace::Value()` etc.). Verified via `-S "IL"`.
- Taste applied: None.
- Commit: `f2568a98`

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline (`d39bdf70`) | Head (`f2568a98`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ThisQualificationTests`+`ThisQualificationDecisionTests`: 54 passed | 54 passed |
| Decompiler PR quick gate | PASS, 0 pass bugs | PASS, 0 pass bugs (residue 251→247, no regressions) |
| Real witness (`DimConsumer::DimCall`) | `Value()` invalid (CS1061) | `((IDimFace)this).Value()` valid + IL-faithful |
| Real witness (`ThisQualificationExplicitFace::CallExplicitInterface`) | `FaceMethod()` invalid (CS1061) | `((IThisQualificationFace)this).FaceMethod()` valid |
| Real witness (`IThisQualificationGeneric<T>::CallViaObjectInstantiation`) | `M()` rebinds to `I<T>::M` (infidelic) | `((IThisQualificationGeneric<object>)this).M()` faithful |

Baseline focused-suite and PR quick gate were run on the base commit `d39bdf70`. The Windows-local pre-existing failures in the broader fast suite (CRLF string-switch raw-literal, `MinimalParameterAttributes` ref/out compile-back CS0269, flaky SourceLink `discover` grouping) reproduce identically at base and are untouched by this PR.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — PR quick gate matched baseline tolerances with 0 pass bugs; the change is validity-only (adds a cast in a previously-declined interface arm), so it cannot regress non-interface renders.

### PR quick gate

Generated card (head vs `tools/DecompilerHarness/corpus/pr-quick-baseline.json`, hash-stable 100 methods/assembly, 15 assemblies / 1,500 methods):

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,500 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

| Metric | Change |
| ------ | ------ |
| Detected lowering residue (population differs) | 251 (16.73%) → 247 (16.47%) |
| Conditional-branch residue (population differs) | 46 (3.07%) → 43 (2.87%) |
| Forward-merge stops (population differs) | 32 (2.13%) → 30 (2.00%) |
| Pass bugs (-) | 0 → 0 (0) |

Current measured debt: 247 methods with detected lowering residue.
Regression verdict: PASS — corpus sensor matched baseline tolerances.

> **Conclusion:** **PASS** — no pass bugs, residue at or below baseline.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.ThisQualificationTests" -class "ILInspector.Decompiler.Tests.ThisQualificationDecisionTests"
```
