### PR TITLE
Migrate quality diff card onto Markout.Templates (#3212)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Markout" Version="0.27.0" />
+    <PackageVersion Include="Markout.Templates" Version="0.3.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -1076,7 +1076,7 @@ public class CorpusSensorComparisonTests
         string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
         string semanticRow = report.Split('\n').Single(line => line.Contains("Semantic defects", StringComparison.Ordinal));
 
-        Assert.Contains("Semantic defects (-)", semanticRow);
+        Assert.Contains("Semantic defects ↓", semanticRow);
         Assert.Contains("✓", semanticRow);
         Assert.EndsWith("| 1 (50.00%) → 0 (0.00%) (-1 methods) ✓ |", semanticRow.TrimEnd());
         Assert.DoesNotContain("sampling differs", report);
@@ -1104,7 +1104,7 @@ public class CorpusSensorComparisonTests
 
         string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
 
-        Assert.Contains("Full malformed (-)", report);
+        Assert.Contains("Full malformed ↓", report);
         Assert.DoesNotContain("Full malformed (sampling differs)", report);
         Assert.Contains("Semantic defects (sampling differs)", report);
     }
@@ -1161,7 +1161,7 @@ public class CorpusSensorComparisonTests
         Assert.Contains("Fidelity operand diffs (sampling differs)", report);
         Assert.Contains("Fidelity unavailable comparisons (sampling differs)", report);
         Assert.Contains("Fidelity exact (sampling differs)", report);
-        Assert.DoesNotContain("Fidelity opcode diffs (-)", report);
+        Assert.DoesNotContain("Fidelity opcode diffs ↓", report);
         Assert.DoesNotContain("✗", report);
     }
 
@@ -1229,9 +1229,9 @@ public class CorpusSensorComparisonTests
 
         string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
 
-        Assert.Contains("Fully raised (+)", report);
+        Assert.Contains("Fully raised ↑", report);
         Assert.Contains("1 (50.00%) → 2 (100.00%) (+1 methods) ✓", report);
-        Assert.Contains("Detected lowering residue (-)", report);
+        Assert.Contains("Detected lowering residue ↓", report);
         Assert.Contains("0 (0.00%) → 0 (0.00%) (0 methods) |", report);
         Assert.True(
             report.IndexOf("| Fully raised", StringComparison.Ordinal)
@@ -1301,7 +1301,7 @@ public class CorpusSensorComparisonTests
 
         string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
 
-        Assert.Contains("Detected lowering residue (-)", report);
+        Assert.Contains("Detected lowering residue ↓", report);
         Assert.Contains("6 (6.45%) → 6 (6.45%) (0 methods) |", report);
     }
 
@@ -1630,5 +1630,110 @@ public class CorpusSensorComparisonTests
             methods.Add(SnapshotMethod(value.Method, fidelityCheck: value.FidelityCheck));
         }
         return methods.ToImmutable();
