### PR TITLE
Identify the crashed method body in --gaps PASS BUG output (#3243)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -76,6 +76,8 @@
              Link="CorpusMetadata.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusMethodIdentity.cs"
              Link="CorpusMethodIdentity.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\PassBugDiagnostic.cs"
+             Link="PassBugDiagnostic.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusMethodDelta.cs"
              Link="CorpusMethodDelta.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusSensor.cs"

--- a/src/ILInspector.Decompiler.Tests/PassBugDiagnosticTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PassBugDiagnosticTests.cs
@@ -1,0 +1,75 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class PassBugDiagnosticTests
+{
+    [Fact]
+    public void DirectPassBugEmitters_UseSharedFormatter()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null
+            && !File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+        {
+            directory = directory.Parent;
+        }
+        Assert.NotNull(directory);
+
+        string harnessDirectory = Path.Combine(directory.FullName, "tools", "DecompilerHarness");
+        string[] offenders = Directory.EnumerateFiles(harnessDirectory, "*.cs")
+            .Where(path => Path.GetFileName(path) != "PassBugDiagnostic.cs")
+            .Where(path => File.ReadAllText(path).Contains("PASS BUG", StringComparison.Ordinal))
+            .Select(path => Path.GetFileName(path)!)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(offenders);
+    }
+
+    [Fact]
+    public void Format_IdentifiesAssemblyAndExactMethodBody()
+    {
+        var exception = new KeyNotFoundException("missing block 3");
+        var stringOverload = new MethodSignature(
+            TypeRef.CoreLib("System", "String"),
+            [new Parameter("value", TypeRef.CoreLib("System", "String"))],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var integerOverload = stringOverload with
+        {
+            Parameters = [new Parameter("value", TypeRef.CoreLib("System", "Int32"))],
+        };
+
+        string first = PassBugDiagnostic.Format(
+            exception,
+            "/packages/example/1.0.0/lib/Example.dll",
+            "Example.Parser",
+            "Parse",
+            stringOverload);
+        string otherAssembly = PassBugDiagnostic.Format(
+            exception,
+            "/packages/example/2.0.0/lib/Example.dll",
+            "Example.Parser",
+            "Parse",
+            stringOverload);
+        string otherOverload = PassBugDiagnostic.Format(
+            exception,
+            "/packages/example/1.0.0/lib/Example.dll",
+            "Example.Parser",
+            "Parse",
+            integerOverload);
+
+        Assert.Equal(
+            "PASS BUG: KeyNotFoundException: missing block 3 " +
+            "(/packages/example/1.0.0/lib/Example.dll!Example.Parser::Parse" +
+            "(corelib:System.String) -> corelib:System.String)",
+            first);
+        Assert.NotEqual(first, otherAssembly);
+        Assert.Contains("/packages/example/2.0.0/lib/Example.dll", otherAssembly);
+        Assert.NotEqual(first, otherOverload);
+        Assert.Contains(
+            "Parse(corelib:System.Int32) -> corelib:System.String",
+            otherOverload);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/PassBugDiagnosticTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PassBugDiagnosticTests.cs
@@ -17,13 +17,32 @@ public class PassBugDiagnosticTests
         Assert.NotNull(directory);
 
         string harnessDirectory = Path.Combine(directory.FullName, "tools", "DecompilerHarness");
-        string[] offenders = Directory.EnumerateFiles(harnessDirectory, "*.cs")
+        string[] files = Directory.EnumerateFiles(harnessDirectory, "*.cs").ToArray();
+        string[] callSites = files
+            .SelectMany(path => Enumerable.Repeat(
+                Path.GetFileName(path)!,
+                File.ReadAllText(path).Split(
+                    "PassBugDiagnostic.Format(",
+                    StringSplitOptions.None).Length - 1))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(
+            [
+                "Program.cs",
+                "Program.cs",
+                "Program.cs",
+                "Program.cs",
+                "SlotResidualCensus.cs",
+                "SlotUnifierCensus.cs",
+            ],
+            callSites);
+
+        string[] offenders = files
             .Where(path => Path.GetFileName(path) != "PassBugDiagnostic.cs")
             .Where(path => File.ReadAllText(path).Contains("PASS BUG", StringComparison.Ordinal))
             .Select(path => Path.GetFileName(path)!)
             .Order(StringComparer.Ordinal)
             .ToArray();
-
         Assert.Empty(offenders);
     }
 
@@ -46,24 +65,34 @@ public class PassBugDiagnosticTests
             "/packages/example/1.0.0/lib/Example.dll",
             "Example.Parser",
             "Parse",
-            stringOverload);
+            stringOverload,
+            0x0600002A);
         string otherAssembly = PassBugDiagnostic.Format(
             exception,
             "/packages/example/2.0.0/lib/Example.dll",
             "Example.Parser",
             "Parse",
-            stringOverload);
+            stringOverload,
+            0x0600002A);
         string otherOverload = PassBugDiagnostic.Format(
             exception,
             "/packages/example/1.0.0/lib/Example.dll",
             "Example.Parser",
             "Parse",
-            integerOverload);
+            integerOverload,
+            0x0600002A);
+        string otherToken = PassBugDiagnostic.Format(
+            exception,
+            "/packages/example/1.0.0/lib/Example.dll",
+            "Example.Parser",
+            "Parse",
+            stringOverload,
+            0x0600002B);
 
         Assert.Equal(
             "PASS BUG: KeyNotFoundException: missing block 3 " +
             "(/packages/example/1.0.0/lib/Example.dll!Example.Parser::Parse" +
-            "(corelib:System.String) -> corelib:System.String)",
+            "(corelib:System.String) -> corelib:System.String [token 0x0600002A])",
             first);
         Assert.NotEqual(first, otherAssembly);
         Assert.Contains("/packages/example/2.0.0/lib/Example.dll", otherAssembly);
