### PR TITLE
Add mdi metadata inspector tool and shared renderer over the table projection

### DIFF
--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -334,6 +334,42 @@ enumeration order. All are cheap and SRM-available
 (`GetTableRowCount`, `GetTableRowSize`, `MetadataTokens.GetHeapOffset`), so they
 are a knob the model can expose, not a wall.
 
+## Implemented: the `mdi` tool and the shared renderer
+
+The first presentation consumer of the projection is **`mdi`** (metadata
+inspector), a standalone tool that renders the tables the way `mdv` does:
+
+- **`src/mdi`** — a `PackAsTool` / `PublishAot` command
+  (`ToolCommandName=mdi`) whose System.CommandLine front-end maps flags onto
+  `MetadataProjectionOptions` and delegates all output to the renderer below.
+  Surface: `mdi <assembly> [--table|-t <Names>] [--format|-f md|tsv|jsonl]
+  [--max-rows|-n N] [--max-bytes N] [--max-chars N]`. Missing files, native
+  images, and unreadable metadata surface as visible errors, never
+  success-shaped empty output.
+- **`src/DotnetInspector.MetadataRendering`** — a small reusable library holding
+  `MetadataProjectionRenderer` (projection → Markout tables). It lives in the
+  product-side `DotnetInspector.*` family, **not** in `ILInspector.Metadata`,
+  which stays presentation-free: the renderer is a sibling of the Metadata layer
+  that consumes the projection, so a future `dotnet-inspect metadata` lens reuses
+  the same code the tool uses today.
+
+Renderer contract. Rendering is a deliberately **lossy** human/inspection view;
+the projection model stays the lossless source of truth (for example for the
+oracle below). Three invariants hold regardless: every cell renders from exactly
+one `MetadataValue` case; a `Malformed` cell keeps a visible `!malformed:`
+marker; and a bounded preview is suffixed with `…` so it is never mistaken for a
+whole value. A leading row-id column lets a reader cross-reference a resolved
+handle target (rendered `TypeRef[5] (System.Object)`) back to its row.
+
+Formats differ only in how a row's table is identified. Markdown introduces each
+table with a `## <Name> (rows)` heading over a pipe table; TSV and JSONL carry a
+leading `Table` column so every row self-identifies, keeping those outputs pure
+machine-readable streams (one `WriteTable` block per table).
+
+The `mdv` oracle is a follow-up increment: because it diffs against the
+projection **model** (not `mdi`'s rendered text), the renderer is free to be
+human-friendly without weakening the oracle.
+
 ## Layer placement
 
 The projection lives in the **Metadata layer** (`ILInspector.Metadata`), beside

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -9,6 +9,7 @@
     <Project Path="src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj" />
     <Project Path="src/dotnet-inspect/dotnet-inspect.csproj" />
     <Project Path="src/DotnetInspector.Core/DotnetInspector.Core.csproj" />
+    <Project Path="src/DotnetInspector.MetadataRendering/DotnetInspector.MetadataRendering.csproj" />
     <Project Path="src/DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
     <Project Path="src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj" />
     <Project Path="src/DotnetInspector.Services/DotnetInspector.Services.csproj" />
@@ -56,6 +57,7 @@
     <Project Path="src/ILInspector.Research/ILInspector.Research.csproj" />
     <Project Path="src/ILInspector.Text.Tests/ILInspector.Text.Tests.csproj" />
     <Project Path="src/ILInspector.Text/ILInspector.Text.csproj" />
+    <Project Path="src/mdi/mdi.csproj" />
     <Project Path="src/runfaster.Tests/runfaster.Tests.csproj" />
     <Project Path="src/runfaster/runfaster.csproj" />
   </Folder>
@@ -66,6 +68,7 @@
     <Project Path="tests/DotnetInspector.Fixtures/DotnetInspector.Fixtures.csproj" />
     <Project Path="tests/DotnetInspector.Fixtures.Tests/DotnetInspector.Fixtures.Tests.csproj" />
     <Project Path="tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj" />
+    <Project Path="tests/DotnetInspector.MetadataRendering.Tests/DotnetInspector.MetadataRendering.Tests.csproj" />
     <Project Path="tests/HarnessReportDiff.Tests/HarnessReportDiff.Tests.csproj" />
     <Project Path="tests/TestExtensions/TestExtensions.csproj" />
   </Folder>

--- a/src/DotnetInspector.MetadataRendering/DotnetInspector.MetadataRendering.csproj
+++ b/src/DotnetInspector.MetadataRendering/DotnetInspector.MetadataRendering.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Richard Lander</Authors>
+    <Description>Renders the ECMA-335 metadata-table projection as Markdown, TSV, or JSONL tables</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="DotnetInspector.MetadataRendering.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ILInspector.Metadata/ILInspector.Metadata.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Markout" />
+  </ItemGroup>
+
+</Project>

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -165,11 +165,18 @@ public static class MetadataProjectionRenderer
             return "nil";
 
         string target = $"{reference.TargetTable}[{reference.TargetRowId}]";
+
+        // A truncated display must always carry the ellipsis so it is never
+        // mistaken for a whole value — even when the budget clipped it to empty,
+        // which must still render as "(…)" rather than a bare target that looks
+        // like an unavailable display.
+        if (reference.DisplayTruncated)
+            return $"{target} ({reference.Display}{Ellipsis})";
+
         if (string.IsNullOrEmpty(reference.Display))
             return target;
 
-        string display = reference.DisplayTruncated ? reference.Display + Ellipsis : reference.Display;
-        return $"{target} ({display})";
+        return $"{target} ({reference.Display})";
     }
 
     static string FormatRange(HandleRange range)

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -1,0 +1,177 @@
+using System.Reflection.Metadata.Ecma335;
+using ILInspector.Metadata;
+using Markout;
+
+namespace DotnetInspector.MetadataRendering;
+
+/// <summary>The table serialization used when rendering a projection.</summary>
+public enum MetadataTableFormat
+{
+    /// <summary>GitHub-flavored Markdown pipe tables (default, human-readable).</summary>
+    Markdown,
+
+    /// <summary>Tab-separated values.</summary>
+    Tsv,
+
+    /// <summary>JSON Lines: one self-describing object per row.</summary>
+    Jsonl,
+}
+
+/// <summary>
+/// Renders a <see cref="MetadataTableProjection"/> as a document of per-table
+/// Markout tables, one section per table.
+///
+/// This is the product-side presentation of the raw metadata projection. The
+/// Metadata layer stays presentation-free (see
+/// <c>docs/design/metadata-table-projection.md</c>), so this renderer is a
+/// sibling of that layer — reused by the <c>mdi</c> tool now and, later, a
+/// <c>dotnet-inspect metadata</c> lens.
+///
+/// Rendering is deliberately lossy: it is a human/inspection view, and the
+/// projection model remains the lossless source of truth (for example for an
+/// oracle diff). Even so, three invariants hold: every cell is rendered from
+/// exactly one <see cref="MetadataValue"/> case; a
+/// <see cref="MetadataValue.Malformed"/> cell stays visibly marked and is never
+/// rendered as a success-shaped empty value; and a bounded preview is suffixed
+/// with an ellipsis so it is never mistaken for a whole value.
+///
+/// The two format families identify a row's table differently. Markdown
+/// introduces each table with a <c>## &lt;Name&gt; (rows)</c> heading; TSV and
+/// JSONL carry a leading <c>Table</c> column so every row self-identifies,
+/// keeping those outputs pure machine-readable streams.
+/// </summary>
+public static class MetadataProjectionRenderer
+{
+    const string Ellipsis = "\u2026";
+
+    /// <summary>Renders <paramref name="projection"/> to <paramref name="output"/>.</summary>
+    public static void Render(
+        MetadataTableProjection projection,
+        TextWriter output,
+        MetadataTableFormat format = MetadataTableFormat.Markdown)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+        ArgumentNullException.ThrowIfNull(output);
+
+        if (format == MetadataTableFormat.Markdown)
+            RenderMarkdown(projection, output);
+        else
+            RenderTabular(projection, output, format);
+    }
+
+    static void RenderMarkdown(MetadataTableProjection projection, TextWriter output)
+    {
+        var writer = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
+
+        bool first = true;
+        foreach (var table in projection.Tables)
+        {
+            if (!first)
+                writer.WriteBlankLine();
+            first = false;
+
+            writer.WriteHeading(2, HeadingText(table));
+            WriteTable(writer, table, identifyTable: false);
+        }
+
+        writer.Flush();
+    }
+
+    static void RenderTabular(MetadataTableProjection projection, TextWriter output, MetadataTableFormat format)
+    {
+        var options = new MarkoutWriterOptions
+        {
+            TableMode = format == MetadataTableFormat.Tsv ? MarkoutTableMode.Tsv : MarkoutTableMode.Jsonl,
+        };
+        var writer = new MarkoutWriter(output, new TableFormatter(showHeader: true), options);
+
+        foreach (var table in projection.Tables)
+            WriteTable(writer, table, identifyTable: true);
+
+        writer.Flush();
+    }
+
+    static string HeadingText(MetadataTableView table)
+        => table.Truncation is { } truncation
+            ? $"{table.Name} (showing {truncation.ProjectedRows} of {truncation.RowCount} rows)"
+            : $"{table.Name} ({table.RowCount} {(table.RowCount == 1 ? "row" : "rows")})";
+
+    static void WriteTable(MarkoutWriter writer, MetadataTableView table, bool identifyTable)
+    {
+        // Markdown identifies the table with a heading; the machine formats carry
+        // a leading Table column instead so every row self-identifies. Both add a
+        // row-id column so a resolved handle target (for example TypeRef[5]) can be
+        // cross-referenced back to that row's number in its table.
+        int prefix = identifyTable ? 2 : 1;
+        var headers = new string[table.Columns.Length + prefix];
+        var headerNames = new string[table.Columns.Length + prefix];
+
+        int slot = 0;
+        if (identifyTable)
+        {
+            headers[slot] = "Table";
+            headerNames[slot] = "table";
+            slot++;
+        }
+
+        headers[slot] = "#";
+        headerNames[slot] = "rid";
+        slot++;
+
+        for (int i = 0; i < table.Columns.Length; i++)
+        {
+            headers[slot + i] = table.Columns[i].Name;
+            headerNames[slot + i] = table.Columns[i].Name;
+        }
+
+        var rows = new List<string[]>(table.Rows.Length);
+        foreach (var row in table.Rows)
+        {
+            var cells = new string[row.Cells.Length + prefix];
+            int cellSlot = 0;
+            if (identifyTable)
+                cells[cellSlot++] = table.Name;
+            cells[cellSlot++] = row.RowId.ToString();
+            for (int i = 0; i < row.Cells.Length; i++)
+                cells[cellSlot + i] = FormatCell(row.Cells[i]);
+            rows.Add(cells);
+        }
+
+        writer.WriteTable(headers, headerNames, rows);
+    }
+
+    static string FormatCell(MetadataValue value) => value switch
+    {
+        MetadataValue.Nil => "nil",
+        MetadataValue.Scalar scalar => scalar.Display,
+        MetadataValue.Flags flags => flags.Decoded,
+        MetadataValue.HeapReference heap => FormatHeap(heap),
+        MetadataValue.Handle handle => FormatHandle(handle.Reference),
+        MetadataValue.Range range => FormatRange(range.Reference),
+        MetadataValue.Malformed malformed => $"!malformed: {malformed.Detail}",
+        _ => throw new InvalidOperationException($"Unhandled metadata value: {value.GetType().Name}"),
+    };
+
+    static string FormatHeap(MetadataValue.HeapReference heap)
+    {
+        // The Blob heap carries no decoded text; its bounded hex preview stands in.
+        string body = heap.Text ?? heap.Preview;
+        return heap.Truncated ? body + Ellipsis : body;
+    }
+
+    static string FormatHandle(HandleRef reference)
+    {
+        if (reference.TargetRowId == 0)
+            return "nil";
+
+        string target = $"{reference.TargetTable}[{reference.TargetRowId}]";
+        if (string.IsNullOrEmpty(reference.Display))
+            return target;
+
+        string display = reference.DisplayTruncated ? reference.Display + Ellipsis : reference.Display;
+        return $"{target} ({display})";
+    }
+
+    static string FormatRange(HandleRange range)
+        => $"{range.TargetTable}[{range.StartRowId}..{range.EndRowId})";
+}

