### PR TITLE
Split CallGraphMermaid into a format-neutral projector plus Mermaid emission

### DIFF
--- a/src/ILInspector.Analysis.Tests/CallGraphProjectionTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphProjectionTests.cs
@@ -1,0 +1,336 @@
+using System.Collections.Immutable;
+
+using ILInspector.Analysis;
+using ILInspector.CallGraph;
+
+namespace ILInspector.Analysis.Tests;
+
+/// <summary>
+/// Covers the format-neutral call-graph projection (issue #3291) as typed data rather
+/// than as rendered text: edge inversion, generic-erased node identity, duplicate and
+/// cycle collapsing, node-kind precedence, loop-edge merging, and deterministic node and
+/// edge ordering. <see cref="CallGraphMermaidTests"/> covers the Mermaid emission on top
+/// of this; these tests exist so graph semantics are asserted directly and a future host
+/// that renders a table or a tree is not relying on Mermaid text to prove them.
+/// Trees are constructed directly so the projection is exercised in isolation from IL
+/// decoding.
+/// </summary>
+public class CallGraphProjectionTests
+{
+    static TypeRef Type(string name) => TypeRef.Definition("Sample", "Sample", name);
+
+    static MemberRef Member(string typeName, string method, params TypeRef[] parameters)
+        => new(Type(typeName), method, [.. parameters], TypeRef.CoreLib("System", "Void"), MemberKind.Method);
+
+    static CallTreePerf Perf(bool inLoop, string? loopHint)
+        => new(0, 0, 1, inLoop, loopHint);
+
+    static CallTreeNode Node(
+        MemberRef member,
+        CallTreeStatus status,
+        ImmutableArray<CallTreeNode> children,
+        bool inLoop = false,
+        string? loopHint = null)
+        => new(member, null, status, children, Perf(inLoop, loopHint));
+
+    static CallTreeNode Leaf(
+        MemberRef member,
+        CallTreeStatus status = CallTreeStatus.Leaf,
+        bool inLoop = false,
+        string? loopHint = null)
+        => Node(member, status, [], inLoop, loopHint);
+
+    static (int From, int To, string? Loop)[] EdgeTuples(CallGraphProjection projection)
+        => [.. projection.Edges.Select(e => (e.From, e.To, e.LoopLabel))];
+
+    [Fact]
+    public void FocusIsAlwaysNodeZero()
+    {
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("Target", "Run"), CallTreeStatus.Expanded, [Leaf(Member("Svc", "Do"))]));
+
+        Assert.Equal(0, projection.Focus.Id);
+        Assert.Equal(CallGraphNodeKind.Focus, projection.Focus.Kind);
+        Assert.Same(projection.Nodes[0], projection.Focus);
+    }
+
+    [Fact]
+    public void CalleeEdgesPointFromFocusToCallee()
+    {
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("Target", "Run"), CallTreeStatus.Expanded, [Leaf(Member("Svc", "Do"))]));
+
+        // Outbound: the selected overload calls its callee.
+        Assert.Equal([(0, 1, (string?)null)], EdgeTuples(projection));
+    }
+
+    [Fact]
+    public void CallerEdgesAreInvertedToPointIntoFocus()
+    {
+        var projection = CallGraphProjection.FromCallers(
+            Node(Member("Target", "Run"), CallTreeStatus.Expanded, [Leaf(Member("Client", "Invoke"))]));
+
+        // Inbound: a reverse tree records the caller as a child, but the projected edge
+        // must be oriented caller -> callee so a host never has to invert it.
+        Assert.Equal([(1, 0, (string?)null)], EdgeTuples(projection));
+    }
+
+    [Fact]
+    public void NodesAreOrderedFocusThenCallersThenCallees()
+    {
+        var target = Member("Widget", "Build");
+        var callers = Node(target, CallTreeStatus.Expanded, [Leaf(Member("Program", "Main"))]);
+        var callees = Node(target, CallTreeStatus.Expanded, [Leaf(Member("Store", "Save"))]);
+
+        var projection = CallGraphProjection.Create(callers, callees);
+
+        Assert.Equal(
+            ["Widget.Build()", "Program.Main()", "Store.Save()"],
+            projection.Nodes.Select(n => n.Label));
+        // Ids are dense and match position: hosts index into Nodes by edge endpoint.
+        Assert.Equal([0, 1, 2], projection.Nodes.Select(n => n.Id));
+    }
+
+    [Fact]
+    public void ProjectionIsDeterministicAcrossRuns()
+    {
+        var target = Member("Widget", "Build");
+        var callers = Node(target, CallTreeStatus.Expanded,
+        [
+            Node(Member("Api", "Handle"), CallTreeStatus.Expanded, [Leaf(Member("Program", "Main"))]),
+            Leaf(Member("Loop", "Tick"), inLoop: true, loopHint: "loop call"),
+        ]);
+        var callees = Node(target, CallTreeStatus.Expanded,
+        [
+            Leaf(Member("Store", "Save")),
+            Leaf(Member("Log", "Write"), CallTreeStatus.External),
+        ]);
+
+        var first = CallGraphProjection.Create(callers, callees);
+        var second = CallGraphProjection.Create(callers, callees);
+
+        Assert.Equal(first.Nodes.Select(n => (n.Id, n.Label, n.Kind)), second.Nodes.Select(n => (n.Id, n.Label, n.Kind)));
+        Assert.Equal(EdgeTuples(first), EdgeTuples(second));
+
+        // Ordering is contract, so pin it exactly: focus, caller DFS, callee DFS.
+        Assert.Equal(
+            ["Widget.Build()", "Api.Handle()", "Program.Main()", "Loop.Tick()", "Store.Save()", "Log.Write()"],
+            first.Nodes.Select(n => n.Label));
+        Assert.Equal(
+            [(1, 0, null), (2, 1, null), (3, 0, "loop call"), (0, 4, null), (0, 5, null)],
+            EdgeTuples(first));
+    }
+
+    [Fact]
+    public void SharedCalleeCollapsesToOneNodeWithTwoIncomingEdges()
+    {
+        var shared = Member("Shared", "S");
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("Root", "M"), CallTreeStatus.Expanded,
+            [
+                Node(Member("A", "A"), CallTreeStatus.Expanded, [Leaf(shared)]),
+                Node(Member("B", "B"), CallTreeStatus.Expanded, [Leaf(shared, CallTreeStatus.AlreadyShown)]),
+            ]));
+
+        Assert.Single(projection.Nodes, n => n.Label == "Shared.S()");
+        Assert.Contains((1, 2, (string?)null), EdgeTuples(projection));
+        Assert.Contains((3, 2, (string?)null), EdgeTuples(projection));
+    }
+
+    [Fact]
+    public void CycleCollapsesBackToTheSameNode()
+    {
+        // A -> B -> A (the second A is recorded AlreadyShown by the tree builder).
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("A", "A"), CallTreeStatus.Expanded,
+            [
+                Node(Member("B", "B"), CallTreeStatus.Expanded,
+                    [Leaf(Member("A", "A"), CallTreeStatus.AlreadyShown)]),
+            ]));
+
+        Assert.Equal(2, projection.Nodes.Length);
+        Assert.Equal([(0, 1, (string?)null), (1, 0, (string?)null)], EdgeTuples(projection));
+    }
+
+    [Fact]
+    public void GenericSelfRecursionCollapsesOntoTheFocusNode()
+    {
+        // The root is built as an open definition while the recursive callee edge is a
+        // constructed MethodSpec. Both must erase to one identity, so recursion is a
+        // self-loop rather than two same-named nodes.
+        var openReturn = TypeRef.MethodGenericParameter(0, "T");
+        var rootMember = new MemberRef(Type("Calc"), "Recurse", [], openReturn, MemberKind.Method) { GenericArity = 1 };
+        var recursiveCall = new MemberRef(Type("Calc"), "Recurse", [], TypeRef.CoreLib("System", "Int32"), MemberKind.Method)
+        {
+            GenericArity = 1,
+            TypeArguments = [TypeRef.CoreLib("System", "Int32")],
+            OpenReturnType = openReturn,
+        };
+
+        var projection = CallGraphProjection.FromCallees(
+            Node(rootMember, CallTreeStatus.Expanded, [Leaf(recursiveCall, CallTreeStatus.AlreadyShown)]));
+
+        Assert.Single(projection.Nodes);
+        Assert.Equal([(0, 0, (string?)null)], EdgeTuples(projection));
+    }
+
+    [Fact]
+    public void IdentityComesFromMemberNotLabel()
+    {
+        // Two members whose declaring type shares namespace + name but differs by assembly
+        // produce the SAME label yet must stay distinct nodes. This is the guard against a
+        // host (or a future refactor) keying nodes on display text.
+        var fromA = new MemberRef(TypeRef.Definition("AsmA", "Shared", "Widget"), "Work", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method);
+        var fromB = new MemberRef(TypeRef.Definition("AsmB", "Shared", "Widget"), "Work", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method);
+
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("Target", "Run"), CallTreeStatus.Expanded, [Leaf(fromA), Leaf(fromB)]));
+
+        Assert.Equal(3, projection.Nodes.Length);
+        Assert.Equal(projection.Nodes[1].Label, projection.Nodes[2].Label);
+        Assert.NotEqual(projection.Nodes[1].Member.DeclaringType.Assembly, projection.Nodes[2].Member.DeclaringType.Assembly);
+    }
+
+    [Fact]
+    public void ReturnTypeOnlyOverloadsStayDistinct()
+    {
+        var toInt = new MemberRef(Type("Conv"), "op_Implicit", [Type("Src")], TypeRef.CoreLib("System", "Int32"), MemberKind.Method);
+        var toString = new MemberRef(Type("Conv"), "op_Implicit", [Type("Src")], TypeRef.CoreLib("System", "String"), MemberKind.Method);
+
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("Target", "Run"), CallTreeStatus.Expanded, [Leaf(toInt), Leaf(toString)]));
+
+        Assert.Equal(3, projection.Nodes.Length);
+    }
+
+    [Theory]
+    [InlineData(CallTreeStatus.External, CallGraphNodeKind.External)]
+    [InlineData(CallTreeStatus.DepthLimited, CallGraphNodeKind.Truncated)]
+    [InlineData(CallTreeStatus.Truncated, CallGraphNodeKind.Truncated)]
+    [InlineData(CallTreeStatus.Leaf, CallGraphNodeKind.Normal)]
+    [InlineData(CallTreeStatus.Expanded, CallGraphNodeKind.Normal)]
+    [InlineData(CallTreeStatus.AlreadyShown, CallGraphNodeKind.Normal)]
+    public void StatusMapsToNodeKind(CallTreeStatus status, CallGraphNodeKind expected)
+    {
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("Target", "Run"), CallTreeStatus.Expanded, [Leaf(Member("Other", "Work"), status)]));
+
+        Assert.Equal(expected, projection.Nodes[1].Kind);
+    }
+
+    [Fact]
+    public void StrongestKindWinsWhenAMemberIsReachedTwice()
+    {
+        var repeated = Member("Deep", "Work");
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("Root", "M"), CallTreeStatus.Expanded,
+            [
+                // Expanded in one place ...
+                Node(repeated, CallTreeStatus.Expanded, [Leaf(Member("Leaf", "L"))]),
+                // ... depth-limited in another. Expanded outranks the boundary.
+                Leaf(repeated, CallTreeStatus.DepthLimited),
+            ]));
+
+        Assert.Equal(CallGraphNodeKind.Normal, projection.Nodes[1].Kind);
+    }
+
+    [Fact]
+    public void FocusKindIsStickyWhenTheFocusIsAlsoReachedAsABoundary()
+    {
+        var target = Member("A", "A");
+        var projection = CallGraphProjection.FromCallees(
+            Node(target, CallTreeStatus.Expanded,
+            [
+                Node(Member("B", "B"), CallTreeStatus.Expanded,
+                    [Leaf(target, CallTreeStatus.DepthLimited)]),
+            ]));
+
+        // The focus must not be demoted to a dead end by a depth-limited back edge.
+        Assert.Equal(CallGraphNodeKind.Focus, projection.Nodes[0].Kind);
+    }
+
+    [Fact]
+    public void LoopAnnotationSurvivesEdgeCollapse()
+    {
+        // The same caller->callee edge seen twice, looped at only one call site, keeps the
+        // loop annotation rather than losing it to whichever site was visited last.
+        var shared = Member("Cache", "Get");
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("Root", "M"), CallTreeStatus.Expanded,
+            [
+                Leaf(shared),
+                Leaf(shared, inLoop: true, loopHint: "hot loop"),
+            ]));
+
+        Assert.Equal([(0, 1, "hot loop")], EdgeTuples(projection));
+    }
+
+    [Fact]
+    public void LoopWithoutHintFallsBackToGenericLabel()
+    {
+        var projection = CallGraphProjection.FromCallees(
+            Node(Member("Target", "Run"), CallTreeStatus.Expanded,
+            [Leaf(Member("Svc", "Do"), inLoop: true, loopHint: null)]));
+
+        Assert.Equal([(0, 1, "loop")], EdgeTuples(projection));
+    }
+
+    [Fact]
+    public void UnsupportedCalleeRootCollapsesOntoResolvedFocus()
+    {
+        var resolved = Member("Widget", "Build");
+        var callers = Node(resolved, CallTreeStatus.Expanded, [Leaf(Member("Program", "Main"))]);
+        var calleeRoot = Leaf(MemberRef.Unsupported("method token 0x06000001"));
+
+        var projection = CallGraphProjection.Create(callers, calleeRoot);
+
+        Assert.Equal(2, projection.Nodes.Length);
+        Assert.Equal("Widget.Build()", projection.Focus.Label);
+        Assert.Equal([(1, 0, (string?)null)], EdgeTuples(projection));
+    }
+
+    [Fact]
+    public void RejectsDifferentSelectedMembers()
+    {
+        var callers = Leaf(Member("Target", "Run"), CallTreeStatus.Expanded);
+        var callees = Leaf(Member("Other", "Run"), CallTreeStatus.Expanded);
+
+        Assert.Throws<ArgumentException>(() => CallGraphProjection.Create(callers, callees));
+    }
+
+    [Fact]
+    public void RejectsDifferentUnsupportedRoots()
+    {
+        var callers = Leaf(MemberRef.Unsupported("method token 0x06000001"));
+        var callees = Leaf(MemberRef.Unsupported("method token 0x06000002"));
+
+        Assert.Throws<ArgumentException>(() => CallGraphProjection.Create(callers, callees));
+    }
+
+    [Fact]
+    public void RejectsEmptyInput()
+        => Assert.Throws<ArgumentException>(() => CallGraphProjection.Create(null, null));
+
+    [Fact]
+    public void RejectsNullSingleSidedRoots()
+    {
+        Assert.Throws<ArgumentNullException>(() => CallGraphProjection.FromCallers(null!));
+        Assert.Throws<ArgumentNullException>(() => CallGraphProjection.FromCallees(null!));
+    }
+
+    [Fact]
+    public void MermaidEmissionAgreesWithTheProjectionItRendersFrom()
+    {
+        // The seam itself: rendering a pre-built projection must produce exactly what
+        // rendering from the roots produces, so a host can hold the projection, render its
+        // own format, and still fall back to the shared Mermaid emitter.
+        var target = Member("Widget", "Build");
+        var callers = Node(target, CallTreeStatus.Expanded, [Leaf(Member("Program", "Main"))]);
+        var callees = Node(target, CallTreeStatus.Expanded, [Leaf(Member("Log", "Write"), CallTreeStatus.External)]);
+
+        var fromRoots = CallGraphMermaid.Render(callers, callees);
+        var fromProjection = CallGraphMermaid.Render(CallGraphProjection.Create(callers, callees));
+
+        Assert.Equal(fromRoots, fromProjection);
+    }
+}

