### PR TITLE
Progressive member call-graph acquisition seam (#3266)

### DIFF
--- a/docs/design/call-graph-mermaid-projection.md
+++ b/docs/design/call-graph-mermaid-projection.md
@@ -89,6 +89,50 @@ The projection owns everything a host must not re-invent in JavaScript:
   they additionally entity-encode the structural delimiters (`()[]{}`) that would
   otherwise corrupt an edge label.
 
+## Progressive acquisition
+
+The projection needs `CallTreeNode` roots; how a host *acquires* them is a
+separate concern (issue #3266). `dotnet-inspect` owns a
+`ProgressiveMemberCallGraph` seam
+(`src/dotnet-inspect/Inspectors/ProgressiveMemberCallGraph.cs`) that serves one
+member's graph in three cumulative layers, cheapest first, so a host can paint
+the outbound half immediately and fill in the expensive tiers as they land:
+
+1. **`Callees`** — a scoped single-body build that decodes only the selected
+   member. The callee tree is bounded at depth 1 (immediate callees); there is
+   no caller tree yet.
+2. **`Callers`** — a full decode of the member's own assembly, adding the
+   intra-library caller tree and deepening the callee tree to the configured
+   depth. Expansion stops at the assembly edge.
+3. **`CrossLibrary`** — decodes the in-scope packages so *both* the caller tree
+   and the callee tree can cross a library boundary up to `depth`.
+
+The layer names name the tier that was unlocked, not a direction: at `depth > 1`
+the `CrossLibrary` layer lets a caller chain *and* a callee chain each cross a
+package boundary. The seam yields presentation-free `CallTreeNode` roots as a
+`MemberCallGraphView` (`Tier`, `CalleeRoot`, `CallerRoot`), so a host renders
+them with its own per-section tree rendering *or* projects them with
+`CallGraphMermaid.Render(CallerRoot, CalleeRoot)` — "with or without mermaid."
+
+**No duplicated work.** At most two target-assembly indexes are ever built — the
+scoped single-body build and the full build — plus one build per cross-library
+package, and each is built once and reused for callees, callers, and any Mermaid
+projection. The scoped build exists only for the progressive first paint: a
+consumer that wants the whole graph calls `Callers()` or `CrossLibrary()`
+directly and pays exactly one full build, with callees derived for free from it.
+Once the full build lands it supersedes the scoped one, which is never rebuilt.
+The `IndexBuildGuard`-collected seam tests assert these build counts through
+`MethodBodyInspectionSession.OpenCountForTests`.
+
+Drive it by pull (`Callees()` / `Callers()` / `CrossLibrary()`, or the lazy
+`Tiers()` stream) or by push (`RunAsync` raising `LayerReady` per layer then
+`Completed`). The push path is a thin wrapper over the same memoized pull core,
+so the two never double the work. The forward cross-library expansion is the
+callee mirror of `BuildCallerTree(scopes)`: `LibraryBodyIndex.BuildCallTree(token,
+calleeScopes, …)` builds a structural forward map keyed by the same erased
+identity the caller builder uses, tagging each boundary-crossing callee with its
+source assembly.
+
 ## Consumers
 
 The browser engine is handed this exact Mermaid document and only asks Mermaid

--- a/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
@@ -12,6 +12,15 @@ namespace Shared
         // (a package boundary), proving the forward map deepens a callee chain across assemblies.
         public static void RunOuter() => Run();
 
+        // #3266 fan-out fixture: two call sites to the same callee. The cross-assembly callee tree
+        // dedups to one Echo child but must still report a fan-out of 2 (true call-site count).
+        // Echo is used so this does not perturb the exact-count caller-graph tests rooted at Ping.
+        public static void RunTwice()
+        {
+            Target.GenericApi.Echo(1);
+            Target.GenericApi.Echo(1);
+        }
+
         // Distinct callers of the int and string Ping overloads. A caller graph rooted at one
         // overload must report only its own caller; a CallerGraphKey that drops parameter
         // types would collapse these onto Ping and cross-link them (#1623 rung 1).

--- a/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
@@ -7,6 +7,11 @@ namespace Shared
     {
         public static void Run() => Target.Api.Ping();
 
+        // Cross-assembly callee-chain fixture (#3266). A callee graph rooted here and scoped
+        // with the target assembly must expand RunOuter -> Run (same assembly) -> Target.Api.Ping
+        // (a package boundary), proving the forward map deepens a callee chain across assemblies.
+        public static void RunOuter() => Run();
+
         // Distinct callers of the int and string Ping overloads. A caller graph rooted at one
         // overload must report only its own caller; a CallerGraphKey that drops parameter
         // types would collapse these onto Ping and cross-link them (#1623 rung 1).

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -691,6 +691,43 @@ public class LibraryBodyIndexTests
         Assert.Equal(FlattenCallTree(single), FlattenCallTree(fallback));
     }
 
+    // #3266 (review): a callee whose defining assembly is not in scope stays External even with a
+    // non-empty scope list — Run -> Ping with only an unrelated caller assembly scoped keeps Ping
+    // External (its own body was never decoded), not a false Leaf.
+    [Fact]
+    public void BuildCallTree_WithScope_MarksUndecodedExternalCalleeAsExternal()
+    {
+        var callerIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var twinIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCallerTwin.AssemblyPath());
+        var targetAssemblyName = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath())
+            .Methods.First().AssemblyName;
+
+        var run = callerIndex.Methods.First(method =>
+            method.DeclaringType.Name == "Entry" && method.Name == "Run" && method.ParameterTypes.Length == 0);
+
+        // The twin scope does not define Target.Api.Ping, so Ping's body is never decoded.
+        var tree = callerIndex.BuildCallTree(run.MetadataToken, new[] { twinIndex }, maxDepth: 3, maxNodes: 50);
+
+        var ping = Assert.Single(tree.Children, child => child.Member.Name == "Ping");
+        Assert.Equal(CallTreeStatus.External, ping.Status);
+        Assert.Equal(targetAssemblyName, ping.Perf?.Source);
+    }
+
+    // #3266 (review): fan-out reports the true outbound call-site count, independent of the
+    // deduplication that collapses repeat call sites to one child — RunTwice calls Echo twice.
+    [Fact]
+    public void BuildCallTree_WithScope_ReportsCallSiteFanoutForRepeatedCallee()
+    {
+        var callerIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var targetIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath());
+
+        var runTwice = callerIndex.Methods.First(method => method.Name == "RunTwice");
+        var tree = callerIndex.BuildCallTree(runTwice.MetadataToken, new[] { targetIndex }, maxDepth: 2, maxNodes: 50);
+
+        Assert.Single(tree.Children, child => child.Member.Name == "Echo");
+        Assert.Equal(2, tree.Perf?.Fanout);
+    }
+
     static List<string> FlattenCallTree(CallTreeNode root)
     {
         var lines = new List<string>();

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -594,6 +594,116 @@ public class LibraryBodyIndexTests
         Assert.DoesNotContain("UseA", bCallers);
     }
 
