### PR TITLE
Resolve property/event/indexer accessors for member body sections (#3265)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,9 @@ A property, indexer, or event has no body of its own, so body sections
 Address them through the overload-index selector: `Name:1` is the getter/adder
 (the default) and `Name:2` the setter/remover, each rooted at its metadata
 accessor name (`get_Name`, `set_Name`, `add_Name`, `remove_Name`). Fields have
-no accessor and stay body-less.
+no accessor and stay body-less. The SourceLink source-file sections
+(`Original Source`, `Source Diff`, `Source Locations`) remain method-only for
+now; accessor source-line mapping is a follow-up.
 
 `allocation-fanout` is an opt-in aggregate view for construction-heavy
 registries, pipelines, and object graphs that do not match a local rewrite

--- a/README.md
+++ b/README.md
@@ -271,7 +271,17 @@ dotnet-inspect library MyLib.dll --where "Finding=analysis.call-site" --jsonl
 dotnet-inspect library MyLib.dll --where "CallerLoop=direct" --order-by "CallerLoopDepth desc" --jsonl
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Call Graph,Facts"
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Caller Graph" --fields "Throw,Catch,Finally"
+dotnet-inspect member MyType Value:1 --library MyLib.dll -S "Call Graph"
+dotnet-inspect member MyType Value:2 --library MyLib.dll -S "Call Graph"
 ```
+
+A property, indexer, or event has no body of its own, so body sections
+(`Call Graph`, `Caller Graph`, `Calls`, `Callers`, `IL`, `Decompiled Source`,
+`Facts`, and the other IL-body views) resolve it to its accessor methods.
+Address them through the overload-index selector: `Name:1` is the getter/adder
+(the default) and `Name:2` the setter/remover, each rooted at its metadata
+accessor name (`get_Name`, `set_Name`, `add_Name`, `remove_Name`). Fields have
+no accessor and stay body-less.
 
 `allocation-fanout` is an opt-in aggregate view for construction-heavy
 registries, pipelines, and object graphs that do not match a local rewrite

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -442,11 +442,13 @@ public class ApiMember
     public int? SetterToken { get; set; }
 
     /// <summary>
-    /// MethodDef tokens of an event's add/remove accessors when known.
+    /// MethodDef tokens of an event's add/remove accessors when known. Serialized (like
+    /// <see cref="GetterToken"/>/<see cref="SetterToken"/>) so JSON consumers can address an
+    /// event's accessor bodies; omitted for members that expose no such accessor.
     /// </summary>
-    [JsonIgnore]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? AdderToken { get; set; }
-    [JsonIgnore]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? RemoverToken { get; set; }
 
     public bool IsStatic { get; set; }

--- a/src/ILInspector.Metadata/MemberTargetResolver.cs
+++ b/src/ILInspector.Metadata/MemberTargetResolver.cs
@@ -258,6 +258,7 @@ public static class MemberTargetResolver
         }
 
         MemberTargetCandidate selected;
+        int? accessorOrdinal = null;
         if (selector.DigestPrefix is { Length: > 0 } digest)
         {
             var matches = candidates
@@ -282,14 +283,29 @@ public static class MemberTargetResolver
         }
         else if (selector.OverloadIndex is { } index)
         {
-            if (index < 1 || index > candidates.Count)
+            // A property or event exposes no overloads of its own, but its accessors are
+            // addressable through the overload-index path (issue #3265): Name:1 = the
+            // getter/adder, Name:2 = the setter/remover. This applies only when the name
+            // resolves to a single property/event; overloaded indexers keep normal overload
+            // selection and default to the getter.
+            var accessorCount = candidates.Count == 1 ? AccessorCount(candidates[0].Member) : 0;
+            var maxIndex = Math.Max(candidates.Count, accessorCount);
+            if (index < 1 || index > maxIndex)
             {
                 return Failure(MemberTargetDiagnosticKind.OverloadOutOfRange,
-                    $"Error: {selector.Name}:{index} is out of range. Use {selector.Name}:1 through {selector.Name}:{candidates.Count}.",
+                    $"Error: {selector.Name}:{index} is out of range. Use {selector.Name}:1 through {selector.Name}:{maxIndex}.",
                     candidates);
             }
 
-            selected = candidates[index - 1];
+            if (accessorCount > 0)
+            {
+                selected = candidates[0];
+                accessorOrdinal = index;
+            }
+            else
+            {
+                selected = candidates[index - 1];
+            }
         }
         else
         {
@@ -305,7 +321,13 @@ public static class MemberTargetResolver
 
         var anchor = selected.Anchor;
         var member = selected.Member;
-        var body = CreateBodyTarget(type, member, anchor, selected.DeclaringOverloadIndex);
+        // A property/event addresses its body through an accessor ordinal (1 = getter/adder,
+        // 2 = setter/remover), defaulting to the getter/adder; a method uses its own overload
+        // position. This ordinal flows to the body sections as the selected overload index.
+        var bodyOverloadIndex = AccessorCount(member) > 0
+            ? accessorOrdinal ?? 1
+            : selected.DeclaringOverloadIndex;
+        var body = CreateBodyTarget(type, member, anchor, bodyOverloadIndex);
         var handle = ApiMemberIdentity.CreateHandle(type, member);
         return new MemberTargetResolution(
             new ResolvedMemberTarget(
@@ -346,6 +368,8 @@ public static class MemberTargetResolver
             && member.MetadataToken is null
             && member.GetterToken is null
             && member.SetterToken is null
+            && member.AdderToken is null
+            && member.RemoverToken is null
             && member.DeclaringOverloadIndex is null)
         {
             return null;
@@ -354,9 +378,22 @@ public static class MemberTargetResolver
         return new BodyTarget(
             declaringType,
             anchor.CanonicalSignature,
-            member.MetadataToken ?? member.GetterToken ?? member.SetterToken,
+            member.MetadataToken ?? member.GetterToken ?? member.SetterToken ?? member.AdderToken ?? member.RemoverToken,
             member.DeclaringOverloadIndex ?? declaringOverloadIndex);
     }
+
+    /// <summary>
+    /// The number of body-backed accessors a member exposes: get/set for a property or
+    /// indexer, add/remove for an event. Zero for methods, fields, and any member with no
+    /// accessor tokens. Used to address accessors through the overload-index path (#3265).
+    /// </summary>
+    static int AccessorCount(ApiMember member)
+        => member.Kind switch
+        {
+            "property" => (member.GetterToken is null ? 0 : 1) + (member.SetterToken is null ? 0 : 1),
+            "event" => (member.AdderToken is null ? 0 : 1) + (member.RemoverToken is null ? 0 : 1),
+            _ => 0
+        };
 
     static MemberTargetKind ToTargetKind(string kind)
         => kind switch

--- a/src/ILInspector.Metadata/MemberTargetResolver.cs
+++ b/src/ILInspector.Metadata/MemberTargetResolver.cs
@@ -378,8 +378,31 @@ public static class MemberTargetResolver
         return new BodyTarget(
             declaringType,
             anchor.CanonicalSignature,
-            member.MetadataToken ?? member.GetterToken ?? member.SetterToken ?? member.AdderToken ?? member.RemoverToken,
+            member.MetadataToken ?? SelectAccessorToken(member, declaringOverloadIndex),
             member.DeclaringOverloadIndex ?? declaringOverloadIndex);
+    }
+
+    /// <summary>
+    /// The MethodDef token of the accessor addressed by the selected ordinal (1 =
+    /// getter/adder, 2 = setter/remover), counting only accessors that exist so a
+    /// write-only property's sole accessor is ordinal 1. Returns <see langword="null"/>
+    /// for a member with no accessor tokens. Mirrors the accessor ordering the body
+    /// sections synthesize (issue #3265), so <see cref="BodyTarget.MetadataToken"/> names
+    /// the same accessor the body render selects by ordinal.
+    /// </summary>
+    static int? SelectAccessorToken(ApiMember member, int? ordinal)
+    {
+        int?[] tokens = member.Kind switch
+        {
+            "property" => [member.GetterToken, member.SetterToken],
+            "event" => [member.AdderToken, member.RemoverToken],
+            _ => []
+        };
+        var present = tokens.Where(token => token is not null).ToArray();
+        if (present.Length == 0)
+            return null;
+        var index = (ordinal ?? 1) - 1;
+        return index >= 0 && index < present.Length ? present[index] : present[0];
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -218,6 +218,60 @@ public class MemberCallGraphSectionTests
         Assert.Contains("Combine", result.Output);
     }
 
+    [Fact]
+    public async Task DecompiledSource_PropertyGetterRendersAccessorDeclaration()
+    {
+        // The getter renders a real method header (not the property's bare return type)
+        // with the setter's body kept off it (#3265).
+        var result = await RunDecompiledAsync(
+            typeof(MemberCallGraphFixture).FullName!, nameof(MemberCallGraphFixture.Descriptor), overloadIndex: null);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Decompiled Source", result.Output);
+        Assert.Contains("get_Descriptor(", result.Output);
+        Assert.DoesNotContain("set_Descriptor(", result.Output);
+    }
+
+    [Fact]
+    public async Task DecompiledSource_PropertySetterRendersVoidAccessorDeclaration()
+    {
+        // Accessor ordinal 2 renders the setter: void return, a trailing `value` parameter.
+        var result = await RunDecompiledAsync(
+            typeof(MemberCallGraphFixture).FullName!, nameof(MemberCallGraphFixture.Descriptor), overloadIndex: 2);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Decompiled Source", result.Output);
+        Assert.Contains("void set_Descriptor(", result.Output);
+        Assert.Contains("value", result.Output);
+        Assert.DoesNotContain("get_Descriptor(", result.Output);
+    }
+
+    [Fact]
+    public async Task DecompiledSource_EventAdderRendersVoidAccessorDeclaration()
+    {
+        // The adder renders as a real void method taking the delegate value, not the
+        // event's bare delegate type as a headless declaration (#3265).
+        var result = await RunDecompiledAsync(
+            typeof(MemberCallGraphFixture).FullName!, nameof(MemberCallGraphFixture.Triggered), overloadIndex: null);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Decompiled Source", result.Output);
+        Assert.Contains("void add_Triggered(", result.Output);
+    }
+
+    static Task<(int ExitCode, string Output, string Error)> RunDecompiledAsync(
+        string typeName, string memberName, int? overloadIndex)
+        => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeName,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [memberName],
+            OverloadIndex = overloadIndex,
+            IncludeSections = [SectionNames.DecompiledSource],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Normal,
+        }));
+
     static Task<(int ExitCode, string Output, string Error)> RunCallGraphAsync(
         string typeName, string memberName)
         => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -168,6 +168,56 @@ public class MemberCallGraphSectionTests
         Assert.Contains("Call Graph\tsection (opt-in)", result.Output);
     }
 
+    [Fact]
+    public async Task CallGraphSection_ResolvesPropertyGetterAccessor()
+    {
+        // A property has no body of its own; the default accessor ordinal addresses the
+        // getter, and the graph roots at the getter's metadata name (#3265).
+        var result = await RunCallGraphAsync(
+            typeof(MemberCallGraphFixture).FullName!, nameof(MemberCallGraphFixture.Descriptor));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Call Graph", result.Output);
+        Assert.Contains("get_Descriptor", result.Output);
+        Assert.Contains(nameof(MemberCallGraphFixture.Inner), result.Output);
+    }
+
+    [Fact]
+    public async Task CallGraphSection_ResolvesPropertySetterAccessorByOrdinal()
+    {
+        // Accessor ordinal 2 addresses the setter: its callee, distinct from the getter's.
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.Descriptor)],
+            OverloadIndex = 2,
+            IncludeSections = [SectionNames.CallGraph],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Normal,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Call Graph", result.Output);
+        Assert.Contains("set_Descriptor", result.Output);
+        Assert.Contains("Consume", result.Output);
+        Assert.DoesNotContain("Describe", result.Output);
+    }
+
+    [Fact]
+    public async Task CallGraphSection_ResolvesEventAdderAccessor()
+    {
+        // An event target resolves to its adder accessor, whose field-like body combines
+        // delegates (#3265).
+        var result = await RunCallGraphAsync(
+            typeof(MemberCallGraphFixture).FullName!, nameof(MemberCallGraphFixture.Triggered));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Call Graph", result.Output);
+        Assert.Contains("add_Triggered", result.Output);
+        Assert.Contains("Combine", result.Output);
+    }
+
     static Task<(int ExitCode, string Output, string Error)> RunCallGraphAsync(
         string typeName, string memberName)
         => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -200,6 +250,28 @@ public static class MemberCallGraphFixture
     public static void Mid() => Inner();
 
     public static void Inner() => Console.WriteLine("leaf");
+
+    // Property whose accessors have distinct, non-trivial bodies so accessor addressing
+    // (Descriptor:1 = getter, Descriptor:2 = setter) resolves to different call trees (#3265).
+    public static string Descriptor
+    {
+        get => Describe();
+        set => Consume(value);
+    }
+
+    static string Describe()
+    {
+        Inner();
+        return "descriptor";
+    }
+
+    static void Consume(string value) => Console.WriteLine(value);
+
+    // Field-like event: the compiler generates add/remove accessor bodies whose call graph
+    // an event target resolves to via its adder/remover accessor (#3265).
+    public static event Action? Triggered;
+
+    public static void Raise() => Triggered?.Invoke();
 
     public static void LoopHeavyCall()
     {

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -259,6 +259,46 @@ public class MemberCallGraphSectionTests
         Assert.Contains("void add_Triggered(", result.Output);
     }
 
+    [Fact]
+    public async Task DecompiledSource_VirtualPropertyGetterKeepsVirtualModifier()
+    {
+        // The accessor shares the property's slot, so a virtual getter renders `virtual`
+        // rather than the owner's bare accessibility (#3265).
+        var result = await RunDecompiledAsync(
+            typeof(MemberAccessorModifierFixture).FullName!,
+            nameof(MemberAccessorModifierFixture.Label), overloadIndex: null);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Decompiled Source", result.Output);
+        Assert.Contains("public virtual string get_Label()", result.Output);
+    }
+
+    [Fact]
+    public async Task DecompiledSource_OverridePropertyGetterKeepsOverrideModifier()
+    {
+        var result = await RunDecompiledAsync(
+            typeof(DerivedAccessorModifierFixture).FullName!,
+            nameof(DerivedAccessorModifierFixture.Label), overloadIndex: null);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Decompiled Source", result.Output);
+        Assert.Contains("public override string get_Label()", result.Output);
+    }
+
+    [Fact]
+    public async Task DecompiledSource_PrivateSetterKeepsAccessorAccessibility()
+    {
+        // A `private set` must render `private`, not the property's public accessibility (#3265).
+        var result = await RunDecompiledAsync(
+            typeof(MemberAccessorModifierFixture).FullName!,
+            nameof(MemberAccessorModifierFixture.State), overloadIndex: 2);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Decompiled Source", result.Output);
+        Assert.Contains("private void set_State(bool value)", result.Output);
+        Assert.DoesNotContain("public void set_State(", result.Output);
+    }
+
     static Task<(int ExitCode, string Output, string Error)> RunDecompiledAsync(
         string typeName, string memberName, int? overloadIndex)
         => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -362,4 +402,19 @@ public static class MemberCallGraphFixture
             System.GC.KeepAlive(x);
         }
     }
+}
+
+// Instance fixtures whose accessors carry non-default modifiers, so the synthesized
+// accessor declarations must reflect virtual/override (from the owning slot) and the
+// per-accessor accessibility of a `private set` rather than the owner's aggregate (#3265).
+public class MemberAccessorModifierFixture
+{
+    public virtual string Label { get; } = "base";
+
+    public bool State { get; private set; }
+}
+
+public class DerivedAccessorModifierFixture : MemberAccessorModifierFixture
+{
+    public override string Label => "derived";
 }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -720,10 +720,7 @@ public class ApiCommand
                 && (mo4.OverloadIndex.HasValue || mo4.HasCallerScope))
             {
                 var requestedSections = GetRequestedMemberSections(type, mo4);
-                var methods = type.Members
-                    .Where(m => m.Kind is "method" or "constructor" or "finalizer" or "operator" or "explicit-interface-implementation" or "extension-method"
-                        && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
-                    .ToList();
+                var methods = ApiOutputFormatter.ResolveBodyMethods(type, requestedSections);
                 if (methods.Count > 0)
                 {
                     var analysisInspection = new ApiMemberAnalysisInspection(
@@ -1405,10 +1402,7 @@ public class ApiCommand
                 && (memberOptions.OverloadIndex.HasValue || memberOptions.HasCallerScope))
             {
                 var requestedSections = GetRequestedMemberSections(type, memberOptions);
-                var methods = type.Members
-                    .Where(m => m.Kind is "method" or "constructor" or "finalizer" or "operator" or "explicit-interface-implementation" or "extension-method"
-                        && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
-                    .ToList();
+                var methods = ApiOutputFormatter.ResolveBodyMethods(type, requestedSections);
                 if (methods.Count > 0)
                 {
                     var analysisInspection = new ApiMemberAnalysisInspection(

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1254,32 +1254,80 @@ public static class ApiOutputFormatter
         switch (member.Kind)
         {
             case "property":
+                // A getter returns the property type and takes only the index parameters; a
+                // setter (and both event accessors) returns void and takes a trailing `value`.
                 if (member.GetterToken is { } getter)
-                    yield return Accessor(member, declaringType, $"get_{member.Name}", getter);
+                    yield return Accessor(member, declaringType, $"get_{member.Name}", getter, valueReturning: true);
                 if (member.SetterToken is { } setter)
-                    yield return Accessor(member, declaringType, $"set_{member.Name}", setter);
+                    yield return Accessor(member, declaringType, $"set_{member.Name}", setter, valueReturning: false);
                 break;
             case "event":
                 if (member.AdderToken is { } adder)
-                    yield return Accessor(member, declaringType, $"add_{member.Name}", adder);
+                    yield return Accessor(member, declaringType, $"add_{member.Name}", adder, valueReturning: false);
                 if (member.RemoverToken is { } remover)
-                    yield return Accessor(member, declaringType, $"remove_{member.Name}", remover);
+                    yield return Accessor(member, declaringType, $"remove_{member.Name}", remover, valueReturning: false);
                 break;
         }
     }
 
-    static ApiMember Accessor(ApiMember owner, string declaringType, string name, int token) => new()
+    /// <summary>
+    /// Builds a method member for one accessor with a structured signature derived from the
+    /// owner property/event, so declaration-rendering sections (Decompiled/Annotated Source,
+    /// the overlays) print a real method header (<c>public string get_Name()</c>) rather than
+    /// the owner's bare return type. The value type is the property/event type; a value-
+    /// returning accessor (a getter) returns it and carries only the index parameters, while a
+    /// void accessor (a setter or an event add/remove) appends it as a trailing <c>value</c>.
+    /// </summary>
+    static ApiMember Accessor(ApiMember owner, string declaringType, string name, int token, bool valueReturning)
     {
-        Name = name,
-        Kind = "method",
-        MetadataToken = token,
-        DeclaringType = declaringType,
-        ReturnType = owner.ReturnType,
-        IsStatic = owner.IsStatic,
-        IsAbstract = owner.IsAbstract,
-        IsUnsafe = owner.IsUnsafe,
-        Accessibility = owner.Accessibility,
-        Documentation = owner.Documentation,
+        var ownerModel = owner.SignatureModel;
+        var valueType = ownerModel?.ReturnType ?? owner.ReturnType ?? "object";
+        var parameters = ownerModel?.Parameters is { Count: > 0 } indexParameters
+            ? indexParameters.Select(CloneAccessorParameter).ToList()
+            : new List<ApiParameter>();
+        string returnType;
+        if (valueReturning)
+        {
+            returnType = valueType;
+        }
+        else
+        {
+            returnType = "void";
+            parameters.Add(new ApiParameter { Name = "value", Type = valueType });
+        }
+
+        var renderedParameters = string.Join(", ", parameters.Select(p => $"{p.TypeWithModifier} {p.Name}"));
+        return new ApiMember
+        {
+            Name = name,
+            Kind = "method",
+            MetadataToken = token,
+            DeclaringType = declaringType,
+            ReturnType = returnType,
+            Signature = $"{returnType} {name}({renderedParameters})",
+            SignatureModel = new ApiSignature
+            {
+                MemberName = name,
+                ReturnType = returnType,
+                Parameters = parameters,
+            },
+            IsStatic = owner.IsStatic,
+            IsAbstract = owner.IsAbstract,
+            IsUnsafe = owner.IsUnsafe,
+            Accessibility = owner.Accessibility,
+            Documentation = owner.Documentation,
+        };
+    }
+
+    static ApiParameter CloneAccessorParameter(ApiParameter parameter) => new()
+    {
+        Name = parameter.Name,
+        Type = parameter.Type,
+        CanonicalType = parameter.CanonicalType,
+        Modifier = parameter.Modifier,
+        HasDefault = parameter.HasDefault,
+        DefaultValueText = parameter.DefaultValueText,
+        Attributes = [.. parameter.Attributes],
     };
 
     internal static void PopulateIndexSections(

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1212,6 +1212,76 @@ public static class ApiOutputFormatter
         return parenStart < 0 ? "()" : declaration[parenStart..];
     }
 
+    /// <summary>
+    /// The method-like members whose IL bodies the index/detail sections analyze. When
+    /// the only selected member is a property or event (including an indexer) it has no
+    /// method body of its own, so it is resolved to its accessor methods (issue #3265):
+    /// get/set for a property or indexer, add/remove for an event, ordered so accessor
+    /// ordinal 1 is the getter/adder and ordinal 2 the setter/remover — the order the
+    /// overload-index selector (<c>Prop:1</c>/<c>Prop:2</c>) addresses. A field carries
+    /// no accessor token and yields no body methods, so its body sections stay N/A.
+    /// </summary>
+    internal static List<ApiMember> ResolveBodyMethods(ApiType type, IReadOnlySet<string> requestedSections)
+    {
+        bool includeAbstract = requestedSections.Contains(SectionNames.UnsafeOperations);
+        var methods = type.Members
+            .Where(m => ApiMemberSectionDescriptors.IsMethodLike(m) && (!m.IsAbstract || includeAbstract))
+            .ToList();
+
+        if (methods.Count == 0
+            && type.Members is [{ } single]
+            && ApiMemberSectionDescriptors.HasAccessorTokens(single))
+        {
+            methods = AccessorMethods(single, type)
+                .Where(m => !m.IsAbstract || includeAbstract)
+                .ToList();
+        }
+
+        return methods;
+    }
+
+    /// <summary>
+    /// Synthesizes method members for a property's or event's accessors, keyed by the
+    /// accessor's own MethodDef token so body sections address the accessor directly.
+    /// The getter/adder is yielded first so the default selection (accessor ordinal 1)
+    /// targets it; the setter/remover follows as ordinal 2. Names use the metadata
+    /// accessor spelling (<c>get_Name</c>, <c>set_Name</c>, <c>add_Name</c>,
+    /// <c>remove_Name</c>) so graph roots and breadcrumbs read as the real method.
+    /// </summary>
+    internal static IEnumerable<ApiMember> AccessorMethods(ApiMember member, ApiType type)
+    {
+        var declaringType = string.IsNullOrEmpty(member.DeclaringType) ? type.FullName : member.DeclaringType!;
+        switch (member.Kind)
+        {
+            case "property":
+                if (member.GetterToken is { } getter)
+                    yield return Accessor(member, declaringType, $"get_{member.Name}", getter);
+                if (member.SetterToken is { } setter)
+                    yield return Accessor(member, declaringType, $"set_{member.Name}", setter);
+                break;
+            case "event":
+                if (member.AdderToken is { } adder)
+                    yield return Accessor(member, declaringType, $"add_{member.Name}", adder);
+                if (member.RemoverToken is { } remover)
+                    yield return Accessor(member, declaringType, $"remove_{member.Name}", remover);
+                break;
+        }
+    }
+
+    static ApiMember Accessor(ApiMember owner, string declaringType, string name, int token) => new()
+    {
+        Name = name,
+        Kind = "method",
+        MetadataToken = token,
+        DeclaringType = declaringType,
+        ReturnType = owner.ReturnType,
+        IsStatic = owner.IsStatic,
+        IsAbstract = owner.IsAbstract,
+        IsUnsafe = owner.IsUnsafe,
+        Accessibility = owner.Accessibility,
+        Documentation = owner.Documentation,
+    };
+
     internal static void PopulateIndexSections(
         TypeView view,
         ApiType type,
@@ -1260,6 +1330,11 @@ public static class ApiOutputFormatter
                     : null
             : null;
         var singleMethodList = singleMethod != null ? new List<ApiMember> { singleMethod } : new List<ApiMember>();
+        // Code and caller sections address a single selected member. When an overload
+        // (or property/event accessor, issue #3265) is selected, restrict them to that
+        // one method so a read/write property's two accessor bodies don't overwrite each
+        // other. Without an explicit selection they still aggregate across all overloads.
+        var bodyMethods = overloadIndex.HasValue ? singleMethodList : methods;
 
         if (request.Calls && singleMethodList is [{ MetadataToken: { } token } callsMethod])
         {
@@ -1308,13 +1383,13 @@ public static class ApiOutputFormatter
             }
         }
 
-        if (request.Callers && methods.Count > 0)
+        if (request.Callers && bodyMethods.Count > 0)
         {
-            RequestTelemetry.Breadcrumb("il-analysis.callers", $"{methods.Count} member(s)");
+            RequestTelemetry.Breadcrumb("il-analysis.callers", $"{bodyMethods.Count} member(s)");
             var rows = new List<CallerSiteRow>();
 
             // Collect callers for each method (all overloads if multiple methods selected)
-            foreach (var method in methods.Where(m => m.MetadataToken.HasValue))
+            foreach (var method in bodyMethods.Where(m => m.MetadataToken.HasValue))
             {
                 var targetToken = method.MetadataToken!.Value;
                 rows.AddRange(analysisInspection.CallerEdges(targetToken)
@@ -1460,7 +1535,7 @@ public static class ApiOutputFormatter
         if (request.DecompiledSource || request.AnnotatedSource || request.CostOverlay || request.SemanticsOverlay || request.IL || request.Attributes || request.Facts || request.FidelityCauses || request.AppliedTaste)
             RequestTelemetry.Breadcrumb("method-body-load", singleMethod?.Name ?? type.Name);
 
-        foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath, options?.IncludeAll ?? false, options?.RenderOptions))
+        foreach (var (member, code) in MemberCodeProvider.Collect(type, bodyMethods, dllPath, overloadIndex, request, pdbPath, options?.IncludeAll ?? false, options?.RenderOptions))
         {
             if (code.Attributes is { Count: > 0 } attributes)
             {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1257,15 +1257,15 @@ public static class ApiOutputFormatter
                 // A getter returns the property type and takes only the index parameters; a
                 // setter (and both event accessors) returns void and takes a trailing `value`.
                 if (member.GetterToken is { } getter)
-                    yield return Accessor(member, declaringType, $"get_{member.Name}", getter, valueReturning: true);
+                    yield return Accessor(member, declaringType, $"get_{member.Name}", getter, "get", valueReturning: true);
                 if (member.SetterToken is { } setter)
-                    yield return Accessor(member, declaringType, $"set_{member.Name}", setter, valueReturning: false);
+                    yield return Accessor(member, declaringType, $"set_{member.Name}", setter, "set", valueReturning: false);
                 break;
             case "event":
                 if (member.AdderToken is { } adder)
-                    yield return Accessor(member, declaringType, $"add_{member.Name}", adder, valueReturning: false);
+                    yield return Accessor(member, declaringType, $"add_{member.Name}", adder, "add", valueReturning: false);
                 if (member.RemoverToken is { } remover)
-                    yield return Accessor(member, declaringType, $"remove_{member.Name}", remover, valueReturning: false);
+                    yield return Accessor(member, declaringType, $"remove_{member.Name}", remover, "remove", valueReturning: false);
                 break;
         }
     }
@@ -1277,8 +1277,13 @@ public static class ApiOutputFormatter
     /// the owner's bare return type. The value type is the property/event type; a value-
     /// returning accessor (a getter) returns it and carries only the index parameters, while a
     /// void accessor (a setter or an event add/remove) appends it as a trailing <c>value</c>.
+    /// Modifiers mirror the accessor: virtual/override/sealed/abstract/static come from the
+    /// owner (both accessors share the property/event slot), while accessibility uses the
+    /// per-accessor entry (a <c>private set</c> stays private) and only falls back to the
+    /// owner's when the accessor declares none — events carry no per-accessor entry and so
+    /// inherit the event's accessibility.
     /// </summary>
-    static ApiMember Accessor(ApiMember owner, string declaringType, string name, int token, bool valueReturning)
+    static ApiMember Accessor(ApiMember owner, string declaringType, string name, int token, string accessorKind, bool valueReturning)
     {
         var ownerModel = owner.SignatureModel;
         var valueType = ownerModel?.ReturnType ?? owner.ReturnType ?? "object";
@@ -1296,6 +1301,11 @@ public static class ApiOutputFormatter
             parameters.Add(new ApiParameter { Name = "value", Type = valueType });
         }
 
+        var accessorEntry = ownerModel?.Accessors.FirstOrDefault(accessor => accessor.Kind == accessorKind);
+        var accessibility = string.IsNullOrEmpty(accessorEntry?.Accessibility)
+            ? owner.Accessibility
+            : accessorEntry!.Accessibility;
+
         var renderedParameters = string.Join(", ", parameters.Select(p => $"{p.TypeWithModifier} {p.Name}"));
         return new ApiMember
         {
@@ -1312,9 +1322,12 @@ public static class ApiOutputFormatter
                 Parameters = parameters,
             },
             IsStatic = owner.IsStatic,
+            IsVirtual = owner.IsVirtual,
             IsAbstract = owner.IsAbstract,
+            IsOverride = owner.IsOverride,
+            IsSealed = owner.IsSealed,
             IsUnsafe = owner.IsUnsafe,
-            Accessibility = owner.Accessibility,
+            Accessibility = accessibility,
             Documentation = owner.Documentation,
         };
     }

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -547,8 +547,8 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberDetailSectionDescriptors.FidelityCauses>(HasSingleBodyBackedMember)
             .Add<ApiMemberDetailSectionDescriptors.AppliedTaste>(HasSingleBodyBackedMember)
             .Add<ApiMemberDetailSectionDescriptors.AnnotatedSource>(HasSingleBodyBackedMember)
-            .Add<ApiMemberSectionDescriptors.OriginalSource>(HasSingleBodyBackedMember)
-            .Add<ApiMemberDetailSectionDescriptors.SourceDiff>(HasSingleBodyBackedMember)
+            .Add<ApiMemberSectionDescriptors.OriginalSource>(HasSingleMethodLikeMember)
+            .Add<ApiMemberDetailSectionDescriptors.SourceDiff>(HasSingleMethodLikeMember)
             .Add<ApiMemberDetailSectionDescriptors.Calls>()
             .Add<ApiMemberDetailSectionDescriptors.ExceptionRegions>()
             .Add<ApiMemberSectionDescriptors.AllocationFacts>(HasSingleBodyBackedMember)
@@ -574,6 +574,12 @@ public static class ApiMemberOverloadSectionDescriptors
 
     private static bool HasSingleBodyBackedMember(ApiType model)
         => model.Members.Count == 1 && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
+
+    // SourceLink source-file sections (Original Source, Source Diff) resolve by the
+    // selected member's own name/token; accessor source mapping is not yet wired, so
+    // they stay method-only rather than rendering empty for a property/event (#3265).
+    private static bool HasSingleMethodLikeMember(ApiType model)
+        => model.Members.Count == 1 && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
 
     public sealed class Methods : ISectionDescriptor<ApiType>
     {
@@ -730,8 +736,11 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities =>
             SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayFetchSources;
         public static string? ScannerKey => null;
+        // SourceLink source-file sections resolve PDB sequence points by the selected
+        // member's own name/token; accessor source-line mapping is not yet wired, so a
+        // property/event stays method-only here rather than rendering empty (issue #3265).
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 
     public sealed class SourceDiff : ISectionDescriptor<ApiType>
@@ -742,9 +751,10 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities =>
             SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayFetchSources;
         public static string? ScannerKey => null;
+        // SourceLink source-file section; accessor source mapping not yet wired (issue #3265).
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 
     public sealed class SourceLocations : ISectionDescriptor<ApiType>
@@ -755,9 +765,10 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool ProbeEffectiveness => false;
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
+        // SourceLink source-file section; accessor source mapping not yet wired (issue #3265).
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
     }
 
     public sealed class ILBody : ISectionDescriptor<ApiType>

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -335,7 +335,7 @@ public static class ApiMemberSectionDescriptors
         public static bool ExplicitOnly => true;
         public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
-        public static bool CanRender(ApiType model) => model.Members.Any(IsMethodLike);
+        public static bool CanRender(ApiType model) => model.Members.Any(IsBodyBacked);
     }
 
     public sealed class SafetyFacts : ISectionDescriptor<ApiType>
@@ -345,7 +345,7 @@ public static class ApiMemberSectionDescriptors
         public static bool ExplicitOnly => true;
         public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
-        public static bool CanRender(ApiType model) => model.Members.Any(IsMethodLike);
+        public static bool CanRender(ApiType model) => model.Members.Any(IsBodyBacked);
     }
 
     public sealed class CostFacts : ISectionDescriptor<ApiType>
@@ -355,7 +355,7 @@ public static class ApiMemberSectionDescriptors
         public static bool ExplicitOnly => true;
         public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
-        public static bool CanRender(ApiType model) => model.Members.Any(IsMethodLike);
+        public static bool CanRender(ApiType model) => model.Members.Any(IsBodyBacked);
     }
 
     public sealed class TopLeverage : ISectionDescriptor<ApiType>
@@ -368,7 +368,7 @@ public static class ApiMemberSectionDescriptors
         public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(IsMethodLike);
+            => model.Members.Any(IsBodyBacked);
     }
 
     public sealed class OptimizationOpportunities : ISectionDescriptor<ApiType>
@@ -381,7 +381,7 @@ public static class ApiMemberSectionDescriptors
         public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(IsMethodLike);
+            => model.Members.Any(IsBodyBacked);
     }
 
     public sealed class SourceLocations : ISectionDescriptor<ApiType>
@@ -441,7 +441,7 @@ public static class ApiMemberSectionDescriptors
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Count == 1 && model.Members.Any(IsMethodLike);
+            => model.Members.Count == 1 && model.Members.Any(IsBodyBacked);
     }
 
     public sealed class OriginalSource : ISectionDescriptor<ApiType>
@@ -457,6 +457,28 @@ public static class ApiMemberSectionDescriptors
 
     internal static bool IsMethodLike(ApiMember member) =>
         member.Kind is "method" or "constructor" or "finalizer" or "operator" or "explicit-interface-implementation" or "extension-method";
+
+    /// <summary>
+    /// True when the member carries executable IL that a body section can analyze.
+    /// A method-like member is its own body; a property/event (including an indexer)
+    /// has no body of its own but is backed by accessor methods (get/set, add/remove)
+    /// whose tokens are recorded on the member. Body sections resolve such a member to
+    /// its accessor method(s) (issue #3265). Fields carry no accessor token and stay
+    /// body-less.
+    /// </summary>
+    internal static bool IsBodyBacked(ApiMember member) =>
+        IsMethodLike(member) || HasAccessorTokens(member);
+
+    /// <summary>
+    /// True when a property/event member records at least one accessor method token
+    /// (get/set/init for a property or indexer, add/remove for an event).
+    /// </summary>
+    internal static bool HasAccessorTokens(ApiMember member) =>
+        member.Kind is "property" or "event"
+        && (member.GetterToken is not null
+            || member.SetterToken is not null
+            || member.AdderToken is not null
+            || member.RemoverToken is not null);
 
     private static bool HasMethods(ApiType model)
         => model.Members.Any(m => m.Kind == "method");
@@ -520,27 +542,27 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.ExplicitInterfaceImplementations>()
             .Add<ApiMemberSectionDescriptors.ExtensionMethods>()
             .Add<ApiMemberSectionDescriptors.Events>()
-            .Add<ApiMemberSectionDescriptors.MethodAttributes>(HasSingleMethodLikeMember)
-            .Add<ApiMemberSectionDescriptors.DecompiledSource>(HasSingleMethodLikeMember)
-            .Add<ApiMemberDetailSectionDescriptors.FidelityCauses>(HasSingleMethodLikeMember)
-            .Add<ApiMemberDetailSectionDescriptors.AppliedTaste>(HasSingleMethodLikeMember)
-            .Add<ApiMemberDetailSectionDescriptors.AnnotatedSource>(HasSingleMethodLikeMember)
-            .Add<ApiMemberSectionDescriptors.OriginalSource>(HasSingleMethodLikeMember)
-            .Add<ApiMemberDetailSectionDescriptors.SourceDiff>(HasSingleMethodLikeMember)
+            .Add<ApiMemberSectionDescriptors.MethodAttributes>(HasSingleBodyBackedMember)
+            .Add<ApiMemberSectionDescriptors.DecompiledSource>(HasSingleBodyBackedMember)
+            .Add<ApiMemberDetailSectionDescriptors.FidelityCauses>(HasSingleBodyBackedMember)
+            .Add<ApiMemberDetailSectionDescriptors.AppliedTaste>(HasSingleBodyBackedMember)
+            .Add<ApiMemberDetailSectionDescriptors.AnnotatedSource>(HasSingleBodyBackedMember)
+            .Add<ApiMemberSectionDescriptors.OriginalSource>(HasSingleBodyBackedMember)
+            .Add<ApiMemberDetailSectionDescriptors.SourceDiff>(HasSingleBodyBackedMember)
             .Add<ApiMemberDetailSectionDescriptors.Calls>()
             .Add<ApiMemberDetailSectionDescriptors.ExceptionRegions>()
-            .Add<ApiMemberSectionDescriptors.AllocationFacts>(HasSingleMethodLikeMember)
-            .Add<ApiMemberSectionDescriptors.SafetyFacts>(HasSingleMethodLikeMember)
-            .Add<ApiMemberSectionDescriptors.CostFacts>(HasSingleMethodLikeMember)
+            .Add<ApiMemberSectionDescriptors.AllocationFacts>(HasSingleBodyBackedMember)
+            .Add<ApiMemberSectionDescriptors.SafetyFacts>(HasSingleBodyBackedMember)
+            .Add<ApiMemberSectionDescriptors.CostFacts>(HasSingleBodyBackedMember)
             .Add<ApiMemberDetailSectionDescriptors.Callers>()
             .Add<ApiMemberDetailSectionDescriptors.CallGraph>()
             .Add<ApiMemberDetailSectionDescriptors.CallerGraph>()
             .Add<ApiMemberDetailSectionDescriptors.UnsafeOperations>()
-            .Add<ApiMemberSectionDescriptors.TopLeverage>(HasSingleMethodLikeMember)
-            .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>(HasSingleMethodLikeMember)
-            .Add<ApiMemberSectionDescriptors.CostOverlay>(HasSingleMethodLikeMember)
-            .Add<ApiMemberSectionDescriptors.SemanticsOverlay>(HasSingleMethodLikeMember)
-            .Add<ApiMemberSectionDescriptors.ILBody>(HasSingleMethodLikeMember)
+            .Add<ApiMemberSectionDescriptors.TopLeverage>(HasSingleBodyBackedMember)
+            .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>(HasSingleBodyBackedMember)
+            .Add<ApiMemberSectionDescriptors.CostOverlay>(HasSingleBodyBackedMember)
+            .Add<ApiMemberSectionDescriptors.SemanticsOverlay>(HasSingleBodyBackedMember)
+            .Add<ApiMemberSectionDescriptors.ILBody>(HasSingleBodyBackedMember)
             .Add<ApiMemberSectionDescriptors.Facts>()
             .AddCategory(SectionCategoryNames.Source,
                 SectionNames.DecompiledSource,
@@ -550,8 +572,8 @@ public static class ApiMemberOverloadSectionDescriptors
                 SectionNames.IL);
     }
 
-    private static bool HasSingleMethodLikeMember(ApiType model)
-        => model.Members.Count == 1 && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+    private static bool HasSingleBodyBackedMember(ApiType model)
+        => model.Members.Count == 1 && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
 
     public sealed class Methods : ISectionDescriptor<ApiType>
     {
@@ -630,7 +652,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class DecompiledSource : ISectionDescriptor<ApiType>
@@ -641,7 +663,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class AnnotatedSource : ISectionDescriptor<ApiType>
@@ -652,7 +674,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class FidelityCauses : ISectionDescriptor<ApiType>
@@ -663,7 +685,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class AppliedTaste : ISectionDescriptor<ApiType>
@@ -674,7 +696,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class CostOverlay : ISectionDescriptor<ApiType>
@@ -686,7 +708,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class SemanticsOverlay : ISectionDescriptor<ApiType>
@@ -698,7 +720,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class OriginalSource : ISectionDescriptor<ApiType>
@@ -709,7 +731,7 @@ public static class ApiMemberDetailSectionDescriptors
             SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayFetchSources;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class SourceDiff : ISectionDescriptor<ApiType>
@@ -722,7 +744,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class SourceLocations : ISectionDescriptor<ApiType>
@@ -735,7 +757,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class ILBody : ISectionDescriptor<ApiType>
@@ -744,7 +766,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool IsExpensive => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class ExceptionRegions : ISectionDescriptor<ApiType>
@@ -755,7 +777,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => model.Members.Count == 1 && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Count == 1 && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class Calls : ISectionDescriptor<ApiType>
@@ -767,7 +789,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class Callers : ISectionDescriptor<ApiType>
@@ -779,7 +801,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class CallGraph : ISectionDescriptor<ApiType>
@@ -791,7 +813,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
  
     public sealed class CallerGraph : ISectionDescriptor<ApiType>
@@ -803,7 +825,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
  
     public sealed class UnsafeOperations : ISectionDescriptor<ApiType>
@@ -815,7 +837,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     /// <summary>
@@ -834,7 +856,7 @@ public static class ApiMemberDetailSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
 }

--- a/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
@@ -177,6 +177,92 @@ public class MemberTargetResolverTests
         Assert.Empty(result.Diagnostic.Candidates);
     }
 
+    [Fact]
+    public void Resolve_ReadWritePropertyDefaultsToGetterAccessorBody()
+    {
+        var type = CreateAccessorSurface();
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("Value"));
+
+        Assert.True(result.Found);
+        Assert.Equal(MemberTargetKind.Property, result.Target!.Kind);
+        Assert.NotNull(result.Target.Body);
+        // Accessor ordinal 1 addresses the getter; the body carries the getter token.
+        Assert.Equal(1, result.Target.Body!.DeclaringOverloadIndex);
+        Assert.Equal(0x06000101, result.Target.Body.MetadataToken);
+    }
+
+    [Fact]
+    public void Resolve_ReadWritePropertySetterSelectableByAccessorOrdinal()
+    {
+        var type = CreateAccessorSurface();
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("Value:2"));
+
+        Assert.True(result.Found);
+        Assert.Equal(MemberTargetKind.Property, result.Target!.Kind);
+        // Accessor ordinal 2 addresses the setter; body sections select it via this index.
+        Assert.Equal(2, result.Target.Body!.DeclaringOverloadIndex);
+    }
+
+    [Fact]
+    public void Resolve_ReadOnlyPropertyRejectsSetterOrdinal()
+    {
+        var type = CreateAccessorSurface();
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("ReadOnly:2"));
+
+        Assert.False(result.Found);
+        Assert.Equal(MemberTargetDiagnosticKind.OverloadOutOfRange, result.Diagnostic!.Kind);
+        Assert.Contains("ReadOnly:1 through ReadOnly:1", result.Diagnostic.Message);
+    }
+
+    [Fact]
+    public void Resolve_EventRemoverSelectableByAccessorOrdinal()
+    {
+        var type = CreateAccessorSurface();
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("Changed:2"));
+
+        Assert.True(result.Found);
+        Assert.Equal(MemberTargetKind.Event, result.Target!.Kind);
+        // Accessor ordinal 1 = adder, 2 = remover.
+        Assert.Equal(2, result.Target.Body!.DeclaringOverloadIndex);
+    }
+
+    static ApiType CreateAccessorSurface()
+        => new()
+        {
+            Namespace = "Sample",
+            Name = "Accessors",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Value",
+                    Kind = "property",
+                    Signature = "int Value { get; set; }",
+                    GetterToken = 0x06000101,
+                    SetterToken = 0x06000102
+                },
+                new ApiMember
+                {
+                    Name = "ReadOnly",
+                    Kind = "property",
+                    Signature = "int ReadOnly { get; }",
+                    GetterToken = 0x06000103
+                },
+                new ApiMember
+                {
+                    Name = "Changed",
+                    Kind = "event",
+                    Signature = "System.EventHandler Changed",
+                    AdderToken = 0x06000104,
+                    RemoverToken = 0x06000105
+                }
+            ]
+        };
+
     static ApiSurface CreateSurface()
         => new()
         {

--- a/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
@@ -203,6 +203,8 @@ public class MemberTargetResolverTests
         Assert.Equal(MemberTargetKind.Property, result.Target!.Kind);
         // Accessor ordinal 2 addresses the setter; body sections select it via this index.
         Assert.Equal(2, result.Target.Body!.DeclaringOverloadIndex);
+        // The body token names the setter accessor, not the getter (issue #3265).
+        Assert.Equal(0x06000102, result.Target.Body.MetadataToken);
     }
 
     [Fact]
@@ -228,6 +230,8 @@ public class MemberTargetResolverTests
         Assert.Equal(MemberTargetKind.Event, result.Target!.Kind);
         // Accessor ordinal 1 = adder, 2 = remover.
         Assert.Equal(2, result.Target.Body!.DeclaringOverloadIndex);
+        // The body token names the remover accessor, not the adder (issue #3265).
+        Assert.Equal(0x06000105, result.Target.Body.MetadataToken);
     }
 
     static ApiType CreateAccessorSurface()


### PR DESCRIPTION
## What & why

Fixes #3265. Member-level **body sections** — Call Graph, Caller Graph, Calls,
Callers, Exception Regions, Facts, Decompiled/Annotated/Original Source, IL, and
the cost/semantics overlays — produced nothing when the selected member was a
**property, indexer, or event**. Those members have no method-body identity of
their own; their IL lives in accessor methods (`get_`/`set_`, `add_`/`remove_`).

This resolves such a member to its accessor method(s) and runs the body sections
against them. Per the issue's preferred design (confirmed by @richlander),
accessors are **addressable overloads**: `Name:1` = getter/adder (the default),
`Name:2` = setter/remover. Graph roots and breadcrumbs use the **metadata
accessor spelling** (`get_Name`, …). Fields carry no accessor token and stay
body-less (unchanged N/A).

## Changes

- **Predicate + gating** (`ApiSectionDescriptors.cs`): new `IsBodyBacked` /
  `HasAccessorTokens`; every body-section `CanRender` gate and the single-member
  overload gate flip from `IsMethodLike` to `IsBodyBacked`.
- **Accessor resolution** (`ApiOutputFormatter.cs`): `ResolveBodyMethods` /
  `AccessorMethods` synthesize accessor method members keyed by the accessor's
  own MethodDef token; both `ApiCommand` build sites use them.
- **Overwrite fix** (`PopulateIndexSections`): `bodyMethods` restricts code and
  caller sections to the selected accessor, so a read/write property's two
  accessor bodies no longer overwrite each other. Method behavior is unchanged
  (single selected member → single method list).
- **Selector** (`MemberTargetResolver.cs`): accepts an accessor overload ordinal
  for a single property/event, defaults to getter/adder, range-checks `1..N`.
- **Projection** (`ApiSurface.cs`): event `AdderToken`/`RemoverToken` now
  serialize (like getter/setter) so JSON consumers can address event accessors.
- **Docs**: README note on accessor addressing.

## Design notes / boundaries

- Overloaded indexers (`Item:2`) keep normal overload selection and default to
  the getter; addressing a specific overload's setter is out of scope.
- The pre-existing bare-FQN auto-select limitation (`member Ns.T.M -S "Call
  Graph"` without an explicit `:N`) affects methods and properties alike and is
  unchanged here — use an explicit selector or `-D`.

## Evidence

- New resolver tests (accessor-ordinal getter default, setter-by-ordinal,
  read-only rejects `:2`, event remover) — 23/23 pass.
- New CLI call-graph tests (property getter, property setter by ordinal, event
  adder) — 12/12 pass.
- Full CLI suite: 2133 total, only the pre-existing network/ilasm-dependent
  `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden`
  fails (baselined identically on `origin/main`); 10 ilasm tests skip.
- Manual CLI spot-checks across getter/setter/event/indexer/field on real
  runtime + package assemblies.

Adversarial review (two models) to follow before marking ready.