### PR TITLE
Raise object initializers in trailing constructor-argument position (#3272)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2927,6 +2927,32 @@ public class CfgSampleClass
         public void Add(int value) => Total += value;
     }
 
+    public sealed class InitConsumer
+    {
+        public InitConsumer(int tag, InitTarget target) { }
+    }
+
+    public sealed class InitConsumer3
+    {
+        public InitConsumer3(int first, int second, InitTarget target) { }
+    }
+
+    static int Identity(int value) => value;
+
+    // #3272 regression: the object initializer is the SECOND constructor argument,
+    // so the first argument is evaluated first and stays live on the stack beneath
+    // the dup chain. The stackifier cannot keep two values on the stack across the
+    // initializer's statement run, so it spills the dup temp into named locals with
+    // version copies (`t2 = t1; t2.X = ...`) — the shape the named-local matcher must
+    // now fold. Identity() keeps the first arg a computed value (as `Pipeline` was).
+    public static InitConsumer MakeConsumerWithTrailingInitializer(int tag, int a, int b)
+        => new InitConsumer(Identity(tag), new InitTarget { X = a, Y = b });
+
+    // #3272 breadth: TWO arguments precede the initializer, so two independent
+    // statements interleave before the first member store; both must be skipped.
+    public static InitConsumer3 MakeConsumerWithTwoLeadingArgs(int tag, int a, int b)
+        => new InitConsumer3(Identity(tag), Identity(a), new InitTarget { X = a, Y = b });
+
     public static InitContainer MakeNestedObject(int a, int b)
         => new InitContainer { Inner = { X = a, Y = b } };
 

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2939,6 +2939,8 @@ public class CfgSampleClass
 
     static int Identity(int value) => value;
 
+    static void SideEffect() { }
+
     // #3272 regression: the object initializer is the SECOND constructor argument,
     // so the first argument is evaluated first and stays live on the stack beneath
     // the dup chain. The stackifier cannot keep two values on the stack across the
@@ -2952,6 +2954,22 @@ public class CfgSampleClass
     // statements interleave before the first member store; both must be skipped.
     public static InitConsumer3 MakeConsumerWithTwoLeadingArgs(int tag, int a, int b)
         => new InitConsumer3(Identity(tag), Identity(a), new InitTarget { X = a, Y = b });
+
+    // #3272 adjudication probe: a side-effecting statement between new() and the
+    // first member store. Roslyn erases the local `t` and lowers this through the
+    // SAME stack-slot dup form as the trailing-argument fixtures, so the skip logic
+    // WOULD apply on shape alone — but folding via the use site would move the
+    // `newobj` after SideEffect(), reordering construction across an observable
+    // call. Here the `newobj` runs at IL offset 0 and SideEffect() at offset 5, so
+    // the offset guard (skip only statements that ran before the newobj) declines
+    // and the object stays lowered.
+    public static InitTarget MakeTargetWithVoidCallBetween(int a)
+    {
+        var t = new InitTarget();
+        SideEffect();
+        t.X = a;
+        return t;
+    }
 
     public static InitContainer MakeNestedObject(int a, int b)
         => new InitContainer { Inner = { X = a, Y = b } };

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -446,6 +446,62 @@ public class ObjectInitializerPassTests
         Assert.Contains("return new InitContainer { @else = { X = value } };", output);
     }
 
