### PR TITLE
Share one lexical scan for declaration-end detection (#3300)

### DIFF
--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -154,9 +154,11 @@ public class SourceLinkResolver
         // next "}" below it closes the enclosing type instead (issue #3278). A range that still
         // has a block open does own one, even when its last line ends in ";": a signature whose
         // "{" sits on the declaration line ends its sequence range on the last statement.
-        bool endsAtDeclaration = startsAtDeclaration && end >= 1 && end <= lines.Length
-            && IsSelfTerminatingLine(lines[end - 1])
-            && !HasUnclosedBlock(lines, from, to);
+        //
+        // Both answers read the same lexical state, so one scan produces both. A trailing
+        // comment must not hide the terminating ";" (issue #3300), and a brace inside a comment
+        // or a literal must not count as structural.
+        bool endsAtDeclaration = startsAtDeclaration && EndsDeclaration(lines, from, to);
 
         // Scan forward to include the closing brace.
         for (int i = to; !endsAtDeclaration && i < Math.Min(to + 3, lines.Length); i++)
@@ -253,118 +255,198 @@ public class SourceLinkResolver
     }
 
     /// <summary>
-    /// True when <paramref name="line"/> ends a declaration outright, so no trailing brace has
-    /// to be recovered by the forward scan in <see cref="ExtractMethodBody"/>.
+    /// True when the captured range <c>[from, to)</c> ends a declaration outright, so the
+    /// forward scan in <see cref="ExtractMethodBody"/> has no trailing brace to recover.
+    /// <para>
+    /// Two conditions must hold. The range's last significant character — the last
+    /// non-whitespace character outside a comment, so a trailing <c>// note</c> cannot hide it
+    /// (issue #3300) — must be <c>;</c> or <c>}</c>, and that character must not sit inside a
+    /// still-open literal, where it terminates nothing. And the range must not leave a block
+    /// open, counting only braces outside comments and literals: a property such as
+    /// <c>public string M =&gt; "{";</c> opens nothing and owns no brace below it.
+    /// </para>
+    /// <para>
+    /// A single-line range is never judged unclosed, and an untracked raw string literal is
+    /// treated as leaving a block open so the forward scan runs, which is the conservative
+    /// answer.
+    /// </para>
     /// </summary>
-    private static bool IsSelfTerminatingLine(string line)
+    private static bool EndsDeclaration(string[] lines, int from, int to)
     {
-        var trimmed = line.TrimEnd();
-        return trimmed.EndsWith(';') || trimmed.EndsWith('}');
-    }
-
-    /// <summary>
-    /// True when the captured range <c>[from, to)</c> opens more blocks than it closes, so a
-    /// closing brace still has to be recovered below it. Braces inside comments, char literals,
-    /// and string literals do not count — a property such as <c>public string M =&gt; "{";</c>
-    /// closes nothing and owns no brace below it. A raw string literal is not tracked; the range
-    /// is reported as still open so the forward scan runs, which is the conservative answer.
-    /// A single line is never judged unclosed, so a one-line declaration needs no such analysis.
-    /// </summary>
-    private static bool HasUnclosedBlock(string[] lines, int from, int to)
-    {
-        if (to - from <= 1)
+        int first = Math.Max(0, from);
+        int last = Math.Min(to, lines.Length);
+        if (last <= first)
             return false;
 
         int depth = 0;
         bool inBlockComment = false;
         bool inVerbatimString = false;
+        bool untracked = false;
+        char terminator = '\0';
 
-        for (int i = Math.Max(0, from); i < Math.Min(to, lines.Length); i++)
-        {
-            var line = lines[i];
-            for (int j = 0; j < line.Length; j++)
-            {
-                char c = line[j];
+        for (int i = first; i < last; i++)
+            terminator = ScanLine(lines[i], ref inBlockComment, ref inVerbatimString, ref depth, ref untracked);
 
-                if (inBlockComment)
-                {
-                    if (c == '*' && j + 1 < line.Length && line[j + 1] == '/')
-                    {
-                        inBlockComment = false;
-                        j++;
-                    }
-                    continue;
-                }
+        if (terminator != ';' && terminator != '}')
+            return false;
 
-                if (inVerbatimString)
-                {
-                    if (c != '"')
-                        continue;
-                    if (j + 1 < line.Length && line[j + 1] == '"')
-                        j++;
-                    else
-                        inVerbatimString = false;
-                    continue;
-                }
-
-                if (c == '/' && j + 1 < line.Length)
-                {
-                    if (line[j + 1] == '/')
-                        break;
-                    if (line[j + 1] == '*')
-                    {
-                        inBlockComment = true;
-                        j++;
-                        continue;
-                    }
-                }
-
-                if (c == '@' && j + 1 < line.Length)
-                {
-                    if (line[j + 1] == '"')
-                    {
-                        inVerbatimString = true;
-                        j++;
-                        continue;
-                    }
-
-                    if (line[j + 1] == '$' && j + 2 < line.Length && line[j + 2] == '"')
-                    {
-                        inVerbatimString = true;
-                        j += 2;
-                        continue;
-                    }
-                }
-
-                if (c == '"')
-                {
-                    if (j + 2 < line.Length && line[j + 1] == '"' && line[j + 2] == '"')
-                        return true;
-
-                    j++;
-                    while (j < line.Length && line[j] != '"')
-                        j += line[j] == '\\' ? 2 : 1;
-                    continue;
-                }
-
-                if (c == '\'')
-                {
-                    j++;
-                    while (j < line.Length && line[j] != '\'')
-                        j += line[j] == '\\' ? 2 : 1;
-                    continue;
-                }
-
-                if (c == '{')
-                    depth++;
-                else if (c == '}')
-                    depth--;
-            }
-        }
-
-        return depth > 0;
+        return last - first <= 1 || (!untracked && depth <= 0);
     }
 
