### PR TITLE
Render boxed-this non-interface access as base/cast, not invalid (this).M() (#3213)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -255,17 +255,70 @@ public sealed class ThisQualificationTests
         Assert.DoesNotContain("(this).FaceMethod()", text);
     }
 
-    // Negative guard: a boxed `this` that reaches a NON-interface member (here
-    // `object.ToString()` via `((object)this).ToString()`) must NOT be over-cast to
-    // the enclosing struct — `IsInterfaceCastThisReceiver` declines a non-interface
-    // callee, so the boxed-this arm never fires. The faithful render keeps the
-    // object cast the boxing spells and never writes `((StructBoxedObjectReceiver)this)`.
+    // A boxed `this` reaching a NON-interface VIRTUAL member (here
+    // `object.ToString()` via `((object)this).ToString()`) renders the cast form
+    // `((object)this).ToString()`: the explicit `box` is the source upcast, and a
+    // virtual `callvirt object::ToString` re-emits from `ldobj; box`. Bare
+    // `(this).ToString()` would instead lower to `constrained. callvirt` (no box) —
+    // not opcode-faithful — and must never be over-cast to the enclosing struct
+    // (#3213, extending #3201 beyond interface callees).
     [Fact]
-    public void StructBoxedThis_NonInterfaceCallee_IsNotOverCast()
+    public void StructBoxedThis_ObjectVirtualCallee_RendersObjectCast()
     {
         var text = RenderMember(typeof(StructBoxedObjectReceiver),
             nameof(StructBoxedObjectReceiver.CallObjectToString));
+        Assert.Contains("((object)this).ToString()", text);
         Assert.DoesNotContain("StructBoxedObjectReceiver)this", text);
+        Assert.DoesNotContain("(this).ToString()", text);
+    }
+
+    // A boxed `this` reaching a NON-interface NON-VIRTUAL base member renders
+    // `base.M()`. A struct overriding `GetHashCode` and calling `base.GetHashCode()`
+    // lowers to `ldarg.0; ldobj S; box S; call System.ValueType::GetHashCode; ret`
+    // — a non-virtual `call` (not `callvirt`) to a base method. Bare
+    // `(this).GetHashCode()` re-dispatches virtually to the struct's own override:
+    // infinite self-recursion. `base.GetHashCode()` re-emits exactly the
+    // `ldobj; box; call ValueType::GetHashCode` (#3213).
+    [Fact]
+    public void StructBoxedThis_NonVirtualBaseCallee_RendersBaseCall()
+    {
+        var text = RenderMember(typeof(StructBaseHashCall),
+            nameof(StructBaseHashCall.GetHashCode));
+        Assert.Contains("base.GetHashCode()", text);
+        Assert.DoesNotContain("(this).GetHashCode()", text);
+        Assert.DoesNotContain(")this).GetHashCode()", text);
+    }
+
+    // A boxed `this` reaching a virtual member through an explicit base cast renders
+    // the cast form, not `base.`. Casting a struct to `System.ValueType` boxes;
+    // because `GetHashCode`'s virtual slot is introduced on `System.Object`, csc
+    // binds the `callvirt` to `object::GetHashCode`, so the faithful cast is
+    // `((object)this).GetHashCode()` (re-emits `ldobj; box; callvirt
+    // object::GetHashCode`). Distinguished from `base.M()` by the call being
+    // virtual, not by the receiver shape (#3213).
+    [Fact]
+    public void StructBoxedThis_ExplicitBaseCastVirtualCallee_RendersObjectCast()
+    {
+        var text = RenderMember(typeof(StructValueTypeCastReceiver),
+            nameof(StructValueTypeCastReceiver.CallViaValueTypeCast));
+        Assert.Contains("((object)this).GetHashCode()", text);
+        Assert.DoesNotContain("base.", text);
+        Assert.DoesNotContain("(this).GetHashCode()", text);
+    }
+
+    // Negative guard (#3213): an implicit `this.ToString()` on a struct that does
+    // NOT box does not go through the boxed-this arm. Because the struct does not
+    // override `ToString`, csc emits `ldarg.0; constrained. S; callvirt
+    // object::ToString()` — a bare `LoadArgument{0,"this"}` receiver with a
+    // `constrained.` prefix and NO `box`, so `IsBoxedThisReceiver` declines. The
+    // render must not gain a cast or `base.` — the constrained call already binds.
+    [Fact]
+    public void StructImplicitThis_ConstrainedCall_IsNotBoxedOrBased()
+    {
+        var text = RenderMember(typeof(StructImplicitToString),
+            nameof(StructImplicitToString.CallImplicitToString));
+        Assert.DoesNotContain("base.", text);
+        Assert.DoesNotContain(")this).ToString()", text);
     }
 
     [Fact]
@@ -688,13 +741,38 @@ public struct StructExplicitFace : IStructFace
     public int CallExplicitInterface() => ((IStructFace)this).FaceMethod();
 }
 
-// Negative fixture (#3201): a struct that boxes `this` to reach a NON-interface
-// member. `((object)this).ToString()` also lowers to `ldarg.0; ldobj S; box S;
-// callvirt object::ToString()`, so its IR receiver is likewise a Box over this —
-// but the callee's declaring type is System.Object, not an interface, so the
-// boxed-this arm must decline and leave the object cast untouched. Guards the
-// arm against firing on every boxed-this receiver.
+// Boxed-this fixtures reaching NON-interface members (#3213). All three box
+// `this` (`ldarg.0; ldobj S; box S; ...`) — the value-type sibling of a reference
+// upcast — but the callee is not an interface member, so the fix must split on
+// call kind rather than interface-ness: a virtual `callvirt` re-emits the cast
+// (`((T)this).M()`); a non-virtual `call` to a base method is `base.M()`.
+//   * CallObjectToString: virtual `callvirt object::ToString` -> `((object)this)`.
+//   * GetHashCode: non-virtual `call ValueType::GetHashCode` -> `base.` (a bare
+//     `(this).GetHashCode()` would recurse into this override forever).
+//   * CallViaValueTypeCast: an explicit `(ValueType)this` cast boxes, but csc
+//     binds the virtual call to the slot-defining `object::GetHashCode`, so it
+//     renders `((object)this)` (still a cast, not `base.`, because it is virtual).
 public struct StructBoxedObjectReceiver
 {
     public string CallObjectToString() => ((object)this).ToString()!;
+}
+
+public struct StructBaseHashCall
+{
+    public override int GetHashCode() => base.GetHashCode();
+}
+
+public struct StructValueTypeCastReceiver
+{
+    public int CallViaValueTypeCast() => ((System.ValueType)this).GetHashCode();
+}
+
+// Negative fixture (#3213): an implicit `this.ToString()` on a struct that does
+// NOT override ToString does NOT box — csc emits `ldarg.0; constrained. S;
+// callvirt object::ToString()`, leaving a bare `LoadArgument{0,"this"}` receiver
+// (with a `constrained.` prefix), not a Box. `IsBoxedThisReceiver` declines, so
+// the boxed-this arm must not fire and the render gains no cast or `base.`.
+public struct StructImplicitToString
+{
+    public string CallImplicitToString() => this.ToString()!;
 }

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -306,6 +306,43 @@ public sealed class ThisQualificationTests
         Assert.DoesNotContain("(this).GetHashCode()", text);
     }
 
