### PR TITLE
Raise the value-swap idiom to the recognized tuple swap form (#3166)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2870,6 +2870,24 @@ public class CfgSampleClass
         return a + b;
     }
 
+    // #3166 compile-back witness: the value-swap idiom. csc lowers the tuple swap
+    // `(a, b) = (b, a)` — and the equivalent manual `temp = b; b = a; a = temp;` —
+    // to a single dup-slot save followed by the two cross-stores (verified
+    // byte-identical for a struct), so SwapIdiomPass raising the surviving carrier
+    // back to `(a, b) = (b, a)` is opcode-exact, not a byte-divergent rewrite. This
+    // mirrors System.Text.Json.JsonElement.DeepEquals, which swaps two JsonElement
+    // structs through one such temp (issue #3166); carrying it into the fidelity
+    // gate proves the raised swap recompiles to the original IL — the check the
+    // internal-surface DeepEquals cannot itself feed to compile-back.
+    public static int SwapStructPair(Pairing a, Pairing b)
+    {
+        if (a.First < b.First)
+        {
+            (a, b) = (b, a);
+        }
+        return a.First - b.First;
+    }
+
     public static object AnonShorthand(int a, string b) => new { a, b };
 
     public static object AnonNamed(int x, string y) => new { Id = x, Name = y };

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -326,6 +326,15 @@ public class FidelityGateTests
         // internal System.Text.Json surface is not recompilable by the compile-back
         // oracle (tracked for a future cross-assembly compile-back capability).
         "SwitchWithTwoLoopingCaseSections",
+        // #3166: the value-swap idiom. csc lowers the tuple swap `(a, b) = (b, a)`
+        // (and the equivalent manual `temp = b; b = a; a = temp;`) to a single
+        // dup-slot save plus the two cross-stores; SwapIdiomPass raises that
+        // surviving carrier back to `(a, b) = (b, a)`. Because the tuple swap and
+        // the one-temp sequence share IL, the raise is opcode-exact — this pins it.
+        // Mirrors System.Text.Json.JsonElement.DeepEquals, which swaps two
+        // JsonElement structs through one such temp but cannot itself be fed to the
+        // compile-back oracle (internal System.Text.Json surface).
+        "SwapStructPair",
         // The compile-back oracle replays the fixture's runtime-async feature,
         // so these methods must retain the same lowering rather than merely
         // remaining recompilable.

--- a/src/ILInspector.Decompiler.Tests/SwapIdiomPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwapIdiomPassTests.cs
@@ -43,6 +43,49 @@ public class SwapIdiomPassTests
         Assert.DoesNotContain("S_", output);
     }
 
