### PR TITLE
Two reporting gestures for annotations: side and caret (#3304)

### DIFF
--- a/docs/design/hidden-fact-annotations.md
+++ b/docs/design/hidden-fact-annotations.md
@@ -95,10 +95,28 @@ prefixes match on a dotted-segment boundary, so `alloc` selects `alloc.box` but
 not `allocator.x`. With no `--focus`, every fact takes the side gesture and the
 output is byte-identical to the pre-gesture renderer.
 
+Promotion never removes a fact, so a `--focus` that matches nothing renders
+exactly like no `--focus` at all. That would make a typo indistinguishable from
+an honest absence, so an unmatched focus reports the families the member does
+have. `--focus` is member-scoped: the sections that carry a caret block —
+Annotated Source, Cost Overlay, Semantics Overlay — are all member sections.
+
 An annotation carries an IL offset and no character span, so a caret underlines
-the **whole trimmed statement** — exactly what the fact is known to be about. A
-span-carrying datum (a compiler diagnostic) can underline a narrower range; that
-is a property of the datum, not of the gesture.
+the **whole trimmed statement** — exactly what the fact is known to be about.
+
+That is the only mode `AnnotationCaret` implements, and deliberately so: no
+annotation can carry a span, so a narrower underline has no data to draw from
+here. A span-carrying datum — a compiler diagnostic — wants a narrow caret, and
+`FidelityCheck.RenderAnnotatedFailure` draws one today with its own geometry.
+These are **two caret renderers, not one substrate**. Unifying them into a
+single span-aware renderer ("no span ⇒ underline the whole statement") is
+tracked as the open question on the follow-up issue; until that is decided,
+neither claims to be the shared one.
+
+Likewise, the gesture here is chosen by `--focus`, not by the shape of the data.
+A data-driven rule ("span-carrying ⇒ caret") cannot exist inside the annotation
+model, because the positive-only contract forbids the span that such a rule
+would key on.
 
 #### One gutter, at the declaration column
 

--- a/docs/design/hidden-fact-annotations.md
+++ b/docs/design/hidden-fact-annotations.md
@@ -77,6 +77,44 @@ settle:
 - **Semantics Overlay** — inter-method behavior/safety facts, such as callees
   with known exception paths or unsafe implementation evidence.
 
+### Two gestures: side and caret
+
+*Where* a fact is drawn is a reporting decision, not a property of the fact. The
+[positive-only contract](#the-positive-only-contract) forbids severity on an
+annotation, and calling a fact "actionable" is a grade — so the choice cannot
+live on `IAnnotation`. It lives in `AnnotationGestureSelector`, chosen per render.
+
+- **Side** (default) — a trailing `//` comment to the right of the statement.
+  Reads as ambient context: "here is something interesting about this line."
+- **Caret** — a `^^^^` underline on `//` lines beneath the statement. Reads as
+  focus: "look *here*." Long details wrap into a readable block instead of the
+  far-right sliver a 190-column trailing comment produces.
+
+`--focus <category|id|id-prefix>` promotes matching facts to the caret gesture;
+prefixes match on a dotted-segment boundary, so `alloc` selects `alloc.box` but
+not `allocator.x`. With no `--focus`, every fact takes the side gesture and the
+output is byte-identical to the pre-gesture renderer.
+
+An annotation carries an IL offset and no character span, so a caret underlines
+the **whole trimmed statement** — exactly what the fact is known to be about. A
+span-carrying datum (a compiler diagnostic) can underline a narrower range; that
+is a property of the datum, not of the gesture.
+
+#### One gutter, at the declaration column
+
+Injected comments anchor to the **member declaration** column rather than to the
+annotated statement's own indent, so the eye tracks a single gutter instead of a
+staircase that follows nesting depth.
+
+That column is below the projected body: the body is member-relative, and the
+declaration line and a uniform four-column indent are added downstream when the
+member is formatted. A caret comment needs three columns to the left of its
+first caret for `"// "`, which a statement on the body's base column cannot
+supply — its carets would sit three columns right of what they point at. So
+`AnnotationCaret` marks its lines with `HoistMarker` and the body formatter
+renders them un-indented. This buys the columns back at *every* depth, which is
+why it is a marker rather than a clamp.
+
 ## Validation: the oracle problem
 
 The decompiler earns trust from **independent ground truth at corpus scale** —

--- a/skills/decompiler/SKILL.md
+++ b/skills/decompiler/SKILL.md
@@ -49,9 +49,10 @@ dnx dotnet-inspect -y -- member Cache --project ./src/App Pump:1 -S "Annotated S
 ```
 
 The value matches an annotation category, an exact id, or a dotted-id prefix on
-a segment boundary (`alloc` selects `alloc.box`, not `allocator.x`). Facts that
-do not match keep the trailing form, so `--focus` narrows attention without
-hiding anything.
+a segment boundary (`alloc` selects `alloc.box`, not `allocator.x`). It
+**promotes, it never filters** — facts that do not match keep the trailing form,
+so `--focus` narrows attention without hiding anything. A focus that matches
+nothing says so and names the families the member does have.
 
 ## Fidelity model
 

--- a/skills/decompiler/SKILL.md
+++ b/skills/decompiler/SKILL.md
@@ -37,6 +37,22 @@ dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Dec
 dnx dotnet-inspect -y -- member Command --project ./src/App Add:1 -S @Source
 ```
 
+### Focusing annotations
+
+By default every hidden fact renders as a trailing `//` comment. A fact with a
+long detail can push that comment far off the right edge. `--focus` promotes
+matching facts to a `^^^^` underline beneath the statement, wrapped into a
+readable block:
+
+```bash
+dnx dotnet-inspect -y -- member Cache --project ./src/App Pump:1 -S "Annotated Source" --focus allocation
+```
+
+The value matches an annotation category, an exact id, or a dotted-id prefix on
+a segment boundary (`alloc` selects `alloc.box`, not `allocator.x`). Facts that
+do not match keep the trailing form, so `--focus` narrows attention without
+hiding anything.
+
 ## Fidelity model
 
 The decompiler degrades honestly: IL with no faithful C# spelling renders as a

--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -1,0 +1,245 @@
+using ILInspector.Decompiler.Annotations;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins the two reporting gestures (#3304). An annotation is data; the gesture is
+/// a reporting choice made per render, so these tests assert the *geometry* of the
+/// caret render and the invariant that the default report is unchanged.
+/// </summary>
+[Trait("Area", "Annotations")]
+public class AnnotationGestureTests
+{
+    static readonly AnnotationDescriptor Alloc =
+        new("alloc.new", AnnotationCategory.Allocation, "allocates");
+    static readonly AnnotationDescriptor Unsafety =
+        new("unsafe.stackalloc", AnnotationCategory.Unsafety, "stack allocates");
+
+    static Annotation Fact(AnnotationDescriptor descriptor, string? detail = null)
+        => new(descriptor, SourceOffset: 0, Detail: detail);
+
+    // ---- selector: the reporting half of the split -------------------------
+
+    [Fact]
+    public void DefaultSelectorLeavesEveryFactOnTheSideGesture()
+    {
+        var facts = new IAnnotation[] { Fact(Alloc), Fact(Unsafety) };
+        Assert.True(AnnotationGestureSelector.SideOnly.AllSide(facts));
+        foreach (var fact in facts)
+            Assert.Equal(AnnotationGesture.Side, AnnotationGestureSelector.SideOnly.For(fact));
+    }
+
+    [Theory]
+    // category name, descriptor id, and dotted id prefix all select
+    [InlineData("allocation", true)]
+    [InlineData("Allocation", true)]
+    [InlineData("alloc.new", true)]
+    [InlineData("alloc", true)]
+    // a prefix must land on a segment boundary, not mid-identifier
+    [InlineData("all", false)]
+    [InlineData("alloc.n", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void FocusPromotesOnlyMatchingFacts(string? focus, bool promoted)
+    {
+        var selector = AnnotationGestureSelector.Focus(focus);
+        var expected = promoted ? AnnotationGesture.Caret : AnnotationGesture.Side;
+        Assert.Equal(expected, selector.For(Fact(Alloc)));
+
+        // None of these focuses name the unsafety family, so it stays on the side
+        // gesture: focusing one family must not drag another along with it.
+        Assert.Equal(AnnotationGesture.Side, selector.For(Fact(Unsafety)));
+    }
+
+    [Fact]
+    public void FocusSelectsTheNamedFamilyAndLeavesTheOtherBehind()
+    {
+        var selector = AnnotationGestureSelector.Focus("unsafety");
+        Assert.Equal(AnnotationGesture.Caret, selector.For(Fact(Unsafety)));
+        Assert.Equal(AnnotationGesture.Side, selector.For(Fact(Alloc)));
+    }
+
+    // ---- caret geometry ----------------------------------------------------
+
+    [Fact]
+    public void CaretUnderlinesTheTrimmedStatementAndNotItsIndent()
+    {
+        // Indented past the member gutter, so "//" has room to sit to its left.
+        string line = "        Sink(new object());";
+        var rendered = AnnotationCaret.Render(line, memberIndent: "    ", [Fact(Alloc, "obj")]);
+
+        string caretLine = rendered[0];
+        int caretStart = caretLine.IndexOf('^');
+        int statementStart = line.Length - line.AsSpan().TrimStart().Length;
+
+        Assert.Equal(statementStart, caretStart);
+        Assert.Equal(line.Trim().Length, caretLine.Count(c => c == '^'));
+    }
+
+    [Fact]
+    public void CaretCommentSitsOnTheMemberGutterRegardlessOfNestingDepth()
+    {
+        // Two statements at different depths must put their "//" in one column:
+        // that single gutter is the whole point of the caret gesture's layout.
+        const string memberIndent = "    ";
+        string shallow = "        a();";
+        string deep = "                    b();";
+
+        string shallowLine = AnnotationCaret.Render(shallow, memberIndent, [Fact(Alloc)])[0];
+        string deepLine = AnnotationCaret.Render(deep, memberIndent, [Fact(Alloc)])[0];
+
+        Assert.Equal(memberIndent.Length, shallowLine.IndexOf("//", StringComparison.Ordinal));
+        Assert.Equal(memberIndent.Length, deepLine.IndexOf("//", StringComparison.Ordinal));
+
+        // ...while each still points at its own statement.
+        Assert.Equal(shallow.Length - shallow.TrimStart().Length, shallowLine.IndexOf('^'));
+        Assert.Equal(deep.Length - deep.TrimStart().Length, deepLine.IndexOf('^'));
+    }
+
+    [Fact]
+    public void EveryRenderedCaretLineIsAComment()
+    {
+        // The block is spliced into a ```csharp fence, so no line may be bare text.
+        string detail = string.Join("; ", Enumerable.Repeat("key=value-that-is-long", 8));
+        var rendered = AnnotationCaret.Render("        Work();", "    ", [Fact(Alloc, detail)]);
+
+        Assert.True(rendered.Count > 1, "a long detail must wrap onto continuation lines");
+        foreach (string line in rendered)
+            Assert.StartsWith("//", line.TrimStart(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ContinuationLinesShareOneDetailColumn()
+    {
+        string detail = string.Join("; ", Enumerable.Repeat("key=value-that-is-long", 8));
+        var rendered = AnnotationCaret.Render("        Work();", "    ", [Fact(Alloc, detail)]);
+
+        var continuations = rendered.Skip(1).ToList();
+        Assert.NotEmpty(continuations);
+        int column = continuations[0].Length - continuations[0].TrimStart().Length
+            + "//".Length;
+        foreach (string line in continuations)
+        {
+            int textStart = line.IndexOf("//", StringComparison.Ordinal) + "//".Length;
+            while (textStart < line.Length && line[textStart] == ' ')
+                textStart++;
+            Assert.Equal(FirstTextColumn(continuations[0]), textStart);
+            Assert.True(column > 0);
+        }
+
+        static int FirstTextColumn(string line)
+        {
+            int start = line.IndexOf("//", StringComparison.Ordinal) + "//".Length;
+            while (start < line.Length && line[start] == ' ')
+                start++;
+            return start;
+        }
+    }
+
+    [Fact]
+    public void EachFactStartsItsOwnLine()
+    {
+        var rendered = AnnotationCaret.Render(
+            "        Work();",
+            "    ",
+            [Fact(Alloc, "one"), Fact(Unsafety, "two")]);
+
+        Assert.Contains(rendered, line => line.Contains("alloc.new(one)", StringComparison.Ordinal));
+        Assert.Contains(rendered, line => line.Contains("unsafe.stackalloc(two)", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            rendered,
+            line => line.Contains("alloc.new(one)", StringComparison.Ordinal)
+                && line.Contains("unsafe.stackalloc(two)", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void NothingIsRenderedForABlankLineOrNoFacts()
+    {
+        Assert.Empty(AnnotationCaret.Render("        Work();", "    ", []));
+        Assert.Empty(AnnotationCaret.Render("      ", "    ", [Fact(Alloc)]));
+    }
+
+    [Fact]
+    public void MemberIndentReadsTheFirstNonBlankLine()
+    {
+        Assert.Equal("    ", AnnotationCaret.MemberIndent(["", "   ", "    void M()", "        x();"]));
+        Assert.Equal("", AnnotationCaret.MemberIndent(["void M()", "    x();"]));
+        Assert.Equal("", AnnotationCaret.MemberIndent([]));
+    }
+
+    /// <summary>
+    /// Without hoisting, the gutter needs three columns ("//" plus a space) to
+    /// the left of the statement, and a statement sitting *at* the gutter cannot
+    /// supply them — the caret shifts right rather than emitting a non-comment
+    /// line. Hoisting exists precisely to buy those columns back, so the same
+    /// input must point exactly. The pair is asserted together because the
+    /// second half is the reason the first half is tolerable.
+    /// </summary>
+    [Fact]
+    public void HoistingIsWhatLetsAStatementOnTheGutterBePointedAtExactly()
+    {
+        string line = "return Work();";
+
+        string flat = AnnotationCaret.Render(line, memberIndent: "", [Fact(Alloc)])[0];
+        Assert.StartsWith("//", flat, StringComparison.Ordinal);
+        Assert.Equal("//".Length + 1, flat.IndexOf('^'));
+
+        string hoisted = AnnotationCaret.Render(line, memberIndent: "", [Fact(Alloc)], hoist: true)[0];
+        Assert.True(AnnotationCaret.TryHoist(hoisted, out string text));
+        // Rendered BodyIndentWidth columns left of the code, so the caret column
+        // in the hoisted line's own coordinates is the statement column plus that.
+        Assert.Equal(AnnotationCaret.BodyIndentWidth, text.IndexOf('^'));
+        Assert.StartsWith("//", text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("return Work();")]
+    [InlineData("    if (x)")]
+    [InlineData("            Sink(new object());")]
+    public void EveryHoistedCaretPointsExactlyAtItsStatement(string line)
+    {
+        // The property the shipped views rely on: at every nesting depth,
+        // including the body's own base column, the carets land on the first
+        // character of the statement once the body indent is removed.
+        var rendered = AnnotationCaret.Render(line, memberIndent: "", [Fact(Alloc)], hoist: true);
+
+        foreach (string emitted in rendered)
+        {
+            Assert.True(AnnotationCaret.TryHoist(emitted, out string text), "every hoisted line is marked");
+            Assert.StartsWith("//", text, StringComparison.Ordinal);
+        }
+
+        AnnotationCaret.TryHoist(rendered[0], out string caretLine);
+        int statementColumn = line.Length - line.AsSpan().TrimStart().Length;
+        Assert.Equal(statementColumn + AnnotationCaret.BodyIndentWidth, caretLine.IndexOf('^'));
+        Assert.Equal(line.Trim().Length, caretLine.Count(c => c == '^'));
+    }
+
+    [Fact]
+    public void OnlyHoistedLinesCarryTheMarker()
+    {
+        foreach (string line in AnnotationCaret.Render("        Work();", "    ", [Fact(Alloc)]))
+        {
+            Assert.False(AnnotationCaret.TryHoist(line, out string text));
+            Assert.Equal(line, text);
+            Assert.DoesNotContain(AnnotationCaret.HoistMarker, line);
+        }
+    }
+
+    [Fact]
+    public void HoistedLinesCarryExactlyOneMarkerAndNoneInTheirText()
+    {
+        // A marker surviving into rendered text would print as a control
+        // character inside a csharp fence.
+        string detail = string.Join("; ", Enumerable.Repeat("key=value-that-is-long", 8));
+        var rendered = AnnotationCaret.Render("    Work();", "", [Fact(Alloc, detail)], hoist: true);
+
+        Assert.True(rendered.Count > 1);
+        foreach (string line in rendered)
+        {
+            Assert.Equal(1, line.Count(c => c == AnnotationCaret.HoistMarker));
+            Assert.True(AnnotationCaret.TryHoist(line, out string text));
+            Assert.DoesNotContain(AnnotationCaret.HoistMarker, text);
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -215,9 +215,47 @@ public class AnnotationGestureTests
         Assert.Equal(line.Trim().Length, caretLine.Count(c => c == '^'));
     }
 
-    [Fact]
-    public void OnlyHoistedLinesCarryTheMarker()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NoRenderedCaretLineExceedsTheWidthBudget(bool hoist)
     {
+        // Measured in *rendered* columns, which for a hoisted line means after
+        // the marker is stripped and the body indent is skipped. Getting this
+        // wrong is invisible in a unit test that only inspects the raw string:
+        // the hoist adjustment leaked into the wrap arithmetic once already and
+        // produced a 104-column line against a 100-column budget.
+        string detail = string.Join("; ", Enumerable.Repeat("key=some-fairly-long-value", 10));
+        foreach (string indent in new[] { "", "    " })
+        {
+            foreach (string line in new[] { indent + "Work();", indent + "        Nested(new object());" })
+            {
+                foreach (string emitted in AnnotationCaret.Render(line, indent, [Fact(Alloc, detail)], hoist))
+                {
+                    AnnotationCaret.TryHoist(emitted, out string text);
+                    Assert.True(
+                        text.Length <= AnnotationCaret.Budget,
+                        $"{text.Length} columns exceeds the {AnnotationCaret.Budget} budget: {text}");
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void FlattenRemovesEveryMarkerForOutputPathsThatCannotHoist()
+    {
+        // Not every consumer of a projected body applies the body indent, and
+        // one that does not must still never emit the control character.
+        var rendered = AnnotationCaret.Render("    Work();", "", [Fact(Alloc, "d")], hoist: true);
+        string joined = string.Join("\n", rendered);
+
+        Assert.Contains(AnnotationCaret.HoistMarker, joined);
+        Assert.DoesNotContain(AnnotationCaret.HoistMarker, AnnotationCaret.Flatten(joined));
+        Assert.Equal("plain", AnnotationCaret.Flatten("plain"));
+    }
+
+    [Fact]
+    public void OnlyHoistedLinesCarryTheMarker()    {
         foreach (string line in AnnotationCaret.Render("        Work();", "    ", [Fact(Alloc)]))
         {
             Assert.False(AnnotationCaret.TryHoist(line, out string text));

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -26,7 +26,7 @@ public static class AnnotationCaret
     // Target rendered width. Detail wraps to stay inside this where the geometry
     // allows it; a deeply indented statement with a long underline can push the
     // detail column out, which is what MinDetailWidth guards against.
-    const int Budget = 100;
+    internal const int Budget = 100;
     const int MinDetailWidth = 32;
 
     // Past this column a trailing detail reads as a far-right sliver even when it
@@ -69,6 +69,15 @@ public static class AnnotationCaret
     }
 
     /// <summary>
+    /// Removes every <see cref="HoistMarker"/> from <paramref name="text"/>.
+    /// The marker is an in-band layout signal and would print as a control
+    /// character, so an output path that cannot honour the hoist must still
+    /// strip it rather than pass it through.
+    /// </summary>
+    public static string Flatten(string text)
+        => text.IndexOf(HoistMarker) < 0 ? text : text.Replace(HoistMarker.ToString(), "");
+
+    /// <summary>
     /// Renders the caret block for <paramref name="annotations"/> under
     /// <paramref name="lineText"/>, returning one or more already-indented
     /// comment lines. Returns an empty list when there is nothing to point at
@@ -103,13 +112,22 @@ public static class AnnotationCaret
         // every depth; without it a statement sitting on the gutter has none, so
         // clamp — a caller can also render a fragment with no member line above.
         int hoisted = hoist ? BodyIndentWidth : 0;
-        int pad = Math.Max(1, caretStart + hoisted - memberIndent.Length - 2);
-        string prefix = hoist ? HoistMarker + memberIndent : memberIndent;
-        string gutter = prefix + "//";
 
-        // Column arithmetic runs in rendered columns, where a hoisted comment
-        // starts BodyIndentWidth to the left of the body it annotates.
-        int commentColumn = memberIndent.Length - hoisted;
+        // All column arithmetic below is in *rendered* columns. A hoisted caret
+        // line escapes the body indent that the code lines receive, so the code
+        // is that much further right than its position in this stream; an
+        // un-hoisted line is indented alongside the code, so the shift is zero
+        // and the relative geometry is unchanged.
+        int commentColumn = memberIndent.Length;
+        int caretColumn = caretStart + hoisted;
+
+        // "//" occupies two columns of the gutter, so the pad that carries the
+        // caret out to the statement is measured from the end of that marker.
+        // Hoisting buys BodyIndentWidth columns of headroom, which is enough at
+        // every depth; without it a statement sitting on the gutter has none, so
+        // clamp — a caller can also render a fragment with no member line above.
+        int pad = Math.Max(1, caretColumn - commentColumn - 2);
+        string gutter = (hoist ? HoistMarker + memberIndent : memberIndent) + "//";
         int caretEnd = commentColumn + 2 + pad + trimmed.Length;
 
         // Prefer trailing the detail on the caret line. When the underline is so

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -1,0 +1,195 @@
+using System.Text;
+
+namespace ILInspector.Decompiler.Annotations;
+
+/// <summary>
+/// Renders the <see cref="AnnotationGesture.Caret"/> gesture: a <c>^^^^</c>
+/// underline on following <c>//</c> lines, pointing at the annotated statement.
+/// </summary>
+/// <remarks>
+/// Two layout decisions, both deliberate:
+/// <list type="bullet">
+/// <item><b>One gutter.</b> The injected <c>//</c> anchors to the <em>member
+/// declaration</em> column, not to the annotated statement's own indent. Every
+/// injected comment in a member therefore shares one column, so the eye tracks a
+/// single gutter instead of a ragged staircase that follows nesting depth.</item>
+/// <item><b>Underline the whole statement.</b> An <see cref="IAnnotation"/> is
+/// keyed to an IL offset and carries no character span (see the contract in
+/// Annotations.cs), so there is no sub-token to point at. The underline covers
+/// the trimmed statement — exactly what the fact is known to be about, and no
+/// more. A span-carrying datum (a compiler diagnostic) can underline a narrower
+/// range; that is a property of the datum, not of this gesture.</item>
+/// </list>
+/// </remarks>
+public static class AnnotationCaret
+{
+    // Target rendered width. Detail wraps to stay inside this where the geometry
+    // allows it; a deeply indented statement with a long underline can push the
+    // detail column out, which is what MinDetailWidth guards against.
+    const int Budget = 100;
+    const int MinDetailWidth = 32;
+
+    // Past this column a trailing detail reads as a far-right sliver even when it
+    // technically fits, so a long underline drops its detail to a block beneath
+    // the carets instead. Short underlines keep the compact trailing form.
+    const int InlineDetailMaxColumn = 40;
+
+    /// <summary>
+    /// Marks a caret line as already positioned at the enclosing member
+    /// declaration column. A consumer that indents the projected body must strip
+    /// this marker and leave the line's own columns alone.
+    /// </summary>
+    /// <remarks>
+    /// The projected body is member-relative: its first statement sits at column
+    /// zero and the declaration line does not exist yet. A caret comment needs
+    /// three columns to the left of its first caret for <c>"// "</c>, so a
+    /// statement at the body's base column has nowhere to put them and its
+    /// carets would sit three columns right of what they point at. Hoisting the
+    /// caret line out of the body indent recovers those columns at every nesting
+    /// depth, which is why the marker exists rather than a clamp.
+    /// </remarks>
+    public const char HoistMarker = '\u0011';
+
+    /// <summary>
+    /// Columns the block-body indent adds to every projected line, and therefore
+    /// the columns a <see cref="HoistMarker"/> line is rendered to the left of it.
+    /// </summary>
+    public const int BodyIndentWidth = 4;
+
+    /// <summary>Strips a leading <see cref="HoistMarker"/>, reporting whether one was present.</summary>
+    public static bool TryHoist(string line, out string text)
+    {
+        if (line.Length > 0 && line[0] == HoistMarker)
+        {
+            text = line[1..];
+            return true;
+        }
+        text = line;
+        return false;
+    }
+
+    /// <summary>
+    /// Renders the caret block for <paramref name="annotations"/> under
+    /// <paramref name="lineText"/>, returning one or more already-indented
+    /// comment lines. Returns an empty list when there is nothing to point at
+    /// (a blank line, or no annotations).
+    /// </summary>
+    /// <param name="lineText">The annotated source line, as rendered.</param>
+    /// <param name="memberIndent">Leading whitespace of the member declaration line — the shared gutter.</param>
+    /// <param name="annotations">The annotations promoted to the caret gesture on this line.</param>
+    /// <param name="hoist">
+    /// When true, each returned line carries a leading <see cref="HoistMarker"/>
+    /// and is laid out as if it will be rendered <see cref="BodyIndentWidth"/>
+    /// columns left of the code lines. See the marker's remarks for why.
+    /// </param>
+    public static IReadOnlyList<string> Render(
+        string lineText,
+        string memberIndent,
+        IReadOnlyList<IAnnotation> annotations,
+        bool hoist = false)
+    {
+        if (annotations.Count == 0)
+            return [];
+
+        string trimmed = lineText.Trim();
+        if (trimmed.Length == 0)
+            return [];
+
+        int caretStart = lineText.Length - lineText.AsSpan().TrimStart().Length;
+
+        // "//" occupies two columns of the gutter, so the pad that carries the
+        // caret out to the statement is measured from the end of that marker.
+        // Hoisting buys BodyIndentWidth columns of headroom, which is enough at
+        // every depth; without it a statement sitting on the gutter has none, so
+        // clamp — a caller can also render a fragment with no member line above.
+        int hoisted = hoist ? BodyIndentWidth : 0;
+        int pad = Math.Max(1, caretStart + hoisted - memberIndent.Length - 2);
+        string prefix = hoist ? HoistMarker + memberIndent : memberIndent;
+        string gutter = prefix + "//";
+
+        // Column arithmetic runs in rendered columns, where a hoisted comment
+        // starts BodyIndentWidth to the left of the body it annotates.
+        int commentColumn = memberIndent.Length - hoisted;
+        int caretEnd = commentColumn + 2 + pad + trimmed.Length;
+
+        // Prefer trailing the detail on the caret line. When the underline is so
+        // long that doing so leaves no usable width, drop the detail to its own
+        // lines on a modest fixed column instead of wrapping into a sliver.
+        bool inline = caretEnd <= InlineDetailMaxColumn && caretEnd + 1 + MinDetailWidth <= Budget;
+        int detailColumn = inline ? caretEnd + 1 : commentColumn + 5;
+        int width = Math.Max(MinDetailWidth, Budget - detailColumn);
+
+        var lines = new List<string>();
+        var caretLine = new StringBuilder()
+            .Append(gutter)
+            .Append(' ', pad)
+            .Append('^', trimmed.Length);
+
+        // Each fact starts on its own line so a multi-fact statement stays
+        // readable; only the first can share the caret line.
+        bool first = true;
+        foreach (var annotation in annotations)
+        {
+            foreach (string chunk in Wrap(AnnotationText.Format(annotation), width))
+            {
+                if (first && inline)
+                {
+                    caretLine.Append(' ').Append(chunk);
+                    lines.Add(caretLine.ToString());
+                }
+                else
+                {
+                    if (first)
+                        lines.Add(caretLine.ToString());
+                    lines.Add(gutter + new string(' ', detailColumn - commentColumn - 2) + chunk);
+                }
+                first = false;
+            }
+        }
+
+        // Every fact formatted empty: still show where the caret points.
+        if (first)
+            lines.Add(caretLine.ToString());
+        return lines;
+    }
+
+    /// <summary>Leading whitespace of the first non-blank line — the member declaration gutter.</summary>
+    public static string MemberIndent(IReadOnlyList<string> lines)
+    {
+        foreach (string line in lines)
+        {
+            if (line.AsSpan().TrimStart().Length == 0)
+                continue;
+            return line[..(line.Length - line.AsSpan().TrimStart().Length)];
+        }
+        return "";
+    }
+
+    // Greedy word wrap. A single token longer than the width is emitted whole
+    // rather than split: these details carry type names and paths, and breaking
+    // one mid-token would make it unsearchable.
+    static IReadOnlyList<string> Wrap(string text, int width)
+    {
+        if (string.IsNullOrEmpty(text))
+            return [];
+        if (text.Length <= width)
+            return [text];
+
+        var chunks = new List<string>();
+        var current = new StringBuilder();
+        foreach (string word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (current.Length > 0 && current.Length + 1 + word.Length > width)
+            {
+                chunks.Add(current.ToString());
+                current.Clear();
+            }
+            if (current.Length > 0)
+                current.Append(' ');
+            current.Append(word);
+        }
+        if (current.Length > 0)
+            chunks.Add(current.ToString());
+        return chunks;
+    }
+}

--- a/src/ILInspector.Decompiler/Annotations/AnnotationGesture.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationGesture.cs
@@ -1,0 +1,108 @@
+namespace ILInspector.Decompiler.Annotations;
+
+// Reporting gestures: how an annotation is *shown*, as opposed to what it *is*.
+//
+// An annotation is data — a fact keyed to a location. Annotations.cs holds that
+// data to a deliberate contract: no severity, no Location, no code fix, because
+// "annotations describe, they never grade." That contract is precisely why the
+// gesture cannot live on the annotation: deciding a fact is worth acting on *is*
+// a grade, and it is a property of the report, not of the fact.
+//
+// So gesture is chosen here, at render time, per view. The same datum renders as
+// a side comment in one view and a caret in another without the fact changing.
+
+/// <summary>
+/// How an annotation is rendered onto a source view. A reporting-layer choice,
+/// deliberately not a member of <see cref="IAnnotation"/>: the annotation model
+/// is positive-only and never grades, while choosing the caret gesture is
+/// exactly the judgement "this one is worth acting on".
+/// </summary>
+public enum AnnotationGesture
+{
+    /// <summary>
+    /// A trailing <c>// …</c> comment to the right of the annotated line — the
+    /// "interesting, FYI" gesture. The natural home for offset-anchored
+    /// descriptive facts, which carry no character span for a caret to point at.
+    /// </summary>
+    Side,
+
+    /// <summary>
+    /// A <c>^^^^</c> underline on the following <c>//</c> line — the "act on
+    /// this" gesture. The natural home for span-carrying diagnostics, and the
+    /// gesture a descriptive fact is promoted to when a view wants it acted on.
+    /// </summary>
+    Caret,
+}
+
+/// <summary>
+/// Chooses a <see cref="AnnotationGesture"/> for each annotation on a render.
+/// This is the "reporting" half of the data/reporting split: the fact stream is
+/// produced once and describes, and a selector decides — per view, per
+/// invocation — which of those facts are promoted from <see cref="AnnotationGesture.Side"/>
+/// to <see cref="AnnotationGesture.Caret"/>.
+/// </summary>
+public sealed class AnnotationGestureSelector
+{
+    readonly Func<IAnnotation, AnnotationGesture> selector;
+
+    AnnotationGestureSelector(Func<IAnnotation, AnnotationGesture> selector)
+        => this.selector = selector;
+
+    /// <summary>
+    /// The default report: every fact is a side comment. Preserves the
+    /// historical rendering exactly, so a view that asks for no promotion is
+    /// byte-identical to one written before gestures existed.
+    /// </summary>
+    public static AnnotationGestureSelector SideOnly { get; } = new(_ => AnnotationGesture.Side);
+
+    /// <summary>
+    /// Promotes to <see cref="AnnotationGesture.Caret"/> every annotation whose
+    /// <see cref="AnnotationDescriptor.Category"/> or <see cref="AnnotationDescriptor.Id"/>
+    /// matches <paramref name="focus"/>; everything else stays
+    /// <see cref="AnnotationGesture.Side"/>. Matching an id by prefix lets
+    /// <c>alloc</c> select the whole <c>alloc.*</c> family without naming each
+    /// descriptor.
+    /// </summary>
+    /// <param name="focus">
+    /// A category name (e.g. <c>allocation</c>), a descriptor id (e.g.
+    /// <c>alloc.box</c>), or a dotted id prefix (e.g. <c>alloc</c>). Compared
+    /// case-insensitively. Null or blank yields <see cref="SideOnly"/>.
+    /// </param>
+    public static AnnotationGestureSelector Focus(string? focus)
+    {
+        if (string.IsNullOrWhiteSpace(focus))
+            return SideOnly;
+
+        string wanted = focus.Trim();
+        return new(annotation => Matches(annotation, wanted)
+            ? AnnotationGesture.Caret
+            : AnnotationGesture.Side);
+    }
+
+    static bool Matches(IAnnotation annotation, string focus)
+    {
+        var descriptor = annotation.Descriptor;
+        if (string.Equals(descriptor.Category.ToString(), focus, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (string.Equals(descriptor.Id, focus, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Dotted-prefix match, on a segment boundary only: "alloc" selects
+        // "alloc.box" but must not select "allocator.x".
+        return descriptor.Id.Length > focus.Length
+            && descriptor.Id[focus.Length] == '.'
+            && descriptor.Id.AsSpan(0, focus.Length).Equals(focus, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The gesture to report <paramref name="annotation"/> with.</summary>
+    public AnnotationGesture For(IAnnotation annotation) => selector(annotation);
+
+    /// <summary>True when no annotation in <paramref name="annotations"/> is promoted.</summary>
+    public bool AllSide(IReadOnlyList<IAnnotation> annotations)
+    {
+        foreach (var annotation in annotations)
+            if (For(annotation) == AnnotationGesture.Caret)
+                return false;
+        return true;
+    }
+}

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -35,7 +35,8 @@ public static partial class ResearchViews
         AnnotationStage AnnotatedStage = AnnotationStage.Raised,
         ResearchFactRegistry? Registry = null,
         int? MethodToken = null,
-        PrinterOptions? PrinterOptions = null);
+        PrinterOptions? PrinterOptions = null,
+        string? CaretFocus = null);
 
     public sealed record MemberProjectionResult(
         DecompilerResult? AnnotatedSource,
@@ -62,6 +63,10 @@ public static partial class ResearchViews
 
             var assembly = ResolveAssemblyContext(imported);
             var effectiveRegistry = request.Registry ?? ResearchFactRegistry.Default;
+            // The reporting half of the data/reporting split: facts are collected
+            // once and describe, and this decides which of them this render
+            // promotes to the caret gesture.
+            var gestures = AnnotationGestureSelector.Focus(request.CaretFocus);
             var context = new ResearchFactContext(request.Source, imported, assembly);
             var facts = effectiveRegistry.Collect(context);
             var headerFacts = request.CostOverlay || request.FactRows
@@ -91,7 +96,8 @@ public static partial class ResearchViews
                         request.OverloadIndex,
                         request.PublicOnly,
                         request.MethodToken,
-                        request.PrinterOptions),
+                        request.PrinterOptions,
+                        gestures),
                         emptyOutputIsFailure: false),
                     request.Source);
             }
@@ -106,7 +112,7 @@ public static partial class ResearchViews
                     .Where(fact => fact.Descriptor.Category == AnnotationCategory.Cost)
                     .ToList();
                 var body = WithTrace(
-                    RunProjection(() => RenderRaisedOverlay(imported, costAnnotations, request.Source), emptyOutputIsFailure: false),
+                    RunProjection(() => RenderRaisedOverlay(imported, costAnnotations, request.Source, gestures), emptyOutputIsFailure: false),
                     request.Source);
                 costOverlay = new CostOverlayResult(body, costHeaderFacts);
             }
@@ -118,7 +124,7 @@ public static partial class ResearchViews
                     .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Semantics)
                     .ToList();
                 semanticsOverlay = WithTrace(
-                    RunProjection(() => RenderRaisedOverlay(imported, semanticsAnnotations, request.Source), emptyOutputIsFailure: false),
+                    RunProjection(() => RenderRaisedOverlay(imported, semanticsAnnotations, request.Source, gestures), emptyOutputIsFailure: false),
                     request.Source);
             }
 
@@ -211,7 +217,8 @@ public static partial class ResearchViews
         int overloadIndex,
         bool publicOnly,
         int? methodToken = null,
-        PrinterOptions? printerOptions = null)
+        PrinterOptions? printerOptions = null,
+        AnnotationGestureSelector? gestures = null)
     {
 
         IrFunction? ImportMethodBody(MethodRef target) => IrImporter.Import(source, target);
@@ -245,7 +252,7 @@ public static partial class ResearchViews
                 : IlProjection.RenderIlBodyLines(source, methodToken.Value);
 
         var stream = CorrelateMixedSource(imported, csText, statementLines, annotations, annotatedInstrLines);
-        return csResult with { Output = RenderMixedStream(stream) };
+        return csResult with { Output = RenderMixedStream(stream, gestures ?? AnnotationGestureSelector.SideOnly) };
     }
 
     // The correlation layer: fold the printed C# body, its statement-line map, the
@@ -341,10 +348,12 @@ public static partial class ResearchViews
     // structured annotations into a trailing "// ..." comment; IL lines are framed
     // as "// ..." comments indented under the preceding C# line, reading the indent
     // straight from that line's leading whitespace.
-    static string RenderMixedStream(IReadOnlyList<AnnotatedSourceLine> stream)
+    static string RenderMixedStream(IReadOnlyList<AnnotatedSourceLine> stream, AnnotationGestureSelector gestures)
     {
         var sb = new StringBuilder();
         string csIndent = "";
+        string memberIndent = AnnotationCaret.MemberIndent(
+            [.. stream.Where(line => line.Kind == SourceLineKind.CSharp).Select(line => line.Text)]);
         foreach (var line in stream)
         {
             if (line.Kind == SourceLineKind.Il)
@@ -354,22 +363,25 @@ public static partial class ResearchViews
             }
 
             csIndent = LeadingWhitespace(line.Text);
+            var (side, caret) = SplitByGesture(line.Annotations, gestures);
             string text = line.Text;
-            if (line.Annotations.Count > 0)
-                text = $"{text}  // {string.Join("; ", line.Annotations.Select(a => AnnotationText.Format(a)))}";
+            if (side.Count > 0)
+                text = $"{text}  // {string.Join("; ", side.Select(a => AnnotationText.Format(a)))}";
             sb.AppendLine(text);
+            foreach (string caretLine in AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true))
+                sb.AppendLine(caretLine);
         }
         return sb.ToString().TrimEnd();
     }
 
-    static DecompilerResult RenderRaisedOverlay(IrFunction imported, IReadOnlyList<IAnnotation> annotations, MetadataSource source)
+    static DecompilerResult RenderRaisedOverlay(IrFunction imported, IReadOnlyList<IAnnotation> annotations, MetadataSource source, AnnotationGestureSelector? gestures = null)
     {
         var result = CSharpPrinter.PrintRaised(imported, out var statementLines, importMethodBody: null, typesProvablyDisjoint: source.AreProvablyDisjoint);
         if (result.Output is not { } output)
             return result;
         var projected = annotations.Count == 0
             ? output
-            : AddTrailingComments(imported, output, statementLines, annotations);
+            : AddTrailingComments(imported, output, statementLines, annotations, gestures ?? AnnotationGestureSelector.SideOnly);
         return result with { Output = projected };
     }
 
@@ -414,10 +426,11 @@ public static partial class ResearchViews
         IrFunction raised,
         string output,
         IReadOnlyDictionary<IrNode, int> statementLines,
-        IReadOnlyList<IAnnotation> annotations)
+        IReadOnlyList<IAnnotation> annotations,
+        AnnotationGestureSelector gestures)
     {
         var stream = CorrelateOverlay(raised, output, statementLines, annotations);
-        return RenderOverlayStream(output, stream);
+        return RenderOverlayStream(output, stream, gestures);
     }
 
     // The C#-only correlation: anchor each annotation group to its printed C# line
@@ -458,11 +471,16 @@ public static partial class ResearchViews
         return stream;
     }
 
-    // The dumb overlay printer: a line with annotations gets a trailing "// ..."
-    // comment (trimmed); other lines pass through untouched. Returns the original
-    // output verbatim when no line resolved an annotation, matching the historical
-    // no-op short-circuit byte for byte (no split/rejoin normalization).
-    static string RenderOverlayStream(string output, IReadOnlyList<AnnotatedSourceLine> stream)
+    // The dumb overlay printer: each line's annotations are reported by gesture —
+    // side facts bake into a trailing "// ..." comment, caret facts emit an
+    // underline block on the member gutter beneath the line. Other lines pass
+    // through untouched. Returns the original output verbatim when no line
+    // resolved an annotation, matching the historical no-op short-circuit byte
+    // for byte (no split/rejoin normalization).
+    static string RenderOverlayStream(
+        string output,
+        IReadOnlyList<AnnotatedSourceLine> stream,
+        AnnotationGestureSelector gestures)
     {
         bool any = false;
         foreach (var line in stream)
@@ -474,15 +492,38 @@ public static partial class ResearchViews
         if (!any)
             return output;
 
-        var lines = new string[stream.Count];
-        for (int i = 0; i < stream.Count; i++)
+        string memberIndent = AnnotationCaret.MemberIndent([.. stream.Select(line => line.Text)]);
+        var lines = new List<string>(stream.Count);
+        foreach (var line in stream)
         {
-            var line = stream[i];
-            lines[i] = line.Annotations.Count > 0
-                ? $"{line.Text.TrimEnd()}  // {AnnotationText.Format(line.Annotations)}"
-                : line.Text;
+            var (side, caret) = SplitByGesture(line.Annotations, gestures);
+            lines.Add(side.Count > 0
+                ? $"{line.Text.TrimEnd()}  // {AnnotationText.Format(side)}"
+                : line.Text);
+            lines.AddRange(AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true));
         }
         return string.Join(Environment.NewLine, lines);
+    }
+
+    // Partition one line's facts by reporting gesture. Order within each bucket is
+    // the producer's, so promoting a fact never reorders the ones left behind.
+    static (IReadOnlyList<IAnnotation> Side, IReadOnlyList<IAnnotation> Caret) SplitByGesture(
+        IReadOnlyList<IAnnotation> annotations,
+        AnnotationGestureSelector gestures)
+    {
+        if (annotations.Count == 0 || gestures.AllSide(annotations))
+            return (annotations, []);
+
+        var side = new List<IAnnotation>();
+        var caret = new List<IAnnotation>();
+        foreach (var annotation in annotations)
+        {
+            if (gestures.For(annotation) == AnnotationGesture.Caret)
+                caret.Add(annotation);
+            else
+                side.Add(annotation);
+        }
+        return (side, caret);
     }
 
     static Dictionary<IAnnotation, int> CSharpLinesByFact(IrFunction imported, IReadOnlyList<IAnnotation> facts, MetadataSource source)

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -43,7 +43,16 @@ public static partial class ResearchViews
         CostOverlayResult? CostOverlay,
         DecompilerResult? SemanticsOverlay,
         IReadOnlyList<FactRow>? Facts,
-        DecompilerTrace? Trace);
+        DecompilerTrace? Trace,
+        /// <summary>
+        /// Set when a caret focus was requested and promoted nothing: the fact
+        /// families this member actually has, so the caller can tell a typo from
+        /// an honest absence. Null when no focus was asked for, or when the
+        /// focus matched. Promotion is silent by nature — every fact still
+        /// renders — so without this a mistyped focus is indistinguishable from
+        /// a correct one.
+        /// </summary>
+        IReadOnlyList<string>? UnmatchedFocusAlternatives = null);
 
     public static MemberProjectionResult ProjectMember(MemberProjectionRequest request)
     {
@@ -137,7 +146,8 @@ public static partial class ResearchViews
                 costOverlay,
                 semanticsOverlay,
                 factRows,
-                annotatedSource?.Trace ?? costOverlay?.Body.Trace ?? semanticsOverlay?.Trace);
+                annotatedSource?.Trace ?? costOverlay?.Body.Trace ?? semanticsOverlay?.Trace,
+                UnmatchedFocusAlternatives(request.CaretFocus, gestures, facts));
         }
         catch (Exception ex)
         {
@@ -156,6 +166,34 @@ public static partial class ResearchViews
                 request.FactRows ? [] : null,
                 failure.Trace);
         }
+    }
+
+    /// <summary>
+    /// The fact families present in <paramref name="facts"/>, returned only when
+    /// a focus was requested and promoted none of them. Promotion never removes
+    /// a fact, so a focus that matches nothing renders exactly like no focus at
+    /// all; this is what lets a caller say so instead of leaving a typo silent.
+    /// </summary>
+    static IReadOnlyList<string>? UnmatchedFocusAlternatives(
+        string? focus,
+        AnnotationGestureSelector gestures,
+        IReadOnlyList<IAnnotation> facts)
+    {
+        if (string.IsNullOrWhiteSpace(focus) || facts.Count == 0 || !gestures.AllSide(facts))
+            return null;
+
+        var families = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var fact in facts)
+        {
+            var descriptor = fact.Descriptor;
+            families.Add(descriptor.Category.ToString().ToLowerInvariant());
+
+            // The dotted prefix is the useful middle ground between a category
+            // and a single descriptor, and it is exactly what Focus accepts.
+            int dot = descriptor.Id.IndexOf('.');
+            families.Add(dot > 0 ? descriptor.Id[..dot] : descriptor.Id);
+        }
+        return [.. families];
     }
 
     public static IReadOnlyList<IAnnotation> CollectFacts(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3963,6 +3963,86 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_AnnotatedSource_UnknownFocus_SaysSoAndNamesTheAvailableFamilies()
+    {
+        // Promotion never hides a fact, so an unmatched focus renders exactly
+        // like no focus at all. Without the note a typo is indistinguishable
+        // from an honest absence.
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "Pump:1", "-S", "Annotated Source", "--focus", "alocation", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("^^^^", output);
+        Assert.Contains("--focus 'alocation' matched no facts here", error);
+        Assert.Contains("allocation", error);
+    }
+
+    [Fact]
+    public async Task Member_AnnotatedSource_MatchedFocus_SaysNothing()
+    {
+        var (exit, _, error) = await RunAppAsync(
+            "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "Pump:1", "-S", "Annotated Source", "--focus", "allocation", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("matched no facts", error);
+    }
+
+    /// <summary>
+    /// Every projection that can carry a caret block, each through a different
+    /// formatting call. Two properties per case: the caret actually renders (so
+    /// the case is not vacuous), and the hoist marker — an in-band control
+    /// character — never survives into output.
+    /// </summary>
+    [Theory]
+    [InlineData("CommandCaretGestureFixture", "Pump:1", "Annotated Source", "allocation")]
+    [InlineData("CommandCaretGestureFixture", "Pump:1", "Annotated Source", "alloc")]
+    [InlineData("CommandCaretGestureFixture", "Make:1", "Annotated Source", "allocation")]
+    [InlineData("CostOverlayFixture", "Caller", "Cost Overlay", "cost")]
+    [InlineData("CostOverlayFixture", "CallsExceptionOnly", "Semantics Overlay", "semantics")]
+    public async Task Member_Focus_RendersCaretsAndNeverLeaksTheHoistMarker(
+        string fixture, string selector, string section, string focus)
+    {
+        string typeName = fixture == "CostOverlayFixture"
+            ? typeof(CostOverlayFixture).FullName!
+            : typeof(CommandCaretGestureFixture).FullName!;
+
+        var (exit, output, _) = await RunAppAsync(
+            "member", typeName, "--library", TestAssemblyPath,
+            selector, "--index", "1", "--all", "-S", section, "--focus", focus, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("^^^^", output);
+        Assert.DoesNotContain(ILInspector.Decompiler.Annotations.AnnotationCaret.HoistMarker, output);
+
+        var lines = output.ReplaceLineEndings("\n").Split('\n');
+        foreach (int i in Enumerable.Range(0, lines.Length)
+            .Where(i => lines[i].Contains("^^^^", StringComparison.Ordinal)))
+        {
+            string statement = lines[i - 1];
+            Assert.StartsWith("//", lines[i], StringComparison.Ordinal);
+            Assert.Equal(
+                statement.Length - statement.AsSpan().TrimStart().Length,
+                lines[i].IndexOf('^'));
+        }
+    }
+
+    [Fact]
+    public async Task Type_DoesNotOfferFocus()
+    {
+        // The caret gesture only renders into member sections (Annotated
+        // Source, Cost Overlay, Semantics Overlay). Offering --focus on `type`
+        // would be a switch that cannot change any output there.
+        var (exit, _, error) = await RunAppAsync(
+            "type", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "--focus", "allocation", "--tips", "q");
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("--focus", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Member_AnnotatedSource_FocusPromotesFactsToAlignedCaretComments()
     {
         var (exit, output, _) = await RunAppAsync(
@@ -10892,6 +10972,8 @@ public sealed class CommandCaretGestureFixture
         }
         return sink.Count.ToString();
     }
+
+    public string Make() => new object().ToString() ?? "";
 }
 
 public sealed class CommandInitializerOnlyFixture

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3951,6 +3951,59 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_AnnotatedSource_WithoutFocus_UsesNoCaretGesture()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "Pump:1", "-S", "Annotated Source", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Annotated Source", output);
+        Assert.DoesNotContain("^^^^", output);
+    }
+
+    [Fact]
+    public async Task Member_AnnotatedSource_FocusPromotesFactsToAlignedCaretComments()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "Pump:1", "-S", "Annotated Source", "--focus", "allocation", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        var lines = output.ReplaceLineEndings("\n").Split('\n');
+        var caretIndexes = Enumerable.Range(0, lines.Length)
+            .Where(i => lines[i].Contains("^^^^", StringComparison.Ordinal))
+            .ToList();
+
+        // The fixture allocates at the body's base column and again inside a
+        // loop, so both depths are exercised.
+        Assert.True(caretIndexes.Count >= 2, $"expected carets at two depths, got {caretIndexes.Count}");
+        Assert.True(
+            caretIndexes.Select(i => lines[i].IndexOf('^')).Distinct().Count() >= 2,
+            "the two carets must sit at different columns");
+
+        foreach (int i in caretIndexes)
+        {
+            string line = lines[i];
+
+            // The block is spliced into a ```csharp fence, so it must stay
+            // comments, and it sits on the member declaration column.
+            Assert.StartsWith("//", line, StringComparison.Ordinal);
+
+            // Carets point at the statement on the preceding line, exactly.
+            string statement = lines[i - 1];
+            Assert.Equal(
+                statement.Length - statement.AsSpan().TrimStart().Length,
+                line.IndexOf('^'));
+            Assert.Equal(statement.Trim().Length, line.Count(c => c == '^'));
+        }
+
+        // The hoist marker is an internal layout signal; it must never survive
+        // into rendered output, where it would print as a control character.
+        Assert.DoesNotContain(ILInspector.Decompiler.Annotations.AnnotationCaret.HoistMarker, output);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_SelectSourceDiff_RendersOriginalVsDecompiledDiff()
     {
         using var stream = File.OpenRead(TestAssemblyPath);
@@ -10820,6 +10873,24 @@ public sealed class CommandExecutionSourceDiffFixture
     public int AddOne(int value)
     {
         return value + 1;
+    }
+}
+
+/// <summary>
+/// Two allocations at different depths: one on the body's own base column and
+/// one nested inside a loop. The caret gesture must point exactly at both, which
+/// is only possible because the caret block is hoisted out of the body indent.
+/// </summary>
+public sealed class CommandCaretGestureFixture
+{
+    public string Pump(int n)
+    {
+        var sink = new List<object>();
+        for (int i = 0; i < n; i++)
+        {
+            sink.Add(new object());
+        }
+        return sink.Count.ToString();
     }
 }
 

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -104,6 +104,7 @@ public static class ApiCommandDefinitions
         typeCommand.Options.Add(opts.PlainText);
         typeCommand.Options.Add(opts.Bare);
         typeCommand.Options.Add(opts.Taste);
+        typeCommand.Options.Add(opts.Focus);
         opts.AddOutputOptionsTo(typeCommand);
         opts.AddNuGetOptionsTo(typeCommand);
 
@@ -244,6 +245,7 @@ public static class ApiCommandDefinitions
         memberCommand.Options.Add(opts.PlainText);
         memberCommand.Options.Add(opts.Bare);
         memberCommand.Options.Add(opts.Taste);
+        memberCommand.Options.Add(opts.Focus);
         opts.AddOutputOptionsTo(memberCommand);
         opts.AddNuGetOptionsTo(memberCommand);
 

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -104,7 +104,6 @@ public static class ApiCommandDefinitions
         typeCommand.Options.Add(opts.PlainText);
         typeCommand.Options.Add(opts.Bare);
         typeCommand.Options.Add(opts.Taste);
-        typeCommand.Options.Add(opts.Focus);
         opts.AddOutputOptionsTo(typeCommand);
         opts.AddNuGetOptionsTo(typeCommand);
 

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -281,6 +281,7 @@ public static class MemberOptionsParser
             PlainText = parseResult.GetValue(opts.PlainText),
             Bare = parseResult.GetValue(opts.Bare),
             RequestAllTaste = parseResult.GetValue(opts.Taste),
+            Focus = parseResult.GetValue(opts.Focus),
             Print = parseResult.GetValue(opts.Print),
             PrintAll = parseResult.GetValue(opts.PrintAll),
             PrintRow = opts.ParsePrintRow(parseResult),

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -181,7 +181,6 @@ public static class TypeOptionsParser
             PlainText = parseResult.GetValue(opts.PlainText),
             Bare = parseResult.GetValue(opts.Bare),
             RequestAllTaste = parseResult.GetValue(opts.Taste),
-            Focus = parseResult.GetValue(opts.Focus),
             Print = parseResult.GetValue(opts.Print),
             PrintAll = parseResult.GetValue(opts.PrintAll),
             PrintRow = opts.ParsePrintRow(parseResult),

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -181,6 +181,7 @@ public static class TypeOptionsParser
             PlainText = parseResult.GetValue(opts.PlainText),
             Bare = parseResult.GetValue(opts.Bare),
             RequestAllTaste = parseResult.GetValue(opts.Taste),
+            Focus = parseResult.GetValue(opts.Focus),
             Print = parseResult.GetValue(opts.Print),
             PrintAll = parseResult.GetValue(opts.PrintAll),
             PrintRow = opts.ParsePrintRow(parseResult),

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -18,7 +18,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class MemberCodeProvider
 {
-    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool CostOverlay, bool SemanticsOverlay, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Facts = false, bool FidelityCauses = false, bool AppliedTaste = false, string? ProjectAssetsPath = null, string? TargetFramework = null);
+    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool CostOverlay, bool SemanticsOverlay, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Facts = false, bool FidelityCauses = false, bool AppliedTaste = false, string? ProjectAssetsPath = null, string? TargetFramework = null, string? CaretFocus = null);
 
     /// <summary>
     /// Code content for one member. C# sections retain the complete decompiler
@@ -220,7 +220,8 @@ internal static class MemberCodeProvider
                         // -- otherwise the two views of one member disagree. The
                         // other projections here (cost/semantics overlays, fact rows)
                         // are style-invariant evidence and keep the shipped defaults.
-                        PrinterOptions: request.AnnotatedSource ? renderOptions : null));
+                        PrinterOptions: request.AnnotatedSource ? renderOptions : null,
+                        CaretFocus: request.CaretFocus));
             }
 
             // Annotated source: raised C# with hidden-fact comments and the

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -222,6 +222,16 @@ internal static class MemberCodeProvider
                         // are style-invariant evidence and keep the shipped defaults.
                         PrinterOptions: request.AnnotatedSource ? renderOptions : null,
                         CaretFocus: request.CaretFocus));
