### PR TITLE
Require asserted safety properties to name their gate (#3271)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,38 @@ Match evidence to the claim and use the smallest existing check that proves it:
   frequency, bytes, or impact; use a benchmark or profiler for runtime claims.
 - Documentation-only changes that make no measured behavior claim require
   Markdown validation, not product builds or tests.
+- A doc comment or README that asserts a safety, soundness, or faithfulness
+  property must name the gate that enforces it, or explicitly mark the
+  property as unverified.
+
+### Asserted properties name their gate
+
+"Unverified" is an acceptable answer; an unmarked, ungated claim is not. A
+green suite plus a confident comment reads exactly like a verified property,
+and a reviewer can only tell them apart by tampering with the code to see
+whether anything notices. Naming the gate moves that cost to the author, where
+it is a one-line answer.
+
+Prefer making the declaration *drive* the enforcement set over restating it, so
+that stale and missing entries both fail:
+
+- `ByteNeutralityGateTests` derives its coverage set from the style catalog
+  (`StyleOptionCatalog.Options.Where(o => !o.ByteDivergent)`) and asserts set
+  equality against the specimens.
+- `SpanAttributionTests` asserts set equality between the body-intrinsic error
+  allowlist and the pin for the current `MethodologyVersion`.
+
+When the property depends on wiring rather than on a set, write one named
+non-vacuity test that fails if the wiring dies, and say in its doc comment that
+it is that test —
+`IrInvariantCheckTests.PipelineRunner_UnderTestHost_ThrowsWhenAPassCorruptsTheTree`
+is the example.
+
+A gate only counts if it runs in the configuration the suite uses. The suite
+runs Release for fixture fidelity (see [Building and
+testing](#building-and-testing)), so a `[Conditional("DEBUG")]` check asserts
+nothing. Make such a check a runtime opt-in that the test host arms; do not
+switch the suite to Debug.
 
 ### Harness boundary
 


### PR DESCRIPTION
Closes #3271.

## What changes

`AGENTS.md` gains one rule under **Evidence and validation**:

> A doc comment or README that asserts a safety, soundness, or faithfulness property must name the gate that enforces it, or explicitly mark the property as unverified.

plus a short `### Asserted properties name their gate` subsection recording the enforcement idioms the repo already uses.

## Why a convention rather than more one-off fixes

The repository states its guarantees precisely and honestly; it enforces them unevenly. Every confirmed instance was accurate when written, and each stopped being checked without anything turning red:

| Instance | The ungated claim |
| --- | --- |
| #3241 / #3250 | `CheckInvariant` was `[Conditional("DEBUG")]` while the suite ran Release — documented, present, asserting nothing. |
| #3247 / #3249 | Byte-neutrality declared per style knob; the enforcement set was hand-maintained beside the declaration and free to drift. |
| #3268 / #3270 | The span-attribution README promised that widening the allowlist requires a new `methodologyVersion`. Prose only — three category-forbidden IDs went in with the full fast gate green. |
| #3267 | `IrInvariants.Enabled` is documented as the pipeline's by-construction guarantee; nothing ensures a host arms it. |
| #3269 | `..._ReturnsValidPath` asserts nothing when the path is null. |
| #3230 | `InlineArrayCollectionPass`'s "elements are re-sequenced into slot order" assumption has fixtures where it is false. |

The failure mode is invisible by construction: a green suite plus a confident comment is indistinguishable from a verified property. A reviewer can only tell them apart by tampering with the code and watching whether anything notices. Requiring the author to name the gate — or say there isn't one — moves that cost to where it is a one-line answer.

## What the subsection records

Both idioms are already demonstrated in-repo, so the rule documents practice rather than inventing it:

- **Declaration drives the enforcement set**, asserted by set equality so stale *and* missing entries fail: `ByteNeutralityGateTests` derives coverage from `StyleOptionCatalog.Options.Where(o => !o.ByteDivergent)`; `SpanAttributionTests.BodyIntrinsicAllowlist_IsPinnedToCurrentMethodologyVersion` pins the allowlist to `MethodologyVersion`.
- **One named non-vacuity test** when the property is wiring-dependent rather than set-shaped: `IrInvariantCheckTests.PipelineRunner_UnderTestHost_ThrowsWhenAPassCorruptsTheTree`, whose doc comment already says it is the only test that fails if the module initializer, the per-pass gate, or the runner's call disappears.

It also pairs the rule with the existing Release requirement, per #3271's closing note: a gate only counts in the configuration the suite runs, so the next person meeting a stripped `[Conditional("DEBUG")]` check makes it a runtime opt-in the test host arms instead of switching the suite to Debug and losing fixture fidelity.

## Boundary

Documentation only. No product, test, or harness code changes; the open instances above stay tracked on their own issues and are not closed by this PR. The rule is prospective — it is not a mandate to sweep every existing comment.

## Validation

Documentation-only change making no measured behavior claim, so per the evidence rules:

```
npx markdownlint-cli AGENTS.md   # clean
```

Citations in the new text were verified against the tree at `ab35977b`: `src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs:162`, `tools/DecompilerHarness/SpanAttribution.cs:78-82`, `src/ILInspector.Decompiler.Tests/IrInvariantCheckTests.cs:252`, and the `## Building and testing` anchor.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 03e294d5-cb8d-417c-9297-676292be6ba2