### PR TITLE
Explain bodyless members instead of rendering nothing (#3299)

### DIFF
--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -359,19 +359,21 @@ public class PdbContext : IDisposable
         if (!_peReader.HasMetadata)
             return null;
 
-        var handle = MetadataTokens.Handle(methodToken);
-        if (handle.Kind != HandleKind.MethodDefinition)
-            return null;
-
         try
         {
+            // Handle() rejects an invalid token by throwing, and an inspected assembly is
+            // untrusted input, so decode inside the guard rather than ahead of it.
+            var handle = MetadataTokens.Handle(methodToken);
+            if (handle.Kind != HandleKind.MethodDefinition)
+                return null;
+
             var reader = _peReader.GetMetadataReader();
             if (IsReferenceAssembly(reader))
                 return null;
 
             return reader.GetMethodDefinition((MethodDefinitionHandle)handle).RelativeVirtualAddress != 0;
         }
-        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
             return null;
         }
@@ -391,17 +393,7 @@ public class PdbContext : IDisposable
         {
             foreach (var handle in reader.GetAssemblyDefinition().GetCustomAttributes())
             {
-                var attribute = reader.GetCustomAttribute(handle);
-                if (attribute.Constructor.Kind != HandleKind.MemberReference)
-                    continue;
-
-                var parent = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor).Parent;
-                if (parent.Kind != HandleKind.TypeReference)
-                    continue;
-
-                var typeRef = reader.GetTypeReference((TypeReferenceHandle)parent);
-                if (reader.StringComparer.Equals(typeRef.Name, "ReferenceAssemblyAttribute")
-                    && reader.StringComparer.Equals(typeRef.Namespace, "System.Runtime.CompilerServices"))
+                if (IsReferenceAssemblyAttribute(reader, reader.GetCustomAttribute(handle)))
                 {
                     result = true;
                     break;
@@ -411,6 +403,44 @@ public class PdbContext : IDisposable
 
         _isReferenceAssembly = result;
         return result;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="attribute"/> is <c>ReferenceAssemblyAttribute</c>. The constructor
+    /// is a MemberReference when the attribute type lives in another assembly and a MethodDef when
+    /// it is defined in this one — which is the common case, since the reference assemblies that
+    /// most need this test define the attribute themselves.
+    /// </summary>
+    private static bool IsReferenceAssemblyAttribute(MetadataReader reader, CustomAttribute attribute)
+    {
+        StringHandle name;
+        StringHandle @namespace;
+
+        switch (attribute.Constructor.Kind)
+        {
+            case HandleKind.MemberReference:
+                var parent = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor).Parent;
+                if (parent.Kind != HandleKind.TypeReference)
+                    return false;
+
+                var typeRef = reader.GetTypeReference((TypeReferenceHandle)parent);
+                name = typeRef.Name;
+                @namespace = typeRef.Namespace;
+                break;
+
+            case HandleKind.MethodDefinition:
+                var method = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                var typeDef = reader.GetTypeDefinition(method.GetDeclaringType());
+                name = typeDef.Name;
+                @namespace = typeDef.Namespace;
+                break;
+
+            default:
+                return false;
+        }
+
+        return reader.StringComparer.Equals(name, "ReferenceAssemblyAttribute")
+            && reader.StringComparer.Equals(@namespace, "System.Runtime.CompilerServices");
     }
 
     public ILOffsetMemberContextInfo? ResolveMemberContext(int methodToken, int ilOffset)

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -94,6 +94,7 @@ public class PdbContext : IDisposable
     private MetadataReaderProvider? _pdbProvider;
     private MetadataReader? _pdbReader;
     private SourceLinkResolver? _resolver;
+    private bool? _isReferenceAssembly;
     private SourceDocumentPathResolver _sourceDocumentPathResolver = SourceDocumentPathResolver.Empty;
     private readonly List<IDisposable> _disposables = [];
     private MethodBodySource? _methodBodies;
@@ -340,6 +341,76 @@ public class PdbContext : IDisposable
 
         var metadataReader = _peReader.GetMetadataReader();
         return _resolver.ResolveTypeSource(metadataReader, _pdbReader, typeName);
+    }
+
+    /// <summary>
+    /// Whether the MethodDef <paramref name="methodToken"/> addresses carries an IL body:
+    /// <see langword="true"/> when it does, <see langword="false"/> when it does not — an
+    /// abstract, interface, extern, or runtime-implemented method — and <see langword="null"/>
+    /// when the token cannot be read as a MethodDef in this assembly, which is not the same
+    /// answer as "no body" and must not be reported as one (issue #3299).
+    /// </summary>
+    /// <remarks>
+    /// A reference assembly answers <see langword="null"/> for every token: it strips all IL, so
+    /// its RVAs report the image's surface-only nature rather than anything about the method.
+    /// </remarks>
+    public bool? MethodHasBody(int methodToken)
+    {
+        if (!_peReader.HasMetadata)
+            return null;
+
+        var handle = MetadataTokens.Handle(methodToken);
+        if (handle.Kind != HandleKind.MethodDefinition)
+            return null;
+
+        try
+        {
+            var reader = _peReader.GetMetadataReader();
+            if (IsReferenceAssembly(reader))
+                return null;
+
+            return reader.GetMethodDefinition((MethodDefinitionHandle)handle).RelativeVirtualAddress != 0;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Whether the assembly carries <c>ReferenceAssemblyAttribute</c>, cached because the answer
+    /// is fixed for the image.
+    /// </summary>
+    private bool IsReferenceAssembly(MetadataReader reader)
+    {
+        if (_isReferenceAssembly is { } cached)
+            return cached;
+
+        bool result = false;
+        if (reader.IsAssembly)
+        {
+            foreach (var handle in reader.GetAssemblyDefinition().GetCustomAttributes())
+            {
+                var attribute = reader.GetCustomAttribute(handle);
+                if (attribute.Constructor.Kind != HandleKind.MemberReference)
+                    continue;
+
+                var parent = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor).Parent;
+                if (parent.Kind != HandleKind.TypeReference)
+                    continue;
+
+                var typeRef = reader.GetTypeReference((TypeReferenceHandle)parent);
+                if (reader.StringComparer.Equals(typeRef.Name, "ReferenceAssemblyAttribute")
+                    && reader.StringComparer.Equals(typeRef.Namespace, "System.Runtime.CompilerServices"))
+                {
+                    result = true;
+                    break;
+                }
+            }
+        }
+
+        _isReferenceAssembly = result;
+        return result;
     }
 
     public ILOffsetMemberContextInfo? ResolveMemberContext(int methodToken, int ilOffset)

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3191,6 +3191,63 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_OriginalSource_BodylessMember_ExplainsWhyThereIsNoSource()
+    {
+        // An abstract method has no IL body, so it has no authored source to resolve. That is a
+        // complete answer, not a failure: say so and keep exit 0 rather than rendering nothing
+        // and leaving the caller unable to tell success from silent failure (#3299).
+        var (abstractExit, abstractOutput, abstractError) = await RunAppAsync(
+            "member", "JsonConverter<T>", "--platform", "System.Text.Json",
+            "Read", "-S", "Original Source", "--tips", "q");
+
+        Assert.Equal(0, abstractExit);
+        Assert.Empty(abstractError);
+        Assert.Contains("## Original Source", abstractOutput);
+        Assert.Contains("has no IL body", abstractOutput);
+
+        // An interface method is bodyless for a different metadata reason and gets the same answer.
+        var (interfaceExit, interfaceOutput, interfaceError) = await RunAppAsync(
+            "member", "IJsonOnDeserialized", "--platform", "System.Text.Json",
+            "OnDeserialized", "-S", "Original Source", "--tips", "q");
+
+        Assert.Equal(0, interfaceExit);
+        Assert.Empty(interfaceError);
+        Assert.Contains("## Original Source", interfaceOutput);
+        Assert.Contains("has no IL body", interfaceOutput);
+    }
+
+    [Fact]
+    public async Task Member_OriginalSource_MemberWithBody_DoesNotClaimTheMemberIsBodyless()
+    {
+        // Close negative: a member that does have a body still renders its authored source, so
+        // the bodyless explanation never displaces real source (#3299).
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonSerializerOptions", "--platform", "System.Text.Json",
+            "MaxDepth:1", "-S", "Original Source", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("get => _maxDepth;", output);
+        Assert.DoesNotContain("has no IL body", output);
+    }
+
+    [Fact]
+    public async Task Member_SourceDiff_BodylessMember_ReportsOriginalSourceUnavailable()
+    {
+        // The bodyless explanation is prose about the member, not source text, so the diff must
+        // report its "before" side unavailable rather than diffing the explanation (#3299).
+        var (exit, output, error) = await RunAppAsync(
+            "member", "JsonConverter<T>", "--platform", "System.Text.Json",
+            "Read", "-S", "Source Diff", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Source Diff", output);
+        Assert.Contains("Original Source unavailable", output);
+        Assert.DoesNotContain("has no IL body", output);
+    }
+
+    [Fact]
     public async Task Member_SourceDiff_PropertyAccessor_ComparesAuthoredSourceToAccessorBody()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -554,7 +554,16 @@ public class ApiCommand
 
     // ===== Method Source Resolution =====
 
-    internal sealed record ResolvedMethodSource(MethodSourceContext? Source, string? PdbPath);
+    /// <param name="Source">Resolved source, or null when none could be resolved.</param>
+    /// <param name="PdbPath">The acquired portable PDB path, when one was acquired.</param>
+    /// <param name="MemberHasNoBody">
+    /// True when the member carries no IL body, so <paramref name="Source"/> is absent because
+    /// there is nothing to show rather than because resolution failed (issue #3299).
+    /// </param>
+    internal sealed record ResolvedMethodSource(
+        MethodSourceContext? Source,
+        string? PdbPath,
+        bool MemberHasNoBody = false);
 
     internal static async Task<ResolvedMethodSource> ResolveMethodSourceAsync(
         string dllPath, string typeName, string methodName, int overloadIndex,
@@ -582,12 +591,18 @@ public class ApiCommand
             // names even when SourceLink/source resolution below fails (PDB available, source not).
             string? pdbPath = context.PortablePdbPath;
 
+            // A member with no IL body has no authored source to resolve, whatever the PDB and
+            // SourceLink situation is. Ask metadata for that fact before the resolution attempt,
+            // so an empty result can say why instead of looking like a silent failure
+            // (issue #3299). Only a definite "no" counts; an unreadable token stays unknown.
+            bool memberHasNoBody = metadataToken != 0 && context.MethodHasBody(metadataToken) == false;
+
             if (!fetchSource || !service.HasPdb || !service.HasSourceLink)
-                return new ResolvedMethodSource(null, pdbPath);
+                return new ResolvedMethodSource(null, pdbPath, memberHasNoBody);
 
             var methodInfo = service.ResolveMethodSource(typeName, methodName, overloadIndex, publicOnly, metadataToken);
             if (methodInfo == null)
-                return new ResolvedMethodSource(null, pdbPath);
+                return new ResolvedMethodSource(null, pdbPath, memberHasNoBody);
 
             // Honor the source the portable PDB records when it is present locally: a non-reproducible
             // (local dev) build keeps a real local path whose exact compiled bytes may exist only here,
@@ -620,7 +635,7 @@ public class ApiCommand
             }
 
             if (content == null)
-                return new ResolvedMethodSource(null, pdbPath);
+                return new ResolvedMethodSource(null, pdbPath, memberHasNoBody);
 
             var sourceCode = SourceLinkResolver.ExtractMethodBody(
                 content, methodInfo.StartLine, methodInfo.EndLine, methodName, isDestructor,
@@ -795,11 +810,20 @@ public class ApiCommand
             }
 
             // Source code (already resolved in command layer)
-            if (options is MemberOptions { MethodSource: not null } mo5
+            if (options is MemberOptions mo5
                 && GetRequestedMemberSections(type, mo5).Overlaps([SectionNames.OriginalSource, SectionNames.SourceDiff]))
             {
-                view.MemberCode ??= new MemberCodeView();
-                view.MemberCode.OriginalSourceCode = new Markout.CodeSection("csharp", mo5.MethodSource.SourceCode);
+                if (mo5.MethodSource is { } resolvedSource)
+                {
+                    view.MemberCode ??= new MemberCodeView();
+                    view.MemberCode.OriginalSourceCode = new Markout.CodeSection("csharp", resolvedSource.SourceCode);
+                }
+                else if (mo5.MemberHasNoBody)
+                {
+                    view.MemberCode ??= new MemberCodeView();
+                    view.MemberCode.OriginalSourceCode = new Markout.CodeSection("csharp", BodylessMemberNote);
+                    view.MemberCode.OriginalSourceUnavailable = true;
+                }
             }
 
             PopulateSourceDiff(view, GetRequestedMemberSections(type, options));
@@ -1422,10 +1446,19 @@ public class ApiCommand
                         memberOptions.IncludeSections, memberOptions);
                 }
 
-                if (memberOptions.MethodSource != null && requestedSections.Overlaps([SectionNames.OriginalSource, SectionNames.SourceDiff]))
+                if (requestedSections.Overlaps([SectionNames.OriginalSource, SectionNames.SourceDiff]))
                 {
-                    view.MemberCode ??= new MemberCodeView();
-                    view.MemberCode.OriginalSourceCode = new Markout.CodeSection("csharp", memberOptions.MethodSource.SourceCode);
+                    if (memberOptions.MethodSource is { } resolvedSource)
+                    {
+                        view.MemberCode ??= new MemberCodeView();
+                        view.MemberCode.OriginalSourceCode = new Markout.CodeSection("csharp", resolvedSource.SourceCode);
+                    }
+                    else if (memberOptions.MemberHasNoBody)
+                    {
+                        view.MemberCode ??= new MemberCodeView();
+                        view.MemberCode.OriginalSourceCode = new Markout.CodeSection("csharp", BodylessMemberNote);
+                        view.MemberCode.OriginalSourceUnavailable = true;
+                    }
                 }
                 PopulateSourceDiff(view, requestedSections);
             }