+    }
+
+    [Fact]
+    public void QualityDiffCard_RealWorld_RendersEntirelyThroughMarkout()
+    {
+        var methods = ValidityMethods(("One", "valid"), ("Two", "semantic-defect:CS0159"));
+        var baseline = Snapshot(
+            totalMethods: 8_000,
+            fullyRaisedMethods: 7_000,
+            fullyRaisedBasisPoints: 8_750,
+            pinnedMethods: methods,
+            validityCompileCap: 2,
+            fullMalformedMethods: 40,
+            semanticCheckedMethods: 2,
+            semanticDefectMethods: 1,
+            featureCoverage: CompleteFeatureCoverage(),
+            classicStateMachineCoverage: CompleteClassicStateMachineCoverage());
+        var current = Snapshot(
+            totalMethods: 8_000,
+            fullyRaisedMethods: 7_100,
+            fullyRaisedBasisPoints: 8_875,
+            pinnedMethods: methods,
+            validityCompileCap: 2,
+            fullMalformedMethods: 42,
+            semanticCheckedMethods: 2,
+            semanticDefectMethods: 1,
+            featureCoverage: CompleteFeatureCoverage(),
+            classicStateMachineCoverage: CompleteClassicStateMachineCoverage());
+
+        string card = CorpusSensor.QualityDiffCardForTesting(
+            baseline, current,
+            regressions: ["Full malformed methods (pinned) increased by 2 (baseline 40, current 42, tolerance 0)"],
+            risky: false,
+            baselineRef: "abc123");
+
+        // The metric table now leads the card, immediately under the heading, so the
+        // glyph table renders as the first thing a reviewer sees.
+        Assert.StartsWith("### Decompiler quality diff\n\n| Metric | Change |\n| ------ | ------ |\n", card);
+        // Scalar fields render as two bulleted groups under soft (bold) headers.
+        Assert.Contains(
+            "**Input**\n\n"
+            + "- Corpus: test 1 assembly, 8,000 methods\n"
+            + "- Baseline ref: `abc123`\n"
+            + "- Sample: hash-stable 100 methods per assembly\n\n"
+            + "**Analysis**\n\n"
+            + "- Correctness coverage: validity compiled 2 methods (compile-cap 2; per-sample, not corpus-wide); fidelity not run\n"
+            + "- Current measured debt: 900 methods with detected lowering residue; 42 malformed Full methods; 1 semantic defect among 2 checked.\n"
+            + "- Regression verdict: FAIL — corpus sensor reported regressions; review before merging.\n",
+            card);
+        Assert.Contains("Feature evidence:", card);
+        Assert.Contains("- `runtime-async-methods`: 1", card);
+        Assert.Contains("Classic state-machine kickoff evidence:", card);
+        Assert.Contains("- `classic-async`: population 1, fully raised 1, residual 0", card);
+        Assert.Contains("\n\n- Full malformed methods (pinned) increased by 2 (baseline 40, current 42, tolerance 0)", card);
+    }
+
+    [Fact]
+    public void QualityDiffCard_OptInNet11_UsesProfileHeadingAndSkipsPinnedGate()
+    {
+        var methods = ValidityMethods(("One", "valid"));
+        var baseline = Snapshot(8_000, 7_000, 8_750, methods, profile: CorpusProfile.OptInNet11);
+        var current = Snapshot(8_000, 7_100, 8_875, methods, profile: CorpusProfile.OptInNet11);
+
+        string card = CorpusSensor.QualityDiffCardForTesting(baseline, current, regressions: []);
+
+        Assert.StartsWith("### Decompiler net11 opt-in feature diff\n\n| Metric | Change |\n| ------ | ------ |\n", card);
+        // No baseline ref for the opt-in profile, so the Input group drops that bullet.
+        Assert.Contains(
+            "**Input**\n\n"
+            + "- Corpus: test 1 assembly, 8,000 methods\n"
+            + "- Sample: hash-stable 100 methods per assembly\n\n"
+            + "**Analysis**\n\n"
+            + "- Correctness coverage: validity not run; fidelity not run\n"
+            + "- Current measured debt: 900 methods with detected lowering residue.\n"
+            + "- Regression verdict: PASS — corpus sensor matched baseline tolerances.",
+            card);
+        Assert.DoesNotContain("Baseline ref:", card);
+        // The pinned-subset gate is a RealWorld-only section.
+        Assert.DoesNotContain("Pinned-subset gate", card);
+    }
+
+    [Fact]
+    public void QualityDiffCard_StaleBaseline_LeadsWithTableThenStalenessAndAppendsCaveat()
+    {
+        var methods = ValidityMethods(("One", "valid"));
+        var baseline = Snapshot(8_050, 7_050, 8_758, methods, validityCompileCap: 2, semanticCheckedMethods: 2);
+        var current = Snapshot(8_000, 7_100, 8_875, methods, validityCompileCap: 2, semanticCheckedMethods: 2);
+
+        string card = CorpusSensor.QualityDiffCardForTesting(
+            baseline, current,
+            regressions: ["detected lowering residue rate (pinned) increased"],
+            risky: true);
+
+        // The table leads; the staleness note follows it (and now reads "table above").
+        Assert.StartsWith("### Decompiler quality diff\n\n| Metric | Change |", card);
+        Assert.Contains("- Risk warning: thin correctness coverage", card);
+        Assert.Contains("Baseline staleness: corpus drifted from the pinned baseline", card);
+        Assert.Contains("aggregate count deltas in the table above", card);
+        Assert.Contains("- total methods 8,050 -> 8,000 (-50)", card);
+        // Exactly one blank line separates the staleness drift list from the Input group.
+        Assert.Contains("(-50)\n\n**Input**", card);
+        Assert.DoesNotContain("(-50)\n\n\n**Input**", card);
+        Assert.Contains(
+            "Caveat: the corpus drifted from the baseline (see baseline staleness above).",
+            card);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Markout" />
+    <PackageReference Include="Markout.Templates" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -11,6 +11,7 @@ using ILInspector.Instructions;
 using ILInspector.Metadata;
 using Markout;
 using Markout.Formatting;
+using Markout.Templates;
 
 namespace ILInspector.DecompilerHarness;
 
@@ -1912,60 +1913,156 @@ internal static class CorpusSensor
         }
     }
 