--- a/src/ILInspector.CallGraph/CallGraphMermaid.cs
+++ b/src/ILInspector.CallGraph/CallGraphMermaid.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;
 using ILInspector.Analysis;
@@ -6,21 +5,16 @@ using ILInspector.Analysis;
 namespace ILInspector.CallGraph;
 
 /// <summary>
-/// Projects the typed call-graph facts that <c>ILInspector.Analysis</c> produces
-/// (<see cref="CallTreeNode"/> caller and callee roots built by
-/// <c>LibraryBodyIndex.BuildCallerTree</c> / <c>BuildCallTree</c>) into a single
-/// deterministic Mermaid <c>flowchart</c> centered on one selected overload:
-/// <code>
-/// callers -&gt; selected overload -&gt; callees
-/// </code>
-/// This is a host-neutral product layer that sits <em>below</em> host applications
-/// so <c>dotnet-inspect</c> and the browser-Wasm prototype share one graph
-/// semantics and one Mermaid document. It owns the concerns a host must not
-/// re-invent: stable node identity, Mermaid escaping, duplicate/shared-node and
-/// cycle collapsing, depth-limited / truncated boundary marking, external-node
-/// styling, and loop-call edge annotations. It takes no dependency on Markout, the
-/// CLI, or inspected-assembly loading and stays SRM-only / NativeAOT / browser-Wasm
-/// friendly (see issue #3120).
+/// Emits a <see cref="CallGraphProjection"/> as a deterministic Mermaid
+/// <c>flowchart</c>.
+/// <para>
+/// This type owns <em>only</em> the Mermaid format: node id spelling, escaping, shape and
+/// class syntax, and edge/label syntax. Every graph decision — node identity and
+/// deduplication, edge direction, cycle collapse, boundary classification, and ordering —
+/// belongs to <see cref="CallGraphProjection"/>, so a host that wants a different format
+/// (a table, a tree, its own diagram) consumes the projection directly and does not
+/// re-derive graph semantics from rendered text.
+/// </para>
 /// </summary>
 public static class CallGraphMermaid
 {
@@ -33,244 +27,75 @@ public static class CallGraphMermaid
     /// both. When both are supplied they must name the same selected member.
     /// </summary>
     public static string Render(CallTreeNode? callerRoot, CallTreeNode? calleeRoot)
-    {
-        if (callerRoot is null && calleeRoot is null)
-            throw new ArgumentException($"At least one of {nameof(callerRoot)} or {nameof(calleeRoot)} must be provided.");
-
-        // Both roots are the selected overload, but the Analysis builders can resolve a
-        // bodiless target (abstract / interface / extern) differently: BuildCallerTree
-        // recovers the real member from an inbound call operand, while BuildCallTree has
-        // no body to resolve and yields an Unsupported placeholder. Treat an Unsupported
-        // placeholder as "unknown identity" so it never contradicts a resolved member, and
-        // prefer the resolved member as the single centered target node.
-        bool callerResolved = callerRoot is { Member.Kind: not MemberKind.Unsupported };
-        bool calleeResolved = calleeRoot is { Member.Kind: not MemberKind.Unsupported };
-        // Compare identities whenever both sides carry one: two resolved roots must name
-        // the same member, and two Unsupported placeholders must at least name the same
-        // token. Only a resolved / placeholder pair may differ — the placeholder is
-        // unknown identity, not a contradiction (a bodiless target the builders resolve
-        // asymmetrically).
-        if (callerRoot is not null && calleeRoot is not null
-            && callerResolved == calleeResolved
-            && IdentityKey(callerRoot.Member) != IdentityKey(calleeRoot.Member))
-            throw new ArgumentException($"{nameof(callerRoot)} and {nameof(calleeRoot)} must describe the same selected member.");
-
-        var target = calleeResolved ? calleeRoot!.Member
-            : callerResolved ? callerRoot!.Member
-            : (calleeRoot ?? callerRoot)!.Member;
-
-        var builder = new GraphBuilder();
-        // The selected overload is the single centered node shared by both trees; each
-        // tree's root *is* that target, so map both roots to the centered id. This keeps a
-        // bodiless placeholder root from becoming a second, stray "?" node.
-        int targetId = builder.RegisterTarget(target);
-        if (callerRoot is not null)
-            builder.WalkCallers(callerRoot, targetId);
-        if (calleeRoot is not null)
-            builder.WalkCallees(calleeRoot, targetId);
-        return builder.Render();
-    }
+        => Render(CallGraphProjection.Create(callerRoot, calleeRoot));
 
     /// <summary>Renders the inbound (caller) half only, centered on the selected overload.</summary>
     public static string RenderCallers(CallTreeNode callerRoot)
-    {
-        ArgumentNullException.ThrowIfNull(callerRoot);
-        return Render(callerRoot, null);
-    }
+        => Render(CallGraphProjection.FromCallers(callerRoot));
 
     /// <summary>Renders the outbound (callee) half only, centered on the selected overload.</summary>
     public static string RenderCallees(CallTreeNode calleeRoot)
-    {
-        ArgumentNullException.ThrowIfNull(calleeRoot);
-        return Render(null, calleeRoot);
-    }
+        => Render(CallGraphProjection.FromCallees(calleeRoot));
 
     /// <summary>
-    /// How a graph node is styled. Higher values win when a member is seen more than
-    /// once: a member expanded somewhere (<see cref="Normal"/>) is not a boundary even
-    /// if depth-limited elsewhere, and the selected <see cref="Target"/> is sticky.
+    /// Renders an already-built projection. Node and edge order come from the projection,
+    /// so the document is byte-stable for a given graph.
     /// </summary>
-    enum NodeClass
+    public static string Render(CallGraphProjection projection)
     {
-        Truncated = 0,
-        External = 1,
-        Normal = 2,
-        Target = 3,
-    }
+        ArgumentNullException.ThrowIfNull(projection);
 
-    sealed class NodeInfo(int id, string label, NodeClass nodeClass)
-    {
-        public int Id { get; } = id;
-        public string Label { get; } = label;
-        public NodeClass Class { get; set; } = nodeClass;
-    }
+        var sb = new StringBuilder();
+        sb.Append("flowchart LR\n");
 
-    readonly record struct Edge(int From, int To, string? LoopLabel);
-
-    sealed class GraphBuilder
-    {
-        readonly Dictionary<string, int> _ids = new(StringComparer.Ordinal);
-        readonly List<NodeInfo> _nodes = [];
-        readonly Dictionary<(int From, int To), int> _edgeIndex = [];
-        readonly List<Edge> _edges = [];
-
-        public int RegisterTarget(MemberRef member) => GetOrAdd(member, NodeClass.Target);
-
-        /// <summary>Walk a reverse (caller) tree: each child calls its parent, so edges point child → parent.</summary>
-        public void WalkCallers(CallTreeNode node, int nodeId)
+        // Nodes in projection order (focus first, then caller DFS, then callee DFS).
+        foreach (var node in projection.Nodes)
         {
-            foreach (var child in node.Children)
-            {
-                int childId = GetOrAdd(child.Member, ClassFor(child.Status));
-                AddEdge(childId, nodeId, LoopLabel(child.Perf));
-                WalkCallers(child, childId);
-            }
+            sb.Append("    ").Append(NodeId(node.Id)).Append("[\"").Append(Escape(node.Label)).Append("\"]");
+            if (ClassName(node.Kind) is { } className)
+                sb.Append(":::").Append(className);
+            sb.Append('\n');
         }
 
-        /// <summary>Walk an outbound (callee) tree: each parent calls its children, so edges point parent → child.</summary>
-        public void WalkCallees(CallTreeNode node, int nodeId)
+        // Edges in projection (first-seen) order.
+        foreach (var edge in projection.Edges)
         {
-            foreach (var child in node.Children)
-            {
-                int childId = GetOrAdd(child.Member, ClassFor(child.Status));
-                AddEdge(nodeId, childId, LoopLabel(child.Perf));
-                WalkCallees(child, childId);
-            }
+            sb.Append("    ").Append(NodeId(edge.From));
+            if (edge.LoopLabel is { } loop)
+                sb.Append(" -->|").Append(Escape(loop, edgeLabel: true)).Append("| ");
+            else
+                sb.Append(" --> ");
+            sb.Append(NodeId(edge.To)).Append('\n');
         }
 
-        int GetOrAdd(MemberRef member, NodeClass candidate)
-        {
-            var key = IdentityKey(member);
-            if (!_ids.TryGetValue(key, out var id))
-            {
-                id = _nodes.Count;
-                _ids[key] = id;
-                _nodes.Add(new NodeInfo(id, Label(member), candidate));
-                return id;
-            }
+        // Emit a classDef only when the class is used, in a fixed order.
+        if (HasKind(projection, CallGraphNodeKind.Focus))
+            sb.Append("    classDef target fill:#dae8fc,stroke:#6c8ebf,stroke-width:2px;\n");
+        if (HasKind(projection, CallGraphNodeKind.External))
+            sb.Append("    classDef external fill:#f5f5f5,stroke:#999999,stroke-dasharray:4 3,color:#666666;\n");
+        if (HasKind(projection, CallGraphNodeKind.Truncated))
+            sb.Append("    classDef truncated fill:#fff2cc,stroke:#d6b656,stroke-dasharray:2 2;\n");
 
-            // A member seen more than once keeps its strongest classification: the
-            // selected target is sticky, an expanded/leaf occurrence outranks a boundary,
-            // so a shared node is not mislabelled a dead end.
-            var info = _nodes[id];
-            if (candidate > info.Class)
-                info.Class = candidate;
-            return id;
-        }
-
-        void AddEdge(int from, int to, string? loopLabel)
-        {
-            if (_edgeIndex.TryGetValue((from, to), out var index))
-            {
-                // A shared edge that is a loop call from any site keeps its loop annotation.
-                if (loopLabel is not null && _edges[index].LoopLabel is null)
-                    _edges[index] = _edges[index] with { LoopLabel = loopLabel };
-                return;
-            }
-
-            _edgeIndex[(from, to)] = _edges.Count;
-            _edges.Add(new Edge(from, to, loopLabel));
-        }
-
-        public string Render()
-        {
-            var sb = new StringBuilder();
-            sb.Append("flowchart LR\n");
-
-            // Nodes in stable id order (target first, then caller DFS, then callee DFS).
-            foreach (var node in _nodes)
-            {
-                sb.Append("    ").Append(NodeId(node.Id)).Append("[\"").Append(Escape(node.Label)).Append("\"]");
-                if (ClassName(node.Class) is { } className)
-                    sb.Append(":::").Append(className);
-                sb.Append('\n');
-            }
-
-            // Edges in stable first-seen order.
-            foreach (var edge in _edges)
-            {
-                sb.Append("    ").Append(NodeId(edge.From));
-                if (edge.LoopLabel is { } loop)
-                    sb.Append(" -->|").Append(Escape(loop, edgeLabel: true)).Append("| ");
-                else
-                    sb.Append(" --> ");
-                sb.Append(NodeId(edge.To)).Append('\n');
-            }
-
-            // Emit a classDef only when the class is used, in a fixed order.
-            if (_nodes.Exists(n => n.Class == NodeClass.Target))
-                sb.Append("    classDef target fill:#dae8fc,stroke:#6c8ebf,stroke-width:2px;\n");
-            if (_nodes.Exists(n => n.Class == NodeClass.External))
-                sb.Append("    classDef external fill:#f5f5f5,stroke:#999999,stroke-dasharray:4 3,color:#666666;\n");
-            if (_nodes.Exists(n => n.Class == NodeClass.Truncated))
-                sb.Append("    classDef truncated fill:#fff2cc,stroke:#d6b656,stroke-dasharray:2 2;\n");
-
-            return sb.ToString();
-        }
+        return sb.ToString();
     }
 
-    /// <summary>
-    /// A stable structural identity for a member so shared callees, cycles, the
-    /// target-as-caller-and-callee, and self-recursion all collapse to one node. This
-    /// mirrors the Analysis layer's cross-assembly caller-graph identity
-    /// (<see cref="GenericMemberIdentity"/>): the open-definition side (the target root
-    /// and caller nodes, which <c>BuildCallerTree</c> builds without method type
-    /// arguments) and the constructed-call-site side (callee edges decoded from IL) must
-    /// erase to the <em>same</em> key, so a generic target that calls itself collapses
-    /// onto <c>n0</c> instead of splitting. Non-generic members keep their exact
-    /// instantiated signature — including the return type, which alone separates C#
-    /// conversion operators — while same-name / same-arity generic overloads coarsen, the
-    /// accepted trade the rest of the product already makes. The declaring type is
-    /// assembly-qualified, so same-namespace / same-name types from different assemblies
-    /// stay distinct (#1741).
-    /// </summary>
-    static string IdentityKey(MemberRef member)
+    static bool HasKind(CallGraphProjection projection, CallGraphNodeKind kind)
     {
-        // Mirror LibraryBodyIndex.CallerGraphKey exactly so the projection and the builder
-        // compute byte-identical keys for the same MemberRef.
-        var eraseGenericSignature = GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, member.TypeArguments);
-        var openDeclaring = GenericMemberIdentity.OpenDeclaringType(member.DeclaringType);
-        var shape = eraseGenericSignature
-            ? GenericMemberIdentity.ErasedParameterShape(member.OpenSignatureParameters)
-            : string.Join(",", member.ParameterTypes.Select(GenericMemberIdentity.KeyFragment));
-        return $"{GenericMemberIdentity.KeyFragment(openDeclaring)}|{member.Name}|{member.ParameterTypes.Length}|{shape}|{GenericMemberIdentity.KeyFragment(member.OpenSignatureReturn)}";
+        foreach (var node in projection.Nodes)
+        {
+            if (node.Kind == kind)
+                return true;
+        }
+        return false;
     }
 