@@ -1517,6 +1550,14 @@ public class ApiCommand
                 writer);
     }
 
+    /// <summary>
+    /// Stands in for Original Source when the selected member carries no IL body. A C# comment
+    /// so it reads naturally inside the section's <c>csharp</c> fence, mirroring how
+    /// <see cref="SourceTextDiffRenderer"/> reports an unavailable diff input (issue #3299).
+    /// </summary>
+    internal const string BodylessMemberNote =
+        "// This member has no IL body, so it has no authored source to show.";
+
     private static void PopulateSourceDiff(TypeView view, IReadOnlySet<string> requestedSections)
     {
         if (!requestedSections.Contains(SectionNames.SourceDiff))
@@ -1526,7 +1567,9 @@ public class ApiCommand
         view.MemberCode.SourceDiffCode = new Markout.CodeSection(
             "diff",
             SourceTextDiffRenderer.CreateUnifiedDiff(
-                view.MemberCode.OriginalSourceCode.Content,
+                // The bodyless note is an explanation, not source text: leave the diff's
+                // "before" side unavailable so it reports that rather than diffing the note.
+                view.MemberCode.OriginalSourceUnavailable ? null : view.MemberCode.OriginalSourceCode.Content,
                 view.MemberCode.DecompiledSourceCode.Content,
                 "Original Source",
                 "Decompiled Source"));

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -318,6 +318,7 @@ public static class MemberCommand
                 effectiveOptions = effectiveOptions with
                 {
                     MethodSource = resolved.Source,
+                    MemberHasNoBody = resolved.MemberHasNoBody,
                     PdbPath = resolved.PdbPath
                 };
             }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -218,6 +218,14 @@ public record MemberOptions : ApiOptions
     public MethodSourceContext? MethodSource { get; init; }
 
     /// <summary>
