### PR TITLE
Consolidate StackSlotCopyPropagationPass onto the shared Cfg.Build model

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
@@ -1,3 +1,5 @@
+using ILInspector.ControlFlow;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
@@ -101,6 +103,7 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
 
     sealed record CopyPath(
         IReadOnlyList<Block> Blocks,
+        IReadOnlyList<BlockEdges> Edges,
         int CopyBlockIndex,
         int CopyStatementIndex,
         int UseBlockIndex,
@@ -121,6 +124,16 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
 
         var blocks = container.Blocks;
         if (HasUnmodeledControlFlow(blocks))
+            return null;
+
+        // Consume the single shared structural CFG rather than a private edge
+        // model. Cfg.Build reports EH leaves and out-of-container branch targets
+        // as flags instead of resolving them, so bail on any incomplete graph —
+        // the same contract DefiniteAssignment uses. This turns the previously
+        // accidental exclusion of leave edges (a side effect of guard
+        // interaction) into an explicit, pinned invariant.
+        var edges = Cfg.Build(blocks);
+        if (edges.Any(edge => edge.LeavesRegion || edge.ExternalTargets.Count > 0))
             return null;
 
         int copyBlockIndex = copyBlock.ChildIndex;
@@ -159,12 +172,12 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
             if (state.BlockIndex == useBlockIndex)
                 continue;
 
-            foreach (int successor in Successors(blocks, state.BlockIndex))
+            foreach (int successor in edges[state.BlockIndex].Successors)
                 stack.Push((successor, 0));
         }
 
         return foundUse
-            ? new CopyPath(blocks, copyBlockIndex, copy.ChildIndex, useBlockIndex, useStatement, region)
+            ? new CopyPath(blocks, edges, copyBlockIndex, copy.ChildIndex, useBlockIndex, useStatement, region)
             : null;
     }
 
@@ -203,7 +216,7 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
                 return false;
 
             state[blockIndex] = 1;
-            foreach (int successor in Successors(path.Blocks, blockIndex))
+            foreach (int successor in path.Edges[blockIndex].Successors)
                 if (Visit(successor))
                     return true;
             state[blockIndex] = 2;
@@ -213,7 +226,7 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
 
     static bool RegionDominatedByCopy(CopyPath path)
     {
-        var predecessors = Predecessors(path.Blocks);
+        var predecessors = Predecessors(path.Edges);
         foreach (int blockIndex in path.RegionBlocks)
         {
             if (blockIndex == path.CopyBlockIndex)
@@ -225,65 +238,17 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
         return true;
     }
 
-    static List<int>[] Predecessors(IReadOnlyList<Block> blocks)
+    static List<int>[] Predecessors(IReadOnlyList<BlockEdges> edges)
     {
-        var predecessors = new List<int>[blocks.Count];
+        var predecessors = new List<int>[edges.Count];
         for (int i = 0; i < predecessors.Length; i++)
             predecessors[i] = [];
-        for (int i = 0; i < blocks.Count; i++)
+        for (int i = 0; i < edges.Count; i++)
         {
-            foreach (int successor in Successors(blocks, i))
+            foreach (int successor in edges[i].Successors)
                 predecessors[successor].Add(i);
         }
         return predecessors;
-    }
-
-    static IEnumerable<int> Successors(IReadOnlyList<Block> blocks, int index)
-    {
-        var children = blocks[index].Children;
-        if (children.Count == 0)
-        {
-            if (index + 1 < blocks.Count)
-                yield return index + 1;
-            yield break;
-        }
-
-        switch (children[^1])
-        {
-            case Branch branch:
-                int branchTarget = IndexOfOffset(blocks, branch.TargetOffset);
-                if (branchTarget >= 0)
-                    yield return branchTarget;
-                yield break;
-            case ConditionalBranch branch:
-                int conditionalTarget = IndexOfOffset(blocks, branch.TargetOffset);
-                if (conditionalTarget >= 0)
-                    yield return conditionalTarget;
-                if (index + 1 < blocks.Count)
-                    yield return index + 1;
-                yield break;
-            case Leave leave:
-                int leaveTarget = IndexOfOffset(blocks, leave.TargetOffset);
-                if (leaveTarget >= 0)
-                    yield return leaveTarget;
-                yield break;
-            case SwitchBranch branch:
-                foreach (int targetOffset in branch.TargetOffsets)
-                {
-                    int switchTarget = IndexOfOffset(blocks, targetOffset);
-                    if (switchTarget >= 0)
-                        yield return switchTarget;
-                }
-                if (index + 1 < blocks.Count)
-                    yield return index + 1;
-                yield break;
-            case Return or Throw or EndFinally or EndFilter:
-                yield break;
-            default:
-                if (index + 1 < blocks.Count)
-                    yield return index + 1;
-                yield break;
-        }
     }
 
     static bool IsIndependentBodyScope(BlockContainer container)
@@ -311,14 +276,6 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
             if (ContainsUnmodeledControlFlow(child))
                 return true;
         return false;
-    }
-
-    static int IndexOfOffset(IReadOnlyList<Block> blocks, int offset)
-    {
-        for (int i = 0; i < blocks.Count; i++)
-            if (blocks[i].StartOffset == offset)
-                return i;
-        return -1;
     }
 
     static IrNode? EnclosingStatement(IrNode node)


### PR DESCRIPTION
## What

`StackSlotCopyPropagationPass` carried its own ~60-line successor/predecessor
derivation that duplicated `Cfg.Build`'s structural edges and **diverged from it
on one opcode**: the private model resolved a `Leave` terminator's target as a
successor, while `Cfg.Build` reports `Leave` as leaving the region with no
successor. Nothing detected the disagreement.

This replaces the private `Successors`/`Predecessors`/`IndexOfOffset` with the
single shared `ILInspector.ControlFlow.BlockEdges` produced by `Cfg.Build`, and
bails when the graph is incomplete (`LeavesRegion` or `ExternalTargets`) —
matching the contract `DefiniteAssignment` already uses.

`Part of #3240. Addresses the CFG-model divergence in #3242` (census posted on
the issue).

## Why it is behavior-preserving

The pass only runs on **flat, EH-free bodies**: `HasUnmodeledControlFlow` bails
on any nested `Block`/`BlockContainer`, and EH regions *are* nested containers.
So no block it processes ever ends in `Leave`, and no branch leaves the
container. Over exactly those bodies, `Cfg.Build` and the old private model
compute **edge-for-edge identical** successors (`Branch`, `ConditionalBranch`,
`SwitchBranch`, `Return`, `Throw`, fall-through — all handled identically; only
`Leave`/external differ, and neither can occur). The `Leave` divergence was inert
only by accident of guard interaction; #3242's instrumentation measured **0 leave
hits over 406,290 methods**. The new explicit bail turns that accidental
exclusion into a pinned invariant and removes the divergent model by
construction — so no separate differential check is needed to watch the two
models agree.

## Evidence

- `StackSlotCopyPropagationPassTests`: **22/22 pass** (includes positive
  propagation cases — the pass still does its work).
- Fast decompiler suite (`-trait- "Speed=Slow"`): **3786/3787**; the single
  failure (`ExpressionTreeLambdaTests.LookalikeExpressionAssembly_StaysFactoryCalls`)
  is a pre-existing environmental red (fixture assembly not built when building
  only the test csproj) — verified identical on the untouched base with the change
  stashed.
- Diff: −64 / +21 (removes the private CFG model).

## Risk

Low, mechanical refactor: one equivalent edge derivation swapped for the shared
one, provably identical on the processed inputs, strictly safer on the
(unreachable) incomplete-graph path. No output shape, section, or verbosity
behavior changes.