### PR TITLE
Lock #3163: DeepEquals open-coded object loop raises to while (regression test)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -506,6 +506,44 @@ public class SwitchBranchRenderingTests
         Assert.DoesNotContain("goto ", output);
         Assert.DoesNotMatch(new Regex(@"(?m)^\s*IL_[0-9A-Fa-f]+:\s*$"), output);
     }
+
+    [Fact]
+    public void FullPipeline_RaisesOpenCodedPairedEnumeratorLoop()
+    {
+        // Regression witness for #3163 (part of #3159), the DeepEquals object arm:
+        // an open-coded paired enumerator loop (two `List<int>` enumerators taken
+        // by hand and advanced in lockstep with manual MoveNext()/Current, no
+        // `foreach` sugar) in a switch's default section. csc lowers it to a
+        // bottom-tested/mid-entry goto loop (`goto COND; BODY: …; COND: if
+        // (e.MoveNext()) goto BODY;`). Before #3161 the unraised switch — entangled
+        // with case 0's `foreach` try/finally — kept the whole container flat, so
+        // this loop survived as raw `goto`s/labels; now SwitchRaisingPass owns the
+        // loop-bearing sections and StructuringPass raises it to a structured
+        // `while` with no residual `goto`/labels.
+        using var source = MetadataSource.Open(typeof(OpenCodedPairedEnumeratorLoopFixture).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(OpenCodedPairedEnumeratorLoopFixture).FullName!,
+            nameof(OpenCodedPairedEnumeratorLoopFixture.Compare));
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function);
+        string output = result.Output ?? "";
+
+        Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+
+        // The switch raised (real IL jump table over the dense cases).
+        Assert.Contains("switch (", output);
+        Assert.DoesNotContain("__switchValue", output);
+
+        // The #3163 outcome: the open-coded paired enumerator loop raised to a
+        // structured `while`, keeping the lockstep second-enumerator advance, with
+        // no residual `goto`/labels anywhere in the body.
+        Assert.Contains("while (e1.MoveNext())", output);
+        Assert.Contains("e2.MoveNext();", output);
+        Assert.DoesNotContain("goto ", output);
+        Assert.DoesNotMatch(new Regex(@"(?m)^\s*IL_[0-9A-Fa-f]+:\s*$"), output);
+    }
 }
 
 /// <summary>
@@ -566,6 +604,63 @@ static class GuardsBeforeLoopingSwitchFixture
                     index++;
                 }
                 return true;