+    // Negative guard (#3213 review, GPT): a boxed-`this` method group whose callee
+    // is a STATIC extension method must NOT be cast to the extension host. A struct
+    // forming `((object)this).ExtValue` (or `this.ExtValue`) as a delegate boxes and
+    // emits `ldobj; box; ldftn Host::ExtValue(object); newobj`, matching the
+    // boxed-this shape — but the callee is static (`method.HasThis` false) and its
+    // declaring type is the static host, which is not a cast target: `((Host)this)`
+    // is CS0716. It falls through to the ordinary receiver path, spelling the boxed
+    // receiver, so the render must show neither the host cast nor `base.`.
+    [Fact]
+    public void StructBoxedThis_StaticExtensionMethodGroup_IsNotCastToHost()
+    {
+        var text = RenderMember(typeof(StructExtensionGroupReceiver),
+            nameof(StructExtensionGroupReceiver.ExtGroup));
+        Assert.Contains("(this).ExtValue", text);
+        Assert.DoesNotContain("BoxedThisExtensionHost)this", text);
+        Assert.DoesNotContain("base.", text);
+    }
+
+    // Negative guard (#3213 review, Gemini): a STATIC method whose first parameter is
+    // spelled `@this` emits the metadata name `"this"` at index 0, so a boxed
+    // `((object)@this).M()` matches the boxed-this shape — but `base`/`this` are
+    // illegal in a static method (CS0026). The boxed-this arm is gated on the
+    // enclosing method having an implicit `this`, so it must NOT synthesize
+    // `base.GetType()` (non-virtual) or `((object)this).ToString()` (virtual) here;
+    // the boxed `@this` parameter falls through to the ordinary receiver path.
+    [Fact]
+    public void StaticMethodWithThisNamedParameter_BoxedReceiver_DoesNotSynthesizeBaseOrCast()
+    {
+        var nonVirtual = RenderMember(typeof(StructStaticThisParameter),
+            nameof(StructStaticThisParameter.BoxNonVirtual));
+        Assert.DoesNotContain("base.", nonVirtual);
+        var virtualText = RenderMember(typeof(StructStaticThisParameter),
+            nameof(StructStaticThisParameter.BoxVirtual));
+        Assert.DoesNotContain("((object)this)", virtualText);
+        Assert.DoesNotContain("base.", virtualText);
+    }
+
     // Negative guard (#3213): an implicit `this.ToString()` on a struct that does
     // NOT box does not go through the boxed-this arm. Because the struct does not
     // override `ToString`, csc emits `ldarg.0; constrained. S; callvirt
@@ -775,4 +812,34 @@ public struct StructValueTypeCastReceiver
 public struct StructImplicitToString
 {
     public string CallImplicitToString() => this.ToString()!;
+}
+
+// Boxed-this method-group whose callee is a STATIC extension method (#3213 review,
+// GPT). `((object)this).ExtValue` boxes and emits `ldobj; box; ldftn
+// BoxedThisExtensionHost::ExtValue(object); newobj Func` — the boxed-this shape,
+// but the callee is static, so `method.HasThis` gates the boxed-this arm off and
+// the render must spell the boxed receiver, never `((BoxedThisExtensionHost)this)`
+// (CS0716 — a static type is not a cast target).
+public static class BoxedThisExtensionHost
+{
+    public static int ExtValue(this object x) => 7;
+}
+
+public struct StructExtensionGroupReceiver
+{
+    public System.Func<int> ExtGroup() => ((object)this).ExtValue;
+}
+
+// A STATIC method whose first parameter is spelled `@this` (#3213 review, Gemini).
+// The compiler emits the metadata name `"this"` at index 0, so a boxed
+// `((object)@this).M()` matches `Box{LoadIndirect{LoadArgument{0,"this"}}}` — yet
+// `base`/`this` are illegal in a static context (CS0026). The boxed-this arm is
+// gated on the ENCLOSING method having an implicit `this` (`_function.Signature
+// .HasThis`), so these must not synthesize `base.`/`((object)this)`; the boxed
+// `@this` parameter falls through to the ordinary receiver path.
+public struct StructStaticThisParameter
+{
+    public static System.Type BoxNonVirtual(ref StructStaticThisParameter @this) => ((object)@this).GetType();
+
+    public static string BoxVirtual(ref StructStaticThisParameter @this) => ((object)@this).ToString()!;
 }

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -358,6 +358,57 @@ public sealed class ThisQualificationTests
         Assert.DoesNotContain(")this).ToString()", text);
     }
 
+    // Regression (#3213 review, Gemini + GPT): a boxed `this` reaching a SEALED
+    // default interface member must render the `((I)this)` cast, NOT `base.`. A
+    // sealed DIM is non-virtual, so `((I)this).SealedPing()` lowers to
+    // `ldobj; box; call ISealedDim::SealedPing` — a non-virtual `call` that shares
+    // the base-call shape (`!IsVirtual && IsCrossType`). Before the ValueType gate
+    // the base arm over-fired here and emitted invalid `base.SealedPing()` (CS0117
+    // — a struct's base `System.ValueType` has no such member). The declaring type
+    // is an interface, not `System.ValueType`, so the cast arm re-emits the exact
+    // non-virtual `call ISealedDim::SealedPing`.
+    [Fact]
+    public void StructBoxedThis_SealedInterfaceCallee_RendersInterfaceCast()
+    {
+        var text = RenderMember(typeof(StructSealedDimReceiver),
+            nameof(StructSealedDimReceiver.CallSealedDim));
+        Assert.Contains("((ISealedDim)this).SealedPing()", text);
+        Assert.DoesNotContain("base.", text);
+        Assert.DoesNotContain("(this).SealedPing()", text);
+    }
+
+    // Regression (#3213 review, Gemini): the method-group form of the sealed-DIM
+    // case. `((ISealedDim)this).SealedPing` (as a delegate) emits `ldobj; box;
+    // ldftn ISealedDim::SealedPing; newobj` — a non-virtual `ldftn` matching the
+    // base-group shape. It must render the `((I)this)` cast, never invalid
+    // `base.SealedPing` (CS0117).
+    [Fact]
+    public void StructBoxedThis_SealedInterfaceMethodGroup_RendersInterfaceCast()
+    {
+        var text = RenderMember(typeof(StructSealedDimReceiver),
+            nameof(StructSealedDimReceiver.SealedDimGroup));
+        Assert.Contains("((ISealedDim)this).SealedPing", text);
+        Assert.DoesNotContain("base.", text);
+    }
+
+    // Regression (#3213 review, GPT): a boxed `this` reaching a NON-VIRTUAL
+    // `System.Object` member (`base.GetType()`) renders the `((object)this)` cast,
+    // not `base.`. `base.GetType()` lowers to `ldobj; box; call object::GetType` —
+    // the callee's declaring type is `System.Object`, not the struct's immediate
+    // base `System.ValueType`, so `base.` is not guaranteed token-exact. Because
+    // `GetType` is non-virtual, the cast `((object)this).GetType()` re-emits the
+    // identical `ldobj; box; call object::GetType` (verified IL-equal to the
+    // `base.GetType()` source), so the ValueType-gated arm routes it to the cast
+    // form. Both spellings round-trip; the printer picks the cast.
+    [Fact]
+    public void StructBoxedThis_ObjectNonVirtualCallee_RendersObjectCast()
+    {
+        var text = RenderMember(typeof(StructBaseGetType),
+            nameof(StructBaseGetType.CallBaseGetType));
+        Assert.Contains("((object)this).GetType()", text);
+        Assert.DoesNotContain("base.", text);
+    }
+
     [Fact]
     public void EventSubscription_DefaultsToBareName()
     {
@@ -842,4 +893,36 @@ public struct StructStaticThisParameter
     public static System.Type BoxNonVirtual(ref StructStaticThisParameter @this) => ((object)@this).GetType();
 
     public static string BoxVirtual(ref StructStaticThisParameter @this) => ((object)@this).ToString()!;
+}
+
+// Sealed default interface member reached from a boxed struct `this` (#3213
+// review, Gemini + GPT). A sealed DIM is NON-VIRTUAL, so `((ISealedDim)this)
+// .SealedPing()` lowers to `ldobj; box; call ISealedDim::SealedPing` and its
+// method group to `ldobj; box; ldftn ISealedDim::SealedPing; newobj` — both share
+// the non-virtual base-call/group shape. The declaring type is an interface, not
+// the struct's immediate base `System.ValueType`, so the printer must re-emit the
+// `((I)this)` cast, never `base.SealedPing` (CS0117 — a struct's base has no such
+// member).
+public interface ISealedDim
+{
+    sealed void SealedPing() { }
+}
+
+public struct StructSealedDimReceiver : ISealedDim
+{
+    public void CallSealedDim() => ((ISealedDim)this).SealedPing();
+
+    public System.Action SealedDimGroup() => ((ISealedDim)this).SealedPing;
+}
+
+// A boxed struct `this` reaching a NON-VIRTUAL `System.Object` member via `base.`
+// (#3213 review, GPT). `base.GetType()` lowers to `ldobj; box; call
+// object::GetType` — the callee's declaring type is `System.Object`, not the
+// struct's immediate base `System.ValueType`. Because `GetType` is non-virtual,
+// `((object)this).GetType()` re-emits the identical `ldobj; box; call
+// object::GetType`, so the ValueType-gated base arm routes it to the cast form
+// (both spellings round-trip; only `System.ValueType` callees stay `base.`).
+public struct StructBaseGetType
+{
+    public System.Type CallBaseGetType() => base.GetType();
 }

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -391,22 +391,44 @@ public sealed class ThisQualificationTests
         Assert.DoesNotContain("base.", text);
     }
 
