### PR TITLE
Model the var-spelling taste family as one value-domain axis (#3169)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -641,6 +641,23 @@ three-token axis rather than two coupled booleans. The catalog is exhaustive: a
 test-only drift guard asserts every backing `PrinterOptions` boolean is reachable
 through some descriptor value, so a new knob cannot land without a catalog entry.
 
+The `var`-spelling family is a second multi-value axis, modeled as one
+`var-spelling-style` descriptor with four tokens — `explicit` (the default) plus
+the three site categories `var-for-built-in-types`, `var-when-type-apparent`, and
+`var-elsewhere`, one per editorconfig key (`csharp_style_var_for_built_in_types`,
+`csharp_style_var_when_type_is_apparent`, `csharp_style_var_elsewhere`). Because a
+declaration site falls into exactly one category, the three category values back
+*independent* booleans (a host may enable any subset), while the axis stays
+single-select for display: `GetValue` reports the coarse first-enabled category
+and `WithValue` selects one exclusively. `var` is byte-neutral — it erases the
+declared type spelling but never changes the IL — so the family sits in the
+`Spelling` tier with `ByteDivergent = false`. Every category value is
+`OracleEndorsed = false` and `CorpusEndorsed = false`: dotnet/runtime's
+`.editorconfig` sets all three `csharp_style_var_*` keys to `false` (prefer
+explicit types), so no `var` value is endorsed by either facet. The family is
+therefore **opt-in only** and never part of the "full taste" aggregate — the
+shipped default spells explicit types everywhere, matching the runtime.
+
 ## Verification and soundness
 
 How these rendering choices are held correct — the verification checks and floors, the

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -356,4 +356,81 @@ public class StyleOptionCatalogTests
         Assert.False(arrow.OracleEndorsed);
         Assert.False(arrow.CorpusEndorsed);
     }
+
+    // ---- var-spelling family (#3169) ----
+
+    private const string VarStyleId = "var-spelling-style";
+
+    [Fact]
+    public void VarSpelling_IsAByteNeutralFourValueSpellingAxis()
+    {
+        var varStyle = Options.Single(o => o.Id == VarStyleId);
+
+        // A spelling choice (IL-identical), never a byte-divergent lens.
+        Assert.Equal(StyleOptionTier.Spelling, varStyle.Tier);
+        Assert.False(varStyle.ByteDivergent);
+
+        var tokens = varStyle.Values.Select(v => v.Token).ToArray();
+        Assert.Equal(
+            new[] { "explicit", "var-for-built-in-types", "var-when-type-apparent", "var-elsewhere" },
+            tokens);
+        // Explicit is the shipped default (every csharp_style_var_* key off).
+        Assert.Equal("explicit", varStyle.DefaultValue);
+        Assert.Equal("explicit", varStyle.GetValue(PrinterOptions.Default));
+    }
+
+    [Fact]
+    public void VarSpelling_ThreeCategories_MapToTheEditorconfigKeys()
+    {
+        var varStyle = Options.Single(o => o.Id == VarStyleId);
+
+        Assert.Equal(
+            "csharp_style_var_for_built_in_types",
+            varStyle.Values.Single(v => v.Token == "var-for-built-in-types").ConfigKey);
+        Assert.Equal(
+            "csharp_style_var_when_type_is_apparent",
+            varStyle.Values.Single(v => v.Token == "var-when-type-apparent").ConfigKey);
+        Assert.Equal(
+            "csharp_style_var_elsewhere",
+            varStyle.Values.Single(v => v.Token == "var-elsewhere").ConfigKey);
+        // The explicit default is not config-selectable (it is the absence of any key).
+        Assert.Null(varStyle.Values.Single(v => v.Token == "explicit").ConfigKey);
+    }
+
+    [Fact]
+    public void VarSpelling_CategoriesAreIndependent_EachKeySetsOnlyItsOwnBool()
+    {
+        var varStyle = Options.Single(o => o.Id == VarStyleId);
+        var builtIn = varStyle.Values.Single(v => v.Token == "var-for-built-in-types");
+        var elsewhere = varStyle.Values.Single(v => v.Token == "var-elsewhere");
+
+        // Enabling two categories independently leaves both selected — they are not
+        // mutually exclusive (a site falls into exactly one bucket, so both can be on).
+        var both = elsewhere.SetSelected(builtIn.SetSelected(PrinterOptions.Default, true), true);
+        Assert.True(both.PreferVarForBuiltInTypes);
+        Assert.True(both.PreferVarElsewhere);
+        Assert.False(both.PreferVarWhenTypeApparent);
+
+        // Clearing one leaves the other set.
+        var onlyElsewhere = builtIn.SetSelected(both, false);
+        Assert.False(onlyElsewhere.PreferVarForBuiltInTypes);
+        Assert.True(onlyElsewhere.PreferVarElsewhere);
+    }
+
+    [Fact]
+    public void VarSpelling_IsEndorsedByNeitherFacet_SoItStaysOptInOnly()
+    {
+        // dotnet/runtime's .editorconfig sets every csharp_style_var_* key false
+        // (prefer explicit), so no var value is oracle- or corpus-endorsed and the
+        // family never joins the "full taste" aggregate.
+        var varStyle = Options.Single(o => o.Id == VarStyleId);
+        Assert.False(varStyle.OracleEndorsed);
+        Assert.False(varStyle.CorpusEndorsed);
+        Assert.DoesNotContain(StyleOptionCatalog.OracleEndorsedOptions, o => o.Id == VarStyleId);
+        Assert.DoesNotContain(StyleOptionCatalog.CorpusEndorsedOptions, o => o.Id == VarStyleId);
+
+        // Full taste leaves the axis on its explicit default.
+        var full = StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default);
+        Assert.Equal("explicit", varStyle.GetValue(full));
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -80,6 +80,44 @@ public sealed record PrinterOptions
     public bool QualifyEventAccess { get; init; }
 
     /// <summary>
