### PR TITLE
Add ResearchViews.ProjectType: neutral type projection + CLI parity (#3206)

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -74,6 +74,32 @@ public sealed class MetadataSource : IDisposable
     public DecompilerSymbolSource Symbols => _symbols;
 
     /// <summary>
+    /// Extracts this assembly's <see cref="ApiSurface"/> from the already-open PE image,
+    /// mirroring <c>AssemblyInspectionSession</c>/<c>PdbContext</c> so callers do not re-open
+    /// the file. Presentation-neutral type projection (<c>ResearchViews.ProjectType</c>) uses
+    /// this to compose type-level views from one live source.
+    /// </summary>
+    public ApiSurface ExtractApiSurface(bool includeAll = false, bool typesOnly = false)
+        => ApiSurfaceExtractor.Extract(Pe, includeAll, typesOnly);
+
+    /// <summary>
+    /// Classifies the async shape of the given MethodDef metadata token (runtime or
+    /// state-machine async), or <see langword="null"/> when the token is not a MethodDef or
+    /// the method is not async. Async is a body-gated fact the API surface deliberately omits
+    /// (docs/design/member-body-substrate.md, <c>ApiMember.IsAsync</c>), so callers that need
+    /// an accurate async signal recover it here from live metadata.
+    /// </summary>
+    public MethodClassification? ClassifyAsync(int methodDefToken)
+    {
+        var entity = MetadataTokens.EntityHandle(methodDefToken);
+        if (entity.Kind != HandleKind.MethodDefinition)
+            return null;
+
+        var method = Reader.GetMethodDefinition((MethodDefinitionHandle)entity);
+        return MethodClassificationScanner.ClassifyAsyncMethod(Reader, method);
+    }
+
+    /// <summary>
     /// Opens an assembly. Throws <see cref="BadImageFormatException"/> for files
     /// without managed metadata. <paramref name="externalPdbPath"/> is a portable
     /// PDB to use for source local names when the assembly carries no embedded

--- a/src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj
+++ b/src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj
@@ -8,6 +8,7 @@
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ILInspector.Research.Tests/ResearchTypeViewsTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchTypeViewsTests.cs
@@ -1,0 +1,183 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+using ILInspector.Research.Tests.TypeFixtures;
+
+namespace ILInspector.Research.Tests;
+
+public class ResearchTypeViewsTests
+{
+    static MetadataSource OpenSelf()
+        => MetadataSource.Open(typeof(ResearchTypeViewsTests).Assembly.Location);
+
+    static ApiType FindType(ApiSurface surface, Type clrType)
+    {
+        var type = surface.Types.FirstOrDefault(t => t.FullName == clrType.FullName)
+            ?? surface.Types.FirstOrDefault(t => t.MetadataName == clrType.Name);
+        Assert.NotNull(type);
+        return type!;
+    }
+
+    [Fact]
+    public void ProjectType_AbstractClass_ExposesInterfacesAndDerivedTypes()
+    {
+        using var source = OpenSelf();
+        var surface = source.ExtractApiSurface(includeAll: true);
+        var animal = FindType(surface, typeof(ResearchAnimal));
+
+        var result = ResearchViews.ProjectType(animal, surface);
+
+        Assert.Equal("class", result.Identity.Kind);
+        Assert.Contains("abstract", result.Identity.Modifiers);
+        // System.Object base is trivial and filtered out.
+        Assert.Null(result.BaseType);
+
+        Assert.Equal(
+            [typeof(IResearchAged).FullName!, typeof(IResearchNamed).FullName!],
+            result.Interfaces);
+
+        Assert.Equal(
+            [typeof(ResearchCat).FullName!, typeof(ResearchDog).FullName!],
+            result.DerivedTypes);
+    }
+
+    [Fact]
+    public void ProjectType_RelationshipGraph_UsesNeutralNodeRoleEdgeModel()
+    {
+        using var source = OpenSelf();
+        var surface = source.ExtractApiSurface(includeAll: true);
+        var animal = FindType(surface, typeof(ResearchAnimal));
+
+        var graph = ResearchViews.ProjectType(animal, surface).Graph;
+        Assert.NotNull(graph);
+
+        var self = Assert.Single(graph!.Nodes, n => n.Role == ResearchViews.TypeRelationshipRole.Self);
+        Assert.Equal(typeof(ResearchAnimal).FullName, self.Id);
+
+        Assert.Equal(2, graph.Nodes.Count(n => n.Role == ResearchViews.TypeRelationshipRole.Interface));
+        Assert.Equal(2, graph.Nodes.Count(n => n.Role == ResearchViews.TypeRelationshipRole.Derived));
+        Assert.DoesNotContain(graph.Nodes, n => n.Role == ResearchViews.TypeRelationshipRole.Base);
+
+        Assert.Equal(2, graph.Edges.Count(e => e.Kind == ResearchViews.TypeRelationshipKind.Implements));
+        Assert.All(
+            graph.Edges.Where(e => e.Kind == ResearchViews.TypeRelationshipKind.Implements),
+            e => Assert.Equal(self.Id, e.FromId));
+
+        Assert.Equal(2, graph.Edges.Count(e => e.Kind == ResearchViews.TypeRelationshipKind.DerivedFrom));
+        Assert.All(
+            graph.Edges.Where(e => e.Kind == ResearchViews.TypeRelationshipKind.DerivedFrom),
+            e => Assert.Equal(self.Id, e.ToId));
+
+        Assert.DoesNotContain(graph.Edges, e => e.Kind == ResearchViews.TypeRelationshipKind.Inherits);
+    }
+
+    [Fact]
+    public void ProjectType_SealedDerivedClass_ReportsBaseAndInheritsEdge()
+    {
+        using var source = OpenSelf();
+        var surface = source.ExtractApiSurface(includeAll: true);
+        var dog = FindType(surface, typeof(ResearchDog));
+
+        var result = ResearchViews.ProjectType(dog, surface);
+
+        Assert.Contains("sealed", result.Identity.Modifiers);
+        Assert.Equal(typeof(ResearchAnimal).FullName, result.BaseType);
+
+        var inherits = Assert.Single(result.Graph!.Edges, e => e.Kind == ResearchViews.TypeRelationshipKind.Inherits);
+        Assert.Equal(typeof(ResearchDog).FullName, inherits.FromId);
+        Assert.Equal(typeof(ResearchAnimal).FullName, inherits.ToId);
+    }
+
+    [Fact]
+    public void ProjectType_GenericType_ProjectsTypeParameterConstraints()
+    {
+        using var source = OpenSelf();
+        var surface = source.ExtractApiSurface(includeAll: true);
+        var repository = FindType(surface, typeof(ResearchRepository<>));
+
+        var result = ResearchViews.ProjectType(repository, surface);
+
+        var tp = Assert.Single(result.TypeParameters);
+        Assert.Equal("T", tp.Name);
+        Assert.Null(tp.Variance);
+        Assert.Contains("class", tp.Constraints);
+        Assert.Contains("new()", tp.Constraints);
+        Assert.Contains(tp.Constraints, c => c.Contains("IResearchNamed"));
+    }
+
+    [Fact]
+    public void ProjectType_Enum_ReportsUnderlyingType()
+    {
+        using var source = OpenSelf();
+        var surface = source.ExtractApiSurface(includeAll: true);
+        var color = FindType(surface, typeof(ResearchColor));
+
+        var result = ResearchViews.ProjectType(color, surface);
+
+        Assert.Equal("enum", result.Identity.Kind);
+        Assert.NotNull(result.EnumUnderlyingType);
+        Assert.Contains("byte", result.EnumUnderlyingType!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ProjectType_RefStruct_And_ReadonlyStruct_CarryModifiers()
+    {
+        using var source = OpenSelf();
+        var surface = source.ExtractApiSurface(includeAll: true);
+
+        var refSpan = ResearchViews.ProjectType(FindType(surface, typeof(ResearchRefSpan)));
+        Assert.Equal("struct", refSpan.Identity.Kind);
+        Assert.Contains("ref", refSpan.Identity.Modifiers);
+
+        var readonlyPoint = ResearchViews.ProjectType(FindType(surface, typeof(ResearchReadonlyPoint)));
+        Assert.Equal("struct", readonlyPoint.Identity.Kind);
+        Assert.Contains("readonly", readonlyPoint.Identity.Modifiers);
+    }
+
+    [Fact]
+    public void ProjectType_Request_ComposesCountsAndRecoversAsync()
+    {
+        using var source = OpenSelf();
+
+        var result = ResearchViews.ProjectType(new ResearchViews.TypeProjectionRequest(
+            source,
+            typeof(ResearchComposite).FullName!));
+
+        Assert.Equal(source.AssemblyName, result.Identity.Assembly);
+
+        var composition = result.Composition;
+        Assert.NotNull(composition);
+        // Two async methods (DoWorkAsync, ComputeAsync) recovered from metadata classification;
+        // ApiSurface extraction alone would report zero (async is a body-gated fact).
+        Assert.Equal(2, composition!.Async);
+        // One unsafe method (Poke) — populated directly by surface extraction.
+        Assert.Equal(1, composition.Unsafe);
+        Assert.True(composition.Static >= 2, $"expected >= 2 static members, got {composition.Static}");
+        Assert.True(composition.Methods >= 5, $"expected >= 5 methods, got {composition.Methods}");
+        Assert.True(composition.Constructors >= 1);
+        Assert.True(composition.Properties >= 1);
+    }
+
+    [Fact]
+    public void ProjectType_Core_DoesNotInventAsync_ButKeepsUnsafe()
+    {
+        using var source = OpenSelf();
+        var surface = source.ExtractApiSurface(includeAll: true);
+        var composite = FindType(surface, typeof(ResearchComposite));
+
+        // Core overload has no MetadataReader, so it composes only the surface-carried flags:
+        // unsafe is populated, async is deliberately not (docs/design/member-body-substrate.md).
+        var result = ResearchViews.ProjectType(composite, surface);
+
+        Assert.Equal(0, result.Composition!.Async);
+        Assert.Equal(1, result.Composition.Unsafe);
+    }
+
+    [Fact]
+    public void ProjectType_Request_ThrowsForUnknownType()
+    {
+        using var source = OpenSelf();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ResearchViews.ProjectType(new ResearchViews.TypeProjectionRequest(source, "No.Such.Type")));
+    }
+}

--- a/src/ILInspector.Research.Tests/ResearchTypeViewsTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchTypeViewsTests.cs
@@ -180,4 +180,39 @@ public class ResearchTypeViewsTests
         Assert.Throws<InvalidOperationException>(() =>
             ResearchViews.ProjectType(new ResearchViews.TypeProjectionRequest(source, "No.Such.Type")));
     }
+
+    [Fact]
+    public void ProjectType_Request_ResolvesByExactFullNameOnly()
+    {
+        using var source = OpenSelf();
+
+        // The bare metadata name (no namespace) must NOT resolve: resolution is exact-FullName
+        // only, matching the product's canonical resolver, so an ambiguous simpler key can never
+        // silently select the wrong type.
+        Assert.Throws<InvalidOperationException>(() =>
+            ResearchViews.ProjectType(new ResearchViews.TypeProjectionRequest(source, nameof(ResearchComposite))));
+
+        // The exact FullName resolves.
+        var result = ResearchViews.ProjectType(
+            new ResearchViews.TypeProjectionRequest(source, typeof(ResearchComposite).FullName!));
+        Assert.Equal(typeof(ResearchComposite).FullName, result.Identity.FullName);
+    }
+
+    [Fact]
+    public void ProjectType_CarriesInspectionFailures_EmptyForCleanSurface()
+    {
+        using var source = OpenSelf();
+        var surface = source.ExtractApiSurface(includeAll: true);
+        var composite = FindType(surface, typeof(ResearchComposite));
+
+        // A clean self-assembly has no rejected rows, but the field is wired and non-null so a
+        // seam consumer can detect incompleteness rather than see success-shaped empty output.
+        var withSurface = ResearchViews.ProjectType(composite, surface);
+        Assert.NotNull(withSurface.InspectionFailures);
+        Assert.Empty(withSurface.InspectionFailures);
+
+        // No surface supplied (the CLI parity path) yields an empty, non-null list too.
+        var withoutSurface = ResearchViews.ProjectType(composite);
+        Assert.Empty(withoutSurface.InspectionFailures);
+    }
 }

