### PR TITLE
Add permanent VB.NET finalizer fixture for #3196

### DIFF
--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -45,6 +45,7 @@
     <Project Path="src/ILInspector.Decompiler.Fixtures.UnsafeChainA/ILInspector.Decompiler.Fixtures.UnsafeChainA.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.UnsafeChainB/ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.UnsafeChainC/ILInspector.Decompiler.Fixtures.UnsafeChainC.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.VbFinalizer/ILInspector.Decompiler.Fixtures.VbFinalizer.vbproj" />
     <Project Path="src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj" />
     <Project Path="src/ILInspector.Decompiler/ILInspector.Decompiler.csproj" />
     <Project Path="src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj" />

--- a/src/ILInspector.Decompiler.Fixtures.VbFinalizer/ILInspector.Decompiler.Fixtures.VbFinalizer.vbproj
+++ b/src/ILInspector.Decompiler.Fixtures.VbFinalizer/ILInspector.Decompiler.Fixtures.VbFinalizer.vbproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    VB.NET fixture for #3196. The VB compiler emits a finalizer as a virtual,
+    reuse-slot, parameterless `void Finalize()` that carries NO `.override`
+    MethodImpl (unlike the Roslyn/C# destructor, which emits the explicit
+    `.override System.Object::Finalize`). This project is the compiler-produced
+    canary that proves `ApiSurfaceExtractor.IsImplicitObjectFinalizeOverride`
+    classifies that shape as a finalizer. Consumed by path through
+    FixtureCatalog (id `decompiler.vb-finalizer`); never referenced for
+    compilation. RootNamespace is cleared so the fixture types are plain
+    `Handle`/`VbBase`/`VbDerived`.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <OutputType>Library</OutputType>
+    <RootNamespace></RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <!-- EnablePreviewFeatures (repo root) sets LangVersion=Preview, which vbc rejects. -->
+    <LangVersion>latest</LangVersion>
+    <EnablePreviewFeatures>false</EnablePreviewFeatures>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.VbFinalizer/VbFinalizer.vb
+++ b/src/ILInspector.Decompiler.Fixtures.VbFinalizer/VbFinalizer.vb
@@ -1,0 +1,33 @@
+' VB.NET finalizer fixture for #3196.
+'
+' `Protected Overrides Sub Finalize()` compiles to a virtual, reuse-slot,
+' parameterless `void Finalize()` with NO `.override` MethodImpl. These shapes
+' are the compiler-produced canary that the implicit-object-Finalize-override
+' detection must classify as finalizers.
+
+' Single finalizer with a field write plus an explicit base call.
+Public Class Handle
+    Private _n As Integer
+
+    Protected Overrides Sub Finalize()
+        _n = 0
+        MyBase.Finalize()
+    End Sub
+End Class
+
+' A base/derived chain where both types override Finalize. The derived override
+' reuses the slot introduced by the base override, so the base walk must climb
+' past the reused slot to System.Object to confirm both are finalizers.
+Public Class VbBase
+    Protected Overrides Sub Finalize()
+        MyBase.Finalize()
+    End Sub
+End Class
+
+Public Class VbDerived
+    Inherits VbBase
+
+    Protected Overrides Sub Finalize()
+        MyBase.Finalize()
+    End Sub
+End Class

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -46,6 +46,7 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainA\ILInspector.Decompiler.Fixtures.UnsafeChainA.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainB\ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainC\ILInspector.Decompiler.Fixtures.UnsafeChainC.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.VbFinalizer\ILInspector.Decompiler.Fixtures.VbFinalizer.vbproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.Ladder\ILInspector.Decompiler.Fixtures.Ladder.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.TypeIdentity\ILInspector.Decompiler.Fixtures.TypeIdentity.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerExpressionBodyTests.cs
@@ -322,6 +322,27 @@ public class MemberBodyProducerExpressionBodyTests
         Assert.False(member.IsFinalizer);
     }
 
