### PR TITLE
Resolve accessor source for property/event source-file sections (#3278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,10 @@ Address them through the overload-index selector: `Name:1` is the getter/adder
 (the default) and `Name:2` the setter/remover, each rooted at its metadata
 accessor name (`get_Name`, `set_Name`, `add_Name`, `remove_Name`). Fields have
 no accessor and stay body-less. The SourceLink source-file sections
-(`Original Source`, `Source Diff`, `Source Locations`) remain method-only for
-now; accessor source-line mapping is a follow-up.
+(`Original Source`, `Source Diff`, `Source Locations`) follow the same
+addressing: they resolve through the accessor's PDB sequence points, so an
+auto-property maps to its declaration line and a hand-written accessor maps to
+its own authored lines.
 
 `allocation-fanout` is an opt-in aggregate view for construction-heavy
 registries, pipelines, and object graphs that do not match a local rewrite

--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -276,22 +276,31 @@ public class SourceLinkResolver
     /// implicitly private one, which <see cref="IsMemberSignatureLine"/> cannot recognize.
     /// <para>
     /// The line must read as a declaration prefix: a run of type-shaped tokens that reaches the
-    /// member's own name, followed by <c>(</c>, <c>&lt;</c>, <c>{</c>, or <c>=&gt;</c>. Requiring
-    /// the name to follow a return type — and rejecting a leading statement keyword — is what
-    /// separates <c>int Target =&gt; 1;</c> from a body line that merely spells the name, such as
-    /// a recursive <c>return Target(n - 1);</c> or an assignment <c>x = Target();</c>. A trailing
-    /// <c>;</c> is deliberately not accepted, so a local declaration such as <c>Foo Target;</c>
-    /// does not qualify.
+    /// member's own name, followed by <c>(</c>, <c>&lt;</c>, <c>{</c>, or <c>=&gt;</c>. Two
+    /// requirements separate a declaration from a body line that merely spells the name. A
+    /// leading statement keyword rejects the line outright, which covers a recursive
+    /// <c>return Target(n - 1);</c>. And the name must open a new token — a return type has to
+    /// precede it — rather than continue a dotted chain, which is what tells the explicit
+    /// implementation <c>int IDefault.Target =&gt; 1;</c> from the qualified call
+    /// <c>Helper.Target();</c>. A trailing <c>;</c> is deliberately not accepted, so a local
+    /// declaration such as <c>Foo Target;</c> does not qualify.
+    /// </para>
+    /// <para>
+    /// An indexer is spelled <c>this[...]</c> rather than by the <c>Item</c> name its accessors
+    /// carry in metadata, so a property accessor also accepts <c>this</c> in the name position.
     /// </para>
     /// </summary>
     private static bool DeclaresMember(string trimmed, string methodName)
     {
-        var name = SourceSpelledMemberName(methodName);
+        var name = SourceSpelledMemberName(methodName, out bool isPropertyAccessor);
         if (name.Length == 0)
             return false;
 
         int i = 0;
-        bool isFirstToken = true;
+        int tokenIndex = 0;
+        int chainStart = 0;
+        bool afterDot = false;
+
         while (i < trimmed.Length)
         {
             while (i < trimmed.Length && char.IsWhiteSpace(trimmed[i]))
@@ -308,29 +317,44 @@ public class SourceLinkResolver
                     i++;
                 var token = trimmed[tokenStart..i];
 
-                if (isFirstToken)
-                {
-                    if (StatementOpeners.Contains(token))
-                        return false;
-                    isFirstToken = false;
-                    continue;
-                }
+                // A dotted continuation stays part of the chain its first token opened; anything
+                // else opens a new one. Only a chain that something precedes can be a member name.
+                if (!afterDot)
+                    chainStart = tokenIndex;
+                afterDot = false;
 
-                if (token != name)
-                    continue;
-
-                int j = i;
-                while (j < trimmed.Length && char.IsWhiteSpace(trimmed[j]))
-                    j++;
-                if (j >= trimmed.Length)
+                if (tokenIndex == 0 && StatementOpeners.Contains(token))
                     return false;
-                if (trimmed[j] is '(' or '<' or '{')
-                    return true;
-                return trimmed[j] == '=' && j + 1 < trimmed.Length && trimmed[j + 1] == '>';
+
+                bool isNamePosition = token == name
+                    || (isPropertyAccessor && token == "this");
+                if (isNamePosition)
+                    return chainStart >= 1 && FollowsDeclarationName(trimmed, i, token == "this");
+
+                tokenIndex++;
+                continue;
             }
 
-            // Punctuation that can appear within a qualified, generic, array, or nullable type.
-            if (c is '.' or '<' or '>' or ',' or '[' or ']' or '?')
+            if (c == '.')
+            {
+                afterDot = true;
+                i++;
+                continue;
+            }
+
+            // A generic argument list or array rank belongs to the type token it follows, so it
+            // must be consumed whole — otherwise a type argument would read as a separate token
+            // and let a qualified call such as Foo<T>.Target() pass as a declaration.
+            if (c is '<' or '[')
+            {
+                int after = SkipBalanced(trimmed, i, c, c == '<' ? '>' : ']');
+                if (after < 0)
+                    return false;
+                i = after;
+                continue;
+            }
+
+            if (c == '?')
             {
                 i++;
                 continue;
@@ -343,18 +367,72 @@ public class SourceLinkResolver
     }
 
     /// <summary>
+    /// True when the character following a candidate member name at <paramref name="index"/>
+    /// can open that member's parameter list, type parameter list, accessor list, or expression
+    /// body. An indexer must be followed by its <c>[</c> parameter list.
+    /// </summary>
+    private static bool FollowsDeclarationName(string trimmed, int index, bool isIndexer)
+    {
+        int j = index;
+        while (j < trimmed.Length && char.IsWhiteSpace(trimmed[j]))
+            j++;
+        if (j >= trimmed.Length)
+            return false;
+
+        if (isIndexer)
+            return trimmed[j] == '[';
+
+        if (trimmed[j] is '(' or '<' or '{')
+            return true;
+
+        return trimmed[j] == '=' && j + 1 < trimmed.Length && trimmed[j + 1] == '>';
+    }
+
+    /// <summary>
+    /// The index just past the <paramref name="close"/> that balances the <paramref name="open"/>
+    /// at <paramref name="index"/>, or -1 when the group does not close on this line (a signature
+    /// whose type argument list wraps), in which case no declaration claim can be made.
+    /// </summary>
+    private static int SkipBalanced(string trimmed, int index, char open, char close)
+    {
+        int depth = 0;
+        for (int i = index; i < trimmed.Length; i++)
+        {
+            if (trimmed[i] == open)
+                depth++;
+            else if (trimmed[i] == close)
+                depth--;
+
+            if (depth == 0)
+                return i + 1;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
     /// The name a member is spelled with in source: an accessor's <c>get_</c>/<c>set_</c>/
     /// <c>add_</c>/<c>remove_</c> prefix names the owning property or event, and an explicit
     /// interface implementation carries a qualifying prefix that source states separately.
     /// </summary>
-    private static string SourceSpelledMemberName(string methodName)
+    private static string SourceSpelledMemberName(string methodName, out bool isPropertyAccessor)
     {
+        isPropertyAccessor = false;
         var name = methodName.AsSpan();
         int lastDot = name.LastIndexOf('.');
         if (lastDot >= 0)
             name = name[(lastDot + 1)..];
 
-        foreach (var prefix in (ReadOnlySpan<string>)["get_", "set_", "add_", "remove_"])
+        foreach (var prefix in (ReadOnlySpan<string>)["get_", "set_"])
+        {
+            if (name.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                isPropertyAccessor = true;
+                return name[prefix.Length..].ToString();
+            }
+        }
+
+        foreach (var prefix in (ReadOnlySpan<string>)["add_", "remove_"])
         {
             if (name.StartsWith(prefix, StringComparison.Ordinal))
                 return name[prefix.Length..].ToString();

--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -151,9 +151,12 @@ public class SourceLinkResolver
 
         // A declaration whose range already terminates on its last line — an expression body's
         // ";" or an auto-property's "{ get; set; }" — owns no trailing brace to recover, so the
-        // next "}" below it closes the enclosing type instead (issue #3278).
+        // next "}" below it closes the enclosing type instead (issue #3278). A range that still
+        // has a block open does own one, even when its last line ends in ";": a signature whose
+        // "{" sits on the declaration line ends its sequence range on the last statement.
         bool endsAtDeclaration = startsAtDeclaration && end >= 1 && end <= lines.Length
-            && IsSelfTerminatingLine(lines[end - 1]);
+            && IsSelfTerminatingLine(lines[end - 1])
+            && !HasUnclosedBlock(lines, from, to);
 
         // Scan forward to include the closing brace.
         for (int i = to; !endsAtDeclaration && i < Math.Min(to + 3, lines.Length); i++)
@@ -260,6 +263,32 @@ public class SourceLinkResolver
     }
 
     /// <summary>
+    /// True when the captured range <c>[from, to)</c> opens more blocks than it closes, so a
+    /// closing brace still has to be recovered below it. A single line is never treated as
+    /// unclosed on a brace count alone, because a brace inside a string literal would otherwise
+    /// send the forward scan after the enclosing type's brace.
+    /// </summary>
+    private static bool HasUnclosedBlock(string[] lines, int from, int to)
+    {
+        if (to - from <= 1)
+            return false;
+
+        int depth = 0;
+        for (int i = Math.Max(0, from); i < Math.Min(to, lines.Length); i++)
+        {
+            foreach (char c in lines[i])
+            {
+                if (c == '{')
+                    depth++;
+                else if (c == '}')
+                    depth--;
+            }
+        }
+
+        return depth > 0;
+    }
+
+    /// <summary>
     /// Words that can open a statement, and so rule out a declaration no matter what follows.
     /// </summary>
     private static readonly HashSet<string> StatementOpeners = new(StringComparer.Ordinal)
@@ -326,10 +355,15 @@ public class SourceLinkResolver
                 if (tokenIndex == 0 && StatementOpeners.Contains(token))
                     return false;
 
+                // A token matching the name is only the member's own name when a return type
+                // precedes it, so a type spelled like its member — CancellationToken
+                // CancellationToken => default; — must keep scanning rather than stop here.
                 bool isNamePosition = token == name
                     || (isPropertyAccessor && token == "this");
-                if (isNamePosition)
-                    return chainStart >= 1 && FollowsDeclarationName(trimmed, i, token == "this");
+                if (isNamePosition
+                    && chainStart >= 1
+                    && FollowsDeclarationName(trimmed, i, token == "this"))
+                    return true;
 
                 tokenIndex++;
                 continue;
@@ -351,6 +385,22 @@ public class SourceLinkResolver
                 if (after < 0)
                     return false;
                 i = after;
+                continue;
+            }
+
+            // A tuple return type occupies the type position and carries no leading identifier,
+            // so it is consumed whole and counts as the type token the member name follows.
+            // Only the type position accepts one, which keeps a parenthesized expression
+            // elsewhere on the line from standing in for a return type.
+            if (c == '(' && tokenIndex == 0)
+            {
+                int after = SkipBalanced(trimmed, i, '(', ')');
+                if (after < 0)
+                    return false;
+                i = after;
+                chainStart = tokenIndex;
+                tokenIndex++;
+                afterDot = false;
                 continue;
             }
 

--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -264,9 +264,11 @@ public class SourceLinkResolver
 
     /// <summary>
     /// True when the captured range <c>[from, to)</c> opens more blocks than it closes, so a
-    /// closing brace still has to be recovered below it. A single line is never treated as
-    /// unclosed on a brace count alone, because a brace inside a string literal would otherwise
-    /// send the forward scan after the enclosing type's brace.
+    /// closing brace still has to be recovered below it. Braces inside comments, char literals,
+    /// and string literals do not count — a property such as <c>public string M =&gt; "{";</c>
+    /// closes nothing and owns no brace below it. A raw string literal is not tracked; the range
+    /// is reported as still open so the forward scan runs, which is the conservative answer.
+    /// A single line is never judged unclosed, so a one-line declaration needs no such analysis.
     /// </summary>
     private static bool HasUnclosedBlock(string[] lines, int from, int to)
     {
@@ -274,10 +276,75 @@ public class SourceLinkResolver
             return false;
 
         int depth = 0;
+        bool inBlockComment = false;
+        bool inVerbatimString = false;
+
         for (int i = Math.Max(0, from); i < Math.Min(to, lines.Length); i++)
         {
-            foreach (char c in lines[i])
+            var line = lines[i];
+            for (int j = 0; j < line.Length; j++)
             {
+                char c = line[j];
+
+                if (inBlockComment)
+                {
+                    if (c == '*' && j + 1 < line.Length && line[j + 1] == '/')
+                    {
+                        inBlockComment = false;
+                        j++;
+                    }
+                    continue;
+                }
+
+                if (inVerbatimString)
+                {
+                    if (c != '"')
+                        continue;
+                    if (j + 1 < line.Length && line[j + 1] == '"')
+                        j++;
+                    else
+                        inVerbatimString = false;
+                    continue;
+                }
+
+                if (c == '/' && j + 1 < line.Length)
+                {
+                    if (line[j + 1] == '/')
+                        break;
+                    if (line[j + 1] == '*')
+                    {
+                        inBlockComment = true;
+                        j++;
+                        continue;
+                    }
+                }
+
+                if (c == '@' && j + 1 < line.Length && line[j + 1] == '"')
+                {
+                    inVerbatimString = true;
+                    j++;
+                    continue;
+                }
+
+                if (c == '"')
+                {
+                    if (j + 2 < line.Length && line[j + 1] == '"' && line[j + 2] == '"')
+                        return true;
+
+                    j++;
+                    while (j < line.Length && line[j] != '"')
+                        j += line[j] == '\\' ? 2 : 1;
+                    continue;
+                }
+
+                if (c == '\'')
+                {
+                    j++;
+                    while (j < line.Length && line[j] != '\'')
+                        j += line[j] == '\\' ? 2 : 1;
+                    continue;
+                }
+
                 if (c == '{')
                     depth++;
                 else if (c == '}')
@@ -351,6 +418,14 @@ public class SourceLinkResolver
                 if (!afterDot)
                     chainStart = tokenIndex;
                 afterDot = false;
+
+                // "ref" and "new" can lead a declaration (a ref return, a shadowing member) and
+                // can also open a statement, so neither decides the line. Skipping them without
+                // consuming a token position leaves the following token to be judged: a real
+                // declaration still has to reach its name after a return type, while
+                // "new Foo().Bar();" and "ref var x = ref y;" are still rejected below.
+                if (tokenIndex == 0 && token is "ref" or "new")
+                    continue;
 
                 if (tokenIndex == 0 && StatementOpeners.Contains(token))
                     return false;

--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -116,8 +116,15 @@ public class SourceLinkResolver
         string? simpleTypeName = string.IsNullOrEmpty(destructorTypeName) ? null : SimpleTypeName(destructorTypeName);
 
         // Scan backward from the first sequence point to capture the method signature.
+        // A member whose first sequence point already lands on its own declaration line — a
+        // one-line expression-bodied member, or a property/event accessor whose points map to
+        // the property declaration — needs no backward scan. Scanning back from such a line
+        // skips the blank separator or opening brace above it and captures the preceding member
+        // or the enclosing type header instead, which misattributes source (issue #3278).
         int sigStart = start;
-        for (int i = start - 2; i >= Math.Max(0, start - 15); i--)
+        bool startsAtDeclaration = start >= 1 && start <= lines.Length
+            && IsMemberSignatureLine(lines[start - 1].TrimStart(), isDestructor, simpleTypeName);
+        for (int i = start - 2; !startsAtDeclaration && i >= Math.Max(0, start - 15); i--)
         {
             var trimmed = lines[i].TrimStart();
             if (trimmed.Length == 0 || trimmed.StartsWith("///") || trimmed.StartsWith("//")
@@ -143,8 +150,14 @@ public class SourceLinkResolver
         int from = sigStart - 1;
         int to = end;
 
+        // A declaration whose range already terminates on its last line — an expression body's
+        // ";" or an auto-property's "{ get; set; }" — owns no trailing brace to recover, so the
+        // next "}" below it closes the enclosing type instead (issue #3278).
+        bool endsAtDeclaration = startsAtDeclaration && end >= 1 && end <= lines.Length
+            && IsSelfTerminatingLine(lines[end - 1]);
+
         // Scan forward to include the closing brace.
-        for (int i = to; i < Math.Min(to + 3, lines.Length); i++)
+        for (int i = to; !endsAtDeclaration && i < Math.Min(to + 3, lines.Length); i++)
         {
             var trimmed = lines[i].TrimStart();
             if (trimmed.StartsWith("}"))
@@ -172,6 +185,33 @@ public class SourceLinkResolver
 
         var dedented = methodLines.Select(l => l.Length >= minIndent ? l[minIndent..] : l);
         return string.Join('\n', dedented).TrimEnd();
+    }
+
+    /// <summary>
+    /// True when <paramref name="trimmed"/> (a leading-whitespace-stripped line) begins a member
+    /// declaration, judged by an accessibility or <c>static</c> modifier. Used only to decide
+    /// whether a first sequence point already sits on its member's declaration line, so the
+    /// backward signature scan in <see cref="ExtractMethodBody"/> can be skipped.
+    /// <para>
+    /// This deliberately omits the scan's <c>Contains(methodName)</c> clause: that clause is a
+    /// safe last resort while walking up toward a known-preceding signature, but a method whose
+    /// first statement recurses would spell its own name and be mistaken for its declaration.
+    /// </para>
+    /// </summary>
+    private static bool IsMemberSignatureLine(string trimmed, bool isDestructor, string? simpleTypeName)
+        => trimmed.StartsWith("public") || trimmed.StartsWith("private")
+            || trimmed.StartsWith("protected") || trimmed.StartsWith("internal")
+            || trimmed.StartsWith("static")
+            || (isDestructor && IsDestructorSignatureLine(trimmed, simpleTypeName));
+
+    /// <summary>
+    /// True when <paramref name="line"/> ends a declaration outright, so no trailing brace has
+    /// to be recovered by the forward scan in <see cref="ExtractMethodBody"/>.
+    /// </summary>
+    private static bool IsSelfTerminatingLine(string line)
+    {
+        var trimmed = line.TrimEnd();
+        return trimmed.EndsWith(';') || trimmed.EndsWith('}');
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -123,7 +123,8 @@ public class SourceLinkResolver
         // or the enclosing type header instead, which misattributes source (issue #3278).
         int sigStart = start;
         bool startsAtDeclaration = start >= 1 && start <= lines.Length
-            && IsMemberSignatureLine(lines[start - 1].TrimStart(), isDestructor, simpleTypeName);
+            && (IsMemberSignatureLine(lines[start - 1].TrimStart(), isDestructor, simpleTypeName)
+                || DeclaresMember(lines[start - 1].TrimStart(), methodName));
         for (int i = start - 2; !startsAtDeclaration && i >= Math.Max(0, start - 15); i--)
         {
             var trimmed = lines[i].TrimStart();
@@ -139,9 +140,7 @@ public class SourceLinkResolver
             }
 
             sigStart = i + 1;
-            if (trimmed.StartsWith("public") || trimmed.StartsWith("private")
-                || trimmed.StartsWith("protected") || trimmed.StartsWith("internal")
-                || trimmed.StartsWith("static")
+            if (StartsWithDeclarationModifier(trimmed)
                 || (isDestructor && IsDestructorSignatureLine(trimmed, simpleTypeName))
                 || trimmed.Contains(methodName))
                 break;
@@ -189,20 +188,66 @@ public class SourceLinkResolver
 
     /// <summary>
     /// True when <paramref name="trimmed"/> (a leading-whitespace-stripped line) begins a member
-    /// declaration, judged by an accessibility or <c>static</c> modifier. Used only to decide
-    /// whether a first sequence point already sits on its member's declaration line, so the
-    /// backward signature scan in <see cref="ExtractMethodBody"/> can be skipped.
+    /// declaration, judged by a leading declaration modifier. Used both to break the backward
+    /// signature scan in <see cref="ExtractMethodBody"/> and to decide whether a first sequence
+    /// point already sits on its member's declaration line, so that scan can be skipped.
     /// <para>
     /// This deliberately omits the scan's <c>Contains(methodName)</c> clause: that clause is a
     /// safe last resort while walking up toward a known-preceding signature, but a method whose
     /// first statement recurses would spell its own name and be mistaken for its declaration.
     /// </para>
+    /// <para>
+    /// A member declared with no modifier at all — an implicitly private member, or an interface
+    /// member — is recognized separately by <see cref="DeclaresMember"/>, which anchors on the
+    /// member's own name rather than on a modifier.
+    /// </para>
     /// </summary>
     private static bool IsMemberSignatureLine(string trimmed, bool isDestructor, string? simpleTypeName)
-        => trimmed.StartsWith("public") || trimmed.StartsWith("private")
-            || trimmed.StartsWith("protected") || trimmed.StartsWith("internal")
-            || trimmed.StartsWith("static")
+        => StartsWithDeclarationModifier(trimmed)
             || (isDestructor && IsDestructorSignatureLine(trimmed, simpleTypeName));
+
+    /// <summary>
+    /// Modifiers that can lead a C# member declaration whose body carries sequence points.
+    /// </summary>
+    private static readonly string[] DeclarationModifiers =
+    [
+        "public", "private", "protected", "internal", "static",
+        "abstract", "async", "extern", "override", "partial",
+        "readonly", "required", "sealed", "unsafe", "virtual"
+    ];
+
+    /// <summary>
+    /// True when <paramref name="trimmed"/> opens with one of <see cref="DeclarationModifiers"/>
+    /// as a whole token followed by the start of a type or name.
+    /// <para>
+    /// The token boundary matters in both directions: it keeps <c>internalCounter = 1;</c> and
+    /// <c>file.Write(x);</c> from reading as declarations, and the follower check keeps the
+    /// <c>unsafe { ... }</c> block statement from doing so. A <c>(</c> is accepted as a follower
+    /// so a tuple-returning declaration still matches; no modifier is a valid expression, so no
+    /// statement can open that way.
+    /// </para>
+    /// </summary>
+    private static bool StartsWithDeclarationModifier(string trimmed)
+    {
+        foreach (var modifier in DeclarationModifiers)
+        {
+            if (!trimmed.StartsWith(modifier, StringComparison.Ordinal))
+                continue;
+
+            int i = modifier.Length;
+            if (i >= trimmed.Length || !char.IsWhiteSpace(trimmed[i]))
+                continue;
+
+            while (i < trimmed.Length && char.IsWhiteSpace(trimmed[i]))
+                i++;
+
+            if (i < trimmed.Length
+                && (char.IsLetter(trimmed[i]) || trimmed[i] == '_' || trimmed[i] == '@' || trimmed[i] == '('))
+                return true;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// True when <paramref name="line"/> ends a declaration outright, so no trailing brace has
@@ -212,6 +257,110 @@ public class SourceLinkResolver
     {
         var trimmed = line.TrimEnd();
         return trimmed.EndsWith(';') || trimmed.EndsWith('}');
+    }
+
+    /// <summary>
+    /// Words that can open a statement, and so rule out a declaration no matter what follows.
+    /// </summary>
+    private static readonly HashSet<string> StatementOpeners = new(StringComparer.Ordinal)
+    {
+        "return", "throw", "yield", "await", "if", "while", "for", "foreach", "do", "switch",
+        "case", "using", "lock", "fixed", "checked", "unchecked", "var", "new", "base", "this",
+        "ref", "out", "in", "goto", "else", "try", "catch", "finally", "break", "continue",
+        "default", "is", "as", "stackalloc", "nameof", "typeof", "sizeof", "delegate"
+    };
+
+    /// <summary>
+    /// True when <paramref name="trimmed"/> declares the member named by
+    /// <paramref name="methodName"/> without a leading modifier — an interface member or an
+    /// implicitly private one, which <see cref="IsMemberSignatureLine"/> cannot recognize.
+    /// <para>
+    /// The line must read as a declaration prefix: a run of type-shaped tokens that reaches the
+    /// member's own name, followed by <c>(</c>, <c>&lt;</c>, <c>{</c>, or <c>=&gt;</c>. Requiring
+    /// the name to follow a return type — and rejecting a leading statement keyword — is what
+    /// separates <c>int Target =&gt; 1;</c> from a body line that merely spells the name, such as
+    /// a recursive <c>return Target(n - 1);</c> or an assignment <c>x = Target();</c>. A trailing
+    /// <c>;</c> is deliberately not accepted, so a local declaration such as <c>Foo Target;</c>
+    /// does not qualify.
+    /// </para>
+    /// </summary>
+    private static bool DeclaresMember(string trimmed, string methodName)
+    {
+        var name = SourceSpelledMemberName(methodName);
+        if (name.Length == 0)
+            return false;
+
+        int i = 0;
+        bool isFirstToken = true;
+        while (i < trimmed.Length)
+        {
+            while (i < trimmed.Length && char.IsWhiteSpace(trimmed[i]))
+                i++;
+            if (i >= trimmed.Length)
+                return false;
+
+            char c = trimmed[i];
+            if (char.IsLetter(c) || c == '_' || c == '@')
+            {
+                int tokenStart = i;
+                while (i < trimmed.Length
+                    && (char.IsLetterOrDigit(trimmed[i]) || trimmed[i] == '_' || trimmed[i] == '@'))
+                    i++;
+                var token = trimmed[tokenStart..i];
+
+                if (isFirstToken)
+                {
+                    if (StatementOpeners.Contains(token))
+                        return false;
+                    isFirstToken = false;
+                    continue;
+                }
+
+                if (token != name)
+                    continue;
+
+                int j = i;
+                while (j < trimmed.Length && char.IsWhiteSpace(trimmed[j]))
+                    j++;
+                if (j >= trimmed.Length)
+                    return false;
+                if (trimmed[j] is '(' or '<' or '{')
+                    return true;
+                return trimmed[j] == '=' && j + 1 < trimmed.Length && trimmed[j + 1] == '>';
+            }
+
+            // Punctuation that can appear within a qualified, generic, array, or nullable type.
+            if (c is '.' or '<' or '>' or ',' or '[' or ']' or '?')
+            {
+                i++;
+                continue;
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The name a member is spelled with in source: an accessor's <c>get_</c>/<c>set_</c>/
+    /// <c>add_</c>/<c>remove_</c> prefix names the owning property or event, and an explicit
+    /// interface implementation carries a qualifying prefix that source states separately.
+    /// </summary>
+    private static string SourceSpelledMemberName(string methodName)
+    {
+        var name = methodName.AsSpan();
+        int lastDot = name.LastIndexOf('.');
+        if (lastDot >= 0)
+            name = name[(lastDot + 1)..];
+
+        foreach (var prefix in (ReadOnlySpan<string>)["get_", "set_", "add_", "remove_"])
+        {
+            if (name.StartsWith(prefix, StringComparison.Ordinal))
+                return name[prefix.Length..].ToString();
+        }
+
+        return name.ToString();
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -319,11 +319,21 @@ public class SourceLinkResolver
                     }
                 }
 
-                if (c == '@' && j + 1 < line.Length && line[j + 1] == '"')
+                if (c == '@' && j + 1 < line.Length)
                 {
-                    inVerbatimString = true;
-                    j++;
-                    continue;
+                    if (line[j + 1] == '"')
+                    {
+                        inVerbatimString = true;
+                        j++;
+                        continue;
+                    }
+
+                    if (line[j + 1] == '$' && j + 2 < line.Length && line[j + 2] == '"')
+                    {
+                        inVerbatimString = true;
+                        j += 2;
+                        continue;
+                    }
                 }
 
                 if (c == '"')

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3149,6 +3149,64 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SourceLocations_PropertyAccessor_ResolvesFromAccessorSequencePoints()
+    {
+        // A property has no MethodDef of its own; its authored source is located through its
+        // accessor's PDB sequence points, reported against the owning property (#3278).
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializerOptions", "--platform", "System.Text.Json",
+            "MaxDepth", "-S", "Source Locations", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Source Locations", output);
+        Assert.Contains("public int MaxDepth { get; set; }", output);
+        Assert.Contains("JsonSerializerOptions.cs", output);
+        Assert.Contains("raw.githubusercontent.com", output);
+    }
+
+    [Fact]
+    public async Task Member_OriginalSource_PropertyAccessorOrdinals_ResolveGetterAndSetterSeparately()
+    {
+        // Ordinal 1 addresses the getter and 2 the setter, matching the accessor addressing the
+        // body sections use, so each renders its own authored accessor source (#3278).
+        var (getterExit, getterOutput, getterError) = await RunAppAsync(
+            "member", "JsonSerializerOptions", "--platform", "System.Text.Json",
+            "MaxDepth:1", "-S", "Original Source", "--tips", "q");
+
+        Assert.Equal(0, getterExit);
+        Assert.Empty(getterError);
+        Assert.Contains("## Original Source", getterOutput);
+        Assert.Contains("get => _maxDepth;", getterOutput);
+        Assert.DoesNotContain("_maxDepth = value;", getterOutput);
+
+        var (setterExit, setterOutput, setterError) = await RunAppAsync(
+            "member", "JsonSerializerOptions", "--platform", "System.Text.Json",
+            "MaxDepth:2", "-S", "Original Source", "--tips", "q");
+
+        Assert.Equal(0, setterExit);
+        Assert.Empty(setterError);
+        Assert.Contains("## Original Source", setterOutput);
+        Assert.Contains("_maxDepth = value;", setterOutput);
+    }
+
+    [Fact]
+    public async Task Member_SourceDiff_PropertyAccessor_ComparesAuthoredSourceToAccessorBody()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializerOptions", "--platform", "System.Text.Json",
+            "MaxDepth:2", "-S", "Source Diff", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Source Diff", output);
+        Assert.Contains("--- Original Source", output);
+        Assert.Contains("+++ Decompiled Source", output);
+        // The decompiled side is the accessor's own body, spelled with its metadata name.
+        Assert.Contains("set_MaxDepth", output);
+    }
+
+    [Fact]
     public async Task Member_SourceLocations_BareSelectedSignature_EmitsSingleUrl()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/MemberSourceTokenTests.cs
+++ b/src/dotnet-inspect.Tests/MemberSourceTokenTests.cs
@@ -1,0 +1,83 @@
+using DotnetInspector.Inspectors;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// A property or event has no MethodDef of its own, so source locations are resolved through its
+/// accessors. Every accessor must be offered in preference order — a preferred accessor can carry
+/// no sequence points while a later one resolves — rather than only the first (issue #3278).
+/// </summary>
+public class MemberSourceTokenTests
+{
+    [Fact]
+    public void Property_OffersBothAccessors_GetterPreferred()
+    {
+        var property = new ApiMember
+        {
+            Name = "Mixed",
+            Kind = "property",
+            GetterToken = 0x0600_0001,
+            SetterToken = 0x0600_0002
+        };
+
+        Assert.Equal(
+            [(0x0600_0001, 0), (0x0600_0002, 1)],
+            MemberSourceLocationCollector.SourceTokens(property).ToArray());
+    }
+
+    [Fact]
+    public void Property_SetterOnly_IsStillOffered()
+    {
+        var property = new ApiMember
+        {
+            Name = "WriteOnly",
+            Kind = "property",
+            SetterToken = 0x0600_0003
+        };
+
+        Assert.Equal(
+            [(0x0600_0003, 0)],
+            MemberSourceLocationCollector.SourceTokens(property).ToArray());
+    }
+
+    [Fact]
+    public void Event_OffersBothAccessors_AdderPreferred()
+    {
+        var member = new ApiMember
+        {
+            Name = "Changed",
+            Kind = "event",
+            AdderToken = 0x0600_0004,
+            RemoverToken = 0x0600_0005
+        };
+
+        Assert.Equal(
+            [(0x0600_0004, 0), (0x0600_0005, 1)],
+            MemberSourceLocationCollector.SourceTokens(member).ToArray());
+    }
+
+    [Fact]
+    public void Method_OffersItsOwnToken_Only()
+    {
+        var method = new ApiMember
+        {
+            Name = "Compute",
+            Kind = "method",
+            MetadataToken = 0x0600_0006,
+            GetterToken = 0x0600_0007
+        };
+
+        Assert.Equal(
+            [(0x0600_0006, 0)],
+            MemberSourceLocationCollector.SourceTokens(method).ToArray());
+    }
+
+    [Fact]
+    public void Property_WithNoAccessorTokens_OffersNothing()
+    {
+        var property = new ApiMember { Name = "Bare", Kind = "property" };
+
+        Assert.Empty(MemberSourceLocationCollector.SourceTokens(property));
+    }
+}

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -277,8 +277,18 @@ public static class MemberCommand
                 bool fetchSource = ApiCommand.GetRequestedMemberSections(apiType, effectiveOptions)
                     .Overlaps([SectionNames.OriginalSource, SectionNames.SourceDiff]);
                 var selectedMember = apiType.Members.Count == 1 ? apiType.Members[0] : null;
-                var sourceTypeName = selectedMember?.DeclaringType ?? apiType.FullName;
-                var sourceOverloadIndex = (selectedMember?.DeclaringOverloadIndex ?? effectiveOptions.OverloadIndex.Value) - 1;
+                // A property/event (including an indexer) has no body of its own: its authored
+                // source lives in the accessor the selected ordinal addresses, so resolve by that
+                // accessor's name and MethodDef token rather than the property's name and absent
+                // token, which would otherwise resolve nothing (issue #3278).
+                var sourceAccessor = ResolveSourceAccessor(apiType, selectedMember, effectiveOptions.OverloadIndex);
+                var sourceMember = sourceAccessor ?? selectedMember;
+                var sourceTypeName = sourceMember?.DeclaringType ?? apiType.FullName;
+                // Accessor names are unique within their declaring type, so the name fallback
+                // (used only when the token cannot be trusted) addresses the first match.
+                var sourceOverloadIndex = sourceAccessor is not null
+                    ? 0
+                    : (selectedMember?.DeclaringOverloadIndex ?? effectiveOptions.OverloadIndex.Value) - 1;
                 // A directly-requested single member (name + overload) is already explicitly named
                 // by the caller. When non-public members are in scope (--all), honor that request
                 // for Original Source / Source Diff regardless of accessibility; member inventories
@@ -296,14 +306,14 @@ public static class MemberCommand
                 // bodies), so fall back to name/overload resolution.
                 var tokenOriginAssembly = apiType.SourceAssemblyPath ?? apiDllPath;
                 var sourceMetadataToken = string.Equals(pdbLookupPath, tokenOriginAssembly, StringComparison.Ordinal)
-                    ? (selectedMember?.MetadataToken ?? 0)
+                    ? (sourceMember?.MetadataToken ?? 0)
                     : 0;
                 var resolved = await ApiCommand.ResolveMethodSourceAsync(
                     pdbLookupPath, sourceTypeName,
-                    effectiveOptions.MemberFilter.First(),
+                    sourceAccessor?.Name ?? effectiveOptions.MemberFilter.First(),
                     sourceOverloadIndex,
                     effectiveOptions, context.HttpClient, logger, fetchSource, publicOnly,
-                    sourceMetadataToken, selectedMember?.IsFinalizer ?? false);
+                    sourceMetadataToken, sourceMember?.IsFinalizer ?? false);
 
                 effectiveOptions = effectiveOptions with
                 {
@@ -568,4 +578,28 @@ public static class MemberCommand
 
     private static bool NeedsMemberSourceLocationResolution(MemberOptions options)
         => options.IncludeSections?.Contains(SectionNames.SourceLocations) == true;
+
+    /// <summary>
+    /// The accessor method that carries a selected property's or event's authored source, or
+    /// <see langword="null"/> when the selected member is already method-like (or is a field,
+    /// which has no accessor). The accessor ordinal follows the same addressing the body
+    /// sections use: 1 is the getter/adder and 2 the setter/remover, counting only accessors
+    /// that exist (issue #3278).
+    /// </summary>
+    private static ApiMember? ResolveSourceAccessor(ApiType apiType, ApiMember? selected, int? accessorOrdinal)
+    {
+        if (selected is null
+            || ApiMemberSectionDescriptors.IsMethodLike(selected)
+            || !ApiMemberSectionDescriptors.HasAccessorTokens(selected))
+        {
+            return null;
+        }
+
+        var accessors = ApiOutputFormatter.AccessorMethods(selected, apiType).ToList();
+        if (accessors.Count == 0)
+            return null;
+
+        var index = (accessorOrdinal ?? 1) - 1;
+        return index >= 0 && index < accessors.Count ? accessors[index] : accessors[0];
+    }
 }

--- a/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
@@ -39,13 +39,18 @@ internal static class MemberSourceLocationCollector
             var subject = new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath));
             var membersByToken = targetMembers
                 .SelectMany(static member => SourceTokens(member)
-                    .Select(token => (Token: token, Member: member)))
+                    .Select(entry => (entry.Token, Candidate: (Member: member, entry.Rank))))
                 .GroupBy(static pair => pair.Token)
                 .ToDictionary(
                     static group => group.Key,
-                    static group => group.Select(static pair => pair.Member).ToArray());
+                    static group => group.Select(static pair => pair.Candidate).ToArray());
             if (membersByToken.Count == 0)
                 return pdbPath;
+
+            // A member can offer several accessor tokens; the best-ranked one that actually
+            // resolves wins, so a later accessor is consulted only when a preferred one carries
+            // no sequence points. Shared across both paths below so ordering cannot regress it.
+            var appliedRank = new Dictionary<ApiMember, int>(ReferenceEqualityComparer.Instance);
 
             var sourceInspection = MetadataFindings.InspectMemberSources(
                 service,
@@ -53,7 +58,7 @@ internal static class MemberSourceLocationCollector
                 new MemberSourceQuery(membersByToken.Keys.ToHashSet()));
             if (sourceInspection.Value is FindingInspection<MemberSourceObservation>.Complete complete)
             {
-                ApplySourceLocations(membersByToken, complete);
+                ApplySourceLocations(membersByToken, complete, appliedRank);
                 return pdbPath;
             }
 
@@ -71,7 +76,7 @@ internal static class MemberSourceLocationCollector
                 if (tokenInspection.Value is FindingInspection<MemberSourceObservation>.Failed failed)
                 {
                     logger.Log(
-                        $"Warning: Failed to resolve source location for {members[0].Name}: "
+                        $"Warning: Failed to resolve source location for {members[0].Member.Name}: "
                         + failed.Error.Reason);
                     continue;
                 }
@@ -80,8 +85,9 @@ internal static class MemberSourceLocationCollector
                     continue;
 
                 ApplySourceLocations(
-                    new Dictionary<int, ApiMember[]> { [token] = members },
-                    tokenComplete);
+                    new Dictionary<int, (ApiMember Member, int Rank)[]> { [token] = members },
+                    tokenComplete,
+                    appliedRank);
             }
 
             return pdbPath;
@@ -94,14 +100,15 @@ internal static class MemberSourceLocationCollector
     }
 
     private static void ApplySourceLocations(
-        IReadOnlyDictionary<int, ApiMember[]> membersByToken,
-        FindingInspection<MemberSourceObservation>.Complete inspection)
+        IReadOnlyDictionary<int, (ApiMember Member, int Rank)[]> membersByToken,
+        FindingInspection<MemberSourceObservation>.Complete inspection,
+        Dictionary<ApiMember, int> appliedRank)
     {
         foreach (var mappings in inspection.Findings
             .Select(static finding => finding.Payload)
             .GroupBy(static mapping => mapping.MetadataToken))
         {
-            if (!membersByToken.TryGetValue(mappings.Key, out var members))
+            if (!membersByToken.TryGetValue(mappings.Key, out var candidates))
                 continue;
 
             // Preserve the legacy resolver's preference for MethodDebugInformation.Document.
@@ -109,8 +116,12 @@ internal static class MemberSourceLocationCollector
                 .OrderByDescending(static candidate => candidate.IsPrimaryDocument)
                 .ThenBy(static candidate => candidate.DocumentRowId)
                 .First();
-            foreach (var member in members)
+            foreach (var (member, rank) in candidates)
             {
+                if (appliedRank.TryGetValue(member, out var existing) && existing <= rank)
+                    continue;
+
+                appliedRank[member] = rank;
                 member.SourceFilePath = mapping.OriginalPath;
                 member.SourceUrl = mapping.ResolvedUrl;
                 member.SourceLineNumber = mapping.StartLine;
@@ -138,26 +149,34 @@ internal static class MemberSourceLocationCollector
     }
 
     /// <summary>
-    /// The MethodDef token(s) whose PDB sequence points locate a member's authored source.
-    /// A method-like member is its own body. A property or event (including an indexer) has
-    /// no MethodDef of its own, so it is located through its accessor — the getter/adder when
-    /// present, otherwise the setter/remover, matching the default accessor ordinal the body
-    /// sections address (issue #3278). The resolved location is applied to the owning member,
-    /// so a property contributes one row rather than one row per accessor.
+    /// The MethodDef token(s) whose PDB sequence points can locate a member's authored source,
+    /// paired with a preference rank (lower wins). A method-like member is its own body. A
+    /// property or event (including an indexer) has no MethodDef of its own, so it is located
+    /// through its accessors — the getter/adder first, then the setter/remover, matching the
+    /// default accessor ordinal the body sections address (issue #3278). Every accessor is
+    /// offered rather than only the first, because a preferred accessor can carry no sequence
+    /// points (a <c>#line hidden</c> or compiler-supplied body) while a later one resolves.
+    /// The winning location is applied to the owning member, so a property contributes one row
+    /// rather than one row per accessor.
     /// </summary>
-    private static IEnumerable<int> SourceTokens(ApiMember member)
+    internal static IEnumerable<(int Token, int Rank)> SourceTokens(ApiMember member)
     {
         if (ApiMemberSectionDescriptors.IsMethodLike(member))
         {
             if (member.MetadataToken is { } methodToken)
-                yield return methodToken;
+                yield return (methodToken, 0);
             yield break;
         }
 
-        var accessorToken = member.GetterToken ?? member.SetterToken
-            ?? member.AdderToken ?? member.RemoverToken;
-        if (accessorToken is { } token)
-            yield return token;
+        int rank = 0;
+        foreach (var accessorToken in new[]
+        {
+            member.GetterToken, member.AdderToken, member.SetterToken, member.RemoverToken
+        })
+        {
+            if (accessorToken is { } token)
+                yield return (token, rank++);
+        }
     }
 
 }

--- a/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
@@ -38,9 +38,12 @@ internal static class MemberSourceLocationCollector
             var targetMembers = GetTargetMembers(apiType, options).ToArray();
             var subject = new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath));
             var membersByToken = targetMembers
-                .Where(static member => member.MetadataToken is not null)
-                .GroupBy(static member => member.MetadataToken!.Value)
-                .ToDictionary(static group => group.Key, static group => group.ToArray());
+                .SelectMany(static member => SourceTokens(member)
+                    .Select(token => (Token: token, Member: member)))
+                .GroupBy(static pair => pair.Token)
+                .ToDictionary(
+                    static group => group.Key,
+                    static group => group.Select(static pair => pair.Member).ToArray());
             if (membersByToken.Count == 0)
                 return pdbPath;
 
@@ -119,7 +122,7 @@ internal static class MemberSourceLocationCollector
     private static IEnumerable<ApiMember> GetTargetMembers(ApiType apiType, MemberOptions options)
     {
         var members = apiType.Members
-            .Where(ApiMemberSectionDescriptors.IsMethodLike)
+            .Where(ApiMemberSectionDescriptors.IsBodyBacked)
             .Where(m => !MemberFilters.IsCompilerGenerated(m.Name));
 
         if (options.MemberFilter.Count > 0)
@@ -132,6 +135,29 @@ internal static class MemberSourceLocationCollector
             members = members.Where(m => m.IsUnsafe);
 
         return members;
+    }
+
+    /// <summary>
+    /// The MethodDef token(s) whose PDB sequence points locate a member's authored source.
+    /// A method-like member is its own body. A property or event (including an indexer) has
+    /// no MethodDef of its own, so it is located through its accessor — the getter/adder when
+    /// present, otherwise the setter/remover, matching the default accessor ordinal the body
+    /// sections address (issue #3278). The resolved location is applied to the owning member,
+    /// so a property contributes one row rather than one row per accessor.
+    /// </summary>
+    private static IEnumerable<int> SourceTokens(ApiMember member)
+    {
+        if (ApiMemberSectionDescriptors.IsMethodLike(member))
+        {
+            if (member.MetadataToken is { } methodToken)
+                yield return methodToken;
+            yield break;
+        }
+
+        var accessorToken = member.GetterToken ?? member.SetterToken
+            ?? member.AdderToken ?? member.RemoverToken;
+        if (accessorToken is { } token)
+            yield return token;
     }
 
 }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -889,7 +889,9 @@ public static class ApiOutputFormatter
         var grouped = GroupMembersByKind(type, options.MemberFilter, options.UnsafeOnly, options.KindFilter);
         var members = grouped
             .SelectMany(g => g.Value)
-            .Where(ApiMemberSectionDescriptors.IsMethodLike)
+            // A property/event is located through its accessor's sequence points, so it
+            // carries a source location like a method does (issue #3278).
+            .Where(ApiMemberSectionDescriptors.IsBodyBacked)
             .OrderBy(m => GetMemberSortOrder(m.Kind))
             .ThenBy(m => m.Name, StringComparer.Ordinal)
             .ThenBy(GetMemberSignatureSortKey, StringComparer.Ordinal)

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -547,8 +547,8 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberDetailSectionDescriptors.FidelityCauses>(HasSingleBodyBackedMember)
             .Add<ApiMemberDetailSectionDescriptors.AppliedTaste>(HasSingleBodyBackedMember)
             .Add<ApiMemberDetailSectionDescriptors.AnnotatedSource>(HasSingleBodyBackedMember)
-            .Add<ApiMemberSectionDescriptors.OriginalSource>(HasSingleMethodLikeMember)
-            .Add<ApiMemberDetailSectionDescriptors.SourceDiff>(HasSingleMethodLikeMember)
+            .Add<ApiMemberSectionDescriptors.OriginalSource>(HasSingleBodyBackedMember)
+            .Add<ApiMemberDetailSectionDescriptors.SourceDiff>(HasSingleBodyBackedMember)
             .Add<ApiMemberDetailSectionDescriptors.Calls>()
             .Add<ApiMemberDetailSectionDescriptors.ExceptionRegions>()
             .Add<ApiMemberSectionDescriptors.AllocationFacts>(HasSingleBodyBackedMember)
@@ -574,12 +574,6 @@ public static class ApiMemberOverloadSectionDescriptors
 
     private static bool HasSingleBodyBackedMember(ApiType model)
         => model.Members.Count == 1 && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
-
-    // SourceLink source-file sections (Original Source, Source Diff) resolve by the
-    // selected member's own name/token; accessor source mapping is not yet wired, so
-    // they stay method-only rather than rendering empty for a property/event (#3265).
-    private static bool HasSingleMethodLikeMember(ApiType model)
-        => model.Members.Count == 1 && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
 
     public sealed class Methods : ISectionDescriptor<ApiType>
     {
@@ -736,11 +730,10 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities =>
             SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayFetchSources;
         public static string? ScannerKey => null;
-        // SourceLink source-file sections resolve PDB sequence points by the selected
-        // member's own name/token; accessor source-line mapping is not yet wired, so a
-        // property/event stays method-only here rather than rendering empty (issue #3265).
+        // A property/event resolves through the accessor the selected ordinal addresses, whose
+        // PDB sequence points carry the authored source, so it renders like a method (#3278).
         public static bool CanRender(ApiType model)
-            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+            => model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class SourceDiff : ISectionDescriptor<ApiType>
@@ -751,10 +744,9 @@ public static class ApiMemberDetailSectionDescriptors
         public static SectionCapabilities Capabilities =>
             SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayFetchSources;
         public static string? ScannerKey => null;
-        // SourceLink source-file section; accessor source mapping not yet wired (issue #3265).
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class SourceLocations : ISectionDescriptor<ApiType>
@@ -765,10 +757,9 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool ProbeEffectiveness => false;
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
-        // SourceLink source-file section; accessor source mapping not yet wired (issue #3265).
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1
-               && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
     }
 
     public sealed class ILBody : ISectionDescriptor<ApiType>

--- a/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
@@ -467,4 +467,168 @@ public class ExtractMethodBodyTests
             "public int Fact(int n)\n{\n    return n <= 1 ? 1 : n * Fact(n - 1);\n}",
             body);
     }
+
+    [Theory]
+    [InlineData("unsafe")]
+    [InlineData("extern")]
+    [InlineData("async")]
+    [InlineData("partial")]
+    [InlineData("sealed override")]
+    [InlineData("required")]
+    public void ModifierLedDeclaration_SequencePointOnDeclaration_ExcludesPrecedingMember(string modifiers)
+    {
+        var declaration = $"    {modifiers} int Target => 1;";
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Before() => 0;",                 // 3
+            "",                                             // 4
+            declaration,                                    // 5  <- StartLine/EndLine
+            "}");                                           // 6
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "get_Target");
+
+        Assert.Equal(declaration.TrimStart(), body);
+    }
+
+    [Fact]
+    public void TupleReturningDeclaration_SequencePointOnDeclaration_ExcludesPrecedingMember()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Before() => 0;",                 // 3
+            "",                                             // 4
+            "    public (int X, int Y) Target => (1, 2);",   // 5  <- StartLine/EndLine
+            "}");                                           // 6
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "get_Target");
+
+        Assert.Equal("public (int X, int Y) Target => (1, 2);", body);
+    }
+
+    [Fact]
+    public void UnsafeBlockStatement_IsNotMistakenForDeclaration_SignatureStillCaptured()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public void Target()",                      // 3
+            "    {",                                        // 4
+            "        unsafe { Poke(); }",                    // 5  <- StartLine/EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "Target");
+
+        Assert.Equal(
+            "public void Target()\n{\n    unsafe { Poke(); }\n}",
+            body);
+    }
+
+    [Fact]
+    public void IdentifierSharingModifierPrefix_IsNotMistakenForDeclaration()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public void Target()",                      // 3
+            "    {",                                        // 4
+            "        internalCounter = 1;",                  // 5  <- StartLine/EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "Target");
+
+        Assert.Equal(
+            "public void Target()\n{\n    internalCounter = 1;\n}",
+            body);
+    }
+
+    [Fact]
+    public void ModifierlessInterfaceMember_SequencePointOnDeclaration_ExcludesPrecedingMember()
+    {
+        var source = Lines(
+            "public interface IDefault",                     // 1
+            "{",                                            // 2
+            "    int Before => 0;",                          // 3
+            "    int Target => 1;",                          // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 4, methodName: "get_Target");
+
+        Assert.Equal("int Target => 1;", body);
+    }
+
+    [Fact]
+    public void ImplicitlyPrivateAutoProperty_SequencePointOnDeclaration_ExcludesPrecedingMember()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    string? Before { get; set; }",              // 3
+            "    string? Target { get; set; }",              // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 4, methodName: "set_Target");
+
+        Assert.Equal("string? Target { get; set; }", body);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceImplementation_SequencePointOnDeclaration_ExcludesPrecedingMember()
+    {
+        var source = Lines(
+            "class C : IDefault",                           // 1
+            "{",                                            // 2
+            "    int Before => 0;",                          // 3
+            "    int IDefault.Target => 1;",                 // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(
+            source, startLine: 4, endLine: 4, methodName: "IDefault.get_Target");
+
+        Assert.Equal("int IDefault.Target => 1;", body);
+    }
+
+    [Theory]
+    [InlineData("return Target(n - 1);")]
+    [InlineData("_cache = Target();")]
+    [InlineData("var next = Target();")]
+    public void BodyLineSpellingMemberName_IsNotMistakenForDeclaration(string firstStatement)
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    int Target(int n)",                         // 3
+            "    {",                                        // 4
+            $"        {firstStatement}",                     // 5  <- StartLine/EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "Target");
+
+        Assert.Equal(
+            $"int Target(int n)\n{{\n    {firstStatement}\n}}",
+            body);
+    }
+
+    [Fact]
+    public void LocalDeclarationSpellingMemberName_IsNotMistakenForDeclaration()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public void Run()",                         // 3
+            "    {",                                        // 4
+            "        Widget Target;",                        // 5  <- StartLine/EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "Target");
+
+        Assert.Equal(
+            "public void Run()\n{\n    Widget Target;\n}",
+            body);
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
@@ -938,4 +938,21 @@ public class ExtractMethodBodyTests
             "public string Target() {\n    return @\"}\";\n}",
             body);
     }