--- a/src/ILInspector.Research.Tests/TypeFixtures.cs
+++ b/src/ILInspector.Research.Tests/TypeFixtures.cs
@@ -1,0 +1,80 @@
+using System.Threading.Tasks;
+
+namespace ILInspector.Research.Tests.TypeFixtures;
+
+internal interface IResearchNamed
+{
+    string Name { get; }
+}
+
+internal interface IResearchAged
+{
+    int Age { get; }
+}
+
+internal abstract class ResearchAnimal : IResearchNamed, IResearchAged
+{
+    public abstract string Name { get; }
+    public int Age { get; protected set; }
+    public virtual void Speak() { }
+}
+
+internal sealed class ResearchDog : ResearchAnimal
+{
+    public override string Name => "Dog";
+    public override void Speak() { }
+}
+
+internal sealed class ResearchCat : ResearchAnimal
+{
+    public override string Name => "Cat";
+}
+
+internal class ResearchRepository<T> where T : class, IResearchNamed, new()
+{
+    public T Create() => new();
+}
+
+internal enum ResearchColor : byte
+{
+    Red,
+    Green,
+    Blue,
+}
+
+internal readonly struct ResearchReadonlyPoint
+{
+    public readonly int X;
+    public ResearchReadonlyPoint(int x) => X = x;
+}
+
+internal ref struct ResearchRefSpan
+{
+    public int Length { get; set; }
+}
+
+internal class ResearchComposite
+{
+    public int Field = 0;
+    public int Value { get; set; }
+
+    public ResearchComposite() { }
+
+    public static async Task DoWorkAsync() => await Task.Yield();
+
+    public async Task<int> ComputeAsync()
+    {
+        await Task.Yield();
+        return Field;
+    }
+
+    public static unsafe void Poke(int* p)
+    {
+        if (p != null)
+            *p = 0;
+    }
+
+    public virtual void Overridable() { }
+
+    public void Plain() { }
+}