+    [Fact]
+    public void CustomVirtualFinalizeSlot_IsNotClassifiedAsFinalizer()
+    {
+        // Close negative (compiler-produced): a custom `new virtual void Finalize()`
+        // slot and an override of it are NOT the object.Finalize destructor. The C#
+        // compiler emits CS0465 (a warning) but the shape is legal metadata, and it
+        // must never fold to `~Type()`.
+        using var assembly = Compile("""
+            public class CustomBase { public virtual void Finalize() { } }
+            public class CustomDerived : CustomBase { public override void Finalize() { } }
+            """);
+
+        var baseMember = ExtractMember(assembly.Path, "CustomBase", "Finalize");
+        Assert.False(baseMember.IsFinalizer);
+        Assert.NotEqual("finalizer", baseMember.Kind);
+
+        var derivedMember = ExtractMember(assembly.Path, "CustomDerived", "Finalize");
+        Assert.False(derivedMember.IsFinalizer);
+        Assert.NotEqual("finalizer", derivedMember.Kind);
+    }
+
     static ApiMember ExtractMember(string path, string typeName, string memberName)
     {
         using var pe = new PEReader(File.OpenRead(path));

--- a/src/ILInspector.Decompiler.Tests/VbFinalizerFixtureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/VbFinalizerFixtureTests.cs
@@ -1,0 +1,68 @@
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Fixtures;
+using ILInspector.Decompiler;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #3196: the VB.NET compiler emits `Protected Overrides Sub Finalize()` as
+// a virtual, reuse-slot, parameterless `void Finalize()` that carries NO
+// `.override System.Object::Finalize` MethodImpl (unlike the Roslyn/C#
+// destructor). `ApiSurfaceExtractor.IsImplicitObjectFinalizeOverride` must
+// classify that shape as a finalizer so it renders as the compilable
+// `void Finalize()` (retaining the explicit base call) instead of the
+// uncompilable `override void Finalize()` (CS0249). These tests run against the
+// permanent, compiler-produced VB fixture (`ILInspector.Decompiler.Fixtures.VbFinalizer`)
+// resolved through FixtureCatalog, so the compiler-shape claim is proven by a
+// real VB artifact in CI rather than a synthetic metadata fixture alone.
+[Trait("Area", "RoundTrip")]
+public class VbFinalizerFixtureTests
+{
+    static string FixturePath => FixtureCatalog.DecompilerVbFinalizer.AssemblyPath();
+
+    [Theory]
+    [InlineData("Handle")]
+    [InlineData("VbBase")]
+    [InlineData("VbDerived")]
+    public void VbImplicitFinalize_IsClassifiedAsFinalizer(string typeName)
+    {
+        var member = ExtractMember(FixturePath, typeName, "Finalize");
+
+        Assert.True(member.IsFinalizer, $"{typeName}.Finalize should be classified as a finalizer.");
+    }
+
+    [Theory]
+    [InlineData("Handle")]
+    [InlineData("VbBase")]
+    [InlineData("VbDerived")]
+    public void VbImplicitFinalize_RendersCompilableFinalize(string typeName)
+    {
+        string source = ComposeType(FixturePath, typeName);
+
+        // Classifying as a finalizer drops the uncompilable `override` (CS0249)
+        // and keeps the explicit base call; it does not (yet, #3232) raise to the
+        // `~Type()` destructor scaffold.
+        Assert.Contains("void Finalize()", source);
+        Assert.Contains("base.Finalize();", source);
+        Assert.DoesNotContain("override void Finalize()", source);
+        Assert.DoesNotContain("~", source);
+    }
+
+    static ApiMember ExtractMember(string path, string typeName, string memberName)
+    {
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: true);
+        var type = Assert.Single(surface.Types, t => t.Name == typeName);
+        return Assert.Single(type.Members, m => m.Name == memberName);
+    }
+
+    static string ComposeType(string path, string typeName)
+    {
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: true);
+        var type = Assert.Single(surface.Types, t => t.Name == typeName);
+        var source = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
+        Assert.NotNull(source);
+        return source!.ReplaceLineEndings("\n");
+    }
+}

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -188,26 +188,27 @@ public static class ApiSurfaceExtractor
                 var isOverride = isVirtual && !isNewSlot && !isExplicitInterfaceImplementation;
 
                 // A class finalizer is the `object.Finalize` override the C#
-                // `~Type()` destructor compiles to. Roslyn emits it with an
-                // explicit `.override` MethodImpl targeting
-                // `System.Object::Finalize`, so we detect it by that target
-                // rather than by name/signature shape. Keying on the overridden
-                // slot (not the name `Finalize`, the reused virtual slot, or the
-                // decoded signature) excludes the false positives a shape
-                // heuristic admits: an implicit generic `Finalize<T>()`, an
-                // override of an unrelated base/interface `Finalize()` slot, and
-                // an explicit `IFoo.Finalize()` implementation (whose MethodImpl
-                // targets the interface, not object). A method whose signature
-                // failed to decode is likewise judged by its MethodImpl target
-                // alone, so a degraded decode cannot masquerade as a finalizer.
-                // A finalizer is never generic, so we still reject a method that
-                // explicitly `.override`s object.Finalize while declaring its own
-                // type parameters — rendering it `~Type()` would erase `<T>`.
-                // VB-style implicit `object.Finalize` overrides carry no
-                // MethodImpl and fall back to the literal `void Finalize()`.
+                // `~Type()` destructor compiles to. It is detected by the
+                // overridden slot (not by name/signature shape), which excludes
+                // the false positives a shape heuristic admits: an implicit
+                // generic `Finalize<T>()`, an override of an unrelated
+                // base/interface `Finalize()` slot, and an explicit
+                // `IFoo.Finalize()` implementation. There are two slot-anchored
+                // shapes:
+                //   * Roslyn (C#) emits an explicit `.override` MethodImpl
+                //     targeting `System.Object::Finalize`; `objectFinalizeOverrides`
+                //     carries those.
+                //   * The VB.NET compiler emits `Protected Overrides Sub Finalize()`
+                //     with NO MethodImpl — it reuses the inherited object.Finalize
+                //     slot implicitly; `IsImplicitObjectFinalizeOverride` proves
+                //     that slot roots at `System.Object` over metadata alone.
+                // A finalizer is never generic, so a method that overrides
+                // object.Finalize while declaring its own type parameters is still
+                // rejected — rendering it `~Type()` would erase `<T>`.
                 var isFinalizer = apiType.Kind == "class"
                     && method.GetGenericParameters().Count == 0
