### PR TITLE
Adversarial review: key on triviality/risk, not change kind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,12 +280,13 @@ family is available.
 **Single-vendor harnesses.** The tiers above set how many reviews and which models
 a PR requires; a harness's capabilities change only *how* those reviews are
 obtained, not the bar. Most harnesses expose only their own vendor's models — for
-example Claude Code or Codex — and cannot run a cross-model review themselves. Such
-a harness first reviews with its own model (independent passes on the fixed head),
-then **requests the tier's required roster-model review from the user**: the
-MAI-Code review for the single-review tier, or the second, different-family review
-for the two-model tier. Its own-model pass is a precondition, not a substitute — do
-not mark the PR ready until the required different-model review is obtained.
+example Claude Code or Codex. For the **single-review tier**, such a harness just
+reviews with its own model (for example an Opus subagent under Claude Code); that
+one review satisfies the tier — no MAI-Code or other cross-model review is
+additionally required. The cross-model requirement applies only to the **two-model
+tier**: there the harness reviews with its own model (independent passes on the
+fixed head), then **requests a second, different-family review from the user**, and
+does **not** mark the PR ready until that different-model review is obtained.
 
 Give each reviewer the same self-contained prompt: exact base and head, design
 intent, relevant diff, concrete attack points, and required real-run evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,11 +277,15 @@ model offers** — e.g. if both Opus 4.8 and Opus 5 are available, use Opus 5.
 For a two-model review, do not review with your own model when another listed
 family is available.
 
-**Single-vendor harnesses.** A harness that only exposes its own vendor's models —
-for example Claude Code or Codex — cannot run a cross-model review itself. It must
-first pass adversarial review with its own model (using independent passes on the
-fixed head), then **request a subsequent review with another roster model from the
-user.** Do not mark the PR ready until that different-model review is obtained.
+**Single-vendor harnesses.** The tiers above set how many reviews and which models
+a PR requires; a harness's capabilities change only *how* those reviews are
+obtained, not the bar. Most harnesses expose only their own vendor's models — for
+example Claude Code or Codex — and cannot run a cross-model review themselves. Such
+a harness first reviews with its own model (independent passes on the fixed head),
+then **requests the tier's required roster-model review from the user**: the
+MAI-Code review for the single-review tier, or the second, different-family review
+for the two-model tier. Its own-model pass is a precondition, not a substitute — do
+not mark the PR ready until the required different-model review is obtained.
 
 Give each reviewer the same self-contained prompt: exact base and head, design
 intent, relevant diff, concrete attack points, and required real-run evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,12 @@ follow-up so readiness remains unambiguous.
 
 ## Adversarial review
 
+**These instructions assume a harness — such as the GitHub Copilot CLI — that can
+delegate a review to any model family in the roster below.** The multi-model tiers
+depend on that ability. Most harnesses do not expose multiple model families; a
+harness that only exposes its own vendor's models handles review differently (see
+*Single-vendor harnesses* below).
+
 **How much review a PR needs is a function of its triviality and risk alone —
 never the kind of change it makes.** Place the PR on that spectrum and match the
 review depth to it:
@@ -269,8 +275,13 @@ should reference it rather than restating it. **Always use the highest version a
 model offers** — e.g. if both Opus 4.8 and Opus 5 are available, use Opus 5.
 
 For a two-model review, do not review with your own model when another listed
-family is available. A single-model agent that cannot delegate may use
-independent passes from its own model.
+family is available.
+
+**Single-vendor harnesses.** A harness that only exposes its own vendor's models —
+for example Claude Code or Codex — cannot run a cross-model review itself. It must
+first pass adversarial review with its own model (using independent passes on the
+fixed head), then **request a subsequent review with another roster model from the
+user.** Do not mark the PR ready until that different-model review is obtained.
 
 Give each reviewer the same self-contained prompt: exact base and head, design
 intent, relevant diff, concrete attack points, and required real-run evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ documentation.
   working-tree changes into your work.
 - Treat worktrees as temporary. For a PR requiring adversarial review, confirm
   the exact reviewed head is pushed, then remove the development and review
-  worktrees with `git worktree remove <path>` as soon as both fixed-head
-  reviews are clean. For a change that does not require adversarial review,
+  worktrees with `git worktree remove <path>` as soon as every required
+  fixed-head review is clean. For a change that does not require adversarial review,
   remove its development worktree after merge. Do not retain inactive
   worktrees in case more work appears; recreate one for the branch if follow-up
   work is needed.
@@ -243,9 +243,21 @@ follow-up so readiness remains unambiguous.
 
 ## Adversarial review
 
-Any PR with non-trivial behavior changes, new heuristics or shapes, or subtle
-correctness, security, or compatibility risk requires adversarial review from
-two different models (latest versions) chosen from:
+**How much review a PR needs is a function of its triviality and risk alone —
+never the kind of change it makes.** Place the PR on that spectrum and match the
+review depth to it:
+
+- **Trivial** — no review. State why the change is trivial.
+- **More than trivial, but not high risk** — a single review, always with
+  **MAI-Code**.
+- **High risk** (subtle correctness, security, or compatibility risk, or a large
+  or uncertain blast radius) — the default for any substantial change — two
+  reviews from two different models.
+
+If you are unsure which tier a PR falls in, escalate: default to more review, not
+less.
+
+Reviewer roster:
 
 - Claude Opus
 - Gemini Pro