+    /// True when the selected member carries no IL body — an abstract, interface, extern, or
+    /// runtime-implemented member — so <see cref="MethodSource"/> is absent because there is
+    /// nothing to show, not because resolution failed. Lets the source sections say so instead
+    /// of rendering success-shaped empty output (issue #3299).
+    /// </summary>
+    public bool MemberHasNoBody { get; init; }
+
+    /// <summary>
     /// Output directories (<c>--bin</c>/<c>--directory</c>) to scan for inbound callers of the
     /// selected member, in addition to the member's own assembly. Empty = own assembly only.
     /// </summary>

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -746,6 +746,13 @@ public class MemberCodeView
     [MarkoutSection(Name = "Original Source")]
     public CodeSection OriginalSourceCode { get; set; }
 
+    /// <summary>
+    /// True when <see cref="OriginalSourceCode"/> holds the bodyless-member explanation rather than
+    /// authored source. Not a section: consumers that treat the original source as text (Source
+    /// Diff) must skip it (issue #3299).
+    /// </summary>
+    public bool OriginalSourceUnavailable { get; set; }
+
     [MarkoutSection(Name = SectionNames.SourceDiff)]
     public CodeSection SourceDiffCode { get; set; }
 

--- a/tests/ILInspector.Metadata.Tests/MethodHasBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MethodHasBodyTests.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Tests for <see cref="PdbContext.MethodHasBody"/>, the metadata fact behind the CLI's
+/// "this member has no authored source" explanation (issue #3299). The distinction that
+/// matters is between a definite "no body" and an unanswerable question: only the former
+/// may be reported as a member property.
+/// </summary>
+public class MethodHasBodyTests
+{
+    static string CoreLibPath => typeof(object).Assembly.Location;
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(unchecked((int)0xFFFFFFFF))]
+    [InlineData(0x7F000001)]
+    public void InvalidToken_IsUnknown_AndDoesNotThrow(int token)
+    {
+        // An inspected assembly is untrusted input and MetadataTokens.Handle rejects an invalid
+        // token by throwing, so the guard must cover the decode itself.
+        using var context = PdbContext.Open(CoreLibPath);
+        Assert.Null(context.MethodHasBody(token));
+    }
+
+    [Fact]
+    public void NonMethodDefToken_IsUnknown()
+    {
+        using var context = PdbContext.Open(CoreLibPath);
+        Assert.Null(context.MethodHasBody(typeof(object).MetadataToken));
+    }
+
+    [Fact]
+    public void OutOfRangeMethodDefRow_IsUnknown()
+    {
+        // Well-formed token kind, row that does not exist: still unanswerable, not "no body".
+        using var context = PdbContext.Open(CoreLibPath);
+        Assert.Null(context.MethodHasBody(MetadataTokens.GetToken(MetadataTokens.MethodDefinitionHandle(0x00FFFFFF))));
+    }
+
+    [Fact]
+    public void ConcreteMethod_HasBody()
+    {
+        using var context = PdbContext.Open(CoreLibPath);
+        var method = typeof(object).GetMethod(nameof(object.ToString), Type.EmptyTypes)!;
+        Assert.True(context.MethodHasBody(method.MetadataToken));
+    }
+
+    [Fact]
+    public void InterfaceMethod_HasNoBody()
+    {
+        using var context = PdbContext.Open(CoreLibPath);
+        var method = typeof(System.Collections.IEnumerator).GetMethod(nameof(System.Collections.IEnumerator.MoveNext))!;
+        Assert.False(context.MethodHasBody(method.MetadataToken));
+    }
+
+    [Fact]
+    public void AbstractMethod_HasNoBody()
+    {
+        using var context = PdbContext.Open(CoreLibPath);
+        var abstractMethod = typeof(System.IO.Stream)
+            .GetMethod(nameof(System.IO.Stream.Read), [typeof(byte[]), typeof(int), typeof(int)])!;
+        Assert.False(context.MethodHasBody(abstractMethod.MetadataToken));
+    }
+
+    [Fact]
+    public void ReferenceAssembly_IsUnknown_ForEveryMethod()
+    {
+        // A reference assembly strips all IL, so RVA 0 describes the image's surface-only nature
+        // rather than the method. Reporting that as "no body" would be false for every member.
+        var referenceAssembly = FindReferenceAssembly();
+        Assert.SkipWhen(referenceAssembly is null, "No targeting-pack reference assembly available.");
+
+        using var context = PdbContext.Open(referenceAssembly!);
+        using var peReader = new System.Reflection.PortableExecutable.PEReader(File.OpenRead(referenceAssembly!));
+        var reader = peReader.GetMetadataReader();
+
+        int checkedMethods = 0;
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            Assert.Null(context.MethodHasBody(MetadataTokens.GetToken(handle)));
+            if (++checkedMethods == 200)
+                break;
+        }
+
+        Assert.True(checkedMethods > 0);
+    }
+
+    static string? FindReferenceAssembly()
+    {
+        // dotnet/packs/Microsoft.NETCore.App.Ref/<version>/ref/<tfm>/System.Runtime.dll
+        var runtimeDir = Path.GetDirectoryName(CoreLibPath);
+        var dotnetRoot = Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(runtimeDir)));
+        if (dotnetRoot is null)
+            return null;
+
+        var packs = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        if (!Directory.Exists(packs))
+            return null;
+
+        return Directory.EnumerateFiles(packs, "System.Runtime.dll", SearchOption.AllDirectories)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .LastOrDefault();
+    }
+}


