### PR TITLE
Name the census that actually pins the call site

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrInvariants.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrInvariants.cs
@@ -81,8 +81,13 @@ public static class IrInvariants
     /// moved <em>independently of</em> <see cref="Enabled"/>, the only setter
     /// involved is <see cref="Enabled"/>'s and it is private, so only this type
     /// can move either, and the one public mover is
-    /// <see cref="DisableForShippedTool"/> — pinned by #3303's public-surface
-    /// census to a single call site in the shipped CLI. So no test can race the
+    /// <see cref="DisableForShippedTool"/> — held to a single call site in the
+    /// shipped CLI by <c>OnlyTheShippedToolEntryPointDeclinesValidation</c>,
+    /// the source census that scans the repository under every preprocessor
+    /// configuration. (Its sibling
+    /// <c>ThePublicSurfaceIsExactlyTheShippedToolOptOut</c> pins the
+    /// complementary half — which members exist at all — so a new mover cannot
+    /// appear unnoticed either.) So no test can race the
     /// collections xUnit runs in parallel by toggling it, and no host can lower
     /// semantics while leaving structural armed.
     /// </para>


### PR DESCRIPTION
Post-merge follow-up to #3316, addressing the optional nano-nit at the end of its review.

## What

The `CheckSemantics` doc credited "#3303's public-surface census" with pinning `DisableForShippedTool()` to a single call site. Two different tests do two different jobs:

- `ThePublicSurfaceIsExactlyTheShippedToolOptOut` pins **which members exist**.
- `OnlyTheShippedToolEntryPointDeclinesValidation` pins **the call site**.

Both are #3303's, so the shorthand was fair — except in that particular paragraph, whose entire subject is being exact about which guarantee is held by what. Being loose about attribution there undercuts the point the paragraph is making.

It now names the source census for the claim it actually backs, and mentions the surface census as the complementary half, so the pair reads as a deliberate division rather than as one test doing both.

Also worth pointing the reader at the source census specifically: it re-parses every preprocessor configuration and matches by identifier, so a decline hidden behind `#if` or reached through an alias does not evade it. That is the more instructive of the two guards.

## Risk

**Doc comment only.** No product code, test code, or behavior changes — the diff is entirely inside one XML doc comment. Per `AGENTS.md`, documentation-only changes do not require adversarial review; this one makes no measured behavior claim.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release` — 0 errors (the comment uses `<c>`/`<see cref=...>`, so the build is the relevant check).
- `IrInvariantsHostContractTests` — 29 pass, 0 fail.