@@ -71,5 +100,7 @@ public class PassBugDiagnosticTests
         Assert.Contains(
             "Parse(corelib:System.Int32) -> corelib:System.String",
             otherOverload);
+        Assert.NotEqual(first, otherToken);
+        Assert.Contains("[token 0x0600002B]", otherToken);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/PassBugDiagnosticTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PassBugDiagnosticTests.cs
@@ -17,10 +17,15 @@ public class PassBugDiagnosticTests
         Assert.NotNull(directory);
 
         string harnessDirectory = Path.Combine(directory.FullName, "tools", "DecompilerHarness");
-        string[] files = Directory.EnumerateFiles(harnessDirectory, "*.cs").ToArray();
+        // Recursive so a new emitter cannot evade the gate by living in a
+        // subdirectory; build output is not harness source.
+        string[] files = Directory
+            .EnumerateFiles(harnessDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(harnessDirectory, path))
+            .ToArray();
         string[] callSites = files
             .SelectMany(path => Enumerable.Repeat(
-                Path.GetFileName(path)!,
+                Relative(harnessDirectory, path),
                 File.ReadAllText(path).Split(
                     "PassBugDiagnostic.Format(",
                     StringSplitOptions.None).Length - 1))
@@ -38,12 +43,25 @@ public class PassBugDiagnosticTests
             callSites);
 
         string[] offenders = files
-            .Where(path => Path.GetFileName(path) != "PassBugDiagnostic.cs")
+            .Where(path => Relative(harnessDirectory, path) != "PassBugDiagnostic.cs")
             .Where(path => File.ReadAllText(path).Contains("PASS BUG", StringComparison.Ordinal))
-            .Select(path => Path.GetFileName(path)!)
+            .Select(path => Relative(harnessDirectory, path))
             .Order(StringComparer.Ordinal)
             .ToArray();
         Assert.Empty(offenders);