+    // #3266: the forward mirror of BuildCallerTree(scopes). A single-assembly callee tree stops
+    // at the assembly boundary (the callee is an External leaf); scoping the callee's assembly
+    // must expand it and tag it with its source assembly.
+    [Fact]
+    public void BuildCallTree_WithScope_IncorporatesAndTagsExternalCallees()
+    {
+        var callerIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var targetIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath());
+        var targetAssemblyName = targetIndex.Methods.First().AssemblyName;
+
+        var run = callerIndex.Methods.First(method =>
+            method.DeclaringType.Name == "Entry" && method.Name == "Run" && method.ParameterTypes.Length == 0);
+
+        var scoped = callerIndex.BuildCallTree(run.MetadataToken, new[] { targetIndex }, maxDepth: 2, maxNodes: 50);
+        var unscoped = callerIndex.BuildCallTree(run.MetadataToken, maxDepth: 2, maxNodes: 50);
+
+        var scopedPing = Assert.Single(scoped.Children, child => child.Member.Name == "Ping");
+        Assert.NotEqual(CallTreeStatus.External, scopedPing.Status);
+        Assert.Equal(targetAssemblyName, scopedPing.Perf?.Source);
+
+        // The single-assembly tree still lists the callee, but as an untagged external leaf.
+        var unscopedPing = Assert.Single(unscoped.Children, child => child.Member.Name == "Ping");
+        Assert.Equal(CallTreeStatus.External, unscopedPing.Status);
+        Assert.Null(unscopedPing.Perf?.Source);
+    }
+
+    // #3266: with the callee's assembly in scope, a callee chain deepens across the package
+    // boundary — RunOuter -> Run (same assembly) -> Target.Api.Ping (another assembly).
+    [Fact]
+    public void BuildCallTree_WithScope_ExpandsCalleeChainAcrossAssemblyBoundary()
+    {
+        var callerIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var targetIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath());
+        var targetAssemblyName = targetIndex.Methods.First().AssemblyName;
+
+        var runOuter = callerIndex.Methods.First(method => method.Name == "RunOuter");
+        var tree = callerIndex.BuildCallTree(runOuter.MetadataToken, new[] { targetIndex }, maxDepth: 3, maxNodes: 50);
+
+        var run = Assert.Single(tree.Children, child => child.Member.Name == "Run");
+        Assert.Null(run.Perf?.Source); // same assembly as the root, so not tagged external
+        var ping = Assert.Single(run.Children, child => child.Member.Name == "Ping");
+        Assert.Equal(targetAssemblyName, ping.Perf?.Source);
+    }
+
+    // #3266: a constructed-generic callee (Echo<int>, a MethodSpec) is pulled into scope and
+    // resolved against the open Echo<T> definition rather than left as an external leaf. Generic
+    // key normalization is shared with BuildCallerTree(scopes) via CallerGraphKey.
+    [Fact]
+    public void BuildCallTree_WithScope_ResolvesConstructedGenericCallee()
+    {
+        var callerIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var targetIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath());
+        var targetAssemblyName = targetIndex.Methods.First().AssemblyName;
+
+        var useEcho = callerIndex.Methods.First(method => method.Name == "UseEcho");
+
+        var scoped = callerIndex.BuildCallTree(useEcho.MetadataToken, new[] { targetIndex }, maxDepth: 2, maxNodes: 50);
+        var unscoped = callerIndex.BuildCallTree(useEcho.MetadataToken, maxDepth: 2, maxNodes: 50);
+
+        var scopedEcho = Assert.Single(scoped.Children, child => child.Member.Name == "Echo");
+        Assert.NotEqual(CallTreeStatus.External, scopedEcho.Status);
+        Assert.Equal(targetAssemblyName, scopedEcho.Perf?.Source);
+
+        var unscopedEcho = Assert.Single(unscoped.Children, child => child.Member.Name == "Echo");
+        Assert.Equal(CallTreeStatus.External, unscopedEcho.Status);
+    }
+
+    // #3266: children are keyed and ordered by structural identity, so an irrelevant scope's
+    // position in the list cannot reorder or duplicate the graph.
+    [Fact]
+    public void BuildCallTree_WithScope_IsDeterministicAcrossScopeOrder()
+    {
+        var callerIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var targetIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath());
+        var twinIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCallerTwin.AssemblyPath());
+
+        var useBox = callerIndex.Methods.First(method => method.Name == "UseBox");
+
+        var forward = callerIndex.BuildCallTree(useBox.MetadataToken, new[] { targetIndex, twinIndex }, maxDepth: 3, maxNodes: 50);
+        var reversed = callerIndex.BuildCallTree(useBox.MetadataToken, new[] { twinIndex, targetIndex }, maxDepth: 3, maxNodes: 50);
+
+        Assert.Equal(FlattenCallTree(forward), FlattenCallTree(reversed));
+    }
+
+    // #3266: with no scopes the multi-assembly overload falls back to the single-assembly builder.
+    [Fact]
+    public void BuildCallTree_WithEmptyScope_MatchesSingleAssemblyBuilder()
+    {
+        var callerIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var useBox = callerIndex.Methods.First(method => method.Name == "UseBox");
+
+        var single = callerIndex.BuildCallTree(useBox.MetadataToken, maxDepth: 3, maxNodes: 50);
+        var fallback = callerIndex.BuildCallTree(useBox.MetadataToken, Array.Empty<LibraryBodyIndex>(), maxDepth: 3, maxNodes: 50);
+
+        Assert.Equal(FlattenCallTree(single), FlattenCallTree(fallback));
+    }
+
+    static List<string> FlattenCallTree(CallTreeNode root)
+    {
+        var lines = new List<string>();
+        void Walk(CallTreeNode node, int depth)
+        {
+            lines.Add($"{depth}|{node.Member.Name}|{node.Status}|{node.Perf?.Source ?? ""}");
+            foreach (var child in node.Children)
+                Walk(child, depth + 1);
+        }
+        Walk(root, 0);
+        return lines;
+    }
+
     // #1741 (unit): the key fragment for a type includes its assembly, so same-FQN types
     // from different assemblies do not collapse.
     [Fact]

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1732,10 +1732,14 @@ public sealed class LibraryBodyIndex
 
             if (key.Length == 0 || !forward.TryGetValue(key, out var rawEdges))
             {
-                // A callee whose defining assembly was never decoded (Unsupported, or a real member
-                // whose home assembly is not in scope) is an unexpandable boundary, not a proven
-                // leaf. Only a decoded definition (present in the definitions map) with no outbound
-                // edges is a genuine leaf.
+                // No outbound edges: classify the boundary. A callee with no definition entry here
+                // (Unsupported, or a real member whose declaring assembly is neither the target nor
+                // any callee scope) is an unexpandable External boundary, not a proven leaf. An
+                // indexed callee with no outbound edges is a leaf. This reads "indexed" as "decoded",
+                // which holds when the in-scope assemblies were fully decoded — the contract the
+                // product's cross-library layer guarantees by passing full-assembly indexes. As with
+                // the single-assembly builder, a body-scoped index can hold an indexed-but-undecoded
+                // body that would read as a leaf here; hardening that is tracked by issue #3275.
                 var leafStatus = depth > 0 && def is null ? CallTreeStatus.External : CallTreeStatus.Leaf;
                 return new CallTreeNode(member, kind, leafStatus, [], new CallTreePerf(0, fanin, 1, inLoop, loopHint, null, sig, source));
             }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1732,7 +1732,11 @@ public sealed class LibraryBodyIndex
 
             if (key.Length == 0 || !forward.TryGetValue(key, out var rawEdges))
             {
-                var leafStatus = key.Length == 0 && depth > 0 ? CallTreeStatus.External : CallTreeStatus.Leaf;
+                // A callee whose defining assembly was never decoded (Unsupported, or a real member
+                // whose home assembly is not in scope) is an unexpandable boundary, not a proven
+                // leaf. Only a decoded definition (present in the definitions map) with no outbound
+                // edges is a genuine leaf.
+                var leafStatus = depth > 0 && def is null ? CallTreeStatus.External : CallTreeStatus.Leaf;
                 return new CallTreeNode(member, kind, leafStatus, [], new CallTreePerf(0, fanin, 1, inLoop, loopHint, null, sig, source));
             }
 