+
+    [Fact]
+    public void OpeningBraceInsideVerbatimInterpolatedString_DoesNotLookLikeAnOpenBlock()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public string Target() => @$\"first",       // 3  <- StartLine
+            "        {{\";",                                 // 4  <- EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 4, methodName: "Target");
+
+        Assert.Equal(
+            "public string Target() => @$\"first\n    {{\";",
+            body);
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
@@ -631,4 +631,123 @@ public class ExtractMethodBodyTests
             "public void Run()\n{\n    Widget Target;\n}",
             body);
     }
+
+    [Theory]
+    [InlineData("Helper.Target();")]
+    [InlineData("_helper.Target();")]
+    [InlineData("Factory<int>.Target();")]
+    [InlineData("Outer.Inner.Target();")]
+    public void QualifiedCallSpellingMemberName_IsNotMistakenForDeclaration(string firstStatement)
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    void Target()",                             // 3
+            "    {",                                        // 4
+            $"        {firstStatement}",                     // 5  <- StartLine/EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "Target");
+
+        Assert.Equal(
+            $"void Target()\n{{\n    {firstStatement}\n}}",
+            body);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceImplementation_IsStillRecognized_DespiteQualifiedNameGuard()
+    {
+        var source = Lines(
+            "class C : IDefault",                           // 1
+            "{",                                            // 2
+            "    int Before => 0;",                          // 3
+            "    int IDefault.Target => 1;",                 // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(
+            source, startLine: 4, endLine: 4, methodName: "IDefault.get_Target");
+
+        Assert.Equal("int IDefault.Target => 1;", body);
+    }
+
+    [Fact]
+    public void ModifierlessIndexer_SequencePointOnDeclaration_ExcludesPrecedingMember()
+    {
+        var source = Lines(
+            "public interface IDefault",                     // 1
+            "{",                                            // 2
+            "    int Before => 0;",                          // 3
+            "    int this[int index] => index;",             // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 4, methodName: "get_Item");
+
+        Assert.Equal("int this[int index] => index;", body);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceIndexer_SequencePointOnDeclaration_ExcludesPrecedingMember()
+    {
+        var source = Lines(
+            "class C : IDefault",                           // 1
+            "{",                                            // 2
+            "    int Before => 0;",                          // 3
+            "    int IDefault.this[int index] => index;",    // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(
+            source, startLine: 4, endLine: 4, methodName: "IDefault.set_Item");
+
+        Assert.Equal("int IDefault.this[int index] => index;", body);
+    }
+
+    [Fact]
+    public void IndexerAccessInBody_IsNotMistakenForIndexerDeclaration()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int this[int index]",                // 3
+            "    {",                                        // 4
+            "        get => _items[index];",                 // 5  <- StartLine/EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "get_Item");
+
+        Assert.Equal(
+            "public int this[int index]\n{\n    get => _items[index];\n}",
+            body);
+    }
+
+    [Fact]
+    public void GenericModifierlessMethod_SequencePointOnDeclaration_ExcludesPrecedingMember()
+    {
+        var source = Lines(
+            "public interface IDefault",                     // 1
+            "{",                                            // 2
+            "    int Before => 0;",                          // 3
+            "    T Target<T>(T value) => value;",            // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 4, methodName: "Target");
+
+        Assert.Equal("T Target<T>(T value) => value;", body);
+    }
+
+    [Fact]
+    public void GenericReturnTypeDeclaration_IsRecognized()
+    {
+        var source = Lines(
+            "public interface IDefault",                     // 1
+            "{",                                            // 2
+            "    int Before => 0;",                          // 3
+            "    Dictionary<string, int> Target => new();",  // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 4, methodName: "get_Target");
+
+        Assert.Equal("Dictionary<string, int> Target => new();", body);
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
@@ -832,4 +832,110 @@ public class ExtractMethodBodyTests
             "public void Run()\n{\n    (var a, var b) = Target();\n}",
             body);
     }
+
+    [Theory]
+    [InlineData("ref int Target() => ref _value;")]
+    [InlineData("new int Target => 1;")]
+    [InlineData("ref readonly int Target() => ref _value;")]
+    public void RefOrNewLedDeclaration_ExcludesPrecedingMember(string declaration)
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Before => 0;",                   // 3
+            $"    {declaration}",                            // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 4, methodName: "get_Target");
+
+        Assert.Equal(declaration, body);
+    }
+
+    [Theory]
+    [InlineData("new Widget().Configure();")]
+    [InlineData("ref var slot = ref _items[0];")]
+    public void RefOrNewLedStatement_IsNotMistakenForDeclaration(string firstStatement)
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public void Target()",                      // 3
+            "    {",                                        // 4
+            $"        {firstStatement}",                     // 5  <- StartLine/EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "Target");
+
+        Assert.Equal(
+            $"public void Target()\n{{\n    {firstStatement}\n}}",
+            body);
+    }
+
+    [Fact]
+    public void BraceInsideStringLiteral_DoesNotLookLikeAnOpenBlock()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public string Target =>",                   // 3  <- StartLine
+            "        \"{\";",                                // 4  <- EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 4, methodName: "get_Target");
+
+        Assert.Equal("public string Target =>\n    \"{\";", body);
+    }
+
+    [Fact]
+    public void BraceInsideComment_DoesNotLookLikeAnOpenBlock()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public string Target => /* { */",           // 3  <- StartLine
+            "        \"x\";",                                // 4  <- EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 4, methodName: "get_Target");
+
+        Assert.Equal("public string Target => /* { */\n    \"x\";", body);
+    }
+
+    [Fact]
+    public void ClosingBraceInsideStringLiteral_DoesNotLookLikeAClosedBlock()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Before() { return 0; }",         // 3
+            "    public string Target() {",                  // 4  <- StartLine
+            "        return \"}\";",                          // 5  <- EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 5, methodName: "Target");
+
+        Assert.Equal(
+            "public string Target() {\n    return \"}\";\n}",
+            body);
+    }
+
+    [Fact]
+    public void ClosingBraceInsideVerbatimString_DoesNotLookLikeAClosedBlock()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public string Target() {",                  // 3  <- StartLine
+            "        return @\"}\";",                         // 4  <- EndLine
+            "    }",                                         // 5
+            "}");                                            // 6
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 4, methodName: "Target");
+
+        Assert.Equal(
+            "public string Target() {\n    return @\"}\";\n}",
+            body);
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
@@ -396,4 +396,75 @@ public class ExtractMethodBodyTests
     {
         Assert.Equal(expected, SourceLinkResolver.SimpleTypeName(fullName));
     }
