### PR TITLE
Skip caller-scope assemblies that cannot reference the target

### DIFF
--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -16,6 +16,7 @@
     <Project Path="src/ILInspector.Analysis.App/ILInspector.Analysis.App.csproj" />
     <Project Path="src/ILInspector.Analysis.CallerGraphCaller/ILInspector.Analysis.CallerGraphCaller.csproj" />
     <Project Path="src/ILInspector.Analysis.CallerGraphCallerTwin/ILInspector.Analysis.CallerGraphCallerTwin.csproj" />
+    <Project Path="src/ILInspector.Analysis.CallerGraphIndirectCaller/ILInspector.Analysis.CallerGraphIndirectCaller.csproj" />
     <Project Path="src/ILInspector.Analysis.CallerGraphLookalikeCaller/ILInspector.Analysis.CallerGraphLookalikeCaller.csproj" />
     <Project Path="src/ILInspector.Analysis.CallerGraphTarget/ILInspector.Analysis.CallerGraphTarget.csproj" />
     <Project Path="src/ILInspector.Analysis.CrossAsmCollisionFixtures/ILInspector.Analysis.CrossAsmCollisionFixtures.csproj" />

--- a/src/ILInspector.Analysis.CallerGraphIndirectCaller/ILInspector.Analysis.CallerGraphIndirectCaller.csproj
+++ b/src/ILInspector.Analysis.CallerGraphIndirectCaller/ILInspector.Analysis.CallerGraphIndirectCaller.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Caller-graph transitive-scope fixture (#3331): an indirect caller. References only the
+    caller assembly, never the target, so a caller graph rooted at Target.Api.Ping reaches
+    it at depth 2 through Shared.Entry.Run. Scope prefiltering must keep it.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCaller\ILInspector.Analysis.CallerGraphCaller.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.CallerGraphIndirectCaller/IndirectEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphIndirectCaller/IndirectEntry.cs
@@ -1,0 +1,14 @@
+// Caller-graph transitive-scope fixture (#3331). This assembly references ONLY the caller
+// assembly, never the target, yet it belongs in a caller graph rooted at Target.Api.Ping:
+// Indirect.Entry.Run -> Shared.Entry.Run -> Target.Api.Ping is two hops.
+//
+// It exists to pin the transitive obligation of the AssemblyRef prefilter. A prefilter that
+// asks only "does this assembly reference the target?" drops this one and silently shortens
+// the graph, so the reference set here must stay free of the target assembly.
+namespace Indirect
+{
+    public static class Entry
+    {
+        public static void Run() => Shared.Entry.Run();
+    }
+}

--- a/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
@@ -309,12 +309,24 @@ public class CallerScopeFilterTests
     // Copies of one assembly under several subdirectories, or several facades canonicalizing
     // together, all share a canonical name. Every copy must be selected — and the walk must stay
     // linear while doing it. Before the adjacency entry was consumed on first visit, each selected
-    // sharer re-enqueued the shared name and re-traversed the whole group: quadratic in group size,
-    // measured at ~10s for 40k sharers against ~13ms after.
+    // sharer re-enqueued the shared name and re-traversed the whole group: quadratic in group size.
+    //
+    // The group size is chosen for separation under mutation, not for realism. Round 6 measured the
+    // earlier 40k version at ~2080ms against this 2000ms bound — a 4% margin, which faster hardware
+    // would erase, letting the quadratic pass. Because the mutant grows quadratically and the fixed
+    // path linearly, raising the group widens both margins at once (3x the group cost 8.9x the
+    // mutant's time, and almost nothing here):
+    //
+    //   sharers    fixed     reverted to a non-consuming lookup
+    //   40,000     ~13ms     ~2,080ms
+    //   120,000    ~40ms     ~18,509ms
+    //
+    // So the bound now sits ~50x above the linear cost and ~9x below the quadratic one, which
+    // discriminates the two shapes rather than measuring this machine.
     [Fact]
     public void SameNamedCandidatesAreAllSelectedInLinearTime()
     {
-        const int sharers = 40_000;
+        const int sharers = 120_000;
         var candidates = new List<CallerScopeFilter.Candidate>(sharers);
         for (int i = 0; i < sharers; i++)
             candidates.Add(CallerScopeFilter.Candidate.Known("Dup", ["Target"]));
@@ -325,8 +337,8 @@ public class CallerScopeFilterTests
 
         Assert.All(selected, Assert.True);
 
-        // Three orders of magnitude of headroom over the linear cost, and two under the quadratic
-        // one, so this discriminates the shapes without being a wall-clock measurement.
+        // See the margin table above: ~50x of headroom over the linear cost and ~9x under the
+        // quadratic one, so this discriminates the shapes without being a wall-clock measurement.
         Assert.True(
             watch.ElapsedMilliseconds < 2_000,
             $"selection over {sharers} same-named candidates took {watch.ElapsedMilliseconds}ms, "

--- a/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
@@ -306,6 +306,44 @@ public class CallerScopeFilterTests
             CallerScopeFilter.SelectCouldReach(target.Name, [caller, indirect, lookalike]));
     }
 
+    // Copies of one assembly under several subdirectories, or several facades canonicalizing
+    // together, all share a canonical name. Every copy must be selected — and the walk must stay
+    // linear while doing it. Before the adjacency entry was consumed on first visit, each selected
+    // sharer re-enqueued the shared name and re-traversed the whole group: quadratic in group size,
+    // measured at ~10s for 40k sharers against ~13ms after.
+    [Fact]
+    public void SameNamedCandidatesAreAllSelectedInLinearTime()
+    {
+        const int sharers = 40_000;
+        var candidates = new List<CallerScopeFilter.Candidate>(sharers);
+        for (int i = 0; i < sharers; i++)
+            candidates.Add(CallerScopeFilter.Candidate.Known("Dup", ["Target"]));
+
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        var selected = CallerScopeFilter.SelectCouldReach("Target", candidates);
+        watch.Stop();
+
+        Assert.All(selected, Assert.True);
+
+        // Three orders of magnitude of headroom over the linear cost, and two under the quadratic
+        // one, so this discriminates the shapes without being a wall-clock measurement.
+        Assert.True(
+            watch.ElapsedMilliseconds < 2_000,
+            $"selection over {sharers} same-named candidates took {watch.ElapsedMilliseconds}ms, "
+                + "which indicates the walk revisits an adjacency entry per sharer");
+    }
+
+    // A candidate whose own name is also one of its references, and a candidate naming the same
+    // reference twice, are both indexed once per name. Nothing above depends on the count, so this
+    // pins the dedupe directly rather than through an observable it cannot reach.
+    [Fact]
+    public void RepeatedNamesIndexACandidateOnce()
+    {
+        Assert.True(Selects("Target", "Target", ["Target", "Target"]));
+        Assert.True(Selects("Target", "Self", ["Self", "Target", "Target"]));
+        Assert.False(Selects("Target", "Self", ["Self", "Self"]));
+    }
+
     [Fact]
     public void EmptyCandidateListSelectsNothing()
     {

--- a/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Fixtures;
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+
+namespace ILInspector.Analysis.Tests;
+
+/// <summary>
+/// <see cref="CallerScopeFilter"/> decides, from assembly identity alone, whether an assembly is
+/// worth opening during cross-assembly caller discovery. Its only correctness obligation is that it
+/// never rules out an assembly the matcher would have matched, so these tests pin the boundary in
+/// both directions and use the same real fixture assemblies the matcher tests use.
+/// </summary>
+public class CallerScopeFilterTests
+{
+    static AssemblyIdentityNames Identity(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        return AssemblyIdentityScanner.Scan(peReader);
+    }
+
+    static bool CouldContainCallerOf(string targetAssemblyPath, string candidateAssemblyPath)
+    {
+        var candidate = Identity(candidateAssemblyPath);
+        return CallerScopeFilter.CouldContainCallerOf(
+            Identity(targetAssemblyPath).Name, candidate.Name, candidate.ReferenceNames);
+    }
+
+    // The real caller fixture references the target, so it must survive the filter and be opened.
+    // This is the assembly BuildCallerTree_WithScope_* proves does contribute callers.
+    [Fact]
+    public void ReferencingAssemblyIsKept()
+    {
+        Assert.True(CouldContainCallerOf(
+            FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath(),
+            FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath()));
+    }
+
+    // The lookalike declares its own Target.Api.Ping and never references the target assembly.
+    // The matcher already excludes it (BuildCallerTree ignores its calls); the filter must reach
+    // the same answer, which is what makes skipping it an optimization rather than a behavior change.
+    [Fact]
+    public void NonReferencingAssemblyIsRuledOut()
+    {
+        Assert.False(CouldContainCallerOf(
+            FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath(),
+            FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath()));
+    }
+
+    // The candidate is the target: its own TypeDefs are callees the matcher can match.
+    [Fact]
+    public void TargetAssemblyItselfIsKept()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        Assert.True(CouldContainCallerOf(target, target));
+    }
+
+    // The facade case, and the reason the filter canonicalizes instead of comparing raw names.
+    // Callers reference System.Runtime; the target is defined in System.Private.CoreLib. A raw name
+    // comparison would rule out essentially every caller of a corelib member.
+    [Theory]
+    [InlineData("System.Runtime")]
+    [InlineData("mscorlib")]
+    [InlineData("netstandard")]
+    [InlineData("System.Runtime.Extensions")]
+    public void CorelibFacadeReferenceIsKept(string facade)
+    {
+        Assert.True(CallerScopeFilter.CouldContainCallerOf(
+            "System.Private.CoreLib", "Some.Consumer", [facade]));
+    }
+
+    [Fact]
+    public void UnrelatedReferencesAreRuledOut()
+    {
+        Assert.False(CallerScopeFilter.CouldContainCallerOf(
+            "Target", "Some.Consumer", ["System.Runtime", "Newtonsoft.Json"]));
+    }
+
+    // Undecidable inputs must fail open: a filter that cannot tell has to let the real matcher decide.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void UnknownTargetFailsOpen(string? target)
+    {
+        Assert.True(CallerScopeFilter.CouldContainCallerOf(target, "Some.Consumer", ["Unrelated"]));
+    }
+
+    [Fact]
+    public void UnknownCandidateReferencesFailOpen()
+    {
+        Assert.True(CallerScopeFilter.CouldContainCallerOf("Target", "Some.Consumer", null));
+    }
+
+    // A reference-free image (no AssemblyRef rows) that is not the target cannot call into it.
+    [Fact]
+    public void EmptyReferenceSetIsRuledOut()
+    {
+        Assert.False(CallerScopeFilter.CouldContainCallerOf("Target", "Some.Consumer", ImmutableArray<string>.Empty));
+    }
+}

--- a/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
@@ -11,6 +11,9 @@ namespace ILInspector.Analysis.Tests;
 /// worth opening during cross-assembly caller discovery. Its only correctness obligation is that it
 /// never rules out an assembly the matcher would have matched, so these tests pin the boundary in
 /// both directions and use the same real fixture assemblies the matcher tests use.
+///
+/// The obligation is over the whole caller <em>graph</em>, not one level of it, so the transitive
+/// cases below are the ones that distinguish the closure from a direct-reference test.
 /// </summary>
 public class CallerScopeFilterTests
 {
@@ -21,19 +24,28 @@ public class CallerScopeFilterTests
         return AssemblyIdentityScanner.Scan(peReader);
     }
 
-    static bool CouldContainCallerOf(string targetAssemblyPath, string candidateAssemblyPath)
+    static CallerScopeFilter.Candidate Candidate(string assemblyPath)
     {
-        var candidate = Identity(candidateAssemblyPath);
-        return CallerScopeFilter.CouldContainCallerOf(
-            Identity(targetAssemblyPath).Name, candidate.Name, candidate.ReferenceNames);
+        var identity = Identity(assemblyPath);
+        return new(identity.Name, identity.ReferenceNames);
     }
+
+    /// <summary>Whether a single candidate survives selection for the given target.</summary>
+    static bool Selects(string? targetAssembly, CallerScopeFilter.Candidate candidate) =>
+        CallerScopeFilter.SelectCouldReach(targetAssembly, [candidate])[0];
+
+    static bool Selects(string? targetAssembly, string? name, IReadOnlyList<string>? references) =>
+        Selects(targetAssembly, new CallerScopeFilter.Candidate(name, references));
+
+    static bool SelectsFile(string targetAssemblyPath, string candidateAssemblyPath) =>
+        Selects(Identity(targetAssemblyPath).Name, Candidate(candidateAssemblyPath));
 
     // The real caller fixture references the target, so it must survive the filter and be opened.
     // This is the assembly BuildCallerTree_WithScope_* proves does contribute callers.
     [Fact]
     public void ReferencingAssemblyIsKept()
     {
-        Assert.True(CouldContainCallerOf(
+        Assert.True(SelectsFile(
             FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath(),
             FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath()));
     }
@@ -44,7 +56,7 @@ public class CallerScopeFilterTests
     [Fact]
     public void NonReferencingAssemblyIsRuledOut()
     {
-        Assert.False(CouldContainCallerOf(
+        Assert.False(SelectsFile(
             FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath(),
             FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath()));
     }
@@ -54,7 +66,7 @@ public class CallerScopeFilterTests
     public void TargetAssemblyItselfIsKept()
     {
         string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
-        Assert.True(CouldContainCallerOf(target, target));
+        Assert.True(SelectsFile(target, target));
     }
 
     // The facade case, and the reason the filter canonicalizes instead of comparing raw names.
@@ -67,15 +79,13 @@ public class CallerScopeFilterTests
     [InlineData("System.Runtime.Extensions")]
     public void CorelibFacadeReferenceIsKept(string facade)
     {
-        Assert.True(CallerScopeFilter.CouldContainCallerOf(
-            "System.Private.CoreLib", "Some.Consumer", [facade]));
+        Assert.True(Selects("System.Private.CoreLib", "Some.Consumer", [facade]));
     }
 
     [Fact]
     public void UnrelatedReferencesAreRuledOut()
     {
-        Assert.False(CallerScopeFilter.CouldContainCallerOf(
-            "Target", "Some.Consumer", ["System.Runtime", "Newtonsoft.Json"]));
+        Assert.False(Selects("Target", "Some.Consumer", ["System.Runtime", "Newtonsoft.Json"]));
     }
 
     // Undecidable inputs must fail open: a filter that cannot tell has to let the real matcher decide.
@@ -84,19 +94,164 @@ public class CallerScopeFilterTests
     [InlineData("")]
     public void UnknownTargetFailsOpen(string? target)
     {
-        Assert.True(CallerScopeFilter.CouldContainCallerOf(target, "Some.Consumer", ["Unrelated"]));
+        Assert.True(Selects(target, "Some.Consumer", ["Unrelated"]));
     }
 
     [Fact]
     public void UnknownCandidateReferencesFailOpen()
     {
-        Assert.True(CallerScopeFilter.CouldContainCallerOf("Target", "Some.Consumer", null));
+        Assert.True(Selects("Target", "Some.Consumer", null));
+    }
+
+    [Fact]
+    public void UnknownCandidateNameFailsOpen()
+    {
+        Assert.True(Selects("Target", null, ["Unrelated"]));
     }
 
     // A reference-free image (no AssemblyRef rows) that is not the target cannot call into it.
     [Fact]
     public void EmptyReferenceSetIsRuledOut()
     {
-        Assert.False(CallerScopeFilter.CouldContainCallerOf("Target", "Some.Consumer", ImmutableArray<string>.Empty));
+        Assert.False(Selects("Target", "Some.Consumer", ImmutableArray<string>.Empty));
+    }
+
+    // The defect a direct-reference test has: a caller graph walks outward several levels, so an
+    // assembly that names only an intermediate still appears in the tree. Ruling it out drops real
+    // callers and silently shortens the graph, which is a wrong answer rather than a slower one.
+    [Fact]
+    public void IndirectCallerIsKeptThroughIntermediate()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            new("Middle", ["Target"]),
+            new("Entry", ["Middle"]),
+        ];
+
+        Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach("Target", candidates));
+    }
+
+    // Closure order must not matter: the upstream assembly is listed before the intermediate that
+    // pulls it in, so a single forward pass would miss it.
+    [Fact]
+    public void ClosureIsOrderIndependent()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            new("Entry", ["Middle"]),
+            new("Middle", ["Target"]),
+        ];
+
+        Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach("Target", candidates));
+    }
+
+    // Depth beyond one intermediate, and a chain that never reaches the target stays out, so the
+    // closure is not simply selecting everything transitively connected to anything.
+    [Fact]
+    public void ClosureReachesArbitraryDepthAndStopsAtUnrelatedChains()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            new("L1", ["Target"]),
+            new("L2", ["L1"]),
+            new("L3", ["L2"]),
+            new("OtherA", ["OtherB"]),
+            new("OtherB", ["Newtonsoft.Json"]),
+        ];
+
+        Assert.Equal(
+            [true, true, true, false, false],
+            CallerScopeFilter.SelectCouldReach("Target", candidates));
+    }
+
+    // A reference cycle must terminate rather than spin, and both members join once either reaches.
+    [Fact]
+    public void ReferenceCycleTerminates()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            new("A", ["B", "Target"]),
+            new("B", ["A"]),
+        ];
+
+        Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach("Target", candidates));
+    }
+
+    // An unreadable candidate is kept, but its unknown name must not widen the closure: nothing may
+    // join merely by referencing an assembly whose identity the filter never established.
+    [Fact]
+    public void UnknownCandidateDoesNotWidenClosure()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            new(null, null),
+            new("Consumer", ["Newtonsoft.Json"]),
+        ];
+
+        Assert.Equal([true, false], CallerScopeFilter.SelectCouldReach("Target", candidates));
+    }
+
+    // Facade canonicalization has to hold at every level of the closure, not just the first hop.
+    [Fact]
+    public void ClosureCanonicalizesAtEveryLevel()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            new("Middle", ["System.Runtime"]),
+            new("Entry", ["Middle"]),
+        ];
+
+        Assert.Equal(
+            [true, true],
+            CallerScopeFilter.SelectCouldReach("System.Private.CoreLib", candidates));
+    }
+
+    [Fact]
+    public void UnknownTargetSelectsEveryCandidate()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            new("A", ["Newtonsoft.Json"]),
+            new("B", ImmutableArray<string>.Empty),
+        ];
+
+        Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach(null, candidates));
+    }
+
+    // The real-artifact form of the transitive obligation. The indirect fixture references only the
+    // caller assembly, so a direct-reference test rules it out even though it reaches the target in
+    // two hops. Asserting the absent reference keeps the fixture honest: if it ever gained a direct
+    // reference to the target this test would stop proving anything.
+    [Fact]
+    public void IndirectCallerAssemblyIsKept()
+    {
+        var target = Identity(FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath());
+        var caller = Candidate(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var indirect = Candidate(FixtureCatalog.AnalysisCallerGraphIndirectCaller.AssemblyPath());
+
+        Assert.DoesNotContain(target.Name, indirect.References!);
+        Assert.False(Selects(target.Name, indirect));
+        Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach(target.Name, [caller, indirect]));
+    }
+
+    // The real-artifact form of the boundary: adding an indirect caller must not drag in an
+    // assembly that reaches the target through nothing.
+    [Fact]
+    public void IndirectClosureStillRulesOutTheLookalike()
+    {
+        var target = Identity(FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath());
+        var caller = Candidate(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var indirect = Candidate(FixtureCatalog.AnalysisCallerGraphIndirectCaller.AssemblyPath());
+        var lookalike = Candidate(FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath());
+
+        Assert.Equal(
+            [true, true, false],
+            CallerScopeFilter.SelectCouldReach(target.Name, [caller, indirect, lookalike]));
+    }
+
+    [Fact]
+    public void EmptyCandidateListSelectsNothing()
+    {
+        Assert.Empty(CallerScopeFilter.SelectCouldReach("Target", []));
     }
 }