--- a/src/ILInspector.Research/ResearchTypeViews.cs
+++ b/src/ILInspector.Research/ResearchTypeViews.cs
@@ -1,0 +1,326 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Research;
+
+/// <summary>
+/// Presentation-neutral, type-level projection that mirrors the member-level
+/// <see cref="ProjectMember(MemberProjectionRequest)"/> seam. Every front end (the CLI's
+/// Markdown/terminal renderer and the WASM web UI) composes type-level metadata from this one
+/// source of truth instead of re-deriving modifiers, base/interface relationships, or
+/// composition counts. The result is Markout-free and HTML-free: each host projects its own
+/// presentation (terminal &#8594; Markdown/Mermaid, web &#8594; interactive SVG).
+/// </summary>
+public static partial class ResearchViews
+{
+    /// <summary>Role a node plays in a <see cref="TypeRelationshipGraph"/>.</summary>
+    public enum TypeRelationshipRole
+    {
+        /// <summary>The projected type itself.</summary>
+        Self,
+
+        /// <summary>The projected type's (non-trivial) base class.</summary>
+        Base,
+
+        /// <summary>An interface the projected type implements.</summary>
+        Interface,
+
+        /// <summary>A type in the same assembly that derives from / implements the projected type.</summary>
+        Derived,
+    }
+
+    /// <summary>Relation an edge expresses in a <see cref="TypeRelationshipGraph"/>.</summary>
+    public enum TypeRelationshipKind
+    {
+        /// <summary>Class inheritance (<c>self &#8594; base</c>).</summary>
+        Inherits,
+
+        /// <summary>Interface implementation (<c>self &#8594; interface</c>).</summary>
+        Implements,
+
+        /// <summary>A derived type inheriting/implementing the projected type (<c>derived &#8594; self</c>).</summary>
+        DerivedFrom,
+    }
+
+    /// <summary>
+    /// Type-level identity: kind, C#-appropriate modifier keywords, accessibility, and location.
+    /// </summary>
+    public sealed record TypeIdentityView(
+        string FullName,
+        string? Namespace,
+        string Name,
+        string Kind,
+        IReadOnlyList<string> Modifiers,
+        string? Accessibility,
+        string? Assembly);
+
+    /// <summary>A generic type parameter with its variance and neutral (unspelled) constraint list.</summary>
+    public sealed record TypeParameterView(
+        string Name,
+        string? Variance,
+        IReadOnlyList<string> Constraints);
+
+    /// <summary>
+    /// Aggregate member counts for the projected type: members by kind plus flagged totals. All
+    /// values are derived from <see cref="ApiMember"/> facts. <c>Async</c> is only meaningful when
+    /// the members carry the body-gated async fact — the <see cref="ProjectType(TypeProjectionRequest)"/>
+    /// path recovers it from live metadata before composing.
+    /// </summary>
+    public sealed record TypeCompositionView(
+        int Methods,
+        int Properties,
+        int Fields,
+        int Events,
+        int Constructors,
+        int Operators,
+        int ExplicitInterfaceImplementations,
+        int ExtensionMethods,
+        int Static,
+        int Unsafe,
+        int Async,
+        int Virtual,
+        int Abstract,
+        int Override,
+        int Extension,
+        int Obsolete,
+        int Total);
+
+    /// <summary>One node in a <see cref="TypeRelationshipGraph"/>, keyed by full type name.</summary>
+    public sealed record TypeRelationshipNode(string Id, string DisplayName, TypeRelationshipRole Role);
+
+    /// <summary>One directed relationship between two nodes.</summary>
+    public sealed record TypeRelationshipEdge(string FromId, string ToId, TypeRelationshipKind Kind);
+
+    /// <summary>
+    /// A structured type-relationship graph (nodes carry identity + role, edges carry relation
+    /// kind) so each host projects its own view. Deliberately NOT a baked Mermaid string — see
+    /// docs/design/call-graph-mermaid-projection.md for the neutral-model &#8594; Mermaid pattern.
+    /// </summary>
+    public sealed record TypeRelationshipGraph(
+        IReadOnlyList<TypeRelationshipNode> Nodes,
+        IReadOnlyList<TypeRelationshipEdge> Edges);
+
+    /// <summary>Knobs for <see cref="ProjectType(ApiType, ApiSurface?, TypeProjectionOptions?)"/>.</summary>
+    public sealed record TypeProjectionOptions(
+        bool PublicOnly = false,
+        bool Composition = true,
+        bool RelationshipGraph = true);
+
+    /// <summary>
+    /// A <see cref="MetadataSource"/>-backed projection request, parallel to
+    /// <see cref="MemberProjectionRequest"/>. Resolves the type from the source's whole-assembly
+    /// surface (also used for the derived-type scan) and recovers the body-gated async fact.
+    /// </summary>
+    public sealed record TypeProjectionRequest(
+        MetadataSource Source,
+        string Type,
+        bool PublicOnly = false,
+        bool Composition = true,
+        bool RelationshipGraph = true);
+
+    /// <summary>The composed, presentation-neutral type view.</summary>
+    public sealed record TypeProjectionResult(
+        TypeIdentityView Identity,
+        string? BaseType,
+        IReadOnlyList<string> Interfaces,
+        IReadOnlyList<string> DerivedTypes,
+        IReadOnlyList<TypeParameterView> TypeParameters,
+        IReadOnlyList<string> Attributes,
+        string? EnumUnderlyingType,
+        TypeCompositionView? Composition,
+        TypeRelationshipGraph? Graph);
+
+    /// <summary>
+    /// The C#-appropriate modifier keywords for a type, in declaration order
+    /// (<c>static</c> | <c>abstract</c>/<c>sealed</c> for classes, <c>readonly</c>/<c>ref</c> for
+    /// structs). The single source of truth for type modifiers across front ends.
+    /// </summary>
+    public static IReadOnlyList<string> TypeModifiers(ApiType type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        List<string> modifiers = [];
+        if (type.IsStatic)
+        {
+            modifiers.Add("static");
+        }
+        else
+        {
+            if (type.IsAbstract && type.Kind == "class") modifiers.Add("abstract");
+            if (type.IsSealed && type.Kind == "class") modifiers.Add("sealed");
+        }
+
+        if (type.IsReadOnly && type.Kind == "struct") modifiers.Add("readonly");
+        if (type.IsByRefLike && type.Kind == "struct") modifiers.Add("ref");
+        return modifiers;
+    }
+
+    /// <summary>
+    /// Composes the neutral type projection from already-extracted metadata facts. When
+    /// <paramref name="surface"/> is supplied it is scanned to populate derived types (a
+    /// whole-assembly fact); when null, <see cref="ApiType.DerivedTypes"/> is used as-is and no
+    /// scan is performed. This overload takes no <see cref="MetadataReader"/>, so the async
+    /// composition count reflects whatever <see cref="ApiMember.IsAsync"/> the members already
+    /// carry — use <see cref="ProjectType(TypeProjectionRequest)"/> for an accurate async count.
+    /// </summary>
+    public static TypeProjectionResult ProjectType(ApiType type, ApiSurface? surface = null, TypeProjectionOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        options ??= new TypeProjectionOptions();
+
+        var baseType = SelectBaseType(type);
+        var interfaces = type.Interfaces.Order().ToList();
+
+        if (surface is not null)
+            ApiSurfaceExtractor.PopulateDerivedTypes(surface, type);
+        var derivedTypes = type.DerivedTypes.ToList();
+
+        var identity = new TypeIdentityView(
+            FullName: type.FullName,
+            Namespace: string.IsNullOrEmpty(type.Namespace) ? null : type.Namespace,
+            Name: type.Name,
+            Kind: type.Kind,
+            Modifiers: TypeModifiers(type),
+            Accessibility: type.Accessibility,
+            Assembly: surface?.Name ?? surface?.Library);
+
+        var typeParameters = type.TypeParameters
+            .Select(tp => new TypeParameterView(tp.Name, tp.Variance, tp.Constraints.ToList()))
+            .ToList();
+
+        var composition = options.Composition ? BuildComposition(type) : null;
+        var graph = options.RelationshipGraph ? BuildRelationshipGraph(type, baseType, interfaces, derivedTypes) : null;
+
+        return new TypeProjectionResult(
+            identity,
+            baseType,
+            interfaces,
+            derivedTypes,
+            typeParameters,
+            type.Attributes.ToList(),
+            type.EnumUnderlyingType,
+            composition,
+            graph);
+    }
+
+    /// <summary>
+    /// Resolves the requested type from the source's whole-assembly surface, recovers the
+    /// body-gated async fact for its methods, and composes the neutral projection. Throws when
+    /// the type cannot be found.
+    /// </summary>
+    public static TypeProjectionResult ProjectType(TypeProjectionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var surface = request.Source.ExtractApiSurface(includeAll: !request.PublicOnly);
+        var type = ResolveType(surface, request.Type)
+            ?? throw new InvalidOperationException(
+                $"Type '{request.Type}' was not found in '{request.Source.AssemblyName}'.");
+
+        if (request.Composition)
+            EnrichAsync(request.Source, type);
+
+        var options = new TypeProjectionOptions(request.PublicOnly, request.Composition, request.RelationshipGraph);
+        var result = ProjectType(type, surface, options);
+        return result with { Identity = result.Identity with { Assembly = request.Source.AssemblyName } };
+    }
+
+    static string? SelectBaseType(ApiType type)
+        => !string.IsNullOrEmpty(type.BaseType)
+            && type.BaseType != "System.Object"
+            && type.BaseType != "System.ValueType"
+            && type.BaseType != "System.Enum"
+            ? type.BaseType
+            : null;
+
+    static TypeCompositionView BuildComposition(ApiType type)
+    {
+        var members = type.Members;
+        return new TypeCompositionView(
+            Methods: members.Count(m => m.Kind == "method"),
+            Properties: members.Count(m => m.Kind == "property"),
+            // Enum members are `field`-kind with a value; exclude them from the field count to
+            // match the CLI's existing type stats (they surface as enum values instead).
+            Fields: members.Count(m => m.Kind == "field" && !m.EnumValue.HasValue),
+            Events: members.Count(m => m.Kind == "event"),
+            Constructors: members.Count(m => m.Kind == "constructor"),
+            Operators: members.Count(m => m.Kind == "operator"),
+            ExplicitInterfaceImplementations: members.Count(m => m.Kind == "explicit-interface-implementation"),
+            ExtensionMethods: members.Count(m => m.Kind == "extension-method"),
+            Static: members.Count(m => m.IsStatic),
+            Unsafe: members.Count(m => m.IsUnsafe),
+            Async: members.Count(m => m.IsAsync),
+            Virtual: members.Count(m => m.IsVirtual),
+            Abstract: members.Count(m => m.IsAbstract),
+            Override: members.Count(m => m.IsOverride),
+            Extension: members.Count(m => m.IsExtension),
+            Obsolete: members.Count(m => m.IsObsolete),
+            Total: members.Count);
+    }
+
+    static TypeRelationshipGraph BuildRelationshipGraph(
+        ApiType type,
+        string? baseType,
+        IReadOnlyList<string> interfaces,
+        IReadOnlyList<string> derivedTypes)
+    {
+        List<TypeRelationshipNode> nodes = [];
+        List<TypeRelationshipEdge> edges = [];
+        HashSet<string> seen = new(StringComparer.Ordinal);
+        var selfId = type.FullName;
+
+        void AddNode(string id, TypeRelationshipRole role)
+        {
+            if (seen.Add(id))
+                nodes.Add(new TypeRelationshipNode(id, id, role));
+        }
+
+        AddNode(selfId, TypeRelationshipRole.Self);
+
+        if (baseType is not null)
+        {
+            AddNode(baseType, TypeRelationshipRole.Base);
+            edges.Add(new TypeRelationshipEdge(selfId, baseType, TypeRelationshipKind.Inherits));
+        }
+
+        foreach (var iface in interfaces)
+        {
+            AddNode(iface, TypeRelationshipRole.Interface);
+            edges.Add(new TypeRelationshipEdge(selfId, iface, TypeRelationshipKind.Implements));
+        }
+
+        foreach (var derived in derivedTypes)
+        {
+            AddNode(derived, TypeRelationshipRole.Derived);
+            edges.Add(new TypeRelationshipEdge(derived, selfId, TypeRelationshipKind.DerivedFrom));
+        }
+
+        return new TypeRelationshipGraph(nodes, edges);
+    }
+
+    static void EnrichAsync(MetadataSource source, ApiType type)
+    {
+        foreach (var member in type.Members)
+        {
+            if (member.MetadataToken is { } token && source.ClassifyAsync(token) is not null)
+                member.IsAsync = true;
+        }
+    }
+
+    static ApiType? ResolveType(ApiSurface surface, string typeName)
+    {
+        foreach (var type in surface.Types)
+            if (string.Equals(type.FullName, typeName, StringComparison.Ordinal))
+                return type;
+
+        foreach (var type in surface.Types)
+            if (string.Equals(type.MetadataName, typeName, StringComparison.Ordinal))
+                return type;
+
+        foreach (var type in surface.Types)
+            if (string.Equals(type.FullName, typeName, StringComparison.OrdinalIgnoreCase))
+                return type;
+
+        return null;
+    }
+}