--- a/src/mdi/MdiCommand.cs
+++ b/src/mdi/MdiCommand.cs
@@ -1,0 +1,209 @@
+using System.Collections.Immutable;
+using System.CommandLine;
+using System.Reflection.Metadata.Ecma335;
+using DotnetInspector.MetadataRendering;
+using ILInspector.Metadata;
+
+namespace Mdi;
+
+/// <summary>
+/// The <c>mdi</c> command: inspect the ECMA-335 metadata tables of a .NET
+/// assembly and render them as Markdown, TSV, or JSONL. The front-end maps its
+/// flags onto <see cref="MetadataProjectionOptions"/> and delegates rendering to
+/// <see cref="MetadataProjectionRenderer"/>; the projection and rendering logic
+/// live in reusable libraries so this tool stays a thin shell.
+/// </summary>
+public static class MdiCommand
+{
+    /// <summary>Builds and runs the command over <paramref name="args"/>.</summary>
+    public static int Invoke(string[] args) => CreateRootCommand().Parse(args).Invoke();
+
+    /// <summary>Builds the System.CommandLine surface (also used by tests).</summary>
+    public static RootCommand CreateRootCommand()
+    {
+        var assemblyArgument = new Argument<string>("assembly")
+        {
+            Description = "Path to a .NET assembly (.dll or .exe).",
+        };
+
+        var tableOption = new Option<string?>("--table")
+        {
+            Description = "Comma-separated ECMA-335 table names to include (for example TypeDef,MethodDef). Default: every supported table.",
+        };
+        tableOption.Aliases.Add("-t");
+
+        var formatOption = new Option<string>("--format")
+        {
+            Description = "Table format: md (default), tsv, or jsonl.",
+            DefaultValueFactory = _ => "md",
+        };
+        formatOption.Aliases.Add("-f");
+
+        var maxRowsOption = new Option<int>("--max-rows")
+        {
+            Description = $"Maximum rows projected per table before explicit truncation (default {MetadataProjectionOptions.DefaultMaxRowsPerTable}).",
+            DefaultValueFactory = _ => MetadataProjectionOptions.DefaultMaxRowsPerTable,
+        };
+        maxRowsOption.Aliases.Add("-n");
+
+        var maxBytesOption = new Option<int>("--max-bytes")
+        {
+            Description = $"Maximum blob-preview bytes per cell (default {MetadataProjectionOptions.DefaultMaxPreviewBytes}).",
+        };
+        maxBytesOption.DefaultValueFactory = _ => MetadataProjectionOptions.DefaultMaxPreviewBytes;
+
+        var maxCharsOption = new Option<int>("--max-chars")
+        {
+            Description = $"Maximum decoded string characters per cell (default {MetadataProjectionOptions.DefaultMaxStringChars}).",
+        };
+        maxCharsOption.DefaultValueFactory = _ => MetadataProjectionOptions.DefaultMaxStringChars;
+
+        var root = new RootCommand("mdi \u2014 inspect the ECMA-335 metadata tables of a .NET assembly.");
+        root.Arguments.Add(assemblyArgument);
+        root.Options.Add(tableOption);
+        root.Options.Add(formatOption);
+        root.Options.Add(maxRowsOption);
+        root.Options.Add(maxBytesOption);
+        root.Options.Add(maxCharsOption);
+
+        root.SetAction(parseResult =>
+        {
+            string assembly = parseResult.GetValue(assemblyArgument)!;
+            string? tableSpec = parseResult.GetValue(tableOption);
+            string formatText = parseResult.GetValue(formatOption)!;
+            int maxRows = parseResult.GetValue(maxRowsOption);
+            int maxBytes = parseResult.GetValue(maxBytesOption);
+            int maxChars = parseResult.GetValue(maxCharsOption);
+
+            if (!TryParseFormat(formatText, out var format))
+            {
+                Console.Error.WriteLine($"Error: unknown format '{formatText}'. Use md, tsv, or jsonl.");
+                return 1;
+            }
+
+            if (maxRows < 0 || maxBytes < 0 || maxChars < 0)
+            {
+                Console.Error.WriteLine("Error: --max-rows, --max-bytes, and --max-chars must be non-negative.");
+                return 1;
+            }
+
+            if (!TryParseTables(tableSpec, out var tables, out var badName))
+            {
+                Console.Error.WriteLine(
+                    $"Error: unknown table '{badName}'. Table names are members of System.Reflection.Metadata.Ecma335.TableIndex (for example TypeDef, MethodDef, Field).");
+                return 1;
+            }
+
+            var options = new MetadataProjectionOptions
+            {
+                MaxRowsPerTable = maxRows,
+                MaxPreviewBytes = maxBytes,
+                MaxStringChars = maxChars,
+                Tables = tables,
+            };
+
+            return Execute(assembly, options, format, Console.Out, Console.Error);
+        });
+
+        return root;
+    }
+
+    /// <summary>
+    /// Opens <paramref name="assemblyPath"/>, projects its metadata tables, and
+    /// renders them. Returns a process exit code; all diagnostics are surfaced on
+    /// <paramref name="error"/> and never collapsed into success-shaped output.
+    /// </summary>
+    public static int Execute(
+        string assemblyPath,
+        MetadataProjectionOptions options,
+        MetadataTableFormat format,
+        TextWriter output,
+        TextWriter error)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        if (!File.Exists(assemblyPath))
+        {
+            error.WriteLine($"Error: file not found: {assemblyPath}");
+            return 1;
+        }
+
+        MetadataTableProjection projection;
+        try
+        {
+            using var session = AssemblyInspectionSession.Open(assemblyPath);
+            if (!session.HasMetadata)
+            {
+                error.WriteLine($"Error: '{assemblyPath}' contains no .NET metadata (not a managed assembly).");
+                return 1;
+            }
+
+            projection = session.MetadataTables(options);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or IOException)
+        {
+            error.WriteLine($"Error: cannot read metadata from '{assemblyPath}': {ex.Message}");
+            return 1;
+        }
+
+        if (projection.Tables.IsEmpty)
+        {
+            error.WriteLine("No metadata tables matched the current selection.");
+            return 0;
+        }
+
+        MetadataProjectionRenderer.Render(projection, output, format);
+        return 0;
+    }
+
+    static bool TryParseFormat(string text, out MetadataTableFormat format)
+    {
+        switch (text.Trim().ToLowerInvariant())
+        {
+            case "md":
+            case "markdown":
+                format = MetadataTableFormat.Markdown;
+                return true;
+            case "tsv":
+                format = MetadataTableFormat.Tsv;
+                return true;
+            case "jsonl":
+                format = MetadataTableFormat.Jsonl;
+                return true;
+            default:
+                format = MetadataTableFormat.Markdown;
+                return false;
+        }
+    }
+
+    static bool TryParseTables(string? spec, out ImmutableArray<TableIndex> tables, out string? badName)
+    {
+        badName = null;
+
+        // A default (unset) array is the projector's signal to include every
+        // supported table; an empty spec keeps that default.
+        if (string.IsNullOrWhiteSpace(spec))
+        {
+            tables = default;
+            return true;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<TableIndex>();
+        foreach (var part in spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (!Enum.TryParse<TableIndex>(part, ignoreCase: true, out var index) || !Enum.IsDefined(index))
+            {
+                badName = part;
+                tables = default;
+                return false;
+            }
+
+            builder.Add(index);
+        }
+
+        tables = builder.ToImmutable();
+        return true;
+    }
+}