+
+    [Fact]
+    public void AutoPropertyAccessor_SequencePointOnDeclaration_ExcludesPrecedingMember()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public string? Before { get; set; }",       // 3
+            "",                                             // 4
+            "    public string? Target { get; set; }",       // 5  <- StartLine/EndLine
+            "",                                             // 6
+            "    public string? After { get; set; }",        // 7
+            "}");                                           // 8
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "get_Target");
+
+        Assert.Equal("public string? Target { get; set; }", body);
+    }
+
+    [Fact]
+    public void ExpressionBodiedMember_FirstInType_ExcludesEnclosingTypeHeader()
+    {
+        var source = Lines(
+            "public sealed record R(int Value)",             // 1
+            "{",                                            // 2
+            "    public int Doubled => Value * 2;",          // 3  <- StartLine/EndLine
+            "}");                                           // 4
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 3, methodName: "get_Doubled");
+
+        Assert.Equal("public int Doubled => Value * 2;", body);
+    }
+
+    [Fact]
+    public void BlockBodiedPropertyAccessor_WalksBackwardToPropertyDeclaration()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public string? Tfm",                       // 3
+            "    {",                                        // 4
+            "        get => _override ?? Compute();",        // 5  <- StartLine/EndLine
+            "        set => _override = value;",             // 6
+            "    }",                                        // 7
+            "}");                                           // 8
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "get_Tfm");
+
+        Assert.Equal(
+            "public string? Tfm\n{\n    get => _override ?? Compute();",
+            body);
+    }
+
+    [Fact]
+    public void RecursiveFirstStatement_SpellingMethodName_StillCapturesSignature()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Fact(int n)",                    // 3
+            "    {",                                        // 4
+            "        return n <= 1 ? 1 : n * Fact(n - 1);",  // 5  <- StartLine/EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "Fact");
+
+        Assert.Equal(
+            "public int Fact(int n)\n{\n    return n <= 1 ? 1 : n * Fact(n - 1);\n}",
+            body);
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
@@ -750,4 +750,86 @@ public class ExtractMethodBodyTests
 
         Assert.Equal("Dictionary<string, int> Target => new();", body);
     }
