### PR TITLE
Cast boxed non-\	his\ interface receivers (#3214)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -499,6 +499,33 @@ public sealed class ThisQualificationTests
         Assert.DoesNotContain("(object)", text);
     }
 
+    // #3214 (review): a boxed POINTER deref reaching a default interface member.
+    // `*p` is loaded by `ldobj; box; callvirt`, so the cast operand is the deref.
+    // It MUST be parenthesized — `((I)(*p))` — because `((I)*p)` reparses as the
+    // multiplication `(I) * p` (CS0119) and dropping the deref (`((I)p)`) is a
+    // pointer-to-interface cast (CS0030).
+    [Fact]
+    public void BoxedNonThisPointer_DefaultInterfaceCallee_RendersParenthesizedDeref()
+    {
+        var text = RenderMember(typeof(BoxedNonThisHost),
+            nameof(BoxedNonThisHost.DimOnPointer));
+        Assert.Contains("((IBoxedNonThisDim)(*p)).Dim()", text);
+        Assert.DoesNotContain("(IBoxedNonThisDim)*p", text);
+        Assert.DoesNotContain("(IBoxedNonThisDim)p)", text);
+    }
+
+    // #3214 (review): the callee interface is the rendering method's OWN enclosing
+    // interface. The enclosing-instantiation carve-out that lets a real `this`
+    // receiver skip the cast must NOT fire for a boxed struct place — the boxed
+    // value still needs the upcast, so bare `(s).OwnDim()` (CS1061) is wrong.
+    [Fact]
+    public void BoxedNonThisParam_EnclosingInterfaceCallee_RendersInterfaceCast()
+    {
+        var text = RenderMember(typeof(IBoxedNonThisSelf),
+            nameof(IBoxedNonThisSelf.CallOnParam));
+        Assert.Contains("((IBoxedNonThisSelf)s).OwnDim()", text);
+    }
+
     [Fact]
     public void EventSubscription_DefaultsToBareName()
     {
@@ -1077,7 +1104,27 @@ public class BoxedNonThisHost
     // boxed field reaching a default interface member
     public int DimOnField() => ((IBoxedNonThisDim)_field).Dim();
 
+    // boxed POINTER deref reaching a default interface member; the deref must be
+    // parenthesized in the cast operand -> `((IBoxedNonThisDim)(*p)).Dim()`.
+    public static unsafe int DimOnPointer(BoxedNonThisStruct* p) => ((IBoxedNonThisDim)(*p)).Dim();
+
     // NEGATIVE: a boxed non-`this` value reaching a base-class (object) member stays
     // uncast — the interface-only gate must not fire (separate fidelity concern).
     public string? BaseOnRefParam(ref BoxedNonThisStruct s) => ((object)s).ToString();
+}
+
+// #3214 (review): the callee interface is the rendering method's OWN enclosing
+// interface. A default interface member of `IBoxedNonThisSelf` boxes a struct
+// parameter and reaches another `IBoxedNonThisSelf` member; the boxed place still
+// needs the `((IBoxedNonThisSelf)s)` upcast (the enclosing-instantiation carve-out
+// is sound only for a real `this` receiver, never a boxed struct place).
+public interface IBoxedNonThisSelf
+{
+    int OwnDim() => 7;
+
+    int CallOnParam(BoxedNonThisSelfStruct s) => ((IBoxedNonThisSelf)s).OwnDim();
+}
+
+public struct BoxedNonThisSelfStruct : IBoxedNonThisSelf
+{
 }

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -431,6 +431,74 @@ public sealed class ThisQualificationTests
         Assert.DoesNotContain(")this).MemberwiseClone", group);
     }
 