-    // Regression (#3213 review, GPT): a boxed `this` reaching a NON-VIRTUAL
-    // `System.Object` member (`base.GetType()`) renders the `((object)this)` cast,
-    // not `base.`. `base.GetType()` lowers to `ldobj; box; call object::GetType` —
-    // the callee's declaring type is `System.Object`, not the struct's immediate
-    // base `System.ValueType`, so `base.` is not guaranteed token-exact. Because
-    // `GetType` is non-virtual, the cast `((object)this).GetType()` re-emits the
-    // identical `ldobj; box; call object::GetType` (verified IL-equal to the
-    // `base.GetType()` source), so the ValueType-gated arm routes it to the cast
-    // form. Both spellings round-trip; the printer picks the cast.
+    // A boxed `this` reaching a NON-VIRTUAL `System.Object` member
+    // (`base.GetType()`) renders `base.GetType()`. `System.Object` is a struct's
+    // (transitive) base class, so `base.GetType()` lowers to `ldobj; box; call
+    // object::GetType`, matching the source; the printer whitelists both a struct's
+    // base classes (ValueType and Object) for the base arm. `GetType` is public and
+    // non-virtual, so `((object)this).GetType()` would ALSO round-trip, but the
+    // printer prefers `base.` (the source spelling, and the only valid spelling for
+    // a protected base member — see the MemberwiseClone regression) (#3213 review).
     [Fact]
-    public void StructBoxedThis_ObjectNonVirtualCallee_RendersObjectCast()
+    public void StructBoxedThis_ObjectNonVirtualCallee_RendersBaseCall()
     {
         var text = RenderMember(typeof(StructBaseGetType),
             nameof(StructBaseGetType.CallBaseGetType));
-        Assert.Contains("((object)this).GetType()", text);
-        Assert.DoesNotContain("base.", text);
+        Assert.Contains("base.GetType()", text);
+        Assert.DoesNotContain(")this).GetType()", text);
+        Assert.DoesNotContain("(this).GetType()", text);
+    }
+
+    // Regression (#3213 review, Gemini + GPT): a boxed `this` reaching the PROTECTED
+    // `System.Object.MemberwiseClone` renders `base.MemberwiseClone()` — the ONLY
+    // valid spelling. `base.MemberwiseClone()` lowers to `ldobj; box; call
+    // object::MemberwiseClone`; the cast `((object)this).MemberwiseClone()` is
+    // CS1540 (a protected member cannot be accessed through a base-typed qualifier),
+    // so the object-cast fallback that serves public members like `GetType` must NOT
+    // apply here. The base arm whitelisting both base classes (ValueType and Object)
+    // keeps this valid. The method-group form must likewise stay `base.`.
+    [Fact]
+    public void StructBoxedThis_ProtectedObjectCallee_RendersBaseCall()
+    {
+        var call = RenderMember(typeof(StructMemberwiseCloneReceiver),
+            nameof(StructMemberwiseCloneReceiver.CloneCall));
+        Assert.Contains("base.MemberwiseClone()", call);
+        Assert.DoesNotContain(")this).MemberwiseClone", call);
+
+        var group = RenderMember(typeof(StructMemberwiseCloneReceiver),
+            nameof(StructMemberwiseCloneReceiver.CloneGroup));
+        Assert.Contains("base.MemberwiseClone", group);
+        Assert.DoesNotContain(")this).MemberwiseClone", group);
     }
 
     [Fact]
@@ -916,13 +938,26 @@ public struct StructSealedDimReceiver : ISealedDim
 }
 
 // A boxed struct `this` reaching a NON-VIRTUAL `System.Object` member via `base.`