-    /// <summary>Compact, host-neutral member spelling used as the Mermaid node label.</summary>
-    static string Label(MemberRef member)
+    static string? ClassName(CallGraphNodeKind kind) => kind switch
     {
-        if (member.Kind == MemberKind.Unsupported)
-            return member.DeclaringType.ToDisplayString();
-
-        var name = member.Name;
-        if (!member.TypeArguments.IsDefaultOrEmpty)
-            name += "<" + string.Join(", ", member.TypeArguments.Select(t => t.ToDisplayString())) + ">";
-        var parameters = string.Join(", ", member.ParameterTypes.Select(p => p.ToDisplayString()));
-        return $"{member.DeclaringType.ToDisplayString()}.{name}({parameters})";
-    }
-
-    static NodeClass ClassFor(CallTreeStatus status) => status switch
-    {
-        CallTreeStatus.External => NodeClass.External,
-        CallTreeStatus.DepthLimited or CallTreeStatus.Truncated => NodeClass.Truncated,
-        _ => NodeClass.Normal,
-    };
-
-    static string? ClassName(NodeClass nodeClass) => nodeClass switch
-    {
-        NodeClass.Target => "target",
-        NodeClass.External => "external",
-        NodeClass.Truncated => "truncated",
+        CallGraphNodeKind.Focus => "target",
+        CallGraphNodeKind.External => "external",
+        CallGraphNodeKind.Truncated => "truncated",
         _ => null,
     };