+    // #3214: a boxed NON-`this` ref parameter reaching a DEFAULT interface member
+    // renders the `((I)s)` cast. `((IBoxedNonThisDim)s).Dim()` lowers to `ldarg.1;
+    // ldobj S; box S; callvirt IBoxedNonThisDim::Dim` — the same box shape as the
+    // boxed-`this` interface case (#3201/#3213) but the boxed operand is a ref
+    // parameter, not arg0/`this`. `Dim` is a DIM not on the struct, so bare
+    // `(s).Dim()` is CS1061; the erased upcast must be re-inserted (#3214).
+    [Fact]
+    public void BoxedNonThisRefParam_DefaultInterfaceCallee_RendersInterfaceCast()
+    {
+        var text = RenderMember(typeof(BoxedNonThisHost),
+            nameof(BoxedNonThisHost.DimOnRefParam));
+        Assert.Contains("((IBoxedNonThisDim)s).Dim()", text);
+        Assert.DoesNotContain("(s).Dim()", text);
+    }
+
+    // #3214: a boxed by-value parameter reaching a normally-implemented interface
+    // member renders `((I)s).Face()`. `Face` IS on the struct, so bare `(s).Face()`
+    // compiles but silently rebinds to the struct's own `call S::Face` (fidelity
+    // loss); the explicit `((IBoxedNonThisFace)s)` re-emits `box; callvirt I::Face`.
+    [Fact]
+    public void BoxedNonThisValueParam_InterfaceCallee_RendersInterfaceCast()
+    {
+        var text = RenderMember(typeof(BoxedNonThisHost),
+            nameof(BoxedNonThisHost.FaceOnValueParam));
+        Assert.Contains("((IBoxedNonThisFace)s).Face()", text);
+        Assert.DoesNotContain("(s).Face()", text);
+    }
+
+    // #3214: a boxed local reaching an interface member renders the cast in both the
+    // call and method-group forms. The local carries no metadata name (spelled
+    // `V_n`), so assert the `((I)` cast prefix and the member tail, not the name.
+    [Fact]
+    public void BoxedNonThisLocal_InterfaceCallee_RendersInterfaceCast()
+    {
+        var call = RenderMember(typeof(BoxedNonThisHost),
+            nameof(BoxedNonThisHost.FaceOnLocal));
+        Assert.Contains("((IBoxedNonThisFace)", call);
+        Assert.Contains(").Face()", call);
+
+        var group = RenderMember(typeof(BoxedNonThisHost),
+            nameof(BoxedNonThisHost.FaceGroupOnLocal));
+        Assert.Contains("((IBoxedNonThisFace)", group);
+        Assert.Contains(").Face)", group);
+    }
+
+    // #3214: a boxed FIELD reaching a default interface member renders
+    // `((I)_field).Dim()`. The boxed operand is `LoadField`, not arg0/`this`.
+    [Fact]
+    public void BoxedNonThisField_DefaultInterfaceCallee_RendersInterfaceCast()
+    {
+        var text = RenderMember(typeof(BoxedNonThisHost),
+            nameof(BoxedNonThisHost.DimOnField));
+        Assert.Contains("((IBoxedNonThisDim)_field).Dim()", text);
+    }
+
+    // Negative (#3214): a boxed non-`this` value reaching a base-CLASS member
+    // (`object::ToString`) must NOT be cast — the arm is gated on a confirmed
+    // interface callee. A boxed value reaching a base-class member is a separate
+    // fidelity concern and stays on the ordinary receiver path (`(s).ToString()`).
+    [Fact]
+    public void BoxedNonThisRefParam_BaseClassCallee_StaysUncast()
+    {
+        var text = RenderMember(typeof(BoxedNonThisHost),
+            nameof(BoxedNonThisHost.BaseOnRefParam));
+        Assert.Contains("(s).ToString()", text);
+        Assert.DoesNotContain("(object)", text);
+    }
+
     [Fact]
     public void EventSubscription_DefaultsToBareName()
     {
@@ -960,4 +1028,56 @@ public struct StructMemberwiseCloneReceiver
     public object CloneCall() => base.MemberwiseClone();
 
     public System.Func<object> CloneGroup() => base.MemberwiseClone;
+}
+
+// #3214 fixtures: a boxed NON-`this` value (parameter, local, field, or ref place)
+// reaching an interface member. csc boxes the value type for the implicit upcast to
+// the interface, so bare `(x).M()` is CS1061 for a default interface member (`Dim`)
+// or a silent rebind to the struct's own method for a normally-implemented one
+// (`Face`); the printer must re-insert the erased `((I)x)` cast (#3214).
+public interface IBoxedNonThisFace
+{
+    int Face();
+}
+
+public interface IBoxedNonThisDim
+{
+    int Dim() => 11;
+}
+
+public struct BoxedNonThisStruct : IBoxedNonThisFace, IBoxedNonThisDim
+{
+    public int Face() => 3;
+}
+
+public class BoxedNonThisHost
+{
+    private BoxedNonThisStruct _field = new BoxedNonThisStruct();
+
+    // boxed ref parameter reaching a default interface member (the CS1061 case)
+    public int DimOnRefParam(ref BoxedNonThisStruct s) => ((IBoxedNonThisDim)s).Dim();
+
+    // boxed by-value parameter reaching a normally-implemented interface member
+    public int FaceOnValueParam(BoxedNonThisStruct s) => ((IBoxedNonThisFace)s).Face();
+
+    // boxed local reaching an interface member (call form)
+    public int FaceOnLocal()
+    {
+        var s = default(BoxedNonThisStruct);
+        return ((IBoxedNonThisFace)s).Face();
+    }
+
+    // boxed local reaching an interface member (method-group form)
+    public System.Func<int> FaceGroupOnLocal()
+    {
+        var s = default(BoxedNonThisStruct);
+        return ((IBoxedNonThisFace)s).Face;
+    }
+
+    // boxed field reaching a default interface member
+    public int DimOnField() => ((IBoxedNonThisDim)_field).Dim();
+
+    // NEGATIVE: a boxed non-`this` value reaching a base-class (object) member stays
+    // uncast — the interface-only gate must not fire (separate fidelity concern).
+    public string? BaseOnRefParam(ref BoxedNonThisStruct s) => ((object)s).ToString();
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -475,6 +475,40 @@ public sealed partial class CSharpPrinter
     static bool IsStructBaseClass(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "ValueType" or "Object" };
 
+    /// <summary>
+    /// True when <paramref name="receiver"/> (or method-group target) is a boxed
+    /// NON-<c>this</c> value — a local, parameter, field, or <c>ref</c>/<c>in</c>
+    /// place — reaching a CONFIRMED interface member of
+    /// <paramref name="declaringType"/>; <paramref name="placeText"/> receives the
+    /// unboxed place spelled as a cast operand. A value type must box to invoke an
+    /// interface member (`<c>ldobj; box; call[virt] I::M</c>` — or `<c>ldftn</c>`
+    /// for a group), so the member is not on the value type and the erased
+    /// <c>((I)x)</c> upcast must be re-inserted: bare <c>(x).M()</c> is CS1061 for a
+    /// default interface member or explicit implementation, and a silent rebind to
+    /// the struct's own method for a normally-implemented one. The boxed
+    /// <c>this</c> case (arg0) is owned by <see cref="IsBoxedThisReceiver"/> (with
+    /// its <c>base</c>/cast split) and is excluded here — including a
+    /// <c>static</c> method's <c>@this</c> parameter, which shares the arg0 name but
+    /// must not be re-cast. Requires a confirmed interface declaring type
+    /// (<see cref="IsInterfaceCastThisReceiver"/> declines an unresolved or
+    /// non-interface callee, so a boxed value reaching a base-class member stays on
+    /// the ordinary path — a separate fidelity concern); the non-<c>this</c>
+    /// sibling of #3201/#3213 (#3214).
+    /// </summary>
+    bool TryBoxedNonThisInterfaceReceiver(IrExpression receiver, TypeRef declaringType, out string placeText)
+    {
+        placeText = "";
+        if (receiver is not Box box)
+            return false;
+        var place = box.Operand is LoadIndirect { Address: { } address } ? address : box.Operand;
+        if (place is LoadArgument { Index: 0, Name: "this" })
+            return false;
+        if (!IsInterfaceCastThisReceiver(declaringType))
+            return false;
+        placeText = Operand(place);
+        return true;
+    }
+
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
     string ReceiverText(IrExpression receiver) => receiver switch
     {
@@ -586,6 +620,12 @@ public sealed partial class CSharpPrinter
                 return $"base.{name}";
             return $"(({TypeText(method.DeclaringType)})this).{name}";
         }
+        // #3214: a boxed NON-this value (local, parameter, field, ref/in place)
+        // reaching a confirmed interface member — the non-this sibling of the
+        // boxed-this interface cast above. `((I)x).M` re-emits `ldobj; box;
+        // ld[virt]ftn I::M`; bare `(x).M` would be CS1061 for a DIM/explicit impl.
+        if (TryBoxedNonThisInterfaceReceiver(target, method.DeclaringType, out var boxedGroupPlace))
+            return $"(({TypeText(method.DeclaringType)}){boxedGroupPlace}).{name}";
         if (PointerMethodReceiver(target) is { } pointerReceiver)
             return $"{pointerReceiver}->{name}";
         return $"{ReceiverText(target)}.{name}";
@@ -711,6 +751,13 @@ public sealed partial class CSharpPrinter
             // opcode-faithful. Subsumes the struct interface-cast case (#3201).
             return $"(({TypeText(call.Callee.DeclaringType)})this).{boxedMethodName}{typeArguments}({rest})";
         }