+    // #3272: the initializer sits in a trailing constructor-argument position, so a
+    // preceding argument is evaluated first and spilled to a local by the stackifier,
+    // interleaving between `new()` and the first member store. The pass now skips that
+    // independent statement and folds via the use site, restoring the source spelling
+    // (which recompiles to the original dup-chain IL — byte-neutral).
+    [Fact]
+    public void TrailingInitializerWithLeadingArgument_FoldsViaUseSite()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeConsumerWithTrailingInitializer));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.False(initializer.IsCollection);
+        Assert.Equal(["X", "Y"], initializer.Members);
+
+        // The whole dup chain and its version copies are gone: no residual slot store,
+        // property store, or spilled local survives.
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+        Assert.Empty(function.Descendants.OfType<StoreLocal>());
+
+        Assert.Contains(
+            "return new InitConsumer(Identity(tag), new InitTarget { X = a, Y = b });",
+            CSharpPrinter.Print(function).Output);
+    }
+
+    // #3272 breadth: two preceding arguments produce two interleaved statements before
+    // the first member store; both are skipped and the initializer still folds (the
+    // spilled arg locals are left for later inlining — orthogonal to this pass).
+    [Fact]
+    public void TrailingInitializerWithTwoLeadingArguments_FoldsViaUseSite()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeConsumerWithTwoLeadingArgs));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Equal(["X", "Y"], initializer.Members);
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+
+        Assert.Contains(
+            "new InitTarget { X = a, Y = b }",
+            CSharpPrinter.Print(function).Output);
+    }
+
+    // Close negative for the skip guard: an interleaved statement that READS the
+    // threaded reference before the first member store is not independent, so it must
+    // break the run (never be skipped) and leave the object lowered.
+    [Fact]
+    public void ForeignReadBeforeMembers_StaysLowered()
+    {
+        var function = FunctionWithForeignReadBeforeFirstMember();
+        IrPasses.Run(function);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+    }
+
     static IrFunction FunctionWithSetter(bool generic, string propertyName = "set_Value")
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "Owner");
@@ -549,6 +605,44 @@ public class ObjectInitializerPassTests
         body.Add(block);
         return new IrFunction(
             "ClobberedReceiver",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(type, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    // A `new()` followed — before any member store — by a statement that reads the
+    // freshly-constructed reference (Observe(t)) and only then a member store. The read
+    // is not independent of the reference, so the pass must not skip it; the object
+    // stays lowered.
+    static IrFunction FunctionWithForeignReadBeforeFirstMember()
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var setter = new MethodRef(type, "set_X", voidType, [intType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+        var observe = new MethodRef(
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            "Observe",
+            voidType,
+            [type],
+            HasThis: false);
+
+        const int slot = 256;
+        var block = new Block();
+        block.Add(new StoreStackSlot(slot, new NewObject(ctor, [])));
+        block.Add(new ExpressionStatement(new Call(observe, isVirtual: false, [new LoadStackSlot(slot, type)])));
+        block.Add(new StoreProperty(setter, new LoadStackSlot(slot, type), [], new Constant(1, intType)));
+        block.Add(new Return(new LoadStackSlot(slot, type)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "ForeignReadBeforeMembers",
             TypeRef.Definition("Synthetic", "Samples", "Owner"),
             new MethodSignature(type, [], HasThis: false, GenericParameterCount: 0),
             [],

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -502,6 +502,21 @@ public class ObjectInitializerPassTests
         Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
     }
 
+    // #3272 provenance guard, real reachable case: `var t = new(); SideEffect(); t.X =
+    // a; return t;`. Roslyn erases `t` into the SAME stack-slot dup form as the
+    // trailing-argument fixtures, so the interleaved SideEffect() call is slot-
+    // independent and would be skipped on shape alone. But the `newobj` runs BEFORE
+    // SideEffect() in the original IL (offset 0 vs 5); folding via the use site would
+    // move the construction after the call, an observable reorder. The offset guard
+    // declines the skip, so the object must stay lowered.
+    [Fact]
+    public void ReorderingVoidCallBetween_StaysLowered()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeTargetWithVoidCallBetween));
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+    }
+
     static IrFunction FunctionWithSetter(bool generic, string propertyName = "set_Value")
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "Owner");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -196,7 +196,20 @@ public sealed class ObjectInitializerPass : IIrPass
             // (never the seed), which keeps the member stores after this statement in
             // their original order. Only tolerated before the first entry so no member
             // store is ever reordered across it.
-            if (entries.Count == 0 && pendingInner is null && !TouchesAnySlot(statement, aliasSlots))
+            //
+            // Skipping is only sound when the statement's own computation already
+            // executed BEFORE the `newobj` (its IL offset precedes the creation's).
+            // Use-site folding moves the `newobj` after the skipped statement, so a
+            // statement that originally ran after the `newobj` (e.g. `t = new();
+            // SideEffect(); t.X = ...`, where Roslyn erased the named local into this
+            // dup form) would have its construction reordered across it — observable
+            // if the constructor or the statement has side effects. The offset guard
+            // admits only genuine preceding-argument spills, which the compiler always
+            // emits before the `newobj`.
+            if (entries.Count == 0
+                && pendingInner is null
+                && !TouchesAnySlot(statement, aliasSlots)
+                && ExecutesBefore(statement, creation))
             {
                 skipped.Add(statement);
                 continue;
@@ -623,6 +636,50 @@ public sealed class ObjectInitializerPass : IIrPass
                 return true;
         }
         return false;
+    }
+
+    // True when the statement's own computation completed BEFORE `creation`'s
+    // `newobj` executed in the original IL, so keeping it ahead of the folded
+    // `newobj` preserves observable order. See EffectOffset for how the offset is
+    // derived. Missing offsets decline the skip (conservative).
+    static bool ExecutesBefore(IrNode statement, NewObject creation)
+    {
+        int creationOffset = creation.SourceOffset;
+        if (creationOffset < 0)
+            return false;
+        int effect = EffectOffset(statement);
+        return effect >= 0 && effect < creationOffset;
+    }
+
+    // The latest IL offset at which the statement's side effect is observed. Later
+    // passes can rebuild a value's root node (e.g. property-access recognition)
+    // and drop its offset, so scan the whole value subtree and take the max
+    // retained offset rather than trusting the root alone. The store/expression
+    // wrapper's own offset is a stackifier artifact that can fall after the
+    // `newobj`, so it is excluded — only the value's computation counts. Because a
+    // statement's operands execute in the same window as the statement, this max
+    // is a sound bound: a statement that ran before the `newobj` has every
+    // retained offset below the creation offset, and one that ran after has every
+    // retained offset above it (or none, which conservatively declines the skip).
+    static int EffectOffset(IrNode statement)
+    {
+        var value = statement switch
+        {
+            StoreStackSlot store => (IrNode)store.Value,
+            StoreLocal store => store.Value,
+            ExpressionStatement expr => expr.Expression,
+            _ => statement,
+        };
+        return MaxOffsetInSubtree(value);
+    }
+
+    static int MaxOffsetInSubtree(IrNode node)
+    {
+        int max = node.SourceOffset;
+        foreach (var descendant in node.Descendants)
+            if (descendant.SourceOffset > max)
+                max = descendant.SourceOffset;
+        return max;
     }
 
     static bool ReferencesLocal(IrNode node, int index)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -102,6 +102,12 @@ public sealed class ObjectInitializerPass : IIrPass
         var aliasSlots = new HashSet<int> { seed.Slot };
         var consumed = new List<IrNode> { seed };
         var entries = new List<EntryPlan>();