-
-    // The loop flag lives on the deeper (child) node and describes the parent↔child
-    // call edge: for a callee tree the parent calls the child in a loop; for a caller
-    // tree the child (caller) calls the parent in a loop.
-    static string? LoopLabel(CallTreePerf? perf)
-        => perf is { InLoop: true } p
-            ? string.IsNullOrEmpty(p.LoopHint) ? "loop" : p.LoopHint
-            : null;
 
     static string NodeId(int id) => "n" + id.ToString(CultureInfo.InvariantCulture);
 

--- a/src/ILInspector.CallGraph/CallGraphProjection.cs
+++ b/src/ILInspector.CallGraph/CallGraphProjection.cs
@@ -1,0 +1,298 @@
+using System.Collections.Immutable;
+using ILInspector.Analysis;
+
+namespace ILInspector.CallGraph;
+
+/// <summary>
+/// How a projected node relates to the rest of the graph. Higher values win when the
+/// same member is reached more than once: a member expanded somewhere
+/// (<see cref="Normal"/>) is not a boundary even if depth-limited elsewhere, and the
+/// selected <see cref="Focus"/> member is sticky.
+/// </summary>
+public enum CallGraphNodeKind
+{
+    /// <summary>Reached only where traversal stopped (depth-limited or truncated).</summary>
+    Truncated = 0,
+
+    /// <summary>Reached only outside the analyzed assembly set.</summary>
+    External = 1,
+
+    /// <summary>Reached as an ordinary expanded or leaf node.</summary>
+    Normal = 2,
+
+    /// <summary>The selected member the graph is centered on.</summary>
+    Focus = 3,
+}
+
+/// <summary>
+/// One node of a <see cref="CallGraphProjection"/>.
+/// </summary>
+/// <param name="Id">
+/// Dense zero-based index into <see cref="CallGraphProjection.Nodes"/>. The focus node is
+/// always id 0.
+/// </param>
+/// <param name="Member">
+/// The typed member identity. This — not <paramref name="Label"/> — is the node's identity;
+/// hosts must not infer identity from display text.
+/// </param>
+/// <param name="Label">
+/// A host-neutral default spelling of <paramref name="Member"/>, offered as a convenience.
+/// A host that owns its own type/member spelling should render <paramref name="Member"/>
+/// itself instead.
+/// </param>
+/// <param name="Kind">The strongest classification observed across every occurrence.</param>
+public sealed record CallGraphNode(int Id, MemberRef Member, string Label, CallGraphNodeKind Kind);
+
+/// <summary>
+/// One directed call edge. The direction is always "caller calls callee", so an inbound
+/// (reverse) tree is inverted during projection rather than left for the host to interpret.
+/// </summary>
+/// <param name="From">Id of the calling member.</param>
+/// <param name="To">Id of the called member.</param>
+/// <param name="LoopLabel">
+/// Non-null when the call occurs inside a loop at any collapsed call site: either the
+/// analysis loop hint or <c>"loop"</c>.
+/// </param>
+public readonly record struct CallGraphEdge(int From, int To, string? LoopLabel);
+
+/// <summary>
+/// A format-neutral projection of the typed call-graph facts that
+/// <c>ILInspector.Analysis</c> produces (<see cref="CallTreeNode"/> caller and callee roots
+/// built by <c>LibraryBodyIndex.BuildCallerTree</c> / <c>BuildCallTree</c>) into a single
+/// deterministic directed graph centered on one selected overload:
+/// <code>
+/// callers -&gt; selected overload -&gt; callees
+/// </code>
+/// <para>
+/// This is the host-neutral product layer that sits <em>below</em> host applications, so
+/// every consumer shares one graph semantics regardless of output format. It owns the
+/// concerns a host must not re-invent: stable generic-erased node identity, duplicate /
+/// shared-node and cycle collapsing, inbound edge inversion, depth-limited and external
+/// boundary classification, loop-call edge annotation, and deterministic node and edge
+/// ordering.
+/// </para>
+/// <para>
+/// It knows nothing about any output format. Rendering — Mermaid, a table, a tree, or
+/// anything else — belongs to the host. It takes no dependency on Markout, the CLI, or
+/// inspected-assembly loading and stays SRM-only / NativeAOT / browser-Wasm friendly
+/// (see issue #3120).
+/// </para>
+/// <para>
+/// Ordering is part of the contract, not an implementation detail: nodes appear focus
+/// first, then caller-side discovery order, then callee-side discovery order, and edges
+/// appear in first-seen order.
+/// </para>
+/// </summary>
+public sealed class CallGraphProjection
+{
+    private CallGraphProjection(ImmutableArray<CallGraphNode> nodes, ImmutableArray<CallGraphEdge> edges)
+    {
+        Nodes = nodes;
+        Edges = edges;
+    }
+
+    /// <summary>Nodes in deterministic order. The focus node is always first.</summary>
+    public ImmutableArray<CallGraphNode> Nodes { get; }
+
+    /// <summary>Edges in deterministic first-seen order, always oriented caller → callee.</summary>
+    public ImmutableArray<CallGraphEdge> Edges { get; }
+
+    /// <summary>The selected overload the graph is centered on.</summary>
+    public CallGraphNode Focus => Nodes[0];
+
+    /// <summary>
+    /// Projects the combined caller/target/callee view. Both roots are the selected
+    /// overload: <paramref name="callerRoot"/>'s children are its inbound callers and
+    /// <paramref name="calleeRoot"/>'s children are its outbound callees. Either root may
+    /// be null (e.g. a caller-only view), but not both. When both are supplied they must
+    /// name the same selected member.
+    /// </summary>
+    public static CallGraphProjection Create(CallTreeNode? callerRoot, CallTreeNode? calleeRoot)
+    {
+        if (callerRoot is null && calleeRoot is null)
+            throw new ArgumentException($"At least one of {nameof(callerRoot)} or {nameof(calleeRoot)} must be provided.");
+
+        // Both roots are the selected overload, but the Analysis builders can resolve a
+        // bodiless target (abstract / interface / extern) differently: BuildCallerTree
+        // recovers the real member from an inbound call operand, while BuildCallTree has
+        // no body to resolve and yields an Unsupported placeholder. Treat an Unsupported
+        // placeholder as "unknown identity" so it never contradicts a resolved member, and
+        // prefer the resolved member as the single centered focus node.
+        bool callerResolved = callerRoot is { Member.Kind: not MemberKind.Unsupported };
+        bool calleeResolved = calleeRoot is { Member.Kind: not MemberKind.Unsupported };
+        // Compare identities whenever both sides carry one: two resolved roots must name
+        // the same member, and two Unsupported placeholders must at least name the same
+        // token. Only a resolved / placeholder pair may differ — the placeholder is
+        // unknown identity, not a contradiction (a bodiless target the builders resolve
+        // asymmetrically).
+        if (callerRoot is not null && calleeRoot is not null
+            && callerResolved == calleeResolved
+            && IdentityKey(callerRoot.Member) != IdentityKey(calleeRoot.Member))
+            throw new ArgumentException($"{nameof(callerRoot)} and {nameof(calleeRoot)} must describe the same selected member.");
+
+        var focus = calleeResolved ? calleeRoot!.Member
+            : callerResolved ? callerRoot!.Member
+            : (calleeRoot ?? callerRoot)!.Member;
+
+        var builder = new Builder();
+        // The selected overload is the single centered node shared by both trees; each
+        // tree's root *is* that focus, so map both roots to the same id. This keeps a
+        // bodiless placeholder root from becoming a second, stray "?" node.
+        int focusId = builder.RegisterFocus(focus);
+        if (callerRoot is not null)
+            builder.WalkCallers(callerRoot, focusId);
+        if (calleeRoot is not null)
+            builder.WalkCallees(calleeRoot, focusId);
+        return builder.Build();
+    }
+
+    /// <summary>Projects the inbound (caller) half only, centered on the selected overload.</summary>
+    public static CallGraphProjection FromCallers(CallTreeNode callerRoot)
+    {
+        ArgumentNullException.ThrowIfNull(callerRoot);
+        return Create(callerRoot, null);
+    }
+
+    /// <summary>Projects the outbound (callee) half only, centered on the selected overload.</summary>
+    public static CallGraphProjection FromCallees(CallTreeNode calleeRoot)
+    {
+        ArgumentNullException.ThrowIfNull(calleeRoot);
+        return Create(null, calleeRoot);
+    }
+
+    private sealed class MutableNode(int id, MemberRef member, string label, CallGraphNodeKind kind)
+    {
+        public int Id { get; } = id;
+        public MemberRef Member { get; } = member;
+        public string Label { get; } = label;
+        public CallGraphNodeKind Kind { get; set; } = kind;
+    }
+
+    private sealed class Builder
+    {
+        private readonly Dictionary<string, int> _ids = new(StringComparer.Ordinal);
+        private readonly List<MutableNode> _nodes = [];
+        private readonly Dictionary<(int From, int To), int> _edgeIndex = [];
+        private readonly List<CallGraphEdge> _edges = [];
+
+        public int RegisterFocus(MemberRef member) => GetOrAdd(member, CallGraphNodeKind.Focus);
+
+        /// <summary>Walk a reverse (caller) tree: each child calls its parent, so edges point child → parent.</summary>
+        public void WalkCallers(CallTreeNode node, int nodeId)
+        {
+            foreach (var child in node.Children)
+            {
+                int childId = GetOrAdd(child.Member, KindFor(child.Status));
+                AddEdge(childId, nodeId, LoopLabel(child.Perf));
+                WalkCallers(child, childId);
+            }
+        }
+
+        /// <summary>Walk an outbound (callee) tree: each parent calls its children, so edges point parent → child.</summary>
+        public void WalkCallees(CallTreeNode node, int nodeId)
+        {
+            foreach (var child in node.Children)
+            {
+                int childId = GetOrAdd(child.Member, KindFor(child.Status));
+                AddEdge(nodeId, childId, LoopLabel(child.Perf));
+                WalkCallees(child, childId);
+            }
+        }
+
+        public CallGraphProjection Build()
+        {
+            var nodes = ImmutableArray.CreateBuilder<CallGraphNode>(_nodes.Count);
+            foreach (var node in _nodes)
+                nodes.Add(new CallGraphNode(node.Id, node.Member, node.Label, node.Kind));
+            return new CallGraphProjection(nodes.MoveToImmutable(), [.. _edges]);
+        }
+
+        private int GetOrAdd(MemberRef member, CallGraphNodeKind candidate)
+        {
+            var key = IdentityKey(member);
+            if (!_ids.TryGetValue(key, out var id))
+            {
+                id = _nodes.Count;
+                _ids[key] = id;
+                _nodes.Add(new MutableNode(id, member, Label(member), candidate));
+                return id;
+            }
+
+            // A member seen more than once keeps its strongest classification: the
+            // selected focus is sticky, an expanded/leaf occurrence outranks a boundary,
+            // so a shared node is not mislabelled a dead end.
+            var info = _nodes[id];
+            if (candidate > info.Kind)
+                info.Kind = candidate;
+            return id;
+        }
+
+        private void AddEdge(int from, int to, string? loopLabel)
+        {
+            if (_edgeIndex.TryGetValue((from, to), out var index))
+            {
+                // A shared edge that is a loop call from any site keeps its loop annotation.
+                if (loopLabel is not null && _edges[index].LoopLabel is null)
+                    _edges[index] = _edges[index] with { LoopLabel = loopLabel };
+                return;
+            }
+
+            _edgeIndex[(from, to)] = _edges.Count;
+            _edges.Add(new CallGraphEdge(from, to, loopLabel));
+        }
+    }
+
+    /// <summary>
+    /// A stable structural identity for a member so shared callees, cycles, the
+    /// focus-as-caller-and-callee, and self-recursion all collapse to one node. This
+    /// mirrors the Analysis layer's cross-assembly caller-graph identity
+    /// (<see cref="GenericMemberIdentity"/>): the open-definition side (the focus root and
+    /// caller nodes, which <c>BuildCallerTree</c> builds without method type arguments)
+    /// and the constructed-call-site side (callee edges decoded from IL) must erase to the
+    /// <em>same</em> key, so a generic member that calls itself collapses onto one node
+    /// instead of splitting. Non-generic members keep their exact instantiated signature —
+    /// including the return type, which alone separates C# conversion operators — while
+    /// same-name / same-arity generic overloads coarsen, the accepted trade the rest of
+    /// the product already makes. The declaring type is assembly-qualified, so
+    /// same-namespace / same-name types from different assemblies stay distinct (#1741).
+    /// </summary>
+    internal static string IdentityKey(MemberRef member)
+    {
+        // Mirror LibraryBodyIndex.CallerGraphKey exactly so the projection and the builder
+        // compute byte-identical keys for the same MemberRef.
+        var eraseGenericSignature = GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, member.TypeArguments);
+        var openDeclaring = GenericMemberIdentity.OpenDeclaringType(member.DeclaringType);
+        var shape = eraseGenericSignature
+            ? GenericMemberIdentity.ErasedParameterShape(member.OpenSignatureParameters)
+            : string.Join(",", member.ParameterTypes.Select(GenericMemberIdentity.KeyFragment));
+        return $"{GenericMemberIdentity.KeyFragment(openDeclaring)}|{member.Name}|{member.ParameterTypes.Length}|{shape}|{GenericMemberIdentity.KeyFragment(member.OpenSignatureReturn)}";
+    }
+
+    /// <summary>Compact, host-neutral member spelling offered as a default node label.</summary>
+    internal static string Label(MemberRef member)
+    {
+        if (member.Kind == MemberKind.Unsupported)
+            return member.DeclaringType.ToDisplayString();
+
+        var name = member.Name;
+        if (!member.TypeArguments.IsDefaultOrEmpty)
+            name += "<" + string.Join(", ", member.TypeArguments.Select(t => t.ToDisplayString())) + ">";
+        var parameters = string.Join(", ", member.ParameterTypes.Select(p => p.ToDisplayString()));
+        return $"{member.DeclaringType.ToDisplayString()}.{name}({parameters})";
+    }
+
+    private static CallGraphNodeKind KindFor(CallTreeStatus status) => status switch
+    {
+        CallTreeStatus.External => CallGraphNodeKind.External,
+        CallTreeStatus.DepthLimited or CallTreeStatus.Truncated => CallGraphNodeKind.Truncated,
+        _ => CallGraphNodeKind.Normal,
+    };
+
+    // The loop flag lives on the deeper (child) node and describes the parent↔child
+    // call edge: for a callee tree the parent calls the child in a loop; for a caller
+    // tree the child (caller) calls the parent in a loop.
+    private static string? LoopLabel(CallTreePerf? perf)
+        => perf is { InLoop: true } p
+            ? string.IsNullOrEmpty(p.LoopHint) ? "loop" : p.LoopHint
+            : null;
+}

