### PR TITLE
Gate byte-neutral style knobs with a compile-back IL-identity check (#3247)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
@@ -30,16 +30,26 @@ namespace ILInspector.Decompiler.Tests;
 /// bind to the same IL. That is a semantic claim — the <c>var x = new()</c> → CS8754
 /// near-miss lived here — so each emitting value is compiled back: rendering a firing
 /// specimen with the value on and off must both recompile to the original IL. A new
-/// Spelling byte-neutral value with no specimen fails
-/// <see cref="EverySpellingByteNeutralValue_HasASpecimen"/>.
+/// byte-neutral value with no specimen fails
+/// <see cref="EveryByteNeutralValue_HasASpecimen"/>.
 /// </description></item>
 /// <item><description>
-/// The <see cref="StyleOptionTier.Formatting"/> (whitespace-only) and
-/// <see cref="StyleOptionTier.Synthesis"/> (local-name-only) byte-neutral knobs change
-/// neither the emitted tokens nor the metadata the IL is decoded from — layout is not
-/// in the assembly at all, and a local's name lives in the PDB, never the method body.
-/// Their byte-neutrality is structural, recorded and pinned by tier rather than
-/// re-proven per knob.
+/// The <see cref="StyleOptionTier.Formatting"/> (whitespace-only) byte-neutral knobs
+/// change layout the assembly never stored. That is still checkable without a compiler:
+/// rendering a firing specimen with the knob on and off must differ (the knob fired) yet
+/// collapse to the same text once insignificant whitespace is removed — a fast lane the
+/// reviewer valued. A knob mis-classified as Formatting that actually moved a token would
+/// fail the whitespace-equality assertion. See <see cref="FormattingValue_On_ChangesOnlyWhitespace"/>.
+/// </description></item>
+/// <item><description>
+/// The one <see cref="StyleOptionTier.Synthesis"/> byte-neutral knob (readable local
+/// names) renames a local, and a local's name lives in the PDB, never the method body,
+/// so it is byte-neutral by construction. It also cannot fire through the member-body
+/// entrypoint when a source name is present — the test assembly's embedded PDB supplies
+/// one — so the gate pins its inert render (on == off) on a source-named local. Firing
+/// the synthesis (proving IL-identity by compile-back, since names are absent from the
+/// IL) needs a name-less compiler temporary this corpus cannot author deterministically;
+/// that is tracked as follow-up.
 /// </description></item>
 /// </list>
 ///
@@ -59,21 +69,28 @@ public sealed class ByteNeutralityGateTests
     static string AssemblyPath => typeof(ByteNeutralityGateTests).Assembly.Location;
 
     /// <summary>
-    /// One specimen per non-default value of a Spelling-tier byte-neutral knob: the
-    /// catalog value token to turn on, the declaring type and method whose decompiled
-    /// body that token governs, and the harness signature that identifies the method
-    /// for compile-back. A knob's value domain — not the knob — is the coverage unit,
-    /// so a multi-value axis (e.g. the three <c>var</c> categories) needs one specimen
-    /// per category, not one per axis.
+    /// One specimen per non-default value of a byte-neutral knob: the catalog value
+    /// token to turn on, the declaring type and method whose decompiled body that token
+    /// governs, and how that value's byte-neutrality is proven. A knob's value domain —
+    /// not the knob — is the coverage unit, so a multi-value axis (e.g. the three
+    /// <c>var</c> categories) needs one specimen per category, not one per axis.
     ///
     /// <para>
-    /// <see cref="Emits"/> distinguishes a value the printer actually consumes today
-    /// (the token is rewritten, so the value is compiled back to prove IL-identity)
-    /// from a value that is declared in the catalog but not yet wired into emission
-    /// (a no-op that renders identically to the default). The unwired values are
-    /// pinned as no-ops on an input they <em>would</em> govern once wired, so the day
-    /// emission lands the pin flips (on-render diverges from off) and forces the
-    /// author to promote the value to an emitting, compiled-back specimen.
+    /// <see cref="Proof"/> selects the check the value's neutrality is held to and must
+    /// agree with the knob's tier (asserted by <see cref="EveryByteNeutralValue_HasASpecimen"/>):
+    /// a Spelling or Synthesis value rewrites tokens or metadata the compiler binds, so
+    /// it is <see cref="NeutralityProof.CompileBack"/>; a Formatting value only moves
+    /// whitespace, so it is <see cref="NeutralityProof.Whitespace"/>.
+    /// </para>
+    ///
+    /// <para>
+    /// <see cref="Emits"/> distinguishes a value the printer actually consumes today (the
+    /// render changes, so the value is exercised) from one that renders identically to
+    /// the default — either a catalog value not yet wired into emission (the deferred var
+    /// buckets) or a knob that is inert on this corpus (readable-local-names, whose
+    /// synthesis a present PDB source name suppresses). The inert values are pinned as
+    /// no-ops on an input they <em>would</em> govern once active, so the day emission
+    /// lands (or a name-less local appears) the pin flips and forces an emitting specimen.
     /// </para>
     /// </summary>
     sealed record ValueSpecimen(
@@ -81,37 +98,69 @@ public sealed class ByteNeutralityGateTests
         string ValueToken,
         System.Type DeclaringType,
         string Method,
-        string Signature,
-        bool Emits);
+        NeutralityProof Proof,
+        string Signature = "",
+        bool Emits = true,
+        FidelityCheck.CompileBackStatus ExpectedBaseline = FidelityCheck.CompileBackStatus.Exact);
+
+    enum NeutralityProof
+    {
+        // Compile the value's on/off render back and prove IL-identity (Spelling, Synthesis).
+        CompileBack,
+        // Prove the value's on/off render differs only in insignificant whitespace (Formatting).
+        Whitespace,
+    }
 
     static readonly IReadOnlyList<ValueSpecimen> Specimens =
     [
         new("qualify-field-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.ReadField),
-            "() -> corelib:System.Int32", Emits: true),
+            NeutralityProof.CompileBack, "() -> corelib:System.Int32"),
         new("qualify-property-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.ReadProperty),
-            "() -> corelib:System.Int32", Emits: true),
+            NeutralityProof.CompileBack, "() -> corelib:System.Int32"),
         new("qualify-method-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.CallMethod),
-            "() -> corelib:System.Int32", Emits: true),
+            NeutralityProof.CompileBack, "() -> corelib:System.Int32"),
+        // The event-subscription decompilation over-renders into a benign OpcodeDiff
+        // baseline (independent of the this. qualifier), so its knob-off compile-back is
+        // anchored at OpcodeDiff, not Exact; the gate proves the knob-on render deviates
+        // from the original identically to knob-off, not that either reaches Exact.
         new("qualify-event-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.Subscribe),
-            "(corelib:System.EventHandler) -> corelib:System.Void", Emits: true),
+            NeutralityProof.CompileBack, "(corelib:System.EventHandler) -> corelib:System.Void",
+            ExpectedBaseline: FidelityCheck.CompileBackStatus.OpcodeDiff),
         new("var-spelling-style", "var-when-type-apparent",
             typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.ObjectCreation),
-            "() -> corelib:System.Int32", Emits: true),
+            NeutralityProof.CompileBack, "() -> corelib:System.Int32"),
         // Declared-but-unwired var categories (deferred #3169). Pinned as no-ops on the
         // input each would govern once emission lands: a built-in-type object creation
         // and a not-apparent local. When the bucket is wired these renders diverge and
-        // SpellingValue_TokenState_MatchesEmits fails, forcing an emitting specimen.
+        // ValueTokenState_MatchesEmits fails, forcing an emitting specimen.
         new("var-spelling-style", "var-for-built-in-types",
             typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.BuiltInObjectCreation),
-            "() -> corelib:System.Int32", Emits: false),
+            NeutralityProof.CompileBack, "() -> corelib:System.Int32", Emits: false),
         new("var-spelling-style", "var-elsewhere",
             typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.NotApparent),
-            "() -> corelib:System.Int32", Emits: false),
+            NeutralityProof.CompileBack, "() -> corelib:System.Int32", Emits: false),
+        // Synthesis: readable-local-names renames a local, and a name lives in the PDB,
+        // not the IL. It is inert here (the embedded PDB names this local), so it is
+        // pinned as a no-op; when a name-less local makes it fire, the pin flips.
+        new("readable-local-names", "true",
+            typeof(FormattingSynthesisSpecimen), nameof(FormattingSynthesisSpecimen.ReadableLocal),
+            NeutralityProof.CompileBack, "() -> corelib:System.Int32", Emits: false),
+        // Formatting: whitespace-only knobs, each on a specimen it wraps or flattens.
+        new("wrap-expression-body-arrow", "true",
+            typeof(FormattingSynthesisSpecimen), nameof(FormattingSynthesisSpecimen.ArrowBody),
+            NeutralityProof.Whitespace),
+        new("wrap-splittable-expressions", "true",
+            typeof(FormattingSynthesisSpecimen), nameof(FormattingSynthesisSpecimen.LongLogicalChain),
+            NeutralityProof.Whitespace),
+        new("disable-one-liner-wrapping", "true",
+            typeof(FormattingSynthesisSpecimen), nameof(FormattingSynthesisSpecimen.LongFluentChain),
+            NeutralityProof.Whitespace),
     ];
