### PR TITLE
Render struct boxed-this interface access with the erased ((I)this) cast (#3201)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -215,6 +215,59 @@ public sealed class ThisQualificationTests
         Assert.DoesNotContain("this.FaceMethod()", text);
     }
 
+    // The value-type sibling of the #3128 arms (#3201). A struct reaches an
+    // interface member through `this` by BOXING — `((IDimSFace)this).Value()`
+    // lowers to `ldarg.0; ldobj Struct; box Struct; callvirt IDimSFace::Value()`,
+    // so the IR receiver is a Box over the this value, not a bare LoadArgument.
+    // The printer must still re-insert the `((I)this)` cast; bare `(this).Value()`
+    // is CS1061. Faithful: the cast re-emits exactly the `ldobj; box` the struct
+    // boxing produced.
+    [Fact]
+    public void StructDefaultInterfaceMemberCall_RendersInterfaceCast_ByDefault()
+    {
+        var text = RenderMember(typeof(StructDimConsumer), nameof(StructDimConsumer.DimCall));
+        Assert.Contains("((IDimSFace)this).Value()", text);
+        Assert.DoesNotContain("(this).Value()", text);
+    }
+
+    // A struct DIM method group over `this` boxes the same way:
+    // `((IDimSFace)this).Value` recompiles to `ldarg.0; ldobj S; box S; dup;
+    // ldvirtftn IDimSFace::Value; newobj Func`. Bare `(this).Value` (CS1061) or the
+    // knob's `this.Value` would not bind.
+    [Fact]
+    public void StructDefaultInterfaceMemberGroup_RendersInterfaceCast_ByDefault()
+    {
+        var text = RenderMember(typeof(StructDimConsumer), nameof(StructDimConsumer.DimGroup));
+        Assert.Contains("((IDimSFace)this).Value", text);
+        Assert.DoesNotContain("(this).Value", text);
+    }
+
+    // An explicit interface implementation on a struct invoked through `this`
+    // reaches the call site with the interface as declaring type and a boxed
+    // receiver; it must render `((IStructFace)this).FaceMethod()` — bare
+    // `(this).FaceMethod()` is CS1061 (#3201).
+    [Fact]
+    public void StructExplicitInterfaceCall_RendersInterfaceCast()
+    {
+        var text = RenderMember(typeof(StructExplicitFace),
+            nameof(StructExplicitFace.CallExplicitInterface));
+        Assert.Contains("((IStructFace)this).FaceMethod()", text);
+        Assert.DoesNotContain("(this).FaceMethod()", text);
+    }
+
+    // Negative guard: a boxed `this` that reaches a NON-interface member (here
+    // `object.ToString()` via `((object)this).ToString()`) must NOT be over-cast to
+    // the enclosing struct — `IsInterfaceCastThisReceiver` declines a non-interface
+    // callee, so the boxed-this arm never fires. The faithful render keeps the
+    // object cast the boxing spells and never writes `((StructBoxedObjectReceiver)this)`.
+    [Fact]
+    public void StructBoxedThis_NonInterfaceCallee_IsNotOverCast()
+    {
+        var text = RenderMember(typeof(StructBoxedObjectReceiver),
+            nameof(StructBoxedObjectReceiver.CallObjectToString));
+        Assert.DoesNotContain("StructBoxedObjectReceiver)this", text);
+    }
+
     [Fact]
     public void EventSubscription_DefaultsToBareName()
     {
@@ -602,4 +655,46 @@ public sealed class DimConsumer : IDimFace
     public int DimCall() => ((IDimFace)this).Value();
 
     public System.Func<int> DimGroup() => ((IDimFace)this).Value;
+}
+
+// The value-type siblings of DimConsumer/ThisQualificationExplicitFace (#3201).
+// A struct reaches an interface member through `this` by BOXING: ((IDimSFace)this)
+// / ((IStructFace)this) lowers to `ldarg.0; ldobj Struct; box Struct; callvirt
+// IFace::M()` (a boxing conversion that DOES emit `box`, unlike the no-IL class
+// upcast of #3128). The IR receiver is therefore a Box over the this value, not a
+// bare LoadArgument{0,"this"}, so the printer must recognise the boxed-this shape
+// and re-insert the ((I)this) cast — bare (this).M() is CS1061.
+public interface IDimSFace
+{
+    int Value() => 7;
+}
+
+public struct StructDimConsumer : IDimSFace
+{
+    public int DimCall() => ((IDimSFace)this).Value();
+
+    public System.Func<int> DimGroup() => ((IDimSFace)this).Value;
+}
+
+public interface IStructFace
+{
+    int FaceMethod();
+}
+
+public struct StructExplicitFace : IStructFace
+{
+    int IStructFace.FaceMethod() => 7;
+
+    public int CallExplicitInterface() => ((IStructFace)this).FaceMethod();
+}
+
+// Negative fixture (#3201): a struct that boxes `this` to reach a NON-interface
+// member. `((object)this).ToString()` also lowers to `ldarg.0; ldobj S; box S;
+// callvirt object::ToString()`, so its IR receiver is likewise a Box over this —
+// but the callee's declaring type is System.Object, not an interface, so the
+// boxed-this arm must decline and leave the object cast untouched. Guards the
+// arm against firing on every boxed-this receiver.
+public struct StructBoxedObjectReceiver
+{
+    public string CallObjectToString() => ((object)this).ToString()!;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -418,6 +418,25 @@ public sealed partial class CSharpPrinter
         => _function.InterfaceTypes.Contains(NamedDefinition(declaringType))
             && !IsEnclosingTypeAtOwnInstantiation(declaringType);
 
+    /// <summary>
+    /// True when <paramref name="receiver"/> is a value type's <c>this</c> boxed
+    /// to reach an interface member. On a struct, <c>((I)this).M()</c> is a
+    /// boxing conversion that lowers to <c>ldobj; box; callvirt I::M</c>, so the
+    /// receiver is a <see cref="Box"/> over the dereferenced <c>this</c> pointer
+    /// (<c>LoadIndirect</c> of <c>LoadArgument{0,"this"}</c>) rather than the bare
+    /// <c>LoadArgument{0,"this"}</c> the reference-type upcast of #3128 leaves.
+    /// The member is not a member of the struct, so bare <c>(this).M()</c> is
+    /// CS1061; re-inserting <c>((I)this)</c> is opcode-faithful because the cast
+    /// re-emits exactly the <c>ldobj; box</c> the boxing conversion produced.
+    /// Uses the same confirmed-interface gate as
+    /// <see cref="IsInterfaceCastThisReceiver"/> (declines when interface-ness is
+    /// unknown), and only <c>this</c> — a boxed field/local/parameter has a
+    /// different address operand and is left to the ordinary receiver path (#3201).
+    /// </summary>
+    bool IsBoxedThisInterfaceReceiver(IrExpression receiver, TypeRef declaringType)
+        => receiver is Box { Operand: LoadIndirect { Address: LoadArgument { Index: 0, Name: "this" } } }
+            && IsInterfaceCastThisReceiver(declaringType);
+
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
     string ReceiverText(IrExpression receiver) => receiver switch
     {
@@ -505,6 +524,13 @@ public sealed partial class CSharpPrinter
             }
             return name;
         }
