### PR TITLE
Add real native-PE regression test for compile-back reference filter (#3015)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackNativeReferenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackNativeReferenceTests.cs
@@ -1,0 +1,54 @@
+using DotnetInspector.Services;
+using ILInspector.DecompilerHarness;
+using Xunit;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Regression guard for #3015 (sibling of #2942). The AspNetCore.App shared
+// framework ships the *native* aspnetcorev2_inprocess.dll, which the product
+// AssemblyDependencyResolver surfaces as a SharedFramework dependency. Handing a
+// native PE to Roslyn as a metadata reference fails every compile-back Emit with
+// CS0009 ("PE image doesn't contain managed metadata"), which previously broke a
+// cluster of ~54 Windows-local compile-back tests. The managed-PE guard shared by
+// every compile-back reference builder must keep it out of the reference set.
+//
+// The existing RoslynTestReferencesTests only feed the filter a malformed "MZ"
+// stub (which fails PEReader construction); this exercises a genuine native PE —
+// a valid image whose CorHeader is null — which is the actual #3015 shape.
+public class CompileBackNativeReferenceTests
+{
+    [Fact]
+    public void SharedFrameworkNativeModule_SurfacedByResolver_IsRejectedByManagedGuards()
+    {
+        // Resolve dependencies exactly as the compile-back reference builders do:
+        // the default options include the AspNetCore.App shared framework.
+        string target = typeof(object).Assembly.Location;
+        Assert.False(string.IsNullOrEmpty(target));
+
+        var resolver = new AssemblyDependencyResolver(
+            new AssemblyDependencyResolutionOptions(target) { ExcludeTargetAssembly = true });
+
+        var native = resolver.ResolveAll().FirstOrDefault(dependency =>
+            Path.GetFileName(dependency.Path)
+                .Equals("aspnetcorev2_inprocess.dll", StringComparison.OrdinalIgnoreCase));
+
+        // Absent on layouts without the AspNetCore.App shared framework beside the
+        // runtime (e.g. Linux CI, where the in-process module is not a .dll), so the
+        // CS0009 hazard cannot arise and there is nothing to guard.
+        if (native is null)
+            return;
+
+        // The resolver does surface the native module, as a shared-framework dependency.
+        Assert.Equal(AssemblyDependencyProvenance.SharedFramework, native.Provenance);
+
+        // Both managed-PE guards — the harness-side ManagedReferenceFilter applied by
+        // every compile-back reference builder, and the test-side RoslynTestReferences
+        // filter — must reject it. Either regressing reintroduces the CS0009 cluster.
+        Assert.False(ManagedReferenceFilter.IsManagedAssembly(native.Path));
+        Assert.False(RoslynTestReferences.IsManagedAssembly(native.Path));
+
+        // A real managed assembly still passes both guards.
+        Assert.True(ManagedReferenceFilter.IsManagedAssembly(target));
+        Assert.True(RoslynTestReferences.IsManagedAssembly(target));
+    }
+}


### PR DESCRIPTION
Closes #3015.

## Summary

**Conclusion:** #3015's root cause is already fixed in code; this PR adds the missing regression test that locks the fix with a **real** native PE, and closes the issue with verification evidence. Test-only, low risk.

`aspnetcorev2_inprocess.dll` is the native ASP.NET Core in-process module in the `Microsoft.AspNetCore.App` shared framework. The product `AssemblyDependencyResolver` surfaces it as a `SharedFramework` dependency; handing a native PE to Roslyn fails every compile-back `Emit` with `CS0009` ("PE image doesn't contain managed metadata"), which previously broke a cluster of Windows-local compile-back tests.

The managed-PE guard (skip any candidate whose `PEHeaders.CorHeader is null` / `!HasMetadata`) is now applied by **every** compile-back reference builder — harness `FidelityCheck.RuntimeReferences`, `TypeBindCheck.ReferencesFor`, `ValidityCheck.RuntimeReferences`, `ReturnToSender`, `ReturnToSenderTypePlanner`, `Program`; and test-side `RoslynTestReferences` / `TestAssemblyReferenceResolvers` — landed incrementally by the earlier #3018 / #3015 work.

## Why a test is the remaining gap

The only existing guard test (`RoslynTestReferencesTests`) feeds the filter a malformed `MZ` stub, which fails `PEReader` construction. It never exercises a **genuine** native PE (a valid image whose `CorHeader` is null — the actual #3015 shape), nor the harness `ManagedReferenceFilter`, nor the end-to-end resolver path.

`CompileBackNativeReferenceTests` resolves the real `aspnetcorev2_inprocess.dll` through the product `AssemblyDependencyResolver` (default options, which include the AspNetCore.App shared framework) and asserts:

- the resolver surfaces it as a `SharedFramework` dependency;
- both managed-PE guards (`ManagedReferenceFilter` and `RoslynTestReferences`) reject it;
- a real managed assembly passes both guards.

The test skips where the native module is absent (e.g. Linux CI, where the in-process module is not a `.dll`). It was verified to actually exercise the module on the Windows daily SDK (a temporary hard `Assert.NotNull` on the resolved dependency passed, confirming it is not a no-op skip here).

## Evidence (Windows, .NET 11.0.100-preview.6.26359.118)

| Check | Result |
| --- | --- |
| `FidelityCheckGeneratedFilterTests`, `LadderRung6GateTests`, `ReturnToSenderFixtureCatalogTests`, `TypeSourceCheckTests` | 180 passed, **0 CS0009** |
| `Area=Fidelity` + `Area=Validity` (incl. slow gates) | 169 tests, **0 CS0009 / 0 `aspnetcorev2` / 0 `RecompileFail`** |
| `CompileBackNativeReferenceTests` (new) | 1 passed; proven to exercise the real native module |

Across the compile-back surface (349 tests) there is **zero** native-DLL `CS0009`, confirming the guard is comprehensive on the layout that originally reproduced the failure.

## Non-actions (out of scope)

- **Uniform product-resolver filter.** Pushing the managed-PE filter into `AssemblyDependencyResolver` itself was considered and rejected here: it changes product behavior, adds a per-file PE read to the hot metadata-resolution path, and is unnecessary since every consumer is already guarded. It would also warrant adversarial review; this PR stays test-only.
- **Pre-existing baseline drift.** The slow gates surfaced 4 unrelated failures on pristine `main` (`FidelityGateTests` / `LoweredFidelityGateTests` dockets and `ValidityCoverageReportingTests.DecompilerAssembly_MissingReturnPopulationIsPinned`, whose actual set carries an extra `SwapIdiomPass` entry). None are `CS0009`; they are baseline-pin drift, not #3015, and are left untouched.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -class "ILInspector.Decompiler.Tests.CompileBackNativeReferenceTests"
```

## Risk

Test-only change (one new file, one `[Fact]`). No product or harness code is touched, so it cannot alter decompiler behavior or output. Simple and mechanical — no adversarial review required.
