### PR TITLE
Add inclusive-terminology guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,17 @@ skill listing.
   presentation as separate concerns. Do not infer one from display text when a
   typed identity exists.
 
+### Terminology
+
+Prefer inclusive terminology in code, identifiers, comments, output, and docs.
+These substitutions are required, not stylistic:
+
+- Write "allow list" instead of "whitelist".
+- Write "deny list" instead of "blacklist".
+
+Match the surrounding casing and word form when substituting (for example
+`allowList`/`AllowList` for an identifier, "deny-listed" for an adjective).
+
 ## Evidence and validation
 
 Match evidence to the claim and use the smallest existing check that proves it:


### PR DESCRIPTION
## What

Turns a recurring review comment into official repository guidance. Adds a **Terminology** subsection under *Repository-wide engineering constraints* in `AGENTS.md` requiring:

- "allow list" instead of "whitelist"
- "deny list" instead of "blacklist"

The guidance applies across code, identifiers, comments, output, and docs, and instructs matching surrounding casing and word form when substituting.

## Scope

Docs-only. No existing `whitelist`/`blacklist` occurrences in `AGENTS.md` — this is purely codifying guidance, not a rename.

## Validation

No measured behavior claim, so Markdown validation only: `npx markdownlint-cli AGENTS.md` is clean.

## Review

Trivial, docs-only governance addition with no behavior change → no adversarial review required per the tiered policy.