### PR TITLE
Make the terminator-inlining guard read the table BuildRegion indexes

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -1318,7 +1318,6 @@ public sealed class StructuringPass : IIrPass
         return false;
     }
 
-    /// <summary>A terminator block that may be inlined into a guard at <paramref name="index"/>.</summary>
     /// <summary>
     /// Snapshots the statements of every block <see cref="IsInlinableTerminator"/> will
     /// report for these inputs. Both <see cref="Ctx"/> factories must build the table

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -210,13 +210,13 @@ public sealed class StructuringPass : IIrPass
                 scatteredReturnDispatchTargets.Add(offset);
         }
 
+        var snapshots = BuildTerminatorSnapshots(
+            blocks, unconditionalTargets, conditionalTargetCounts, fallenInto, isComparisonTree, scatteredReturnDispatchTargets);
         var droppable = new HashSet<int>();
-        var snapshots = new Dictionary<int, IReadOnlyList<IrNode>>();
         for (int i = 0; i < blocks.Count; i++)
         {
-            if (!IsSharedTerminator(blocks[i], unconditionalTargets, conditionalTargetCounts, fallenInto, isComparisonTree, scatteredReturnDispatchTargets))
+            if (!snapshots.ContainsKey(i))
                 continue;
-            snapshots[i] = blocks[i].Children.ToList();
             // A scattered dispatch target reached by a forward-goto trampoline
             // (issue #2973) is inlined into its conditional guards but must stay
             // in place: the trampoline arm reaches it by falling through the
@@ -988,6 +988,15 @@ public sealed class StructuringPass : IIrPass
             if (FallsThrough(blocks[i - 1]))
                 fallenInto.Add(blocks[i].StartOffset);
 
+        // The inline context carries no comparison-tree or scattered-dispatch
+        // classification, so build its terminator snapshots from exactly the
+        // inputs the returned Ctx exposes: IsInlinableTerminator must never
+        // report a block whose snapshot is absent (BuildRegion indexes it).
+        var isComparisonTree = false;
+        var scatteredReturnDispatchTargets = new HashSet<int>();
+        var snapshots = BuildTerminatorSnapshots(
+            blocks, unconditionalTargets, conditionalTargetCounts, fallenInto, isComparisonTree, scatteredReturnDispatchTargets);
+
         return new Ctx
         {
             Blocks = blocks,
@@ -996,10 +1005,10 @@ public sealed class StructuringPass : IIrPass
             ConditionalTargetCounts = conditionalTargetCounts,
             BranchTargets = branchTargets,
             DroppableBlocks = [],
-            TerminatorSnapshots = new Dictionary<int, IReadOnlyList<IrNode>>(),
+            TerminatorSnapshots = snapshots,
             FallenInto = fallenInto,
-            IsComparisonTree = false,
-            ScatteredReturnDispatchTargets = [],
+            IsComparisonTree = isComparisonTree,
+            ScatteredReturnDispatchTargets = scatteredReturnDispatchTargets,
             RegionExitLeaveTarget = null,
             Recorder = null,
         };
@@ -1310,8 +1319,35 @@ public sealed class StructuringPass : IIrPass
     }
 
     /// <summary>A terminator block that may be inlined into a guard at <paramref name="index"/>.</summary>
+    /// <summary>
+    /// Snapshots the statements of every block <see cref="IsInlinableTerminator"/> will
+    /// report for these inputs. Both <see cref="Ctx"/> factories must build the table
+    /// this way: <c>BuildRegion</c> indexes it directly, so a context whose predicate and
+    /// snapshot table disagree crashes instead of declining to inline.
+    /// </summary>
+    static Dictionary<int, IReadOnlyList<IrNode>> BuildTerminatorSnapshots(
+        IReadOnlyList<Block> blocks,
+        HashSet<int> unconditionalTargets,
+        Dictionary<int, int> conditionalTargetCounts,
+        HashSet<int> fallenInto,
+        bool isComparisonTree,
+        HashSet<int> scatteredReturnDispatchTargets)
+    {
+        var snapshots = new Dictionary<int, IReadOnlyList<IrNode>>();
+        for (int i = 0; i < blocks.Count; i++)
+            if (IsSharedTerminator(blocks[i], unconditionalTargets, conditionalTargetCounts, fallenInto, isComparisonTree, scatteredReturnDispatchTargets))
+                snapshots[i] = blocks[i].Children.ToList();
+        return snapshots;
+    }
+
+    /// <summary>
+    /// Whether block <paramref name="index"/> is a shared terminator that may be inlined
+    /// into its conditional guards. This reads the precomputed snapshot table rather than
+    /// re-deriving the predicate: <c>BuildRegion</c> indexes that table directly, so the
+    /// guard and the data it gates must be the same source of truth.
+    /// </summary>
     static bool IsInlinableTerminator(Ctx ctx, int index) =>