+
+                // Promotion never hides a fact, so a focus that matched nothing
+                // renders identically to no focus at all. Say so, and name the
+                // families this member does have, or a typo is invisible.
+                if (researchProjection.UnmatchedFocusAlternatives is { Count: > 0 } alternatives)
+                {
+                    Console.Error.WriteLine(
+                        $"note: --focus '{request.CaretFocus}' matched no facts here; "
+                        + $"available: {string.Join(", ", alternatives)}");
+                }
             }
 
             // Annotated source: raised C# with hidden-fact comments and the

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -57,6 +57,12 @@ public partial record ApiOptions
     /// facts collected are identical either way, because annotations describe and
     /// never grade.
     /// </summary>
+    /// <remarks>
+    /// Member-scoped only. The caret gesture renders into an annotated source
+    /// view, and the only sections that carry one — Annotated Source, Cost
+    /// Overlay, Semantics Overlay — are member sections. Registering the option
+    /// on <c>type</c> would offer a switch that cannot change any output there.
+    /// </remarks>
     public string? Focus { get; init; }
 
     /// <summary>

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -48,6 +48,18 @@ public partial record ApiOptions
     public PrinterOptions? RenderOptions { get; init; }
 
     /// <summary>
+    /// The <c>--focus</c> gesture: promote a fact family from the default side
+    /// comment to the caret gesture, so the facts worth acting on are underlined
+    /// beneath the statement instead of trailing it. Accepts a category
+    /// (<c>allocation</c>), a descriptor id (<c>alloc.box</c>), or a dotted id
+    /// prefix (<c>alloc</c>). Null leaves every fact on the side gesture, which is
+    /// byte-for-byte the historical render. This is a reporting choice only: the
+    /// facts collected are identical either way, because annotations describe and
+    /// never grade.
+    /// </summary>
+    public string? Focus { get; init; }
+
+    /// <summary>
     /// The <c>--taste</c> gesture: request the whole oracle-endorsed style set for
     /// this run, equivalent to <c>dotnet_inspect_style_full_taste = true</c> in
     /// <c>.dotnet-inspectconfig</c> but scoped to one invocation. Applied after the

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1374,7 +1374,8 @@ public static class ApiOutputFormatter
             FidelityCauses: requestedSections.Contains(SectionNames.FidelityCauses),
             AppliedTaste: requestedSections.Contains(SectionNames.AppliedTaste),
             ProjectAssetsPath: options?.ProjectAssetsPath,