-                    && objectFinalizeOverrides.Contains(methodHandle);
+                    && (objectFinalizeOverrides.Contains(methodHandle)
+                        || IsImplicitObjectFinalizeOverride(reader, typeDefHandle, method));
 
                 var member = new ApiMember
                 {
@@ -843,13 +844,15 @@ public static class ApiSurfaceExtractor
     }
 
     /// <summary>
-    /// True when <paramref name="methodHandle"/> is a C# destructor: a non-generic method named
-    /// <c>Finalize</c> that <c>.override</c>s <c>System.Object::Finalize</c> via a MethodImpl. This
-    /// mirrors the <see cref="ApiMember.IsFinalizer"/> object.Finalize-override signal and is shared
-    /// with the source-mapping producer (<see cref="PdbContext.EnumerateMemberSources"/>) so a
-    /// destructor's <c>~Type()</c> source line is anchored from metadata identity rather than
-    /// inferred from source text. The <c>Finalize</c> name gate keeps the MethodImpl enumeration off
-    /// the hot path for every other method.
+    /// True when <paramref name="methodHandle"/> is a C# destructor / VB finalizer: a non-generic
+    /// method named <c>Finalize</c> that overrides <c>System.Object::Finalize</c>, either via an
+    /// explicit <c>.override</c> MethodImpl (the Roslyn/C# shape) or by implicitly reusing the
+    /// inherited object.Finalize slot (the VB.NET shape, which carries no MethodImpl). This mirrors
+    /// the <see cref="ApiMember.IsFinalizer"/> object.Finalize-override signal and is shared with the
+    /// source-mapping producer (<see cref="PdbContext.EnumerateMemberSources"/>) so a destructor's
+    /// <c>~Type()</c> source line is anchored from metadata identity rather than inferred from source
+    /// text. The <c>Finalize</c> name gate keeps the MethodImpl enumeration off the hot path for
+    /// every other method.
     /// </summary>
     internal static bool IsFinalizerMethod(MetadataReader reader, MethodDefinitionHandle methodHandle)
     {
@@ -859,7 +862,8 @@ public static class ApiSurfaceExtractor
         if (method.GetGenericParameters().Count != 0)
             return false;
 
-        var typeDef = reader.GetTypeDefinition(method.GetDeclaringType());
+        var typeHandle = method.GetDeclaringType();
+        var typeDef = reader.GetTypeDefinition(typeHandle);
         foreach (var implementationHandle in typeDef.GetMethodImplementations())
         {
             var implementation = reader.GetMethodImplementation(implementationHandle);
@@ -871,7 +875,135 @@ public static class ApiSurfaceExtractor
             }
         }
 