--- a/src/ILInspector.CallGraph/ILInspector.CallGraph.csproj
+++ b/src/ILInspector.CallGraph/ILInspector.CallGraph.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <Authors>Richard Lander</Authors>
-    <Description>Host-neutral projection of Analysis call-graph facts into a deterministic Mermaid document (NativeAOT / browser-Wasm friendly)</Description>
+    <Description>Host-neutral, format-neutral projection of Analysis call-graph facts into a deterministic directed graph, plus an optional Mermaid emitter (NativeAOT / browser-Wasm friendly)</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #3291.

`CallGraphMermaid.cs` had a name that said Mermaid and a body that was mostly graph semantics. None of it is formatting, and all of it is needed by any consumer regardless of output format, so it belongs to the data layer per the layer-ownership rule in `AGENTS.md`.

## What moved

Everything below moves out of the Mermaid file into a new format-neutral `CallGraphProjection`:

- generic-erased node identity and deduplication
- bodiless-root reconciliation (resolved member wins over an `Unsupported` placeholder)
- inbound edge inversion
- duplicate and cycle collapse
- node status precedence (focus is sticky; expanded outranks a boundary)
- loop-edge merging
- deterministic node and edge ordering

## Shape

```csharp
public sealed class CallGraphProjection
{
    public ImmutableArray<CallGraphNode> Nodes { get; }   // focus first, then caller DFS, then callee DFS
    public ImmutableArray<CallGraphEdge> Edges { get; }   // first-seen order, always caller -> callee
    public CallGraphNode Focus { get; }

    public static CallGraphProjection Create(CallTreeNode? callerRoot, CallTreeNode? calleeRoot);
    public static CallGraphProjection FromCallers(CallTreeNode callerRoot);
    public static CallGraphProjection FromCallees(CallTreeNode calleeRoot);
}
```