--- a/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
@@ -27,15 +27,24 @@ public class CallerScopeFilterTests
     static CallerScopeFilter.Candidate Candidate(string assemblyPath)
     {
         var identity = Identity(assemblyPath);
-        return new(identity.Name, identity.ReferenceNames);
+        return CallerScopeFilter.Candidate.Known(identity.Name, identity.ReferenceNames);
     }
+
+    /// <summary>A candidate from raw names, mapping null to the matching undecidable state.</summary>
+    static CallerScopeFilter.Candidate MakeCandidate(string? name, IReadOnlyList<string>? references)
+        => (name, references) switch
+        {
+            (null, _) => CallerScopeFilter.Candidate.Unknown(),
+            (not null, null) => CallerScopeFilter.Candidate.UnknownReferences(name),
+            _ => CallerScopeFilter.Candidate.Known(name, references),
+        };
 
     /// <summary>Whether a single candidate survives selection for the given target.</summary>
     static bool Selects(string? targetAssembly, CallerScopeFilter.Candidate candidate) =>
         CallerScopeFilter.SelectCouldReach(targetAssembly, [candidate])[0];
 
     static bool Selects(string? targetAssembly, string? name, IReadOnlyList<string>? references) =>
-        Selects(targetAssembly, new CallerScopeFilter.Candidate(name, references));
+        Selects(targetAssembly, MakeCandidate(name, references));
 
     static bool SelectsFile(string targetAssemblyPath, string candidateAssemblyPath) =>
         Selects(Identity(targetAssemblyPath).Name, Candidate(candidateAssemblyPath));
@@ -124,8 +133,8 @@ public class CallerScopeFilterTests
     {
         CallerScopeFilter.Candidate[] candidates =
         [
-            new("Middle", ["Target"]),
-            new("Entry", ["Middle"]),
+            CallerScopeFilter.Candidate.Known("Middle", ["Target"]),
+            CallerScopeFilter.Candidate.Known("Entry", ["Middle"]),
         ];
 
         Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach("Target", candidates));
@@ -138,8 +147,8 @@ public class CallerScopeFilterTests
     {
         CallerScopeFilter.Candidate[] candidates =
         [
-            new("Entry", ["Middle"]),
-            new("Middle", ["Target"]),
+            CallerScopeFilter.Candidate.Known("Entry", ["Middle"]),
+            CallerScopeFilter.Candidate.Known("Middle", ["Target"]),
         ];
 
         Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach("Target", candidates));
@@ -152,11 +161,11 @@ public class CallerScopeFilterTests
     {
         CallerScopeFilter.Candidate[] candidates =
         [
-            new("L1", ["Target"]),
-            new("L2", ["L1"]),
-            new("L3", ["L2"]),
-            new("OtherA", ["OtherB"]),
-            new("OtherB", ["Newtonsoft.Json"]),
+            CallerScopeFilter.Candidate.Known("L1", ["Target"]),
+            CallerScopeFilter.Candidate.Known("L2", ["L1"]),
+            CallerScopeFilter.Candidate.Known("L3", ["L2"]),
+            CallerScopeFilter.Candidate.Known("OtherA", ["OtherB"]),
+            CallerScopeFilter.Candidate.Known("OtherB", ["Newtonsoft.Json"]),
         ];
 
         Assert.Equal(
@@ -170,25 +179,73 @@ public class CallerScopeFilterTests
     {
         CallerScopeFilter.Candidate[] candidates =
         [
-            new("A", ["B", "Target"]),
-            new("B", ["A"]),
+            CallerScopeFilter.Candidate.Known("A", ["B", "Target"]),
+            CallerScopeFilter.Candidate.Known("B", ["A"]),
         ];
 
         Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach("Target", candidates));
     }
 
-    // An unreadable candidate is kept, but its unknown name must not widen the closure: nothing may
-    // join merely by referencing an assembly whose identity the filter never established.
+    // Round-4 review found the previous rule here was unsound. An unreadable candidate is still
+    // OPENED and can still contribute edges, so anything referencing it can be a caller-of-a-caller.
+    // Refusing to widen the closure cut those assemblies off and truncated the graph — reproduced
+    // end to end with a single-byte mutation that broke identity reading while body indexing still
+    // succeeded. An unnameable assembly could sit anywhere in the chain, so nothing above it can be
+    // ruled out and the whole scope has to be selected.
     [Fact]
-    public void UnknownCandidateDoesNotWidenClosure()
+    public void UnknownIdentityCandidateSelectsTheWholeScope()
     {
         CallerScopeFilter.Candidate[] candidates =
         [
-            new(null, null),
-            new("Consumer", ["Newtonsoft.Json"]),
+            CallerScopeFilter.Candidate.Unknown(),
+            CallerScopeFilter.Candidate.Known("Consumer", ["Newtonsoft.Json"]),
         ];
 
-        Assert.Equal([true, false], CallerScopeFilter.SelectCouldReach("Target", candidates));
+        Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach("Target", candidates));
+    }
+
+    // ...but an unopenable file could not have contributed edges under the old unfiltered walk
+    // either, so it must NOT drag the scope in with it. Otherwise a single stray native DLL in a
+    // --bin directory would defeat the whole optimization.
+    [Fact]
+    public void UnopenableCandidateDoesNotSelectTheScope()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            CallerScopeFilter.Candidate.Unopenable(),
+            CallerScopeFilter.Candidate.Known("Consumer", ["Newtonsoft.Json"]),
+        ];
+
+        Assert.Equal([false, false], CallerScopeFilter.SelectCouldReach("Target", candidates));
+    }
+
+    // The narrower half of the same defect: a candidate whose NAME was read but whose reference set
+    // was not. It must be selected (a dropped reference row could have been the target), and it must
+    // still publish its own name, or callers above it are cut off.
+    [Fact]
+    public void UnknownReferencesCandidateWidensTheClosureUnderItsOwnName()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            CallerScopeFilter.Candidate.UnknownReferences("Middle"),
+            CallerScopeFilter.Candidate.Known("Entry", ["Middle"]),
+        ];
+
+        Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach("Target", candidates));
+    }
+
+    // An unopenable candidate must not be selected even when the target is unknown, since it can
+    // contribute nothing at all.
+    [Fact]
+    public void UnknownTargetStillRulesOutUnopenableCandidates()
+    {
+        CallerScopeFilter.Candidate[] candidates =
+        [
+            CallerScopeFilter.Candidate.Known("A", ["Newtonsoft.Json"]),
+            CallerScopeFilter.Candidate.Unopenable(),
+        ];
+
+        Assert.Equal([true, false], CallerScopeFilter.SelectCouldReach(null, candidates));
     }
 
     // Facade canonicalization has to hold at every level of the closure, not just the first hop.