+        // A struct's interface method group boxes this: ((I)this).M lowers to
+        // `ldobj; box; dup; ldvirtftn I::M`, so the target is a Box over this, not
+        // a bare LoadArgument. Re-insert the ((I)this) cast the boxing spells —
+        // bare (this).M / this.M is CS1061 (#3201), the value-type sibling of the
+        // reference-type arm above.
+        if (IsBoxedThisInterfaceReceiver(target, method.DeclaringType))
+            return $"(({TypeText(method.DeclaringType)})this).{name}";
         if (PointerMethodReceiver(target) is { } pointerReceiver)
             return $"{pointerReceiver}->{name}";
         return $"{ReceiverText(target)}.{name}";
@@ -605,6 +631,14 @@ public sealed partial class CSharpPrinter
         }
         if (call.Callee.Name == "Invoke" && receiver is Lambda lambda)
             return $"(({TypeText(lambda.DelegateType)}){Operand(lambda)}).Invoke({rest})";
+        // A struct reaching an interface member through this boxes the value:
+        // ((I)this).M() lowers to `ldobj; box; callvirt I::M`, so the receiver is
+        // a Box over this, not a bare LoadArgument. Re-insert the ((I)this) cast
+        // the boxing conversion spells — bare (this).M() is CS1061 (#3201), the
+        // value-type sibling of the reference-type this arm below. Faithful: the
+        // cast re-emits exactly the `ldobj; box` the struct boxing produced.
+        if (IsBoxedThisInterfaceReceiver(receiver, call.Callee.DeclaringType))
+            return $"(({TypeText(call.Callee.DeclaringType)})this).{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         if (receiver is LoadArgument { Index: 0, Name: "this" })
         {
             string thisMethodName = CSharpNaming.SourceMethodName(call.Callee.Name);


### PR DESCRIPTION
- Fixes #3201
- Renders struct/value-type default-interface-member and explicit-interface access through `this` with the required `((I)this)` cast instead of invalid `(this).M()`
- Card revision: `30efd400`

Stacked on #3200 (base branch `fix/3128-dim-interface-cast-this`). #3200 fixed the reference-type (class→interface, no-IL upcast) case; this is its value-type sibling, where the interface cast is a **boxing conversion** that emits `ldobj; box`.

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a struct reaching an interface member through `this` boxes the receiver, so the IR target is a `Box` over `this` rather than a bare `LoadArgument`; the printer dropped the cast and emitted CS1061 `(this).M()`. Re-inserting `((I)this)` is opcode-faithful because the cast re-emits exactly the `ldobj; box` the boxing produced.

### Benchmark target

Benchmark target: `ILInspector.Decompiler.Tests` fixture assembly (`StructDimConsumer`, `StructExplicitFace`, added by this PR).

dotnet-inspect command:

```bash
dotnet-inspect member ILInspector.Decompiler.Tests.StructDimConsumer.DimCall -S "Decompiled Source"
```

### Original source

```csharp
public struct StructDimConsumer : IDimSFace
{
    public int DimCall() => ((IDimSFace)this).Value();
```

IL anchor: `ldarg.0; ldobj StructDimConsumer; box StructDimConsumer; callvirt IDimSFace::Value(); ret`.

### Before

```csharp
public int DimCall() => (this).Value();
```

- Valid: False
- Correct: False
- IL fidelity: False
- Taste applied: None
- Commit: `f2568a98`

`(this)` is the boxed struct receiver with the interface cast erased; `IDimSFace.Value()` is a DIM, not a member of `StructDimConsumer`, so this is CS1061.

### After

```csharp
public int DimCall() => ((IDimSFace)this).Value();
```

- Valid: True
- Correct: True
- IL fidelity: True
- Taste applied: None
- Commit: `30efd400`

Byte-identical to the authored fixture source, which is the compiled form of the shown IL, so it recompiles to exactly `ldobj; box; callvirt`.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline (`f2568a98`) | Head (`30efd400`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ThisQualification[Decision]Tests`: 54 passed | `ThisQualification[Decision]Tests`: 58 passed (+4) |
| Decompiler fast suite | 3729, 1 failed | 3729, 1 failed |
| Reduced fixture validity | `(this).Value()` invalid (CS1061) | `((IDimSFace)this).Value()` valid |
| Reduced fixture fidelity | not faithful | recompiles to `ldobj; box; callvirt` |
| Real witness | `StructDimConsumer::DimCall`, `StructExplicitFace::CallExplicitInterface` broken | fixed |

The 1 fast-suite failure is pre-existing and unrelated: `StringSwitchRaisingTests.SmallStringSwitch_RendersSwitchOnString` fails Windows-locally on CRLF vs LF (`\r\n` expected vs `\n`), identical on baseline and head.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — pinned PR quick gate matched baseline tolerances with zero pass bugs; lowering residue edged down as some struct interface-cast residue resolves.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly (15 assemblies, 1,500 methods); validity/fidelity not run (`--compile-cap 0 --corpus-fidelity-cap 0`).

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 16.73% | 16.40% | -0.33pp |
| Conditional-branch residue (-) | 3.07% | 2.93% | -0.14pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — corpus sensor matched baseline tolerances; 0 pass bugs.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.ThisQualificationTests" -class "ILInspector.Decompiler.Tests.ThisQualificationDecisionTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