@@ -1745,7 +1749,9 @@ public sealed class LibraryBodyIndex
                 .OrderBy(edge => edge.CalleeKey, StringComparer.Ordinal)
                 .ToList();
 
-            var fanout = edges.Count;
+            // Fan-out is the true outbound call-site count (matching the single-assembly builder),
+            // independent of the deduplication that collapses repeat call sites into one child.
+            var fanout = rawEdges.Count;
             if (depth >= maxDepth)
                 return new CallTreeNode(member, kind, CallTreeStatus.DepthLimited, [], new CallTreePerf(fanout, fanin, 1, inLoop, loopHint, null, sig, source));
             if (!expanded.Add(key))

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1634,6 +1634,146 @@ public sealed class LibraryBodyIndex
         return Build(rootMember, rootKey, targetAssembly, rootSignals, 0, false);
     }
 
+    readonly record struct ForwardCalleeEdge(MemberRef Callee, string CalleeKey, CallKind Kind, bool InLoop);
+
+    /// <summary>
+    /// Like <see cref="BuildCallTree(int,int,int)"/>, but extends the bounded outbound (callee)
+    /// graph across additional assemblies (the <c>--bin</c>/<c>--project</c>/<c>--caller-package</c>
+    /// scope), the forward mirror of <see cref="BuildCallerTree(int,IReadOnlyList{LibraryBodyIndex},int,int)"/>.
+    /// A single-assembly callee tree stops at the assembly boundary (a callee defined elsewhere is an
+    /// <see cref="CallTreeStatus.External"/> leaf); with <paramref name="calleeScopes"/> the callee's
+    /// own body — decoded in whichever scope defines it — is expanded, so a callee chain can cross a
+    /// package boundary. The graph is keyed by structural member identity (<see cref="CallerGraphKey(MemberRef)"/>)
+    /// rather than assembly-local tokens, so a constructed call site links to its open-definition
+    /// callee across assemblies. Nodes defined in an assembly other than the selected member's own
+    /// carry their source assembly in <see cref="CallTreePerf.Source"/>. Unlike the single-assembly
+    /// builder (which keeps one child per call site in IL order), this deduplicates to one child per
+    /// distinct callee and orders children by structural key, so output is independent of scope order.
+    /// Falls back to the single-assembly builder when no scopes are supplied.
+    /// </summary>
+    public CallTreeNode BuildCallTree(int rootMethodToken, IReadOnlyList<LibraryBodyIndex> calleeScopes, int maxDepth = 3, int maxNodes = 25)
+    {
+        if (calleeScopes is not { Count: > 0 })
+            return BuildCallTree(rootMethodToken, maxDepth, maxNodes);
+
+        var rootIdentity = Methods.FirstOrDefault(method => method.MetadataToken == rootMethodToken);
+        MemberRef rootMember;
+        string rootKey;
+        if (rootIdentity is { } identity)
+        {
+            rootMember = new MemberRef(identity.DeclaringType, identity.Name, identity.ParameterTypes, identity.ReturnType, MemberKind.Method);
+            rootKey = CallerGraphKey(identity);
+        }
+        else
+        {
+            // Bodiless/absent selected member (abstract/interface/extern): it has no body of its own,
+            // so it has no outbound callees and renders as a leaf. Recover its label from any inbound
+            // edge in this assembly so the graph still names the target.
+            rootMember = DirectCalls.FirstOrDefault(call => call.CalleeDefinitionToken == rootMethodToken
+                && call.Callee.Kind != MemberKind.Unsupported) is { Callee: { } resolved }
+                ? resolved
+                : MemberRef.Unsupported($"method token 0x{rootMethodToken:X8}");
+            rootKey = rootMember.Kind != MemberKind.Unsupported ? CallerGraphKey(rootMember) : "";
+        }
+
+        string targetAssembly = rootIdentity?.AssemblyName
+            ?? Methods.FirstOrDefault()?.AssemblyName
+            ?? "";
+
+        // Structural forward map across the selected member's assembly plus the callee scopes:
+        // caller structural key -> outbound callee edges. A companion definition map records each
+        // decoded method's home assembly and signals (both assembly-local by token), so an expanded
+        // callee reports its source assembly and perf signals from wherever it is actually defined.
+        var forward = new Dictionary<string, List<ForwardCalleeEdge>>(StringComparer.Ordinal);
+        var incoming = new Dictionary<string, int>(StringComparer.Ordinal);
+        var definitions = new Dictionary<string, (string Assembly, MethodSignals Signals)>(StringComparer.Ordinal);
+        void IndexAssembly(LibraryBodyIndex assembly)
+        {
+            var signals = assembly.Signals;
+            foreach (var call in assembly.DirectCalls)
+            {
+                if (call.Callee.Kind == MemberKind.Unsupported)
+                    continue;
+                var callerKey = CallerGraphKey(call.Caller);
+                var calleeKey = CallerGraphKey(call.Callee);
+                var edge = new ForwardCalleeEdge(call.Callee, calleeKey, call.Kind, call.InLoop);
+                if (forward.TryGetValue(callerKey, out var list))
+                    list.Add(edge);
+                else
+                    forward[callerKey] = [edge];
+                incoming[calleeKey] = incoming.GetValueOrDefault(calleeKey) + 1;
+            }
+            foreach (var method in assembly.Methods)
+            {
+                var key = CallerGraphKey(method);
+                if (!definitions.ContainsKey(key))
+                    definitions[key] = (method.AssemblyName, signals.GetValueOrDefault(method.MetadataToken, MethodSignals.None));
+            }
+        }
+        IndexAssembly(this);
+        foreach (var scope in calleeScopes)
+            IndexAssembly(scope);
+
+        int budget = Math.Max(1, maxNodes);
+        int created = 1;
+        var expanded = new HashSet<string>(StringComparer.Ordinal);
+
+        CallTreeNode Build(MemberRef member, string key, CallKind? kind, int depth, bool inLoop)
+        {
+            (string Assembly, MethodSignals Signals)? def =
+                key.Length > 0 && definitions.TryGetValue(key, out var found) ? found : null;
+            string assembly = def?.Assembly
+                ?? (member.Kind != MemberKind.Unsupported ? member.DeclaringType.Assembly : "");
+            var sig = def?.Signals ?? MethodSignals.None;
+            bool external = assembly.Length > 0 && !string.Equals(assembly, targetAssembly, StringComparison.Ordinal);
+            string? source = external ? assembly : null;
+            string? loopHint = inLoop ? "loop" : null;
+            int fanin = incoming.GetValueOrDefault(key);
+
+            if (key.Length == 0 || !forward.TryGetValue(key, out var rawEdges))
+            {
+                var leafStatus = key.Length == 0 && depth > 0 ? CallTreeStatus.External : CallTreeStatus.Leaf;
+                return new CallTreeNode(member, kind, leafStatus, [], new CallTreePerf(0, fanin, 1, inLoop, loopHint, null, sig, source));
+            }
+
+            // One edge per distinct callee (the graph reports callees by identity, not call sites);
+            // preserve an in-loop edge if any call site to that callee sat in a loop. Sort by
+            // structural key so output is deterministic across scope order.
+            var edges = rawEdges
+                .GroupBy(edge => edge.CalleeKey, StringComparer.Ordinal)
+                .Select(group => group.FirstOrDefault(edge => edge.InLoop, group.First()))
+                .OrderBy(edge => edge.CalleeKey, StringComparer.Ordinal)
+                .ToList();
+
+            var fanout = edges.Count;
+            if (depth >= maxDepth)
+                return new CallTreeNode(member, kind, CallTreeStatus.DepthLimited, [], new CallTreePerf(fanout, fanin, 1, inLoop, loopHint, null, sig, source));
+            if (!expanded.Add(key))
+                return new CallTreeNode(member, kind, CallTreeStatus.AlreadyShown, [], new CallTreePerf(fanout, fanin, 1, inLoop, loopHint, null, sig, source));
+
+            var children = ImmutableArray.CreateBuilder<CallTreeNode>();
+            bool truncated = false;
+            foreach (var edge in edges)
+            {
+                if (created >= budget)
+                {
+                    truncated = true;
+                    break;
+                }
+                created++;
+                children.Add(Build(edge.Callee, edge.CalleeKey, edge.Kind, depth + 1, edge.InLoop));
+            }
+
+            var nodeStatus = truncated
+                ? CallTreeStatus.Truncated
+                : children.Count == 0 ? CallTreeStatus.Leaf : CallTreeStatus.Expanded;
+            var maxTreeDepth = children.Count == 0 ? 1 : 1 + children.Max(child => child.Perf?.MaxDepth ?? 1);
+            return new CallTreeNode(member, kind, nodeStatus, children.ToImmutable(), new CallTreePerf(fanout, fanin, maxTreeDepth, inLoop, loopHint, null, sig, source));
+        }
+
+        return Build(rootMember, rootKey, null, 0, false);
+    }
+
     // Cross-assembly caller-graph identity key. The multi-assembly reverse map matches members
     // structurally (tokens are assembly-local), so the key leads with the declaring type's
     // assembly and adds parameter arity and the return type to the qualified declaring type,

