### PR TITLE
Make the IR invariant check run in Release (#3241, PR 1 of stack)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,17 @@ Tests use xUnit executable projects. **Use `dotnet run`, not `dotnet test`**;
 | Shared services | `dotnet run --project src/DotnetInspector.Services.Tests -c Release` |
 | Metadata | `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` |
 
+Run the suite in **Release** for input fidelity, not speed: the optimized IL a
+Release build of the compilers emits is what ships and what the decompiler
+corpus consumes, so a Debug run would validate the decompiler against IL shapes
+users never see. Because the suite runs Release, correctness checks must not
+hide behind `[Conditional("DEBUG")]` — such a call is stripped from the Release
+test assembly and asserts nothing. The IR structural invariant check
+(`IrNode.CheckInvariant`) is instead a runtime opt-in (`IrInvariants.Enabled`,
+env var `DOTNET_INSPECT_IR_INVARIANTS`) that the decompiler test host turns on
+suite-wide, so the pipeline is validated after every pass in the same build
+users run, while the shipped tool pays nothing on the decompile hot path.
+
 Some CLI tests require `ilasm`/`ildasm` and skip when those tools are absent.
 The IL round-trip project has separate dependency restore and fast/full test
 commands; follow `tests/DotnetInspector.ILRoundtrip.Tests/README.md`.

--- a/src/ILInspector.Decompiler.Tests/IrInvariantCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrInvariantCheckTests.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Negative controls proving <see cref="IrNode.CheckInvariant"/> actually
+/// detects a corrupt parent/child link. Without these the check could silently
+/// become a no-op (its whole failure mode under #3241) and every other test
+/// would still pass. Corruption is forced through the private backing fields the
+/// normal API never lets a caller reach.
+/// </summary>
+public sealed class IrInvariantCheckTests
+{
+    static readonly FieldInfo ParentField = typeof(IrNode)
+        .GetField("<Parent>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    static readonly FieldInfo ChildIndexField = typeof(IrNode)
+        .GetField("<ChildIndex>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    static Block ParentWithTwoChildren(out Block first, out Block second)
+    {
+        first = new Block(0x10);
+        second = new Block(0x20);
+        var parent = new Block();
+        parent.Add(first);
+        parent.Add(second);
+        return parent;
+    }
+
+    [Fact]
+    public void CheckInvariant_PassesForWellFormedTree()
+    {
+        var parent = ParentWithTwoChildren(out _, out _);
+
+        parent.CheckInvariant();
+    }
+
+    [Fact]
+    public void CheckInvariant_ThrowsWhenChildParentPointerIsWrong()
+    {
+        var parent = ParentWithTwoChildren(out _, out var second);
+        ParentField.SetValue(second, null);
+
+        var ex = Assert.Throws<InvalidOperationException>(parent.CheckInvariant);
+        Assert.Contains("wrong parent", ex.Message);
+    }
+
+    [Fact]
+    public void CheckInvariant_ThrowsWhenChildSlotIsWrong()
+    {
+        var parent = ParentWithTwoChildren(out _, out var second);
+        ChildIndexField.SetValue(second, 99);
+
+        var ex = Assert.Throws<InvalidOperationException>(parent.CheckInvariant);
+        Assert.Contains("slot", ex.Message);
+    }
+
+    [Fact]
+    public void CheckInvariant_DetectsCorruptionInADeepChild()
+    {
+        var leaf = new Block(0x30);
+        var mid = new Block(0x20);
+        mid.Add(leaf);
+        var root = new Block();
+        root.Add(mid);
+        ChildIndexField.SetValue(leaf, 7);
+
+        Assert.Throws<InvalidOperationException>(root.CheckInvariant);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/IrInvariantCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrInvariantCheckTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection;
 using ILInspector.Decompiler.Pipeline;
 
@@ -67,5 +68,46 @@ public sealed class IrInvariantCheckTests
         ChildIndexField.SetValue(leaf, 7);
 
         Assert.Throws<InvalidOperationException>(root.CheckInvariant);
+    }
+
+    /// <summary>
+    /// The end-to-end teeth test: it does NOT set <see cref="IrInvariants.Enabled"/>
+    /// itself. It relies on the test host's module initializer having turned the
+    /// flag on, and on the pipeline runner honoring it after every pass. A
+    /// corrupting pass breaks the tree; running it through <see cref="IrPasses.Run"/>
+    /// must throw. This is the only test that fails if the module initializer is
+    /// removed, the per-pass gate is deleted, or the runner stops calling
+    /// CheckInvariant — the direct-call tests above would all still pass.
+    /// </summary>
+    [Fact]
+    public void PipelineRunner_UnderTestHost_ThrowsWhenAPassCorruptsTheTree()
+    {
+        Assert.True(IrInvariants.Enabled,
+            "Test host module initializer should have enabled IR invariants for the suite.");
+
+        var (function, block) = MinimalFunction();
+        var passes = ImmutableArray.Create<IIrPass>(new SlotCorruptingPass(block));
+
+        Assert.Throws<InvalidOperationException>(() => IrPasses.Run(function, passes));
+    }
+
+    static (IrFunction Function, Block Block) MinimalFunction()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(new Constant(0, intType)));
+        container.Add(block);
+        var signature = new MethodSignature(intType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+        return (function, block);
+    }
+
+    sealed class SlotCorruptingPass(Block target) : IIrPass
+    {
+        public string Name => "SlotCorrupting(test)";
+
+        public void Run(IrFunction function, PassContext context) =>
+            ChildIndexField.SetValue(target, 99);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/IrInvariantsTestHost.cs
+++ b/src/ILInspector.Decompiler.Tests/IrInvariantsTestHost.cs
@@ -1,0 +1,18 @@
+using System.Runtime.CompilerServices;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Turns the IR structural invariant check on for the whole test run. The check
+/// is off by default in the shipped tool (<see cref="IrInvariants"/>), so without
+/// this the suite would exercise the pipeline exactly as production does but
+/// never validate the tree after each pass. Enabling it here — in the Release
+/// configuration the suite runs under (see AGENTS.md) — is what gives the check
+/// its teeth: any pass that corrupts parent/child wiring fails a real test.
+/// </summary>
+internal static class IrInvariantsTestHost
+{
+    [ModuleInitializer]
+    public static void Enable() => IrInvariants.Enabled = true;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -560,7 +560,8 @@ public static class IrImporter
 
         ResolveTypeInfo(source, function);
         RecordUnsupportedTypeDiagnostics(function);
-        function.CheckInvariant();
+        if (IrInvariants.Enabled)
+            function.CheckInvariant();
         return function;
     }
 
@@ -1933,7 +1934,8 @@ public static class IrImporter
         body.Add(new ExpressionStatement(new UnsupportedNode(offset, opcode, reason)));
         function.Diagnostics.Add(new DecompilerDiagnostic(
             DiagnosticIds.UnsupportedConstruct, $"IL_{offset:X4} {opcode}: {reason}"));
-        function.CheckInvariant();
+        if (IrInvariants.Enabled)
+            function.CheckInvariant();
     }
 
     static (ComparisonKind Kind, bool IsUnsigned) ComparisonOf(ILOpCode opcode) => opcode switch

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrInvariants.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrInvariants.cs
@@ -1,0 +1,30 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Runtime opt-in for the IR structural invariant check
+/// (<see cref="IrNode.CheckInvariant"/>). Off by default so the shipped tool
+/// pays nothing on the decompile hot path; the test host and the harness corpus
+/// sweep enable it to validate the pipeline after every pass in Release.
+/// <para>
+/// This replaces the check's former <c>[Conditional("DEBUG")]</c> gate, which
+/// stripped every call site in the Release configuration the test suite actually
+/// runs — so the check that reads as if it asserts IR integrity asserted it zero
+/// times (#3241). A runtime opt-in runs in any build, including the optimized
+/// product assembly the corpus sweeps consume, with no change to product
+/// codegen. It is the same separation the .NET runtime uses for its
+/// <c>Checked</c> configuration: optimized codegen, assertions live.
+/// </para>
+/// </summary>
+public static class IrInvariants
+{
+    /// <summary>
+    /// When true, the pipeline runner and importer validate the IR after every
+    /// pass. Initialized from the <c>DOTNET_INSPECT_IR_INVARIANTS</c> environment
+    /// variable (<c>1</c> or <c>true</c>), and settable by the test host and the
+    /// harness so a corpus sweep can turn the check on without an environment
+    /// variable. Explicit <see cref="IrNode.CheckInvariant"/> calls (e.g. in
+    /// tests) run regardless of this flag.
+    /// </summary>
+    public static bool Enabled { get; set; } =
+        Environment.GetEnvironmentVariable("DOTNET_INSPECT_IR_INVARIANTS") is "1" or "true";
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
@@ -7,7 +5,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// a mutable tree with parent pointers and child slots, in the ILSpy
 /// <c>ILInstruction</c> tradition. <see cref="ReplaceWith"/> is the primitive
 /// rewrite; <see cref="CheckInvariant"/> validates parent/child consistency
-/// after every pass in debug builds.
+/// after every pass when <see cref="IrInvariants.Enabled"/> is set.
 /// </summary>
 public abstract class IrNode
 {
@@ -173,10 +171,12 @@ public abstract class IrNode
     }
 
     /// <summary>
-    /// Validates parent/child consistency for this subtree. Debug builds run
-    /// this after every pass; a violation is a pipeline bug, never input data.
+    /// Validates parent/child consistency for this subtree. Runs after every
+    /// pass when <see cref="IrInvariants.Enabled"/> is set, and on every explicit
+    /// call; a violation is a pipeline bug, never input data. Always compiled (no
+    /// <c>[Conditional]</c>) so it runs in the optimized Release build the test
+    /// suite and corpus sweeps use.
     /// </summary>
-    [Conditional("DEBUG")]
     public void CheckInvariant()
     {
         for (int i = 0; i < _children.Count; i++)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -17,7 +17,7 @@ public interface IIrPass
     void Run(IrFunction function, PassContext context);
 }
 
-/// <summary>The pipeline's pass list and runner. Debug builds validate tree invariants after every pass — a violation is a pass bug, never input data.</summary>
+/// <summary>The pipeline's pass list and runner. When <see cref="ILInspector.Decompiler.Pipeline.IrInvariants.Enabled"/> is set, the runner validates tree invariants after every pass — a violation is a pass bug, never input data.</summary>
 public static class IrPasses
 {
     public static ImmutableArray<IIrPass> Default { get; } =
@@ -481,7 +481,8 @@ public static class IrPasses
         foreach (var pass in passes)
         {
             pass.Run(function, context);
-            function.CheckInvariant();
+            if (IrInvariants.Enabled)
+                function.CheckInvariant();
         }
     }
 
@@ -514,8 +515,9 @@ public static class IrPasses
     /// Runs <paramref name="passes"/>, capturing <paramref name="project"/>'s
     /// output at the importer boundary and after each pass. The projection runs
     /// between mutations, so each captured string is the tree as that stage left
-    /// it. Debug builds validate invariants after every pass, exactly as
-    /// <see cref="Run(IrFunction, ImmutableArray{IIrPass})"/> does.
+    /// it. Invariants are validated after every pass when
+    /// <see cref="ILInspector.Decompiler.Pipeline.IrInvariants.Enabled"/> is set,
+    /// exactly as <see cref="Run(IrFunction, ImmutableArray{IIrPass})"/> does.
     /// </summary>
     public static IReadOnlyList<PipelineStage> RunWithStages(
         IrFunction function, ImmutableArray<IIrPass> passes, Func<IrFunction, string> project)
@@ -539,7 +541,8 @@ public static class IrPasses
         foreach (var pass in passes)
         {
             pass.Run(function, context);
-            function.CheckInvariant();
+            if (IrInvariants.Enabled)
+                function.CheckInvariant();
             stages.Add(new(pass.Name, project(function), function.Fidelity));
         }
         return stages;
@@ -573,7 +576,8 @@ public static class IrPasses
             foreach (var pass in Default)
             {
                 pass.Run(function, context);
-                function.CheckInvariant();
+                if (IrInvariants.Enabled)
+                    function.CheckInvariant();
             }
         }
         catch (StepLimitReachedException)


### PR DESCRIPTION
Closes the first, foundational part of #3241 (part of the #3240 cluster). **Base of a stack** — teeth and the corpus gate follow on this branch.

## Problem

`IrNode.CheckInvariant` was `[Conditional("DEBUG")]`. AGENTS.md prescribes `-c Release` for the test suite, and `[Conditional]` strips the *call site* in a caller that lacks the symbol — so in the Release test assembly all 600+ call sites (120 test files + 5 product hooks) were stripped. The check that reads as if it guarantees IR tree integrity **asserted zero times**.

Debug can't be the fix: the suite fails ~171 tests under Debug for unrelated Debug-IL-shape reasons, and Release is required for **input fidelity** — the optimized IL a Release compiler emits is what ships and what the decompiler corpus consumes. A runtime opt-in is the only path that runs the check in the build users actually run.

## This PR (make it run + prove it has teeth)

No product codegen change on the shipped hot path.

- **Remove `[Conditional("DEBUG")]`** from `IrNode.CheckInvariant` so explicit calls always run, in any configuration.
- **Add `IrInvariants.Enabled`** (env var `DOTNET_INSPECT_IR_INVARIANTS`, default **off**) gating the 5 product per-pass hooks (`IrPass` runner ×3, `IrImporter` ×2). The shipped CLI pays nothing per pass; opt-in hosts validate after every pass.
- **Enable it suite-wide** in the decompiler test host via `[ModuleInitializer]`.
- **Negative-control tests** corrupt a child's `Parent`/`ChildIndex` backing field via reflection and assert `CheckInvariant` throws — proving the check is not a silent no-op (its whole failure mode here).
- **AGENTS.md**: document why the suite runs Release (input fidelity, not speed) and why correctness checks must not hide behind `[Conditional("DEBUG")]`.

The check body is intentionally still the existing weak parent/child-wiring check in this PR; expanding it (arity, `ResultType` at sinks, branch-target existence — each corpus-validated) and the CoreLib+pool corpus-sweep gate are the follow-up PRs stacked on this branch.

## Validation (Linux, Release)

- Decompiler fast suite: **3812 real tests pass** with per-pass invariant checks live suite-wide — **zero invariant violations**. The lone failure `LookalikeExpressionAssembly_StaysFactoryCalls` is a missing fixture from building only the test csproj (`FileNotFoundException` on `System.Linq.Expressions.dll`), identical on base and green in a full `slnx` build / CI.
- Negative-control tests: **4/4 pass** (well-formed tree passes; wrong parent, wrong slot, and deep-child corruption each throw).

Part of #3240.