-// (#3213 review, GPT). `base.GetType()` lowers to `ldobj; box; call
-// object::GetType` — the callee's declaring type is `System.Object`, not the
-// struct's immediate base `System.ValueType`. Because `GetType` is non-virtual,
-// `((object)this).GetType()` re-emits the identical `ldobj; box; call
-// object::GetType`, so the ValueType-gated base arm routes it to the cast form
-// (both spellings round-trip; only `System.ValueType` callees stay `base.`).
+// (#3213 review). `base.GetType()` lowers to `ldobj; box; call object::GetType` —
+// `System.Object` is one of a struct's two base classes (with `System.ValueType`),
+// both whitelisted for the `base.` arm, so this renders `base.GetType()`. `GetType`
+// is public and non-virtual, so `((object)this).GetType()` would also round-trip,
+// but the printer prefers the source `base.` spelling.
 public struct StructBaseGetType
 {
     public System.Type CallBaseGetType() => base.GetType();
+}
+
+// A boxed struct `this` reaching the PROTECTED `System.Object.MemberwiseClone` via
+// `base.` (#3213 review, Gemini + GPT). `base.MemberwiseClone()` lowers to `ldobj;
+// box; call object::MemberwiseClone`; the group is `ldobj; box; ldftn
+// object::MemberwiseClone; newobj`. `MemberwiseClone` is protected, so the
+// `((object)this).MemberwiseClone()` cast that serves a public member like
+// `GetType` is CS1540 here — only `base.` compiles, which is why the base arm must
+// whitelist `System.Object` (not just `System.ValueType`).
+public struct StructMemberwiseCloneReceiver
+{
+    public object CloneCall() => base.MemberwiseClone();
+
+    public System.Func<object> CloneGroup() => base.MemberwiseClone;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -419,23 +419,32 @@ public sealed partial class CSharpPrinter
             && !IsEnclosingTypeAtOwnInstantiation(declaringType);
 
     /// <summary>
-    /// True when <paramref name="receiver"/> (or method-group target) is a value
-    /// type's <c>this</c> boxed to reach a member of a type the struct was cast
-    /// to. A struct must box to invoke a base (<c>System.ValueType</c>/
-    /// <c>System.Object</c>) or interface member, so <c>((T)this).M()</c> /
-    /// <c>base.M()</c> lowers to <c>ldarg.0; ldobj S; box S; call[virt] T::M</c> —
-    /// the receiver is a <see cref="Box"/> over the dereferenced <c>this</c>
-    /// pointer (<c>LoadIndirect</c> of <c>LoadArgument{0,"this"}</c>), not the bare
+    /// True when <paramref name="receiver"/> (or method-group target) is the
+    /// enclosing value type's <c>this</c> boxed to reach a member of a type the
+    /// struct was cast to. A struct must box to invoke a base
+    /// (<c>System.ValueType</c>/<c>System.Object</c>) or interface member, so
+    /// <c>((T)this).M()</c> / <c>base.M()</c> lowers to
+    /// <c>ldarg.0; ldobj S; box S; call[virt] T::M</c> — the receiver is a
+    /// <see cref="Box"/> over the dereferenced <c>this</c> pointer
+    /// (<c>LoadIndirect</c> of <c>LoadArgument{0,"this"}</c>), not the bare
     /// <c>LoadArgument{0,"this"}</c> a reference-type upcast (no IL) leaves. Only a
-    /// value type produces this shape (a class <c>this</c> is already a reference),
-    /// and only <c>this</c> — a boxed field/local/parameter has a different address
-    /// operand and is left to the ordinary receiver path. The <see cref="Box"/> is
-    /// itself the evidence of the cast, so no interface metadata is needed:
-    /// callers re-insert the cast (virtual) or spell <c>base.</c> (non-virtual)
-    /// from the callee's declaring type and its call kind (#3201, #3213).
+    /// value type produces this shape (a class <c>this</c> is already a reference).
+    /// The <see cref="Box"/> is itself the evidence of the cast, so no interface
+    /// metadata is needed: callers re-insert the cast (virtual) or spell
+    /// <c>base.</c> (non-virtual) from the callee's declaring type and call kind
+    /// (#3201, #3213).
+    /// <para>
+    /// Gated on the enclosing method having an implicit <c>this</c>: a
+    /// <c>static</c> method (or extension method) whose first parameter is spelled
+    /// <c>@this</c> emits the metadata name <c>"this"</c> at index 0, matching the
+    /// shape, but <c>base</c>/<c>this</c> are illegal there (CS0026). Such a boxed
+    /// <c>@this</c> parameter falls through to the ordinary receiver path, which
+    /// spells the parameter by name (#3213 review).
+    /// </para>
     /// </summary>
-    static bool IsBoxedThisReceiver(IrExpression receiver)
-        => receiver is Box { Operand: LoadIndirect { Address: LoadArgument { Index: 0, Name: "this" } } };
+    bool IsBoxedThisReceiver(IrExpression receiver)
+        => _function.Signature.HasThis
+            && receiver is Box { Operand: LoadIndirect { Address: LoadArgument { Index: 0, Name: "this" } } };
 
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
     string ReceiverText(IrExpression receiver) => receiver switch
@@ -532,9 +541,15 @@ public sealed partial class CSharpPrinter
         // dup; ldvirtftn T::M`. Bare (this).M / this.M would be CS1061 or rebind
         // to the derived override. Subsumes the struct interface-cast case (#3201)
         // and the base-class case (#3213). Mirrors the bare-this arms above.
-        if (IsBoxedThisReceiver(target))
+        // HasThis gates the whole branch: a closed static extension method group
+        // (`((object)this).Ext`) shares the `ldobj; box; ldftn` shape but binds the
+        // boxed this as its first argument, so its DeclaringType is the static
+        // extension host — not a cast target (`((E)this).Ext` is CS0716). Those
+        // fall through to the ordinary receiver path, which spells the boxed
+        // receiver ((object)this) the extension already carries.
+        if (method.HasThis && IsBoxedThisReceiver(target))
         {
-            if (method.HasThis && !isVirtual && IsCrossType(method.DeclaringType))
+            if (!isVirtual && IsCrossType(method.DeclaringType))
                 return $"base.{name}";
             return $"(({TypeText(method.DeclaringType)})this).{name}";
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -430,12 +430,13 @@ public sealed partial class CSharpPrinter
     /// <c>LoadArgument{0,"this"}</c> a reference-type upcast (no IL) leaves. Only a
     /// value type produces this shape (a class <c>this</c> is already a reference).
     /// The <see cref="Box"/> is itself the evidence of the cast, so no interface
-    /// metadata is needed: callers re-spell it as <c>base.M</c> only when the
-    /// non-virtual callee is declared on <see cref="System.ValueType"/> (the
-    /// struct's guaranteed immediate base, where base-suppression binds the exact
-    /// token), and as the erased <c>((T)this).M</c> cast otherwise — a virtual
-    /// call, or a non-virtual call to a base <see cref="System.Object"/> or
-    /// interface member (#3201, #3213). See <see cref="IsSystemValueType"/>.
+    /// metadata is needed: callers re-spell it as <c>base.M</c> when the
+    /// non-virtual callee is declared on one of the struct's base classes
+    /// (<see cref="System.ValueType"/> or <see cref="System.Object"/>, where
+    /// base-suppression reaches the base member and <c>base</c> is the only valid
+    /// spelling for a <c>protected</c> member), and as the erased
+    /// <c>((T)this).M</c> cast otherwise — a virtual call, or a non-virtual call to
+    /// an interface member (#3201, #3213). See <see cref="IsStructBaseClass"/>.
     /// <para>
     /// Gated on the enclosing method having an implicit <c>this</c>: a
     /// <c>static</c> method (or extension method) whose first parameter is spelled
@@ -450,21 +451,29 @@ public sealed partial class CSharpPrinter
             && receiver is Box { Operand: LoadIndirect { Address: LoadArgument { Index: 0, Name: "this" } } };
 
     /// <summary>
-    /// True when <paramref name="type"/> is <c>System.ValueType</c>, a struct's
-    /// guaranteed immediate base. A non-virtual boxed-<c>this</c> call to a member
-    /// declared here is the ONE case a struct can re-spell as <c>base.M()</c>: the
-    /// base is exactly <c>ValueType</c>, so base-suppression (<c>call</c>, no
-    /// virtual dispatch) binds the exact callee token. A non-virtual call to a
-    /// <c>System.Object</c> member instead has no faithful <c>base.</c> spelling
-    /// (base lookup would rebind <c>GetHashCode</c>/<c>Equals</c>/<c>ToString</c>
-    /// to <c>ValueType</c>'s override), and a call to an interface member (a sealed
-    /// default interface member emits a non-virtual <c>call I::M</c>) has no
-    /// <c>base</c> at all (CS0117); both take the erased <c>((T)this).M()</c> cast,
-    /// which is <c>ldobj; box; call T::M</c> — opcode-faithful for a non-virtual
-    /// method like <c>object::GetType</c> and a sealed DIM (#3213 review).
+    /// True when <paramref name="type"/> is one of a struct's two base classes,
+    /// <c>System.ValueType</c> or <c>System.Object</c>. A non-virtual boxed-
+    /// <c>this</c> call to a member declared on a base class re-spells as
+    /// <c>base.M()</c>: base-suppression (<c>call</c>, no virtual dispatch) reaches
+    /// the base member, and <c>base</c> is the ONLY spelling that stays valid for a
+    /// <c>protected</c> base member like <c>object::MemberwiseClone</c> — an
+    /// <c>((object)this).MemberwiseClone()</c> cast is CS1540 (protected access
+    /// through a base-typed qualifier). An interface callee is excluded (a sealed
+    /// default interface member emits a non-virtual <c>call I::M</c>, yet has no
+    /// <c>base</c>: CS0117); it takes the erased <c>((I)this).M()</c> cast, which is
+    /// opcode-faithful <c>ldobj; box; call I::M</c> (#3213 review).
+    /// <para>
+    /// Residual: a non-virtual <c>call</c> to an <em>overridable</em> base member
+    /// that <c>ValueType</c> overrides (e.g. a hand-emitted <c>call
+    /// object::GetHashCode</c>) has no faithful spelling either way — <c>base.</c>
+    /// rebinds to <c>ValueType</c>'s override and a cast re-dispatches
+    /// (<c>callvirt</c>). C# cannot express it, and csc never emits it; the
+    /// <c>base.</c> form here (matching a real <c>base.GetType()</c> call) is a
+    /// best-effort, valid-C# render of that synthetic shape.
+    /// </para>
     /// </summary>
-    static bool IsSystemValueType(TypeRef type)
-        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "ValueType" };
+    static bool IsStructBaseClass(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "ValueType" or "Object" };
 
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
     string ReceiverText(IrExpression receiver) => receiver switch
@@ -554,16 +563,17 @@ public sealed partial class CSharpPrinter
             return name;
         }
         // A method group through a boxed this to a type the struct was cast to
