### PR TITLE
Spell var for apparent-type declarations (opt-in bucket) (#3169)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/VarWhenApparentSpecimen.cs
+++ b/src/ILInspector.Decompiler.Tests/VarWhenApparentSpecimen.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Compiled specimens for the opt-in apparent-type <c>var</c> bucket
+/// (<see cref="ILInspector.Decompiler.Pipeline.PrinterOptions.PreferVarWhenTypeApparent"/>,
+/// <c>csharp_style_var_when_type_is_apparent</c>). Each method declares a real local
+/// (used more than once so it survives as a declaring store) whose type is — or is
+/// deliberately not — apparent from its initializer.
+/// </summary>
+public sealed class VarWhenApparentSpecimen
+{
+    // Apparent via object creation of the exact (non-built-in) type. The default view
+    // shortens the RHS to `new()`; the var bucket must keep the explicit `new List<int>()`
+    // (a bare `var x = new()` is CS8754), so the two spellings are mutually exclusive.
+    public static int ObjectCreation()
+    {
+        List<int> items = new List<int>();
+        items.Add(1);
+        return items.Count;
+    }
+
+    // Apparent via single-dimension array creation. The declared type `int[]` is a shape,
+    // not a built-in keyword type, so the built-in exclusion does not apply here.
+    public static int ArrayCreation()
+    {
+        int[] buffer = new int[4];
+        buffer[0] = 7;
+        return buffer[0];
+    }
+
+    // Apparent via an explicit reference cast to a non-built-in type.
+    public static int ReferenceCast(object o)
+    {
+        Node node = (Node)o;
+        return node.Value + node.Value;
+    }
+
+    // Negative: apparent, but the declared type is a C# built-in keyword type
+    // (`string`) — governed by the separate built-in-types bucket, so the apparent
+    // bucket must decline and leave the explicit type.
+    public static int BuiltInObjectCreation()
+    {
+        string text = new string('x', 3);
+        return text.Length + text.Length;
+    }
+
+    // Negative: the type is not apparent from the initializer (a plain call), so the
+    // apparent bucket must decline regardless of the option.
+    public static int NotApparent()
+    {
+        List<int> items = Make();
+        items.Add(1);
+        return items.Count;
+    }
+
+    static List<int> Make() => new();
+
+    public sealed class Node
+    {
+        public int Value;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/VarWhenApparentTests.cs
+++ b/src/ILInspector.Decompiler.Tests/VarWhenApparentTests.cs
@@ -1,0 +1,124 @@
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The opt-in apparent-type <c>var</c> bucket
+/// (<see cref="PrinterOptions.PreferVarWhenTypeApparent"/>,
+/// <c>csharp_style_var_when_type_is_apparent</c>): when the declared type is apparent
+/// from the initializer (object creation of the exact type, an array creation, or an
+/// explicit reference cast) and is not a C# built-in keyword type, the declaration is
+/// spelled <c>var</c> instead of its explicit type.
+///
+/// <para>
+/// <c>var</c> is byte-neutral — a compile-time inference with no IL consequence — so
+/// this is a spelling choice, not a lens: the emitted <c>var</c> form recompiles to
+/// the exact same IL as the explicit form, because apparency guarantees the
+/// initializer's static type <em>is</em> the declared type. These tests pin the
+/// default (explicit, byte-stable), the opt-in rewrite for each apparent shape, the
+/// either/or interaction with the target-typed-<c>new</c> shortener (never
+/// <c>var x = new()</c>, which is CS8754), and the two decline cases (built-in type,
+/// non-apparent initializer).
+/// </para>
+/// </summary>
+[Trait("Area", "RoundTrip")]
+public sealed class VarWhenApparentTests
+{
+    static string AssemblyPath => typeof(VarWhenApparentTests).Assembly.Location;
+
+    static readonly PrinterOptions VarWhenApparent = new() { PreferVarWhenTypeApparent = true };
+
+    static ApiType Specimen()
+    {
+        using var pe = new PEReader(File.OpenRead(AssemblyPath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        return Assert.Single(api.Types, t => t.FullName == typeof(VarWhenApparentSpecimen).FullName);
+    }
+
+    static string Render(string memberName, PrinterOptions? options = null)
+    {
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == memberName);
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null, printerOptions: options);
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.NotNull(rendered.Text);
+        return rendered.Text!;
+    }
+
+    [Fact]
+    public void ObjectCreation_Default_KeepsExplicitTypeAndShortensNew()
+    {
+        var text = Render(nameof(VarWhenApparentSpecimen.ObjectCreation));
+        // Byte-stable default: explicit LHS type, and the always-on target-typed-new
+        // shortener drops the RHS type to `new()`.
+        Assert.Contains("List<int>", text);
+        Assert.Contains("= new();", text);
+        Assert.DoesNotContain("var ", text);
+    }
+
+    [Fact]
+    public void ObjectCreation_VarOn_SpellsVarAndKeepsExplicitNew()
+    {
+        var text = Render(nameof(VarWhenApparentSpecimen.ObjectCreation), VarWhenApparent);
+        Assert.Contains("var ", text);
+        // Either/or: spelling `var` suppresses the shortener, so the RHS keeps its
+        // explicit `new List<int>()`. A bare `var x = new()` would be CS8754.
+        Assert.Contains("= new List<int>();", text);
+        Assert.DoesNotContain("new();", text);
+    }
+
+    [Fact]
+    public void ArrayCreation_VarOn_SpellsVar_ArrayShapeIsNotBuiltIn()
+    {
+        var defaultText = Render(nameof(VarWhenApparentSpecimen.ArrayCreation));
+        Assert.Contains("int[] ", defaultText);
+        Assert.DoesNotContain("var ", defaultText);
+
+        var text = Render(nameof(VarWhenApparentSpecimen.ArrayCreation), VarWhenApparent);
+        Assert.Contains("var ", text);
+        Assert.Contains("= new int[4];", text);
+        Assert.DoesNotContain("int[] ", text);
+    }
+
+    [Fact]
+    public void ReferenceCast_VarOn_SpellsVar()
+    {
+        var defaultText = Render(nameof(VarWhenApparentSpecimen.ReferenceCast));
+        Assert.Contains("Node ", defaultText);
+        Assert.Contains("= (Node)o;", defaultText);
+        Assert.DoesNotContain("var ", defaultText);
+
+        var text = Render(nameof(VarWhenApparentSpecimen.ReferenceCast), VarWhenApparent);
+        Assert.Contains("var ", text);
+        // The cast still names the type, so the value keeps its exact static type.
+        Assert.Contains("= (Node)o;", text);
+    }
+
+    [Fact]
+    public void BuiltInObjectCreation_VarOn_DeclinesBuiltInType()
+    {
+        // `string` is a C# built-in keyword type, owned by the separate built-in-types
+        // bucket. The apparent bucket must decline, leaving the output byte-identical
+        // to the default (which still shortens to `new(...)`).
+        var defaultText = Render(nameof(VarWhenApparentSpecimen.BuiltInObjectCreation));
+        var text = Render(nameof(VarWhenApparentSpecimen.BuiltInObjectCreation), VarWhenApparent);
+        Assert.Equal(defaultText, text);
+        Assert.Contains("string ", text);
+        Assert.DoesNotContain("var ", text);
+    }
+
+    [Fact]
+    public void NotApparent_VarOn_Declines()
+    {
+        // The initializer is a plain call, so the type is not apparent — the bucket
+        // declines and the output is byte-identical to the default.
+        var defaultText = Render(nameof(VarWhenApparentSpecimen.NotApparent));
+        var text = Render(nameof(VarWhenApparentSpecimen.NotApparent), VarWhenApparent);
+        Assert.Equal(defaultText, text);
+        Assert.Contains("List<int> ", text);
+        Assert.DoesNotContain("var ", text);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2467,7 +2467,7 @@ public sealed partial class CSharpPrinter
             ? $"{TypeText(s.Type)} {LocalName(s.Index)} = ref {Deref(s.Value)};"
             : $"{LocalName(s.Index)} = ref {Deref(s.Value)};",
         StoreLocal s => _declaringStores.Contains(s)
-            ? $"{DeclarationTypeText(s.Type, s.Value)} {LocalName(s.Index)} = {InitializerText(s.Value, s.Type)};"
+            ? $"{DeclarationTypeText(s.Type, s.Value)} {LocalName(s.Index)} = {InitializerText(s.Value, s.Type, SpellVarForApparentType(s.Type, s.Value) ? null : s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
         DeconstructionAssignment d => $"({string.Join(", ", d.Targets.Select(DeconstructionTargetText))}) = {Expression(d.Source)};",
         ChainedAssignment c => $"{string.Join(" = ", c.Targets.Select(ChainedAssignmentTargetText))} = {CoerceText(c.Value, c.InnermostTargetType)};",
@@ -2481,7 +2481,7 @@ public sealed partial class CSharpPrinter
             ? $"{TypeText(refType)} {StackSlotName(s)} = ref {Deref(s.Value)};"
             : $"{StackSlotName(s)} = ref {Deref(s.Value)};",
         StoreStackSlot s => _declaringStores.Contains(s)
-            ? $"{DeclarationTypeText(StackSlotTargetType(s)!, s.Value)} {StackSlotName(s)} = {InitializerText(s.Value, StackSlotTargetType(s))};"
+            ? $"{DeclarationTypeText(StackSlotTargetType(s)!, s.Value)} {StackSlotName(s)} = {InitializerText(s.Value, StackSlotTargetType(s), SpellVarForApparentType(StackSlotTargetType(s)!, s.Value) ? null : StackSlotTargetType(s))};"
             : AssignmentText(StackSlotName(s), s.Value, left => left is LoadStackSlot load && StackSlotName(load) == StackSlotName(s), StackSlotTargetType(s)),
         StoreField s => AssignmentText(
             FieldTarget(s.Field, s.Instance), s.Value,
@@ -5364,18 +5364,46 @@ public sealed partial class CSharpPrinter
 
     string DeclarationTypeText(TypeRef type, IrExpression initializer)
         // An anonymous type has no spellable name, so `var` is mandatory here — not a
-        // taste call. Every other declaration keeps its explicit type on the byte-stable
-        // default. A future opt-in `var` lens will consult `TypeIsApparent(type,
-        // initializer)` to decide whether to spell `var`. Note that `var` and the
-        // target-typed-`new` shortener are *mutually exclusive* spellings of the same
-        // apparent site, not simultaneous: dropping both ends of `List<int> x = new
-        // List<int>()` at once yields `var x = new()`, which is CS8754 (no target type
-        // for `new()`). The shared predicate is only the apparency input; that lens must
-        // own the either/or decision (keep the RHS type when spelling `var`, or keep the
-        // LHS type when shortening to `new()`).
-        => initializer is AnonymousObject anonymous && type.Equals(anonymous.Type)
+        // taste call. Otherwise the declaration keeps its explicit type unless the
+        // opt-in apparent-type `var` bucket applies (see `SpellVarForApparentType`),
+        // which is off on the byte-stable default. `var` and the target-typed-`new`
+        // shortener are *mutually exclusive* spellings of the same apparent site, not
+        // simultaneous: dropping both ends of `List<int> x = new List<int>()` at once
+        // yields `var x = new()`, which is CS8754 (no target type for `new()`). When
+        // this returns `var`, the caller suppresses the shortener (passing a null
+        // `new` target to `InitializerText`) so the RHS keeps its explicit `new T(...)`.
+        => (initializer is AnonymousObject anonymous && type.Equals(anonymous.Type))
+            || SpellVarForApparentType(type, initializer)
             ? "var"
             : TypeText(type);
+
+    /// <summary>
+    /// Whether an opt-in apparent-type <c>var</c> spelling applies to a local
+    /// declaration (`csharp_style_var_when_type_is_apparent`). True only when the
+    /// bucket is enabled, the declared type is <em>not</em> a C# built-in keyword type
+    /// (those belong to the separate built-in-types bucket, keeping the two families a
+    /// clean partition), and the initializer makes the type apparent
+    /// (<see cref="TypeIsApparent"/> — object creation of the exact type, an array
+    /// creation, or an explicit reference cast). Apparency guarantees the initializer's
+    /// static type is exactly the declared type, so <c>var</c> infers that same type:
+    /// byte-neutral (no IL consequence) and always faithful. Off by default.
+    /// </summary>
+    bool SpellVarForApparentType(TypeRef type, IrExpression initializer)
+        => _options.PreferVarWhenTypeApparent
+            && !IsBuiltInType(type)
+            && TypeIsApparent(type, initializer);
+
+    /// <summary>
+    /// Whether a declared type is a C# built-in (predefined keyword) type — the set
+    /// the built-in-types <c>var</c> bucket owns. Drawn from the shared keyword table
+    /// (<see cref="PrimitiveTypeNames"/>, the same one <see cref="TypeText"/> renders
+    /// keywords from) so both <c>var</c> buckets partition declaration sites
+    /// identically. <c>void</c> is excluded — it is never a local's type.
+    /// </summary>
+    static bool IsBuiltInType(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            && PrimitiveTypeNames.TryToKeywordForSystemType(type.Name, out var keyword)
+            && keyword != "void";
 
     string TypeOfTypeText(TypeRef type)
         => type.Kind == TypeRefKind.Definition && OpenGenericArity(type) is { } arity


### PR DESCRIPTION
## What

Lights up the **printer emission** for the apparent-type `var` bucket (`csharp_style_var_when_type_is_apparent` / `PreferVarWhenTypeApparent`), building on the byte-neutral plumbing from #3202. When the option is set and a local declaration's type is **apparent** from its initializer — object creation of the exact type, an array creation, or an explicit reference cast — and the declared type is **not** a C# built-in keyword type, the declaration is spelled `var` instead of its explicit type.

This is the first of the three var buckets to emit; **built-in** and **elsewhere** are deferred to a follow-up PR (they need a type-safety gate across the full coercion surface).

## Why it's faithful & byte-safe

- **Byte-neutral.** `var` is a compile-time inference with no IL consequence. Apparency *guarantees* the initializer's static type **is** the declared type, so `var` infers exactly that type and the emitted form recompiles to identical IL.
- **Off by default → default output unchanged.** With the option false, `SpellVarForApparentType` short-circuits, `DeclarationTypeText` returns `TypeText(type)` as before, and `InitializerText(s.Value, s.Type, s.Type)` is identical to the previous 2-arg call. The default path is byte-for-byte unchanged (3740 fast decompiler tests green).

## Either/or with the target-typed-`new` shortener

Spelling `var` and shortening the RHS to `new()` are mutually exclusive spellings of the same apparent site — `var x = new()` is CS8754. So when `var` is chosen, the shortener is suppressed for that site (a null new-target), and an apparent object creation renders `var x = new List<int>()`, never `var x = new()`.

Observed emission:

| shape | default | `var_when_type_is_apparent = true` |
| --- | --- | --- |
| `List<int> x = new List<int>()` | `List<int> x = new();` | `var x = new List<int>();` |
| `int[] x = new int[4]` | `int[] x = new int[4];` | `var x = new int[4];` |
| `Node x = (Node)o` | `Node x = (Node)o;` | `var x = (Node)o;` |
| `string x = new string('x',3)` (built-in) | `string x = new('x',3);` | *unchanged* (declines) |
| `List<int> x = Make()` (not apparent) | `List<int> x = Make();` | *unchanged* (declines) |

## Design

- The built-in exclusion (`IsBuiltInType`, drawn from the shared `PrimitiveTypeNames` keyword table — the same one `TypeText` renders keywords from) keeps the apparent and built-in-types buckets a clean partition.
- Reuses the merged `TypeIsApparent` predicate (#3194); no new apparency logic. SRM-only, Roslyn-free, NativeAOT-friendly.

## Tests

`VarWhenApparentTests` over compiled specimens pin: the default (explicit, shortened), the `var` rewrite for each apparent shape, the either/or interaction (asserts **no** `var x = new()`), and both decline cases (built-in type, non-apparent initializer). Full fast decompiler suite (3740) green.

Note: the heavy `Speed=Slow` Fidelity gates surfaced 3 pre-existing/environmental failures unrelated to this change — they run at **default** options (which this PR leaves byte-identical), assert only on named external fixtures (not this PR's specimen), and are **not** part of the merge-blocking `test` job (CI runs `-trait- "Speed=Slow"`).

Part of #3169. Stacks on #3202. Follow-up PR: built-in + elsewhere buckets.