-            TargetFramework: options?.Tfm);
+            TargetFramework: options?.Tfm,
+            CaretFocus: options?.Focus);
 
         // An index-backed section that is explicitly selected (via -S or a category like
         // @Audit) renders an empty-state note instead of vanishing when it yields no rows.
@@ -2616,7 +2617,10 @@ public static class ApiOutputFormatter
             : formattedBodyLines;
         var indentedBody = string.Join(
             Environment.NewLine,
-            lines.Select(line => line.Length == 0 ? "" : $"    {line}"));
+            lines.Select(line =>
+                line.Length == 0 ? ""
+                : Decompiler.Annotations.AnnotationCaret.TryHoist(line, out var hoisted) ? hoisted
+                : $"    {line}"));
 
         return $"{Annotate(declaration)}{Environment.NewLine}{{{Environment.NewLine}{indentedBody}{Environment.NewLine}}}";
     }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2580,13 +2580,13 @@ public static class ApiOutputFormatter
         if (string.IsNullOrWhiteSpace(declaration))
         {
             return declarationTrailingComment is { Length: > 0 } bareComment
-                ? $"// {bareComment}{Environment.NewLine}{body}"
-                : body;
+                ? $"// {bareComment}{Environment.NewLine}{Decompiler.Annotations.AnnotationCaret.Flatten(body)}"
+                : Decompiler.Annotations.AnnotationCaret.Flatten(body);
         }
 
         bool hasLeadingComments = leadingBodyComments is { Count: > 0 };
         if (!hasLeadingComments && preferExpressionBodied && CSharpExpressionBody.FromSingleStatement(body) is { } expressionBody)