+    // --- Negative: place types that forbid a tuple swap (byref / pointer / ref struct) ---
+
+    public static TheoryData<string, TypeRef> UnspellableSwapPlaceTypes() => new()
+    {
+        { "byref (a `ref` reseat, not a value swap)", TypeRef.ByRef(Int) },
+        { "pointer (illegal ValueTuple element, CS0306)", TypeRef.Pointer(Int) },
+        { "ref struct (illegal ValueTuple element, CS9244)",
+            TypeRef.GenericInstance(TypeRef.CoreLib("System", "Span"), [Int]) },
+    };
+
+    [Theory]
+    [MemberData(nameof(UnspellableSwapPlaceTypes))]
+    public void SwapOfUnspellablePlaceType_NotRaised(string _, TypeRef placeType)
+    {
+        // S = a; a = b; b = S;  over two places of a type that cannot appear as
+        // a ValueTuple element (or would reseat rather than assign): decline.
+        var function = BuildBlock(
+            new StoreStackSlot(0, new LoadArgument(0, "p0", placeType)),
+            new StoreArgument(0, "p0", placeType, new LoadArgument(1, "p1", placeType)),
+            new StoreArgument(1, "p1", placeType, new LoadStackSlot(0, placeType)));
+
+        new SwapIdiomPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<DeconstructionAssignment>());
+        Assert.Empty(function.Descendants.OfType<TupleExpression>());
+    }
+
+    [Fact]
+    public void SwapOfReferenceTypePlaces_Raises()
+    {
+        // Reference-type swaps are byte-exact and legal ValueTuple elements, so
+        // the guard must not over-reject them: `S = a; a = b; b = S;` still raises.
+        var stringType = TypeRef.CoreLib("System", "String");
+        var function = BuildBlock(
+            new StoreStackSlot(0, new LoadArgument(0, "p0", stringType)),
+            new StoreArgument(0, "p0", stringType, new LoadArgument(1, "p1", stringType)),
+            new StoreArgument(1, "p1", stringType, new LoadStackSlot(0, stringType)));
+
+        new SwapIdiomPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
+    }
+
     // --- Negative: synthesized IR exercising each decline gate directly ---
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/SwapIdiomPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwapIdiomPassTests.cs
@@ -1,0 +1,161 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "Pass")]
+public class SwapIdiomPassTests
+{
+    static IrFunction Raised(string methodName, Type? type = null)
+    {
+        type ??= typeof(CfgSampleClass);
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(source, type.FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function;
+    }
+
+    // --- Positive: the real compiler shape (CfgSampleClass.SwapStructPair) ---
+
+    [Fact]
+    public void ValueSwap_RaisesToTupleDeconstruction()
+    {
+        var function = Raised(nameof(CfgSampleClass.SwapStructPair));
+
+        var deconstruction = Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
+        Assert.Equal(2, deconstruction.Targets.Length);
+        Assert.All(deconstruction.Targets, t => Assert.Equal(DeconstructionTargetKind.Argument, t.Kind));
+        Assert.IsType<TupleExpression>(deconstruction.Source);
+        // The swap carrier is consumed: no surviving stack-slot store/load remains.
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+    }
+
+    [Fact]
+    public void PrintRaised_RendersRecognizedSwapForm()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.SwapStructPair))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("(a, b) = (b, a);", output);
+        Assert.DoesNotContain("S_", output);
+    }
+
+    // --- Negative: synthesized IR exercising each decline gate directly ---
+
+    [Fact]
+    public void SwapOfTwoArguments_Raises()
+    {
+        // S = a; a = b; b = S;  ->  (b, a) = (a, b);
+        var function = BuildBlock(
+            SaveSlot(0, Arg(0)),
+            StoreArg(0, Arg(1)),
+            StoreArg(1, LoadSlot(0)));
+
+        new SwapIdiomPass().Run(function, PassContext.None);
+
+        var deconstruction = Assert.Single(function.Descendants.OfType<DeconstructionAssignment>());
+        Assert.Equal([1, 0], deconstruction.Targets.Select(t => t.ArgumentIndex).ToArray());
+        var tuple = Assert.IsType<TupleExpression>(deconstruction.Source);
+        Assert.Equal([0, 1], tuple.Elements.Cast<LoadArgument>().Select(l => l.Index).ToArray());
+    }
+
+    [Fact]
+    public void SavedValueIsComputed_NotRaised()
+    {
+        // S = f(a); a = b; b = S;  — the saved value is a call result, not a
+        // simple place, so this is not a swap (b := f(old a), a := b).
+        var function = BuildBlock(
+            new StoreStackSlot(0, ComputeCall(Arg(0))),
+            StoreArg(0, Arg(1)),
+            StoreArg(1, LoadSlot(0)));
+
+        new SwapIdiomPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<DeconstructionAssignment>());
+    }
+
+    [Fact]
+    public void RestoreWritesDifferentPlace_NotRaised()
+    {
+        // S = a; a = b; c = S;  — a three-place rotation, not a two-place swap:
+        // the saved value lands in c, not back into the place b was read from.
+        var function = BuildBlock(
+            SaveSlot(0, Arg(0)),
+            StoreArg(0, Arg(1)),
+            StoreArg(2, LoadSlot(0)));
+
+        new SwapIdiomPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<DeconstructionAssignment>());
+    }
+
+    [Fact]
+    public void CrossAssignsIntoSamePlace_NotRaised()
+    {
+        // S = a; a = a; a = S;  — both cross-stores target the same place, so
+        // the two "exchanged" places are identical: not a swap.
+        var function = BuildBlock(
+            SaveSlot(0, Arg(0)),
+            StoreArg(0, Arg(0)),
+            StoreArg(0, LoadSlot(0)));
+
+        new SwapIdiomPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<DeconstructionAssignment>());
+    }
+
+    [Fact]
+    public void CarrierReusedElsewhere_NotRaised()
+    {
+        // S = a; a = b; b = S; c = S;  — the carrier is read a second time, so
+        // it is not a throwaway swap temp and must survive.
+        var function = BuildBlock(
+            SaveSlot(0, Arg(0)),
+            StoreArg(0, Arg(1)),
+            StoreArg(1, LoadSlot(0)),
+            StoreArg(2, LoadSlot(0)));
+
+        new SwapIdiomPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<DeconstructionAssignment>());
+    }
+
+    // --- Synthesis helpers ---
+
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+
+    static LoadArgument Arg(int index) => new(index, $"p{index}", Int);
+    static StoreArgument StoreArg(int index, IrExpression value) => new(index, $"p{index}", Int, value);
+    static StoreStackSlot SaveSlot(int slot, IrExpression value) => new(slot, value);
+    static LoadStackSlot LoadSlot(int slot) => new(slot, Int);
+
+    static Call ComputeCall(IrExpression argument)
+    {
+        var method = new MethodRef(
+            TypeRef.Definition("UserAssembly", "Samples", "Factory"),
+            "Compute", Int, [Int], HasThis: false);
+        return new Call(method, isVirtual: false, [argument]);
+    }
+
+    static IrFunction BuildBlock(params IrNode[] statements)
+    {
+        var block = new Block();
+        foreach (var statement in statements)
+            block.Add(statement);
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(
+                TypeRef.CoreLib("System", "Void"),
+                [new Parameter("p0", Int), new Parameter("p1", Int), new Parameter("p2", Int)],
+                HasThis: false,
+                GenericParameterCount: 0),
+            ImmutableArray<TypeRef>.Empty,
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/SwapIdiomPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwapIdiomPassTests.cs
@@ -51,6 +51,8 @@ public class SwapIdiomPassTests
         { "pointer (illegal ValueTuple element, CS0306)", TypeRef.Pointer(Int) },
         { "ref struct (illegal ValueTuple element, CS9244)",
             TypeRef.GenericInstance(TypeRef.CoreLib("System", "Span"), [Int]) },
+        { "generic parameter (may allow ref struct, CS9244)",
+            TypeRef.MethodGenericParameter(0, "T") },
     };
 
     [Theory]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -428,6 +428,14 @@ public static class IrPasses
         // `c ? … : false` diamond shape, and before coercion insertion so the
         // reshaped bool value is coerced at its sink.
         new ShortCircuitTernaryPass(),