+    // The quality diff card is authored as a prose-first Markout template: the fixed
+    // narrative structure lives here as Markdown, while the genuinely data-driven parts
+    // (the glyph metric table, evidence lists, staleness, pinned gate, advisory) are
+    // pre-rendered to strings and injected as block bindings. The metric table leads;
+    // the scalar fields render as two bulleted groups under soft (bold) "Input" and
+    // "Analysis" headers so they read well as Markdown instead of a run of plain lines.
+    // Standalone {{#if}}/{{/if}} directive lines gate the optional blocks while
+    // preserving single-blank-line spacing.
+    const string QualityDiffCardTemplate =
+        """
+        ### {{title}}
+
+        {{metric_table}}
+
+        {{#if has_staleness}}
+        {{staleness}}
+
+        {{/if}}
+        **Input**
+
+        {{input}}
+
+        **Analysis**
+
+        {{analysis}}
+
+        {{#if has_features}}
+        {{feature_block}}
+
+        {{/if}}
+        {{#if has_pinned_gate}}
+        {{pinned_gate}}
+
+        {{/if}}
+        {{#if has_advisory}}
+        {{advisory}}
+
+        {{/if}}
+        {{#if has_regressions}}
+        Regressions:
+
+        {{regressions}}
+        {{#if has_caveat}}
+
+        {{caveat}}
+        {{/if}}
+        {{/if}}
+        """;
+
     static void PrintQualityDiffCard(
+        CorpusSensorSnapshot baseline,
+        CorpusSensorSnapshot current,
+        IReadOnlyList<string> regressions,
+        bool risky,
+        string? baselineRef,
+        TextWriter? output = null)
+    {
+        (output ?? Console.Out).Write(
+            RenderQualityDiffCard(baseline, current, regressions, risky, baselineRef));
+    }
+
+    internal static string QualityDiffCardForTesting(
+        CorpusSensorSnapshot baseline,
+        CorpusSensorSnapshot current,
+        IReadOnlyList<string> regressions,
+        bool risky = false,
+        string? baselineRef = null)
+        => RenderQualityDiffCard(baseline, current, regressions, risky, baselineRef);
+
+    static string RenderQualityDiffCard(
         CorpusSensorSnapshot baseline,
         CorpusSensorSnapshot current,
         IReadOnlyList<string> regressions,
         bool risky,
         string? baselineRef)
     {
-        Console.WriteLine(QualityCardHeadingForProfile(current.Profile));
-        Console.WriteLine();
-        Console.WriteLine($"Corpus: {current.Description} {AssemblyCount(current.Assemblies.Count)}, {Number(current.Metrics.TotalMethods)} methods");
-        if (baselineRef is not null)
-            Console.WriteLine($"Baseline ref: `{baselineRef}`");
-        if (current.MethodCap is { } cap)
-            Console.WriteLine($"Sample: hash-stable {Number(cap)} methods per assembly");
-        Console.WriteLine($"Correctness coverage: {CoverageSummary(current)}");
-        if (risky)
-            PrintRiskyCoverageGuidance(current);
-        PrintBaselineStaleness(baseline, current);
-        Console.WriteLine();
-        PrintQualityMetricChanges(baseline, current);
-        PrintFeatureCoverage(current);
-        if (current.Profile == CorpusProfile.RealWorld)
-            PrintPinnedGate(baseline, current);
-        if (!risky && current.Profile == CorpusProfile.RealWorld)
-            PrintAdvisoryRateMovements(baseline, current);
-        Console.WriteLine();
-        Console.WriteLine($"Current measured debt: {CurrentMeasuredDebt(current)}");
-        Console.WriteLine(RegressionVerdict(regressions.Count));
-        if (regressions.Count > 0)
+        bool realWorld = current.Profile == CorpusProfile.RealWorld;
+        string metricTable = RenderBlock(w => WriteQualityMetricChanges(w, baseline, current));
+        string staleness = RenderBlock(w => WriteBaselineStaleness(w, baseline, current));
+        string featureBlock = RenderBlock(w => WriteFeatureCoverage(w, current));
+        string pinnedGate = realWorld ? (PinnedGateSummary(baseline, current) ?? "") : "";
+        string advisory = !risky && realWorld
+            ? RenderBlock(w => WriteAdvisoryRateMovements(w, baseline, current))
+            : "";
+        string caveat = RegressionCaveat(baseline, current, regressions);
+
+        var input = new List<string>
         {
-            Console.WriteLine();
-            Console.WriteLine("Regressions:");
-            foreach (var regression in regressions)
-                Console.WriteLine($"- {regression}");
-            if (IsBaselineStale(baseline, current) && current.Profile == CorpusProfile.RealWorld)
-            {
-                Console.WriteLine();
-                Console.WriteLine(
-                    "Caveat: the corpus drifted from the baseline (see baseline staleness above). "
-                    + "The aggregate rows above mix the PR with that drift, but rate/count "
-                    + "regressions are gated on the pinned-NuGet subset where available (a fixed method set), so any "
-                    + "`(pinned)` regression listed here is a real decompiler delta, not drift.");
-            }
+            $"Corpus: {current.Description} {AssemblyCount(current.Assemblies.Count)}, {Number(current.Metrics.TotalMethods)} methods",
+        };
+        if (baselineRef is not null)
+            input.Add($"Baseline ref: `{baselineRef}`");
+        if (current.MethodCap is { } cap)
+            input.Add($"Sample: hash-stable {Number(cap)} methods per assembly");
 
-            else if (IsBaselineStale(baseline, current))
-            {
-                Console.WriteLine();
-                Console.WriteLine(
-                    "Caveat: the opt-in corpus population differs from its baseline. "
-                    + "Advance fixture sources or the pinned SDK and regenerate the baseline "
-                    + "together; otherwise treat this as unexpected corpus drift.");
-            }
+        var analysis = new List<string> { $"Correctness coverage: {CoverageSummary(current)}" };
+        if (risky)
+            analysis.Add(RenderBlock(w => WriteRiskyCoverageGuidance(w, current)));
+        analysis.Add($"Current measured debt: {CurrentMeasuredDebt(current)}");
+        analysis.Add(RegressionVerdict(regressions.Count));
 
-        }
+        string card = MarkoutTemplate.Parse(QualityDiffCardTemplate)
+            .Bind("title", QualityCardTitleForProfile(current.Profile))
+            .Bind("metric_table", metricTable)
+            .Bind("has_staleness", staleness.Length > 0)
+            .Bind("staleness", staleness)
+            .Bind("input", input)
+            .Bind("analysis", analysis)
+            .Bind("has_features", featureBlock.Length > 0)
+            .Bind("feature_block", featureBlock)
+            .Bind("has_pinned_gate", pinnedGate.Length > 0)
+            .Bind("pinned_gate", pinnedGate)
+            .Bind("has_advisory", advisory.Length > 0)
+            .Bind("advisory", advisory)
+            .Bind("has_regressions", regressions.Count > 0)
+            .Bind("regressions", regressions)
+            .Bind("has_caveat", caveat.Length > 0)
+            .Bind("caveat", caveat)
+            .Render();
+
+        return card.TrimEnd('\n') + "\n";
+    }
+
+    static string RegressionCaveat(
+        CorpusSensorSnapshot baseline,
+        CorpusSensorSnapshot current,
+        IReadOnlyList<string> regressions)
+    {
+        if (regressions.Count == 0 || !IsBaselineStale(baseline, current))
+            return "";
+        return current.Profile == CorpusProfile.RealWorld
+            ? "Caveat: the corpus drifted from the baseline (see baseline staleness above). "
+                + "The aggregate rows above mix the PR with that drift, but rate/count "
+                + "regressions are gated on the pinned-NuGet subset where available (a fixed method set), so any "
+                + "`(pinned)` regression listed here is a real decompiler delta, not drift."
+            : "Caveat: the opt-in corpus population differs from its baseline. "
+                + "Advance fixture sources or the pinned SDK and regenerate the baseline "
+                + "together; otherwise treat this as unexpected corpus drift.";
+    }
+
+    // Renders a card sub-block through a scratch MarkoutWriter and trims the outer
+    // blank lines so the template owns the spacing between blocks. Returns "" when the
+    // writer emits nothing (the sub-block gates itself), which drives the {{#if}} flags.
+    static string RenderBlock(Action<MarkoutWriter> write)
+    {
+        using var sw = new StringWriter();
+        var writer = new MarkoutWriter(sw, new MarkdownFormatter());
+        write(writer);
+        writer.Flush();
+        return sw.ToString().Trim('\n');
     }
 
     static string CurrentMeasuredDebt(CorpusSensorSnapshot snapshot)