+    }
+
+    static string Relative(string root, string path) =>
+        Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/');
+
+    static bool IsBuildOutput(string root, string path)
+    {
+        string relative = Path.GetRelativePath(root, path);
+        return relative
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(segment =>
+                segment.Equals("bin", StringComparison.OrdinalIgnoreCase)
+                || segment.Equals("obj", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/tools/DecompilerHarness/PassBugDiagnostic.cs
+++ b/tools/DecompilerHarness/PassBugDiagnostic.cs
@@ -1,0 +1,18 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+static class PassBugDiagnostic
+{
+    public static string Format(
+        Exception exception,
+        string assemblyPath,
+        string typeName,
+        string methodName,
+        MethodSignature signature)
+    {
+        string identity =
+            $"{assemblyPath}!{typeName}::{methodName}{CorpusMethodIdentity.SignatureText(signature)}";
+        return $"PASS BUG: {exception.GetType().Name}: {exception.Message} ({identity})";
+    }
+}

--- a/tools/DecompilerHarness/PassBugDiagnostic.cs
+++ b/tools/DecompilerHarness/PassBugDiagnostic.cs
@@ -9,10 +9,12 @@ static class PassBugDiagnostic
         string assemblyPath,
         string typeName,
         string methodName,
-        MethodSignature signature)
+        MethodSignature signature,
+        int metadataToken)
     {
         string identity =
-            $"{assemblyPath}!{typeName}::{methodName}{CorpusMethodIdentity.SignatureText(signature)}";
+            $"{assemblyPath}!{typeName}::{methodName}{CorpusMethodIdentity.SignatureText(signature)} " +
+            $"[token 0x{metadataToken:X8}]";
         return $"PASS BUG: {exception.GetType().Name}: {exception.Message} ({identity})";
     }
 }

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -845,7 +845,9 @@ static class Program
                 {
                     crashes++;
                     Console.Error.WriteLine(
-                        PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
+                        PassBugDiagnostic.Format(
+                            ex, assemblyPath, typeName, methodName,
+                            function.Signature, function.MetadataToken));
                     continue;
                 }
 
@@ -959,7 +961,9 @@ static class Program
                 {
                     crashes++;
                     Console.Error.WriteLine(
-                        PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
+                        PassBugDiagnostic.Format(
+                            ex, assemblyPath, typeName, methodName,
+                            function.Signature, function.MetadataToken));
                     continue;
                 }
                 var fidelityCensus = FidelityCauseBuckets.Inspect(function, id);
@@ -1035,7 +1039,9 @@ static class Program
                 {
                     crashes++;
                     Console.Error.WriteLine(
-                        PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
+                        PassBugDiagnostic.Format(
+                            ex, assemblyPath, typeName, methodName,
+                            function.Signature, function.MetadataToken));
                     continue;
                 }
                 var changed = StageDump.PassesThatChanged(stages);
