### PR TITLE
Annotate compile-back failures with a caret under the diagnostic span (#3238)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnnotatedCompileBackFailureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedCompileBackFailureTests.cs
@@ -1,0 +1,64 @@
+using ILInspector.DecompilerHarness;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins the annotated compile-back failure render (#3238): a RecompileFail's
+/// emitted C# is shown with a caret underline under the exact diagnostic span,
+/// and invisible/format runes on that line are revealed so the caret points at
+/// something the reader can see. The caret sits on a <c>//</c> comment so the
+/// block stays valid C# inside a code fence.
+/// </summary>
+[Trait("Area", "Fidelity")]
+public class AnnotatedCompileBackFailureTests
+{
+    // The "killer" shape: an identifier carrying a zero-width non-joiner
+    // (U+200C). Roslyn cannot bind `Missing<ZWNJ>Type`, so the CS0246 span
+    // covers the whole identifier — including the invisible rune.
+    const char Zwnj = '\u200C';
+
+    static Diagnostic FirstError(string source)
+    {
+        var comp = CSharpCompilation.Create("annot",
+            [CSharpSyntaxTree.ParseText(source)],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var ms = new MemoryStream();
+        return comp.Emit(ms).Diagnostics.First(d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void RevealsInvisibleRuneAndAlignsCaretUnderTheSpan()
+    {
+        string source =
+            "class Seq\n" +
+            "{\n" +
+            "    void M() { Missing" + Zwnj + "Type x = null; }\n" +
+            "}\n";
+
+        string render = FidelityCheck.RenderAnnotatedFailure(source, FirstError(source))!;
+        string[] lines = render.Split('\n');
+
+        // The code line reveals the ZWNJ as a visible token.
+        Assert.Contains("Missing\u2039ZWNJ\u203AType", lines[0]);
+        Assert.DoesNotContain('\u200C', render);
+
+        // The caret line is a // comment carrying the diagnostic, with carets
+        // aligned under the revealed identifier (7 + 6 for <ZWNJ> + 4 = 17).
+        Assert.StartsWith("    //", lines[1]);
+        Assert.Contains(new string('^', 17), lines[1]);
+        Assert.Contains("CS0246", lines[1]);
+
+        int caretColumn = lines[1].IndexOf('^');
+        int revealedIdentColumn = lines[0].IndexOf("Missing", StringComparison.Ordinal);
+        Assert.Equal(revealedIdentColumn, caretColumn);
+    }
+
+    [Fact]
+    public void ReturnsNullWhenDiagnosticHasNoInSourceLocation()
+        => Assert.Null(FidelityCheck.RenderAnnotatedFailure("class C {}", Diagnostic.Create(
+            new DiagnosticDescriptor("XX000", "t", "no location", "c", DiagnosticSeverity.Error, true),
+            Location.None)));
+}

--- a/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
@@ -53,6 +53,7 @@ public sealed class DynamicCompilationSiteInventoryTests
             ["ClosureDiagnosticEvidenceTests.cs"] = (6, "Input matrix + semantic-model seam: many compile-error/closure sources across a Theory."),
             ["FidelityCheckGeneratedFilterTests.cs"] = (2, "Seam isolation: exercises the generated-code filter over constructed compilations."),
             ["ValidityShellNoiseTests.cs"] = (1, "Seam isolation: injects deliberate shell noise into a validity compilation."),
+            ["AnnotatedCompileBackFailureTests.cs"] = (1, "Seam isolation: compiles a synthesized invisible-rune source to obtain a real Roslyn diagnostic for the annotated compile-back failure caret render (#3238)."),
 
             // Optimization / parse-option matrices intrinsic to the claim.
             ["IteratorReconstructionPassTests.cs"] = (1, "Optimization matrix: compiles the same source under Debug and Release."),
@@ -99,9 +100,12 @@ public sealed class DynamicCompilationSiteInventoryTests
     //     to the span-attribution classifier. #3231 also adds a second site to
     //     ReturnToSenderPrototypeTests.cs (1 -> 2): the fault-isolation helper
     //     compiles composed decompiled source to obtain its diagnostics.
-    //   Combined: 36 files, 45 sites.
-    const int ExpectedDynamicFiles = 36;
-    const int ExpectedDynamicSites = 45;
+    //   #3238 adds AnnotatedCompileBackFailureTests.cs (1 site): compiles a
+    //     synthesized invisible-rune source to obtain a real diagnostic for the
+    //     annotated compile-back failure caret render.
+    //   Combined: 37 files, 46 sites.
+    const int ExpectedDynamicFiles = 37;
+    const int ExpectedDynamicSites = 46;
 
     // Migrated away from Dynamic in this change; must not reappear in the scan.
     static readonly string[] MigratedFiles = ["CompileBackTypeIdentityTests.cs"];

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -288,7 +289,8 @@ static class FidelityCheck
         string OriginalOpcodes, string RecompiledOpcodes, string? Detail,
         CaptureMode Capture = CaptureMode.WholeModule,
         string? CaptureDetail = null,
-        IlBodyDiffResult? FidelityDiff = null);
+        IlBodyDiffResult? FidelityDiff = null,
+        string? Annotated = null);
 
     internal static CompileBackStatus ClassifyStatus(
         bool isFull,
@@ -935,8 +937,15 @@ static class FidelityCheck
         foreach (var row in examples)
         {
             Console.WriteLine($"  {row.Target.DisplayMethod}");
-            if (!string.IsNullOrWhiteSpace(row.Result.Detail))
+            if (!string.IsNullOrWhiteSpace(row.Result.Annotated))
+            {
+                foreach (var annotatedLine in row.Result.Annotated.Split('\n'))
+                    Console.WriteLine($"    {annotatedLine}");
+            }
+            else if (!string.IsNullOrWhiteSpace(row.Result.Detail))
+            {
                 Console.WriteLine($"    {row.Result.Detail}");
+            }
             if (includeOpcodes)
             {
                 Console.WriteLine($"    orig : {row.Result.OriginalOpcodes}");
@@ -1372,7 +1381,7 @@ static class FidelityCheck
                 File.WriteAllText(path, unit);
                 Console.Error.WriteLine($"{path}: {err}");
             }
-            return new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.RecompileFail, e.OrigText, "", FormatDiagnostic(err));
+            return new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.RecompileFail, e.OrigText, "", FormatDiagnostic(err), Annotated: RenderAnnotatedFailure(unit, err));
         }
         ms.Position = 0;
         using var rpe = new PEReader(ms);
@@ -2020,6 +2029,75 @@ static class FidelityCheck
         if (!string.IsNullOrWhiteSpace(message))
             parts.Add(message);
         return parts.Count == 0 ? null : string.Join(": ", parts);
+    }
+
+    /// <summary>
+    /// Renders the failing emitted line with a caret underline under the
+    /// diagnostic span — the compiler's own squiggle, and the "act on this"
+    /// gesture for a recompile failure. Invisible/format runes on the line are
+    /// revealed (e.g. U+200C becomes &lt;ZWNJ&gt;) so the caret points at
+    /// something the reader can see, and the caret sits on a <c>//</c> comment so
+    /// the whole block stays valid C# inside a code fence. Null when the
+    /// diagnostic carries no in-source location (nothing to point at).
+    /// </summary>
+    internal static string? RenderAnnotatedFailure(string source, Diagnostic? diagnostic)
+    {
+        if (diagnostic is null || !diagnostic.Location.IsInSource)
+            return null;
+
+        var span = diagnostic.Location.GetLineSpan().Span;
+        int lineIndex = span.Start.Line;
+        string[] lines = source.Replace("\r\n", "\n").Split('\n');
+        if (lineIndex < 0 || lineIndex >= lines.Length)
+            return null;
+
+        string raw = lines[lineIndex];
+
+        // Reveal invisible runes, mapping each raw column to its revealed column
+        // so the caret aligns under what the reader actually sees, not the raw
+        // (possibly zero-width) span.
+        var revealed = new StringBuilder();
+        int[] map = new int[raw.Length + 1];
+        for (int i = 0; i < raw.Length; i++)
+        {
+            map[i] = revealed.Length;
+            revealed.Append(RevealRune(raw[i]));
+        }
+        map[raw.Length] = revealed.Length;
+
+        int startCol = Math.Clamp(span.Start.Character, 0, raw.Length);
+        int endCol = span.End.Line == lineIndex ? Math.Clamp(span.End.Character, 0, raw.Length) : raw.Length;
+        int caretStart = map[startCol];
+        int caretLen = Math.Max(1, map[endCol] - caretStart);
+
+        string indent = raw[..(raw.Length - raw.AsSpan().TrimStart().Length)];
+        int pad = Math.Max(1, caretStart - indent.Length - 2); // 2 == "//"
+
+        var sb = new StringBuilder();
+        sb.Append(revealed).Append('\n');
+        sb.Append(indent).Append("//").Append(' ', pad).Append('^', caretLen)
+          .Append(' ').Append(diagnostic.Id).Append(": ").Append(diagnostic.GetMessage());
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Substitutes a visible token for a rune that would otherwise be invisible
+    /// or ambiguous in the rendered source — format characters (e.g. the U+200C
+    /// zero-width non-joiner that silently breaks an identifier match), controls,
+    /// and non-spacing combining marks. Everything else passes through unchanged.
+    /// </summary>
+    static string RevealRune(char c)
+    {
+        if (c == '\t')
+            return "\t";
+        if (c == '\u200C')
+            return "\u2039ZWNJ\u203A";
+        if (c == '\u200D')
+            return "\u2039ZWJ\u203A";
+        return CharUnicodeInfo.GetUnicodeCategory(c)
+            is UnicodeCategory.Format or UnicodeCategory.Control or UnicodeCategory.NonSpacingMark
+            ? $"\u2039U+{(int)c:X4}\u203A"
+            : c.ToString();
     }
 
     static string DiagnosticCode(string? detail)


### PR DESCRIPTION
Closes #3238 (layers 1–2).

## What

A `RecompileFail` used to record only `CS####: message` — the diagnostic
`Location` was thrown away in `FormatDiagnostic`, so a reviewer had to
hand-reconstruct *which* emitted qualifier bound to the wrong thing. This adds
the compiler's own "squiggle" to the harness: the failing emitted C# line,
rendered with a caret underline under the exact diagnostic span, plus a reveal
of any invisible runes on that line.

## Rendered output

The `Recompile-fail examples:` section now shows, per example:

```text
Recompile-fail examples:

  Seq.M()
    void M() { Missing‹ZWNJ›Type x = null; }
    //         ^^^^^^^^^^^^^^^^^ CS0246: The type or namespace name 'MissingType' could not be found ...
```

The caret line is a `//` comment, so the whole block stays valid C# inside a
```csharp fence. The invisible U+200C (zero-width non-joiner) — the exact rune
that silently breaks an explicit-interface identifier match — is revealed as
`‹ZWNJ›`, and the caret is mapped onto the *revealed* columns so it points at
what the reader can actually see, not the zero-width raw span.

## How

- `RenderAnnotatedFailure(source, diagnostic)` builds the block at the failure
  site in `CompileOne`, where the parsed `unit` and the Roslyn `Diagnostic` are
  both in hand. It reads `Diagnostic.Location.GetLineSpan()` for the exact
  line + character span (the same data `csc` uses).
- Result flows through a new optional `CompileBackResult.Annotated` field;
  `PrintTargetExamples` prints it in place of the one-line detail.
- `Detail` is left unchanged, so the existing recompile-fail bucket/code
  classifiers keep parsing `CS####: message`.
- `RevealRune` substitutes a visible token for `UnicodeCategory.Format` /
  `Control` / `NonSpacingMark` runes (named tokens for ZWNJ/ZWJ).

Harness-reporting only — **no product-output behavior change**.

## Scope

This is layers 1–2 of #3238 (mechanical caret + rune-reveal). Layer 3
(cause classification — "why the emitted identifier bound elsewhere") is left
for a follow-up, and unrecognized diagnostics already fall back cleanly to the
plain `Id: message`.

## Tests

- `AnnotatedCompileBackFailureTests` pins the render: reveals the ZWNJ, aligns
  the caret under the revealed identifier, keeps the caret line a `//` comment,
  and returns null when the diagnostic has no in-source location.
- Registered the test's `CSharpCompilation.Create` in the dynamic-site
  governance manifest (fingerprint 35→36 files / 43→44 sites).
- Full non-slow suite: 3811 passed, 0 failed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 43dbbaf0-9cf3-43c6-81c4-5f1b68de2738