+
+    [Fact]
+    public void ReturnTypeSpelledLikeMemberName_IsStillRecognizedAsDeclaration()
+    {
+        var source = Lines(
+            "public interface IDefault",                     // 1
+            "{",                                            // 2
+            "    int Before => 0;",                          // 3
+            "    CancellationToken CancellationToken => default;", // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(
+            source, startLine: 4, endLine: 4, methodName: "get_CancellationToken");
+
+        Assert.Equal("CancellationToken CancellationToken => default;", body);
+    }
+
+    [Fact]
+    public void BlockOpeningOnDeclarationLine_StillRecoversClosingBrace()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Target() {",                     // 3  <- StartLine
+            "        return 1;",                             // 4  <- EndLine
+            "    }",                                         // 5
+            "}");                                            // 6
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 4, methodName: "Target");
+
+        Assert.Equal(
+            "public int Target() {\n    return 1;\n}",
+            body);
+    }
+
+    [Fact]
+    public void SelfTerminatingSingleLineDeclaration_StillSuppressesForwardScan()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Target() { return 1; }",         // 3  <- StartLine/EndLine
+            "}");                                           // 4
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 3, methodName: "Target");
+
+        Assert.Equal("public int Target() { return 1; }", body);
+    }
+
+    [Fact]
+    public void ModifierlessTupleReturnDeclaration_ExcludesPrecedingMember()
+    {
+        var source = Lines(
+            "public interface IDefault",                     // 1
+            "{",                                            // 2
+            "    int Before => 0;",                          // 3
+            "    (int X, int Y) Target => (1, 2);",          // 4  <- StartLine/EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 4, methodName: "get_Target");
+
+        Assert.Equal("(int X, int Y) Target => (1, 2);", body);
+    }
+
+    [Fact]
+    public void DeconstructionAssignment_IsNotMistakenForTupleDeclaration()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public void Run()",                         // 3
+            "    {",                                        // 4
+            "        (var a, var b) = Target();",            // 5  <- StartLine/EndLine
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 5, endLine: 5, methodName: "Target");
+
+        Assert.Equal(
+            "public void Run()\n{\n    (var a, var b) = Target();\n}",
+            body);
+    }
 }


