### PR TITLE
RTS: reconstruct multi-member external explicit-interface methods (#3112, Increment 2)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1792,6 +1792,91 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_InheritedBaseInterfaceMemberFallsBackWithoutRecompileFail()
+    {
+        // #3112 Increment 2 base-interface atomicity: an external interface that INHERITS from
+        // another interface flattens the base's members into the required surface, but the
+        // synthesized stubs record no declaring-interface identity and are all qualified with
+        // the ROOT interface. An inherited member emitted as `void IRoot.Member()` is CS0539
+        // (not a member of IRoot) and leaves the base member unimplemented (CS0535 =
+        // RecompileFail). The gate must decline the WHOLE surface to the sanitized ContextFail
+        // floor whenever a base interface contributes a required member.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "namespace RtsInh { public interface IBase { void Sibling(); } public interface IDerived : IBase { void Target(); } }",
+            directory: fixtureDir,
+            assemblyName: "RtsInhContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class InhImpl : RtsInh.IDerived
+            {
+                void RtsInh.IDerived.Target() { }
+                void RtsInh.IBase.Sibling() { }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("InhImpl", "RtsInh.IDerived.Target", 0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsInh_IDerived_Target", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsInh.IDerived.Target", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_NestedExternalMultiMemberInterfaceFallsBackWithoutRecompileFail()
+    {
+        // #3112 Increment 2: a nested external interface (`Outer.IProbe`) cannot be named in the
+        // reconstructed base list — its metadata separator (`Outer+IProbe`) is not bindable C#
+        // and its TypeReference resolves through the enclosing type rather than an assembly
+        // reference. The engagement must decline to the sanitized ContextFail floor rather than
+        // emit an unspellable `Outer+IProbe` qualifier (CS1001/CS0246 = RecompileFail).
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "namespace RtsNest { public class Outer { public interface IProbe { void Target(); void Sibling(); } } }",
+            directory: fixtureDir,
+            assemblyName: "RtsNestContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class NestImpl : RtsNest.Outer.IProbe
+            {
+                void RtsNest.Outer.IProbe.Target() { }
+                void RtsNest.Outer.IProbe.Sibling() { }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("NestImpl", "RtsNest.Outer.IProbe.Target", 0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("RtsNest_Outer_IProbe_Target", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_GenericExternalExplicitInterfaceFallsBackWithoutRecompileFail()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1625,7 +1625,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_MultiMemberExternalExplicitInterfaceFallsBackWithoutRecompileFail()
+    public void CompileBackTargets_RoundTripsExternalMultiMemberExplicitInterfaceMethod()
     {
         var assemblyPath = CompileFixture("""
             using System;
@@ -1660,11 +1660,130 @@ public class ReturnToSenderPrototypeTests
                     "System.IConvertible.ToBoolean",
                     0)]));
 
+            // #3112 Increment 2: a multi-member external interface engages by reconstructing the
+            // target member with its real body and synthesizing `throw null` explicit-interface
+            // stubs for every OTHER required member, so the full surface satisfies CS0535 and the
+            // fidelity lookup finds the correctly-named explicit member (Exact, not the sanitized
+            // `System_IConvertible_ToBoolean` ContextFail floor).
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.Source.Contains(": System.IConvertible", StringComparison.Ordinal)
+                || result.Source.Contains(": IConvertible", StringComparison.Ordinal),
+                result.Source);
+            // The target member reconstructs as a real explicit implementation.
+            Assert.Contains("IConvertible.ToBoolean(", result.Source, StringComparison.Ordinal);
+            // A non-target member is synthesized as a `throw null` explicit-interface stub so the
+            // interface's full required surface is satisfied.
+            Assert.Contains("IConvertible.GetTypeCode(", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("System_IConvertible_ToBoolean", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_MultiMemberExternalExplicitInterfaceWithUnspellableSiblingFallsBackWithoutRecompileFail()
+    {
+        // #3112 Increment 2 whole-surface atomicity: engaging a multi-member external interface
+        // names it in the base list, which forces the reconstructed type to implement EVERY
+        // required member (CS0535). The target member (`Target`) is perfectly representable, but
+        // a SIBLING member (`Sibling(ref int)`) carries by-ref detail SignatureDecoder cannot
+        // spell unambiguously. Synthesizing a stub for it (or omitting it) would leave the
+        // surface unsatisfied or drifted (CS0535/CS0539 = RecompileFail). The gate must decline
+        // the WHOLE interface when ANY member is unspellable and keep the sanitized ContextFail
+        // floor, even though the requested target member itself is fine.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "namespace RtsMulti { public interface IProbe { void Target(); void Sibling(ref int value); } }",
+            directory: fixtureDir,
+            assemblyName: "RtsMultiContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class MultiImpl : RtsMulti.IProbe
+            {
+                void RtsMulti.IProbe.Target() { }
+                void RtsMulti.IProbe.Sibling(ref int value) => value = 0;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "MultiImpl",
+                    "RtsMulti.IProbe.Target",
+                    0)]));
+
             Assert.True(
                 result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
-            Assert.Contains("System_IConvertible_ToBoolean", result.Source, StringComparison.Ordinal);
-            Assert.DoesNotContain("System.IConvertible.ToBoolean", result.Source, StringComparison.Ordinal);
+            Assert.Contains("RtsMulti_IProbe_Target", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsMulti.IProbe.Target", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_MultiMemberExternalExplicitInterfaceWithOverloadedSiblingsRoundTrips()
+    {
+        // #3112 Increment 2 overload robustness: a real corpus interface such as
+        // System.ComponentModel.ICustomTypeDescriptor carries same-name overloads
+        // (`GetProperties()` / `GetProperties(Attribute[])`). Every non-target member is
+        // synthesized as a `throw null` explicit-interface stub, and two overloads share one
+        // explicit member name (`RtsOv.IProbe.Overloaded`) while differing only by signature.
+        // The reconstructed members must NOT be deduplicated by name (that would drop one
+        // overload, leaving the interface surface unsatisfied, CS0535). Both stubs must emit as
+        // distinct explicit implementations so the type compiles and the target reconstructs
+        // Exact.
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "namespace RtsOv { public interface IProbe { void Target(); int Overloaded(); int Overloaded(string label); } }",
+            directory: fixtureDir,
+            assemblyName: "RtsOvContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class OvImpl : RtsOv.IProbe
+            {
+                void RtsOv.IProbe.Target() { }
+                int RtsOv.IProbe.Overloaded() => 0;
+                int RtsOv.IProbe.Overloaded(string label) => 0;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "OvImpl",
+                    "RtsOv.IProbe.Target",
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.Source.Contains(": RtsOv.IProbe", StringComparison.Ordinal)
+                || result.Source.Contains(": IProbe", StringComparison.Ordinal),
+                result.Source);
+            // Both overloads must be present as distinct explicit-interface stubs.
+            Assert.Contains("RtsOv.IProbe.Overloaded()", result.Source, StringComparison.Ordinal);
+            Assert.Contains("RtsOv.IProbe.Overloaded(string", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RtsOv_IProbe_Target", result.Source, StringComparison.Ordinal);
         }
         finally
         {

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1899,7 +1899,17 @@ public static class CompileBackSourceComposer
     sealed class UnrepresentableSignatureProbe : ISignatureTypeProvider<bool, object?>
     {
         public static readonly UnrepresentableSignatureProbe Instance = new();
-        public bool GetPrimitiveType(PrimitiveTypeCode typeCode) => false;
+
+        // `typedref` (System.TypedReference) is a restricted primitive that cannot be a method
+        // return type in C# (CS1599) — nor a field, type argument, or array element — so an
+        // interface member mentioning it cannot be reconstructed as a bindable explicit
+        // implementation or `throw null` stub (the surface would emit CS1599 = RecompileFail).
+        // SignatureDecoder spells it as the bare token `TypedReference`, which carries no `+`/`!`
+        // marker for SignatureTypeIsUnspellable to catch, and it is not emittable from C# source
+        // (it appears only on hand-authored / Reflection.Emit IL), so treat it as unrepresentable
+        // detail here and decline the whole surface to the ContextFail floor (#3112). Every other
+        // primitive is a faithful, bindable C# spelling.
+        public bool GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode == PrimitiveTypeCode.TypedReference;
         public bool GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => false;
         public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => false;
         public bool GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
@@ -2110,6 +2120,20 @@ public static class CompileBackSourceComposer
         foreach (var implementationHandle in interfaceDef.GetInterfaceImplementations())
         {
             var implementation = reader.GetInterfaceImplementation(implementationHandle);
+
+            // A member inherited from a base interface is collected here with no record of the
+            // interface that DECLARED it: ExternalInterfaceRequiredMethod carries only name,
+            // arity, and signature, and the caller qualifies every synthesized stub with the
+            // ROOT interface's display name. C# requires an inherited member to be spelled with
+            // its declaring interface (`void IBase.M()`), so a stub emitted as `void IRoot.M()`
+            // is CS0539 (not a member of IRoot) and leaves the base member unimplemented
+            // (CS0535 = RecompileFail). A base interface that contributes NO required members
+            // (an empty marker, or one carrying only already-declined property/event/generic
+            // members) is harmless. So allow base interfaces that add nothing to the surface,
+            // but decline the whole engagement to the ContextFail floor the moment any base
+            // interface contributes a required member (#3112).
+            int methodsBefore = methods.Count;
+
             if (implementation.Interface.Kind == HandleKind.TypeDefinition)
             {
                 if (!TryCollectRequiredInterfaceMethods(
@@ -2122,6 +2146,8 @@ public static class CompileBackSourceComposer
                 {
                     return false;
                 }
+                if (methods.Count != methodsBefore)
+                    return false;
                 continue;
             }
 
@@ -2140,6 +2166,8 @@ public static class CompileBackSourceComposer
                 {
                     return false;
                 }
+                if (methods.Count != methodsBefore)
+                    return false;
                 continue;
             }
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -409,7 +409,8 @@ internal sealed record ExplicitInterfaceEventInfo(
 
 internal sealed record ExternalExplicitInterfaceMethodInfo(
     string InterfaceDisplayName,
-    string ExplicitInterfaceMemberName);
+    string ExplicitInterfaceMemberName,
+    IReadOnlyList<CompileBackMemberRequirement> AdditionalInterfaceStubs);
 
 internal sealed record ExternalInterfaceReferenceInfo(
     string MetadataFullName,
@@ -1459,18 +1460,16 @@ public static class CompileBackSourceComposer
             if (!string.Equals(interfaceReference.MetadataFullName, interfaceMetadataName, StringComparison.Ordinal))
                 continue;
 
+            // The full transitive required surface of the external interface. #3112 Increment 1
+            // engaged only when this was exactly the single target member; Increment 2 also
+            // engages on multi-member interfaces by synthesizing `throw null` explicit-interface
+            // stubs for every non-target member (below). An empty surface cannot contain the
+            // target member, so decline to the ContextFail floor.
             if (!TryReadExternalInterfaceSurface(
                     assemblyPath,
                     interfaceReference,
                     out var requiredMethods)
-                || requiredMethods.Count != 1)
-            {
-                return null;
-            }
-
-            var requiredMethod = requiredMethods[0];
-            if (!string.Equals(requiredMethod.Name, declarationName, StringComparison.Ordinal)
-                || requiredMethod.GenericArity != targetMethodGenericArity)
+                || requiredMethods.Count == 0)
             {
                 return null;
             }
@@ -1510,11 +1509,28 @@ public static class CompileBackSourceComposer
             {
                 return null;
             }
-            if (!string.Equals(targetSignature.ReturnType, requiredMethod.ReturnType, StringComparison.Ordinal)
-                || !targetSignature.ParameterTypes.SequenceEqual(requiredMethod.ParameterTypes, StringComparer.Ordinal))
+
+            // Identify which required interface method the target implements: it must agree by
+            // name, generic arity, and full decoded signature. Interface methods are unique by
+            // signature, so exactly one required method may match; zero (the target's spelling
+            // is not part of the resolved surface -> CS0539) or more than one (ambiguous)
+            // declines to the ContextFail floor.
+            int matchIndex = -1;
+            for (int index = 0; index < requiredMethods.Count; index++)
             {
-                return null;
+                var candidate = requiredMethods[index];
+                if (string.Equals(candidate.Name, declarationName, StringComparison.Ordinal)
+                    && candidate.GenericArity == targetMethodGenericArity
+                    && string.Equals(candidate.ReturnType, targetSignature.ReturnType, StringComparison.Ordinal)
+                    && candidate.ParameterTypes.SequenceEqual(targetSignature.ParameterTypes, StringComparer.Ordinal))
+                {
+                    if (matchIndex >= 0)
+                        return null;
+                    matchIndex = index;
+                }
             }
+            if (matchIndex < 0)
+                return null;
 
             // A reconstructed sibling type (or sibling sub-namespace) in the recompile
             // closure can intercept the leading identifier of the external interface
@@ -1536,15 +1552,101 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
+            // Naming the interface in the base list forces the reconstructed type to satisfy
+            // its ENTIRE required surface (CS0535). The target method reconstructs the matched
+            // member with its real body; every OTHER required member is synthesized here as a
+            // `throw null` explicit-interface stub. If any such member cannot be spelled as
+            // valid, bindable C# (a member name that does not round-trip, or a signature type
+            // SignatureDecoder renders unbindably), decline the WHOLE engagement and keep the
+            // sanitized ContextFail floor rather than emit a partial surface (CS0535) or an
+            // unbindable stub (CS0246 = RecompileFail).
+            var additionalInterfaceStubs = new List<CompileBackMemberRequirement>(requiredMethods.Count - 1);
+            for (int index = 0; index < requiredMethods.Count; index++)
+            {
+                if (index == matchIndex)
+                    continue;
+                if (SynthesizeExternalInterfaceStub(interfaceReference.DisplayFullName, requiredMethods[index]) is not { } stub)
+                    return null;
+                additionalInterfaceStubs.Add(stub);
+            }
+
             string explicitInterfaceMemberName =
                 $"{interfaceReference.DisplayFullName}.{Identifier(declarationName)}";
             return new ExternalExplicitInterfaceMethodInfo(
                 interfaceReference.DisplayFullName,
-                explicitInterfaceMemberName);
+                explicitInterfaceMemberName,
+                additionalInterfaceStubs);
         }
 
         return null;
     }
+
+    // Synthesizes a `throw null` explicit-interface stub for a NON-target member of an external
+    // interface, so the reconstructed type satisfies the interface's full required surface
+    // (CS0535) after the interface is named in the base list. Returns null when the member
+    // cannot be spelled as valid, bindable C#, in which case the caller declines the whole
+    // engagement and keeps the ContextFail floor. Only arity-0 methods reach here
+    // (TryCollectRequiredInterfaceMethods declines every generic/property/event/non-public
+    // member and every by-ref/pointer/array/function-pointer/modifier signature), so the stub
+    // has no type parameters and its decoded signature strings are a faithful C# spelling — the
+    // same strings the target signature match above already trusts.
+    static CompileBackMemberRequirement? SynthesizeExternalInterfaceStub(
+        string interfaceDisplayName,
+        ExternalInterfaceRequiredMethod method)
+    {
+        // The stub names the member via `IType.<member>()`; a name that does not round-trip
+        // through a C# identifier binds to no interface member (CS0539), leaving the interface
+        // member unimplemented (CS0535). Re-defend arity here even though the surface is
+        // arity-0: a generic stub would need to restate constraints it cannot see.
+        if (method.GenericArity != 0 || !MetadataIdentifierRoundTrips(method.Name))
+            return null;
+
+        // SignatureDecoder spells nested types with the metadata separator (`Outer+Inner`),
+        // which is not bindable C#, and degrades a generic-parameter-bearing type to a bare
+        // `object` (via CleanTypeDisplay's `!` guard) that would silently mis-satisfy the
+        // member. The required surface already declined generics and unrepresentable detail, so
+        // neither marker should survive; decline defensively if one does rather than emit an
+        // unbindable (CS0246) or drifted (CS0535) stub.
+        if (SignatureTypeIsUnspellable(method.ReturnType)
+            || method.ParameterTypes.Any(SignatureTypeIsUnspellable))
+        {
+            return null;
+        }
+
+        string explicitName = $"{interfaceDisplayName}.{Identifier(method.Name)}";
+        var returnType = CompileBackTypeSignature.Display(method.ReturnType);
+        var parameters = method.ParameterTypes
+            .Select((type, index) => new CompileBackParameter(
+                $"arg{index}",
+                CompileBackTypeSignature.Display(type)))
+            .ToArray();
+        string declarationSignature = ExplicitInterfaceMethodDeclarationSignature(
+            explicitName,
+            returnType,
+            [],
+            parameters);
+        return new CompileBackMemberRequirement(
+            new CompileBackMethodIdentity(interfaceDisplayName, method.Name, 0, declarationSignature),
+            CompileBackMemberKind.Method,
+            false,
+            parameters,
+            returnType,
+            [],
+            CompileBackStubBodyKind.Throw,
+            null,
+            [new CompileBackFact("metadata", "external-interface-stub", explicitName)],
+            ExplicitInterfaceMemberName: explicitName,
+            DeclarationSignature: declarationSignature);
+    }
+
+    // A decoded signature type is unspellable when it carries a metadata artifact that
+    // SignatureDecoder/CleanTypeDisplay cannot turn into bindable C#: `+` (a nested type's
+    // metadata separator, e.g. `Outer+Inner`) or `!` (a generic parameter, which CleanTypeDisplay
+    // collapses to `object`). Neither character can appear in a legal C# type spelling, so
+    // rejecting them never declines a spellable type — it only preserves the floor.
+    static bool SignatureTypeIsUnspellable(string decodedType)
+        => decodedType.Contains('+', StringComparison.Ordinal)
+           || decodedType.Contains('!', StringComparison.Ordinal);
 
     // True when every dotted segment of the external interface's raw metadata full name
     // round-trips through the display spelling the reconstruction emits. Clean(metadataFullName)
@@ -2511,6 +2613,17 @@ public static class CompileBackSourceComposer
                 DeclarationSignature: explicitInterfaceDeclarationSignature,
                 RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function))
         ];
+        if (externalExplicitInterfaceMethod is { AdditionalInterfaceStubs.Count: > 0 })
+        {
+            // Naming a multi-member external interface in the base list requires the
+            // reconstructed type to implement its full required surface (CS0535). Supply every
+            // non-target member as a `throw null` explicit-interface stub. The gate excluded the
+            // matched target member from these stubs, so none duplicates the target's own
+            // explicit implementation (CS0111), and external interface members are never closure
+            // members (they live outside the target assembly), so none collides with the record
+            // or closure surface added below.
+            targetMembers.AddRange(externalExplicitInterfaceMethod.AdditionalInterfaceStubs);
+        }
         bool includeRecordSurface = false;
         if (!isConstructor && IsRecordGeneratedFieldReadHelper(reader, targetTypeDef, targetIdentity, methodName, signature, function))
         {


### PR DESCRIPTION
- Advances #3112 (Increment 2 of a stacked pair; Increment 1 was #3222)
- Changes RTS explicit-interface reconstruction for **multi-member external/BCL**
  interfaces (harness-only; product output unchanged)
- Evidence revision: `15e260fa`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — Increment 1 (#3222) taught RTS to reconstruct a
**single-member** external explicit-interface method as a real explicit
implementation (ContextFail → Exact), but declined every **multi-member**
external interface (`System.IConvertible`, `System.ComponentModel.ICustomTypeDescriptor`, …)
to the sanitized `ContextFail` floor: naming the interface in the base list forces
the reconstructed type to satisfy the interface's *entire* required surface
(CS0535), and Increment 1 only supplied the single target member. This change
reconstructs the requested target member with its real body **and synthesizes a
`throw null` explicit-interface stub for every other required member**, so the
full surface is satisfied and the target round-trips **Exact**. The engagement is
floor-first and atomic: it engages only when every required member is confidently
spellable, otherwise it declines the whole interface to the pre-fix sanitized
shape — so no `RecompileFail` regression is introduced.

### Reconstructed render (Original → Before → After → Fully raised)

Target: `Convertible System.IConvertible.ToBoolean(IFormatProvider) instance`

**Original** (authoritative anchor — the explicit-interface member the
reconstruction must round-trip; fixture C#):

```csharp
public sealed class Convertible : IConvertible
{
    bool IConvertible.ToBoolean(IFormatProvider provider) => false;
    // + the other 16 IConvertible members (GetTypeCode, ToByte, ToChar, …)
}
```

**Before** (emitted C# at base `ee13d4e2` + verdict): the multi-member external
interface declines to the sanitized floor — `IConvertible` is dropped from the
base list and the dotted member name is decomposed to an underscore-joined plain
method, so the recompiled assembly no longer contains an explicit
`IConvertible.ToBoolean` to opcode-compare:

```csharp
#pragma warning disable
using System;
public sealed class Convertible
{
    bool System_IConvertible_ToBoolean(IFormatProvider provider)
    {
        return false;
    }
}
```

- Verdict: ContextFail (method-not-found)
- Valid: True · Correct: False · IL fidelity: not currently checkable
- Commit: `ee13d4e2`

**After** (emitted C# at head `15e260fa` + verdict — verbatim harness compile-back
source): the interface is named in the base list, the target member is a real
explicit implementation with its original body, and every other required member
is a `throw null` explicit-interface stub so the surface satisfies CS0535:

```csharp
#pragma warning disable
using System;
public sealed class Convertible : IConvertible
{
    bool System.IConvertible.ToBoolean(IFormatProvider provider)
    {
        return false;
    }
    TypeCode System.IConvertible.GetTypeCode() { throw null; }
    char System.IConvertible.ToChar(IFormatProvider arg0) { throw null; }
    sbyte System.IConvertible.ToSByte(IFormatProvider arg0) { throw null; }
    byte System.IConvertible.ToByte(IFormatProvider arg0) { throw null; }
    short System.IConvertible.ToInt16(IFormatProvider arg0) { throw null; }
    ushort System.IConvertible.ToUInt16(IFormatProvider arg0) { throw null; }
    int System.IConvertible.ToInt32(IFormatProvider arg0) { throw null; }
    uint System.IConvertible.ToUInt32(IFormatProvider arg0) { throw null; }
    long System.IConvertible.ToInt64(IFormatProvider arg0) { throw null; }
    ulong System.IConvertible.ToUInt64(IFormatProvider arg0) { throw null; }
    float System.IConvertible.ToSingle(IFormatProvider arg0) { throw null; }
    double System.IConvertible.ToDouble(IFormatProvider arg0) { throw null; }
    decimal System.IConvertible.ToDecimal(IFormatProvider arg0) { throw null; }
    DateTime System.IConvertible.ToDateTime(IFormatProvider arg0) { throw null; }
    string System.IConvertible.ToString(IFormatProvider arg0) { throw null; }
    object System.IConvertible.ToType(Type arg0, IFormatProvider arg1) { throw null; }
}
```

- Verdict: Exact
- Valid: True · Correct: True · IL fidelity: True (target member round-trips to
  original opcodes)
- Commit: `15e260fa`

**Fully raised.** `The After render is in the fully raised state.` — the requested
target member (`ToBoolean`) reconstructs `Exact` and opcode-faithful. The
`throw null` stubs are intentional RTS scaffolding whose only role is to satisfy
the interface surface so the target's IL can be compiled and compared; they are
not a fidelity gap for the requested target.

## Scope and safety

- **Root cause:** Increment 1 gated engagement on the external interface's
  required surface being *exactly one* method (`requiredMethods.Count != 1` →
  decline). A multi-member interface therefore always declined to the sanitized
  floor even when every member was representable, because naming the interface in
  the base list demands the type implement all of them (CS0535).
- **Fix shape (harness orchestration only):** In
  `tools/DecompilerHarness/ReturnToSenderTypePlanner.cs`, relax the count gate to
  `== 0` (nothing to reconstruct) and find the single required method matching the
  target by name **and** generic arity **and** full decoded signature. For every
  other required member, synthesize a `CompileBackMemberRequirement`
  (`Kind=Method`, `StubBody=Throw`, `ExplicitInterfaceMemberName` +
  `DeclarationSignature`), reusing the exact explicit-interface emit path
  Increment 1 already validated (`throw null` body, verbatim declaration text).
  Stubs are appended to the reconstructed type's members.
- **Product impact:** None. No product source/printer/API changes; all new code is
  under `tools/DecompilerHarness/`.
- **Scope boundary (atomic + floor-first):** Engagement is whole-surface atomic.
  All pre-existing Increment-1 interface-level declines still fire in
  `TryCollectRequiredInterfaceMethods` (generic/property/event/non-public
  interface, non-public member, obsolete-error, `CompilerFeatureRequired`, generic
  method, varargs, and the `SignatureHasUnrepresentableDetail` probe covering
  by-ref/modifier/MDArray/function-pointer/`TypeSpec`), and each declines the
  **entire** surface — so a multi-member interface with any unspellable member
  declines atomically to the floor. A new stub-synthesis guard
  (`SynthesizeExternalInterfaceStub` / `SignatureTypeIsUnspellable`) additionally
  declines the whole engagement if any synthesized member has non-zero generic
  arity, a non-round-tripping name, or a decoded signature containing `+` (nested
  type) or `!` (a generic parameter that `CleanTypeDisplay` degrades to `object`).
- **RTS boundary:** RTS only orchestrates closure + Roslyn + contract-V1 body
  comparison; product/shared code owns C# source generation. The synthesized stubs
  reuse the existing product-owned explicit-interface member emit path unchanged.

## Evidence

| Check | Result |
| --- | --- |
| Product/harness build (`tools/DecompilerHarness -c Release`) | Pass (0 errors, 0 warnings) |
| Test build (`ILInspector.Decompiler.Tests -c Release`) | Pass (0 errors, 0 warnings) |
| Focused tests (`*External*`) | 37 total, 30 passed, 7 skipped (ilasm absent) |
| Full RTS class (`ReturnToSenderPrototypeTests`) | 184 total, 175 passed, 7 skipped, 2 pre-existing failures (#3251, unrelated) |
| Broad EVIL-corpus A/B | Not run in this environment (pinned corpus artifact unavailable on this Windows host, as for #3222); mechanism proven by focused round-trip tests |

New / changed focused tests
(`src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs`):

- `CompileBackTargets_RoundTripsExternalMultiMemberExplicitInterfaceMethod` —
  `Convertible : IConvertible` (16 members), target
  `System.IConvertible.ToBoolean` → asserts **Exact**, base list + real explicit
  target + `throw null` sibling stub present, sanitized name absent. (Converted
  from the Increment-1 test that asserted the *decline*.)
- `CompileBackTargets_MultiMemberExternalExplicitInterfaceWithUnspellableSiblingFallsBackWithoutRecompileFail`
  — a representable target with a `ref int` **sibling** → the whole interface
  declines to the floor (not `RecompileFail`), proving whole-surface atomicity.
- `CompileBackTargets_MultiMemberExternalExplicitInterfaceWithOverloadedSiblingsRoundTrips`
  — same-name overloads (`Overloaded()` / `Overloaded(string)`, mirroring
  `ICustomTypeDescriptor.GetProperties`) emit as **distinct** explicit stubs (no
  name dedup) → **Exact**.

The `throw null` stubs are load-bearing: neutralizing stub emission (verified
locally) makes the positive test fail `CS0535: 'Convertible' does not implement
interface member 'IConvertible.GetTypeCode()'`, confirming the stubs are what
satisfy the surface and the positive test is a genuine regression guard.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Multi-member external **method-only** interfaces (`IConvertible`, method-only `ICustomTypeDescriptor` slice) | Fixed | Synthesize `throw null` stubs for the non-target members + name base list → Exact |
| External interfaces exposing **properties/events** (`ICollection`, property-bearing `ICustomTypeDescriptor` slice) | Left as frontier | `TryCollectRequiredInterfaceMethods` declines property/event-bearing interfaces; deferred (still safe: declines to floor) |
| Any member with by-ref / pointer / function-pointer / MDArray / `TypeSpec` / generic-method / varargs / non-public / obsolete-error detail | Declines atomically | Cannot spell confidently in a fresh compilation; whole interface reverts to the sanitized `ContextFail` floor |
| Nested (`+`) or generic-parameter (`!`) member signatures | Declines | `CleanTypeDisplay` would degrade them to `object`; rejected before emit |
| Generic external interfaces (`IEnumerable<T>`) | Not changed | Out of scope (unchanged from Increment 1) |
| `#3251` slow-gated RTS failures (`FullReconstructsPlainEventAccessorTarget`, `FirstPropertyGetter_EmitsClosureConstructorRequirement`) | Pre-existing / unrelated | Fail identically on base `ee13d4e2` (broken by #3129's `.ctor`→`__ctor` sanitizer); tracked in #3251 |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| GPT | Pending | Two-model review dispatched at head `15e260fa` |
| Gemini Pro | Pending | Two-model review dispatched at head `15e260fa` |

**Review conclusion:** **REVIEW** — high-risk (arbitrary external signature
translation with a floor-first safety invariant); two-model adversarial review in
progress. Reconciliation and `Ready to merge` to follow on the PR once both
fixed-head reviews are clean.

## Validation

```bash
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method "*RoundTripsExternalMultiMemberExplicitInterfaceMethod*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method "*External*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests"
```