+        // Raise the compiler's value-swap lowering (a single-def/single-use temp
+        // saving one place across the two cross-assignments) into the recognized
+        // swap form (q, p) = (p, q). Roslyn lowers that tuple swap to exactly this
+        // one-temp sequence, so the raise is opcode-exact. Runs last, after every
+        // slot/local settling pass, so it matches the final surviving carrier
+        // (stack slot or hidden local); before coercion insertion so the tuple
+        // elements are coerced at their sinks like any load (issue #3166).
+        new SwapIdiomPass(),
         new CoercionInsertionPass(),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -107,6 +107,8 @@ internal static class NativePasses
     public static OptionalArgumentElisionPass OptionalArgumentElision => new();
     [Native(NativeCategory.EmitArtifact, "a when-true-constant bool ternary (the slot-diamond spelling of a short-circuit && / ||, e.g. c ? false : y) re-formed into the LogicalBinary operator the compiler lowered to branches")]
     public static ShortCircuitTernaryPass ShortCircuitTernary => new();
+    [Native(NativeCategory.EmitArtifact, "the compiler's one-temp value-swap codegen shape (S = p; p = q; q = S over two distinct same-type by-value places) folded back to the recognized tuple deconstruction swap (q, p) = (p, q) — byte-identical to the manual temp swap, so it inverts a codegen shape, not the named DeconstructionAssignmentOperator lowering")]
+    public static SwapIdiomPass SwapIdiom => new();
 
     // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
     [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwapIdiomPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwapIdiomPass.cs
@@ -1,0 +1,217 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the compiler's value-swap lowering — a single-def/single-use temp
+/// carrying one place across the two cross-assignments that exchange two
+/// simple lvalues:
+/// <code>
+/// S = p;      // save p
+/// p = q;      // p := q
+/// q = S;      // q := old p
+/// </code>
+/// into the recognized swap form <c>(q, p) = (p, q);</c>. Roslyn lowers the
+/// tuple swap <c>(q, p) = (p, q)</c> to exactly this one-temp sequence (the
+/// dup-slot save, then the two stores), so the raise is opcode-exact, not a
+/// byte-divergent rewrite: it recompiles to the same IL the flat form came
+/// from. Left flat, the surviving carrier renders with a synthetic
+/// <c>S_{slot}</c> / hidden-local name (issue #3166).
+///
+/// Scoped to the safe, alias-free case: the two exchanged places are distinct
+/// by-value parameters or locals of the same type (side-effect-free,
+/// non-aliasing lvalues), and the carrier is a stack slot or an unnamed
+/// (compiler) local referenced only by the save and the final restore. Field,
+/// element, indexer, pointer, and byref places — which can alias or carry
+/// side effects — keep their explicit three-statement spelling.
+/// </summary>
+public sealed class SwapIdiomPass : IIrPass
+{
+    public string Name => "swap-idiom";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            // Re-scan from the top after each raise: the three matched
+            // statements collapse to one, so indices shift. Swaps are rare;
+            // a restart keeps the index bookkeeping trivially correct.
+            bool raisedAny;
+            do
+            {
+                raisedAny = false;
+                var children = block.Children;
+                for (int i = 0; i + 2 < children.Count; i++)
+                {
+                    if (TryRaiseSwap(function, block, i, context))
+                    {
+                        raisedAny = true;
+                        break;
+                    }
+                }
+            }
+            while (raisedAny);
+        }
+    }
+
+    static bool TryRaiseSwap(IrFunction function, Block block, int i, PassContext context)
+    {
+        var children = block.Children;
+        var save = children[i];
+        var cross = children[i + 1];
+        var restore = children[i + 2];
+
+        // 1. save: `carrier = load(p)` — a stack slot or unnamed-local temp.
+        if (MatchCarrier(function, save) is not { } carrier
+            || MatchPlace(carrier.SavedValue) is not { } p)
+        {
+            return false;
+        }
+
+        // 2. cross: `p = load(q)` — assigns into the just-saved place p.
+        if (MatchStore(cross) is not { } crossStore
+            || !crossStore.Place.Equals(p)
+            || MatchPlace(crossStore.Value) is not { } q)
+        {
+            return false;
+        }
+
+        // 3. restore: `q = carrier` — writes the saved old-p value into q.
+        if (MatchStore(restore) is not { } restoreStore
+            || !restoreStore.Place.Equals(q)
+            || !carrier.Matches(restoreStore.Value))
+        {
+            return false;
+        }
+
+        // A swap exchanges two *distinct* places of the same type. Equal
+        // places, or a type mismatch, are not the swap idiom.
+        if (p.Equals(q) || !p.Type.Equals(q.Type))
+            return false;
+
+        // The carrier must be a genuine single-def/single-use temp: referenced
+        // only by this save and this restore. Any other read or write means it
+        // is not a throwaway swap slot and the sequence is not a swap.
+        if (!carrier.ReferencedOnlyWithin(function, save, restore))
+            return false;
+
+        // Emit `(q, p) = (p, q);`. The deconstruction evaluates the tuple
+        // (old p, old q) then assigns left-to-right: q := old p, p := old q —
+        // the swap. Targets list q first so the source lists p first, matching
+        // the natural declaration-order reading of the original code.
+        var tupleType = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System", "ValueTuple"), [p.Type, q.Type]);
+        var source = new TupleExpression(tupleType, [p.Load(), q.Load()]);
+        var deconstruction = new DeconstructionAssignment(
+            [q.Target(), p.Target()], source);
+
+        context.Stepper.StepOver("raise value-swap temp to tuple deconstruction", save);
+        save.ReplaceWith(deconstruction);
+        cross.Detach();
+        restore.Detach();
+        return true;
+    }
+
+    /// <summary>A distinct by-value parameter or local lvalue in a swap.</summary>
+    abstract record Place(TypeRef Type)
+    {
+        public abstract IrExpression Load();
+        public abstract DeconstructionTarget Target();
+    }
+
+    sealed record ArgumentPlace(int Index, string PlaceName, TypeRef Type) : Place(Type)
+    {
+        public override IrExpression Load() => new LoadArgument(Index, PlaceName, Type);
+        public override DeconstructionTarget Target()
+            => DeconstructionTarget.Argument(Index, PlaceName, Type);
+    }
+
+    sealed record LocalPlace(int Index, TypeRef Type) : Place(Type)
+    {
+        public override IrExpression Load() => new LoadLocal(Index, Type);
+        public override DeconstructionTarget Target()
+            => DeconstructionTarget.Local(Index, Type, isDeclared: false);
+    }
+
+    static Place? MatchPlace(IrExpression expression) => expression switch
+    {
+        LoadArgument argument => new ArgumentPlace(argument.Index, argument.Name, argument.Type),
+        LoadLocal local => new LocalPlace(local.Index, local.Type),
+        _ => null,
+    };
+
+    readonly record struct StoreMatch(Place Place, IrExpression Value);
+
+    static StoreMatch? MatchStore(IrNode node) => node switch
+    {
+        StoreArgument argument => new StoreMatch(
+            new ArgumentPlace(argument.Index, argument.Name, argument.Type), argument.Value),
+        StoreLocal local => new StoreMatch(
+            new LocalPlace(local.Index, local.Type), local.Value),
+        _ => null,
+    };
+
+    /// <summary>The throwaway temp carrying the saved value across the swap.</summary>
+    abstract record Carrier
+    {
+        public required IrExpression SavedValue { get; init; }
+
+        /// <summary>True when <paramref name="value"/> reads this carrier.</summary>
+        public abstract bool Matches(IrExpression value);
+
+        /// <summary>True when the carrier is referenced only by <paramref name="save"/> and <paramref name="restore"/>.</summary>
+        public bool ReferencedOnlyWithin(IrFunction function, IrNode save, IrNode restore)
+        {
+            foreach (var node in function.Descendants)
+                if (IsReference(node)
+                    && !ReferenceOwnership.IsInside(node, save)
+                    && !ReferenceOwnership.IsInside(node, restore))
+                {
+                    return false;
+                }
+            return true;
+        }
+
+        protected abstract bool IsReference(IrNode node);
+    }
+
+    sealed record StackSlotCarrier(int Slot) : Carrier
+    {
+        public override bool Matches(IrExpression value)
+            => value is LoadStackSlot load && load.Slot == Slot;
+
+        protected override bool IsReference(IrNode node) => node switch
+        {
+            LoadStackSlot load => load.Slot == Slot,
+            StoreStackSlot store => store.Slot == Slot,
+            _ => false,
+        };
+    }
+
+    sealed record HiddenLocalCarrier(int Index) : Carrier
+    {
+        public override bool Matches(IrExpression value)
+            => value is LoadLocal load && load.Index == Index;
+
+        protected override bool IsReference(IrNode node) => node switch
+        {
+            LoadLocal load => load.Index == Index,
+            StoreLocal store => store.Index == Index,
+            LoadLocalAddress address => address.Index == Index,
+            _ => false,
+        };
+    }
+
+    static Carrier? MatchCarrier(IrFunction function, IrNode node) => node switch
+    {
+        StoreStackSlot slot => new StackSlotCarrier(slot.Slot) { SavedValue = slot.Value },
+        StoreLocal local when IsHiddenLocal(function, local.Index)
+            => new HiddenLocalCarrier(local.Index) { SavedValue = local.Value },
+        _ => null,
+    };
+
+    static bool IsHiddenLocal(IrFunction function, int index)
+        => index >= 0
+            && index < function.LocalNames.Length
+            && function.LocalNames[index] is null;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwapIdiomPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwapIdiomPass.cs
@@ -23,9 +23,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// non-aliasing lvalues) that are legal ValueTuple elements, and the carrier is
 /// a stack slot or an unnamed (compiler) local referenced only by the save and
 /// the final restore. Field, element, indexer, pointer, function-pointer,