Two deliberate choices:

- **Edges are always oriented caller → callee.** A reverse (caller) tree records the caller as a *child*, so the inversion happens once during projection instead of being reinterpreted by every host.
- **`CallGraphNode` carries both `MemberRef` and `Label`.** The `MemberRef` is the identity; the label is a convenience spelling a host may ignore. `AGENTS.md` separates identifiers from presentation, and `IdentityComesFromMemberNotLabel` pins it with two members that share a label but differ by assembly.

Ordering is documented as contract rather than left as an implementation detail, since hosts index into `Nodes` by edge endpoint.

## What `CallGraphMermaid` keeps

Only the Mermaid format: node id spelling, escaping, shape/class syntax, edge syntax. Its three existing entry points are unchanged, and it gains a `Render(CallGraphProjection)` overload so a host can hold the projection, render its own format, and still fall back to the shared emitter.

## Not in scope

No user-visible behavior change. Removing the Mermaid emission entirely is the follow-up adoption work in #3280, not this PR. This PR is independent of richlander/markout#162 and #163 and can land on its own.

## Validation

| Check | Result |
| --- | --- |
| `dotnet build dotnet-inspect.slnx -c Release` | succeeds (3 pre-existing nullability warnings in `ILInspector.Metadata.Tests`, untouched) |
| `ILInspector.Analysis.Tests` on `origin/main` | 513 total, 1 failed |
| `ILInspector.Analysis.Tests` on this branch | 539 total, 1 failed |
| `dotnet-inspect.Tests` `ProgressiveMemberCallGraphTests` | 10/10 |

+26 new projector tests. The single failure is pre-existing and identical in both runs — `LibraryBodyIndexTests.CrossAssemblyMetadataResolver_ResolvesFrameworkTypeDefinition` — measured against a clean detached `origin/main` worktree, not assumed.

**The no-behavior-change evidence is that the 20 existing `CallGraphMermaidTests` are unmodified and still pass**, including the byte-exact combined-document assertion, escaping, ordering, cycle collapse, and status styling.

The new tests assert graph semantics as typed data rather than as rendered text, so a future host that renders a table or a tree is not relying on Mermaid strings to prove them. `MermaidEmissionAgreesWithTheProjectionItRendersFrom` pins the seam itself.