+        // No MethodImpl: fall back to the implicit-slot shape the VB.NET compiler emits.
+        return IsImplicitObjectFinalizeOverride(reader, typeHandle, method);
+    }
+
+    // A malformed or adversarial base-type chain can be arbitrarily long or cyclic; the visited-set
+    // below stops in-assembly cycles, and this cap stops an unbounded walk through a long legitimate
+    // (or degenerate) hierarchy. Real finalizer-bearing hierarchies are far shallower than this.
+    private const int MaxBaseChainDepth = 256;
+
+    /// <summary>
+    /// True when <paramref name="method"/> on <paramref name="typeDefHandle"/> implicitly overrides
+    /// <c>System.Object.Finalize</c> through the inherited virtual slot rather than an explicit
+    /// <c>.override</c> MethodImpl — the shape the VB.NET compiler emits for
+    /// <c>Protected Overrides Sub Finalize()</c>. The method must be a non-generic, parameterless,
+    /// <c>void</c>-returning, non-static, non-abstract virtual that reuses (does not new-slot) the
+    /// inherited slot, and the declaring type's base chain must be provably rooted at
+    /// <c>System.Object</c> using metadata alone (SRM-only, no inspected-assembly loading):
+    /// <list type="bullet">
+    /// <item>a base reference resolving to the strong-name-anchored <c>System.Object</c> confirms;</item>
+    /// <item>an in-assembly base that introduces its own <c>new virtual void Finalize()</c> slot is a
+    /// custom slot (the round-1 false-positive shape) and rejects;</item>
+    /// <item>a base that leaves the assembly without resolving to <c>System.Object</c> — including a
+    /// generic (<see cref="TypeSpecification"/>) base — cannot be proven and rejects conservatively,
+    /// so no guessed <c>~Type()</c> is spelled for an unresolvable chain.</item>
+    /// </list>
+    /// </summary>
+    private static bool IsImplicitObjectFinalizeOverride(
+        MetadataReader reader, TypeDefinitionHandle typeDefHandle, MethodDefinition method)
+    {
+        if (!string.Equals(reader.GetString(method.Name), "Finalize", StringComparison.Ordinal))
+            return false;
+
+        var attributes = method.Attributes;
+        // A finalizer reuses the inherited object.Finalize slot: Virtual and NOT NewSlot. An explicit
+        // interface implementation is NewSlot (and name-mangled), so it is excluded here too. Static
+        // and abstract methods are never finalizers.
+        if ((attributes & MethodAttributes.Virtual) == 0
+            || (attributes & MethodAttributes.NewSlot) != 0
+            || (attributes & MethodAttributes.Static) != 0
+            || (attributes & MethodAttributes.Abstract) != 0)
+            return false;
+        if (method.GetGenericParameters().Count != 0)
+            return false;
+        if (!HasVoidNullaryInstanceSignature(reader, method))
+            return false;
+
+        // Walk the base-type chain. The slot roots at whichever ancestor first declares a
+        // `new virtual void Finalize()`; for a genuine finalizer that ancestor is System.Object,
+        // which we recognize by reaching its (typically cross-assembly) reference without any
+        // in-assembly base introducing its own Finalize slot first.
+        var visited = new HashSet<TypeDefinitionHandle>();
+        var currentType = reader.GetTypeDefinition(typeDefHandle);
+        for (int depth = 0; depth < MaxBaseChainDepth; depth++)
+        {
+            var baseHandle = currentType.BaseType;
+            if (baseHandle.IsNil)
+                return false;
+
+            switch (baseHandle.Kind)
+            {
+                case HandleKind.TypeReference:
+                    // Reached a cross-assembly base: only System.Object roots the object.Finalize slot.
+                    return IsSystemObjectType(reader, baseHandle);
+                case HandleKind.TypeDefinition:
+                    var baseTypeHandle = (TypeDefinitionHandle)baseHandle;
+                    if (!visited.Add(baseTypeHandle))
+                        return false; // cyclic base chain in malformed metadata
+                    var baseType = reader.GetTypeDefinition(baseTypeHandle);
+                    if (DeclaresNewVirtualFinalize(reader, baseType))
+                        return false; // custom Finalize slot introduced below object — not a destructor
+                    if (IsSystemObjectType(reader, baseTypeHandle))
+                        return true; // in-assembly System.Object (inspecting the core library itself)
+                    currentType = baseType;
+                    continue;
+                default:
+                    // TypeSpecification (generic base) or any other shape: the slot root cannot be
+                    // proven from the handle alone, so reject rather than guess.
+                    return false;
+            }
+        }
+
         return false;
+    }
+
+    /// <summary>
+    /// True when <paramref name="type"/> declares a <c>new virtual void Finalize()</c> — a
+    /// parameterless, <c>void</c>-returning, non-generic method named <c>Finalize</c> that new-slots
+    /// its own virtual slot. Such a slot shadows <c>object.Finalize</c>, so an override binding to it
+    /// is not the object finalizer and must not be spelled <c>~Type()</c>. A base that merely
+    /// <em>overrides</em> Finalize (reuse-slot) does not introduce a new slot and is walked past.
+    /// </summary>
+    private static bool DeclaresNewVirtualFinalize(MetadataReader reader, TypeDefinition type)
+    {
+        foreach (var methodHandle in type.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (!string.Equals(reader.GetString(method.Name), "Finalize", StringComparison.Ordinal))
+                continue;
+            var attributes = method.Attributes;
+            if ((attributes & MethodAttributes.Virtual) != 0
+                && (attributes & MethodAttributes.NewSlot) != 0
+                && method.GetGenericParameters().Count == 0
+                && HasVoidNullaryInstanceSignature(reader, method))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when <paramref name="method"/>'s signature is an instance <c>void Method()</c>: a method
+    /// (not property/field) calling convention, no parameters, and a plain <c>void</c> return with no
+    /// custom modifiers or by-ref. This matches the fixed <c>object.Finalize</c> slot signature; a
+    /// mismatch (extra parameters, a non-void return, or a modified return) cannot bind that slot, so
+    /// it rejects — a name-only collision cannot masquerade as a finalizer.
+    /// </summary>
+    private static bool HasVoidNullaryInstanceSignature(MetadataReader reader, MethodDefinition method)
+    {
+        var blob = reader.GetBlobReader(method.Signature);
+        var header = blob.ReadSignatureHeader();
+        if (header.Kind != SignatureKind.Method)
+            return false;
+        if (header.IsGeneric)
+            blob.ReadCompressedInteger(); // generic parameter count
+        if (blob.ReadCompressedInteger() != 0) // parameter count
+            return false;
+        // Return type: a plain ELEMENT_TYPE_VOID. Any leading custom modifier or by-ref token is
+        // read here instead of Void and correctly rejects.
+        return blob.ReadSignatureTypeCode() == SignatureTypeCode.Void;
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -942,11 +942,15 @@ public static class ApiSurfaceExtractor
                     var baseTypeHandle = (TypeDefinitionHandle)baseHandle;
                     if (!visited.Add(baseTypeHandle))
                         return false; // cyclic base chain in malformed metadata
+                    // Recognize the in-assembly System.Object root before the custom-slot rejection:
+                    // the genuine object.Finalize is itself a NewSlot virtual, so testing
+                    // DeclaresNewVirtualFinalize first would wrongly reject the real root when
+                    // inspecting the core library that defines System.Object.
+                    if (IsSystemObjectType(reader, baseTypeHandle))
+                        return true; // in-assembly System.Object (inspecting the core library itself)
                     var baseType = reader.GetTypeDefinition(baseTypeHandle);
                     if (DeclaresNewVirtualFinalize(reader, baseType))
                         return false; // custom Finalize slot introduced below object — not a destructor
-                    if (IsSystemObjectType(reader, baseTypeHandle))
-                        return true; // in-assembly System.Object (inspecting the core library itself)
                     currentType = baseType;
                     continue;
                 default:
@@ -985,25 +989,40 @@ public static class ApiSurfaceExtractor
     }
 
     /// <summary>
-    /// True when <paramref name="method"/>'s signature is an instance <c>void Method()</c>: a method
-    /// (not property/field) calling convention, no parameters, and a plain <c>void</c> return with no
-    /// custom modifiers or by-ref. This matches the fixed <c>object.Finalize</c> slot signature; a
-    /// mismatch (extra parameters, a non-void return, or a modified return) cannot bind that slot, so
-    /// it rejects — a name-only collision cannot masquerade as a finalizer.
+    /// True when <paramref name="method"/>'s signature is exactly the fixed <c>object.Finalize</c>
+    /// slot signature: an instance (<c>HASTHIS</c>, no explicit <c>this</c>), default-calling-convention,
+    /// non-generic method with no parameters and a plain <c>void</c> return (no custom modifiers or
+    /// by-ref). A vararg or generic calling convention, an explicit-this or static signature, extra
+    /// parameters, or a non-void/modified return cannot bind that slot and rejects — so a name-only
+    /// collision cannot masquerade as a finalizer. A malformed or truncated signature blob is treated
+    /// as a non-match (returns false) rather than throwing.
     /// </summary>
     private static bool HasVoidNullaryInstanceSignature(MetadataReader reader, MethodDefinition method)
     {
-        var blob = reader.GetBlobReader(method.Signature);
-        var header = blob.ReadSignatureHeader();
-        if (header.Kind != SignatureKind.Method)
+        try
+        {
+            var blob = reader.GetBlobReader(method.Signature);
+            var header = blob.ReadSignatureHeader();
+            // object.Finalize is `instance void ()` with the default managed calling convention.
+            // Reject anything else: field/property sigs, vararg/unmanaged conventions, generic
+            // methods, static signatures, and explicit-this.
+            if (header.Kind != SignatureKind.Method
+                || header.CallingConvention != SignatureCallingConvention.Default
+                || header.IsGeneric
+                || !header.IsInstance
+                || header.HasExplicitThis)
+                return false;
+            if (blob.ReadCompressedInteger() != 0) // parameter count
+                return false;
+            // Return type: a plain ELEMENT_TYPE_VOID. Any leading custom modifier or by-ref token is
+            // read here instead of Void and correctly rejects.
+            return blob.ReadSignatureTypeCode() == SignatureTypeCode.Void;
+        }
+        catch (BadImageFormatException)
+        {
+            // A truncated or otherwise malformed signature blob is not the object.Finalize slot.
             return false;
-        if (header.IsGeneric)
-            blob.ReadCompressedInteger(); // generic parameter count
-        if (blob.ReadCompressedInteger() != 0) // parameter count
-            return false;
-        // Return type: a plain ELEMENT_TYPE_VOID. Any leading custom modifier or by-ref token is
-        // read here instead of Void and correctly rejects.
-        return blob.ReadSignatureTypeCode() == SignatureTypeCode.Void;
+        }
     }
 
     /// <summary>

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -87,6 +87,7 @@ public static class FixtureIds
     public const string DecompilerUnsafeChainA = "decompiler.unsafe.chain-a";
     public const string DecompilerUnsafeChainB = "decompiler.unsafe.chain-b";
     public const string DecompilerUnsafeChainC = "decompiler.unsafe.chain-c";
+    public const string DecompilerVbFinalizer = "decompiler.vb-finalizer";
 
     public const string RunFasterAllocation = "runfaster.allocation";
 }
@@ -342,6 +343,13 @@ public static class FixtureCatalog
         Boundaries(FixtureBoundary.CrossAssemblyBoundary, FixtureBoundary.ModuleAttribute, FixtureBoundary.OutputKind),
         "decompiler", "unsafe", "chain", "legacy-memory-safety", "executable");
 