--- a/src/dotnet-inspect.Tests/ProgressiveMemberCallGraphTests.cs
+++ b/src/dotnet-inspect.Tests/ProgressiveMemberCallGraphTests.cs
@@ -57,6 +57,21 @@ public class ProgressiveMemberCallGraphTests
         Assert.Empty(ping.Children);
     }
 
+    // The scoped first paint decodes only the target body, so an in-assembly callee whose own body
+    // is not yet decoded must read as bounded/unknown (DepthLimited), never as a proven Leaf that
+    // would falsely claim the callee is terminal.
+    [Fact]
+    public void Callees_ScopedFirstPaint_MarksInAssemblyCalleeBounded()
+    {
+        int runOuter = MemberToken(CallerPath, "Entry", "RunOuter");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, runOuter, NullResolver, [TargetPath]);
+
+        var view = graph.Callees();
+
+        var run = Child(view.CalleeRoot!, "Run");
+        Assert.Equal(Analysis.CallTreeStatus.DepthLimited, run.Status);
+    }
+
     // A consumer that wants the whole graph calls a later tier directly and pays exactly one full
     // build — the scoped build is never made — and gets both roots.
     [Fact]
@@ -184,5 +199,26 @@ public class ProgressiveMemberCallGraphTests
             [CallGraphTier.Callees, CallGraphTier.Callers, CallGraphTier.CrossLibrary],
             layers);
         Assert.Equal(1, completed);
+    }
+
+    // Cancellation is observed BEFORE each tier is acquired: cancelling in the first LayerReady
+    // handler must stop the next (more expensive) tier from building at all.
+    [Fact]
+    public void RunAsync_CancelInFirstLayer_DoesNotBuildNextTier()
+    {
+        int runOuter = MemberToken(CallerPath, "Entry", "RunOuter");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, runOuter, NullResolver, [TargetPath]);
+
+        using var cts = new CancellationTokenSource();
+        var layers = new List<CallGraphTier>();
+        graph.LayerReady += (_, view) => { layers.Add(view.Tier); cts.Cancel(); };
+
+        MethodBodyInspectionSession.OpenCountForTests = 0;
+        var task = graph.RunAsync(cts.Token);
+        Assert.ThrowsAny<OperationCanceledException>(() => task.GetAwaiter().GetResult());
+
+        Assert.Equal([CallGraphTier.Callees], layers);
+        // Only the scoped first-paint build ran; Callers() was never reached.
+        Assert.Equal(1, MethodBodyInspectionSession.OpenCountForTests);
     }
 }