@@ -2071,30 +2168,46 @@ internal static class CorpusSensor
         }
     }
 
+    static void WriteFeatureCoverage(MarkoutWriter writer, CorpusSensorSnapshot snapshot)
+    {
+        if (snapshot.FeatureCoverage is { Count: > 0 } coverage)
+        {
+            writer.WriteParagraph("Feature evidence:");
+            writer.WriteList(
+                [.. coverage
+                    .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                    .Select(pair => $"`{pair.Key}`: {pair.Value}")]);
+        }
+
+        if (snapshot.ClassicStateMachineCoverage is { Count: > 0 } stateMachines)
+        {
+            writer.WriteParagraph("Classic state-machine kickoff evidence:");
+            writer.WriteList(
+                [.. stateMachines
+                    .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                    .Select(pair =>
+                        $"`{pair.Key}`: population {pair.Value.Population}, "
+                        + $"fully raised {pair.Value.FullyRaised}, residual {pair.Value.Residual}")]);
+        }
+    }
+
     internal static string QualityCardHeadingForProfile(CorpusProfile profile)
+        => "### " + QualityCardTitleForProfile(profile);
+
+    static string QualityCardTitleForProfile(CorpusProfile profile)
         => profile switch
         {
-            CorpusProfile.RealWorld => "### Decompiler quality diff",
-            CorpusProfile.OptInNet11 => "### Decompiler net11 opt-in feature diff",
+            CorpusProfile.RealWorld => "Decompiler quality diff",
+            CorpusProfile.OptInNet11 => "Decompiler net11 opt-in feature diff",
             _ => throw new ArgumentOutOfRangeException(nameof(profile)),
         };
 
     /// <summary>
     /// Shows the pinned-NuGet-subset metrics that drive the PR quick verdict, so
     /// reviewers can see the stable gate alongside the drifting aggregate rows.
