### PR TITLE
Preserve .ctor as the RTS constructor metadata identity (#3251)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberIdentifierNameTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentifierNameTests.cs
@@ -1,0 +1,52 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Fast gate for the ReturnToSender constructor identity restored by #3251.
+///
+/// The end-to-end coverage in <c>ReturnToSenderPrototypeTests</c> is
+/// <c>Speed=Slow</c>, and the PR test job drops that trait — which is exactly how
+/// the #3129 sanitizer silently rewrote <c>.ctor</c> to <c>__ctor</c> on
+/// <c>main</c>. These cases carry no trait, so they run in the PR job.
+/// </summary>
+[Trait("Area", "RoundTrip")]
+public class MemberIdentifierNameTests
+{
+    [Fact]
+    public void Constructor_KeepsMetadataName()
+    {
+        Assert.Equal(
+            ".ctor",
+            CompileBackSourceComposer.MemberIdentifierName(".ctor", isConstructor: true));
+    }
+
+    /// <summary>
+    /// Non-vacuity: the sanitizer really does corrupt <c>.ctor</c>, so
+    /// <see cref="Constructor_KeepsMetadataName"/> cannot pass by accident if the
+    /// guard is deleted.
+    /// </summary>
+    [Fact]
+    public void Sanitizer_WouldCorruptConstructorName_SoTheGuardIsLoadBearing()
+    {
+        string sanitized = CSharpNaming.SourceMethodName(".ctor");
+
+        Assert.NotEqual(".ctor", sanitized);
+        Assert.Equal(
+            sanitized,
+            CompileBackSourceComposer.MemberIdentifierName(".ctor", isConstructor: false));
+    }
+
+    [Theory]
+    [InlineData("Parse")]
+    [InlineData("<Run>g__Local|0_0")]
+    [InlineData("<>c__DisplayClass0_0")]
+    [InlineData("op_Addition")]
+    public void NonConstructor_StillRoutesThroughTheSanitizer(string metadataName)
+    {
+        Assert.Equal(
+            CSharpNaming.SourceMethodName(metadataName),
+            CompileBackSourceComposer.MemberIdentifierName(metadataName, isConstructor: false));
+    }
+}

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -4136,6 +4136,23 @@ public static class CompileBackSourceComposer
         return true;
     }
 
+    /// <summary>
+    /// The name a member carries as its <see cref="CompileBackMethodIdentity"/>
+    /// key. This is model identity, not C# spelling: it is matched against other
+    /// requirement/production entries, never emitted as an identifier.
+    /// Constructors therefore keep their metadata name <c>.ctor</c> — the
+    /// declaring type name is what the emitter spells, selected by
+    /// <see cref="CompileBackMemberKind.Constructor"/>. Every other name is a
+    /// method name that can reach emitted source, so it goes through the #3129
+    /// residual-name sanitizer.
+    /// Gate: <c>MemberIdentifierNameTests</c>. That gate is fast on purpose — the
+    /// end-to-end <c>ReturnToSenderPrototypeTests</c> coverage is
+    /// <c>Speed=Slow</c> and so does not run in the PR test job, which is how
+    /// #3251 reached <c>main</c> unnoticed.
+    /// </summary>
+    internal static string MemberIdentifierName(string metadataName, bool isConstructor)
+        => isConstructor ? metadataName : CSharpNaming.SourceMethodName(metadataName);
+
     sealed class TypeProducer
     {
         public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
@@ -4539,7 +4556,7 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
-            string identifierName = isConstructor ? name : CSharpNaming.SourceMethodName(name);
+            string identifierName = MemberIdentifierName(name, isConstructor);
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, identifierName, DeclaringOverloadIndex(reader, typeDef, methodHandle, name), MethodSignatureText(identifierName, signature)),
                 isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
@@ -5300,7 +5317,7 @@ public static class CompileBackSourceComposer
                 }
 
                 bool isConstructor = name == ".ctor";