+        }
+    }
+}
+
+/// <summary>
+/// Real-IL fixture for
+/// <see cref="SwitchBranchRenderingTests.FullPipeline_RaisesOpenCodedPairedEnumeratorLoop"/>:
+/// mirrors the object-comparison arm of
+/// <c>System.Text.Json.JsonElement.DeepEquals</c> — an <em>open-coded</em> paired
+/// enumerator loop (two <see cref="System.Collections.Generic.List{T}"/>
+/// enumerators taken by hand and advanced in lockstep with manual
+/// <c>MoveNext()</c>/<c>Current</c>, no <c>foreach</c> sugar). csc lowers it to a
+/// bottom-tested/mid-entry goto loop (<c>goto COND; BODY: …; COND: if (e.MoveNext())
+/// goto BODY;</c>). It sits in a <c>switch</c> whose <c>case 0</c> carries an
+/// EH-entangled <c>foreach</c> (a <c>try/finally</c> with a surviving <c>Leave</c>),
+/// so before #3161 the unraised switch kept the whole container flat and this loop
+/// survived as raw <c>goto</c>s/labels (issue #3163). Once <c>SwitchRaisingPass</c>
+/// owns the loop-bearing sections, <c>StructuringPass</c> raises it into a
+/// structured <c>while</c> with no residual <c>goto</c>/labels.
+/// </summary>
+static class OpenCodedPairedEnumeratorLoopFixture
+{
+    public static bool Compare(int kind, System.Collections.Generic.List<int> left, System.Collections.Generic.List<int> right)
+    {
+        switch (kind)
+        {
+            case 0:
+                foreach (int value in left)
+                {
+                    if (value < 0)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            case 1:
+                return left.Count == right.Count;
+            case 2:
+                return true;
+            case 3:
+                return left.Count > 0;
+            case 4:
+                return right.Count > 0;
+            default:
+                int count = left.Count;
+                System.Collections.Generic.List<int>.Enumerator e1 = left.GetEnumerator();
+                System.Collections.Generic.List<int>.Enumerator e2 = right.GetEnumerator();
+                while (e1.MoveNext())
+                {
+                    e2.MoveNext();
+                    if (e1.Current != e2.Current)
+                    {
+                        return false;
+                    }
+                    count--;
+                }
+                return count == 0;
         }
     }
 }


### PR DESCRIPTION
Closes #3163 (part of #3159).

## Conclusion

The `JsonElement.DeepEquals` object-comparison loop reported in #3163 — emitted as
raw `goto`s/labels — is **already gone**, resolved as a byproduct of the #3161
switch-raising fix (#3174). This PR is **test-only**: it adds the missing
regression guard so the loop can't silently revert to a goto shape.

## Why #3174 fixed it

The object arm is an open-coded paired enumerator loop that csc lowers to a
bottom-tested/mid-entry goto loop:

```csharp
objectEnumerator1 = element1.EnumerateObject();
objectEnumerator2 = element2.EnumerateObject();
goto IL_0195;
IL_014B:
objectEnumerator2.MoveNext();
...
count--;
IL_0195:
if (objectEnumerator1.MoveNext()) goto IL_014B;
return true;
```

`StructuringPass` is all-or-nothing per container: the method's **unraised
jump-table switch**, entangled with the enumerator `try/finally` regions (a
surviving `Leave` target), kept the whole body flat — so this loop stayed a raw
goto loop. Once `SwitchRaisingPass` owns the loop-bearing sections (#3174),
`StructuringPass` structures the container and raises the loop. Current output
(`dotnet-inspect System.Text.Json.JsonElement.DeepEquals -S "Decom*"`, `net11.0`)
is exactly the issue's **Expected**:

```csharp
objectEnumerator1 = element1.EnumerateObject();
objectEnumerator2 = element2.EnumerateObject();
while (objectEnumerator1.MoveNext())
{
    objectEnumerator2.MoveNext();
    prop1 = objectEnumerator1.Current;
    prop2 = objectEnumerator2.Current;
    ...
    count--;
}
return true;
```

No `goto`/labels. (Residual synthetic names — `S_256`, `count` — are #3165; the
`foreach` recovery over these paired enumerators is #3164; both orthogonal.)

## What this PR adds

A compiled fixture and one full-pipeline test:

- `OpenCodedPairedEnumeratorLoopFixture.Compare` — a `switch` over dense cases
  `0..4` (case 0 an **EH-entangled** `foreach` whose `try/finally` + `Leave` keeps
  the container flat pre-#3161) whose **default** arm is an open-coded paired
  `List<int>` enumerator loop (manual `MoveNext()`/`Current` in lockstep, no
  `foreach` sugar).
- `SwitchBranchRenderingTests.FullPipeline_RaisesOpenCodedPairedEnumeratorLoop` —
  imports the compiled method through the full pipeline and asserts `Full`
  fidelity, a raised `switch`, the paired loop raised to a structured
  `while (e1.MoveNext())` keeping the lockstep `e2.MoveNext();` advance, and **no
  `goto`/`IL_` labels** anywhere.

Verified decompiled output of the fixture (via `IrImporter` + `CSharpPrinter.PrintRaised`):

```csharp
switch (kind)
{
    case 0:
        using (List<int>.Enumerator V_3 = left.GetEnumerator())
        {
            while (V_3.MoveNext()) { if (V_3.Current < 0) { return false; } }
        }
        return true;
    // case 1..4 scalar arms …
    default:
        count = left.Count;
        e1 = left.GetEnumerator();
        e2 = right.GetEnumerator();
        while (e1.MoveNext())
        {
            e2.MoveNext();
            if (e1.Current != e2.Current) { return false; }
            count--;
        }
        return count == 0;
}
```

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -class "ILInspector.Decompiler.Tests.SwitchBranchRenderingTests"
```

- `SwitchBranchRenderingTests`: 13 total, 0 failed (incl. the new test and the
  existing `FullPipeline_Raises*` switch/guard witnesses).

## Risk

Test-only, no product change. No adversarial review required (mechanical, low
risk): a fixture + assertion over already-shipping behavior.