@@ -197,8 +254,8 @@ public class CallerScopeFilterTests
     {
         CallerScopeFilter.Candidate[] candidates =
         [
-            new("Middle", ["System.Runtime"]),
-            new("Entry", ["Middle"]),
+            CallerScopeFilter.Candidate.Known("Middle", ["System.Runtime"]),
+            CallerScopeFilter.Candidate.Known("Entry", ["Middle"]),
         ];
 
         Assert.Equal(
@@ -211,8 +268,8 @@ public class CallerScopeFilterTests
     {
         CallerScopeFilter.Candidate[] candidates =
         [
-            new("A", ["Newtonsoft.Json"]),
-            new("B", ImmutableArray<string>.Empty),
+            CallerScopeFilter.Candidate.Known("A", ["Newtonsoft.Json"]),
+            CallerScopeFilter.Candidate.Known("B", ImmutableArray<string>.Empty),
         ];
 
         Assert.Equal([true, true], CallerScopeFilter.SelectCouldReach(null, candidates));

--- a/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeFilterTests.cs
@@ -333,15 +333,46 @@ public class CallerScopeFilterTests
                 + "which indicates the walk revisits an adjacency entry per sharer");
     }
 
-    // A candidate whose own name is also one of its references, and a candidate naming the same
-    // reference twice, are both indexed once per name. Nothing above depends on the count, so this
-    // pins the dedupe directly rather than through an observable it cannot reach.
+    // An assembly may name the same reference more than once, and its own name may repeat a
+    // reference. Selection must be correct either way.
     [Fact]
-    public void RepeatedNamesIndexACandidateOnce()
+    public void RepeatedNamesSelectTheSameAsDistinctOnes()
     {
         Assert.True(Selects("Target", "Target", ["Target", "Target"]));
         Assert.True(Selects("Target", "Self", ["Self", "Target", "Target"]));
         Assert.False(Selects("Target", "Self", ["Self", "Self"]));
+    }
+
+    // Round-6 review: the previous version of this test asserted only the selection results above,
+    // which hold with or without the dedupe in Index — it survived its own mutation and pinned
+    // nothing. Deduping is invisible in the ANSWER; it is visible in the FOOTPRINT, which is the
+    // binding constraint for the interactive consumer this change exists to serve.
+    //
+    // A candidate whose reference list is entirely duplicates indexes one entry rather than one
+    // per row: measured at 592 bytes flat with the dedupe against ~1 MB at 100k rows and ~8.4 MB
+    // at 1M rows without it. The bound below sits three orders of magnitude above the former and
+    // an order of magnitude below the latter, so it discriminates without being a tight
+    // measurement.
+    [Fact]
+    public void RepeatedReferencesDoNotGrowTheIndex()
+    {
+        const int references = 100_000;
+        var duplicates = new string[references];
+        Array.Fill(duplicates, "Target");
+        var candidates = new[] { CallerScopeFilter.Candidate.Known("Dup", duplicates) };
+
+        // Warm up so first-call JIT and canonicalization caches are not attributed to the walk.
+        CallerScopeFilter.SelectCouldReach("Target", candidates);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        var selected = CallerScopeFilter.SelectCouldReach("Target", candidates);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(selected[0]);
+        Assert.True(
+            allocated < 64 * 1024,
+            $"selection over a candidate with {references} duplicate references allocated "
+                + $"{allocated} bytes, which indicates the reverse index grows with duplicate rows");
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTarget\ILInspector.Analysis.CallerGraphTarget.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCaller\ILInspector.Analysis.CallerGraphCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCallerTwin\ILInspector.Analysis.CallerGraphCallerTwin.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Analysis.CallerGraphIndirectCaller\ILInspector.Analysis.CallerGraphIndirectCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphLookalikeCaller\ILInspector.Analysis.CallerGraphLookalikeCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffAsmFixtures.Target\DiffAsmFixtures.Target.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffAsmFixtures.Caller\DiffAsmFixtures.Caller.csproj" ReferenceOutputAssembly="false" />

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -343,6 +343,72 @@ public class LibraryBodyIndexTests
             => node.Perf?.Source == source || node.Children.Any(child => HasSource(child, source));
     }
 
+    // #3331: the scoped and unscoped builders key the reverse graph differently (structural member
+    // identity vs assembly-local tokens) and do not produce the same tree. Prefiltering scope
+    // assemblies on assembly identity therefore must not be allowed to decide which builder runs,
+    // or narrowing a scope to nothing would silently change the answer instead of just costing
+    // less. An empty-but-supplied scope list means "cross-assembly walk requested, nothing
+    // survived"; only a null list means "no scope requested".
+    //
+    // The scan is deliberately self-locating rather than pinned to one method: it asserts the
+    // correctness claim on every method it visits, and separately requires that at least one of
+    // them distinguishes the two builders, so the test cannot quietly become vacuous if the call
+    // structure of this assembly changes.
+    [Fact]
+    public void BuildCallerTree_PrefilteringScopeAssembliesNeverChangesTheTree()
+    {
+        var index = LibraryBodyIndex.Open(typeof(LibraryBodyIndex).Assembly.Location);
+
+        // A fixture that does not reference the analysis assembly, so it can never contribute a
+        // caller. Opening it and prefiltering it away must be indistinguishable.
+        var nonContributing = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath());
+
+        int discriminating = 0;
+        int visited = 0;
+        foreach (var method in index.Methods.Take(60))
+        {
+            var noScopeRequested = FlattenCallTree(index.BuildCallerTree(method.MetadataToken, callerScopes: null, maxDepth: 2, maxNodes: 50));
+            var scopeOpened = FlattenCallTree(index.BuildCallerTree(method.MetadataToken, new[] { nonContributing }, maxDepth: 2, maxNodes: 50));
+            var scopePrefilteredAway = FlattenCallTree(index.BuildCallerTree(method.MetadataToken, Array.Empty<LibraryBodyIndex>(), maxDepth: 2, maxNodes: 50));
+
+            Assert.Equal(scopeOpened, scopePrefilteredAway);
+
+            visited++;
+            if (!noScopeRequested.SequenceEqual(scopePrefilteredAway))
+                discriminating++;
+        }
+
+        Assert.True(visited > 0, "expected to visit methods");
+        Assert.True(
+            discriminating > 0,
+            "no method distinguished the scoped builder from the unscoped one, so this test proves nothing; "
+                + "if the two builders have genuinely converged, the null/empty scope distinction can be removed");
+    }
+
+    // #3331: the same claim against the cross-assembly fixtures the matcher tests use — an assembly
+    // that cannot reference the target contributes no edges, so skipping it before opening it must
+    // produce an identical tree.
+    [Fact]
+    public void BuildCallerTree_SkippingANonContributingScopeAssemblyDoesNotChangeTheTree()
+    {
+        var targetIndex = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath());
+        var caller = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        var lookalike = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath());
+        var ping = targetIndex.Methods.First(method => method.Name == "Ping");
+
+        var unfiltered = targetIndex.BuildCallerTree(ping.MetadataToken, new[] { caller, lookalike }, maxDepth: 2, maxNodes: 50);
+        var prefiltered = targetIndex.BuildCallerTree(ping.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50);
+
+        Assert.Equal(FlattenCallTree(unfiltered), FlattenCallTree(prefiltered));
+
+        // And when the prefilter removes every scope assembly, the result must still match the walk
+        // that opened them all and found nothing.
+        var onlyNonContributing = targetIndex.BuildCallerTree(ping.MetadataToken, new[] { lookalike }, maxDepth: 2, maxNodes: 50);
+        var allFilteredOut = targetIndex.BuildCallerTree(ping.MetadataToken, Array.Empty<LibraryBodyIndex>(), maxDepth: 2, maxNodes: 50);
+
+        Assert.Equal(FlattenCallTree(onlyNonContributing), FlattenCallTree(allFilteredOut));
+    }
+
     [Fact]
     public void BuildCallerTree_WithScope_OmitsCallersOfSameNameMemberInAnotherAssembly()
     {

--- a/src/ILInspector.Analysis/CallerScopeFilter.cs
+++ b/src/ILInspector.Analysis/CallerScopeFilter.cs
@@ -152,7 +152,14 @@ public static class CallerScopeFilter
 
         while (pending.Count > 0)
         {
-            if (!referrers.TryGetValue(pending.Dequeue(), out var mentioning))
+            // Removing the entry is what keeps the walk linear. Once a name has been processed
+            // every candidate mentioning it is selected, so a second visit could never select
+            // anything new — but it would still re-traverse the whole adjacency list. Candidates
+            // sharing a canonical name (facades, or the same assembly copied into several
+            // subdirectories) each re-enqueue that shared name on selection, so leaving the entry
+            // in place costs one traversal per sharer: quadratic in the size of the largest
+            // same-named group.
+            if (!referrers.Remove(pending.Dequeue(), out var mentioning))
                 continue;
 
             foreach (int i in mentioning)

--- a/src/ILInspector.Analysis/CallerScopeFilter.cs
+++ b/src/ILInspector.Analysis/CallerScopeFilter.cs
@@ -23,27 +23,71 @@ namespace ILInspector.Analysis;
 /// silently shortens the tree. Selection is therefore the reverse-reference closure: the target,
 /// then everything referencing it, then everything referencing those, to a fixpoint.</para>
 ///
+/// <para><b>Selection and reachability are the same question.</b> Anything selected will be opened
+/// and may contribute edges, so it must also widen the closure — otherwise the assemblies above it
+/// are cut off and the graph is silently truncated. That is why a candidate whose references cannot
+/// be read still publishes its own name, and why a candidate whose <em>name</em> cannot be read
+/// forces every candidate to be selected: an unnameable assembly could sit anywhere in the chain
+/// and nothing above it could be ruled out soundly.</para>
+///
 /// Wider type forwarding (a candidate reaching the target only through an unrelated facade) is not
 /// modelled here, and does not need to be: the matcher already misses those callers, so this filter
 /// stays exactly as permissive as the behavior it guards.
 /// </summary>
 public static class CallerScopeFilter
 {
-    /// <summary>
-    /// The identity of one caller-scope candidate. <see cref="Name"/> or <see cref="References"/>
-    /// being <see langword="null"/> means the identity could not be read, which is undecidable and
-    /// so is always selected.
-    /// </summary>
-    public readonly record struct Candidate(string? Name, IReadOnlyList<string>? References);
+    /// <summary>How much of a candidate's identity could be read.</summary>
+    public enum CandidateIdentity
+    {
+        /// <summary>Name and full reference set were read. Fully decidable.</summary>
+        Known,
+
+        /// <summary>
+        /// The name was read but the reference set is incomplete. The candidate is always selected,
+        /// because a reference that could not be read might have been the one naming the target,
+        /// and it still widens the closure under its own name.
+        /// </summary>
+        UnknownReferences,
+
+        /// <summary>
+        /// Nothing usable was read from an image that may still open for analysis. Nothing above
+        /// such a candidate can be ruled out, so its presence selects the entire scope.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// The image cannot be opened for caller analysis at all, so it can neither contribute
+        /// edges nor carry the relation. Ruling it out here matches what opening it would produce.
+        /// </summary>
+        Unopenable,
+    }
+
+    /// <summary>The identity of one caller-scope candidate.</summary>
+    public readonly record struct Candidate(
+        CandidateIdentity Kind,
+        string? Name,
+        IReadOnlyList<string>? References)
+    {
+        public static Candidate Known(string name, IReadOnlyList<string> references) =>
+            new(CandidateIdentity.Known, name, references);
+
+        public static Candidate UnknownReferences(string name) =>
+            new(CandidateIdentity.UnknownReferences, name, null);
+
+        public static Candidate Unknown() => new(CandidateIdentity.Unknown, null, null);
+
+        public static Candidate Unopenable() => new(CandidateIdentity.Unopenable, null, null);
+    }
 
     /// <summary>
     /// Selects the candidates that could contribute to the caller graph of a member defined in
     /// <paramref name="targetAssembly"/>, by reverse-reference closure. Returns one flag per
     /// candidate, in order.
     ///
-    /// Every candidate is selected when the target assembly is unknown, and an individual candidate
-    /// whose identity could not be read is always selected, so an undecidable case never silently
-    /// narrows discovery.
+    /// Runs in time linear in the number of candidates plus the number of references across them.
+    /// That bound is the point: a scope is user-supplied and can be an arbitrary directory, so a
+    /// filter whose cost grows with the shape of the reference graph could cost more than the
+    /// analysis it is meant to avoid.
     /// </summary>
     public static bool[] SelectCouldReach(
         string? targetAssembly,
@@ -54,84 +98,90 @@ public static class CallerScopeFilter
         var selected = new bool[candidates.Count];
         if (string.IsNullOrEmpty(targetAssembly))
         {
-            Array.Fill(selected, true);
+            SelectAllOpenable(candidates, selected);
             return selected;
         }
 
-        // Assemblies already known to be called into, starting with the target itself. A candidate
-        // joins once it names anything in here, and then its own name joins too, which is what
-        // carries the relation outward one level at a time.
-        var reached = new HashSet<string>(StringComparer.Ordinal)
-        {
-            TypeRef.CanonicalAssembly(targetAssembly),
-        };
+        // Reverse adjacency: canonical name -> the candidates that mention it, either as their own
+        // identity or as a reference. Built once, so each reference is canonicalized exactly once.
+        var referrers = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+        var ownNames = new string?[candidates.Count];
+        var pending = new Queue<string>();
+        pending.Enqueue(TypeRef.CanonicalAssembly(targetAssembly));
 
-        bool grew = true;
-        while (grew)
+        for (int i = 0; i < candidates.Count; i++)
         {
-            grew = false;
-            for (int i = 0; i < candidates.Count; i++)
+            var candidate = candidates[i];
+            switch (candidate.Kind)
+            {
+                case CandidateIdentity.Unopenable:
+                    continue;
+
+                case CandidateIdentity.Unknown:
+                    // Undecidable at the identity level, and undecidable for everything above it.
+                    SelectAllOpenable(candidates, selected);
+                    return selected;
+
+                case CandidateIdentity.UnknownReferences when candidate.Name is not null:
+                    // Might reference anything, so select it now; its own name still carries the
+                    // relation onward to whoever references it.
+                    ownNames[i] = TypeRef.CanonicalAssembly(candidate.Name);
+                    selected[i] = true;
+                    pending.Enqueue(ownNames[i]!);
+                    Index(referrers, ownNames[i]!, i);
+                    continue;
+
+                case CandidateIdentity.Known when candidate.Name is not null
+                                              && candidate.References is not null:
+                    ownNames[i] = TypeRef.CanonicalAssembly(candidate.Name);
+                    Index(referrers, ownNames[i]!, i);
+                    foreach (string reference in candidate.References)
+                    {
+                        if (!string.IsNullOrEmpty(reference))
+                            Index(referrers, TypeRef.CanonicalAssembly(reference), i);
+                    }
+
+                    continue;
+
+                default:
+                    // A malformed candidate is undecidable, and is treated as such.
+                    SelectAllOpenable(candidates, selected);
+                    return selected;
+            }
+        }
+
+        while (pending.Count > 0)
+        {
+            if (!referrers.TryGetValue(pending.Dequeue(), out var mentioning))
+                continue;
+
+            foreach (int i in mentioning)
             {
                 if (selected[i])
                     continue;
 
-                var candidate = candidates[i];
-                if (candidate.Name is null || candidate.References is null)
-                {
-                    // Undecidable: keep it, but an unknown name cannot widen the closure.
-                    selected[i] = true;
-                    grew = true;
-                    continue;
-                }
-
-                bool names = false;
-                foreach (string reachedName in reached)
-                {
-                    if (NamesAssembly(reachedName, candidate.Name, candidate.References))
-                    {
-                        names = true;
-                        break;
-                    }
-                }
-
-                if (!names)
-                    continue;
-
                 selected[i] = true;
-                grew = true;
-                reached.Add(TypeRef.CanonicalAssembly(candidate.Name));
+                if (ownNames[i] is { } own)
+                    pending.Enqueue(own);
             }
         }
 
         return selected;
     }
 
-    static bool NamesAssembly(
-        string canonicalName,
-        string? candidateAssembly,
-        IEnumerable<string>? candidateReferences)
+    static void SelectAllOpenable(IReadOnlyList<Candidate> candidates, bool[] selected)
     {
-        if (!string.IsNullOrEmpty(candidateAssembly)
-            && string.Equals(
-                TypeRef.CanonicalAssembly(candidateAssembly), canonicalName, StringComparison.Ordinal))
-        {
-            return true;
-        }
+        for (int i = 0; i < candidates.Count; i++)
+            selected[i] = candidates[i].Kind != CandidateIdentity.Unopenable;
+    }
 
-        if (candidateReferences is null)
-            return true;
+    static void Index(Dictionary<string, List<int>> referrers, string name, int index)
+    {
+        if (!referrers.TryGetValue(name, out var mentioning))
+            referrers[name] = mentioning = [];
 
-        foreach (string reference in candidateReferences)
-        {
-            if (string.IsNullOrEmpty(reference))
-                continue;
-            if (string.Equals(
-                TypeRef.CanonicalAssembly(reference), canonicalName, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        // References are walked in order per candidate, so a duplicate can only be the last entry.
+        if (mentioning.Count == 0 || mentioning[^1] != index)
+            mentioning.Add(index);
     }
 }

--- a/src/ILInspector.Analysis/CallerScopeFilter.cs
+++ b/src/ILInspector.Analysis/CallerScopeFilter.cs
@@ -1,8 +1,8 @@
 namespace ILInspector.Analysis;
 
 /// <summary>
-/// Whether an assembly could contain a cross-assembly caller of a member defined in some target
-/// assembly, decided from assembly identity alone.
+/// Which assemblies in a caller scope could contribute to the caller graph of a member defined in
+/// some target assembly, decided from assembly identity alone.
 ///
 /// This exists so caller discovery can rule an assembly out before paying to decode its method
 /// bodies. It is deliberately the same identity test the matcher applies, expressed over names
@@ -10,12 +10,18 @@ namespace ILInspector.Analysis;
 /// candidate callee's declaring <see cref="TypeRef"/> to the target's, and <see cref="TypeRef"/>
 /// equality includes <see cref="TypeRef.Assembly"/>, which is canonicalized on construction. A
 /// callee's declaring assembly can therefore only be the candidate's own assembly or one of its
-/// assembly references, so an assembly naming neither cannot produce a match.
+/// assembly references, so an assembly naming neither cannot call into the target.
 ///
 /// The canonicalization is what makes this safe across the corelib facades: a candidate that
 /// references <c>System.Runtime</c> is kept for a target defined in <c>System.Private.CoreLib</c>,
 /// because both canonicalize to the same identity. Skipping such a candidate would drop callers the
 /// matcher would have matched.
+///
+/// <para><b>The relation is transitive.</b> A caller <em>graph</em> walks outward from the target
+/// through several levels, so an assembly that never names the target can still appear in it by
+/// calling something that does. Testing a direct reference alone drops those upstream callers and
+/// silently shortens the tree. Selection is therefore the reverse-reference closure: the target,
+/// then everything referencing it, then everything referencing those, to a fixpoint.</para>
 ///
 /// Wider type forwarding (a candidate reaching the target only through an unrelated facade) is not
 /// modelled here, and does not need to be: the matcher already misses those callers, so this filter
@@ -24,23 +30,90 @@ namespace ILInspector.Analysis;
 public static class CallerScopeFilter
 {
     /// <summary>
-    /// Whether <paramref name="candidateAssembly"/> — declaring the references in
-    /// <paramref name="candidateReferences"/> — could contain a caller of a member defined in
-    /// <paramref name="targetAssembly"/>. Returns <see langword="true"/> when the target assembly is
-    /// unknown, so an undecidable case never silently narrows discovery.
+    /// The identity of one caller-scope candidate. <see cref="Name"/> or <see cref="References"/>
+    /// being <see langword="null"/> means the identity could not be read, which is undecidable and
+    /// so is always selected.
     /// </summary>
-    public static bool CouldContainCallerOf(
+    public readonly record struct Candidate(string? Name, IReadOnlyList<string>? References);
+
+    /// <summary>
+    /// Selects the candidates that could contribute to the caller graph of a member defined in
+    /// <paramref name="targetAssembly"/>, by reverse-reference closure. Returns one flag per
+    /// candidate, in order.
+    ///
+    /// Every candidate is selected when the target assembly is unknown, and an individual candidate
+    /// whose identity could not be read is always selected, so an undecidable case never silently
+    /// narrows discovery.
+    /// </summary>
+    public static bool[] SelectCouldReach(
         string? targetAssembly,
+        IReadOnlyList<Candidate> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        var selected = new bool[candidates.Count];
+        if (string.IsNullOrEmpty(targetAssembly))
+        {
+            Array.Fill(selected, true);
+            return selected;
+        }
+
+        // Assemblies already known to be called into, starting with the target itself. A candidate
+        // joins once it names anything in here, and then its own name joins too, which is what
+        // carries the relation outward one level at a time.
+        var reached = new HashSet<string>(StringComparer.Ordinal)
+        {
+            TypeRef.CanonicalAssembly(targetAssembly),
+        };
+
+        bool grew = true;
+        while (grew)
+        {
+            grew = false;
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                if (selected[i])
+                    continue;
+
+                var candidate = candidates[i];
+                if (candidate.Name is null || candidate.References is null)
+                {
+                    // Undecidable: keep it, but an unknown name cannot widen the closure.
+                    selected[i] = true;
+                    grew = true;
+                    continue;
+                }
+
+                bool names = false;
+                foreach (string reachedName in reached)
+                {
+                    if (NamesAssembly(reachedName, candidate.Name, candidate.References))
+                    {
+                        names = true;
+                        break;
+                    }
+                }
+
+                if (!names)
+                    continue;
+
+                selected[i] = true;
+                grew = true;
+                reached.Add(TypeRef.CanonicalAssembly(candidate.Name));
+            }
+        }
+
+        return selected;
+    }
+
+    static bool NamesAssembly(
+        string canonicalName,
         string? candidateAssembly,
         IEnumerable<string>? candidateReferences)
     {
-        if (string.IsNullOrEmpty(targetAssembly))
-            return true;
-
-        string target = TypeRef.CanonicalAssembly(targetAssembly);
-
         if (!string.IsNullOrEmpty(candidateAssembly)
-            && string.Equals(TypeRef.CanonicalAssembly(candidateAssembly), target, StringComparison.Ordinal))
+            && string.Equals(
+                TypeRef.CanonicalAssembly(candidateAssembly), canonicalName, StringComparison.Ordinal))
         {
             return true;
         }
@@ -52,8 +125,11 @@ public static class CallerScopeFilter
         {
             if (string.IsNullOrEmpty(reference))
                 continue;
-            if (string.Equals(TypeRef.CanonicalAssembly(reference), target, StringComparison.Ordinal))
+            if (string.Equals(
+                TypeRef.CanonicalAssembly(reference), canonicalName, StringComparison.Ordinal))
+            {
                 return true;
+            }
         }
 
         return false;

--- a/src/ILInspector.Analysis/CallerScopeFilter.cs
+++ b/src/ILInspector.Analysis/CallerScopeFilter.cs
@@ -1,0 +1,61 @@
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Whether an assembly could contain a cross-assembly caller of a member defined in some target
+/// assembly, decided from assembly identity alone.
+///
+/// This exists so caller discovery can rule an assembly out before paying to decode its method
+/// bodies. It is deliberately the same identity test the matcher applies, expressed over names
+/// instead of over decoded types: <see cref="MemberPattern.MatchesCrossAssembly"/> compares the
+/// candidate callee's declaring <see cref="TypeRef"/> to the target's, and <see cref="TypeRef"/>
+/// equality includes <see cref="TypeRef.Assembly"/>, which is canonicalized on construction. A
+/// callee's declaring assembly can therefore only be the candidate's own assembly or one of its
+/// assembly references, so an assembly naming neither cannot produce a match.
+///
+/// The canonicalization is what makes this safe across the corelib facades: a candidate that
+/// references <c>System.Runtime</c> is kept for a target defined in <c>System.Private.CoreLib</c>,
+/// because both canonicalize to the same identity. Skipping such a candidate would drop callers the
+/// matcher would have matched.
+///
+/// Wider type forwarding (a candidate reaching the target only through an unrelated facade) is not
+/// modelled here, and does not need to be: the matcher already misses those callers, so this filter
+/// stays exactly as permissive as the behavior it guards.
+/// </summary>
+public static class CallerScopeFilter
+{
+    /// <summary>
+    /// Whether <paramref name="candidateAssembly"/> — declaring the references in
+    /// <paramref name="candidateReferences"/> — could contain a caller of a member defined in
+    /// <paramref name="targetAssembly"/>. Returns <see langword="true"/> when the target assembly is
+    /// unknown, so an undecidable case never silently narrows discovery.
+    /// </summary>
+    public static bool CouldContainCallerOf(
+        string? targetAssembly,
+        string? candidateAssembly,
+        IEnumerable<string>? candidateReferences)
+    {
+        if (string.IsNullOrEmpty(targetAssembly))
+            return true;
+
+        string target = TypeRef.CanonicalAssembly(targetAssembly);
+
+        if (!string.IsNullOrEmpty(candidateAssembly)
+            && string.Equals(TypeRef.CanonicalAssembly(candidateAssembly), target, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (candidateReferences is null)
+            return true;
+
+        foreach (string reference in candidateReferences)
+        {
+            if (string.IsNullOrEmpty(reference))
+                continue;
+            if (string.Equals(TypeRef.CanonicalAssembly(reference), target, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -6486,7 +6486,3 @@ public sealed class LibraryBodyIndex
                 or ArgumentOutOfRangeException or IndexOutOfRangeException;
     }
 }
-
-
-
-

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1517,12 +1517,18 @@ public sealed class LibraryBodyIndex
     /// <c>--caller-package</c> scope). The graph is keyed by structural member identity rather
     /// than assembly-local tokens, so a dependency member can surface the product entry points
     /// and callers that reach it. Nodes from an assembly other than the selected member's own
-    /// carry their source assembly in <see cref="CallTreePerf.Source"/>. Falls back to the
-    /// single-assembly builder when no scopes are supplied.
+    /// carry their source assembly in <see cref="CallTreePerf.Source"/>.
+    ///
+    /// <paramref name="callerScopes"/> distinguishes "no cross-assembly scope was requested"
+    /// (<see langword="null"/>, which falls back to the single-assembly token-keyed builder) from
+    /// "a scope was requested but contributed no additional assemblies" (an empty list, which still
+    /// takes the structural walk). The two builders key the reverse graph differently and do not
+    /// produce identical trees, so the choice must follow what the user asked for and never the
+    /// incidental number of assemblies that survived scope filtering.
     /// </summary>
-    public CallTreeNode BuildCallerTree(int rootMethodToken, IReadOnlyList<LibraryBodyIndex> callerScopes, int maxDepth = 3, int maxNodes = 25)
+    public CallTreeNode BuildCallerTree(int rootMethodToken, IReadOnlyList<LibraryBodyIndex>? callerScopes, int maxDepth = 3, int maxNodes = 25)
     {
-        if (callerScopes is not { Count: > 0 })
+        if (callerScopes is null)
             return BuildCallerTree(rootMethodToken, maxDepth, maxNodes);
 
         var rootIdentity = Methods.FirstOrDefault(method => method.MetadataToken == rootMethodToken);
@@ -6480,3 +6486,7 @@ public sealed class LibraryBodyIndex
                 or ArgumentOutOfRangeException or IndexOutOfRangeException;
     }
 }
+
+
+
+

--- a/src/ILInspector.Metadata/AssemblyIdentityScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyIdentityScanner.cs
@@ -8,8 +8,16 @@ namespace ILInspector.Metadata;
 /// The simple assembly names an image publishes for itself and for every assembly it references.
 /// Names only: no version, culture, or public-key token, because the consumers of this facet decide
 /// reachability by simple name.
+///
+/// <paramref name="ReferencesComplete"/> is <see langword="false"/> when a row of the
+/// <c>AssemblyRef</c> table could not be read. The names that were read are still returned, but a
+/// consumer deciding reachability must treat the set as unknown rather than absent — a dropped row
+/// could have been the one that mattered.
 /// </summary>
-public sealed record AssemblyIdentityNames(string Name, ImmutableArray<string> ReferenceNames);
+public sealed record AssemblyIdentityNames(
+    string Name,
+    ImmutableArray<string> ReferenceNames,
+    bool ReferencesComplete = true);
 
 /// <summary>
 /// Reads only the <c>Assembly</c> and <c>AssemblyRef</c> tables. This is the cheapest question that
@@ -26,10 +34,23 @@ public static class AssemblyIdentityScanner
             ? reader.GetString(reader.GetAssemblyDefinition().Name)
             : string.Empty;
 
+        // A malformed row must not discard the identity that was read successfully. Reporting the
+        // name with an incomplete reference set lets a consumer keep the assembly under
+        // consideration on its own terms instead of losing it entirely.
         var references = ImmutableArray.CreateBuilder<string>(reader.AssemblyReferences.Count);
+        bool complete = true;
         foreach (var handle in reader.AssemblyReferences)
-            references.Add(reader.GetString(reader.GetAssemblyReference(handle).Name));
+        {
+            try
+            {
+                references.Add(reader.GetString(reader.GetAssemblyReference(handle).Name));
+            }
+            catch (BadImageFormatException)
+            {
+                complete = false;
+            }
+        }
 
-        return new AssemblyIdentityNames(name, references.ToImmutable());
+        return new AssemblyIdentityNames(name, references.ToImmutable(), complete);
     }
 }

--- a/src/ILInspector.Metadata/AssemblyIdentityScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyIdentityScanner.cs
@@ -1,0 +1,35 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// The simple assembly names an image publishes for itself and for every assembly it references.
+/// Names only: no version, culture, or public-key token, because the consumers of this facet decide
+/// reachability by simple name.
+/// </summary>
+public sealed record AssemblyIdentityNames(string Name, ImmutableArray<string> ReferenceNames);
+
+/// <summary>
+/// Reads only the <c>Assembly</c> and <c>AssemblyRef</c> tables. This is the cheapest question that
+/// can be asked of an image — no method bodies, no signatures, no public-key token derivation — so
+/// it suits callers that need to decide whether a fuller, far more expensive analysis of the image
+/// is worth starting at all.
+/// </summary>
+public static class AssemblyIdentityScanner
+{
+    public static AssemblyIdentityNames Scan(PEReader peReader)
+    {
+        var reader = peReader.GetMetadataReader();
+        string name = reader.IsAssembly
+            ? reader.GetString(reader.GetAssemblyDefinition().Name)
+            : string.Empty;
+
+        var references = ImmutableArray.CreateBuilder<string>(reader.AssemblyReferences.Count);
+        foreach (var handle in reader.AssemblyReferences)
+            references.Add(reader.GetString(reader.GetAssemblyReference(handle).Name));
+
+        return new AssemblyIdentityNames(name, references.ToImmutable());
+    }
+}

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -44,6 +44,15 @@ public sealed class AssemblyInspectionSession : IDisposable
     public AssemblyInfo AssemblyInfo(bool includeReferences = false)
         => AssemblyInspector.ExtractAssemblyInfo(_image.PEReader, includeReferences);
 
+    /// <summary>
+    /// The image's own simple assembly name and the simple names of its assembly references,
+    /// read from the <c>Assembly</c> and <c>AssemblyRef</c> tables alone. Use this in preference to
+    /// <see cref="AssemblyInfo"/> when only reachability by name is needed: it decodes no
+    /// signatures and derives no public-key tokens.
+    /// </summary>
+    public AssemblyIdentityNames IdentityNames()
+        => AssemblyIdentityScanner.Scan(_image.PEReader);
+
     /// <summary>The public (or, with <paramref name="includeAll"/>, full) API surface.</summary>
     public ApiSurface ApiSurface(bool includeAll = false, bool typesOnly = false)
         => ApiSurfaceExtractor.Extract(_image.PEReader, includeAll, typesOnly);

--- a/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
+++ b/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
@@ -234,6 +234,29 @@ public class ApiMemberAnalysisInspectionTests
         }
     }
 
+    // Round-8 review (Gemini): the routing flag must not be set by a candidate this walk opens
+    // itself. Classification could not decide this path, so it is SELECTED, so the open below
+    // settles whether the scope really had a session — and when that open fails, the unfiltered
+    // walk also ended with an empty opened list and took the token builder. Deriving the flag from
+    // every candidate rather than only the ruled-out ones routed this to the structural builder
+    // instead and printed a different tree for the same request.
+    //
+    // The path carries an embedded null, so File.OpenRead throws ArgumentException — outside the
+    // BadImageFormatException/IOException/UnauthorizedAccessException set that means "definitely
+    // unopenable". It therefore classifies as undecidable, which is the whole point: an
+    // undecidable candidate must not be treated as evidence that the scope was openable, because
+    // this walk goes on to open it and find out.
+    [Fact]
+    public void CallerScopes_WhenTheOnlySelectedScopeEntryFailsToOpen_SelectsTheSameAssemblyBuilder()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        string undecidable = "scope\0entry.dll";
+
+        var scopes = Create(target, [undecidable]).CallerScopes(includeAllocations: true);
+
+        Assert.Null(scopes);
+    }
+
     static IReadOnlyList<string> ReferenceNames(string assemblyPath)
     {
         using var stream = File.OpenRead(assemblyPath);

--- a/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
+++ b/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
@@ -73,21 +73,21 @@ public class ApiMemberAnalysisInspectionTests
         Assert.Single(scopes);
     }
 
-    // Round-2 review found that the previous "would the unfiltered walk have opened it?" rule was
-    // not decidable: an image whose Assembly/AssemblyRef tables read cleanly (so the prefilter can
-    // rule it out) can still throw when its bodies are indexed. Reproduced with single-byte
-    // mutations of a real assembly — 8 of 3000 produced exactly that. Openability therefore cannot
-    // drive the choice, so a scoped request gets the cross-assembly builder even when nothing in
-    // the scope can be opened at all.
+    // Round-2 review found that "would the unfiltered walk have opened it?" is not decidable in
+    // general: an image whose Assembly/AssemblyRef tables read cleanly can still throw when its
+    // bodies are indexed. Reproduced with single-byte mutations of a real assembly — 8 of 3000
+    // produced exactly that. But the weaker question this routing needs — could ANY scope entry be
+    // opened at all — is decidable, and it is the question the unfiltered walk effectively asked:
+    // it routed on whether its opened list came back empty. A scope whose every entry is
+    // unopenable produced an empty list and took the token-keyed builder, so this must too.
     [Fact]
-    public void CallerScopes_WhenNoScopeAssemblyCanBeOpened_StillSelectsTheCrossAssemblyBuilder()
+    public void CallerScopes_WhenNoScopeEntryIsOpenable_SelectsTheSameAssemblyBuilder()
     {
         string missing = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.dll");
 
         var scopes = Create(SelfPath, [missing]).CallerScopes(includeAllocations: false);
 
-        Assert.NotNull(scopes);
-        Assert.Empty(scopes);
+        Assert.Null(scopes);
     }
 
     // The two lenses are cached independently and must decide identically.
@@ -106,17 +106,34 @@ public class ApiMemberAnalysisInspectionTests
         Assert.Same(graph, inspection.CallerScopes(includeAllocations: true));
     }
 
-    // A file with no managed metadata must fail open rather than be ruled out: --bin enumerates
-    // every top-level *.dll with no managed-image filter, so ruling it out here would only
-    // duplicate the catch around MethodBodyInspectionSession.Open. Either way the scope yields
-    // nothing, and the request was still scoped.
+    // A scope holding only a native image yields nothing either way, but it must yield nothing the
+    // same way the unfiltered walk did. --bin enumerates every top-level *.dll with no managed-image
+    // filter, so this is an ordinary input, not a corner: pointing --bin at a native runtime
+    // directory hits it. The unfiltered walk failed to open the native image, ended with an empty
+    // opened list, and took the token-keyed builder. Round 7 caught this routing to the structural
+    // builder instead and printing a different tree (62 lines against 60) for the same request.
     [Fact]
-    public void CallerScopes_WhenTheOnlyScopeEntryIsNotManaged_StillSelectsTheCrossAssemblyBuilder()
+    public void CallerScopes_WhenTheOnlyScopeEntryIsNotManaged_SelectsTheSameAssemblyBuilder()
     {
         string? native = FindNativeImage();
         Assert.SkipWhen(native is null, "No native PE image available in the runtime directory.");
 
         var scopes = Create(SelfPath, [native!]).CallerScopes(includeAllocations: false);
+
+        Assert.Null(scopes);
+    }
+
+    // The counterpart to the two above, and the reason routing cannot simply follow the opened
+    // count: here the scope entry IS openable and is merely ruled out by the closure. The
+    // unfiltered walk would have opened it, so the request keeps the cross-assembly builder even
+    // though nothing survived selection.
+    [Fact]
+    public void CallerScopes_WhenAnOpenableScopeEntryIsRuledOut_StillSelectsTheCrossAssemblyBuilder()
+    {
+        string? native = FindNativeImage();
+        Assert.SkipWhen(native is null, "No native PE image available in the runtime directory.");
+
+        var scopes = Create(SelfPath, [native!, AnalysisPath]).CallerScopes(includeAllocations: false);
 
         Assert.NotNull(scopes);
         Assert.Empty(scopes);

--- a/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
+++ b/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
@@ -10,6 +10,10 @@ namespace DotnetInspector.Tests;
 /// selects the cross-assembly one, and the two do not produce identical trees. These assert the
 /// decision itself rather than a rendered tree, because the small call-graph fixtures happen not to
 /// distinguish the two builders at all — an output-level test here would pass no matter what.
+///
+/// The decision is a question about the <em>request</em>, never about how readable the scope turned
+/// out to be, so most of these pin cases where the scope yields nothing to walk yet the choice must
+/// still hold.
 /// </summary>
 public class ApiMemberAnalysisInspectionTests
 {
@@ -68,16 +72,21 @@ public class ApiMemberAnalysisInspectionTests
         Assert.Single(scopes);
     }
 
-    // Every scope entry unopenable is indistinguishable from having nothing to walk, which is what
-    // the unfiltered walk did with an all-garbage scope, so it keeps the same-assembly builder.
+    // Round-2 review found that the previous "would the unfiltered walk have opened it?" rule was
+    // not decidable: an image whose Assembly/AssemblyRef tables read cleanly (so the prefilter can
+    // rule it out) can still throw when its bodies are indexed. Reproduced with single-byte
+    // mutations of a real assembly — 8 of 3000 produced exactly that. Openability therefore cannot
+    // drive the choice, so a scoped request gets the cross-assembly builder even when nothing in
+    // the scope can be opened at all.
     [Fact]
-    public void CallerScopes_WhenNoScopeAssemblyCanBeOpened_SelectsTheSameAssemblyBuilder()
+    public void CallerScopes_WhenNoScopeAssemblyCanBeOpened_StillSelectsTheCrossAssemblyBuilder()
     {
         string missing = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.dll");
 
-        var inspection = Create(SelfPath, [missing]);
+        var scopes = Create(SelfPath, [missing]).CallerScopes(includeAllocations: false);
 
-        Assert.Null(inspection.CallerScopes(includeAllocations: false));
+        Assert.NotNull(scopes);
+        Assert.Empty(scopes);
     }
 
     // The two lenses are cached independently and must decide identically.
@@ -96,19 +105,20 @@ public class ApiMemberAnalysisInspectionTests
         Assert.Same(graph, inspection.CallerScopes(includeAllocations: true));
     }
 
-    // A file with no managed metadata must fail open rather than count as a prefilter skip: --bin
-    // enumerates every top-level *.dll with no managed-image filter, so a native binary in scope is
-    // one the unfiltered walk could never have opened. Reporting it as skipped would flip an
-    // all-native scope from the same-assembly builder to the cross-assembly one.
+    // A file with no managed metadata must fail open rather than be ruled out: --bin enumerates
+    // every top-level *.dll with no managed-image filter, so ruling it out here would only
+    // duplicate the catch around MethodBodyInspectionSession.Open. Either way the scope yields
+    // nothing, and the request was still scoped.
     [Fact]
-    public void CallerScopes_WhenTheOnlyScopeEntryIsNotManaged_SelectsTheSameAssemblyBuilder()
+    public void CallerScopes_WhenTheOnlyScopeEntryIsNotManaged_StillSelectsTheCrossAssemblyBuilder()
     {
         string? native = FindNativeImage();
         Assert.SkipWhen(native is null, "No native PE image available in the runtime directory.");
 
-        var inspection = Create(SelfPath, [native!]);
+        var scopes = Create(SelfPath, [native!]).CallerScopes(includeAllocations: false);
 
-        Assert.Null(inspection.CallerScopes(includeAllocations: false));
+        Assert.NotNull(scopes);
+        Assert.Empty(scopes);
     }
 
     static string? FindNativeImage()

--- a/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
+++ b/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
@@ -1,0 +1,134 @@
+using DotnetInspector.Inspectors;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// The caller-scope prefilter (#3331) is only allowed to change how much work a caller query does,
+/// never which reverse-graph builder answers it. <see cref="ApiMemberAnalysisInspection.CallerScopes"/>
+/// is that decision: <see langword="null"/> selects the same-assembly builder and any non-null list
+/// selects the cross-assembly one, and the two do not produce identical trees. These assert the
+/// decision itself rather than a rendered tree, because the small call-graph fixtures happen not to
+/// distinguish the two builders at all — an output-level test here would pass no matter what.
+/// </summary>
+public class ApiMemberAnalysisInspectionTests
+{
+    static readonly string SelfPath = typeof(ApiMemberAnalysisInspectionTests).Assembly.Location;
+    static readonly string AnalysisPath = typeof(ILInspector.Analysis.LibraryBodyIndex).Assembly.Location;
+    static readonly string CliPath = typeof(ApiMemberAnalysisInspection).Assembly.Location;
+
+    static ApiMemberAnalysisInspection Create(string assemblyPath, IReadOnlyList<string>? scope)
+        => new(assemblyPath, [], new HashSet<string> { SectionNames.CallGraph }, scope, null);
+
+    // Regression: MemberOptions.CallerScopeAssemblies defaults to a non-null EMPTY list and the
+    // command layer passes it unconditionally, so a null check here is dead code that routes every
+    // ordinary request — the overwhelmingly common case — through the cross-assembly builder and
+    // silently changes the default Call Graph and Callers output.
+    [Fact]
+    public void CallerScopes_WhenTheScopeListIsNull_SelectsTheSameAssemblyBuilder()
+    {
+        var inspection = Create(SelfPath, null);
+
+        Assert.Null(inspection.CallerScopes(includeAllocations: false));
+        Assert.Null(inspection.CallerScopes(includeAllocations: true));
+    }
+
+    [Fact]
+    public void CallerScopes_WhenTheScopeListIsEmpty_SelectsTheSameAssemblyBuilder()
+    {
+        var inspection = Create(SelfPath, []);
+
+        Assert.Null(inspection.CallerScopes(includeAllocations: false));
+        Assert.Null(inspection.CallerScopes(includeAllocations: true));
+    }
+
+    // The prefilter emptying the survivor list must not be mistaken for "no scope was requested".
+    // ILInspector.Analysis names neither itself nor dotnet-inspect.Tests as a reference, so it is
+    // ruled out without being opened, leaving nothing to walk — but the request was still scoped.
+    [Fact]
+    public void CallerScopes_WhenEveryScopeAssemblyIsPrefiltered_StillSelectsTheCrossAssemblyBuilder()
+    {
+        var inspection = Create(SelfPath, [AnalysisPath]);
+
+        var scopes = inspection.CallerScopes(includeAllocations: false);
+
+        Assert.NotNull(scopes);
+        Assert.Empty(scopes);
+    }
+
+    // The prefilter must not rule out an assembly that really does reference the target.
+    [Fact]
+    public void CallerScopes_WhenAScopeAssemblyReferencesTheTarget_OpensIt()
+    {
+        var inspection = Create(AnalysisPath, [CliPath]);
+
+        var scopes = inspection.CallerScopes(includeAllocations: false);
+
+        Assert.NotNull(scopes);
+        Assert.Single(scopes);
+    }
+
+    // Every scope entry unopenable is indistinguishable from having nothing to walk, which is what
+    // the unfiltered walk did with an all-garbage scope, so it keeps the same-assembly builder.
+    [Fact]
+    public void CallerScopes_WhenNoScopeAssemblyCanBeOpened_SelectsTheSameAssemblyBuilder()
+    {
+        string missing = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.dll");
+
+        var inspection = Create(SelfPath, [missing]);
+
+        Assert.Null(inspection.CallerScopes(includeAllocations: false));
+    }
+
+    // The two lenses are cached independently and must decide identically.
+    [Fact]
+    public void CallerScopes_CachesTheAllocationLensSeparatelyFromTheCallerLens()
+    {
+        var inspection = Create(AnalysisPath, [CliPath]);
+
+        var callers = inspection.CallerScopes(includeAllocations: false);
+        var graph = inspection.CallerScopes(includeAllocations: true);
+
+        Assert.NotNull(callers);
+        Assert.NotNull(graph);
+        Assert.NotSame(callers, graph);
+        Assert.Same(callers, inspection.CallerScopes(includeAllocations: false));
+        Assert.Same(graph, inspection.CallerScopes(includeAllocations: true));
+    }
+
+    // A file with no managed metadata must fail open rather than count as a prefilter skip: --bin
+    // enumerates every top-level *.dll with no managed-image filter, so a native binary in scope is
+    // one the unfiltered walk could never have opened. Reporting it as skipped would flip an
+    // all-native scope from the same-assembly builder to the cross-assembly one.
+    [Fact]
+    public void CallerScopes_WhenTheOnlyScopeEntryIsNotManaged_SelectsTheSameAssemblyBuilder()
+    {
+        string? native = FindNativeImage();
+        Assert.SkipWhen(native is null, "No native PE image available in the runtime directory.");
+
+        var inspection = Create(SelfPath, [native!]);
+
+        Assert.Null(inspection.CallerScopes(includeAllocations: false));
+    }
+
+    static string? FindNativeImage()
+    {
+        foreach (string path in Directory.EnumerateFiles(
+            System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(), "*.dll"))
+        {
+            try
+            {
+                using var stream = File.OpenRead(path);
+                using var reader = new System.Reflection.PortableExecutable.PEReader(stream);
+                if (!reader.HasMetadata)
+                    return path;
+            }
+            catch
+            {
+                // Not a readable PE; keep looking.
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
+++ b/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Fixtures;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Sections;
 
@@ -119,6 +120,53 @@ public class ApiMemberAnalysisInspectionTests
 
         Assert.NotNull(scopes);
         Assert.Empty(scopes);
+    }
+
+    // Round-3 review found the prefilter's premise was too narrow: it tested a DIRECT reference to
+    // the target, but a caller graph walks outward several levels, so an assembly that names only
+    // an intermediate still belongs in the tree. The indirect fixture references only the caller
+    // assembly, never the target, and reproduced the defect end to end — the graph lost a whole
+    // depth-3 branch. Selection is now a reverse-reference closure, so both must open.
+    [Fact]
+    public void CallerScopes_WhenAScopeAssemblyReferencesTheTargetOnlyIndirectly_OpensIt()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        string caller = FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath();
+        string indirect = FixtureCatalog.AnalysisCallerGraphIndirectCaller.AssemblyPath();
+
+        // The fixture only proves anything while it stays free of a direct reference to the target.
+        Assert.DoesNotContain(
+            "ILInspector.Analysis.CallerGraphTarget",
+            ReferenceNames(indirect));
+
+        var scopes = Create(target, [caller, indirect]).CallerScopes(includeAllocations: true);
+
+        Assert.NotNull(scopes);
+        Assert.Equal(2, scopes.Count);
+    }
+
+    // ...and the closure must not degenerate into keeping everything. It closes over the SCOPE, so
+    // an assembly whose only bridge to the target was not itself supplied stays out — the walk
+    // could not have traversed that bridge either. The lookalike declares its own Target.Api.Ping
+    // and reaches the target through nothing at all.
+    [Fact]
+    public void CallerScopes_WhenNoScopeAssemblyBridgesToTheTarget_RulesThemAllOut()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        string indirect = FixtureCatalog.AnalysisCallerGraphIndirectCaller.AssemblyPath();
+        string lookalike = FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath();
+
+        var scopes = Create(target, [indirect, lookalike]).CallerScopes(includeAllocations: true);
+
+        Assert.NotNull(scopes);
+        Assert.Empty(scopes);
+    }
+
+    static IReadOnlyList<string> ReferenceNames(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var reader = new System.Reflection.PortableExecutable.PEReader(stream);
+        return ILInspector.Metadata.AssemblyIdentityScanner.Scan(reader).ReferenceNames;
     }
 
     static string? FindNativeImage()

--- a/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
+++ b/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
@@ -162,6 +162,61 @@ public class ApiMemberAnalysisInspectionTests
         Assert.Empty(scopes);
     }
 
+    // Round-5 review: a zero-byte or malformed *.dll beside real ones was classified as
+    // undecidable, which selects the whole scope and disables the prefilter entirely — the 960 MB
+    // behavior this change exists to remove, reintroduced by one junk file in a --bin directory.
+    // Such an image cannot be opened as a PE at all, and caller analysis opens the same path the
+    // same way, so it could not have contributed edges and must be ruled out instead.
+    [Fact]
+    public void CallerScopes_WhenAScopeEntryIsNotAPortableExecutable_StillRulesOutTheOthers()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        string lookalike = FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath();
+        string directory = Path.Combine(Path.GetTempPath(), $"scope-junk-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string empty = Path.Combine(directory, "empty.dll");
+            string truncated = Path.Combine(directory, "truncated.dll");
+            File.WriteAllBytes(empty, []);
+            File.WriteAllBytes(truncated, "MZ not really a PE"u8.ToArray());
+
+            var scopes = Create(target, [empty, truncated, lookalike])
+                .CallerScopes(includeAllocations: true);
+
+            Assert.NotNull(scopes);
+            Assert.Empty(scopes);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    // The complement, so the fix above cannot be "rule out anything that fails to read". An image
+    // that opens but reads badly may still decode bodies, so it stays undecidable and keeps the
+    // scope selected.
+    [Fact]
+    public void CallerScopes_WhenAScopeEntryIsAnUnreadableDirectory_StillRulesOutTheOthers()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        string lookalike = FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath();
+        string directory = Path.Combine(Path.GetTempPath(), $"scope-dir-{Guid.NewGuid():N}.dll");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var scopes = Create(target, [directory, lookalike])
+                .CallerScopes(includeAllocations: true);
+
+            Assert.NotNull(scopes);
+            Assert.Empty(scopes);
+        }
+        finally
+        {
+            Directory.Delete(directory);
+        }
+    }
+
     static IReadOnlyList<string> ReferenceNames(string assemblyPath)
     {
         using var stream = File.OpenRead(assemblyPath);

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -203,6 +203,17 @@ internal sealed class ApiMemberAnalysisInspection
     /// Treating an unopenable image as undecidable is not merely conservative — one malformed or
     /// zero-byte <c>*.dll</c> beside a real one would select every other candidate and disable the
     /// prefilter for the whole scope.
+    ///
+    /// This classification reads each candidate once, and that read is the tool's sample of a file
+    /// whose contents it does not own. A scope directory being rewritten by a concurrent build has
+    /// no stable answer to sample: reading earlier is not less correct than reading later, only
+    /// earlier. Analysis without the prefilter is timing-dependent on such input too — it simply
+    /// samples each candidate at the point it opens it for body indexing, which is later because
+    /// that work is slower. Measured against a candidate replaced mid-run behind one large scope
+    /// assembly, both answers flip, at different delays: without the prefilter at ~1800ms, with it
+    /// at ~300ms. Prefiltering therefore narrows the window in which a half-written image is seen
+    /// as finished; it does not introduce nondeterminism that a stable scope would not have.
+    /// Callers needing a reproducible answer must present a scope that is not being written.
     /// </summary>
     static Analysis.CallerScopeFilter.Candidate ScopeIdentity(string scopePath)
     {

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -84,24 +84,22 @@ internal sealed class ApiMemberAnalysisInspection
         _bodyScope);
 
     /// <summary>
-    /// The caller-scope sessions, or <see langword="null"/> when the reverse graph should be built
-    /// from the target's own assembly alone. The distinction matters because the scoped and
-    /// unscoped reverse-graph builders key their graphs differently and do not produce identical
-    /// trees, so this predicate must stay exactly as selective as it was before prefiltering
-    /// existed. Before, the scoped builder ran iff at least one scope assembly opened successfully.
-    /// So:
-    /// <list type="bullet">
-    /// <item>no scope assemblies supplied at all — <see langword="null"/>. Note that the CLI's
-    /// default is a non-null empty list, not <see langword="null"/>, so this is an emptiness check
-    /// rather than a null check; it is also a fast path that avoids reading the target's metadata
-    /// for the overwhelmingly common unscoped request.</item>
-    /// <item>every supplied assembly failed to open — <see langword="null"/>, which is what an
-    /// unfiltered walk with nothing to open did.</item>
-    /// <item>at least one assembly opened or was skipped by the prefilter — the scoped builder,
-    /// even when every one of them was skipped and the returned list is empty. A skipped assembly
-    /// is one the unfiltered walk would have opened successfully and found nothing in, so skipping
-    /// it must not change which builder runs.</item>
-    /// </list>
+    /// The caller-scope sessions, or <see langword="null"/> when the user did not ask for a
+    /// cross-assembly scope at all. The distinction matters because
+    /// <c>LibraryBodyIndex.BuildCallerTree</c> keys its reverse graph differently in the two cases
+    /// and the resulting trees are not identical, so this predicate decides which one answers.
+    ///
+    /// It is deliberately a question about the <em>request</em>, not about how much of the scope
+    /// turned out to be readable. Before prefiltering, the answer fell out of "did at least one
+    /// scope assembly open successfully", which made the shape of the tree depend on whether a
+    /// directory happened to contain openable DLLs — adding one unreadable file could not change
+    /// it, but adding one readable one could. Prefiltering cannot preserve that accident: an
+    /// assembly ruled out by its <c>AssemblyRef</c> table is never opened, so whether it *would*
+    /// have opened is unknowable without paying exactly the cost being avoided. Basing the choice
+    /// on intent removes the dependency instead of guessing at it.
+    ///
+    /// Note that the CLI's default is a non-null empty list, not <see langword="null"/>, so this
+    /// has to be an emptiness check rather than a null check.
     ///
     /// Skipping is the optimization: opening a scope assembly costs a full body decode of the
     /// image, while ruling it out costs a read of its <c>AssemblyRef</c> table, so the common "no
@@ -120,15 +118,11 @@ internal sealed class ApiMemberAnalysisInspection
             return null;
 
         var opened = new List<MethodBodyInspectionSession>();
-        int skipped = 0;
         string? targetAssembly = TargetAssemblyName;
         foreach (var scopePath in _callerScopeAssemblies)
         {
             if (!CouldContainCaller(scopePath, targetAssembly))
-            {
-                skipped++;
                 continue;
-            }
 
             try
             {
@@ -143,9 +137,6 @@ internal sealed class ApiMemberAnalysisInspection
                 // Caller scope is best-effort; unreadable assemblies do not contribute edges.
             }
         }
-
-        if (opened.Count == 0 && skipped == 0)
-            return null;
 
         cached = opened;
         return cached;
@@ -184,13 +175,9 @@ internal sealed class ApiMemberAnalysisInspection
     /// <see cref="MethodBodyInspectionSession.Open"/>, which decodes every method body in the image,
     /// and an assembly that names neither itself nor the target as the declaring assembly cannot
     /// produce a match (see <see cref="Analysis.CallerScopeFilter"/>). Any failure to decide falls
-    /// through to the previous behavior of opening the assembly.
-    ///
-    /// A non-managed file returns <see langword="true"/> rather than being reported as skipped:
-    /// <c>--bin</c> enumerates every top-level <c>*.dll</c> with no managed-image filter, and those
-    /// are already handled by the caller's <c>catch</c>. Counting them as "skipped" would
-    /// misrepresent a file the unfiltered walk could never have opened as one it opened and found
-    /// nothing in, which is the distinction the caller's builder choice rests on.
+    /// through to the previous behavior of opening the assembly, including a file with no managed
+    /// metadata — <c>--bin</c> enumerates every top-level <c>*.dll</c> with no managed-image
+    /// filter, and ruling those out here would only duplicate the caller's <c>catch</c>.
     /// </summary>
     static bool CouldContainCaller(string scopePath, string? targetAssembly)
     {

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -104,7 +104,8 @@ internal sealed class ApiMemberAnalysisInspection
     /// Skipping is the optimization: opening a scope assembly costs a full body decode of the
     /// image, while ruling it out costs a read of its <c>AssemblyRef</c> table, so the common "no
     /// caller anywhere in a large scope" answer no longer pays to index every assembly to discover
-    /// it is empty.
+    /// it is empty. Selection is a reverse-reference <em>closure</em> rather than a direct-reference
+    /// test, because the caller graph is transitive — see <see cref="Analysis.CallerScopeFilter"/>.
     /// </summary>
     internal IReadOnlyList<MethodBodyInspectionSession>? CallerScopes(bool includeAllocations)
     {
@@ -117,13 +118,16 @@ internal sealed class ApiMemberAnalysisInspection
         if (_callerScopeAssemblies is not { Count: > 0 })
             return null;
 
+        var selected = Analysis.CallerScopeFilter.SelectCouldReach(
+            TargetAssemblyName, ScopeIdentities(_callerScopeAssemblies));
+
         var opened = new List<MethodBodyInspectionSession>();
-        string? targetAssembly = TargetAssemblyName;
-        foreach (var scopePath in _callerScopeAssemblies)
+        for (int i = 0; i < _callerScopeAssemblies.Count; i++)
         {
-            if (!CouldContainCaller(scopePath, targetAssembly))
+            if (!selected[i])
                 continue;
 
+            string scopePath = _callerScopeAssemblies[i];
             try
             {
                 opened.Add(MethodBodyInspectionSession.Open(
@@ -140,6 +144,37 @@ internal sealed class ApiMemberAnalysisInspection
 
         cached = opened;
         return cached;
+    }
+
+    /// <summary>
+    /// Reads assembly identity for every scope candidate. This is the cheap question that makes
+    /// prefiltering worthwhile: it touches only the <c>Assembly</c> and <c>AssemblyRef</c> tables,
+    /// where <see cref="MethodBodyInspectionSession.Open"/> decodes every method body in the image.
+    /// A candidate whose identity cannot be read — including a file with no managed metadata, since
+    /// <c>--bin</c> enumerates every top-level <c>*.dll</c> with no managed-image filter — is
+    /// reported as unknown so the filter keeps it and the open path decides.
+    /// </summary>
+    static Analysis.CallerScopeFilter.Candidate[] ScopeIdentities(IReadOnlyList<string> scopePaths)
+    {
+        var identities = new Analysis.CallerScopeFilter.Candidate[scopePaths.Count];
+        for (int i = 0; i < scopePaths.Count; i++)
+        {
+            try
+            {
+                using var session = AssemblyInspectionSession.Open(scopePaths[i]);
+                if (session.HasMetadata)
+                {
+                    var names = session.IdentityNames();
+                    identities[i] = new(names.Name, names.ReferenceNames);
+                }
+            }
+            catch
+            {
+                // Undecidable: left as the default unknown candidate, which is always selected.
+            }
+        }
+
+        return identities;
     }
 
     /// <summary>
@@ -166,36 +201,6 @@ internal sealed class ApiMemberAnalysisInspection
             }
 
             return _targetAssemblyName;
-        }
-    }
-
-    /// <summary>
-    /// Whether a scope assembly is worth opening for caller discovery. Reading its
-    /// <c>AssemblyRef</c> table is orders of magnitude cheaper than
-    /// <see cref="MethodBodyInspectionSession.Open"/>, which decodes every method body in the image,
-    /// and an assembly that names neither itself nor the target as the declaring assembly cannot
-    /// produce a match (see <see cref="Analysis.CallerScopeFilter"/>). Any failure to decide falls
-    /// through to the previous behavior of opening the assembly, including a file with no managed
-    /// metadata — <c>--bin</c> enumerates every top-level <c>*.dll</c> with no managed-image
-    /// filter, and ruling those out here would only duplicate the caller's <c>catch</c>.
-    /// </summary>
-    static bool CouldContainCaller(string scopePath, string? targetAssembly)
-    {
-        if (targetAssembly is null)
-            return true;
-
-        try
-        {
-            using var session = AssemblyInspectionSession.Open(scopePath);
-            if (!session.HasMetadata)
-                return true;
-
-            var names = session.IdentityNames();
-            return Analysis.CallerScopeFilter.CouldContainCallerOf(targetAssembly, names.Name, names.ReferenceNames);
-        }
-        catch
-        {
-            return true;
         }
     }
 }

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -26,6 +26,7 @@ internal sealed class ApiMemberAnalysisInspection
     bool _graphScopesResolved;
     string? _targetAssemblyName;
     bool _targetAssemblyNameResolved;
+    IReadOnlyList<string>? _selectedScopePaths;
 
     internal ApiMemberAnalysisInspection(
         string assemblyPath,
@@ -118,16 +119,11 @@ internal sealed class ApiMemberAnalysisInspection
         if (_callerScopeAssemblies is not { Count: > 0 })
             return null;
 
-        var selected = Analysis.CallerScopeFilter.SelectCouldReach(
-            TargetAssemblyName, ScopeIdentities(_callerScopeAssemblies));
+        var selected = SelectedScopePaths();
 
         var opened = new List<MethodBodyInspectionSession>();
-        for (int i = 0; i < _callerScopeAssemblies.Count; i++)
+        foreach (string scopePath in selected)
         {
-            if (!selected[i])
-                continue;
-
-            string scopePath = _callerScopeAssemblies[i];
             try
             {
                 opened.Add(MethodBodyInspectionSession.Open(
@@ -147,12 +143,41 @@ internal sealed class ApiMemberAnalysisInspection
     }
 
     /// <summary>
+    /// The scope assemblies that survive prefiltering, resolved once. The two lenses open separate
+    /// sessions because they decode different things, but they ask the same identity question, and
+    /// the scan is the whole cost of prefiltering — running it twice for a request that renders
+    /// both the <c>Callers</c> table and the <c>Call Graph</c> would halve the saving.
+    /// </summary>
+    IReadOnlyList<string> SelectedScopePaths()
+    {
+        if (_selectedScopePaths is not null)
+            return _selectedScopePaths;
+
+        var scopePaths = _callerScopeAssemblies!;
+        var selected = Analysis.CallerScopeFilter.SelectCouldReach(
+            TargetAssemblyName, ScopeIdentities(scopePaths));
+
+        var survivors = new List<string>();
+        for (int i = 0; i < scopePaths.Count; i++)
+        {
+            if (selected[i])
+                survivors.Add(scopePaths[i]);
+        }
+
+        _selectedScopePaths = survivors;
+        return survivors;
+    }
+
+    /// <summary>
     /// Reads assembly identity for every scope candidate. This is the cheap question that makes
     /// prefiltering worthwhile: it touches only the <c>Assembly</c> and <c>AssemblyRef</c> tables,
     /// where <see cref="MethodBodyInspectionSession.Open"/> decodes every method body in the image.
-    /// A candidate whose identity cannot be read — including a file with no managed metadata, since
-    /// <c>--bin</c> enumerates every top-level <c>*.dll</c> with no managed-image filter — is
-    /// reported as unknown so the filter keeps it and the open path decides.
+    ///
+    /// The distinctions matter for soundness, not tidiness. A file that cannot be opened or carries
+    /// no managed metadata — <c>--bin</c> enumerates every top-level <c>*.dll</c> with no
+    /// managed-image filter — could not have contributed edges either, so ruling it out matches
+    /// what opening it would have produced. An image that reads partially is the dangerous case: it
+    /// may still open for analysis, so it has to stay in the relation rather than be dropped.
     /// </summary>
     static Analysis.CallerScopeFilter.Candidate[] ScopeIdentities(IReadOnlyList<string> scopePaths)
     {
@@ -162,15 +187,32 @@ internal sealed class ApiMemberAnalysisInspection
             try
             {
                 using var session = AssemblyInspectionSession.Open(scopePaths[i]);
-                if (session.HasMetadata)
+                if (!session.HasMetadata)
                 {
-                    var names = session.IdentityNames();
-                    identities[i] = new(names.Name, names.ReferenceNames);
+                    identities[i] = Analysis.CallerScopeFilter.Candidate.Unopenable();
+                    continue;
                 }
+
+                var names = session.IdentityNames();
+                identities[i] = names.ReferencesComplete
+                    ? Analysis.CallerScopeFilter.Candidate.Known(names.Name, names.ReferenceNames)
+                    : Analysis.CallerScopeFilter.Candidate.UnknownReferences(names.Name);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException)
+            {
+                // The image exists and may still open for analysis, but nothing about its identity
+                // is trustworthy, so nothing above it can be ruled out.
+                identities[i] = Analysis.CallerScopeFilter.Candidate.Unknown();
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Unreadable as a file; opening it for analysis would fail the same way.
+                identities[i] = Analysis.CallerScopeFilter.Candidate.Unopenable();
             }
             catch
             {
-                // Undecidable: left as the default unknown candidate, which is always selected.
+                // Anything else is undecidable, and undecidable must fail open.
+                identities[i] = Analysis.CallerScopeFilter.Candidate.Unknown();
             }
         }
 

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -21,7 +21,9 @@ internal sealed class ApiMemberAnalysisInspection
     readonly IReadOnlySet<int>? _bodyScope;
     MethodBodyInspectionSession? _session;
     List<MethodBodyInspectionSession>? _callerScopes;
+    bool _callerScopesResolved;
     List<MethodBodyInspectionSession>? _graphScopes;
+    bool _graphScopesResolved;
     string? _targetAssemblyName;
     bool _targetAssemblyNameResolved;
 
@@ -82,34 +84,55 @@ internal sealed class ApiMemberAnalysisInspection
         _bodyScope);
 
     /// <summary>
-    /// The caller-scope sessions, or <see langword="null"/> when no cross-assembly scope was
-    /// requested at all. The distinction matters: an empty list still means "scoped walk", and the
-    /// scoped and unscoped reverse-graph builders do not produce identical trees.
+    /// The caller-scope sessions, or <see langword="null"/> when the reverse graph should be built
+    /// from the target's own assembly alone. The distinction matters because the scoped and
+    /// unscoped reverse-graph builders key their graphs differently and do not produce identical
+    /// trees, so this predicate must stay exactly as selective as it was before prefiltering
+    /// existed. Before, the scoped builder ran iff at least one scope assembly opened successfully.
+    /// So:
+    /// <list type="bullet">
+    /// <item>no scope assemblies supplied at all — <see langword="null"/>. Note that the CLI's
+    /// default is a non-null empty list, not <see langword="null"/>, so this is an emptiness check
+    /// rather than a null check; it is also a fast path that avoids reading the target's metadata
+    /// for the overwhelmingly common unscoped request.</item>
+    /// <item>every supplied assembly failed to open — <see langword="null"/>, which is what an
+    /// unfiltered walk with nothing to open did.</item>
+    /// <item>at least one assembly opened or was skipped by the prefilter — the scoped builder,
+    /// even when every one of them was skipped and the returned list is empty. A skipped assembly
+    /// is one the unfiltered walk would have opened successfully and found nothing in, so skipping
+    /// it must not change which builder runs.</item>
+    /// </list>
     ///
-    /// Scope assemblies that cannot reference the target's assembly are skipped without being
-    /// opened. Opening one costs a full body decode of the image, while ruling it out costs a read
-    /// of its <c>AssemblyRef</c> table, so the common "no caller anywhere in a large scope" answer
-    /// no longer pays to index every assembly to discover it is empty.
+    /// Skipping is the optimization: opening a scope assembly costs a full body decode of the
+    /// image, while ruling it out costs a read of its <c>AssemblyRef</c> table, so the common "no
+    /// caller anywhere in a large scope" answer no longer pays to index every assembly to discover
+    /// it is empty.
     /// </summary>
-    IReadOnlyList<MethodBodyInspectionSession>? CallerScopes(bool includeAllocations)
+    internal IReadOnlyList<MethodBodyInspectionSession>? CallerScopes(bool includeAllocations)
     {
-        if (_callerScopeAssemblies is null)
-            return null;
-
         ref var cached = ref includeAllocations ? ref _graphScopes : ref _callerScopes;
-        if (cached is not null)
+        ref var resolved = ref includeAllocations ? ref _graphScopesResolved : ref _callerScopesResolved;
+        if (resolved)
             return cached;
 
-        cached = [];
+        resolved = true;
+        if (_callerScopeAssemblies is not { Count: > 0 })
+            return null;
+
+        var opened = new List<MethodBodyInspectionSession>();
+        int skipped = 0;
         string? targetAssembly = TargetAssemblyName;
         foreach (var scopePath in _callerScopeAssemblies)
         {
             if (!CouldContainCaller(scopePath, targetAssembly))
+            {
+                skipped++;
                 continue;
+            }
 
             try
             {
-                cached.Add(MethodBodyInspectionSession.Open(
+                opened.Add(MethodBodyInspectionSession.Open(
                     scopePath,
                     ApiAnalysisInspection.CreateReferenceResolver(scopePath, _options),
                     includeAllocations,
@@ -121,6 +144,10 @@ internal sealed class ApiMemberAnalysisInspection
             }
         }
 
+        if (opened.Count == 0 && skipped == 0)
+            return null;
+
+        cached = opened;
         return cached;
     }
 
@@ -158,6 +185,12 @@ internal sealed class ApiMemberAnalysisInspection
     /// and an assembly that names neither itself nor the target as the declaring assembly cannot
     /// produce a match (see <see cref="Analysis.CallerScopeFilter"/>). Any failure to decide falls
     /// through to the previous behavior of opening the assembly.
+    ///
+    /// A non-managed file returns <see langword="true"/> rather than being reported as skipped:
+    /// <c>--bin</c> enumerates every top-level <c>*.dll</c> with no managed-image filter, and those
+    /// are already handled by the caller's <c>catch</c>. Counting them as "skipped" would
+    /// misrepresent a file the unfiltered walk could never have opened as one it opened and found
+    /// nothing in, which is the distinction the caller's builder choice rests on.
     /// </summary>
     static bool CouldContainCaller(string scopePath, string? targetAssembly)
     {
@@ -168,7 +201,7 @@ internal sealed class ApiMemberAnalysisInspection
         {
             using var session = AssemblyInspectionSession.Open(scopePath);
             if (!session.HasMetadata)
-                return false;
+                return true;
 
             var names = session.IdentityNames();
             return Analysis.CallerScopeFilter.CouldContainCallerOf(targetAssembly, names.Name, names.ReferenceNames);

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -183,40 +183,80 @@ internal sealed class ApiMemberAnalysisInspection
     {
         var identities = new Analysis.CallerScopeFilter.Candidate[scopePaths.Count];
         for (int i = 0; i < scopePaths.Count; i++)
+            identities[i] = ScopeIdentity(scopePaths[i]);
+
+        return identities;
+    }
+
+    /// <summary>
+    /// Classifies one candidate. Opening the image, proving it is a managed PE, and reading its
+    /// identity are separated because they fail differently: an image whose PE structure cannot be
+    /// parsed at all is <c>Unopenable</c>, while an image that parses but whose metadata reads
+    /// badly is undecidable and must stay in the relation.
+    ///
+    /// The split falls at <see cref="AssemblyInspectionSession.HasMetadata"/> rather than at
+    /// <c>Open</c> because <c>PEReader</c> is lazy: opening a zero-byte or truncated file succeeds,
+    /// and the header parse throws on first use. <see cref="LibraryBodyIndex.Open"/> parses the
+    /// same headers from the same file and throws in the same place, so ruling such an image out
+    /// matches what opening it for analysis would have produced.
+    ///
+    /// Treating an unopenable image as undecidable is not merely conservative — one malformed or
+    /// zero-byte <c>*.dll</c> beside a real one would select every other candidate and disable the
+    /// prefilter for the whole scope.
+    /// </summary>
+    static Analysis.CallerScopeFilter.Candidate ScopeIdentity(string scopePath)
+    {
+        AssemblyInspectionSession session;
+        try
+        {
+            session = AssemblyInspectionSession.Open(scopePath);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException
+                                      or IOException
+                                      or UnauthorizedAccessException)
+        {
+            // Not openable as a PE, or not readable as a file. Analysis opens the same path the
+            // same way — both construct a PEReader over a FileStream — so it would fail here too.
+            return Analysis.CallerScopeFilter.Candidate.Unopenable();
+        }
+        catch
+        {
+            // An unanticipated failure says nothing about whether analysis could open the image.
+            return Analysis.CallerScopeFilter.Candidate.Unknown();
+        }
+
+        using (session)
         {
             try
             {
-                using var session = AssemblyInspectionSession.Open(scopePaths[i]);
+                // Forces the deferred PE header parse, so an unparseable image is ruled out here
+                // rather than mistaken for an assembly with unreadable metadata.
                 if (!session.HasMetadata)
-                {
-                    identities[i] = Analysis.CallerScopeFilter.Candidate.Unopenable();
-                    continue;
-                }
-
-                var names = session.IdentityNames();
-                identities[i] = names.ReferencesComplete
-                    ? Analysis.CallerScopeFilter.Candidate.Known(names.Name, names.ReferenceNames)
-                    : Analysis.CallerScopeFilter.Candidate.UnknownReferences(names.Name);
+                    return Analysis.CallerScopeFilter.Candidate.Unopenable();
             }
-            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException)
+            catch (BadImageFormatException)
             {
-                // The image exists and may still open for analysis, but nothing about its identity
-                // is trustworthy, so nothing above it can be ruled out.
-                identities[i] = Analysis.CallerScopeFilter.Candidate.Unknown();
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-            {
-                // Unreadable as a file; opening it for analysis would fail the same way.
-                identities[i] = Analysis.CallerScopeFilter.Candidate.Unopenable();
+                return Analysis.CallerScopeFilter.Candidate.Unopenable();
             }
             catch
             {
-                // Anything else is undecidable, and undecidable must fail open.
-                identities[i] = Analysis.CallerScopeFilter.Candidate.Unknown();
+                return Analysis.CallerScopeFilter.Candidate.Unknown();
+            }
+
+            try
+            {
+                var names = session.IdentityNames();
+                return names.ReferencesComplete
+                    ? Analysis.CallerScopeFilter.Candidate.Known(names.Name, names.ReferenceNames)
+                    : Analysis.CallerScopeFilter.Candidate.UnknownReferences(names.Name);
+            }
+            catch
+            {
+                // The PE structure parsed, so analysis can still open the image and decode bodies
+                // from it. Its identity is untrustworthy, so nothing above it can be ruled out.
+                return Analysis.CallerScopeFilter.Candidate.Unknown();
             }
         }
-
-        return identities;
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -22,6 +22,8 @@ internal sealed class ApiMemberAnalysisInspection
     MethodBodyInspectionSession? _session;
     List<MethodBodyInspectionSession>? _callerScopes;
     List<MethodBodyInspectionSession>? _graphScopes;
+    string? _targetAssemblyName;
+    bool _targetAssemblyNameResolved;
 
     internal ApiMemberAnalysisInspection(
         string assemblyPath,
@@ -79,18 +81,32 @@ internal sealed class ApiMemberAnalysisInspection
         _includeOpportunities,
         _bodyScope);
 
-    IReadOnlyList<MethodBodyInspectionSession> CallerScopes(bool includeAllocations)
+    /// <summary>
+    /// The caller-scope sessions, or <see langword="null"/> when no cross-assembly scope was
+    /// requested at all. The distinction matters: an empty list still means "scoped walk", and the
+    /// scoped and unscoped reverse-graph builders do not produce identical trees.
+    ///
+    /// Scope assemblies that cannot reference the target's assembly are skipped without being
+    /// opened. Opening one costs a full body decode of the image, while ruling it out costs a read
+    /// of its <c>AssemblyRef</c> table, so the common "no caller anywhere in a large scope" answer
+    /// no longer pays to index every assembly to discover it is empty.
+    /// </summary>
+    IReadOnlyList<MethodBodyInspectionSession>? CallerScopes(bool includeAllocations)
     {
+        if (_callerScopeAssemblies is null)
+            return null;
+
         ref var cached = ref includeAllocations ? ref _graphScopes : ref _callerScopes;
         if (cached is not null)
             return cached;
 
         cached = [];
-        if (_callerScopeAssemblies is null)
-            return cached;
-
+        string? targetAssembly = TargetAssemblyName;
         foreach (var scopePath in _callerScopeAssemblies)
         {
+            if (!CouldContainCaller(scopePath, targetAssembly))
+                continue;
+
             try
             {
                 cached.Add(MethodBodyInspectionSession.Open(
@@ -106,5 +122,60 @@ internal sealed class ApiMemberAnalysisInspection
         }
 
         return cached;
+    }
+
+    /// <summary>
+    /// The simple name of the assembly the target member is defined in, read once from metadata
+    /// alone so that scope prefiltering never forces the target's own body index to be built.
+    /// </summary>
+    string? TargetAssemblyName
+    {
+        get
+        {
+            if (_targetAssemblyNameResolved)
+                return _targetAssemblyName;
+
+            _targetAssemblyNameResolved = true;
+            try
+            {
+                using var session = AssemblyInspectionSession.Open(_assemblyPath);
+                if (session.HasMetadata)
+                    _targetAssemblyName = session.IdentityNames().Name;
+            }
+            catch
+            {
+                // Undecidable: leave null so every scope assembly is scanned, as before.
+            }
+
+            return _targetAssemblyName;
+        }
+    }
+
+    /// <summary>
+    /// Whether a scope assembly is worth opening for caller discovery. Reading its
+    /// <c>AssemblyRef</c> table is orders of magnitude cheaper than
+    /// <see cref="MethodBodyInspectionSession.Open"/>, which decodes every method body in the image,
+    /// and an assembly that names neither itself nor the target as the declaring assembly cannot
+    /// produce a match (see <see cref="Analysis.CallerScopeFilter"/>). Any failure to decide falls
+    /// through to the previous behavior of opening the assembly.
+    /// </summary>
+    static bool CouldContainCaller(string scopePath, string? targetAssembly)
+    {
+        if (targetAssembly is null)
+            return true;
+
+        try
+        {
+            using var session = AssemblyInspectionSession.Open(scopePath);
+            if (!session.HasMetadata)
+                return false;
+
+            var names = session.IdentityNames();
+            return Analysis.CallerScopeFilter.CouldContainCallerOf(targetAssembly, names.Name, names.ReferenceNames);
+        }
+        catch
+        {
+            return true;
+        }
     }
 }

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -27,6 +27,7 @@ internal sealed class ApiMemberAnalysisInspection
     string? _targetAssemblyName;
     bool _targetAssemblyNameResolved;
     IReadOnlyList<string>? _selectedScopePaths;
+    bool _scopeHasOpenableCandidate;
 
     internal ApiMemberAnalysisInspection(
         string assemblyPath,
@@ -121,6 +122,25 @@ internal sealed class ApiMemberAnalysisInspection
 
         var selected = SelectedScopePaths();
 
+        // Builder routing has to reproduce what the unfiltered walk would have chosen, and that
+        // choice was made on whether ANY scope assembly opened successfully — not on whether the
+        // scope list was non-empty. Without the prefilter, a scope holding only native or
+        // unreadable images produced an empty opened list and therefore took the single-assembly
+        // token-keyed builder. Returning an empty list here instead would take the structural
+        // builder and print a different tree for the same input, which round 7 reproduced on a
+        // scope containing one native DLL (62 lines against 60).
+        //
+        // So the distinction is "was anything here openable at all", not "did anything survive
+        // selection". An openable candidate that the closure ruled out still means the unfiltered
+        // walk would have opened something, so that case keeps the structural builder.
+        //
+        // This is decidable from classification alone. The residual gap is an image whose identity
+        // tables read cleanly but whose bodies fail to index — round 2 found those exist — where
+        // the unfiltered walk would have ended with an empty opened list and taken the token
+        // builder. Deciding that would require the body index this prefilter exists to avoid.
+        if (!_scopeHasOpenableCandidate)
+            return cached;
+
         var opened = new List<MethodBodyInspectionSession>();
         foreach (string scopePath in selected)
         {
@@ -154,8 +174,18 @@ internal sealed class ApiMemberAnalysisInspection
             return _selectedScopePaths;
 
         var scopePaths = _callerScopeAssemblies!;
-        var selected = Analysis.CallerScopeFilter.SelectCouldReach(
-            TargetAssemblyName, ScopeIdentities(scopePaths));
+        var identities = ScopeIdentities(scopePaths);
+
+        foreach (var identity in identities)
+        {
+            if (identity.Kind is not Analysis.CallerScopeFilter.CandidateIdentity.Unopenable)
+            {
+                _scopeHasOpenableCandidate = true;
+                break;
+            }
+        }
+
+        var selected = Analysis.CallerScopeFilter.SelectCouldReach(TargetAssemblyName, identities);
 
         var survivors = new List<string>();
         for (int i = 0; i < scopePaths.Count; i++)
@@ -204,16 +234,24 @@ internal sealed class ApiMemberAnalysisInspection
     /// zero-byte <c>*.dll</c> beside a real one would select every other candidate and disable the
     /// prefilter for the whole scope.
     ///
-    /// This classification reads each candidate once, and that read is the tool's sample of a file
-    /// whose contents it does not own. A scope directory being rewritten by a concurrent build has
-    /// no stable answer to sample: reading earlier is not less correct than reading later, only
-    /// earlier. Analysis without the prefilter is timing-dependent on such input too — it simply
-    /// samples each candidate at the point it opens it for body indexing, which is later because
-    /// that work is slower. Measured against a candidate replaced mid-run behind one large scope
-    /// assembly, both answers flip, at different delays: without the prefilter at ~1800ms, with it
-    /// at ~300ms. Prefiltering therefore narrows the window in which a half-written image is seen
-    /// as finished; it does not introduce nondeterminism that a stable scope would not have.
-    /// Callers needing a reproducible answer must present a scope that is not being written.
+    /// This classification reads each candidate once, and body indexing reads the survivors again
+    /// later. Any change to a scope file between those two reads is invisible: selection is
+    /// computed from a generation that may no longer be on disk. This is not limited to
+    /// half-written images — a valid assembly replaced by a different valid assembly behaves the
+    /// same way, because the gap is between the two reads rather than in either one.
+    ///
+    /// The unfiltered walk is timing-dependent on such input too, but it is not equivalent, and
+    /// prefiltering is not merely narrower: it samples earlier and therefore **widens** the window
+    /// in which an assembly that becomes a caller mid-run is missed. Measured against a candidate
+    /// replaced behind one large scope assembly, the unfiltered walk reported it up to a ~1800ms
+    /// delay while prefiltering stopped reporting it past ~300ms, for both the malformed-to-valid
+    /// and valid-to-valid cases.
+    ///
+    /// This is accepted rather than fixed. Treating unreadable images as undecidable would fail
+    /// open on the native DLLs that populate an ordinary <c>--bin</c> directory and disable the
+    /// prefilter outright, and revalidating only transient failures would not cover the
+    /// valid-to-valid case at all. See the tracking issue for the measurements and the options.
+    /// A caller needing a reproducible answer must present a scope that is not being written.
     /// </summary>
     static Analysis.CallerScopeFilter.Candidate ScopeIdentity(string scopePath)
     {

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -27,7 +27,7 @@ internal sealed class ApiMemberAnalysisInspection
     string? _targetAssemblyName;
     bool _targetAssemblyNameResolved;
     IReadOnlyList<string>? _selectedScopePaths;
-    bool _scopeHasOpenableCandidate;
+    bool _ruledOutScopeIsOpenable;
 
     internal ApiMemberAnalysisInspection(
         string assemblyPath,
@@ -131,16 +131,23 @@ internal sealed class ApiMemberAnalysisInspection
         // scope containing one native DLL (62 lines against 60).
         //
         // So the distinction is "was anything here openable at all", not "did anything survive
-        // selection". An openable candidate that the closure ruled out still means the unfiltered
-        // walk would have opened something, so that case keeps the structural builder.
+        // selection". That question splits by whether this walk opens the candidate itself:
         //
-        // This is decidable from classification alone. The residual gap is an image whose identity
-        // tables read cleanly but whose bodies fail to index — round 2 found those exist — where
-        // the unfiltered walk would have ended with an empty opened list and taken the token
-        // builder. Deciding that would require the body index this prefilter exists to avoid.
-        if (!_scopeHasOpenableCandidate)
-            return cached;
-
+        //   - Candidates that survive selection are opened below, so `opened` answers directly.
+        //   - Candidates that selection ruled out are never opened, so the only available
+        //     evidence is their classification. A ruled-out candidate that read as an assembly
+        //     means the unfiltered walk would have opened something, and the structural builder
+        //     has to be kept for it.
+        //
+        // Deriving the flag from every candidate rather than only the ruled-out ones would be
+        // wrong: a candidate that classification could not decide is always selected, so this
+        // walk does open it, and treating its classification as proof of openability would take
+        // the structural builder even when the open then failed and the unfiltered walk took the
+        // token builder. Round 8 found that case.
+        //
+        // The residual gap is an image whose identity tables read cleanly, which selection then
+        // rules out, but which body indexing would have failed to read — round 2 found those
+        // exist. Deciding that would require the body index this prefilter exists to avoid.
         var opened = new List<MethodBodyInspectionSession>();
         foreach (string scopePath in selected)
         {
@@ -157,6 +164,9 @@ internal sealed class ApiMemberAnalysisInspection
                 // Caller scope is best-effort; unreadable assemblies do not contribute edges.
             }
         }
+
+        if (opened.Count == 0 && !_ruledOutScopeIsOpenable)
+            return cached;
 
         cached = opened;
         return cached;
@@ -176,22 +186,22 @@ internal sealed class ApiMemberAnalysisInspection
         var scopePaths = _callerScopeAssemblies!;
         var identities = ScopeIdentities(scopePaths);
 
-        foreach (var identity in identities)
-        {
-            if (identity.Kind is not Analysis.CallerScopeFilter.CandidateIdentity.Unopenable)
-            {
-                _scopeHasOpenableCandidate = true;
-                break;
-            }
-        }
-
         var selected = Analysis.CallerScopeFilter.SelectCouldReach(TargetAssemblyName, identities);
 
         var survivors = new List<string>();
         for (int i = 0; i < scopePaths.Count; i++)
         {
             if (selected[i])
+            {
                 survivors.Add(scopePaths[i]);
+            }
+            else if (identities[i].Kind is not Analysis.CallerScopeFilter.CandidateIdentity.Unopenable)
+            {
+                // Ruled out, so this walk never opens it and never learns whether it would have
+                // opened. Its classification is the only evidence that the unfiltered walk would
+                // have had a session here, which is what builder routing turns on.
+                _ruledOutScopeIsOpenable = true;
+            }
         }
 
         _selectedScopePaths = survivors;
@@ -233,6 +243,18 @@ internal sealed class ApiMemberAnalysisInspection
     /// Treating an unopenable image as undecidable is not merely conservative — one malformed or
     /// zero-byte <c>*.dll</c> beside a real one would select every other candidate and disable the
     /// prefilter for the whole scope.
+    ///
+    /// Reading identity does not prove the image will index, but the line does not fall where it
+    /// looks like it should. Failures <em>inside</em> a method body do not escape:
+    /// <see cref="LibraryBodyIndex"/> suppresses per-method decode failures, so an invalid IL
+    /// opcode — or even a fat body header declaring a code size past the end of the image — still
+    /// opens and simply contributes no edges for that method. What escapes is a fault in metadata
+    /// that body indexing reads and identity scanning never touches, which is a much narrower
+    /// region than "the bodies" and does not correspond to any single table. One byte inside the
+    /// metadata streams is enough to cross it while the <c>Assembly</c> and <c>AssemblyRef</c>
+    /// tables still read perfectly, so this is a real class of input rather than a theoretical
+    /// one, and it is the one place where classification and body indexing disagree. See the
+    /// tracking issue.
     ///
     /// This classification reads each candidate once, and body indexing reads the survivors again
     /// later. Any change to a scope file between those two reads is invisible: selection is

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -108,13 +108,18 @@ public sealed class MethodBodyInspectionSession
 
     /// <summary>
     /// Inbound caller graph rooted at one method, extended across sibling caller-scope
-    /// <paramref name="scopes"/> (opened as their own sessions). Empty scopes fall back to the
-    /// same-assembly-only reverse graph.
+    /// <paramref name="scopes"/> (opened as their own sessions).
+    ///
+    /// A <see langword="null"/> <paramref name="scopes"/> means no cross-assembly scope was
+    /// requested and selects the same-assembly-only reverse graph. A non-null but empty list means
+    /// a scope was requested and contributed no assemblies; that still takes the cross-assembly
+    /// builder, because the two builders key the reverse graph differently and the result must not
+    /// depend on how many scope assemblies happened to survive filtering.
     /// </summary>
-    public Analysis.CallTreeNode CallerTree(int methodToken, IReadOnlyList<MethodBodyInspectionSession> scopes)
-        => scopes is { Count: > 0 }
-            ? BodyIndex.BuildCallerTree(methodToken, scopes.Select(s => s.BodyIndex).ToArray())
-            : BodyIndex.BuildCallerTree(methodToken);
+    public Analysis.CallTreeNode CallerTree(int methodToken, IReadOnlyList<MethodBodyInspectionSession>? scopes)
+        => scopes is null
+            ? BodyIndex.BuildCallerTree(methodToken)
+            : BodyIndex.BuildCallerTree(methodToken, scopes.Select(s => s.BodyIndex).ToArray());
 
     /// <summary>
     /// Inbound call edges targeting one method (<paramref name="targetToken"/>), each tagged with the

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -57,6 +57,7 @@ public static class FixtureIds
 
     public const string AnalysisCallerGraphCaller = "analysis.caller-graph.caller";
     public const string AnalysisCallerGraphCallerTwin = "analysis.caller-graph.caller-twin";
+    public const string AnalysisCallerGraphIndirectCaller = "analysis.caller-graph.indirect-caller";
     public const string AnalysisCallerGraphLookalikeCaller = "analysis.caller-graph.lookalike-caller";
     public const string AnalysisCallerGraphTarget = "analysis.caller-graph.target";
     public const string AnalysisCallerLoop = "analysis.caller-loop";
@@ -149,6 +150,13 @@ public static class FixtureCatalog
         "ILInspector.Analysis.CallerGraphCallerTwin.dll",
         Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "analysis", "caller-graph", "caller", "twin");
+
+    public static readonly FixtureDefinition AnalysisCallerGraphIndirectCaller = Fixture(
+        FixtureIds.AnalysisCallerGraphIndirectCaller,
+        "ILInspector.Analysis.CallerGraphIndirectCaller",
+        "ILInspector.Analysis.CallerGraphIndirectCaller.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
+        "analysis", "caller-graph", "indirect");
 
     public static readonly FixtureDefinition AnalysisCallerGraphLookalikeCaller = Fixture(
         FixtureIds.AnalysisCallerGraphLookalikeCaller,
@@ -368,6 +376,7 @@ public static class FixtureCatalog
         DiffAsmTarget,
         AnalysisCallerGraphCaller,
         AnalysisCallerGraphCallerTwin,
+        AnalysisCallerGraphIndirectCaller,
         AnalysisCallerGraphLookalikeCaller,
         AnalysisCallerGraphTarget,
         AnalysisCallerLoop,
@@ -413,6 +422,7 @@ public static class FixtureCatalog
             AnalysisCallerGraphTarget,
             AnalysisCallerGraphCaller,
             AnalysisCallerGraphCallerTwin,
+            AnalysisCallerGraphIndirectCaller,
             AnalysisCallerGraphLookalikeCaller,
             AnalysisCallerLoop,
             AnalysisCrossAsmCollision,


### PR DESCRIPTION
Closes #3331. Increment 1 of #3333.

## What

Cross-assembly caller discovery opened and fully body-indexed **every** assembly in the `--bin` / `--project` / `--caller-package` scope before asking whether any of them called the target. When the answer is empty — the common case for a framework or dependency member — that pays the entire cost of the scope to learn there is nothing to report.

An assembly can only call the target if the callee's declaring type resolves to the target's assembly, and a callee's declaring assembly is either the candidate itself (a `TypeDef`) or one of its `AssemblyRef`s (a `TypeRef` scope). Reading those two tables rules an assembly out with certainty, and costs nothing next to decoding its method bodies.

## Measured

`member TypeRef.Definition` with the 182 assemblies of `Microsoft.NETCore.App 9.0.17` in scope. Peak working set sampled from the OS counter while the process was alive. **Output is byte-identical in every row.**

| Case | Before | After |
| --- | --- | --- |
| `Callers`, empty answer | 7.3s / 705 MB | **0.9s / 85 MB** |
| `Call Graph`, empty answer | 9.7s / 960 MB | **0.9s / 90 MB** |
| `Callers`, real answer (corelib) | 10.2s / 732 MB | 9.7s / 727 MB |

The last row is the decisive canonicalization check: the target is defined in `System.Private.CoreLib` while its callers reference the `System.Runtime` facade. All 4280 lines of output are unchanged, and the cost is essentially unchanged because every assembly genuinely must be opened. A filter that compared raw assembly names would have reported zero callers here.

Memory matters as much as time: the wasm consumer has no parallelism to trade against, so reducing work is the only lever (#3333).

## Why it cannot narrow discovery

`MemberPattern.MatchesCrossAssembly` compares the candidate callee's declaring `TypeRef` to the target's, and `TypeRef.Equals` includes `Assembly`, canonicalized on construction. `CallerScopeFilter` applies that same identity test over names, and:

- canonicalizes through `TypeRef.CanonicalAssembly`, so the corelib facades collapse together;
- returns `true` for any undecidable input (unknown target, unreadable image, missing reference table), so it is never more selective than the matcher;
- does not model wider type forwarding, which the matcher already misses, so it stays exactly as permissive as the behavior it guards.

I confirmed the matcher really is assembly-sensitive before relying on it, rather than assuming: a three-assembly fixture where two assemblies both define `N.T.M` and the caller references only one of them reports the caller for the referenced target and not for the other.

## Behavior hazard fixed along the way

`BuildCallerTree` chose between two *different* reverse-graph builders — one keyed by assembly-local tokens, one by structural member identity — based on whether the scope list was non-empty. Those builders do not produce identical trees. Prefiltering can empty the list, so without this fix the optimization would have silently changed the answer instead of just costing less. I caught this because the `Call Graph` equivalence check came back **different**, and chased it rather than accepting it as benign.

The scope list is now nullable and carries intent instead of a survivor count:

- `null` — no cross-assembly scope was requested; use the token-keyed builder.
- empty but non-null — a scope was requested and nothing survived filtering; still take the structural walk.

This preserves current behavior on both sides rather than picking a winner. That the two builders disagree at all is a pre-existing inconsistency this PR only exposes; I have not tried to reconcile them here.

## Evidence

- `CallerScopeFilterTests` (12 cases) pins the boundary in both directions against the **same real fixture assemblies the matcher tests use**, including the lookalike caller that declares its own `Target.Api.Ping` and never references the target — the filter must reach the same answer the matcher already does. Plus the four corelib facade names, unrelated-references, and every fail-open path.
- `BuildCallerTree_PrefilteringScopeAssembliesNeverChangesTheTree` asserts that opening a non-contributing assembly and prefiltering it away are indistinguishable. It is deliberately self-locating rather than pinned to one method: it also requires that at least one visited method distinguishes the two builders, so it cannot quietly become vacuous if this assembly's call structure changes.
- **Mutation-tested**: reverting the `is null` guard to `is not { Count: > 0 }` fails that test with `Expected: "1|<Create>b__17_4|Expanded|"` / `Actual: "1|Create|Expanded|"`. My first attempt at this test passed under the mutation, so I replaced it rather than shipping a guard that proved nothing.
- `BuildCallerTree_SkippingANonContributingScopeAssemblyDoesNotChangeTheTree` covers the same claim on the cross-assembly fixtures, including the all-filtered-out case.
- Suites at baseline: Analysis 537/1, CLI 2216/1 + 10 skipped (both failures pre-existing and unrelated).

## Non-goals

Two further increments of #3333 remain: a `TypeRef`/`MemberRef` second-level filter for the *hit* case (the third row above is untouched by this PR), and peak-memory retention work.