--- a/src/ILInspector.Research/ResearchTypeViews.cs
+++ b/src/ILInspector.Research/ResearchTypeViews.cs
@@ -108,8 +108,9 @@ public static partial class ResearchViews
 
     /// <summary>
     /// A <see cref="MetadataSource"/>-backed projection request, parallel to
-    /// <see cref="MemberProjectionRequest"/>. Resolves the type from the source's whole-assembly
-    /// surface (also used for the derived-type scan) and recovers the body-gated async fact.
+    /// <see cref="MemberProjectionRequest"/>. Resolves the type by exact <c>FullName</c> from the
+    /// source's whole-assembly surface (also used for the derived-type scan) and recovers the
+    /// body-gated async fact.
     /// </summary>
     public sealed record TypeProjectionRequest(
         MetadataSource Source,
@@ -119,6 +120,13 @@ public static partial class ResearchViews
         bool RelationshipGraph = true);
 
     /// <summary>The composed, presentation-neutral type view.</summary>
+    /// <param name="InspectionFailures">
+    /// Metadata rows the surface extractor rejected and excluded from the projected relationships
+    /// (a non-empty list means the derived-type/relationship view may be incomplete). The CLI
+    /// surfaces these independently at the command layer, but a front end that consumes this seam
+    /// directly (e.g. the WASM web UI) relies on this list so incompleteness is never rendered as
+    /// success-shaped complete output. Empty when no surface was supplied or none were rejected.
+    /// </param>
     public sealed record TypeProjectionResult(
         TypeIdentityView Identity,
         string? BaseType,
@@ -128,7 +136,8 @@ public static partial class ResearchViews
         IReadOnlyList<string> Attributes,
         string? EnumUnderlyingType,
         TypeCompositionView? Composition,
-        TypeRelationshipGraph? Graph);
+        TypeRelationshipGraph? Graph,
+        IReadOnlyList<ApiSurfaceInspectionFailure> InspectionFailures);
 
     /// <summary>
     /// The C#-appropriate modifier keywords for a type, in declaration order
