### PR TITLE
Broaden metadata-table projection to mdv's dumped tables (#3282)

### DIFF
--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -132,8 +132,10 @@ tools); it is not a dependency *of the planner*.
 ## Scope
 
 Given an assembly image, enumerate the ECMA-335 metadata tables (`Module`,
-`TypeRef`, `TypeDef`, `Field`, `MethodDef`, `Param`, `MemberRef`,
-`CustomAttribute`, `AssemblyRef`, …) and produce, per table, its rows with:
+`TypeRef`, `TypeDef`, `Field`, `MethodDef`, `Param`, `MemberRef`, `Constant`,
+`CustomAttribute`, `StandAloneSig`, `MethodImpl`, `TypeSpec`, `Assembly`,
+`AssemblyRef`, `ExportedType`, `GenericParam`, `MethodSpec`, …) and produce, per
+table, its rows with:
 
 1. **Each column value in raw form**, plus a friendly decode where cheap (flag
    enums, a name/namespace pulled from the string heap, well-known GUIDs). The
@@ -368,7 +370,9 @@ machine-readable streams (one `WriteTable` block per table).
 
 The `mdv` oracle is a follow-up increment: because it diffs against the
 projection **model** (not `mdi`'s rendered text), the renderer is free to be
-human-friendly without weakening the oracle.
+human-friendly without weakening the oracle. Supported-table coverage is kept in
+step with the tables `mdv` dumps, so every supported table's physical row count
+is cross-validated against `mdv` for free on the product assembly.
 
 ## Layer placement
 

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -42,6 +42,18 @@ public static class MetadataTableProjector
         TableIndex.GenericParamConstraint, TableIndex.MethodSpec,
     ];
 
+    static readonly ImmutableArray<TableIndex> HasConstantTargets =
+        [TableIndex.Field, TableIndex.Param, TableIndex.Property];
+
+    static readonly ImmutableArray<TableIndex> MethodDefOrRefTargets =
+        [TableIndex.MethodDef, TableIndex.MemberRef];
+
+    static readonly ImmutableArray<TableIndex> ImplementationTargets =
+        [TableIndex.File, TableIndex.ExportedType, TableIndex.AssemblyRef];
+
+    static readonly ImmutableArray<TableIndex> TypeOrMethodDefTargets =
+        [TableIndex.TypeDef, TableIndex.MethodDef];
+
     static readonly ImmutableArray<TableSpec> SupportedTables =
     [
         new(TableIndex.Module, "Module", ModuleColumns, ReadModuleRow),
@@ -51,8 +63,16 @@ public static class MetadataTableProjector
         new(TableIndex.MethodDef, "MethodDef", MethodDefColumns, ReadMethodDefRow),
         new(TableIndex.Param, "Param", ParamColumns, ReadParamRow),
         new(TableIndex.MemberRef, "MemberRef", MemberRefColumns, ReadMemberRefRow),
+        new(TableIndex.Constant, "Constant", ConstantColumns, ReadConstantRow),
         new(TableIndex.CustomAttribute, "CustomAttribute", CustomAttributeColumns, ReadCustomAttributeRow),
+        new(TableIndex.StandAloneSig, "StandAloneSig", StandAloneSigColumns, ReadStandAloneSigRow),
+        new(TableIndex.MethodImpl, "MethodImpl", MethodImplColumns, ReadMethodImplRow),
+        new(TableIndex.TypeSpec, "TypeSpec", TypeSpecColumns, ReadTypeSpecRow),
+        new(TableIndex.Assembly, "Assembly", AssemblyColumns, ReadAssemblyRow),
         new(TableIndex.AssemblyRef, "AssemblyRef", AssemblyRefColumns, ReadAssemblyRefRow),
+        new(TableIndex.ExportedType, "ExportedType", ExportedTypeColumns, ReadExportedTypeRow),
+        new(TableIndex.GenericParam, "GenericParam", GenericParamColumns, ReadGenericParamRow),
+        new(TableIndex.MethodSpec, "MethodSpec", MethodSpecColumns, ReadMethodSpecRow),
     ];
 
     /// <summary>