+    /// <summary>
+    /// Index just past the first run of at least <paramref name="minimum"/> consecutive quotes
+    /// at or after <paramref name="start"/>, or <c>-1</c> when the line holds no such run.
+    /// </summary>
+    private static int IndexOfQuoteRun(string line, int start, int minimum)
+    {
+        for (int i = start; i < line.Length; i++)
+        {
+            if (line[i] != '"')
+                continue;
+
+            int end = i;
+            while (end < line.Length && line[end] == '"')
+                end++;
+
+            if (end - i >= minimum)
+                return end;
+
+            i = end - 1;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Scans one line of C# text, carrying <paramref name="inBlockComment"/> and
+    /// <paramref name="inVerbatimString"/> across lines, and returns the last significant
+    /// character on it — the last non-whitespace character that is not inside a comment.
+    /// Braces outside comments and literals are counted into <paramref name="depth"/>.
+    /// Raw string literals are not tracked; <paramref name="untracked"/> is set instead so the
+    /// caller can fall back to the unconditional forward scan, which is the conservative answer.
+    /// </summary>
+    private static char ScanLine(
+        string line,
+        ref bool inBlockComment,
+        ref bool inVerbatimString,
+        ref int depth,
+        ref bool untracked)
+    {
+        char significant = '\0';
+
+        for (int j = 0; j < line.Length; j++)
+        {
+            char c = line[j];
+
+            if (inBlockComment)
+            {
+                if (c == '*' && j + 1 < line.Length && line[j + 1] == '/')
+                {
+                    inBlockComment = false;
+                    j++;
+                }
+                continue;
+            }
+
+            if (inVerbatimString)
+            {
+                if (c == '"')
+                {
+                    if (j + 1 < line.Length && line[j + 1] == '"')
+                    {
+                        j++;
+                    }
+                    else
+                    {
+                        inVerbatimString = false;
+                        significant = '"';
+                    }
+                }
+
+                continue;
+            }
+
+            if (c == '/' && j + 1 < line.Length)
+            {
+                if (line[j + 1] == '/')
+                    break;
+                if (line[j + 1] == '*')
+                {
+                    inBlockComment = true;
+                    j++;
+                    continue;
+                }
+            }
+
+            if (c == '@' && j + 1 < line.Length)
+            {
+                if (line[j + 1] == '"')
+                {
+                    inVerbatimString = true;
+                    significant = '"';
+                    j++;
+                    continue;
+                }
+
+                if (line[j + 1] == '$' && j + 2 < line.Length && line[j + 2] == '"')
+                {
+                    inVerbatimString = true;
+                    significant = '"';
+                    j += 2;
+                    continue;
+                }
+            }
+
+            if (c == '"')
+            {
+                if (j + 2 < line.Length && line[j + 1] == '"' && line[j + 2] == '"')
+                {
+                    int open = j;
+                    while (open < line.Length && line[open] == '"')
+                        open++;
+                    int quotes = open - j;
+
+                    int close = IndexOfQuoteRun(line, open, quotes);
+                    if (close < 0)
+                    {
+                        // A raw string that spans lines is not tracked; report the range as
+                        // still open so the caller falls back to the forward scan.
+                        untracked = true;
+                        return significant;
+                    }
+
+                    j = close - 1;
+                    significant = '"';
+                    continue;
+                }
+
+                j++;
+                while (j < line.Length && line[j] != '"')
+                    j += line[j] == '\\' ? 2 : 1;
+                significant = '"';
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                j++;
+                while (j < line.Length && line[j] != '\'')
+                    j += line[j] == '\\' ? 2 : 1;
+                significant = '\'';
+                continue;
+            }
+
+            if (c == '{')
+                depth++;
+            else if (c == '}')
+                depth--;
+
+            if (!char.IsWhiteSpace(c))
+                significant = c;
+        }
+
+        return significant;
+    }
     /// <summary>
     /// Words that can open a statement, and so rule out a declaration no matter what follows.
     /// </summary>

--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -259,11 +259,11 @@ public class SourceLinkResolver
     /// forward scan in <see cref="ExtractMethodBody"/> has no trailing brace to recover.
     /// <para>
     /// Two conditions must hold. The range's last significant character — the last
-    /// non-whitespace character outside a comment, so a trailing <c>// note</c> cannot hide it
-    /// (issue #3300) — must be <c>;</c> or <c>}</c>, and that character must not sit inside a
-    /// still-open literal, where it terminates nothing. And the range must not leave a block
-    /// open, counting only braces outside comments and literals: a property such as
-    /// <c>public string M =&gt; "{";</c> opens nothing and owns no brace below it.
+    /// non-whitespace character outside a comment, so neither a trailing <c>// note</c> nor a
+    /// blank or comment-only line below the declaration can hide it (issue #3300) — must be
+    /// <c>;</c> or <c>}</c>. And the range must not leave a block open, counting only braces
+    /// outside comments and literals: a property such as <c>public string M =&gt; "{";</c>
+    /// opens nothing and owns no brace below it.
     /// </para>
     /// <para>
     /// A single-line range is never judged unclosed, and an untracked raw string literal is
@@ -285,7 +285,13 @@ public class SourceLinkResolver
         char terminator = '\0';
 
         for (int i = first; i < last; i++)
-            terminator = ScanLine(lines[i], ref inBlockComment, ref inVerbatimString, ref depth, ref untracked);
+        {
+            // A blank, whitespace-only, or comment-only line contributes no significant
+            // character, and must not erase the terminator an earlier line established.
+            char significant = ScanLine(lines[i], ref inBlockComment, ref inVerbatimString, ref depth, ref untracked);
+            if (significant != '\0')
+                terminator = significant;
+        }
 
         if (terminator != ';' && terminator != '}')
             return false;

--- a/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
@@ -955,4 +955,80 @@ public class ExtractMethodBodyTests
             "public string Target() => @$\"first\n    {{\";",
             body);
     }