@@ -200,7 +209,8 @@ public static partial class ResearchViews
             type.Attributes.ToList(),
             type.EnumUnderlyingType,
             composition,
-            graph);
+            graph,
+            surface?.InspectionFailures.ToList() ?? []);
     }
 
     /// <summary>
@@ -309,16 +319,13 @@ public static partial class ResearchViews
 
     static ApiType? ResolveType(ApiSurface surface, string typeName)
     {
+        // Exact full-name match only, mirroring the product's canonical type resolver
+        // (IrImporter.ResolveMethodHandle compares against reader.GetFullTypeName). FullName is
+        // unique within a surface, so this cannot silently pick the wrong type the way a
+        // namespace-less or case-insensitive fallback could when two types collide on a simpler
+        // key. A not-found returns null; the caller turns that into a visible throw.
         foreach (var type in surface.Types)
             if (string.Equals(type.FullName, typeName, StringComparison.Ordinal))
-                return type;
-
-        foreach (var type in surface.Types)
-            if (string.Equals(type.MetadataName, typeName, StringComparison.Ordinal))
-                return type;
-
-        foreach (var type in surface.Types)
-            if (string.Equals(type.FullName, typeName, StringComparison.OrdinalIgnoreCase))
                 return type;
 
         return null;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -332,12 +332,17 @@ public static class ApiOutputFormatter
             ? $" ({packageName} {packageVersion})"
             : packageName != null ? $" ({packageName})" : "";
 
-        var modifiers = BuildTypeModifiers(type);
+        // One source of truth for type-level modifiers, base type, and interface ordering: the
+        // presentation-neutral projection in ILInspector.Research. C# constraint spelling for
+        // type parameters stays in this layer (ConstraintSummary) because Research is Roslyn-free
+        // and does not own C# rendering.
+        var projection = ILInspector.Research.ResearchViews.ProjectType(
+            type,
+            surface: null,
+            new ILInspector.Research.ResearchViews.TypeProjectionOptions(Composition: false, RelationshipGraph: false));
 
-        // Base type (filter out trivial bases)
-        string? baseType = null;
-        if (!string.IsNullOrEmpty(type.BaseType) && type.BaseType != "System.Object" && type.BaseType != "System.ValueType" && type.BaseType != "System.Enum")
-            baseType = type.BaseType;
+        var modifiers = projection.Identity.Modifiers;
+        string? baseType = projection.BaseType;
 
         // Type parameters inline (Quiet only — at Minimal+ the section replaces this)
         string? typeParamsInline = null;
@@ -373,7 +378,7 @@ public static class ApiOutputFormatter
         List<InterfaceRow>? interfaceRows = null;
         if (!memberFilterActive && type.Interfaces.Count > 0)
         {
-            interfaceRows = type.Interfaces.Order()
+            interfaceRows = projection.Interfaces
                 .Select(i => new InterfaceRow { Interface = i })
                 .ToList();
         }
@@ -585,7 +590,7 @@ public static class ApiOutputFormatter
             }
         }
 