+        // Statements interleaved before the first initializer entry that are
+        // independent of the threaded reference (a sibling constructor argument
+        // spilled to its own slot because it was live on the stack beneath this dup
+        // chain). They are left in place and the escape is treated as if they were
+        // not present. See the skip branch below.
+        var skipped = new List<IrNode>();
         bool? isCollection = null;
 
         // A run of nested ops on the same member folds into one InitializerBlock
@@ -181,6 +187,21 @@ public sealed class ObjectInitializerPass : IIrPass
                 continue;
             }
 
+            // A statement interleaved before the first initializer entry that neither
+            // reads nor writes the threaded reference — e.g. `t = new(); a = Other();
+            // t.X = ...` where `a` is a preceding constructor argument the stackifier
+            // spilled because it was live beneath the dup chain. It cannot observe the
+            // partially-built object, so leave it in place and skip it; the escape
+            // logic below treats it as a permitted gap and folds via the use site
+            // (never the seed), which keeps the member stores after this statement in
+            // their original order. Only tolerated before the first entry so no member
+            // store is ever reordered across it.
+            if (entries.Count == 0 && pendingInner is null && !TouchesAnySlot(statement, aliasSlots))
+            {
+                skipped.Add(statement);
+                continue;
+            }
+
             break;
         }
 
@@ -224,6 +245,10 @@ public sealed class ObjectInitializerPass : IIrPass
         // statements sit between the run and the escape, materialize the initializer at
         // the original seed instead: that keeps member-value side effects before the
         // gap and still collapses the compiler temp chain into one initialized value.
