### PR TITLE
Pin the span-attribution allowlist to methodologyVersion (#3079)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SpanAttributionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SpanAttributionTests.cs
@@ -292,4 +292,68 @@ public class SpanAttributionTests
 
         Assert.False(isolated);
     }
+
+    // The allowlist that each methodology version is defined by. A version's entry is
+    // historical once stamped: rows carrying that stamp were produced by exactly this set,
+    // so an entry may never be edited — only a new version added.
+    static readonly ImmutableDictionary<int, ImmutableHashSet<string>> AllowlistByMethodologyVersion =
+        ImmutableDictionary.CreateRange(
+        [
+            // v2: syntax errors in the body span, plus duplicate-local only. Every
+            // context-dependent class (resolution, conversion, overload, scope collision)
+            // is excluded because a broken shell reconstructs them identically to a real
+            // body defect — see SpanAttribution.IsolatingBodyError.
+            KeyValuePair.Create(2, ImmutableHashSet.Create(StringComparer.Ordinal, "CS0128")),
+        ]);
+
+    [Fact]
+    public void BodyIntrinsicAllowlist_IsPinnedToCurrentMethodologyVersion()
+    {
+        // The allowlist is the operative definition of productBodyDefect under the stamped
+        // methodologyVersion, but it lives in a different file from the stamp with no code
+        // path between them. Without this gate a contributor can widen the soundness rule —
+        // adding, say, CS0136, which this PR's own review identified as shell-dependent
+        // (a shell parameter collision produces it) — and ship it under an unchanged v2.
+        // The damage is not just a wrong count: rows sharing a stamp are supposed to be
+        // comparable, so a silent widening makes the history card chart a v2 -> v2 step
+        // across two different methodologies, defeating the boundary split that
+        // Render_MovementSplitsProductDefectAcrossMethodologyBoundaryWithoutCharting exists
+        // to enforce.
+        //
+        // Set equality (not a subset check) is the point: any addition, removal, or
+        // substitution fails here until the version is bumped and a new pin recorded.
+        int version = SpanAttribution.MethodologyVersion;
+
+        Assert.True(
+            AllowlistByMethodologyVersion.ContainsKey(version),
+            $"methodologyVersion {version} has no pinned body-intrinsic allowlist. Bumping the "
+                + "version requires recording the allowlist that defines it here.");
+
+        Assert.Equal(AllowlistByMethodologyVersion[version], SpanAttribution.BodyIntrinsicSemanticErrorIds);
+    }
+
+    [Fact]
+    public void BodyIntrinsicAllowlist_ExcludesContextDependentErrorClasses()
+    {
+        // The README forbids whole categories, not just the IDs the close-negative tests
+        // happen to exercise. This pins the categories themselves: one representative of
+        // each class a broken shell can manufacture. CS0136 is the sharp end — Gemini's
+        // review probe showed a shell parameter collision yields exactly CS0136 — and the
+        // conversion/overload IDs were reachable additions that no other gate caught.
+        string[] shellReachable =
+        [
+            "CS0103", "CS0246", "CS0234", "CS1061", "CS1069", // resolution
+            "CS0029", "CS1503",                               // conversion / overload
+            "CS0136",                                         // scope collision
+            "CS0165",                                         // definite assignment (const-dependent)
+        ];
+
+        foreach (string id in shellReachable)
+        {
+            Assert.False(
+                SpanAttribution.BodyIntrinsicSemanticErrorIds.Contains(id),
+                $"{id} is producible by shell reconstruction, so crediting it would break the "
+                    + "lower-bound guarantee on productBodyDefect.");
+        }
+    }
 }