--- a/src/mdi/MdiCommand.cs
+++ b/src/mdi/MdiCommand.cs
@@ -142,7 +142,7 @@ public static class MdiCommand
 
             projection = session.MetadataTables(options);
         }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or IOException)
+        catch (Exception ex) when (IsExpectedReadFailure(ex))
         {
             error.WriteLine($"Error: cannot read metadata from '{assemblyPath}': {ex.Message}");
             return 1;
@@ -155,8 +155,39 @@ public static class MdiCommand
         }
 
         MetadataProjectionRenderer.Render(projection, output, format);
+
+        // Markdown announces truncation inline in each table heading. The machine
+        // formats carry no heading, so a bounded table would otherwise be
+        // indistinguishable from a complete one (and a fully-clipped request could
+        // even emit nothing at all). Report truncation on the error writer so it
+        // stays visible without polluting the row stream on stdout.
+        if (format != MetadataTableFormat.Markdown)
+        {
+            foreach (var table in projection.Tables)
+            {
+                if (table.Truncation is { } truncation)
+                    error.WriteLine(
+                        $"Note: table {table.Name} truncated to {truncation.ProjectedRows} of {truncation.RowCount} rows; raise --max-rows to include more.");
+            }
+        }
+
         return 0;
     }
+
+    /// <summary>
+    /// Whether <paramref name="ex"/> is an expected failure of opening or reading
+    /// an assembly file — a bad image, an unreadable or inaccessible file, or an
+    /// invalid path — as opposed to an unexpected programming error. These are
+    /// turned into a clean diagnostic and a non-zero exit; anything else is left
+    /// to propagate.
+    /// </summary>
+    internal static bool IsExpectedReadFailure(Exception ex) =>
+        ex is BadImageFormatException
+           or InvalidOperationException
+           or IOException
+           or UnauthorizedAccessException
+           or ArgumentException
+           or NotSupportedException;
 
     static bool TryParseFormat(string text, out MetadataTableFormat format)
     {

--- a/src/mdi/Program.cs
+++ b/src/mdi/Program.cs
@@ -1,0 +1,1 @@
+return Mdi.MdiCommand.Invoke(args);

--- a/src/mdi/mdi.csproj
+++ b/src/mdi/mdi.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <RollForward>LatestMajor</RollForward>
+  </PropertyGroup>
+
+  <!-- Native AOT size optimizations (only apply when publishing with AOT) -->
+  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Size</OptimizationPreference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="DotnetInspector.MetadataRendering.Tests" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <Authors>Richard Lander</Authors>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>mdi</ToolCommandName>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <PackageId>mdi</PackageId>
+    <Description>A CLI tool for inspecting ECMA-335 metadata tables in .NET assemblies</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <!-- RID-specific tool packaging: Native AOT for common platforms, CoreCLR fallback for others -->
+    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
+    <PublishAot>true</PublishAot>
+    <!-- Keep debug symbols out of the published tool package. -->
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <DebugType>embedded</DebugType>
+    <Deterministic>true</Deterministic>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
+    <ProjectReference Include="..\DotnetInspector.MetadataRendering\DotnetInspector.MetadataRendering.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DotnetInspector.MetadataRendering.Tests/DotnetInspector.MetadataRendering.Tests.csproj
+++ b/tests/DotnetInspector.MetadataRendering.Tests/DotnetInspector.MetadataRendering.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/DotnetInspector.MetadataRendering/DotnetInspector.MetadataRendering.csproj" />
+    <ProjectReference Include="../../src/mdi/mdi.csproj" />
+    <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
@@ -1,0 +1,99 @@
+using System.Reflection.Metadata.Ecma335;
+using ILInspector.Metadata;
+using Mdi;
+
+namespace DotnetInspector.MetadataRendering.Tests;
+
+/// <summary>
+/// Tests for the <see cref="MdiCommand"/> front-end: option wiring and the
+/// error contract of <see cref="MdiCommand.Execute"/> (failures stay visible on
+/// the error writer and are never collapsed into success-shaped output).
+/// </summary>
+public class MdiCommandTests
+{
+    static readonly string SelfPath = typeof(MdiCommandTests).Assembly.Location;
+
+    [Fact]
+    public void Execute_MissingFile_ReturnsErrorAndReports()
+    {
+        var error = new StringWriter();
+        int code = MdiCommand.Execute(
+            "does-not-exist.dll",
+            new MetadataProjectionOptions(),
+            MetadataTableFormat.Markdown,
+            new StringWriter(),
+            error);
+
+        Assert.Equal(1, code);
+        Assert.Contains("file not found", error.ToString());
+    }
+
+    [Fact]
+    public void Execute_NonManagedFile_ReportsFailure()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "this is not a PE image");
+
+            var error = new StringWriter();
+            var output = new StringWriter();
+            int code = MdiCommand.Execute(
+                path,
+                new MetadataProjectionOptions(),
+                MetadataTableFormat.Markdown,
+                output,
+                error);
+
+            Assert.Equal(1, code);
+            Assert.False(string.IsNullOrWhiteSpace(error.ToString()));
+            Assert.Equal(string.Empty, output.ToString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Execute_SelfAssembly_RendersTables()
+    {
+        var output = new StringWriter();
+        int code = MdiCommand.Execute(
+            SelfPath,
+            new MetadataProjectionOptions(),
+            MetadataTableFormat.Markdown,
+            output,
+            new StringWriter());
+
+        Assert.Equal(0, code);
+        Assert.Contains("## TypeDef", output.ToString());
+    }
+
+    [Fact]
+    public void Execute_TableSelection_RestrictsOutput()
+    {
+        var output = new StringWriter();
+        int code = MdiCommand.Execute(
+            SelfPath,
+            new MetadataProjectionOptions { Tables = [TableIndex.Module] },
+            MetadataTableFormat.Markdown,
+            output,
+            new StringWriter());
+
+        Assert.Equal(0, code);
+        var text = output.ToString();
+        Assert.Contains("## Module", text);
+        Assert.DoesNotContain("## TypeDef", text);
+    }
+
+    [Fact]
+    public void CreateRootCommand_ParsesKnownOptions_WithoutErrors()
+    {
+        var root = MdiCommand.CreateRootCommand();
+
+        var result = root.Parse(["some.dll", "--format", "jsonl", "-t", "TypeDef,MethodDef", "-n", "10"]);
+
+        Assert.Empty(result.Errors);
+    }
+}

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
@@ -96,4 +96,63 @@ public class MdiCommandTests
 
         Assert.Empty(result.Errors);
     }