+        // Skipped pre-entry statements (see the loop) are permitted gaps: they must be
+        // folded via the use site so the member stores stay after them, never via the
+        // seed (which would hoist the member stores before them).
+        var skippedSet = skipped.ToHashSet();
         IrNode escapeStatement = outsideUses[0];
         while (escapeStatement.Parent is { } parent && !ReferenceEquals(parent, seed.Parent))
             escapeStatement = parent;
@@ -232,12 +257,19 @@ public sealed class ObjectInitializerPass : IIrPass
         bool contiguousEscape = true;
         for (int i = seed.ChildIndex + 1; i < escapeStatement.ChildIndex; i++)
         {
-            if (!consumedSet.Contains(statements[i]))
+            var between = statements[i];
+            if (!consumedSet.Contains(between) && !skippedSet.Contains(between))
             {
                 contiguousEscape = false;
                 break;
             }
         }
+
+        // A skip forces use-site folding. If the escape is not contiguous (a real gap
+        // after the members that would need seed materialization), seed folding would
+        // hoist the members before the skipped statement — unsound — so decline.
+        if (!contiguousEscape && skipped.Count != 0)
+            return null;
 
         return new Plan(
             consumed,
@@ -569,6 +601,29 @@ public sealed class ObjectInitializerPass : IIrPass
     static bool ReferencesAnySlot(IrNode node, HashSet<int> slots)
         => (node is LoadStackSlot load && slots.Contains(load.Slot))
             || node.Descendants.OfType<LoadStackSlot>().Any(descendant => slots.Contains(descendant.Slot));
+
+    /// <summary>
+    /// Whether a statement subtree reads or writes any of the threaded-reference
+    /// slots. Used to prove an interleaved statement is independent of the object
+    /// under construction before skipping it: independence requires it neither
+    /// loads the reference (observing the partial object) nor stores an alias slot
+    /// (clobbering the reference).
+    /// </summary>
+    static bool TouchesAnySlot(IrNode node, HashSet<int> slots)
+    {
+        if (node is LoadStackSlot load && slots.Contains(load.Slot))
+            return true;
+        if (node is StoreStackSlot store && slots.Contains(store.Slot))
+            return true;
+        foreach (var descendant in node.Descendants)
+        {
+            if (descendant is LoadStackSlot d && slots.Contains(d.Slot))
+                return true;
+            if (descendant is StoreStackSlot s && slots.Contains(s.Slot))
+                return true;
+        }
+        return false;
+    }
 
     static bool ReferencesLocal(IrNode node, int index)
         => (node is LoadLocal load && load.Index == index)


### PR DESCRIPTION
- Fixes #3272
- Changes: raises object initializers that sit in a trailing constructor-argument position (the preceding argument spilled beneath the dup chain no longer breaks the run)
- Card revision: `5b31d4d1`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the verbose version-copy expansion folds to the canonical `new T(arg, new U { ... })`, which recompiles to the original IL (byte-neutral) and matches the style oracle's preference for object initializers.

### Benchmark target

Benchmark target: `OpenAI@2.12.0`

dotnet-inspect command:

```bash
dotnet-inspect member OpenAI.OpenAIClient GetRealtimeClient -S "Decompiled Source" --package OpenAI
```

### Original source

SourceLink cannot supply C# for this package (no source server), so the raw IL section is the authoritative anchor. It is the canonical dup-chain initializer lowering: `Pipeline` (arg0) is evaluated first, then `newobj RealtimeClientOptions`, `(dup; get; set)×4`, then `newobj RealtimeClient`.

```il
IL_0000: ldarg.0
IL_0001: call         OpenAI.OpenAIClient::get_Pipeline()
IL_0006: newobj       OpenAI.Realtime.RealtimeClientOptions::.ctor()
IL_000B: dup
IL_000C: ldarg.0
IL_000D: ldfld        OpenAI.OpenAIClient::_options
IL_0012: callvirt     OpenAI.OpenAIClientOptions::get_Endpoint()
IL_0017: callvirt     OpenAI.Realtime.RealtimeClientOptions::set_Endpoint(System.Uri)
IL_001C: dup
...  (get/set OrganizationId, ProjectId, UserAgentApplicationId)
IL_004F: newobj       OpenAI.Realtime.RealtimeClient::.ctor(System.ClientModel.Primitives.ClientPipeline, OpenAI.Realtime.RealtimeClientOptions)
IL_0054: ret
```

### Before

```csharp
public virtual OpenAI.Realtime.RealtimeClient GetRealtimeClient()
{
    RealtimeClientOptions S_256 = new();
    ClientPipeline S_257 = Pipeline;
    S_256.Endpoint = _options.Endpoint;
    RealtimeClientOptions S_258 = S_256;
    S_258.OrganizationId = _options.OrganizationId;
    RealtimeClientOptions S_259 = S_258;
    S_259.ProjectId = _options.ProjectId;
    RealtimeClientOptions S_260 = S_259;
    S_260.UserAgentApplicationId = _options.UserAgentApplicationId;
    return new RealtimeClient(S_257, S_260);
}
```

- Valid: True
- Correct: True
- IL fidelity: False (the version-copy expansion recompiles with extra local spills and an allocation reorder, not the original opcodes)
- Taste applied: None
- Commit: `729cc359` (origin/main)

The `S_257 = Pipeline` spill (the first constructor argument, live on the stack beneath the dup chain) interleaves between `new()` and the first member store, breaking the stack-slot matcher's run.

### After

```csharp
public virtual OpenAI.Realtime.RealtimeClient GetRealtimeClient() => new RealtimeClient(Pipeline, new RealtimeClientOptions { Endpoint = _options.Endpoint, OrganizationId = _options.OrganizationId, ProjectId = _options.ProjectId, UserAgentApplicationId = _options.UserAgentApplicationId });
```

- Valid: True
- Correct: True
- IL fidelity: True (recompiles to the Original-source IL above; verified by a Roslyn opcode-stream comparison of the folded vs expanded spellings)
- Taste applied: None
- Commit: `5b31d4d1`

### Fully raised

The After decompilation is in the fully raised state.

## Change detail

`ObjectInitializerPass`'s stack-slot matcher threads a freshly-constructed reference through a dup chain, applying member stores until the reference escapes once. When the initializer is a trailing constructor argument, the stackifier spills the *preceding* argument to its own slot (it is live on the stack beneath the dup chain), producing a store interleaved between `new()` and the first member store. The matcher broke its run at that first non-matching statement.

The fix teaches the matcher to **skip** a statement interleaved *before the first initializer entry* that neither reads nor writes the threaded reference (`TouchesAnySlot`) — a sibling argument that cannot observe the partially-built object. Guardrails:

- Skips are tolerated **only before the first entry**, so no member store is ever reordered across a skipped statement.
- A skip **forces use-site folding** (the members stay after the skipped statement, restoring source order). Seed materialization would hoist the members *before* the skipped statement, so a genuine post-member gap combined with a skip declines instead of folding unsoundly.
- All existing guards are preserved: single escape, no clobber, no self-reference, no duplicate members.

## Evidence

| Check | Baseline (origin/main `729cc359`) | Head (`5b31d4d1`) |
| --- | --- | --- |
| `ObjectInitializerPassTests` | 30/30 pass | 33/33 pass (3 new) |
| `Area=Pass` fast (`-trait- Speed=Slow`) | pass | 1348/1348 pass |
| Full decompiler fast suite | 5 pre-existing RoundTrip compile-back-fragment fails | same 5 fails, 0 new |
| Real corpus target (`OpenAI@2.12.0`) | verbose version-copy expansion | fully raised (above) |

Byte-neutrality proof: a self-contained Roslyn compile of the folded spelling `new InitConsumer(Identity(tag), new InitTarget { X = a, Y = b })` emits the identical opcode stream as the OpenAI Original-source IL (Pipeline/arg0 first, dup-chain, no locals). The expanded version-copy source compiles to a different stream (newobj-first + local spills), confirming Before was byte-divergent and After restores the original.

The 5 RoundTrip failures (`ReturnToSenderPrototypeTests`, `GeneratedFixtureCatalogTests`) reproduce **unchanged** on a clean `origin/main` build — pre-existing, environmental (compile-back body-fragment expectations under the current preview SDK), not introduced here.

## Follow-up

The equivalent named-local `TryBuild` path could gain the same interleave tolerance, but no corpus case exercises it (OpenAI and the synthetic fixtures lower through the stack-slot path). Deferred until a reproducing shape appears.