@@ -253,27 +265,24 @@ two different models (latest versions) chosen from:
 - MAI-Code
 
 This list is the single source of truth for the reviewer roster; scenario docs
-should reference it rather than restating it.
+should reference it rather than restating it. **Always use the highest version a
+model offers** — e.g. if both Opus 4.8 and Opus 5 are available, use Opus 5.
 
-Do not review with your own model when another listed family is available. A
-single-model agent that cannot delegate may use independent passes from its own
-model.
+For a two-model review, do not review with your own model when another listed
+family is available. A single-model agent that cannot delegate may use
+independent passes from its own model.
 
-Give both reviewers the same self-contained prompt: exact base and head, design
+Give each reviewer the same self-contained prompt: exact base and head, design
 intent, relevant diff, concrete attack points, and required real-run evidence.
 Isolate every reviewer in a separate linked review worktree; never detach the
 primary checkout for review. Require scratch work under `/tmp/` and prohibit
 `git reset`, `git add`, and commits in review trees. Before acting on a blocking
 finding, reproduce it on a clean exact-head review worktree.
 
-After addressing findings, re-review the fixed exact head. Reconcile both
-reviews publicly on the PR: attribute findings, state what was verified or
-dismissed, and link resolution commits or explain explicit non-actions. Do not
-mark the PR ready until both fixed-head reviews are clean.
-
-Simple, mechanical, or documentation-only changes do not require adversarial
-review; state why the change is low risk. If the blast radius is uncertain,
-default to review.
+After addressing findings, re-review the fixed exact head. Reconcile the reviews
+publicly on the PR: attribute findings, state what was verified or dismissed, and
+link resolution commits or explain explicit non-actions. Do not mark the PR ready
+until every required fixed-head review is clean.
 
 ## PR and CI discipline
 

--- a/NIGHTSHIFT.md
+++ b/NIGHTSHIFT.md
@@ -91,16 +91,14 @@ theme into orders:
 
 ## How this composes with the repo's review gate
 
-`AGENTS.md` already requires adversarial review from **two different models** for any non-trivial
-behavior change — this **is** Nightshift's two-clean gate, so the two do not stack: a worker's two
-clean reviews from two different models on the final head satisfy both. Where the two bars differ,
-**Nightshift is the stricter one and it governs the shift.** `AGENTS.md` exempts simple, mechanical,
-or documentation-only changes from adversarial review; a Nightshift **order** does **not** inherit
-that exemption — **every order clears the two-clean gate on its final head, docs and design orders
-included.** Scale the review *effort* to the blast radius — a docs order is cleared by confirming its
-claims and links are accurate, a heuristic or shape change by attacking its correctness — but never
-waive the two-clean bar itself. Keep the repo's readiness convention: when all merge-blocking
-validation and required review are complete, the clearance note is `Ready to merge`.
+`AGENTS.md` sets the repo's review policy: how much adversarial review a change needs scales with its
+triviality and risk — from none for a trivial change, to a single review, to two reviews from two
+different models for a high-risk one. **Nightshift is the stricter bar and it governs the shift:** a
+Nightshift **order** does **not** take the reduced tiers — **every order clears the two-clean gate on
+its final head**, two clean reviews from two different models, regardless of how small the order looks.
+Scale the review *effort* to the blast radius, but never waive the two-clean bar itself. Keep the
+repo's readiness convention: when all merge-blocking validation and required review are complete, the
+clearance note is `Ready to merge`.
 
 The mechanics of expressing an order and driving it to merge — the plan format, the two-clean review
 gate, landing — are standard Nightshift and belong to your skill.


### PR DESCRIPTION
## What

Rewrites the `AGENTS.md` **Adversarial review** policy so review depth is a function of a PR's **triviality and risk alone — never the kind of change**:

| Tier | Review |
| --- | --- |
| **Trivial** | none (state why) |
| **More than trivial, not high risk** | a single review, **always MAI-Code** |
| **High risk** (default for any substantial change) | two reviews from two different models |

Also:

- **Removes the change-kind guidance** from the review rules — the `simple, mechanical, or documentation-only` exemption and the `new heuristics or shapes` trigger are gone; triviality is the only test.
- **Adds a highest-version rule:** always use the highest version a chosen model offers (e.g. if Opus 4.8 and Opus 5 are both available, use Opus 5).
- Generalizes `both reviewers` / `both fixed-head reviews` wording so it also covers the new single-review tier.
- Updates `NIGHTSHIFT.md`'s review-gate section (merged in #3155) so it no longer quotes the removed documentation-only exemption; it now states Nightshift orders always take the two-clean bar regardless of the repo's reduced tiers.

## Evidence / risk

Documentation-only wording change to governance docs; both files pass `markdownlint-cli`. Verified no other adversarial-review rule restates the old kind-based exemption (the remaining `documentation-only` mentions are *validation-evidence* rules — markdownlint vs builds — a separate concern, left unchanged).

## Review tier for this PR

Per the new policy this is more-than-trivial (it changes the review bar itself) but doc-only and directly dictated — I'd put it at the **single MAI-Code** tier. Confirm the tier and I'll run it before marking ready.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>