### PR TITLE
Apply taste to Annotated Source, and drop interleaved IL for byte-divergent lenses (#3191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,11 @@ DecompilerHarness.
 The `Decompiled Source` view renders the shipped canonical C# by default. A
 tool-owned `.dotnet-inspectconfig` file (discovered by walking up from the
 working directory) selects opt-in class-3 spellings — today `this`-qualification
-of field and property access — using `.editorconfig` key names. See
+of field and property access — using `.editorconfig` key names. `--taste`
+requests the whole oracle-endorsed set for one invocation without a config file.
+`Annotated Source` names the applied spellings in a trailing comment on the
+member signature, and drops its interleaved IL for any member a byte-divergent
+lens actually rewrote. See
 [docs/decompiler-taste.md](docs/decompiler-taste.md#style-configuration).
 
 ```bash

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -590,8 +590,8 @@ the full account, with each rule's detail and fidelity as table rows.
 Nothing is annotated by default: no style decision is recorded unless a knob was
 requested, so the comment appears exactly when the reader asked for taste.
 `--taste` is the one-invocation gesture for requesting the whole oracle-endorsed
-set (the flag form of `dotnet_inspect_style_full_taste`); it folds on top of any
-resolved config, so a per-knob line still refines it.
+set (the flag form of `dotnet_inspect_style_full_taste`); it applies after the
+config file resolves and wins for the knobs it covers.
 
 The lowered Annotated stage applies the byte-preserving knobs but never runs the
 lenses at all: they are raised-altitude sugar, and the lowered pipeline exists to
@@ -654,10 +654,12 @@ dotnet_style_prefer_conditional_expression_over_return = true
   `dotnet_style_qualification_for_field = false` is "full taste minus one knob".
 - `--taste` on `member` and `type` is the same aggregate as a one-invocation
   gesture, for asking a single question without leaving a config file behind. It
-  folds on top of the resolved config rather than replacing it, so a config that
-  already refines a knob keeps that refinement. Because the aggregate includes
-  the ternary lens, the Annotated view drops its interleaved IL for any member
-  that lens actually rewrites.
+  applies after the file resolves, so for the knobs the aggregate covers the
+  flag wins: an explicit gesture is never silently narrowed by a checked-in
+  `full_taste = true` + `dotnet_style_qualification_for_field = false`. Knobs
+  outside the endorsed set — the branchless lens — keep whatever the file
+  selected. Because the aggregate includes the ternary lens, the Annotated view
+  drops its interleaved IL for any member that lens actually rewrites.
 - The recognized keys are not hand-maintained in the resolver: they come from the
   library-owned `StyleOptionCatalog` (see [Option catalog](#option-catalog)), so
   the CLI vocabulary and the option surface cannot drift.

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -485,8 +485,7 @@ behavior-preserving; that is what lets the lens re-offer a fold the default had
 to decline. It deliberately stops at IDE0046: the further `c ? true : d` → `c ||
 d` collapse (IDE0075) is a separate future knob, so a literal-arm ternary such as
 `a ? true : b` is kept as written rather than simplified. The lens runs only on
-the opt-in raised path, after the default pipeline, and the IL-anchored Annotated
-view never applies it (it must stay byte-faithful for line/IL alignment).
+the opt-in raised path, after the default pipeline.
 
 The second lens is `PrinterOptions.PreferBranchlessBoolean`
 (`dotnet_inspect_style_prefer_branchless_boolean`). It targets the *same* declined
@@ -520,6 +519,39 @@ present, it would rebind to that operator's semantics), or valid but not branchl
 (a negation spelled as the ternary `(t ? false : true)` re-embeds a branch).
 Over-declining is always valid and faithful. When both lenses are enabled the
 oracle-endorsed ternary wins the shared shape.
+
+### Lenses and the Annotated view
+
+The Annotated view renders the same member as Decompiled Source, so it applies
+the same resolved style options: a member must not be spelled `this._count` in
+one section and `_count` in the other. For every byte-preserving knob this is
+free — the knob changes only the C# spelling, so the interleaved IL beneath each
+statement is byte-identical to the default render, and the view demonstrates the
+knob's contract rather than obscuring it.
+
+A style lens cannot keep that bargain. Its render no longer reproduces the
+member's opcodes, so anchoring the raw IL beneath it would assert a
+statement-to-opcode correspondence that does not hold — the single claim this
+view exists to make. When a lens **actually rewrites** (it records a
+`style-lens.*` decision under the `style-lens` category), the Annotated view
+therefore drops the interleaved IL and says so in the body, naming the applied
+lens and pointing at `-S "Applied Taste"`:
+
+```csharp
+// Interleaved IL suppressed: a byte-divergent style lens shaped this render.
+// Applied lens: style-lens.prefer-conditional-return.
+return a ? b : c;
+```
+
+Suppression keys on what the render *did*, not on what the host *asked for*: a
+lens that is enabled but finds no shape to rewrite is byte-faithful for that
+member, so its IL stays. The fact-comment overlay also stays, because a fact is
+a property of the member, not a claim about which opcodes a printed statement
+reproduces.
+
+The lowered Annotated stage applies the byte-preserving knobs but never runs the
+lenses at all: they are raised-altitude sugar, and the lowered pipeline exists to
+show the shape beneath that sugar.
 
 ## Names
 

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -534,20 +534,64 @@ member's opcodes, so anchoring the raw IL beneath it would assert a
 statement-to-opcode correspondence that does not hold — the single claim this
 view exists to make. When a lens **actually rewrites** (it records a
 `style-lens.*` decision under the `style-lens` category), the Annotated view
-therefore drops the interleaved IL and says so in the body, naming the applied
-lens and pointing at `-S "Applied Taste"`:
-
-```csharp
-// Interleaved IL suppressed: a byte-divergent style lens shaped this render.
-// Applied lens: style-lens.prefer-conditional-return.
-return a ? b : c;
-```
+therefore drops the interleaved IL for that member.
 
 Suppression keys on what the render *did*, not on what the host *asked for*: a
 lens that is enabled but finds no shape to rewrite is byte-faithful for that
 member, so its IL stays. The fact-comment overlay also stays, because a fact is
 a property of the member, not a claim about which opcodes a printed statement
 reproduces.
+
+### Reading applied taste in the Annotated view
+
+The applied knobs travel on the result as typed decisions, and the Annotated view
+renders them as a single trailing side comment on the member's signature — the
+same shape the fact overlay uses for analysis, so style and analysis read alike:
+
+```csharp
+public object? Pick(bool useName, string suffix)  // taste.qualify-property-access(Name); taste.qualify-field-access(_count)
+{
+    if (useName)
+        // IL_0000: ldarg.1                                              // arg: useName; stack: [bool]
+        // IL_0001: brfalse.s    IL_0009                                 // stack: []
+    {
+        return new object();  // alloc.new(object; alloc=System.Object; path=branch; path-confidence=behind-branch; post-dominance=return-post-dominates; escape=escapes; escape-kind=escapes-return; multiplicity=conditional)
+            // IL_0003: newobj       object::.ctor()  // alloc.new(object; alloc=System.Object; path=branch; path-confidence=behind-branch; post-dominance=return-post-dominates; escape=escapes; escape-kind=escapes-return; multiplicity=conditional); stack: [object]
+            // IL_0008: ret                                                  // stack: []
+    }
+    return string.Concat(this.Name, suffix, this._count.ToString());
+        // IL_0009: ldarg.0                                              // arg: this; stack: [Cache]
+        // IL_000A: call         Cache::get_Name()                       // stack: [string]
+        // IL_000F: ldarg.2                                              // arg: suffix; stack: [string, string]
+        // IL_0010: ldarg.0                                              // arg: this; stack: [string, string, Cache]
+        // IL_0011: ldflda       int Cache::_count                       // stack: [string, string, ref int]
+        // IL_0016: call         int::ToString()                         // stack: [string, string, string]
+        // IL_001B: call         string::Concat(string, string, string)  // stack: [string]
+        // IL_0020: ret                                                  // stack: []
+}
+```
+
+Both knobs above are byte-preserving, so the IL is byte-identical to the default
+render. A byte-divergent lens reports its fidelity instead of its subject (the
+subject is the enclosing method, already spelled on that line), and that is also
+the signal explaining the absent IL:
+
+```csharp
+public bool Allow(bool trusted, bool cached)  // taste.qualify-property-access(Name); taste.qualify-field-access(_count); taste.prefer-conditional-return(fidelity=byte-divergent)
+{
+    return trusted ? cached : (this.Name.Length > this._count);
+}
+```
+
+The comment is anchored to the signature rather than to a statement because a
+style decision carries a subject but no IL offset. `-S "Applied Taste"` remains
+the full account, with each rule's detail and fidelity as table rows.
+
+Nothing is annotated by default: no style decision is recorded unless a knob was
+requested, so the comment appears exactly when the reader asked for taste.
+`--taste` is the one-invocation gesture for requesting the whole oracle-endorsed
+set (the flag form of `dotnet_inspect_style_full_taste`); it folds on top of any
+resolved config, so a per-knob line still refines it.
 
 The lowered Annotated stage applies the byte-preserving knobs but never runs the
 lenses at all: they are raised-altitude sugar, and the lowered pipeline exists to
@@ -608,6 +652,12 @@ dotnet_style_prefer_conditional_expression_over_return = true
   order like any other key, so a later explicit per-knob line overrides it
   (last-write-wins) — `full_taste = true` then
   `dotnet_style_qualification_for_field = false` is "full taste minus one knob".
+- `--taste` on `member` and `type` is the same aggregate as a one-invocation
+  gesture, for asking a single question without leaving a config file behind. It
+  folds on top of the resolved config rather than replacing it, so a config that
+  already refines a knob keeps that refinement. Because the aggregate includes
+  the ternary lens, the Annotated view drops its interleaved IL for any member
+  that lens actually rewrites.
 - The recognized keys are not hand-maintained in the resolver: they come from the
   library-owned `StyleOptionCatalog` (see [Option catalog](#option-catalog)), so
   the CLI vocabulary and the option surface cannot drift.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -91,73 +91,91 @@ public sealed partial class CSharpPrinter
         PrinterOptions? options = null,
         Func<TypeRef, TypeRef, bool>? typesProvablyDisjoint = null)
     {
-        var appliedLenses = new List<DecompilerDecision>();
+        List<DecompilerDecision> appliedLenses;
         try
         {
-            var context = RaiseContext(importMethodBody, typesProvablyDisjoint);
-            IrPasses.Run(function, IrPasses.Default, context);
-            // Opt-in tier-3 style lens (#3138), byte-divergent by design: runs
-            // only when requested, after the byte-faithful default pipeline has
-            // left the guarded bool return flat. The oracle-endorsed ternary runs
-            // first so that, when both lenses are enabled, it wins the shared shape
-            // (it consumes the guarded return, leaving the branchless pass a no-op).
-            // When a lens actually rewrites, record a byte-divergent applied-lens
-            // decision so a host can surface that the render is no longer
-            // opcode-faithful (the #3127 signal) instead of inferring it from prose.
-            if (options?.PreferConditionalExpressionReturn == true)
-            {
-                var pass = new PreferConditionalReturnPass();
-                pass.Run(function, context);
-                if (pass.Rewrites > 0)
-                    appliedLenses.Add(new DecompilerDecision(
-                        "style-lens.prefer-conditional-return",
-                        DecompilerDecisionCategories.StyleLens,
-                        function.Name,
-                        "Rewrote a guarded boolean return as a conditional expression "
-                            + "(dotnet_style_prefer_conditional_expression_over_return, IDE0046). "
-                            + "Behavior-preserving but byte-divergent: the render no longer "
-                            + "reproduces the original branch opcodes.")
-                    {
-                        OldValue = "if (c) return A; return B;",
-                        NewValue = "return c ? A : B;",
-                    });
-            }
-            if (options?.PreferBranchlessBoolean == true)
-            {
-                var pass = new PreferBranchlessBooleanPass();
-                pass.Run(function, context);
-                if (pass.Rewrites > 0)
-                    appliedLenses.Add(new DecompilerDecision(
-                        "style-lens.prefer-branchless-boolean",
-                        DecompilerDecisionCategories.StyleLens,
-                        function.Name,
-                        "Folded a guarded boolean return into the compact short-circuit "
-                            + "\"bool hack\" (dotnet_inspect_style_prefer_branchless_boolean; not "
-                            + "oracle-endorsed). Behavior-preserving but byte-divergent: the render "
-                            + "no longer reproduces the original branch opcodes.")
-                    {
-                        OldValue = "if (c) return false; return B;",
-                        NewValue = "return !c && B;",
-                    });
-            }
+            appliedLenses = RaiseWithStyleLenses(function, importMethodBody, options, typesProvablyDisjoint);
         }
         catch (Exception ex)
         {
             return DecompilerResult.Failure(DiagnosticIds.InternalError, $"{ex.GetType().Name}: {ex.Message}");
         }
-        var result = Print(function, options);
-        if (appliedLenses.Count > 0 && result.Output is not null)
+        return WithAppliedLenses(Print(function, options), appliedLenses);
+    }
+
+    /// <summary>
+    /// Runs the default raising pipeline, then any opt-in byte-divergent style
+    /// lens, and returns the decisions for the lenses that actually rewrote.
+    /// Shared by both <see cref="PrintRaised(IrFunction, Func{MethodRef, IrFunction}, PrinterOptions, Func{TypeRef, TypeRef, bool})"/>
+    /// and the statement-line-map overload the annotated view uses, so the two
+    /// paths raise and apply taste identically instead of drifting apart.
+    /// </summary>
+    static List<DecompilerDecision> RaiseWithStyleLenses(
+        IrFunction function,
+        Func<MethodRef, IrFunction?>? importMethodBody,
+        PrinterOptions? options,
+        Func<TypeRef, TypeRef, bool>? typesProvablyDisjoint)
+    {
+        var appliedLenses = new List<DecompilerDecision>();
+        var context = RaiseContext(importMethodBody, typesProvablyDisjoint);
+        IrPasses.Run(function, IrPasses.Default, context);
+        // Opt-in tier-3 style lens (#3138), byte-divergent by design: runs
+        // only when requested, after the byte-faithful default pipeline has
+        // left the guarded bool return flat. The oracle-endorsed ternary runs
+        // first so that, when both lenses are enabled, it wins the shared shape
+        // (it consumes the guarded return, leaving the branchless pass a no-op).
+        // When a lens actually rewrites, record a byte-divergent applied-lens
+        // decision so a host can surface that the render is no longer
+        // opcode-faithful (the #3127 signal) instead of inferring it from prose.
+        if (options?.PreferConditionalExpressionReturn == true)
         {
-            result = result with
+            var pass = new PreferConditionalReturnPass();
+            pass.Run(function, context);
+            if (pass.Rewrites > 0)
+                appliedLenses.Add(new DecompilerDecision(
+                    "style-lens.prefer-conditional-return",
+                    DecompilerDecisionCategories.StyleLens,
+                    function.Name,
+                    "Rewrote a guarded boolean return as a conditional expression "
+                        + "(dotnet_style_prefer_conditional_expression_over_return, IDE0046). "
+                        + "Behavior-preserving but byte-divergent: the render no longer "
+                        + "reproduces the original branch opcodes.")
+                {
+                    OldValue = "if (c) return A; return B;",
+                    NewValue = "return c ? A : B;",
+                });
+        }
+        if (options?.PreferBranchlessBoolean == true)
+        {
+            var pass = new PreferBranchlessBooleanPass();
+            pass.Run(function, context);
+            if (pass.Rewrites > 0)
+                appliedLenses.Add(new DecompilerDecision(
+                    "style-lens.prefer-branchless-boolean",
+                    DecompilerDecisionCategories.StyleLens,
+                    function.Name,
+                    "Folded a guarded boolean return into the compact short-circuit "
+                        + "\"bool hack\" (dotnet_inspect_style_prefer_branchless_boolean; not "
+                        + "oracle-endorsed). Behavior-preserving but byte-divergent: the render "
+                        + "no longer reproduces the original branch opcodes.")
+                {
+                    OldValue = "if (c) return false; return B;",
+                    NewValue = "return !c && B;",
+                });
+        }
+        return appliedLenses;
+    }
+
+    static DecompilerResult WithAppliedLenses(DecompilerResult result, List<DecompilerDecision> appliedLenses)
+        => appliedLenses.Count == 0 || result.Output is null
+            ? result
+            : result with
             {
                 Metadata = result.Metadata with
                 {
                     Decisions = [.. result.Metadata.Decisions, .. appliedLenses],
                 },
             };
-        }
-        return result;
-    }
 
     /// <summary>
     /// The product path with a statement line map: same output as
@@ -170,14 +188,27 @@ public sealed partial class CSharpPrinter
         => PrintRaised(function, out statementLines, importMethodBody: null);
 
     /// <inheritdoc cref="PrintRaised(IrFunction, out IReadOnlyDictionary{IrNode, int})"/>
+    /// <remarks>
+    /// <paramref name="options"/> applies the same taste as the plain
+    /// <see cref="PrintRaised(IrFunction, Func{MethodRef, IrFunction}, PrinterOptions, Func{TypeRef, TypeRef, bool})"/>
+    /// path, so a line-anchored overlay never renders a different spelling than
+    /// the Source view for the same member. When a byte-divergent style lens
+    /// actually rewrites, the result carries a
+    /// <see cref="DecompilerDecisionCategories.StyleLens"/> decision: the render
+    /// no longer reproduces the original opcodes, so an overlay that interleaves
+    /// raw IL must consult those decisions rather than presenting the two as
+    /// corresponding.
+    /// </remarks>
     public static DecompilerResult PrintRaised(
         IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines, Func<MethodRef, IrFunction?>? importMethodBody,
-        Func<TypeRef, TypeRef, bool>? typesProvablyDisjoint = null)
+        Func<TypeRef, TypeRef, bool>? typesProvablyDisjoint = null,
+        PrinterOptions? options = null)
     {
         statementLines = new Dictionary<IrNode, int>();
+        List<DecompilerDecision> appliedLenses;
         try
         {
-            IrPasses.Run(function, IrPasses.Default, RaiseContext(importMethodBody, typesProvablyDisjoint));
+            appliedLenses = RaiseWithStyleLenses(function, importMethodBody, options, typesProvablyDisjoint);
         }
         catch (Exception ex)
         {
@@ -187,10 +218,10 @@ public sealed partial class CSharpPrinter
         try
         {
             var sink = new Dictionary<IrNode, int>();
-            var printer = new CSharpPrinter(function) { _statementLines = sink };
+            var printer = new CSharpPrinter(function, options) { _statementLines = sink };
             string output = printer.PrintBody(function);
             statementLines = sink;
-            return printer.Result(output, function);
+            return WithAppliedLenses(printer.Result(output, function), appliedLenses);
         }
         catch (Exception ex)
         {
@@ -232,8 +263,16 @@ public sealed partial class CSharpPrinter
         => PrintLowered(function, out statementLines, importMethodBody: null);
 
     /// <inheritdoc cref="PrintLowered(IrFunction, out IReadOnlyDictionary{IrNode, int})"/>
+    /// <remarks>
+    /// <paramref name="options"/> applies the printer's byte-preserving spelling
+    /// and layout knobs so the lowered annotated view spells a member the same way
+    /// the Source view does. The byte-divergent style lenses are deliberately not
+    /// run here: they are raised-altitude sugar, and the lowered pipeline exists to
+    /// show the shape below that sugar.
+    /// </remarks>
     public static DecompilerResult PrintLowered(
-        IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines, Func<MethodRef, IrFunction?>? importMethodBody)
+        IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines, Func<MethodRef, IrFunction?>? importMethodBody,
+        PrinterOptions? options = null)
     {
         statementLines = new Dictionary<IrNode, int>();
         try
@@ -248,7 +287,7 @@ public sealed partial class CSharpPrinter
         try
         {
             var sink = new Dictionary<IrNode, int>();
-            var printer = new CSharpPrinter(function) { _statementLines = sink };
+            var printer = new CSharpPrinter(function, options) { _statementLines = sink };
             string output = printer.PrintBody(function);
             statementLines = sink;
             return printer.Result(output, function);

--- a/src/ILInspector.Research.Tests/AnnotatedSourceTasteTests.cs
+++ b/src/ILInspector.Research.Tests/AnnotatedSourceTasteTests.cs
@@ -1,0 +1,169 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Research.Tests;
+
+/// <summary>
+/// The annotated projection renders the same member as the Source view, so it
+/// must apply the same taste (#3191) — otherwise one tool shows two spellings of
+/// one member. The interleaved IL is what makes this view worth having, so these
+/// tests pin the two halves of the contract: a byte-preserving knob changes the
+/// C# and leaves the IL untouched, while a byte-divergent style lens (whose
+/// render no longer reproduces the member's opcodes) suppresses the IL rather
+/// than asserting a correspondence that does not hold.
+/// </summary>
+public class AnnotatedSourceTasteTests
+{
+    static string Annotated(string method, PrinterOptions? options)
+    {
+        using var source = MetadataSource.Open(typeof(AnnotatedTasteFixture).Assembly.Location);
+        var projection = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+            source,
+            typeof(AnnotatedTasteFixture).FullName!,
+            method,
+            AnnotatedSource: true,
+            PrinterOptions: options));
+
+        var result = Assert.IsType<DecompilerResult>(projection.AnnotatedSource);
+        Assert.True(result.Succeeded, string.Join(Environment.NewLine, result.Diagnostics));
+        return Assert.IsType<string>(result.Output);
+    }
+
+    // The interleaved IL lines, in order. Comparing these instead of the whole
+    // render is what separates "the C# spelling changed" from "the IL changed".
+    static string[] IlLines(string annotated) =>
+        [.. annotated
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.StartsWith("// IL_", StringComparison.Ordinal))];
+
+    static string[] CSharpLines(string annotated) =>
+        [.. annotated
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => !line.StartsWith("//", StringComparison.Ordinal))];
+
+    [Fact]
+    public void ByteReservingKnob_ChangesCSharpSpelling_AndLeavesInterleavedIlIdentical()
+    {
+        string shipped = Annotated(nameof(AnnotatedTasteFixture.Compute), options: null);
+        string qualified = Annotated(
+            nameof(AnnotatedTasteFixture.Compute),
+            new PrinterOptions { QualifyFieldAccess = true, QualifyPropertyAccess = true });
+
+        // The knob reached the annotated projection at all (the #3191 gap).
+        Assert.DoesNotContain("this._count", shipped);
+        Assert.Contains("this._count", qualified);
+        Assert.Contains("this.Extra", qualified);
+
+        // ...and it changed only the spelling: the IL beneath is byte-identical,
+        // which is the whole claim the annotated view makes.
+        Assert.NotEmpty(IlLines(shipped));
+        Assert.Equal(IlLines(shipped), IlLines(qualified));
+    }
+
+    [Fact]
+    public void NoOptions_RendersIdenticallyToExplicitDefaults()
+    {
+        Assert.Equal(
+            Annotated(nameof(AnnotatedTasteFixture.Compute), options: null),
+            Annotated(nameof(AnnotatedTasteFixture.Compute), PrinterOptions.Default));
+    }
+
+    [Fact]
+    public void ByteDivergentLens_WhenApplied_SuppressesInterleavedIl()
+    {
+        string lensed = Annotated(
+            nameof(AnnotatedTasteFixture.GuardBothVariable),
+            new PrinterOptions { PreferConditionalExpressionReturn = true });
+
+        // The lens shaped the render...
+        Assert.Contains("return a ? b : c;", lensed);
+        // ...so the raw IL is gone, and the reader is told why and by which knob
+        // rather than being left with a view that silently lost half its content.
+        Assert.Empty(IlLines(lensed));
+        Assert.Contains("Interleaved IL suppressed", lensed);
+        Assert.Contains("style-lens.prefer-conditional-return", lensed);
+        Assert.Contains("Applied Taste", lensed);
+    }
+
+    [Fact]
+    public void ByteDivergentLens_WhenApplied_KeepsTheSuppressedRenderValidCSharp()
+    {
+        string lensed = Annotated(
+            nameof(AnnotatedTasteFixture.GuardBothVariable),
+            new PrinterOptions { PreferConditionalExpressionReturn = true });
+
+        // The note is spelled as comments, so the body is still a C# block: no
+        // stray prose leaks into the code the section presents as source.
+        Assert.All(
+            CSharpLines(lensed).Where(line => line.Length > 0),
+            line => Assert.DoesNotContain("suppressed", line, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ByteDivergentLens_WhenRequestedButDeclined_KeepsInterleavedIl()
+    {
+        // The close negative case: the lens is requested, but this member has no
+        // guarded boolean return for it to rewrite, so nothing byte-divergent was
+        // applied. Suppression keys on what the render actually did, not on which
+        // knobs the host asked for — otherwise merely enabling a lens would strip
+        // the IL from every member in the assembly.
+        string requested = Annotated(
+            nameof(AnnotatedTasteFixture.Compute),
+            new PrinterOptions { PreferConditionalExpressionReturn = true });
+
+        Assert.Equal(
+            IlLines(Annotated(nameof(AnnotatedTasteFixture.Compute), options: null)),
+            IlLines(requested));
+        Assert.DoesNotContain("Interleaved IL suppressed", requested);
+    }
+
+    [Fact]
+    public void ByteDivergentLens_WhenApplied_StillReportsTheLensDecision()
+    {
+        using var source = MetadataSource.Open(typeof(AnnotatedTasteFixture).Assembly.Location);
+        var projection = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+            source,
+            typeof(AnnotatedTasteFixture).FullName!,
+            nameof(AnnotatedTasteFixture.GuardBothVariable),
+            AnnotatedSource: true,
+            PrinterOptions: new PrinterOptions { PreferConditionalExpressionReturn = true }));
+
+        // Suppressing the IL must not swallow the evidence that explains it: the
+        // Applied Taste section reads these decisions off the same result.
+        var decision = Assert.Single(
+            Assert.IsType<DecompilerResult>(projection.AnnotatedSource).Decisions,
+            d => d.RuleId == "style-lens.prefer-conditional-return");
+        Assert.Equal(DecompilerDecisionCategories.StyleLens, decision.Category);
+    }
+}
+
+public sealed class AnnotatedTasteFixture
+{
+    int _count = 1;
+
+    public int Extra { get; set; }
+
+    // Instance field and property reads on the enclosing type at its own
+    // instantiation: the byte-preserving `this.` qualification knobs apply here.
+    public int Compute(string s)
+    {
+        int len = s.Length;
+        return _count + Extra + len;
+    }
+
+    // Both arms variable, so the default pipeline declines the short-circuit fold
+    // (no such fold is opcode-faithful) and leaves the guarded return flat — the
+    // shape the byte-divergent conditional-return lens rewrites.
+    public static bool GuardBothVariable(bool a, bool b, bool c)
+    {
+        if (a)
+        {
+            return b;
+        }
+
+        return c;
+    }
+}

--- a/src/ILInspector.Research.Tests/AnnotatedSourceTasteTests.cs
+++ b/src/ILInspector.Research.Tests/AnnotatedSourceTasteTests.cs
@@ -138,6 +138,40 @@ public class AnnotatedSourceTasteTests
             d => d.RuleId == "style-lens.prefer-conditional-return");
         Assert.Equal(DecompilerDecisionCategories.StyleLens, decision.Category);
     }
+
+    [Fact]
+    public void ByteDivergentLens_DoesNotLeakIntoTheStyleInvariantOverlays()
+    {
+        // Printing raises and rewrites the IR in place, so an annotated render
+        // that shares its function with the overlays would let a lens requested
+        // for this one view reshape renders that never asked for it: selecting a
+        // section would change a different section's output. Pin that the overlays
+        // render the member's own control flow no matter which sections are also
+        // requested in the same projection.
+        static ResearchViews.MemberProjectionResult Project(bool annotated)
+        {
+            using var source = MetadataSource.Open(typeof(AnnotatedTasteFixture).Assembly.Location);
+            return ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+                source,
+                typeof(AnnotatedTasteFixture).FullName!,
+                nameof(AnnotatedTasteFixture.GuardBothVariable),
+                AnnotatedSource: annotated,
+                CostOverlay: true,
+                SemanticsOverlay: true,
+                PrinterOptions: annotated ? new PrinterOptions { PreferConditionalExpressionReturn = true } : null));
+        }
+
+        var overlaysOnly = Project(annotated: false);
+        var withAnnotated = Project(annotated: true);
+
+        // The lens did fire, so this is a live test and not a vacuous one.
+        Assert.Contains("Interleaved IL suppressed", Assert.IsType<string>(withAnnotated.AnnotatedSource?.Output));
+
+        Assert.Equal(overlaysOnly.CostOverlay?.Body.Output, withAnnotated.CostOverlay?.Body.Output);
+        Assert.Equal(overlaysOnly.SemanticsOverlay?.Output, withAnnotated.SemanticsOverlay?.Output);
+        Assert.DoesNotContain("a ? b : c", Assert.IsType<string>(withAnnotated.CostOverlay?.Body.Output));
+        Assert.DoesNotContain("a ? b : c", Assert.IsType<string>(withAnnotated.SemanticsOverlay?.Output));
+    }
 }
 
 public sealed class AnnotatedTasteFixture

--- a/src/ILInspector.Research.Tests/AnnotatedSourceTasteTests.cs
+++ b/src/ILInspector.Research.Tests/AnnotatedSourceTasteTests.cs
@@ -38,12 +38,6 @@ public class AnnotatedSourceTasteTests
             .Select(line => line.Trim())
             .Where(line => line.StartsWith("// IL_", StringComparison.Ordinal))];
 
-    static string[] CSharpLines(string annotated) =>
-        [.. annotated
-            .Split('\n')
-            .Select(line => line.Trim())
-            .Where(line => !line.StartsWith("//", StringComparison.Ordinal))];
-
     [Fact]
     public void ByteReservingKnob_ChangesCSharpSpelling_AndLeavesInterleavedIlIdentical()
     {
@@ -80,26 +74,23 @@ public class AnnotatedSourceTasteTests
 
         // The lens shaped the render...
         Assert.Contains("return a ? b : c;", lensed);
-        // ...so the raw IL is gone, and the reader is told why and by which knob
-        // rather than being left with a view that silently lost half its content.
+        // ...so the raw IL is gone: anchoring it beneath a render that no longer
+        // reproduces these opcodes would assert a correspondence that does not hold.
         Assert.Empty(IlLines(lensed));
-        Assert.Contains("Interleaved IL suppressed", lensed);
-        Assert.Contains("style-lens.prefer-conditional-return", lensed);
-        Assert.Contains("Applied Taste", lensed);
     }
 
     [Fact]
-    public void ByteDivergentLens_WhenApplied_KeepsTheSuppressedRenderValidCSharp()
+    public void ByteDivergentLens_WhenApplied_ReturnsBodyWithoutExplanatoryProse()
     {
         string lensed = Annotated(
             nameof(AnnotatedTasteFixture.GuardBothVariable),
             new PrinterOptions { PreferConditionalExpressionReturn = true });
 
-        // The note is spelled as comments, so the body is still a C# block: no
-        // stray prose leaks into the code the section presents as source.
-        Assert.All(
-            CSharpLines(lensed).Where(line => line.Length > 0),
-            line => Assert.DoesNotContain("suppressed", line, StringComparison.OrdinalIgnoreCase));
+        // This layer returns source, not commentary about source: the applied lens
+        // travels as a typed decision so a host can render it as a light side
+        // comment on the signature it owns, and a host that wants none of it is
+        // not stuck with a paragraph baked into the body.
+        Assert.Equal("return a ? b : c;", lensed.Trim());
     }
 
     [Fact]
@@ -117,7 +108,6 @@ public class AnnotatedSourceTasteTests
         Assert.Equal(
             IlLines(Annotated(nameof(AnnotatedTasteFixture.Compute), options: null)),
             IlLines(requested));
-        Assert.DoesNotContain("Interleaved IL suppressed", requested);
     }
 
     [Fact]
@@ -165,7 +155,9 @@ public class AnnotatedSourceTasteTests
         var withAnnotated = Project(annotated: true);
 
         // The lens did fire, so this is a live test and not a vacuous one.
-        Assert.Contains("Interleaved IL suppressed", Assert.IsType<string>(withAnnotated.AnnotatedSource?.Output));
+        Assert.Contains(
+            "return a ? b : c;",
+            Assert.IsType<string>(withAnnotated.AnnotatedSource?.Output));
 
         Assert.Equal(overlaysOnly.CostOverlay?.Body.Output, withAnnotated.CostOverlay?.Body.Output);
         Assert.Equal(overlaysOnly.SemanticsOverlay?.Output, withAnnotated.SemanticsOverlay?.Output);

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -48,14 +48,16 @@ public static partial class ResearchViews
     {
         try
         {
-            var imported = (request.MethodToken is null
+            IrFunction? ImportFunction() => request.MethodToken is null
                 ? IrImporter.Import(
                     request.Source,
                     request.Type,
                     request.Method,
                     request.OverloadIndex,
                     request.PublicOnly)
-                : IrImporter.Import(request.Source, request.MethodToken.Value))
+                : IrImporter.Import(request.Source, request.MethodToken.Value);
+
+            var imported = ImportFunction()
                 ?? throw new InvalidOperationException($"{request.Type}::{request.Method} has no IL body");
 
             var assembly = ResolveAssemblyContext(imported);
@@ -69,12 +71,21 @@ public static partial class ResearchViews
             DecompilerResult? annotatedSource = null;
             if (request.AnnotatedSource)
             {
+                // Printing raises and rewrites the IR in place, so the annotated
+                // render cannot share this function with the overlay and fact-row
+                // projections: a byte-divergent style lens applies only to this
+                // view, but its rewrites would survive on the shared graph and
+                // silently reshape renders that are supposed to be style-invariant.
+                // Give the annotated render its own import so the isolation does
+                // not depend on projection order.
+                var annotatedFunction = ImportFunction()
+                    ?? throw new InvalidOperationException($"{request.Type}::{request.Method} has no IL body");
                 annotatedSource = WithTrace(
                     RunProjection(() => RenderMixedCore(
                         request.Source,
                         request.Type,
                         request.Method,
-                        imported,
+                        annotatedFunction,
                         facts,
                         request.AnnotatedStage,
                         request.OverloadIndex,

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -225,43 +225,22 @@ public static partial class ResearchViews
         // longer reproduces the member's original opcodes. Interleaving the raw IL
         // beneath it would assert a statement-to-opcode correspondence that does
         // not hold, which is the one claim this view exists to make. Drop the IL
-        // and say why rather than rendering a correspondence we cannot stand
-        // behind. The fact overlay stays: a fact is a property of the member, not
-        // a claim about which opcodes a printed statement reproduces.
-        var appliedLenses = csResult.Metadata.Decisions
-            .Where(decision => decision.Category == DecompilerDecisionCategories.StyleLens)
-            .Select(decision => decision.RuleId)
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(id => id, StringComparer.Ordinal)
-            .ToList();
-        if (appliedLenses.Count > 0)
-        {
-            var lensOnly = CorrelateMixedSource(imported, csText, statementLines, annotations, []);
-            return csResult with { Output = LensSuppressionNote(appliedLenses) + RenderMixedStream(lensOnly) };
-        }
-
-        var annotatedInstrLines = methodToken is null
-            ? IlProjection.RenderIlBodyLines(source, type, method, overloadIndex, publicOnly)
-            : IlProjection.RenderIlBodyLines(source, methodToken.Value);
+        // rather than rendering a correspondence we cannot stand behind. The
+        // applied lens stays on the result as a typed decision, so a host can say
+        // which knob shaped the render without this layer baking prose into the
+        // source it returns. The fact overlay stays too: a fact is a property of
+        // the member, not a claim about which opcodes a printed statement
+        // reproduces.
+        bool lensApplied = csResult.Metadata.Decisions
+            .Any(decision => decision.Category == DecompilerDecisionCategories.StyleLens);
+        var annotatedInstrLines = lensApplied
+            ? []
+            : methodToken is null
+                ? IlProjection.RenderIlBodyLines(source, type, method, overloadIndex, publicOnly)
+                : IlProjection.RenderIlBodyLines(source, methodToken.Value);
 
         var stream = CorrelateMixedSource(imported, csText, statementLines, annotations, annotatedInstrLines);
         return csResult with { Output = RenderMixedStream(stream) };
-    }
-
-    // The suppression note, spelled as C# comments so the annotated body stays a
-    // valid C# block in every render mode. It names the applied lens rule ids
-    // rather than restating their descriptions, and points at Applied Taste for
-    // the full account of what shaped the render.
-    static string LensSuppressionNote(IReadOnlyList<string> appliedLenses)
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine("// Interleaved IL suppressed: a byte-divergent style lens shaped this render.");
-        sb.AppendLine($"// Applied lens: {string.Join(", ", appliedLenses)}.");
-        sb.AppendLine("// The C# below is behavior-faithful but no longer reproduces this member's");
-        sb.AppendLine("// original opcodes, so the raw IL cannot be anchored to it. Run the member");
-        sb.AppendLine("// without the lens for the interleaved IL, or -S \"Applied Taste\" for the");
-        sb.AppendLine("// full list of style choices applied to this render.");
-        return sb.ToString();
     }
 
     // The correlation layer: fold the printed C# body, its statement-line map, the

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -34,7 +34,8 @@ public static partial class ResearchViews
         bool FactRows = false,
         AnnotationStage AnnotatedStage = AnnotationStage.Raised,
         ResearchFactRegistry? Registry = null,
-        int? MethodToken = null);
+        int? MethodToken = null,
+        PrinterOptions? PrinterOptions = null);
 
     public sealed record MemberProjectionResult(
         DecompilerResult? AnnotatedSource,
@@ -78,7 +79,8 @@ public static partial class ResearchViews
                         request.AnnotatedStage,
                         request.OverloadIndex,
                         request.PublicOnly,
-                        request.MethodToken),
+                        request.MethodToken,
+                        request.PrinterOptions),
                         emptyOutputIsFailure: false),
                     request.Source);
             }
@@ -197,15 +199,35 @@ public static partial class ResearchViews
         AnnotationStage stage,
         int overloadIndex,
         bool publicOnly,
-        int? methodToken = null)
+        int? methodToken = null,
+        PrinterOptions? printerOptions = null)
     {
 
         IrFunction? ImportMethodBody(MethodRef target) => IrImporter.Import(source, target);
         var csResult = stage == AnnotationStage.Lowered
-            ? CSharpPrinter.PrintLowered(imported, out var statementLines, importMethodBody: ImportMethodBody)
-            : CSharpPrinter.PrintRaised(imported, out statementLines, importMethodBody: ImportMethodBody, typesProvablyDisjoint: source.AreProvablyDisjoint);
+            ? CSharpPrinter.PrintLowered(imported, out var statementLines, importMethodBody: ImportMethodBody, options: printerOptions)
+            : CSharpPrinter.PrintRaised(imported, out statementLines, importMethodBody: ImportMethodBody, typesProvablyDisjoint: source.AreProvablyDisjoint, options: printerOptions);
         if (csResult.Output is not { } csText)
             return csResult;
+
+        // A byte-divergent style lens rewrote this render, so the printed C# no
+        // longer reproduces the member's original opcodes. Interleaving the raw IL
+        // beneath it would assert a statement-to-opcode correspondence that does
+        // not hold, which is the one claim this view exists to make. Drop the IL
+        // and say why rather than rendering a correspondence we cannot stand
+        // behind. The fact overlay stays: a fact is a property of the member, not
+        // a claim about which opcodes a printed statement reproduces.
+        var appliedLenses = csResult.Metadata.Decisions
+            .Where(decision => decision.Category == DecompilerDecisionCategories.StyleLens)
+            .Select(decision => decision.RuleId)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToList();
+        if (appliedLenses.Count > 0)
+        {
+            var lensOnly = CorrelateMixedSource(imported, csText, statementLines, annotations, []);
+            return csResult with { Output = LensSuppressionNote(appliedLenses) + RenderMixedStream(lensOnly) };
+        }
 
         var annotatedInstrLines = methodToken is null
             ? IlProjection.RenderIlBodyLines(source, type, method, overloadIndex, publicOnly)
@@ -213,6 +235,22 @@ public static partial class ResearchViews
 
         var stream = CorrelateMixedSource(imported, csText, statementLines, annotations, annotatedInstrLines);
         return csResult with { Output = RenderMixedStream(stream) };
+    }
+
+    // The suppression note, spelled as C# comments so the annotated body stays a
+    // valid C# block in every render mode. It names the applied lens rule ids
+    // rather than restating their descriptions, and points at Applied Taste for
+    // the full account of what shaped the render.
+    static string LensSuppressionNote(IReadOnlyList<string> appliedLenses)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// Interleaved IL suppressed: a byte-divergent style lens shaped this render.");
+        sb.AppendLine($"// Applied lens: {string.Join(", ", appliedLenses)}.");
+        sb.AppendLine("// The C# below is behavior-faithful but no longer reproduces this member's");
+        sb.AppendLine("// original opcodes, so the raw IL cannot be anchored to it. Run the member");
+        sb.AppendLine("// without the lens for the interleaved IL, or -S \"Applied Taste\" for the");
+        sb.AppendLine("// full list of style choices applied to this render.");
+        return sb.ToString();
     }
 
     // The correlation layer: fold the printed C# body, its statement-line map, the

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -228,9 +228,14 @@ public static partial class ResearchViews
         // rather than rendering a correspondence we cannot stand behind. The
         // applied lens stays on the result as a typed decision, so a host can say
         // which knob shaped the render without this layer baking prose into the
-        // source it returns. The fact overlay stays too: a fact is a property of
-        // the member, not a claim about which opcodes a printed statement
-        // reproduces.
+        // source it returns. That is the contract for suppression here: this layer
+        // returns source, and the StyleLens decisions on Metadata.Decisions are the
+        // whole signal for why the IL is absent, so a host that renders this Output
+        // without reading those decisions is responsible for the missing
+        // explanation. The CLI honors it by naming applied taste, including
+        // fidelity=byte-divergent, on the member signature. The fact overlay stays
+        // too: a fact is a property of the member, not a claim about which opcodes
+        // a printed statement reproduces.
         bool lensApplied = csResult.Metadata.Decisions
             .Any(decision => decision.Category == DecompilerDecisionCategories.StyleLens);
         var annotatedInstrLines = lensApplied

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -95,6 +95,125 @@ public class ApiOutputFormatterTests
         Assert.False(ApiAnalysisInspection.SameType(typeRef, apiType));
     }
 
+    // The taste side comment rides the signature line, so it has to survive every
+    // declaration suffix and body shape the formatter can emit (#3191).
+
+    [Fact]
+    public void FormatSourceWithDeclaration_TrailingComment_RidesTheSignatureLine()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var method = new ApiMember
+        {
+            Name = "Read",
+            Kind = "method",
+            SignatureModel = new ApiSignature { MemberName = "Read", ReturnType = "System.Int32" }
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            method,
+            methodGenericParameters: null,
+            DecompilerResult.Success("return this._count;"),
+            declarationTrailingComment: "taste.qualify-field-access(_count)");
+
+        var lines = source.ReplaceLineEndings("\n").Split('\n');
+        Assert.EndsWith("  // taste.qualify-field-access(_count)", lines[0]);
+        Assert.Equal("{", lines[1]);
+        // The body is untouched source: the comment never leaks into it.
+        Assert.Contains("    return this._count;", lines);
+    }
+
+    [Fact]
+    public void FormatSourceWithDeclaration_TrailingComment_FollowsTheConstructorChain()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var constructor = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            SignatureModel = new ApiSignature { MemberName = "#ctor" }
+        };
+        var result = DecompilerResult.Success("return;") with { ConstructorChain = "base(42)" };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            constructor,
+            methodGenericParameters: null,
+            result,
+            declarationTrailingComment: "taste.prefer-conditional-return(fidelity=byte-divergent)");
+
+        var first = source.ReplaceLineEndings("\n").Split('\n')[0];
+        Assert.EndsWith(
+            ": base(42)  // taste.prefer-conditional-return(fidelity=byte-divergent)",
+            first);
+    }
+
+    [Fact]
+    public void FormatSourceWithDeclaration_TrailingComment_FollowsAnExpressionBodyTerminator()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var method = new ApiMember
+        {
+            Name = "Read",
+            Kind = "method",
+            SignatureModel = new ApiSignature { MemberName = "Read", ReturnType = "System.Int32" }
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            method,
+            methodGenericParameters: null,
+            DecompilerResult.Success("return this._count;"),
+            preferExpressionBodied: true,
+            declarationTrailingComment: "taste.qualify-field-access(_count)");
+
+        // After the ';', never inside the expression.
+        Assert.EndsWith(";  // taste.qualify-field-access(_count)", source);
+    }
+
+    [Fact]
+    public void FormatSourceWithDeclaration_NoTrailingComment_IsUnchanged()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var method = new ApiMember
+        {
+            Name = "Read",
+            Kind = "method",
+            SignatureModel = new ApiSignature { MemberName = "Read", ReturnType = "System.Int32" }
+        };
+        var result = DecompilerResult.Success("return this._count;");
+
+        Assert.Equal(
+            ApiOutputFormatter.FormatSourceWithDeclaration(type, method, null, result),
+            ApiOutputFormatter.FormatSourceWithDeclaration(
+                type, method, null, result, declarationTrailingComment: null));
+    }
+
+    [Fact]
+    public void FormatSourceWithDeclaration_NoDeclaration_KeepsTheCommentAsOneLeadingLine()
+    {
+        // A member the formatter cannot spell a declaration for still gets the
+        // signal, on one line above the body rather than dropped on the floor.
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var method = new ApiMember
+        {
+            Name = "Read",
+            Kind = "method",
+            SignatureModel = new ApiSignature { MemberName = "Read" }
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            method,
+            methodGenericParameters: null,
+            DecompilerResult.Success("return this._count;"),
+            declarationTrailingComment: "taste.qualify-field-access(_count)");
+
+        var lines = source.ReplaceLineEndings("\n").Split('\n');
+        Assert.Equal("// taste.qualify-field-access(_count)", lines[0]);
+        Assert.Equal("return this._count;", lines[1]);
+    }
+
     [Fact]
     public void FormatSourceWithDeclaration_UsesTypedConstructorChain()
     {

--- a/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
+++ b/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
@@ -166,6 +166,7 @@ public class AppliedTasteSectionTests
     [Theory]
     [InlineData("\u001b[31m", "\\u001B[31m")]   // ANSI escape: recolors or rewrites the terminal
     [InlineData("\u202E", "\\u202E")]       // bidi override: reorders what follows it
+    [InlineData("\u061C", "\\u061C")]       // Arabic letter mark: Bidi_Control, easy to overlook
     [InlineData("\u2066", "\\u2066")]       // isolate: same class
     [InlineData("\u000B", "\\u000B")]       // vertical tab: not a C# terminator, still moves the cursor
     [InlineData("\u0000", "\\u0000")]

--- a/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
+++ b/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
@@ -132,6 +132,37 @@ public class AppliedTasteSectionTests
         Assert.Null(ApiOutputFormatter.BuildTasteAnnotation([frameworkImport]));
     }
 
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r")]
+    [InlineData("\r\n")]
+    [InlineData("\u0085")]
+    [InlineData("\u2028")]
+    [InlineData("\u2029")]
+    public void TasteAnnotation_SubjectCarryingALineTerminator_CannotEscapeTheComment(string terminator)
+    {
+        // Subjects are metadata names, and metadata is untrusted. A name carrying
+        // any terminator C# recognizes would close the // comment and leave the
+        // remainder of the annotation as active code in source a reader may paste
+        // or compile, so the annotation must always stay on one line.
+        var hostile = $"field{terminator}    public int Injected() => 42; //";
+        var decision = new DecompilerDecision(
+            "qualify-field-access",
+            DecompilerDecisionCategories.Taste,
+            hostile,
+            "Qualified instance member with 'this.'.");
+
+        var annotation = ApiOutputFormatter.BuildTasteAnnotation([decision]);
+
+        Assert.NotNull(annotation);
+        Assert.DoesNotContain('\n', annotation);
+        Assert.DoesNotContain('\r', annotation);
+        Assert.DoesNotContain('\u0085', annotation);
+        Assert.DoesNotContain('\u2028', annotation);
+        Assert.DoesNotContain('\u2029', annotation);
+        Assert.Contains("Injected", annotation, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void TasteAnnotation_NoDecisions_YieldsNothing()
         => Assert.Null(ApiOutputFormatter.BuildTasteAnnotation([]));

--- a/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
+++ b/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
@@ -84,4 +84,71 @@ public class AppliedTasteSectionTests
     [Fact]
     public void BuildRows_NoDecisions_YieldsEmpty()
         => Assert.Empty(ApiOutputFormatter.BuildAppliedTasteRows([]));
+
+    // The Annotated view's inline taste annotation: one trailing side comment on
+    // the signature, in the same shape the fact overlay uses for analysis, so a
+    // reader scans style and analysis the same way (#3191).
+
+    [Fact]
+    public void TasteAnnotation_BytePreservingDecision_NamesTheRuleAndSubject()
+    {
+        var decision = new DecompilerDecision(
+            "qualify-field-access",
+            DecompilerDecisionCategories.Taste,
+            "_count",
+            "Qualified instance member '_count' with 'this.'.");
+
+        Assert.Equal(
+            "taste.qualify-field-access(_count)",
+            ApiOutputFormatter.BuildTasteAnnotation([decision]));
+    }
+
+    [Fact]
+    public void TasteAnnotation_StyleLens_ReportsFidelityInsteadOfSubject()
+    {
+        // A lens's subject is the enclosing method, already spelled on the line
+        // this comment rides. Its fidelity is the fact the reader does not
+        // otherwise have -- and the only signal explaining the absent IL.
+        var decision = new DecompilerDecision(
+            "style-lens.prefer-conditional-return",
+            DecompilerDecisionCategories.StyleLens,
+            "Allow",
+            "Rewrote a guarded boolean return as a conditional expression.");
+
+        Assert.Equal(
+            "taste.prefer-conditional-return(fidelity=byte-divergent)",
+            ApiOutputFormatter.BuildTasteAnnotation([decision]));
+    }
+
+    [Fact]
+    public void TasteAnnotation_ExcludesAlwaysOnFrameworkImport()
+    {
+        var frameworkImport = new DecompilerDecision(
+            "type-name.framework-imported",
+            DecompilerDecisionCategories.Taste,
+            "MakeList",
+            "Imported List<T>.");
+
+        Assert.Null(ApiOutputFormatter.BuildTasteAnnotation([frameworkImport]));
+    }
+
+    [Fact]
+    public void TasteAnnotation_NoDecisions_YieldsNothing()
+        => Assert.Null(ApiOutputFormatter.BuildTasteAnnotation([]));
+
+    [Fact]
+    public void TasteAnnotation_RepeatedDecisionsOnOneKnob_CollapseToOnePart()
+    {
+        // A knob that fires on several members of the same name records a decision
+        // each time; the signature comment is a summary, not a tally.
+        var decision = new DecompilerDecision(
+            "qualify-field-access",
+            DecompilerDecisionCategories.Taste,
+            "_count",
+            "Qualified instance member '_count' with 'this.'.");
+
+        Assert.Equal(
+            "taste.qualify-field-access(_count)",
+            ApiOutputFormatter.BuildTasteAnnotation([decision, decision]));
+    }
 }

--- a/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
+++ b/src/dotnet-inspect.Tests/AppliedTasteSectionTests.cs
@@ -163,6 +163,47 @@ public class AppliedTasteSectionTests
         Assert.Contains("Injected", annotation, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("\u001b[31m", "\\u001B[31m")]   // ANSI escape: recolors or rewrites the terminal
+    [InlineData("\u202E", "\\u202E")]       // bidi override: reorders what follows it
+    [InlineData("\u2066", "\\u2066")]       // isolate: same class
+    [InlineData("\u000B", "\\u000B")]       // vertical tab: not a C# terminator, still moves the cursor
+    [InlineData("\u0000", "\\u0000")]
+    public void TasteAnnotation_SubjectCarryingARenderingHazard_IsEscapedButStillLegible(
+        string hazard,
+        string expectedEscape)
+    {
+        // These do not break C# syntax, so folding them to a space would be wrong —
+        // they are part of the real metadata name. Escape them visibly instead, so
+        // a name cannot silently misrepresent itself or its neighbors in a terminal
+        // while the reader can still tell which name it was.
+        var decision = new DecompilerDecision(
+            "qualify-field-access",
+            DecompilerDecisionCategories.Taste,
+            $"x{hazard}y",
+            "Qualified instance member with 'this.'.");
+
+        var annotation = ApiOutputFormatter.BuildTasteAnnotation([decision]);
+
+        Assert.Equal($"taste.qualify-field-access(x{expectedEscape}y)", annotation);
+    }
+
+    [Fact]
+    public void TasteAnnotation_OrdinarySubject_IsLeftExactlyAsItIs()
+    {
+        // The escaping pass must be inert for every well-formed name, so normal
+        // output is byte-identical and the hazard path stays exceptional.
+        var decision = new DecompilerDecision(
+            "qualify-method-access",
+            DecompilerDecisionCategories.Taste,
+            "Compute<T>",
+            "Qualified instance member with 'this.'.");
+
+        Assert.Equal(
+            "taste.qualify-method-access(Compute<T>)",
+            ApiOutputFormatter.BuildTasteAnnotation([decision]));
+    }
+
     [Fact]
     public void TasteAnnotation_NoDecisions_YieldsNothing()
         => Assert.Null(ApiOutputFormatter.BuildTasteAnnotation([]));

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -31,6 +31,38 @@ public class CommandLineTests
         Assert.Empty(result.Errors);
     }
 
+    // --taste is the one-invocation form of the config's full-taste aggregate
+    // (#3191). It is an api-surface gesture: only the commands that render member
+    // source consume RenderOptions.
+
+    [Theory]
+    [InlineData("member")]
+    [InlineData("type")]
+    public void ApiCommands_AcceptTasteGesture(string command)
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse([command, "System.Math", "--taste"]);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void NonApiCommand_DoesNotDeclareTasteGesture()
+    {
+        // --taste only means something where RenderOptions is consumed, so it must
+        // not appear on commands that never render member source.
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        Assert.True(DeclaresTaste(root, "member"));
+        Assert.True(DeclaresTaste(root, "type"));
+        Assert.False(DeclaresTaste(root, "package"));
+
+        static bool DeclaresTaste(Command root, string name) =>
+            root.Subcommands
+                .Single(c => c.Name == name)
+                .Options
+                .Any(o => o.Name == "--taste");
+    }
+
     [Fact]
     public void RootCommand_WithInvalidVerbosity_ReportsParseError()
     {

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -566,10 +566,42 @@ public class RenderStyleConfigTests
         Assert.DoesNotContain("this.Pinged", code);
     }
 
+    // Annotated Source renders the same member as Decompiled Source, through a
+    // different printer path (the statement-line-map overload the interleaved-IL
+    // overlay anchors onto). Both must consume the resolved config: a member that
+    // spells `this._count` in one section and `_count` in the other is one tool
+    // disagreeing with itself (#3191).
+
+    [Fact]
+    public void Collect_AnnotatedSource_AppliesTheSameTasteAsDecompiledSource()
+    {
+        var (decompiled, annotated) = RenderSpecimenBothViews(
+            nameof(ThisQualificationConfigSpecimen.Compute),
+            PrinterOptions.Default with { QualifyFieldAccess = true, QualifyPropertyAccess = true });
+
+        Assert.Contains("this._count", decompiled);
+        Assert.Contains("this.Extra", decompiled);
+        Assert.Contains("this._count", annotated);
+        Assert.Contains("this.Extra", annotated);
+
+        // The knob is byte-preserving, so the annotated view keeps its IL.
+        Assert.Matches(@"// IL_[0-9A-Fa-f]{4}: ", annotated);
+    }
+
+    [Fact]
+    public void Collect_AnnotatedSource_WithoutRenderOptions_RendersBareThisMemberAccess()
+    {
+        var (_, annotated) = RenderSpecimenBothViews(
+            nameof(ThisQualificationConfigSpecimen.Compute), renderOptions: null);
+
+        Assert.Contains("_count", annotated);
+        Assert.DoesNotContain("this._count", annotated);
+        Assert.Matches(@"// IL_[0-9A-Fa-f]{4}: ", annotated);
+    }
+
     // Whole-type decompilation (the `type -S "Decompiled Source"` path) routes
     // through MemberBodyProducer.Project rather than Collect, so it needs the
     // resolved options threaded separately.
-
     [Fact]
     public void WholeType_WithoutRenderOptions_RendersBareThisMemberAccess()
     {
@@ -833,6 +865,36 @@ public class RenderStyleConfigTests
         var decompiled = code.DecompiledResult;
         Assert.NotNull(decompiled?.Output);
         return (decompiled!.Output, decompiled);
+    }
+
+    private static (string Decompiled, string Annotated) RenderSpecimenBothViews(
+        string memberName, PrinterOptions? renderOptions)
+    {
+        string assemblyPath = typeof(ThisQualificationConfigSpecimen).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(ThisQualificationConfigSpecimen).FullName);
+        var methods = type.Members.Where(m => m.Name == memberName).ToList();
+
+        var request = new MemberCodeProvider.Request(
+            DecompiledSource: true,
+            AnnotatedSource: true,
+            CostOverlay: false,
+            SemanticsOverlay: false,
+            IL: false,
+            Attributes: false,
+            Calls: false,
+            Callers: false,
+            CallGraph: false,
+            UnsafeOperations: false);
+
+        var results = MemberCodeProvider.Collect(
+            type, methods, assemblyPath, overloadIndex: 0, request, renderOptions: renderOptions);
+
+        var (_, code) = Assert.Single(results);
+        Assert.NotNull(code.DecompiledResult?.Output);
+        Assert.NotNull(code.AnnotatedResult?.Output);
+        return (code.DecompiledResult!.Output!, code.AnnotatedResult!.Output!);
     }
 
     private static string RenderSpecimenWholeType(PrinterOptions? renderOptions)

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -190,6 +190,42 @@ public class RenderStyleConfigTests
     }
 
     [Fact]
+    public void TasteGesture_WinsOverAConfigThatNarrowsTheEndorsedSet()
+    {
+        // --taste is an explicit per-invocation request, so it must not be silently
+        // narrowed by a checked-in config: for the knobs the aggregate covers, the
+        // gesture wins. This is the precedence docs/decompiler-taste.md states.
+        var config = RenderStyleConfig.Parse(
+            """
+            dotnet_inspect_style_full_taste = true
+            dotnet_style_qualification_for_field = false
+            """,
+            origin: "cfg");
+        Assert.False(config.Options.QualifyFieldAccess);
+
+        var gestured = StyleOptionCatalog.ApplyFullTaste(config.Options);
+
+        Assert.True(gestured.QualifyFieldAccess);
+        Assert.True(gestured.PreferConditionalExpressionReturn);
+    }
+
+    [Fact]
+    public void TasteGesture_LeavesKnobsOutsideTheEndorsedSetAlone()
+    {
+        // The aggregate is the oracle-endorsed subset only, so a config selection on
+        // a non-endorsed knob survives the gesture rather than being reset.
+        var config = RenderStyleConfig.Parse(
+            "dotnet_inspect_style_prefer_branchless_boolean = true",
+            origin: "cfg");
+        Assert.True(config.Options.PreferBranchlessBoolean);
+
+        var gestured = StyleOptionCatalog.ApplyFullTaste(config.Options);
+
+        Assert.True(gestured.PreferBranchlessBoolean);
+        Assert.True(gestured.QualifyFieldAccess);
+    }
+
+    [Fact]
     public void Parse_FullTasteFalse_IsRecognizedAndLeavesSubsetOff()
     {
         var result = RenderStyleConfig.Parse("dotnet_inspect_style_full_taste = false", origin: null);

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -103,6 +103,7 @@ public static class ApiCommandDefinitions
         typeCommand.Options.Add(opts.Markdown);
         typeCommand.Options.Add(opts.PlainText);
         typeCommand.Options.Add(opts.Bare);
+        typeCommand.Options.Add(opts.Taste);
         opts.AddOutputOptionsTo(typeCommand);
         opts.AddNuGetOptionsTo(typeCommand);
 
@@ -242,6 +243,7 @@ public static class ApiCommandDefinitions
         memberCommand.Options.Add(opts.Markdown);
         memberCommand.Options.Add(opts.PlainText);
         memberCommand.Options.Add(opts.Bare);
+        memberCommand.Options.Add(opts.Taste);
         opts.AddOutputOptionsTo(memberCommand);
         opts.AddNuGetOptionsTo(memberCommand);
 

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -280,6 +280,7 @@ public static class MemberOptionsParser
             FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
             PlainText = parseResult.GetValue(opts.PlainText),
             Bare = parseResult.GetValue(opts.Bare),
+            RequestAllTaste = parseResult.GetValue(opts.Taste),
             Print = parseResult.GetValue(opts.Print),
             PrintAll = parseResult.GetValue(opts.PrintAll),
             PrintRow = opts.ParsePrintRow(parseResult),

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -180,6 +180,7 @@ public static class TypeOptionsParser
             MarkdownExplicitlySet = parseResult.GetResult(opts.Markdown) is { Implicit: false },
             PlainText = parseResult.GetValue(opts.PlainText),
             Bare = parseResult.GetValue(opts.Bare),
+            RequestAllTaste = parseResult.GetValue(opts.Taste),
             Print = parseResult.GetValue(opts.Print),
             PrintAll = parseResult.GetValue(opts.PrintAll),
             PrintRow = opts.ParsePrintRow(parseResult),

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -208,9 +208,9 @@ public class ApiCommand
         // styled output. No latch is attached for a discovery request.
         var renderStyle = RenderStyleConfig.Resolve(Environment.CurrentDirectory);
         // --taste is the one-invocation form of the config's full-taste aggregate.
-        // It folds on top of the resolved config rather than replacing it, so a
-        // config that already refines a knob keeps that refinement, and a run with
-        // no config file gets the endorsed set on shipped defaults.
+        // It applies after the file resolves and wins for the knobs the aggregate
+        // covers, so an explicit gesture is not silently narrowed by a checked-in
+        // config; knobs outside the endorsed set keep whatever the file selected.
         var renderOptions = options.RequestAllTaste
             ? ILInspector.Decompiler.Pipeline.StyleOptionCatalog.ApplyFullTaste(renderStyle.Options)
             : renderStyle.Options;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -207,9 +207,16 @@ public class ApiCommand
         // so its internal source render must not be mistaken for user-visible
         // styled output. No latch is attached for a discovery request.
         var renderStyle = RenderStyleConfig.Resolve(Environment.CurrentDirectory);
+        // --taste is the one-invocation form of the config's full-taste aggregate.
+        // It folds on top of the resolved config rather than replacing it, so a
+        // config that already refines a knob keeps that refinement, and a run with
+        // no config file gets the endorsed set on shipped defaults.
+        var renderOptions = options.RequestAllTaste
+            ? ILInspector.Decompiler.Pipeline.StyleOptionCatalog.ApplyFullTaste(renderStyle.Options)
+            : renderStyle.Options;
         options = options with
         {
-            RenderOptions = renderStyle.Options,
+            RenderOptions = renderOptions,
             RenderConfigWarnings = renderStyle.Warnings.Count > 0 && options.Discover is null
                 ? new RenderConfigWarningSink(renderStyle.Warnings)
                 : null,

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -214,7 +214,13 @@ internal static class MemberCodeProvider
                         CostOverlay: request.CostOverlay,
                         SemanticsOverlay: request.SemanticsOverlay,
                         FactRows: request.Facts,
-                        MethodToken: methodToken));
+                        MethodToken: methodToken,
+                        // Annotated Source spells the same member as Decompiled
+                        // Source, so it renders with the same resolved style options
+                        // -- otherwise the two views of one member disagree. The
+                        // other projections here (cost/semantics overlays, fact rows)
+                        // are style-invariant evidence and keep the shipped defaults.
+                        PrinterOptions: request.AnnotatedSource ? renderOptions : null));
             }
 
             // Annotated source: raised C# with hidden-fact comments and the
@@ -223,6 +229,12 @@ internal static class MemberCodeProvider
                 && researchProjection?.AnnotatedSource is { } annotated
                     ? TrimOutput(annotated)
                     : null;
+
+            // Annotated Source now renders with the resolved style options too, so an
+            // Annotated-Source-only run consumes the config and must surface its
+            // warnings on the same latch rather than swallowing them.
+            if (request.AnnotatedSource && annotatedResult?.Output is not null)
+                styledProjectionProduced = true;
 
             Decompiler.DecompilerResult? costOverlayResult = null;
             IReadOnlyList<string>? costOverlayHeaderComments = null;

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -48,6 +48,16 @@ public partial record ApiOptions
     public PrinterOptions? RenderOptions { get; init; }
 
     /// <summary>
+    /// The <c>--taste</c> gesture: request the whole oracle-endorsed style set for
+    /// this run, equivalent to <c>dotnet_inspect_style_full_taste = true</c> in
+    /// <c>.dotnet-inspectconfig</c> but scoped to one invocation. Applied on top of
+    /// the resolved config, so a per-knob line in a config file still refines it.
+    /// Includes byte-divergent lenses, so the Annotated view drops its interleaved
+    /// IL for any member a lens actually rewrites.
+    /// </summary>
+    public bool RequestAllTaste { get; init; }
+
+    /// <summary>
     /// Pending <c>.dotnet-inspectconfig</c> parse/read warnings, emitted to stderr
     /// exactly once at the point a decompiled-source render consumes
     /// <see cref="RenderOptions"/> (see

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -50,10 +50,12 @@ public partial record ApiOptions
     /// <summary>
     /// The <c>--taste</c> gesture: request the whole oracle-endorsed style set for
     /// this run, equivalent to <c>dotnet_inspect_style_full_taste = true</c> in
-    /// <c>.dotnet-inspectconfig</c> but scoped to one invocation. Applied on top of
-    /// the resolved config, so a per-knob line in a config file still refines it.
-    /// Includes byte-divergent lenses, so the Annotated view drops its interleaved
-    /// IL for any member a lens actually rewrites.
+    /// <c>.dotnet-inspectconfig</c> but scoped to one invocation. Applied after the
+    /// config resolves and wins for the knobs the aggregate covers, so an explicit
+    /// gesture is not silently narrowed by a checked-in config; knobs outside the
+    /// oracle-endorsed set keep whatever the file selected. Includes byte-divergent
+    /// lenses, so the Annotated view drops its interleaved IL for any member a lens
+    /// actually rewrites.
     /// </summary>
     public bool RequestAllTaste { get; init; }
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -6,6 +6,7 @@ using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 using System.Collections.Immutable;
 using System.Text;
+using System.Globalization;
 using DotnetInspector.Options;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
@@ -1670,12 +1671,51 @@ public static class ApiOutputFormatter
         if (parts.Count == 0)
             return null;
 
-        // A subject is a metadata name, and metadata strings are untrusted: a name
-        // carrying any C# line terminator would end the // comment and leave the
-        // rest of the annotation as active code in output a reader may compile or
-        // paste. ReplaceLineEndings folds every terminator C# recognizes (CR, LF,
-        // CRLF, FF, NEL, LS, PS), so the annotation cannot leave its own line.
-        return string.Join("; ", parts).ReplaceLineEndings(" ");
+        // A subject is a metadata name, and metadata names are untrusted: the CLR
+        // does not require them to be spellable, printable, or even single-line.
+        return NeutralizeForSideComment(string.Join("; ", parts));
+    }
+
+    // Makes an untrusted metadata string safe to carry in a trailing // comment
+    // without losing which name it was.
+    //
+    // Two separate hazards, so two separate treatments. A C# line terminator ends
+    // the comment, which would leave the rest of the annotation as active code in
+    // a block a reader may paste or compile; those fold to a space so the comment
+    // cannot leave its line. ReplaceLineEndings covers exactly the terminators C#
+    // recognizes (CR, LF, CRLF, FF, NEL, LS, PS). Everything else here is a
+    // rendering hazard rather than a syntax one — ANSI escapes recolor or rewrite
+    // the terminal, and bidi overrides reorder what follows them, so a name can
+    // misrepresent itself or its neighbors. Those become visible \uXXXX escapes,
+    // which keeps the identity legible instead of dropping characters that are
+    // part of the real name.
+    private static string NeutralizeForSideComment(string value)
+    {
+        var folded = value.ReplaceLineEndings(" ");
+        if (!folded.Any(IsRenderingHazard))
+            return folded;
+
+        var builder = new StringBuilder(folded.Length);
+        foreach (var ch in folded)
+        {
+            if (IsRenderingHazard(ch))
+                builder.Append(CultureInfo.InvariantCulture, $"\\u{(int)ch:X4}");
+            else
+                builder.Append(ch);
+        }
+
+        return builder.ToString();
+
+        // Tab is deliberately allowed: it is legal in a comment and renders as
+        // space. Vertical tab is not a C# line terminator, so ReplaceLineEndings
+        // leaves it, but it does move the cursor down a line in a terminal — it is
+        // caught here as the C0 control it is.
+        static bool IsRenderingHazard(char ch) =>
+            ch != '\t'
+            && (char.IsControl(ch)
+                || ch is '\u200E' or '\u200F'
+                    or >= '\u202A' and <= '\u202E'
+                    or >= '\u2066' and <= '\u2069');
     }
 
     static string TrimLensPrefix(string ruleId)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1667,7 +1667,15 @@ public static class ApiOutputFormatter
                 : $"taste.{d.RuleId}({d.Subject})")
             .Distinct(StringComparer.Ordinal)
             .ToList();
-        return parts.Count == 0 ? null : string.Join("; ", parts);
+        if (parts.Count == 0)
+            return null;
+
+        // A subject is a metadata name, and metadata strings are untrusted: a name
+        // carrying any C# line terminator would end the // comment and leave the
+        // rest of the annotation as active code in output a reader may compile or
+        // paste. ReplaceLineEndings folds every terminator C# recognizes (CR, LF,
+        // CRLF, FF, NEL, LS, PS), so the annotation cannot leave its own line.
+        return string.Join("; ", parts).ReplaceLineEndings(" ");
     }
 
     static string TrimLensPrefix(string ruleId)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1711,11 +1711,17 @@ public static class ApiOutputFormatter
         // leaves it, but it does move the cursor down a line in a terminal — it is
         // caught here as the C0 control it is.
         static bool IsRenderingHazard(char ch) =>
-            ch != '\t'
-            && (char.IsControl(ch)
-                || ch is '\u200E' or '\u200F'
-                    or >= '\u202A' and <= '\u202E'
-                    or >= '\u2066' and <= '\u2069');
+            ch != '\t' && (char.IsControl(ch) || IsBidiControl(ch));
+
+        // Exactly Unicode's Bidi_Control set: ALM, LRM/RLM, the LRE/RLE/PDF/LRO/RLO
+        // embeddings and overrides, and the LRI/RLI/FSI/PDI isolates. Deliberately
+        // narrower than the Cf category — a zero-width joiner or a BOM does not
+        // reorder its neighbors, and legitimate identifiers may contain format
+        // characters, so escaping all of Cf would corrupt ordinary names.
+        static bool IsBidiControl(char ch) =>
+            ch is '\u061C' or '\u200E' or '\u200F'
+                or >= '\u202A' and <= '\u202E'
+                or >= '\u2066' and <= '\u2069';
     }
 
     static string TrimLensPrefix(string ruleId)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1555,7 +1555,8 @@ public static class ApiOutputFormatter
                 code.MethodGenericParameters,
                 annotatedResult,
                 requiresAsyncBodyModifier: code.RequiresAsyncBodyModifier,
-                includeCustomAttributes: true);
+                includeCustomAttributes: true,
+                declarationTrailingComment: BuildTasteAnnotation(annotatedResult.Decisions));
             hasCode = true;
         }
 
@@ -1641,6 +1642,38 @@ public static class ApiOutputFormatter
                     failed.Error.Reason)
             ],
         };
+
+    // The inline taste annotation for the Annotated view: one trailing side
+    // comment on the member's signature, in the same shape the fact overlay uses
+    // for analysis ("// alloc.new(object; path=branch)"), so a reader scans style
+    // and analysis the same way. Anchored to the signature rather than to a
+    // statement because a style decision carries a subject but no IL offset; the
+    // Applied Taste section remains the full account.
+    //
+    // Nothing is annotated by default: no style decision is recorded unless a
+    // knob was requested, so this comment appears exactly when the reader asked
+    // for taste. A byte-divergent lens reports its fidelity instead of its
+    // subject (the subject is the enclosing method, already on this line) — that
+    // is also the only signal explaining why the interleaved IL is absent.
+    internal static string? BuildTasteAnnotation(
+        IReadOnlyList<Decompiler.DecompilerDecision> decisions)
+    {
+        var parts = decisions
+            // Same exclusion as the Applied Taste rows: the framework-import
+            // rewrite is always-on, not a configurable taste choice.
+            .Where(static d => d.RuleId != "type-name.framework-imported")
+            .Select(static d => d.Category == Decompiler.DecompilerDecisionCategories.StyleLens
+                ? $"taste.{TrimLensPrefix(d.RuleId)}(fidelity=byte-divergent)"
+                : $"taste.{d.RuleId}({d.Subject})")
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        return parts.Count == 0 ? null : string.Join("; ", parts);
+    }
+
+    static string TrimLensPrefix(string ruleId)
+        => ruleId.StartsWith("style-lens.", StringComparison.Ordinal)
+            ? ruleId["style-lens.".Length..]
+            : ruleId;
 
     internal static List<AppliedTasteRow> BuildAppliedTasteRows(
         IReadOnlyList<Decompiler.DecompilerDecision> decisions)
@@ -2274,7 +2307,8 @@ public static class ApiOutputFormatter
         bool preferExpressionBodied = false,
         IReadOnlyList<string>? leadingBodyComments = null,
         bool requiresAsyncBodyModifier = false,
-        bool includeCustomAttributes = false)
+        bool includeCustomAttributes = false,
+        string? declarationTrailingComment = null)
     {
         if (!result.Succeeded)
             return new CodeSection("csharp", DiagnosticComment(result));
@@ -2291,7 +2325,8 @@ public static class ApiOutputFormatter
                     preferExpressionBodied,
                     leadingBodyComments,
                     requiresAsyncBodyModifier,
-                    includeCustomAttributes));
+                    includeCustomAttributes,
+                    declarationTrailingComment));
         }
         catch (Exception ex)
         {
@@ -2309,7 +2344,8 @@ public static class ApiOutputFormatter
         bool preferExpressionBodied = false,
         IReadOnlyList<string>? leadingBodyComments = null,
         bool requiresAsyncBodyModifier = false,
-        bool includeCustomAttributes = false)
+        bool includeCustomAttributes = false,
+        string? declarationTrailingComment = null)
     {
         var lowered = result.Output
             ?? throw new ArgumentException("A successful decompiler result is required.", nameof(result));
@@ -2337,12 +2373,27 @@ public static class ApiOutputFormatter
         }
         var body = lowered.TrimEnd();
 
+        // The trailing side comment rides the signature line, so it has to be
+        // appended after every declaration suffix (the constructor chain above)
+        // and after the terminating ';' of an expression-bodied render, never
+        // inside the expression. A member with no declaration to hang it on
+        // (a bare body projection) keeps the signal as a single leading line
+        // rather than dropping it.
+        string Annotate(string line)
+            => declarationTrailingComment is { Length: > 0 } comment
+                ? $"{line}  // {comment}"
+                : line;
+
         if (string.IsNullOrWhiteSpace(declaration))
-            return body;
+        {
+            return declarationTrailingComment is { Length: > 0 } bareComment
+                ? $"// {bareComment}{Environment.NewLine}{body}"
+                : body;
+        }
 
         bool hasLeadingComments = leadingBodyComments is { Count: > 0 };
         if (!hasLeadingComments && preferExpressionBodied && CSharpExpressionBody.FromSingleStatement(body) is { } expressionBody)
-            return $"{declaration} => {expressionBody};";
+            return Annotate($"{declaration} => {expressionBody};");
 
         // A multi-line single-statement expression body renders expression-bodied
         // too (a raised switch return, issue #3088; a wrapped fluent chain in
@@ -2364,7 +2415,7 @@ public static class ApiOutputFormatter
                 if (i == multilineExpression.Count - 1)
                     expression.Append(';');
             }
-            return expression.ToString();
+            return Annotate(expression.ToString());
         }
 
         var formattedBodyLines = body.ReplaceLineEndings("\n").Split('\n');
@@ -2375,7 +2426,7 @@ public static class ApiOutputFormatter
             Environment.NewLine,
             lines.Select(line => line.Length == 0 ? "" : $"    {line}"));
 
-        return $"{declaration}{Environment.NewLine}{{{Environment.NewLine}{indentedBody}{Environment.NewLine}}}";
+        return $"{Annotate(declaration)}{Environment.NewLine}{{{Environment.NewLine}{indentedBody}{Environment.NewLine}}}";
     }
 
     private static string FormatMemberDeclaration(

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -21,6 +21,7 @@ public class SharedOptions
     public Option<bool> RawUrls { get; } = new("--raw") { Description = "Emit GitHub URLs as raw/fetchable URLs (default; URL-shape modifier, not an output-shape modifier)" };
     public Option<bool> BrowsableUrls { get; } = new("--blob") { Description = "Emit GitHub URLs as browser-friendly /blob/ URLs (URL-shape modifier, not an output-shape modifier)" };
     public Option<bool> Mermaid { get; } = new("--mermaid") { Description = "Output as mermaid diagram (standalone or with --markdown for embedded)" };
+    public Option<bool> Taste { get; } = new("--taste") { Description = "Render source with the full oracle-endorsed style set (includes byte-divergent lenses); Annotated Source names the applied knobs on the signature" };
     public Option<bool> Table { get; } = new("--table") { Description = "Output as a pretty table (space-padded columns)" };
     public Option<bool> Tsv { get; } = new("--tsv") { Description = "Output as normalized tab-separated values" };
     public Option<bool> Jsonl { get; } = new("--jsonl") { Description = "Output as JSON Lines (one object per row)" };


### PR DESCRIPTION
Closes #3191.

## What this does

`-S "Annotated Source"` renders decompiled C# with raw IL interleaved beneath each statement — a claim of statement-to-opcode correspondence. Taste knobs broke that view in two ways, and this PR fixes both.

**1. Applied taste was invisible.** The view rendered `this._count` with no indication the `this.` was a configured spelling rather than the compiler's. The only account lived in a separate `Applied Taste` table. Taste now rides the member signature as a single trailing side comment, in the same shape the fact overlay already uses for analysis, so a reader scans style and analysis the same way:

```csharp
public object? Pick(bool useName, string suffix)  // taste.qualify-property-access(Name); taste.qualify-field-access(_count)
{
    if (useName)
        // IL_0000: ldarg.1                        // arg: useName; stack: [bool]
        // IL_0001: brfalse.s    IL_0009           // stack: []
    {
        return new object();  // alloc.new(object; alloc=System.Object; path=branch; escape=escapes-return; ...)
    }
    return string.Concat(this.Name, suffix, this._count.ToString());
        // IL_0009: ldarg.0                        // arg: this; stack: [Cache]
        // ...
}
```

**2. A byte-divergent lens contradicted the view's premise.** `StyleOptionTier.Lens` rewrites shapes — a guarded boolean return becomes a ternary — so the printed source no longer reproduces the member's opcodes. Interleaving IL beneath it would assert a correspondence that does not hold. The Annotated view now drops the IL for any member a lens actually rewrote, and the annotation reports why:

```csharp
public bool Allow(bool trusted, bool cached)  // taste.qualify-property-access(Name); taste.qualify-field-access(_count); taste.prefer-conditional-return(fidelity=byte-divergent)
{
    return trusted ? cached : (this.Name.Length > this._count);
}
```

Suppression keys on what the render *did*, not what the host *asked for*: a lens that is enabled but finds no shape to rewrite is byte-faithful for that member, so its IL stays.

**3. `--taste`** on `member` and `type` is a one-invocation form of the pre-existing `dotnet_inspect_style_full_taste` config aggregate, so trying this out no longer requires leaving a config file behind.

## Design notes

- **The comment rides the signature** because `DecompilerDecision` carries a subject but **no IL offset**. There is no honest statement-level anchor available today. A lens's subject is just the enclosing method — already spelled on that line — so it reports `fidelity=byte-divergent` instead, which doubles as the signal explaining the absent IL.
- **The annotation is built in the CLI, not Research.** Research `Output` is body-only; the CLI's `FormatSourceWithDeclaration` owns the signature line. This also removed a prose block that had been baking presentation text into the layer that owns source.
- **`Decompiled Source` is deliberately left unannotated**, preserving its clean-source contract.
- **Nothing is annotated by default.** No style decision is recorded unless a knob was requested, so the comment appears exactly when the reader asked for taste.

## Compatibility

Default output is unchanged: no config and no `--taste` means no decisions, no annotation, and no suppression. The escaping pass added below is inert for every well-formed metadata name.

## Docs

`docs/decompiler-taste.md` had an annotated example showing a **body only, with no member signature** — contradicting the view's own contract. Replaced with real captured output, plus a worked example mixing allocation facts and taste on one member. `README.md` notes `--taste`.

## Validation

| Suite | Result |
| --- | --- |
| `src/dotnet-inspect.Tests` | 2160 passed, 12 skipped |
| `src/ILInspector.Research.Tests` | 132 passed |
| `src/ILInspector.Decompiler.Tests -- -trait- "Speed=Slow"` | 3781 passed |
| `dotnet build dotnet-inspect.slnx -c Release` | clean |
| `npx markdownlint-cli` | clean |

The full decompiler suite was run on the first head: 6 failures, all verified pre-existing on a pristine `origin/main` worktree (the compile-back harness cannot resolve corelib in this environment).

## Adversarial review

Four rounds with Gemini 3.1 Pro and GPT-5.6 Sol in isolated worktrees. Both signed off on `55380643`. Findings and resolutions are reconciled in a comment below.