### PR TITLE
Apply inclusive-terminology guidance to test comments

### DIFF
--- a/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OuterTypePatternDispatchRaisingTests.cs
@@ -289,7 +289,7 @@ public class OuterTypePatternDispatchRaisingTests
     {
         // GPT review (#3124): csc emits `isinst T; unbox.any T; stloc T` for an
         // unconstrained (or struct-constrained) generic parameter, and `T t` is a
-        // legal C# declaration pattern. An over-strict kind whitelist wrongly
+        // legal C# declaration pattern. An over-strict kind allow list wrongly
         // declined these; IsSpellableValueTypePattern now admits generic
         // parameters directly, so the value-type arm raises — matching the shape
         // the compiler itself produces.

--- a/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ThisQualificationTests.cs
@@ -394,7 +394,7 @@ public sealed class ThisQualificationTests
     // A boxed `this` reaching a NON-VIRTUAL `System.Object` member
     // (`base.GetType()`) renders `base.GetType()`. `System.Object` is a struct's
     // (transitive) base class, so `base.GetType()` lowers to `ldobj; box; call
-    // object::GetType`, matching the source; the printer whitelists both a struct's
+    // object::GetType`, matching the source; the printer allow-lists both a struct's
     // base classes (ValueType and Object) for the base arm. `GetType` is public and
     // non-virtual, so `((object)this).GetType()` would ALSO round-trip, but the
     // printer prefers `base.` (the source spelling, and the only valid spelling for
@@ -415,7 +415,7 @@ public sealed class ThisQualificationTests
     // object::MemberwiseClone`; the cast `((object)this).MemberwiseClone()` is
     // CS1540 (a protected member cannot be accessed through a base-typed qualifier),
     // so the object-cast fallback that serves public members like `GetType` must NOT
-    // apply here. The base arm whitelisting both base classes (ValueType and Object)
+    // apply here. The base arm allow-listing both base classes (ValueType and Object)
     // keeps this valid. The method-group form must likewise stay `base.`.
     [Fact]
     public void StructBoxedThis_ProtectedObjectCallee_RendersBaseCall()
@@ -1035,7 +1035,7 @@ public struct StructSealedDimReceiver : ISealedDim
 // A boxed struct `this` reaching a NON-VIRTUAL `System.Object` member via `base.`
 // (#3213 review). `base.GetType()` lowers to `ldobj; box; call object::GetType` —
 // `System.Object` is one of a struct's two base classes (with `System.ValueType`),
-// both whitelisted for the `base.` arm, so this renders `base.GetType()`. `GetType`
+// both allow-listed for the `base.` arm, so this renders `base.GetType()`. `GetType`
 // is public and non-virtual, so `((object)this).GetType()` would also round-trip,
 // but the printer prefers the source `base.` spelling.
 public struct StructBaseGetType
@@ -1049,7 +1049,7 @@ public struct StructBaseGetType
 // object::MemberwiseClone; newobj`. `MemberwiseClone` is protected, so the
 // `((object)this).MemberwiseClone()` cast that serves a public member like
 // `GetType` is CS1540 here — only `base.` compiles, which is why the base arm must
-// whitelist `System.Object` (not just `System.ValueType`).
+// allow-list `System.Object` (not just `System.ValueType`).
 public struct StructMemberwiseCloneReceiver
 {
     public object CloneCall() => base.MemberwiseClone();


### PR DESCRIPTION
## What

Follow-up sweep after #3293 codified the inclusive-terminology guidance in `AGENTS.md`. Brings the existing tree into line with it.

A full-repo scan for the prohibited terms found:

- **`blacklist`** — 0 occurrences.
- **`whitelist`** — 5 occurrences, all in decompiler-test *comments* (`OuterTypePatternDispatchRaisingTests.cs`, `ThisQualificationTests.cs`).

Each is rewritten to the required form, matching word form and casing:

- noun → "allow list"
- verb/adjective → "allow-lists" / "allow-listing" / "allow-listed" / "allow-list"

## Scope

Comment-only. No code, identifiers, control flow, or output touched — zero behavior change.

## Validation

No measured behavior claim and no Markdown changed, so no product build/test or markdownlint is applicable. `diff` confirms every changed line is a `//` comment.

## Review

Trivial, comment-only cleanup with no behavior change → no adversarial review required per the tiered policy.