### PR DESCRIPTION
Answers #3278, and resolves it as an oversight rather than an intentional restriction.

## The question

#3278 asked whether `Original Source` and `Source Diff` were deliberately left on `HasSingleMethodLikeMember` while their neighbors moved to `HasSingleBodyBackedMember` in #3274, offering a plausible intentional reason: compiler-generated accessor bodies "often have no meaningful sequence points or map to the declaration line", so the section "would be empty or misleading".

## The answer: not borne out; it was an unfinished wire

I probed the PDB directly (SRM, every property accessor in `ILInspector.Metadata.dll`, classified auto vs hand-written by `CompilerGeneratedAttribute`):

| accessor kind | with sequence points | without |
| --- | --- | --- |
| hand-written | 116 | 73 |
| auto-property | 1354 | 83 |

Accessors do carry usable sequence points. Auto-property accessors map to the property's own declaration line -- which is the correct answer for "where is this property written", not a misleading one.

The real reason those three gates stayed behind is what I scoped out of #3274: source resolution addressed the selected member by *its own* name and MethodDef token. A property/event has neither (`ApiMember.MetadataToken` is null), so it resolved nothing. I held the sections back rather than let them render empty. This PR finishes the wire.

## What changed

- **`MemberCommand`** resolves a selected property/event to the accessor its ordinal addresses -- `1` = getter/adder, `2` = setter/remover, the same addressing the body sections use -- and passes that accessor's metadata name and MethodDef token to `ResolveMethodSourceAsync`. `PdbContext.ResolveMethodSource` short-circuits on a non-zero token straight to a MethodDef lookup, so this bypasses name matching entirely; the existing token-trust guard (facade / ref-vs-impl mismatch forces the token to 0) is preserved, and the accessor case uses overload index 0 for the name fallback because accessor names are unique in their type.
- **`MemberSourceLocationCollector`** maps the accessor token back onto the **owning** member rather than emitting synthetic accessor members, so a property contributes one row carrying its own signature (`public int MaxDepth { get; set; }`), not one row per accessor. Deterministic: getter/adder first, else setter/remover.
- **Gates** -- `OriginalSource` and `SourceDiff` registrations move to `HasSingleBodyBackedMember`; the `CanRender` predicates for all three move from `IsMethodLike` to `IsBodyBacked`; the now-unused `HasSingleMethodLikeMember` helper and its #3265 comment are removed. `ApiOutputFormatter.PopulateMemberSourceLocations` had the same method-only filter at render time and would otherwise have dropped the row it had just resolved.
- **Extractor fix (`SourceLinkResolver.ExtractMethodBody`)** -- the backward signature scan now stops when the first sequence point already lands on the member's declaration line. Every auto-property and expression-bodied member has that shape, and scanning back from it skipped the blank separator or opening brace above and captured **the preceding member or the enclosing type header** as the selected member's source. Pre-existing (it also hit one-line methods), but every property goes through it, so leaving it would have produced exactly the misleading output #3278 worried about.