+
 
     static IReadOnlyList<StyleOptionDescriptor> ByteNeutralKnobs =>
         StyleOptionCatalog.Options.Where(o => !o.ByteDivergent).ToArray();
@@ -150,28 +199,55 @@ public sealed class ByteNeutralityGateTests
                 [AssemblyPath], [.. specimens.Select(Target)], lowered: false, options)
             .ToDictionary(r => $"{r.Type}::{r.Method}", r => r, StringComparer.Ordinal);
 
-    // Every non-default value token of a Spelling-tier byte-neutral knob, the coverage
-    // unit the drift guard and value-state test are keyed on.
-    static IReadOnlyList<(string KnobId, string ValueToken)> SpellingNonDefaultValues =>
+    // Insignificant-whitespace normalization: keep a whitespace run only where it
+    // separates two word characters (so `int alpha` never collapses to `intalpha`, which
+    // would mask a token change), and drop it everywhere else. Two renders that differ
+    // only in layout normalize equal; a render that moved a real token does not.
+    static string NormalizeWhitespace(string text)
+    {
+        var significant = System.Text.RegularExpressions.Regex.Replace(text, @"(?<=\w)\s+(?=\w)", " ");
+        return System.Text.RegularExpressions.Regex.Replace(significant, @"\s+", "").Trim();
+    }
+
+    // Every non-default value token of a byte-neutral knob, across all tiers — the
+    // coverage unit the drift guard and value-state tests are keyed on.
+    static IReadOnlyList<(string KnobId, string ValueToken)> ByteNeutralNonDefaultValues =>
         ByteNeutralKnobs
-            .Where(o => o.Tier == StyleOptionTier.Spelling)
             .SelectMany(o => o.Values
                 .Where(v => v.Token != o.DefaultValue)
                 .Select(v => (o.Id, v.Token)))
             .ToArray();
 
-    [Fact]
-    public void EverySpellingByteNeutralValue_HasASpecimen()
+    // The proof a knob's tier is entitled to: token/metadata-changing tiers are compiled
+    // back; whitespace-only Formatting is checked by normalized-text equality.
+    static NeutralityProof ProofForTier(StyleOptionTier tier) => tier switch
     {
-        // Drift guard: the gate must cover every non-default value of every Spelling-tier
-        // byte-neutral knob — the value, not the knob, is the byte-neutrality unit, so a
-        // multi-value axis (the three var categories) needs one specimen per category. A
-        // new value added without a specimen fails here, keeping the gate — driven off
-        // the classification — exhaustive over the tier whose byte-neutrality is a
-        // semantic (token-binding) claim rather than structural.
-        var required = SpellingNonDefaultValues.ToHashSet();
+        StyleOptionTier.Formatting => NeutralityProof.Whitespace,
+        _ => NeutralityProof.CompileBack,
+    };
+
+    [Fact]
+    public void EveryByteNeutralValue_HasASpecimen()
+    {
+        // Drift guard: the gate must cover every non-default value of every byte-neutral
+        // knob — the value, not the knob, is the byte-neutrality unit, so a multi-value
+        // axis (the three var categories) needs one specimen per category. A new value
+        // added without a specimen fails here, keeping the gate — driven off the
+        // classification — exhaustive over the whole byte-neutral set.
+        var required = ByteNeutralNonDefaultValues.ToHashSet();
         var covered = Specimens.Select(s => (s.KnobId, s.ValueToken)).ToHashSet();
         Assert.Equal(required, covered);
+
+        // Tier/proof agreement: a specimen must be checked by the proof its knob's tier
+        // entitles it to. This is what catches a mis-tiered knob — tagging a
+        // token-changing knob Formatting would demand a whitespace specimen it cannot
+        // satisfy (its render moves a token, so NormalizeWhitespace stays unequal), and
+        // tagging a whitespace knob Spelling would demand a compile-back it does not need.
+        foreach (var specimen in Specimens)
+        {
+            var tier = Knob(specimen.KnobId).Tier;
+            Assert.Equal(ProofForTier(tier), specimen.Proof);
+        }
     }
 
     [Fact]
@@ -188,14 +264,15 @@ public sealed class ByteNeutralityGateTests
     }
 
     [Fact]
-    public void SpellingValue_TokenState_MatchesEmits()
+    public void ValueTokenState_MatchesEmits()
     {
         // Non-vacuity + wiring pin, fast (no compile-back). An emitting value must
-        // actually rewrite its specimen's tokens (off != on) — this is what makes the
-        // slow IL-identity proof below a real check rather than a comparison of two
-        // identical renders. A declared-but-unwired value must render identically to the
-        // default (off == on) on the input it would govern; when the bucket is wired
-        // that equality breaks and this test forces the value into the emitting set.
+        // actually change its specimen's render (off != on) — this is what makes the
+        // neutrality proofs below real checks rather than comparisons of two identical
+        // renders. An inert value (a declared-but-unwired var bucket, or readable local
+        // names when a source name is present) must render identically to the default
+        // (off == on) on the input it would govern; when the value becomes active that
+        // equality breaks and this test forces it into the emitting set.
         foreach (var specimen in Specimens)
         {
             var offText = Render(specimen.DeclaringType, specimen.Method, options: null);
@@ -204,21 +281,43 @@ public sealed class ByteNeutralityGateTests
                 Assert.NotEqual(offText, onText);
             else
                 Assert.True(offText == onText,
-                    $"{specimen.KnobId}={specimen.ValueToken} is marked unwired (Emits:false) but its render changed; " +
-                    $"the bucket is now emitting — add a firing specimen and set Emits:true so it is compiled back.");
+                    $"{specimen.KnobId}={specimen.ValueToken} is marked inert (Emits:false) but its render changed; " +
+                    $"the value is now active — add a firing specimen and set Emits:true so it is proven.");
+        }
+    }
+
+    [Fact]
+    public void FormattingValue_On_ChangesOnlyWhitespace()
+    {
+        // The Formatting-tier claim: a whitespace-only knob moves layout the assembly
+        // never stored, so it cannot change the IL. Checked fast, without a compiler:
+        // the on/off renders must differ (the knob fired — ValueTokenState_MatchesEmits
+        // pins that too, re-asserted here for locality) yet be equal once insignificant
+        // whitespace is normalized away. A knob mis-classified as Formatting that moved a
+        // real token would leave the normalized texts unequal and fail here.
+        foreach (var specimen in Specimens.Where(s => s.Proof == NeutralityProof.Whitespace))
+        {
+            var offText = Render(specimen.DeclaringType, specimen.Method, options: null);
+            var onText = Render(specimen.DeclaringType, specimen.Method, On(specimen));
+            var label = $"{specimen.KnobId}={specimen.ValueToken}";
+
+            Assert.NotEqual(offText, onText);
+            Assert.True(NormalizeWhitespace(offText) == NormalizeWhitespace(onText),
+                $"{label}: knob-on render differs from knob-off in more than whitespace — the knob " +
+                $"is tagged Formatting but moved a token, so it is not byte-neutral by layout alone.");
         }
     }
 
     [Fact]
     [Trait("Speed", "Slow")]
-    public void SpellingValue_On_RecompilesToTheSameIlAsOff()
+    public void CompileBackValue_On_RecompilesToTheSameIlAsOff()
     {
-        // The claim under test: an emitting Spelling value's rewritten output recompiles
-        // to the same IL as the shipped default. Proving that soundly means comparing the
-        // two recompiled bodies to EACH OTHER, not each to the original: a coarser
-        // off-vs-on comparison of status + opcode names would accept two renders that
-        // both diverge from the original (and each other) in the same category — e.g. two
-        // OperandDiff renders with different operands.
+        // The claim under test: an emitting compile-back value's rewritten output
+        // recompiles to the same IL as the shipped default. Proving that soundly means
+        // comparing the two recompiled bodies to EACH OTHER, not each to the original: a
+        // coarser off-vs-on comparison of status + opcode names would accept two renders
+        // that both diverge from the original (and each other) in the same category —
+        // e.g. two OperandDiff renders with different operands.
         //
         // The harness compiles each render back and diffs it against the shared original
         // under compile-back contract V1 (a complete LCS operand/branch-target diff). If
@@ -234,7 +333,7 @@ public sealed class ByteNeutralityGateTests
         // together also exercises the same-line interaction the catalog flags
         // (qualification x var), while each method's site is governed by exactly one
         // value, so the per-method verdict still isolates that value's neutrality.
-        var emitting = Specimens.Where(s => s.Emits).ToArray();
+        var emitting = Specimens.Where(s => s.Proof == NeutralityProof.CompileBack && s.Emits).ToArray();
         var off = CompileBackAll(emitting, options: null);
 
         foreach (var group in emitting.GroupBy(s => s.DeclaringType))
@@ -254,6 +353,16 @@ public sealed class ByteNeutralityGateTests
                     $"{label}: knob-off render did not compile back ({offResult.Status}: {offResult.Detail}).");
                 Assert.False(IsUncheckable(onResult.Status),
                     $"{label}: knob-on render did not compile back ({onResult.Status}: {onResult.Detail}).");