-        IsSharedTerminator(ctx.Blocks[index], ctx.UnconditionalTargets, ctx.ConditionalTargetCounts, ctx.FallenInto, ctx.IsComparisonTree, ctx.ScatteredReturnDispatchTargets);
+        ctx.TerminatorSnapshots.ContainsKey(index);
 
     /// <summary>Whether control reaching the end of this block continues into its successor (vs. returning, throwing, or branching away).</summary>
     static bool FallsThrough(Block block) =>


### PR DESCRIPTION
A guard in `StructuringPass` and the data it gated were two different sources of truth. They disagreed in one of the two `Ctx` factories, so a block the guard accepted had no entry in the table `BuildRegion` indexes, and the pass threw `KeyNotFoundException` instead of declining to inline. This makes them the same source of truth.

The crash happened inside `Validate` — the phase whose job is to prove a shape is safe *before* anything is rewritten.

## The defect

`Ctx.TerminatorSnapshots` maps a block index to a frozen copy of that block's statements. `BuildRegion` indexes it directly (`ctx.TerminatorSnapshots[target]`), gated by `IsInlinableTerminator(ctx, target)`.

Two factories build `Ctx`:

- The primary factory populated the table for exactly the blocks satisfying `IsSharedTerminator(...)`, so the guard and the table agreed.
- `CreateInlineCtx` — used by the speculative `CanInlinePastRegionTarget` analysis — populated **every field `IsSharedTerminator` reads** but left the table **empty**.

`IsInlinableTerminator` re-derived the predicate from those fields, so in the inline context it returned `true` against an empty table:

```
KeyNotFoundException: The given key '3' was not present in the dictionary
  StructuringPass.BuildRegion <- TryBuildPastRegionTarget <- CanInlinePastRegionTarget <- Validate
  Google.Apis.Requests.ClientServiceRequest`1.<ParseResponse>d__38::MoveNext
```

Repro (needs the reference closure — `Google.Apis.dll` alone does not reproduce):

```bash
dotnet run --project tools/DecompilerHarness -c Release -- --gaps \
  .../google.apis.core/1.75.0/Google.Apis.Core.dll \
  .../google.apis/1.75.0/Google.Apis.dll