-        var modifiers = BuildTypeModifiers(type);
+        var modifiers = ILInspector.Research.ResearchViews.TypeModifiers(type);
 
         var packageInfo = packageName != null && packageVersion != null
             ? $" ({packageName} {packageVersion})"
@@ -610,24 +615,6 @@ public static class ApiOutputFormatter
     // unavailable (see CSharpDeclarationWriter.FormatConstraintList).
     private static string ConstraintSummary(IReadOnlyList<TypeParameter> typeParameters, TypeParameter typeParameter)
         => CSharpFormatter.FormatTypeParameterConstraints(typeParameter, typeParameters.Select(p => p.Name));
-
-    private static List<string> BuildTypeModifiers(ApiType type)
-    {
-        List<string> modifiers = [];
-        if (type.IsStatic)
-        {
-            modifiers.Add("static");
-        }
-        else
-        {
-            if (type.IsAbstract && type.Kind == "class") modifiers.Add("abstract");
-            if (type.IsSealed && type.Kind == "class") modifiers.Add("sealed");
-        }
-
-        if (type.IsReadOnly && type.Kind == "struct") modifiers.Add("readonly");
-        if (type.IsByRefLike && type.Kind == "struct") modifiers.Add("ref");
-        return modifiers;
-    }
 
     // ===== Internal Rendering Methods =====
 


