### PR TITLE
Move the fan-in test into the class its filter names

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -3550,6 +3550,64 @@ public class LibraryBodyIndexTests
         Assert.Equal(CallerUnsafeMode.Implicit, pointerExtern.Mode);
         Assert.DoesNotContain(top, e => e.Method.Name == nameof(UnsafeEvidenceFixtures.CallsUnsafeAs));
     }
+
+    [Fact]
+    public void CallTreeFanInCountsDistinctCallersNotCallSites()
+    {
+        var (path, directory) = BuildRepeatedCallSiteFixture();
+        try
+        {
+            var index = LibraryBodyIndex.Open(path);
+            var target = index.Methods.First(method => method.Name == "Target");
+            var caller = index.Methods.First(method => method.Name == "CallsTargetTwice");
+
+            var tree = index.BuildCallTree(caller.MetadataToken, maxDepth: 2, maxNodes: 50);
+            var targetNode = tree.Children.First(child => child.Member.Name == "Target");
+
+            // Three call sites reach Target, but only two distinct methods do. Fan-in is a
+            // leverage cue and the reverse graph draws one edge per distinct caller, so the
+            // number has to agree with the edges rather than count repeated sites.
+            Assert.Equal(3, index.DirectCalls.Count(call => call.Callee.Name == "Target"));
+            Assert.Equal(2, targetNode.Perf?.Fanin);
+            Assert.NotNull(target);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    static (string Path, string Directory) BuildRepeatedCallSiteFixture()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "dotnet-inspect-repeated-call-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "RepeatedCallSiteFixture.dll");
+
+        var assemblyName = new AssemblyName("RepeatedCallSiteFixture");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        var type = module.DefineType("RepeatedCallSiteFixture", TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+
+        var target = type.DefineMethod("Target", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
+        target.GetILGenerator().Emit(OpCodes.Ret);
+
+        // Two call sites from one caller.
+        var twice = type.DefineMethod("CallsTargetTwice", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
+        var twiceIl = twice.GetILGenerator();
+        twiceIl.Emit(OpCodes.Call, target);
+        twiceIl.Emit(OpCodes.Call, target);
+        twiceIl.Emit(OpCodes.Ret);
+
+        // One call site from a second caller.
+        var once = type.DefineMethod("CallsTargetOnce", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
+        var onceIl = once.GetILGenerator();
+        onceIl.Emit(OpCodes.Call, target);
+        onceIl.Emit(OpCodes.Ret);
+
+        type.CreateType();
+        assembly.Save(path);
+        return (path, directory);
+    }
 }
 
 public class OptimizationOpportunityFixtures
@@ -5721,62 +5779,4 @@ public static class OverloadCallers
 public sealed class LookalikeEnumeratorCollection
 {
     public System.Collections.Generic.IEnumeratorLookalike GetEnumerator() => new();
-
-    [Fact]
-    public void CallTreeFanInCountsDistinctCallersNotCallSites()
-    {
-        var (path, directory) = BuildRepeatedCallSiteFixture();
-        try
-        {
-            var index = LibraryBodyIndex.Open(path);
-            var target = index.Methods.First(method => method.Name == "Target");
-            var caller = index.Methods.First(method => method.Name == "CallsTargetTwice");
-
-            var tree = index.BuildCallTree(caller.MetadataToken, maxDepth: 2, maxNodes: 50);
-            var targetNode = tree.Children.First(child => child.Member.Name == "Target");
-
-            // Three call sites reach Target, but only two distinct methods do. Fan-in is a
-            // leverage cue and the reverse graph draws one edge per distinct caller, so the
-            // number has to agree with the edges rather than count repeated sites.
-            Assert.Equal(3, index.DirectCalls.Count(call => call.Callee.Name == "Target"));
-            Assert.Equal(2, targetNode.Perf?.Fanin);
-            Assert.NotNull(target);
-        }
-        finally
-        {
-            Directory.Delete(directory, recursive: true);
-        }
-    }
-
-    static (string Path, string Directory) BuildRepeatedCallSiteFixture()
-    {
-        var directory = Path.Combine(Path.GetTempPath(), "dotnet-inspect-repeated-call-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
-        string path = Path.Combine(directory, "RepeatedCallSiteFixture.dll");
-
-        var assemblyName = new AssemblyName("RepeatedCallSiteFixture");
-        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
-        var module = assembly.DefineDynamicModule(assemblyName.Name!);
-        var type = module.DefineType("RepeatedCallSiteFixture", TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
-
-        var target = type.DefineMethod("Target", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
-        target.GetILGenerator().Emit(OpCodes.Ret);
-
-        // Two call sites from one caller.
-        var twice = type.DefineMethod("CallsTargetTwice", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
-        var twiceIl = twice.GetILGenerator();
-        twiceIl.Emit(OpCodes.Call, target);
-        twiceIl.Emit(OpCodes.Call, target);
-        twiceIl.Emit(OpCodes.Ret);
-
-        // One call site from a second caller.
-        var once = type.DefineMethod("CallsTargetOnce", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
-        var onceIl = once.GetILGenerator();
-        onceIl.Emit(OpCodes.Call, target);
-        onceIl.Emit(OpCodes.Ret);
-
-        type.CreateType();
-        assembly.Save(path);
-        return (path, directory);
-    }
 }


### PR DESCRIPTION
`CallTreeFanInCountsDistinctCallersNotCallSites` was defined inside `LookalikeEnumeratorCollection` — a fixture data class — instead of `LibraryBodyIndexTests`.

xUnit still discovered and ran it in a full suite run, so it was never silently skipped. But the class filter documented for this area could not match it:

```
dotnet run --project src\ILInspector.Analysis.Tests -c Release -- -class "ILInspector.Analysis.Tests.LibraryBodyIndexTests"
```

Anyone narrowing to the call-tree tests while working on fan-in would have run everything *except* the test that pins fan-in.

This moves the test and its `PersistedAssemblyBuilder` helper into `LibraryBodyIndexTests` and restores `LookalikeEnumeratorCollection` to the fixture it is documented to be. No assertion changes.

**Evidence**

- The documented filter now selects it: `-class "...LibraryBodyIndexTests" -method "...CallTreeFanInCountsDistinctCallersNotCallSites"` → `Total: 1, Failed: 0`. Before the move that filter could not have matched, since the test was not in that class.
- Full suite total unchanged at **523**, 1 pre-existing unrelated failure (`CrossAssemblyMetadataResolver_ResolvesFrameworkTypeDefinition`) — confirming the test was already running and this only relocates it.

Follow-up from the round-3 adversarial review of #3312, reported independently by both reviewers.

**Review tier: trivial.** This moves an existing test between classes with no change to its assertions, its helper, or any product code, and the suite total is provably unchanged. No review requested.