+    /// When set, a local declaration whose declared type is a C# built-in
+    /// (predefined) type — <c>int</c>, <c>string</c>, <c>bool</c>, <c>double</c>,
+    /// and the rest of the keyword types — is spelled <c>var</c> instead of the
+    /// explicit type, provided <c>var</c> is faithful there (the initializer's type
+    /// is exactly the declared type and it is not a target-typed form such as
+    /// <c>default</c>/<c>null</c>/<c>new()</c>). Byte-neutral: <c>var</c> is a
+    /// compile-time inference with no IL consequence, so this is a spelling choice,
+    /// not a lens. Off by default — the shipped output keeps the explicit type,
+    /// matching dotnet/runtime's <c>csharp_style_var_for_built_in_types = false</c>.
+    /// Mirrors <c>csharp_style_var_for_built_in_types</c>.
+    /// </summary>
+    public bool PreferVarForBuiltInTypes { get; init; }
+
+    /// <summary>
+    /// When set, a local declaration whose type is <em>apparent</em> from the
+    /// initializer (see <see cref="CSharpPrinter"/>'s apparency predicate — object
+    /// creation of the exact type, an array creation, or an explicit cast) is
+    /// spelled <c>var</c> instead of the explicit type. Applies to the apparent,
+    /// non-built-in bucket (the built-in bucket is governed by
+    /// <see cref="PreferVarForBuiltInTypes"/>). Byte-neutral (a spelling choice, no
+    /// IL consequence). Off by default, matching dotnet/runtime's
+    /// <c>csharp_style_var_when_type_is_apparent = false</c>. Mirrors
+    /// <c>csharp_style_var_when_type_is_apparent</c>.
+    /// </summary>
+    public bool PreferVarWhenTypeApparent { get; init; }
+
+    /// <summary>
+    /// When set, a local declaration that is neither a built-in-type nor an
+    /// apparent-type site is spelled <c>var</c> instead of the explicit type,
+    /// provided <c>var</c> is faithful there (the initializer's type is exactly the
+    /// declared type and it is not a target-typed form). Byte-neutral (a spelling
+    /// choice, no IL consequence). Off by default, matching dotnet/runtime's
+    /// <c>csharp_style_var_elsewhere = false</c>. Mirrors
+    /// <c>csharp_style_var_elsewhere</c>.
+    /// </summary>
+    public bool PreferVarElsewhere { get; init; }
+
+    /// <summary>
     /// When set, a guarded boolean return the default view must render as a flat
     /// <c>if (c) return A; return B;</c> — because no short-circuit fold is
     /// opcode-faithful for that shape (see <c>ShortCircuitFidelity</c> / #3114) —

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -252,6 +252,12 @@ public static class StyleOptionCatalog
     private const string GuardedReturnConditional = "conditional-expression";
     private const string GuardedReturnBranchless = "branchless";
 