```

## The fix

1. Extract `BuildTerminatorSnapshots(...)` as the single builder of the table; both factories call it.
2. `IsInlinableTerminator` becomes `ctx.TerminatorSnapshots.ContainsKey(index)` — it reads the table instead of re-deriving the predicate.

The second step is what makes the bug class structurally impossible rather than merely repaired: the guard and the gated data are now literally the same object.

This also matches the documented intent at the call site, which already says the statements are *"cloned from the pre-mutation snapshot"* — reading the frozen table is more faithful to that contract than the old re-derivation, which answered against current block state.

## Evidence

| Check | `origin/main` | This branch |
| --- | --- | --- |
| Repro (897 methods) | **1 pass bug** | **0 pass bugs** |
| `--gaps` CoreLib (41,952) | 40,460 raised / 0 bugs / 1,492 gaps | identical |
| `--gaps` EVIL pool (364,338) | 310,647 raised / **1 pass bug** / 53,690 gaps | **310,648 raised / 0 pass bugs** / 53,690 gaps |
| `--idempotence-check` | 286 rewrites / 0 crashes | identical |
| `--validity-check` | 0 Full malformed, 63/4,000 semantic | identical |
| Decompiler fast gate | — | 3,781 total, **0 failed** |

The `+1` raised method is precisely the one that used to crash. The gap docket is otherwise unchanged, so this converts a crash into a successful raise without reclassifying anything else.

## Adversarial review

Two models, per `AGENTS.md`, each isolated in its own linked review worktree at the exact head, with an identical self-contained brief covering six named attack points.

**Gemini 3.1 Pro — CLEAN.** Built a custom instrumented binary asserting `ContainsKey(index) == IsSharedTerminator(...)` live at every call site: **0 divergences over 42,849 methods**.

**GPT-5.6 — CLEAN.** Independent static trace plus full corpus runs; no stale-snapshot evidence.

Attack points and how they were closed:

1. **Static vs dynamic predicate** (the real risk — a frozen answer handing back a stale snapshot would be a silent miscompile, worse than the crash). Cleared three ways: both call sites require `target > i`, so the queried block is strictly forward and has not been visited or detached; predicate input sets are never mutated after construction; and the instrumented sweep found 0 disagreements.
2. **Fix makes speculative analysis more permissive.** Cleared — the old predicate *already* returned `true`; only materialization failed. The change is crash → correct result, not reject → accept.
3. **`CreateInlineCtx` passes `isComparisonTree = false` and an empty scattered-return set.** Both reviewers concluded *strictly fewer*, and I verified both halves independently: the `Return` arm reduces to `(false && …) || false` = `false`, and the `!scattered && unconditionalTargets.Contains(…)` early exit always fires. The speculative context admits a **strict subset** of the primary context — the safe direction, since `Validate` can only under-approximate the real pass, never bless a shape it would structure differently.
4. **Post-construction mutation of the table.** Cleared — assigned only by the two factories; `DroppableBlocks` reads keys, never writes.
5. **Ungated sibling reads.** Cleared — exactly one indexer read (line 1526), immediately inside its guard (line 1523). The validation-side call at line 434 does not index.
6. **Snapshot aliasing.** Cleared — insertion uses `statement.Clone()`, so shared `IrNode` references cannot be re-parented out from under the snapshot.

Reviewer-requested items, reconciled:

- GPT wanted an instrumented disagreement sweep — Gemini ran exactly that (0/42,849).
- GPT flagged a 43-method difference from my originally-reported corpus baseline. Confirmed **not** attributable to this change. My first numbers predate the rebase; `e97cf17d` (unspellable-name sanitizer, #3129) accounts for the movement. Measured directly on `origin/main` at `08ab86b1`: **310,647 raised / 1 pass bug / 53,690 gaps** — the crash reproduces there, and the gap docket is identical to the head's 53,690. That isolates this change's contribution to exactly the `+1` recovered method.
- Both reviewers wanted a focused regression fixture. Not delivered — see below.

## Not covered

Stated plainly rather than implied:

- **No shape-specific fixture.** Eleven hand-authored C# shapes failed to reproduce. Instrumenting the pre-fix build gave the real trigger — a past-region trailing `Throw` block that is *both* fallen into *and* reached by exactly one conditional, inside a state machine (`StoreField` ⇒ hoisted locals) — but Roslyn would not emit it from authored C#; it likely needs hand-written IL. The corpus sweep is the current proof. Both reviewers named this as the remaining want.
- **`Speed=Slow` / `Area=Fidelity` gates did not run.** The machine was under multi-hour three-way contention. These are the lanes that carry the real regression ratchets (`CorpusSweepGateTests`, `FidelityGateTests`), so they should run on a quiet machine before merge.
- I did **not** add a `Debug.Assert` on the invariant. Tests run `-c Release`, so it would never execute — an assertion that cannot fire is worse than none.

## Unrelated observations (not fixed here)

- `PlatformResolverTests.GetPacksDirectory_ReturnsValidPath` asserts `EndsWith("packs")`, but `PlatformPackService.PacksCategory` is now `"packs-v2"`. It passes in isolation and fails in a full run depending on which path `GetPacksDirectory()` selects — both directories exist in the shared cache. Pre-existing, unrelated to structuring.
- The two "fast" selectors disagree on test count: `--gate fast` reported 3,417 cases, `-trait- "Speed=Slow"` reported 3,781. Same 0 failures, but they are not the same set — worth reconciling separately.