--- a/src/dotnet-inspect.Tests/ProgressiveMemberCallGraphTests.cs
+++ b/src/dotnet-inspect.Tests/ProgressiveMemberCallGraphTests.cs
@@ -1,0 +1,188 @@
+using DotnetInspector.Inspectors;
+using DotnetInspector.Fixtures;
+using ILInspector.CallGraph;
+using ILInspector.Metadata;
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Tests the progressive member call-graph acquisition seam (issue #3266):
+/// <see cref="ProgressiveMemberCallGraph"/> serving callees, then callers, then the cross-library
+/// tier, with the no-duplicated-build invariant. Shares the non-parallel
+/// <c>IndexBuildGuard</c> collection so the process-wide
+/// <see cref="MethodBodyInspectionSession.OpenCountForTests"/> counter stays reliable.
+/// </summary>
+[Collection("IndexBuildGuard")]
+public class ProgressiveMemberCallGraphTests
+{
+    static string CallerPath => FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath();
+    static string TargetPath => FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+
+    static readonly Func<string, IAssemblyReferenceResolver?> NullResolver = _ => null;
+
+    static int MemberToken(string assemblyPath, string typeName, string methodName)
+    {
+        var index = Analysis.LibraryBodyIndex.Open(assemblyPath);
+        return index.Methods.First(method =>
+            method.DeclaringType.Name == typeName && method.Name == methodName).MetadataToken;
+    }
+
+    static string TargetAssemblyName()
+        => Analysis.LibraryBodyIndex.Open(TargetPath).Methods.First().AssemblyName;
+
+    static Analysis.CallTreeNode Child(Analysis.CallTreeNode node, string name)
+        => node.Children.Single(child => child.Member.Name == name);
+
+    // Layer 1 is the cheap first paint: a scoped single-body build that decodes only the selected
+    // member, so exactly one session opens, no caller root exists, and the callee tree is depth 1
+    // (the callee across the package boundary is still an untagged external leaf).
+    [Fact]
+    public void Callees_ScopedFirstPaint_BuildsScopedIndexOnly()
+    {
+        int run = MemberToken(CallerPath, "Entry", "Run");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, run, NullResolver, [TargetPath]);
+
+        MethodBodyInspectionSession.OpenCountForTests = 0;
+        var view = graph.Callees();
+
+        Assert.Equal(1, MethodBodyInspectionSession.OpenCountForTests);
+        Assert.Equal(CallGraphTier.Callees, view.Tier);
+        Assert.Null(view.CallerRoot);
+        Assert.NotNull(view.CalleeRoot);
+        Assert.Equal("Run", view.CalleeRoot!.Member.Name);
+
+        var ping = Child(view.CalleeRoot, "Ping");
+        Assert.Equal(Analysis.CallTreeStatus.External, ping.Status);
+        Assert.Empty(ping.Children);
+    }
+
+    // A consumer that wants the whole graph calls a later tier directly and pays exactly one full
+    // build — the scoped build is never made — and gets both roots.
+    [Fact]
+    public void Callers_RequestedDirectly_BuildsExactlyOneFullIndex()
+    {
+        int run = MemberToken(CallerPath, "Entry", "Run");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, run, NullResolver, [TargetPath]);
+
+        MethodBodyInspectionSession.OpenCountForTests = 0;
+        var view = graph.Callers();
+
+        Assert.Equal(1, MethodBodyInspectionSession.OpenCountForTests);
+        Assert.Equal(CallGraphTier.Callers, view.Tier);
+        Assert.NotNull(view.CallerRoot);
+        Assert.NotNull(view.CalleeRoot);
+
+        // Full intra-assembly build surfaces Run's own caller.
+        Assert.Contains(view.CallerRoot!.Children, child => child.Member.Name == "RunOuter");
+    }
+
+    // Once the full build has landed, requesting the callee tier reuses it (no second build) and the
+    // callee tree deepens past the scoped depth-1 bound to the configured depth.
+    [Fact]
+    public void Callees_AfterFullBuild_ReusesFullIndex_DeepensChain()
+    {
+        int runOuter = MemberToken(CallerPath, "Entry", "RunOuter");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, runOuter, NullResolver, [TargetPath]);
+
+        MethodBodyInspectionSession.OpenCountForTests = 0;
+        _ = graph.Callers();
+        var view = graph.Callees();
+
+        Assert.Equal(1, MethodBodyInspectionSession.OpenCountForTests);
+        Assert.Null(view.CallerRoot);
+
+        // RunOuter -> Run -> Ping: the reused full build expands Run past a scoped depth-1 stop.
+        var run = Child(view.CalleeRoot!, "Run");
+        Assert.Contains(run.Children, child => child.Member.Name == "Ping");
+    }
+
+    // The cross-library tier decodes the in-scope package and expands the callee chain across the
+    // assembly boundary, tagging the boundary-crossing callee with its source assembly. Requested
+    // directly it costs one full build plus one package build (no scoped build).
+    [Fact]
+    public void CrossLibrary_ExpandsCalleeChainAcrossBoundary_TagsSource()
+    {
+        int runOuter = MemberToken(CallerPath, "Entry", "RunOuter");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, runOuter, NullResolver, [TargetPath]);
+
+        MethodBodyInspectionSession.OpenCountForTests = 0;
+        var view = graph.CrossLibrary();
+
+        Assert.Equal(2, MethodBodyInspectionSession.OpenCountForTests);
+        Assert.Equal(CallGraphTier.CrossLibrary, view.Tier);
+        Assert.NotNull(view.CallerRoot);
+
+        var run = Child(view.CalleeRoot!, "Run");
+        var ping = Child(run, "Ping");
+        Assert.NotEqual(Analysis.CallTreeStatus.External, ping.Status);
+        Assert.Equal(TargetAssemblyName(), ping.Perf?.Source);
+    }
+
+    // Streaming yields the three layers in acquisition order with no duplicated build: a scoped
+    // build, a full build, and one package build — three session opens total.
+    [Fact]
+    public void Tiers_StreamInOrder_WithoutDuplicateBuilds()
+    {
+        int runOuter = MemberToken(CallerPath, "Entry", "RunOuter");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, runOuter, NullResolver, [TargetPath]);
+
+        MethodBodyInspectionSession.OpenCountForTests = 0;
+        var views = graph.Tiers().ToList();
+
+        Assert.Equal(3, MethodBodyInspectionSession.OpenCountForTests);
+        Assert.Equal(
+            [CallGraphTier.Callees, CallGraphTier.Callers, CallGraphTier.CrossLibrary],
+            views.Select(view => view.Tier));
+        Assert.Null(views[0].CallerRoot);
+        Assert.NotNull(views[1].CallerRoot);
+        Assert.Equal(TargetAssemblyName(), Child(Child(views[2].CalleeRoot!, "Run"), "Ping").Perf?.Source);
+    }
+
+    // Without cross-library scope the stream stops after the caller tier.
+    [Fact]
+    public void Tiers_NoCrossLibraryScope_StopsAtCallers()
+    {
+        int run = MemberToken(CallerPath, "Entry", "Run");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, run, NullResolver);
+
+        Assert.False(graph.HasCrossLibraryScope);
+        Assert.Equal(
+            [CallGraphTier.Callees, CallGraphTier.Callers],
+            graph.Tiers().Select(view => view.Tier));
+    }
+
+    // The seam yields presentation-free roots that project through the shared Mermaid document.
+    [Fact]
+    public void Roots_RoundTripThroughCallGraphMermaid()
+    {
+        int run = MemberToken(CallerPath, "Entry", "Run");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, run, NullResolver, [TargetPath]);
+
+        var view = graph.CrossLibrary();
+        var mermaid = CallGraphMermaid.Render(view.CallerRoot, view.CalleeRoot);
+
+        Assert.Contains("flowchart", mermaid);
+        Assert.Contains("Run", mermaid);
+    }
+
+    // The push driver raises LayerReady for each layer in order, then Completed once.
+    [Fact]
+    public async Task RunAsync_RaisesLayerReadyPerTier_ThenCompleted()
+    {
+        int runOuter = MemberToken(CallerPath, "Entry", "RunOuter");
+        var graph = ProgressiveMemberCallGraph.Open(CallerPath, runOuter, NullResolver, [TargetPath]);
+
+        var layers = new List<CallGraphTier>();
+        int completed = 0;
+        graph.LayerReady += (_, view) => layers.Add(view.Tier);
+        graph.Completed += (_, _) => completed++;
+
+        await graph.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            [CallGraphTier.Callees, CallGraphTier.Callers, CallGraphTier.CrossLibrary],
+            layers);
+        Assert.Equal(1, completed);
+    }
+}