-        // (base class or interface). Only a non-virtual (ldftn) group to a
-        // ValueType member is base.M — the struct's immediate base, so `base.M`
-        // lowers to exactly `ldobj; box; ldftn ValueType::M` and binds the exact
-        // token. A virtual (ldvirtftn) group, and a non-virtual group to a base
-        // System.Object member (e.g. GetType) or a sealed interface member, are
-        // the erased ((T)this).M upcast — `((T)this).M` lowers to `ldobj; box;
-        // [dup;] ld[virt]ftn T::M`, opcode-faithful for each. Bare (this).M /
-        // this.M would be CS1061 or rebind to the derived override; a base.M to an
-        // interface would be CS0117. Subsumes the struct interface-cast case
-        // (#3201) and the base-class case (#3213).
+        // (base class or interface). A non-virtual (ldftn) group to a base-class
+        // member (ValueType or Object) is base.M — base-suppression reaches the
+        // base member, so `base.M` lowers to `ldobj; box; ldftn T::M`, and base. is
+        // the only valid spelling for a protected base member like
+        // object::MemberwiseClone. A virtual (ldvirtftn) group, and a non-virtual
+        // group to a sealed interface member, are the erased ((T)this).M upcast —
+        // `((T)this).M` lowers to `ldobj; box; [dup;] ld[virt]ftn T::M`,
+        // opcode-faithful for each. Bare (this).M / this.M would be CS1061 or
+        // rebind to the derived override; a base.M to an interface would be CS0117.
+        // Subsumes the struct interface-cast case (#3201) and the base-class case
+        // (#3213).
         // HasThis gates the whole branch: a closed static extension method group
         // (`((object)this).Ext`) shares the `ldobj; box; ldftn` shape but binds the
         // boxed this as its first argument, so its DeclaringType is the static
@@ -572,7 +582,7 @@ public sealed partial class CSharpPrinter
         // receiver ((object)this) the extension already carries.
         if (method.HasThis && IsBoxedThisReceiver(target))
         {
-            if (!isVirtual && IsCrossType(method.DeclaringType) && IsSystemValueType(method.DeclaringType))
+            if (!isVirtual && IsCrossType(method.DeclaringType) && IsStructBaseClass(method.DeclaringType))
                 return $"base.{name}";
             return $"(({TypeText(method.DeclaringType)})this).{name}";
         }
@@ -679,27 +689,26 @@ public sealed partial class CSharpPrinter
         if (IsBoxedThisReceiver(receiver))
         {
             string boxedMethodName = CSharpNaming.SourceMethodName(call.Callee.Name);
-            // A non-virtual call through a boxed this to a System.ValueType member
-            // is base.M(): ValueType is the struct's immediate base, so `base.M()`
-            // lowers to exactly `ldobj; box; call ValueType::M` and base-suppression
-            // binds the exact token. Bare (this).M() here re-dispatches virtually to
-            // the struct's own override — self-recursion or a wrong target (e.g.
-            // GetHashCode calling itself) (#3213). Stays base. even under the
-            // qualify knob. A non-virtual call to a base System.Object member (e.g.
-            // GetType) or a sealed interface member takes the cast arm below, not
-            // base.: base would rebind an object virtual to ValueType's override, or
-            // be CS0117 for an interface — `((object)this).GetType()` /
-            // `((I)this).M()` re-emit the same non-virtual `call T::M` (#3213 review).
-            if (!call.IsVirtual && IsCrossType(call.Callee.DeclaringType) && IsSystemValueType(call.Callee.DeclaringType))
+            // A non-virtual call through a boxed this to a base-class member
+            // (System.ValueType or System.Object) is base.M(): base-suppression
+            // (`call`, no dispatch) reaches the base member and `base.M()` lowers to
+            // `ldobj; box; call T::M`. Bare (this).M() here re-dispatches virtually
+            // to the struct's own override — self-recursion or a wrong target (e.g.
+            // GetHashCode calling itself) (#3213). base. is also the ONLY valid
+            // spelling for a protected base member like object::MemberwiseClone —
+            // ((object)this).MemberwiseClone() is CS1540. Stays base. even under the
+            // qualify knob. A non-virtual call to a sealed interface member takes
+            // the cast arm below, not base.: base would be CS0117 for an interface —
+            // `((I)this).M()` re-emits the same non-virtual `call I::M` (#3213
+            // review).
+            if (!call.IsVirtual && IsCrossType(call.Callee.DeclaringType) && IsStructBaseClass(call.Callee.DeclaringType))
                 return $"base.{boxedMethodName}{typeArguments}({rest})";
-            // A call through a boxed this to a type the struct was cast to (a base
-            // class like object/ValueType, or an interface): ((T)this).M(). The
-            // explicit box is the source's upcast; ((T)this).M() re-emits `ldobj;
-            // box; call[virt] T::M` — callvirt for a virtual callee, call for a
-            // non-virtual one (object::GetType, a sealed DIM). A bare this.M() would
-            // instead emit `constrained. callvirt` (no box) — not opcode-faithful.
-            // Subsumes the struct interface-cast case (#3201) and the base-class
-            // case (#3213).
+            // A call through a boxed this to an interface the struct was cast to:
+            // ((I)this).M(). The explicit box is the source's upcast; ((I)this).M()
+            // re-emits `ldobj; box; call[virt] I::M` — callvirt for a virtual
+            // callee, call for a non-virtual one (a sealed DIM). A bare this.M()
+            // would instead emit `constrained. callvirt` (no box) — not
+            // opcode-faithful. Subsumes the struct interface-cast case (#3201).
             return $"(({TypeText(call.Callee.DeclaringType)})this).{boxedMethodName}{typeArguments}({rest})";
         }
         if (receiver is LoadArgument { Index: 0, Name: "this" })

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -430,9 +430,12 @@ public sealed partial class CSharpPrinter
     /// <c>LoadArgument{0,"this"}</c> a reference-type upcast (no IL) leaves. Only a
     /// value type produces this shape (a class <c>this</c> is already a reference).
     /// The <see cref="Box"/> is itself the evidence of the cast, so no interface