+
+    [Theory]
+    [InlineData(typeof(UnauthorizedAccessException))]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(BadImageFormatException))]
+    [InlineData(typeof(InvalidOperationException))]
+    [InlineData(typeof(ArgumentException))]
+    [InlineData(typeof(NotSupportedException))]
+    public void IsExpectedReadFailure_TreatsFileAccessFailuresAsExpected(Type exceptionType)
+    {
+        var ex = (Exception)Activator.CreateInstance(exceptionType)!;
+        Assert.True(MdiCommand.IsExpectedReadFailure(ex));
+    }
+
+    [Theory]
+    [InlineData(typeof(OutOfMemoryException))]
+    [InlineData(typeof(StackOverflowException))]
+    public void IsExpectedReadFailure_LetsUnexpectedErrorsPropagate(Type exceptionType)
+    {
+        var ex = (Exception)Activator.CreateInstance(exceptionType)!;
+        Assert.False(MdiCommand.IsExpectedReadFailure(ex));
+    }
+
+    [Fact]
+    public void Execute_TruncatedTable_MachineFormat_ReportsTruncationOnError()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        int code = MdiCommand.Execute(
+            SelfPath,
+            new MetadataProjectionOptions { MaxRowsPerTable = 1 },
+            MetadataTableFormat.Jsonl,
+            output,
+            error);
+
+        Assert.Equal(0, code);
+        // Machine output stays a pure stream on stdout; the truncation stays
+        // visible as a diagnostic on stderr rather than being silently dropped.
+        Assert.False(string.IsNullOrWhiteSpace(output.ToString()));
+        Assert.Contains("truncated to 1 of", error.ToString());
+    }
+
+    [Fact]
+    public void Execute_TruncatedTable_Markdown_ShowsInHeadingNotOnError()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        int code = MdiCommand.Execute(
+            SelfPath,
+            new MetadataProjectionOptions { MaxRowsPerTable = 1 },
+            MetadataTableFormat.Markdown,
+            output,
+            error);
+
+        Assert.Equal(0, code);
+        Assert.Contains("showing 1 of", output.ToString());
+        // Markdown carries truncation inline, so it does not also emit the note.
+        Assert.DoesNotContain("truncated to", error.ToString());
+    }
 }

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataProjectionRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataProjectionRendererTests.cs
@@ -114,6 +114,44 @@ public class MetadataProjectionRendererTests
     }
 
     [Fact]