--- a/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
+++ b/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\dotnet-inspect\dotnet-inspect.csproj" />
+    <ProjectReference Include="..\ILInspector.CallGraph\ILInspector.CallGraph.csproj" />
     <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\tests\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />

--- a/src/dotnet-inspect/Inspectors/ProgressiveMemberCallGraph.cs
+++ b/src/dotnet-inspect/Inspectors/ProgressiveMemberCallGraph.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ILInspector.Metadata;
@@ -138,10 +140,35 @@ public sealed class ProgressiveMemberCallGraph
     /// </summary>
     public MemberCallGraphView Callees()
     {
-        var index = ScopedOrFullIndex;
-        int calleeDepth = _fullSession is not null ? _depth : 1;
-        var calleeRoot = index.BuildCallTree(_memberToken, maxDepth: calleeDepth, maxNodes: _maxNodes);
-        return new MemberCallGraphView(CallGraphTier.Callees, calleeRoot, CallerRoot: null);
+        if (_fullSession is not null)
+        {
+            var full = _fullSession.BodyIndex.BuildCallTree(_memberToken, maxDepth: _depth, maxNodes: _maxNodes);
+            return new MemberCallGraphView(CallGraphTier.Callees, full, CallerRoot: null);
+        }
+
+        // Scoped first paint: only the target body was decoded, so its immediate callees appear but
+        // their own bodies are unknown. A single-body build reports an undecoded in-assembly callee
+        // as a Leaf (no outbound edges found), which would falsely claim the callee is terminal;
+        // restamp those depth-1 callees as DepthLimited (bounded/unknown) until a fuller tier
+        // decodes them.
+        var scopedRoot = ScopedOrFullIndex.BuildCallTree(_memberToken, maxDepth: 1, maxNodes: _maxNodes);
+        return new MemberCallGraphView(CallGraphTier.Callees, MarkImmediateCalleesBounded(scopedRoot), CallerRoot: null);
+    }
+
+    // The scoped single-body build cannot see any callee's own body, so it reports every immediate
+    // callee that resolves in-assembly as a Leaf. Restamp those as DepthLimited so the first paint
+    // never asserts a callee is terminal; External and other boundary statuses are already correct.
+    static Analysis.CallTreeNode MarkImmediateCalleesBounded(Analysis.CallTreeNode root)
+    {
+        if (root.Children.IsDefaultOrEmpty)
+            return root;
+
+        var children = root.Children
+            .Select(child => child.Status == Analysis.CallTreeStatus.Leaf
+                ? child with { Status = Analysis.CallTreeStatus.DepthLimited }
+                : child)
+            .ToImmutableArray();
+        return root with { Children = children };
     }
 
     /// <summary>
@@ -197,12 +224,21 @@ public sealed class ProgressiveMemberCallGraph
         => Task.Run(
             () =>
             {
-                foreach (var view in Tiers())
+                // Observe cancellation before requesting each tier, so a cancelling LayerReady
+                // handler stops the next (more expensive) build from running.
+                cancellationToken.ThrowIfCancellationRequested();
+                LayerReady?.Invoke(this, Callees());
+
+                cancellationToken.ThrowIfCancellationRequested();
+                LayerReady?.Invoke(this, Callers());
+
+                if (HasCrossLibraryScope)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    LayerReady?.Invoke(this, view);
+                    LayerReady?.Invoke(this, CrossLibrary());
                 }
 
+                cancellationToken.ThrowIfCancellationRequested();
                 Completed?.Invoke(this, EventArgs.Empty);
             },
             cancellationToken);
@@ -242,18 +278,14 @@ public sealed class ProgressiveMemberCallGraph
         var scopes = new List<Analysis.LibraryBodyIndex>();
         foreach (var scopePath in _crossLibraryAssemblies)
         {
-            try
-            {
-                scopes.Add(MethodBodyInspectionSession.Open(
-                    scopePath,
-                    _resolverFactory(scopePath),
-                    includeAllocations: true,
-                    includeOpportunities: false).BodyIndex);
-            }
-            catch
-            {
-                // Cross-library scope is best-effort; an unreadable package contributes no edges.
-            }
+            // Surface acquisition failures instead of swallowing them: an unreadable or missing
+            // cross-library package must fail the request, not silently yield a success-shaped graph
+            // that hides the boundary-crossing edges it should have contributed.
+            scopes.Add(MethodBodyInspectionSession.Open(
+                scopePath,
+                _resolverFactory(scopePath),
+                includeAllocations: true,
+                includeOpportunities: false).BodyIndex);
         }
 
         return scopes;