@@ -1115,7 +1121,9 @@ static class Program
                 {
                     crashes++;
                     Console.Error.WriteLine(
-                        PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
+                        PassBugDiagnostic.Format(
+                            ex, assemblyPath, typeName, methodName,
+                            function.Signature, function.MetadataToken));
                     continue;
                 }
 

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -844,7 +844,8 @@ static class Program
                 catch (Exception ex)
                 {
                     crashes++;
-                    Console.Error.WriteLine($"PASS BUG: {ex.GetType().Name}: {ex.Message}");
+                    Console.Error.WriteLine(
+                        PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
                     continue;
                 }
 
@@ -957,7 +958,8 @@ static class Program
                 catch (Exception ex)
                 {
                     crashes++;
-                    Console.Error.WriteLine($"PASS BUG: {ex.GetType().Name}: {ex.Message}");
+                    Console.Error.WriteLine(
+                        PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
                     continue;
                 }
                 var fidelityCensus = FidelityCauseBuckets.Inspect(function, id);
@@ -1032,7 +1034,8 @@ static class Program
                 catch (Exception ex)
                 {
                     crashes++;
-                    Console.Error.WriteLine($"PASS BUG: {ex.GetType().Name}: {ex.Message} ({typeName}::{methodName})");
+                    Console.Error.WriteLine(
+                        PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
                     continue;
                 }
                 var changed = StageDump.PassesThatChanged(stages);
@@ -1111,7 +1114,8 @@ static class Program
                 catch (Exception ex)
                 {
                     crashes++;
-                    Console.Error.WriteLine($"PASS BUG: {ex.GetType().Name}: {ex.Message} ({typeName}::{methodName})");
+                    Console.Error.WriteLine(
+                        PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
                     continue;
                 }
 

--- a/tools/DecompilerHarness/SlotResidualCensus.cs
+++ b/tools/DecompilerHarness/SlotResidualCensus.cs
@@ -43,7 +43,8 @@ static class SlotResidualCensus
                 {
                     totals.PassBugs++;
                     if (examples.Count < maxExamples)
-                        examples.Add($"PASS BUG {ex.GetType().Name}: {ex.Message} ({typeName}::{methodName})");
+                        examples.Add(
+                            PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
                     continue;
                 }
 

--- a/tools/DecompilerHarness/SlotResidualCensus.cs
+++ b/tools/DecompilerHarness/SlotResidualCensus.cs
@@ -44,7 +44,9 @@ static class SlotResidualCensus
                     totals.PassBugs++;
                     if (examples.Count < maxExamples)
                         examples.Add(
-                            PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
+                            PassBugDiagnostic.Format(
+                                ex, assemblyPath, typeName, methodName,
+                                function.Signature, function.MetadataToken));
                     continue;
                 }
 

--- a/tools/DecompilerHarness/SlotUnifierCensus.cs
+++ b/tools/DecompilerHarness/SlotUnifierCensus.cs
@@ -42,7 +42,8 @@ static class SlotUnifierCensus
                 {
                     totals.PassBugs++;
                     if (examples.Count < maxExamples)
-                        examples.Add($"PASS BUG {ex.GetType().Name}: {ex.Message} ({typeName}::{methodName})");
+                        examples.Add(
+                            PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
                 }
             }
             if (capped)

--- a/tools/DecompilerHarness/SlotUnifierCensus.cs
+++ b/tools/DecompilerHarness/SlotUnifierCensus.cs
@@ -43,7 +43,9 @@ static class SlotUnifierCensus
                     totals.PassBugs++;
                     if (examples.Count < maxExamples)
                         examples.Add(
-                            PassBugDiagnostic.Format(ex, assemblyPath, typeName, methodName, function.Signature));
+                            PassBugDiagnostic.Format(
+                                ex, assemblyPath, typeName, methodName,
+                                function.Signature, function.MetadataToken));
                 }
             }
             if (capped)


### PR DESCRIPTION
## What

`--gaps` PASS BUG output now identifies the exact crashed method body at all
four emit sites, and the diagnostic has one owner instead of four inline
format strings.

Fixes #3243.

## Why

The issue reports that two of the four PASS BUG sites in the harness drop the
method identity entirely. This is not hypothetical: the crash fixed by #3236
surfaced from a 364,338-method sweep as nothing but
`PASS BUG: KeyNotFoundException: The given key '3' was not present in the
dictionary.` — no assembly, no type, no method. Locating it took a manual
bisect of the assembly pool.

The issue also asks whether a type/method pair alone is enough across a large
pool. It is not. A sweep spans many assemblies, an assembly can carry
overloads with the same `Type::Method` spelling, and the same
assembly-relative name can appear at more than one version. So the identity
this PR emits is the one that actually names a single method body:

`<assemblyPath>!<Type>::<Method><signature> [token 0x........]`

## What changed

- New `tools/DecompilerHarness/PassBugDiagnostic.cs` owns the one PASS BUG
  format, reusing `CorpusMethodIdentity.SignatureText` for the signature so
  the spelling matches the harness's existing method identity.
- All four `Program.cs` sites plus `SlotResidualCensus` and `SlotUnifierCensus`
  call it. The two sites that already had `(Type::Method)` are folded onto the
  same formatter rather than left as a second spelling.

## Evidence

`PassBugDiagnosticTests` is the gate for both claims this PR makes:

- `Format_IdentifiesAssemblyAndExactMethodBody` pins the exact rendered text
  and asserts that changing *only* the assembly path, *only* the overload
  signature, or *only* the metadata token produces a different diagnostic —
  i.e. the identity discriminates the axes that a large sweep collides on.
- `DirectPassBugEmitters_UseSharedFormatter` asserts set equality on the
  `PassBugDiagnostic.Format(` call sites across the harness *and* that no
  harness file other than `PassBugDiagnostic.cs` contains the literal
  `PASS BUG`. A new inline emitter or a deleted call site both fail the gate,
  so the "one owner" property cannot silently rot.

```console
$ dotnet build dotnet-inspect.slnx -c Release
0 Error(s)
$ dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
Total: 3895, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
$ dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
    -class ILInspector.Decompiler.Tests.PassBugDiagnosticTests
Total: 2, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

## Boundary

Harness diagnostic text only. No product path, no default CLI output, no
decompiler behavior, and no change to crash counting — a PASS BUG still
increments `crashes` and continues.