-            return Annotate($"{declaration} => {expressionBody};");
+            return Annotate($"{declaration} => {Decompiler.Annotations.AnnotationCaret.Flatten(expressionBody)};");
 
         // A multi-line single-statement expression body renders expression-bodied
         // too (a raised switch return, issue #3088; a wrapped fluent chain in
@@ -2600,11 +2600,12 @@ public static class ApiOutputFormatter
             && CSharpExpressionBody.MultilineExpressionBodyLines(body) is { Count: > 0 } multilineExpression)
         {
             var expression = new StringBuilder();
-            expression.Append(declaration).Append(" => ").Append(multilineExpression[0]);
+            expression.Append(declaration).Append(" => ")
+                .Append(Decompiler.Annotations.AnnotationCaret.Flatten(multilineExpression[0]));
             for (int i = 1; i < multilineExpression.Count; i++)
             {
                 expression.Append(Environment.NewLine);
-                expression.Append(multilineExpression[i]);
+                expression.Append(Decompiler.Annotations.AnnotationCaret.Flatten(multilineExpression[i]));
                 if (i == multilineExpression.Count - 1)
                     expression.Append(';');
             }
@@ -2615,12 +2616,18 @@ public static class ApiOutputFormatter
         var lines = hasLeadingComments
             ? leadingBodyComments!.Concat(formattedBodyLines)
             : formattedBodyLines;
+
+        // A caret line is pre-positioned at this declaration's column, so it is
+        // the one body line that must not be indented. The indent width is the
+        // caret renderer's constant rather than a literal: the two have to agree
+        // or the carets shear away from the code they point at.
+        string bodyIndent = new(' ', Decompiler.Annotations.AnnotationCaret.BodyIndentWidth);
         var indentedBody = string.Join(
             Environment.NewLine,
             lines.Select(line =>
                 line.Length == 0 ? ""
                 : Decompiler.Annotations.AnnotationCaret.TryHoist(line, out var hoisted) ? hoisted
-                : $"    {line}"));
+                : bodyIndent + line));
 
         return $"{Annotate(declaration)}{Environment.NewLine}{{{Environment.NewLine}{indentedBody}{Environment.NewLine}}}";
     }

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -22,6 +22,7 @@ public class SharedOptions
     public Option<bool> BrowsableUrls { get; } = new("--blob") { Description = "Emit GitHub URLs as browser-friendly /blob/ URLs (URL-shape modifier, not an output-shape modifier)" };
     public Option<bool> Mermaid { get; } = new("--mermaid") { Description = "Output as mermaid diagram (standalone or with --markdown for embedded)" };
     public Option<bool> Taste { get; } = new("--taste") { Description = "Render source with the full oracle-endorsed style set (includes byte-divergent lenses); Annotated Source names the applied knobs on the signature" };