### PR DESCRIPTION
## What & why

Closes #3206. Introduces `ResearchViews.ProjectType(...)` — a presentation-neutral, type-level projection seam in `ILInspector.Research` that mirrors the existing member-level `ProjectMember` seam. Every front end (the CLI's Markdown/terminal renderer and the deferred WASM web UI) can now compose type identity, base/interface/derived relationships, type parameters, attributes, enum underlying type, member composition counts, and a **structured** relationship graph from one source of truth instead of re-deriving them.

**Scope (this PR): seam + CLI parity.** New CLI profile/graph sections and the WASM engine refactor are deferred to follow-ups.

## Changes

- **`src/ILInspector.Research/ResearchTypeViews.cs`** (new): neutral records (`TypeIdentityView`, `TypeParameterView`, `TypeCompositionView`, `TypeRelationshipNode/Edge/Graph`, `TypeProjectionOptions/Request/Result`), a public `TypeModifiers(ApiType)` helper, and two `ProjectType` overloads:
  - core `ProjectType(ApiType, ApiSurface?, options)` — pure composition from already-extracted facts; derived-type scan runs only when a surface is supplied.
  - `ProjectType(TypeProjectionRequest)` — extracts the whole-assembly surface via `MetadataSource`, resolves the type, recovers the body-gated async fact, then composes.
  - The relationship graph is a **structured node/role/edge model, not a baked Mermaid string** (per `docs/design/call-graph-mermaid-projection.md`).