--- a/src/dotnet-inspect/Inspectors/ProgressiveMemberCallGraph.cs
+++ b/src/dotnet-inspect/Inspectors/ProgressiveMemberCallGraph.cs
@@ -1,0 +1,261 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ILInspector.Metadata;
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// Which progressive layer of a member call graph a <see cref="MemberCallGraphView"/> carries
+/// (issue #3266). The layers are cumulative and ordered by acquisition cost: each unlocks more of
+/// the graph by decoding more bodies. The value names the layer that was unlocked, not a direction
+/// — at <c>depth &gt; 1</c> the <see cref="CrossLibrary"/> layer lets both a caller chain and a
+/// callee chain cross a package boundary.
+/// </summary>
+public enum CallGraphTier
+{
+    /// <summary>
+    /// Outbound (callee) half only, from a scoped single-body build that decodes just the selected
+    /// member. The callee tree is bounded at depth 1 (the immediate callees) because no other body
+    /// is decoded yet; callers are not available.
+    /// </summary>
+    Callees,
+
+    /// <summary>
+    /// Adds the inbound (caller) half and deepens the callee tree, from a full decode of the
+    /// selected member's own assembly. Expansion is bounded at the assembly edge.
+    /// </summary>
+    Callers,
+
+    /// <summary>
+    /// Adds the in-scope caller/callee packages, so both the caller tree and the callee tree can
+    /// cross a library boundary up to the configured depth.
+    /// </summary>
+    CrossLibrary,
+}
+
+/// <summary>
+/// One progressive snapshot of a member call graph: the selected overload as both an outbound
+/// (callee) and inbound (caller) tree root. Presentation-free — a host renders these roots with its
+/// own per-section tree rendering, or projects them with
+/// <c>ILInspector.CallGraph.CallGraphMermaid.Render(CallerRoot, CalleeRoot)</c> ("with or without
+/// mermaid"). Either root may be null (there is no caller root in the first <see cref="CallGraphTier.Callees"/>
+/// layer); both are the same selected member.
+/// </summary>
+public sealed record MemberCallGraphView(
+    CallGraphTier Tier,
+    Analysis.CallTreeNode? CalleeRoot,
+    Analysis.CallTreeNode? CallerRoot);
+
+/// <summary>
+/// Progressive acquisition seam for a single member's call graph (issue #3266). Serves the graph in
+/// three cumulative layers so a host can paint the cheap outbound half first and fill in the
+/// expensive caller tiers as they land:
+/// <list type="number">
+///   <item><see cref="Callees"/> — a scoped single-body build (decode only the target body).</item>
+///   <item><see cref="Callers"/> — a full decode of the target assembly (intra-library callers, deeper callees).</item>
+///   <item><see cref="CrossLibrary"/> — decode the in-scope packages so both directions cross library boundaries.</item>
+/// </list>
+///
+/// <para><b>No duplicated work.</b> At most two target-assembly indexes are ever built — the scoped
+/// single-body build and the full build — plus one build per cross-library package, and each is
+/// built at most once and then reused for callees, callers, and any Mermaid projection. The scoped
+/// build exists only for the progressive first paint: a consumer that wants the whole graph calls
+/// <see cref="Callers"/> or <see cref="CrossLibrary"/> directly and pays exactly one full build,
+/// with callees derived for free from it (the scoped build is never made). Once the full build
+/// lands it supersedes the scoped one, which is never rebuilt.</para>
+///
+/// <para>Drive it by pull — <see cref="Callees"/>/<see cref="Callers"/>/<see cref="CrossLibrary"/>,
+/// or the lazy <see cref="Tiers"/> stream — or by push, via <see cref="RunAsync"/> raising
+/// <see cref="LayerReady"/> per layer then <see cref="Completed"/>. The push path is a thin wrapper
+/// over the same memoized pull core, so the two never double the work. A single instance assumes one
+/// logical consumer; do not mix concurrent pull calls with <see cref="RunAsync"/>.</para>
+/// </summary>
+public sealed class ProgressiveMemberCallGraph
+{
+    readonly string _assemblyPath;
+    readonly int _memberToken;
+    readonly Func<string, IAssemblyReferenceResolver?> _resolverFactory;
+    readonly IReadOnlyList<string> _crossLibraryAssemblies;
+    readonly int _depth;
+    readonly int _maxNodes;
+
+    MethodBodyInspectionSession? _scopedSession;
+    MethodBodyInspectionSession? _fullSession;
+    List<Analysis.LibraryBodyIndex>? _crossScopes;
+
+    ProgressiveMemberCallGraph(
+        string assemblyPath,
+        int memberToken,
+        Func<string, IAssemblyReferenceResolver?> resolverFactory,
+        IReadOnlyList<string> crossLibraryAssemblies,
+        int depth,
+        int maxNodes)
+    {
+        _assemblyPath = assemblyPath;
+        _memberToken = memberToken;
+        _resolverFactory = resolverFactory;
+        _crossLibraryAssemblies = crossLibraryAssemblies;
+        _depth = Math.Max(1, depth);
+        _maxNodes = Math.Max(1, maxNodes);
+    }
+
+    /// <summary>
+    /// Opens a progressive call graph rooted at <paramref name="memberToken"/> in
+    /// <paramref name="assemblyPath"/>. <paramref name="resolverFactory"/> supplies a reference
+    /// resolver per assembly path (the selected assembly and each cross-library scope);
+    /// <paramref name="crossLibraryAssemblies"/> are the packages consulted for the
+    /// <see cref="CrossLibrary"/> layer. <paramref name="depth"/> bounds the walk in both
+    /// directions (levels of callers up, callees down) and <paramref name="maxNodes"/> caps each
+    /// tree's node budget. No index is built until a layer is requested.
+    /// </summary>
+    public static ProgressiveMemberCallGraph Open(
+        string assemblyPath,
+        int memberToken,
+        Func<string, IAssemblyReferenceResolver?> resolverFactory,
+        IReadOnlyList<string>? crossLibraryAssemblies = null,
+        int depth = 3,
+        int maxNodes = 25)
+    {
+        ArgumentNullException.ThrowIfNull(assemblyPath);
+        ArgumentNullException.ThrowIfNull(resolverFactory);
+        return new ProgressiveMemberCallGraph(
+            assemblyPath,
+            memberToken,
+            resolverFactory,
+            crossLibraryAssemblies ?? [],
+            depth,
+            maxNodes);
+    }
+
+    /// <summary>True when cross-library packages were supplied, so a <see cref="CrossLibrary"/> layer exists.</summary>
+    public bool HasCrossLibraryScope => _crossLibraryAssemblies.Count > 0;
+
+    /// <summary>
+    /// Layer 1: the outbound callee tree from a scoped single-body build. Bounded at depth 1 while
+    /// only the scoped build exists; if the full build has already landed, the callee tree reaches
+    /// the configured depth and no scoped build is made.
+    /// </summary>
+    public MemberCallGraphView Callees()
+    {
+        var index = ScopedOrFullIndex;
+        int calleeDepth = _fullSession is not null ? _depth : 1;
+        var calleeRoot = index.BuildCallTree(_memberToken, maxDepth: calleeDepth, maxNodes: _maxNodes);
+        return new MemberCallGraphView(CallGraphTier.Callees, calleeRoot, CallerRoot: null);
+    }
+
+    /// <summary>
+    /// Layer 2: the full target-assembly build — the intra-library caller tree plus the callee tree
+    /// deepened to the configured depth. Reuses the full build if one already exists.
+    /// </summary>
+    public MemberCallGraphView Callers()
+    {
+        var index = FullIndex;
+        var calleeRoot = index.BuildCallTree(_memberToken, maxDepth: _depth, maxNodes: _maxNodes);
+        var callerRoot = index.BuildCallerTree(_memberToken, maxDepth: _depth, maxNodes: _maxNodes);
+        return new MemberCallGraphView(CallGraphTier.Callers, calleeRoot, callerRoot);
+    }
+
+    /// <summary>
+    /// Layer 3: extends both directions across the in-scope packages, so a caller or callee chain
+    /// can cross a library boundary. Reuses the full target-assembly build and each scope build.
+    /// </summary>
+    public MemberCallGraphView CrossLibrary()
+    {
+        var index = FullIndex;
+        var scopes = CrossScopes;
+        var calleeRoot = index.BuildCallTree(_memberToken, scopes, maxDepth: _depth, maxNodes: _maxNodes);
+        var callerRoot = index.BuildCallerTree(_memberToken, scopes, maxDepth: _depth, maxNodes: _maxNodes);
+        return new MemberCallGraphView(CallGraphTier.CrossLibrary, calleeRoot, callerRoot);
+    }
+
+    /// <summary>
+    /// Lazily streams the layers in order: <see cref="Callees"/>, then <see cref="Callers"/>, then
+    /// <see cref="CrossLibrary"/> when cross-library packages were supplied. A host renders or
+    /// re-renders per yielded snapshot.
+    /// </summary>
+    public IEnumerable<MemberCallGraphView> Tiers()
+    {
+        yield return Callees();
+        yield return Callers();
+        if (HasCrossLibraryScope)
+            yield return CrossLibrary();
+    }
+
+    /// <summary>Raised on each new layer as it becomes available, in <see cref="Tiers"/> order.</summary>
+    public event EventHandler<MemberCallGraphView>? LayerReady;
+
+    /// <summary>Raised once after the last layer has been delivered.</summary>
+    public event EventHandler? Completed;
+
+    /// <summary>
+    /// Non-blocking push driver: walks <see cref="Tiers"/> off the calling thread, raising
+    /// <see cref="LayerReady"/> for each layer and then <see cref="Completed"/>. Cancellation is
+    /// observed between layers.
+    /// </summary>
+    public Task RunAsync(CancellationToken cancellationToken = default)
+        => Task.Run(
+            () =>
+            {
+                foreach (var view in Tiers())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    LayerReady?.Invoke(this, view);
+                }
+
+                Completed?.Invoke(this, EventArgs.Empty);
+            },
+            cancellationToken);
+
+    // The full target-assembly index, built at most once. Supersedes the scoped build for every
+    // later query, so callees derived here reach the full depth without a second decode.
+    Analysis.LibraryBodyIndex FullIndex
+        => (_fullSession ??= MethodBodyInspectionSession.Open(
+            _assemblyPath,
+            _resolverFactory(_assemblyPath),
+            includeAllocations: true,
+            includeOpportunities: false,
+            bodyScope: null)).BodyIndex;
+
+    // The scoped single-body index for the first paint — unless a full build already exists, in
+    // which case that is reused (the scoped build is never made once superseded).
+    Analysis.LibraryBodyIndex ScopedOrFullIndex
+    {
+        get
+        {
+            if (_fullSession is not null)
+                return _fullSession.BodyIndex;
+
+            return (_scopedSession ??= MethodBodyInspectionSession.Open(
+                _assemblyPath,
+                _resolverFactory(_assemblyPath),
+                includeAllocations: true,
+                includeOpportunities: false,
+                bodyScope: new HashSet<int> { _memberToken })).BodyIndex;
+        }
+    }
+
+    IReadOnlyList<Analysis.LibraryBodyIndex> CrossScopes => _crossScopes ??= BuildCrossScopes();
+
+    List<Analysis.LibraryBodyIndex> BuildCrossScopes()
+    {
+        var scopes = new List<Analysis.LibraryBodyIndex>();
+        foreach (var scopePath in _crossLibraryAssemblies)
+        {
+            try
+            {
+                scopes.Add(MethodBodyInspectionSession.Open(
+                    scopePath,
+                    _resolverFactory(scopePath),
+                    includeAllocations: true,
+                    includeOpportunities: false).BodyIndex);
+            }
+            catch
+            {
+                // Cross-library scope is best-effort; an unreadable package contributes no edges.
+            }
+        }
+
+        return scopes;
+    }
+}