+
+                // Baseline anchor: the knob-off render must reach the specific compile-back
+                // status this specimen is expected to (Exact for most; the event specimen's
+                // benign OpcodeDiff). Without this the off-vs-on equality below would still
+                // pass if the baseline silently degraded (e.g. an unrelated regression made
+                // both renders OperandDiff), so pin the strongest status the baseline earns.
+                Assert.True(offResult.Status == specimen.ExpectedBaseline,
+                    $"{label}: knob-off compile-back baseline is {offResult.Status}, expected " +
+                    $"{specimen.ExpectedBaseline}. A changed baseline can hide an off-vs-on match that " +
+                    $"is only equal because both renders regressed; re-establish or update the anchor.");
 
                 var offDiff = offResult.FidelityDiff;
                 var onDiff = onResult.FidelityDiff;

--- a/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
@@ -5,6 +5,7 @@ using System.Reflection.PortableExecutable;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.DecompilerHarness;
+using ILInspector.Instructions;
 using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Tests;
@@ -27,9 +28,10 @@ namespace ILInspector.Decompiler.Tests;
 /// The <see cref="StyleOptionTier.Spelling"/> byte-neutral knobs change emitted C#
 /// <em>tokens</em> (a <c>this.</c> qualifier, a <c>var</c> inference) the compiler must
 /// bind to the same IL. That is a semantic claim — the <c>var x = new()</c> → CS8754
-/// near-miss lived here — so each is compiled back: rendering a firing specimen with
-/// the knob on and off must produce the same recompiled IL. A new Spelling byte-neutral
-/// knob with no firing specimen fails <see cref="EverySpellingByteNeutralKnob_HasAFiringSpecimen"/>.
+/// near-miss lived here — so each emitting value is compiled back: rendering a firing
+/// specimen with the value on and off must both recompile to the original IL. A new
+/// Spelling byte-neutral value with no specimen fails
+/// <see cref="EverySpellingByteNeutralValue_HasASpecimen"/>.
 /// </description></item>
 /// <item><description>
 /// The <see cref="StyleOptionTier.Formatting"/> (whitespace-only) and
@@ -57,34 +59,58 @@ public sealed class ByteNeutralityGateTests
     static string AssemblyPath => typeof(ByteNeutralityGateTests).Assembly.Location;
 
     /// <summary>
-    /// One firing specimen per Spelling-tier byte-neutral knob: the catalog value token
-    /// to turn on, the declaring type and method whose decompiled body that token
-    /// rewrites, and the harness signature that identifies the method for compile-back.
+    /// One specimen per non-default value of a Spelling-tier byte-neutral knob: the
+    /// catalog value token to turn on, the declaring type and method whose decompiled
+    /// body that token governs, and the harness signature that identifies the method
+    /// for compile-back. A knob's value domain — not the knob — is the coverage unit,
+    /// so a multi-value axis (e.g. the three <c>var</c> categories) needs one specimen
+    /// per category, not one per axis.
+    ///
+    /// <para>
+    /// <see cref="Emits"/> distinguishes a value the printer actually consumes today
+    /// (the token is rewritten, so the value is compiled back to prove IL-identity)
+    /// from a value that is declared in the catalog but not yet wired into emission
+    /// (a no-op that renders identically to the default). The unwired values are
+    /// pinned as no-ops on an input they <em>would</em> govern once wired, so the day
+    /// emission lands the pin flips (on-render diverges from off) and forces the
+    /// author to promote the value to an emitting, compiled-back specimen.
+    /// </para>
     /// </summary>
-    sealed record FiringSpecimen(
+    sealed record ValueSpecimen(
         string KnobId,
         string ValueToken,
         System.Type DeclaringType,
         string Method,
-        string Signature);
+        string Signature,
+        bool Emits);
 
-    static readonly IReadOnlyList<FiringSpecimen> Specimens =
+    static readonly IReadOnlyList<ValueSpecimen> Specimens =
     [
         new("qualify-field-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.ReadField),
-            "() -> corelib:System.Int32"),
+            "() -> corelib:System.Int32", Emits: true),
         new("qualify-property-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.ReadProperty),
-            "() -> corelib:System.Int32"),
+            "() -> corelib:System.Int32", Emits: true),
         new("qualify-method-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.CallMethod),
-            "() -> corelib:System.Int32"),
+            "() -> corelib:System.Int32", Emits: true),
         new("qualify-event-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.Subscribe),
-            "(corelib:System.EventHandler) -> corelib:System.Void"),
+            "(corelib:System.EventHandler) -> corelib:System.Void", Emits: true),
         new("var-spelling-style", "var-when-type-apparent",
             typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.ObjectCreation),
-            "() -> corelib:System.Int32"),
+            "() -> corelib:System.Int32", Emits: true),
+        // Declared-but-unwired var categories (deferred #3169). Pinned as no-ops on the
+        // input each would govern once emission lands: a built-in-type object creation
+        // and a not-apparent local. When the bucket is wired these renders diverge and
+        // SpellingValue_TokenState_MatchesEmits fails, forcing an emitting specimen.
+        new("var-spelling-style", "var-for-built-in-types",
+            typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.BuiltInObjectCreation),
+            "() -> corelib:System.Int32", Emits: false),
+        new("var-spelling-style", "var-elsewhere",
+            typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.NotApparent),
+            "() -> corelib:System.Int32", Emits: false),
     ];
 
     static IReadOnlyList<StyleOptionDescriptor> ByteNeutralKnobs =>
@@ -95,7 +121,7 @@ public sealed class ByteNeutralityGateTests
 
     // The knob's non-default state, built through the catalog descriptor (never a raw
     // property set) so the gate exercises the same value-domain plumbing a host uses.
-    static PrinterOptions On(FiringSpecimen specimen) =>
+    static PrinterOptions On(ValueSpecimen specimen) =>
         Knob(specimen.KnobId).WithValue(PrinterOptions.Default, specimen.ValueToken);
 
     static string Render(System.Type declaringType, string member, PrinterOptions? options)
@@ -110,32 +136,41 @@ public sealed class ByteNeutralityGateTests
         return rendered.Text!;
     }
 
-    static FidelityCheck.CompileBackTarget Target(FiringSpecimen specimen) =>
+    static FidelityCheck.CompileBackTarget Target(ValueSpecimen specimen) =>
         new(AssemblyPath, specimen.DeclaringType.FullName!, specimen.Method, Overload: 0, Signature: specimen.Signature);
 
-    static string Key(FiringSpecimen specimen) => $"{specimen.DeclaringType.FullName}::{specimen.Method}";
+    static string Key(ValueSpecimen specimen) => $"{specimen.DeclaringType.FullName}::{specimen.Method}";
 
     // One compile-back pass over a set of specimens under a single options set. The
     // (large) test assembly is decompiled up to the target types, so batching every
     // target into one pass keeps the gate to a few passes instead of one per knob.
     static IReadOnlyDictionary<string, FidelityCheck.CompileBackResult> CompileBackAll(
-        IReadOnlyList<FiringSpecimen> specimens, PrinterOptions? options)
+        IReadOnlyList<ValueSpecimen> specimens, PrinterOptions? options)
         => FidelityCheck.EvaluateTargets(
                 [AssemblyPath], [.. specimens.Select(Target)], lowered: false, options)
             .ToDictionary(r => $"{r.Type}::{r.Method}", r => r, StringComparer.Ordinal);
 
-    [Fact]
-    public void EverySpellingByteNeutralKnob_HasAFiringSpecimen()
-    {
-        // Drift guard: the compile-back gate must cover every Spelling-tier byte-neutral
-        // knob. A new one added without a firing specimen fails here, forcing the gate —
-        // driven off the classification — to stay exhaustive over the tier whose
-        // byte-neutrality is a semantic (token-binding) claim rather than structural.
-        var required = ByteNeutralKnobs
+    // Every non-default value token of a Spelling-tier byte-neutral knob, the coverage
+    // unit the drift guard and value-state test are keyed on.
+    static IReadOnlyList<(string KnobId, string ValueToken)> SpellingNonDefaultValues =>
+        ByteNeutralKnobs
             .Where(o => o.Tier == StyleOptionTier.Spelling)
-            .Select(o => o.Id)
-            .ToHashSet(StringComparer.Ordinal);
-        var covered = Specimens.Select(s => s.KnobId).ToHashSet(StringComparer.Ordinal);
+            .SelectMany(o => o.Values
+                .Where(v => v.Token != o.DefaultValue)
+                .Select(v => (o.Id, v.Token)))
+            .ToArray();
+
+    [Fact]
+    public void EverySpellingByteNeutralValue_HasASpecimen()
+    {
+        // Drift guard: the gate must cover every non-default value of every Spelling-tier
+        // byte-neutral knob — the value, not the knob, is the byte-neutrality unit, so a
+        // multi-value axis (the three var categories) needs one specimen per category. A
+        // new value added without a specimen fails here, keeping the gate — driven off
+        // the classification — exhaustive over the tier whose byte-neutrality is a
+        // semantic (token-binding) claim rather than structural.
+        var required = SpellingNonDefaultValues.ToHashSet();
+        var covered = Specimens.Select(s => (s.KnobId, s.ValueToken)).ToHashSet();
         Assert.Equal(required, covered);
     }
 
@@ -153,36 +188,56 @@ public sealed class ByteNeutralityGateTests
     }
 
     [Fact]