-                string identifierName = isConstructor ? name : CSharpNaming.SourceMethodName(name);
+                string identifierName = MemberIdentifierName(name, isConstructor);
                 int existingMethodIndex = members.FindIndex(member =>
                     member.Kind == (isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method)
                     && member.Identity.Method == identifierName);

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -4539,7 +4539,7 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
-            string identifierName = CSharpNaming.SourceMethodName(name);
+            string identifierName = isConstructor ? name : CSharpNaming.SourceMethodName(name);
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, identifierName, DeclaringOverloadIndex(reader, typeDef, methodHandle, name), MethodSignatureText(identifierName, signature)),
                 isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
@@ -5300,7 +5300,7 @@ public static class CompileBackSourceComposer
                 }
 
                 bool isConstructor = name == ".ctor";
-                string identifierName = CSharpNaming.SourceMethodName(name);
+                string identifierName = isConstructor ? name : CSharpNaming.SourceMethodName(name);
                 int existingMethodIndex = members.FindIndex(member =>
                     member.Kind == (isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method)
                     && member.Identity.Method == identifierName);


### PR DESCRIPTION
## What

The ReturnToSender requirement model keeps `.ctor` as a constructor's metadata
identity instead of routing it through the unspellable-name sanitizer, which
had been rewriting it to `__ctor`.

Fixes #3251.

## Answer to the issue's open question

#3251 asks the owner to decide whether the `.ctor` → `__ctor` rewrite is
intended for RTS constructor labels, or a product regression in the
sanitizer's scope. **It is a regression.** The sanitizer exists to turn an
identifier that cannot be *spelled in C#* into one that can. `.ctor` is not a
C# identifier the model ever emits: constructors are emitted under the
declaring type's name, and `CompileBackMemberKind.Constructor` already carries
that fact. What `.ctor` is, in this model, is the *metadata* name — the key the
requirement model matches members on. Sanitizing it corrupts an identity that
is never printed, which is exactly the "do not infer identity from display
text" boundary in AGENTS.md.

So the fix restores the metadata spelling rather than updating the two
assertions to `__ctor`.

## What changed

Two call sites in `CompileBackSourceComposer` (`ReturnToSenderTypePlanner.cs`)
now skip the sanitizer when the member is a constructor. Both sites already
computed `isConstructor` immediately adjacent, so the guard reuses the existing
discriminator:

```csharp
string identifierName = isConstructor ? name : CSharpNaming.SourceMethodName(name);
```

Non-constructor names keep going through `CSharpNaming.SourceMethodName`
unchanged, so #3129's residual-name handling is untouched for the case it was
written for.

## Evidence

The two tests named in the issue are the gate. They fail on current `main` and
pass on this branch:

```console
# current main, df67a285
$ dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
    -method "*CompileBackFirstPropertyGetter_EmitsClosureConstructorRequirement" \
    -method "*FullReconstructsPlainEventAccessorTarget"
Total: 2, Errors: 0, Failed: 2

# this branch
$ dotnet run --project src/ILInspector.Decompiler.Tests -c Release \
    -- -class ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests
Total: 186, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

Wider `Area=RoundTrip`, which is where these slow RTS gates live:

| Head | `Area=RoundTrip` result |
| --- | --- |
| `origin/main` (df67a285) | Total 533, **Failed 5** |
| this branch | Total 533, **Failed 3** |

The two removed failures are exactly the two from #3251. The remaining three
(`GeneratedFixtureCatalogTests`, all reporting
`minimal.parameter-attributes … compile-back=RecompileFail`) reproduce
identically on `origin/main` and are unrelated to this change; they are not
introduced or masked here.

## Boundary

Constructor identity in the RTS requirement/production model only. No printer
change, no change to how constructors are *emitted* in compile-back source
(they were already emitted under the type name), and no change to the
sanitizer itself or to any non-constructor name.

## Follow-up (non-blocking)

#3251 also notes that CI missed this because `ReturnToSenderPrototypeTests` is
`[Trait("Speed", "Slow")]` and the PR `test` job drops the slow gate. Whether
to run the slow RTS gate periodically is a separate scheduling decision and is
deliberately not bundled here.