--- a/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
@@ -21,15 +21,11 @@ static class AuthoredCorpusBenchmark
 {
     /// <summary>
     /// Methodology version for how <c>invalidBreakdown.productBodyDefect</c> is
-    /// computed. v1 = substitution control only (authored body must compile in
-    /// the failing shell; a broken shell masks the body defect, so the count is
-    /// a lower bound). v2 = v1 plus span attribution, which additionally credits
-    /// a body defect when the shell is broken but the authored body is error-free
-    /// within its own body span while the decompiled body carries an in-body
-    /// error. The two versions are not directly comparable; the history card must
-    /// not diff productBodyDefect across the boundary.
+    /// computed. Defined by, and co-located with, the attribution rule it stamps
+    /// (see <see cref="SpanAttribution.MethodologyVersion"/>); this alias keeps
+    /// the serialization site readable.
     /// </summary>
-    internal const int MethodologyVersion = 2;
+    internal const int MethodologyVersion = SpanAttribution.MethodologyVersion;
 
     public static int Run(IReadOnlyList<string> assemblies, string corpusPath, bool json)
     {

--- a/tools/DecompilerHarness/SpanAttribution.cs
+++ b/tools/DecompilerHarness/SpanAttribution.cs
@@ -62,7 +62,27 @@ internal static class SpanAttribution
     // adversarial review). CS0128 has no such dependency: it requires two local
     // declarations sharing a name inside the body, which no shell state can
     // create.
-    static readonly ImmutableHashSet<string> BodyIntrinsicSemanticErrorIds =
+    /// <summary>
+    /// Methodology version for how <c>invalidBreakdown.productBodyDefect</c> is
+    /// computed. v1 = substitution control only (authored body must compile in
+    /// the failing shell; a broken shell masks the body defect). v2 = v1 plus
+    /// span attribution, which additionally credits a body defect when the shell
+    /// is broken but the decompiled body carries a provably shell-independent
+    /// in-body error. Both are lower bounds and are not directly comparable; the
+    /// history card must not diff productBodyDefect across the boundary.
+    ///
+    /// This lives beside <see cref="BodyIntrinsicSemanticErrorIds"/> because that
+    /// allowlist is the operative definition of the version: widening it changes
+    /// what the stamp means, so the two must move together.
+    /// </summary>
+    internal const int MethodologyVersion = 2;
+
+    // Pinned by MethodologyVersion via
+    // SpanAttributionTests.BodyIntrinsicAllowlist_IsPinnedToCurrentMethodologyVersion.
+    // Adding an ID here without bumping MethodologyVersion fails that gate: the allowlist
+    // *is* the definition of the stamped methodology, so a silent change would make rows
+    // sharing a stamp incomparable and defeat the history card's version-boundary split.
+    internal static readonly ImmutableHashSet<string> BodyIntrinsicSemanticErrorIds =
         ImmutableHashSet.Create(
             StringComparer.Ordinal,
             "CS0128"); // duplicate local variable name (strictly body-internal)

--- a/tools/DecompilerHarness/corpus/evil-runs/README.md
+++ b/tools/DecompilerHarness/corpus/evil-runs/README.md
@@ -69,9 +69,15 @@ Each row contains these fields:
   deliberate false negative that preserves the lower bound.
 
   Because the allowlist defines what `v2` means, expanding it requires a new
-  `methodologyVersion`; do not add IDs under the existing stamp. v1 and v2
-  counts are not directly comparable, and the progress card never diffs
-  `productBodyDefect` across the boundary.
+  `methodologyVersion`; do not add IDs under the existing stamp. This is
+  enforced mechanically, not by convention:
+  `SpanAttributionTests.BodyIntrinsicAllowlist_IsPinnedToCurrentMethodologyVersion`
+  asserts set equality between the live allowlist and the set pinned for the
+  current version, so any addition fails the gate until the version is bumped
+  and a new pin recorded. A companion test pins the excluded *categories*
+  (resolution, conversion, overload, scope collision, definite assignment) that
+  the prose above forbids. v1 and v2 counts are not directly comparable, and the
+  progress card never diffs `productBodyDefect` across the boundary.
 
 ## Append procedure
 


### PR DESCRIPTION
## Summary

Converts the README's allowlist rule from prose into a tripwire. Follow-up to the non-blocking finding on #3231.

The body-intrinsic error allowlist (`SpanAttribution.BodyIntrinsicSemanticErrorIds`) is the operative definition of `productBodyDefect` under the stamped `methodologyVersion` — but the two lived in different files with no code path between them, and `BodyIntrinsicSemanticErrorIds` had zero references repo-wide outside its own file.

## The gap was real, and partially unguarded

Reviewer's tampering runs against the full `--gate fast`, `methodologyVersion` left at 2 in every one:

| allowlist addition | category | before |
| --- | --- | --- |
| `CS0165` | definite assignment | caught (1 failed) |
| `CS0246, CS0103, CS1061, CS0234` | resolution | caught (2 failed) |
| `CS0029, CS1503, CS0136` | conversion / overload / scope collision | **not caught** (3828 passed, 0 failed) |

The *enumerated* never-credited IDs were genuinely pinned by the existing close-negative tests. But the README also forbids whole **categories**, and those had no pin.

`CS0136` is the sharp end: #3231's own review identified it as shell-dependent — Gemini's probe showed a shell parameter collision yields exactly `CS0136` — i.e. precisely the class condition 2 of the soundness rule exists to exclude. Nothing stopped it being added tomorrow under an unchanged `v2`.

The damage isn't only a wrong count. Rows sharing a stamp are supposed to be comparable, so a silent widening under a fixed `v2` would make the history card chart a **v2 → v2 step across two different methodologies**, defeating the boundary split that `Render_MovementSplitsProductDefectAcrossMethodologyBoundaryWithoutCharting` exists to enforce.

## Change

Applies the house pattern from #3249 — the declaration drives the enforcement set, asserted by set equality:

- **`MethodologyVersion` moves next to the allowlist that defines it.** Widening the allowlist changes what the stamp means, so the two must move together. `AuthoredCorpusBenchmark` now aliases it, and the constant is reachable from the gate.
- **`BodyIntrinsicAllowlist_IsPinnedToCurrentMethodologyVersion`** asserts set equality between the live allowlist and the set pinned for the current version. Set equality rather than a subset check, so any addition, removal, or substitution fails. A version's pin is historical once stamped and may never be edited — only a new version added.
- **`BodyIntrinsicAllowlist_ExcludesContextDependentErrorClasses`** pins one representative of each forbidden category (resolution, conversion, overload, scope collision, definite assignment), so the categories the README forbids are enforced rather than only the IDs other tests happen to exercise.

## Evidence

Both directions of the contract verified by real runs:

| scenario | result |
| --- | --- |
| add `CS0136` (v2 unchanged) | **2 failed** ✓ now caught |
| add `CS0029, CS1503` (v2 unchanged) | **2 failed** ✓ now caught |
| add `CS0246, CS0103` (v2 unchanged) | **4 failed** ✓ |
| bump to `v3` with no pin recorded | **fails** with `methodologyVersion 3 has no pinned body-intrinsic allowlist` |
| untampered tree | **32/32 pass** |

`SpanAttributionTests`, `DynamicCompilationSiteInventoryTests`, `AuthoredCorpusHistoryCardTests` all green; harness builds clean; README passes markdownlint.

**No behavior change** — the allowlist is byte-identical (`{CS0128}`) and no shipped number moves. This only constrains future edits.

## Review

Low risk: test-only enforcement plus a constant relocation, no attribution logic touched and no metric affected. Proposing single-review tier.
