### PR TITLE
RTS: reconstruct single-member external explicit-interface methods (#3112, Increment 1)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1402,6 +1402,53 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    // Regression for #3112 review (unrepresentable interface name): a hand-authored external
+    // interface can live in a namespace whose segment is a compiler-unspeakable name (`<Bad>`)
+    // — legal in metadata but not a legal C# identifier. Clean() sanitizes it lossily to a
+    // DIFFERENT identifier (`__Bad_`), so the reconstruction would emit `using __Bad_;` /
+    // `__Bad_.IProbe.M()` referencing a type that does not exist (CS0246 = RecompileFail). The
+    // gate must recognize the name cannot round-trip and decline to the sanitized ContextFail
+    // floor. Uses two IL assemblies (an external contract plus the target) resolved as
+    // siblings.
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceDeclinesWhenNameIsUnrepresentable()
+    {
+        var ilasm = TryLocateIlasm();
+        if (ilasm is null)
+        {
+            Assert.Skip("ilasm not available; skipping hand-authored IL unrepresentable-name regression.");
+            return;
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        AssembleIlFixture(ilasm, UnrepresentableContractsIl, directory, "GeneratedContracts");
+        var assemblyPath = AssembleIlFixture(ilasm, UnrepresentableFixtureIl, directory, "badfixture");
+        try
+        {
+            var target = new ReturnToSender.RequestedTarget("N.Seq", "<Bad>.IProbe.M", 0);
+
+            // All would reconstruct the interface spelling from the lossily-sanitized display
+            // name (`__Bad_.IProbe`), which names no type. The gate must decline rather than
+            // emit a new RecompileFail (CS0246). The name-representability guard is what
+            // catches this; the raw metadata name is not identifier-like.
+            var all = Assert.Single(
+                ReturnToSender.CompileBackTargets(assemblyPath, [target], RoundTripScope.All));
+            Assert.True(
+                all.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"all {all.Status}: {all.Detail}{Environment.NewLine}{all.Source}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
     [Fact]
     public void CompileBackTargets_MultiMemberExternalExplicitInterfaceFallsBackWithoutRecompileFail()
     {
@@ -7618,6 +7665,48 @@ public class ReturnToSenderPrototypeTests
         .class public auto ansi sealed beforefieldinit N.'class'
             extends [System.Runtime]System.Object
         {
+          .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+          {
+            ldarg.0
+            call instance void [System.Runtime]System.Object::.ctor()
+            ret
+          }
+        }
+        """;
+
+    // External contract for the unrepresentable-name regression: an interface whose namespace
+    // segment is a compiler-unspeakable name (`<Bad>`) — legal in metadata, not a legal C#
+    // identifier — so Clean() sanitizes it lossily to a different name (`__Bad_`).
+    const string UnrepresentableContractsIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly GeneratedContracts { }
+        .module GeneratedContracts.dll
+
+        .class interface public abstract auto ansi '<Bad>'.IProbe
+        {
+          .method public hidebysig newslot abstract virtual instance void M() cil managed {}
+        }
+        """;
+
+    // Target for the unrepresentable-name regression: N.Seq explicitly implements the external
+    // `<Bad>.IProbe`. The reconstruction would emit the sanitized `__Bad_.IProbe`, which names
+    // no real type (CS0246) — the gate must decline to the sanitized ContextFail floor instead.
+    const string UnrepresentableFixtureIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly extern GeneratedContracts { }
+        .assembly badfixture { }
+        .module badfixture.dll
+
+        .class public auto ansi sealed beforefieldinit N.Seq
+            extends [System.Runtime]System.Object
+            implements [GeneratedContracts]'<Bad>'.IProbe
+        {
+          .method private final hidebysig newslot virtual
+              instance void '<Bad>.IProbe.M'() cil managed
+          {
+            .override [GeneratedContracts]'<Bad>'.IProbe::M
+            ret
+          }
           .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
           {
             ldarg.0

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1576,6 +1576,57 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithInternalMemberFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: a PUBLIC interface may still declare a NON-public member (C# 8+
+        // allows explicit accessibility on interface members). The interface type passes the
+        // IsPubliclyAccessible gate, but the reconstructed assembly
+        // ("return-to-sender-source-oracle") is not granted InternalsVisibleTo, so it cannot
+        // name the internal member even though the target implements it via IVT to its own name.
+        // Engaging would emit `void RtsVis.IProbe.M()` against a member the recompile cannot see
+        // (CS0122 = RecompileFail). The gate must decline any non-public required method and keep
+        // the sanitized ContextFail floor.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            """
+            using System.Runtime.CompilerServices;
+            [assembly: InternalsVisibleTo("fixture")]
+            namespace RtsVis { public interface IProbe { internal abstract void M(); } }
+            """,
+            directory: fixtureDir,
+            assemblyName: "RtsVisContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class VisImpl : RtsVis.IProbe
+            {
+                void RtsVis.IProbe.M() { }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "VisImpl",
+                    "RtsVis.IProbe.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsVis_IProbe_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsVis.IProbe.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_ExternalExplicitInterfaceWithGenericParameterDriftFallsBackWithoutRecompileFail()
     {
         // Regression guard: SignatureDecoder spells generic method parameters by their metadata

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1233,6 +1233,60 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    // Close-negative for the shadow-decline (#3112 review): a compiler-authored sibling whose
+    // simple name matches a *middle* segment of the interface spelling
+    // (`N.Collections` vs `System.Collections.IEnumerable`) must NOT trigger a decline. The
+    // explicit-member qualifier is emitted fully qualified (`System.Collections.IEnumerable.
+    // GetEnumerator`, leading `System`) and the base-list entry is shortened to the bare type
+    // name (`IEnumerable`); the middle `Collections` never appears in leading position, so the
+    // reconstruction stays compilable. Under RoundTripScope.All the sibling `N.Collections` is
+    // reconstructed alongside the real explicit impl and the whole shape must round-trip Exact,
+    // not fall back to the sanitized `System_Collections_IEnumerable_GetEnumerator` floor.
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceKeepsExactWhenClosureSiblingMatchesMiddleSegment()
+    {
+        var assemblyPath = CompileFixture("""
+            namespace N;
+            public sealed class Collections { }
+            public sealed class Seq : System.Collections.IEnumerable
+            {
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+                {
+                    throw null;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "N.Seq",
+                    "System.Collections.IEnumerable.GetEnumerator",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "System.Collections.IEnumerable.GetEnumerator()",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "System_Collections_IEnumerable_GetEnumerator",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.Contains("class Collections", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     // Regression for #3112 review: a hand-authored IL assembly can carry a *clean*
     // explicit-interface metadata name (`System.Collections.IEnumerable.GetEnumerator`)
     // while also declaring a sibling type `N.System` that shadows the `System` namespace

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1424,6 +1424,63 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithByRefKindDriftFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: a decoded-signature string cannot distinguish by-ref kinds.
+        // SignatureDecoder renders `ref T`, `out T`, and `in T` identically as "ref T", so a
+        // name + arity + decoded-string gate would treat `void M(ref int)` and
+        // `void M(out int)` as equal. The target here is compiled against a reference
+        // interface method `void M(ref int)`, but the copy resolved at reconstruction time
+        // (the sibling on disk) declares `void M(out int)`. Engaging would emit
+        // `void RtsRef.IProbe.M(ref int)`, which binds to no member of the resolved
+        // interface (CS0539 = RecompileFail). The gate must decline any signature carrying
+        // by-ref detail and keep the sanitized ContextFail floor.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referenceDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        // Reference build the target compiles against: M takes a ref int.
+        var referencePath = CompileFixture(
+            "namespace RtsRef { public interface IProbe { void M(ref int value); } }",
+            directory: referenceDir,
+            assemblyName: "RtsRefContracts");
+        // Drifted build placed next to the target: same type, but M takes an out int.
+        CompileFixture(
+            "namespace RtsRef { public interface IProbe { void M(out int value); } }",
+            directory: fixtureDir,
+            assemblyName: "RtsRefContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class RefImpl : RtsRef.IProbe
+            {
+                void RtsRef.IProbe.M(ref int value) => value = 0;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(referencePath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "RefImpl",
+                    "RtsRef.IProbe.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsRef_IProbe_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsRef.IProbe.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (Directory.Exists(referenceDir))
+                Directory.Delete(referenceDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericExplicitInterfaceMethod()
     {
         // A generic method on a non-generic interface implemented explicitly keeps its method

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1447,6 +1447,91 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    // Regression for #3112 review (format-character member name): a hand-authored external
+    // interface method name can carry a Unicode format character (U+200C) that is
+    // identifier-like yet does NOT round-trip — Roslyn strips format characters when binding,
+    // so the emitted `Good.IProbe.M\u200C()` binds to `Good.IProbe.M`, which the interface
+    // (declaring the raw `M\u200C`) does not contain (CS0539 = RecompileFail). The member-name
+    // round-trip guard must reject format characters, not merely check identifier-likeness.
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceDeclinesWhenMemberNameHasFormatCharacter()
+    {
+        var ilasm = TryLocateIlasm();
+        if (ilasm is null)
+        {
+            Assert.Skip("ilasm not available; skipping hand-authored IL format-character member regression.");
+            return;
+        }
+
+        const string zwnj = "\u200C";
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        AssembleIlFixture(ilasm, CfMemberContractsIl.Replace("%ZWNJ%", zwnj), directory, "CfContracts");
+        var assemblyPath = AssembleIlFixture(
+            ilasm, CfMemberFixtureIl.Replace("%ZWNJ%", zwnj), directory, "cffixture");
+        try
+        {
+            var target = new ReturnToSender.RequestedTarget("N.Seq", $"Good.IProbe.M{zwnj}", 0);
+
+            var all = Assert.Single(
+                ReturnToSender.CompileBackTargets(assemblyPath, [target], RoundTripScope.All));
+            Assert.True(
+                all.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"all {all.Status}: {all.Detail}{Environment.NewLine}{all.Source}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    // Regression for #3112 review (format-character namespace): the same format-character
+    // hazard applies to the interface TYPE name. A namespace segment `G\u200Cood` is
+    // identifier-like but does not round-trip (Roslyn strips U+200C, so the emitted
+    // `G\u200Cood.IProbe` binds to `Good.IProbe`, which does not exist — CS0246). The
+    // interface-name representability guard must reject format characters per segment.
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceDeclinesWhenNamespaceHasFormatCharacter()
+    {
+        var ilasm = TryLocateIlasm();
+        if (ilasm is null)
+        {
+            Assert.Skip("ilasm not available; skipping hand-authored IL format-character namespace regression.");
+            return;
+        }
+
+        const string zwnj = "\u200C";
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        AssembleIlFixture(ilasm, CfNamespaceContractsIl.Replace("%ZWNJ%", zwnj), directory, "CfNsContracts");
+        var assemblyPath = AssembleIlFixture(
+            ilasm, CfNamespaceFixtureIl.Replace("%ZWNJ%", zwnj), directory, "cfnsfixture");
+        try
+        {
+            var target = new ReturnToSender.RequestedTarget("N.Seq", $"G{zwnj}ood.IProbe.M", 0);
+
+            var all = Assert.Single(
+                ReturnToSender.CompileBackTargets(assemblyPath, [target], RoundTripScope.All));
+            Assert.True(
+                all.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"all {all.Status}: {all.Detail}{Environment.NewLine}{all.Source}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
     // Regression for #3112 review (unrepresentable interface name): a hand-authored external
     // interface can live in a namespace whose segment is a compiler-unspeakable name (`<Bad>`)
     // — legal in metadata but not a legal C# identifier. Clean() sanitizes it lossily to a
@@ -7792,6 +7877,82 @@ public class ReturnToSenderPrototypeTests
               instance void 'Good.IProbe.<Bad>'() cil managed
           {
             .override [BadMethodContracts]Good.IProbe::'<Bad>'
+            ret
+          }
+          .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+          {
+            ldarg.0
+            call instance void [System.Runtime]System.Object::.ctor()
+            ret
+          }
+        }
+        """;
+
+    // External contract for the format-character regressions: the `%ZWNJ%` placeholder is
+    // replaced with U+200C (a Unicode format character) at test time. Roslyn strips format
+    // characters when binding identifiers, so a member name `M\u200C` binds as `M` — a name
+    // that is identifier-like yet does not round-trip. Interface variant: namespace `G\u200Cood`.
+    const string CfMemberContractsIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly CfContracts { }
+        .module CfContracts.dll
+
+        .class interface public abstract auto ansi Good.IProbe
+        {
+          .method public hidebysig newslot abstract virtual instance void 'M%ZWNJ%'() cil managed {}
+        }
+        """;
+
+    const string CfMemberFixtureIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly extern CfContracts { }
+        .assembly cffixture { }
+        .module cffixture.dll
+
+        .class public auto ansi sealed beforefieldinit N.Seq
+            extends [System.Runtime]System.Object
+            implements [CfContracts]Good.IProbe
+        {
+          .method private final hidebysig newslot virtual
+              instance void 'Good.IProbe.M%ZWNJ%'() cil managed
+          {
+            .override [CfContracts]Good.IProbe::'M%ZWNJ%'
+            ret
+          }
+          .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+          {
+            ldarg.0
+            call instance void [System.Runtime]System.Object::.ctor()
+            ret
+          }
+        }
+        """;
+
+    const string CfNamespaceContractsIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly CfNsContracts { }
+        .module CfNsContracts.dll
+
+        .class interface public abstract auto ansi 'G%ZWNJ%ood'.IProbe
+        {
+          .method public hidebysig newslot abstract virtual instance void M() cil managed {}
+        }
+        """;
+
+    const string CfNamespaceFixtureIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly extern CfNsContracts { }
+        .assembly cfnsfixture { }
+        .module cfnsfixture.dll
+
+        .class public auto ansi sealed beforefieldinit N.Seq
+            extends [System.Runtime]System.Object
+            implements [CfNsContracts]'G%ZWNJ%ood'.IProbe
+        {
+          .method private final hidebysig newslot virtual
+              instance void 'G%ZWNJ%ood.IProbe.M'() cil managed
+          {
+            .override [CfNsContracts]'G%ZWNJ%ood'.IProbe::M
             ret
           }
           .method public hidebysig specialname rtspecialname instance void .ctor() cil managed

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1354,6 +1354,54 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    // Regression for #3112 review (escaped-identifier shadow): a hand-authored external
+    // interface can live in a namespace whose segment is a C# keyword (`class`), so its raw
+    // metadata full name is `class.IProbe` but its C# display name is `@class.IProbe`. A
+    // sibling type `N.class` (raw) is emitted as `class @class` and shadows the `@class` root
+    // of the spelling under RoundTripScope.All (CS0426). The shadow check must compare the
+    // leading segment against the raw metadata name (`class`), not the escaped display name
+    // (`@class`) — otherwise the collision is missed and a new RecompileFail escapes. The gate
+    // must decline to the sanitized ContextFail floor. Uses two IL assemblies (an external
+    // contract plus the target) resolved as siblings.
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceDeclinesWhenKeywordNamespaceSiblingShadowsSpelling()
+    {
+        var ilasm = TryLocateIlasm();
+        if (ilasm is null)
+        {
+            Assert.Skip("ilasm not available; skipping hand-authored IL keyword-shadow regression.");
+            return;
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        AssembleIlFixture(ilasm, KeywordContractsIl, directory, "KeywordContracts");
+        var assemblyPath = AssembleIlFixture(ilasm, KeywordShadowFixtureIl, directory, "keywordfixture");
+        try
+        {
+            var target = new ReturnToSender.RequestedTarget("N.Seq", "class.IProbe.M", 0);
+
+            // All reconstructs the sibling N.class (emitted `class @class`), which shadows the
+            // escaped `@class` root of the spelling. The gate must decline to the sanitized
+            // shape rather than emit a new RecompileFail (CS0426). The raw-metadata-name
+            // comparison is what catches this; the escaped display name would miss it.
+            var all = Assert.Single(
+                ReturnToSender.CompileBackTargets(assemblyPath, [target], RoundTripScope.All));
+            Assert.True(
+                all.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"all {all.Status}: {all.Detail}{Environment.NewLine}{all.Source}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
     [Fact]
     public void CompileBackTargets_MultiMemberExternalExplicitInterfaceFallsBackWithoutRecompileFail()
     {
@@ -7523,6 +7571,58 @@ public class ReturnToSenderPrototypeTests
               call instance void [System.Runtime]System.Object::.ctor()
               ret
             }
+          }
+        }
+        """;
+
+    // External contract for the keyword-namespace shadow regression: an interface in a
+    // namespace whose segment is the C# keyword `class` (raw metadata `class.IProbe`).
+    const string KeywordContractsIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly KeywordContracts { }
+        .module KeywordContracts.dll
+
+        .class interface public abstract auto ansi 'class'.IProbe
+        {
+          .method public hidebysig newslot abstract virtual instance void M() cil managed {}
+        }
+        """;
+
+    // Target for the keyword-namespace shadow regression: N.Seq explicitly implements the
+    // external `class.IProbe` with a clean metadata override name (`class.IProbe.M`), and a
+    // sibling type N.'class' shadows the `class` root of the spelling once reconstructed.
+    const string KeywordShadowFixtureIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly extern KeywordContracts { }
+        .assembly keywordfixture { }
+        .module keywordfixture.dll
+
+        .class public auto ansi sealed beforefieldinit N.Seq
+            extends [System.Runtime]System.Object
+            implements [KeywordContracts]'class'.IProbe
+        {
+          .method private final hidebysig newslot virtual
+              instance void 'class.IProbe.M'() cil managed
+          {
+            .override [KeywordContracts]'class'.IProbe::M
+            ret
+          }
+          .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+          {
+            ldarg.0
+            call instance void [System.Runtime]System.Object::.ctor()
+            ret
+          }
+        }
+
+        .class public auto ansi sealed beforefieldinit N.'class'
+            extends [System.Runtime]System.Object
+        {
+          .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+          {
+            ldarg.0
+            call instance void [System.Runtime]System.Object::.ctor()
+            ret
           }
         }
         """;

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1319,6 +1319,111 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithSignatureDriftFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: the external explicit-interface gate must compare full
+        // signatures, not just name + generic arity. The target is compiled against a
+        // reference interface method `int M(int)`, but the copy of that interface resolved
+        // at reconstruction time (the sibling on disk) declares `int M(string)`. A
+        // name+arity-only gate would engage and emit `int RtsDrift.IProbe.M(int)`, which
+        // binds to no member of the resolved interface (CS0539 = RecompileFail). The gate
+        // must decline and keep the sanitized ContextFail floor.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referenceDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        // Reference build the target compiles against: M takes an int.
+        var referencePath = CompileFixture(
+            "namespace RtsDrift { public interface IProbe { int M(int value); } }",
+            directory: referenceDir,
+            assemblyName: "RtsDriftContracts");
+        // Drifted build placed next to the target: same type, but M takes a string.
+        CompileFixture(
+            "namespace RtsDrift { public interface IProbe { int M(string value); } }",
+            directory: fixtureDir,
+            assemblyName: "RtsDriftContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class DriftImpl : RtsDrift.IProbe
+            {
+                int RtsDrift.IProbe.M(int value) => value;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(referencePath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "DriftImpl",
+                    "RtsDrift.IProbe.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsDrift_IProbe_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsDrift.IProbe.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (Directory.Exists(referenceDir))
+                Directory.Delete(referenceDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithAmbiguousDefinitionFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: the reconstructed base list names the interface by display name
+        // only, with no extern alias, so it must be defined by exactly one assembly across
+        // the recompile closure. Here two sibling assemblies both define `RtsDup.IShape`.
+        // Engaging would emit `: RtsDup.IShape`, which the recompile cannot disambiguate
+        // (CS0433 = RecompileFail). The gate must decline and keep the sanitized floor.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        const string interfaceSource =
+            "namespace RtsDup { public interface IShape { int M(int value); } }";
+        var primaryPath = CompileFixture(
+            interfaceSource,
+            directory: fixtureDir,
+            assemblyName: "RtsDupPrimary");
+        CompileFixture(
+            interfaceSource,
+            directory: fixtureDir,
+            assemblyName: "RtsDupSecondary");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class DupImpl : RtsDup.IShape
+            {
+                int RtsDup.IShape.M(int value) => value;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(primaryPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "DupImpl",
+                    "RtsDup.IShape.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsDup_IShape_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsDup.IShape.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericExplicitInterfaceMethod()
     {
         // A generic method on a non-generic interface implemented explicitly keeps its method

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1233,6 +1233,66 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    // Regression for #3112 review: a hand-authored IL assembly can carry a *clean*
+    // explicit-interface metadata name (`System.Collections.IEnumerable.GetEnumerator`)
+    // while also declaring a sibling type `N.System` that shadows the `System` namespace
+    // root of that spelling. No conformant C# compiler can emit this shape — a shadowing
+    // sibling forces `global::` into the explicit override's metadata name, which the gate
+    // declines — but IL is not bound by that rule. Under RoundTripScope.All the sibling is
+    // reconstructed into namespace N, so the unrooted `System.Collections.IEnumerable`
+    // spelling binds to the sibling (CS0426). The gate must decline to the sanitized shape
+    // rather than introduce that new RecompileFail. Under RoundTripScope.Cluster the sibling
+    // is not reconstructed, so engagement must be preserved (round-trips Exact): the decline
+    // is scope-aware, not a blanket stand-down.
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceDeclinesWhenClosureSiblingShadowsSpelling()
+    {
+        var ilasm = TryLocateIlasm();
+        if (ilasm is null)
+        {
+            Assert.Skip("ilasm not available; skipping hand-authored IL shadow regression.");
+            return;
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var assemblyPath = AssembleIlFixture(ilasm, ShadowingSiblingIl, directory, "shadowrepro");
+        try
+        {
+            var target = new ReturnToSender.RequestedTarget(
+                "N.Seq",
+                "System.Collections.IEnumerable.GetEnumerator",
+                0);
+
+            // Cluster does not reconstruct the shadowing sibling N.System, so the external
+            // explicit-interface reconstruction engages and round-trips Exact.
+            var cluster = Assert.Single(
+                ReturnToSender.CompileBackTargets(assemblyPath, [target], RoundTripScope.Cluster));
+            Assert.True(
+                cluster.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"cluster {cluster.Status}: {cluster.Detail}");
+
+            // All reconstructs N.System, which shadows the `System` root of the spelling.
+            // The gate must decline to the sanitized shape (the pre-#3112 ContextFail floor)
+            // rather than emit a new RecompileFail (CS0426). Strictly better or identical,
+            // never worse.
+            var all = Assert.Single(
+                ReturnToSender.CompileBackTargets(assemblyPath, [target], RoundTripScope.All));
+            Assert.True(
+                all.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"all {all.Status}: {all.Detail}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
     [Fact]
     public void CompileBackTargets_MultiMemberExternalExplicitInterfaceFallsBackWithoutRecompileFail()
     {
@@ -7360,6 +7420,118 @@ public class ReturnToSenderPrototypeTests
         var image = new BlobBuilder();
         pe.Serialize(image);
         return image.ToArray();
+    }
+
+    // Hand-authored IL exercising the shadowing-sibling regression: a class with a clean
+    // explicit-interface metadata name for System.Collections.IEnumerable.GetEnumerator plus
+    // a sibling type `N.System` in the same namespace. Assembled with ilasm because no C#
+    // compiler can produce a clean explicit-override name alongside an in-scope shadow.
+    const string ShadowingSiblingIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly shadowrepro { }
+        .module shadowrepro.dll
+
+        .namespace N
+        {
+          .class public auto ansi sealed beforefieldinit Seq
+              extends [System.Runtime]System.Object
+              implements [System.Runtime]System.Collections.IEnumerable
+          {
+            .method private hidebysig newslot virtual final
+                instance class [System.Runtime]System.Collections.IEnumerator
+                'System.Collections.IEnumerable.GetEnumerator'() cil managed
+            {
+              .override [System.Runtime]System.Collections.IEnumerable::GetEnumerator
+              ldnull
+              throw
+            }
+            .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+            {
+              ldarg.0
+              call instance void [System.Runtime]System.Object::.ctor()
+              ret
+            }
+          }
+
+          .class public auto ansi sealed beforefieldinit System
+              extends [System.Runtime]System.Object
+          {
+            .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+            {
+              ldarg.0
+              call instance void [System.Runtime]System.Object::.ctor()
+              ret
+            }
+          }
+        }
+        """;
+
+    // Locates a usable ilasm: an ILASM_PATH override, then PATH, then the restored
+    // runtime.<rid>.microsoft.netcore.ilasm NuGet package cache. Returns null when none is
+    // available so the caller can skip.
+    static string? TryLocateIlasm()
+    {
+        string exe = OperatingSystem.IsWindows() ? "ilasm.exe" : "ilasm";
+
+        var overridePath = Environment.GetEnvironmentVariable("ILASM_PATH");
+        if (!string.IsNullOrEmpty(overridePath) && File.Exists(overridePath))
+            return overridePath;
+
+        foreach (var dir in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
+        {
+            if (dir.Length == 0)
+                continue;
+            var candidate = Path.Combine(dir, exe);
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        var nuget = Environment.GetEnvironmentVariable("NUGET_PACKAGES")
+            ?? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".nuget",
+                "packages");
+        if (Directory.Exists(nuget))
+        {
+            foreach (var pkg in Directory.EnumerateDirectories(nuget)
+                .Where(d => Path.GetFileName(d).Contains("microsoft.netcore.ilasm", StringComparison.OrdinalIgnoreCase)))
+            {
+                var hit = Directory.EnumerateFiles(pkg, exe, SearchOption.AllDirectories).FirstOrDefault();
+                if (hit is not null)
+                    return hit;
+            }
+        }
+
+        return null;
+    }
+
+    static string AssembleIlFixture(string ilasm, string il, string directory, string assemblyName)
+    {
+        Directory.CreateDirectory(directory);
+        var ilPath = Path.Combine(directory, assemblyName + ".il");
+        var dllPath = Path.Combine(directory, assemblyName + ".dll");
+        File.WriteAllText(ilPath, il);
+
+        var psi = new System.Diagnostics.ProcessStartInfo(ilasm)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        psi.ArgumentList.Add(ilPath);
+        psi.ArgumentList.Add("-dll");
+        psi.ArgumentList.Add("-output=" + dllPath);
+
+        using var process = System.Diagnostics.Process.Start(psi)!;
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(
+            File.Exists(dllPath),
+            $"ilasm did not produce an assembly:{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
+        return dllPath;
     }
 
     static string CompileFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 namespace ILInspector.Decompiler.Tests;
@@ -1673,6 +1674,64 @@ public class ReturnToSenderPrototypeTests
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains("RtsObs_IProbe_M", result.Source, StringComparison.Ordinal);
             Assert.DoesNotContain("RtsObs.IProbe.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (Directory.Exists(referenceDir))
+                Directory.Delete(referenceDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithCompilerFeatureRequiredInterfaceFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: naming the interface in the reconstructed base list (`: N.IProbe`)
+        // forces the recompile to bind to it, which demands every feature the interface requires
+        // via [CompilerFeatureRequired]. If the resolved interface carries an unsatisfiable feature
+        // marker, binding it is a hard CS9041, turning the sanitized ContextFail floor (which never
+        // names the interface, so never triggers the requirement) into a RecompileFail. This
+        // attribute is not emittable from C# source (CS8335), so the poison sibling is authored
+        // directly as metadata: a target built against a clean single-member interface, whose
+        // sibling resolved at reconstruction demands an unknown compiler feature.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referenceDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referencePath = CompileFixture(
+            "namespace RtsCfr { public interface IProbe { void M(); } }",
+            directory: referenceDir,
+            assemblyName: "RtsCfrContracts");
+        Directory.CreateDirectory(fixtureDir);
+        File.WriteAllBytes(
+            Path.Combine(fixtureDir, "RtsCfrContracts.dll"),
+            BuildCompilerFeatureRequiredInterfaceImage(
+                assemblyName: "RtsCfrContracts",
+                namespaceName: "RtsCfr",
+                typeName: "IProbe",
+                methodName: "M"));
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class CfrImpl : RtsCfr.IProbe
+            {
+                void RtsCfr.IProbe.M() { }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(referencePath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "CfrImpl",
+                    "RtsCfr.IProbe.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsCfr_IProbe_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsCfr.IProbe.M", result.Source, StringComparison.Ordinal);
         }
         finally
         {
@@ -7201,6 +7260,106 @@ public class ReturnToSenderPrototypeTests
         {
             DeleteFixture(assemblyPath);
         }
+    }
+
+    // Emits a loadable IL-only assembly containing a single-member public interface whose type
+    // definition carries [CompilerFeatureRequired("<unknown feature>")]. The attribute is not
+    // authorable from C# source (CS8335 even when self-defined), so it is written directly as
+    // metadata: a TypeReference to the real corelib CompilerFeatureRequiredAttribute, a
+    // MemberReference to its (string) constructor, and a CustomAttribute naming an unknown feature
+    // with IsOptional defaulting to false — the shape a downlevel/hand-authored producer emits and
+    // that raises CS9041 when a consumer binds to the interface.
+    static byte[] BuildCompilerFeatureRequiredInterfaceImage(
+        string assemblyName,
+        string namespaceName,
+        string typeName,
+        string methodName)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString($"{assemblyName}.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(assemblyName),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: AssemblyHashAlgorithm.None);
+
+        var coreLib = typeof(object).Assembly.GetName();
+        var coreLibRef = metadata.AddAssemblyReference(
+            metadata.GetOrAddString(coreLib.Name!),
+            coreLib.Version!,
+            culture: default,
+            publicKeyOrToken: metadata.GetOrAddBlob(coreLib.GetPublicKeyToken()!),
+            flags: default,
+            hashValue: default);
+        var cfrTypeRef = metadata.AddTypeReference(
+            coreLibRef,
+            metadata.GetOrAddString("System.Runtime.CompilerServices"),
+            metadata.GetOrAddString("CompilerFeatureRequiredAttribute"));
+        var cfrCtorSig = new BlobBuilder();
+        cfrCtorSig.WriteByte(0x20); // HASTHIS, default calling convention
+        cfrCtorSig.WriteCompressedInteger(1); // one parameter
+        cfrCtorSig.WriteByte(0x01); // return type: void
+        cfrCtorSig.WriteByte(0x0e); // parameter type: string
+        var cfrCtorRef = metadata.AddMemberReference(
+            cfrTypeRef,
+            metadata.GetOrAddString(".ctor"),
+            metadata.GetOrAddBlob(cfrCtorSig));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var interfaceHandle = metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract,
+            metadata.GetOrAddString(namespaceName),
+            metadata.GetOrAddString(typeName),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var methodSig = new BlobBuilder();
+        methodSig.WriteByte(0x20); // HASTHIS, default calling convention
+        methodSig.WriteCompressedInteger(0); // no parameters
+        methodSig.WriteByte(0x01); // return type: void
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public
+                | MethodAttributes.HideBySig
+                | MethodAttributes.NewSlot
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString(methodName),
+            metadata.GetOrAddBlob(methodSig),
+            bodyOffset: -1,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var attributeValue = new BlobBuilder();
+        attributeValue.WriteUInt16(0x0001); // custom attribute prolog
+        attributeValue.WriteSerializedString("TotallyUnknownFeature");
+        attributeValue.WriteUInt16(0); // zero named arguments
+        metadata.AddCustomAttribute(
+            interfaceHandle,
+            cfrCtorRef,
+            metadata.GetOrAddBlob(attributeValue));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
     }
 
     static string CompileFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1402,6 +1402,51 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    // Regression for #3112 review (unspeakable member name): a hand-authored external interface
+    // can have a legal type name (`Good.IProbe`) but a method whose metadata name is
+    // compiler-unspeakable (`<Bad>`). The explicit-member spelling emits
+    // Identifier(declarationName), which sanitizes `<Bad>` lossily to `__Bad_`; the interface
+    // still declares `<Bad>`, so `Good.IProbe.__Bad_()` binds to no interface member
+    // (CS0539 = RecompileFail). The gate must decline to the sanitized ContextFail floor.
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceDeclinesWhenMemberNameIsUnrepresentable()
+    {
+        var ilasm = TryLocateIlasm();
+        if (ilasm is null)
+        {
+            Assert.Skip("ilasm not available; skipping hand-authored IL unspeakable-member regression.");
+            return;
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        AssembleIlFixture(ilasm, UnspeakableMemberContractsIl, directory, "BadMethodContracts");
+        var assemblyPath = AssembleIlFixture(ilasm, UnspeakableMemberFixtureIl, directory, "badmethodfixture");
+        try
+        {
+            var target = new ReturnToSender.RequestedTarget("N.Seq", "Good.IProbe.<Bad>", 0);
+
+            // All would reconstruct `Good.IProbe.__Bad_()` from the lossily-sanitized member
+            // name; the interface declares `<Bad>`, so it binds to nothing (CS0539). The gate
+            // must decline rather than emit a new RecompileFail. The member-name guard is what
+            // catches this; the raw member name is not identifier-like.
+            var all = Assert.Single(
+                ReturnToSender.CompileBackTargets(assemblyPath, [target], RoundTripScope.All));
+            Assert.True(
+                all.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"all {all.Status}: {all.Detail}{Environment.NewLine}{all.Source}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
     // Regression for #3112 review (unrepresentable interface name): a hand-authored external
     // interface can live in a namespace whose segment is a compiler-unspeakable name (`<Bad>`)
     // — legal in metadata but not a legal C# identifier. Clean() sanitizes it lossily to a
@@ -7705,6 +7750,48 @@ public class ReturnToSenderPrototypeTests
               instance void '<Bad>.IProbe.M'() cil managed
           {
             .override [GeneratedContracts]'<Bad>'.IProbe::M
+            ret
+          }
+          .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+          {
+            ldarg.0
+            call instance void [System.Runtime]System.Object::.ctor()
+            ret
+          }
+        }
+        """;
+
+    // External contract for the unspeakable-member regression: an interface with a legal name
+    // (`Good.IProbe`) but a method whose metadata name is compiler-unspeakable (`<Bad>`).
+    const string UnspeakableMemberContractsIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly BadMethodContracts { }
+        .module BadMethodContracts.dll
+
+        .class interface public abstract auto ansi Good.IProbe
+        {
+          .method public hidebysig newslot abstract virtual instance void '<Bad>'() cil managed {}
+        }
+        """;
+
+    // Target for the unspeakable-member regression: N.Seq explicitly implements the external
+    // `Good.IProbe.<Bad>`. The reconstruction would emit `Good.IProbe.__Bad_()`, which binds
+    // to no interface member (CS0539) — the gate must decline to the sanitized ContextFail
+    // floor instead.
+    const string UnspeakableMemberFixtureIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly extern BadMethodContracts { }
+        .assembly badmethodfixture { }
+        .module badmethodfixture.dll
+
+        .class public auto ansi sealed beforefieldinit N.Seq
+            extends [System.Runtime]System.Object
+            implements [BadMethodContracts]Good.IProbe
+        {
+          .method private final hidebysig newslot virtual
+              instance void 'Good.IProbe.<Bad>'() cil managed
+          {
+            .override [BadMethodContracts]Good.IProbe::'<Bad>'
             ret
           }
           .method public hidebysig specialname rtspecialname instance void .ctor() cil managed

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1234,20 +1234,27 @@ public class ReturnToSenderPrototypeTests
     }
 
     // Close-negative for the shadow-decline (#3112 review): a compiler-authored sibling whose
-    // simple name matches a *middle* segment of the interface spelling
-    // (`N.Collections` vs `System.Collections.IEnumerable`) must NOT trigger a decline. The
-    // explicit-member qualifier is emitted fully qualified (`System.Collections.IEnumerable.
-    // GetEnumerator`, leading `System`) and the base-list entry is shortened to the bare type
-    // name (`IEnumerable`); the middle `Collections` never appears in leading position, so the
-    // reconstruction stays compilable. Under RoundTripScope.All the sibling `N.Collections` is
-    // reconstructed alongside the real explicit impl and the whole shape must round-trip Exact,
-    // not fall back to the sanitized `System_Collections_IEnumerable_GetEnumerator` floor.
-    [Fact]
-    public void CompileBackTargets_ExternalExplicitInterfaceKeepsExactWhenClosureSiblingMatchesMiddleSegment()
+    // simple name matches a *non-leading* segment of the interface spelling must NOT trigger a
+    // decline. Only the FIRST segment (`System`) can be shadowed into a compile error, because
+    // the explicit-member qualifier is always emitted fully qualified
+    // (`System.Collections.IEnumerable.GetEnumerator`) and the collision-aware using-collapser
+    // only shortens the base-list entry to the bare `IEnumerable` when nothing collides:
+    //  - `N.Collections` (middle segment): collapser shortens to `class Seq : IEnumerable`; the
+    //    middle `Collections` never leads, so it compiles.
+    //  - `N.IEnumerable` (final type name): collapser detects the collision and KEEPS the base
+    //    list fully qualified (`class Seq : System.Collections.IEnumerable`, leading `System`),
+    //    so it still compiles.
+    // Under RoundTripScope.All the sibling is reconstructed alongside the real explicit impl and
+    // the whole shape must round-trip Exact, not fall back to the sanitized
+    // `System_Collections_IEnumerable_GetEnumerator` floor.
+    [Theory]
+    [InlineData("Collections")]
+    [InlineData("IEnumerable")]
+    public void CompileBackTargets_ExternalExplicitInterfaceKeepsExactWhenClosureSiblingMatchesNonLeadingSegment(string siblingName)
     {
-        var assemblyPath = CompileFixture("""
+        var assemblyPath = CompileFixture($$"""
             namespace N;
-            public sealed class Collections { }
+            public sealed class {{siblingName}} { }
             public sealed class Seq : System.Collections.IEnumerable
             {
                 System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
@@ -1279,7 +1286,7 @@ public class ReturnToSenderPrototypeTests
                 "System_Collections_IEnumerable_GetEnumerator",
                 result.Source,
                 StringComparison.Ordinal);
-            Assert.Contains("class Collections", result.Source, StringComparison.Ordinal);
+            Assert.Contains($"class {siblingName}", result.Source, StringComparison.Ordinal);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1481,6 +1481,154 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithVarArgsFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: the decoded return/parameter strings do not carry a method's
+        // calling convention, so a VarArgs (`__arglist`) interface method is spelled
+        // identically to a fixed-arity one. C# cannot express `__arglist` in a reconstructed
+        // explicit interface member, so engaging would emit `void RtsVar.IProbe.M()` (the
+        // `__arglist` dropped), which binds to no member of the resolved interface
+        // (CS0539 = RecompileFail). The gate must decline any non-default calling convention
+        // and keep the sanitized ContextFail floor.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "namespace RtsVar { public interface IProbe { void M(__arglist); } }",
+            directory: fixtureDir,
+            assemblyName: "RtsVarContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class VarImpl : RtsVar.IProbe
+            {
+                void RtsVar.IProbe.M(__arglist) { }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "VarImpl",
+                    "RtsVar.IProbe.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsVar_IProbe_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsVar.IProbe.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithInternalInterfaceFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: the reconstructed assembly ("return-to-sender-source-oracle")
+        // references the interface's defining assembly but is not granted InternalsVisibleTo,
+        // so it cannot name an internal interface even though the target implements it via IVT
+        // to its own name. Engaging would emit `: RtsInt.IProbe` against a type the recompile
+        // cannot see (CS0122 = RecompileFail). The gate must decline any non-publicly-accessible
+        // interface and keep the sanitized ContextFail floor.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            """
+            using System.Runtime.CompilerServices;
+            [assembly: InternalsVisibleTo("fixture")]
+            namespace RtsInt { internal interface IProbe { void M(); } }
+            """,
+            directory: fixtureDir,
+            assemblyName: "RtsIntContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class IntImpl : RtsInt.IProbe
+            {
+                void RtsInt.IProbe.M() { }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "IntImpl",
+                    "RtsInt.IProbe.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsInt_IProbe_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsInt.IProbe.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithGenericParameterDriftFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: SignatureDecoder spells generic method parameters by their metadata
+        // name, not their position, so `int M<T, U>(U)` and `int M<U, T>(U)` both decode their
+        // parameter to "U" and compare equal — yet the parameter is the 2nd type parameter in
+        // one and the 1st in the other. The target is compiled against `int M<T, U>(U)`, but the
+        // sibling resolved at reconstruction declares `int M<U, T>(U)`. Engaging would emit an
+        // explicit member binding to no interface member (CS0539 = RecompileFail). The gate must
+        // decline any signature carrying generic parameters and keep the sanitized floor.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referenceDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referencePath = CompileFixture(
+            "namespace RtsGen { public interface IProbe { int M<T, U>(U value); } }",
+            directory: referenceDir,
+            assemblyName: "RtsGenContracts");
+        CompileFixture(
+            "namespace RtsGen { public interface IProbe { int M<U, T>(U value); } }",
+            directory: fixtureDir,
+            assemblyName: "RtsGenContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class GenImpl : RtsGen.IProbe
+            {
+                int RtsGen.IProbe.M<T, U>(U value) => 0;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(referencePath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "GenImpl",
+                    "RtsGen.IProbe.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsGen_IProbe_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsGen.IProbe.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (Directory.Exists(referenceDir))
+                Directory.Delete(referenceDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericExplicitInterfaceMethod()
     {
         // A generic method on a non-generic interface implemented explicitly keeps its method

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1627,6 +1627,62 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithObsoleteErrorInterfaceFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: the reconstructed explicit member names the interface twice — the base
+        // list `: RtsObs.IProbe` and the qualifier `void RtsObs.IProbe.M()`. If the interface the
+        // recompile resolves is marked `[Obsolete(..., error: true)]`, naming it is a hard CS0619
+        // (the emitted `#pragma warning disable` suppresses only the warning form), turning the
+        // sanitized ContextFail floor into a RecompileFail. A target cannot itself be compiled
+        // against an obsolete-error interface (CS0619 at its own build), so the obsolete form only
+        // arises as version drift: the target is built against a clean interface, and the sibling
+        // resolved at reconstruction has since become obsolete-error. The gate must decline.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referenceDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referencePath = CompileFixture(
+            "namespace RtsObs { public interface IProbe { void M(); } }",
+            directory: referenceDir,
+            assemblyName: "RtsObsContracts");
+        CompileFixture(
+            """
+            namespace RtsObs { [System.Obsolete("gone", true)] public interface IProbe { void M(); } }
+            """,
+            directory: fixtureDir,
+            assemblyName: "RtsObsContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class ObsImpl : RtsObs.IProbe
+            {
+                void RtsObs.IProbe.M() { }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(referencePath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ObsImpl",
+                    "RtsObs.IProbe.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsObs_IProbe_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsObs.IProbe.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (Directory.Exists(referenceDir))
+                Directory.Delete(referenceDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_ExternalExplicitInterfaceWithGenericParameterDriftFallsBackWithoutRecompileFail()
     {
         // Regression guard: SignatureDecoder spells generic method parameters by their metadata

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1629,6 +1629,65 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceWithConstraintOnlyGenericFallsBackWithoutRecompileFail()
+    {
+        // Regression guard: a generic type parameter can appear ONLY in a constraint, invisible
+        // to the return/parameter signature the probe inspects. `void M<T>() where T : Base` has
+        // an empty signature, so a signature-only gate would engage. An explicit interface member
+        // cannot restate constraints — it inherits them from the resolved interface. The target is
+        // compiled against the constrained interface (its body calls the constraint member), but
+        // the sibling resolved at reconstruction declares `void M<T>()` with NO constraint.
+        // Engaging would emit `void RtsCon.IProbe.M<T>()` whose inherited (drifted, unconstrained)
+        // T no longer permits the call — CS1061 = RecompileFail. The sanitized floor instead emits
+        // a plain generic method that restates `where T : Base`, so it still compiles. The gate
+        // must decline any generic interface method and keep the ContextFail floor.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referenceDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var referencePath = CompileFixture(
+            "namespace RtsCon { public class Base { public void Foo() { } } public interface IProbe { void M<T>() where T : Base; } }",
+            directory: referenceDir,
+            assemblyName: "RtsConContracts");
+        CompileFixture(
+            "namespace RtsCon { public class Base { public void Foo() { } } public interface IProbe { void M<T>(); } }",
+            directory: fixtureDir,
+            assemblyName: "RtsConContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class ConImpl : RtsCon.IProbe
+            {
+                void RtsCon.IProbe.M<T>()
+                {
+                    default(T).Foo();
+                }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(referencePath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ConImpl",
+                    "RtsCon.IProbe.M",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsCon_IProbe_M", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsCon.IProbe.M", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (Directory.Exists(referenceDir))
+                Directory.Delete(referenceDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericExplicitInterfaceMethod()
     {
         // A generic method on a non-generic interface implemented explicitly keeps its method

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1532,6 +1532,51 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    // Regression for #3112 review (decomposed / non-NFC member name): the round-trip guard must
+    // NOT over-decline. Roslyn strips format (Cf) characters when binding identifiers but does
+    // NOT apply Unicode normalization, so a decomposed member name `e` + U+0301 (which is NOT in
+    // NFC — its composed form is U+00E9) is emitted and bound verbatim and round-trips exactly.
+    // A prior guard that additionally required NFC declined this compiler-producible shape to the
+    // sanitized ContextFail floor, regressing a real Exact. The gate must engage and round-trip
+    // Exact, not decline.
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceKeepsExactWhenMemberNameIsDecomposed()
+    {
+        var ilasm = TryLocateIlasm();
+        if (ilasm is null)
+        {
+            Assert.Skip("ilasm not available; skipping hand-authored IL decomposed-identifier member regression.");
+            return;
+        }
+
+        const string comb = "\u0301";
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        AssembleIlFixture(ilasm, NfcMemberContractsIl.Replace("%COMB%", comb), directory, "NfcContracts");
+        var assemblyPath = AssembleIlFixture(
+            ilasm, NfcMemberFixtureIl.Replace("%COMB%", comb), directory, "nfcfixture");
+        try
+        {
+            var target = new ReturnToSender.RequestedTarget("N.Seq", $"Good.IProbe.e{comb}", 0);
+
+            var all = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath, [target], RoundTripScope.All, RoundTripBodyPolicy.Full));
+            Assert.True(
+                all.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"all {all.Status}: {all.Detail}{Environment.NewLine}{all.Source}");
+            Assert.False(all.UsedCompileBackFloor, all.Detail);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
     // Regression for #3112 review (unrepresentable interface name): a hand-authored external
     // interface can live in a namespace whose segment is a compiler-unspeakable name (`<Bad>`)
     // — legal in metadata but not a legal C# identifier. Clean() sanitizes it lossily to a
@@ -7953,6 +7998,46 @@ public class ReturnToSenderPrototypeTests
               instance void 'G%ZWNJ%ood.IProbe.M'() cil managed
           {
             .override [CfNsContracts]'G%ZWNJ%ood'.IProbe::M
+            ret
+          }
+          .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+          {
+            ldarg.0
+            call instance void [System.Runtime]System.Object::.ctor()
+            ret
+          }
+        }
+        """;
+
+    // External contract for the decomposed-identifier (non-NFC) regression: the `%COMB%`
+    // placeholder is replaced with U+0301 (combining acute accent) at test time, so the member
+    // name is `e` + U+0301 — identifier-like, format-character-free, and NOT in NFC. Roslyn binds
+    // it verbatim (no normalization), so it round-trips Exact and must NOT be declined.
+    const string NfcMemberContractsIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly NfcContracts { }
+        .module NfcContracts.dll
+
+        .class interface public abstract auto ansi Good.IProbe
+        {
+          .method public hidebysig newslot abstract virtual instance void 'e%COMB%'() cil managed {}
+        }
+        """;
+
+    const string NfcMemberFixtureIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly extern NfcContracts { }
+        .assembly nfcfixture { }
+        .module nfcfixture.dll
+
+        .class public auto ansi sealed beforefieldinit N.Seq
+            extends [System.Runtime]System.Object
+            implements [NfcContracts]Good.IProbe
+        {
+          .method private final hidebysig newslot virtual
+              instance void 'Good.IProbe.e%COMB%'() cil managed
+          {
+            .override [NfcContracts]Good.IProbe::'e%COMB%'
             ret
           }
           .method public hidebysig specialname rtspecialname instance void .ctor() cil managed

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1185,6 +1185,140 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsExternalSingleMemberExplicitInterfaceMethod()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Seq : System.Collections.IEnumerable
+            {
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+                {
+                    throw null;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Seq",
+                    "System.Collections.IEnumerable.GetEnumerator",
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.Source.Contains("class Seq : System.Collections.IEnumerable", StringComparison.Ordinal)
+                || result.Source.Contains("class Seq : IEnumerable", StringComparison.Ordinal),
+                result.Source);
+            Assert.True(
+                result.Source.Contains(
+                    "System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()",
+                    StringComparison.Ordinal)
+                || result.Source.Contains(
+                    "IEnumerator System.Collections.IEnumerable.GetEnumerator()",
+                    StringComparison.Ordinal)
+                || result.Source.Contains(
+                    "IEnumerator IEnumerable.GetEnumerator()",
+                    StringComparison.Ordinal),
+                result.Source);
+            Assert.DoesNotContain("System_Collections_IEnumerable_GetEnumerator", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_MultiMemberExternalExplicitInterfaceFallsBackWithoutRecompileFail()
+    {
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public sealed class Convertible : IConvertible
+            {
+                TypeCode IConvertible.GetTypeCode() => TypeCode.Empty;
+                bool IConvertible.ToBoolean(IFormatProvider provider) => false;
+                byte IConvertible.ToByte(IFormatProvider provider) => 0;
+                char IConvertible.ToChar(IFormatProvider provider) => '\0';
+                DateTime IConvertible.ToDateTime(IFormatProvider provider) => default;
+                decimal IConvertible.ToDecimal(IFormatProvider provider) => 0m;
+                double IConvertible.ToDouble(IFormatProvider provider) => 0d;
+                short IConvertible.ToInt16(IFormatProvider provider) => 0;
+                int IConvertible.ToInt32(IFormatProvider provider) => 0;
+                long IConvertible.ToInt64(IFormatProvider provider) => 0L;
+                sbyte IConvertible.ToSByte(IFormatProvider provider) => 0;
+                float IConvertible.ToSingle(IFormatProvider provider) => 0f;
+                string IConvertible.ToString(IFormatProvider provider) => "";
+                object IConvertible.ToType(Type conversionType, IFormatProvider provider) => this;
+                ushort IConvertible.ToUInt16(IFormatProvider provider) => 0;
+                uint IConvertible.ToUInt32(IFormatProvider provider) => 0U;
+                ulong IConvertible.ToUInt64(IFormatProvider provider) => 0UL;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Convertible",
+                    "System.IConvertible.ToBoolean",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("System_IConvertible_ToBoolean", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("System.IConvertible.ToBoolean", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_GenericExternalExplicitInterfaceFallsBackWithoutRecompileFail()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class IntSeq : System.Collections.Generic.IEnumerable<int>
+            {
+                System.Collections.Generic.IEnumerator<int> System.Collections.Generic.IEnumerable<int>.GetEnumerator()
+                {
+                    throw null;
+                }
+
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+                {
+                    throw null;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "IntSeq",
+                    "System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator",
+                    0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("System_Collections_Generic_IEnumerable_System_Int32__GetEnumerator", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericExplicitInterfaceMethod()
     {
         // A generic method on a non-generic interface implemented explicitly keeps its method

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1526,30 +1526,29 @@ public static class CompileBackSourceComposer
 
     // True when a type declared in the recompile closure would intercept the leading
     // identifier of <paramref name="interfaceDisplayFullName"/> as spelled from inside the
-    // target type's namespace. The external-interface spelling appears in two positions, and
-    // only two of its identifiers can ever appear in leading position: the FIRST segment (the
-    // explicit-member qualifier is always emitted fully qualified, e.g.
-    // `System.Collections.IEnumerable.GetEnumerator`, so its head is the first segment; a
-    // fully-qualified base-list entry leads with the same segment) and the FINAL simple type
-    // name (the using-collapser shortens the base-list entry to the bare type name, e.g.
-    // `IEnumerable`, never to a partial `Collections.IEnumerable`). A middle segment such as
-    // `Collections` therefore never leads and must not trigger a decline (that over-declines a
+    // target type's namespace. The external-interface spelling appears in two positions —
+    // the base-list entry and the explicit-member qualifier — and only its FIRST segment can
+    // ever be shadowed into a compile error. The explicit-member qualifier is always emitted
+    // fully qualified (e.g. `System.Collections.IEnumerable.GetEnumerator`), so its head is
+    // the first segment. The base-list entry is either emitted fully qualified (same first
+    // segment) or shortened by the using-collapser to the bare type name (e.g. `IEnumerable`);
+    // the collapser is collision-aware (CSharpDeclarationWriter.TypeNamePlan keeps a name
+    // qualified when its simple name is ambiguous), so it only shortens to a simple name that
+    // does NOT collide with a sibling — a sibling matching the final type name forces the base
+    // list to stay fully qualified (leading `System`) and still compiles. No partial
+    // qualification (`Collections.IEnumerable`) is ever emitted, so middle and final segments
+    // never lead into a failure and must not trigger a decline (that over-declines a
     // compiler-authored Exact). <paramref name="closureRoots"/> already reflects the active
     // scope, so under RoundTripScope.Cluster (which does not reconstruct the shadowing sibling)
     // this returns false and engagement proceeds; under RoundTripScope.All it declines the
-    // crafted-IL shadow shape.
+    // crafted-IL first-segment shadow shape.
     static bool ExternalInterfaceSpellingShadowedByClosure(
         MetadataReader reader,
         TypeDefinition targetType,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         string interfaceDisplayFullName)
     {
-        string[] parts = interfaceDisplayFullName.Split('.');
-        var segments = new HashSet<string>(StringComparer.Ordinal)
-        {
-            parts[0],       // leads when the spelling is emitted fully qualified
-            parts[^1],      // leads when the base-list entry is shortened to the simple name
-        };
+        string leadingSegment = interfaceDisplayFullName.Split('.', 2)[0];
         string targetNamespace = reader.GetString(targetType.Namespace);
 
         foreach (var handle in closureRoots)
@@ -1557,11 +1556,11 @@ public static class CompileBackSourceComposer
             var candidate = reader.GetTypeDefinition(handle);
             string candidateNamespace = reader.GetString(candidate.Namespace);
 
-            // Type collision: a reconstructed top-level type whose simple name matches a
+            // Type collision: a reconstructed top-level type whose simple name matches the
             // leading spelling identifier and that sits in the target's namespace, an ancestor
             // namespace, or the global namespace is nearer than the external namespace
             // chain and intercepts the identifier.
-            if (segments.Contains(reader.GetString(candidate.Name))
+            if (string.Equals(reader.GetString(candidate.Name), leadingSegment, StringComparison.Ordinal)
                 && NamespaceIsInScope(candidateNamespace, targetNamespace))
             {
                 return true;
@@ -1572,7 +1571,7 @@ public static class CompileBackSourceComposer
             // intercept the identifier. Types beneath the global namespace merge with the
             // external namespace chain instead of shadowing it, so global is excluded here.
             if (LeadingSegmentBelowInScopeNonGlobalNamespace(candidateNamespace, targetNamespace) is { } childSegment
-                && segments.Contains(childSegment))
+                && string.Equals(childSegment, leadingSegment, StringComparison.Ordinal))
             {
                 return true;
             }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1570,11 +1570,12 @@ public static class CompileBackSourceComposer
     // True when a raw metadata identifier round-trips through the C# identifier the
     // reconstruction emits (via CSharpIdentifier.Sanitize / Clean). Lexical identifier-likeness
     // is necessary but not sufficient: Roslyn's identifier binding additionally removes Unicode
-    // format (Cf) characters and applies Unicode normalization form C, so a name carrying a Cf
-    // character (e.g. U+200C) or a non-NFC form binds to a DIFFERENT name than its exact
-    // metadata spelling (CS0246/CS0539 = RecompileFail). Require the name to be identifier-like,
-    // free of Cf characters, and already in NFC; keyword names still round-trip (Escape only
-    // prepends `@`, which binding strips).
+    // format (Cf) characters, so a name carrying a Cf character (e.g. U+200C) binds to a
+    // DIFFERENT name than its exact metadata spelling (CS0246/CS0539 = RecompileFail). Roslyn
+    // does NOT apply Unicode normalization to identifiers: a decomposed (non-NFC) metadata name
+    // such as `e` + U+0301 is emitted and bound verbatim, so it round-trips exactly and must
+    // NOT be declined. Require the name to be identifier-like and free of Cf characters; keyword
+    // names still round-trip (Escape only prepends `@`, which binding strips).
     static bool MetadataIdentifierRoundTrips(string name)
     {
         if (!CSharpIdentifier.IsIdentifierLike(name))
@@ -1586,7 +1587,7 @@ public static class CompileBackSourceComposer
                 return false;
         }
 
-        return name.IsNormalized(NormalizationForm.FormC);
+        return true;
     }
 
     // True when a type declared in the recompile closure would intercept the leading

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1607,9 +1607,11 @@ public static class CompileBackSourceComposer
     // Probes whether a method signature carries detail that SignatureDecoder renders
     // ambiguously, making a decoded-string comparison unsound: by-ref parameters (in/out/ref
     // all decode to "ref T"), custom modifiers (dropped by GetModifiedType), multidimensional
-    // arrays (a rank-1 MDArray decodes identically to an SZArray), and function pointers
-    // (calling-convention modopts). When a signature is free of all of these, its decoded
-    // string form is a faithful identity and string equality is an exact signature check.
+    // arrays (a rank-1 MDArray decodes identically to an SZArray), function pointers
+    // (calling-convention modopts), and generic parameters (spelled by their metadata name,
+    // so a reordered/renamed drift can compare equal while binding to a different position).
+    // When a signature is free of all of these, its decoded string form is a faithful
+    // identity and string equality is an exact signature check.
     sealed class UnrepresentableSignatureProbe : ISignatureTypeProvider<bool, object?>
     {
         public static readonly UnrepresentableSignatureProbe Instance = new();
@@ -1617,15 +1619,25 @@ public static class CompileBackSourceComposer
         public bool GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => false;
         public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => false;
         public bool GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
-            => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+        {
+            // Mirror SignatureDecoder.GetTypeFromSpecification: a cross-handle TypeSpec
+            // re-entry (including a cycle back to this row) must be bounded or a crafted
+            // dependency could overflow the stack — uncatchable, crashing the harness. A
+            // TypeSpec too deep or structurally unsafe to decode is, for our purposes,
+            // unrepresentable: treat it as such and decline.
+            if (!TypeSpecGuard.TryEnter(reader, handle, out var scope))
+                return true;
+            using (scope)
+                return reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+        }
         public bool GetSZArrayType(bool elementType) => elementType;
         public bool GetArrayType(bool elementType, ArrayShape shape) => true;
         public bool GetByReferenceType(bool elementType) => true;
         public bool GetPointerType(bool elementType) => elementType;
         public bool GetGenericInstantiation(bool genericType, ImmutableArray<bool> typeArguments)
             => genericType || typeArguments.Any(argument => argument);
-        public bool GetGenericMethodParameter(object? genericContext, int index) => false;
-        public bool GetGenericTypeParameter(object? genericContext, int index) => false;
+        public bool GetGenericMethodParameter(object? genericContext, int index) => true;
+        public bool GetGenericTypeParameter(object? genericContext, int index) => true;
         public bool GetFunctionPointerType(MethodSignature<bool> signature) => true;
         public bool GetModifiedType(bool modifier, bool unmodifiedType, bool isRequired) => true;
         public bool GetPinnedType(bool elementType) => elementType;
@@ -1636,11 +1648,34 @@ public static class CompileBackSourceComposer
         try
         {
             var signature = method.DecodeSignature(UnrepresentableSignatureProbe.Instance, (object?)null);
-            return signature.ReturnType || signature.ParameterTypes.Any(parameter => parameter);
+            // The decoded return/parameter strings do not carry the method's calling
+            // convention, so a VarArgs (`__arglist`) method is spelled identically to a
+            // fixed-arity one. C# cannot express `__arglist` in a reconstructed explicit
+            // member, so any non-default calling convention is unrepresentable and declines.
+            return signature.Header.CallingConvention != SignatureCallingConvention.Default
+                || signature.ReturnType
+                || signature.ParameterTypes.Any(parameter => parameter);
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
             return true;
+        }
+    }
+
+    // Whether a type (and every enclosing type) is accessible to an assembly that references
+    // the defining assembly without InternalsVisibleTo: a top-level type must be public, and a
+    // nested type must be nested-public with a publicly accessible declaring type.
+    static bool IsPubliclyAccessible(MetadataReader reader, TypeDefinition type)
+    {
+        while (true)
+        {
+            var visibility = type.Attributes & TypeAttributes.VisibilityMask;
+            var declaring = type.GetDeclaringType();
+            if (declaring.IsNil)
+                return visibility == TypeAttributes.Public;
+            if (visibility != TypeAttributes.NestedPublic)
+                return false;
+            type = reader.GetTypeDefinition(declaring);
         }
     }
 
@@ -1709,6 +1744,14 @@ public static class CompileBackSourceComposer
         {
             return false;
         }
+        // The reconstructed assembly references the interface's defining assembly but is not
+        // granted InternalsVisibleTo, so it can only name a publicly accessible interface.
+        // Engaging on an internal (or nested non-public) interface would emit `: DisplayName`
+        // against a type the recompile cannot see (CS0122 = RecompileFail). A public interface
+        // also guarantees, by C#'s consistent-accessibility rule, that its method signature
+        // types are at least as accessible, so the emitted members reference only public types.
+        if (!IsPubliclyAccessible(reader, interfaceDef))
+            return false;
         if (interfaceDef.GetProperties().Count != 0 || interfaceDef.GetEvents().Count != 0)
             return false;
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1752,6 +1752,18 @@ public static class CompileBackSourceComposer
         // types are at least as accessible, so the emitted members reference only public types.
         if (!IsPubliclyAccessible(reader, interfaceDef))
             return false;
+
+        // The reconstructed explicit member names the interface twice — in the base list
+        // (`: DisplayName`) and in the member qualifier (`void DisplayName.M()`). If the resolved
+        // interface is marked `[Obsolete(..., error: true)]`, naming it is a hard CS0619 error,
+        // turning the sanitized ContextFail floor (which never names the interface) into a
+        // RecompileFail. `#pragma warning disable` in the emitted source suppresses warning-level
+        // obsolescence but not the error form, so decline any real (non-compiler-compat) obsolete
+        // interface. TryGetObsoleteAttribute already excludes Roslyn's synthetic compiler-compat
+        // [Obsolete] markers (required members, ref structs), which do not error when referenced.
+        if (AttributeReader.TryGetObsoleteAttribute(reader, interfaceDef.GetCustomAttributes(), out _))
+            return false;
+
         if (interfaceDef.GetProperties().Count != 0 || interfaceDef.GetEvents().Count != 0)
             return false;
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1764,6 +1764,16 @@ public static class CompileBackSourceComposer
         if (AttributeReader.TryGetObsoleteAttribute(reader, interfaceDef.GetCustomAttributes(), out _))
             return false;
 
+        // Naming the interface in the base list (`: DisplayName`) forces the recompile to bind to
+        // it, which requires every feature the interface demands via [CompilerFeatureRequired]. If
+        // the resolved interface carries an unsatisfiable feature marker, binding it is a hard
+        // CS9041 (feature not supported), turning the sanitized ContextFail floor (which never
+        // names the interface, so never triggers the requirement) into a RecompileFail. This
+        // attribute is not emittable from C# source and appears only on hand-authored or
+        // future/downlevel-drifted IL, so decline any interface that carries it and keep the floor.
+        if (AttributeReader.HasAttribute(reader, interfaceDef.GetCustomAttributes(), KnownAttributeNames.CompilerFeatureRequiredAttribute))
+            return false;
+
         if (interfaceDef.GetProperties().Count != 0 || interfaceDef.GetEvents().Count != 0)
             return false;
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1526,22 +1526,30 @@ public static class CompileBackSourceComposer
 
     // True when a type declared in the recompile closure would intercept the leading
     // identifier of <paramref name="interfaceDisplayFullName"/> as spelled from inside the
-    // target type's namespace. The external-interface spelling appears both as a base-list
-    // entry and as the explicit-member qualifier; the using-directive collapser can shorten
-    // it to any of its segments, so every segment is treated as a potential leading
-    // identifier. <paramref name="closureRoots"/> already reflects the active scope, so under
-    // RoundTripScope.Cluster (which does not reconstruct the shadowing sibling) this returns
-    // false and engagement proceeds; under RoundTripScope.All it declines the crafted-IL
-    // shadow shape.
+    // target type's namespace. The external-interface spelling appears in two positions, and
+    // only two of its identifiers can ever appear in leading position: the FIRST segment (the
+    // explicit-member qualifier is always emitted fully qualified, e.g.
+    // `System.Collections.IEnumerable.GetEnumerator`, so its head is the first segment; a
+    // fully-qualified base-list entry leads with the same segment) and the FINAL simple type
+    // name (the using-collapser shortens the base-list entry to the bare type name, e.g.
+    // `IEnumerable`, never to a partial `Collections.IEnumerable`). A middle segment such as
+    // `Collections` therefore never leads and must not trigger a decline (that over-declines a
+    // compiler-authored Exact). <paramref name="closureRoots"/> already reflects the active
+    // scope, so under RoundTripScope.Cluster (which does not reconstruct the shadowing sibling)
+    // this returns false and engagement proceeds; under RoundTripScope.All it declines the
+    // crafted-IL shadow shape.
     static bool ExternalInterfaceSpellingShadowedByClosure(
         MetadataReader reader,
         TypeDefinition targetType,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         string interfaceDisplayFullName)
     {
-        var segments = new HashSet<string>(
-            interfaceDisplayFullName.Split('.'),
-            StringComparer.Ordinal);
+        string[] parts = interfaceDisplayFullName.Split('.');
+        var segments = new HashSet<string>(StringComparer.Ordinal)
+        {
+            parts[0],       // leads when the spelling is emitted fully qualified
+            parts[^1],      // leads when the base-list entry is shortened to the simple name
+        };
         string targetNamespace = reader.GetString(targetType.Namespace);
 
         foreach (var handle in closureRoots)
@@ -1550,7 +1558,7 @@ public static class CompileBackSourceComposer
             string candidateNamespace = reader.GetString(candidate.Namespace);
 
             // Type collision: a reconstructed top-level type whose simple name matches a
-            // spelling segment and that sits in the target's namespace, an ancestor
+            // leading spelling identifier and that sits in the target's namespace, an ancestor
             // namespace, or the global namespace is nearer than the external namespace
             // chain and intercepts the identifier.
             if (segments.Contains(reader.GetString(candidate.Name))

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1766,6 +1766,16 @@ public static class CompileBackSourceComposer
                 return false;
             }
 
+            // A generic interface method carries constraints that the reconstructed explicit
+            // member cannot restate (C# inherits them from the interface). A type parameter can
+            // appear only in a constraint — invisible to the return/parameter signature probe —
+            // so a constraint drift between the target and the resolved interface would emit a
+            // body that no longer satisfies the interface's constraint (CS1061/CS0535). The
+            // signature comparison also cannot distinguish generic parameters by position (they
+            // are spelled by name). Decline every generic method and keep the ContextFail floor.
+            if (method.GetGenericParameters().Count != 0)
+                return false;
+
             // A required method whose signature SignatureDecoder cannot represent faithfully
             // (by-ref kinds, custom modifiers, multidimensional arrays, function pointers)
             // cannot be safely signature-compared against the target, so decline the whole

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1509,7 +1509,7 @@ public static class CompileBackSourceComposer
                     reader,
                     targetType,
                     closureRoots,
-                    interfaceReference.DisplayFullName))
+                    interfaceReference.MetadataFullName))
             {
                 return null;
             }
@@ -1525,8 +1525,8 @@ public static class CompileBackSourceComposer
     }
 
     // True when a type declared in the recompile closure would intercept the leading
-    // identifier of <paramref name="interfaceDisplayFullName"/> as spelled from inside the
-    // target type's namespace. The external-interface spelling appears in two positions —
+    // identifier of the external interface spelling as spelled from inside the target type's
+    // namespace. The external-interface spelling appears in two positions —
     // the base-list entry and the explicit-member qualifier — and only its FIRST segment can
     // ever be shadowed into a compile error. The explicit-member qualifier is always emitted
     // fully qualified (e.g. `System.Collections.IEnumerable.GetEnumerator`), so its head is
@@ -1542,13 +1542,19 @@ public static class CompileBackSourceComposer
     // scope, so under RoundTripScope.Cluster (which does not reconstruct the shadowing sibling)
     // this returns false and engagement proceeds; under RoundTripScope.All it declines the
     // crafted-IL first-segment shadow shape.
+    //
+    // The leading segment is taken from the raw METADATA full name, not the C# display name,
+    // so it compares raw-to-raw against the closure types' metadata names/namespaces. A
+    // namespace segment that is a C# keyword (e.g. `class`) is escaped to `@class` in the
+    // display name but stored raw in metadata; deriving the segment from the display name here
+    // would miss a real `N.class`-shadows-`class.IProbe` collision and emit a new RecompileFail.
     static bool ExternalInterfaceSpellingShadowedByClosure(
         MetadataReader reader,
         TypeDefinition targetType,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
-        string interfaceDisplayFullName)
+        string interfaceMetadataFullName)
     {
-        string leadingSegment = interfaceDisplayFullName.Split('.', 2)[0];
+        string leadingSegment = interfaceMetadataFullName.Split('.', 2)[0];
         string targetNamespace = reader.GetString(targetType.Namespace);
 
         foreach (var handle in closureRoots)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1414,7 +1414,8 @@ public static class CompileBackSourceComposer
         TypeDefinition targetType,
         MethodDefinitionHandle targetMethod,
         string metadataMethodName,
-        int targetMethodGenericArity)
+        int targetMethodGenericArity,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots)
     {
         if (!TrySplitExplicitInterfaceMetadataName(metadataMethodName, out var interfaceMetadataName, out var targetMemberName))
             return null;
@@ -1493,11 +1494,113 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
+            // A reconstructed sibling type (or sibling sub-namespace) in the recompile
+            // closure can intercept the leading identifier of the external interface
+            // spelling when the target lives inside a namespace, binding the clean
+            // `Namespace.IType.Member` spelling against the sibling instead of the external
+            // interface (CS0426/CS0535/CS0540 = RecompileFail). Roslyn cannot author such a
+            // shape (a shadowing sibling forces `global::` into the explicit override's
+            // metadata name, which the equality check above already declines), but
+            // hand-rolled IL can, and RoundTripScope.All reconstructs every sibling into its
+            // namespace. When any closure type would shadow a spelling segment in a namespace
+            // in scope of the target, decline to the plain sanitized shape (the pre-#3112
+            // ContextFail floor) rather than emit a new RecompileFail.
+            if (ExternalInterfaceSpellingShadowedByClosure(
+                    reader,
+                    targetType,
+                    closureRoots,
+                    interfaceReference.DisplayFullName))
+            {
+                return null;
+            }
+
             string explicitInterfaceMemberName =
                 $"{interfaceReference.DisplayFullName}.{Identifier(declarationName)}";
             return new ExternalExplicitInterfaceMethodInfo(
                 interfaceReference.DisplayFullName,
                 explicitInterfaceMemberName);
+        }
+
+        return null;
+    }
+
+    // True when a type declared in the recompile closure would intercept the leading
+    // identifier of <paramref name="interfaceDisplayFullName"/> as spelled from inside the
+    // target type's namespace. The external-interface spelling appears both as a base-list
+    // entry and as the explicit-member qualifier; the using-directive collapser can shorten
+    // it to any of its segments, so every segment is treated as a potential leading
+    // identifier. <paramref name="closureRoots"/> already reflects the active scope, so under
+    // RoundTripScope.Cluster (which does not reconstruct the shadowing sibling) this returns
+    // false and engagement proceeds; under RoundTripScope.All it declines the crafted-IL
+    // shadow shape.
+    static bool ExternalInterfaceSpellingShadowedByClosure(
+        MetadataReader reader,
+        TypeDefinition targetType,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots,
+        string interfaceDisplayFullName)
+    {
+        var segments = new HashSet<string>(
+            interfaceDisplayFullName.Split('.'),
+            StringComparer.Ordinal);
+        string targetNamespace = reader.GetString(targetType.Namespace);
+
+        foreach (var handle in closureRoots)
+        {
+            var candidate = reader.GetTypeDefinition(handle);
+            string candidateNamespace = reader.GetString(candidate.Namespace);
+
+            // Type collision: a reconstructed top-level type whose simple name matches a
+            // spelling segment and that sits in the target's namespace, an ancestor
+            // namespace, or the global namespace is nearer than the external namespace
+            // chain and intercepts the identifier.
+            if (segments.Contains(reader.GetString(candidate.Name))
+                && NamespaceIsInScope(candidateNamespace, targetNamespace))
+            {
+                return true;
+            }
+
+            // Sub-namespace collision: a reconstructed type declared beneath a non-global
+            // in-scope namespace introduces a nearer namespace whose leading segment can
+            // intercept the identifier. Types beneath the global namespace merge with the
+            // external namespace chain instead of shadowing it, so global is excluded here.
+            if (LeadingSegmentBelowInScopeNonGlobalNamespace(candidateNamespace, targetNamespace) is { } childSegment
+                && segments.Contains(childSegment))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // True when a type declared in <paramref name="candidateNamespace"/> is visible by its
+    // simple name from inside <paramref name="targetNamespace"/>: the same namespace, an
+    // ancestor namespace, or the global namespace.
+    static bool NamespaceIsInScope(string candidateNamespace, string targetNamespace)
+        => candidateNamespace.Length == 0
+           || string.Equals(candidateNamespace, targetNamespace, StringComparison.Ordinal)
+           || targetNamespace.StartsWith(candidateNamespace + ".", StringComparison.Ordinal);
+
+    // When <paramref name="candidateNamespace"/> is strictly nested under the target
+    // namespace or one of its non-global ancestors, returns the single namespace segment
+    // introduced directly beneath the nearest such in-scope namespace (which becomes a name
+    // visible unqualified from the target). Returns null otherwise.
+    static string? LeadingSegmentBelowInScopeNonGlobalNamespace(string candidateNamespace, string targetNamespace)
+    {
+        if (targetNamespace.Length == 0 || candidateNamespace.Length == 0)
+            return null;
+
+        for (string scope = targetNamespace; scope.Length > 0;)
+        {
+            if (candidateNamespace.StartsWith(scope + ".", StringComparison.Ordinal))
+            {
+                string rest = candidateNamespace[(scope.Length + 1)..];
+                int dot = rest.IndexOf('.');
+                return dot < 0 ? rest : rest[..dot];
+            }
+
+            int lastDot = scope.LastIndexOf('.');
+            scope = lastDot < 0 ? "" : scope[..lastDot];
         }
 
         return null;
@@ -2287,7 +2390,8 @@ public static class CompileBackSourceComposer
                     targetTypeDef,
                     targetMethod,
                     methodName,
-                    targetTypeParameters.Count)
+                    targetTypeParameters.Count,
+                    closureRoots)
                 : null;
         string? explicitInterfaceMemberName =
             sameAssemblyExplicitInterfaceMemberName

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1464,6 +1464,17 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
+            // The reconstructed C# spelling emits the interface's DISPLAY name
+            // (Clean(metadataFullName)) in both the base-list entry and the explicit-member
+            // qualifier. Clean keyword-escapes an identifier-like segment losslessly
+            // (`class` -> `@class`), but rewrites a segment that is not a legal C# identifier
+            // through a lossy sanitizing branch (`<Bad>` -> `__Bad_`), which then references a
+            // type that does not exist (CS0246 = RecompileFail). Only engage when the raw
+            // metadata name round-trips through the display name; otherwise decline to the
+            // plain sanitized shape (the pre-#3112 ContextFail floor).
+            if (!ExternalInterfaceNameIsRepresentable(interfaceReference.MetadataFullName))
+                return null;
+
             // Name + arity alone are signature-blind: a resolved interface method whose
             // parameter or return types differ from what the target actually implements
             // (e.g. a reference resolved to a different build than the target was compiled
@@ -1522,6 +1533,27 @@ public static class CompileBackSourceComposer
         }
 
         return null;
+    }
+
+    // True when every dotted segment of the external interface's raw metadata full name is a
+    // legal C# identifier (keyword segments included). Such a name round-trips through the
+    // display spelling the reconstruction emits: Clean(metadataFullName) keyword-escapes an
+    // identifier-like segment losslessly (`class` -> `@class`, which C# resolves back to
+    // `class`). A segment that is not identifier-like (e.g. a compiler-unspeakable
+    // `<Bad>`) is instead rewritten by Clean's sanitizing branch into a different identifier
+    // (`__Bad_`) that names no real type, so the emitted `using __Bad_;` / `__Bad_.IProbe`
+    // spelling fails to bind (CS0246 = RecompileFail). Nested external types are qualified
+    // with `.` (Outer.Inner), so an ordinary nested interface passes; only genuinely
+    // unrepresentable names are declined here to the sanitized ContextFail floor.
+    static bool ExternalInterfaceNameIsRepresentable(string metadataFullName)
+    {
+        foreach (var segment in metadataFullName.Split('.'))
+        {
+            if (!CSharpIdentifier.IsIdentifierLike(segment))
+                return false;
+        }
+
+        return true;
     }
 
     // True when a type declared in the recompile closure would intercept the leading

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1,9 +1,12 @@
 using System.Globalization;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 using System.Text;
+using DotnetInspector.Services;
 using DotnetInspector.RoundTripCompilation;
 using ILInspector.CSharp;
 using ILInspector.Decompiler;
@@ -351,6 +354,7 @@ public sealed record CompileBackTypeRequirement(
     public CompileBackTypeKind Kind => RequiredKind;
     public IReadOnlyList<CompileBackMemberRequirement> Members => RequiredMembers;
     public bool IncludeMemberSurface { get; init; }
+    public IReadOnlyList<string> ExternalInterfaces { get; init; } = [];
 }
 
 public sealed record CompileBackMemberRequirement(
@@ -402,6 +406,17 @@ internal sealed record ExplicitInterfaceEventInfo(
     EventDefinitionHandle InterfaceEvent,
     string QualifiedName,
     string AccessorName);
+
+internal sealed record ExternalExplicitInterfaceMethodInfo(
+    string InterfaceDisplayName,
+    string ExplicitInterfaceMemberName);
+
+internal sealed record ExternalInterfaceReferenceInfo(
+    string MetadataFullName,
+    string DisplayFullName,
+    AssemblyReferenceIdentity AssemblyIdentity);
+
+internal sealed record ExternalInterfaceRequiredMethod(string Name, int GenericArity);
 
 public static class CompileBackSourceComposer
 {
@@ -1384,6 +1399,277 @@ public static class CompileBackSourceComposer
         return false;
     }
 
+    // External explicit-interface implementations must also name the interface in the
+    // containing type's base list (CS0540) and satisfy its complete required surface
+    // (CS0535). Engage only for non-generic external interfaces whose transitive
+    // required surface is exactly the target method; every uncertain case keeps the
+    // previous plain sanitized shape and its ContextFail floor (#3112).
+    static ExternalExplicitInterfaceMethodInfo? ExternalExplicitInterfaceMethod(
+        MetadataReader reader,
+        string assemblyPath,
+        TypeDefinition targetType,
+        MethodDefinitionHandle targetMethod,
+        string metadataMethodName,
+        int targetMethodGenericArity)
+    {
+        if (!TrySplitExplicitInterfaceMetadataName(metadataMethodName, out var interfaceMetadataName, out var targetMemberName))
+            return null;
+
+        foreach (var implementationHandle in targetType.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody != targetMethod)
+                continue;
+
+            if (implementation.MethodDeclaration.Kind == HandleKind.TypeSpecification)
+                return null;
+            if (implementation.MethodDeclaration.Kind != HandleKind.MemberReference)
+                continue;
+
+            var declaration = reader.GetMemberReference((MemberReferenceHandle)implementation.MethodDeclaration);
+            if (declaration.Parent.Kind == HandleKind.TypeSpecification)
+                return null;
+            if (declaration.Parent.Kind != HandleKind.TypeReference)
+                return null;
+
+            string declarationName = reader.GetString(declaration.Name);
+            if (!string.Equals(declarationName, targetMemberName, StringComparison.Ordinal))
+                continue;
+            if (OperatorNames.FormatDisplayName(declarationName) != declarationName)
+                return null;
+
+            if (ExternalInterfaceReference(reader, (TypeReferenceHandle)declaration.Parent) is not { } interfaceReference)
+                return null;
+            if (!string.Equals(interfaceReference.MetadataFullName, interfaceMetadataName, StringComparison.Ordinal))
+                continue;
+
+            if (!TryReadExternalInterfaceSurface(
+                    assemblyPath,
+                    interfaceReference,
+                    out var requiredMethods)
+                || requiredMethods.Count != 1)
+            {
+                return null;
+            }
+
+            var requiredMethod = requiredMethods[0];
+            if (!string.Equals(requiredMethod.Name, declarationName, StringComparison.Ordinal)
+                || requiredMethod.GenericArity != targetMethodGenericArity)
+            {
+                return null;
+            }
+
+            string explicitInterfaceMemberName =
+                $"{interfaceReference.DisplayFullName}.{Identifier(declarationName)}";
+            return new ExternalExplicitInterfaceMethodInfo(
+                interfaceReference.DisplayFullName,
+                explicitInterfaceMemberName);
+        }
+
+        return null;
+    }
+
+    static bool TryReadExternalInterfaceSurface(
+        string assemblyPath,
+        ExternalInterfaceReferenceInfo interfaceReference,
+        out IReadOnlyList<ExternalInterfaceRequiredMethod> requiredMethods)
+    {
+        // Reading a referenced interface's transitive surface opens and scans its
+        // defining assembly (often CoreLib). The same interface (e.g.
+        // System.Collections.IEnumerable) recurs across many targets in a single run,
+        // so memoize per (target assembly, interface): rescanning CoreLib for every
+        // explicit-impl target is an unbounded slowdown. The resolver itself is also
+        // cached per target assembly, and negative results are cached so an
+        // unresolvable interface is not retried.
+        string cacheKey = $"{assemblyPath}|{interfaceReference.MetadataFullName}";
+        var cached = _externalInterfaceSurfaces.GetOrAdd(cacheKey, _ =>
+        {
+            var resolver = _externalInterfaceResolvers.GetOrAdd(assemblyPath, static path =>
+                new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(path)
+                {
+                    AllowPlatformAssemblyVersionRollForward = true,
+                    ExcludeTargetAssembly = true,
+                }));
+            if (ResolveExternalAssembly(resolver, interfaceReference.AssemblyIdentity) is not { } assembly)
+                return null;
+
+            var collected = new List<ExternalInterfaceRequiredMethod>();
+            return TryCollectExternalInterfaceMethods(
+                    assembly,
+                    interfaceReference.MetadataFullName,
+                    resolver,
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                    collected)
+                ? collected
+                : null;
+        });
+
+        if (cached is null)
+        {
+            requiredMethods = [];
+            return false;
+        }
+
+        requiredMethods = cached;
+        return true;
+    }
+
+    static readonly ConcurrentDictionary<string, AssemblyDependencyResolver> _externalInterfaceResolvers =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    static readonly ConcurrentDictionary<string, IReadOnlyList<ExternalInterfaceRequiredMethod>?> _externalInterfaceSurfaces =
+        new(StringComparer.Ordinal);
+
+    static bool TryCollectExternalInterfaceMethods(
+        ResolvedAssemblyReference assembly,
+        string metadataFullName,
+        AssemblyDependencyResolver resolver,
+        HashSet<string> visited,
+        List<ExternalInterfaceRequiredMethod> methods)
+    {
+        try
+        {
+            var location = TypeForwardResolver.LocateType(
+                    assembly,
+                    metadataFullName,
+                    resolver,
+                    scope: AssemblyResolutionScope.Any)
+                ?? TypeForwardResolver.LocateType(
+                    assembly,
+                    metadataFullName,
+                    resolver,
+                    scope: AssemblyResolutionScope.Platform);
+            if (location is null)
+                return false;
+
+            using var stream = location.OpenRead();
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return false;
+
+            var externalReader = peReader.GetMetadataReader();
+            if (TypeProducer.FindType(externalReader, location.FullTypeName) is not { } interfaceHandle)
+                return false;
+
+            string assemblyKey = location.AssemblyPath is { Length: > 0 } path
+                ? Path.GetFullPath(path)
+                : location.AssemblyKey;
+            return TryCollectRequiredInterfaceMethods(
+                externalReader,
+                interfaceHandle,
+                resolver,
+                assemblyKey,
+                visited,
+                methods);
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException or ArgumentException or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    static bool TryCollectRequiredInterfaceMethods(
+        MetadataReader reader,
+        TypeDefinitionHandle interfaceHandle,
+        AssemblyDependencyResolver resolver,
+        string assemblyKey,
+        HashSet<string> visited,
+        List<ExternalInterfaceRequiredMethod> methods)
+    {
+        var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+        string interfaceName = reader.GetFullTypeName(interfaceDef);
+        if (!visited.Add($"{assemblyKey}|{interfaceName}"))
+            return false;
+        if ((interfaceDef.Attributes & TypeAttributes.Interface) == 0
+            || interfaceDef.GetGenericParameters().Count != 0)
+        {
+            return false;
+        }
+        if (interfaceDef.GetProperties().Count != 0 || interfaceDef.GetEvents().Count != 0)
+            return false;
+
+        foreach (var methodHandle in interfaceDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            string methodName = reader.GetString(method.Name);
+            if (method.Attributes.HasFlag(MethodAttributes.Static)
+                || (method.Attributes & MethodAttributes.Abstract) == 0
+                || OperatorNames.FormatDisplayName(methodName) != methodName)
+            {
+                return false;
+            }
+
+            methods.Add(new ExternalInterfaceRequiredMethod(
+                methodName,
+                method.GetGenericParameters().Count));
+        }
+
+        foreach (var implementationHandle in interfaceDef.GetInterfaceImplementations())
+        {
+            var implementation = reader.GetInterfaceImplementation(implementationHandle);
+            if (implementation.Interface.Kind == HandleKind.TypeDefinition)
+            {
+                if (!TryCollectRequiredInterfaceMethods(
+                        reader,
+                        (TypeDefinitionHandle)implementation.Interface,
+                        resolver,
+                        assemblyKey,
+                        visited,
+                        methods))
+                {
+                    return false;
+                }
+                continue;
+            }
+
+            if (implementation.Interface.Kind == HandleKind.TypeReference)
+            {
+                if (ExternalInterfaceReference(reader, (TypeReferenceHandle)implementation.Interface) is not { } baseReference)
+                    return false;
+                if (ResolveExternalAssembly(resolver, baseReference.AssemblyIdentity) is not { } baseAssembly)
+                    return false;
+                if (!TryCollectExternalInterfaceMethods(
+                        baseAssembly,
+                        baseReference.MetadataFullName,
+                        resolver,
+                        visited,
+                        methods))
+                {
+                    return false;
+                }
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    static ResolvedAssemblyReference? ResolveExternalAssembly(
+        AssemblyDependencyResolver resolver,
+        AssemblyReferenceIdentity identity)
+        => resolver.Resolve(identity, AssemblyResolutionScope.Any)
+           ?? resolver.Resolve(identity, AssemblyResolutionScope.Platform);
+
+    static ExternalInterfaceReferenceInfo? ExternalInterfaceReference(
+        MetadataReader reader,
+        TypeReferenceHandle handle)
+    {
+        var typeRef = reader.GetTypeReference(handle);
+        if (typeRef.ResolutionScope.Kind != HandleKind.AssemblyReference)
+            return null;
+
+        string metadataFullName = reader.GetFullTypeName(typeRef);
+        if (metadataFullName.Contains('`', StringComparison.Ordinal))
+            return null;
+
+        return new ExternalInterfaceReferenceInfo(
+            metadataFullName,
+            Clean(metadataFullName),
+            AssemblyReferenceIdentity.From(reader, (AssemblyReferenceHandle)typeRef.ResolutionScope));
+    }
+
     // Compatibility declaration text for an explicit-interface method target. The C#
     // printer keeps method-shaped explicit-interface implementations on compatibility
     // text (TryRenderSignatureModel only models plain methods), so RTS supplies the
@@ -1768,11 +2054,25 @@ public static class CompileBackSourceComposer
         // (`IType.Member`) must be reconstructed as an explicit-interface implementation,
         // not a plain method with the dotted name sanitized to `IType_Member`. The latter
         // compiles but carries the wrong metadata name, so the fidelity lookup fails as
-        // ContextFail/method-not-found (#3112). Only supported non-generic interface
-        // targets resolve here; anything else keeps the pre-existing plain shape.
-        string? explicitInterfaceMemberName = isConstructor
+        // ContextFail/method-not-found (#3112). Same-assembly interfaces are handled by
+        // TypeProducer.FindType; the external path engages only after proving that adding
+        // the interface base-list entry cannot create CS0540/CS0535 regressions.
+        string? sameAssemblyExplicitInterfaceMemberName = isConstructor
             ? null
             : ExplicitInterfaceMemberName(reader, methodName);
+        var externalExplicitInterfaceMethod =
+            !isConstructor && sameAssemblyExplicitInterfaceMemberName is null
+                ? ExternalExplicitInterfaceMethod(
+                    reader,
+                    assemblyPath,
+                    targetTypeDef,
+                    targetMethod,
+                    methodName,
+                    targetTypeParameters.Count)
+                : null;
+        string? explicitInterfaceMemberName =
+            sameAssemblyExplicitInterfaceMemberName
+            ?? externalExplicitInterfaceMethod?.ExplicitInterfaceMemberName;
         string? explicitInterfaceDeclarationSignature = explicitInterfaceMemberName is null
             ? null
             : ExplicitInterfaceMethodDeclarationSignature(
@@ -1908,7 +2208,10 @@ public static class CompileBackSourceComposer
                 targetFacts)
             {
                 IncludeMemberSurface = includeRecordSurface
-                    || targetFacts.Any(fact => fact.Id == "closure-member")
+                    || targetFacts.Any(fact => fact.Id == "closure-member"),
+                ExternalInterfaces = externalExplicitInterfaceMethod is null
+                    ? []
+                    : [externalExplicitInterfaceMethod.InterfaceDisplayName],
             }
         };
         AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
@@ -1921,28 +2224,32 @@ public static class CompileBackSourceComposer
             AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
         }
 
-        if (explicitInterfaceMemberName is not null
-            && !AddExplicitInterfaceMethodDeclaration(requirements, reader, targetTypeDef, targetMethod))
+        if (explicitInterfaceMemberName is not null)
         {
-            // The interface member declaration could not be supplied (unsupported
-            // interface-member signature, or the interface is not a standalone closure
-            // requirement — e.g. a nested interface reached only through its enclosing
-            // root). Revert the target to the plain sanitized shape rather than emit
-            // `IType.Member()` against an interface that cannot declare it, which would
-            // turn a method-not-found ContextFail into a CS0539 RecompileFail.
-            // requirements[0].RequiredMembers wraps the still-mutable targetMembers list,
-            // so clearing the explicit-interface fields here reverts the rendered shape.
-            int targetIndex = targetMembers.FindIndex(member =>
-                member.Kind == CompileBackMemberKind.Method
-                && member.StubBody == CompileBackStubBodyKind.TargetBody
-                && member.ExplicitInterfaceMemberName == explicitInterfaceMemberName);
-            if (targetIndex >= 0)
+            bool explicitInterfaceShapeIsViable = externalExplicitInterfaceMethod is not null
+                || AddExplicitInterfaceMethodDeclaration(requirements, reader, targetTypeDef, targetMethod);
+            if (!explicitInterfaceShapeIsViable)
             {
-                targetMembers[targetIndex] = targetMembers[targetIndex] with
+                // The interface member declaration could not be supplied (unsupported
+                // interface-member signature, or the interface is not a standalone closure
+                // requirement — e.g. a nested interface reached only through its enclosing
+                // root). Revert the target to the plain sanitized shape rather than emit
+                // `IType.Member()` against an interface that cannot declare it, which would
+                // turn a method-not-found ContextFail into a CS0539 RecompileFail.
+                // requirements[0].RequiredMembers wraps the still-mutable targetMembers list,
+                // so clearing the explicit-interface fields here reverts the rendered shape.
+                int targetIndex = targetMembers.FindIndex(member =>
+                    member.Kind == CompileBackMemberKind.Method
+                    && member.StubBody == CompileBackStubBodyKind.TargetBody
+                    && member.ExplicitInterfaceMemberName == explicitInterfaceMemberName);
+                if (targetIndex >= 0)
                 {
-                    ExplicitInterfaceMemberName = null,
-                    DeclarationSignature = null,
-                };
+                    targetMembers[targetIndex] = targetMembers[targetIndex] with
+                    {
+                        ExplicitInterfaceMemberName = null,
+                        DeclarationSignature = null,
+                    };
+                }
             }
         }
 
@@ -3247,11 +3554,13 @@ public static class CompileBackSourceComposer
         MetadataReader reader,
         string metadataPropertyName)
     {
-        int separator = metadataPropertyName.LastIndexOf('.');
-        if (separator <= 0 || separator == metadataPropertyName.Length - 1)
+        if (!TrySplitExplicitInterfaceMetadataName(
+                metadataPropertyName,
+                out var interfaceMetadataName,
+                out var memberMetadataName))
+        {
             return null;
-
-        string interfaceMetadataName = metadataPropertyName[..separator];
+        }
         if (TypeProducer.FindType(reader, interfaceMetadataName) is not { } interfaceHandle)
             return null;
         var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
@@ -3262,8 +3571,26 @@ public static class CompileBackSourceComposer
         }
 
         string interfaceName = Clean(interfaceMetadataName);
-        string memberName = CSharpIdentifier.Sanitize(metadataPropertyName[(separator + 1)..]);
+        string memberName = CSharpIdentifier.Sanitize(memberMetadataName);
         return $"{interfaceName}.{memberName}";
+    }
+
+    static bool TrySplitExplicitInterfaceMetadataName(
+        string metadataMemberName,
+        out string interfaceMetadataName,
+        out string memberMetadataName)
+    {
+        int separator = metadataMemberName.LastIndexOf('.');
+        if (separator <= 0 || separator == metadataMemberName.Length - 1)
+        {
+            interfaceMetadataName = "";
+            memberMetadataName = "";
+            return false;
+        }
+
+        interfaceMetadataName = metadataMemberName[..separator];
+        memberMetadataName = metadataMemberName[(separator + 1)..];
+        return true;
     }
 
     sealed class TypeProducer
@@ -3768,6 +4095,8 @@ public static class CompileBackSourceComposer
                 Kind: ToShellKind(kind),
                 InterfaceDisplayNames: InterfaceSignatures(reader, typeDef, requirementsByMetadataName)
                     .Select(signature => signature.DisplayName)
+                    .Concat(requirement.ExternalInterfaces)
+                    .Distinct(StringComparer.Ordinal)
                     .ToList(),
                 MemberPolicies: policies,
                 PrimaryConstructorParameters: primaryConstructorParameters,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1446,12 +1446,12 @@ public static class CompileBackSourceComposer
             // The explicit-member spelling emits Identifier(declarationName) =
             // CSharpIdentifier.Sanitize(declarationName). A keyword member name is escaped
             // losslessly (`class` -> `@class`, which binds back to `class`), but a member name
-            // that is not a legal C# identifier (e.g. a compiler-unspeakable `<Bad>`) is
-            // rewritten by the lossy sanitizing branch (`<Bad>` -> `__Bad_`). The interface
-            // still declares `<Bad>`, so the reconstructed `IType.__Bad_()` binds to no
-            // interface member (CS0539 = RecompileFail). Only engage when the raw member name
-            // round-trips; otherwise decline to the sanitized ContextFail floor.
-            if (!CSharpIdentifier.IsIdentifierLike(declarationName))
+            // that does not round-trip through a C# identifier — a compiler-unspeakable name
+            // (`<Bad>` -> lossily sanitized `__Bad_`), or one carrying a Unicode format
+            // character that Roslyn strips when binding (`M\u200C` -> `M`) — reconstructs an
+            // `IType.<member>()` that binds to no interface member (CS0539 = RecompileFail).
+            // Only engage when the raw member name round-trips; else decline to the floor.
+            if (!MetadataIdentifierRoundTrips(declarationName))
                 return null;
 
             if (ExternalInterfaceReference(reader, (TypeReferenceHandle)declaration.Parent) is not { } interfaceReference)
@@ -1546,25 +1546,47 @@ public static class CompileBackSourceComposer
         return null;
     }
 
-    // True when every dotted segment of the external interface's raw metadata full name is a
-    // legal C# identifier (keyword segments included). Such a name round-trips through the
-    // display spelling the reconstruction emits: Clean(metadataFullName) keyword-escapes an
-    // identifier-like segment losslessly (`class` -> `@class`, which C# resolves back to
-    // `class`). A segment that is not identifier-like (e.g. a compiler-unspeakable
-    // `<Bad>`) is instead rewritten by Clean's sanitizing branch into a different identifier
-    // (`__Bad_`) that names no real type, so the emitted `using __Bad_;` / `__Bad_.IProbe`
-    // spelling fails to bind (CS0246 = RecompileFail). Nested external types are qualified
-    // with `.` (Outer.Inner), so an ordinary nested interface passes; only genuinely
-    // unrepresentable names are declined here to the sanitized ContextFail floor.
+    // True when every dotted segment of the external interface's raw metadata full name
+    // round-trips through the display spelling the reconstruction emits. Clean(metadataFullName)
+    // keyword-escapes an identifier-like segment losslessly (`class` -> `@class`, which C#
+    // resolves back to `class`). A segment that does not round-trip — a compiler-unspeakable
+    // name (`<Bad>`, rewritten by Clean's sanitizing branch to a different identifier
+    // `__Bad_`) or one carrying a Unicode format character Roslyn strips when binding
+    // (`G\u200Cood` -> `Good`) — names no real type, so the emitted `using`/qualifier fails to
+    // bind (CS0246 = RecompileFail). Nested external types are qualified with `.` (Outer.Inner),
+    // so an ordinary nested interface passes; only genuinely unrepresentable names are declined
+    // here to the sanitized ContextFail floor.
     static bool ExternalInterfaceNameIsRepresentable(string metadataFullName)
     {
         foreach (var segment in metadataFullName.Split('.'))
         {
-            if (!CSharpIdentifier.IsIdentifierLike(segment))
+            if (!MetadataIdentifierRoundTrips(segment))
                 return false;
         }
 
         return true;
+    }
+
+    // True when a raw metadata identifier round-trips through the C# identifier the
+    // reconstruction emits (via CSharpIdentifier.Sanitize / Clean). Lexical identifier-likeness
+    // is necessary but not sufficient: Roslyn's identifier binding additionally removes Unicode
+    // format (Cf) characters and applies Unicode normalization form C, so a name carrying a Cf
+    // character (e.g. U+200C) or a non-NFC form binds to a DIFFERENT name than its exact
+    // metadata spelling (CS0246/CS0539 = RecompileFail). Require the name to be identifier-like,
+    // free of Cf characters, and already in NFC; keyword names still round-trip (Escape only
+    // prepends `@`, which binding strips).
+    static bool MetadataIdentifierRoundTrips(string name)
+    {
+        if (!CSharpIdentifier.IsIdentifierLike(name))
+            return false;
+
+        foreach (var rune in name.EnumerateRunes())
+        {
+            if (Rune.GetUnicodeCategory(rune) == UnicodeCategory.Format)
+                return false;
+        }
+
+        return name.IsNormalized(NormalizationForm.FormC);
     }
 
     // True when a type declared in the recompile closure would intercept the leading

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -416,7 +416,11 @@ internal sealed record ExternalInterfaceReferenceInfo(
     string DisplayFullName,
     AssemblyReferenceIdentity AssemblyIdentity);
 
-internal sealed record ExternalInterfaceRequiredMethod(string Name, int GenericArity);
+internal sealed record ExternalInterfaceRequiredMethod(
+    string Name,
+    int GenericArity,
+    string ReturnType,
+    ImmutableArray<string> ParameterTypes);
 
 public static class CompileBackSourceComposer
 {
@@ -1459,6 +1463,40 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
+            // Name + arity alone are signature-blind: a resolved interface method whose
+            // parameter or return types differ from what the target actually implements
+            // (e.g. a rolled-forward dependency, or a reference resolved to a different
+            // build than the target was compiled against) would still match here, and the
+            // reconstructed explicit member would bind to no interface member (CS0539 =
+            // RecompileFail). Require the full decoded signatures to agree; on any mismatch
+            // (or a signature we cannot decode) decline and keep the ContextFail floor.
+            MethodSignature<string> targetSignature;
+            try
+            {
+                var targetMethodDefinition = reader.GetMethodDefinition(targetMethod);
+                targetSignature = targetMethodDefinition.DecodeSignature(
+                    SignatureDecoder.Instance,
+                    GenericContext.ForMethod(reader, targetType, targetMethodDefinition));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return null;
+            }
+            if (!string.Equals(targetSignature.ReturnType, requiredMethod.ReturnType, StringComparison.Ordinal)
+                || !targetSignature.ParameterTypes.SequenceEqual(requiredMethod.ParameterTypes, StringComparer.Ordinal))
+            {
+                return null;
+            }
+
+            // The interface is named in the reconstructed base list by its display full name
+            // only. C# resolves that name against the whole recompile reference set with no
+            // way to disambiguate (RTS does not emit extern aliases), so if more than one
+            // referenced assembly defines that type the emitted source is ambiguous (CS0433 =
+            // RecompileFail). Engage only when the interface has a single definition across
+            // the recompile closure; otherwise decline and keep the ContextFail floor.
+            if (!ExternalInterfaceDefinitionIsUnique(assemblyPath, interfaceReference))
+                return null;
+
             string explicitInterfaceMemberName =
                 $"{interfaceReference.DisplayFullName}.{Identifier(declarationName)}";
             return new ExternalExplicitInterfaceMethodInfo(
@@ -1481,7 +1519,7 @@ public static class CompileBackSourceComposer
         // explicit-impl target is an unbounded slowdown. The resolver itself is also
         // cached per target assembly, and negative results are cached so an
         // unresolvable interface is not retried.
-        string cacheKey = $"{assemblyPath}|{interfaceReference.MetadataFullName}";
+        string cacheKey = $"{assemblyPath}|{interfaceReference.AssemblyIdentity}|{interfaceReference.MetadataFullName}";
         var cached = _externalInterfaceSurfaces.GetOrAdd(cacheKey, _ =>
         {
             var resolver = _externalInterfaceResolvers.GetOrAdd(assemblyPath, static path =>
@@ -1519,6 +1557,59 @@ public static class CompileBackSourceComposer
 
     static readonly ConcurrentDictionary<string, IReadOnlyList<ExternalInterfaceRequiredMethod>?> _externalInterfaceSurfaces =
         new(StringComparer.Ordinal);
+
+    static readonly ConcurrentDictionary<string, bool> _externalInterfaceDefinitionUnique =
+        new(StringComparer.Ordinal);
+
+    // The reconstructed base list names the external interface by display name only. C#
+    // resolves that name against the entire recompile reference set (the same closure
+    // ReturnToSender.CompilationReferences builds from resolver.ResolveAll(), deduplicated
+    // by simple assembly name), with no way to disambiguate two assemblies that define the
+    // same full type name (CS0433). Engage only when exactly one distinct-simple-name
+    // managed assembly in that closure actually defines the interface as a TypeDefinition;
+    // type forwarders are ExportedType rows (not definitions) and so never count. Any
+    // ambiguity, or an inability to prove a single definition, declines to keep the floor.
+    static bool ExternalInterfaceDefinitionIsUnique(
+        string assemblyPath,
+        ExternalInterfaceReferenceInfo interfaceReference)
+    {
+        string cacheKey = $"{assemblyPath}|{interfaceReference.AssemblyIdentity}|{interfaceReference.MetadataFullName}";
+        return _externalInterfaceDefinitionUnique.GetOrAdd(cacheKey, _ =>
+        {
+            var resolver = _externalInterfaceResolvers.GetOrAdd(assemblyPath, static path =>
+                new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(path)
+                {
+                    AllowPlatformAssemblyVersionRollForward = true,
+                    ExcludeTargetAssembly = true,
+                }));
+
+            var definingSimpleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var dependency in resolver.ResolveAll())
+            {
+                if (!ManagedReferenceFilter.IsManagedAssembly(dependency.Path))
+                    continue;
+                try
+                {
+                    using var stream = File.OpenRead(dependency.Path);
+                    using var peReader = new PEReader(stream);
+                    if (!peReader.HasMetadata)
+                        continue;
+                    var dependencyReader = peReader.GetMetadataReader();
+                    if (TypeProducer.FindType(dependencyReader, interfaceReference.MetadataFullName) is null)
+                        continue;
+                    definingSimpleNames.Add(Path.GetFileNameWithoutExtension(dependency.Path));
+                    if (definingSimpleNames.Count > 1)
+                        return false;
+                }
+                catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException or ArgumentException)
+                {
+                    // A dependency we cannot inspect cannot be shown to define the type; skip it.
+                }
+            }
+
+            return definingSimpleNames.Count == 1;
+        });
+    }
 
     static bool TryCollectExternalInterfaceMethods(
         ResolvedAssemblyReference assembly,
@@ -1599,9 +1690,14 @@ public static class CompileBackSourceComposer
                 return false;
             }
 
+            var requiredSignature = method.DecodeSignature(
+                SignatureDecoder.Instance,
+                GenericContext.ForMethod(reader, interfaceDef, method));
             methods.Add(new ExternalInterfaceRequiredMethod(
                 methodName,
-                method.GetGenericParameters().Count));
+                method.GetGenericParameters().Count,
+                requiredSignature.ReturnType,
+                requiredSignature.ParameterTypes));
         }
 
         foreach (var implementationHandle in interfaceDef.GetInterfaceImplementations())

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1443,6 +1443,17 @@ public static class CompileBackSourceComposer
             if (OperatorNames.FormatDisplayName(declarationName) != declarationName)
                 return null;
 
+            // The explicit-member spelling emits Identifier(declarationName) =
+            // CSharpIdentifier.Sanitize(declarationName). A keyword member name is escaped
+            // losslessly (`class` -> `@class`, which binds back to `class`), but a member name
+            // that is not a legal C# identifier (e.g. a compiler-unspeakable `<Bad>`) is
+            // rewritten by the lossy sanitizing branch (`<Bad>` -> `__Bad_`). The interface
+            // still declares `<Bad>`, so the reconstructed `IType.__Bad_()` binds to no
+            // interface member (CS0539 = RecompileFail). Only engage when the raw member name
+            // round-trips; otherwise decline to the sanitized ContextFail floor.
+            if (!CSharpIdentifier.IsIdentifierLike(declarationName))
+                return null;
+
             if (ExternalInterfaceReference(reader, (TypeReferenceHandle)declaration.Parent) is not { } interfaceReference)
                 return null;
             if (!string.Equals(interfaceReference.MetadataFullName, interfaceMetadataName, StringComparison.Ordinal))

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1766,6 +1766,15 @@ public static class CompileBackSourceComposer
                 return false;
             }
 
+            // A public interface may still declare a non-public member (C# 8+ allows explicit
+            // accessibility on interface members). The reconstructed assembly references the
+            // interface's defining assembly but is not granted InternalsVisibleTo, so it can only
+            // name a public member; emitting `void IProbe.M()` for an `internal`/`protected`
+            // member would be inaccessible (CS0122 = RecompileFail). Decline any non-public
+            // required method and keep the ContextFail floor.
+            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
+                return false;
+
             // A generic interface method carries constraints that the reconstructed explicit
             // member cannot restate (C# inherits them from the interface). A type parameter can
             // appear only in a constraint — invisible to the return/parameter signature probe —

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1465,15 +1465,20 @@ public static class CompileBackSourceComposer
 
             // Name + arity alone are signature-blind: a resolved interface method whose
             // parameter or return types differ from what the target actually implements
-            // (e.g. a rolled-forward dependency, or a reference resolved to a different
-            // build than the target was compiled against) would still match here, and the
-            // reconstructed explicit member would bind to no interface member (CS0539 =
-            // RecompileFail). Require the full decoded signatures to agree; on any mismatch
-            // (or a signature we cannot decode) decline and keep the ContextFail floor.
+            // (e.g. a reference resolved to a different build than the target was compiled
+            // against) would still match here, and the reconstructed explicit member would
+            // bind to no interface member (CS0539 = RecompileFail). Require the full decoded
+            // signatures to agree. SignatureDecoder renders by-ref kinds, custom modifiers,
+            // and multidimensional arrays ambiguously, so the decoded-string comparison is
+            // only sound when neither signature carries such detail; the interface surface
+            // already declined any required method that does, so decline the target here too.
+            var targetMethodDefinition = reader.GetMethodDefinition(targetMethod);
+            if (SignatureHasUnrepresentableDetail(reader, targetMethodDefinition))
+                return null;
+
             MethodSignature<string> targetSignature;
             try
             {
-                var targetMethodDefinition = reader.GetMethodDefinition(targetMethod);
                 targetSignature = targetMethodDefinition.DecodeSignature(
                     SignatureDecoder.Instance,
                     GenericContext.ForMethod(reader, targetType, targetMethodDefinition));
@@ -1487,15 +1492,6 @@ public static class CompileBackSourceComposer
             {
                 return null;
             }
-
-            // The interface is named in the reconstructed base list by its display full name
-            // only. C# resolves that name against the whole recompile reference set with no
-            // way to disambiguate (RTS does not emit extern aliases), so if more than one
-            // referenced assembly defines that type the emitted source is ambiguous (CS0433 =
-            // RecompileFail). Engage only when the interface has a single definition across
-            // the recompile closure; otherwise decline and keep the ContextFail floor.
-            if (!ExternalInterfaceDefinitionIsUnique(assemblyPath, interfaceReference))
-                return null;
 
             string explicitInterfaceMemberName =
                 $"{interfaceReference.DisplayFullName}.{Identifier(declarationName)}";
@@ -1512,34 +1508,84 @@ public static class CompileBackSourceComposer
         ExternalInterfaceReferenceInfo interfaceReference,
         out IReadOnlyList<ExternalInterfaceRequiredMethod> requiredMethods)
     {
-        // Reading a referenced interface's transitive surface opens and scans its
-        // defining assembly (often CoreLib). The same interface (e.g.
-        // System.Collections.IEnumerable) recurs across many targets in a single run,
-        // so memoize per (target assembly, interface): rescanning CoreLib for every
-        // explicit-impl target is an unbounded slowdown. The resolver itself is also
-        // cached per target assembly, and negative results are cached so an
-        // unresolvable interface is not retried.
+        // Read the interface surface from the SAME filename-deduplicated dependency closure
+        // the recompile references (ReturnToSender.CompilationReferences: resolver.ResolveAll()
+        // with ExcludeTargetAssembly, deduplicated by simple assembly name). Reading from that
+        // exact closure — rather than an identity/platform resolution that can select a
+        // different file than the recompile ends up referencing — guarantees the members
+        // validated here are precisely the members C# will require against the reconstructed
+        // `: DisplayName`, and lets us prove the interface is defined by exactly one assembly
+        // in the closure (otherwise the unqualified base-list name is ambiguous, CS0433).
+        // Memoize per (target assembly, interface identity, interface full name): the same
+        // interface recurs across many targets and rescanning the closure per target is an
+        // unbounded slowdown. Negative results (unresolvable, ambiguous, or unrepresentable)
+        // are cached so they are not retried.
         string cacheKey = $"{assemblyPath}|{interfaceReference.AssemblyIdentity}|{interfaceReference.MetadataFullName}";
         var cached = _externalInterfaceSurfaces.GetOrAdd(cacheKey, _ =>
         {
             var resolver = _externalInterfaceResolvers.GetOrAdd(assemblyPath, static path =>
                 new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(path)
                 {
-                    AllowPlatformAssemblyVersionRollForward = true,
                     ExcludeTargetAssembly = true,
                 }));
-            if (ResolveExternalAssembly(resolver, interfaceReference.AssemblyIdentity) is not { } assembly)
+
+            // Locate the single closure assembly that defines the interface as a
+            // TypeDefinition. Type forwarders are ExportedType rows (FindType returns null),
+            // so a BCL interface defined once in CoreLib and forwarded elsewhere resolves to
+            // exactly one definition. Zero, or more than one, definition declines.
+            string? definitionPath = null;
+            foreach (var dependency in resolver.ResolveAll())
+            {
+                if (!ManagedReferenceFilter.IsManagedAssembly(dependency.Path))
+                    continue;
+                try
+                {
+                    using var probeStream = File.OpenRead(dependency.Path);
+                    using var probeReader = new PEReader(probeStream);
+                    if (!probeReader.HasMetadata)
+                        continue;
+                    if (TypeProducer.FindType(probeReader.GetMetadataReader(), interfaceReference.MetadataFullName) is null)
+                        continue;
+                }
+                catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException or ArgumentException)
+                {
+                    // A dependency we cannot inspect cannot be shown to define the type; skip it.
+                    continue;
+                }
+
+                if (definitionPath is not null)
+                    return null;
+                definitionPath = dependency.Path;
+            }
+
+            if (definitionPath is null)
                 return null;
 
-            var collected = new List<ExternalInterfaceRequiredMethod>();
-            return TryCollectExternalInterfaceMethods(
-                    assembly,
-                    interfaceReference.MetadataFullName,
-                    resolver,
-                    new HashSet<string>(StringComparer.OrdinalIgnoreCase),
-                    collected)
-                ? collected
-                : null;
+            try
+            {
+                using var stream = File.OpenRead(definitionPath);
+                using var peReader = new PEReader(stream);
+                if (!peReader.HasMetadata)
+                    return null;
+                var reader = peReader.GetMetadataReader();
+                if (TypeProducer.FindType(reader, interfaceReference.MetadataFullName) is not { } interfaceHandle)
+                    return null;
+
+                var collected = new List<ExternalInterfaceRequiredMethod>();
+                return TryCollectRequiredInterfaceMethods(
+                        reader,
+                        interfaceHandle,
+                        resolver,
+                        Path.GetFullPath(definitionPath),
+                        new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                        collected)
+                    ? collected
+                    : null;
+            }
+            catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException or ArgumentException or InvalidOperationException)
+            {
+                return null;
+            }
         });
 
         if (cached is null)
@@ -1558,57 +1604,44 @@ public static class CompileBackSourceComposer
     static readonly ConcurrentDictionary<string, IReadOnlyList<ExternalInterfaceRequiredMethod>?> _externalInterfaceSurfaces =
         new(StringComparer.Ordinal);
 
-    static readonly ConcurrentDictionary<string, bool> _externalInterfaceDefinitionUnique =
-        new(StringComparer.Ordinal);
-
-    // The reconstructed base list names the external interface by display name only. C#
-    // resolves that name against the entire recompile reference set (the same closure
-    // ReturnToSender.CompilationReferences builds from resolver.ResolveAll(), deduplicated
-    // by simple assembly name), with no way to disambiguate two assemblies that define the
-    // same full type name (CS0433). Engage only when exactly one distinct-simple-name
-    // managed assembly in that closure actually defines the interface as a TypeDefinition;
-    // type forwarders are ExportedType rows (not definitions) and so never count. Any
-    // ambiguity, or an inability to prove a single definition, declines to keep the floor.
-    static bool ExternalInterfaceDefinitionIsUnique(
-        string assemblyPath,
-        ExternalInterfaceReferenceInfo interfaceReference)
+    // Probes whether a method signature carries detail that SignatureDecoder renders
+    // ambiguously, making a decoded-string comparison unsound: by-ref parameters (in/out/ref
+    // all decode to "ref T"), custom modifiers (dropped by GetModifiedType), multidimensional
+    // arrays (a rank-1 MDArray decodes identically to an SZArray), and function pointers
+    // (calling-convention modopts). When a signature is free of all of these, its decoded
+    // string form is a faithful identity and string equality is an exact signature check.
+    sealed class UnrepresentableSignatureProbe : ISignatureTypeProvider<bool, object?>
     {
-        string cacheKey = $"{assemblyPath}|{interfaceReference.AssemblyIdentity}|{interfaceReference.MetadataFullName}";
-        return _externalInterfaceDefinitionUnique.GetOrAdd(cacheKey, _ =>
+        public static readonly UnrepresentableSignatureProbe Instance = new();
+        public bool GetPrimitiveType(PrimitiveTypeCode typeCode) => false;
+        public bool GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => false;
+        public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => false;
+        public bool GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+            => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+        public bool GetSZArrayType(bool elementType) => elementType;
+        public bool GetArrayType(bool elementType, ArrayShape shape) => true;
+        public bool GetByReferenceType(bool elementType) => true;
+        public bool GetPointerType(bool elementType) => elementType;
+        public bool GetGenericInstantiation(bool genericType, ImmutableArray<bool> typeArguments)
+            => genericType || typeArguments.Any(argument => argument);
+        public bool GetGenericMethodParameter(object? genericContext, int index) => false;
+        public bool GetGenericTypeParameter(object? genericContext, int index) => false;
+        public bool GetFunctionPointerType(MethodSignature<bool> signature) => true;
+        public bool GetModifiedType(bool modifier, bool unmodifiedType, bool isRequired) => true;
+        public bool GetPinnedType(bool elementType) => elementType;
+    }
+
+    static bool SignatureHasUnrepresentableDetail(MetadataReader reader, MethodDefinition method)
+    {
+        try
         {
-            var resolver = _externalInterfaceResolvers.GetOrAdd(assemblyPath, static path =>
-                new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(path)
-                {
-                    AllowPlatformAssemblyVersionRollForward = true,
-                    ExcludeTargetAssembly = true,
-                }));
-
-            var definingSimpleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var dependency in resolver.ResolveAll())
-            {
-                if (!ManagedReferenceFilter.IsManagedAssembly(dependency.Path))
-                    continue;
-                try
-                {
-                    using var stream = File.OpenRead(dependency.Path);
-                    using var peReader = new PEReader(stream);
-                    if (!peReader.HasMetadata)
-                        continue;
-                    var dependencyReader = peReader.GetMetadataReader();
-                    if (TypeProducer.FindType(dependencyReader, interfaceReference.MetadataFullName) is null)
-                        continue;
-                    definingSimpleNames.Add(Path.GetFileNameWithoutExtension(dependency.Path));
-                    if (definingSimpleNames.Count > 1)
-                        return false;
-                }
-                catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException or ArgumentException)
-                {
-                    // A dependency we cannot inspect cannot be shown to define the type; skip it.
-                }
-            }
-
-            return definingSimpleNames.Count == 1;
-        });
+            var signature = method.DecodeSignature(UnrepresentableSignatureProbe.Instance, (object?)null);
+            return signature.ReturnType || signature.ParameterTypes.Any(parameter => parameter);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return true;
+        }
     }
 
     static bool TryCollectExternalInterfaceMethods(
@@ -1690,6 +1723,12 @@ public static class CompileBackSourceComposer
                 return false;
             }
 
+            // A required method whose signature SignatureDecoder cannot represent faithfully
+            // (by-ref kinds, custom modifiers, multidimensional arrays, function pointers)
+            // cannot be safely signature-compared against the target, so decline the whole
+            // surface and keep the ContextFail floor rather than risk a CS0535/CS0539 emit.
+            if (SignatureHasUnrepresentableDetail(reader, method))
+                return false;
             var requiredSignature = method.DecodeSignature(
                 SignatureDecoder.Instance,
                 GenericContext.ForMethod(reader, interfaceDef, method));


### PR DESCRIPTION
- Advances #3112 (Increment 1 of a stacked pair)
- Changes RTS explicit-interface **method** reconstruction for **external/BCL**
  interfaces (harness-only; product output unchanged)
- Head: `2e0fcb65`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — PR #3199 taught RTS to reconstruct **same-assembly**
explicit-interface methods as real explicit implementations (ContextFail → Exact),
but explicit implementations of **external/referenced** interfaces (e.g.
`System.Collections.IEnumerable.GetEnumerator`) still sanitized their dotted
metadata name (`System_Collections_IEnumerable_GetEnumerator`) and landed at the
`ContextFail` floor. This change reconstructs the **single-member external** case as
a real explicit-interface implementation and names the external interface in the
containing type's base list, so the recompiled method carries the correct dotted
metadata name and round-trips **Exact**. Every uncertain shape declines atomically to
the pre-fix sanitized shape, so no `RecompileFail` regression is introduced.

Before:

```text
compileBackStatus == ContextFail, detail == method-not-found
// class emits: public IEnumerator System_Collections_IEnumerable_GetEnumerator() { ... }
// base list:   class Seq { }              (interface not named)
```

After:

```text
STATUS = Exact
// class emits: IEnumerator System.Collections.IEnumerable.GetEnumerator() { ... }
// base list:   class Seq : System.Collections.IEnumerable { }
```

## Scope and safety

- **Root cause:** For external explicit-interface targets, `ExplicitInterfaceMemberName`
  resolves the interface via `TypeProducer.FindType`, which scans only the
  target-assembly `TypeDefinitions`; an external interface returns null so the target
  kept the plain sanitized shape. The base-list builder (`InterfaceSignatures`) and the
  same-assembly declaration helper (`AddExplicitInterfaceMethodDeclaration`) both gate
  on `Kind == TypeDefinition`/`MethodDefinition`, so an external interface was never
  named and never reconstructed as explicit.
- **Fix shape (harness orchestration only):** When a target has a `MethodImpl` whose
  declaration is a `MemberReference` with a **non-generic `TypeReference`** parent, and
  the external interface's **full transitive required surface is exactly one** abstract
  instance method matching the target by name and generic arity, the harness (a)
  reconstructs the target as an explicit implementation spelled
  `<InterfaceDisplayName>.<Member>` and (b) adds `<InterfaceDisplayName>` to the base
  list. Both use the same display spelling so they agree. Signature match is guaranteed
  by the `MethodImpl` linkage — no arbitrary signature translation is performed.
- **Product impact:** None. No product source/printer/API changes; all new code is under
  `tools/DecompilerHarness/ReturnToSenderTypePlanner.cs`.
- **Scope boundary (atomic + safe fallback):** Engagement is fully gated; the target is
  reconstructed as explicit **only** when the emitted C# is guaranteed to compile.
  Otherwise it reverts to the plain sanitized shape, preserving the pre-fix
  `ContextFail` rather than introducing a `RecompileFail`. It declines for:
  - **Generic / `TypeSpecification` parents** (e.g. `IEnumerable<int>`) — out of scope.
  - **Multi-member interfaces** (surface ≠ 1, e.g. `IConvertible`) — a partial surface
    would be CS0535; deferred to Increment 2.
  - **Interfaces exposing properties/events**, or members that are
    **non-abstract / static / operator** — cannot be supplied as a single bodyless
    method declaration.
  - **Unresolvable assemblies** or **metadata-name mismatch** — cannot verify identity.
- **Performance:** external interface surface reads open and scan the defining assembly
  (often CoreLib). The same interface recurs across many targets in one run, so resolver
  construction and surface results are memoized per `(target assembly, interface)`,
  including negative results, to avoid repeated CoreLib scans.

## Evidence

| Check | Result |
| --- | --- |
| Harness/test build (`ILInspector.Decompiler.Tests -c Release`) | Pass (0 errors, 0 warnings) |
| Full RTS class (`ReturnToSenderPrototypeTests`) | 163 passed, 0 failed |
| `*External*` focused tests | 16 passed (incl. 3 new) |
| Broad EVIL-corpus A/B | Not run in this environment (pinned corpus artifact unavailable on this Windows host); root cause + fix validated by focused round-trip tests |

New focused tests (`src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs`):

- `CompileBackTargets_RoundTripsExternalSingleMemberExplicitInterfaceMethod` —
  `Seq : IEnumerable`, target `System.Collections.IEnumerable.GetEnumerator` → asserts
  **Exact**, base list + explicit method present, sanitized name absent.
- `CompileBackTargets_MultiMemberExternalExplicitInterfaceFallsBackWithoutRecompileFail` —
  `Convertible : IConvertible` (fully implemented) → **not** `RecompileFail`, sanitized
  name present (declines).
- `CompileBackTargets_GenericExternalExplicitInterfaceFallsBackWithoutRecompileFail` —
  `IntSeq : IEnumerable<int>` → **not** `RecompileFail`, sanitized name present (declines).

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Single-member external interfaces (e.g. `IEnumerable`, `ICloneable`, `IDisposable`) | Fixed | Reconstruct as explicit + name in base list → Exact |
| Multi-member external interfaces (`IConvertible`, `ICustomTypeDescriptor`, `ICollection`) | Deferred | Increment 2 (stacked follow-up): synthesize the full external surface as throw-stub explicit impls |
| Generic external interfaces (`IEnumerable<T>`) | Not changed | Out of scope; keeps prior plain shape (unchanged Invalid, not worse) |
| External interfaces exposing properties/events, or non-abstract/static/operator members | Fall back | Cannot supply as a single bodyless method declaration |

## Stacked-PR structure

This is **PR A** (base `main`). **PR B** (Increment 2, multi-member external interfaces)
will be branched off this branch and stacked; GitHub retargets it to `main` when this
merges.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method "*External*"
```
