### PR TITLE
Give the metadata projection a row window and on-demand row lookup

### DIFF
--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -345,8 +345,8 @@ inspector), a standalone tool that renders the tables the way `mdv` does:
   (`ToolCommandName=mdi`) whose System.CommandLine front-end maps flags onto
   `MetadataProjectionOptions` and delegates all output to the renderer below.
   Surface: `mdi <assembly> [--table|-t <Names>] [--format|-f md|tsv|jsonl]
-  [--max-rows|-n N] [--max-bytes N] [--max-chars N]`. Missing files, native
-  images, and unreadable metadata surface as visible errors, never
+  [--max-rows|-n N] [--start-row|-s N] [--max-bytes N] [--max-chars N]`. Missing
+  files, native images, and unreadable metadata surface as visible errors, never
   success-shaped empty output.
 - **`src/DotnetInspector.MetadataRendering`** — a small reusable library holding
   `MetadataProjectionRenderer` (projection → Markout tables). It lives in the
@@ -373,6 +373,41 @@ projection **model** (not `mdi`'s rendered text), the renderer is free to be
 human-friendly without weakening the oracle. Supported-table coverage is kept in
 step with the tables `mdv` dumps, so every supported table's physical row count
 is cross-validated against `mdv` for free on the product assembly.
+
+## Implemented: random access for a browser host
+
+The projection's other planned consumer is the wasm **Metadata Explorer** (issue
+#3341), which browses tables interactively rather than dumping them. That host
+imposes three constraints a batch dump does not, all met without changing the
+model:
+
+- **No filesystem.** `MetadataTableProjector.Project(PEReader, options)` is the
+  entry point; a browser host constructs `new PEReader(new MemoryStream(bytes))`
+  and never supplies a path. `AssemblyInspectionSession` stays the desktop-shaped
+  convenience over the same projector.
+- **No whole-table materialization.** `MetadataProjectionOptions.StartRowId`
+  pairs with `MaxRowsPerTable` to form a **row window**, so a table of 5,000 rows
+  is browsed a page at a time. A window changes coverage, never content: rows
+  keep their absolute `RowId`, `MetadataTableView.RowCount` stays the physical
+  count, and any partial coverage is marked by `Truncation`. A window past the
+  end of a populated table yields that table with zero rows rather than dropping
+  it, so paging cannot make a table look absent.
+- **No dead-end handles.** A `HandleRef` is the click-through primitive, and its
+  target frequently lies outside the current window.
+  `MetadataTableProjector.ProjectRow(peReader, table, rowId)` reads that one row
+  on demand and returns it inside its table's view, so the caller also gets the
+  column schema and the table's real size. It is a one-row window over the same
+  reader, not a second row path, so malformed-row containment and every budget
+  behave identically.
+
+Because a window can start anywhere, presentation must **name** the window
+rather than only its size: `mdi` renders `showing rows 4–6 of 366`, and its
+machine formats report the same range on stderr. Reporting `3 of 366` alone
+would read as the first three rows.
+
+Allocation shape — windowed or lazy materialization, and `ReadOnlySpan<T>` views
+over the current `ImmutableArray<T>` — remains open and **measurement-gated**;
+the browser's memory ceiling is the real constraint, and no benchmark exists yet.
 
 ## Layer placement
 

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -376,10 +376,10 @@ is cross-validated against `mdv` for free on the product assembly.
 
 ## Implemented: random access for a browser host
 
-The projection's other planned consumer is the wasm **Metadata Explorer** (issue
-#3341), which browses tables interactively rather than dumping them. That host
-imposes three constraints a batch dump does not, all met without changing the
-model:
+The projection's other planned consumer is the wasm **Metadata Explorer**
+(issue #3341), which browses tables interactively rather than dumping them.
+That host imposes three constraints a batch dump does not, all met without
+changing the model:
 
 - **No filesystem.** `MetadataTableProjector.Project(PEReader, options)` is the
   entry point; a browser host constructs `new PEReader(new MemoryStream(bytes))`

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -92,9 +92,21 @@ public static class MetadataProjectionRenderer
     }
 
     static string HeadingText(MetadataTableView table)
-        => table.Truncation is { } truncation
+    {
+        if (table.Truncation is not { } truncation)
+            return $"{table.Name} ({table.RowCount} {(table.RowCount == 1 ? "row" : "rows")})";
+
+        if (table.Rows.IsEmpty)
+            return $"{table.Name} (showing 0 of {truncation.RowCount} rows)";
+
+        // A row window that does not start at row 1 must say where it sits:
+        // "showing 4 of 100 rows" alone would read as the first four rows.
+        int first = table.Rows[0].RowId;
+        int last = table.Rows[^1].RowId;
+        return first == 1
             ? $"{table.Name} (showing {truncation.ProjectedRows} of {truncation.RowCount} rows)"
-            : $"{table.Name} ({table.RowCount} {(table.RowCount == 1 ? "row" : "rows")})";
+            : $"{table.Name} (showing rows {first}\u2013{last} of {truncation.RowCount})";
+    }
 
     static void WriteTable(MarkoutWriter writer, MetadataTableView table, bool identifyTable)
     {

--- a/src/ILInspector.Metadata/MetadataTableProjection.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjection.cs
@@ -69,8 +69,8 @@ public sealed record MetadataTableView
     public ImmutableArray<MetadataRow> Rows { get; }
 
     /// <summary>
-    /// Non-null when the row budget stopped enumeration before the physical end
-    /// of the table. Enumeration never silently truncates without this marker.
+    /// Non-null when the row window covered fewer than all of the table's rows.
+    /// Enumeration never silently truncates without this marker.
     /// </summary>
     public MetadataTableTruncation? Truncation { get; }
 }
@@ -273,8 +273,9 @@ public sealed record HandleRange
 }
 
 /// <summary>
-/// Evidence that a table's row budget stopped enumeration before its physical
-/// end. Its presence makes truncation explicit rather than silent.
+/// Evidence that a table's row window projected fewer than all of its rows. Its
+/// presence makes partial coverage explicit rather than silent, whether the
+/// cause was the row budget or a window that starts past row 1.
 /// </summary>
 public sealed record MetadataTableTruncation
 {
@@ -286,7 +287,7 @@ public sealed record MetadataTableTruncation
         this.RowCount = RowCount;
     }
 
-    /// <summary>How many rows were projected before the budget stopped enumeration.</summary>
+    /// <summary>How many rows the window projected.</summary>
     public int ProjectedRows { get; }
 
     /// <summary>The physical row count of the table.</summary>
@@ -299,6 +300,9 @@ public sealed record MetadataProjectionOptions
     /// <summary>The default per-table row ceiling.</summary>
     public const int DefaultMaxRowsPerTable = 4096;
 
+    /// <summary>The default first row projected from each table.</summary>
+    public const int DefaultStartRowId = 1;
+
     /// <summary>The default bounded blob preview length, in bytes.</summary>
     public const int DefaultMaxPreviewBytes = 32;
 
@@ -307,6 +311,21 @@ public sealed record MetadataProjectionOptions
 
     /// <summary>The maximum number of rows projected per table before truncation.</summary>
     public int MaxRowsPerTable { get; init; } = DefaultMaxRowsPerTable;
+
+    /// <summary>
+    /// The 1-based row id at which each table's projection begins. Together with
+    /// <see cref="MaxRowsPerTable"/> this forms a row window, letting a consumer
+    /// page through a large table without materializing it whole. Values below 1
+    /// are clamped to 1, matching how <see cref="MaxRowsPerTable"/> clamps.
+    ///
+    /// A window never hides the table's size: <see cref="MetadataTableView.RowCount"/>
+    /// stays the physical count, each <see cref="MetadataRow.RowId"/> locates the
+    /// row absolutely, and a partial window is marked by
+    /// <see cref="MetadataTableView.Truncation"/>. A window past the end of a
+    /// non-empty table yields that table's view with zero rows rather than
+    /// dropping the table.
+    /// </summary>
+    public int StartRowId { get; init; } = DefaultStartRowId;
 
     /// <summary>The maximum number of blob bytes captured in a bounded preview.</summary>
     public int MaxPreviewBytes { get; init; } = DefaultMaxPreviewBytes;

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -121,8 +121,17 @@ public static class MetadataTableProjector
     /// The row is returned inside its table's <see cref="MetadataTableView"/> so
     /// the caller also gets the column schema and the table's physical
     /// <see cref="MetadataTableView.RowCount"/>, which a single row cannot carry.
-    /// Returns <see langword="null"/> when the image has no metadata, the table
-    /// is not projected, or <paramref name="rowId"/> is past the table's end.
+    ///
+    /// <paramref name="table"/> names the target directly, so
+    /// <see cref="MetadataProjectionOptions.Tables"/> and
+    /// <see cref="MetadataProjectionOptions.StartRowId"/> are deliberately
+    /// ignored here; only the cell budgets apply. Honouring the table selection
+    /// would dead-end the very edges this method exists to follow — a caller
+    /// browsing TypeRef could not follow a TypeRef row into TypeDef.
+    ///
+    /// Returns <see langword="null"/> when the image has no metadata, when
+    /// <paramref name="table"/> is not one this projector supports, or when
+    /// <paramref name="rowId"/> is past the table's last row.
     /// </summary>
     public static MetadataTableView? ProjectRow(
         PEReader peReader,

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -112,16 +112,72 @@ public static class MetadataTableProjector
         return new MetadataTableProjection(views.ToImmutable());
     }
 
+    /// <summary>
+    /// Projects a single row of one table on demand, independent of any row
+    /// window applied to a wider projection. This is the handle click-through
+    /// primitive: a <see cref="HandleRef"/> whose target lies outside the current
+    /// window is still reachable without re-projecting the target table.
+    ///
+    /// The row is returned inside its table's <see cref="MetadataTableView"/> so
+    /// the caller also gets the column schema and the table's physical
+    /// <see cref="MetadataTableView.RowCount"/>, which a single row cannot carry.
+    /// Returns <see langword="null"/> when the image has no metadata, the table
+    /// is not projected, or <paramref name="rowId"/> is past the table's end.
+    /// </summary>
+    public static MetadataTableView? ProjectRow(
+        PEReader peReader,
+        TableIndex table,
+        int rowId,
+        MetadataProjectionOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(peReader);
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowId, 1);
+        options ??= new MetadataProjectionOptions();
+
+        if (!peReader.HasMetadata)
+            return null;
+
+        TableSpec? match = null;
+        foreach (var candidate in SupportedTables)
+        {
+            if (candidate.Index == table)
+            {
+                match = candidate;
+                break;
+            }
+        }
+
+        if (match is not { } spec)
+            return null;
+
+        var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+        int rowCount = reader.GetTableRowCount(spec.Index);
+        if (rowId > rowCount)
+            return null;
+
+        // Reuse the windowed reader rather than a second row path: a one-row
+        // window at rowId is exactly this lookup, including malformed-row containment.
+        return BuildView(reader, spec, rowCount, options with { StartRowId = rowId, MaxRowsPerTable = 1 });
+    }
+
     static MetadataTableView BuildView(
         MetadataReader reader,
         TableSpec spec,
         int rowCount,
         MetadataProjectionOptions options)
     {
-        int limit = Math.Min(rowCount, Math.Max(0, options.MaxRowsPerTable));
-        var rows = ImmutableArray.CreateBuilder<MetadataRow>(limit);
+        int start = Math.Max(1, options.StartRowId);
+        int budget = Math.Max(0, options.MaxRowsPerTable);
 
-        for (int rid = 1; rid <= limit; rid++)
+        // Widen before adding: a caller-supplied start near int.MaxValue would
+        // otherwise overflow into a window that wrongly overlaps the table.
+        long inclusiveEnd = (long)start + budget - 1;
+        int end = (int)Math.Min(rowCount, inclusiveEnd);
+        int projected = end < start ? 0 : end - start + 1;
+
+        var rows = ImmutableArray.CreateBuilder<MetadataRow>(projected);
+
+        for (int rid = start; rid <= end; rid++)
         {
             int token = ((int)spec.Index << 24) | rid;
 
@@ -141,7 +197,7 @@ public static class MetadataTableProjector
             }
         }
 
-        var truncation = limit < rowCount ? new MetadataTableTruncation(limit, rowCount) : null;
+        var truncation = projected < rowCount ? new MetadataTableTruncation(projected, rowCount) : null;
         return new MetadataTableView(spec.Index, spec.Name, rowCount, spec.Columns, rows.ToImmutable(), truncation);
     }
 

--- a/src/mdi/MdiCommand.cs
+++ b/src/mdi/MdiCommand.cs
@@ -46,6 +46,13 @@ public static class MdiCommand
         };
         maxRowsOption.Aliases.Add("-n");
 
+        var startRowOption = new Option<int>("--start-row")
+        {
+            Description = $"1-based row id each table starts at, forming a row window with --max-rows (default {MetadataProjectionOptions.DefaultStartRowId}).",
+            DefaultValueFactory = _ => MetadataProjectionOptions.DefaultStartRowId,
+        };
+        startRowOption.Aliases.Add("-s");
+
         var maxBytesOption = new Option<int>("--max-bytes")
         {
             Description = $"Maximum blob-preview bytes per cell (default {MetadataProjectionOptions.DefaultMaxPreviewBytes}).",
@@ -63,6 +70,7 @@ public static class MdiCommand
         root.Options.Add(tableOption);
         root.Options.Add(formatOption);
         root.Options.Add(maxRowsOption);
+        root.Options.Add(startRowOption);
         root.Options.Add(maxBytesOption);
         root.Options.Add(maxCharsOption);
 
@@ -72,6 +80,7 @@ public static class MdiCommand
             string? tableSpec = parseResult.GetValue(tableOption);
             string formatText = parseResult.GetValue(formatOption)!;
             int maxRows = parseResult.GetValue(maxRowsOption);
+            int startRow = parseResult.GetValue(startRowOption);
             int maxBytes = parseResult.GetValue(maxBytesOption);
             int maxChars = parseResult.GetValue(maxCharsOption);
 
@@ -87,6 +96,12 @@ public static class MdiCommand
                 return 1;
             }
 
+            if (startRow < 1)
+            {
+                Console.Error.WriteLine("Error: --start-row must be 1 or greater (row ids are 1-based).");
+                return 1;
+            }
+
             if (!TryParseTables(tableSpec, out var tables, out var badName))
             {
                 Console.Error.WriteLine(
@@ -97,6 +112,7 @@ public static class MdiCommand
             var options = new MetadataProjectionOptions
             {
                 MaxRowsPerTable = maxRows,
+                StartRowId = startRow,
                 MaxPreviewBytes = maxBytes,
                 MaxStringChars = maxChars,
                 Tables = tables,
@@ -165,9 +181,17 @@ public static class MdiCommand
         {
             foreach (var table in projection.Tables)
             {
-                if (table.Truncation is { } truncation)
-                    error.WriteLine(
-                        $"Note: table {table.Name} truncated to {truncation.ProjectedRows} of {truncation.RowCount} rows; raise --max-rows to include more.");
+                if (table.Truncation is not { } truncation)
+                    continue;
+
+                // Name the window, not just its size: "4 of 100 rows" would read as
+                // the first four rows even when --start-row moved the window.
+                string window = table.Rows.IsEmpty
+                    ? "no rows"
+                    : $"rows {table.Rows[0].RowId} to {table.Rows[^1].RowId}";
+
+                error.WriteLine(
+                    $"Note: table {table.Name} shows {window} of {truncation.RowCount}; raise --max-rows or move --start-row to include more.");
             }
         }
 

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
@@ -135,7 +135,49 @@ public class MdiCommandTests
         // Machine output stays a pure stream on stdout; the truncation stays
         // visible as a diagnostic on stderr rather than being silently dropped.
         Assert.False(string.IsNullOrWhiteSpace(output.ToString()));
-        Assert.Contains("truncated to 1 of", error.ToString());
+        Assert.Contains("shows rows 1 to 1 of", error.ToString());
+    }
+
+    [Fact]
+    public void Execute_WindowedTable_MachineFormat_NamesTheWindowNotJustItsSize()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        int code = MdiCommand.Execute(
+            SelfPath,
+            new MetadataProjectionOptions { StartRowId = 3, MaxRowsPerTable = 2 },
+            MetadataTableFormat.Jsonl,
+            output,
+            error);
+
+        Assert.Equal(0, code);
+        // "2 of N rows" would read as the first two rows; the note must locate the window.
+        Assert.Contains("shows rows 3 to 4 of", error.ToString());
+    }
+
+    [Fact]
+    public void Execute_WindowedTable_Markdown_HeadingNamesTheRowRange()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        int code = MdiCommand.Execute(
+            SelfPath,
+            new MetadataProjectionOptions { Tables = [TableIndex.TypeDef], StartRowId = 3, MaxRowsPerTable = 2 },
+            MetadataTableFormat.Markdown,
+            output,
+            error);
+
+        Assert.Equal(0, code);
+        Assert.Contains("showing rows 3\u20134 of", output.ToString());
+        Assert.True(string.IsNullOrWhiteSpace(error.ToString()));
+    }
+
+    [Fact]
+    public void CreateRootCommand_RejectsAStartRowBelowOne()
+    {
+        int code = MdiCommand.CreateRootCommand().Parse([SelfPath, "--start-row", "0"]).Invoke();
+
+        Assert.NotEqual(0, code);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/MetadataProjectionWindowTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataProjectionWindowTests.cs
@@ -1,0 +1,267 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Tests for the projection's random-access surface: the per-table row window
+/// (<see cref="MetadataProjectionOptions.StartRowId"/> plus
+/// <see cref="MetadataProjectionOptions.MaxRowsPerTable"/>), the on-demand
+/// single-row lookup <see cref="MetadataTableProjector.ProjectRow"/>, and the
+/// filesystem-free <see cref="MetadataTableProjector.Project"/> entry point.
+///
+/// These are the seams a browser host needs (see issue #3341): it cannot afford
+/// to materialize a large table whole, cannot reach a handle target that falls
+/// outside the current window without re-reading the table, and has no
+/// filesystem to open the image from.
+/// </summary>
+public class MetadataProjectionWindowTests
+{
+    static string SelfPath => typeof(MetadataProjectionWindowTests).Assembly.Location;
+
+    /// <summary>
+    /// Opens this assembly through an in-memory stream. The bytes are read here
+    /// once; the projector itself is only ever handed a <see cref="PEReader"/>,
+    /// never a path, which is what makes it usable from a browser host.
+    /// </summary>
+    static PEReader OpenSelfFromBytes() => new(new MemoryStream(File.ReadAllBytes(SelfPath)));
+
+    static MetadataTableView Window(TableIndex index, int startRowId, int maxRows)
+    {
+        using var peReader = OpenSelfFromBytes();
+        var projection = MetadataTableProjector.Project(
+            peReader,
+            new MetadataProjectionOptions
+            {
+                Tables = [index],
+                StartRowId = startRowId,
+                MaxRowsPerTable = maxRows,
+            });
+
+        return Assert.Single(projection.Tables, table => table.Index == index);
+    }
+
+    static MetadataTableView FullTable(TableIndex index)
+    {
+        using var peReader = OpenSelfFromBytes();
+        var projection = MetadataTableProjector.Project(
+            peReader,
+            new MetadataProjectionOptions { Tables = [index], MaxRowsPerTable = int.MaxValue });
+
+        return Assert.Single(projection.Tables, table => table.Index == index);
+    }
+
+    [Fact]
+    public void Project_ReadsFromBytes_WithoutBeingGivenAPath()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var projection = MetadataTableProjector.Project(peReader);
+
+        Assert.NotEmpty(projection.Tables);
+        Assert.Contains(projection.Tables, table => table.Index == TableIndex.TypeDef);
+    }
+
+    [Fact]
+    public void RowWindow_PagesCoverEveryRowExactlyOnce_InOrder()
+    {
+        var full = FullTable(TableIndex.TypeDef);
+        Assert.True(full.RowCount > 4, "Expected the test assembly to define more than four types.");
+
+        const int PageSize = 3;
+        var paged = ImmutableArray.CreateBuilder<int>();
+        for (int start = 1; start <= full.RowCount; start += PageSize)
+        {
+            foreach (var row in Window(TableIndex.TypeDef, start, PageSize).Rows)
+                paged.Add(row.RowId);
+        }
+
+        Assert.Equal(full.Rows.Select(row => row.RowId), paged);
+    }
+
+    [Fact]
+    public void RowWindow_ReportsAbsoluteRowIds_AndThePhysicalRowCount()
+    {
+        var full = FullTable(TableIndex.TypeDef);
+        var second = Window(TableIndex.TypeDef, startRowId: 3, maxRows: 2);
+
+        Assert.Equal([3, 4], second.Rows.Select(row => row.RowId));
+        Assert.Equal(full.RowCount, second.RowCount);
+    }
+
+    [Fact]
+    public void RowWindow_ProjectsIdenticalCells_ToTheUnwindowedProjection()
+    {
+        var full = FullTable(TableIndex.TypeDef);
+        var windowed = Window(TableIndex.TypeDef, startRowId: 3, maxRows: 2);
+
+        // A window changes coverage, never content.
+        Assert.Equal(full.Columns, windowed.Columns);
+        foreach (var row in windowed.Rows)
+        {
+            var expected = full.Rows.Single(candidate => candidate.RowId == row.RowId);
+            Assert.Equal(expected.Token, row.Token);
+            Assert.Equal(expected.Cells, row.Cells);
+        }
+    }
+
+    [Fact]
+    public void RowWindow_MarksPartialCoverage_Explicitly()
+    {
+        var full = FullTable(TableIndex.TypeDef);
+        var windowed = Window(TableIndex.TypeDef, startRowId: 2, maxRows: 2);
+
+        Assert.NotNull(windowed.Truncation);
+        Assert.Equal(2, windowed.Truncation!.ProjectedRows);
+        Assert.Equal(full.RowCount, windowed.Truncation.RowCount);
+    }
+
+    [Fact]
+    public void RowWindow_CoveringTheWholeTable_ReportsNoTruncation()
+    {
+        var full = FullTable(TableIndex.TypeDef);
+        var windowed = Window(TableIndex.TypeDef, startRowId: 1, maxRows: full.RowCount);
+
+        Assert.Null(windowed.Truncation);
+        Assert.Equal(full.RowCount, windowed.Rows.Length);
+    }
+
+    [Fact]
+    public void RowWindow_PastTheEnd_KeepsTheTableVisible_WithZeroRows()
+    {
+        var full = FullTable(TableIndex.TypeDef);
+
+        // Dropping the table here would report a populated table as absent.
+        var beyond = Window(TableIndex.TypeDef, startRowId: full.RowCount + 1, maxRows: 16);
+
+        Assert.Empty(beyond.Rows);
+        Assert.Equal(full.RowCount, beyond.RowCount);
+        Assert.NotNull(beyond.Truncation);
+        Assert.Equal(0, beyond.Truncation!.ProjectedRows);
+        Assert.Equal(full.RowCount, beyond.Truncation.RowCount);
+        Assert.Equal(full.Columns, beyond.Columns);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void RowWindow_ClampsAStartRowIdBelowOne(int startRowId)
+    {
+        var fromOne = Window(TableIndex.TypeDef, startRowId: 1, maxRows: 2);
+        var clamped = Window(TableIndex.TypeDef, startRowId, maxRows: 2);
+
+        Assert.Equal(fromOne.Rows.Select(row => row.RowId), clamped.Rows.Select(row => row.RowId));
+    }
+
+    [Fact]
+    public void RowWindow_WithAStartBeyondIntRange_DoesNotWrapIntoTheTable()
+    {
+        // start + budget - 1 must be widened before the comparison, or the window
+        // overflows to a negative end and silently overlaps real rows.
+        var overflowing = Window(TableIndex.TypeDef, startRowId: int.MaxValue, maxRows: int.MaxValue);
+
+        Assert.Empty(overflowing.Rows);
+        Assert.True(overflowing.RowCount > 0);
+    }
+
+    [Fact]
+    public void RowWindow_WithAZeroBudget_ProjectsNothing()
+    {
+        var empty = Window(TableIndex.TypeDef, startRowId: 1, maxRows: 0);
+
+        Assert.Empty(empty.Rows);
+        Assert.NotNull(empty.Truncation);
+        Assert.Equal(0, empty.Truncation!.ProjectedRows);
+    }
+
+    [Fact]
+    public void ProjectRow_ReadsARow_OutsideTheCurrentWindow()
+    {
+        var full = FullTable(TableIndex.TypeDef);
+        int lastRowId = full.RowCount;
+        Assert.True(lastRowId > 1, "Expected more than one TypeDef row.");
+
+        // The caller's window covers only row 1; the lookup must not be bounded by it.
+        var window = Window(TableIndex.TypeDef, startRowId: 1, maxRows: 1);
+        Assert.DoesNotContain(window.Rows, row => row.RowId == lastRowId);
+
+        using var peReader = OpenSelfFromBytes();
+        var view = MetadataTableProjector.ProjectRow(peReader, TableIndex.TypeDef, lastRowId);
+
+        Assert.NotNull(view);
+        var row = Assert.Single(view!.Rows);
+        Assert.Equal(lastRowId, row.RowId);
+
+        // The schema and the table's real size travel with the row.
+        Assert.Equal(full.Columns, view.Columns);
+        Assert.Equal(full.RowCount, view.RowCount);
+    }
+
+    [Fact]
+    public void ProjectRow_MatchesTheSameRow_FromAFullProjection()
+    {
+        var full = FullTable(TableIndex.MemberRef);
+        var expected = full.Rows[^1];
+
+        using var peReader = OpenSelfFromBytes();
+        var view = MetadataTableProjector.ProjectRow(peReader, TableIndex.MemberRef, expected.RowId);
+
+        var actual = Assert.Single(view!.Rows);
+        Assert.Equal(expected.Token, actual.Token);
+        Assert.Equal(expected.Cells, actual.Cells);
+    }
+
+    [Fact]
+    public void ProjectRow_FollowsAHandleRef_ToItsTargetRow()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var projection = MetadataTableProjector.Project(peReader);
+
+        // The click-through path: pick any resolvable handle edge and land on its row.
+        var edge = projection.Tables
+            .SelectMany(table => table.Rows)
+            .SelectMany(row => row.Cells)
+            .OfType<MetadataValue.Handle>()
+            .Select(handle => handle.Reference)
+            .First(reference => reference.TargetRowId >= 1
+                && reference.TargetTable is TableIndex.TypeDef or TableIndex.TypeRef or TableIndex.AssemblyRef);
+
+        var view = MetadataTableProjector.ProjectRow(peReader, edge.TargetTable, edge.TargetRowId);
+
+        Assert.NotNull(view);
+        Assert.Equal(edge.TargetTable, view!.Index);
+        var row = Assert.Single(view.Rows);
+        Assert.Equal(edge.TargetRowId, row.RowId);
+        Assert.Equal(edge.Token, row.Token);
+    }
+
+    [Fact]
+    public void ProjectRow_ReturnsNull_ForARowIdPastTheEnd()
+    {
+        var full = FullTable(TableIndex.TypeDef);
+
+        using var peReader = OpenSelfFromBytes();
+
+        Assert.Null(MetadataTableProjector.ProjectRow(peReader, TableIndex.TypeDef, full.RowCount + 1));
+    }
+
+    [Fact]
+    public void ProjectRow_ReturnsNull_ForATableTheProjectionDoesNotCover()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        Assert.Null(MetadataTableProjector.ProjectRow(peReader, TableIndex.InterfaceImpl, 1));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ProjectRow_RejectsANonPositiveRowId(int rowId)
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => MetadataTableProjector.ProjectRow(peReader, TableIndex.TypeDef, rowId));
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataProjectionWindowTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataProjectionWindowTests.cs
@@ -237,6 +237,57 @@ public class MetadataProjectionWindowTests
     }
 
     [Fact]
+    public void ProjectRow_IgnoresTheTableSelection_SoCrossTableEdgesStillResolve()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        // A caller browsing only TypeRef must still be able to follow a TypeRef
+        // row's edge into TypeDef. Honouring Tables here would dead-end exactly
+        // the navigation this method exists to serve.
+        var view = MetadataTableProjector.ProjectRow(
+            peReader,
+            TableIndex.TypeDef,
+            1,
+            new MetadataProjectionOptions { Tables = [TableIndex.TypeRef] });
+
+        Assert.NotNull(view);
+        Assert.Equal(TableIndex.TypeDef, view!.Index);
+        Assert.Equal(1, Assert.Single(view.Rows).RowId);
+    }
+
+    [Fact]
+    public void ProjectRow_IgnoresTheWindowStart_ButKeepsTheCellBudgets()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        // StartRowId belongs to the window, not to a targeted lookup: rowId wins.
+        var view = MetadataTableProjector.ProjectRow(
+            peReader,
+            TableIndex.TypeDef,
+            2,
+            new MetadataProjectionOptions { StartRowId = 900, MaxStringChars = 4 });
+
+        var row = Assert.Single(view!.Rows);
+        Assert.Equal(2, row.RowId);
+
+        // The budget the caller did supply still applies to the row's cells.
+        var name = Assert.IsType<MetadataValue.HeapReference>(
+            row.Cells[ColumnIndexOf(view, "Name")]);
+        Assert.True(name.Truncated, "Expected a 4-character budget to bound the type name.");
+    }
+
+    static int ColumnIndexOf(MetadataTableView table, string name)
+    {
+        for (int i = 0; i < table.Columns.Length; i++)
+        {
+            if (table.Columns[i].Name == name)
+                return i;
+        }
+
+        throw new Xunit.Sdk.XunitException($"Column '{name}' not found in table '{table.Name}'.");
+    }
+
+    [Fact]
     public void ProjectRow_ReturnsNull_ForARowIdPastTheEnd()
     {
         var full = FullTable(TableIndex.TypeDef);


### PR DESCRIPTION
Serves #3341 acceptance items 1, 2, and 3. The wasm Metadata Explorer browses metadata tables interactively rather than dumping them, and the projection could not serve that.

## What was blocking

- `MaxRowsPerTable` always counted from row 1 (`for (int rid = 1; rid <= limit; rid++)`), so **"page 2" was inexpressible**.
- Following a `HandleRef` whose target row fell outside the current budget **dead-ended**; the only recovery was re-projecting the whole target table.
- `Project(PEReader, ...)` was already filesystem-free, but nothing pinned that, so it could regress silently.

## What this changes

**Row window.** `MetadataProjectionOptions.StartRowId` pairs with `MaxRowsPerTable` to form a per-table window. A window changes **coverage, never content**:

- rows keep their absolute `RowId` and `Token`;
- `MetadataTableView.RowCount` stays the physical count;
- partial coverage is still marked by `Truncation`;
- a window past the end of a populated table yields that table **with zero rows** rather than dropping it, so paging cannot make a populated table look absent;
- the window end is widened to `long` before the comparison, so a start near `int.MaxValue` cannot overflow to a negative end and wrap back into real rows.

**On-demand row lookup.** `MetadataTableProjector.ProjectRow(peReader, table, rowId)` is the click-through primitive. It reads one row independent of any window on the containing table and returns it **inside that table's view**, so the caller also gets the column schema and the table's real size — neither of which a bare row can carry. It is a one-row window over the shared `BuildView`, **not a second row path**, so malformed-row containment and every budget behave identically. Returns `null` for no metadata, an unprojected table, or a row id past the end.

**Presentation must name the window.** Because a window can start anywhere, `showing 3 of 366 rows` would read as the *first* three rows. The renderer heading becomes `showing rows 4–6 of 366` when a window does not start at row 1, and `mdi` gains `--start-row|-s` with a matching stderr note for the machine formats.

## Compatibility

Purely additive. `StartRowId` defaults to 1, so every existing projection, every `mdi` invocation, and every rendered heading is byte-identical to before. The only behavior reachable solely through the new option is the past-the-end empty view.

## Evidence

- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — **966 passed, 0 failed, 0 skipped** (up from 947; the mdv cross-implementation oracle ran, it did not skip).
- `dotnet run --project tests/DotnetInspector.MetadataRendering.Tests -c Release` — **33 passed, 0 failed** (up from 30).
- `dotnet build dotnet-inspect.slnx -c Release` — clean, 0 errors.
- `git grep` confirms these two suites cover **every** consumer of `MetadataProjectionOptions`/`MetadataTableTruncation` in the repo; the `dotnet-inspect` CLI does not consume the projection.

19 new tests, including the ones that would catch this going wrong:

- pages of 3 over TypeDef **reconstruct the full row-id sequence exactly** — no gap, no duplicate, no reorder;
- a windowed row's cells are **equal** to the same row from an unwindowed projection;
- `StartRowId = int.MaxValue` with `MaxRowsPerTable = int.MaxValue` projects nothing (the overflow guard);
- a start below 1 clamps, matching how `MaxRowsPerTable` already clamps;
- a window past the end keeps the table visible with `Truncation(0, RowCount)` and its full schema;
- `ProjectRow` reaches the last row while the caller's window covers only row 1, and its cells match the full projection;
- a real `HandleRef` is followed to its target row and the returned row's `Token` matches the edge's;
- `Project` is driven from a `MemoryStream` over bytes, never a path.

End-to-end through `mdi` on `ILInspector.Metadata.dll` (366 TypeDef rows), showing pages are contiguous and correctly labelled:

```
$ mdi ILInspector.Metadata.dll -t TypeDef -n 3
## TypeDef (showing 3 of 366 rows)
| 1 | NotPublic | <Module> | ...
| 2 | Sealed, BeforeFieldInit | <>z__ReadOnlyArray1 | ...
| 3 | Sealed, BeforeFieldInit | <>z__ReadOnlyList1 | ...

$ mdi ILInspector.Metadata.dll -t TypeDef -s 4 -n 3
## TypeDef (showing rows 4–6 of 366)
| 4 | Sealed, BeforeFieldInit | <>z__ReadOnlySingleElementList1 | ...
| 5 | ... | 6 | ...

$ mdi ILInspector.Metadata.dll -t TypeDef -s 4 -n 3 -f jsonl
Note: table TypeDef shows rows 4 to 6 of 366; raise --max-rows or move --start-row to include more.
{"table":"TypeDef","rid":"4",...}
```

## Not in scope

Allocation shape (#3341 increment 3) stays **measurement-gated** — no benchmark exists yet, and AGENTS.md forbids claiming runtime impact from static structure. Reverse index/search and heap/header surfacing remain open. The `dotnet-inspect metadata` CLI lens (#3282) is deliberately sequenced last.