-    public void SpellingKnob_On_RewritesTheSpecimenTokens()
+    public void SpellingValue_TokenState_MatchesEmits()
     {
-        // Non-vacuity, fast (no compile-back): each knob, on alone, actually rewrites
-        // its firing specimen's tokens. This is what makes the slow IL-identity proof
-        // below a real check rather than a comparison of two identical renders.
+        // Non-vacuity + wiring pin, fast (no compile-back). An emitting value must
+        // actually rewrite its specimen's tokens (off != on) — this is what makes the
+        // slow IL-identity proof below a real check rather than a comparison of two
+        // identical renders. A declared-but-unwired value must render identically to the
+        // default (off == on) on the input it would govern; when the bucket is wired
+        // that equality breaks and this test forces the value into the emitting set.
         foreach (var specimen in Specimens)
         {
             var offText = Render(specimen.DeclaringType, specimen.Method, options: null);
             var onText = Render(specimen.DeclaringType, specimen.Method, On(specimen));
-            Assert.NotEqual(offText, onText);
+            if (specimen.Emits)
+                Assert.NotEqual(offText, onText);
+            else
+                Assert.True(offText == onText,
+                    $"{specimen.KnobId}={specimen.ValueToken} is marked unwired (Emits:false) but its render changed; " +
+                    $"the bucket is now emitting — add a firing specimen and set Emits:true so it is compiled back.");
         }
     }
 
     [Fact]
     [Trait("Speed", "Slow")]
-    public void SpellingKnob_On_RecompilesToIdenticalIl()
+    public void SpellingValue_On_RecompilesToTheSameIlAsOff()
     {
-        // The claim under test: a Spelling knob's rewritten output recompiles to the
-        // same IL as the shipped default. Compare the recompiled opcode stream
-        // (opcode-level identity) AND the compile-back contract-V1 verdict
-        // (operand/branch-target identity) of the knob-on and knob-off renders.
+        // The claim under test: an emitting Spelling value's rewritten output recompiles
+        // to the same IL as the shipped default. Proving that soundly means comparing the
+        // two recompiled bodies to EACH OTHER, not each to the original: a coarser
+        // off-vs-on comparison of status + opcode names would accept two renders that
+        // both diverge from the original (and each other) in the same category — e.g. two
+        // OperandDiff renders with different operands.
         //
-        // Batched to three passes over the large test assembly: one knob-off baseline
-        // for all specimens, then one knob-on pass per declaring type. Turning a type's
-        // knobs on together also exercises the same-line interaction the catalog flags
-        // (qualification x var), while each method's site is rewritten by exactly one
-        // knob, so the per-method comparison still isolates that knob's neutrality.
-        var off = CompileBackAll(Specimens, options: null);
+        // The harness compiles each render back and diffs it against the shared original
+        // under compile-back contract V1 (a complete LCS operand/branch-target diff). If
+        // the knob-off and knob-on renders produce the SAME contract-V1 diff against that
+        // one original, they deviate from it identically and are therefore IL-identical to
+        // each other — even when the shared baseline is itself a benign over-render (the
+        // event-subscription decompilation is an OpcodeDiff, not Exact, independent of the
+        // `this.` qualifier). Comparing under the same contract the product's own fidelity
+        // claims use keeps the gate consistent with those claims.
+        //
+        // Batched over the large test assembly: one knob-off baseline for all emitting
+        // specimens, then one knob-on pass per declaring type. Turning a type's values on
+        // together also exercises the same-line interaction the catalog flags
+        // (qualification x var), while each method's site is governed by exactly one
+        // value, so the per-method verdict still isolates that value's neutrality.
+        var emitting = Specimens.Where(s => s.Emits).ToArray();
+        var off = CompileBackAll(emitting, options: null);
 
-        foreach (var group in Specimens.GroupBy(s => s.DeclaringType))
+        foreach (var group in emitting.GroupBy(s => s.DeclaringType))
         {
             var groupSpecimens = group.ToArray();
             var onOptions = groupSpecimens.Aggregate(
@@ -193,13 +248,29 @@ public sealed class ByteNeutralityGateTests
             {
                 var offResult = off[Key(specimen)];
                 var onResult = on[Key(specimen)];
+                var label = $"{specimen.KnobId}={specimen.ValueToken}";
 
                 Assert.False(IsUncheckable(offResult.Status),
-                    $"{specimen.KnobId}: knob-off render did not compile back ({offResult.Status}: {offResult.Detail}).");
+                    $"{label}: knob-off render did not compile back ({offResult.Status}: {offResult.Detail}).");
                 Assert.False(IsUncheckable(onResult.Status),
-                    $"{specimen.KnobId}: knob-on render did not compile back ({onResult.Status}: {onResult.Detail}).");
+                    $"{label}: knob-on render did not compile back ({onResult.Status}: {onResult.Detail}).");
+
+                var offDiff = offResult.FidelityDiff;
+                var onDiff = onResult.FidelityDiff;
+                Assert.True(offDiff is { IsAvailable: true },
+                    $"{label}: knob-off compile-back fidelity is unavailable, so IL identity cannot be proven.");
+                Assert.True(onDiff is { IsAvailable: true },
+                    $"{label}: knob-on compile-back fidelity is unavailable, so IL identity cannot be proven.");
+
+                // Opcode-level identity of the two recompiled bodies (fast belt).
                 Assert.Equal(offResult.RecompiledOpcodes, onResult.RecompiledOpcodes);
-                Assert.Equal(offResult.Status, onResult.Status);
+
+                // Operand/branch-target identity: both recompiled bodies deviate from the
+                // shared original identically under contract V1, hence equal each other.
+                Assert.Equal(offDiff!.Outcome, onDiff!.Outcome);
+                Assert.True(offDiff.Rows.SequenceEqual(onDiff.Rows),
+                    $"{label}: knob-on recompiled body diverges from knob-off at the operand or " +
+                    $"branch-target level (contract-V1 diff-vs-original differs between the two renders).");
             }
         }
 

--- a/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
@@ -35,11 +35,13 @@ namespace ILInspector.Decompiler.Tests;
 /// </description></item>
 /// <item><description>
 /// The <see cref="StyleOptionTier.Formatting"/> (whitespace-only) byte-neutral knobs
-/// change layout the assembly never stored. That is still checkable without a compiler:
-/// rendering a firing specimen with the knob on and off must differ (the knob fired) yet
-/// collapse to the same text once insignificant whitespace is removed — a fast lane the
-/// reviewer valued. A knob mis-classified as Formatting that actually moved a token would
-/// fail the whitespace-equality assertion. See <see cref="FormattingValue_On_ChangesOnlyWhitespace"/>.
+/// only move layout the assembly never stored, so their emitted forms recompile to the
+/// same IL as the default. They are held to the same compile-back IL-identity proof as
+/// the Spelling knobs — a text-level "differs only in whitespace" check was considered
+/// but abandoned because insignificant whitespace in C# cannot be recognized soundly
+/// from text or even a token stream (the lexer splits the range operator, so
+/// <c>1..2</c> and <c>1 . . 2</c> tokenize alike yet compile differently), whereas
+/// compile-back proves neutrality at the IL level a mis-tiered token change cannot pass.
 /// </description></item>
 /// <item><description>
 /// The one <see cref="StyleOptionTier.Synthesis"/> byte-neutral knob (readable local
@@ -69,23 +71,24 @@ public sealed class ByteNeutralityGateTests
     static string AssemblyPath => typeof(ByteNeutralityGateTests).Assembly.Location;
 
     /// <summary>
-    /// One specimen per non-default value of a byte-neutral knob: the catalog value
-    /// token to turn on, the declaring type and method whose decompiled body that token
-    /// governs, and how that value's byte-neutrality is proven. A knob's value domain —
-    /// not the knob — is the coverage unit, so a multi-value axis (e.g. the three
-    /// <c>var</c> categories) needs one specimen per category, not one per axis.
+    /// One specimen per non-default value of a byte-neutral knob: the catalog value token
+    /// to turn on, the declaring type and method whose decompiled body that token governs,
+    /// and the harness signature that identifies the method for compile-back. A knob's
+    /// value domain — not the knob — is the coverage unit, so a multi-value axis (e.g. the
+    /// three <c>var</c> categories) needs one specimen per category, not one per axis.
     ///
     /// <para>