+    public Option<string?> Focus { get; } = new("--focus") { Description = "Report a fact family with the caret gesture (underlined beneath the statement) instead of a trailing comment: a category (allocation), a descriptor id (alloc.box), or an id prefix (alloc)", Arity = ArgumentArity.ZeroOrOne, DefaultValueFactory = _ => null };
     public Option<bool> Table { get; } = new("--table") { Description = "Output as a pretty table (space-padded columns)" };
     public Option<bool> Tsv { get; } = new("--tsv") { Description = "Output as normalized tab-separated values" };
     public Option<bool> Jsonl { get; } = new("--jsonl") { Description = "Output as JSON Lines (one object per row)" };

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -22,7 +22,7 @@ public class SharedOptions
     public Option<bool> BrowsableUrls { get; } = new("--blob") { Description = "Emit GitHub URLs as browser-friendly /blob/ URLs (URL-shape modifier, not an output-shape modifier)" };
     public Option<bool> Mermaid { get; } = new("--mermaid") { Description = "Output as mermaid diagram (standalone or with --markdown for embedded)" };
     public Option<bool> Taste { get; } = new("--taste") { Description = "Render source with the full oracle-endorsed style set (includes byte-divergent lenses); Annotated Source names the applied knobs on the signature" };
-    public Option<string?> Focus { get; } = new("--focus") { Description = "Report a fact family with the caret gesture (underlined beneath the statement) instead of a trailing comment: a category (allocation), a descriptor id (alloc.box), or an id prefix (alloc)", Arity = ArgumentArity.ZeroOrOne, DefaultValueFactory = _ => null };
+    public Option<string?> Focus { get; } = new("--focus") { Description = "Report a fact family with the caret gesture (underlined beneath the statement) instead of a trailing comment: a category (allocation), a descriptor id (alloc.box), or an id prefix (alloc). Promotes, never filters: unmatched facts keep their trailing comment", Arity = ArgumentArity.ExactlyOne };
     public Option<bool> Table { get; } = new("--table") { Description = "Output as a pretty table (space-padded columns)" };
     public Option<bool> Tsv { get; } = new("--tsv") { Description = "Output as normalized tab-separated values" };
     public Option<bool> Jsonl { get; } = new("--jsonl") { Description = "Output as JSON Lines (one object per row)" };


