### PR TITLE
Add Metadata-layer raw metadata-table projection (#3282)

### DIFF
--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -106,5 +106,14 @@ public sealed class AssemblyInspectionSession : IDisposable
     public PresenceFlags PresenceFlags()
         => AssemblyDetailScanner.ScanPresenceFlags(_image.PEReader);
 
+    /// <summary>
+    /// A raw ECMA-335 metadata-table projection (see
+    /// <c>docs/design/metadata-table-projection.md</c>). Structurally lossless
+    /// over SRM's logical table/heap graph and a sibling of the typed facets
+    /// above, never derived from them.
+    /// </summary>
+    public MetadataTableProjection MetadataTables(MetadataProjectionOptions? options = null)
+        => MetadataTableProjector.Project(_image.PEReader, options);
+
     public void Dispose() => _image.Dispose();
 }

--- a/src/ILInspector.Metadata/MetadataTableProjection.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjection.cs
@@ -1,0 +1,304 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// A raw ECMA-335 metadata-table projection over a single assembly: one
+/// <see cref="MetadataTableView"/> per supported table, each carrying its
+/// columns and per-row cells with resolvable handles.
+///
+/// This is the structurally-lossless sibling of the typed extractors (see
+/// <c>docs/design/metadata-table-projection.md</c>): it mirrors SRM's logical
+/// table/heap graph without curating it into a semantic view, and it is never
+/// a dependency of those typed extractors.
+/// </summary>
+public sealed record MetadataTableProjection
+{
+    public MetadataTableProjection(ImmutableArray<MetadataTableView> Tables)
+    {
+        if (Tables.IsDefault)
+            throw new ArgumentException("Tables must be initialized.", nameof(Tables));
+
+        this.Tables = Tables;
+    }
+
+    /// <summary>The projected tables, in ECMA-335 table order.</summary>
+    public ImmutableArray<MetadataTableView> Tables { get; }
+}
+
+/// <summary>A single metadata table: its identity, schema, and projected rows.</summary>
+public sealed record MetadataTableView
+{
+    public MetadataTableView(
+        TableIndex Index,
+        string Name,
+        int RowCount,
+        ImmutableArray<MetadataColumn> Columns,
+        ImmutableArray<MetadataRow> Rows,
+        MetadataTableTruncation? Truncation = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(Name);
+        ArgumentOutOfRangeException.ThrowIfNegative(RowCount);
+        if (Columns.IsDefault)
+            throw new ArgumentException("Columns must be initialized.", nameof(Columns));
+        if (Rows.IsDefault)
+            throw new ArgumentException("Rows must be initialized.", nameof(Rows));
+
+        this.Index = Index;
+        this.Name = Name;
+        this.RowCount = RowCount;
+        this.Columns = Columns;
+        this.Rows = Rows;
+        this.Truncation = Truncation;
+    }
+
+    /// <summary>The ECMA-335 table this view projects.</summary>
+    public TableIndex Index { get; }
+
+    /// <summary>The table's canonical name (for example <c>TypeDef</c>).</summary>
+    public string Name { get; }
+
+    /// <summary>The physical row count reported by the metadata, before any row budget.</summary>
+    public int RowCount { get; }
+
+    /// <summary>The column schema, aligned positionally to each row's cells.</summary>
+    public ImmutableArray<MetadataColumn> Columns { get; }
+
+    /// <summary>The projected rows, ordered by row id.</summary>
+    public ImmutableArray<MetadataRow> Rows { get; }
+
+    /// <summary>
+    /// Non-null when the row budget stopped enumeration before the physical end
+    /// of the table. Enumeration never silently truncates without this marker.
+    /// </summary>
+    public MetadataTableTruncation? Truncation { get; }
+}
+
+/// <summary>A single column in a table's schema.</summary>
+public sealed record MetadataColumn
+{
+    public MetadataColumn(
+        string Name,
+        MetadataColumnKind Kind,
+        ImmutableArray<TableIndex> CandidateTargets = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(Name);
+        this.Name = Name;
+        this.Kind = Kind;
+        this.CandidateTargets = CandidateTargets.IsDefault
+            ? ImmutableArray<TableIndex>.Empty
+            : CandidateTargets;
+    }
+
+    /// <summary>The column's ECMA-335 name (for example <c>Extends</c>).</summary>
+    public string Name { get; }
+
+    /// <summary>What kind of value this column carries.</summary>
+    public MetadataColumnKind Kind { get; }
+
+    /// <summary>
+    /// For <see cref="MetadataColumnKind.Handle"/> and
+    /// <see cref="MetadataColumnKind.HandleRange"/> columns, the schema-declared
+    /// set of tables a value may point at (a coded index resolves to exactly one
+    /// of these). Empty for other column kinds.
+    /// </summary>
+    public ImmutableArray<TableIndex> CandidateTargets { get; }
+}
+
+/// <summary>What kind of value a <see cref="MetadataColumn"/> carries.</summary>
+public enum MetadataColumnKind
+{
+    /// <summary>A raw scalar (row id detail, sequence, RVA, version part).</summary>
+    Scalar,
+
+    /// <summary>A flag enumeration (attributes), kept as raw bits plus decoded names.</summary>
+    Flags,
+
+    /// <summary>A reference into a heap (String, Blob, Guid, or UserString).</summary>
+    Heap,
+
+    /// <summary>A single coded/simple index into another table.</summary>
+    Handle,
+
+    /// <summary>A contiguous run of rows in another table (a list column).</summary>
+    HandleRange,
+}
+
+/// <summary>A single projected row: its coordinates and positional cells.</summary>
+public sealed record MetadataRow
+{
+    public MetadataRow(int RowId, int Token, ImmutableArray<MetadataValue> Cells)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(RowId, 1);
+        if (Cells.IsDefault)
+            throw new ArgumentException("Cells must be initialized.", nameof(Cells));
+
+        this.RowId = RowId;
+        this.Token = Token;
+        this.Cells = Cells;
+    }
+
+    /// <summary>The 1-based row number within the table.</summary>
+    public int RowId { get; }
+
+    /// <summary>The full metadata token (table tag | row id).</summary>
+    public int Token { get; }
+
+    /// <summary>The row's cells, aligned positionally to the table's columns.</summary>
+    public ImmutableArray<MetadataValue> Cells { get; }
+}
+
+/// <summary>
+/// A projected cell value. This is a closed discriminated union: every cell is
+/// exactly one of the nested variants. Friendly decodes are always additive —
+/// they sit beside the raw value, never replace it.
+/// </summary>
+public abstract record MetadataValue
+{
+    private protected MetadataValue()
+    {
+    }
+
+    /// <summary>An empty column: a nil handle or an absent value.</summary>
+    public sealed record Nil : MetadataValue;
+
+    /// <summary>A raw scalar value plus its display text.</summary>
+    public sealed record Scalar(long Raw, string Display) : MetadataValue;
+
+    /// <summary>A flag enumeration: the raw bits plus the decoded flag names.</summary>
+    public sealed record Flags(long Raw, string Decoded) : MetadataValue;
+
+    /// <summary>
+    /// A reference into a metadata heap. <see cref="Text"/> is the decoded,
+    /// display-escaped string for the String/UserString/Guid heaps; it is null
+    /// for the Blob heap, whose <see cref="Preview"/> carries a bounded hex dump.
+    /// </summary>
+    public sealed record HeapReference(
+        HeapKind Heap,
+        int Offset,
+        int Length,
+        string? Text,
+        string Preview) : MetadataValue;
+
+    /// <summary>A single resolvable index into another table.</summary>
+    public sealed record Handle(HandleRef Reference) : MetadataValue;
+
+    /// <summary>A contiguous run of rows in another table (a list column).</summary>
+    public sealed record Range(HandleRange Reference) : MetadataValue;
+
+    /// <summary>
+    /// A cell that could not be trusted: SRM rejected the value or a handle was
+    /// malformed. Never a success-shaped empty value.
+    /// </summary>
+    public sealed record Malformed(string Detail) : MetadataValue;
+}
+
+/// <summary>The metadata heaps a <see cref="MetadataValue.HeapReference"/> can point at.</summary>
+public enum HeapKind
+{
+    String,
+    Blob,
+    Guid,
+    UserString,
+}
+
+/// <summary>
+/// A resolvable edge into a single row of another table. The
+/// <see cref="TargetTable"/>/<see cref="TargetRowId"/> pair is authoritative;
+/// <see cref="Display"/> is best-effort convenience text.
+/// </summary>
+public sealed record HandleRef
+{
+    public HandleRef(TableIndex TargetTable, int TargetRowId, int Token, string? Display = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(TargetRowId);
+        this.TargetTable = TargetTable;
+        this.TargetRowId = TargetRowId;
+        this.Token = Token;
+        this.Display = Display;
+    }
+
+    /// <summary>The table the edge points into.</summary>
+    public TableIndex TargetTable { get; }
+
+    /// <summary>The 1-based row number in <see cref="TargetTable"/>, or 0 for a nil target.</summary>
+    public int TargetRowId { get; }
+
+    /// <summary>The full metadata token of the target.</summary>
+    public int Token { get; }
+
+    /// <summary>Best-effort display text for the target, or null when unavailable.</summary>
+    public string? Display { get; }
+}
+
+/// <summary>
+/// A contiguous run of rows in a target table (an ECMA-335 list column such as
+/// <c>TypeDef.FieldList</c>). The run is half-open: <c>[StartRowId, EndRowId)</c>.
+/// </summary>
+public sealed record HandleRange
+{
+    public HandleRange(TableIndex TargetTable, int StartRowId, int EndRowId)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(StartRowId);
+        ArgumentOutOfRangeException.ThrowIfLessThan(EndRowId, StartRowId);
+        this.TargetTable = TargetTable;
+        this.StartRowId = StartRowId;
+        this.EndRowId = EndRowId;
+    }
+
+    /// <summary>The table the run points into.</summary>
+    public TableIndex TargetTable { get; }
+
+    /// <summary>The 1-based row number of the first row in the run.</summary>
+    public int StartRowId { get; }
+
+    /// <summary>The 1-based row number just past the last row in the run (exclusive).</summary>
+    public int EndRowId { get; }
+
+    /// <summary>The number of rows in the run.</summary>
+    public int Count => EndRowId - StartRowId;
+}
+
+/// <summary>
+/// Evidence that a table's row budget stopped enumeration before its physical
+/// end. Its presence makes truncation explicit rather than silent.
+/// </summary>
+public sealed record MetadataTableTruncation
+{
+    public MetadataTableTruncation(int ProjectedRows, int RowCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(ProjectedRows);
+        ArgumentOutOfRangeException.ThrowIfLessThan(RowCount, ProjectedRows);
+        this.ProjectedRows = ProjectedRows;
+        this.RowCount = RowCount;
+    }
+
+    /// <summary>How many rows were projected before the budget stopped enumeration.</summary>
+    public int ProjectedRows { get; }
+
+    /// <summary>The physical row count of the table.</summary>
+    public int RowCount { get; }
+}
+
+/// <summary>Bounds and selection for a <see cref="MetadataTableProjection"/>.</summary>
+public sealed record MetadataProjectionOptions
+{
+    /// <summary>The default per-table row ceiling.</summary>
+    public const int DefaultMaxRowsPerTable = 4096;
+
+    /// <summary>The default bounded blob preview length, in bytes.</summary>
+    public const int DefaultMaxPreviewBytes = 32;
+
+    /// <summary>The maximum number of rows projected per table before truncation.</summary>
+    public int MaxRowsPerTable { get; init; } = DefaultMaxRowsPerTable;
+
+    /// <summary>The maximum number of blob bytes captured in a bounded preview.</summary>
+    public int MaxPreviewBytes { get; init; } = DefaultMaxPreviewBytes;
+
+    /// <summary>
+    /// When non-default, restricts projection to these tables. Default projects
+    /// every supported table.
+    /// </summary>
+    public ImmutableArray<TableIndex> Tables { get; init; } = default;
+}