-    /// <see cref="Proof"/> selects the check the value's neutrality is held to and must
-    /// agree with the knob's tier (asserted by <see cref="EveryByteNeutralValue_HasASpecimen"/>):
-    /// a Spelling or Synthesis value rewrites tokens or metadata the compiler binds, so
-    /// it is <see cref="NeutralityProof.CompileBack"/>; a Formatting value only moves
-    /// whitespace, so it is <see cref="NeutralityProof.Whitespace"/>.
+    /// Every byte-neutral value is held to the same proof: its knob-on and knob-off
+    /// renders must recompile to the same IL (established off-vs-on under compile-back
+    /// contract V1, below). Formatting, Spelling and Synthesis knobs all claim IL-identity
+    /// — layout, a <c>this.</c> qualifier, a <c>var</c> inference, a local name — and
+    /// compile-back proves that claim uniformly at the IL level, where a mis-tiered token
+    /// change that actually altered the IL cannot pass.
     /// </para>
     ///
     /// <para>
     /// <see cref="Emits"/> distinguishes a value the printer actually consumes today (the
-    /// render changes, so the value is exercised) from one that renders identically to
+    /// render changes, so the value is compiled back) from one that renders identically to
     /// the default — either a catalog value not yet wired into emission (the deferred var
     /// buckets) or a knob that is inert on this corpus (readable-local-names, whose
     /// synthesis a present PDB source name suppresses). The inert values are pinned as
@@ -98,68 +101,62 @@ public sealed class ByteNeutralityGateTests
         string ValueToken,
         System.Type DeclaringType,
         string Method,
-        NeutralityProof Proof,
-        string Signature = "",
+        string Signature,
         bool Emits = true,
         FidelityCheck.CompileBackStatus ExpectedBaseline = FidelityCheck.CompileBackStatus.Exact);
-
-    enum NeutralityProof
-    {
-        // Compile the value's on/off render back and prove IL-identity (Spelling, Synthesis).
-        CompileBack,
-        // Prove the value's on/off render differs only in insignificant whitespace (Formatting).
-        Whitespace,
-    }
 
     static readonly IReadOnlyList<ValueSpecimen> Specimens =
     [
         new("qualify-field-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.ReadField),
-            NeutralityProof.CompileBack, "() -> corelib:System.Int32"),
+            "() -> corelib:System.Int32"),
         new("qualify-property-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.ReadProperty),
-            NeutralityProof.CompileBack, "() -> corelib:System.Int32"),
+            "() -> corelib:System.Int32"),
         new("qualify-method-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.CallMethod),
-            NeutralityProof.CompileBack, "() -> corelib:System.Int32"),
+            "() -> corelib:System.Int32"),
         // The event-subscription decompilation over-renders into a benign OpcodeDiff
         // baseline (independent of the this. qualifier), so its knob-off compile-back is
         // anchored at OpcodeDiff, not Exact; the gate proves the knob-on render deviates
         // from the original identically to knob-off, not that either reaches Exact.
         new("qualify-event-access", "true",
             typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.Subscribe),
-            NeutralityProof.CompileBack, "(corelib:System.EventHandler) -> corelib:System.Void",
+            "(corelib:System.EventHandler) -> corelib:System.Void",
             ExpectedBaseline: FidelityCheck.CompileBackStatus.OpcodeDiff),
         new("var-spelling-style", "var-when-type-apparent",
             typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.ObjectCreation),
-            NeutralityProof.CompileBack, "() -> corelib:System.Int32"),
+            "() -> corelib:System.Int32"),
         // Declared-but-unwired var categories (deferred #3169). Pinned as no-ops on the
         // input each would govern once emission lands: a built-in-type object creation
         // and a not-apparent local. When the bucket is wired these renders diverge and
         // ValueTokenState_MatchesEmits fails, forcing an emitting specimen.
         new("var-spelling-style", "var-for-built-in-types",
             typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.BuiltInObjectCreation),
-            NeutralityProof.CompileBack, "() -> corelib:System.Int32", Emits: false),
+            "() -> corelib:System.Int32", Emits: false),
         new("var-spelling-style", "var-elsewhere",
             typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.NotApparent),
-            NeutralityProof.CompileBack, "() -> corelib:System.Int32", Emits: false),
+            "() -> corelib:System.Int32", Emits: false),
         // Synthesis: readable-local-names renames a local, and a name lives in the PDB,
         // not the IL. It is inert here (the embedded PDB names this local), so it is
         // pinned as a no-op; when a name-less local makes it fire, the pin flips.
         new("readable-local-names", "true",
             typeof(FormattingSynthesisSpecimen), nameof(FormattingSynthesisSpecimen.ReadableLocal),
-            NeutralityProof.CompileBack, "() -> corelib:System.Int32", Emits: false),
+            "() -> corelib:System.Int32", Emits: false),
         // Formatting: whitespace-only knobs, each on a specimen it wraps or flattens.
+        // Compiled back like every other byte-neutral value — layout never reaches the IL,
+        // so the on/off renders recompile identically.
         new("wrap-expression-body-arrow", "true",
             typeof(FormattingSynthesisSpecimen), nameof(FormattingSynthesisSpecimen.ArrowBody),
-            NeutralityProof.Whitespace),
+            "() -> corelib:System.Int32"),
         new("wrap-splittable-expressions", "true",
             typeof(FormattingSynthesisSpecimen), nameof(FormattingSynthesisSpecimen.LongLogicalChain),
-            NeutralityProof.Whitespace),
+            "(corelib:System.Int32) -> corelib:System.Boolean"),
         new("disable-one-liner-wrapping", "true",
             typeof(FormattingSynthesisSpecimen), nameof(FormattingSynthesisSpecimen.LongFluentChain),
-            NeutralityProof.Whitespace),
+            "() -> corelib:System.String"),
     ];
+
 
 
     static IReadOnlyList<StyleOptionDescriptor> ByteNeutralKnobs =>
@@ -199,21 +196,6 @@ public sealed class ByteNeutralityGateTests
                 [AssemblyPath], [.. specimens.Select(Target)], lowered: false, options)
             .ToDictionary(r => $"{r.Type}::{r.Method}", r => r, StringComparer.Ordinal);
 
-    // Insignificant-whitespace normalization: keep a single space only where removing it
-    // would fuse two tokens of the same class — two word characters (so `int alpha` never
-    // collapses to `intalpha`) or two operator characters (so `+ +` never collapses to
-    // `++`) — and drop all other whitespace. A sentinel protects the kept spaces from the
-    // strip that removes the rest, so two renders that differ only in layout normalize
-    // equal while a render that fused a real token does not.
-    static string NormalizeWhitespace(string text)
-    {
-        const string keep = "\u0001";
-        var guarded = System.Text.RegularExpressions.Regex.Replace(
-            text, @"(?<=\w)\s+(?=\w)|(?<=[-+*/%&|^!=<>?:])\s+(?=[-+*/%&|^!=<>?:])", keep);
-        var stripped = System.Text.RegularExpressions.Regex.Replace(guarded, @"\s+", "");
-        return stripped.Replace(keep, " ").Trim();
-    }
-
     // Every non-default value token of a byte-neutral knob, across all tiers — the
     // coverage unit the drift guard and value-state tests are keyed on.
     static IReadOnlyList<(string KnobId, string ValueToken)> ByteNeutralNonDefaultValues =>
@@ -222,14 +204,6 @@ public sealed class ByteNeutralityGateTests
                 .Where(v => v.Token != o.DefaultValue)
                 .Select(v => (o.Id, v.Token)))
             .ToArray();
-
-    // The proof a knob's tier is entitled to: token/metadata-changing tiers are compiled
-    // back; whitespace-only Formatting is checked by normalized-text equality.
-    static NeutralityProof ProofForTier(StyleOptionTier tier) => tier switch
-    {
-        StyleOptionTier.Formatting => NeutralityProof.Whitespace,
-        _ => NeutralityProof.CompileBack,
-    };
 
     [Fact]
     public void EveryByteNeutralValue_HasASpecimen()
@@ -242,27 +216,17 @@ public sealed class ByteNeutralityGateTests
         var required = ByteNeutralNonDefaultValues.ToHashSet();
         var covered = Specimens.Select(s => (s.KnobId, s.ValueToken)).ToHashSet();
         Assert.Equal(required, covered);