+        // #3214: a boxed NON-this value (local, parameter, field, ref/in place)
+        // reaching a confirmed interface member — the non-this sibling of the
+        // boxed-this interface cast above. `((I)x).M()` re-emits `ldobj; box;
+        // call[virt] I::M`; bare `(x).M()` would be CS1061 for a DIM/explicit impl,
+        // or a silent rebind to the value type's own method otherwise.
+        if (TryBoxedNonThisInterfaceReceiver(receiver, call.Callee.DeclaringType, out var boxedNonThisPlace))
+            return $"(({TypeText(call.Callee.DeclaringType)}){boxedNonThisPlace}).{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         if (receiver is LoadArgument { Index: 0, Name: "this" })
         {
             string thisMethodName = CSharpNaming.SourceMethodName(call.Callee.Name);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -487,13 +487,34 @@ public sealed partial class CSharpPrinter
     /// default interface member or explicit implementation, and a silent rebind to
     /// the struct's own method for a normally-implemented one. The boxed
     /// <c>this</c> case (arg0) is owned by <see cref="IsBoxedThisReceiver"/> (with
-    /// its <c>base</c>/cast split) and is excluded here — including a
-    /// <c>static</c> method's <c>@this</c> parameter, which shares the arg0 name but
-    /// must not be re-cast. Requires a confirmed interface declaring type
-    /// (<see cref="IsInterfaceCastThisReceiver"/> declines an unresolved or
-    /// non-interface callee, so a boxed value reaching a base-class member stays on
-    /// the ordinary path — a separate fidelity concern); the non-<c>this</c>
-    /// sibling of #3201/#3213 (#3214).
+    /// its <c>base</c>/cast split) and is excluded here. A <c>static</c> method's
+    /// <c>@this</c> parameter shares the arg0 metadata name but is a genuine
+    /// non-<c>this</c> place; it is also excluded because the printer still spells
+    /// arg0-<c>"this"</c> with the <c>this</c> keyword (CS0026 in a static body) —
+    /// a pre-existing spelling limitation (#3260) — so it stays on the ordinary
+    /// path, unchanged from before this arm existed, rather than gaining an invalid
+    /// <c>((I)this)</c> cast.
+    /// <para>
+    /// The place is spelled deref-aware: a <c>ref</c>/<c>in</c> managed reference
+    /// reads back as the bare identifier/member (<c>s</c>) via
+    /// <see cref="DerefLoad"/>, while any other <see cref="LoadIndirect"/> — an
+    /// unmanaged pointer especially — is spelled through <see cref="Operand"/> so
+    /// its dereference is PARENTHESIZED: bare <c>*p</c> after a cast reparses as
+    /// multiplication (<c>(I)*p</c> is <c>(I) * p</c>, CS0119), whereas
+    /// <c>(I)(*p)</c> binds as a cast. Unwrapping the address instead would drop
+    /// the <c>*</c> entirely and emit <c>((I)p).M()</c> for a <c>T*</c> (CS0030).
+    /// </para>
+    /// <para>
+    /// Gated on a CONFIRMED interface declaring type
+    /// (<see cref="IrFunction.InterfaceTypes"/>; an unresolved or non-interface
+    /// callee is absent, so a boxed value reaching a base-class member stays on the
+    /// ordinary path — a separate fidelity concern). Unlike
+    /// <see cref="IsInterfaceCastThisReceiver"/> it does NOT apply the
+    /// enclosing-instantiation exclusion: that carve-out is sound only for a real
+    /// <c>this</c> receiver (already typed as the interface), whereas a boxed
+    /// struct place always needs the cast even when the callee interface is the
+    /// enclosing type. The non-<c>this</c> sibling of #3201/#3213 (#3214).
+    /// </para>
     /// </summary>
     bool TryBoxedNonThisInterfaceReceiver(IrExpression receiver, TypeRef declaringType, out string placeText)
     {
@@ -503,9 +524,11 @@ public sealed partial class CSharpPrinter
         var place = box.Operand is LoadIndirect { Address: { } address } ? address : box.Operand;
         if (place is LoadArgument { Index: 0, Name: "this" })
             return false;
-        if (!IsInterfaceCastThisReceiver(declaringType))
+        if (!_function.InterfaceTypes.Contains(NamedDefinition(declaringType)))
             return false;
-        placeText = Operand(place);
+        placeText = box.Operand is LoadIndirect { Address.ResultType.Kind: TypeRefKind.ByRef } byRefDeref
+            ? DerefLoad(byRefDeref)
+            : Operand(box.Operand);
         return true;
     }
 


### PR DESCRIPTION
- Fixes #3214
- Changes a boxed non-`this` value (local, parameter, field, or `ref`/`in` place) reaching an interface member to render the erased `((I)x)` upcast instead of invalid/unfaithful `(x).M()`.
- Card revision: `cfe2fb5c`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the non-`this` sibling of #3201/#3213: a value type must box to invoke an interface member, and re-inserting the erased `((I)x)` cast turns a CS1061 (or a silent rebind) back into a valid, opcode-faithful render.

### Benchmark target

Benchmark target: the committed csc fixture `BoxedNonThisHost` in `src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs` — a `struct BoxedNonThisStruct : IBoxedNonThisFace, IBoxedNonThisDim` reached through a boxed `ref`/`in` parameter, by-value parameter, local, field, and pointer. `RenderMember` compiles and round-trips these real types, so the fixture source is the reproduction. The aggregate corpus quality is measured over the 15 pinned quick-gate assemblies (below).

dotnet-inspect command:

```bash
dotnet-inspect member ILInspector.Decompiler.Tests.BoxedNonThisHost.DimOnRefParam --library ILInspector.Decompiler.Tests.dll -S "Decompiled Source"
```

### Original source

The authored fixture C# (`src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs`):

```csharp
public interface IBoxedNonThisFace
{
    int Face();
}

public interface IBoxedNonThisDim
{
    int Dim() => 11;
}

public struct BoxedNonThisStruct : IBoxedNonThisFace, IBoxedNonThisDim
{
    public int Face() => 3;
}

public class BoxedNonThisHost
{
    // boxed ref parameter reaching a default interface member (the CS1061 case)
    public int DimOnRefParam(ref BoxedNonThisStruct s) => ((IBoxedNonThisDim)s).Dim();
}
```

The `((IBoxedNonThisDim)s)` upcast is the erased source cast: csc lowers it to `ldobj; box; callvirt IBoxedNonThisDim::Dim`, so the `box` is the anchor the decompiler must re-spell.

### Before

```csharp
public int DimOnRefParam(ref BoxedNonThisStruct s) => (s).Dim();
```

- Valid: **False**
- Correct: **False**
- IL fidelity: not currently checkable (does not compile)
- Taste applied: None
- Commit: `6f441b84`

`Dim` is a default interface member not declared on `BoxedNonThisStruct`, so bare `(s).Dim()` is CS1061. (For a normally-implemented member such as `((IBoxedNonThisFace)s).Face()`, the pre-change render `(s).Face()` instead compiled but silently rebound to the struct's own `call BoxedNonThisStruct::Face` — a fidelity loss rather than a hard error.)

### After

```csharp
public int DimOnRefParam(ref BoxedNonThisStruct s) => ((IBoxedNonThisDim)s).Dim();
```

- Valid: **True**
- Correct: **True**
- IL fidelity: **True** (recompiles to `ldobj; box; callvirt IBoxedNonThisDim::Dim`, verified by round-trip)
- Taste applied: None
- Commit: `cfe2fb5c`

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ThisQualificationTests`: 40 passed | `ThisQualificationTests`: 45 passed (+5) |
| Decompiler fast suite | 3766, 1 failed | 3766, 1 failed |
| RoundTrip area (incl. slow) | 473, 3 failed | 478, 3 failed |
| Reduced fixture validity | Pass | Pass |
| Reduced fixture fidelity | Pass (round-trip) | Pass (round-trip) |
| Real witness | `BoxedNonThisHost.DimOnRefParam` → CS1061 | `BoxedNonThisHost.DimOnRefParam` → `((IBoxedNonThisDim)s).Dim()` |

Baseline failures are pre-existing and unchanged by this PR:

- Fast suite: `StringSwitchRaisingTests.SmallStringSwitch_RendersSwitchOnString` (Windows-local CRLF).
- RoundTrip area: three `GeneratedFixtureCatalogTests` (`ReturnToSenderRecordCatalog_CoversGeneratedRecordHelpers`, `MinimalCompileBackRungs_ReportExpectedOutcomesByFixtureId`, `CompilerLoweringFrontier_IsSelectableButNotInDefaultRun`).

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — pinned quick gate PASS with 0 pass bugs; detected lowering residue improves 251 → 246.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly; 15 assemblies, 1,500 methods; validity/fidelity not run.

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 16.73% | 16.40% | -0.33 pp |
| Conditional-branch residue (-) | 3.07% | 2.87% | -0.20 pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — corpus sensor matched baseline tolerances; residue improved.

### Aggregate context

Corpus: 15 assemblies, 1,500 methods. Baseline drift: none.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Detected lowering residue (-) | 251 (16.73%) | 246 (16.40%) |
| Conditional-branch residue (-) | 46 (3.07%) | 43 (2.87%) |
| Forward-merge stops (-) | 32 (2.13%) | 30 (2.00%) |

> **Conclusion:** **PASS** — every tracked metric moved in the goal direction or held.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ThisQualificationTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait "Area=RoundTrip"
```
