### PR TITLE
Raise address-spilled inline-array collection expressions (#3129, S4)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4958,6 +4958,27 @@ public class CfgSampleClass
                 return -1;
         }
     }
+
+    static int UseObjectSpan(System.ReadOnlySpan<object> s) => s.Length;
+
+    // A collection expression whose element VALUE carries a branch AND a call:
+    // `s is not null ? s.ToUpper() : "null"` in a params ReadOnlySpan<object>
+    // context. csc cannot evaluate that element in one push, so it computes the
+    // element-ref ADDRESS first and spills it to an evaluation-stack temp, then
+    // spills the conditional's value to a second temp, and finally stores through
+    // the spilled address — `ref object A = ref InlineArrayElementRef(ref buffer,
+    // 1); object V = s is not null ? s.ToUpper() : "null"; A = V;`. The `object`
+    // element type (boxing) and the method call keep that double spill alive all
+    // the way to InlineArrayCollectionPass, unlike a scalar `flag ? 1 : 2` whose
+    // spill an earlier ternary fold collapses to a direct store. This is the shape
+    // EncLocalInfo's params `string.Format` hits in the wild (issue #3129, S4):
+    // the pass recovers the spilled address+value and raises the whole thing back
+    // to `[a, s is not null ? s.ToUpper() : "null"]`, re-sequencing into slot
+    // (= source) order. Placed last in the class so its two extra methods do not
+    // shift any pre-existing method's compiler-generated ordinal (the fidelity
+    // docket keys on `<>9__N`/`<>c__DisplayClassN` names — see issue #3129, S4).
+    public static int InlineArrayObjectConditionalElementSpan(int a, string? s)
+        => UseObjectSpan([a, s is not null ? s.ToUpper() : "null"]);
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
@@ -186,6 +186,55 @@ public class InlineArraySpilledElementTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void NullCoalescingAssignmentValueSpan_StaysFlat()
+    {
+        // The span is the right operand of `local ??= span`, evaluated only when the
+        // target is null. `NullCoalescingAssignment` is one of the conditional IR
+        // nodes an enumerated blacklist missed; the sound-by-default whitelist leaves
+        // it flat because the node is not a recognized unconditional container.
+        var function = BuildOrderingCollection(OrderingShape.NullCoalescingAssignmentValue);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void UnionSwitchArmValueSpan_StaysFlat()
+    {
+        // The span is a union-switch-expression arm value, evaluated only when its arm
+        // matches. `UnionSwitchExpressionArm` does not derive from `SwitchExpressionArm`,
+        // so a blacklist keyed on the base arm type missed it; the whitelist rejects any
+        // parent it does not explicitly recognize as unconditional, so it stays flat.
+        var function = BuildOrderingCollection(OrderingShape.UnionSwitchArmValue);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void WhileConditionSpan_StaysFlat()
+    {
+        // The span is a while-loop condition: evaluated unconditionally but once per
+        // iteration. Lifting the element stores into it would call each element
+        // function once per loop test instead of once. The whitelist rejects the
+        // WhileLoop condition edge (not a once-through container), so it stays flat —
+        // covering the exactly-once axis, not just definite evaluation.
+        var function = BuildOrderingCollection(OrderingShape.WhileConditionSpan);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
     enum OrderingShape
     {
         InterleavedStatement,
@@ -193,6 +242,9 @@ public class InlineArraySpilledElementTests
         InlineEffectBeforeSpan,
         SpilledPrefixBeforeSpan,
         ConditionalSpanArm,
+        NullCoalescingAssignmentValue,
+        UnionSwitchArmValue,
+        WhileConditionSpan,
     }
 
     /// <summary>
@@ -273,6 +325,33 @@ public class InlineArraySpilledElementTests
                             span,
                             new LoadLocal(1, SpanObject))])));
                 break;
+            case OrderingShape.NullCoalescingAssignmentValue:
+                // local ??= span: the span is the ??= right operand, evaluated only
+                // when the target is null. NothingEffectfulBefore passes (the span is
+                // the only child), so only the definite-evaluation whitelist rejects
+                // this — the missed conditional node from adversarial review.
+                block.Add(new NullCoalescingAssignment(1, SpanObject, span));
+                break;
+            case OrderingShape.UnionSwitchArmValue:
+                // local = scrutinee switch { Case => span, ... }: the span is a switch
+                // arm value, evaluated only when its arm matches. A union-switch arm is
+                // a distinct IR node from SwitchExpressionArm, so the whitelist (not an
+                // enumerated blacklist) must still reject it.
+                block.Add(new StoreLocal(1, SpanObject,
+                    new UnionSwitchExpression(
+                        new LoadArgument(0, "arg", Object),
+                        [new UnionSwitchExpressionArm(Object, null, span)])));
+                break;
+            case OrderingShape.WhileConditionSpan:
+                // while (Predicate(span)) { }: the span is unconditionally evaluated
+                // but re-evaluated on every loop iteration. Definite evaluation alone
+                // is not enough — the span must also be evaluated exactly once, so the
+                // whitelist rejects a WhileLoop condition edge (it is not a recognized
+                // once-through container), leaving the collection flat.
+                block.Add(new WhileLoop(
+                    new Call(PredicateSpanMethod(), isVirtual: false, [span]),
+                    new Block()));
+                break;
             default:
                 // ReadOnlySpan<object> span = InlineArrayAsReadOnlySpan(ref buffer, 2); (local 1)
                 block.Add(new StoreLocal(1, SpanObject, span));
@@ -333,6 +412,15 @@ public class InlineArraySpilledElementTests
             TypeRef.Definition("Synthetic", "", "Fx"),
             "Consume",
             Void,
+            [SpanObject],
+            HasThis: false);
+
+    // bool Predicate(ReadOnlySpan<object> span)
+    static MethodRef PredicateSpanMethod()
+        => new(
+            TypeRef.Definition("Synthetic", "", "Fx"),
+            "Predicate",
+            Bool,
             [SpanObject],
             HasThis: false);
 