+    public void Handle_TruncatedDisplay_KeepsEllipsis()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Extends", MetadataColumnKind.Handle),
+            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 19, 0x01000013, "Sys", DisplayTruncated: true)));
+
+        Assert.Contains("TypeRef[19] (Sys\u2026)", Render(projection));
+    }
+
+    [Fact]
+    public void Handle_EmptyButTruncatedDisplay_StillShowsEllipsis()
+    {
+        // A --max-chars 0 budget clips the display to empty while still marking it
+        // truncated; the cell must not read as a bare, whole target.
+        var projection = OneCell(
+            "TypeDef",
+            Column("Extends", MetadataColumnKind.Handle),
+            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 19, 0x01000013, "", DisplayTruncated: true)));
+
+        Assert.Contains("TypeRef[19] (\u2026)", Render(projection));
+    }
+
+    [Fact]
+    public void Handle_UnavailableDisplay_RendersTargetWithoutParentheses()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Extends", MetadataColumnKind.Handle),
+            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 19, 0x01000013, Display: null, DisplayTruncated: false)));
+
+        var markdown = Render(projection);
+
+        Assert.Contains("TypeRef[19]", markdown);
+        Assert.DoesNotContain("TypeRef[19] (", markdown);
+    }
+
+    [Fact]
     public void Range_RendersHalfOpenInterval()
     {
         var projection = OneCell(

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataProjectionRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataProjectionRendererTests.cs
@@ -1,0 +1,199 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata.Ecma335;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.MetadataRendering.Tests;
+
+/// <summary>
+/// Tests for <see cref="MetadataProjectionRenderer"/>. Most cases render a small
+/// synthetic <see cref="MetadataTableProjection"/> so a single
+/// <see cref="MetadataValue"/> case is exercised in isolation; one case renders
+/// this test assembly end to end.
+/// </summary>
+public class MetadataProjectionRendererTests
+{
+    static string Render(MetadataTableProjection projection, MetadataTableFormat format = MetadataTableFormat.Markdown)
+    {
+        var writer = new StringWriter();
+        MetadataProjectionRenderer.Render(projection, writer, format);
+        return writer.ToString();
+    }
+
+    static MetadataTableProjection OneCell(
+        string tableName,
+        MetadataColumn column,
+        MetadataValue cell,
+        MetadataTableTruncation? truncation = null,
+        int rowCount = 1)
+        => new(ImmutableArray.Create(
+            new MetadataTableView(
+                TableIndex.TypeDef,
+                tableName,
+                rowCount,
+                ImmutableArray.Create(column),
+                ImmutableArray.Create(new MetadataRow(1, 0x02000001, ImmutableArray.Create(cell))),
+                truncation)));
+
+    static MetadataColumn Column(string name, MetadataColumnKind kind) => new(name, kind);
+
+    [Fact]
+    public void Markdown_WritesHeadingHeaderRowAndRidColumn()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Name", MetadataColumnKind.Heap),
+            new MetadataValue.HeapReference(HeapKind.String, 10, 6, "System", "System", Truncated: false));
+
+        var markdown = Render(projection);
+
+        Assert.Contains("## TypeDef (1 row)", markdown);
+        Assert.Contains("System", markdown);
+        // A leading row-id column is prepended before the table's own columns.
+        Assert.Contains("#", markdown);
+        Assert.Contains("Name", markdown);
+        // A Markdown pipe table has at least one row line that starts with '|'.
+        Assert.Contains(markdown.Split('\n'), line => line.TrimStart().StartsWith('|'));
+    }
+
+    [Fact]
+    public void Malformed_RendersVisibleMarker_NeverEmpty()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Extends", MetadataColumnKind.Handle),
+            new MetadataValue.Malformed("Handle 0x02000099 targets TypeDef row 153, outside [1, 40]."));
+
+        var markdown = Render(projection);
+
+        Assert.Contains("!malformed:", markdown);
+        Assert.Contains("outside [1, 40]", markdown);
+    }
+
+    [Fact]
+    public void TruncatedHeap_RendersEllipsis()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Name", MetadataColumnKind.Heap),
+            new MetadataValue.HeapReference(HeapKind.String, 0, 100, "abc", "abc", Truncated: true));
+
+        Assert.Contains("abc\u2026", Render(projection));
+    }
+
+    [Fact]
+    public void BlobHeap_RendersHexPreview()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Signature", MetadataColumnKind.Heap),
+            new MetadataValue.HeapReference(HeapKind.Blob, 0, 3, Text: null, "0A1B2C", Truncated: false));
+
+        Assert.Contains("0A1B2C", Render(projection));
+    }
+
+    [Fact]
+    public void Handle_RendersTargetCoordinateAndDisplay()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Extends", MetadataColumnKind.Handle),
+            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 5, 0x01000005, "System.Object")));
+
+        Assert.Contains("TypeRef[5] (System.Object)", Render(projection));
+    }
+
+    [Fact]
+    public void Handle_NilTarget_RendersNil()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Extends", MetadataColumnKind.Handle),
+            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 0, 0)));
+
+        Assert.Contains("nil", Render(projection));
+    }
+
+    [Fact]
+    public void Range_RendersHalfOpenInterval()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("MethodList", MetadataColumnKind.HandleRange),
+            new MetadataValue.Range(new HandleRange(TableIndex.MethodDef, 1, 5)));
+
+        Assert.Contains("MethodDef[1..5)", Render(projection));
+    }
+
+    [Fact]
+    public void Nil_RendersNilMarker()
+    {
+        var projection = OneCell(
+            "Module",
+            Column("EncId", MetadataColumnKind.Heap),
+            new MetadataValue.Nil());
+
+        Assert.Contains("nil", Render(projection));
+    }
+
+    [Fact]
+    public void TableTruncation_ShownInHeading()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Name", MetadataColumnKind.Heap),
+            new MetadataValue.HeapReference(HeapKind.String, 0, 6, "System", "System", Truncated: false),
+            truncation: new MetadataTableTruncation(1, 40),
+            rowCount: 40);
+
+        Assert.Contains("## TypeDef (showing 1 of 40 rows)", Render(projection));
+    }
+
+    [Fact]
+    public void Tsv_IsTabDelimitedWithSelfIdentifyingTableColumn()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Name", MetadataColumnKind.Heap),
+            new MetadataValue.HeapReference(HeapKind.String, 0, 6, "System", "System", Truncated: false));
+
+        var tsv = Render(projection, MetadataTableFormat.Tsv);
+
+        Assert.Contains("\t", tsv);
+        Assert.Contains("System", tsv);
+        // The row self-identifies via a leading Table column instead of a heading.
+        Assert.Contains("TypeDef", tsv);
+        Assert.DoesNotContain("## TypeDef", tsv);
+        // TSV rows are not Markdown pipe tables.
+        Assert.DoesNotContain("| ", tsv);
+    }
+
+    [Fact]
+    public void Jsonl_EmitsOneObjectPerRowWithTableAndRidKeys()
+    {
+        var projection = OneCell(
+            "TypeDef",
+            Column("Name", MetadataColumnKind.Heap),
+            new MetadataValue.HeapReference(HeapKind.String, 0, 6, "System", "System", Truncated: false));
+
+        var jsonl = Render(projection, MetadataTableFormat.Jsonl);
+
+        Assert.Contains("\"table\"", jsonl);
+        Assert.Contains("\"rid\"", jsonl);
+        Assert.Contains("System", jsonl);
+        Assert.DoesNotContain("## TypeDef", jsonl);
+        Assert.Contains(jsonl.Split('\n'), line => line.TrimStart().StartsWith('{'));
+    }
+
+    [Fact]
+    public void Render_SelfAssembly_ProducesModuleAndTypeDefTables()
+    {
+        using var session = AssemblyInspectionSession.Open(typeof(MetadataProjectionRendererTests).Assembly.Location);
+        var projection = session.MetadataTables();
+
+        var markdown = Render(projection);
+
+        Assert.Contains("## Module", markdown);
+        Assert.Contains("## TypeDef", markdown);
+        Assert.Contains(nameof(MetadataProjectionRendererTests), markdown);
+    }
+}