+    // Value tokens for the var-spelling family axis.
+    private const string VarStyleExplicit = "explicit";
+    private const string VarStyleBuiltInTypes = "var-for-built-in-types";
+    private const string VarStyleWhenApparent = "var-when-type-apparent";
+    private const string VarStyleElsewhere = "var-elsewhere";
+
     /// <summary>
     /// Every opt-in knob, in a stable presentation order (formatting and spelling
     /// first, then the byte-divergent lens). Two-state knobs carry a
@@ -335,6 +341,7 @@ public static class StyleOptionCatalog
             get: static o => o.QualifyEventAccess,
             with: static (o, v) => o with { QualifyEventAccess = v }),
         GuardedBooleanReturnStyle(),
+        VarSpellingStyle(),
     ];
 
     /// <summary>
@@ -476,6 +483,75 @@ public static class StyleOptionCatalog
                     ConfigKey = "dotnet_inspect_style_prefer_branchless_boolean",
                     IsSelected = static o => o.PreferBranchlessBoolean,
                     SetSelected = static (o, on) => o with { PreferBranchlessBoolean = on },
+                },
+            ],
+        };
+
+    // The var-spelling family as one value-domain axis. Its value domain is the
+    // C# `var` decision as dotnet/runtime's editorconfig models it: an `explicit`
+    // default (every csharp_style_var_* key false — the shipped, byte-stable
+    // spelling the runtime prefers) plus three independent site-category values
+    // mapping 1:1 onto the three csharp_style_var_* keys and their backing bools.
+    //
+    // The three categories partition declaration sites (built-in type, else
+    // type-apparent, else elsewhere), so at most one governs any given site — the
+    // printer classifies each site into one bucket and reads that bucket's bool.
+    // Because they are independent keys (a user may enable any subset), each value's
+    // SetSelected sets only its own bool and the `explicit` default's SetSelected
+    // clears all three; GetValue reports the first enabled category in Values order
+    // as a coarse summary (WithValue single-select is a picker affordance — the
+    // authoritative state is the three independent bools set via config). None is
+    // oracle-endorsed: dotnet/runtime's .editorconfig sets every csharp_style_var_*
+    // key false (prefer explicit), so `var` never joins the "full taste" aggregate.
+    // Byte-neutral (Spelling tier): `var` is compile-time inference with no IL
+    // consequence, so the axis is IL-identical to the explicit spelling.
+    private static StyleOptionDescriptor VarSpellingStyle()
+        => new()
+        {
+            Id = "var-spelling-style",
+            Title = "var vs. explicit type",
+            Summary = "When to spell a local declaration with var instead of its explicit type: never (explicit, the default), for built-in types, when the type is apparent from the initializer, and/or elsewhere. Byte-neutral; the three var categories are independent, matching the csharp_style_var_* editorconfig keys.",
+            Tier = StyleOptionTier.Spelling,
+            ByteDivergent = false,
+            DefaultValue = VarStyleExplicit,
+            Values =
+            [
+                new StyleOptionValue
+                {
+                    Token = VarStyleExplicit,
+                    Title = "Explicit type (byte-stable default)",
+                    IsSelected = static o => !o.PreferVarForBuiltInTypes && !o.PreferVarWhenTypeApparent && !o.PreferVarElsewhere,
+                    // Selecting the explicit default clears the whole axis; deselecting
+                    // it is a no-op (a sibling selection clears it instead).
+                    SetSelected = static (o, on) =>
+                        on ? o with { PreferVarForBuiltInTypes = false, PreferVarWhenTypeApparent = false, PreferVarElsewhere = false } : o,
+                },
+                new StyleOptionValue
+                {
+                    Token = VarStyleBuiltInTypes,
+                    Title = "var for built-in types",
+                    OracleEndorsed = false,
+                    ConfigKey = "csharp_style_var_for_built_in_types",
+                    IsSelected = static o => o.PreferVarForBuiltInTypes,
+                    SetSelected = static (o, on) => o with { PreferVarForBuiltInTypes = on },
+                },
+                new StyleOptionValue
+                {
+                    Token = VarStyleWhenApparent,
+                    Title = "var when the type is apparent",
+                    OracleEndorsed = false,
+                    ConfigKey = "csharp_style_var_when_type_is_apparent",
+                    IsSelected = static o => o.PreferVarWhenTypeApparent,
+                    SetSelected = static (o, on) => o with { PreferVarWhenTypeApparent = on },
+                },
+                new StyleOptionValue
+                {
+                    Token = VarStyleElsewhere,
+                    Title = "var elsewhere",
+                    OracleEndorsed = false,
+                    ConfigKey = "csharp_style_var_elsewhere",
+                    IsSelected = static o => o.PreferVarElsewhere,
+                    SetSelected = static (o, on) => o with { PreferVarElsewhere = on },
                 },
             ],
         };

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -105,6 +105,61 @@ public class RenderStyleConfigTests
     }
 
     [Fact]