+    public static readonly FixtureDefinition DecompilerVbFinalizer = Fixture(
+        FixtureIds.DecompilerVbFinalizer,
+        "ILInspector.Decompiler.Fixtures.VbFinalizer",
+        "ILInspector.Decompiler.Fixtures.VbFinalizer.dll",
+        Boundaries(FixtureBoundary.CompilerLowering),
+        "decompiler", "vb", "finalizer");
+
     public static readonly FixtureDefinition RunFasterAllocation = Fixture(
         FixtureIds.RunFasterAllocation,
         "RunFaster.AllocationFixture",
@@ -389,6 +397,7 @@ public static class FixtureCatalog
         DecompilerUnsafeChainA,
         DecompilerUnsafeChainB,
         DecompilerUnsafeChainC,
+        DecompilerVbFinalizer,
         RunFasterAllocation,
     ];
 

--- a/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
@@ -1,0 +1,231 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Metadata-layer coverage for the VB.NET-shape implicit <c>object.Finalize</c>
+/// override: a virtual, reuse-slot, parameterless <c>void Finalize()</c> that
+/// carries NO <c>.override</c> MethodImpl (unlike the C#/Roslyn destructor). The
+/// synthetic images below emit that exact shape and its close negatives so the
+/// classifier proves the slot roots at a strong-name-anchored <c>System.Object</c>
+/// over metadata alone, with no inspected-assembly loading. The compiler-produced
+/// VB shape is verified end-to-end separately; these seam-isolation fixtures let
+/// every close negative run without a VB compiler or ilasm on the box.
+/// </summary>
+public class ImplicitFinalizerDetectionTests
+{
+    // Instance (HASTHIS) signature blobs: [callconv, paramCount, retType, params...].
+    static readonly byte[] VoidNullary = [0x20, 0x00, 0x01];       // void Finalize()
+    static readonly byte[] VoidOneParam = [0x20, 0x01, 0x01, 0x08]; // void Finalize(int)
+    static readonly byte[] IntNullary = [0x20, 0x00, 0x08];         // int Finalize()
+
+    const MethodAttributes ReuseSlot =
+        MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig;
+    const MethodAttributes NewSlot = ReuseSlot | MethodAttributes.NewSlot;
+
+    [Fact]
+    public void ImplicitObjectFinalizeOverride_IsClassifiedAsFinalizer()
+    {
+        var member = ExtractMember(
+            BuildImage(new TypeSpec("Handle", BaseKind.Object, new MethodSpec("Finalize", ReuseSlot, VoidNullary))),
+            "Handle",
+            "Finalize");
+
+        Assert.True(member.IsFinalizer);
+        Assert.Equal("finalizer", member.Kind);
+    }
+
+    [Fact]
+    public void ImplicitOverride_WalksPastReuseSlotBase_IsClassifiedAsFinalizer()
+    {
+        // VbBase overrides object.Finalize (reuse-slot); VbDerived overrides again.
+        // The walk must step past VbBase's reuse-slot Finalize and reach System.Object.
+        byte[] image = BuildImage(
+            new TypeSpec("VbBase", BaseKind.Object, new MethodSpec("Finalize", ReuseSlot, VoidNullary)),
+            new TypeSpec("VbDerived", BaseKind.Def("VbBase"), new MethodSpec("Finalize", ReuseSlot, VoidNullary)));
+
+        Assert.True(ExtractMember(image, "VbBase", "Finalize").IsFinalizer);
+        Assert.True(ExtractMember(image, "VbDerived", "Finalize").IsFinalizer);
+    }
+
+    [Fact]
+    public void CustomNewVirtualFinalizeSlot_IsNotClassifiedAsFinalizer()
+    {
+        // CustomBase declares `new virtual void Finalize()`; CustomDerived overrides
+        // that custom slot, NOT object.Finalize. Neither is a destructor.
+        byte[] image = BuildImage(
+            new TypeSpec("CustomBase", BaseKind.Object, new MethodSpec("Finalize", NewSlot, VoidNullary)),
+            new TypeSpec("CustomDerived", BaseKind.Def("CustomBase"), new MethodSpec("Finalize", ReuseSlot, VoidNullary)));
+
+        Assert.False(ExtractMember(image, "CustomBase", "Finalize").IsFinalizer);
+        Assert.False(ExtractMember(image, "CustomDerived", "Finalize").IsFinalizer);
+    }
+
+    [Fact]
+    public void ReuseSlotFinalize_WithParameter_IsNotClassifiedAsFinalizer()
+    {
+        var member = ExtractMember(
+            BuildImage(new TypeSpec("Handle", BaseKind.Object, new MethodSpec("Finalize", ReuseSlot, VoidOneParam))),
+            "Handle",
+            "Finalize");
+
+        Assert.False(member.IsFinalizer);
+    }
+
+    [Fact]
+    public void ReuseSlotFinalize_WithNonVoidReturn_IsNotClassifiedAsFinalizer()
+    {
+        var member = ExtractMember(
+            BuildImage(new TypeSpec("Handle", BaseKind.Object, new MethodSpec("Finalize", ReuseSlot, IntNullary))),
+            "Handle",
+            "Finalize");
+
+        Assert.False(member.IsFinalizer);
+    }
+
+    [Fact]
+    public void ReuseSlotFinalize_OverNonObjectCrossAssemblyBase_IsNotClassifiedAsFinalizer()
+    {
+        // Base leaves the assembly as System.Exception (a real core-library type,
+        // but not System.Object): the slot root cannot be proven, so reject.
+        var member = ExtractMember(
+            BuildImage(new TypeSpec("Handle", BaseKind.Exception, new MethodSpec("Finalize", ReuseSlot, VoidNullary))),
+            "Handle",
+            "Finalize");
+
+        Assert.False(member.IsFinalizer);
+    }
+
+    [Fact]
+    public void NewSlotFinalize_IsNotClassifiedAsFinalizer()
+    {
+        // A NewSlot virtual Finalize introduces its own slot; it does not override
+        // object.Finalize even with the object base and matching signature.
+        var member = ExtractMember(
+            BuildImage(new TypeSpec("Handle", BaseKind.Object, new MethodSpec("Finalize", NewSlot, VoidNullary))),
+            "Handle",
+            "Finalize");
+
+        Assert.False(member.IsFinalizer);
+    }
+
+    static ApiMember ExtractMember(byte[] image, string typeName, string memberName)
+    {
+        using var stream = new MemoryStream(image);
+        var surface = AssemblyReader.ExtractApiSurface(stream, includeAll: true, typesOnly: false);
+        Assert.NotNull(surface);
+        var type = Assert.Single(surface!.Types, t => t.Name == typeName);
+        return Assert.Single(type.Members, m => m.Name == memberName);
+    }
+
+    enum BaseTag { Object, Exception, Def }
+
+    readonly record struct BaseKind(BaseTag Tag, string? DefName)
+    {
+        public static readonly BaseKind Object = new(BaseTag.Object, null);
+        public static readonly BaseKind Exception = new(BaseTag.Exception, null);
+        public static BaseKind Def(string name) => new(BaseTag.Def, name);
+    }
+
+    sealed record MethodSpec(string Name, MethodAttributes Attributes, byte[] Signature);
+
+    sealed record TypeSpec(string Name, BaseKind Base, MethodSpec Method);
+
+    static byte[] BuildImage(params TypeSpec[] types)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+
+        // System.Private.CoreLib reference carrying its real strong-name token so
+        // the classifier's IsSystemObjectType accepts the cross-assembly object ref.
+        var coreLib = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: metadata.GetOrAddBlob(
+                new byte[] { 0x7c, 0xec, 0x85, 0xd7, 0xbe, 0xa7, 0x79, 0x8e }),
+            flags: default,
+            hashValue: default);
+        var objectRef = metadata.AddTypeReference(
+            coreLib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+        var exceptionRef = metadata.AddTypeReference(
+            coreLib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Exception"));
+
+        // Shared trivial `ret` body; the extractor never reads method bodies.
+        var instructions = new BlobBuilder();
+        var encoder = new InstructionEncoder(instructions, new ControlFlowBuilder());
+        encoder.OpCode(ILOpCode.Ret);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = new MethodBodyStreamEncoder(methodBodies).AddMethodBody(encoder, maxStack: 0);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var defHandles = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
+        int methodRow = 1;
+        for (int i = 0; i < types.Length; i++)
+        {
+            EntityHandle baseHandle = types[i].Base.Tag switch
+            {
+                BaseTag.Object => objectRef,
+                BaseTag.Exception => exceptionRef,
+                BaseTag.Def => defHandles[types[i].Base.DefName!],
+                _ => default,
+            };
+            var handle = metadata.AddTypeDefinition(
+                TypeAttributes.Public | TypeAttributes.Class,
+                default,
+                metadata.GetOrAddString(types[i].Name),
+                baseHandle,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(methodRow));
+            defHandles[types[i].Name] = handle;
+            methodRow++;
+        }
+
+        foreach (var type in types)
+        {
+            var spec = type.Method;
+            metadata.AddMethodDefinition(
+                spec.Attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString(spec.Name),
+                metadata.GetOrAddBlob(spec.Signature),
+                bodyOffset,
+                parameterList: MetadataTokens.ParameterHandle(1));
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
@@ -21,6 +21,7 @@ public class ImplicitFinalizerDetectionTests
     static readonly byte[] VoidNullary = [0x20, 0x00, 0x01];       // void Finalize()
     static readonly byte[] VoidOneParam = [0x20, 0x01, 0x01, 0x08]; // void Finalize(int)
     static readonly byte[] IntNullary = [0x20, 0x00, 0x08];         // int Finalize()
+    static readonly byte[] VarargNullary = [0x25, 0x00, 0x01];      // vararg void Finalize()
 
     const MethodAttributes ReuseSlot =
         MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig;
@@ -112,6 +113,33 @@ public class ImplicitFinalizerDetectionTests
         Assert.False(member.IsFinalizer);
     }
 
+    [Fact]
+    public void VarargFinalize_IsNotClassifiedAsFinalizer()
+    {
+        // A vararg calling convention cannot bind object.Finalize's default-convention
+        // slot, so even a virtual reuse-slot `vararg void Finalize()` over System.Object
+        // must reject — a name-only collision on a different convention is not a finalizer.
+        var member = ExtractMember(
+            BuildImage(new TypeSpec("Handle", BaseKind.Object, new MethodSpec("Finalize", ReuseSlot, VarargNullary))),
+            "Handle",
+            "Finalize");
+
+        Assert.False(member.IsFinalizer);
+    }
+
+    [Fact]
+    public void InAssemblyObjectRoot_DerivedFinalize_IsClassifiedAsFinalizer()
+    {
+        // Inspecting the core library that defines System.Object itself: the genuine
+        // object.Finalize is a NewSlot virtual, so the walk must recognize the in-assembly
+        // System.Object root BEFORE applying the custom-slot rejection.
+        byte[] image = BuildImage(
+            new TypeSpec("Object", BaseKind.Nil, new MethodSpec("Finalize", NewSlot, VoidNullary), Namespace: "System"),
+            new TypeSpec("Derived", BaseKind.Def("Object"), new MethodSpec("Finalize", ReuseSlot, VoidNullary)));
+
+        Assert.True(ExtractMember(image, "Derived", "Finalize").IsFinalizer);
+    }
+
     static ApiMember ExtractMember(byte[] image, string typeName, string memberName)
     {
         using var stream = new MemoryStream(image);
@@ -121,18 +149,19 @@ public class ImplicitFinalizerDetectionTests
         return Assert.Single(type.Members, m => m.Name == memberName);
     }
 
-    enum BaseTag { Object, Exception, Def }
+    enum BaseTag { Object, Exception, Def, Nil }
 
     readonly record struct BaseKind(BaseTag Tag, string? DefName)
     {
         public static readonly BaseKind Object = new(BaseTag.Object, null);
         public static readonly BaseKind Exception = new(BaseTag.Exception, null);
+        public static readonly BaseKind Nil = new(BaseTag.Nil, null);
         public static BaseKind Def(string name) => new(BaseTag.Def, name);
     }
 
     sealed record MethodSpec(string Name, MethodAttributes Attributes, byte[] Signature);
 
-    sealed record TypeSpec(string Name, BaseKind Base, MethodSpec Method);
+    sealed record TypeSpec(string Name, BaseKind Base, MethodSpec Method, string? Namespace = null);
 
     static byte[] BuildImage(params TypeSpec[] types)
     {
@@ -198,7 +227,7 @@ public class ImplicitFinalizerDetectionTests
             };
             var handle = metadata.AddTypeDefinition(
                 TypeAttributes.Public | TypeAttributes.Class,
-                default,
+                types[i].Namespace is { } ns ? metadata.GetOrAddString(ns) : default,
                 metadata.GetOrAddString(types[i].Name),
                 baseHandle,
                 fieldList: MetadataTokens.FieldDefinitionHandle(1),


### PR DESCRIPTION
Stacked on #3224 (base `fix/3196-vb-implicit-finalizer`; GitHub auto-retargets to `main` when #3224 merges).

## Conclusion

Adds a permanent, compiler-produced **VB.NET** finalizer fixture so #3196's classification (a VB implicit `object.Finalize` override is a finalizer) is exercised by a real VB artifact in CI — not only by synthetic metadata fixtures and throwaway `vbc` runs. Test-infrastructure only; **no product code change**.

## Change

- **`src/ILInspector.Decompiler.Fixtures.VbFinalizer`** (new `.vbproj`) emits:
  - `Handle` — a single finalizer with a field write plus explicit `MyBase.Finalize()`.
  - `VbBase`/`VbDerived` — an override chain (derived reuses the base's finalizer slot), so the base walk must climb past the reused slot to `System.Object`.

  VB compiles each `Protected Overrides Sub Finalize()` to a virtual, reuse-slot, parameterless `void Finalize()` carrying **no** `.override System.Object::Finalize` MethodImpl — the exact shape #3224 detects. `LangVersion` is pinned to `latest` because `vbc` rejects the repo-inherited `Preview` value.
- **`FixtureCatalog`** — registers id `decompiler.vb-finalizer` with `FixtureBoundary.CompilerLowering` (VB's MethodImpl-less finalizer emission is a compiler-lowering axis distinct from the Roslyn/C# destructor).
- **`ILInspector.Decompiler.Tests/VbFinalizerFixtureTests`** — resolves the fixture DLL through `FixtureCatalog.AssemblyPath()` and asserts, via the product-owned `ApiSurfaceExtractor` and `MemberBodyProducer`, that `Handle`/`VbBase`/`VbDerived` classify as finalizers (`IsFinalizer`) and render as the compilable `void Finalize()` — never the uncompilable `override void Finalize()`, nor (yet, #3232) `~Type()`.

## Evidence

- New `VbFinalizerFixtureTests` — 6 cases green.
- `DotnetInspector.Fixtures.Tests` — 17 green (catalog governance: unique ids, resolves-to-built-assembly, boundary-axis coverage).
- Fast decompiler suite (`-trait- "Speed=Slow"`) — 3759 green.
- Full `dotnet build dotnet-inspect.slnx -c Release` clean; the VB project builds into `artifacts/bin` cross-platform (`vbc` ships in the SDK — no ilasm-style skip).

## Review

Low-risk, test-infrastructure only (per AGENTS.md's simple/mechanical exemption): no product code path changes, and the assertions exercise product-owned capabilities rather than reconstructing them. The one non-trivial aspect is adding VB to the build graph, which the full-solution build and CI validate directly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>