### PR DESCRIPTION
## What

Adds **`mdi`** (metadata inspector), the first presentation consumer of the ECMA-335 `MetadataTableProjection` landed in #3301, plus a reusable renderer library it shares with a future `dotnet-inspect metadata` lens. Design context: #3282.

## Behavioral claim

`mdi <assembly>` renders the projected metadata tables as Markdown (default), TSV, or JSONL, with resolvable handle targets, explicit truncation, and visible failures.

```
mdi <assembly> [--table|-t <Names>] [--format|-f md|tsv|jsonl]
    [--max-rows|-n N] [--max-bytes N] [--max-chars N]
```

- **`src/DotnetInspector.MetadataRendering`** — `MetadataProjectionRenderer` maps a projection to Markout tables. It lives in the product-side `DotnetInspector.*` family, **not** in `ILInspector.Metadata` (which stays presentation-free): the renderer is a *sibling* of the Metadata layer, so a future lens reuses the same code.
- **`src/mdi`** — `PackAsTool` / `PublishAot` System.CommandLine front-end mapping flags onto `MetadataProjectionOptions` and delegating all output to the renderer. Missing files, native images, and unreadable metadata surface as errors on stderr with exit 1 — never success-shaped empty output.

Rendering is deliberately **lossy** (a human/inspection view); the projection **model** stays the lossless source of truth, which keeps a future `mdv` oracle able to diff against the model rather than rendered text.

## Evidence

- 17 tests pass (`dotnet run --project tests/DotnetInspector.MetadataRendering.Tests -c Release`): synthetic per-`MetadataValue`-case coverage (Nil/Scalar/Flags/HeapReference incl. truncation & blob/Handle incl. nil & display/Range/Malformed), format shape (md pipe table, tsv tab + `Table` column, jsonl `table`/`rid` keys), self-assembly end-to-end, and the `Execute` error contract.
- Full solution builds clean: `dotnet build dotnet-inspect.slnx -c Release` (0 warnings, 0 errors).
- Real-binary smoke test on `ILInspector.Metadata.dll` across md/tsv/jsonl and error paths (missing file, unknown table) confirms resolved handles (`AssemblyRef[1] (System.Runtime)`), truncation headings (`showing 3 of 426 rows`), self-identifying JSONL rows, and exit-1 errors.

## Non-action boundary

- **Oracle deferred** to a stacked follow-up PR (parse real `mdv` text → tuples, diff against the projection model + ilasm known-answer fixtures).
- **Publishing/CI not broadened** here — the tool packs like `dotnet-inspect` but no release wiring is added.
- Product paths remain SRM-only, NativeAOT-friendly, Roslyn-free, read-only.