### PR DESCRIPTION
## What

`Original Source` rendered *nothing at all* for a member with no IL body — no
section, no text — and still exited 0. A caller could not distinguish a
complete answer ("this member has no source, by construction") from a silent
failure ("resolution broke and we swallowed it").

Now a definitely-bodyless member gets an explanation in the section:

```console
$ dotnet-inspect member "JsonConverter<T>" --platform System.Text.Json Read -S "Original Source"
## Original Source

```csharp
// This member has no IL body, so it has no authored source to show.
```
```

Exit stays 0: this is a correct, complete answer, not a failure.

## How

- `PdbContext.MethodHasBody(int)` (Metadata owns the metadata fact) answers
  `true` / `false` / `null`.
- `ResolveMethodSourceAsync` asks *before* attempting resolution, so the answer
  does not depend on how far resolution got, and flows the flag to the render
  sites through `MemberOptions`.
- The two `OriginalSourceCode` assignment sites render the note when there is no
  resolved source and the member is definitely bodyless.

## Boundaries — what this deliberately does *not* claim

- **Only a definite "no" counts.** An unreadable or non-MethodDef token is
  `null` (unknown), not "no body".
- **Reference assemblies answer `null` for every token.** A ref assembly strips
  all IL, so its RVAs describe the image's surface-only nature, not the method.
  Without this guard every ref-assembly member would falsely claim to be
  bodyless.
- **The other five unresolved paths are unchanged** (`!fetchSource`, no PDB, no
  SourceLink, unresolved method, no content, exception). They stay silent rather
  than claiming a reason they cannot prove. Narrowing those is separate work.
- **Source Diff is unaffected.** The note is prose about the member, not source
  text, so a `MemberCodeView.OriginalSourceUnavailable` flag keeps it out of the
  diff input; the diff still reports `Original Source unavailable`.

Wording and placement follow the existing `SourceTextDiffRenderer` precedent: a
comment-prefixed line inside the section's fence.

## Validation

- New CLI tests: abstract method, interface method, close negative (member
  *with* a body still renders real source and never shows the note), and the
  Source Diff non-pollution case.
- `dotnet build dotnet-inspect.slnx -c Release` — clean.
- Metadata **915/915**, Services **319/319**, CLI **2191** (10 skipped) with one
  failure, `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden`,
  reproduced unchanged on clean `origin/main` (`3fc6f1c8`) — pre-existing, not a
  regression.

Fixes #3299.