-    /// Silent when per-method detail is unavailable (the verdict then falls back
-    /// to aggregate counts/rates).
+    /// Silent (returns null) when per-method detail is unavailable (the verdict then
+    /// falls back to aggregate counts/rates).
     /// </summary>
-    static void PrintPinnedGate(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
-    {
-        string? summary = PinnedGateSummary(baseline, current);
-        if (summary is null)
-            return;
-
-        Console.WriteLine();
-        Console.WriteLine(summary);
-    }
-
     internal static string? PinnedGateSummaryForTesting(
         CorpusSensorSnapshot baseline,
         CorpusSensorSnapshot current)
@@ -2152,7 +2265,7 @@ internal static class CorpusSensor
             + fidelity + ".";
     }
 
-    static void PrintAdvisoryRateMovements(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+    static void WriteAdvisoryRateMovements(MarkoutWriter writer, CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
     {
         var tolerance = baseline.Tolerances ?? CorpusSensorTolerances.Default;
         var advisories = new List<string>();
@@ -2167,10 +2280,8 @@ internal static class CorpusSensor
         if (advisories.Count == 0)
             return;
 
-        Console.WriteLine();
-        Console.WriteLine("Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes):");
-        foreach (var advisory in advisories)
-            Console.WriteLine($"- {advisory}");
+        writer.WriteParagraph("Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes):");
+        writer.WriteList([.. advisories]);
 
         void AddAdvisory(string name, int baselineRate, int currentRate, int toleranceBps, bool lowerIsRegression)
         {
@@ -2192,20 +2303,18 @@ internal static class CorpusSensor
     /// Surface the drift explicitly so reviewers rebaseline instead of chasing a
     /// phantom regression.
     /// </summary>
-    static void PrintBaselineStaleness(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+    static void WriteBaselineStaleness(MarkoutWriter writer, CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
     {
         var drift = DescribeBaselineDrift(baseline, current);
         if (drift.Count == 0)
             return;
 
-        Console.WriteLine();
-        Console.WriteLine(
+        writer.WriteParagraph(
             $"Baseline staleness: corpus drifted from the pinned baseline "
-            + $"(generated {baseline.GeneratedUtc:yyyy-MM-dd}). Aggregate count deltas below include "
+            + $"(generated {baseline.GeneratedUtc:yyyy-MM-dd}). The aggregate count deltas in the table above include "
             + "this corpus change and are not a clean PR signal; rebaseline against current main "
             + "(--emit-corpus-baseline) before trusting count-based regressions.");
-        foreach (var line in drift)
-            Console.WriteLine($"- {line}");
+        writer.WriteList([.. drift]);
     }
 
     static bool IsBaselineStale(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
@@ -2244,10 +2353,10 @@ internal static class CorpusSensor
         return lines;
     }
 
-    static void PrintQualityMetricChanges(
+    static void WriteQualityMetricChanges(
+        MarkoutWriter writer,
         CorpusSensorSnapshot baseline,
-        CorpusSensorSnapshot current,
-        TextWriter? output = null)
+        CorpusSensorSnapshot current)
     {
         bool comparableStructuralPopulation = HaveSameMethodSample(
             baseline.Methods,
@@ -2451,7 +2560,6 @@ internal static class CorpusSensor
         if (fullyRaisedRow is { } raisedRow)
             rows.Add(raisedRow);
 
-        var writer = new MarkoutWriter(output ?? Console.Out, new MarkdownFormatter());
         writer.WriteMultiSourceTable("Metric", rows);
     }
 
@@ -2494,9 +2602,11 @@ internal static class CorpusSensor
         CorpusSensorSnapshot baseline,
         CorpusSensorSnapshot current)
     {
-        using var writer = new StringWriter();
-        PrintQualityMetricChanges(baseline, current, writer);
-        return writer.ToString();
+        using var stringWriter = new StringWriter();
+        var writer = new MarkoutWriter(stringWriter, new MarkdownFormatter());
+        WriteQualityMetricChanges(writer, baseline, current);
+        writer.Flush();
+        return stringWriter.ToString();
     }
 
     static MultiSourceRow CountChangeRow(
@@ -2505,12 +2615,13 @@ internal static class CorpusSensor
         int current,
         Goal goal,
         bool countDeltaKnown = true)
-        => new(
-            MetricLabel(metric, goal),
+        => new MultiSourceRow(
+            metric,
             new Source(
                 "Change",
                 new Change<int>(baseline, current),
-                new MarkoutCellFormat { Goal = goal, Delta = countDeltaKnown ? Markout.Delta.Absolute : Markout.Delta.None, NumberFormat = "N0" }));
+                new MarkoutCellFormat { Goal = goal, Delta = countDeltaKnown ? Markout.Delta.Absolute : Markout.Delta.None, NumberFormat = "N0" }))
+        { Goal = goal };
 
     static MultiSourceRow ShareChangeRow(
         string metric,
@@ -2520,12 +2631,13 @@ internal static class CorpusSensor
         int currentTotal,
         Goal goal,
         bool countDeltaKnown = true)
-        => new(
-            MetricLabel(metric, goal),
+        => new MultiSourceRow(
+            metric,
             new Source(
                 "Change",
                 new Change<QualityRate>(new QualityRate(baseline, baselineTotal), new QualityRate(current, currentTotal)),
-                new MarkoutCellFormat { Goal = goal, DeltaNoun = countDeltaKnown ? "methods" : null, NumberFormat = "N0" }));
+                new MarkoutCellFormat { Goal = goal, DeltaNoun = countDeltaKnown ? "methods" : null, NumberFormat = "N0" }))
+        { Goal = goal };
 
     static bool HaveSameMethodSample(
         IReadOnlyList<CorpusMethodSnapshot>? baselineMethods,
@@ -2541,14 +2653,6 @@ internal static class CorpusSensor
             .ToHashSet(StringComparer.Ordinal)
             .SetEquals(currentMethods.Where(isChecked).Select(MethodKey));
     }
-
-    static string MetricLabel(string metric, Goal goal)
-        => goal switch
-        {
-            Goal.Higher => metric + " (+)",
-            Goal.Lower => metric + " (-)",
-            _ => metric,
-        };
 
     static string CoverageSummary(CorpusSensorSnapshot snapshot)
     {
@@ -2584,7 +2688,7 @@ internal static class CorpusSensor
             _ => profile.ToString(),
         };
 
-    static void PrintRiskyCoverageGuidance(CorpusSensorSnapshot snapshot)
+    static void WriteRiskyCoverageGuidance(MarkoutWriter writer, CorpusSensorSnapshot snapshot)
     {
         List<string> warnings = [];
         if (snapshot.ValidityCompileCap <= 0)
@@ -2599,11 +2703,11 @@ internal static class CorpusSensor
 
         if (warnings.Count > 0)
         {
-            Console.WriteLine($"Risk warning: thin correctness coverage ({string.Join("; ", warnings)}). Add targeted improved examples and still-flat near misses; aggregate numbers are not sufficient alone.");
+            writer.WriteParagraph($"Risk warning: thin correctness coverage ({string.Join("; ", warnings)}). Add targeted improved examples and still-flat near misses; aggregate numbers are not sufficient alone.");
             return;
         }
 
-        Console.WriteLine("Risk guidance: add targeted improved examples and still-flat near misses; aggregate numbers are not sufficient alone.");
+        writer.WriteParagraph("Risk guidance: add targeted improved examples and still-flat near misses; aggregate numbers are not sufficient alone.");
     }
 
     static string Coverage(int checkedMethods, int totalMethods)

--- a/tools/DecompilerHarness/DecompilerHarness.csproj
+++ b/tools/DecompilerHarness/DecompilerHarness.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
     <!-- Validity check: parse and bind the decompiled C# to measure validity. -->
     <PackageReference Include="Markout" />
+    <PackageReference Include="Markout.Templates" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Migrates the DecompilerHarness **quality diff card** from imperative `MarkoutWriter`
composition onto the **Markout.Templates** engine (0.3.0). The card is authored as a
prose-first Markdown template: the fixed narrative is plain Markdown, while the
genuinely data-driven blocks are pre-rendered and injected as block bindings.

Closes #3212.

## Layout

The redesign leads with the **metric table** (directly under the heading) and renders the
scalar fields as two bulleted groups under soft (bold) `**Input**` and `**Analysis**`
headers, instead of a run of plain lines that renders poorly in Markdown. The
baseline-staleness note now follows the table and reads "table above".

## Example (RealWorld profile)

<details>
<summary>Rendered card output</summary>

````markdown
### Decompiler quality diff

| Metric | Change |
| ------ | ------ |
| Detected lowering residue ↓ | 1,000 (12.50%) → 900 (11.25%) (-100 methods) ✓ |
| Conditional-branch residue ↓ | 0 (0.00%) → 0 (0.00%) (0 methods) |
| Forward-merge stops ↓ | 0 (0.00%) → 0 (0.00%) (0 methods) |
| Full malformed ↓ | 40 → 42 (+2) ✗ |
| Semantic defects ↓ | 1 (50.00%) → 1 (50.00%) (0 methods) |
| Pass bugs ↓ | 0 → 0 (0) |
| Fully raised ↑ | 1 (50.00%) → 1 (50.00%) (0 methods) |

**Input**

- Corpus: test 1 assembly, 8,000 methods
- Baseline ref: `abc123`
- Sample: hash-stable 100 methods per assembly

**Analysis**

- Correctness coverage: validity compiled 2 methods (compile-cap 2; per-sample, not corpus-wide); fidelity not run
- Current measured debt: 900 methods with detected lowering residue; 42 malformed Full methods; 1 semantic defect among 2 checked.
- Regression verdict: FAIL — corpus sensor reported regressions; review before merging.

Feature evidence:

- `await-recovery-methods`: 1
- `cross-assembly-requires-unsafe-methods`: 1
- `legacy-memory-safety-control-methods`: 1
- `runtime-async-await-using-methods`: 1
- `runtime-async-awaiter-methods`: 1
- `runtime-async-exception-methods`: 1
- `runtime-async-loop-methods`: 1
- `runtime-async-methods`: 1
- `union-declarations`: 1
- `union-switch-methods`: 1
- `union-types`: 1
- `updated-memory-safety-methods`: 1

Classic state-machine kickoff evidence:

- `classic-async`: population 1, fully raised 1, residual 0
- `classic-async-iterator`: population 1, fully raised 1, residual 0
- `classic-iterator`: population 1, fully raised 1, residual 0

Pinned-subset gate (PR quick rate/count regressions evaluated here): detected lowering residue 0.00% -> 0.00% (0 pp); conditional-branch residue 0.00% -> 0.00% (0 pp); Full malformed 0 -> 0 (0); semantic defects 1 -> 1 (0); fidelity ungated (sampling differs; rely on changed-method fidelity).

Regressions:

- Full malformed methods (pinned) increased by 2 (baseline 40, current 42, tolerance 0)
````

</details>

## Approach

- **Template skeleton** (`QualityDiffCardTemplate` const): standalone `{{#if}}`/`{{/if}}`
  directive lines gate the optional multi-line blocks (staleness, feature evidence, pinned
  gate, advisory, regressions) while preserving single-blank-line spacing.
- **Block bindings**: `RenderBlock(Action<MarkoutWriter>)` renders each data-driven section
  through a scratch `MarkoutWriter` and trims outer blanks, so the template owns inter-block
  spacing. The glyph metric table, evidence lists, and drift lists render verbatim. The
  Input/Analysis groups are bound as `IEnumerable<string>` bullet lists.
- Dropped the now-unused `WritePinnedGate` wrapper (`PinnedGateSummary` is bound directly).
  All internal test seams (`QualityDiffCardForTesting`, `QualityMetricChangesForTesting`,
  `PinnedGateSummaryForTesting`, `CurrentMeasuredDebtForTesting`, `RegressionVerdictForTesting`)
  are preserved.

## Validation

- Full solution builds clean; `ILInspector.Decompiler.Tests` non-slow suite: **3744 passed / 0 failed**.
- Card tests updated to lock the new table-first Input/Analysis layout across all three
  scenarios (RealWorld, OptInNet11, stale-baseline).
- Same information as before (headings per profile, metric rows, pinned-gate text, PASS/FAIL
  verdict, risky guidance, staleness caveats) — reorganized for cleaner Markdown.

> [!NOTE]
> Requires `Markout.Templates` 0.3.0 (already published/indexed on NuGet). The branch is
> based on an earlier `main` and may need a rebase before merge.