--- a/src/ILInspector.Metadata/MetadataTableProjection.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjection.cs
@@ -171,15 +171,20 @@ public abstract record MetadataValue
 
     /// <summary>
     /// A reference into a metadata heap. <see cref="Text"/> is the decoded,
-    /// display-escaped string for the String/UserString/Guid heaps; it is null
-    /// for the Blob heap, whose <see cref="Preview"/> carries a bounded hex dump.
+    /// control-escaped string for the String/Guid heaps (safe to render as data:
+    /// terminal control sequences are neutralized); it is null for the Blob heap,
+    /// whose <see cref="Preview"/> carries a bounded hex dump. <see cref="Length"/>
+    /// is the full decoded size; <see cref="Truncated"/> is true when the bounded
+    /// preview stopped short of it, so a preview is never mistaken for the whole
+    /// value. The complete heap value remains addressable via <see cref="Offset"/>.
     /// </summary>
     public sealed record HeapReference(
         HeapKind Heap,
         int Offset,
         int Length,
         string? Text,
-        string Preview) : MetadataValue;
+        string Preview,
+        bool Truncated) : MetadataValue;
 
     /// <summary>A single resolvable index into another table.</summary>
     public sealed record Handle(HandleRef Reference) : MetadataValue;
@@ -290,11 +295,21 @@ public sealed record MetadataProjectionOptions
     /// <summary>The default bounded blob preview length, in bytes.</summary>
     public const int DefaultMaxPreviewBytes = 32;
 
+    /// <summary>The default bounded string/name preview length, in characters.</summary>
+    public const int DefaultMaxStringChars = 1024;
+
     /// <summary>The maximum number of rows projected per table before truncation.</summary>
     public int MaxRowsPerTable { get; init; } = DefaultMaxRowsPerTable;
 
     /// <summary>The maximum number of blob bytes captured in a bounded preview.</summary>
     public int MaxPreviewBytes { get; init; } = DefaultMaxPreviewBytes;
+
+    /// <summary>
+    /// The maximum number of characters retained from a decoded string/name
+    /// value. A longer value is projected as a bounded preview with
+    /// <see cref="HeapReference.Truncated"/> set, bounding output amplification.
+    /// </summary>
+    public int MaxStringChars { get; init; } = DefaultMaxStringChars;
 
     /// <summary>
     /// When non-default, restricts projection to these tables. Default projects

--- a/src/ILInspector.Metadata/MetadataTableProjection.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjection.cs
@@ -215,13 +215,14 @@ public enum HeapKind
 /// </summary>
 public sealed record HandleRef
 {
-    public HandleRef(TableIndex TargetTable, int TargetRowId, int Token, string? Display = null)
+    public HandleRef(TableIndex TargetTable, int TargetRowId, int Token, string? Display = null, bool DisplayTruncated = false)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(TargetRowId);
         this.TargetTable = TargetTable;
         this.TargetRowId = TargetRowId;
         this.Token = Token;
         this.Display = Display;
+        this.DisplayTruncated = DisplayTruncated;
     }
 
     /// <summary>The table the edge points into.</summary>
@@ -235,6 +236,12 @@ public sealed record HandleRef
 
     /// <summary>Best-effort display text for the target, or null when unavailable.</summary>
     public string? Display { get; }
