### PR TITLE
Make "only the tools ship" a property of the projects (#3330)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,12 @@ to these trait filters (e.g. `--gate fast`, `--gate no-corpus`); run
 `--gate list` for the table.
 
 Pack and publish flows remain separate and build `src/dotnet-inspect`
-directly.
+directly. Packaging is off by default (`IsPackable=false` in the root
+`Directory.Build.props`), so only `src/dotnet-inspect` and `src/runfaster` opt
+back in and no other project can ship however pack is invoked. Internal
+libraries have no versioning story and no API-stability commitment; treat their
+public surface as an internal design constraint, not an external compatibility
+surface. `PackagingSurfaceTests` pins both halves.
 
 ## Output contract
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,5 +13,17 @@
     <DefaultTargetFramework Condition="'$(DefaultTargetFramework)' == '' and '$(OfficialBuild)' == 'true' and '$(PublishAot)' == 'false'">net10.0</DefaultTargetFramework>
     <DefaultTargetFramework Condition="'$(DefaultTargetFramework)' == ''">net$(NETCoreAppMaximumVersion)</DefaultTargetFramework>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <!--
+      Only the shipping tools produce packages, and that is a property of the
+      projects rather than of the argument each pack invocation happens to pass
+      (issue #3330). The internal libraries have no versioning story, no API
+      stability commitment, and no intent to be consumed externally; if one of
+      them reached a feed at 1.0.0, the layering rules in AGENTS.md would become
+      an external compatibility surface instead of an internal design
+      constraint. Off by default so a new library inherits "does not ship" and
+      shipping is the explicit act: src/dotnet-inspect and src/runfaster opt back
+      in, and PackagingSurfaceTests pins that set.
+    -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>

--- a/src/dotnet-inspect.Tests/PackagingSurfaceTests.cs
+++ b/src/dotnet-inspect.Tests/PackagingSurfaceTests.cs
@@ -1,0 +1,113 @@
+using System.Xml.Linq;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// What this repository ships (#3330). Only the two tools produce packages, and
+/// that must be a property of the projects rather than of the argument each
+/// <c>dotnet pack</c> invocation happens to pass. Before the default was
+/// inverted, <c>dotnet pack dotnet-inspect.slnx</c> emitted 17 packages: the two
+/// tools plus 15 internal libraries and a benchmark fixture, all at
+/// <c>1.0.0</c>, for code with no versioning story and no intent to be consumed
+/// externally. A library that reaches a feed turns the layering rules in
+/// <c>AGENTS.md</c> into an external compatibility surface instead of an
+/// internal design constraint.
+/// <para>
+/// The enforcement is the root <c>Directory.Build.props</c>: with
+/// <c>IsPackable=false</c> inherited, a new project ships nothing unless someone
+/// writes the opt-in, so shipping is the explicit act. These tests hold the two
+/// halves that makes true — that the default is actually declared, and that the
+/// set of projects opting back in is exactly the shipping tools. They also give
+/// review a local answer to "can this library's public API break anyone?",
+/// which on #3306 had to be settled by reading two workflow files.
+/// </para>
+/// </summary>
+public sealed class PackagingSurfaceTests
+{
+    static readonly string[] ShippingProjects =
+    [
+        "src/dotnet-inspect/dotnet-inspect.csproj",
+        "src/runfaster/runfaster.csproj",
+    ];
+
+    /// <summary>
+    /// The opt-in census. Matching ignores any <c>Condition</c>: a project that
+    /// packs under some configuration still ships under that configuration, so
+    /// it belongs in this list rather than hiding behind a condition that
+    /// happens to be false today.
+    /// </summary>
+    [Fact]
+    public void OnlyTheShippingToolsOptIntoPackaging()
+    {
+        var (packable, scanned) = ScanProjects();
+
+        Assert.True(scanned > 0, "Scanned no project files; the census would pass vacuously.");
+        Assert.Equal(ShippingProjects.OrderBy(static p => p, StringComparer.Ordinal).ToArray(), packable);
+    }
+
+    /// <summary>
+    /// The half that keeps the census above from passing vacuously in the way
+    /// that actually matters. Deleting the default restores the SDK's
+    /// <c>IsPackable=true</c> for every project, at which point no project needs
+    /// an opt-in and <see cref="OnlyTheShippingToolsOptIntoPackaging"/> still
+    /// reports green while 16 unintended packages come back. An unconditional
+    /// declaration is required for the same reason: a condition that stops
+    /// holding is indistinguishable from the property being gone.
+    /// </summary>
+    [Fact]
+    public void PackagingIsOffByDefaultForEveryProject()
+    {
+        string root = FindRepositoryRoot();
+        var properties = XDocument
+            .Load(Path.Combine(root, "Directory.Build.props"))
+            .Descendants()
+            .Where(static element => element.Name.LocalName == "IsPackable")
+            .ToArray();
+
+        var element = Assert.Single(properties);
+
+        Assert.Null(element.Attribute("Condition"));
+        Assert.Equal("false", element.Value.Trim(), ignoreCase: true);
+    }
+
+    static (string[] Packable, int Scanned) ScanProjects()
+    {
+        string root = FindRepositoryRoot();
+        List<string> packable = [];
+        int scanned = 0;
+
+        foreach (string path in Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories))
+        {
+            if (IsExcluded(root, path))
+                continue;
+
+            scanned++;
+            bool optsIn = XDocument.Load(path)
+                .Descendants()
+                .Any(static element => element.Name.LocalName == "IsPackable"
+                    && string.Equals(element.Value.Trim(), "true", StringComparison.OrdinalIgnoreCase));
+
+            if (optsIn)
+                packable.Add(Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/'));
+        }
+
+        packable.Sort(StringComparer.Ordinal);
+        return (packable.ToArray(), scanned);
+    }
+
+    static bool IsExcluded(string root, string path) =>
+        Path.GetRelativePath(root, path)
+            .Split(Path.DirectorySeparatorChar)
+            .Any(static segment => segment is "bin" or "obj" or ".git" or "artifacts" or "node_modules");
+
+    static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+                return directory.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not find repository root containing dotnet-inspect.slnx.");
+    }
+}

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -22,6 +22,8 @@
 
   <PropertyGroup>
     <Authors>Richard Lander</Authors>
+    <!-- Opts back in to the repo-wide IsPackable=false default (#3330). -->
+    <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
     <VersionPrefix>0.16.0</VersionPrefix>

--- a/src/runfaster/runfaster.csproj
+++ b/src/runfaster/runfaster.csproj
@@ -11,6 +11,8 @@
 
   <PropertyGroup>
     <Authors>Richard Lander</Authors>
+    <!-- Opts back in to the repo-wide IsPackable=false default (#3330). -->
+    <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>runfaster</ToolCommandName>
     <VersionPrefix>0.1.0</VersionPrefix>


### PR DESCRIPTION
Closes #3330.

## The gap

Nothing unintended ships today, but the reason is the **argument to `dotnet pack`**, not a property of the projects. The internal libraries inherited the SDK`s `IsPackable=true`.

Measured on `bf60a965`, before the change:

```
$ dotnet pack dotnet-inspect.slnx -c Release
17 packages
```

```
DotnetInspector.Core.1.0.0            ILInspector.Findings.1.0.0
DotnetInspector.MetadataRendering.1.0.0  ILInspector.Instructions.1.0.0
DotnetInspector.Packages.1.0.0        ILInspector.Metadata.1.0.0
DotnetInspector.Services.1.0.0        ILInspector.MetadataPrimitives.1.0.0
ILInspector.Analysis.1.0.0            ILInspector.Research.1.0.0
ILInspector.CSharp.1.0.0              ILInspector.Text.1.0.0
ILInspector.CallGraph.1.0.0           RunFaster.AllocationFixture.1.0.0
ILInspector.ControlFlow.1.0.0         runfaster.0.1.0
ILInspector.Decompiler.1.0.0
```

One beyond the issue`s list: `RunFaster.AllocationFixture`, a benchmark fixture, also packed.

## Change

Inverts the default in the root `Directory.Build.props`, with `src/dotnet-inspect` and `src/runfaster` opting back in. A new project now inherits "does not ship", so shipping is the explicit act — the same shape as #3289`s inverted validation default, applied to the build.

The 58 projects that already set `IsPackable=false` keep their explicit setting. Removing them would touch 58 files for no behavior change; they are now redundant rather than wrong.

**`PackagingSurfaceTests`** holds both halves, because either alone is insufficient:

- `OnlyTheShippingToolsOptIntoPackaging` pins the opt-in set by set equality, ignoring `Condition` — a project that packs under *some* configuration ships under that configuration.
- `PackagingIsOffByDefaultForEveryProject` asserts the default is declared, and unconditionally. Without it the census passes vacuously in the way that actually matters: delete the default, every project is packable again, no project needs an opt-in, and the census still reports green. Verified below — that is not a hypothetical.

## Evidence

| Check | Before (`bf60a965`) | After |
| --- | --- | --- |
| `dotnet pack dotnet-inspect.slnx -c Release` | **17 packages** | **1** (`runfaster`) |
| `dotnet pack src/ILInspector.Decompiler -c Release` | 1 package | **0** |
| `dotnet pack src/dotnet-inspect -c Release -r any -p:PublishAot=false -p:OfficialBuild=true` | packs | **packs** (`dotnet-inspect.any.0.16.0`) |
| `src/dotnet-inspect.Tests` full run | — | **2203 passed, 0 failed**, 12 skipped |
| `markdownlint AGENTS.md` | — | clean |

Gate teeth, each tampered and reverted:

| Tamper | Result |
| --- | --- |
| delete `IsPackable` from `Directory.Build.props` | **1 failed** — `PackagingIsOffByDefaultForEveryProject`; the census stayed green, which is the point |
| give the default a `Condition` that does not hold | **1 failed** — same gate |
| add `<IsPackable>true</IsPackable>` to `ILInspector.Decompiler` | **1 failed** — `OnlyTheShippingToolsOptIntoPackaging` |
| untampered | **2 passed** |

### One pre-existing failure, not caused by this change

`dotnet pack src/dotnet-inspect -c Release -p:SelfContained=true -p:OfficialBuild=true` (the pointer package, `ci.yml:583`) fails locally with `NETSDK1047 ... doesn`t have a target for net11.0/linux-x64`. I reproduced it on a **clean `origin/main` worktree** before concluding that — it is a local SDK/RID condition on this machine, unrelated to packability, and CI`s `pack` job is the authority. Flagging rather than burying it. The `-r any` invocation, which exercises the same project`s packability, works.

## Docs

`AGENTS.md` said pack flows "build `src/dotnet-inspect` directly", which stays true. It now also records that packaging is off by default and that internal library public surface is an internal design constraint rather than an external compatibility surface — the review question that produced this issue.

## Risk

Mechanical and build-only. No product code, no test behavior, no output. The only behavior change is that projects which were never intended to ship no longer produce packages; both shipping tools verified to still pack. Proposing single-review tier.