### PR DESCRIPTION
Closes #3304.

Where a hidden fact is *drawn* is a reporting decision, not a property of the fact. The shipped Annotated Source views hard-coded one gesture — a trailing `//` comment — so a fact with a long detail produced a sliver off the right edge, and there was no way to say "look **here**" about a particular fact.

## Before

A real render of `AnnotationText.Format:1` — the trailing comment runs to **190 columns**:

```csharp
    StringBuilder sb = new(fact.Descriptor.Id);   // alloc.new(StringBuilder; alloc=System.Text.StringBuilder; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; multiplicity=once; churned=System.Char[])
```

## After

`--focus allocation` promotes that fact to the caret gesture:

```csharp
public static string Format(Annotation fact)
{
    StringBuilder sb = new(fact.Descriptor.Id);
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//   alloc.new(StringBuilder; alloc=System.Text.StringBuilder; path=straight-line;
//   path-confidence=dominates-return; post-dominance=return-post-dominates; multiplicity=once;
//   churned=System.Char[])
```

Both depths, from the end-to-end test fixture:

```csharp
public string Pump(int n)
{
    List<object> sink = new();
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ alloc.new(List<object>;
//                             alloc=System.Collections.Generic.List<System.Object>; path=straight-line;
//                             path-confidence=dominates-return; multiplicity=once;
//                             churned=System.Object[])
    for (int i = 0; i < n; i++)
    {
        sink.Add(new object());
//      ^^^^^^^^^^^^^^^^^^^^^^^ alloc.new(object; alloc=System.Object; path=loop-body;
```