+
+    /// <summary>
+    /// True when <see cref="Display"/> was bounded by the projection's string
+    /// budget, so the retained text is a prefix rather than the full name.
+    /// </summary>
+    public bool DisplayTruncated { get; }
 }
 
 /// <summary>

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -1,0 +1,533 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Projects an assembly's ECMA-335 metadata tables into a
+/// <see cref="MetadataTableProjection"/>: a structurally-lossless view of SRM's
+/// logical table/heap graph. Handles become resolvable
+/// <see cref="HandleRef"/>/<see cref="HandleRange"/> edges, heaps surface as
+/// bounded <see cref="MetadataValue.HeapReference"/> cells, and friendly decodes
+/// are always additive.
+///
+/// This producer is a sibling of the typed extractors, never a dependency of
+/// them (see <c>docs/design/metadata-table-projection.md</c>). It is read-only,
+/// SRM-only, and applies explicit per-table row and blob-preview budgets with
+/// typed rejection rather than silent truncation.
+/// </summary>
+public static class MetadataTableProjector
+{
+    static readonly ImmutableArray<TableIndex> ResolutionScopeTargets =
+        [TableIndex.Module, TableIndex.ModuleRef, TableIndex.AssemblyRef, TableIndex.TypeRef];
+
+    static readonly ImmutableArray<TableIndex> TypeDefOrRefTargets =
+        [TableIndex.TypeDef, TableIndex.TypeRef, TableIndex.TypeSpec];
+
+    static readonly ImmutableArray<TableIndex> MemberRefParentTargets =
+        [TableIndex.TypeDef, TableIndex.TypeRef, TableIndex.ModuleRef, TableIndex.MethodDef, TableIndex.TypeSpec];
+
+    static readonly ImmutableArray<TableIndex> CustomAttributeTypeTargets =
+        [TableIndex.MethodDef, TableIndex.MemberRef];
+
+    static readonly ImmutableArray<TableIndex> HasCustomAttributeTargets =
+    [
+        TableIndex.MethodDef, TableIndex.Field, TableIndex.TypeRef, TableIndex.TypeDef,
+        TableIndex.Param, TableIndex.InterfaceImpl, TableIndex.MemberRef, TableIndex.Module,
+        TableIndex.DeclSecurity, TableIndex.Property, TableIndex.Event, TableIndex.StandAloneSig,
+        TableIndex.ModuleRef, TableIndex.TypeSpec, TableIndex.Assembly, TableIndex.AssemblyRef,
+        TableIndex.File, TableIndex.ExportedType, TableIndex.ManifestResource, TableIndex.GenericParam,
+        TableIndex.GenericParamConstraint, TableIndex.MethodSpec,
+    ];
+
+    static readonly ImmutableArray<TableSpec> SupportedTables =
+    [
+        new(TableIndex.Module, "Module", ModuleColumns, ReadModuleRow),
+        new(TableIndex.TypeRef, "TypeRef", TypeRefColumns, ReadTypeRefRow),
+        new(TableIndex.TypeDef, "TypeDef", TypeDefColumns, ReadTypeDefRow),
+        new(TableIndex.Field, "Field", FieldColumns, ReadFieldRow),
+        new(TableIndex.MethodDef, "MethodDef", MethodDefColumns, ReadMethodDefRow),
+        new(TableIndex.Param, "Param", ParamColumns, ReadParamRow),
+        new(TableIndex.MemberRef, "MemberRef", MemberRefColumns, ReadMemberRefRow),
+        new(TableIndex.CustomAttribute, "CustomAttribute", CustomAttributeColumns, ReadCustomAttributeRow),
+        new(TableIndex.AssemblyRef, "AssemblyRef", AssemblyRefColumns, ReadAssemblyRefRow),
+    ];
+
+    /// <summary>
+    /// Projects the supported metadata tables of <paramref name="peReader"/>.
+    /// Returns an empty projection when the image carries no metadata.
+    /// </summary>
+    public static MetadataTableProjection Project(PEReader peReader, MetadataProjectionOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(peReader);
+        options ??= new MetadataProjectionOptions();
+
+        if (!peReader.HasMetadata)
+            return new MetadataTableProjection(ImmutableArray<MetadataTableView>.Empty);
+
+        var reader = peReader.GetMetadataReader();
+
+        var selected = options.Tables.IsDefaultOrEmpty
+            ? (IReadOnlyCollection<TableIndex>?)null
+            : options.Tables.ToImmutableHashSet();
+
+        var views = ImmutableArray.CreateBuilder<MetadataTableView>();
+        foreach (var spec in SupportedTables)
+        {
+            if (selected is not null && !selected.Contains(spec.Index))
+                continue;
+
+            int rowCount = reader.GetTableRowCount(spec.Index);
+            if (rowCount == 0)
+                continue;
+
+            views.Add(BuildView(reader, spec, rowCount, options));
+        }
+
+        return new MetadataTableProjection(views.ToImmutable());
+    }
+
+    static MetadataTableView BuildView(
+        MetadataReader reader,
+        TableSpec spec,
+        int rowCount,
+        MetadataProjectionOptions options)
+    {
+        int limit = Math.Min(rowCount, Math.Max(0, options.MaxRowsPerTable));
+        var rows = ImmutableArray.CreateBuilder<MetadataRow>(limit);
+
+        for (int rid = 1; rid <= limit; rid++)
+        {
+            int token = ((int)spec.Index << 24) | rid;
+            var cells = spec.ReadRow(reader, rid, options);
+            rows.Add(new MetadataRow(rid, token, cells));
+        }
+
+        var truncation = limit < rowCount ? new MetadataTableTruncation(limit, rowCount) : null;
+        return new MetadataTableView(spec.Index, spec.Name, rowCount, spec.Columns, rows.ToImmutable(), truncation);
+    }
+
+    // ---- Per-table column schemas ----------------------------------------
+
+    static ImmutableArray<MetadataColumn> ModuleColumns =>
+    [
+        new("Generation", MetadataColumnKind.Scalar),
+        new("Name", MetadataColumnKind.Heap),
+        new("Mvid", MetadataColumnKind.Heap),
+        new("EncId", MetadataColumnKind.Heap),
+        new("EncBaseId", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> TypeRefColumns =>
+    [
+        new("ResolutionScope", MetadataColumnKind.Handle, ResolutionScopeTargets),
+        new("Name", MetadataColumnKind.Heap),
+        new("Namespace", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> TypeDefColumns =>
+    [
+        new("Attributes", MetadataColumnKind.Flags),
+        new("Name", MetadataColumnKind.Heap),
+        new("Namespace", MetadataColumnKind.Heap),
+        new("Extends", MetadataColumnKind.Handle, TypeDefOrRefTargets),
+        new("FieldList", MetadataColumnKind.HandleRange, [TableIndex.Field]),
+        new("MethodList", MetadataColumnKind.HandleRange, [TableIndex.MethodDef]),
+    ];
+
+    static ImmutableArray<MetadataColumn> FieldColumns =>
+    [
+        new("Attributes", MetadataColumnKind.Flags),
+        new("Name", MetadataColumnKind.Heap),
+        new("Signature", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> MethodDefColumns =>
+    [
+        new("Rva", MetadataColumnKind.Scalar),
+        new("ImplAttributes", MetadataColumnKind.Flags),
+        new("Attributes", MetadataColumnKind.Flags),
+        new("Name", MetadataColumnKind.Heap),
+        new("Signature", MetadataColumnKind.Heap),
+        new("ParamList", MetadataColumnKind.HandleRange, [TableIndex.Param]),
+    ];
+
+    static ImmutableArray<MetadataColumn> ParamColumns =>
+    [
+        new("Attributes", MetadataColumnKind.Flags),
+        new("Sequence", MetadataColumnKind.Scalar),
+        new("Name", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> MemberRefColumns =>
+    [
+        new("Class", MetadataColumnKind.Handle, MemberRefParentTargets),
+        new("Name", MetadataColumnKind.Heap),
+        new("Signature", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> CustomAttributeColumns =>
+    [
+        new("Parent", MetadataColumnKind.Handle, HasCustomAttributeTargets),
+        new("Type", MetadataColumnKind.Handle, CustomAttributeTypeTargets),
+        new("Value", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> AssemblyRefColumns =>
+    [
+        new("MajorVersion", MetadataColumnKind.Scalar),
+        new("MinorVersion", MetadataColumnKind.Scalar),
+        new("BuildNumber", MetadataColumnKind.Scalar),
+        new("RevisionNumber", MetadataColumnKind.Scalar),
+        new("Flags", MetadataColumnKind.Flags),
+        new("PublicKeyOrToken", MetadataColumnKind.Heap),
+        new("Name", MetadataColumnKind.Heap),
+        new("Culture", MetadataColumnKind.Heap),
+        new("HashValue", MetadataColumnKind.Heap),
+    ];
+
+    // ---- Per-table row readers -------------------------------------------
+
+    static ImmutableArray<MetadataValue> ReadModuleRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var module = reader.GetModuleDefinition();
+        return
+        [
+            new MetadataValue.Scalar(module.Generation, module.Generation.ToString()),
+            StringCell(reader, module.Name),
+            GuidCell(reader, module.Mvid),
+            GuidCell(reader, module.GenerationId),
+            GuidCell(reader, module.BaseGenerationId),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadTypeRefRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var typeRef = reader.GetTypeReference(MetadataTokens.TypeReferenceHandle(rid));
+        return
+        [
+            HandleCell(reader, typeRef.ResolutionScope),
+            StringCell(reader, typeRef.Name),
+            StringCell(reader, typeRef.Namespace),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadTypeDefRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var handle = MetadataTokens.TypeDefinitionHandle(rid);
+        var typeDef = reader.GetTypeDefinition(handle);
+        return
+        [
+            FlagsCell((long)typeDef.Attributes, typeDef.Attributes.ToString()),
+            StringCell(reader, typeDef.Name),
+            StringCell(reader, typeDef.Namespace),
+            HandleCell(reader, typeDef.BaseType),
+            RangeCell(TableIndex.Field, typeDef.GetFields()),
+            RangeCell(TableIndex.MethodDef, typeDef.GetMethods()),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadFieldRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var field = reader.GetFieldDefinition(MetadataTokens.FieldDefinitionHandle(rid));
+        return
+        [
+            FlagsCell((long)field.Attributes, field.Attributes.ToString()),
+            StringCell(reader, field.Name),
+            BlobCell(reader, field.Signature, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadMethodDefRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var method = reader.GetMethodDefinition(MetadataTokens.MethodDefinitionHandle(rid));
+        return
+        [
+            new MetadataValue.Scalar(method.RelativeVirtualAddress, $"0x{method.RelativeVirtualAddress:X8}"),
+            FlagsCell((long)method.ImplAttributes, method.ImplAttributes.ToString()),
+            FlagsCell((long)method.Attributes, method.Attributes.ToString()),
+            StringCell(reader, method.Name),
+            BlobCell(reader, method.Signature, options),
+            RangeCell(TableIndex.Param, method.GetParameters()),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadParamRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var param = reader.GetParameter(MetadataTokens.ParameterHandle(rid));
+        return
+        [
+            FlagsCell((long)param.Attributes, param.Attributes.ToString()),
+            new MetadataValue.Scalar(param.SequenceNumber, param.SequenceNumber.ToString()),
+            StringCell(reader, param.Name),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadMemberRefRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var memberRef = reader.GetMemberReference(MetadataTokens.MemberReferenceHandle(rid));
+        return
+        [
+            HandleCell(reader, memberRef.Parent),
+            StringCell(reader, memberRef.Name),
+            BlobCell(reader, memberRef.Signature, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadCustomAttributeRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var attribute = reader.GetCustomAttribute(MetadataTokens.CustomAttributeHandle(rid));
+        return
+        [
+            HandleCell(reader, attribute.Parent),
+            HandleCell(reader, attribute.Constructor),
+            BlobCell(reader, attribute.Value, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadAssemblyRefRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var assemblyRef = reader.GetAssemblyReference(MetadataTokens.AssemblyReferenceHandle(rid));
+        var version = assemblyRef.Version;
+        return
+        [
+            new MetadataValue.Scalar(version.Major, version.Major.ToString()),
+            new MetadataValue.Scalar(version.Minor, version.Minor.ToString()),
+            new MetadataValue.Scalar(version.Build, version.Build.ToString()),
+            new MetadataValue.Scalar(version.Revision, version.Revision.ToString()),
+            FlagsCell((long)assemblyRef.Flags, assemblyRef.Flags.ToString()),
+            BlobCell(reader, assemblyRef.PublicKeyOrToken, options),
+            StringCell(reader, assemblyRef.Name),
+            StringCell(reader, assemblyRef.Culture),
+            BlobCell(reader, assemblyRef.HashValue, options),
+        ];
+    }
+
+    // ---- Cell builders ----------------------------------------------------
+
+    static MetadataValue StringCell(MetadataReader reader, StringHandle handle)
+    {
+        if (handle.IsNil)
+            return new MetadataValue.Nil();
+
+        try
+        {
+            string raw = reader.GetString(handle);
+            string text = ILStringEscaper.ForDisplay(raw);
+            return new MetadataValue.HeapReference(HeapKind.String, HeapOffset(handle), raw.Length, text, text);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return new MetadataValue.Malformed($"String heap read failed: {ex.Message}");
+        }
+    }
+
+    static MetadataValue GuidCell(MetadataReader reader, GuidHandle handle)
+    {
+        if (handle.IsNil)
+            return new MetadataValue.Nil();
+
+        try
+        {
+            string text = reader.GetGuid(handle).ToString();
+            return new MetadataValue.HeapReference(HeapKind.Guid, HeapOffset(handle), 16, text, text);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return new MetadataValue.Malformed($"Guid heap read failed: {ex.Message}");
+        }
+    }
+
+    static MetadataValue BlobCell(MetadataReader reader, BlobHandle handle, MetadataProjectionOptions options)
+    {
+        if (handle.IsNil)
+            return new MetadataValue.Nil();
+
+        try
+        {
+            var blobReader = reader.GetBlobReader(handle);
+            int length = blobReader.Length;
+            int take = Math.Min(length, Math.Max(0, options.MaxPreviewBytes));
+            byte[] bytes = blobReader.ReadBytes(take);
+            string preview = Convert.ToHexString(bytes);
+            if (take < length)
+                preview += "\u2026";
+
+            return new MetadataValue.HeapReference(HeapKind.Blob, HeapOffset(handle), length, Text: null, preview);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return new MetadataValue.Malformed($"Blob heap read failed: {ex.Message}");
+        }
+    }
+
+    static int HeapOffset(StringHandle handle)
+    {
+        try
+        {
+            return MetadataTokens.GetHeapOffset(handle);
+        }
+        catch (ArgumentException)
+        {
+            return -1;
+        }
+    }
+
+    static int HeapOffset(GuidHandle handle)
+    {
+        try
+        {
+            return MetadataTokens.GetHeapOffset(handle);
+        }
+        catch (ArgumentException)
+        {
+            return -1;
+        }
+    }
+
+    static int HeapOffset(BlobHandle handle)
+    {
+        try
+        {
+            return MetadataTokens.GetHeapOffset(handle);
+        }
+        catch (ArgumentException)
+        {
+            return -1;
+        }
+    }
+
+    static MetadataValue HandleCell(MetadataReader reader, EntityHandle handle)
+    {
+        if (handle.IsNil)
+            return new MetadataValue.Nil();
+
+        try
+        {
+            if (!MetadataTokens.TryGetTableIndex(handle.Kind, out var table))
+                return new MetadataValue.Malformed($"Handle kind {handle.Kind} does not map to a table.");
+
+            int rid = MetadataTokens.GetRowNumber(handle);
+            int token = MetadataTokens.GetToken(handle);
+            string? display = ResolveHandleDisplay(reader, handle);
+            return new MetadataValue.Handle(new HandleRef(table, rid, token, display));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return new MetadataValue.Malformed($"Handle resolution failed: {ex.Message}");
+        }
+    }
+
+    static MetadataValue RangeCell(TableIndex target, FieldDefinitionHandleCollection fields)
+    {
+        if (fields.Count == 0)
+            return new MetadataValue.Nil();
+
+        try
+        {
+            int start = 0;
+            foreach (var handle in fields)
+            {
+                start = MetadataTokens.GetRowNumber(handle);
+                break;
+            }
+
+            return new MetadataValue.Range(new HandleRange(target, start, start + fields.Count));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return new MetadataValue.Malformed($"List column read failed: {ex.Message}");
+        }
+    }
+
+    static MetadataValue RangeCell(TableIndex target, MethodDefinitionHandleCollection methods)
+    {
+        if (methods.Count == 0)
+            return new MetadataValue.Nil();
+
+        try
+        {
+            int start = 0;
+            foreach (var handle in methods)
+            {
+                start = MetadataTokens.GetRowNumber(handle);
+                break;
+            }
+
+            return new MetadataValue.Range(new HandleRange(target, start, start + methods.Count));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return new MetadataValue.Malformed($"List column read failed: {ex.Message}");
+        }
+    }
+
+    static MetadataValue RangeCell(TableIndex target, ParameterHandleCollection parameters)
+    {
+        if (parameters.Count == 0)
+            return new MetadataValue.Nil();
+
+        try
+        {
+            int start = 0;
+            foreach (var handle in parameters)
+            {
+                start = MetadataTokens.GetRowNumber(handle);
+                break;
+            }
+
+            return new MetadataValue.Range(new HandleRange(target, start, start + parameters.Count));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return new MetadataValue.Malformed($"List column read failed: {ex.Message}");
+        }
+    }
+
+    static string? ResolveHandleDisplay(MetadataReader reader, EntityHandle handle)
+    {
+        try
+        {
+            switch (handle.Kind)
+            {
+                case HandleKind.TypeDefinition:
+                case HandleKind.TypeReference:
+                case HandleKind.TypeSpecification:
+                case HandleKind.MethodDefinition:
+                case HandleKind.MemberReference:
+                case HandleKind.FieldDefinition:
+                    string text = ILTokenResolver.ResolveToken(reader, MetadataTokens.GetToken(handle));
+                    return text.StartsWith("0x", StringComparison.Ordinal) ? null : text;
+
+                case HandleKind.AssemblyReference:
+                    return ILStringEscaper.ForDisplay(
+                        reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)handle).Name));
+
+                case HandleKind.ModuleReference:
+                    return ILStringEscaper.ForDisplay(
+                        reader.GetString(reader.GetModuleReference((ModuleReferenceHandle)handle).Name));
+
+                case HandleKind.ModuleDefinition:
+                    return ILStringEscaper.ForDisplay(reader.GetString(reader.GetModuleDefinition().Name));
+
+                default:
+                    return null;
+            }
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    static MetadataValue FlagsCell(long raw, string decoded)
+        => new MetadataValue.Flags(raw, decoded);
+
+    readonly record struct TableSpec(
+        TableIndex Index,
+        string Name,
+        ImmutableArray<MetadataColumn> Columns,
+        Func<MetadataReader, int, MetadataProjectionOptions, ImmutableArray<MetadataValue>> ReadRow);
+}

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -563,44 +563,7 @@ public static class MetadataTableProjector
     /// the preview within budget.
     /// </summary>
     static string EscapeText(string value, int maxChars, out bool truncated)
-    {
-        int limit = Math.Max(0, maxChars);
-        var builder = new System.Text.StringBuilder(Math.Min(value.Length, limit));
-        truncated = false;
-
-        for (int i = 0; i < value.Length; i++)
-        {
-            char c = value[i];
-            int width = c switch
-            {
-                '\\' or '"' or '\n' or '\r' or '\t' => 2,
-                _ => IsControl(c) ? 6 : 1,
-            };
-
-            if (builder.Length + width > limit)
-            {
-                truncated = true;
-                break;
-            }
-
-            switch (c)
-            {
-                case '\\': builder.Append("\\\\"); break;
-                case '"': builder.Append("\\\""); break;
-                case '\n': builder.Append("\\n"); break;
-                case '\r': builder.Append("\\r"); break;
-                case '\t': builder.Append("\\t"); break;
-                default:
-                    if (IsControl(c))
-                        builder.Append("\\u").Append(((int)c).ToString("X4"));
-                    else
-                        builder.Append(c);
-                    break;
-            }
-        }
-
-        return builder.ToString();
-    }
+        => EscapeCore(value, maxChars, escapeStructural: true, out truncated);
 
     /// <summary>
     /// Renders every control character in a display string as <c>\uXXXX</c>,
@@ -613,26 +576,85 @@ public static class MetadataTableProjector
     /// the text within budget.
     /// </summary>
     static string NeutralizeControls(string value, int maxChars, out bool truncated)
+        => EscapeCore(value, maxChars, escapeStructural: false, out truncated);
+
+    /// <summary>
+    /// Shared budget-bounded escaper. Walks the UTF-16 value one scalar at a
+    /// time so a well-formed surrogate pair is kept atomic — the budget boundary
+    /// can never retain a lone (malformed) surrogate — while an unpaired
+    /// surrogate is rendered as <c>\uXXXX</c> so it cannot corrupt the output on
+    /// UTF-8 conversion. When <paramref name="escapeStructural"/> is set,
+    /// <c>\ " \n \r \t</c> are escaped for use as data; either way every control
+    /// character is rendered as <c>\uXXXX</c>. The <paramref name="maxChars"/>
+    /// budget is enforced on the emitted length; <paramref name="truncated"/>
+    /// reports whether any input was dropped to stay within it.
+    /// </summary>
+    static string EscapeCore(string value, int maxChars, bool escapeStructural, out bool truncated)
     {
         int limit = Math.Max(0, maxChars);
         var builder = new System.Text.StringBuilder(Math.Min(value.Length, limit));
         truncated = false;
 
-        for (int i = 0; i < value.Length; i++)
+        int i = 0;
+        while (i < value.Length)
         {
             char c = value[i];
-            int width = IsControl(c) ? 6 : 1;
 
+            // A well-formed surrogate pair is one scalar; emit it atomically.
+            if (char.IsHighSurrogate(c) && i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]))
+            {
+                if (builder.Length + 2 > limit)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                builder.Append(c).Append(value[i + 1]);
+                i += 2;
+                continue;
+            }
+
+            // A lone surrogate is ill-formed text; escape it rather than emit it.
+            if (char.IsSurrogate(c))
+            {
+                if (builder.Length + 6 > limit)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                builder.Append("\\u").Append(((int)c).ToString("X4"));
+                i++;
+                continue;
+            }
+
+            string? structural = escapeStructural
+                ? c switch
+                {
+                    '\\' => "\\\\",
+                    '"' => "\\\"",
+                    '\n' => "\\n",
+                    '\r' => "\\r",
+                    '\t' => "\\t",
+                    _ => null,
+                }
+                : null;
+
+            int width = structural is not null ? structural.Length : (IsControl(c) ? 6 : 1);
             if (builder.Length + width > limit)
             {
                 truncated = true;
                 break;
             }
 
-            if (IsControl(c))
+            if (structural is not null)
+                builder.Append(structural);
+            else if (IsControl(c))
                 builder.Append("\\u").Append(((int)c).ToString("X4"));
             else
                 builder.Append(c);
+
+            i++;
         }
 
         return builder.ToString();

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -67,7 +67,10 @@ public static class MetadataTableProjector
         if (!peReader.HasMetadata)
             return new MetadataTableProjection(ImmutableArray<MetadataTableView>.Empty);
 
-        var reader = peReader.GetMetadataReader();
+        // MetadataReaderOptions.None keeps the projection raw: the default enables
+        // Windows-Runtime projection, which would replace real table/heap values
+        // with synthesized aliases and defeat structural losslessness.
+        var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
 
         var selected = options.Tables.IsDefaultOrEmpty
             ? (IReadOnlyCollection<TableIndex>?)null
@@ -101,8 +104,21 @@ public static class MetadataTableProjector
         for (int rid = 1; rid <= limit; rid++)
         {
             int token = ((int)spec.Index << 24) | rid;
-            var cells = spec.ReadRow(reader, rid, options);
-            rows.Add(new MetadataRow(rid, token, cells));
+
+            // A single malformed row must not abort the whole projection: contain
+            // SRM's rejection as a typed Malformed row aligned to the columns.
+            try
+            {
+                rows.Add(new MetadataRow(rid, token, spec.ReadRow(reader, rid, options)));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or ArgumentException or InvalidOperationException)
+            {
+                var malformed = ImmutableArray.CreateBuilder<MetadataValue>(spec.Columns.Length);
+                for (int column = 0; column < spec.Columns.Length; column++)
+                    malformed.Add(new MetadataValue.Malformed($"Row read failed: {ex.Message}"));
+
+                rows.Add(new MetadataRow(rid, token, malformed.MoveToImmutable()));
+            }
         }
 
         var truncation = limit < rowCount ? new MetadataTableTruncation(limit, rowCount) : null;
@@ -196,7 +212,7 @@ public static class MetadataTableProjector
         return
         [
             new MetadataValue.Scalar(module.Generation, module.Generation.ToString()),
-            StringCell(reader, module.Name),
+            StringCell(reader, module.Name, options),
             GuidCell(reader, module.Mvid),
             GuidCell(reader, module.GenerationId),
             GuidCell(reader, module.BaseGenerationId),
@@ -209,8 +225,8 @@ public static class MetadataTableProjector
         return
         [
             HandleCell(reader, typeRef.ResolutionScope),
-            StringCell(reader, typeRef.Name),
-            StringCell(reader, typeRef.Namespace),
+            StringCell(reader, typeRef.Name, options),
+            StringCell(reader, typeRef.Namespace, options),
         ];
     }
 
@@ -221,8 +237,8 @@ public static class MetadataTableProjector
         return
         [
             FlagsCell((long)typeDef.Attributes, typeDef.Attributes.ToString()),
-            StringCell(reader, typeDef.Name),
-            StringCell(reader, typeDef.Namespace),
+            StringCell(reader, typeDef.Name, options),
+            StringCell(reader, typeDef.Namespace, options),
             HandleCell(reader, typeDef.BaseType),
             RangeCell(TableIndex.Field, typeDef.GetFields()),
             RangeCell(TableIndex.MethodDef, typeDef.GetMethods()),
@@ -235,7 +251,7 @@ public static class MetadataTableProjector
         return
         [
             FlagsCell((long)field.Attributes, field.Attributes.ToString()),
-            StringCell(reader, field.Name),
+            StringCell(reader, field.Name, options),
             BlobCell(reader, field.Signature, options),
         ];
     }
@@ -248,7 +264,7 @@ public static class MetadataTableProjector
             new MetadataValue.Scalar(method.RelativeVirtualAddress, $"0x{method.RelativeVirtualAddress:X8}"),
             FlagsCell((long)method.ImplAttributes, method.ImplAttributes.ToString()),
             FlagsCell((long)method.Attributes, method.Attributes.ToString()),
-            StringCell(reader, method.Name),
+            StringCell(reader, method.Name, options),
             BlobCell(reader, method.Signature, options),
             RangeCell(TableIndex.Param, method.GetParameters()),
         ];
@@ -261,7 +277,7 @@ public static class MetadataTableProjector
         [
             FlagsCell((long)param.Attributes, param.Attributes.ToString()),
             new MetadataValue.Scalar(param.SequenceNumber, param.SequenceNumber.ToString()),
-            StringCell(reader, param.Name),
+            StringCell(reader, param.Name, options),
         ];
     }
 
@@ -271,7 +287,7 @@ public static class MetadataTableProjector
         return
         [
             HandleCell(reader, memberRef.Parent),
-            StringCell(reader, memberRef.Name),
+            StringCell(reader, memberRef.Name, options),
             BlobCell(reader, memberRef.Signature, options),
         ];
     }
@@ -299,15 +315,15 @@ public static class MetadataTableProjector
             new MetadataValue.Scalar(version.Revision, version.Revision.ToString()),
             FlagsCell((long)assemblyRef.Flags, assemblyRef.Flags.ToString()),
             BlobCell(reader, assemblyRef.PublicKeyOrToken, options),
-            StringCell(reader, assemblyRef.Name),
-            StringCell(reader, assemblyRef.Culture),
+            StringCell(reader, assemblyRef.Name, options),
+            StringCell(reader, assemblyRef.Culture, options),
             BlobCell(reader, assemblyRef.HashValue, options),
         ];
     }
 
     // ---- Cell builders ----------------------------------------------------
 
-    static MetadataValue StringCell(MetadataReader reader, StringHandle handle)
+    static MetadataValue StringCell(MetadataReader reader, StringHandle handle, MetadataProjectionOptions options)
     {
         if (handle.IsNil)
             return new MetadataValue.Nil();
@@ -315,8 +331,9 @@ public static class MetadataTableProjector
         try
         {
             string raw = reader.GetString(handle);
-            string text = ILStringEscaper.ForDisplay(raw);
-            return new MetadataValue.HeapReference(HeapKind.String, HeapOffset(handle), raw.Length, text, text);
+            string text = EscapeText(raw, options.MaxStringChars, out bool truncated);
+            return new MetadataValue.HeapReference(
+                HeapKind.String, HeapOffset(handle), raw.Length, text, text, truncated);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
@@ -332,7 +349,8 @@ public static class MetadataTableProjector
         try
         {
             string text = reader.GetGuid(handle).ToString();
-            return new MetadataValue.HeapReference(HeapKind.Guid, HeapOffset(handle), 16, text, text);
+            return new MetadataValue.HeapReference(
+                HeapKind.Guid, HeapOffset(handle), 16, text, text, Truncated: false);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
@@ -352,10 +370,9 @@ public static class MetadataTableProjector
             int take = Math.Min(length, Math.Max(0, options.MaxPreviewBytes));
             byte[] bytes = blobReader.ReadBytes(take);
             string preview = Convert.ToHexString(bytes);
-            if (take < length)
-                preview += "\u2026";
 
-            return new MetadataValue.HeapReference(HeapKind.Blob, HeapOffset(handle), length, Text: null, preview);
+            return new MetadataValue.HeapReference(
+                HeapKind.Blob, HeapOffset(handle), length, Text: null, preview, Truncated: take < length);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
@@ -411,7 +428,18 @@ public static class MetadataTableProjector
 
             int rid = MetadataTokens.GetRowNumber(handle);
             int token = MetadataTokens.GetToken(handle);
+
+            // A coded index can decode to a row that does not exist in the target
+            // table; a dangling edge is a visible failure, not a resolvable handle.
+            int targetRows = reader.GetTableRowCount(table);
+            if (rid < 1 || rid > targetRows)
+                return new MetadataValue.Malformed(
+                    $"Handle 0x{token:X8} targets {table} row {rid}, outside [1, {targetRows}].");
+
             string? display = ResolveHandleDisplay(reader, handle);
+            if (display is not null)
+                display = NeutralizeControls(display);
+
             return new MetadataValue.Handle(new HandleRef(table, rid, token, display));
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
@@ -502,15 +530,13 @@ public static class MetadataTableProjector
                     return text.StartsWith("0x", StringComparison.Ordinal) ? null : text;
 
                 case HandleKind.AssemblyReference:
-                    return ILStringEscaper.ForDisplay(
-                        reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)handle).Name));
+                    return reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)handle).Name);
 
                 case HandleKind.ModuleReference:
-                    return ILStringEscaper.ForDisplay(
-                        reader.GetString(reader.GetModuleReference((ModuleReferenceHandle)handle).Name));
+                    return reader.GetString(reader.GetModuleReference((ModuleReferenceHandle)handle).Name);
 
                 case HandleKind.ModuleDefinition:
-                    return ILStringEscaper.ForDisplay(reader.GetString(reader.GetModuleDefinition().Name));
+                    return reader.GetString(reader.GetModuleDefinition().Name);
 
                 default:
                     return null;
@@ -524,6 +550,78 @@ public static class MetadataTableProjector
 
     static MetadataValue FlagsCell(long raw, string decoded)
         => new MetadataValue.Flags(raw, decoded);
+
+    /// <summary>
+    /// Escapes a decoded heap string for use as data and bounds it to
+    /// <paramref name="maxChars"/> characters. Backslash and quote are escaped,
+    /// and every control character (including ESC) is rendered as <c>\uXXXX</c>
+    /// so the value cannot inject terminal control sequences or break structured
+    /// output. <paramref name="truncated"/> reports whether the bound was hit.
+    /// </summary>
+    static string EscapeText(string value, int maxChars, out bool truncated)
+    {
+        int limit = Math.Max(0, maxChars);
+        truncated = value.Length > limit;
+        int take = truncated ? limit : value.Length;
+
+        var builder = new System.Text.StringBuilder(take);
+        for (int i = 0; i < take; i++)
+        {
+            char c = value[i];
+            switch (c)
+            {
+                case '\\': builder.Append("\\\\"); break;
+                case '"': builder.Append("\\\""); break;
+                case '\n': builder.Append("\\n"); break;
+                case '\r': builder.Append("\\r"); break;
+                case '\t': builder.Append("\\t"); break;
+                default:
+                    if (IsControl(c))
+                        builder.Append("\\u").Append(((int)c).ToString("X4"));
+                    else
+                        builder.Append(c);
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Renders every control character in a display string as <c>\uXXXX</c>,
+    /// leaving all other characters (including the structural <c>::</c>, quotes,
+    /// and generic-arity marks in resolved names) intact.
+    /// </summary>
+    static string NeutralizeControls(string value)
+    {
+        bool needsEscape = false;
+        foreach (char c in value)
+        {
+            if (IsControl(c))
+            {
+                needsEscape = true;
+                break;
+            }
+        }
+
+        if (!needsEscape)
+            return value;
+
+        var builder = new System.Text.StringBuilder(value.Length + 8);
+        foreach (char c in value)
+        {
+            if (IsControl(c))
+                builder.Append("\\u").Append(((int)c).ToString("X4"));
+            else
+                builder.Append(c);
+        }
+
+        return builder.ToString();
+    }
+
+    // C0 controls, DEL, and the C1 control range — none of which are safe to
+    // emit verbatim into a terminal or a structured record.
+    static bool IsControl(char c) => c < ' ' || c == '\x7f' || (c >= '\x80' && c <= '\x9f');
 
     readonly record struct TableSpec(
         TableIndex Index,

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -224,7 +224,7 @@ public static class MetadataTableProjector
         var typeRef = reader.GetTypeReference(MetadataTokens.TypeReferenceHandle(rid));
         return
         [
-            HandleCell(reader, typeRef.ResolutionScope),
+            HandleCell(reader, typeRef.ResolutionScope, options),
             StringCell(reader, typeRef.Name, options),
             StringCell(reader, typeRef.Namespace, options),
         ];
@@ -239,7 +239,7 @@ public static class MetadataTableProjector
             FlagsCell((long)typeDef.Attributes, typeDef.Attributes.ToString()),
             StringCell(reader, typeDef.Name, options),
             StringCell(reader, typeDef.Namespace, options),
-            HandleCell(reader, typeDef.BaseType),
+            HandleCell(reader, typeDef.BaseType, options),
             RangeCell(TableIndex.Field, typeDef.GetFields()),
             RangeCell(TableIndex.MethodDef, typeDef.GetMethods()),
         ];
@@ -286,7 +286,7 @@ public static class MetadataTableProjector
         var memberRef = reader.GetMemberReference(MetadataTokens.MemberReferenceHandle(rid));
         return
         [
-            HandleCell(reader, memberRef.Parent),
+            HandleCell(reader, memberRef.Parent, options),
             StringCell(reader, memberRef.Name, options),
             BlobCell(reader, memberRef.Signature, options),
         ];
@@ -297,8 +297,8 @@ public static class MetadataTableProjector
         var attribute = reader.GetCustomAttribute(MetadataTokens.CustomAttributeHandle(rid));
         return
         [
-            HandleCell(reader, attribute.Parent),
-            HandleCell(reader, attribute.Constructor),
+            HandleCell(reader, attribute.Parent, options),
+            HandleCell(reader, attribute.Constructor, options),
             BlobCell(reader, attribute.Value, options),
         ];
     }
@@ -416,7 +416,7 @@ public static class MetadataTableProjector
         }
     }
 
-    static MetadataValue HandleCell(MetadataReader reader, EntityHandle handle)
+    static MetadataValue HandleCell(MetadataReader reader, EntityHandle handle, MetadataProjectionOptions options)
     {
         if (handle.IsNil)
             return new MetadataValue.Nil();
@@ -437,10 +437,11 @@ public static class MetadataTableProjector
                     $"Handle 0x{token:X8} targets {table} row {rid}, outside [1, {targetRows}].");
 
             string? display = ResolveHandleDisplay(reader, handle);
+            bool displayTruncated = false;
             if (display is not null)
-                display = NeutralizeControls(display);
+                display = NeutralizeControls(display, options.MaxStringChars, out displayTruncated);
 
-            return new MetadataValue.Handle(new HandleRef(table, rid, token, display));
+            return new MetadataValue.Handle(new HandleRef(table, rid, token, display, displayTruncated));
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
@@ -552,22 +553,36 @@ public static class MetadataTableProjector
         => new MetadataValue.Flags(raw, decoded);
 
     /// <summary>
-    /// Escapes a decoded heap string for use as data and bounds it to
-    /// <paramref name="maxChars"/> characters. Backslash and quote are escaped,
-    /// and every control character (including ESC) is rendered as <c>\uXXXX</c>
-    /// so the value cannot inject terminal control sequences or break structured
-    /// output. <paramref name="truncated"/> reports whether the bound was hit.
+    /// Escapes a decoded heap string for use as data and bounds the EMITTED
+    /// preview to <paramref name="maxChars"/> characters. Backslash and quote
+    /// are escaped, and every control character (including ESC) is rendered as
+    /// <c>\uXXXX</c> so the value cannot inject terminal control sequences or
+    /// break structured output. Because escaping can expand a single character,
+    /// the budget is enforced on the output length, not the input length;
+    /// <paramref name="truncated"/> reports whether any input was dropped to keep
+    /// the preview within budget.
     /// </summary>
     static string EscapeText(string value, int maxChars, out bool truncated)
     {
         int limit = Math.Max(0, maxChars);
-        truncated = value.Length > limit;
-        int take = truncated ? limit : value.Length;
+        var builder = new System.Text.StringBuilder(Math.Min(value.Length, limit));
+        truncated = false;
 
-        var builder = new System.Text.StringBuilder(take);
-        for (int i = 0; i < take; i++)
+        for (int i = 0; i < value.Length; i++)
         {
             char c = value[i];
+            int width = c switch
+            {
+                '\\' or '"' or '\n' or '\r' or '\t' => 2,
+                _ => IsControl(c) ? 6 : 1,
+            };
+
+            if (builder.Length + width > limit)
+            {
+                truncated = true;
+                break;
+            }
+
             switch (c)
             {
                 case '\\': builder.Append("\\\\"); break;
@@ -590,26 +605,30 @@ public static class MetadataTableProjector
     /// <summary>
     /// Renders every control character in a display string as <c>\uXXXX</c>,
     /// leaving all other characters (including the structural <c>::</c>, quotes,
-    /// and generic-arity marks in resolved names) intact.
+    /// and generic-arity marks in resolved names) intact, and bounds the EMITTED
+    /// text to <paramref name="maxChars"/> characters so a large resolved name
+    /// cannot be re-materialized across every referencing row. The budget is
+    /// enforced on the output length, not the input length;
+    /// <paramref name="truncated"/> reports whether any input was dropped to keep
+    /// the text within budget.
     /// </summary>
-    static string NeutralizeControls(string value)
+    static string NeutralizeControls(string value, int maxChars, out bool truncated)
     {
-        bool needsEscape = false;
-        foreach (char c in value)
+        int limit = Math.Max(0, maxChars);
+        var builder = new System.Text.StringBuilder(Math.Min(value.Length, limit));
+        truncated = false;
+
+        for (int i = 0; i < value.Length; i++)
         {
-            if (IsControl(c))
+            char c = value[i];
+            int width = IsControl(c) ? 6 : 1;
+
+            if (builder.Length + width > limit)
             {
-                needsEscape = true;
+                truncated = true;
                 break;
             }
-        }
 
-        if (!needsEscape)
-            return value;
-
-        var builder = new System.Text.StringBuilder(value.Length + 8);
-        foreach (char c in value)
-        {
             if (IsControl(c))
                 builder.Append("\\u").Append(((int)c).ToString("X4"));
             else

--- a/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
@@ -1,0 +1,180 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Tests for <see cref="MetadataTableProjector"/> — the raw ECMA-335
+/// metadata-table projection (see <c>docs/design/metadata-table-projection.md</c>).
+/// Projects this test assembly (a known, self-describing image) and asserts the
+/// structural shape: table identity, positional cells, resolvable handles,
+/// list-column ranges, additive heap decodes, and explicit budgets.
+/// </summary>
+public class MetadataTableProjectionTests
+{
+    static string SelfPath => typeof(MetadataTableProjectionTests).Assembly.Location;
+
+    static MetadataTableProjection Project(MetadataProjectionOptions? options = null)
+    {
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+        return session.MetadataTables(options);
+    }
+
+    static MetadataTableView Table(MetadataTableProjection projection, TableIndex index)
+        => Assert.Single(projection.Tables, table => table.Index == index);
+
+    static int ColumnIndex(MetadataTableView table, string name)
+    {
+        for (int i = 0; i < table.Columns.Length; i++)
+        {
+            if (table.Columns[i].Name == name)
+                return i;
+        }
+
+        throw new Xunit.Sdk.XunitException($"Column '{name}' not found in table '{table.Name}'.");
+    }
+
+    static MetadataValue Cell(MetadataTableView table, MetadataRow row, string column)
+        => row.Cells[ColumnIndex(table, column)];
+
+    static string? StringText(MetadataTableView table, MetadataRow row, string column)
+        => (Cell(table, row, column) as MetadataValue.HeapReference)?.Text;
+
+    [Fact]
+    public void Project_ProducesTablesInEcmaOrder()
+    {
+        var projection = Project();
+
+        Assert.NotEmpty(projection.Tables);
+        var order = projection.Tables.Select(table => (int)table.Index).ToArray();
+        Assert.Equal(order.OrderBy(value => value).ToArray(), order);
+    }
+
+    [Fact]
+    public void EveryRow_HasOneCellPerColumn()
+    {
+        foreach (var table in Project().Tables)
+        {
+            foreach (var row in table.Rows)
+                Assert.Equal(table.Columns.Length, row.Cells.Length);
+        }
+    }
+
+    [Fact]
+    public void ModuleTable_HasSingleRow_WithDecodedNameAndMvid()
+    {
+        var module = Table(Project(), TableIndex.Module);
+
+        var row = Assert.Single(module.Rows);
+        Assert.Equal(1, row.RowId);
+
+        var name = Assert.IsType<MetadataValue.HeapReference>(Cell(module, row, "Name"));
+        Assert.Equal(HeapKind.String, name.Heap);
+        Assert.False(string.IsNullOrEmpty(name.Text));
+
+        var mvid = Assert.IsType<MetadataValue.HeapReference>(Cell(module, row, "Mvid"));
+        Assert.Equal(HeapKind.Guid, mvid.Heap);
+
+        // A single-generation assembly carries no EnC generation ids.
+        Assert.IsType<MetadataValue.Nil>(Cell(module, row, "EncId"));
+        Assert.IsType<MetadataValue.Nil>(Cell(module, row, "EncBaseId"));
+    }
+
+    [Fact]
+    public void TypeDefRow_ForTestType_ResolvesBaseTypeAndMethodRange()
+    {
+        var projection = Project();
+        var typeDef = Table(projection, TableIndex.TypeDef);
+
+        var row = Assert.Single(
+            typeDef.Rows,
+            candidate => StringText(typeDef, candidate, "Name") == nameof(MetadataTableProjectionTests));
+
+        // Extends is a resolvable edge to System.Object in the TypeRef table.
+        var extends = Assert.IsType<MetadataValue.Handle>(Cell(typeDef, row, "Extends"));
+        Assert.Equal(TableIndex.TypeRef, extends.Reference.TargetTable);
+        Assert.True(extends.Reference.TargetRowId >= 1);
+        Assert.Contains("Object", extends.Reference.Display);
+
+        // MethodList is a contiguous run in the MethodDef table; this type has methods.
+        var methods = Assert.IsType<MetadataValue.Range>(Cell(typeDef, row, "MethodList"));
+        Assert.Equal(TableIndex.MethodDef, methods.Reference.TargetTable);
+        Assert.True(methods.Reference.Count >= 1);
+        Assert.Equal(methods.Reference.EndRowId, methods.Reference.StartRowId + methods.Reference.Count);
+    }
+
+    [Fact]
+    public void MethodDefRow_SignatureIsBoundedBlobPreview()
+    {
+        var methodDef = Table(Project(), TableIndex.MethodDef);
+        var row = methodDef.Rows.First();
+
+        var signature = Assert.IsType<MetadataValue.HeapReference>(Cell(methodDef, row, "Signature"));
+        Assert.Equal(HeapKind.Blob, signature.Heap);
+        Assert.Null(signature.Text);
+        Assert.False(string.IsNullOrEmpty(signature.Preview));
+    }
+
+    [Fact]
+    public void AssemblyRefTable_IncludesResolvedReferenceNames()
+    {
+        var assemblyRef = Table(Project(), TableIndex.AssemblyRef);
+
+        var names = assemblyRef.Rows
+            .Select(row => StringText(assemblyRef, row, "Name"))
+            .ToArray();
+
+        Assert.All(names, name => Assert.False(string.IsNullOrEmpty(name)));
+        Assert.Contains("System.Runtime", names);
+    }
+
+    [Fact]
+    public void RowBudget_TruncatesExplicitly_NeverSilently()
+    {
+        var full = Table(Project(), TableIndex.TypeDef);
+        Assert.True(full.RowCount > 1, "Expected the test assembly to define more than one type.");
+
+        var capped = Table(
+            Project(new MetadataProjectionOptions { MaxRowsPerTable = 1 }),
+            TableIndex.TypeDef);
+
+        Assert.Single(capped.Rows);
+        Assert.Equal(full.RowCount, capped.RowCount);
+        Assert.NotNull(capped.Truncation);
+        Assert.Equal(1, capped.Truncation!.ProjectedRows);
+        Assert.Equal(full.RowCount, capped.Truncation.RowCount);
+    }
+
+    [Fact]
+    public void TableSelection_RestrictsProjectionToRequestedTables()
+    {
+        var projection = Project(new MetadataProjectionOptions
+        {
+            Tables = [TableIndex.Module],
+        });
+
+        var table = Assert.Single(projection.Tables);
+        Assert.Equal(TableIndex.Module, table.Index);
+    }
+
+    [Fact]
+    public void HandleColumns_DeclareCandidateTargets()
+    {
+        var typeDef = Table(Project(), TableIndex.TypeDef);
+        var extends = typeDef.Columns[ColumnIndex(typeDef, "Extends")];
+
+        Assert.Equal(MetadataColumnKind.Handle, extends.Kind);
+        Assert.Contains(TableIndex.TypeDef, extends.CandidateTargets);
+        Assert.Contains(TableIndex.TypeRef, extends.CandidateTargets);
+        Assert.Contains(TableIndex.TypeSpec, extends.CandidateTargets);
+    }
+
+    [Fact]
+    public void EmptyImage_HasNoMetadataTables()
+    {
+        // The projector never fabricates a success-shaped table set; a metadata
+        // image simply projects to whatever tables carry rows.
+        var projection = Project();
+        Assert.DoesNotContain(projection.Tables, table => table.Rows.IsDefault);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
@@ -259,6 +259,38 @@ public class MetadataTableProjectionTests
     }
 
     [Fact]
+    public void EscapeText_KeepsSurrogatePairsAtomicAndEscapesLoneSurrogates()
+    {
+        // The budget is measured in UTF-16 code units, but a supplementary scalar
+        // is two of them; truncation must never retain a lone high surrogate, and
+        // an unpaired surrogate must be escaped rather than emitted raw.
+        var escape = typeof(MetadataTableProjector).GetMethod(
+            "EscapeText",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+        const string emoji = "\U0001F600"; // one scalar, two UTF-16 code units
+
+        // Budget 2: 'A' fits (1); the pair needs 2 more and is dropped as a unit.
+        var dropped = new object?[] { "A" + emoji, 2, null };
+        var droppedText = (string)escape.Invoke(null, dropped)!;
+        Assert.Equal("A", droppedText);
+        Assert.True((bool)dropped[2]!);
+        Assert.DoesNotContain(droppedText, char.IsSurrogate);
+
+        // Budget 3: 'A' plus the atomic pair fit exactly; nothing is truncated.
+        var kept = new object?[] { "A" + emoji, 3, null };
+        var keptText = (string)escape.Invoke(null, kept)!;
+        Assert.Equal("A" + emoji, keptText);
+        Assert.False((bool)kept[2]!);
+
+        // A lone (unpaired) surrogate is escaped, never emitted as raw text.
+        var lone = new object?[] { "\uD83D", 10, null };
+        var loneText = (string)escape.Invoke(null, lone)!;
+        Assert.Equal("\\uD83D", loneText);
+        Assert.DoesNotContain(loneText, char.IsSurrogate);
+    }
+
+    [Fact]
     public void EmptyImage_HasNoMetadataTables()
     {
         // The projector never fabricates a success-shaped table set; a metadata

--- a/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
@@ -170,6 +170,50 @@ public class MetadataTableProjectionTests
     }
 
     [Fact]
+    public void StringBudget_ProjectsBoundedPreviewWithExplicitTruncation()
+    {
+        var projection = Project(new MetadataProjectionOptions { MaxStringChars = 1 });
+
+        var truncated = projection.Tables
+            .SelectMany(table => table.Rows)
+            .SelectMany(row => row.Cells)
+            .OfType<MetadataValue.HeapReference>()
+            .Where(heap => heap.Heap == HeapKind.String && heap.Truncated)
+            .ToList();
+
+        Assert.NotEmpty(truncated);
+        Assert.All(truncated, heap =>
+        {
+            // Length reports the full decoded size; the retained preview is bounded.
+            Assert.True(heap.Length > 1);
+            Assert.False(string.IsNullOrEmpty(heap.Text));
+        });
+    }
+
+    [Fact]
+    public void BlobBudget_ProjectsBoundedHexPreviewWithExplicitTruncation()
+    {
+        var methodDef = Table(
+            Project(new MetadataProjectionOptions { MaxPreviewBytes = 2 }),
+            TableIndex.MethodDef);
+
+        var truncated = methodDef.Rows
+            .Select(row => Cell(methodDef, row, "Signature"))
+            .OfType<MetadataValue.HeapReference>()
+            .Where(heap => heap.Truncated)
+            .ToList();
+
+        Assert.NotEmpty(truncated);
+        Assert.All(truncated, heap =>
+        {
+            Assert.Equal(HeapKind.Blob, heap.Heap);
+            Assert.Null(heap.Text);
+            Assert.Equal(4, heap.Preview.Length); // two bytes -> four hex chars
+            Assert.True(heap.Length > 2);
+        });
+    }
+
+    [Fact]
     public void EmptyImage_HasNoMetadataTables()
     {
         // The projector never fabricates a success-shaped table set; a metadata

--- a/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
@@ -214,6 +214,51 @@ public class MetadataTableProjectionTests
     }
 
     [Fact]
+    public void HandleDisplay_RespectsStringBudgetWithExplicitTruncation()
+    {
+        // A handle's convenience Display is a resolved name drawn from the heaps,
+        // so it is subject to the same character budget as a heap string cell; a
+        // large shared name must not be re-materialized across every referencing
+        // row via the Display path.
+        const int budget = 4;
+        var references = Project(new MetadataProjectionOptions { MaxStringChars = budget })
+            .Tables
+            .SelectMany(table => table.Rows)
+            .SelectMany(row => row.Cells)
+            .OfType<MetadataValue.Handle>()
+            .Select(cell => cell.Reference)
+            .Where(reference => reference.Display is not null)
+            .ToList();
+
+        Assert.NotEmpty(references);
+        Assert.All(references, reference => Assert.True(
+            reference.Display!.Length <= budget,
+            $"Display '{reference.Display}' exceeds the {budget}-char budget."));
+        Assert.Contains(references, reference => reference.DisplayTruncated);
+    }
+
+    [Fact]
+    public void StringPreview_NeverExceedsCharBudgetEvenWhenEscaped()
+    {
+        // Escaping can expand a single character, so the budget is enforced on the
+        // emitted length: no retained string preview exceeds MaxStringChars, even
+        // for a value that is nominally within the character count.
+        const int budget = 4;
+        var strings = Project(new MetadataProjectionOptions { MaxStringChars = budget })
+            .Tables
+            .SelectMany(table => table.Rows)
+            .SelectMany(row => row.Cells)
+            .OfType<MetadataValue.HeapReference>()
+            .Where(heap => heap.Heap == HeapKind.String && heap.Text is not null)
+            .ToList();
+
+        Assert.NotEmpty(strings);
+        Assert.All(strings, heap => Assert.True(
+            heap.Text!.Length <= budget,
+            $"String preview '{heap.Text}' exceeds the {budget}-char budget."));
+    }
+
+    [Fact]
     public void EmptyImage_HasNoMetadataTables()
     {
         // The projector never fabricates a success-shaped table set; a metadata


### PR DESCRIPTION
## What

Increment 1 of the raw ECMA-335 metadata-table projection specified in `docs/design/metadata-table-projection.md` (design merged in #3288). Adds the **Metadata-layer core** only — no CLI surface yet.

The projection is the *structurally lossless* sibling of the typed extractors: it mirrors SRM's logical table/heap graph without curating it into a semantic view, and it is **never a dependency** of the typed extractors (`ApiSurfaceExtractor`, Findings, C# views).

## Changes

- **`MetadataTableProjection.cs`** — model: `MetadataTableProjection` → `MetadataTableView` → `MetadataColumn`/`MetadataRow`, with a closed `MetadataValue` union (`Nil | Scalar | Flags | HeapReference | Handle | Range | Malformed`), resolvable `HandleRef`/`HandleRange` edges, explicit `MetadataTableTruncation`, and `MetadataProjectionOptions` (row/blob budgets + table selection).
- **`MetadataTableProjector.cs`** — read-only, SRM-only static `Project(PEReader, options)` over the first table tranche: **Module, TypeRef, TypeDef, Field, MethodDef, Param, MemberRef, CustomAttribute, AssemblyRef**. Enumerates uniformly by row number; handles become resolvable edges; list columns become `HandleRange`; heaps surface as bounded `HeapReference` cells (blobs as bounded hex preview). **Friendly decodes are additive** (a column beside the raw value, never replacing it). Reuses `ILTokenResolver` for handle display and `ILStringEscaper` for name text.
- **`AssemblyInspectionSession.MetadataTables(...)`** facet.
- **Tests** (`MetadataTableProjectionTests.cs`, 10 facts) projecting this test assembly.

## Safety

Read-only, SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading. Per-table row and blob-preview **budgets truncate explicitly** via `MetadataTableTruncation` — never silent truncation. A cell that SRM rejects becomes `MetadataValue.Malformed`, never a success-shaped empty value. Heap offsets are best-effort (`-1`) so a readable name never degrades to `Malformed`.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release` → 0 errors.
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` → **865 passed, 0 failed** (10 new).

## Deferred (non-blocking follow-up)

- CLI `metadata` lens surface, heap-surfacing flags, and table-selection grammar — **blocked on the design doc's open questions** (need decisions before wiring; not guessed here).
- Additional tables and signature/custom-attribute blob friendly decode (currently bounded hex preview).

Refs #3282.
