### PR TITLE
Assert the packs-directory contract instead of silently passing

### DIFF
--- a/src/DotnetInspector.Services/PlatformPackService.cs
+++ b/src/DotnetInspector.Services/PlatformPackService.cs
@@ -5,13 +5,23 @@ namespace DotnetInspector.Services;
 
 /// <summary>
 /// Downloads and caches .NET platform ref/runtime packs from NuGet.
-/// Packs are cached in the app cache directory mirroring the SDK packs layout:
-/// {cache}/dotnet-inspect/packs/{PackName}/{Version}/ref/net{TFM}/*.dll
+/// Packs are cached in the app cache directory mirroring the SDK packs layout under a
+/// versioned category directory:
+/// {cache}/dotnet-inspect/packs-v2/{PackName}/{Version}/ref/net{TFM}/*.dll
 /// </summary>
 public static class PlatformPackService
 {
-    private const string PacksCategory = "packs-v2";
-    private const string PacksCategoryPrefix = "packs-v";
+    /// <summary>
+    /// The current app cache category directory name for platform packs.
+    /// Unlike SDK-installed packs, this is versioned and does not equal <c>packs</c>.
+    /// </summary>
+    public const string PacksCategory = "packs-v2";
+
+    /// <summary>
+    /// The prefix shared by every app cache packs category directory name.
+    /// </summary>
+    public const string PacksCategoryPrefix = "packs-v";
+
     private const string CommitMarkerFileName = ".dotnet-inspect.pack.complete";
 
     static PlatformPackService()

--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -91,7 +91,9 @@ public static class PlatformResolver
         FrameworkMappings.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Discovers the .NET SDK packs directory (first match).
+    /// Discovers the highest-priority existing packs directory: the app cache packs
+    /// category when populated, otherwise an SDK-installed <c>packs</c> directory.
+    /// Returns null when no candidate directory exists.
     /// </summary>
     public static string? GetPacksDirectory()
     {
@@ -101,8 +103,7 @@ public static class PlatformResolver
 
     /// <summary>
     /// Returns all valid packs directories in priority order.
-    /// On Linux, the app cache is searched first (Microsoft packs preferred over distro builds).
-    /// On Windows/macOS, the app cache is searched last (local SDK preferred).
+    /// The app cache is always searched first (Microsoft packs preferred over distro builds).
     /// </summary>
     public static List<string> GetAllPacksDirectories()
     {

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -332,19 +332,43 @@ public class PlatformResolverTests
     }
 
     /// <summary>
-    /// Verifies GetPacksDirectory returns the app cache packs path.
+    /// Verifies GetPacksDirectory returns an existing packs directory: either the app cache
+    /// packs category (preferred, versioned as <c>packs-v*</c>) or an SDK-installed
+    /// <c>packs</c> directory. Skips, rather than silently passing, when neither exists.
     /// </summary>
     [Fact]
     public void GetPacksDirectory_ReturnsValidPath()
     {
         var result = PlatformResolver.GetPacksDirectory();
 
-        // Must return a packs directory (app cache or SDK-installed)
-        if (result != null)
-        {
-            Assert.EndsWith("packs", result);
-            Assert.True(Directory.Exists(result), $"Packs directory should exist: {result}");
-        }
+        Assert.SkipWhen(
+            result is null,
+            "No packs directory exists on this machine: the app cache packs category is absent and no SDK-installed packs directory was found.");
+
+        Assert.True(Directory.Exists(result), $"Packs directory should exist: {result}");
+
+        // The app cache category is versioned (packs-v2), so a bare "packs" suffix only
+        // describes the SDK-installed branch.
+        var name = Path.GetFileName(result!.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var isAppCachePacks = name.StartsWith(PlatformPackService.PacksCategoryPrefix, StringComparison.Ordinal);
+        Assert.True(
+            isAppCachePacks || name == "packs",
+            $"Expected the app cache packs category ('{PlatformPackService.PacksCategoryPrefix}*') or an SDK-installed 'packs' directory, but got: {result}");
+    }
+
+    /// <summary>
+    /// Pins the invariant that makes GetPacksDirectory's suffix contract two-shaped: the app cache
+    /// packs category is versioned and never the bare "packs" name used by SDK installs. If this
+    /// ever changes, GetPacksDirectory_ReturnsValidPath's suffix check must be revisited.
+    /// </summary>
+    [Fact]
+    public void PacksCacheCategory_IsVersioned_AndNotBarePacks()
+    {
+        Assert.StartsWith(
+            PlatformPackService.PacksCategoryPrefix,
+            PlatformPackService.PacksCategory,
+            StringComparison.Ordinal);
+        Assert.NotEqual("packs", PlatformPackService.PacksCategory);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #3269.

`PlatformResolverTests.GetPacksDirectory_ReturnsValidPath` had two masking defects: it asserted nothing on the null path, and its one suffix assertion could not hold for the branch `GetPacksDirectory()` prefers.

## Behavioral claim

- **Null path is no longer silent.** Every assertion sat inside `if (result != null)` with no `else`. On a machine with neither app cache packs nor SDK-installed packs, the test passed having asserted nothing while its name claimed a valid path. That case is now an explicit `Assert.SkipWhen` with a stated reason.
- **Suffix check now matches both real shapes.** `Assert.EndsWith("packs", result)` cannot be satisfied by the app cache branch, whose category is `packs-v2` and which `GetPacksDirectoryCandidates()` searches *first*. The check now accepts the SDK-installed bare `packs` directory or the versioned app cache category, named via the product constant rather than a literal.
- **`PacksCategory` / `PacksCategoryPrefix` are now public** so the test asserts against the real category identity instead of duplicating it. No behavior change; the values and the registered versioned-category cleanup are unchanged.
- **Companion test** `PacksCacheCategory_IsVersioned_AndNotBarePacks` pins the invariant that makes the contract two-shaped, so a future rename back to a bare `packs` fails loudly instead of silently re-breaking the suffix check.
- **Stale docs corrected.** `PlatformPackService` documented the cache layout as `{cache}/dotnet-inspect/packs/…` (issue's aside), and `GetAllPacksDirectories` claimed the app cache is searched last on Windows/macOS when it is always searched first.

## Evidence

The old assertion really does fail on the preferred branch. Probe with a temp cache root containing `packs-v2` (`CoreCache.Initialize("dotnet-inspect", tempRoot)`):

```
GetPacksDirectory()  = /tmp/packs-probe-034a04b4.../packs-v2
cache path           = /tmp/packs-probe-034a04b4.../packs-v2
old assert EndsWith("packs") = False
new assert                    = True
```

The skip path was verified by temporarily inverting the condition on this machine (which has SDK packs), confirming the reason renders instead of a vacuous pass:

```
DotnetInspector.Tests.PlatformResolverTests.GetPacksDirectory_ReturnsValidPath [SKIP]
  No packs directory exists on this machine: the app cache packs category is absent and no SDK-installed packs directory was found.
```

Validation, all on `c4495716`:

```
dotnet build dotnet-inspect.slnx -c Release                      # 0 errors
dotnet run --project src/dotnet-inspect.Tests -c Release         # 2161 total, 0 failed, 12 skipped
dotnet run --project src/DotnetInspector.Services.Tests -c Release  # 319 total, 0 failed
```

The full CLI run exercises the case where other tests have initialized `CoreCache`, so the fixed assertion holds under both orderings.

## Non-actions

No injectable seam was added to `GetPacksDirectoryCandidates()` to force the app cache branch inside the test process; that would mean product surface existing only for a test, and mutating the process-global `CoreCache` base path from a parallel test assembly is unsafe. The branch is covered by the invariant test plus the probe above.

## Risk

Low: one test rewritten, two consts widened to public with unchanged values, three doc comments corrected. No product control flow changed, so no adversarial review.