@@ -184,6 +204,13 @@ public static class MetadataTableProjector
         new("Signature", MetadataColumnKind.Heap),
     ];
 
+    static ImmutableArray<MetadataColumn> ConstantColumns =>
+    [
+        new("Type", MetadataColumnKind.Scalar),
+        new("Parent", MetadataColumnKind.Handle, HasConstantTargets),
+        new("Value", MetadataColumnKind.Heap),
+    ];
+
     static ImmutableArray<MetadataColumn> CustomAttributeColumns =>
     [
         new("Parent", MetadataColumnKind.Handle, HasCustomAttributeTargets),
@@ -202,6 +229,59 @@ public static class MetadataTableProjector
         new("Name", MetadataColumnKind.Heap),
         new("Culture", MetadataColumnKind.Heap),
         new("HashValue", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> StandAloneSigColumns =>
+    [
+        new("Signature", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> MethodImplColumns =>
+    [
+        new("Class", MetadataColumnKind.Handle, [TableIndex.TypeDef]),
+        new("MethodBody", MetadataColumnKind.Handle, MethodDefOrRefTargets),
+        new("MethodDeclaration", MetadataColumnKind.Handle, MethodDefOrRefTargets),
+    ];
+
+    static ImmutableArray<MetadataColumn> TypeSpecColumns =>
+    [
+        new("Signature", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> AssemblyColumns =>
+    [
+        new("HashAlgId", MetadataColumnKind.Scalar),
+        new("MajorVersion", MetadataColumnKind.Scalar),
+        new("MinorVersion", MetadataColumnKind.Scalar),
+        new("BuildNumber", MetadataColumnKind.Scalar),
+        new("RevisionNumber", MetadataColumnKind.Scalar),
+        new("Flags", MetadataColumnKind.Flags),
+        new("PublicKey", MetadataColumnKind.Heap),
+        new("Name", MetadataColumnKind.Heap),
+        new("Culture", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> ExportedTypeColumns =>
+    [
+        new("Attributes", MetadataColumnKind.Flags),
+        new("TypeDefId", MetadataColumnKind.Scalar),
+        new("Name", MetadataColumnKind.Heap),
+        new("Namespace", MetadataColumnKind.Heap),
+        new("Implementation", MetadataColumnKind.Handle, ImplementationTargets),
+    ];
+
+    static ImmutableArray<MetadataColumn> GenericParamColumns =>
+    [
+        new("Number", MetadataColumnKind.Scalar),
+        new("Attributes", MetadataColumnKind.Flags),
+        new("Owner", MetadataColumnKind.Handle, TypeOrMethodDefTargets),
+        new("Name", MetadataColumnKind.Heap),
+    ];
+
+    static ImmutableArray<MetadataColumn> MethodSpecColumns =>
+    [
+        new("Method", MetadataColumnKind.Handle, MethodDefOrRefTargets),
+        new("Instantiation", MetadataColumnKind.Heap),
     ];
 
     // ---- Per-table row readers -------------------------------------------
@@ -292,6 +372,17 @@ public static class MetadataTableProjector
         ];
     }
 
+    static ImmutableArray<MetadataValue> ReadConstantRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var constant = reader.GetConstant(MetadataTokens.ConstantHandle(rid));
+        return
+        [
+            new MetadataValue.Scalar((long)constant.TypeCode, constant.TypeCode.ToString()),
+            HandleCell(reader, constant.Parent, options),
+            BlobCell(reader, constant.Value, options),
+        ];
+    }
+
     static ImmutableArray<MetadataValue> ReadCustomAttributeRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
     {
         var attribute = reader.GetCustomAttribute(MetadataTokens.CustomAttributeHandle(rid));
@@ -318,6 +409,89 @@ public static class MetadataTableProjector
             StringCell(reader, assemblyRef.Name, options),
             StringCell(reader, assemblyRef.Culture, options),
             BlobCell(reader, assemblyRef.HashValue, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadStandAloneSigRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var signature = reader.GetStandaloneSignature(MetadataTokens.StandaloneSignatureHandle(rid));
+        return
+        [
+            BlobCell(reader, signature.Signature, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadMethodImplRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var methodImpl = reader.GetMethodImplementation(MetadataTokens.MethodImplementationHandle(rid));
+        return
+        [
+            HandleCell(reader, methodImpl.Type, options),
+            HandleCell(reader, methodImpl.MethodBody, options),
+            HandleCell(reader, methodImpl.MethodDeclaration, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadTypeSpecRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var typeSpec = reader.GetTypeSpecification(MetadataTokens.TypeSpecificationHandle(rid));
+        return
+        [
+            BlobCell(reader, typeSpec.Signature, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadAssemblyRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var assembly = reader.GetAssemblyDefinition();
+        var version = assembly.Version;
+        return
+        [
+            new MetadataValue.Scalar((long)assembly.HashAlgorithm, assembly.HashAlgorithm.ToString()),
+            new MetadataValue.Scalar(version.Major, version.Major.ToString()),
+            new MetadataValue.Scalar(version.Minor, version.Minor.ToString()),
+            new MetadataValue.Scalar(version.Build, version.Build.ToString()),
+            new MetadataValue.Scalar(version.Revision, version.Revision.ToString()),
+            FlagsCell((long)assembly.Flags, assembly.Flags.ToString()),
+            BlobCell(reader, assembly.PublicKey, options),
+            StringCell(reader, assembly.Name, options),
+            StringCell(reader, assembly.Culture, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadExportedTypeRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var exportedType = reader.GetExportedType(MetadataTokens.ExportedTypeHandle(rid));
+        int typeDefId = exportedType.GetTypeDefinitionId();
+        return
+        [
+            FlagsCell((long)exportedType.Attributes, exportedType.Attributes.ToString()),
+            new MetadataValue.Scalar(typeDefId, $"0x{typeDefId:X8}"),
+            StringCell(reader, exportedType.Name, options),
+            StringCell(reader, exportedType.Namespace, options),
+            HandleCell(reader, exportedType.Implementation, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadGenericParamRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var genericParam = reader.GetGenericParameter(MetadataTokens.GenericParameterHandle(rid));
+        return
+        [
+            new MetadataValue.Scalar(genericParam.Index, genericParam.Index.ToString()),
+            FlagsCell((long)genericParam.Attributes, genericParam.Attributes.ToString()),
+            HandleCell(reader, genericParam.Parent, options),
+            StringCell(reader, genericParam.Name, options),
+        ];
+    }
+
+    static ImmutableArray<MetadataValue> ReadMethodSpecRow(MetadataReader reader, int rid, MetadataProjectionOptions options)
+    {
+        var methodSpec = reader.GetMethodSpecification(MetadataTokens.MethodSpecificationHandle(rid));
+        return
+        [
+            HandleCell(reader, methodSpec.Method, options),
+            BlobCell(reader, methodSpec.Signature, options),
         ];
     }
 

--- a/tests/ILInspector.Metadata.Tests/ExportedTypeForwarderFixture.cs
+++ b/tests/ILInspector.Metadata.Tests/ExportedTypeForwarderFixture.cs
@@ -1,0 +1,9 @@
+using System.Runtime.CompilerServices;
+
+// Forwards a referenced type so this test assembly carries a deterministic
+// ExportedType (0x27) row. That lets MetadataTableProjectionTests assert the
+// ExportedType projection's shape against SelfPath uniformly with every other
+// supported table (the test assembly otherwise defines no forwarders). The
+// forward is inert at runtime: nothing resolves this type name against the test
+// assembly, and the type genuinely lives in ILInspector.Metadata.
+[assembly: TypeForwardedTo(typeof(ILInspector.Metadata.MetadataTableProjector))]

--- a/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
@@ -129,6 +129,179 @@ public class MetadataTableProjectionTests
     }
 
     [Fact]
+    public void ConstantTable_DecodesTypeCode_AndResolvesParentIntoConstantOwner()
+    {
+        var constant = Table(Project(), TableIndex.Constant);
+        Assert.True(constant.RowCount >= 1, "Expected the test assembly to define constants.");
+
+        // Type is the ConstantTypeCode carried as a scalar with an additive
+        // decoded name (e.g. Int32, String, Boolean), never an opaque number.
+        foreach (var row in constant.Rows)
+        {
+            var typeCode = Assert.IsType<MetadataValue.Scalar>(Cell(constant, row, "Type"));
+            Assert.False(string.IsNullOrEmpty(typeCode.Display));
+
+            // Parent is a HasConstant coded index; every edge lands in one of the
+            // three owner tables and points at a live row.
+            var parent = Assert.IsType<MetadataValue.Handle>(Cell(constant, row, "Parent"));
+            Assert.Contains(
+                parent.Reference.TargetTable,
+                new[] { TableIndex.Field, TableIndex.Param, TableIndex.Property });
+            Assert.True(parent.Reference.TargetRowId >= 1);
+        }
+
+        // The column advertises all three HasConstant candidate targets.
+        var parentColumn = constant.Columns[ColumnIndex(constant, "Parent")];
+        Assert.Equal(MetadataColumnKind.Handle, parentColumn.Kind);
+        Assert.Contains(TableIndex.Field, parentColumn.CandidateTargets);
+        Assert.Contains(TableIndex.Param, parentColumn.CandidateTargets);
+        Assert.Contains(TableIndex.Property, parentColumn.CandidateTargets);
+
+        // At least one constant carries a value blob preview.
+        Assert.Contains(
+            constant.Rows,
+            row => Cell(constant, row, "Value") is MetadataValue.HeapReference { Heap: HeapKind.Blob });
+    }
+
+    [Fact]
+    public void StandAloneSigTable_IsBoundedBlobPreview()
+    {
+        var standAloneSig = Table(Project(), TableIndex.StandAloneSig);
+        var row = standAloneSig.Rows.First();
+
+        var signature = Assert.IsType<MetadataValue.HeapReference>(Cell(standAloneSig, row, "Signature"));
+        Assert.Equal(HeapKind.Blob, signature.Heap);
+        Assert.Null(signature.Text);
+    }
+
+    [Fact]
+    public void MethodImplTable_ResolvesClassAndMethodEdges()
+    {
+        var methodImpl = Table(Project(), TableIndex.MethodImpl);
+        Assert.True(methodImpl.RowCount >= 1, "Expected the test assembly to define method overrides.");
+
+        foreach (var row in methodImpl.Rows)
+        {
+            // Class is a direct TypeDef handle (not a coded index).
+            var declaringType = Assert.IsType<MetadataValue.Handle>(Cell(methodImpl, row, "Class"));
+            Assert.Equal(TableIndex.TypeDef, declaringType.Reference.TargetTable);
+
+            // Body and declaration are MethodDefOrRef coded indices.
+            var body = Assert.IsType<MetadataValue.Handle>(Cell(methodImpl, row, "MethodBody"));
+            Assert.Contains(body.Reference.TargetTable, new[] { TableIndex.MethodDef, TableIndex.MemberRef });
+
+            var declaration = Assert.IsType<MetadataValue.Handle>(Cell(methodImpl, row, "MethodDeclaration"));
+            Assert.Contains(declaration.Reference.TargetTable, new[] { TableIndex.MethodDef, TableIndex.MemberRef });
+        }
+
+        var bodyColumn = methodImpl.Columns[ColumnIndex(methodImpl, "MethodBody")];
+        Assert.Contains(TableIndex.MethodDef, bodyColumn.CandidateTargets);
+        Assert.Contains(TableIndex.MemberRef, bodyColumn.CandidateTargets);
+    }
+
+    [Fact]
+    public void TypeSpecTable_IsBoundedBlobPreview()
+    {
+        var typeSpec = Table(Project(), TableIndex.TypeSpec);
+        var row = typeSpec.Rows.First();
+
+        var signature = Assert.IsType<MetadataValue.HeapReference>(Cell(typeSpec, row, "Signature"));
+        Assert.Equal(HeapKind.Blob, signature.Heap);
+        Assert.Null(signature.Text);
+    }
+
+    [Fact]
+    public void AssemblyTable_HasSingleRow_WithDecodedNameHashAlgorithmAndFlags()
+    {
+        var assembly = Table(Project(), TableIndex.Assembly);
+
+        var row = Assert.Single(assembly.Rows);
+        Assert.Equal(1, row.RowId);
+
+        var name = Assert.IsType<MetadataValue.HeapReference>(Cell(assembly, row, "Name"));
+        Assert.Equal(HeapKind.String, name.Heap);
+        Assert.Equal("ILInspector.Metadata.Tests", name.Text);
+
+        // HashAlgId is a single-valued enum surfaced as a scalar with an additive
+        // decoded name (SHA-1 is the csc default), not a bitflag set.
+        var hashAlg = Assert.IsType<MetadataValue.Scalar>(Cell(assembly, row, "HashAlgId"));
+        Assert.False(string.IsNullOrEmpty(hashAlg.Display));
+
+        // Flags is a genuine bitflag enumeration.
+        Assert.IsType<MetadataValue.Flags>(Cell(assembly, row, "Flags"));
+
+        // The four version parts are scalars.
+        Assert.IsType<MetadataValue.Scalar>(Cell(assembly, row, "MajorVersion"));
+        Assert.IsType<MetadataValue.Scalar>(Cell(assembly, row, "RevisionNumber"));
+    }
+
+    [Fact]
+    public void ExportedTypeTable_ResolvesImplementation_ForForwardedType()
+    {
+        // ExportedTypeForwarderFixture forwards MetadataTableProjector, so the
+        // test assembly carries a deterministic ExportedType row.
+        var exportedType = Table(Project(), TableIndex.ExportedType);
+
+        var row = Assert.Single(
+            exportedType.Rows,
+            candidate => StringText(exportedType, candidate, "Name") == "MetadataTableProjector");
+
+        Assert.IsType<MetadataValue.Flags>(Cell(exportedType, row, "Attributes"));
+
+        var @namespace = Assert.IsType<MetadataValue.HeapReference>(Cell(exportedType, row, "Namespace"));
+        Assert.Equal("ILInspector.Metadata", @namespace.Text);
+
+        // A forwarded type's Implementation is an AssemblyRef edge to the defining
+        // assembly; the column advertises the full Implementation coded-index set.
+        var implementation = Assert.IsType<MetadataValue.Handle>(Cell(exportedType, row, "Implementation"));
+        Assert.Equal(TableIndex.AssemblyRef, implementation.Reference.TargetTable);
+
+        var implementationColumn = exportedType.Columns[ColumnIndex(exportedType, "Implementation")];
+        Assert.Contains(TableIndex.File, implementationColumn.CandidateTargets);
+        Assert.Contains(TableIndex.ExportedType, implementationColumn.CandidateTargets);
+        Assert.Contains(TableIndex.AssemblyRef, implementationColumn.CandidateTargets);
+    }
+
+    [Fact]
+    public void GenericParamTable_DecodesNumberAndResolvesOwner()
+    {
+        var genericParam = Table(Project(), TableIndex.GenericParam);
+        Assert.True(genericParam.RowCount >= 1, "Expected the test assembly to define generic parameters.");
+
+        foreach (var row in genericParam.Rows)
+        {
+            Assert.IsType<MetadataValue.Scalar>(Cell(genericParam, row, "Number"));
+            Assert.IsType<MetadataValue.Flags>(Cell(genericParam, row, "Attributes"));
+
+            var owner = Assert.IsType<MetadataValue.Handle>(Cell(genericParam, row, "Owner"));
+            Assert.Contains(owner.Reference.TargetTable, new[] { TableIndex.TypeDef, TableIndex.MethodDef });
+
+            var name = Assert.IsType<MetadataValue.HeapReference>(Cell(genericParam, row, "Name"));
+            Assert.False(string.IsNullOrEmpty(name.Text));
+        }
+
+        var ownerColumn = genericParam.Columns[ColumnIndex(genericParam, "Owner")];
+        Assert.Contains(TableIndex.TypeDef, ownerColumn.CandidateTargets);
+        Assert.Contains(TableIndex.MethodDef, ownerColumn.CandidateTargets);
+    }
+
+    [Fact]
+    public void MethodSpecTable_ResolvesMethod_AndBlobInstantiation()
+    {
+        var methodSpec = Table(Project(), TableIndex.MethodSpec);
+        Assert.True(methodSpec.RowCount >= 1, "Expected the test assembly to instantiate generic methods.");
+
+        foreach (var row in methodSpec.Rows)
+        {
+            var method = Assert.IsType<MetadataValue.Handle>(Cell(methodSpec, row, "Method"));
+            Assert.Contains(method.Reference.TargetTable, new[] { TableIndex.MethodDef, TableIndex.MemberRef });
+
+            var instantiation = Assert.IsType<MetadataValue.HeapReference>(Cell(methodSpec, row, "Instantiation"));
+            Assert.Equal(HeapKind.Blob, instantiation.Heap);
+        }
+    }
+
+    [Fact]
     public void RowBudget_TruncatesExplicitly_NeverSilently()
     {
         var full = Table(Project(), TableIndex.TypeDef);


### PR DESCRIPTION
## What

Broadens the raw ECMA-335 `MetadataTableProjection` from 9 to 17 supported
tables by adding the eight tables `mdv` dumps that we lacked:

`Constant` (0x0B), `StandAloneSig` (0x11), `MethodImpl` (0x19),
`TypeSpec` (0x1B), `Assembly` (0x20), `ExportedType` (0x27),
`GenericParam` (0x2A), `MethodSpec` (0x2B).

Tracking: #3282.

## Why this batch

Each new table is exactly one that the merged `MdvOracleComparisonTests`
already dumps, so adding them means their **physical row counts are
cross-validated against `mdv` for free** on the product assembly — a
second, independent ECMA-335 reader confirms the projection enumerates the
same rows. The oracle ran here (0 skipped) and its parity check now covers
all eight.

## How

Each table follows the established projector pattern with no new
abstractions: a column schema, a row reader, and registration in
`SupportedTables` in ascending `TableIndex` order (enforced by
`Project_ProducesTablesInEcmaOrder`). Reuses the existing
`StringCell`/`BlobCell`/`HandleCell`/`FlagsCell` builders, row/blob/string
budgets, and per-row `Malformed` containment.

Modeling decisions:
- Handle columns declare their coded-index candidate targets: `HasConstant`
  (Field/Param/Property), `MethodDefOrRef` (MethodDef/MemberRef),
  `Implementation` (File/ExportedType/AssemblyRef), `TypeOrMethodDef`
  (TypeDef/MethodDef). `MethodImpl.Class` is a direct `TypeDef` handle, not
  a coded index.
- Single-valued enums (`Constant.Type` → `ConstantTypeCode`,
  `Assembly.HashAlgId` → `AssemblyHashAlgorithm`) surface as
  **additive-decoded `Scalar`** cells (raw + decoded name). Genuine bitflag
  sets (`Attributes`, `Flags`) stay `Flags` cells. This matches the existing
  Scalar-vs-Flags split.

## Evidence

- **Structural tests** (`MetadataTableProjectionTests`, +8) assert per-table
  identity, enum/flag decode, resolvable handle edges, and candidate targets
  for all eight tables against the self image. A minimal `TypeForwardedTo`
  fixture gives the test assembly a deterministic `ExportedType` row
  (mirroring `src`'s existing `SignatureBlobGuardForwarder`).
- **mdv oracle**: ran (not skipped); row-count parity now covers all eight
  new tables on `ILInspector.Metadata.dll`.
- **Full Metadata suite**: 947 passed / 0 failed / 0 skipped.
- **Full `dotnet-inspect.slnx`** builds clean; renderer suite 30/0.
- **Output**: `mdi` renders all new tables in `md`, `tsv`, and `jsonl`
  (resolved handle displays + explicit truncation preserved).

## Boundary / non-goals

Product paths stay SRM-only, NativeAOT-friendly, Roslyn-free, read-only, and
presentation-free in `ILInspector.Metadata`. No blob/signature friendly
decode (still a bounded hex preview — a separate additive follow-up). No CLI
`metadata` lens (deferred, blocked on design-doc open questions).