- **`src/ILInspector.Decompiler/Pipeline/MetadataSource.cs`**: additive `ExtractApiSurface(...)` and `ClassifyAsync(token)` so the request path reuses the already-open PE image and recovers async (`ApiMember.IsAsync` is deliberately unpopulated by surface extraction — `docs/design/member-body-substrate.md`).
- **`src/dotnet-inspect/Output/ApiOutputFormatter.cs`**: `BuildTypeView`/`BuildShapeView` now consume the projection for type modifiers, base-type filtering, and interface ordering; the private `BuildTypeModifiers` helper is removed. **`api` output is unchanged.** C# constraint spelling stays in the CLI (`ConstraintSummary`) because Research is Roslyn-free.

## Layering

`ILInspector.Research` references Metadata + Decompiler (reaches `ApiType`, `ApiSurfaceExtractor`, `MetadataSource`) but **not** `ILInspector.CSharp`; the projection carries only neutral raw constraint strings, and C# rendering stays in the CLI.

## Evidence

- `ILInspector.Research.Tests`: **123 passed** (9 new in `ResearchTypeViewsTests`, covering modifiers, base/interface/derived relationships, the neutral graph, generic constraints, enum underlying type, ref/readonly struct modifiers, composition counts, and async recovery via the request path; core-does-not-invent-async negative case; unknown-type throw).
- `dotnet-inspect.Tests` (`ApiOutputFormatterTests` + `OutputFormatterTests` + `CSharpDeclarationFormatterTests`): **155 passed, 1 skipped** (ilasm unavailable), confirming `api` parity.
- Rebased onto latest `origin/main`; rebuilt and re-ran both suites green.

## Follow-ups (deferred)

- New CLI type profile/relationship-graph sections consuming the composition + graph.
- WASM `inspect-web` engine refactor onto the same seam.

Adversarial review to follow per `AGENTS.md` (non-trivial new shape).