--- a/src/dotnet-inspect/Inspectors/ProgressiveMemberCallGraph.cs
+++ b/src/dotnet-inspect/Inspectors/ProgressiveMemberCallGraph.cs
@@ -82,6 +82,10 @@ public sealed class ProgressiveMemberCallGraph
     readonly int _depth;
     readonly int _maxNodes;
 
+    // These memoized session/scope fields are intentionally unsynchronized: the class contract is a
+    // single logical consumer (see the type doc), so pull calls and RunAsync never touch them
+    // concurrently and each index is still built at most once. If a future consumer needs concurrent
+    // pull+push, switch these to Lazy<T> with ExecutionAndPublication.
     MethodBodyInspectionSession? _scopedSession;
     MethodBodyInspectionSession? _fullSession;
     List<Analysis.LibraryBodyIndex>? _crossScopes;


### PR DESCRIPTION
## What

Implements #3266: a reusable product acquisition seam that serves a member call graph **progressively, with no duplicated index build**, feeding either per-section tree rendering or `CallGraphMermaid` (with or without mermaid as the final target).

`ProgressiveMemberCallGraph` (`src/dotnet-inspect/Inspectors/`) serves one member''s graph in three cumulative, memoized layers, cheapest first:

1. **`Callees`** — a scoped single-body build (decode only the target body); depth-1 callees, no caller tree yet.
2. **`Callers`** — a full target-assembly decode; adds the intra-library caller tree and deepens callees to `depth`.
3. **`CrossLibrary`** — decode in-scope packages so **both** the caller and callee trees can cross a library boundary up to `depth`.

`depth` is first-class (levels up = callers, down = callees). The seam yields presentation-free `CallTreeNode` roots as a `MemberCallGraphView(Tier, CalleeRoot, CallerRoot)`; a host renders them itself or projects with `CallGraphMermaid.Render(CallerRoot, CalleeRoot)`.

Drive it by **pull** (`Callees()`/`Callers()`/`CrossLibrary()` or the lazy `Tiers()` stream) or by **push** (`RunAsync` raising `LayerReady` per layer then `Completed`). Both share one memoized core.

For full up/down symmetry this PR also adds the cross-assembly forward/callee builder `LibraryBodyIndex.BuildCallTree(token, calleeScopes, ...)` — the mirror of `BuildCallerTree(scopes)` — keyed on the same erased identity and tagging each boundary-crossing callee with its source assembly.

## No-duplication invariant

At most two target-assembly indexes are ever built (scoped single-body + full), plus one per cross-library package; each is built once and reused for callees, callers, and any Mermaid projection. A non-progressive consumer calling `Callers()`/`CrossLibrary()` directly pays exactly one full build (the scoped build is never made); callees come free. Once the full build lands it supersedes the scoped one, which is never rebuilt.

## Evidence

- **Analysis** (`ILInspector.Analysis.Tests`): 5 new tests for the cross-assembly callee builder — external-callee pull-in + source tagging, depth-2 chain across an assembly boundary, constructed-generic resolution, scope-order determinism, empty-scope fallback parity. All pass.
- **Seam** (`dotnet-inspect.Tests`, new `ProgressiveMemberCallGraphTests`, in the non-parallel `IndexBuildGuard` collection): tier-1 scoped-only build, exactly-one-full-build when `Callers()` is requested directly, full-index reuse (no scoped build) after a full build, cross-boundary callee expansion + source tagging, `Tiers()` order + build counts (3 opens), no-cross-scope stop-at-callers, `CallGraphMermaid` round-trip, and the `RunAsync` push sequence. All 8 pass. Build counts asserted via `MethodBodyInspectionSession.OpenCountForTests`.
- Full `dotnet build dotnet-inspect.slnx -c Release` clean. Full Analysis and `dotnet-inspect.Tests` suites run; the only failures (`CrossAssemblyMetadataResolver_ResolvesFrameworkTypeDefinition`, `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden`) reproduce identically on clean `main` — pre-existing environment/ref-pack/SourceLink failures, unrelated to this change.
- Docs: `docs/design/call-graph-mermaid-projection.md` gains a "Progressive acquisition" section; passes `markdownlint`.

## Compatibility

Additive only: a new seam type, a new public `LibraryBodyIndex.BuildCallTree(scopes)` overload, one fixture method (`Entry.RunOuter`), and tests. No existing signatures or output changed. Product paths stay SRM-only / NativeAOT-friendly / Roslyn-free; the seam takes no dependency on `ILInspector.CallGraph` (only the test project references it for the projection round-trip).

Closes #3266.
