### PR TITLE
Lock #3162: DeepEquals prologue guards fold to if-clauses (regression test)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -466,4 +466,106 @@ public class SwitchBranchRenderingTests
         Assert.DoesNotContain("__switchValue", output);
         AssertGotoTargetsHaveLabels(output);
     }
+
+    [Fact]
+    public void FullPipeline_RaisesGuardsBeforeLoopingSwitch()
+    {
+        // Regression witness for #3162 (part of #3159), the DeepEquals prologue:
+        // a guard-throw (`if (!c) throw;`) and a guard-return
+        // (`if (a != b) return false;`) standing in front of a `switch` whose
+        // sections carry EH-entangled `foreach` loops. csc lowers each guard to a
+        // forward branch over a throw/return island (`if (c) goto L; …; L:`).
+        // Before #3161 the unraised switch kept the whole container flat, so those
+        // guards survived as residual `IL_xxxx:` labels and `goto`s; now
+        // SwitchRaisingPass owns the loop-bearing sections, StructuringPass
+        // structures the container, and the guards fold into inverted `if` clauses
+        // with no residual labels or gotos.
+        using var source = MetadataSource.Open(typeof(GuardsBeforeLoopingSwitchFixture).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(GuardsBeforeLoopingSwitchFixture).FullName!,
+            nameof(GuardsBeforeLoopingSwitchFixture.Compare));
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function);
+        string output = result.Output ?? "";
+
+        Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+
+        // The switch raised and both loops structured.
+        Assert.Contains("switch (", output);
+        Assert.DoesNotContain("__switchValue", output);
+
+        // The two prologue guards folded into inverted `if` clauses — the #3162
+        // outcome: guard-throw negated, guard-return negated, no `goto`/labels.
+        Assert.Contains("if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())", output);
+        Assert.Contains("throw new InsufficientExecutionStackException();", output);
+        Assert.Contains("if (kind != right.Count)", output);
+
+        // No residual forward-branch scaffolding survives anywhere in the body.
+        Assert.DoesNotContain("goto ", output);
+        Assert.DoesNotMatch(new Regex(@"(?m)^\s*IL_[0-9A-Fa-f]+:\s*$"), output);
+    }
+}
+
+/// <summary>
+/// Real-IL fixture for
+/// <see cref="SwitchBranchRenderingTests.FullPipeline_RaisesGuardsBeforeLoopingSwitch"/>:
+/// mirrors the distinctive prologue of
+/// <c>System.Text.Json.JsonElement.DeepEquals</c> — a guard-throw
+/// (<c>if (!c) throw;</c>) and a guard-return (<c>if (a != b) return false;</c>)
+/// standing in front of a <c>switch</c> whose case sections carry EH-entangled
+/// <c>foreach</c> loops (a <see cref="System.Collections.Generic.List{T}"/>
+/// enumerator lowers to a <c>try/finally</c> with a surviving <c>Leave</c>). csc
+/// lowers each guard to a forward branch over a throw/return island
+/// (<c>if (c) goto L; …; L:</c>). Before #3161 the unraised switch kept the whole
+/// container flat, so those guards survived as residual <c>IL_xxxx:</c> labels and
+/// <c>goto</c>s (issue #3162); once <c>SwitchRaisingPass</c> owns the loop-bearing
+/// sections, <c>StructuringPass</c> structures the container and folds the guards
+/// into inverted <c>if</c> clauses.
+/// </summary>
+static class GuardsBeforeLoopingSwitchFixture
+{
+    public static bool Compare(int kind, System.Collections.Generic.List<int> left, System.Collections.Generic.List<int> right)
+    {
+        if (!System.Runtime.CompilerServices.RuntimeHelpers.TryEnsureSufficientExecutionStack())
+        {
+            throw new System.InsufficientExecutionStackException();
+        }
+        if (kind != right.Count)
+        {
+            return false;
+        }
+        switch (kind)
+        {
+            case 0:
+                if (left.Count != right.Count)
+                {
+                    return false;
+                }
+                foreach (int value in left)
+                {
+                    if (value < 0)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            case 1:
+                return left.Count == right.Count;
+            case 2:
+                return true;
+            default:
+                int index = 0;
+                foreach (int value in right)
+                {
+                    if (value != left[index])
+                    {
+                        return false;
+                    }
+                    index++;
+                }
+                return true;
+        }
+    }
 }


### PR DESCRIPTION
Closes #3162 (part of #3159).

## Conclusion

The `JsonElement.DeepEquals` forward-`goto`/label residue reported in #3162 is
**already gone** — resolved as a byproduct of the #3161 switch-raising fix
(#3174). This PR is **test-only**: it adds the missing regression guard that locks
the outcome so the guards can't silently un-fold if switch raising or container
structuring regresses.

## Why #3174 fixed it

DeepEquals opens with two forward guards:

```csharp
if (RuntimeHelpers.TryEnsureSufficientExecutionStack()) goto IL_000C;
ThrowHelper.ThrowInsufficientExecutionStackException_...();
IL_000C:
...
if (kind == element2.ValueKind) goto IL_002E;
return false;
IL_002E:
```

csc lowers each `if (!c) throw;` / `if (a != b) return false;` to a forward branch
over a throw/return island. `StructuringPass` is all-or-nothing per container: the
method's **unraised jump-table switch**, entangled with the enumerator
`try/finally` regions (a surviving `Leave` target in the container), kept the
whole body flat — so these leading guards survived as `IL_xxxx:` labels and
`goto`s even though they precede the switch.

Once `SwitchRaisingPass` owns the loop-bearing sections (#3174), `StructuringPass`
structures the container and folds the guards into inverted `if` clauses. Current
output (`dotnet-inspect System.Text.Json.JsonElement.DeepEquals -S "Decom*"`,
`net11.0`):

```csharp
if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
{
    ThrowHelper.ThrowInsufficientExecutionStackException_JsonElementDeepEqualsInsufficientExecutionStack();
}
element1.CheckValidInstance();
element2.CheckValidInstance();
JsonValueKind kind = element1.ValueKind;
if (kind != element2.ValueKind)
{
    return false;
}
switch (kind - 2) { /* … raised, no goto/labels … */ }
```

No `goto`/labels remain. (The residual synthetic local names — `S_256`, `V_5` — are
#3165, orthogonal; the `switch (kind - 2)` enum-bias label spelling is #3159.)

## What this PR adds

A compiled, DeepEquals-shaped regression fixture and one full-pipeline test:

- `GuardsBeforeLoopingSwitchFixture.Compare` — a guard-throw (`if (!c) throw;`) and
  a guard-return (`if (kind != right.Count) return false;`) in front of a `switch`
  whose case sections carry **EH-entangled** `foreach` loops over a `List<int>`
  enumerator (the `try/finally` + `Leave` that mirrors DeepEquals's flat-keeping
  entanglement).
- `SwitchBranchRenderingTests.FullPipeline_RaisesGuardsBeforeLoopingSwitch` —
  imports the compiled method through the full pipeline and asserts `Full`
  fidelity, a raised `switch`, both guards folded to inverted `if` clauses, and
  **no `goto`/`IL_` labels** anywhere in the body.

Verified decompiled output of the fixture (via `IrImporter` + `CSharpPrinter.PrintRaised`):

```csharp
if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
{
    throw new InsufficientExecutionStackException();
}
if (kind != right.Count)
{
    return false;
}
switch (kind)
{
    case 0:
        if (left.Count != right.Count) { return false; }
        V_1 = left.GetEnumerator();
        try { while (V_1.MoveNext()) { if (V_1.Current < 0) { return false; } } }
        finally { V_1.Dispose(); }
        return true;
    // case 1/2 scalar arms …
    default:
        index = 0;
        V_1 = right.GetEnumerator();
        try { while (V_1.MoveNext()) { if (V_1.Current != left[index]) { return false; } index++; } }
        finally { V_1.Dispose(); }
        return true;
}
```

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -class "ILInspector.Decompiler.Tests.SwitchBranchRenderingTests"
```

- `SwitchBranchRenderingTests`: 12 total, 0 failed (incl. the new test and the two
  existing `FullPipeline_Raises*` switch witnesses).

## Risk

Test-only, no product change. No adversarial review required (mechanical, low
risk): it adds a fixture + assertion over already-shipping behavior.