+    public void Parse_VarKeys_MapToTheirIndependentBackingBools()
+    {
+        // Each csharp_style_var_* key selects only its own bucket; the three are
+        // independent (a site falls into exactly one, so any subset can be on).
+        var builtIn = RenderStyleConfig.Parse("csharp_style_var_for_built_in_types = true", origin: null);
+        Assert.True(builtIn.Options.PreferVarForBuiltInTypes);
+        Assert.False(builtIn.Options.PreferVarWhenTypeApparent);
+        Assert.False(builtIn.Options.PreferVarElsewhere);
+        Assert.Empty(builtIn.Warnings);
+
+        var apparent = RenderStyleConfig.Parse("csharp_style_var_when_type_is_apparent = true", origin: null);
+        Assert.True(apparent.Options.PreferVarWhenTypeApparent);
+        Assert.False(apparent.Options.PreferVarForBuiltInTypes);
+
+        var elsewhere = RenderStyleConfig.Parse("csharp_style_var_elsewhere = true", origin: null);
+        Assert.True(elsewhere.Options.PreferVarElsewhere);
+    }
+
+    [Fact]
+    public void Parse_VarKeys_DefaultOff_TolerateSeverity_AndClearWithFalse()
+    {
+        // Shipped default: explicit everywhere (matches dotnet/runtime).
+        var empty = RenderStyleConfig.Parse("", origin: null).Options;
+        Assert.False(empty.PreferVarForBuiltInTypes);
+        Assert.False(empty.PreferVarWhenTypeApparent);
+        Assert.False(empty.PreferVarElsewhere);
+
+        // The editorconfig value:severity form copied straight from a real file parses.
+        var withSeverity = RenderStyleConfig.Parse("csharp_style_var_elsewhere = true:suggestion", origin: null);
+        Assert.True(withSeverity.Options.PreferVarElsewhere);
+        Assert.Empty(withSeverity.Warnings);
+
+        // = false clears its own bucket only.
+        var mixed = RenderStyleConfig.Parse(
+            "csharp_style_var_for_built_in_types = true\n" +
+            "csharp_style_var_elsewhere = true\n" +
+            "csharp_style_var_for_built_in_types = false\n",
+            origin: null);
+        Assert.False(mixed.Options.PreferVarForBuiltInTypes);
+        Assert.True(mixed.Options.PreferVarElsewhere);
+        Assert.Empty(mixed.Warnings);
+    }
+
+    [Fact]
+    public void Parse_FullTaste_DoesNotEnableVar()
+    {
+        // var is opt-in only (the runtime endorses explicit), so the "full taste"
+        // aggregate must never turn it on.
+        var result = RenderStyleConfig.Parse("dotnet_inspect_style_full_taste = true", origin: null);
+        Assert.False(result.Options.PreferVarForBuiltInTypes);
+        Assert.False(result.Options.PreferVarWhenTypeApparent);
+        Assert.False(result.Options.PreferVarElsewhere);
+    }
+
+    [Fact]
     public void Parse_FullTasteKey_EnablesTheOracleEndorsedSubset()
     {
         // The "full taste" aggregate turns on the whole oracle-endorsed subset with
@@ -206,14 +261,14 @@ public class RenderStyleConfigTests
     public void Parse_UnknownKey_WarnsButKeepsRecognizedKeys()
     {
         var result = RenderStyleConfig.Parse(
-            "csharp_style_var_when_type_is_apparent = true\n" +
+            "csharp_style_expression_bodied_methods = true\n" +
             "dotnet_style_qualification_for_field = true\n",
             origin: null);
 
         Assert.True(result.Options.QualifyFieldAccess);
         var warning = Assert.Single(result.Warnings);
         Assert.Contains("unknown key", warning);
-        Assert.Contains("csharp_style_var_when_type_is_apparent", warning);
+        Assert.Contains("csharp_style_expression_bodied_methods", warning);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Adds the `var`-spelling taste family to the style-option catalog as a single **`var-spelling-style`** value-domain descriptor: an `explicit` default plus three site-category values that map 1:1 onto the three `csharp_style_var_*` editorconfig keys.

This is **byte-neutral plumbing only** (stacked-PR base). It adds the options, the catalog descriptor, and the automatic config wiring — but **no printer emission**. The printer still ignores these options, so default output is unchanged and IL-identical. **PR B will stack the `DeclarationTypeText` emission on top of this branch.**

## Changes

- **`PrinterOptions`**: three new `init` bools — `PreferVarForBuiltInTypes`, `PreferVarWhenTypeApparent`, `PreferVarElsewhere`. All default `false` (byte-stable).
- **`StyleOptionCatalog`**: new `VarSpellingStyle()` descriptor (`Spelling` tier, `ByteDivergent = false`), registered in `Options`. Four tokens: `explicit` (default, clears all three bools) + `var-for-built-in-types` / `var-when-type-apparent` / `var-elsewhere`, each carrying its own `ConfigKey` and independent backing bool.
- **Config wiring is automatic** via `RenderStyleConfig.KnobsByKey` (derives recognized keys from each value's `ConfigKey`) — no resolver change needed.
- **Docs**: documented the family in `docs/decompiler-taste.md`.

## Design notes

- The three keys back **independent** bools (a user may enable any subset), but declaration sites partition into exactly one bucket (built-in → else apparent → else elsewhere), so at most one governs a site. `GetValue` reports the coarse first-enabled category; `WithValue` single-selects. Mechanically identical to the existing guarded-boolean-return family.
- **Opt-in only.** dotnet/runtime's `.editorconfig` sets all three `csharp_style_var_*` keys to `false` (prefer explicit types), so every value is `OracleEndorsed = false` — `var` is **never** part of the "full taste" aggregate. The shipped default spells explicit types everywhere, matching the runtime.
- The drift guard (`EveryBackingBooleanProperty_IsReachableThroughSomeCatalogValue`) requires the bools + catalog values to land together, keeping this base green.

## Tests

- **Catalog** (4): byte-neutral four-value axis; three categories map to the editorconfig keys; categories are independent (each key sets only its own bool); endorsed by neither facet (stays opt-in).
- **Config parse** (4): each key → its bool; `:severity` suffix tolerated; `= false` clears only its own bucket; `dotnet_inspect_style_full_taste = true` leaves all three var bools `false`.
- Updated a pre-existing unknown-key test that had used `csharp_style_var_when_type_is_apparent` as its *example* of an unknown key — now a recognized key (good confirmation the wiring works).
- Full `dotnet-inspect.slnx` build clean; catalog suite 28/28, config suite 51/51.

Part of #3169. PR B (printer emission) stacks on this branch.