### PR TITLE
Route find type search through the closed-set corpus (#3180, layer 4a)

### DIFF
--- a/src/ILInspector.Metadata/Corpus.cs
+++ b/src/ILInspector.Metadata/Corpus.cs
@@ -134,7 +134,10 @@ public sealed class Corpus
     /// <summary>
     /// Finds types in the corpus whose full or simple name matches any pattern. Exact patterns use
     /// the shared namespace/arity-aware <see cref="TypeMatcher.MatchesTypeFilter"/>; patterns with
-    /// <c>*</c>/<c>?</c> are globs. A type is emitted once per pattern it matches.
+    /// <c>*</c>/<c>?</c> are globs. A type is emitted once per pattern it matches. An unbounded
+    /// search scans members in parallel but yields results in a deterministic member order identical
+    /// to a sequential pass; a bounded search (<paramref name="limit"/>) scans sequentially so it can
+    /// stop early.
     /// </summary>
     /// <param name="patterns">Type-name patterns.</param>
     /// <param name="includeAll">When true, non-public types are included; otherwise public only.</param>
@@ -152,49 +155,111 @@ public sealed class Corpus
         if (patterns.Count == 0)
             return new CorpusTypeSearchOutcome(results, skipped);
 
+        // Unbounded search scans members concurrently — each member is an independent metadata read —
+        // then reassembles matches and skips in member order, so the output is identical to a
+        // sequential pass. A bounded search cannot early-exit deterministically in parallel, so it
+        // stays sequential.
+        if (limit is null)
+        {
+            var perMember = new List<CorpusTypeMatch>[_members.Count];
+            var perMemberSkip = new string?[_members.Count];
+
+            Parallel.For(0, _members.Count, i =>
+            {
+                perMember[i] = ScanTypesInMember(_members[i], patterns, includeAll, out perMemberSkip[i]);
+            });
+
+            for (var i = 0; i < _members.Count; i++)
+            {
+                results.AddRange(perMember[i]);
+                if (perMemberSkip[i] is string skippedPath)
+                    skipped.Add(skippedPath);
+            }
+
+            return new CorpusTypeSearchOutcome(results, skipped);
+        }
+
         foreach (var member in _members)
         {
-            if (limit is int cap && results.Count >= cap)
+            if (results.Count >= limit.Value)
                 break;
 
-            var surface = AssemblyReader.ExtractApiSurface(member.AssemblyPath, includeAll, typesOnly: true);
-            if (surface is null)
+            var matches = ScanTypesInMember(member, patterns, includeAll, out var skippedPath);
+            if (skippedPath is not null)
             {
-                skipped.Add(member.AssemblyPath);
+                skipped.Add(skippedPath);
                 continue;
             }
 
-            var assemblyName = Path.GetFileNameWithoutExtension(member.AssemblyPath);
-
-            foreach (var type in surface.Types)
+            foreach (var match in matches)
             {
-                foreach (var pattern in patterns)
-                {
-                    if (limit is int innerCap && results.Count >= innerCap)
-                        return new CorpusTypeSearchOutcome(results, skipped);
-
-                    var isGlob = pattern.Contains('*') || pattern.Contains('?');
-                    if (!TypeMatcher.MatchesTypeFilter(type.FullName, pattern))
-                        continue;
-
-                    results.Add(new CorpusTypeMatch
-                    {
-                        Pattern = pattern,
-                        TypeName = type.Name,
-                        Namespace = type.Namespace,
-                        FullName = type.FullName,
-                        Kind = type.Kind,
-                        Assembly = assemblyName,
-                        Source = member.Source,
-                        Version = member.Version,
-                        Tfm = member.Tfm,
-                        IsGlob = isGlob,
-                    });
-                }
+                if (results.Count >= limit.Value)
+                    return new CorpusTypeSearchOutcome(results, skipped);
+                results.Add(match);
             }
         }
 
         return new CorpusTypeSearchOutcome(results, skipped);
+    }
+
+    /// <summary>
+    /// Scans one member for type matches. An assembly whose metadata cannot be read is surfaced via
+    /// <paramref name="skippedPath"/> (never as a fake "no matches" success and never by aborting the
+    /// whole corpus search), matching the closed-set "keep failure visible" contract.
+    /// </summary>
+    private static List<CorpusTypeMatch> ScanTypesInMember(
+        CorpusMember member,
+        IReadOnlyList<string> patterns,
+        bool includeAll,
+        out string? skippedPath)
+    {
+        var matches = new List<CorpusTypeMatch>();
+
+        ApiSurface? surface;
+        try
+        {
+            surface = AssemblyReader.ExtractApiSurface(member.AssemblyPath, includeAll, typesOnly: true);
+        }
+        catch
+        {
+            skippedPath = member.AssemblyPath;
+            return matches;
+        }
+
+        if (surface is null)
+        {
+            skippedPath = member.AssemblyPath;
+            return matches;
+        }
+
+        skippedPath = null;
+        var assemblyName = Path.GetFileNameWithoutExtension(member.AssemblyPath);
+
+        foreach (var type in surface.Types)
+        {
+            foreach (var pattern in patterns)
+            {
+                var isGlob = pattern.Contains('*') || pattern.Contains('?');
+                if (!TypeMatcher.MatchesTypeFilter(type.FullName, pattern))
+                    continue;
+
+                matches.Add(new CorpusTypeMatch
+                {
+                    Pattern = pattern,
+                    TypeName = type.Name,
+                    Namespace = type.Namespace,
+                    FullName = type.FullName,
+                    Kind = type.Kind,
+                    Assembly = assemblyName,
+                    Source = member.Source,
+                    Version = member.Version,
+                    Tfm = member.Tfm,
+                    IsGlob = isGlob,
+                });
+            }
+        }
+
+        return matches;
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -264,6 +264,11 @@ internal static class TypeSearchService
     {
         List<TypeSearchResult> results = [];
 
+        // Search the resolved closed set through the corpus. A specific pattern filters during the
+        // scan; a null pattern enumerates every type ("*" matches all) for the callers that collect
+        // first and match later (the multi-pattern and fuzzy-fallback paths).
+        IReadOnlyList<string> searchPatterns = pattern is null ? ["*"] : [pattern];
+
         bool ReachedLimit() => pattern != null && options.Limit.HasValue && results.Count >= options.Limit.Value;
 
         AssemblySetRequest CreateFindRequest(
@@ -301,28 +306,36 @@ internal static class TypeSearchService
             };
         }
 
-        List<TypeSearchResult> Scan(AssemblySetEntry assembly)
-        {
-            var types = CollectFromAssembly(assembly.Path, pattern, options.IncludeAll, logger);
-            foreach (var t in types)
-            {
-                t.Source = assembly.Source;
-                t.SourceVersion = assembly.Version;
-            }
-
-            return types;
-        }
-
         async Task CollectAndScanAsync(AssemblySetRequest request)
         {
             using var assemblySet = await AssemblySetResolver.CollectAsync(httpClient, request, logger.Log);
             AssemblySetDiagnosticWriter.Write(assemblySet);
 
-            foreach (var assembly in assemblySet.Assemblies)
-            {
-                if (ReachedLimit()) break;
+            // Streaming (pattern + limit) caps each source at the remaining budget so later sources are
+            // never resolved once the limit is met; the unbounded path passes null so the corpus scans
+            // the whole set in parallel.
+            int? remaining = pattern != null && options.Limit.HasValue
+                ? options.Limit.Value - results.Count
+                : null;
 
-                results.AddRange(Scan(assembly));
+            var corpus = CorpusProducer.ToCorpus(assemblySet);
+            var outcome = corpus.SearchTypes(searchPatterns, options.IncludeAll, remaining);
+
+            foreach (var skippedPath in outcome.SkippedAssemblies)
+                logger.Log($"Warning: Could not read {skippedPath}");
+
+            foreach (var match in outcome.Results)
+            {
+                results.Add(new TypeSearchResult
+                {
+                    TypeName = match.TypeName,
+                    Namespace = match.Namespace,
+                    FullName = match.FullName,
+                    Kind = match.Kind,
+                    Assembly = match.Assembly,
+                    Source = match.Source,
+                    SourceVersion = match.Version,
+                });
             }
         }
 
@@ -404,60 +417,7 @@ internal static class TypeSearchService
         }
 
         var request = CreateFindRequest();
-        using var assemblySet = await AssemblySetResolver.CollectAsync(httpClient, request, logger.Log);
-        AssemblySetDiagnosticWriter.Write(assemblySet);
-
-        var perAssembly = new List<TypeSearchResult>[assemblySet.Assemblies.Count];
-        Parallel.For(0, assemblySet.Assemblies.Count, i =>
-        {
-            perAssembly[i] = Scan(assemblySet.Assemblies[i]);
-        });
-
-        foreach (var types in perAssembly)
-            results.AddRange(types);
-
-        return results;
-    }
-
-    /// <summary>
-    /// Extracts types from a single assembly, optionally filtered by pattern.
-    /// </summary>
-    public static List<TypeSearchResult> CollectFromAssembly(string assemblyPath, string? pattern, bool includeAll, VerboseLogger logger)
-    {
-        List<TypeSearchResult> results = [];
-
-        try
-        {
-            var api = AssemblyReader.ExtractApiSurface(assemblyPath, includeAll, typesOnly: true);
-            if (api == null)
-                return results;
-
-            var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-
-            foreach (var type in api.Types)
-            {
-                // Use MatchesTypeFilter which handles both glob patterns and exact matches
-                // (including generic type base names like SortedDictionary -> SortedDictionary`2)
-                if (pattern != null && !TypeMatcher.MatchesTypeFilter(type.FullName, pattern))
-                {
-                    continue;
-                }
-
-                results.Add(new TypeSearchResult
-                {
-                    TypeName = type.Name,
-                    Namespace = type.Namespace,
-                    FullName = type.FullName,
-                    Kind = type.Kind,
-                    Assembly = assemblyName
-                });
-            }
-        }
-        catch (Exception ex)
-        {
-            logger.Log($"Warning: Could not read {assemblyPath}: {ex.Message}");
-        }
-
+        await CollectAndScanAsync(request);
         return results;
     }
 }