+
+    [Fact]
+    public void TrailingLineCommentAfterTerminator_DoesNotTriggerTheForwardScan()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Target() => 0; // opens nothing {", // 3  <- StartLine/EndLine
+            "}");                                           // 4
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 3, methodName: "Target");
+
+        Assert.Equal("public int Target() => 0; // opens nothing {", body);
+    }
+
+    [Fact]
+    public void TrailingBlockCommentAfterTerminator_DoesNotTriggerTheForwardScan()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Target() => 0; /* note */",      // 3  <- StartLine/EndLine
+            "}");                                           // 4
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 3, methodName: "Target");
+
+        Assert.Equal("public int Target() => 0; /* note */", body);
+    }
+
+    [Fact]
+    public void TerminatorInsideTrailingComment_DoesNotEndTheDeclaration()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Target() // ;",                  // 3  <- StartLine
+            "    {",                                         // 4
+            "        return 0;",                             // 5
+            "    }",                                         // 6
+            "}");                                            // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 5, methodName: "Target");
+
+        Assert.Equal("public int Target() // ;\n{\n    return 0;\n}", body);
+    }
+
+    [Fact]
+    public void MultiLineRawStringLiteral_FallsBackToTheForwardScan()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public string Target() => \"\"\"",         // 3  <- StartLine
+            "        a",                                    // 4
+            "        \"\"\";",                              // 5  <- EndLine
+            "    }",                                        // 6
+            "}");                                           // 7
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 5, methodName: "Target");
+
+        Assert.Equal("public string Target() => \"\"\"\n    a\n    \"\"\";\n}", body);
+    }
+
+    [Fact]
+    public void SingleLineRawStringLiteral_StillEndsTheDeclaration()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public string Target() => \"\"\"a\"\"\";",  // 3  <- StartLine/EndLine
+            "}");                                           // 4
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 3, methodName: "Target");
+
+        Assert.Equal("public string Target() => \"\"\"a\"\"\";", body);
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
@@ -1031,4 +1031,34 @@ public class ExtractMethodBodyTests
 
         Assert.Equal("public string Target() => \"\"\"a\"\"\";", body);
     }