## Scope note

The issue names only `Original Source` and `Source Diff`. #3274 reverted `Source Locations` too, and it shares the same root cause, so I included all three. Flagging it since it is slightly beyond the literal ask.

## Evidence

Real runs against a shipping assembly with real SourceLink (`System.Text.Json`, hand-written read/write `JsonSerializerOptions.MaxDepth`):

- `MaxDepth -S "Source Locations"` -> `public int MaxDepth { get; set; }` | `JsonSerializerOptions.cs` | 580
- `MaxDepth:1 -S "Original Source"` -> renders `get => _maxDepth;`, and **not** the setter body
- `MaxDepth:2 -S "Original Source"` -> renders the full validating setter through `_maxDepth = value;`
- `MaxDepth:2 -S "Source Diff"` -> authored property source vs the decompiled `set_MaxDepth` body

Failure stays visible: an accessor without sequence points resolves nothing and the section is omitted, exactly as a method without sequence points behaves today -- no success-shaped empty output. Fields have no accessor token, remain not body-backed, and are unchanged.

Tests: 3 new CLI tests (accessor source location, getter/setter ordinals resolving separately, accessor source diff) and 4 new `ExtractMethodBodyTests` (auto-property excludes preceding member; expression-bodied first-in-type excludes the type header; block-bodied accessor still walks back to the property declaration; recursive first statement still captures its signature).

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` -- clean
- `tests/ILInspector.Metadata.Tests` -- 859/859
- `src/DotnetInspector.Services.Tests` -- 319/319
- `src/dotnet-inspect.Tests` -- 2182 total, 1 failure: `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden`, which fails identically on a clean `origin/main` worktree (verified). A second failure varied per run (`DiffCommandTests...FindingTransitionsException`, then `CliDiscoverySections_AreSelectable`); both pass in isolation -- parallel/network flake, not this change.

README updated: the "SourceLink source-file sections remain method-only for now" caveat from #3274 is replaced with the accessor behavior.