-/// byref, and ref-struct / stack-only places — which can alias, carry side
-/// effects, reseat rather than assign, or are illegal as tuple elements — keep
-/// their explicit three-statement spelling.
+/// byref, generic-parameter, and ref-struct / stack-only places — which can
+/// alias, carry side effects, reseat rather than assign, or are illegal as
+/// tuple elements — keep their explicit three-statement spelling.
 /// </summary>
 public sealed class SwapIdiomPass : IIrPass
 {
@@ -232,11 +232,15 @@ public sealed class SwapIdiomPass : IIrPass
     // ref-struct / stack-only reasoning in PatternSwitchExpressionPass
     // (IsStackOnlyValueType / IsByRefLike): those helpers live there privately,
     // so the swap pass keeps its own trimmed copies rather than raising invalid
-    // or meaning-changing `Full` C#.
+    // or meaning-changing `Full` C#. Generic parameters are declined
+    // conservatively: a `where T : allows ref struct` parameter can be a ref
+    // struct at some instantiation, which is illegal as a tuple element
+    // (CS9244), and that anti-constraint is not tracked in the IR.
     static bool IsSwappablePlaceType(IrFunction function, TypeRef type)
     {
         if (type.Kind is TypeRefKind.ByRef or TypeRefKind.Pointer
-            or TypeRefKind.FunctionPointer or TypeRefKind.Pinned or TypeRefKind.Unsupported)
+            or TypeRefKind.FunctionPointer or TypeRefKind.Pinned or TypeRefKind.Unsupported
+            or TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter)
         {
             return false;
         }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwapIdiomPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwapIdiomPass.cs
@@ -20,10 +20,12 @@ namespace ILInspector.Decompiler.Pipeline;
 ///
 /// Scoped to the safe, alias-free case: the two exchanged places are distinct
 /// by-value parameters or locals of the same type (side-effect-free,
-/// non-aliasing lvalues), and the carrier is a stack slot or an unnamed
-/// (compiler) local referenced only by the save and the final restore. Field,
-/// element, indexer, pointer, and byref places — which can alias or carry
-/// side effects — keep their explicit three-statement spelling.
+/// non-aliasing lvalues) that are legal ValueTuple elements, and the carrier is
+/// a stack slot or an unnamed (compiler) local referenced only by the save and
+/// the final restore. Field, element, indexer, pointer, function-pointer,
+/// byref, and ref-struct / stack-only places — which can alias, carry side
+/// effects, reseat rather than assign, or are illegal as tuple elements — keep
+/// their explicit three-statement spelling.
 /// </summary>
 public sealed class SwapIdiomPass : IIrPass
 {
@@ -87,6 +89,16 @@ public sealed class SwapIdiomPass : IIrPass
         // A swap exchanges two *distinct* places of the same type. Equal
         // places, or a type mismatch, are not the swap idiom.
         if (p.Equals(q) || !p.Type.Equals(q.Type))
+            return false;
+
+        // The exchanged places must be spellable, non-aliasing, by-value
+        // lvalues that are legal ValueTuple elements. Byref (`ref`
+        // parameters/locals — a byref reseat, not a value swap), pointers,
+        // function pointers, and ref-struct / stack-only value types either
+        // change meaning under tuple deconstruction (a `ref` reseat becomes a
+        // value write to the referent) or cannot appear as a tuple element at
+        // all (CS9244 / CS0306). Leave those in the flat three-statement form.
+        if (!IsSwappablePlaceType(function, p.Type))
             return false;
 
         // The carrier must be a genuine single-def/single-use temp: referenced
@@ -214,4 +226,47 @@ public sealed class SwapIdiomPass : IIrPass
         => index >= 0
             && index < function.LocalNames.Length
             && function.LocalNames[index] is null;
+
+    // A place type is swappable only when it is a spellable, boxable-or-plain
+    // by-value type that is legal as a ValueTuple element. Mirrors the
+    // ref-struct / stack-only reasoning in PatternSwitchExpressionPass
+    // (IsStackOnlyValueType / IsByRefLike): those helpers live there privately,
+    // so the swap pass keeps its own trimmed copies rather than raising invalid
+    // or meaning-changing `Full` C#.
+    static bool IsSwappablePlaceType(IrFunction function, TypeRef type)
+    {
+        if (type.Kind is TypeRefKind.ByRef or TypeRefKind.Pointer
+            or TypeRefKind.FunctionPointer or TypeRefKind.Pinned or TypeRefKind.Unsupported)
+        {
+            return false;
+        }
+        return !IsStackOnlyValueType(type) && !IsByRefLike(function, type);
+    }
+
+    // The corelib stack-only value types (ref structs and byref-like intrinsics)
+    // recognised by name, since their ref-struct nature lives on the
+    // cross-assembly corelib definition rather than this TypeRef. Matching
+    // `System` avoids user types of the same simple name; user-defined ref
+    // structs in the inspected assembly are caught by IsByRefLike instead.
+    static bool IsStackOnlyValueType(TypeRef type)
+    {
+        var (name, ns) = type.Kind is TypeRefKind.GenericInstance
+            ? (type.ElementType?.Name, type.ElementType?.Namespace)
+            : (type.Name, type.Namespace);
+        if (ns != "System" || name is null)
+            return false;
+        int tick = name.IndexOf('`');
+        string simple = tick < 0 ? name : name[..tick];
+        return simple is "Span" or "ReadOnlySpan" or "TypedReference"
+            or "ArgIterator" or "RuntimeArgumentHandle";
+    }
+
+    // Whether the type (or a generic instance's definition) carries the
+    // compiler's [IsByRefLike] fact recovered at import — a user-defined
+    // `ref struct` in the inspected assembly.
+    static bool IsByRefLike(IrFunction function, TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is not null && function.ByRefLikeTypes.Contains(definition);
+    }
 }


### PR DESCRIPTION
- Fixes/advances #3166
- Changes the value-swap idiom `tmp = q; q = p; p = tmp;` to render as the recognized tuple swap `(p, q) = (q, p);` when it is opcode-exact.
- Card revision: `ab787539aec41255e2fc8ce12bf107a59bc92802`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the raise reproduces the original source's own tuple-swap spelling and is opcode-exact (Roslyn lowers `(a,b)=(b,a)` to the identical one-temp dup-slot IL as the manual swap), so it is a byte-faithful default with a compile-back-checkable witness fixture pinned Exact.

### Benchmark target

Benchmark target: `System.Text.Json` (platform, net11.0)

dotnet-inspect command:

```bash
dotnet-inspect member System.Text.Json.JsonElement.DeepEquals -S "Decompiled Source"
```

### Original source

```csharp
public static bool DeepEquals(JsonElement element1, JsonElement element2)
{
    // ...
    if (element2.ValueIsEscaped)
    {
        if (element1.ValueIsEscaped)
        {
            return JsonReaderHelper.UnescapeAndCompareBothInputs(element1.ValueSpan, element2.ValueSpan);
        }

        // Swap values so that unescaping is handled by the LHS.
        (element1, element2) = (element2, element1);
    }
    // ...
    static bool NameEquals(JsonProperty left, JsonProperty right)
    {
        if (right.NameIsEscaped)
        {
            if (left.NameIsEscaped)
            {
                return JsonReaderHelper.UnescapeAndCompareBothInputs(left.NameSpan, right.NameSpan);
            }

            // Swap values so that unescaping is handled by the LHS
            (left, right) = (right, left);
        }
        return left.NameEquals(right.NameSpan);
    }
}
```

The authored source uses the C# tuple-swap in both places.

### Before

```csharp
case JsonValueKind.Object:
    if (element2.ValueIsEscaped)
    {
        if (element1.ValueIsEscaped)
        {
            return JsonReaderHelper.UnescapeAndCompareBothInputs(element1.ValueSpan, element2.ValueSpan);
        }
        S_257 = element2;
        element2 = element1;
        element1 = S_257;
    }
    return element1.ValueEquals(element2.ValueSpan);
// ... and in NameEquals:
    right = left;
    left = S_256_1;
```

- Valid: True
- Correct: True
- IL fidelity: True (opcode-exact; the flat 3-statement form and the tuple form lower to identical IL)
- Taste applied: None
- Commit: 08ab86b1

The pre-change render exposes the compiler's one-temp swap carrier (`S_257`, a synthetic dup-slot name) instead of the source's tuple swap.

### After

```csharp
case JsonValueKind.Object:
    if (element2.ValueIsEscaped)
    {
        if (element1.ValueIsEscaped)
        {
            return JsonReaderHelper.UnescapeAndCompareBothInputs(element1.ValueSpan, element2.ValueSpan);
        }
        (element1, element2) = (element2, element1);
    }
    return element1.ValueEquals(element2.ValueSpan);
// ... and in NameEquals:
    (left, right) = (right, left);
```

- Valid: True
- Correct: True
- IL fidelity: True — witnessed by the pinned `CfgSampleClass.SwapStructPair` fixture (compile-back **Exact**). DeepEquals itself remains uncheckable by the compile-back harness (internal STJ surface, per #3197), but the shape is proven opcode-exact by the fixture.
- Taste applied: None
- Commit: ab787539aec41255e2fc8ce12bf107a59bc92802

The After render reproduces the original source's `(element1, element2) = (element2, element1);` and `(left, right) = (right, left);` verbatim. The remaining `S_256` in the `Array` arm is a genuine non-swap value spill (`element1.GetRawValue().Span`), correctly left untouched (tracked separately under #3165).

The raise is scoped to distinct, same-type, by-value parameter/local places that are legal `ValueTuple` elements. Byref (a `ref` reseat, not a value swap), pointer, function-pointer, generic-parameter (may `allow ref struct`), and ref-struct / stack-only places are declined and keep their flat three-statement form — otherwise the tuple would either change meaning or be uncompilable (CS9244 / CS0306). See the adversarial-review reconciliation comment for the two guard fixes and their reproductions.

### Fully raised

The After decompilation is in the fully raised state for the swap idiom.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | n/a (new file) | `SwapIdiomPassTests`: 12 passed; `DeconstructionAssignmentPassTests`: 32 passed |
| Decompiler fast suite | 288 RoundTrip passed | 288 RoundTrip passed |
| Reduced fixture validity | Pass | Pass |
| Reduced fixture fidelity | not applicable (fixture new) | `SwapStructPair`: compile-back **Exact** |
| Real witness | `JsonElement::DeepEquals` swap renders `S_257 = element2; ...` | `JsonElement::DeepEquals` swap renders `(element1, element2) = (element2, element1);` |

Pre-existing baseline fidelity failures unchanged by this PR (same tests, same reasons): `ManualConstantOnlyComparisonFactory` (OpcodeDiff, expr-tree factory temp spill), `StatementBodyLambdaInsideIf` (OperandDiff, csc lambda-ordinal drift), `TupleRest` (RecompileFail CS0246, environmental). `SwapStructPair` is absent from the entire diff set on both base and head.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/SwapIdiomPassTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=RoundTrip" -trait- "Speed=Slow"
```