-
-        // Tier/proof agreement: a specimen must be checked by the proof its knob's tier
-        // entitles it to. This is what catches a mis-tiered knob — tagging a
-        // token-changing knob Formatting would demand a whitespace specimen it cannot
-        // satisfy (its render moves a token, so NormalizeWhitespace stays unequal), and
-        // tagging a whitespace knob Spelling would demand a compile-back it does not need.
-        foreach (var specimen in Specimens)
-        {
-            var tier = Knob(specimen.KnobId).Tier;
-            Assert.Equal(ProofForTier(tier), specimen.Proof);
-        }
     }
 
     [Fact]
     public void ByteNeutralKnobs_AreOnlyFormattingSpellingOrSynthesis()
     {
-        // The gate's account of the byte-neutral set: Spelling knobs are compiled back
-        // (below); Formatting and Synthesis knobs are byte-neutral by construction
-        // (layout is absent from the assembly; a local name lives in the PDB, not the
-        // method body). No other tier may be byte-neutral, so the two accounts together
-        // cover the whole classification.
+        // The gate's account of the byte-neutral set. Every byte-neutral value is proven
+        // by compile-back IL identity (below); this test guards the classification itself,
+        // pinning that only Formatting, Spelling or Synthesis knobs claim byte-neutrality —
+        // the tiers whose changes (layout, tokens the compiler rebinds, a PDB-only local
+        // name) leave the IL intact. A new tier claiming byte-neutrality fails here until
+        // its neutrality rationale and specimen are added.
         Assert.All(ByteNeutralKnobs, o => Assert.True(
             o.Tier is StyleOptionTier.Formatting or StyleOptionTier.Spelling or StyleOptionTier.Synthesis,
             $"Byte-neutral knob '{o.Id}' has unexpected tier {o.Tier}; it needs a compile-back gate or a structural-neutrality rationale."));
@@ -273,7 +237,7 @@ public sealed class ByteNeutralityGateTests
     {
         // Non-vacuity + wiring pin, fast (no compile-back). An emitting value must
         // actually change its specimen's render (off != on) — this is what makes the
-        // neutrality proofs below real checks rather than comparisons of two identical
+        // compile-back proof below a real check rather than a comparison of two identical
         // renders. An inert value (a declared-but-unwired var bucket, or readable local
         // names when a source name is present) must render identically to the default
         // (off == on) on the input it would govern; when the value becomes active that
@@ -288,28 +252,6 @@ public sealed class ByteNeutralityGateTests
                 Assert.True(offText == onText,
                     $"{specimen.KnobId}={specimen.ValueToken} is marked inert (Emits:false) but its render changed; " +
                     $"the value is now active — add a firing specimen and set Emits:true so it is proven.");
-        }
-    }
-
-    [Fact]
-    public void FormattingValue_On_ChangesOnlyWhitespace()
-    {
-        // The Formatting-tier claim: a whitespace-only knob moves layout the assembly
-        // never stored, so it cannot change the IL. Checked fast, without a compiler:
-        // the on/off renders must differ (the knob fired — ValueTokenState_MatchesEmits
-        // pins that too, re-asserted here for locality) yet be equal once insignificant
-        // whitespace is normalized away. A knob mis-classified as Formatting that moved a
-        // real token would leave the normalized texts unequal and fail here.
-        foreach (var specimen in Specimens.Where(s => s.Proof == NeutralityProof.Whitespace))
-        {
-            var offText = Render(specimen.DeclaringType, specimen.Method, options: null);
-            var onText = Render(specimen.DeclaringType, specimen.Method, On(specimen));
-            var label = $"{specimen.KnobId}={specimen.ValueToken}";
-
-            Assert.NotEqual(offText, onText);
-            Assert.True(NormalizeWhitespace(offText) == NormalizeWhitespace(onText),
-                $"{label}: knob-on render differs from knob-off in more than whitespace — the knob " +
-                $"is tagged Formatting but moved a token, so it is not byte-neutral by layout alone.");
         }
     }
 
@@ -338,7 +280,7 @@ public sealed class ByteNeutralityGateTests
         // together also exercises the same-line interaction the catalog flags
         // (qualification x var), while each method's site is governed by exactly one
         // value, so the per-method verdict still isolates that value's neutrality.
-        var emitting = Specimens.Where(s => s.Proof == NeutralityProof.CompileBack && s.Emits).ToArray();
+        var emitting = Specimens.Where(s => s.Emits).ToArray();
         var off = CompileBackAll(emitting, options: null);
 
         foreach (var group in emitting.GroupBy(s => s.DeclaringType))