-    /// metadata is needed: callers re-insert the cast (virtual) or spell
-    /// <c>base.</c> (non-virtual) from the callee's declaring type and call kind
-    /// (#3201, #3213).
+    /// metadata is needed: callers re-spell it as <c>base.M</c> only when the
+    /// non-virtual callee is declared on <see cref="System.ValueType"/> (the
+    /// struct's guaranteed immediate base, where base-suppression binds the exact
+    /// token), and as the erased <c>((T)this).M</c> cast otherwise — a virtual
+    /// call, or a non-virtual call to a base <see cref="System.Object"/> or
+    /// interface member (#3201, #3213). See <see cref="IsSystemValueType"/>.
     /// <para>
     /// Gated on the enclosing method having an implicit <c>this</c>: a
     /// <c>static</c> method (or extension method) whose first parameter is spelled
@@ -445,6 +448,23 @@ public sealed partial class CSharpPrinter
     bool IsBoxedThisReceiver(IrExpression receiver)
         => _function.Signature.HasThis
             && receiver is Box { Operand: LoadIndirect { Address: LoadArgument { Index: 0, Name: "this" } } };
+
+    /// <summary>
+    /// True when <paramref name="type"/> is <c>System.ValueType</c>, a struct's
+    /// guaranteed immediate base. A non-virtual boxed-<c>this</c> call to a member
+    /// declared here is the ONE case a struct can re-spell as <c>base.M()</c>: the
+    /// base is exactly <c>ValueType</c>, so base-suppression (<c>call</c>, no
+    /// virtual dispatch) binds the exact callee token. A non-virtual call to a
+    /// <c>System.Object</c> member instead has no faithful <c>base.</c> spelling
+    /// (base lookup would rebind <c>GetHashCode</c>/<c>Equals</c>/<c>ToString</c>
+    /// to <c>ValueType</c>'s override), and a call to an interface member (a sealed
+    /// default interface member emits a non-virtual <c>call I::M</c>) has no
+    /// <c>base</c> at all (CS0117); both take the erased <c>((T)this).M()</c> cast,
+    /// which is <c>ldobj; box; call T::M</c> — opcode-faithful for a non-virtual
+    /// method like <c>object::GetType</c> and a sealed DIM (#3213 review).
+    /// </summary>
+    static bool IsSystemValueType(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "ValueType" };
 
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
     string ReceiverText(IrExpression receiver) => receiver switch
@@ -534,13 +554,16 @@ public sealed partial class CSharpPrinter
             return name;
         }
         // A method group through a boxed this to a type the struct was cast to
-        // (base class or interface). A non-virtual (ldftn) group to a base method
-        // is base.M — the ldftn captures the base slot; `base.M` lowers to
-        // `ldobj; box; ldftn Base::M`. A virtual (ldvirtftn) group is ((T)this).M
-        // — the box is the source's upcast; `((T)this).M` lowers to `ldobj; box;
-        // dup; ldvirtftn T::M`. Bare (this).M / this.M would be CS1061 or rebind
-        // to the derived override. Subsumes the struct interface-cast case (#3201)
-        // and the base-class case (#3213). Mirrors the bare-this arms above.
+        // (base class or interface). Only a non-virtual (ldftn) group to a
+        // ValueType member is base.M — the struct's immediate base, so `base.M`
+        // lowers to exactly `ldobj; box; ldftn ValueType::M` and binds the exact
+        // token. A virtual (ldvirtftn) group, and a non-virtual group to a base
+        // System.Object member (e.g. GetType) or a sealed interface member, are
+        // the erased ((T)this).M upcast — `((T)this).M` lowers to `ldobj; box;
+        // [dup;] ld[virt]ftn T::M`, opcode-faithful for each. Bare (this).M /
+        // this.M would be CS1061 or rebind to the derived override; a base.M to an
+        // interface would be CS0117. Subsumes the struct interface-cast case
+        // (#3201) and the base-class case (#3213).
         // HasThis gates the whole branch: a closed static extension method group
         // (`((object)this).Ext`) shares the `ldobj; box; ldftn` shape but binds the
         // boxed this as its first argument, so its DeclaringType is the static
@@ -549,7 +572,7 @@ public sealed partial class CSharpPrinter
         // receiver ((object)this) the extension already carries.
         if (method.HasThis && IsBoxedThisReceiver(target))
         {
-            if (!isVirtual && IsCrossType(method.DeclaringType))
+            if (!isVirtual && IsCrossType(method.DeclaringType) && IsSystemValueType(method.DeclaringType))
                 return $"base.{name}";
             return $"(({TypeText(method.DeclaringType)})this).{name}";
         }
@@ -656,21 +679,27 @@ public sealed partial class CSharpPrinter
         if (IsBoxedThisReceiver(receiver))
         {
             string boxedMethodName = CSharpNaming.SourceMethodName(call.Callee.Name);
-            // A non-virtual call through a boxed this to a base-declared method is
-            // base.M(): a struct must box to invoke a base (System.ValueType/
-            // Object) method non-virtually, so `base.M()` lowers to exactly
-            // `ldobj; box; call Base::M`. Bare (this).M() here re-dispatches
-            // virtually to the struct's own override — self-recursion or a wrong
-            // target (e.g. GetHashCode calling itself) (#3213). Mirrors the
-            // bare-this base arm below; stays base. even under the qualify knob.
-            if (!call.IsVirtual && IsCrossType(call.Callee.DeclaringType))
+            // A non-virtual call through a boxed this to a System.ValueType member
+            // is base.M(): ValueType is the struct's immediate base, so `base.M()`
+            // lowers to exactly `ldobj; box; call ValueType::M` and base-suppression
+            // binds the exact token. Bare (this).M() here re-dispatches virtually to
+            // the struct's own override — self-recursion or a wrong target (e.g.
+            // GetHashCode calling itself) (#3213). Stays base. even under the
+            // qualify knob. A non-virtual call to a base System.Object member (e.g.
+            // GetType) or a sealed interface member takes the cast arm below, not
+            // base.: base would rebind an object virtual to ValueType's override, or
+            // be CS0117 for an interface — `((object)this).GetType()` /
+            // `((I)this).M()` re-emit the same non-virtual `call T::M` (#3213 review).
+            if (!call.IsVirtual && IsCrossType(call.Callee.DeclaringType) && IsSystemValueType(call.Callee.DeclaringType))
                 return $"base.{boxedMethodName}{typeArguments}({rest})";
-            // A virtual call through a boxed this to a type the struct was cast to
-            // (a base class like object/ValueType, or an interface): ((T)this).M().
-            // The explicit box is the source's upcast; ((T)this).M() re-emits
-            // `ldobj; box; callvirt T::M`. A bare this.M() would instead emit
-            // `constrained. callvirt` (no box) — not opcode-faithful. Subsumes the
-            // struct interface-cast case (#3201) and the base-class case (#3213).
+            // A call through a boxed this to a type the struct was cast to (a base
+            // class like object/ValueType, or an interface): ((T)this).M(). The
+            // explicit box is the source's upcast; ((T)this).M() re-emits `ldobj;
+            // box; call[virt] T::M` — callvirt for a virtual callee, call for a
+            // non-virtual one (object::GetType, a sealed DIM). A bare this.M() would
+            // instead emit `constrained. callvirt` (no box) — not opcode-faithful.
+            // Subsumes the struct interface-cast case (#3201) and the base-class
+            // case (#3213).
             return $"(({TypeText(call.Callee.DeclaringType)})this).{boxedMethodName}{typeArguments}({rest})";
         }
         if (receiver is LoadArgument { Index: 0, Name: "this" })

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -419,23 +419,23 @@ public sealed partial class CSharpPrinter
             && !IsEnclosingTypeAtOwnInstantiation(declaringType);
 
     /// <summary>