--- a/tests/ILInspector.Metadata.Tests/CorpusTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CorpusTests.cs
@@ -122,6 +122,44 @@ namespace ILInspector.Metadata.Tests
         }
 
         [Fact]
+        public void SearchTypes_unbounded_scan_preserves_member_order()
+        {
+            // The same assembly listed twice with distinct provenance: the unbounded (parallel) scan
+            // must still emit member 0's matches before member 1's, identical to a sequential pass.
+            var corpus = new Corpus(
+            [
+                new CorpusMember { AssemblyPath = SelfAssembly, Source = "first" },
+                new CorpusMember { AssemblyPath = SelfAssembly, Source = "second" },
+            ]);
+
+            var sources = corpus.SearchTypes(["CorpusProbeType*"]).Results.Select(r => r.Source).ToList();
+
+            var firstBlock = sources.TakeWhile(s => s == "first").Count();
+            Assert.True(firstBlock > 0);
+            Assert.All(sources.Take(firstBlock), s => Assert.Equal("first", s));
+            Assert.All(sources.Skip(firstBlock), s => Assert.Equal("second", s));
+            Assert.Equal(sources.Count(s => s == "first"), sources.Count(s => s == "second"));
+        }
+
+        [Fact]
+        public void SearchTypes_unbounded_scan_surfaces_skips_between_good_members()
+        {
+            var missing = Path.Combine(Path.GetTempPath(), "corpus-types-order-3f9a.dll");
+            var corpus = new Corpus(
+            [
+                new CorpusMember { AssemblyPath = SelfAssembly, Source = "good-1" },
+                new CorpusMember { AssemblyPath = missing, Source = "bad" },
+                new CorpusMember { AssemblyPath = SelfAssembly, Source = "good-2" },
+            ]);
+
+            var outcome = corpus.SearchTypes(["CorpusProbeTypeAlpha"]);
+
+            Assert.Contains(outcome.Results, r => r.Source == "good-1");
+            Assert.Contains(outcome.Results, r => r.Source == "good-2");
+            Assert.Equal(missing, Assert.Single(outcome.SkippedAssemblies));
+        }
+
+        [Fact]
         public void SearchMembers_finds_member_with_declaring_type_and_provenance()
         {
             var outcome = SelfCorpus().SearchMembers(["CorpusProbeMemberAlpha"]);


### PR DESCRIPTION
## Layer 4a of #3180 — route `find`'s type search through the closed-set corpus

**Stacked on #3198 (Layer 3).** Base branch: `feature/issue-3180-corpus-producer`. Review only the top commit (`53f09e21`).

### What & why

This is a **behavior-preserving re-plumb**: `find`'s type collection/search now flows through the Services-owned closed-set corpus instead of a hand-rolled per-assembly scan, making `find` the first CLI consumer of the corpus primitive built in Layers 1–3.

- **`TypeSearchService.CollectTypesAsync`** (shared by `find`, `type`, `TypeLookupService`, `TypeFindIfMissResolver`) still resolves the `AssemblySet` exactly as before (`AssemblySetResolver.CollectAsync` — not `PopulateAsync`, so a zero-resolution `find` still returns `NotFound` rather than throwing), then builds a `Corpus` via `CorpusProducer.ToCorpus(assemblySet)` and searches it with `Corpus.SearchTypes`. A specific pattern filters during the scan; a null pattern enumerates every type via `["*"]` for the collect-then-match callers (multi-pattern, fuzzy/namespace-prefix fallback). Streaming early-exit is preserved (each source capped at the remaining budget; later sources never resolved once the limit is met). Dead `CollectFromAssembly`/`Scan` helpers removed.
- **`Corpus.SearchTypes`** now scans members in parallel for an **unbounded** search — reassembling matches and skips in member order so output is byte-identical to a sequential pass — and stays **sequential** for a **bounded** search so it can early-exit. Extracted `ScanTypesInMember` surfaces any per-member metadata-read failure through the existing `SkippedAssemblies` channel (fail-visible; never a fake empty-success, never aborts the whole search).

Provenance (`Source`/`Version`), `IncludeAll` semantics, `NotFound` classification, and named-profile resolution (`--platform`/`--extensions`/`--aspnetcore` flatten into the request, then flow through the corpus) are unchanged.

### Validation

- Full `dotnet-inspect.slnx` build clean.
- `ILInspector.Metadata` **CorpusTests: 17 pass** (incl. 2 new tests: parallel member-order preservation + skip ordering between good members).
- `dotnet-inspect` **find/type + `TypeSearchServiceTests`: 51 pass** (incl. `CollectTypesAsync_WithLimitDoesNotResolveLaterSources`).
- **Byte-identical stdout+stderr** before/after across 6 representative `find` paths (single, streaming glob+limit, multi-pattern, fuzzy-miss, JSON, package) with comparable timing.
- Full CLI suite's only failures are pre-existing **network/source-provenance** tests (source-file URL columns, NuGet version listing, skills paths) — confirmed failing identically on base `cfdeec59`, out of scope.

### Adversarial review (both reviewers non-Claude, fixed head `53f09e21`)

Two isolated review worktrees at exact head. Attack points issued: (a) parallel order/skip preservation vs sequential + data races; (b) streaming early-exit + `remaining` bounds + bounded-vs-unbounded selection; (c) broad-catch resilience vs fail-visible; (d) `["*"]` enumerate-all correctness; (e) parity for the other `CollectTypesAsync` callers.

- **Gemini 3.1 Pro — clean/blocking-free.** Verified all five attack points: order preserved via pre-allocated `perMember[i]`/`perMemberSkip[i]` written strictly by index then gathered in member order; `_globCache` is a thread-safe `ConcurrentDictionary`; `ReachedLimit()` short-circuits before resolving later sources; `remaining` prevents over-collection; `pattern==null → remaining==null → unbounded` matches the old tail path; broad catch + null-surface both surface `AssemblyPath` via `SkippedAssemblies`; `MatchesGlob(…, "*")` → `^.*$`. Ran Metadata CorpusTests (17) + TypeSearchServiceTests + real `find` invocations (provenance strings intact).
- **GPT-5.6 — clean/blocking-free.** CLI/solution builds succeeded; 47 focused tests passed; bounded-glob, multi-pattern, and fuzzy real-CLI checks produced expected results.

No blocking findings from either reviewer; nothing to reconcile. Both fixed-head reviews on `53f09e21` are clean.

### Follow-up (non-blocking)

Layer 4b (next stacked PR) adds the `find --members` lens (member-name search via `Corpus.SearchMembers`) with a leading-`.` auto-enable shortcut.