--- a/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
@@ -1,0 +1,227 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The byte-neutrality gate (#3247). The <see cref="StyleOptionCatalog"/> classifies
+/// every opt-in knob as <see cref="StyleOptionDescriptor.ByteDivergent"/> true/false,
+/// and that bit selects the fidelity contract the knob's output is held to. The
+/// byte-neutral (<c>ByteDivergent = false</c>) knobs claim IL-identity — the emitted
+/// form recompiles to the same IL as the shipped default — but nothing exercised that
+/// claim: <see cref="StyleOptionCatalogTests"/> only checks the classification agrees
+/// with itself, and the quality harness never set an option.
+///
+/// <para>
+/// This gate closes that hole and is driven off the classification, not a hand list,
+/// so a new byte-neutral knob is covered automatically:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// The <see cref="StyleOptionTier.Spelling"/> byte-neutral knobs change emitted C#
+/// <em>tokens</em> (a <c>this.</c> qualifier, a <c>var</c> inference) the compiler must
+/// bind to the same IL. That is a semantic claim — the <c>var x = new()</c> → CS8754
+/// near-miss lived here — so each is compiled back: rendering a firing specimen with
+/// the knob on and off must produce the same recompiled IL. A new Spelling byte-neutral
+/// knob with no firing specimen fails <see cref="EverySpellingByteNeutralKnob_HasAFiringSpecimen"/>.
+/// </description></item>
+/// <item><description>
+/// The <see cref="StyleOptionTier.Formatting"/> (whitespace-only) and
+/// <see cref="StyleOptionTier.Synthesis"/> (local-name-only) byte-neutral knobs change
+/// neither the emitted tokens nor the metadata the IL is decoded from — layout is not
+/// in the assembly at all, and a local's name lives in the PDB, never the method body.
+/// Their byte-neutrality is structural, recorded and pinned by tier rather than
+/// re-proven per knob.
+/// </description></item>
+/// </list>
+///
+/// <para>
+/// The complement — the <see cref="StyleOptionTier.Lens"/> (<c>ByteDivergent = true</c>)
+/// knobs — is deliberately excluded from this byte gate: a lens is behavior-preserving
+/// but <em>not</em> opcode-faithful, so it earns a behavioral (100%) gate instead of a
+/// byte gate. Those live in <see cref="PreferConditionalReturnLensTests"/> and
+/// <see cref="PreferBranchlessBooleanLensTests"/>, which pin executed runtime
+/// equivalence over every input. <see cref="ByteDivergentKnobs_AreExcludedAndBehaviorGated"/>
+/// records that contract.
+/// </para>
+/// </summary>
+[Trait("Area", "Fidelity")]
+public sealed class ByteNeutralityGateTests
+{
+    static string AssemblyPath => typeof(ByteNeutralityGateTests).Assembly.Location;
+
+    /// <summary>
+    /// One firing specimen per Spelling-tier byte-neutral knob: the catalog value token
+    /// to turn on, the declaring type and method whose decompiled body that token
+    /// rewrites, and the harness signature that identifies the method for compile-back.
+    /// </summary>
+    sealed record FiringSpecimen(
+        string KnobId,
+        string ValueToken,
+        System.Type DeclaringType,
+        string Method,
+        string Signature);
+
+    static readonly IReadOnlyList<FiringSpecimen> Specimens =
+    [
+        new("qualify-field-access", "true",
+            typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.ReadField),
+            "() -> corelib:System.Int32"),
+        new("qualify-property-access", "true",
+            typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.ReadProperty),
+            "() -> corelib:System.Int32"),
+        new("qualify-method-access", "true",
+            typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.CallMethod),
+            "() -> corelib:System.Int32"),
+        new("qualify-event-access", "true",
+            typeof(ThisQualificationSpecimen), nameof(ThisQualificationSpecimen.Subscribe),
+            "(corelib:System.EventHandler) -> corelib:System.Void"),
+        new("var-spelling-style", "var-when-type-apparent",
+            typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.ObjectCreation),
+            "() -> corelib:System.Int32"),
+    ];
+
+    static IReadOnlyList<StyleOptionDescriptor> ByteNeutralKnobs =>
+        StyleOptionCatalog.Options.Where(o => !o.ByteDivergent).ToArray();
+
+    static StyleOptionDescriptor Knob(string id) =>
+        StyleOptionCatalog.Options.Single(o => o.Id == id);
+
+    // The knob's non-default state, built through the catalog descriptor (never a raw
+    // property set) so the gate exercises the same value-domain plumbing a host uses.
+    static PrinterOptions On(FiringSpecimen specimen) =>
+        Knob(specimen.KnobId).WithValue(PrinterOptions.Default, specimen.ValueToken);
+
+    static string Render(System.Type declaringType, string member, PrinterOptions? options)
+    {
+        using var pe = new PEReader(File.OpenRead(AssemblyPath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == declaringType.FullName);
+        var m = Assert.Single(type.Members, x => x.Name == member);
+        var rendered = MemberBodyProducer.ProduceMember(type, m, AssemblyPath, pdbPath: null, printerOptions: options);
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.NotNull(rendered.Text);
+        return rendered.Text!;
+    }
+
+    static FidelityCheck.CompileBackTarget Target(FiringSpecimen specimen) =>
+        new(AssemblyPath, specimen.DeclaringType.FullName!, specimen.Method, Overload: 0, Signature: specimen.Signature);
+
+    static string Key(FiringSpecimen specimen) => $"{specimen.DeclaringType.FullName}::{specimen.Method}";
+
+    // One compile-back pass over a set of specimens under a single options set. The
+    // (large) test assembly is decompiled up to the target types, so batching every
+    // target into one pass keeps the gate to a few passes instead of one per knob.
+    static IReadOnlyDictionary<string, FidelityCheck.CompileBackResult> CompileBackAll(
+        IReadOnlyList<FiringSpecimen> specimens, PrinterOptions? options)
+        => FidelityCheck.EvaluateTargets(
+                [AssemblyPath], [.. specimens.Select(Target)], lowered: false, options)
+            .ToDictionary(r => $"{r.Type}::{r.Method}", r => r, StringComparer.Ordinal);
+
+    [Fact]
+    public void EverySpellingByteNeutralKnob_HasAFiringSpecimen()
+    {
+        // Drift guard: the compile-back gate must cover every Spelling-tier byte-neutral
+        // knob. A new one added without a firing specimen fails here, forcing the gate —
+        // driven off the classification — to stay exhaustive over the tier whose
+        // byte-neutrality is a semantic (token-binding) claim rather than structural.
+        var required = ByteNeutralKnobs
+            .Where(o => o.Tier == StyleOptionTier.Spelling)
+            .Select(o => o.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        var covered = Specimens.Select(s => s.KnobId).ToHashSet(StringComparer.Ordinal);
+        Assert.Equal(required, covered);
+    }
+
+    [Fact]
+    public void ByteNeutralKnobs_AreOnlyFormattingSpellingOrSynthesis()
+    {
+        // The gate's account of the byte-neutral set: Spelling knobs are compiled back
+        // (below); Formatting and Synthesis knobs are byte-neutral by construction
+        // (layout is absent from the assembly; a local name lives in the PDB, not the
+        // method body). No other tier may be byte-neutral, so the two accounts together
+        // cover the whole classification.
+        Assert.All(ByteNeutralKnobs, o => Assert.True(
+            o.Tier is StyleOptionTier.Formatting or StyleOptionTier.Spelling or StyleOptionTier.Synthesis,
+            $"Byte-neutral knob '{o.Id}' has unexpected tier {o.Tier}; it needs a compile-back gate or a structural-neutrality rationale."));
+    }
+
+    [Fact]
+    public void SpellingKnob_On_RewritesTheSpecimenTokens()
+    {
+        // Non-vacuity, fast (no compile-back): each knob, on alone, actually rewrites
+        // its firing specimen's tokens. This is what makes the slow IL-identity proof
+        // below a real check rather than a comparison of two identical renders.
+        foreach (var specimen in Specimens)
+        {
+            var offText = Render(specimen.DeclaringType, specimen.Method, options: null);
+            var onText = Render(specimen.DeclaringType, specimen.Method, On(specimen));
+            Assert.NotEqual(offText, onText);
+        }
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void SpellingKnob_On_RecompilesToIdenticalIl()
+    {
+        // The claim under test: a Spelling knob's rewritten output recompiles to the
+        // same IL as the shipped default. Compare the recompiled opcode stream
+        // (opcode-level identity) AND the compile-back contract-V1 verdict
+        // (operand/branch-target identity) of the knob-on and knob-off renders.
+        //
+        // Batched to three passes over the large test assembly: one knob-off baseline
+        // for all specimens, then one knob-on pass per declaring type. Turning a type's
+        // knobs on together also exercises the same-line interaction the catalog flags
+        // (qualification x var), while each method's site is rewritten by exactly one
+        // knob, so the per-method comparison still isolates that knob's neutrality.
+        var off = CompileBackAll(Specimens, options: null);
+
+        foreach (var group in Specimens.GroupBy(s => s.DeclaringType))
+        {
+            var groupSpecimens = group.ToArray();
+            var onOptions = groupSpecimens.Aggregate(
+                PrinterOptions.Default, (o, s) => Knob(s.KnobId).WithValue(o, s.ValueToken));
+            var on = CompileBackAll(groupSpecimens, onOptions);
+
+            foreach (var specimen in groupSpecimens)
+            {
+                var offResult = off[Key(specimen)];
+                var onResult = on[Key(specimen)];
+
+                Assert.False(IsUncheckable(offResult.Status),
+                    $"{specimen.KnobId}: knob-off render did not compile back ({offResult.Status}: {offResult.Detail}).");
+                Assert.False(IsUncheckable(onResult.Status),
+                    $"{specimen.KnobId}: knob-on render did not compile back ({onResult.Status}: {onResult.Detail}).");
+                Assert.Equal(offResult.RecompiledOpcodes, onResult.RecompiledOpcodes);
+                Assert.Equal(offResult.Status, onResult.Status);
+            }
+        }
+
+        static bool IsUncheckable(FidelityCheck.CompileBackStatus status) =>
+            status is FidelityCheck.CompileBackStatus.RecompileFail
+                or FidelityCheck.CompileBackStatus.ContextFail
+                or FidelityCheck.CompileBackStatus.FidelityUnavailable;
+    }
+
+    [Fact]
+    public void ByteDivergentKnobs_AreExcludedAndBehaviorGated()
+    {
+        // The complement of the byte gate. A byte-divergent knob is behavior-preserving
+        // but not opcode-faithful, so it is excluded from this byte gate by design and
+        // instead held to a behavioral (100%) contract — pinned by executed runtime
+        // equivalence in PreferConditionalReturnLensTests / PreferBranchlessBooleanLensTests.
+        var byteDivergent = StyleOptionCatalog.Options.Where(o => o.ByteDivergent).ToArray();
+        Assert.NotEmpty(byteDivergent);
+        Assert.All(byteDivergent, o => Assert.Equal(StyleOptionTier.Lens, o.Tier));
+
+        // None of them is in the byte gate's covered (Spelling) set.
+        var covered = Specimens.Select(s => s.KnobId).ToHashSet(StringComparer.Ordinal);
+        Assert.All(byteDivergent, o => Assert.DoesNotContain(o.Id, covered));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
@@ -199,14 +199,19 @@ public sealed class ByteNeutralityGateTests
                 [AssemblyPath], [.. specimens.Select(Target)], lowered: false, options)
             .ToDictionary(r => $"{r.Type}::{r.Method}", r => r, StringComparer.Ordinal);
 
-    // Insignificant-whitespace normalization: keep a whitespace run only where it
-    // separates two word characters (so `int alpha` never collapses to `intalpha`, which
-    // would mask a token change), and drop it everywhere else. Two renders that differ
-    // only in layout normalize equal; a render that moved a real token does not.
+    // Insignificant-whitespace normalization: keep a single space only where removing it
+    // would fuse two tokens of the same class — two word characters (so `int alpha` never
+    // collapses to `intalpha`) or two operator characters (so `+ +` never collapses to
+    // `++`) — and drop all other whitespace. A sentinel protects the kept spaces from the
+    // strip that removes the rest, so two renders that differ only in layout normalize
+    // equal while a render that fused a real token does not.
     static string NormalizeWhitespace(string text)
     {
-        var significant = System.Text.RegularExpressions.Regex.Replace(text, @"(?<=\w)\s+(?=\w)", " ");
-        return System.Text.RegularExpressions.Regex.Replace(significant, @"\s+", "").Trim();
+        const string keep = "\u0001";
+        var guarded = System.Text.RegularExpressions.Regex.Replace(
+            text, @"(?<=\w)\s+(?=\w)|(?<=[-+*/%&|^!=<>?:])\s+(?=[-+*/%&|^!=<>?:])", keep);
+        var stripped = System.Text.RegularExpressions.Regex.Replace(guarded, @"\s+", "");
+        return stripped.Replace(keep, " ").Trim();
     }
 
     // Every non-default value token of a byte-neutral knob, across all tiers — the

--- a/src/ILInspector.Decompiler.Tests/FormattingSynthesisSpecimen.cs
+++ b/src/ILInspector.Decompiler.Tests/FormattingSynthesisSpecimen.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Compiled specimens for the byte-neutral Formatting (whitespace-only) and Synthesis
+/// (local-name-only) knobs. Each method exercises the exact construct its knob rewrites
+/// so the byte-neutrality gate can prove — not merely assert by tier — that turning the
+/// knob on changes only layout or local identifiers, never the IL.
+/// </summary>
+public sealed class FormattingSynthesisSpecimen
+{
+    // Synthesis: a method with ordinary source-named locals. The test assembly carries
+    // an embedded PDB, so ProduceMember binds the real names (sum, i) even with
+    // pdbPath:null and readable-local-names stays inert here — its synthesis only fires
+    // for a local the PDB does not name (a compiler temporary). The gate pins that inert
+    // state; see ByteNeutralityGateTests for the structural byte-neutrality rationale.
+    public static int ReadableLocal()
+    {
+        int sum = 0;
+        for (int i = 0; i < 10; i++)
+            sum += i * i;
+        return sum;
+    }
+
+    // Formatting: an expression-bodied member whose => wrap-expression-body-arrow moves
+    // onto the next line.
+    public static int ArrowBody() => 42;
+
+    // Formatting: a short-circuit && chain long enough (> the 120-column wrap width) that
+    // wrap-splittable-expressions breaks it one operand per line.
+    public static bool LongLogicalChain(int alpha, int beta, int gamma, int delta, int epsilon, int zeta)
+        => alpha > 0 && beta > 1 && gamma > 2 && delta > 3 && epsilon > 4 && zeta > 5 && alpha < beta && gamma < delta && epsilon < zeta;
+
+    // Formatting: a fluent instance-call chain long enough that the always-on wrapper
+    // breaks it by default; disable-one-liner-wrapping keeps it on a single line.
+    public static string LongFluentChain()
+        => new System.Text.StringBuilder().Append("alpha").Append("beta").Append("gamma").Append("delta").Append("epsilon").Append("zeta").ToString();
+}

--- a/src/ILInspector.Decompiler.Tests/FormattingSynthesisSpecimen.cs
+++ b/src/ILInspector.Decompiler.Tests/FormattingSynthesisSpecimen.cs
@@ -28,9 +28,10 @@ public sealed class FormattingSynthesisSpecimen
     public static int ArrowBody() => 42;
 
     // Formatting: a short-circuit && chain long enough (> the 120-column wrap width) that
-    // wrap-splittable-expressions breaks it one operand per line.
-    public static bool LongLogicalChain(int alpha, int beta, int gamma, int delta, int epsilon, int zeta)
-        => alpha > 0 && beta > 1 && gamma > 2 && delta > 3 && epsilon > 4 && zeta > 5 && alpha < beta && gamma < delta && epsilon < zeta;
+    // wrap-splittable-expressions breaks it one operand per line. The single int operand
+    // keeps every comparison non-constant (so nothing folds away) and the signature simple.
+    public static bool LongLogicalChain(int n)
+        => n > 0 && n > 1 && n > 2 && n > 3 && n > 4 && n > 5 && n > 6 && n > 7 && n > 8 && n > 9 && n > 10 && n > 11 && n > 12;
 
     // Formatting: a fluent instance-call chain long enough that the always-on wrapper
     // breaks it by default; disable-one-liner-wrapping keeps it on a single line.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -79,7 +79,6 @@ public sealed record PrinterOptions
     public bool QualifyPropertyAccess { get; init; }
 
     /// <summary>
-    /// <summary>
     /// When set, an instance method invoked through <c>this</c> renders the explicit
     /// <c>this.</c> qualifier even where the bare name is unambiguous. IL-identical —
     /// <c>this.M()</c> and <c>M()</c> both emit <c>ldarg.0; call/callvirt</c>. A

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -51,10 +51,19 @@ static class FidelityCheck
     // view with the cross-method import seam bound (so lambda raising can reach
     // a synthesized body in the same module). The lowered view carries no seam
     // yet, so a lambda there stays a delegate creation.
+    // The default (byte-faithful) renderer threads no PrinterOptions, so every
+    // corpus/gate path renders the shipped output. The optional options overload
+    // is the opt-in-knob seam the byte-neutrality gate uses to render the raised
+    // view with a single knob on and prove it recompiles to the same IL. Options
+    // apply to the raised view (the view every opt-in knob targets); the lowered
+    // view has no opt-in knobs, so it keeps the shipped renderer.
     static Func<IrFunction, DecompilerResult> Renderer(MetadataSource source, bool lowered)
+        => Renderer(source, lowered, options: null);
+
+    static Func<IrFunction, DecompilerResult> Renderer(MetadataSource source, bool lowered, PrinterOptions? options)
         => lowered
             ? CSharpPrinter.PrintLowered
-            : function => CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+            : function => CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method), options);
 
     public static int Run(
         IReadOnlyList<string> assemblies,
@@ -663,6 +672,19 @@ static class FidelityCheck
         IReadOnlyList<string> assemblies,
         IReadOnlyList<CompileBackTarget> targets,
         bool lowered = false)
+        => EvaluateTargets(assemblies, targets, lowered, options: null);
+
+    /// <summary>
+    /// As <see cref="EvaluateTargets(IReadOnlyList{string}, IReadOnlyList{CompileBackTarget}, bool)"/>,
+    /// but renders the (raised) view with <paramref name="options"/> applied — the
+    /// seam the byte-neutrality gate uses to compile-back a single opt-in knob's
+    /// output and assert it recompiles to the same IL as the shipped default.
+    /// </summary>
+    internal static IReadOnlyList<CompileBackResult> EvaluateTargets(
+        IReadOnlyList<string> assemblies,
+        IReadOnlyList<CompileBackTarget> targets,
+        bool lowered,
+        PrinterOptions? options)
     {
         var methodTargets = targets
             .Select(target => new MethodTarget(
@@ -675,12 +697,15 @@ static class FidelityCheck
                 DisplayMethod: $"{target.Type}::{target.Method}"))
             .ToArray();
 
-        return EvaluateTargets(assemblies, methodTargets, lowered)
+        return EvaluateTargets(assemblies, methodTargets, lowered, options)
             .Select(row => row.Result)
             .ToArray();
     }
 
     static IReadOnlyList<TargetedCompileBackResult> EvaluateTargets(IReadOnlyList<string> assemblies, IReadOnlyList<MethodTarget> targets, bool lowered)
+        => EvaluateTargets(assemblies, targets, lowered, options: null);
+
+    static IReadOnlyList<TargetedCompileBackResult> EvaluateTargets(IReadOnlyList<string> assemblies, IReadOnlyList<MethodTarget> targets, bool lowered, PrinterOptions? options)
     {
         if (targets.Count == 0)
             return [];
@@ -720,7 +745,7 @@ static class FidelityCheck
                     if (assemblyTargets.Count == 0)
                         continue;
 
-                    var render = Renderer(source, lowered);
+                    var render = Renderer(source, lowered, options);
                     var references = RuntimeReferences(assemblyPath, assemblies);
                     foreach (var typeHandle in reader.TypeDefinitions)
                     {


### PR DESCRIPTION
## Summary

Closes the one property the style-option catalog **declares but never checks**: the byte-neutral (`ByteDivergent = false`) knobs claim their output recompiles to the same IL as the shipped default, but `StyleOptionCatalogTests` only checked the classification agrees with itself (`ByteDivergent == (Tier == Lens)`), and the quality harness never set an option (`grep -c PrinterOptions tools/DecompilerHarness/*.cs` → 0).

Adds a **byte-neutrality gate driven off the classification** (`StyleOptionCatalog.Options.Where(o => !o.ByteDivergent)`), so a new byte-neutral knob is covered automatically rather than via a hand-maintained list.

## What it checks

| Tier | Byte-neutral? | How it's gated |
| --- | --- | --- |
| **Spelling** (`this.` qualification, `var`) | yes | **Compiled back**: a firing specimen rendered knob-on vs knob-off must produce the same recompiled IL (opcode stream + compile-back contract-V1 verdict). The `var x = new()` → CS8754 near-miss lived in this tier — its neutrality is a *semantic* (token-binding) claim, so it is proven, not asserted. |
| **Formatting** (whitespace), **Synthesis** (local names) | yes | **Structural**: layout is absent from the assembly and a local's name lives in the PDB, never the method body, so neutrality is recorded/pinned by tier. |
| **Lens** (`ByteDivergent = true`) | no | **Excluded by design** and held to a behavioral (100%) gate instead — the existing `PreferConditionalReturnLensTests` / `PreferBranchlessBooleanLensTests` executed-equivalence tests. A test records that contract (ask #3). |

Drift guard: a new **Spelling** byte-neutral knob with no firing specimen fails `EverySpellingByteNeutralKnob_HasAFiringSpecimen`, keeping the gate exhaustive over the tier whose neutrality is non-structural.

## Implementation notes

- Reuses existing firing specimens (`ThisQualificationSpecimen`, `VarWhenApparentSpecimen`) and the harness compile-back machinery rather than reconstructing either (harness-boundary rule).
- `FidelityCheck.EvaluateTargets` gains an optional `PrinterOptions` overload that threads the option into the **raised** renderer. The default (`options = null`) path is **byte-for-byte unchanged** — every existing corpus/gate call still renders the shipped output.
- The compile-back proof is batched to **three passes** over the large test assembly and marked `Speed=Slow` (matching how every other compile-back gate in the repo is classified); the structural / drift / token-rewrite checks stay fast and run in the merge `test` job.
- Turning a type's byte-neutral knobs on together also exercises the on-the-same-line interaction the catalog flags (qualification × var); each method's site is rewritten by exactly one knob, so the per-method comparison still isolates that knob's neutrality.
- **Drive-by**: fixes a malformed duplicate `<summary>` open tag on `PrinterOptions.QualifyMethodAccess`.

## Evidence

- Full solution builds clean (`dotnet build dotnet-inspect.slnx -c Release`).
- `ByteNeutralityGateTests`: 5/5 green (fast subset 1.5s; slow compile-back 77s).
- No regression in the harness `EvaluateTargets` refactor or the drive-by: `StyleOptionCatalogTests`, `ThisQualificationTests`, `VarWhenApparentTests`, `NullCoalescingAssignmentPassTests` (exercises the refactored targeted compile-back) — 111/111 green.

## Non-goals / follow-ups

- The `FullTaste` aggregate (#3176) as a byte-neutral *configuration*: the endorsed subset includes a byte-**divergent** lens (the ternary), so a whole-aggregate byte gate isn't meaningful; the byte-neutral endorsed subset (the four qualify knobs) is already exercised together here.
- XML-doc validation for `PrinterOptions.cs` (the issue notes it as "worth considering") — separate infra change.

Closes #3247.