-    /// True when <paramref name="receiver"/> is a value type's <c>this</c> boxed
-    /// to reach an interface member. On a struct, <c>((I)this).M()</c> is a
-    /// boxing conversion that lowers to <c>ldobj; box; callvirt I::M</c>, so the
-    /// receiver is a <see cref="Box"/> over the dereferenced <c>this</c> pointer
-    /// (<c>LoadIndirect</c> of <c>LoadArgument{0,"this"}</c>) rather than the bare
-    /// <c>LoadArgument{0,"this"}</c> the reference-type upcast of #3128 leaves.
-    /// The member is not a member of the struct, so bare <c>(this).M()</c> is
-    /// CS1061; re-inserting <c>((I)this)</c> is opcode-faithful because the cast
-    /// re-emits exactly the <c>ldobj; box</c> the boxing conversion produced.
-    /// Uses the same confirmed-interface gate as
-    /// <see cref="IsInterfaceCastThisReceiver"/> (declines when interface-ness is
-    /// unknown), and only <c>this</c> — a boxed field/local/parameter has a
-    /// different address operand and is left to the ordinary receiver path (#3201).
+    /// True when <paramref name="receiver"/> (or method-group target) is a value
+    /// type's <c>this</c> boxed to reach a member of a type the struct was cast
+    /// to. A struct must box to invoke a base (<c>System.ValueType</c>/
+    /// <c>System.Object</c>) or interface member, so <c>((T)this).M()</c> /
+    /// <c>base.M()</c> lowers to <c>ldarg.0; ldobj S; box S; call[virt] T::M</c> —
+    /// the receiver is a <see cref="Box"/> over the dereferenced <c>this</c>
+    /// pointer (<c>LoadIndirect</c> of <c>LoadArgument{0,"this"}</c>), not the bare
+    /// <c>LoadArgument{0,"this"}</c> a reference-type upcast (no IL) leaves. Only a
+    /// value type produces this shape (a class <c>this</c> is already a reference),
+    /// and only <c>this</c> — a boxed field/local/parameter has a different address
+    /// operand and is left to the ordinary receiver path. The <see cref="Box"/> is
+    /// itself the evidence of the cast, so no interface metadata is needed:
+    /// callers re-insert the cast (virtual) or spell <c>base.</c> (non-virtual)
+    /// from the callee's declaring type and its call kind (#3201, #3213).
     /// </summary>
-    bool IsBoxedThisInterfaceReceiver(IrExpression receiver, TypeRef declaringType)
-        => receiver is Box { Operand: LoadIndirect { Address: LoadArgument { Index: 0, Name: "this" } } }
-            && IsInterfaceCastThisReceiver(declaringType);
+    static bool IsBoxedThisReceiver(IrExpression receiver)
+        => receiver is Box { Operand: LoadIndirect { Address: LoadArgument { Index: 0, Name: "this" } } };
 
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
     string ReceiverText(IrExpression receiver) => receiver switch
@@ -524,13 +524,20 @@ public sealed partial class CSharpPrinter
             }
             return name;
         }
-        // A struct's interface method group boxes this: ((I)this).M lowers to
-        // `ldobj; box; dup; ldvirtftn I::M`, so the target is a Box over this, not
-        // a bare LoadArgument. Re-insert the ((I)this) cast the boxing spells —
-        // bare (this).M / this.M is CS1061 (#3201), the value-type sibling of the
-        // reference-type arm above.
-        if (IsBoxedThisInterfaceReceiver(target, method.DeclaringType))
+        // A method group through a boxed this to a type the struct was cast to
+        // (base class or interface). A non-virtual (ldftn) group to a base method
+        // is base.M — the ldftn captures the base slot; `base.M` lowers to
+        // `ldobj; box; ldftn Base::M`. A virtual (ldvirtftn) group is ((T)this).M
+        // — the box is the source's upcast; `((T)this).M` lowers to `ldobj; box;
+        // dup; ldvirtftn T::M`. Bare (this).M / this.M would be CS1061 or rebind
+        // to the derived override. Subsumes the struct interface-cast case (#3201)
+        // and the base-class case (#3213). Mirrors the bare-this arms above.
+        if (IsBoxedThisReceiver(target))
+        {
+            if (method.HasThis && !isVirtual && IsCrossType(method.DeclaringType))
+                return $"base.{name}";
             return $"(({TypeText(method.DeclaringType)})this).{name}";
+        }
         if (PointerMethodReceiver(target) is { } pointerReceiver)
             return $"{pointerReceiver}->{name}";
         return $"{ReceiverText(target)}.{name}";
@@ -631,14 +638,26 @@ public sealed partial class CSharpPrinter
         }
         if (call.Callee.Name == "Invoke" && receiver is Lambda lambda)
             return $"(({TypeText(lambda.DelegateType)}){Operand(lambda)}).Invoke({rest})";