--- a/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
@@ -169,12 +169,30 @@ public class InlineArraySpilledElementTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void ConditionalSpanArmInConsumer_StaysFlat()
+    {
+        // The span sits in a ternary arm (Consume(cond ? span : other)), so it is only
+        // conditionally evaluated. The element stores are unconditional; lifting them
+        // into that arm would suppress their side effects whenever the false arm is
+        // taken. Block order is canonical, so only the conditional guard rejects it —
+        // the shape must stay flat.
+        var function = BuildOrderingCollection(OrderingShape.ConditionalSpanArm);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
     enum OrderingShape
     {
         InterleavedStatement,
         DescendingSlotOrder,
         InlineEffectBeforeSpan,
         SpilledPrefixBeforeSpan,
+        ConditionalSpanArm,
     }
 
     /// <summary>
@@ -244,6 +262,17 @@ public class InlineArraySpilledElementTests
                 block.Add(new ExpressionStatement(
                     new Call(ConsumeMethod(), isVirtual: false, [new LoadStackSlot(0, Object), span])));
                 break;
+            case OrderingShape.ConditionalSpanArm:
+                // Consume(cond ? span : other): the span is in a ternary arm, so it
+                // is only conditionally evaluated. Lifting the unconditional element
+                // stores into that arm would drop their effects on the false path.
+                block.Add(new ExpressionStatement(
+                    new Call(ConsumeSpanMethod(), isVirtual: false, [
+                        new Conditional(
+                            new Constant(true, Bool),
+                            span,
+                            new LoadLocal(1, SpanObject))])));
+                break;
             default:
                 // ReadOnlySpan<object> span = InlineArrayAsReadOnlySpan(ref buffer, 2); (local 1)
                 block.Add(new StoreLocal(1, SpanObject, span));
@@ -296,6 +325,15 @@ public class InlineArraySpilledElementTests
             "Consume",
             Void,
             [Object, SpanObject],
+            HasThis: false);
+
+    // void Consume(ReadOnlySpan<object> span)
+    static MethodRef ConsumeSpanMethod()
+        => new(
+            TypeRef.Definition("Synthetic", "", "Fx"),
+            "Consume",
+            Void,
+            [SpanObject],
             HasThis: false);
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
@@ -1,0 +1,202 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Synthetic coverage for <see cref="InlineArrayCollectionPass"/>'s address-spilled
+/// element-store recovery (issue #3129, S4). When a collection-expression element
+/// value carries a branch, csc evaluates the element-ref address before the branch
+/// and spills the <c>ref</c> — and often the branch value — to single-use
+/// evaluation-stack slots, then stores through the spilled address. The pass
+/// recovers that shape only when every spill slot is written once and read once; a
+/// multi-use spill slot or a volatile store must leave the whole collection flat.
+/// The compiled-fixture canary lives in <c>CfgSampleClass.InlineArrayObjectConditionalElementSpan</c>;
+/// these tests pin the guard boundaries a compiled fixture cannot express.
+/// </summary>
+[Trait("Area", "Pass")]
+public class InlineArraySpilledElementTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef ByRefObject = TypeRef.ByRef(Object);
+
+    // A compiler-synthesized inline-array buffer (the older `<>y__InlineArrayN`
+    // spelling) instantiated over object — the span source csc emits for a params
+    // ReadOnlySpan<object> collection expression.
+    static readonly TypeRef BufferDefinition =
+        TypeRef.Definition(TypeRef.CoreLibrary, "", "<>y__InlineArray2`1", ValueTypeHint.ValueType, MetadataFactState.Yes);
+    static readonly TypeRef Buffer = TypeRef.GenericInstance(BufferDefinition, [Object]);
+    static readonly TypeRef SpanObject = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [Object]);
+
+    enum SpillDefect
+    {
+        None,
+        AddressSlotReadTwice,
+        ValueSlotReadTwice,
+        VolatileStore,
+    }
+
+    [Fact]
+    public void SpilledAddressAndValue_RaisesToCollectionExpression()
+    {
+        var function = BuildSpilledCollection(SpillDefect.None);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        var collection = Assert.Single(function.Descendants.OfType<CollectionExpression>());
+        // Elements are re-sequenced into slot (= source) order: the direct element 0
+        // then the spilled element 1, recovered to its real branch value.
+        Assert.Collection(
+            collection.Children,
+            first => Assert.IsType<Box>(first),
+            second => Assert.IsType<Conditional>(second));
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        Assert.DoesNotContain(
+            function.Descendants.OfType<Call>(),
+            c => c.Callee.Name.Contains("InlineArray", StringComparison.Ordinal));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void AddressSpillReadTwice_StaysFlat()
+    {
+        // The spilled element-ref address must be read exactly once — the address
+        // computation has no observable effect only when the collection expression
+        // is the sole consumer. A second read means the ref escapes; leave it flat.
+        var function = BuildSpilledCollection(SpillDefect.AddressSlotReadTwice);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ValueSpillReadTwice_StaysFlat()
+    {
+        // A spilled element value read more than once cannot be lifted into the
+        // element position without duplicating (and re-evaluating) it; leave flat.
+        var function = BuildSpilledCollection(SpillDefect.ValueSlotReadTwice);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void VolatileSpilledStore_StaysFlat()
+    {
+        // A volatile store through the spilled address is an observable memory
+        // operation the collection expression would silently drop; leave flat.
+        var function = BuildSpilledCollection(SpillDefect.VolatileStore);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
+    /// <summary>
+    /// Builds the two-element params ReadOnlySpan&lt;object&gt; collection shape:
+    /// element 0 is a direct indirect store of <c>box a</c>; element 1's value
+    /// carries a branch, so its element-ref address is spilled to slot 0 and its
+    /// conditional value to slot 1 before the store through the spilled address.
+    /// <paramref name="defect"/> perturbs exactly one guard input to prove the
+    /// negative leaves the collection flat.
+    /// </summary>
+    static IrFunction BuildSpilledCollection(SpillDefect defect)
+    {
+        const int AddressSlot = 0;
+        const int ValueSlot = 1;
+
+        var block = new Block();
+
+        // <>y__InlineArray2<object> buffer = default; (local 0)
+        block.Add(new InitObject(Buffer, new LoadLocalAddress(0, Buffer)));
+
+        // Element 0: *(InlineArrayElementRef(ref buffer, 0)) = box a;
+        block.Add(new StoreIndirect(
+            Object,
+            ElementRef(0),
+            new Box(Int32, new LoadArgument(0, "a", Int32))));
+
+        // Element 1: ref object address = InlineArrayElementRef(ref buffer, 1);
+        block.Add(new StoreStackSlot(AddressSlot, ElementRef(1)));
+        // object value = flag ? box 1 : box 2;
+        block.Add(new StoreStackSlot(
+            ValueSlot,
+            new Conditional(
+                new LoadArgument(1, "flag", Bool),
+                new Box(Int32, new Constant(1, Int32)),
+                new Box(Int32, new Constant(2, Int32)))));
+        // *address = value;
+        block.Add(new StoreIndirect(Object, new LoadStackSlot(AddressSlot, ByRefObject), new LoadStackSlot(ValueSlot, Object))
+        {
+            IsVolatile = defect == SpillDefect.VolatileStore,
+        });
+
+        // A second read of a spill slot perturbs the single-use guard.
+        if (defect == SpillDefect.AddressSlotReadTwice)
+            block.Add(new StoreLocal(2, ByRefObject, new LoadStackSlot(AddressSlot, ByRefObject)));
+        else if (defect == SpillDefect.ValueSlotReadTwice)
+            block.Add(new StoreLocal(2, Object, new LoadStackSlot(ValueSlot, Object)));
+
+        // ReadOnlySpan<object> span = InlineArrayAsReadOnlySpan<...>(ref buffer, 2); (local 1)
+        block.Add(new StoreLocal(1, SpanObject, new Call(
+            AsReadOnlySpan(),
+            isVirtual: false,
+            [new LoadLocalAddress(0, Buffer), new Constant(2, Int32)])));
+        block.Add(new Return(null));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(
+            Void,
+            [new Parameter("a", Int32), new Parameter("flag", Bool)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var declaringType = TypeRef.Definition("Synthetic", "", "T");
+        return defect switch
+        {
+            SpillDefect.AddressSlotReadTwice =>
+                new IrFunction("M", declaringType, signature, [Buffer, SpanObject, ByRefObject], body),
+            SpillDefect.ValueSlotReadTwice =>
+                new IrFunction("M", declaringType, signature, [Buffer, SpanObject, Object], body),
+            _ => new IrFunction("M", declaringType, signature, [Buffer, SpanObject], body),
+        };
+    }
+
+    static Call ElementRef(int slot)
+        => new(
+            new MethodRef(
+                TypeRef.Definition(TypeRef.CoreLibrary, "", "<PrivateImplementationDetails>"),
+                "InlineArrayElementRef",
+                ByRefObject,
+                [TypeRef.ByRef(Buffer), Int32],
+                HasThis: false)
+            {
+                TypeArguments = [Buffer, Object],
+                DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+            },
+            isVirtual: false,
+            [new LoadLocalAddress(0, Buffer), new Constant(slot, Int32)]);
+
+    static MethodRef AsReadOnlySpan()
+        => new(
+            TypeRef.Definition(TypeRef.CoreLibrary, "", "<PrivateImplementationDetails>"),
+            "InlineArrayAsReadOnlySpan",
+            SpanObject,
+            [TypeRef.ByRef(Buffer), Int32],
+            HasThis: false)
+        {
+            TypeArguments = [Buffer, Object],
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+}

--- a/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
@@ -235,6 +235,80 @@ public class InlineArraySpilledElementTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void BinaryOperandSpanConsumer_RaisesToCollectionExpression()
+    {
+        // The span-consuming call is the left operand of `IntFromSpan(span) + 1` — a
+        // non-short-circuiting Binary that evaluates it exactly once, unconditionally.
+        // The whitelist recognizes Binary, so the fidelity a Call-only whitelist would
+        // lose is recovered: the collection still raises.
+        var function = BuildOrderingCollection(OrderingShape.BinaryOperandSpan);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        var collection = Assert.Single(function.Descendants.OfType<CollectionExpression>());
+        Assert.Equal(2, collection.Children.Count);
+        Assert.DoesNotContain(
+            function.Descendants.OfType<Call>(),
+            c => c.Callee.Name.Contains("InlineArray", StringComparison.Ordinal));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void IfConditionSpanConsumer_RaisesToCollectionExpression()
+    {
+        // The span sits in a forward `if (Predicate(span))` condition — evaluated
+        // exactly once when the statement is reached (this pass runs after loop
+        // structuring, so an if-statement is never a back edge). The per-edge whitelist
+        // accepts the condition edge, so the collection raises.
+        var function = BuildOrderingCollection(OrderingShape.IfConditionSpan);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        var collection = Assert.Single(function.Descendants.OfType<CollectionExpression>());
+        Assert.Equal(2, collection.Children.Count);
+        Assert.DoesNotContain(
+            function.Descendants.OfType<Call>(),
+            c => c.Callee.Name.Contains("InlineArray", StringComparison.Ordinal));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SwitchValueSpanConsumer_RaisesToCollectionExpression()
+    {
+        // The span sits in a forward `switch (IntFromSpan(span))` scrutinee —
+        // evaluated exactly once. The per-edge whitelist accepts the Switch value edge
+        // (the sections are the conditional parts), so the collection raises.
+        var function = BuildOrderingCollection(OrderingShape.SwitchValueSpan);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        var collection = Assert.Single(function.Descendants.OfType<CollectionExpression>());
+        Assert.Equal(2, collection.Children.Count);
+        Assert.DoesNotContain(
+            function.Descendants.OfType<Call>(),
+            c => c.Callee.Name.Contains("InlineArray", StringComparison.Ordinal));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ThrowValueSpanConsumer_RaisesToCollectionExpression()
+    {
+        // The span-consuming call is the `throw MakeException(span)` value — evaluated
+        // exactly once, unconditionally. The whitelist recognizes Throw, so the
+        // collection raises (matching the vetted peer StackAllocSpanPass consumer set).
+        var function = BuildOrderingCollection(OrderingShape.ThrowValueSpan);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        var collection = Assert.Single(function.Descendants.OfType<CollectionExpression>());
+        Assert.Equal(2, collection.Children.Count);
+        Assert.DoesNotContain(
+            function.Descendants.OfType<Call>(),
+            c => c.Callee.Name.Contains("InlineArray", StringComparison.Ordinal));
+        function.CheckInvariant();
+    }
+
     enum OrderingShape
     {
         InterleavedStatement,
@@ -245,6 +319,10 @@ public class InlineArraySpilledElementTests
         NullCoalescingAssignmentValue,
         UnionSwitchArmValue,
         WhileConditionSpan,
+        BinaryOperandSpan,
+        IfConditionSpan,
+        SwitchValueSpan,
+        ThrowValueSpan,
     }
 
     /// <summary>
@@ -352,6 +430,43 @@ public class InlineArraySpilledElementTests
                     new Call(PredicateSpanMethod(), isVirtual: false, [span]),
                     new Block()));
                 break;
+            case OrderingShape.BinaryOperandSpan:
+                // local = IntFromSpan(span) + 1: the span-consuming call is the left
+                // operand of a non-short-circuiting Binary, evaluated exactly once and
+                // unconditionally. The whitelist recognizes Binary, so the collection
+                // still raises (recovering fidelity a Call-only whitelist would lose).
+                block.Add(new StoreLocal(2, Int32,
+                    new Binary(
+                        BinaryKind.Add,
+                        isChecked: false,
+                        isUnsigned: false,
+                        new Call(IntFromSpanMethod(), isVirtual: false, [span]),
+                        new Constant(1, Int32))));
+                break;
+            case OrderingShape.IfConditionSpan:
+                // if (Predicate(span)) { }: the span sits in a forward if-statement
+                // condition, evaluated exactly once when the statement is reached. The
+                // per-edge whitelist accepts the condition edge, so the collection raises.
+                block.Add(new IfStatement(
+                    new Call(PredicateSpanMethod(), isVirtual: false, [span]),
+                    new Block(),
+                    null));
+                break;
+            case OrderingShape.SwitchValueSpan:
+                // switch (IntFromSpan(span)) { }: the span sits in a forward switch
+                // scrutinee, evaluated exactly once. The per-edge whitelist accepts the
+                // Switch value edge, so the collection raises.
+                block.Add(new Switch(
+                    new Call(IntFromSpanMethod(), isVirtual: false, [span]),
+                    []));
+                break;
+            case OrderingShape.ThrowValueSpan:
+                // throw MakeException(span): the span-consuming call is the throw value,
+                // evaluated exactly once and unconditionally. The whitelist recognizes
+                // Throw, so the collection raises.
+                block.Add(new Throw(
+                    new Call(ThrowableFromSpanMethod(), isVirtual: false, [span])));
+                break;
             default:
                 // ReadOnlySpan<object> span = InlineArrayAsReadOnlySpan(ref buffer, 2); (local 1)
                 block.Add(new StoreLocal(1, SpanObject, span));
@@ -421,6 +536,25 @@ public class InlineArraySpilledElementTests
             TypeRef.Definition("Synthetic", "", "Fx"),
             "Predicate",
             Bool,
+            [SpanObject],
+            HasThis: false);
+
+    // int IntFromSpan(ReadOnlySpan<object> span)
+    static MethodRef IntFromSpanMethod()
+        => new(
+            TypeRef.Definition("Synthetic", "", "Fx"),
+            "IntFromSpan",
+            Int32,
+            [SpanObject],
+            HasThis: false);
+
+    // object MakeException(ReadOnlySpan<object> span) — a reference-returning call
+    // used as a throw value; the pass never type-checks throwability.
+    static MethodRef ThrowableFromSpanMethod()
+        => new(
+            TypeRef.Definition("Synthetic", "", "Fx"),
+            "MakeException",
+            Object,
             [SpanObject],
             HasThis: false);
 

--- a/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
@@ -134,10 +134,47 @@ public class InlineArraySpilledElementTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void InlineEffectBeforeSpanInConsumer_StaysFlat()
+    {
+        // The consumer evaluates a side-effecting call inline before the span
+        // (Consume(PrefixEffect(), span)). Block order is canonical, but lifting the
+        // elements to the span's position would move them past PrefixEffect(),
+        // inverting their order; the shape must stay flat.
+        var function = BuildOrderingCollection(OrderingShape.InlineEffectBeforeSpan);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SpilledPrefixBeforeSpanInConsumer_RaisesToCollectionExpression()
+    {
+        // The canonical csc shape: a prefix effect evaluated before the collection is
+        // spilled to a stack slot ahead of the fill, so the consumer loads that slot
+        // (Consume(spilledPrefix, span)) and only a side-effect-free load precedes the
+        // span. The within-consumer guard must not over-tighten this — it still raises.
+        var function = BuildOrderingCollection(OrderingShape.SpilledPrefixBeforeSpan);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        var collection = Assert.Single(function.Descendants.OfType<CollectionExpression>());
+        Assert.Equal(2, collection.Children.Count);
+        Assert.DoesNotContain(
+            function.Descendants.OfType<Call>(),
+            c => c.Callee.Name.Contains("InlineArray", StringComparison.Ordinal));
+        function.CheckInvariant();
+    }
+
     enum OrderingShape
     {
         InterleavedStatement,
         DescendingSlotOrder,
+        InlineEffectBeforeSpan,
+        SpilledPrefixBeforeSpan,
     }
 
     /// <summary>
@@ -146,13 +183,24 @@ public class InlineArraySpilledElementTests
     /// <see cref="OrderingShape.InterleavedStatement"/> drops an unrelated
     /// side-effecting call between the two stores;
     /// <see cref="OrderingShape.DescendingSlotOrder"/> emits the stores in
-    /// descending slot order. Each is a shape csc never emits but arbitrary IL can,
-    /// and lifting either would re-sequence element side effects — so both must
-    /// leave the collection flat.
+    /// descending slot order;
+    /// <see cref="OrderingShape.InlineEffectBeforeSpan"/> evaluates an effectful
+    /// call inline before the span inside the consumer;
+    /// <see cref="OrderingShape.SpilledPrefixBeforeSpan"/> spills that prefix effect
+    /// to a stack slot ahead of the fill (exactly what csc emits) so only a
+    /// side-effect-free load precedes the span. The first three are shapes csc never
+    /// emits but arbitrary IL can, and lifting any would re-sequence element side
+    /// effects — so all must leave the collection flat; the last is the canonical
+    /// csc shape and must still raise.
     /// </summary>
     static IrFunction BuildOrderingCollection(OrderingShape shape)
     {
         var block = new Block();
+
+        // csc spills a prefix effect evaluated before the collection to a stack slot
+        // ahead of the fill; the consumer then loads that slot (side-effect free).
+        if (shape == OrderingShape.SpilledPrefixBeforeSpan)
+            block.Add(new StoreStackSlot(0, PrefixEffect()));
 
         // <>y__InlineArray2<object> buffer = default; (local 0)
         block.Add(new InitObject(Buffer, new LoadLocalAddress(0, Buffer)));
@@ -163,19 +211,45 @@ public class InlineArraySpilledElementTests
             block.Add(new StoreIndirect(Object, ElementRef(1), BoxInt(2)));
             block.Add(new StoreIndirect(Object, ElementRef(0), BoxInt(1)));
         }
-        else
+        else if (shape == OrderingShape.InterleavedStatement)
         {
             // Store slot 0, an unrelated side-effecting statement, then slot 1.
             block.Add(new StoreIndirect(Object, ElementRef(0), BoxInt(1)));
             block.Add(new ExpressionStatement(Separator()));
             block.Add(new StoreIndirect(Object, ElementRef(1), BoxInt(2)));
         }
+        else
+        {
+            block.Add(new StoreIndirect(Object, ElementRef(0), BoxInt(1)));
+            block.Add(new StoreIndirect(Object, ElementRef(1), BoxInt(2)));
+        }
 
-        // ReadOnlySpan<object> span = InlineArrayAsReadOnlySpan<...>(ref buffer, 2); (local 1)
-        block.Add(new StoreLocal(1, SpanObject, new Call(
+        var span = new Call(
             AsReadOnlySpan(),
             isVirtual: false,
-            [new LoadLocalAddress(0, Buffer), new Constant(2, Int32)])));
+            [new LoadLocalAddress(0, Buffer), new Constant(2, Int32)]);
+
+        switch (shape)
+        {
+            case OrderingShape.InlineEffectBeforeSpan:
+                // Consume(PrefixEffect(), span): an effect evaluated inline before
+                // the span in the same statement — lifting the elements to the span
+                // would move them past that effect.
+                block.Add(new ExpressionStatement(
+                    new Call(ConsumeMethod(), isVirtual: false, [PrefixEffect(), span])));
+                break;
+            case OrderingShape.SpilledPrefixBeforeSpan:
+                // Consume(spilledPrefix, span): only a side-effect-free load precedes
+                // the span, so the raise is order preserving.
+                block.Add(new ExpressionStatement(
+                    new Call(ConsumeMethod(), isVirtual: false, [new LoadStackSlot(0, Object), span])));
+                break;
+            default:
+                // ReadOnlySpan<object> span = InlineArrayAsReadOnlySpan(ref buffer, 2); (local 1)
+                block.Add(new StoreLocal(1, SpanObject, span));
+                break;
+        }
+
         block.Add(new Return(null));
 
         var body = new BlockContainer();
@@ -202,6 +276,27 @@ public class InlineArraySpilledElementTests
                 HasThis: false),
             isVirtual: false,
             []);
+
+    // An object-returning side-effecting call, used as a consumer prefix argument.
+    static Call PrefixEffect()
+        => new(
+            new MethodRef(
+                TypeRef.Definition("Synthetic", "", "Fx"),
+                "PrefixEffect",
+                Object,
+                [],
+                HasThis: false),
+            isVirtual: false,
+            []);
+
+    // void Consume(object prefix, ReadOnlySpan<object> span)
+    static MethodRef ConsumeMethod()
+        => new(
+            TypeRef.Definition("Synthetic", "", "Fx"),
+            "Consume",
+            Void,
+            [Object, SpanObject],
+            HasThis: false);
 
     /// <summary>
     /// Builds the two-element params ReadOnlySpan&lt;object&gt; collection shape:

--- a/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
@@ -191,7 +191,7 @@ public class InlineArraySpilledElementTests
     {
         // The span is the right operand of `local ??= span`, evaluated only when the
         // target is null. `NullCoalescingAssignment` is one of the conditional IR
-        // nodes an enumerated blacklist missed; the sound-by-default whitelist leaves
+        // nodes an enumerated deny list missed; the sound-by-default allow list leaves
         // it flat because the node is not a recognized unconditional container.
         var function = BuildOrderingCollection(OrderingShape.NullCoalescingAssignmentValue);
 
@@ -207,7 +207,7 @@ public class InlineArraySpilledElementTests
     {
         // The span is a union-switch-expression arm value, evaluated only when its arm
         // matches. `UnionSwitchExpressionArm` does not derive from `SwitchExpressionArm`,
-        // so a blacklist keyed on the base arm type missed it; the whitelist rejects any
+        // so a deny list keyed on the base arm type missed it; the allow list rejects any
         // parent it does not explicitly recognize as unconditional, so it stays flat.
         var function = BuildOrderingCollection(OrderingShape.UnionSwitchArmValue);
 
@@ -223,7 +223,7 @@ public class InlineArraySpilledElementTests
     {
         // The span is a while-loop condition: evaluated unconditionally but once per
         // iteration. Lifting the element stores into it would call each element
-        // function once per loop test instead of once. The whitelist rejects the
+        // function once per loop test instead of once. The allow list rejects the
         // WhileLoop condition edge (not a once-through container), so it stays flat —
         // covering the exactly-once axis, not just definite evaluation.
         var function = BuildOrderingCollection(OrderingShape.WhileConditionSpan);
@@ -240,7 +240,7 @@ public class InlineArraySpilledElementTests
     {
         // The span-consuming call is the left operand of `IntFromSpan(span) + 1` — a
         // non-short-circuiting Binary that evaluates it exactly once, unconditionally.
-        // The whitelist recognizes Binary, so the fidelity a Call-only whitelist would
+        // The allow list recognizes Binary, so the fidelity a Call-only allow list would
         // lose is recovered: the collection still raises.
         var function = BuildOrderingCollection(OrderingShape.BinaryOperandSpan);
 
@@ -259,7 +259,7 @@ public class InlineArraySpilledElementTests
     {
         // The span sits in a forward `if (Predicate(span))` condition — evaluated
         // exactly once when the statement is reached (this pass runs after loop
-        // structuring, so an if-statement is never a back edge). The per-edge whitelist
+        // structuring, so an if-statement is never a back edge). The per-edge allow list
         // accepts the condition edge, so the collection raises.
         var function = BuildOrderingCollection(OrderingShape.IfConditionSpan);
 
@@ -277,7 +277,7 @@ public class InlineArraySpilledElementTests
     public void SwitchValueSpanConsumer_RaisesToCollectionExpression()
     {
         // The span sits in a forward `switch (IntFromSpan(span))` scrutinee —
-        // evaluated exactly once. The per-edge whitelist accepts the Switch value edge
+        // evaluated exactly once. The per-edge allow list accepts the Switch value edge
         // (the sections are the conditional parts), so the collection raises.
         var function = BuildOrderingCollection(OrderingShape.SwitchValueSpan);
 
@@ -295,7 +295,7 @@ public class InlineArraySpilledElementTests
     public void ThrowValueSpanConsumer_RaisesToCollectionExpression()
     {
         // The span-consuming call is the `throw MakeException(span)` value — evaluated
-        // exactly once, unconditionally. The whitelist recognizes Throw, so the
+        // exactly once, unconditionally. The allow list recognizes Throw, so the
         // collection raises (matching the vetted peer StackAllocSpanPass consumer set).
         var function = BuildOrderingCollection(OrderingShape.ThrowValueSpan);
 
@@ -406,15 +406,15 @@ public class InlineArraySpilledElementTests
             case OrderingShape.NullCoalescingAssignmentValue:
                 // local ??= span: the span is the ??= right operand, evaluated only
                 // when the target is null. NothingEffectfulBefore passes (the span is
-                // the only child), so only the definite-evaluation whitelist rejects
+                // the only child), so only the definite-evaluation allow list rejects
                 // this — the missed conditional node from adversarial review.
                 block.Add(new NullCoalescingAssignment(1, SpanObject, span));
                 break;
             case OrderingShape.UnionSwitchArmValue:
                 // local = scrutinee switch { Case => span, ... }: the span is a switch
                 // arm value, evaluated only when its arm matches. A union-switch arm is
-                // a distinct IR node from SwitchExpressionArm, so the whitelist (not an
-                // enumerated blacklist) must still reject it.
+                // a distinct IR node from SwitchExpressionArm, so the allow list (not an
+                // enumerated deny list) must still reject it.
                 block.Add(new StoreLocal(1, SpanObject,
                     new UnionSwitchExpression(
                         new LoadArgument(0, "arg", Object),
@@ -424,7 +424,7 @@ public class InlineArraySpilledElementTests
                 // while (Predicate(span)) { }: the span is unconditionally evaluated
                 // but re-evaluated on every loop iteration. Definite evaluation alone
                 // is not enough — the span must also be evaluated exactly once, so the
-                // whitelist rejects a WhileLoop condition edge (it is not a recognized
+                // allow list rejects a WhileLoop condition edge (it is not a recognized
                 // once-through container), leaving the collection flat.
                 block.Add(new WhileLoop(
                     new Call(PredicateSpanMethod(), isVirtual: false, [span]),
@@ -433,8 +433,8 @@ public class InlineArraySpilledElementTests
             case OrderingShape.BinaryOperandSpan:
                 // local = IntFromSpan(span) + 1: the span-consuming call is the left
                 // operand of a non-short-circuiting Binary, evaluated exactly once and
-                // unconditionally. The whitelist recognizes Binary, so the collection
-                // still raises (recovering fidelity a Call-only whitelist would lose).
+                // unconditionally. The allow list recognizes Binary, so the collection
+                // still raises (recovering fidelity a Call-only allow list would lose).
                 block.Add(new StoreLocal(2, Int32,
                     new Binary(
                         BinaryKind.Add,
@@ -446,7 +446,7 @@ public class InlineArraySpilledElementTests
             case OrderingShape.IfConditionSpan:
                 // if (Predicate(span)) { }: the span sits in a forward if-statement
                 // condition, evaluated exactly once when the statement is reached. The
-                // per-edge whitelist accepts the condition edge, so the collection raises.
+                // per-edge allow list accepts the condition edge, so the collection raises.
                 block.Add(new IfStatement(
                     new Call(PredicateSpanMethod(), isVirtual: false, [span]),
                     new Block(),
@@ -454,7 +454,7 @@ public class InlineArraySpilledElementTests
                 break;
             case OrderingShape.SwitchValueSpan:
                 // switch (IntFromSpan(span)) { }: the span sits in a forward switch
-                // scrutinee, evaluated exactly once. The per-edge whitelist accepts the
+                // scrutinee, evaluated exactly once. The per-edge allow list accepts the
                 // Switch value edge, so the collection raises.
                 block.Add(new Switch(
                     new Call(IntFromSpanMethod(), isVirtual: false, [span]),
@@ -462,7 +462,7 @@ public class InlineArraySpilledElementTests
                 break;
             case OrderingShape.ThrowValueSpan:
                 // throw MakeException(span): the span-consuming call is the throw value,
-                // evaluated exactly once and unconditionally. The whitelist recognizes
+                // evaluated exactly once and unconditionally. The allow list recognizes
                 // Throw, so the collection raises.
                 block.Add(new Throw(
                     new Call(ThrowableFromSpanMethod(), isVirtual: false, [span])));

--- a/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArraySpilledElementTests.cs
@@ -103,6 +103,106 @@ public class InlineArraySpilledElementTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void InterleavedStatementBetweenStores_StaysFlat()
+    {
+        // An unrelated side-effecting statement sits between the two element
+        // stores. The raise lifts the elements to the AsSpan site, which would move
+        // their side effects past that statement and silently re-sequence the
+        // program; the shape must stay flat.
+        var function = BuildOrderingCollection(OrderingShape.InterleavedStatement);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DescendingSlotOrderStores_StaysFlat()
+    {
+        // The element stores are emitted in descending slot order. The raise
+        // re-sequences them into ascending (source) order, inverting the evaluation
+        // order of the two element values; the shape must stay flat.
+        var function = BuildOrderingCollection(OrderingShape.DescendingSlotOrder);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsReadOnlySpan");
+        function.CheckInvariant();
+    }
+
+    enum OrderingShape
+    {
+        InterleavedStatement,
+        DescendingSlotOrder,
+    }
+
+    /// <summary>
+    /// Builds a two-element params ReadOnlySpan&lt;object&gt; collection with direct
+    /// element stores, perturbed to prove the statement-ordering guard.
+    /// <see cref="OrderingShape.InterleavedStatement"/> drops an unrelated
+    /// side-effecting call between the two stores;
+    /// <see cref="OrderingShape.DescendingSlotOrder"/> emits the stores in
+    /// descending slot order. Each is a shape csc never emits but arbitrary IL can,
+    /// and lifting either would re-sequence element side effects — so both must
+    /// leave the collection flat.
+    /// </summary>
+    static IrFunction BuildOrderingCollection(OrderingShape shape)
+    {
+        var block = new Block();
+
+        // <>y__InlineArray2<object> buffer = default; (local 0)
+        block.Add(new InitObject(Buffer, new LoadLocalAddress(0, Buffer)));
+
+        if (shape == OrderingShape.DescendingSlotOrder)
+        {
+            // Store slot 1 before slot 0.
+            block.Add(new StoreIndirect(Object, ElementRef(1), BoxInt(2)));
+            block.Add(new StoreIndirect(Object, ElementRef(0), BoxInt(1)));
+        }
+        else
+        {
+            // Store slot 0, an unrelated side-effecting statement, then slot 1.
+            block.Add(new StoreIndirect(Object, ElementRef(0), BoxInt(1)));
+            block.Add(new ExpressionStatement(Separator()));
+            block.Add(new StoreIndirect(Object, ElementRef(1), BoxInt(2)));
+        }
+
+        // ReadOnlySpan<object> span = InlineArrayAsReadOnlySpan<...>(ref buffer, 2); (local 1)
+        block.Add(new StoreLocal(1, SpanObject, new Call(
+            AsReadOnlySpan(),
+            isVirtual: false,
+            [new LoadLocalAddress(0, Buffer), new Constant(2, Int32)])));
+        block.Add(new Return(null));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(
+            Void,
+            [],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var declaringType = TypeRef.Definition("Synthetic", "", "T");
+        return new IrFunction("M", declaringType, signature, [Buffer, SpanObject], body);
+    }
+
+    static Box BoxInt(int value) => new(Int32, new Constant(value, Int32));
+
+    // A void call with no buffer reference — a standalone side-effecting statement.
+    static Call Separator()
+        => new(
+            new MethodRef(
+                TypeRef.Definition("Synthetic", "", "Fx"),
+                "Separator",
+                Void,
+                [],
+                HasThis: false),
+            isVirtual: false,
+            []);
+
     /// <summary>
     /// Builds the two-element params ReadOnlySpan&lt;object&gt; collection shape:
     /// element 0 is a direct indirect store of <c>box a</c>; element 1's value

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -508,6 +508,32 @@ public class IrImporterTests
     }
 
     [Fact]
+    public void InlineArrayObjectConditionalElementSpan_RaisesSpilledStore()
+    {
+        // The address-spilled dual of InlineArraySpan: an element VALUE that
+        // carries a branch and a call (`s is not null ? s.ToUpper() : "null"`) in
+        // a params ReadOnlySpan<object> context cannot be evaluated in one push,
+        // so csc computes the element-ref address first and spills it to an
+        // evaluation-stack temp, spills the conditional's value to a second temp,
+        // then stores through the spilled address. Left flat, both the angle-
+        // bracketed buffer name and the raw stack temps never parse.
+        // InlineArrayCollectionPass recovers the spilled address+value and raises
+        // the whole thing back to `[a, s is not null ? s.ToUpper() : "null"]`.
+        // This is the shape EncLocalInfo's params string.Format hits in the wild
+        // (issue #3129, S4).
+        var function = ImportFixture(nameof(CfgSampleClass.InlineArrayObjectConditionalElementSpan));
+        IrPasses.Run(function);
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Single(function.Descendants.OfType<CollectionExpression>());
+        Assert.Contains("[a, s is not null ? s.ToUpper() : \"null\"]", output);
+        Assert.DoesNotContain("InlineArray", output);
+        Assert.DoesNotContain("PrivateImplementationDetails", output);
+    }
+
+
+    [Fact]
     public void InlineArrayFieldAsSpan_RaisesToCast()
     {
         // A real [InlineArray(4)] field viewed as a Span<int>: csc lowers the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -27,8 +27,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// as <c>TwoObjects</c> used by string.Format's params lowering are a distinct
 /// shape and left untouched), default-initialized once, written by exactly N
 /// element stores covering slots 0..N-1, and used by exactly one
-/// AsReadOnlySpan — nothing else references the local. Anything outside this is
-/// left flat. The whole shape is proven before any node is detached.</para>
+/// AsReadOnlySpan — nothing else references the local. Each element store is
+/// either a direct indirect store or, when the element value carries a branch,
+/// an element-ref address spilled to a single-use evaluation-stack slot and
+/// stored through; anything outside this is left flat. The whole shape is proven
+/// before any node is detached.</para>
 /// </summary>
 public sealed class InlineArrayCollectionPass : IIrPass
 {
@@ -73,16 +76,23 @@ public sealed class InlineArrayCollectionPass : IIrPass
             if (stores is null)
                 continue;
 
-            // Shape proven. Detach each element value (discarding the
-            // ElementRef address subtree), build the collection expression, and
-            // replace the span source; then drop the init and the stores.
-            var elements = stores.Select(s => (IrExpression)s.DetachChildren()[1]).ToList();
+            // Shape proven. Detach each element value from its store, build the
+            // collection expression, replace the span source, then drop the init
+            // and every consumed store/spill statement.
+            var elements = new List<IrExpression>(stores.Count);
+            foreach (var store in stores)
+            {
+                store.Value.Detach();
+                elements.Add(store.Value);
+            }
+
             var collection = new CollectionExpression(element, spanType, elements);
             context.Stepper.StepOver("raise inline-array lowering to collection expression", span);
             span.ReplaceWith(collection);
             init.Detach();
             foreach (var store in stores)
-                store.Detach();
+                foreach (var statement in store.Consumed)
+                    statement.Detach();
         }
 
         RaisePlaceConversions(function, context);
@@ -730,32 +740,112 @@ public sealed class InlineArrayCollectionPass : IIrPass
     }
 
     /// <summary>
-    /// The N element stores for the inline-array local, ordered by slot index, or
-    /// null when they do not cover exactly slots 0..N-1 through
-    /// <c>InlineArrayElementRef(ref local, i)</c> — each a statement directly in a
-    /// block (its own slot, so it can be detached).
+    /// A single inline-array element store, resolved to the stored value
+    /// expression and the block statements that must be removed when the store is
+    /// folded into the collection expression. A direct store consumes one
+    /// statement; a spilled store consumes its address spill, its indirect store,
+    /// and (when the value is itself spilled) its value spill.
     /// </summary>
-    static List<StoreIndirect>? CollectElementStores(IrFunction function, int local, int count)
+    sealed record InlineArrayElementStore(int Slot, IrExpression Value, IReadOnlyList<IrNode> Consumed);
+
+    /// <summary>
+    /// The N element stores for the inline-array local, ordered by slot index, or
+    /// null when they do not cover exactly slots 0..N-1.
+    ///
+    /// <para>Two store shapes are recognized. The common shape is a direct
+    /// <c>*(InlineArrayElementRef(ref local, i)) = value</c> statement. When an
+    /// element's value contains a branch (a ternary or short-circuit), csc must
+    /// evaluate the element-ref address before that branch and so spills the
+    /// <c>ref</c> to an evaluation-stack slot: <c>slot_a =
+    /// InlineArrayElementRef(ref local, i); [slot_v = value;] *slot_a =
+    /// slot_v-or-value;</c>. That spilled shape is recognized too, but only when
+    /// every spill slot is written once and read once — so the address computation
+    /// (which has no observable effect once the collection expression drops it) and
+    /// the value can be recovered and re-sequenced into slot order safely. Anything
+    /// else (a multi-use spill slot, a volatile store, an unrecovered stack-slot
+    /// value) returns null and the whole shape is left flat.</para>
+    /// </summary>
+    static List<InlineArrayElementStore>? CollectElementStores(IrFunction function, int local, int count)
     {
-        var byIndex = new SortedDictionary<int, StoreIndirect>();
-        foreach (var store in function.Descendants.OfType<StoreIndirect>())
+        var elementRefs = function.Descendants.OfType<Call>()
+            .Where(c => IsPrivateImpl(c.Callee, "InlineArrayElementRef")
+                && c.Arguments is [LoadLocalAddress { Index: var refLocal }, Constant { Value: int }]
+                && refLocal == local)
+            .ToList();
+        if (elementRefs.Count != count)
+            return null;
+
+        var byIndex = new SortedDictionary<int, InlineArrayElementStore>();
+        foreach (var elementRef in elementRefs)
         {
-            // A volatile. stind has no faithful spelling inside a collection
-            // expression; leave it flat so fidelity caps (issue #1434).
-            if (store.IsVolatile)
-                continue;
-            if (store.Address is not Call elementRef || !IsPrivateImpl(elementRef.Callee, "InlineArrayElementRef"))
-                continue;
-            if (elementRef.Arguments is not [LoadLocalAddress { Index: var refLocal }, Constant { Value: int slot }] || refLocal != local)
-                continue;
-            if (store.Parent is not Block)
+            if (elementRef.Arguments is not [_, Constant { Value: int slot }])
                 return null;
             if (slot < 0 || slot >= count || byIndex.ContainsKey(slot))
                 return null;
-            byIndex[slot] = store;
+            if (ResolveElementStore(function, elementRef, slot) is not { } resolved)
+                return null;
+            byIndex[slot] = resolved;
         }
-        if (byIndex.Count != count)
-            return null;
-        return byIndex.Values.ToList();
+
+        return byIndex.Count == count ? byIndex.Values.ToList() : null;
     }
+
+    /// <summary>
+    /// Resolves the store that writes <paramref name="elementRef"/>'s slot: a
+    /// direct indirect store, or an address spilled to a single-use evaluation-stack
+    /// slot and stored through — recovering a single-use value spill so the element
+    /// is the real expression, never a dangling stack-slot load. Null for any other
+    /// shape.
+    /// </summary>
+    static InlineArrayElementStore? ResolveElementStore(IrFunction function, Call elementRef, int slot)
+    {
+        switch (elementRef.Parent)
+        {
+            // Direct: *(InlineArrayElementRef(ref local, slot)) = value.
+            case StoreIndirect { IsVolatile: false, Parent: Block } direct when direct.Address == elementRef:
+                return new InlineArrayElementStore(slot, direct.Value, [direct]);
+
+            // Address spilled: slot_a = InlineArrayElementRef(ref local, slot); the
+            // stored value flows through slot_a exactly once.
+            case StoreStackSlot { Parent: Block, Slot: var addressSlot } addressSpill when addressSpill.Value == elementRef:
+            {
+                if (StackSlotStoreCount(function, addressSlot) != 1 || StackSlotLoadCount(function, addressSlot) != 1)
+                    return null;
+                var addressLoad = function.Descendants.OfType<LoadStackSlot>().Single(l => l.Slot == addressSlot);
+                if (addressLoad.Parent is not StoreIndirect { IsVolatile: false, Parent: Block } indirect
+                    || indirect.Address != addressLoad)
+                {
+                    return null;
+                }
+
+                var value = indirect.Value;
+                List<IrNode> consumed = [addressSpill, indirect];
+
+                // A stack-slot load cannot be a collection element on its own; when
+                // the value was itself spilled, recover it — but only from a clean
+                // single-def/single-use spill, else leave the whole shape flat.
+                if (value is LoadStackSlot { Slot: var valueSlot })
+                {
+                    if (StackSlotStoreCount(function, valueSlot) != 1 || StackSlotLoadCount(function, valueSlot) != 1)
+                        return null;
+                    var valueSpill = function.Descendants.OfType<StoreStackSlot>().Single(s => s.Slot == valueSlot);
+                    if (valueSpill.Parent is not Block)
+                        return null;
+                    value = valueSpill.Value;
+                    consumed = [addressSpill, valueSpill, indirect];
+                }
+
+                return new InlineArrayElementStore(slot, value, consumed);
+            }
+
+            default:
+                return null;
+        }
+    }
+
+    static int StackSlotStoreCount(IrFunction function, int slot)
+        => function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == slot);
+
+    static int StackSlotLoadCount(IrFunction function, int slot)
+        => function.Descendants.OfType<LoadStackSlot>().Count(l => l.Slot == slot);
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -76,6 +76,17 @@ public sealed class InlineArrayCollectionPass : IIrPass
             if (stores is null)
                 continue;
 
+            // The collection expression materializes at the AsSpan call site and
+            // evaluates its elements there in ascending slot order, so the raise is
+            // only order-preserving when the init and element stores are a
+            // contiguous run of statements in the AsSpan's own block, in ascending
+            // slot order, immediately before the statement that consumes the span.
+            // csc always emits exactly that; arbitrary IL can interleave a statement
+            // between the stores or emit them out of slot order, which would
+            // silently re-sequence element side effects — leave those flat.
+            if (!ElementStoresPreserveOrder(init, stores, span))
+                continue;
+
             // Shape proven. Detach each element value from its store, build the
             // collection expression, replace the span source, then drop the init
             // and every consumed store/spill statement.
@@ -788,6 +799,68 @@ public sealed class InlineArrayCollectionPass : IIrPass
         }
 
         return byIndex.Count == count ? byIndex.Values.ToList() : null;
+    }
+
+    /// <summary>
+    /// Verifies that the collection's <paramref name="init"/> and element
+    /// <paramref name="stores"/> can be lifted to the <paramref name="span"/> call
+    /// site without re-sequencing any observable side effect.
+    ///
+    /// <para>The raise removes the init and store statements and evaluates the
+    /// element values, in ascending slot order, at the position of the span call.
+    /// That preserves program order only when those statements form a contiguous
+    /// run in the span-consuming statement's own block, in ascending slot order,
+    /// immediately before that statement — the exact shape csc emits (default the
+    /// buffer, fill slots 0..N-1 in order, then read the span). Arbitrary IL
+    /// (ilasm, obfuscators, other front ends) can interleave an unrelated statement
+    /// within the fill or between the fill and the span, or store the slots out of
+    /// order; lifting either would move element side effects across a statement or
+    /// invert their evaluation order, silently emitting wrong C#. Anything but the
+    /// canonical run returns false so the shape is left flat.</para>
+    /// </summary>
+    static bool ElementStoresPreserveOrder(IrNode init, List<InlineArrayElementStore> stores, Call span)
+    {
+        // The span-consuming statement: the innermost ancestor of the span call
+        // that is a direct child of a block.
+        IrNode consumer = span;
+        while (consumer.Parent is { } parent and not Block)
+            consumer = parent;
+        if (consumer.Parent is not Block block)
+            return false;
+        int consumerIndex = consumer.ChildIndex;
+
+        // Every consumed statement (the init and each store's statements) keyed to
+        // its owning slot; the init sorts first with a sentinel slot.
+        var run = new List<(int Index, int Slot)>(1 + stores.Sum(s => s.Consumed.Count));
+        if (init.Parent != block || init.ChildIndex >= consumerIndex)
+            return false;
+        run.Add((init.ChildIndex, -1));
+        foreach (var store in stores)
+            foreach (var statement in store.Consumed)
+            {
+                if (statement.Parent != block || statement.ChildIndex >= consumerIndex)
+                    return false;
+                run.Add((statement.ChildIndex, store.Slot));
+            }
+
+        run.Sort((a, b) => a.Index.CompareTo(b.Index));
+
+        // Contiguous run of distinct statements ending immediately before the
+        // consuming statement: no unrelated statement sits within the fill or
+        // between the fill and the span.
+        if (run[^1].Index != consumerIndex - 1)
+            return false;
+        for (int i = 1; i < run.Count; i++)
+            if (run[i].Index != run[i - 1].Index + 1)
+                return false;
+
+        // Slots non-decreasing across the run (init's sentinel sorts first): the
+        // block order of the element writes matches ascending slot = source order.
+        for (int i = 1; i < run.Count; i++)
+            if (run[i].Slot < run[i - 1].Slot)
+                return false;
+
+        return true;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -882,7 +882,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
         // null-conditional member, a lambda body) would drop their side effects on
         // the skipped paths, and into a repeatedly evaluated position (a loop
         // condition) would run them more than once. Both are rejected by the
-        // sound-by-default whitelist in SpanUnconditionallyEvaluated.
+        // sound-by-default allow list in SpanUnconditionallyEvaluated.
         return NothingEffectfulBefore(consumer, span)
             && SpanUnconditionallyEvaluated(consumer, span);
     }
@@ -911,7 +911,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
     /// Whether <paramref name="span"/> is evaluated on every path through the
     /// <paramref name="consumer"/> statement: every edge on the parent chain from
     /// the span up to the consumer must be an unconditionally evaluated one per the
-    /// sound-by-default whitelist in <see cref="EvaluatesChildUnconditionally"/>.
+    /// sound-by-default allow list in <see cref="EvaluatesChildUnconditionally"/>.
     /// The element values are unconditional statements before the consumer, so
     /// lifting them into a conditionally evaluated position (a ternary arm, a
     /// short-circuit <c>&amp;&amp;</c>/<c>||</c> or <c>??</c> right operand, a
@@ -938,9 +938,9 @@ public sealed class InlineArrayCollectionPass : IIrPass
     /// once, unconditionally, on every path <paramref name="parent"/> is itself
     /// evaluated on.
     ///
-    /// <para>Sound by default: this is a <b>whitelist</b> of the container nodes that
-    /// evaluate a given child exactly once, unconditionally, mirroring the whitelist
-    /// walk in <see cref="StackAllocSpanPass"/>. A blacklist of the known
+    /// <para>Sound by default: this is an <b>allow list</b> of the container nodes that
+    /// evaluate a given child exactly once, unconditionally, mirroring the allow-list
+    /// walk in <see cref="StackAllocSpanPass"/>. A deny list of the known
     /// short-circuiting / repeating nodes would be unsound: any conditional or
     /// repeatedly evaluated node not enumerated — and any such node added to the IR
     /// later — would silently fall through as "unconditional" and let the element
@@ -949,7 +949,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
     /// (the collection is left flat) while a missed conditional/repeated shape emits
     /// confidently-wrong C#, the default is <c>false</c>.</para>
     ///
-    /// <para>Two families are whitelisted. First, the container / operator nodes that
+    /// <para>Two families are allow-listed. First, the container / operator nodes that
     /// evaluate every child exactly once, left to right: the statement and store
     /// wrappers, call/constructor argument lists (C# never short-circuits an argument
     /// list), pass-through conversions, and the non-short-circuiting operator
@@ -976,7 +976,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
     /// <see cref="IfStatement"/>/<see cref="Switch"/> after loop structuring.
     /// Short-circuit, coalesce, ternary, switch-expression arm, null-conditional
     /// member, <c>??=</c> right operand, <c>with</c> initializer, and lambda bodies
-    /// are likewise not whitelisted.</para>
+    /// are likewise not allow-listed.</para>
     /// </summary>
     static bool EvaluatesChildUnconditionally(IrNode parent, IrNode child) => parent switch
     {
@@ -987,7 +987,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
         // Call/constructor arguments and the receiver are all evaluated
         // unconditionally, left to right — C# has no short-circuiting in an
         // argument list; short-circuiting lives only in the dedicated expression
-        // nodes, none of which are whitelisted here.
+        // nodes, none of which are allow-listed here.
         Call or CallIndirect or NewObject => true,
         // A conversion / box wrapping the span passes it through unconditionally.
         Convert or Coerce or CastClass or Box or Unbox or UnboxAny

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -934,28 +934,49 @@ public sealed class InlineArrayCollectionPass : IIrPass
     }
 
     /// <summary>
-    /// Whether <paramref name="parent"/> evaluates <paramref name="child"/> on every
-    /// path <paramref name="parent"/> is itself evaluated on.
+    /// Whether <paramref name="parent"/> evaluates <paramref name="child"/> exactly
+    /// once, unconditionally, on every path <paramref name="parent"/> is itself
+    /// evaluated on.
     ///
     /// <para>Sound by default: this is a <b>whitelist</b> of the container nodes that
-    /// evaluate every child exactly once, unconditionally, left to right, mirroring
-    /// the whitelist walk in <see cref="StackAllocSpanPass"/>
-    /// (<c>ReachesAsOnlyPrecedingEffect</c> descends only <see cref="Call"/>/<see
-    /// cref="NewObject"/> arguments and rejects every other shape). A blacklist of the
-    /// known short-circuiting nodes would be unsound: any conditional or repeatedly
-    /// evaluated node not enumerated — and any such node added to the IR later —
-    /// would silently fall through as "unconditional" and let the element side
-    /// effects be lifted into a branch that may not run, or a loop condition that
-    /// runs them many times. Because an unrecognized shape only costs fidelity (the
-    /// collection is left flat), and a missed conditional/repeated shape emits
+    /// evaluate a given child exactly once, unconditionally, mirroring the whitelist
+    /// walk in <see cref="StackAllocSpanPass"/>. A blacklist of the known
+    /// short-circuiting / repeating nodes would be unsound: any conditional or
+    /// repeatedly evaluated node not enumerated — and any such node added to the IR
+    /// later — would silently fall through as "unconditional" and let the element
+    /// side effects be lifted into a branch that may not run, or a loop condition
+    /// that runs them many times. Because an unrecognized shape only costs fidelity
+    /// (the collection is left flat) while a missed conditional/repeated shape emits
     /// confidently-wrong C#, the default is <c>false</c>.</para>
     ///
-    /// <para>The whitelisted nodes are exactly those on the real csc inline-array
-    /// params-span consumer paths: the statement wrapper / store that consumes the
-    /// span, and the call / constructor / pass-through conversion it is nested in.
-    /// A short-circuit, coalesce, ternary, switch-expression arm, null-conditional
-    /// member, <c>??=</c> right operand, lambda body, or any other shape is not on
-    /// that list, so the span reached through one is left flat.</para>
+    /// <para>Two families are whitelisted. First, the container / operator nodes that
+    /// evaluate every child exactly once, left to right: the statement and store
+    /// wrappers, call/constructor argument lists (C# never short-circuits an argument
+    /// list), pass-through conversions, and the non-short-circuiting operator
+    /// expressions — the bitwise/arithmetic <see cref="Binary"/>,
+    /// <see cref="Comparison"/>, <see cref="Unary"/>, <see cref="LogicalNot"/>, tuple
+    /// construction/comparison, <see cref="Throw"/>, and <see cref="YieldReturn"/>.
+    /// Second, the scrutinee edge of a forward selection statement — the
+    /// <c>if</c>/<c>switch</c> condition — which is evaluated exactly once each time
+    /// the statement is reached; the arms/sections are the conditional parts and are
+    /// rejected by the per-edge <see cref="object.ReferenceEquals(object?,object?)"/>
+    /// check.</para>
+    ///
+    /// <para>Loops are deliberately excluded. This pass runs after loop structuring
+    /// (<c>DoWhileLoopPass</c>/<c>ForLoopPass</c>/<c>StructuringPass</c>/
+    /// <c>ForeachStatementPass</c>), so back edges are already
+    /// <see cref="WhileLoop"/>/<see cref="ForLoop"/>/etc. A loop node evaluates its
+    /// condition many times per single evaluation of the node while the element
+    /// stores — earlier siblings of the loop in the same block — run once; lifting
+    /// them into a loop condition would call each element function once per iteration.
+    /// The low-level <see cref="ConditionalBranch"/>/<see cref="SwitchBranch"/> are
+    /// also excluded: a residual back edge would only be safe under a single-entry
+    /// basic-block invariant this guard does not assert, and the real csc <c>if</c>/
+    /// <c>switch</c> span consumers are already the structured
+    /// <see cref="IfStatement"/>/<see cref="Switch"/> after loop structuring.
+    /// Short-circuit, coalesce, ternary, switch-expression arm, null-conditional
+    /// member, <c>??=</c> right operand, <c>with</c> initializer, and lambda bodies
+    /// are likewise not whitelisted.</para>
     /// </summary>
     static bool EvaluatesChildUnconditionally(IrNode parent, IrNode child) => parent switch
     {
@@ -971,6 +992,18 @@ public sealed class InlineArrayCollectionPass : IIrPass
         // A conversion / box wrapping the span passes it through unconditionally.
         Convert or Coerce or CastClass or Box or Unbox or UnboxAny
             or InlineArraySpanConversion => true,
+        // Non-short-circuiting operator expressions evaluate every operand exactly
+        // once. These are the bitwise/arithmetic forms — the short-circuiting
+        // LogicalBinary (&&/||), Coalesce (??), Conditional (?:) and NullConditional
+        // (?.) are NOT here and are left flat by the default.
+        Binary or Comparison or Unary or LogicalNot or TupleExpression
+            or TupleBinaryExpression or Throw or YieldReturn => true,
+        // Forward selection statements evaluate their scrutinee exactly once each
+        // time they are reached; only the condition edge qualifies (the arms /
+        // sections are conditional). Loops re-evaluate their condition per iteration
+        // and are excluded by falling through to the default.
+        IfStatement ifStatement => ReferenceEquals(child, ifStatement.Condition),
+        Switch @switch => ReferenceEquals(child, @switch.Value),
         _ => false,
     };
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -876,10 +876,13 @@ public sealed class InlineArrayCollectionPass : IIrPass
         // can instead evaluate an effectful expression inline before the span
         // (e.g. `Consume(PrefixEffect(), span)`); lifting the elements past it
         // would invert their order, so leave that flat. Likewise the span must be
-        // evaluated on every path through the consumer: lifting the unconditional
-        // element stores into a conditionally evaluated position (a ternary arm, a
-        // short-circuit / coalesce right operand, a switch arm, a null-conditional
-        // member) would suppress their side effects when that path is not taken.
+        // evaluated exactly once, on every path through the consumer: lifting the
+        // unconditional element stores into a conditionally evaluated position (a
+        // ternary/switch arm, a short-circuit or coalesce or `??=` right operand, a
+        // null-conditional member, a lambda body) would drop their side effects on
+        // the skipped paths, and into a repeatedly evaluated position (a loop
+        // condition) would run them more than once. Both are rejected by the
+        // sound-by-default whitelist in SpanUnconditionallyEvaluated.
         return NothingEffectfulBefore(consumer, span)
             && SpanUnconditionallyEvaluated(consumer, span);
     }
@@ -906,14 +909,16 @@ public sealed class InlineArrayCollectionPass : IIrPass
 
     /// <summary>
     /// Whether <paramref name="span"/> is evaluated on every path through the
-    /// <paramref name="consumer"/> statement: the parent chain from the span up to
-    /// the consumer must cross no conditionally evaluated edge. The element values
-    /// are unconditional statements before the consumer, so lifting them into a
-    /// conditionally evaluated position (a ternary arm, a short-circuit
-    /// <c>&amp;&amp;</c>/<c>||</c> or <c>??</c> right operand, a switch-expression
-    /// arm, or a null-conditional member) would drop their side effects on the
-    /// paths that skip the span. csc never emits the span in such a position;
-    /// arbitrary IL can, so leave those flat.
+    /// <paramref name="consumer"/> statement: every edge on the parent chain from
+    /// the span up to the consumer must be an unconditionally evaluated one per the
+    /// sound-by-default whitelist in <see cref="EvaluatesChildUnconditionally"/>.
+    /// The element values are unconditional statements before the consumer, so
+    /// lifting them into a conditionally evaluated position (a ternary arm, a
+    /// short-circuit <c>&amp;&amp;</c>/<c>||</c> or <c>??</c> right operand, a
+    /// switch-expression arm, a null-conditional member, a <c>??=</c> right operand,
+    /// or a lambda body) would drop their side effects on the paths that skip the
+    /// span. csc never emits the span in such a position; arbitrary IL can, so leave
+    /// those flat.
     /// </summary>
     static bool SpanUnconditionallyEvaluated(IrNode consumer, IrNode span)
     {
@@ -930,19 +935,43 @@ public sealed class InlineArrayCollectionPass : IIrPass
 
     /// <summary>
     /// Whether <paramref name="parent"/> evaluates <paramref name="child"/> on every
-    /// path <paramref name="parent"/> is itself evaluated on. Only the
-    /// short-circuiting / conditional expression nodes gate a child; every other
-    /// node evaluates its children unconditionally, left to right. Revisit if a new
-    /// conditional-evaluation node is added to the IR.
+    /// path <paramref name="parent"/> is itself evaluated on.
+    ///
+    /// <para>Sound by default: this is a <b>whitelist</b> of the container nodes that
+    /// evaluate every child exactly once, unconditionally, left to right, mirroring
+    /// the whitelist walk in <see cref="StackAllocSpanPass"/>
+    /// (<c>ReachesAsOnlyPrecedingEffect</c> descends only <see cref="Call"/>/<see
+    /// cref="NewObject"/> arguments and rejects every other shape). A blacklist of the
+    /// known short-circuiting nodes would be unsound: any conditional or repeatedly
+    /// evaluated node not enumerated — and any such node added to the IR later —
+    /// would silently fall through as "unconditional" and let the element side
+    /// effects be lifted into a branch that may not run, or a loop condition that
+    /// runs them many times. Because an unrecognized shape only costs fidelity (the
+    /// collection is left flat), and a missed conditional/repeated shape emits
+    /// confidently-wrong C#, the default is <c>false</c>.</para>
+    ///
+    /// <para>The whitelisted nodes are exactly those on the real csc inline-array
+    /// params-span consumer paths: the statement wrapper / store that consumes the
+    /// span, and the call / constructor / pass-through conversion it is nested in.
+    /// A short-circuit, coalesce, ternary, switch-expression arm, null-conditional
+    /// member, <c>??=</c> right operand, lambda body, or any other shape is not on
+    /// that list, so the span reached through one is left flat.</para>
     /// </summary>
     static bool EvaluatesChildUnconditionally(IrNode parent, IrNode child) => parent switch
     {
-        Conditional conditional => ReferenceEquals(child, conditional.Condition),
-        LogicalBinary logical => ReferenceEquals(child, logical.Left),
-        Coalesce coalesce => ReferenceEquals(child, coalesce.Left),
-        SwitchExpression switchExpression => ReferenceEquals(child, switchExpression.Value),
-        SwitchExpressionArm or NullConditional => false,
-        _ => true,
+        // The statement / store that consumes the span evaluates its operand(s)
+        // unconditionally.
+        ExpressionStatement or Return or StoreLocal or StoreField or StoreArgument
+            or StoreIndirect or StoreElement or StoreProperty => true,
+        // Call/constructor arguments and the receiver are all evaluated
+        // unconditionally, left to right — C# has no short-circuiting in an
+        // argument list; short-circuiting lives only in the dedicated expression
+        // nodes, none of which are whitelisted here.
+        Call or CallIndirect or NewObject => true,
+        // A conversion / box wrapping the span passes it through unconditionally.
+        Convert or Coerce or CastClass or Box or Unbox or UnboxAny
+            or InlineArraySpanConversion => true,
+        _ => false,
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -815,8 +815,11 @@ public sealed class InlineArrayCollectionPass : IIrPass
     /// (ilasm, obfuscators, other front ends) can interleave an unrelated statement
     /// within the fill or between the fill and the span, or store the slots out of
     /// order; lifting either would move element side effects across a statement or
-    /// invert their evaluation order, silently emitting wrong C#. Anything but the
-    /// canonical run returns false so the shape is left flat.</para>
+    /// invert their evaluation order, silently emitting wrong C#. It can also
+    /// evaluate an effectful expression inside the consumer before the span itself;
+    /// lifting the elements to the span's position would then move them past that
+    /// effect. Anything but the canonical run with a side-effect-free consumer
+    /// prefix returns false so the shape is left flat.</para>
     /// </summary>
     static bool ElementStoresPreserveOrder(IrNode init, List<InlineArrayElementStore> stores, Call span)
     {
@@ -860,8 +863,56 @@ public sealed class InlineArrayCollectionPass : IIrPass
             if (run[i].Slot < run[i - 1].Slot)
                 return false;
 
+        // Block-level order is not sufficient on its own: the element values are
+        // lifted to the span's position *inside* the consuming statement, so
+        // anything the consumer evaluates before the span would move ahead of
+        // those element side effects. csc never puts an effect there — a prefix
+        // argument or receiver evaluated before the collection is spilled to a
+        // stack slot (a side-effect-free load) ahead of the fill, so at the span
+        // position only such loads precede it. Arbitrary IL (ilasm, obfuscators)
+        // can instead evaluate an effectful expression inline before the span
+        // (e.g. `Consume(PrefixEffect(), span)`); lifting the elements past it
+        // would invert their order, so leave that flat.
+        return NothingEffectfulBefore(consumer, span);
+    }
+
+    /// <summary>
+    /// Whether every expression the <paramref name="consumer"/> statement evaluates
+    /// before <paramref name="span"/> is side-effect free, walking the parent chain
+    /// from the span up to (but excluding) the consumer and checking each earlier
+    /// sibling. Mirrors the same-named guard in <see cref="RangeFromGetSubArrayPass"/>.
+    /// </summary>
+    static bool NothingEffectfulBefore(IrNode consumer, IrNode span)
+    {
+        for (IrNode node = span; node != consumer; node = node.Parent!)
+        {
+            if (node.Parent is not { } parent)
+                return false;
+            for (int i = 0; i < node.ChildIndex; i++)
+                if (parent.Children[i] is not IrExpression sibling || !IsSideEffectFree(sibling))
+                    return false;
+        }
+
         return true;
     }
+
+    /// <summary>
+    /// Allow-list of non-observable expressions, mirroring the same-named helpers
+    /// in <see cref="RangeFromGetSubArrayPass"/> and <see cref="StackAllocSpanPass"/>:
+    /// anything outside the proven-safe set is treated as possibly effectful.
+    /// </summary>
+    static bool IsSideEffectFree(IrExpression expression) => expression switch
+    {
+        Constant or LoadLocal or LoadArgument or LoadStackSlot
+            or LoadLocalAddress or LoadArgumentAddress or SizeOf => true,
+        Unary unary => IsSideEffectFree(unary.Operand),
+        Binary { Kind: BinaryKind.Divide or BinaryKind.Remainder } => false,
+        Binary { IsChecked: true } => false,
+        Binary binary => IsSideEffectFree(binary.Left) && IsSideEffectFree(binary.Right),
+        Convert { IsChecked: true } => false,
+        Convert convert => IsSideEffectFree(convert.Operand),
+        _ => false,
+    };
 
     /// <summary>
     /// Resolves the store that writes <paramref name="elementRef"/>'s slot: a

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -818,7 +818,10 @@ public sealed class InlineArrayCollectionPass : IIrPass
     /// invert their evaluation order, silently emitting wrong C#. It can also
     /// evaluate an effectful expression inside the consumer before the span itself;
     /// lifting the elements to the span's position would then move them past that
-    /// effect. Anything but the canonical run with a side-effect-free consumer
+    /// effect. It can also place the span in a conditionally evaluated position (a
+    /// ternary arm, a short-circuit or coalesce right operand, a switch arm), which
+    /// would drop the element side effects on the paths that skip it. Anything but
+    /// the canonical run with a side-effect-free, unconditionally evaluated consumer
     /// prefix returns false so the shape is left flat.</para>
     /// </summary>
     static bool ElementStoresPreserveOrder(IrNode init, List<InlineArrayElementStore> stores, Call span)
@@ -872,8 +875,13 @@ public sealed class InlineArrayCollectionPass : IIrPass
         // position only such loads precede it. Arbitrary IL (ilasm, obfuscators)
         // can instead evaluate an effectful expression inline before the span
         // (e.g. `Consume(PrefixEffect(), span)`); lifting the elements past it
-        // would invert their order, so leave that flat.
-        return NothingEffectfulBefore(consumer, span);
+        // would invert their order, so leave that flat. Likewise the span must be
+        // evaluated on every path through the consumer: lifting the unconditional
+        // element stores into a conditionally evaluated position (a ternary arm, a
+        // short-circuit / coalesce right operand, a switch arm, a null-conditional
+        // member) would suppress their side effects when that path is not taken.
+        return NothingEffectfulBefore(consumer, span)
+            && SpanUnconditionallyEvaluated(consumer, span);
     }
 
     /// <summary>
@@ -895,6 +903,47 @@ public sealed class InlineArrayCollectionPass : IIrPass
 
         return true;
     }
+
+    /// <summary>
+    /// Whether <paramref name="span"/> is evaluated on every path through the
+    /// <paramref name="consumer"/> statement: the parent chain from the span up to
+    /// the consumer must cross no conditionally evaluated edge. The element values
+    /// are unconditional statements before the consumer, so lifting them into a
+    /// conditionally evaluated position (a ternary arm, a short-circuit
+    /// <c>&amp;&amp;</c>/<c>||</c> or <c>??</c> right operand, a switch-expression
+    /// arm, or a null-conditional member) would drop their side effects on the
+    /// paths that skip the span. csc never emits the span in such a position;
+    /// arbitrary IL can, so leave those flat.
+    /// </summary>
+    static bool SpanUnconditionallyEvaluated(IrNode consumer, IrNode span)
+    {
+        for (IrNode node = span; node != consumer; node = node.Parent!)
+        {
+            if (node.Parent is not { } parent)
+                return false;
+            if (!EvaluatesChildUnconditionally(parent, node))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="parent"/> evaluates <paramref name="child"/> on every
+    /// path <paramref name="parent"/> is itself evaluated on. Only the
+    /// short-circuiting / conditional expression nodes gate a child; every other
+    /// node evaluates its children unconditionally, left to right. Revisit if a new
+    /// conditional-evaluation node is added to the IR.
+    /// </summary>
+    static bool EvaluatesChildUnconditionally(IrNode parent, IrNode child) => parent switch
+    {
+        Conditional conditional => ReferenceEquals(child, conditional.Condition),
+        LogicalBinary logical => ReferenceEquals(child, logical.Left),
+        Coalesce coalesce => ReferenceEquals(child, coalesce.Left),
+        SwitchExpression switchExpression => ReferenceEquals(child, switchExpression.Value),
+        SwitchExpressionArm or NullConditional => false,
+        _ => true,
+    };
 
     /// <summary>
     /// Allow-list of non-observable expressions, mirroring the same-named helpers


### PR DESCRIPTION
- Advances #3129
- Raises csc's address-spilled inline-array collection-expression element stores (the `params ReadOnlySpan<T>` lowering where an element value carries a branch) back to a collection expression `[e0, …, eN]`
- Card revision: `d481b3b6`

> S0 (#3204) and S5 (#3216) have merged to `main`; this slice now targets `main` directly (single commit `d481b3b6`, rebased off the merged stack).

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a previously-unraised, unspellable inline-array `params`-span shape (an element value carries a branch, so csc spills the element-ref address + value to eval-stack slots and stores through the spilled address) now raises to a valid, correct collection expression, guarded so it fires only on the exact single-use spill shape and leaves every ambiguous shape flat.

### Benchmark target

Benchmark target: `Microsoft.CodeAnalysis@5.0.0` (real witness `Microsoft.CodeAnalysis.Emit.EncLocalInfo::GetDebuggerDisplay`).

dotnet-inspect command:

```bash
dotnet-inspect member Microsoft.CodeAnalysis.Emit.EncLocalInfo GetDebuggerDisplay --library Microsoft.CodeAnalysis.dll --all -S "Decompiled Source"
```

### Original source

```csharp
private string GetDebuggerDisplay()
{
    if (IsDefault)
    {
        return "[default]";
    }

    if (IsUnused)
    {
        return "[invalid]";
    }

    return string.Format("[Id={0}, SynthesizedKind={1}, Type={2}, Constraints={3}, Sig={4}]",
        SlotInfo.Id,
        SlotInfo.SynthesizedKind,
        Type,
        Constraints,
        (Signature != null) ? BitConverter.ToString(Signature) : "null");
}
```

The 5-argument `string.Format` binds to the `params ReadOnlySpan<object>` overload, which csc lowers to an `<>y__InlineArray5<object>` buffer. Element 4 carries a ternary, so csc evaluates the element-ref **address** before the branch and spills both the address and the branch value to evaluation-stack slots.

### Before

```csharp
private string GetDebuggerDisplay()
{
    if (IsDefault)
    {
        return "[default]";
    }
    if (IsUnused)
    {
        return "[invalid]";
    }
    ___y__InlineArray5<object> V_0 = default;
    V_0[0] = SlotInfo.Id;
    V_0[1] = SlotInfo.SynthesizedKind;
    V_0[2] = Type;
    V_0[3] = Constraints;
    ref object S_1 = ref V_0[4];
    string S_2 = Signature is not null ? BitConverter.ToString(Signature) : "null";
    S_1 = S_2;
    return string.Format("[Id={0}, SynthesizedKind={1}, Type={2}, Constraints={3}, Sig={4}]", __PrivateImplementationDetails_.InlineArrayAsReadOnlySpan<___y__InlineArray5<object>, object>(V_0, 5));
}
```

- Valid: False — parses (S0 sanitized the `<>` names to `___…`) but does not bind: `___y__InlineArray5` and `__PrivateImplementationDetails_` are not real types (CS0246).
- Correct: False — cannot bind, so no observable behavior.
- IL fidelity: False — does not compile.
- Taste applied: None.
- Commit: `08ab86b1` (`main`; pre-S4 base)

The spilled element 4 (`ref S_1 = ref V_0[4]; … S_1 = S_2;`) fails the pass's direct-store match, so the **entire** inline-array shape is left flat and honestly `Partial`.

### After

```csharp
private string GetDebuggerDisplay()
{
    if (IsDefault)
    {
        return "[default]";
    }
    if (IsUnused)
    {
        return "[invalid]";
    }
    return string.Format("[Id={0}, SynthesizedKind={1}, Type={2}, Constraints={3}, Sig={4}]", [SlotInfo.Id, SlotInfo.SynthesizedKind, Type, Constraints, Signature is not null ? BitConverter.ToString(Signature) : "null"]);
}
```

- Valid: True — `[…]` target-types to `string.Format`'s `ReadOnlySpan<object>` parameter and binds.
- Correct: True — a 5-element span in source order, identical to the lowering.
- IL fidelity: Full on the compiled fixture `InlineArrayObjectConditionalElementSpan` (the identical address+value-spilled shape; the raised text equals source and it is absent from the compile-back docket diff set). On this older-Roslyn witness the render is valid and correct but stays **Partial** solely because a residual dead, unreferenced `<>y__InlineArray5` buffer local remains in the locals table with an unspellable type name (DEC0009) — a separate concern tracked in #3221, not this raise.
- Taste applied: None (the `!= null` → `is not null` normalization is default rendering and appears in both Before and After).
- Commit: `d481b3b6`

### Fully raised

The After decompilation renders the fully raised collection expression `[…]`. On this older-Roslyn witness fidelity stays `Partial` only because of the residual dead inline-array buffer local (`<>y__InlineArray5`, unspellable): the buffer is no longer referenced in the raised body but remains in the method's locals table, and `CSharpSpellability` iterates all locals. That dead-local cleanup is a separate slice (it also affects the pre-existing direct path).

- Required tracking issue: #3221 — remove/relax the residual dead inline-array buffer local so older-Roslyn witnesses reach Full.

## Implementation

Extends `InlineArrayCollectionPass` (the single owner of the inline-array `CollectionExpression` lowering). Previously the pass recognized only a **direct** element store `*(InlineArrayElementRef(ref buf, i)) = value`. When an element value carries a branch, csc must evaluate the element-ref address before the branch, so it spills:

```text
S_a = InlineArrayElementRef(ref buf, i);   // address spilled to an eval-stack slot
[S_v = value;]                             // branch value spilled to a second slot
*S_a = S_v-or-value;                       // StoreIndirect through the spilled address
```

New logic:

- `CollectElementStores` now returns `List<InlineArrayElementStore>?`; `ResolveElementStore` classifies each element as either a direct non-volatile `StoreIndirect`, or an address spilled to a **single-use** eval-stack slot then stored through, recovering a single-use value spill.
- Spill recovery fires only when every spill slot is written **once** and read **once** (`StackSlotStoreCount`/`StackSlotLoadCount` == 1); a multi-use slot, a volatile store, or an unrecovered stack-slot value returns `null` and the **whole** shape is left flat (honest `Partial`).
- Elements are re-sequenced into slot (source) order.
- The existing over-raise guards (exact synthesized `<>y__InlineArrayN`/`InlineArrayN` metadata name, `count + 2` element-ref count, no residual `LoadLocal` of the buffer, unique init) are unchanged, so the runtime's own `params` buffers and user structs stay excluded.

The two new fixture methods are appended at the **end** of `CfgSampleClass` so no existing method's compiler-generated ordinal shifts (the fidelity docket keys on those ordinals).

## Evidence

| Check | Baseline (`08ab86b1`) | Head (`d481b3b6`) |
| --- | --- | --- |
| Product build (`dotnet-inspect.slnx`) | Pass | Pass |
| Focused tests | new (n/a) | `InlineArraySpilledElementTests` (4) + `IrImporterTests` spilled-store import (1): 5 passed |
| Decompiler fast suite (`-trait- Speed=Slow`) | 3781, 1 failed | 3786, 1 failed |
| Reduced fixture fidelity | n/a | `InlineArrayObjectConditionalElementSpan` **Full** (opcode-exact) |
| Real witness | `EncLocalInfo::GetDebuggerDisplay` invalid (flat inline-array) | `EncLocalInfo::GetDebuggerDisplay` valid `[…]` (Partial only via dead-local #3221) |

The single fast-suite failure is the pre-existing `StringSwitchRaisingTests.SmallStringSwitch_RendersSwitchOnString` (CRLF-vs-LF, #3018) — identical on baseline and head, unrelated to this change. The `+5` are this PR's new tests.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **ADVISORY** — the full PR corpus quick-gate was not run for this focused slice. The change is additive and tightly guarded: it only recovers a previously-residual, spilled inline-array element shape into an already-supported collection expression, gated on single-use spill slots; no existing raise path is modified, so no previously-raised method can regress and residue can only decrease or hold.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.InlineArraySpilledElementTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Speed=Slow"
```