## Design

`AnnotationGestureSelector` picks a gesture per render. `--focus <category|id|id-prefix>` promotes matching facts to the caret; prefixes match on a dotted-segment boundary, so `alloc` selects `alloc.box` but not `allocator.x`. Non-matching facts keep the trailing form, so `--focus` narrows attention without hiding anything.

**Gesture is deliberately not on `IAnnotation`.** The annotation contract is positive-only and carries no severity. Deciding a fact is worth acting on *is* a grade, and grading belongs to the reporting layer — which is exactly the data/reporting split this issue asks for.

**Default output is byte-identical.** With no `--focus` the selector short-circuits through the historical path. Verified by diffing full CLI renders against `main`, not by inspection.

## The geometry, and why there is a marker

Injected comments anchor to the **member declaration** column, so every one in a member shares a single gutter rather than a staircase following nesting depth.

That column sits *below* the projected body: the body is member-relative, and the declaration line plus a uniform four-column indent are added downstream in `FormatSourceWithDeclaration`. A caret comment needs three columns to the left of its first caret for `"// "`, which a statement on the body's base column cannot supply — its carets land three columns right of what they point at. So `AnnotationCaret` marks its lines with `HoistMarker` and the body formatter renders them un-indented, recovering those columns at *every* depth.

This was measured, not assumed: the alternative (gutter at the body base column) was implemented and rendered first, and the three-column offset is visible in its real output.

An annotation is keyed to an IL offset and carries no character span, so a caret underlines the **whole trimmed statement** — exactly what the fact is known to be about, and no more. A span-carrying datum (a compiler diagnostic, as in #3238/#3256) can underline a narrower range; that is a property of the datum, not the gesture.

## Validation

- `AnnotationGestureTests` — 23 cases pinning selector semantics and caret geometry. The hoist geometry tests were run against `hoist: false` first and **3 fail**; they pass with the fix.
- `CommandExecutionTests` end-to-end: `--focus` promotes facts at two different depths, every caret line is a `//` comment (it is spliced into a ` ```csharp ` fence), carets match the preceding statement's column and length exactly, and `HoistMarker` never survives into output.
- Default-render byte-identical diff vs `main`.
- `ILInspector.Decompiler.Tests` 3914, `dotnet-inspect.Tests` 1606 non-slow + 584 `CommandExecutionTests`, `ILInspector.Research.Tests` 132 — all green. Full solution builds clean.
- markdownlint clean on both changed docs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 43dbbaf0-9cf3-43c6-81c4-5f1b68de2738