-        // A struct reaching an interface member through this boxes the value:
-        // ((I)this).M() lowers to `ldobj; box; callvirt I::M`, so the receiver is
-        // a Box over this, not a bare LoadArgument. Re-insert the ((I)this) cast
-        // the boxing conversion spells — bare (this).M() is CS1061 (#3201), the
-        // value-type sibling of the reference-type this arm below. Faithful: the
-        // cast re-emits exactly the `ldobj; box` the struct boxing produced.
-        if (IsBoxedThisInterfaceReceiver(receiver, call.Callee.DeclaringType))
-            return $"(({TypeText(call.Callee.DeclaringType)})this).{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
+        if (IsBoxedThisReceiver(receiver))
+        {
+            string boxedMethodName = CSharpNaming.SourceMethodName(call.Callee.Name);
+            // A non-virtual call through a boxed this to a base-declared method is
+            // base.M(): a struct must box to invoke a base (System.ValueType/
+            // Object) method non-virtually, so `base.M()` lowers to exactly
+            // `ldobj; box; call Base::M`. Bare (this).M() here re-dispatches
+            // virtually to the struct's own override — self-recursion or a wrong
+            // target (e.g. GetHashCode calling itself) (#3213). Mirrors the
+            // bare-this base arm below; stays base. even under the qualify knob.
+            if (!call.IsVirtual && IsCrossType(call.Callee.DeclaringType))
+                return $"base.{boxedMethodName}{typeArguments}({rest})";
+            // A virtual call through a boxed this to a type the struct was cast to
+            // (a base class like object/ValueType, or an interface): ((T)this).M().
+            // The explicit box is the source's upcast; ((T)this).M() re-emits
+            // `ldobj; box; callvirt T::M`. A bare this.M() would instead emit
+            // `constrained. callvirt` (no box) — not opcode-faithful. Subsumes the
+            // struct interface-cast case (#3201) and the base-class case (#3213).
+            return $"(({TypeText(call.Callee.DeclaringType)})this).{boxedMethodName}{typeArguments}({rest})";
+        }
         if (receiver is LoadArgument { Index: 0, Name: "this" })
         {
             string thisMethodName = CSharpNaming.SourceMethodName(call.Callee.Name);


### PR DESCRIPTION
- Fixes #3213
- Changes boxed-`this` access to a non-interface member so it renders `base.M()` / `((T)this).M()` instead of the invalid, self-recursive `(this).M()`
- Card revision: `febb077a`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a struct that boxes `this` to reach a base member no longer renders self-recursive `(this).GetHashCode()`; the call kind selects `base.M()` (non-virtual) or `((T)this).M()` (virtual), and #3201's interface renders are unchanged.

### Benchmark target

Benchmark target: `System.Private.CoreLib.dll` @ runtime `11.0.0-preview.6.26359.118`

dotnet-inspect command:

```bash
dotnet-inspect member System.Reflection.CustomAttributeNamedArgument GetHashCode --all -S "Decompiled Source"
```

### Original source

SourceLink C# was not used; the raw IL is the authoritative anchor. A struct
override boxes `this` and calls the base slot non-virtually:

```il
IL_0000: ldarg.0
IL_0001: ldobj        System.Reflection.CustomAttributeNamedArgument
IL_0006: box          System.Reflection.CustomAttributeNamedArgument
IL_000B: call         System.ValueType::GetHashCode()
IL_0010: ret
```

### Before

```csharp
public override int GetHashCode() => (this).GetHashCode();
```

- Valid: True
- Correct: **False**
- IL fidelity: **False**
- Taste applied: None
- Commit: `abec2dd7`

`(this).GetHashCode()` binds, but re-dispatches virtually to this same override:
infinite self-recursion (StackOverflow). It is the #3127 trap inverted — it does
not even reach IL fidelity because it drops the `box; call ValueType::GetHashCode`
entirely.

### After

```csharp
public override int GetHashCode() => base.GetHashCode();
```

- Valid: True
- Correct: True
- IL fidelity: True
- Taste applied: None
- Commit: `febb077a`

The non-virtual `call` to a base-declared method through a boxed `this` is exactly
C#'s `base.GetHashCode()`, which recompiles to the original `ldobj; box; call
System.ValueType::GetHashCode` (verified by the `StructBaseHashCall` fixture, whose
`base.GetHashCode()` source lowers to that IL and round-trips `compile-back=Exact`).

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline (`abec2dd7`) | Head (`febb077a`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ThisQualificationTests`: 31 passed; `ThisQualificationDecisionTests`: 27 passed | `ThisQualificationTests`: 34 passed; `ThisQualificationDecisionTests`: 27 passed |
| Decompiler fast suite (`-trait- "Speed=Slow"`) | 3752, 1 failed | 3755, 1 failed |
| RoundTrip area (`-trait "Area=RoundTrip"`, incl. slow compile-back) | 464, 3 failed | 467, 3 failed |
| Reduced fixture validity | Pass | Pass |
| Reduced fixture fidelity | Pass (`compile-back=Exact`) | Pass (`compile-back=Exact`) |
| Real witness | `CustomAttributeNamedArgument::GetHashCode` → self-recursive `(this).GetHashCode()` | fixed → `base.GetHashCode()` |

Pre-existing Windows-local failures, confirmed identical at base and head (same
tests, same reason), unrelated to this diff. Baseline full-suite totals above are
the head run minus the 3 newly-added (passing) `ThisQualificationTests`; every
failing test was run and reproduced at base individually:

- Fast suite: `StringSwitchRaisingTests.SmallStringSwitch_RendersSwitchOnString`
  (CRLF vs LF).
- RoundTrip slow gates (3):
  `GeneratedFixtureCatalogTests.ReturnToSenderRecordCatalog_CoversGeneratedRecordHelpers`,
  `…MinimalCompileBackRungs_ReportExpectedOutcomesByFixtureId`,
  `…CompilerLoweringFrontier_IsSelectableButNotInDefaultRun`
  (`compile-back=RecompileFail` / `target-body-fragment-missing` on
  `GeneratedFixtures.*` record/parameter-attribute fixtures — boxed *parameters*,
  not `this`, so outside this change's `LoadArgument{0,"this"}`-gated scope).

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — pinned gate PASS with 0 pass bugs; detected lowering residue drops 251 → 246 as boxed-`this` base/cast methods are now raised.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly; 15 assemblies, 1,500
methods; validity/fidelity not run (`--corpus-fidelity-cap 0 --compile-cap 0`).

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 16.73% | 16.40% | -0.33pp |
| Conditional-branch residue (-) | 3.07% | 2.87% | -0.20pp |
| Forward-merge stops (-) | 2.13% | 2.00% | -0.13pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — corpus sensor matched baseline tolerances; residue strictly improved.

## Approach

The value-type sibling of #3128/#3201. A struct reaching a member of a type it was
cast to must box `this`, so the IR receiver is
`Box{Operand: LoadIndirect{Address: LoadArgument{0,"this"}}}` — the shape #3201
already matched, but only fired when the callee was a **confirmed interface**. A
struct boxing to reach a **base class** member (`object`/`System.ValueType`) fell
through to the bare receiver path and rendered invalid `(this).M()`.

The explicit `box` over `this` is itself proof of a value-type upcast, so no
interface metadata is needed — the call kind fully disambiguates. This PR replaces
the interface-only `IsBoxedThisInterfaceReceiver` with a shape-only
`IsBoxedThisReceiver` and, in both `CallText` and `MethodGroupText`, mirrors the
existing bare-`this` arms:

- non-virtual `call` / `ldftn` to a cross-type base method → `base.M()` / `base.M`
- virtual `callvirt` / `ldvirtftn` to the cast target → `((T)this).M()` / `((T)this).M`

This subsumes #3201 (interface calls are virtual → `((I)this).M()`, unchanged) and
additionally fixes the base-class cases (#3213). A non-boxed implicit `this.ToString()`
(a `constrained. callvirt`, no `box`) is untouched.

Note: issue #3213 proposed `((ValueType)this).GetHashCode()` for the witness, but
the non-virtual `call` opcode makes `base.GetHashCode()` the correct spelling; an
explicit `((ValueType)this)` *virtual* cast instead binds to the `object`
GetHashCode slot and renders `((object)this)`.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.ThisQualificationTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=RoundTrip"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