+
+    [Fact]
+    public void BlankLineBelowDeclaration_DoesNotEraseTheTerminator()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Target() => 0;",                 // 3  <- StartLine
+            "",                                             // 4  <- EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 4, methodName: "Target");
+
+        Assert.Equal("public int Target() => 0;", body);
+    }
+
+    [Fact]
+    public void CommentOnlyLineBelowDeclaration_DoesNotEraseTheTerminator()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    public int Target() => 0;",                 // 3  <- StartLine
+            "    // trailing note",                          // 4  <- EndLine
+            "}");                                           // 5
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 3, endLine: 4, methodName: "Target");
+
+        Assert.Equal("public int Target() => 0;\n// trailing note", body);
+    }
 }


### PR DESCRIPTION
Fixes #3300.

## What was wrong

`IsSelfTerminatingLine` decided whether an extracted range already ended at a natural stopping point by inspecting the raw trailing characters of the line. A declaration whose line ends in a comment was therefore not recognized as terminated:

```csharp
public int Target() => 0; // opens nothing {
```

`ExtractMethodBody` fell through to the forward brace scan it did not need, which can append the enclosing type''s closing brace to the extracted source.

`HasUnclosedBlock`, sitting immediately below it, already knew how to skip line comments, block comments, char literals, and regular, verbatim, and verbatim-interpolated strings — but it answered a *different* question about the *same* text. Two scanners over one line can disagree about where that line really ends, which is the actual defect; the trailing comment is just where it showed.

## What changed

Both are replaced by a single `EndsDeclaration`, which runs one lexical scan (`ScanLine`) across the range and reads both answers off the same state:

- the **last significant character** — the last non-whitespace character outside a comment — which must be `;` or `}`
- the **brace depth**, counting only structural braces

Two behaviors fall out of sharing the scan, both of which I consider corrections rather than side effects:

- A `;` or `}` inside a string or comment no longer reads as a terminator, because it terminates nothing.
- A raw string literal closed on its own line is now scanned properly instead of abandoning the range to the forward scan. A raw string that *spans* lines stays conservative, exactly as before.

The single-line exemption from depth analysis is preserved, so a one-line declaration still owns no brace below it.

## Evidence

Five new tests in `ExtractMethodBodyTests`, covering the issue repro, a trailing block comment, a `;` that appears only inside a trailing comment (must *not* count), a multi-line raw string (must still fall back), and a single-line raw string (must not).

| Suite | Result |
| --- | --- |
| `tests/ILInspector.Metadata.Tests` | 920 / 920 |
| `src/DotnetInspector.Services.Tests` | 319 / 319 |
| `src/dotnet-inspect.Tests` | 2188, 10 skipped (ilasm/ildasm absent) |

Two CLI failures are accounted for and neither is mine:

- `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden` — reproduced on clean `origin/main` at `3fc6f1c8` in a separate worktree, same `Assert.DoesNotContain()` assertion.
- `PerformanceTriagePredicates_DoNotAlterDiscovery(command: "library")` — the suite''s known parallel flake; passes in isolation.

End-to-end canary against a real platform assembly, byte-identical to `origin/main`:

```text
dotnet-inspect member "System.Text.Json.JsonSerializerOptions" --platform System.Text.Json MaxDepth -S "Original Source"
```

## Risk

This is a behavior change to a heuristic shared by **every** member''s source extraction, not just the case in the issue — the same surface that produced every review finding on #3287. Sized as high risk accordingly.
