### PR TITLE
Classify compile-back failures with a cause + paired fix (#3256)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnnotatedCompileBackFailureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedCompileBackFailureTests.cs
@@ -87,12 +87,16 @@ public class AnnotatedCompileBackFailureTests
 
     // ---- Concrete fixes, held to their claim (apply -> recompile -> clean) ----
 
-    [Fact]
-    public void InvisibleRuneFixIsVerifiedByRecompile()
+    [Theory]
+    // ordinary stem — dropping the rune is sufficient
+    [InlineData("class \u200CFoo { }\n")]
+    // keyword stem — dropping alone would expose the bare keyword 'class', which
+    // is *worse* than the original lex error, so the fix must also escape it
+    [InlineData("class \u200Cclass { }\n")]
+    public void InvisibleRuneFixIsVerifiedByRecompile(string source)
     {
         // A leading Cf is a valid identifier-part but not an identifier-start, so
         // it breaks *lexing* (CS1001). Dropping it is a real fix.
-        string source = "class " + Zwnj + "Foo { }\n";
         Diagnostic err = FirstError(source);
         Assert.Contains(err.Id, new[] { "CS1001", "CS1056" });
 
@@ -101,6 +105,13 @@ public class AnnotatedCompileBackFailureTests
         Assert.StartsWith("invisible-rune", cf!.Value.Cause);
         Assert.NotNull(cf.Value.From);
         Assert.NotNull(cf.Value.To);
+
+        // The proposal must never be a bare reserved keyword. IsValidIdentifier is
+        // a character-rules check and returns true for 'class', so it cannot serve
+        // as the keyword filter.
+        Assert.False(
+            SyntaxFacts.IsReservedKeyword(SyntaxFacts.GetKeywordKind(cf.Value.To!)),
+            $"fix proposed a bare keyword: '{cf.Value.To}'");
 
         string patched = source.Replace(cf.Value.From!, cf.Value.To!);
         Assert.DoesNotContain(Zwnj, patched);
@@ -145,18 +156,20 @@ public class AnnotatedCompileBackFailureTests
     // ---- The former harmful precedence case, now correct ----
 
     [Fact]
-    public void KeywordStemCarryingCfIsNeverConvertedIntoAKeyword()
+    public void LeadingCfOverAKeywordStemProposesTheEscapedForm()
     {
-        // 'class\u200C' is a *legal identifier* - the rune is what makes it legal.
-        // The classifier must never propose `class\u200C -> class`, which would
-        // manufacture a keyword error.
-        FidelityCheck.CauseFix? cf = FidelityCheck.ClassifyCause("class" + Zwnj, 0, 6, "CS0103");
+        // Stripping the rune from '\u200Cclass' leaves 'class'. SyntaxFacts
+        // .IsValidIdentifier("class") is true - it checks character rules only and
+        // knows nothing about keywords - so the proposal must be composed from both
+        // causes: drop the rune *and* escape the keyword it exposes.
+        string source = "class " + Zwnj + "class { }\n";
 
-        if (cf is { } value)
-        {
-            Assert.DoesNotContain("keyword-escape", value.Cause);
-            Assert.NotEqual("class", value.To);
-        }
+        FidelityCheck.CauseFix? cf = Classify(source, FirstError(source));
+
+        Assert.NotNull(cf);
+        Assert.Equal(Zwnj + "class", cf!.Value.From);
+        Assert.Equal("@class", cf.Value.To);
+        Assert.Contains("escape", cf.Value.Fix);
     }
 
     // ---- Fall-through: not every span is a classifiable identifier ----

--- a/src/ILInspector.Decompiler.Tests/AnnotatedCompileBackFailureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedCompileBackFailureTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 using ILInspector.DecompilerHarness;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -5,28 +7,45 @@ using Microsoft.CodeAnalysis.CSharp;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// Pins the annotated compile-back failure render (#3238): a RecompileFail's
-/// emitted C# is shown with a caret underline under the exact diagnostic span,
-/// and invisible/format runes on that line are revealed so the caret points at
-/// something the reader can see. The caret sits on a <c>//</c> comment so the
-/// block stays valid C# inside a code fence.
+/// Pins the annotated compile-back failure render (#3238) and its cause/fix
+/// classification (#3256). Layers 1-2: the emitted C# is shown with a caret under
+/// the exact diagnostic span, invisible runes revealed. Layer 3: a classified
+/// <c>cause</c> + paired <c>fix</c>. The concrete-fix causes are held to their
+/// claim - apply the fix, recompile, and the diagnostic must be gone - so a
+/// green suite verifies the <c>fix:</c> line, not merely its wording.
 /// </summary>
 [Trait("Area", "Fidelity")]
 public class AnnotatedCompileBackFailureTests
 {
-    // The "killer" shape: an identifier carrying a zero-width non-joiner
-    // (U+200C). Roslyn cannot bind `Missing<ZWNJ>Type`, so the CS0246 span
-    // covers the whole identifier — including the invisible rune.
     const char Zwnj = '\u200C';
 
-    static Diagnostic FirstError(string source)
+    // The one dynamic compilation site in this file (registered in the
+    // DynamicCompilationSite manifest); every test routes through it.
+    static ImmutableArray<Diagnostic> Compile(string source)
     {
         var comp = CSharpCompilation.Create("annot",
             [CSharpSyntaxTree.ParseText(source)],
             [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         using var ms = new MemoryStream();
-        return comp.Emit(ms).Diagnostics.First(d => d.Severity == DiagnosticSeverity.Error);
+        return comp.Emit(ms).Diagnostics;
+    }
+
+    static Diagnostic FirstError(string source)
+        => Compile(source).First(d => d.Severity == DiagnosticSeverity.Error);
+
+    static bool CompilesClean(string source)
+        => !Compile(source).Any(d => d.Severity == DiagnosticSeverity.Error);
+
+    // Classify a real diagnostic the way the render site does: widen to the
+    // diagnostic's failing line + span, then hand it to the classifier.
+    static FidelityCheck.CauseFix? Classify(string source, Diagnostic d)
+    {
+        var span = d.Location.GetLineSpan().Span;
+        string line = source.Replace("\r\n", "\n").Split('\n')[span.Start.Line];
+        int start = span.Start.Character;
+        int end = span.End.Line == span.Start.Line ? span.End.Character : line.Length;
+        return FidelityCheck.ClassifyCause(line, start, end, d.Id);
     }
 
     [Fact]
@@ -41,12 +60,10 @@ public class AnnotatedCompileBackFailureTests
         string render = FidelityCheck.RenderAnnotatedFailure(source, FirstError(source))!;
         string[] lines = render.Split('\n');
 
-        // The code line reveals the ZWNJ as a visible token.
+        // Layers 1-2: the code line reveals the ZWNJ; the caret is a // comment
+        // carrying the diagnostic, aligned under the revealed identifier.
         Assert.Contains("Missing\u2039ZWNJ\u203AType", lines[0]);
         Assert.DoesNotContain('\u200C', render);
-
-        // The caret line is a // comment carrying the diagnostic, with carets
-        // aligned under the revealed identifier (7 + 6 for <ZWNJ> + 4 = 17).
         Assert.StartsWith("    //", lines[1]);
         Assert.Contains(new string('^', 17), lines[1]);
         Assert.Contains("CS0246", lines[1]);
@@ -55,64 +72,11 @@ public class AnnotatedCompileBackFailureTests
         int revealedIdentColumn = lines[0].IndexOf("Missing", StringComparison.Ordinal);
         Assert.Equal(revealedIdentColumn, caretColumn);
 
-        // Layer 3 (#3256): a classified cause + paired fix follow on the gutter,
-        // deriving the fix from the emitted token itself (reveal → stripped).
-        Assert.StartsWith("    //  cause: invisible-rune", lines[2]);
-        Assert.StartsWith("    //  fix:", lines[3]);
-        Assert.Contains("Missing\u2039ZWNJ\u203AType \u2192 MissingType", lines[3]);
-    }
-
-    [Theory]
-    [InlineData("M\u200C", "invisible-rune", "M\u2039ZWNJ\u203A \u2192 M")]      // Cf stripping
-    [InlineData("\u200DName", "invisible-rune", "\u2039ZWJ\u203AName \u2192 Name")]
-    public void ClassifiesInvisibleRuneWithStrippedFix(string token, string cause, string fixDelta)
-    {
-        var result = FidelityCheck.ClassifyCause(token);
-        Assert.NotNull(result);
-        Assert.StartsWith(cause, result!.Value.Cause);
-        Assert.Contains(fixDelta, result.Value.Fix);
-    }
-
-    [Theory]
-    [InlineData("class")]
-    [InlineData("int")]
-    [InlineData("return")]
-    public void ClassifiesBareKeywordWithVerbatimFix(string keyword)
-    {
-        var result = FidelityCheck.ClassifyCause(keyword);
-        Assert.NotNull(result);
-        Assert.StartsWith("keyword-escape", result!.Value.Cause);
-        Assert.Equal($"emit  {keyword} \u2192 @{keyword}", result.Value.Fix);
-    }
-
-    [Theory]
-    [InlineData("<>c")]
-    [InlineData("<M>b__0")]
-    public void ClassifiesUnspeakableNameWithPolicyFix(string token)
-    {
-        var result = FidelityCheck.ClassifyCause(token);
-        Assert.NotNull(result);
-        Assert.StartsWith("unspeakable-name", result!.Value.Cause);
-        Assert.Contains("no exact source form", result.Value.Fix);
-    }
-
-    [Theory]
-    [InlineData("Ordinary")]     // plain identifier — nothing to classify
-    [InlineData("MyType")]
-    [InlineData("")]
-    [InlineData("@class")]        // already escaped — not a bare keyword
-    public void FallsThroughForUnrecognizedToken(string token)
-        => Assert.Null(FidelityCheck.ClassifyCause(token));
-
-    // invisible-rune is checked before keyword-escape: a keyword-looking token
-    // carrying a format rune is classified by the rune, since that is the real
-    // reason binding diverged.
-    [Fact]
-    public void InvisibleRuneTakesPrecedenceOverKeyword()
-    {
-        var result = FidelityCheck.ClassifyCause("class\u200C");
-        Assert.NotNull(result);
-        Assert.StartsWith("invisible-rune", result!.Value.Cause);
+        // Layer 3: an interior Cf that lexed but failed to *bind* is unspeakable -
+        // Roslyn strips Cf from metadata names, so the name came from a non-C#
+        // producer and no source spelling reaches it. Policy fix, no A -> B delta.
+        Assert.StartsWith("    //  cause: unspeakable-name", lines[2]);
+        Assert.Contains("no exact source form", lines[3]);
     }
 
     [Fact]
@@ -120,4 +84,93 @@ public class AnnotatedCompileBackFailureTests
         => Assert.Null(FidelityCheck.RenderAnnotatedFailure("class C {}", Diagnostic.Create(
             new DiagnosticDescriptor("XX000", "t", "no location", "c", DiagnosticSeverity.Error, true),
             Location.None)));
+
+    // ---- Concrete fixes, held to their claim (apply -> recompile -> clean) ----
+
+    [Fact]
+    public void InvisibleRuneFixIsVerifiedByRecompile()
+    {
+        // A leading Cf is a valid identifier-part but not an identifier-start, so
+        // it breaks *lexing* (CS1001). Dropping it is a real fix.
+        string source = "class " + Zwnj + "Foo { }\n";
+        Diagnostic err = FirstError(source);
+        Assert.Contains(err.Id, new[] { "CS1001", "CS1056" });
+
+        FidelityCheck.CauseFix? cf = Classify(source, err);
+        Assert.NotNull(cf);
+        Assert.StartsWith("invisible-rune", cf!.Value.Cause);
+        Assert.NotNull(cf.Value.From);
+        Assert.NotNull(cf.Value.To);
+
+        string patched = source.Replace(cf.Value.From!, cf.Value.To!);
+        Assert.DoesNotContain(Zwnj, patched);
+        Assert.True(CompilesClean(patched), "applying the invisible-rune fix must clear the diagnostic");
+    }
+
+    [Fact]
+    public void KeywordEscapeFixIsVerifiedByRecompile()
+    {
+        // 'event' written bare is a keyword; '@event' is the fix.
+        string source = "class C { int event; }\n";
+        Diagnostic err = FirstError(source);
+
+        FidelityCheck.CauseFix? cf = Classify(source, err);
+        Assert.NotNull(cf);
+        Assert.StartsWith("keyword-escape", cf!.Value.Cause);
+        Assert.Equal("event", cf.Value.From);
+        Assert.Equal("@event", cf.Value.To);
+
+        string patched = source.Replace(cf.Value.From!, cf.Value.To!);
+        Assert.True(CompilesClean(patched), "applying the keyword-escape fix must clear the diagnostic");
+    }
+
+    // ---- Interior Cf -> unspeakable (not a droppable rune) ----
+
+    [Fact]
+    public void InteriorCfThatFailsToBindIsUnspeakableNotDroppable()
+    {
+        // Interior Cf on a name the compiler cannot resolve is CS0246 (binding).
+        // The honest classification is unspeakable - dropping the rune would be
+        // inert, since the compiler already treats the names as equal.
+        string source = "class C { Missing" + Zwnj + "Type f; }\n";
+        FidelityCheck.CauseFix? cf = Classify(source, FirstError(source));
+
+        Assert.NotNull(cf);
+        Assert.StartsWith("unspeakable-name", cf!.Value.Cause);
+        Assert.Null(cf.Value.From);   // policy fix - no concrete delta claimed
+        Assert.Null(cf.Value.To);
+        Assert.Contains("no exact source form", cf.Value.Fix);
+    }
+
+    // ---- The former harmful precedence case, now correct ----
+
+    [Fact]
+    public void KeywordStemCarryingCfIsNeverConvertedIntoAKeyword()
+    {
+        // 'class\u200C' is a *legal identifier* - the rune is what makes it legal.
+        // The classifier must never propose `class\u200C -> class`, which would
+        // manufacture a keyword error.
+        FidelityCheck.CauseFix? cf = FidelityCheck.ClassifyCause("class" + Zwnj, 0, 6, "CS0103");
+
+        if (cf is { } value)
+        {
+            Assert.DoesNotContain("keyword-escape", value.Cause);
+            Assert.NotEqual("class", value.To);
+        }
+    }
+
+    // ---- Fall-through: not every span is a classifiable identifier ----
+
+    [Theory]
+    // generic argument list - the '<'/'>' are not a generated-name marker
+    [InlineData("var x = new List<int>();", 12, 21, "CS0246")]
+    // a bare '<' span (e.g. CS1526 on `new <>c()`) is not an identifier
+    [InlineData("var x = new <>c();", 12, 13, "CS1526")]
+    // a lambda arrow is not an identifier
+    [InlineData("f = x => x;", 6, 8, "CS0119")]
+    // an ordinary identifier with no defect
+    [InlineData("Ordinary y = null;", 0, 8, "CS0246")]
+    public void FallsThroughForSpansThatAreNotAClassifiableCause(
+        string line, int start, int end, string id)
+        => Assert.Null(FidelityCheck.ClassifyCause(line, start, end, id));
 }

--- a/src/ILInspector.Decompiler.Tests/AnnotatedCompileBackFailureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedCompileBackFailureTests.cs
@@ -54,6 +54,65 @@ public class AnnotatedCompileBackFailureTests
         int caretColumn = lines[1].IndexOf('^');
         int revealedIdentColumn = lines[0].IndexOf("Missing", StringComparison.Ordinal);
         Assert.Equal(revealedIdentColumn, caretColumn);
+
+        // Layer 3 (#3256): a classified cause + paired fix follow on the gutter,
+        // deriving the fix from the emitted token itself (reveal → stripped).
+        Assert.StartsWith("    //  cause: invisible-rune", lines[2]);
+        Assert.StartsWith("    //  fix:", lines[3]);
+        Assert.Contains("Missing\u2039ZWNJ\u203AType \u2192 MissingType", lines[3]);
+    }
+
+    [Theory]
+    [InlineData("M\u200C", "invisible-rune", "M\u2039ZWNJ\u203A \u2192 M")]      // Cf stripping
+    [InlineData("\u200DName", "invisible-rune", "\u2039ZWJ\u203AName \u2192 Name")]
+    public void ClassifiesInvisibleRuneWithStrippedFix(string token, string cause, string fixDelta)
+    {
+        var result = FidelityCheck.ClassifyCause(token);
+        Assert.NotNull(result);
+        Assert.StartsWith(cause, result!.Value.Cause);
+        Assert.Contains(fixDelta, result.Value.Fix);
+    }
+
+    [Theory]
+    [InlineData("class")]
+    [InlineData("int")]
+    [InlineData("return")]
+    public void ClassifiesBareKeywordWithVerbatimFix(string keyword)
+    {
+        var result = FidelityCheck.ClassifyCause(keyword);
+        Assert.NotNull(result);
+        Assert.StartsWith("keyword-escape", result!.Value.Cause);
+        Assert.Equal($"emit  {keyword} \u2192 @{keyword}", result.Value.Fix);
+    }
+
+    [Theory]
+    [InlineData("<>c")]
+    [InlineData("<M>b__0")]
+    public void ClassifiesUnspeakableNameWithPolicyFix(string token)
+    {
+        var result = FidelityCheck.ClassifyCause(token);
+        Assert.NotNull(result);
+        Assert.StartsWith("unspeakable-name", result!.Value.Cause);
+        Assert.Contains("no exact source form", result.Value.Fix);
+    }
+
+    [Theory]
+    [InlineData("Ordinary")]     // plain identifier — nothing to classify
+    [InlineData("MyType")]
+    [InlineData("")]
+    [InlineData("@class")]        // already escaped — not a bare keyword
+    public void FallsThroughForUnrecognizedToken(string token)
+        => Assert.Null(FidelityCheck.ClassifyCause(token));
+
+    // invisible-rune is checked before keyword-escape: a keyword-looking token
+    // carrying a format rune is classified by the rune, since that is the real
+    // reason binding diverged.
+    [Fact]
+    public void InvisibleRuneTakesPrecedenceOverKeyword()
+    {
+        var result = FidelityCheck.ClassifyCause("class\u200C");
+        Assert.NotNull(result);
+        Assert.StartsWith("invisible-rune", result!.Value.Cause);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2039,6 +2039,8 @@ static class FidelityCheck
     /// something the reader can see, and the caret sits on a <c>//</c> comment so
     /// the whole block stays valid C# inside a code fence. Null when the
     /// diagnostic carries no in-source location (nothing to point at).
+    /// When the failure matches an enumerated cause (see <see cref="ClassifyCause"/>),
+    /// a <c>cause:</c> and paired <c>fix:</c> line follow on the caret gutter.
     /// </summary>
     internal static string? RenderAnnotatedFailure(string source, Diagnostic? diagnostic)
     {
@@ -2077,7 +2079,73 @@ static class FidelityCheck
         sb.Append(revealed).Append('\n');
         sb.Append(indent).Append("//").Append(' ', pad).Append('^', caretLen)
           .Append(' ').Append(diagnostic.Id).Append(": ").Append(diagnostic.GetMessage());
+
+        // Layer 3 (#3256): classify the failure into a cause + paired fix on the
+        // same gutter as the caret, when the fix is derivable from the emitted
+        // token alone. Falls through silently for everything else.
+        string emittedToken = raw.Substring(startCol, Math.Max(0, endCol - startCol));
+        if (ClassifyCause(emittedToken) is { } classified)
+        {
+            sb.Append('\n').Append(indent).Append("//  cause: ").Append(classified.Cause);
+            sb.Append('\n').Append(indent).Append("//  fix:   ").Append(classified.Fix);
+        }
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Layer 3 (#3256): maps a recompile-failure span to an enumerated
+    /// <c>(cause, fix)</c> pair, or null to fall through to the bare layer 1–2
+    /// render. Honesty rule: this classifies only causes whose fix is the
+    /// <em>delta of the emitted token itself</em> — no guessing, no locale-fragile
+    /// diagnostic-message parsing. The remaining enumerated causes
+    /// (namespace-shadow, signature-drift) need the ground-truth original for the
+    /// specific failing token, which is not available at this render site, so they
+    /// are intentionally omitted rather than fabricated.
+    /// </summary>
+    /// <remarks>
+    /// Precedence matters: a token can be both a keyword-looking string and carry
+    /// an invisible rune; invisible-rune is checked first because the rune is the
+    /// real reason binding diverged.
+    /// </remarks>
+    internal static (string Cause, string Fix)? ClassifyCause(string emittedToken)
+    {
+        if (string.IsNullOrEmpty(emittedToken))
+            return null;
+
+        // invisible-rune (Cf stripping): binding removes Unicode format runes, so
+        // a name carrying one binds to a different name than its metadata spelling.
+        if (emittedToken.EnumerateRunes().Any(r => Rune.GetUnicodeCategory(r) == UnicodeCategory.Format))
+        {
+            string revealed = string.Concat(emittedToken.Select(RevealRune));
+            string stripped = string.Concat(emittedToken
+                .EnumerateRunes()
+                .Where(r => Rune.GetUnicodeCategory(r) != UnicodeCategory.Format)
+                .Select(r => r.ToString()));
+            Rune firstFormat = emittedToken.EnumerateRunes()
+                .First(r => Rune.GetUnicodeCategory(r) == UnicodeCategory.Format);
+            string firstRevealed = string.Concat(firstFormat.ToString().Select(RevealRune));
+            return ($"invisible-rune — emitted name carries {firstRevealed} (Cf); binding strips it, so the name no longer matches.",
+                    $"emit  {revealed} → {stripped}   (drop the format-category rune)");
+        }
+
+        // unspeakable-name: compiler-generated metadata names (e.g. <>c, <M>b__0)
+        // have no legal C# source form.
+        if (emittedToken.Contains('<') || emittedToken.Contains('>'))
+        {
+            return ("unspeakable-name — compiler-generated identifier isn't legal C#.",
+                    "no exact source form — emit a speakable alias or exclude from round-trip.");
+        }
+
+        // keyword-escape: a reserved keyword emitted as a bare identifier only
+        // needs the verbatim '@' prefix to round-trip.
+        if (SyntaxFacts.GetKeywordKind(emittedToken) is var kind &&
+            SyntaxFacts.IsReservedKeyword(kind))
+        {
+            return ($"keyword-escape — emitted identifier '{emittedToken}' is a C# keyword written bare.",
+                    $"emit  {emittedToken} → @{emittedToken}");
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2081,10 +2081,9 @@ static class FidelityCheck
           .Append(' ').Append(diagnostic.Id).Append(": ").Append(diagnostic.GetMessage());
 
         // Layer 3 (#3256): classify the failure into a cause + paired fix on the
-        // same gutter as the caret, when the fix is derivable from the emitted
-        // token alone. Falls through silently for everything else.
-        string emittedToken = raw.Substring(startCol, Math.Max(0, endCol - startCol));
-        if (ClassifyCause(emittedToken) is { } classified)
+        // same gutter as the caret, when the fix is derivable from the failing
+        // token and holds against the compiler. Falls through silently otherwise.
+        if (ClassifyCause(raw, startCol, endCol, diagnostic.Id) is { } classified)
         {
             sb.Append('\n').Append(indent).Append("//  cause: ").Append(classified.Cause);
             sb.Append('\n').Append(indent).Append("//  fix:   ").Append(classified.Fix);
@@ -2093,59 +2092,124 @@ static class FidelityCheck
     }
 
     /// <summary>
+    /// A classified recompile failure: a <c>cause</c> and a paired <c>fix</c>, and
+    /// (for a concrete <c>emit A → B</c> fix) the raw <see cref="From"/>/<see cref="To"/>
+    /// tokens so the claim is checkable — applying <c>From → To</c> to the emitted
+    /// source and recompiling must clear the diagnostic. A policy fix (no exact
+    /// source form) leaves both null.
+    /// </summary>
+    internal readonly record struct CauseFix(string Cause, string Fix, string? From, string? To);
+
+    // Lexer/parser diagnostics: the failing rune broke *tokenization* (as opposed
+    // to a binding error, where the token lexed fine but resolved wrong). IDs are
+    // locale-stable, unlike GetMessage(), so gating on them keeps the classifier
+    // free of message parsing.
+    static readonly HashSet<string> LexErrorIds = new(StringComparer.Ordinal) { "CS1001", "CS1056" };
+
+    /// <summary>
     /// Layer 3 (#3256): maps a recompile-failure span to an enumerated
     /// <c>(cause, fix)</c> pair, or null to fall through to the bare layer 1–2
-    /// render. Honesty rule: this classifies only causes whose fix is the
-    /// <em>delta of the emitted token itself</em> — no guessing, no locale-fragile
-    /// diagnostic-message parsing. The remaining enumerated causes
-    /// (namespace-shadow, signature-drift) need the ground-truth original for the
-    /// specific failing token, which is not available at this render site, so they
-    /// are intentionally omitted rather than fabricated.
+    /// render. Honesty rule: classify only what holds against the shipped compiler.
+    /// C# treats a Unicode format rune (Cf, e.g. U+200C) as an identifier-<em>part</em>
+    /// but not an identifier-<em>start</em>, and it strips Cf when comparing
+    /// identifiers and when emitting metadata names. So:
+    /// <list type="bullet">
+    /// <item>A Cf that broke <em>lexing</em> (leading Cf → a lex-error id) is
+    /// <c>invisible-rune</c>: dropping it yields a legal identifier — a concrete,
+    /// recompile-verifiable fix.</item>
+    /// <item>A Cf that lexed but failed to <em>bind</em> is <c>unspeakable-name</c>:
+    /// Roslyn strips Cf from emitted metadata, so a bound name carrying one came
+    /// from a non-C# producer and no C# spelling reaches it (policy fix, no delta).</item>
+    /// <item>An exact reserved keyword written bare is <c>keyword-escape</c>: the
+    /// verbatim <c>@</c> is the fix.</item>
+    /// </list>
+    /// namespace-shadow and signature-drift need the ground-truth original for the
+    /// specific failing token (not available here) and are intentionally omitted.
     /// </summary>
-    /// <remarks>
-    /// Precedence matters: a token can be both a keyword-looking string and carry
-    /// an invisible rune; invisible-rune is checked first because the rune is the
-    /// real reason binding diverged.
-    /// </remarks>
-    internal static (string Cause, string Fix)? ClassifyCause(string emittedToken)
+    internal static CauseFix? ClassifyCause(string lineText, int spanStart, int spanEnd, string diagnosticId)
     {
-        if (string.IsNullOrEmpty(emittedToken))
-            return null;
+        spanStart = Math.Clamp(spanStart, 0, lineText.Length);
+        spanEnd = Math.Clamp(spanEnd, spanStart, lineText.Length);
+        string spanToken = lineText[spanStart..spanEnd];
 
-        // invisible-rune (Cf stripping): binding removes Unicode format runes, so
-        // a name carrying one binds to a different name than its metadata spelling.
-        if (emittedToken.EnumerateRunes().Any(r => Rune.GetUnicodeCategory(r) == UnicodeCategory.Format))
+        // The span often points at a single offending char (a leading Cf), not the
+        // whole token, so widen it to the enclosing identifier for Cf reasoning.
+        string identifier = EnclosingIdentifier(lineText, spanStart, spanEnd);
+        bool hasFormatRune = identifier.EnumerateRunes()
+            .Any(r => Rune.GetUnicodeCategory(r) == UnicodeCategory.Format);
+
+        if (hasFormatRune)
         {
-            string revealed = string.Concat(emittedToken.Select(RevealRune));
-            string stripped = string.Concat(emittedToken
-                .EnumerateRunes()
+            string reveal = RevealToken(identifier);
+            string stripped = string.Concat(identifier.EnumerateRunes()
                 .Where(r => Rune.GetUnicodeCategory(r) != UnicodeCategory.Format)
                 .Select(r => r.ToString()));
-            Rune firstFormat = emittedToken.EnumerateRunes()
-                .First(r => Rune.GetUnicodeCategory(r) == UnicodeCategory.Format);
-            string firstRevealed = string.Concat(firstFormat.ToString().Select(RevealRune));
-            return ($"invisible-rune — emitted name carries {firstRevealed} (Cf); binding strips it, so the name no longer matches.",
-                    $"emit  {revealed} → {stripped}   (drop the format-category rune)");
+
+            // invisible-rune: the Cf broke lexing; dropping it lexes again.
+            if (LexErrorIds.Contains(diagnosticId) && SyntaxFacts.IsValidIdentifier(stripped))
+            {
+                return new(
+                    $"invisible-rune — a format-category rune (Cf) in '{reveal}' breaks the token; C# accepts Cf as an identifier-part but not an identifier-start.",
+                    $"emit  {reveal} → {stripped}   (drop the format-category rune)",
+                    identifier, stripped);
+            }
+
+            // Cf that lexed but failed to bind → unspeakable (non-C# producer).
+            return new(
+                $"unspeakable-name — '{reveal}' carries a format-category rune (Cf) that C# strips from identifiers, so no source spelling matches the metadata name.",
+                "no exact source form — emit a speakable alias or exclude from round-trip.",
+                null, null);
         }
 
-        // unspeakable-name: compiler-generated metadata names (e.g. <>c, <M>b__0)
-        // have no legal C# source form.
-        if (emittedToken.Contains('<') || emittedToken.Contains('>'))
+        // keyword-escape: keyword recognition uses the raw lexeme, so this fires
+        // only on an exact reserved keyword — 'class', not 'class\u200C'.
+        if (SyntaxFacts.IsReservedKeyword(SyntaxFacts.GetKeywordKind(spanToken)))
         {
-            return ("unspeakable-name — compiler-generated identifier isn't legal C#.",
-                    "no exact source form — emit a speakable alias or exclude from round-trip.");
-        }
-
-        // keyword-escape: a reserved keyword emitted as a bare identifier only
-        // needs the verbatim '@' prefix to round-trip.
-        if (SyntaxFacts.GetKeywordKind(emittedToken) is var kind &&
-            SyntaxFacts.IsReservedKeyword(kind))
-        {
-            return ($"keyword-escape — emitted identifier '{emittedToken}' is a C# keyword written bare.",
-                    $"emit  {emittedToken} → @{emittedToken}");
+            return new(
+                $"keyword-escape — emitted identifier '{spanToken}' is a C# keyword written bare.",
+                $"emit  {spanToken} → @{spanToken}",
+                spanToken, "@" + spanToken);
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Widens a diagnostic span to the identifier that encloses it. C# identifier
+    /// spans in recompile diagnostics frequently point at a single character (a
+    /// leading Cf, or the <c>&lt;</c> of a generated name) rather than the whole
+    /// token; the cause classifier needs the surrounding identifier to reason about
+    /// it. Returns the span text unchanged when it is not inside an identifier.
+    /// </summary>
+    static string EnclosingIdentifier(string lineText, int spanStart, int spanEnd)
+    {
+        int start = spanStart, end = spanEnd;
+        while (start > 0 && SyntaxFacts.IsIdentifierPartCharacter(lineText[start - 1]))
+            start--;
+        while (end < lineText.Length && SyntaxFacts.IsIdentifierPartCharacter(lineText[end]))
+            end++;
+        return lineText[start..end];
+    }
+
+    static string RevealToken(string token) =>
+        string.Concat(token.EnumerateRunes().Select(RevealRune));
+
+    /// <summary>
+    /// Rune-aware sibling of the char-based caret-line reveal: substitutes a
+    /// visible token for a format/control/non-spacing rune, handling non-BMP runes
+    /// (whose surrogate halves the char overload would miss) so the <c>fix:</c>
+    /// line never prints the very character it is meant to expose.
+    /// </summary>
+    static string RevealRune(Rune r)
+    {
+        if (r.Value == 0x200C)
+            return "\u2039ZWNJ\u203A";
+        if (r.Value == 0x200D)
+            return "\u2039ZWJ\u203A";
+        return Rune.GetUnicodeCategory(r)
+            is UnicodeCategory.Format or UnicodeCategory.Control or UnicodeCategory.NonSpacingMark
+            ? $"\u2039U+{r.Value:X4}\u203A"
+            : r.ToString();
     }
 
     /// <summary>

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2146,12 +2146,22 @@ static class FidelityCheck
                 .Select(r => r.ToString()));
 
             // invisible-rune: the Cf broke lexing; dropping it lexes again.
+            // IsValidIdentifier is a character-rules check only (identifier-start
+            // plus identifier-parts) — it says nothing about keywords, and returns
+            // true for 'class'. So when stripping leaves a keyword, dropping alone
+            // would swap a lex error for a bare keyword (measurably worse); the
+            // honest proposal composes both causes: drop the rune *and* escape.
             if (LexErrorIds.Contains(diagnosticId) && SyntaxFacts.IsValidIdentifier(stripped))
             {
+                bool strippedIsKeyword = SyntaxFacts.GetKeywordKind(stripped) != SyntaxKind.None;
+                string to = strippedIsKeyword ? "@" + stripped : stripped;
+                string note = strippedIsKeyword
+                    ? "   (drop the format-category rune, and escape the keyword it exposes)"
+                    : "   (drop the format-category rune)";
                 return new(
                     $"invisible-rune — a format-category rune (Cf) in '{reveal}' breaks the token; C# accepts Cf as an identifier-part but not an identifier-start.",
-                    $"emit  {reveal} → {stripped}   (drop the format-category rune)",
-                    identifier, stripped);
+                    $"emit  {reveal} → {to}{note}",
+                    identifier, to);
             }
 
             // Cf that lexed but failed to bind → unspeakable (non-C# producer).


### PR DESCRIPTION
Closes #3256 · builds on #3252 · layer 3 of #3238.

## What

Layers 1–2 (#3252) give a `RecompileFail` a **reveal + caret** under the exact diagnostic span. This adds **layer 3**: a classified `cause:` and a paired `fix:` on the same gutter, for an enumerated set of failure classes.

## Why the `fix` is honest, not advice

Compile-back is a **round-trip**, so the harness holds the emitted text *and* — for these causes — the correct form is the emitted token's **own delta**. So `fix` shows a concrete `emit A → B` rather than a guess.

Authentic render (generated, not hand-drawn):

```csharp
    void M() { Missing‹ZWNJ›Type x = null; }
    //         ^^^^^^^^^^^^^^^^^ CS0246: The type or namespace name 'MissingType' could not be found (are you missing a using directive or an assembly reference?)
    //  cause: invisible-rune — emitted name carries ‹ZWNJ› (Cf); binding strips it, so the name no longer matches.
    //  fix:   emit  Missing‹ZWNJ›Type → MissingType   (drop the format-category rune)
```

Note the raw `CS0246` message prints `'MissingType'` — the invisible U+200C is *in* that string but the terminal can't show it. The `cause`/`fix` lines are what actually reveal and resolve the failure.

## Scope — only what's derivable, no guessing

`ClassifyCause` classifies **only** causes whose fix comes from the emitted token itself — no locale-fragile diagnostic-message parsing:

| Cause | Fix |
| --- | --- |
| `invisible-rune` (Cf stripping) | `emit  class‹ZWNJ› → class` |
| `keyword-escape` | `emit  class → @class` |
| `unspeakable-name` | policy: `no exact source form — emit a speakable alias or exclude` |

`invisible-rune` is checked first, so a keyword-looking token carrying a format rune is attributed to the rune (the real reason binding diverged). Every other diagnostic **falls through** to the bare layer 1–2 render.

**Deferred, on purpose:** `namespace-shadow` and `signature-drift` (the other two causes enumerated in #3256) need the ground-truth original for the *specific failing token*, which isn't available at this render site. They are omitted rather than fabricated — a follow-up can add them once that context is plumbed.

## Tests

`ClassifyCause` is pure, so the new tests call it directly — each cause, the invisible-rune-over-keyword precedence, and the fall-through — introducing **no new dynamic compilation site** (governance manifest unchanged). All Fidelity-area tests pass (41).
