### PR TITLE
Schedule Deep Inspect slow lanes weekly and surface failures

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -84,7 +84,9 @@ jobs:
 
   test:
     name: Test lane
-    if: inputs.lane == 'test' || inputs.lane == 'all'
+    # Runs on the weekly schedule (automated slow-gate coverage) and on manual
+    # dispatch (lane test/all).
+    if: github.event_name == 'schedule' || inputs.lane == 'test' || inputs.lane == 'all'
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
@@ -150,7 +152,8 @@ jobs:
     # Split out of the test lane so the multi-hour corpus sweep gets its own
     # 6h job budget instead of sharing the test job's budget with the other
     # slow gates (which previously pushed the combined job past its timeout).
-    if: inputs.lane == 'test' || inputs.lane == 'all'
+    # Runs alongside the test lane on the weekly schedule and on dispatch.
+    if: github.event_name == 'schedule' || inputs.lane == 'test' || inputs.lane == 'all'
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
@@ -483,3 +486,32 @@ jobs:
           name: deep-inspect-opt-in-corpus
           path: artifacts/opt-in-corpus/
           if-no-files-found: warn
+
+  report-scheduled-failure:
+    name: Report scheduled failure
+    # Deep Inspect has no interactive watcher, so a failed *scheduled* run would
+    # otherwise go unnoticed. Open (or comment on) a tracking issue when any
+    # scheduled slow lane fails. Manual dispatches are watched by the dispatcher
+    # and are intentionally excluded.
+    needs: [package-sweep, test, decompiler-corpus]
+    if: ${{ github.event_name == 'schedule' && failure() }}
+    runs-on: ubuntu-26.04
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          title="Deep Inspect scheduled run failed"
+          num=$(gh issue list --state open --search "$title in:title" \
+            --json number,title \
+            --jq "map(select(.title == \"$title\")) | .[0].number // empty")
+          if [ -n "$num" ]; then
+            gh issue comment "$num" --body "Another scheduled Deep Inspect run failed: $RUN_URL"
+          else
+            gh issue create --title "$title" --body $'The weekly Deep Inspect scheduled run failed.\n\nRun: '"$RUN_URL"$'\n\nThe failed lane(s) are visible on the run. This issue was opened automatically; it will not auto-close, so close it once the failure is triaged.'
+          fi


### PR DESCRIPTION
## What

The weekly Deep Inspect cron (`0 9 * * 1`) previously ran **only** the `package-sweep` lane. The slow `test` lane and the `decompiler-corpus` lane (the multi-hour sweep split out in #3193) ran on **manual dispatch only**, so the slow decompiler gates had **no automated cadence** — nothing scheduled ever exercised them. A failed scheduled run also had no surfacing beyond the red run itself (no notification, no tracking issue), so a failure could go unnoticed.

## Change

- Gate the `test` and `decompiler-corpus` jobs on the `schedule` event so both run on the weekly cron alongside `package-sweep` (they remain available on manual dispatch as before).
- Add a `report-scheduled-failure` job that, on a **scheduled** run where any of those three lanes failed, opens (or comments on) a deduplicated tracking issue titled "Deep Inspect scheduled run failed", including the run URL. Manual dispatches are intentionally excluded — they are watched by the dispatcher.

`census` and `nightly` remain manual-only (out of scope here); see follow-ups.

## Evidence

- YAML parses cleanly (YamlDotNet `RepresentationModel`): all six jobs present, including the new `report-scheduled-failure`.
- No tabs; jobs indent at 2 spaces mirroring the existing siblings.
- Failure-surfacing job uses the standard `permissions: { issues: write }` + `GH_TOKEN: ${{ github.token }}` pattern; dedupes by exact title via `gh issue list ... --jq` before creating.

Deep Inspect only runs on dispatch/schedule, so PR CI does not exercise this workflow; the scheduling/issue logic will first execute on the next weekly cron (or a manual `schedule`-equivalent dispatch).

## Risk

Low — CI-only, no product path. Mechanical `if:` gating plus one new reporting job. No adversarial review per `AGENTS.md` (simple CI change). One operational caveat: the reporter relies on `GITHUB_TOKEN` being permitted to create issues; if org policy restricts that, the reporter job fails visibly on an already-red run and we adjust.

## Follow-ups (non-blocking)

- Apply the same `no-corpus`/`corpus` split to `release.yml`, which still runs the decompiler suite unfiltered (same timeout exposure).
- Decide whether to also schedule `census` weekly.
