### PR TITLE
Add reverse-reference search to the metadata projection

### DIFF
--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -436,11 +436,22 @@ oversights:
   could report "nothing points here" while a pointer sat in an unsearched table,
   which is worse than a slower answer.
 - **Blind spots are reported, not folded in.** `Truncated` marks a scan the
-  result budget stopped, and `UnreadableRows` lists rows that could not be
-  decoded and therefore could not be inspected. `IsComplete` is true only when
-  neither happened, which is what makes an empty result trustworthy. Unlike
-  `MetadataTableTruncation`, `Truncated` carries no total: a stopped scan never
-  learns how many references it did not reach.
+  result budget stopped, and `UnreadableRows` lists rows whose edges could not
+  be fully determined. `IsComplete` is true only when neither happened, which is
+  what makes an empty result trustworthy. Unlike `MetadataTableTruncation`,
+  `Truncated` carries no total: a stopped scan never learns how many references
+  it did not reach.
+
+`UnreadableRows` is subtler than "the row failed to read". The cell readers
+**contain** a decode failure as a `Malformed` cell rather than throwing, so a
+row holding a broken handle or list column reads back successfully and would
+otherwise pass as fully searched — a missed reference that reads as an absent
+one. A `Malformed` cell in an edge column therefore marks its row a blind spot.
+The **column's declared kind decides, not the cell**: a `Malformed` heap,
+scalar, or flags cell was never an edge and cannot hide a reference, so it is
+not counted. A row stays a blind spot only once, and after its good edges have
+been collected, so one broken column never costs the caller the edges that row
+does have.
 
 The search reuses the projection's single row-reading path rather than a faster
 private one, so a `HandleRef` or `HandleRange` means the same thing in a search

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -450,14 +450,43 @@ oversights:
   blind spot that under-reports is the whole failure this exists to prevent.
   Entering a table is deliberately not enough: a loop that stops part-way leaves
   rows unread, and an edge onto the target could sit in any of them. That also
-  makes the budget interaction fall out for free — a scan the budget stops
-  leaves both the table it stopped inside and every table after it unsearched,
-  and all of them are reported. Note that reaching the end of the row loop is
-  *also* not enough, because the budget is checked inside the **column** loop:
-  truncation on a table's final row leaves that row entered and abandoned
-  part-way through its columns while the row counter still passes the row count,
-  so a completed scan and a scan stopped on the last row are indistinguishable
-  from the counter alone. `Truncated` is what separates them.
+  makes the budget interaction mostly fall out for free — a scan the budget
+  stops leaves every table after it unsearched, and all of them are reported.
+
+  Reaching the end of the row loop is *also* not enough, because the budget is
+  checked inside the **column** loop: truncation on a table's final row leaves
+  that row entered and abandoned part-way through its columns while the row
+  counter still passes the row count, so the counter alone cannot tell a
+  completed scan from one stopped on the last row.
+
+  `Truncated` is too blunt to separate them, though, because of the boundary
+  case: if the budget trips on the **last column of the last row**, every cell
+  the table has was examined and the table genuinely was searched in full, even
+  though the scan ended inside it. Reporting it unscanned there would be a false
+  blind spot — it would tell the reader an unexamined cell could hide an edge
+  when no cell went unexamined. So the scan tracks the precise fact instead:
+  whether anything in this table was left unlooked-at, which is the columns
+  after the stop on that row, or any row after it.
+
+  That also keeps the malformed-cell blind spot sound. A stop before the last
+  column leaves the remaining columns unchecked for malformed edges, so the row
+  might belong in `UnreadableRows` without the scan knowing — but that is
+  exactly the case where the table is reported unscanned, so the gap is still
+  disclosed. When the stop is on the last column, every column was checked and
+  the row's status is fully determined.
+- **`UnscannedTables` covers unexamined cells, not just unread rows.** A table
+  lands there for three different reasons — never entered, entered and stopped
+  between rows, or entered and stopped between columns of its final row — and
+  only the first two leave a whole row unread. The caveat is therefore worded
+  around a cell the scan never examined, which is true of all three.
+- **A table with an unreadable row is not an `UnscannedTables` entry.** The two
+  blind spots partition the space rather than overlapping: `UnreadableRows` is
+  for rows the scan **read but could not decode**, `UnscannedTables` for cells it
+  **never examined**. A row whose read threw, or whose edge column decoded as
+  `Malformed`, is named individually in `UnreadableRows` and forces `IsComplete`
+  false, which is strictly more precise than implicating its whole table. Folding
+  it into `UnscannedTables` would also print a false statement, since every row
+  of that table was in fact read.
 - **Signature blobs are not searched, and that limit is not detectable.** The
   scan matches `Handle` and `HandleRange` columns. A `TypeDefOrRef` coded token
   spelled inside a signature blob lives in a `Heap` column, which is correctly

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -440,8 +440,8 @@ oversights:
   tables. A real assembly populates tables outside that subset — `NestedClass`,
   `MethodSemantics`, `InterfaceImpl`, `Property` and friends — so an edge living
   in one of them is invisible to the search. A nested type's declaring type is
-  exactly such an edge. `UnscannedTables` names the populated tables no row of
-  which was searched, so the gap is disclosed rather than answered as an
+  exactly such an edge. `UnscannedTables` names the populated tables the scan
+  did not read in full, so the gap is disclosed rather than answered as an
   absence. Empty tables are excluded: they cannot hide a reference.
 - **`UnscannedTables` is derived from the traversal, not declared.** The scan
   records a table only after examining every row the image says it has, and the
@@ -455,8 +455,8 @@ oversights:
   and all of them are reported.
 - **Blind spots are reported, not folded in.** `Truncated` marks a scan the
   result budget stopped, `UnreadableRows` lists rows whose edges could not be
-  fully determined, and `UnscannedTables` lists the populated tables no row of
-  which was searched. `IsComplete` is true only when none of the three happened,
+  fully determined, and `UnscannedTables` lists the populated tables the scan
+  did not read in full. `IsComplete` is true only when none of the three happened,
   which is what would make an empty result trustworthy — and today that means it
   is **false for essentially every real assembly**, because the third blind spot
   always fires. That is the honest reading: until the projection covers every

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -460,15 +460,28 @@ oversights:
   from the counter alone. `Truncated` is what separates them.
 - **Signature blobs are not searched, and that limit is not detectable.** The
   scan matches `Handle` and `HandleRange` columns. A `TypeDefOrRef` coded token
-  spelled inside a signature blob — `Field.Signature`, `MethodDef.Signature`,
-  `MemberRef.Signature`, `TypeSpec.Signature`, `StandAloneSig.Signature`,
-  `MethodSpec.Instantiation` — lives in a `Heap` column, which is correctly not
-  an edge column, on a row of a table the scan reads in full. So no blind spot
-  fires: the row is read, the table is searched, and the edge is simply not
-  looked for. Decoding blobs is future work (see the reverse-reference tagging
-  note above); until then the limit is disclosed **unconditionally** by the
-  renderer rather than by a per-scan signal, because there is no per-scan signal
-  to give.
+  spelled inside a signature blob lives in a `Heap` column, which is correctly
+  not an edge column, on a row of a table the scan reads in full. So no blind
+  spot fires: the row is read, the table is searched, and the edge is simply not
+  looked for. Among the tables modelled today those columns are
+  `Field.Signature`, `MethodDef.Signature`, `MemberRef.Signature`,
+  `TypeSpec.Signature`, `StandAloneSig.Signature` and
+  `MethodSpec.Instantiation`. Unmodelled tables hold signature blobs too —
+  `Property.Type` is one — but those tables are already disclosed by
+  `UnscannedTables`, so modelling one later moves its signature column into this
+  list rather than out of any disclosure. Decoding blobs is future work (see the
+  reverse-reference tagging note above); until then the limit is disclosed
+  **unconditionally** by the renderer rather than by a per-scan signal, because
+  there is no per-scan signal to give.
+
+  The caveat deliberately covers two unlike things. A signature blob spells a
+  reference as a TypeDefOrRef coded **token**, which is a genuine missed
+  row-to-row edge. A `CustomAttribute.Value` blob spells a `System.Type`
+  argument as a serialized type **name** (ECMA-335 II.23.3) — `[My(typeof(Alpha))]`
+  stores the bytes `0100 05 "Alpha" 0000`, with no token anywhere — so it is not
+  a row-to-row edge at all and is out of scope for a search defined over tokens.
+  A reader asking "what references this type?" is not served by that
+  distinction, though, so the caveat names both rather than resting on it.
 
   The risk runs backwards here, which is why the unconditional caveat is not
   redundant. `IsComplete` is true exactly when every populated table happens to

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -432,15 +432,28 @@ Two design points are deliberate and worth stating, because both look like
 oversights:
 
 - **`options.Tables` is not honored.** Like `ProjectRow`, the search is a query
-  over the whole image, not a projection of a selection. Narrowing the scan
-  could report "nothing points here" while a pointer sat in an unsearched table,
-  which is worse than a slower answer.
+  over the whole projection, not a projection of a selection. Narrowing the scan
+  per call could report "nothing points here" while a pointer sat in an
+  unsearched table, which is worse than a slower answer.
+- **The projection's table coverage is itself a blind spot.** The scan cannot
+  be wider than the projection, and the projection models a subset of ECMA-335's
+  tables. A real assembly populates tables outside that subset — `NestedClass`,
+  `MethodSemantics`, `InterfaceImpl`, `Property` and friends — so an edge living
+  in one of them is invisible to the search. A nested type's declaring type is
+  exactly such an edge. `UnscannedTables` names the populated unmodelled tables
+  so the gap is disclosed rather than answered as an absence. Empty tables are
+  excluded: they cannot hide a reference.
 - **Blind spots are reported, not folded in.** `Truncated` marks a scan the
-  result budget stopped, and `UnreadableRows` lists rows whose edges could not
-  be fully determined. `IsComplete` is true only when neither happened, which is
-  what makes an empty result trustworthy. Unlike `MetadataTableTruncation`,
-  `Truncated` carries no total: a stopped scan never learns how many references
-  it did not reach.
+  result budget stopped, `UnreadableRows` lists rows whose edges could not be
+  fully determined, and `UnscannedTables` lists the populated tables the scan
+  never visited. `IsComplete` is true only when none of the three happened,
+  which is what would make an empty result trustworthy — and today that means it
+  is **false for essentially every real assembly**, because the third blind spot
+  always fires. That is the honest reading: until the projection covers every
+  table, the search has not covered the whole image. Callers that only want to
+  know whether the scan itself finished should read `Truncated`. Unlike
+  `MetadataTableTruncation`, `Truncated` carries no total: a stopped scan never
+  learns how many references it did not reach.
 
 `UnreadableRows` is subtler than "the row failed to read". The cell readers
 **contain** a decode failure as a `Malformed` cell rather than throwing, so a

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -440,13 +440,21 @@ oversights:
   tables. A real assembly populates tables outside that subset — `NestedClass`,
   `MethodSemantics`, `InterfaceImpl`, `Property` and friends — so an edge living
   in one of them is invisible to the search. A nested type's declaring type is
-  exactly such an edge. `UnscannedTables` names the populated unmodelled tables
-  so the gap is disclosed rather than answered as an absence. Empty tables are
-  excluded: they cannot hide a reference.
+  exactly such an edge. `UnscannedTables` names the populated tables the scan
+  did not reach so the gap is disclosed rather than answered as an absence.
+  Empty tables are excluded: they cannot hide a reference.
+- **`UnscannedTables` is derived from the traversal, not declared.** The scan
+  records each table as it finishes it, and the blind spot is the populated
+  tables missing from that record. Computing it from the list of tables the
+  scan *intends* to visit would let the two drift, and a blind spot that
+  under-reports is the whole failure this exists to prevent. It also makes the
+  budget interaction fall out for free: a scan the budget stops leaves modelled
+  tables unreached, and those are unscanned in exactly the sense the report
+  means.
 - **Blind spots are reported, not folded in.** `Truncated` marks a scan the
   result budget stopped, `UnreadableRows` lists rows whose edges could not be
   fully determined, and `UnscannedTables` lists the populated tables the scan
-  never visited. `IsComplete` is true only when none of the three happened,
+  never reached. `IsComplete` is true only when none of the three happened,
   which is what would make an empty result trustworthy — and today that means it
   is **false for essentially every real assembly**, because the third blind spot
   always fires. That is the honest reading: until the projection covers every

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -345,7 +345,8 @@ inspector), a standalone tool that renders the tables the way `mdv` does:
   (`ToolCommandName=mdi`) whose System.CommandLine front-end maps flags onto
   `MetadataProjectionOptions` and delegates all output to the renderer below.
   Surface: `mdi <assembly> [--table|-t <Names>] [--format|-f md|tsv|jsonl]
-  [--max-rows|-n N] [--start-row|-s N] [--max-bytes N] [--max-chars N]`. Missing
+  [--max-rows|-n N] [--start-row|-s N] [--references|-r Table:RowId]
+  [--max-references N] [--max-bytes N] [--max-chars N]`. Missing
   files, native images, and unreadable metadata surface as visible errors, never
   success-shaped empty output.
 - **`src/DotnetInspector.MetadataRendering`** — a small reusable library holding
@@ -408,6 +409,49 @@ would read as the first three rows.
 Allocation shape — windowed or lazy materialization, and `ReadOnlySpan<T>` views
 over the current `ImmutableArray<T>` — remains open and **measurement-gated**;
 the browser's memory ceiling is the real constraint, and no benchmark exists yet.
+
+## Implemented: reverse references
+
+Forward navigation is only half of browsing. A reader looking at `Field[1]` asks
+"what declares this?", and looking at `TypeDef[5]` asks "what points here?".
+Neither question is answerable by following the projection's edges, because
+those edges only run one way.
+
+`MetadataTableProjector.FindReferences(peReader, targetTable, targetRowId,
+maxReferences)` inverts them, returning a `MetadataRowReferenceSet`: the
+`MetadataRowLocation` of every row pointing at the target, with the pointing
+column's index, its name, and whether the edge was a `Handle` or a `Range`.
+
+The `Range` case is the load-bearing one. ECMA-335 does not give an owned row a
+back-pointer to its owner: a `Field` is owned by whichever `TypeDef.FieldList`
+run covers it, and a `Param` by whichever `MethodDef.ParamList` run covers it.
+Reverse search over list columns is therefore how ownership is resolved at all —
+not an extra convenience on top of handle search.
+
+Two design points are deliberate and worth stating, because both look like
+oversights:
+
+- **`options.Tables` is not honored.** Like `ProjectRow`, the search is a query
+  over the whole image, not a projection of a selection. Narrowing the scan
+  could report "nothing points here" while a pointer sat in an unsearched table,
+  which is worse than a slower answer.
+- **Blind spots are reported, not folded in.** `Truncated` marks a scan the
+  result budget stopped, and `UnreadableRows` lists rows that could not be
+  decoded and therefore could not be inspected. `IsComplete` is true only when
+  neither happened, which is what makes an empty result trustworthy. Unlike
+  `MetadataTableTruncation`, `Truncated` carries no total: a stopped scan never
+  learns how many references it did not reach.
+
+The search reuses the projection's single row-reading path rather than a faster
+private one, so a `HandleRef` or `HandleRange` means the same thing in a search
+result as in a rendered table. Cost is therefore proportional to the whole image
+per query; whether that needs an index is a measurement question, filed with the
+allocation work above rather than guessed at here.
+
+The renderer and `mdi` carry the blind spots into every format:
+`mdi --references TypeDef:5` prints them inline under the Markdown table, and
+the TSV/JSONL streams report them on stderr, since a pure row stream cannot
+distinguish a complete scan from a stopped one.
 
 ## Layer placement
 

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -452,18 +452,50 @@ oversights:
   rows unread, and an edge onto the target could sit in any of them. That also
   makes the budget interaction fall out for free — a scan the budget stops
   leaves both the table it stopped inside and every table after it unsearched,
-  and all of them are reported.
+  and all of them are reported. Note that reaching the end of the row loop is
+  *also* not enough, because the budget is checked inside the **column** loop:
+  truncation on a table's final row leaves that row entered and abandoned
+  part-way through its columns while the row counter still passes the row count,
+  so a completed scan and a scan stopped on the last row are indistinguishable
+  from the counter alone. `Truncated` is what separates them.
+- **Signature blobs are not searched, and that limit is not detectable.** The
+  scan matches `Handle` and `HandleRange` columns. A `TypeDefOrRef` coded token
+  spelled inside a signature blob — `Field.Signature`, `MethodDef.Signature`,
+  `MemberRef.Signature`, `TypeSpec.Signature`, `StandAloneSig.Signature`,
+  `MethodSpec.Instantiation` — lives in a `Heap` column, which is correctly not
+  an edge column, on a row of a table the scan reads in full. So no blind spot
+  fires: the row is read, the table is searched, and the edge is simply not
+  looked for. Decoding blobs is future work (see the reverse-reference tagging
+  note above); until then the limit is disclosed **unconditionally** by the
+  renderer rather than by a per-scan signal, because there is no per-scan signal
+  to give.
+
+  The risk runs backwards here, which is why the unconditional caveat is not
+  redundant. `IsComplete` is true exactly when every populated table happens to
+  be modelled — that is, on small, simple assemblies, which are precisely the
+  images where a blob edge is the *only* remaining way to miss a reference. A
+  caveat conditioned on incompleteness would therefore go quiet exactly where it
+  is most needed.
 - **Blind spots are reported, not folded in.** `Truncated` marks a scan the
   result budget stopped, `UnreadableRows` lists rows whose edges could not be
-  fully determined, and `UnscannedTables` lists the populated tables the scan
-  did not read in full. `IsComplete` is true only when none of the three happened,
-  which is what would make an empty result trustworthy — and today that means it
-  is **false for essentially every real assembly**, because the third blind spot
-  always fires. That is the honest reading: until the projection covers every
-  table, the search has not covered the whole image. Callers that only want to
-  know whether the scan itself finished should read `Truncated`. Unlike
-  `MetadataTableTruncation`, `Truncated` carries no total: a stopped scan never
-  learns how many references it did not reach.
+  fully determined, `UnscannedTables` lists the populated tables the scan did not
+  read in full, and `TargetExists` marks a target row id past the end of its
+  table. `IsComplete` is true only when the scan hit none of the blind spots it
+  can detect — and today that means it is **false for essentially every real
+  assembly**, because the table-coverage blind spot always fires. That is the
+  honest reading: until the projection covers every table, the search has not
+  covered the whole image. `IsComplete` describes the scan, not the image: it
+  cannot account for the signature-blob limit above, which no scan can detect.
+  Callers that only want to know whether the scan itself finished should read
+  `Truncated`. Unlike `MetadataTableTruncation`, `Truncated` carries no total: a
+  stopped scan never learns how many references it did not reach.
+- **A row id past the end of its table is answered, not rejected.** Asking what
+  points at a row that does not exist is a well-formed question — a dangling
+  edge points at exactly the rows that are not there, so the search must stay
+  askable. What it must not do is answer "nothing points at this row", which
+  claims the image was searched and came back clean. `TargetExists` records the
+  distinction and takes `IsComplete` down with it, so an absent row reads as a
+  question that could not be answered rather than as an answer.
 
 `UnreadableRows` is subtler than "the row failed to read". The cell readers
 **contain** a decode failure as a `Malformed` cell rather than throwing, so a

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -440,21 +440,23 @@ oversights:
   tables. A real assembly populates tables outside that subset — `NestedClass`,
   `MethodSemantics`, `InterfaceImpl`, `Property` and friends — so an edge living
   in one of them is invisible to the search. A nested type's declaring type is
-  exactly such an edge. `UnscannedTables` names the populated tables the scan
-  did not reach so the gap is disclosed rather than answered as an absence.
-  Empty tables are excluded: they cannot hide a reference.
+  exactly such an edge. `UnscannedTables` names the populated tables no row of
+  which was searched, so the gap is disclosed rather than answered as an
+  absence. Empty tables are excluded: they cannot hide a reference.
 - **`UnscannedTables` is derived from the traversal, not declared.** The scan
-  records each table as it finishes it, and the blind spot is the populated
-  tables missing from that record. Computing it from the list of tables the
-  scan *intends* to visit would let the two drift, and a blind spot that
-  under-reports is the whole failure this exists to prevent. It also makes the
-  budget interaction fall out for free: a scan the budget stops leaves modelled
-  tables unreached, and those are unscanned in exactly the sense the report
-  means.
+  records a table only after examining every row the image says it has, and the
+  blind spot is the populated tables missing from that record. Computing it from
+  the list of tables the scan *intends* to visit would let the two drift, and a
+  blind spot that under-reports is the whole failure this exists to prevent.
+  Entering a table is deliberately not enough: a loop that stops part-way leaves
+  rows unread, and an edge onto the target could sit in any of them. That also
+  makes the budget interaction fall out for free — a scan the budget stops
+  leaves both the table it stopped inside and every table after it unsearched,
+  and all of them are reported.
 - **Blind spots are reported, not folded in.** `Truncated` marks a scan the
   result budget stopped, `UnreadableRows` lists rows whose edges could not be
-  fully determined, and `UnscannedTables` lists the populated tables the scan
-  never reached. `IsComplete` is true only when none of the three happened,
+  fully determined, and `UnscannedTables` lists the populated tables no row of
+  which was searched. `IsComplete` is true only when none of the three happened,
   which is what would make an empty result trustworthy — and today that means it
   is **false for essentially every real assembly**, because the third blind spot
   always fires. That is the honest reading: until the projection covers every

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -95,10 +95,11 @@ public static class MetadataProjectionRenderer
     /// Renders a reverse-reference search — the rows pointing at one row — to
     /// <paramref name="output"/>.
     ///
-    /// A reverse search has two blind spots the table renderer has no equivalent
-    /// of, and neither may be dropped: a budget that stopped the scan, and rows
-    /// that could not be decoded. Both are rendered as explicit caveats, so an
-    /// empty result is never mistaken for a confident "nothing points here".
+    /// A reverse search has three blind spots the table renderer has no
+    /// equivalent of, and none may be dropped: a budget that stopped the scan,
+    /// rows that could not be decoded, and populated tables no row of which was
+    /// searched. All are rendered as explicit caveats, so an empty result is
+    /// never mistaken for a confident "nothing points here".
     /// </summary>
     public static void Render(
         MetadataRowReferenceSet references,

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -207,7 +207,11 @@ public static class MetadataProjectionRenderer
         {
             int count = references.UnscannedTables.Length;
             var names = string.Join(", ", references.UnscannedTables);
-            yield return $"{count} populated {(count == 1 ? "table is" : "tables are")} not modelled by the projection and {(count == 1 ? "was" : "were")} not searched, so an edge from {(count == 1 ? "it" : "them")} would have been missed: {names}.";
+            // Deliberately does not say *why* a table went unsearched. A table is
+            // here either because the projection does not model it or because the
+            // budget stopped the scan first, and naming one cause would be a
+            // false claim about the other.
+            yield return $"{count} populated {(count == 1 ? "table was" : "tables were")} not searched, so an edge from {(count == 1 ? "it" : "them")} would have been missed: {names}.";
         }
     }
 

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -91,6 +91,120 @@ public static class MetadataProjectionRenderer
         writer.Flush();
     }
 
+    /// <summary>
+    /// Renders a reverse-reference search — the rows pointing at one row — to
+    /// <paramref name="output"/>.
+    ///
+    /// A reverse search has two blind spots the table renderer has no equivalent
+    /// of, and neither may be dropped: a budget that stopped the scan, and rows
+    /// that could not be decoded. Both are rendered as explicit caveats, so an
+    /// empty result is never mistaken for a confident "nothing points here".
+    /// </summary>
+    public static void Render(
+        MetadataRowReferenceSet references,
+        TextWriter output,
+        MetadataTableFormat format = MetadataTableFormat.Markdown)
+    {
+        ArgumentNullException.ThrowIfNull(references);
+        ArgumentNullException.ThrowIfNull(output);
+
+        if (format == MetadataTableFormat.Markdown)
+            RenderReferencesMarkdown(references, output);
+        else
+            RenderReferencesTabular(references, output, format);
+    }
+
+    static void RenderReferencesMarkdown(MetadataRowReferenceSet references, TextWriter output)
+    {
+        var writer = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
+
+        writer.WriteHeading(2, $"References to {Describe(references.Target)} ({references.References.Length})");
+
+        if (references.References.IsEmpty)
+            writer.WriteParagraph($"No row points at {Describe(references.Target)}.");
+        else
+            WriteReferenceTable(writer, references, identifyTarget: false);
+
+        foreach (string caveat in Caveats(references))
+        {
+            writer.WriteBlankLine();
+            writer.WriteParagraph(caveat);
+        }
+
+        writer.Flush();
+    }
+
+    static void RenderReferencesTabular(
+        MetadataRowReferenceSet references,
+        TextWriter output,
+        MetadataTableFormat format)
+    {
+        var options = new MarkoutWriterOptions
+        {
+            TableMode = format == MetadataTableFormat.Tsv ? MarkoutTableMode.Tsv : MarkoutTableMode.Jsonl,
+        };
+        var writer = new MarkoutWriter(output, new TableFormatter(showHeader: true), options);
+
+        WriteReferenceTable(writer, references, identifyTarget: true);
+
+        writer.Flush();
+    }
+
+    static void WriteReferenceTable(MarkoutWriter writer, MetadataRowReferenceSet references, bool identifyTarget)
+    {
+        // Markdown names the target in its heading; the machine formats have no
+        // heading, so they carry a leading Target column and every row stays
+        // self-describing.
+        string[] headers = identifyTarget
+            ? ["Target", "Table", "#", "Column", "Kind"]
+            : ["Table", "#", "Column", "Kind"];
+        string[] headerNames = identifyTarget
+            ? ["target", "table", "rid", "column", "kind"]
+            : ["table", "rid", "column", "kind"];
+
+        string target = Describe(references.Target);
+        var rows = new List<string[]>(references.References.Length);
+        foreach (var reference in references.References)
+        {
+            rows.Add(identifyTarget
+                ?
+                [
+                    target,
+                    reference.Source.Table.ToString(),
+                    reference.Source.RowId.ToString(),
+                    reference.ColumnName,
+                    reference.Kind.ToString(),
+                ]
+                :
+                [
+                    reference.Source.Table.ToString(),
+                    reference.Source.RowId.ToString(),
+                    reference.ColumnName,
+                    reference.Kind.ToString(),
+                ]);
+        }
+
+        writer.WriteTable(headers, headerNames, rows);
+    }
+
+    /// <summary>
+    /// The limits of a reverse search, as caveats a reader must see. Empty when
+    /// the search covered the whole image, which is what makes an empty result
+    /// trustworthy.
+    /// </summary>
+    public static IEnumerable<string> Caveats(MetadataRowReferenceSet references)
+    {        if (references.Truncated)
+            yield return "The result budget stopped this scan before it finished, so more references may exist.";
+
+        if (!references.UnreadableRows.IsEmpty)
+        {
+            int count = references.UnreadableRows.Length;
+            yield return $"{count} {(count == 1 ? "row" : "rows")} could not be decoded and {(count == 1 ? "was" : "were")} not searched, so a reference from {(count == 1 ? "it" : "them")} would have been missed.";
+        }
+    }
+
+    static string Describe(MetadataRowLocation location) => $"{location.Table}[{location.RowId}]";
+
     static string HeadingText(MetadataTableView table)
     {
         if (table.Truncation is not { } truncation)

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -95,11 +95,13 @@ public static class MetadataProjectionRenderer
     /// Renders a reverse-reference search — the rows pointing at one row — to
     /// <paramref name="output"/>.
     ///
-    /// A reverse search has three blind spots the table renderer has no
-    /// equivalent of, and none may be dropped: a budget that stopped the scan,
-    /// rows that could not be decoded, and populated tables the scan did not
-    /// read in full. All are rendered as explicit caveats, so an empty result is
-    /// never mistaken for a confident "nothing points here".
+    /// A reverse search has blind spots the table renderer has no equivalent of,
+    /// and none may be dropped: a target row that is not there, a budget that
+    /// stopped the scan, rows that could not be decoded, populated tables the
+    /// scan did not read in full, and — always, since no per-query signal can
+    /// reveal it — edges spelled only inside signature blobs. All are rendered
+    /// as explicit caveats, so an empty result is never mistaken for a confident
+    /// "nothing points here".
     /// </summary>
     public static void Render(
         MetadataRowReferenceSet references,
@@ -189,12 +191,16 @@ public static class MetadataProjectionRenderer
     }
 
     /// <summary>
-    /// The limits of a reverse search, as caveats a reader must see. Empty when
-    /// the search covered the whole image, which is what makes an empty result
-    /// trustworthy.
+    /// The limits of a reverse search, as caveats a reader must see. Never
+    /// empty: three limits are reported when they fire, and the signature-blob
+    /// limit always applies, so an empty result is never presented as a bare
+    /// "nothing points here".
     /// </summary>
     public static IEnumerable<string> Caveats(MetadataRowReferenceSet references)
     {
+        if (!references.TargetExists)
+            yield return $"{Describe(references.Target)} is past the end of its table, so no row exists to point at — a row id this large is usually a typo.";
+
         if (references.Truncated)
             yield return "The result budget stopped this scan before it finished, so more references may exist.";
 
@@ -216,6 +222,16 @@ public static class MetadataProjectionRenderer
             // none of its rows was read would be false.
             yield return $"{count} populated {(count == 1 ? "table was" : "tables were")} not searched in full, so an edge in a row the scan never read would have been missed: {names}.";
         }
+
+        // Unconditional, unlike the three above, because no per-query signal can
+        // reveal it. Signature blobs carry TypeDefOrRef tokens in heap-kind
+        // columns of tables the scan reads in full, so the column is correctly
+        // not an edge column, the row is not blind, and the table is genuinely
+        // searched — nothing fires. A caveat printed only alongside the others
+        // would therefore be absent exactly on the small, clean images where
+        // this is the only limit left, which is where "No row points at X" reads
+        // most like a guarantee.
+        yield return "References spelled only inside signature blobs are not searched, so an edge that a signature carries is not reported.";
     }
 
     static string Describe(MetadataRowLocation location) => $"{location.Table}[{location.RowId}]";

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -99,7 +99,7 @@ public static class MetadataProjectionRenderer
     /// and none may be dropped: a target row that is not there, a budget that
     /// stopped the scan, rows that could not be decoded, populated tables the
     /// scan did not read in full, and — always, since no per-query signal can
-    /// reveal it — edges spelled only inside signature blobs. All are rendered
+    /// reveal it — references spelled only inside blobs. All are rendered
     /// as explicit caveats, so an empty result is never mistaken for a confident
     /// "nothing points here".
     /// </summary>
@@ -192,8 +192,8 @@ public static class MetadataProjectionRenderer
 
     /// <summary>
     /// The limits of a reverse search, as caveats a reader must see. Never
-    /// empty: three limits are reported when they fire, and the signature-blob
-    /// limit always applies, so an empty result is never presented as a bare
+    /// empty: four limits are reported when they fire, and the blob limit
+    /// always applies, so an empty result is never presented as a bare
     /// "nothing points here".
     /// </summary>
     public static IEnumerable<string> Caveats(MetadataRowReferenceSet references)
@@ -223,15 +223,22 @@ public static class MetadataProjectionRenderer
             yield return $"{count} populated {(count == 1 ? "table was" : "tables were")} not searched in full, so an edge in a row the scan never read would have been missed: {names}.";
         }
 
-        // Unconditional, unlike the three above, because no per-query signal can
-        // reveal it. Signature blobs carry TypeDefOrRef tokens in heap-kind
-        // columns of tables the scan reads in full, so the column is correctly
-        // not an edge column, the row is not blind, and the table is genuinely
-        // searched — nothing fires. A caveat printed only alongside the others
-        // would therefore be absent exactly on the small, clean images where
-        // this is the only limit left, which is where "No row points at X" reads
-        // most like a guarantee.
-        yield return "References spelled only inside signature blobs are not searched, so an edge that a signature carries is not reported.";
+        // Unconditional, unlike the four above, because no per-query signal can
+        // reveal it. Blob payloads sit in heap-kind columns of tables the scan
+        // reads in full, so the column is correctly not an edge column, the row
+        // is not blind, and the table is genuinely searched — nothing fires. A
+        // caveat printed only alongside the others would therefore be absent
+        // exactly on the small, clean images where this is the only limit left,
+        // which is where "No row points at X" reads most like a guarantee.
+        //
+        // Two unlike things are covered deliberately. A signature blob spells a
+        // reference as a TypeDefOrRef coded *token*, which is a genuine missed
+        // row-to-row edge. A custom-attribute value spells one as a serialized
+        // type *name*, which is not a token edge at all and so is out of scope
+        // for a search defined over tokens — but a reader asking "what
+        // references this type?" is not served by that distinction, and an
+        // unqualified empty answer would still mislead them.
+        yield return "Blob payloads are not searched, so a reference spelled inside one — as a type token in a signature, or as a type name in a custom-attribute value — is not reported.";
     }
 
     static string Describe(MetadataRowLocation location) => $"{location.Table}[{location.RowId}]";

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -220,7 +220,13 @@ public static class MetadataProjectionRenderer
             // false claim about the other. "in full" is load-bearing for the same
             // reason: the budget can stop part-way through a table, so claiming
             // none of its rows was read would be false.
-            yield return $"{count} populated {(count == 1 ? "table was" : "tables were")} not searched in full, so an edge in a row the scan never read would have been missed: {names}.";
+            // "Cell" rather than "row" deliberately. A table lands here for
+            // three different reasons — never entered, entered and stopped
+            // between rows, or entered and stopped between columns of its final
+            // row — and only the first two leave a row unread. The third leaves
+            // every row read but some cells unexamined, so "a row the scan never
+            // read" would be false there.
+            yield return $"{count} populated {(count == 1 ? "table was" : "tables were")} not searched in full, so an edge in a cell the scan never examined would have been missed: {names}.";
         }
 
         // Unconditional, unlike the four above, because no per-query signal can

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -193,13 +193,14 @@ public static class MetadataProjectionRenderer
     /// trustworthy.
     /// </summary>
     public static IEnumerable<string> Caveats(MetadataRowReferenceSet references)
-    {        if (references.Truncated)
+    {
+        if (references.Truncated)
             yield return "The result budget stopped this scan before it finished, so more references may exist.";
 
         if (!references.UnreadableRows.IsEmpty)
         {
             int count = references.UnreadableRows.Length;
-            yield return $"{count} {(count == 1 ? "row" : "rows")} could not be decoded and {(count == 1 ? "was" : "were")} not searched, so a reference from {(count == 1 ? "it" : "them")} would have been missed.";
+            yield return $"{count} {(count == 1 ? "row" : "rows")} had {(count == 1 ? "an edge" : "edges")} that could not be read, so a reference from {(count == 1 ? "it" : "them")} would have been missed.";
         }
     }
 

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -97,8 +97,8 @@ public static class MetadataProjectionRenderer
     ///
     /// A reverse search has three blind spots the table renderer has no
     /// equivalent of, and none may be dropped: a budget that stopped the scan,
-    /// rows that could not be decoded, and populated tables no row of which was
-    /// searched. All are rendered as explicit caveats, so an empty result is
+    /// rows that could not be decoded, and populated tables the scan did not
+    /// read in full. All are rendered as explicit caveats, so an empty result is
     /// never mistaken for a confident "nothing points here".
     /// </summary>
     public static void Render(
@@ -211,8 +211,10 @@ public static class MetadataProjectionRenderer
             // Deliberately does not say *why* a table went unsearched. A table is
             // here either because the projection does not model it or because the
             // budget stopped the scan first, and naming one cause would be a
-            // false claim about the other.
-            yield return $"{count} populated {(count == 1 ? "table was" : "tables were")} not searched, so an edge from {(count == 1 ? "it" : "them")} would have been missed: {names}.";
+            // false claim about the other. "in full" is load-bearing for the same
+            // reason: the budget can stop part-way through a table, so claiming
+            // none of its rows was read would be false.
+            yield return $"{count} populated {(count == 1 ? "table was" : "tables were")} not searched in full, so an edge in a row the scan never read would have been missed: {names}.";
         }
     }
 

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -202,6 +202,13 @@ public static class MetadataProjectionRenderer
             int count = references.UnreadableRows.Length;
             yield return $"{count} {(count == 1 ? "row" : "rows")} had {(count == 1 ? "an edge" : "edges")} that could not be read, so a reference from {(count == 1 ? "it" : "them")} would have been missed.";
         }
+
+        if (!references.UnscannedTables.IsEmpty)
+        {
+            int count = references.UnscannedTables.Length;
+            var names = string.Join(", ", references.UnscannedTables);
+            yield return $"{count} populated {(count == 1 ? "table is" : "tables are")} not modelled by the projection and {(count == 1 ? "was" : "were")} not searched, so an edge from {(count == 1 ? "it" : "them")} would have been missed: {names}.";
+        }
     }
 
     static string Describe(MetadataRowLocation location) => $"{location.Table}[{location.RowId}]";

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -124,5 +124,29 @@ public sealed class AssemblyInspectionSession : IDisposable
     public MetadataTableProjection MetadataTables(MetadataProjectionOptions? options = null)
         => MetadataTableProjector.Project(_image.PEReader, options);
 
+    /// <summary>
+    /// A single row of one metadata table, read on demand and independent of any
+    /// row window. This is the handle click-through primitive: it reaches a
+    /// target row that a windowed <see cref="MetadataTables"/> call did not
+    /// include. Null when the table is unsupported or the row id is past its end.
+    /// </summary>
+    public MetadataTableView? MetadataTableRow(
+        System.Reflection.Metadata.Ecma335.TableIndex table,
+        int rowId,
+        MetadataProjectionOptions? options = null)
+        => MetadataTableProjector.ProjectRow(_image.PEReader, table, rowId, options);
+
+    /// <summary>
+    /// The reverse of the projection's handle edges: every row pointing at the
+    /// given row, including through list-column runs so ownership resolves. The
+    /// result reports its own blind spots rather than folding them into an empty
+    /// answer.
+    /// </summary>
+    public MetadataRowReferenceSet MetadataReferences(
+        System.Reflection.Metadata.Ecma335.TableIndex targetTable,
+        int targetRowId,
+        int maxReferences = MetadataRowReferenceSet.DefaultMaxReferences)
+        => MetadataTableProjector.FindReferences(_image.PEReader, targetTable, targetRowId, maxReferences);
+
     public void Dispose() => _image.Dispose();
 }

--- a/src/ILInspector.Metadata/MetadataRowReferences.cs
+++ b/src/ILInspector.Metadata/MetadataRowReferences.cs
@@ -87,7 +87,7 @@ public sealed record MetadataRowReference
 /// result: <see cref="Truncated"/> when the result budget stopped the scan,
 /// <see cref="UnreadableRows"/> for rows the scan could not decode and therefore
 /// could not inspect, and <see cref="UnscannedTables"/> for populated tables the
-/// projection does not model and so never visited.
+/// scan did not read in full.
 /// </summary>
 public sealed record MetadataRowReferenceSet
 {
@@ -138,11 +138,13 @@ public sealed record MetadataRowReferenceSet
     public ImmutableArray<MetadataRowLocation> UnreadableRows { get; }
 
     /// <summary>
-    /// Populated tables no row of which was searched: either the projection does
-    /// not model the table, or the result budget stopped the scan before it
-    /// covered every row of it. A table is only counted as searched once every
-    /// one of its rows was examined, because an edge onto the target could sit
-    /// in any row left unread.
+    /// Populated tables the scan did not read in full: either the projection
+    /// does not model the table, so no row of it was read, or the result budget
+    /// stopped the scan part-way through the table or before reaching it. A
+    /// table is only counted as searched once every one of its rows was
+    /// examined, because an edge onto the target could sit in any row left
+    /// unread — a table read in part is as unable to rule out an edge as one
+    /// never opened.
     ///
     /// This is the largest blind spot of the three and the only one that fires
     /// on well-formed metadata, because the search covers the projected tables

--- a/src/ILInspector.Metadata/MetadataRowReferences.cs
+++ b/src/ILInspector.Metadata/MetadataRowReferences.cs
@@ -92,9 +92,10 @@ public sealed record MetadataRowReference
 /// its table.
 ///
 /// A fifth limit cannot be reported per query, because nothing about a given
-/// query reveals it: the search matches edges spelled as handle columns, so an
-/// edge carried inside a signature blob is never found and never disclosed.
-/// See <see cref="IsComplete"/>.
+/// query reveals it: the search matches edges spelled as handle columns, so a
+/// reference carried inside a blob is never found. It is disclosed all the
+/// same — unconditionally, by the renderer, since there is no per-query signal
+/// to condition it on. See <see cref="IsComplete"/>.
 /// </summary>
 public sealed record MetadataRowReferenceSet
 {
@@ -155,8 +156,8 @@ public sealed record MetadataRowReferenceSet
     /// unread — a table read in part is as unable to rule out an edge as one
     /// never opened.
     ///
-    /// This is the largest blind spot of the three and the only one that fires
-    /// on well-formed metadata, because the search covers the projected tables
+    /// This is the largest of the four detectable blind spots, and the only one
+    /// that fires on well-formed metadata, because the search covers the projected tables
     /// rather than all of ECMA-335 — so an edge in an unmodelled table
     /// (<c>NestedClass</c>, <c>MethodSemantics</c>, <c>InterfaceImpl</c> and
     /// friends on a typical assembly) is invisible to it. A nested type's
@@ -193,7 +194,7 @@ public sealed record MetadataRowReferenceSet
     ///
     /// This describes the scan, not the image. It does not mean nothing points
     /// at <see cref="Target"/>: the search sees only edges that metadata spells
-    /// as handle columns, so an edge carried inside a signature blob is
+    /// as handle columns, so a reference carried inside a blob is
     /// invisible to it whether this is <see langword="true"/> or
     /// <see langword="false"/>.
     /// </summary>
@@ -203,12 +204,17 @@ public sealed record MetadataRowReferenceSet
     /// <see cref="Truncated"/>, <see cref="UnreadableRows"/> and
     /// <see cref="UnscannedTables"/>.
     ///
-    /// A fifth is <b>not</b> disclosed, because no per-query signal can reveal
-    /// it. Signature blobs carry TypeDefOrRef coded tokens, and they sit in
-    /// heap-kind columns of tables the scan reads in full —
-    /// <c>Field.Signature</c>, <c>MethodDef.Signature</c>,
-    /// <c>MemberRef.Signature</c>, <c>TypeSpec.Signature</c>,
-    /// <c>StandAloneSig.Signature</c>, <c>MethodSpec.Instantiation</c>. The
+    /// A fifth is not <i>detectable</i>, because no per-query signal can reveal
+    /// it — it is disclosed unconditionally by the renderer instead. Blobs carry
+    /// references, and they sit in
+    /// heap-kind columns of tables the scan reads in full — among the tables
+    /// the projection models today, that is <c>Field.Signature</c>,
+    /// <c>MethodDef.Signature</c>, <c>MemberRef.Signature</c>,
+    /// <c>TypeSpec.Signature</c>, <c>StandAloneSig.Signature</c> and
+    /// <c>MethodSpec.Instantiation</c>. Signature blobs in unmodelled tables
+    /// (<c>Property.Type</c> and friends) carry the same tokens, but those
+    /// tables are already disclosed by <see cref="UnscannedTables"/>, so
+    /// modelling one later adds a column to this list. The
     /// column is correctly not an edge column, the row is not blind, and the
     /// table is genuinely searched, so nothing fires and the edge is simply not
     /// reported. Decoding those blobs is a separate feature, not a bug fix.

--- a/src/ILInspector.Metadata/MetadataRowReferences.cs
+++ b/src/ILInspector.Metadata/MetadataRowReferences.cs
@@ -82,12 +82,19 @@ public sealed record MetadataRowReference
 /// <see cref="Target"/>, plus the honest limits of that search.
 ///
 /// A reverse search must never answer "nothing points here" when it simply
-/// stopped early, could not read part of the metadata, or never looked at part
-/// of it, so all three blind spots are reported rather than folded into an empty
-/// result: <see cref="Truncated"/> when the result budget stopped the scan,
-/// <see cref="UnreadableRows"/> for rows the scan could not decode and therefore
-/// could not inspect, and <see cref="UnscannedTables"/> for populated tables the
-/// scan did not read in full.
+/// stopped early, could not read part of the metadata, never looked at part of
+/// it, or was handed a row that is not there, so those four blind spots are
+/// reported rather than folded into an empty result: <see cref="Truncated"/>
+/// when the result budget stopped the scan, <see cref="UnreadableRows"/> for
+/// rows the scan could not decode and therefore could not inspect,
+/// <see cref="UnscannedTables"/> for populated tables the scan did not read in
+/// full, and <see cref="TargetExists"/> when the target row is past the end of
+/// its table.
+///
+/// A fifth limit cannot be reported per query, because nothing about a given
+/// query reveals it: the search matches edges spelled as handle columns, so an
+/// edge carried inside a signature blob is never found and never disclosed.
+/// See <see cref="IsComplete"/>.
 /// </summary>
 public sealed record MetadataRowReferenceSet
 {
@@ -99,7 +106,8 @@ public sealed record MetadataRowReferenceSet
         ImmutableArray<MetadataRowReference> References,
         ImmutableArray<MetadataRowLocation> UnreadableRows,
         ImmutableArray<TableIndex> UnscannedTables,
-        bool Truncated)
+        bool Truncated,
+        bool TargetExists)
     {
         ArgumentNullException.ThrowIfNull(Target);
         if (References.IsDefault)
@@ -114,6 +122,7 @@ public sealed record MetadataRowReferenceSet
         this.UnreadableRows = UnreadableRows;
         this.UnscannedTables = UnscannedTables;
         this.Truncated = Truncated;
+        this.TargetExists = TargetExists;
     }
 
     /// <summary>The row the search was run for.</summary>
@@ -165,19 +174,53 @@ public sealed record MetadataRowReferenceSet
     public bool Truncated { get; }
 
     /// <summary>
-    /// Whether the search covered the whole image: it ran to completion, every
-    /// row was readable, and no populated table went unscanned, so an empty
-    /// <see cref="References"/> genuinely means nothing points at
-    /// <see cref="Target"/>.
+    /// Whether <see cref="Target"/> names a row the image actually has.
+    ///
+    /// Reported rather than rejected. A row id past the end of its table is
+    /// usually a typo, and answering one with a clean empty result would make
+    /// that typo indistinguishable from a real row nothing points at. But it is
+    /// not merely invalid input: a dangling edge points at exactly the rows that
+    /// do not exist, so asking what points at an absent row is a legitimate
+    /// question, and one this search can answer with
+    /// <see cref="UnreadableRows"/>.
+    /// </summary>
+    public bool TargetExists { get; }
+
+    /// <summary>
+    /// Whether the search hit none of the blind spots it can detect: the target
+    /// row exists, the scan ran to completion, every row it read was readable,
+    /// and every populated table was read in full.
+    ///
+    /// This describes the scan, not the image. It does not mean nothing points
+    /// at <see cref="Target"/>: the search sees only edges that metadata spells
+    /// as handle columns, so an edge carried inside a signature blob is
+    /// invisible to it whether this is <see langword="true"/> or
+    /// <see langword="false"/>.
     /// </summary>
     /// <remarks>
-    /// This is <see langword="false"/> for essentially every real assembly,
-    /// because the projection models a subset of ECMA-335's tables and typical
-    /// metadata populates tables outside it. That is the honest answer rather
-    /// than a defect in the caller's input: until the projection covers every
-    /// table, the search cannot claim to have covered the whole image. Callers
-    /// that only want to know whether the scan itself finished should read
-    /// <see cref="Truncated"/>.
+    /// Four limits are disclosed per query, and this property is exactly the
+    /// four of them being clear: <see cref="TargetExists"/>,
+    /// <see cref="Truncated"/>, <see cref="UnreadableRows"/> and
+    /// <see cref="UnscannedTables"/>.
+    ///
+    /// A fifth is <b>not</b> disclosed, because no per-query signal can reveal
+    /// it. Signature blobs carry TypeDefOrRef coded tokens, and they sit in
+    /// heap-kind columns of tables the scan reads in full —
+    /// <c>Field.Signature</c>, <c>MethodDef.Signature</c>,
+    /// <c>MemberRef.Signature</c>, <c>TypeSpec.Signature</c>,
+    /// <c>StandAloneSig.Signature</c>, <c>MethodSpec.Instantiation</c>. The
+    /// column is correctly not an edge column, the row is not blind, and the
+    /// table is genuinely searched, so nothing fires and the edge is simply not
+    /// reported. Decoding those blobs is a separate feature, not a bug fix.
+    ///
+    /// That inverts the risk, which is why this property must not be read as
+    /// "nothing points here". It is <see langword="false"/> for essentially
+    /// every real assembly, because typical metadata populates tables the
+    /// projection does not model — so it is <see langword="true"/> mainly on
+    /// small, simple images, which is exactly where a blob edge is the only
+    /// limit left to hide one. Callers that only want to know whether the scan
+    /// itself finished should read <see cref="Truncated"/>.
     /// </remarks>
-    public bool IsComplete => !Truncated && UnreadableRows.IsEmpty && UnscannedTables.IsEmpty;
+    public bool IsComplete =>
+        TargetExists && !Truncated && UnreadableRows.IsEmpty && UnscannedTables.IsEmpty;
 }

--- a/src/ILInspector.Metadata/MetadataRowReferences.cs
+++ b/src/ILInspector.Metadata/MetadataRowReferences.cs
@@ -1,0 +1,143 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Metadata;
+
+/// <summary>A single row, identified absolutely by its table and 1-based row id.</summary>
+public sealed record MetadataRowLocation
+{
+    public MetadataRowLocation(TableIndex Table, int RowId)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(RowId, 1);
+        this.Table = Table;
+        this.RowId = RowId;
+    }
+
+    /// <summary>The table the row belongs to.</summary>
+    public TableIndex Table { get; }
+
+    /// <summary>The 1-based row number within <see cref="Table"/>.</summary>
+    public int RowId { get; }
+
+    /// <summary>The row's metadata token: the table index in the high byte, the row id below it.</summary>
+    public int Token => ((int)Table << 24) | RowId;
+}
+
+/// <summary>How a source row points at a target row.</summary>
+public enum MetadataRowReferenceKind
+{
+    /// <summary>
+    /// A handle column naming the target row directly — the reverse of a
+    /// <see cref="MetadataValue.Handle"/> cell.
+    /// </summary>
+    Handle,
+
+    /// <summary>
+    /// A list column whose contiguous run of rows contains the target — the
+    /// reverse of a <see cref="MetadataValue.Range"/> cell. This is the edge
+    /// that answers ownership questions such as which <c>TypeDef</c> declares a
+    /// given <c>Field</c>, since ECMA-335 encodes that as a run rather than a
+    /// back-pointer on the owned row.
+    /// </summary>
+    Range,
+}
+
+/// <summary>One row that points at the row a reverse search was run for.</summary>
+public sealed record MetadataRowReference
+{
+    public MetadataRowReference(
+        MetadataRowLocation Source,
+        int ColumnIndex,
+        string ColumnName,
+        MetadataRowReferenceKind Kind)
+    {
+        ArgumentNullException.ThrowIfNull(Source);
+        ArgumentOutOfRangeException.ThrowIfNegative(ColumnIndex);
+        ArgumentException.ThrowIfNullOrEmpty(ColumnName);
+
+        this.Source = Source;
+        this.ColumnIndex = ColumnIndex;
+        this.ColumnName = ColumnName;
+        this.Kind = Kind;
+    }
+
+    /// <summary>The row holding the pointing cell.</summary>
+    public MetadataRowLocation Source { get; }
+
+    /// <summary>
+    /// The pointing cell's position in the source table's column schema, aligned
+    /// to <see cref="MetadataTableView.Columns"/> and <see cref="MetadataRow.Cells"/>.
+    /// </summary>
+    public int ColumnIndex { get; }
+
+    /// <summary>The pointing column's name, carried so a caller need not re-project the source table.</summary>
+    public string ColumnName { get; }
+
+    /// <summary>Whether the edge is a direct handle or membership in a list-column run.</summary>
+    public MetadataRowReferenceKind Kind { get; }
+}
+
+/// <summary>
+/// The result of a reverse-reference search: every row found pointing at
+/// <see cref="Target"/>, plus the honest limits of that search.
+///
+/// A reverse search must never answer "nothing points here" when it simply
+/// stopped early or could not read part of the metadata, so both blind spots are
+/// reported rather than folded into an empty result: <see cref="Truncated"/>
+/// when the result budget stopped the scan, and <see cref="UnreadableRows"/> for
+/// rows the scan could not decode and therefore could not inspect.
+/// </summary>
+public sealed record MetadataRowReferenceSet
+{
+    /// <summary>The default ceiling on how many references a search collects.</summary>
+    public const int DefaultMaxReferences = 4096;
+
+    public MetadataRowReferenceSet(
+        MetadataRowLocation Target,
+        ImmutableArray<MetadataRowReference> References,
+        ImmutableArray<MetadataRowLocation> UnreadableRows,
+        bool Truncated)
+    {
+        ArgumentNullException.ThrowIfNull(Target);
+        if (References.IsDefault)
+            throw new ArgumentException("References must be initialized.", nameof(References));
+        if (UnreadableRows.IsDefault)
+            throw new ArgumentException("UnreadableRows must be initialized.", nameof(UnreadableRows));
+
+        this.Target = Target;
+        this.References = References;
+        this.UnreadableRows = UnreadableRows;
+        this.Truncated = Truncated;
+    }
+
+    /// <summary>The row the search was run for.</summary>
+    public MetadataRowLocation Target { get; }
+
+    /// <summary>
+    /// The rows found pointing at <see cref="Target"/>, in table order and then
+    /// row order, matching the order the tables are projected in.
+    /// </summary>
+    public ImmutableArray<MetadataRowReference> References { get; }
+
+    /// <summary>
+    /// Rows the scan could not decode. Each is a row whose edges could not be
+    /// inspected, so a reference from it would have been missed. Empty for
+    /// well-formed metadata.
+    /// </summary>
+    public ImmutableArray<MetadataRowLocation> UnreadableRows { get; }
+
+    /// <summary>
+    /// Whether the result budget stopped the scan before it finished. Unlike
+    /// <see cref="MetadataTableTruncation"/> this carries no total, because a
+    /// stopped scan never learns how many references it did not reach; raise the
+    /// budget to see more.
+    /// </summary>
+    public bool Truncated { get; }
+
+    /// <summary>
+    /// Whether the search covered the whole image: it ran to completion and
+    /// every row was readable, so an empty <see cref="References"/> genuinely
+    /// means nothing points at <see cref="Target"/>.
+    /// </summary>
+    public bool IsComplete => !Truncated && UnreadableRows.IsEmpty;
+}

--- a/src/ILInspector.Metadata/MetadataRowReferences.cs
+++ b/src/ILInspector.Metadata/MetadataRowReferences.cs
@@ -120,9 +120,14 @@ public sealed record MetadataRowReferenceSet
     public ImmutableArray<MetadataRowReference> References { get; }
 
     /// <summary>
-    /// Rows the scan could not decode. Each is a row whose edges could not be
-    /// inspected, so a reference from it would have been missed. Empty for
-    /// well-formed metadata.
+    /// Rows whose edges could not be fully determined, so a reference from one
+    /// of them would have been missed. This covers a row that failed to decode
+    /// outright and a row with an edge column the projection could only report
+    /// as <see cref="MetadataValue.Malformed"/> — the cell readers contain such
+    /// failures rather than throwing, so the row would otherwise pass as fully
+    /// searched. A malformed heap, scalar, or flags cell is not counted: it was
+    /// never an edge and cannot hide a reference. Empty for well-formed
+    /// metadata.
     /// </summary>
     public ImmutableArray<MetadataRowLocation> UnreadableRows { get; }
 

--- a/src/ILInspector.Metadata/MetadataRowReferences.cs
+++ b/src/ILInspector.Metadata/MetadataRowReferences.cs
@@ -138,12 +138,13 @@ public sealed record MetadataRowReferenceSet
     public ImmutableArray<MetadataRowLocation> UnreadableRows { get; }
 
     /// <summary>
-    /// Populated tables the scan never looked at, because the projection does
-    /// not model them. This is the largest blind spot of the three and the only
-    /// one that fires on well-formed metadata: the search covers the projected
-    /// tables, not all of ECMA-335, so an edge living in an unmodelled table —
-    /// <c>NestedClass</c>, <c>MethodSemantics</c>, <c>InterfaceImpl</c> and
-    /// friends on a typical assembly — is invisible to it. A nested type's
+    /// Populated tables the scan never reached: either the projection does not
+    /// model them, or the result budget stopped the scan before it got to them.
+    /// This is the largest blind spot of the three and the only one that fires
+    /// on well-formed metadata, because the search covers the projected tables
+    /// rather than all of ECMA-335 — so an edge in an unmodelled table
+    /// (<c>NestedClass</c>, <c>MethodSemantics</c>, <c>InterfaceImpl</c> and
+    /// friends on a typical assembly) is invisible to it. A nested type's
     /// declaring type is exactly such an edge. Empty tables are excluded: they
     /// cannot hide a reference.
     /// </summary>

--- a/src/ILInspector.Metadata/MetadataRowReferences.cs
+++ b/src/ILInspector.Metadata/MetadataRowReferences.cs
@@ -82,10 +82,12 @@ public sealed record MetadataRowReference
 /// <see cref="Target"/>, plus the honest limits of that search.
 ///
 /// A reverse search must never answer "nothing points here" when it simply
-/// stopped early or could not read part of the metadata, so both blind spots are
-/// reported rather than folded into an empty result: <see cref="Truncated"/>
-/// when the result budget stopped the scan, and <see cref="UnreadableRows"/> for
-/// rows the scan could not decode and therefore could not inspect.
+/// stopped early, could not read part of the metadata, or never looked at part
+/// of it, so all three blind spots are reported rather than folded into an empty
+/// result: <see cref="Truncated"/> when the result budget stopped the scan,
+/// <see cref="UnreadableRows"/> for rows the scan could not decode and therefore
+/// could not inspect, and <see cref="UnscannedTables"/> for populated tables the
+/// projection does not model and so never visited.
 /// </summary>
 public sealed record MetadataRowReferenceSet
 {
@@ -96,6 +98,7 @@ public sealed record MetadataRowReferenceSet
         MetadataRowLocation Target,
         ImmutableArray<MetadataRowReference> References,
         ImmutableArray<MetadataRowLocation> UnreadableRows,
+        ImmutableArray<TableIndex> UnscannedTables,
         bool Truncated)
     {
         ArgumentNullException.ThrowIfNull(Target);
@@ -103,10 +106,13 @@ public sealed record MetadataRowReferenceSet
             throw new ArgumentException("References must be initialized.", nameof(References));
         if (UnreadableRows.IsDefault)
             throw new ArgumentException("UnreadableRows must be initialized.", nameof(UnreadableRows));
+        if (UnscannedTables.IsDefault)
+            throw new ArgumentException("UnscannedTables must be initialized.", nameof(UnscannedTables));
 
         this.Target = Target;
         this.References = References;
         this.UnreadableRows = UnreadableRows;
+        this.UnscannedTables = UnscannedTables;
         this.Truncated = Truncated;
     }
 
@@ -132,6 +138,18 @@ public sealed record MetadataRowReferenceSet
     public ImmutableArray<MetadataRowLocation> UnreadableRows { get; }
 
     /// <summary>
+    /// Populated tables the scan never looked at, because the projection does
+    /// not model them. This is the largest blind spot of the three and the only
+    /// one that fires on well-formed metadata: the search covers the projected
+    /// tables, not all of ECMA-335, so an edge living in an unmodelled table —
+    /// <c>NestedClass</c>, <c>MethodSemantics</c>, <c>InterfaceImpl</c> and
+    /// friends on a typical assembly — is invisible to it. A nested type's
+    /// declaring type is exactly such an edge. Empty tables are excluded: they
+    /// cannot hide a reference.
+    /// </summary>
+    public ImmutableArray<TableIndex> UnscannedTables { get; }
+
+    /// <summary>
     /// Whether the result budget stopped the scan before it finished. Unlike
     /// <see cref="MetadataTableTruncation"/> this carries no total, because a
     /// stopped scan never learns how many references it did not reach; raise the
@@ -140,9 +158,19 @@ public sealed record MetadataRowReferenceSet
     public bool Truncated { get; }
 
     /// <summary>
-    /// Whether the search covered the whole image: it ran to completion and
-    /// every row was readable, so an empty <see cref="References"/> genuinely
-    /// means nothing points at <see cref="Target"/>.
+    /// Whether the search covered the whole image: it ran to completion, every
+    /// row was readable, and no populated table went unscanned, so an empty
+    /// <see cref="References"/> genuinely means nothing points at
+    /// <see cref="Target"/>.
     /// </summary>
-    public bool IsComplete => !Truncated && UnreadableRows.IsEmpty;
+    /// <remarks>
+    /// This is <see langword="false"/> for essentially every real assembly,
+    /// because the projection models a subset of ECMA-335's tables and typical
+    /// metadata populates tables outside it. That is the honest answer rather
+    /// than a defect in the caller's input: until the projection covers every
+    /// table, the search cannot claim to have covered the whole image. Callers
+    /// that only want to know whether the scan itself finished should read
+    /// <see cref="Truncated"/>.
+    /// </remarks>
+    public bool IsComplete => !Truncated && UnreadableRows.IsEmpty && UnscannedTables.IsEmpty;
 }

--- a/src/ILInspector.Metadata/MetadataRowReferences.cs
+++ b/src/ILInspector.Metadata/MetadataRowReferences.cs
@@ -138,8 +138,12 @@ public sealed record MetadataRowReferenceSet
     public ImmutableArray<MetadataRowLocation> UnreadableRows { get; }
 
     /// <summary>
-    /// Populated tables the scan never reached: either the projection does not
-    /// model them, or the result budget stopped the scan before it got to them.
+    /// Populated tables no row of which was searched: either the projection does
+    /// not model the table, or the result budget stopped the scan before it
+    /// covered every row of it. A table is only counted as searched once every
+    /// one of its rows was examined, because an edge onto the target could sit
+    /// in any row left unread.
+    ///
     /// This is the largest blind spot of the three and the only one that fires
     /// on well-formed metadata, because the search covers the projected tables
     /// rather than all of ECMA-335 — so an edge in an unmodelled table

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -186,7 +186,7 @@ public static class MetadataTableProjector
     /// <see cref="MetadataProjectionOptions"/> at all, and in particular offers
     /// no equivalent of <see cref="MetadataProjectionOptions.Tables"/>, because
     /// a reverse search narrowed to part of the image could report "nothing
-    /// points here" while a pointer sat in an unsearched table. Its three blind
+    /// points here" while a pointer sat in an unsearched table. Three blind
     /// spots are reported instead of hidden:
     /// <see cref="MetadataRowReferenceSet.Truncated"/> when
     /// <paramref name="maxReferences"/> stopped the scan,
@@ -197,6 +197,12 @@ public static class MetadataTableProjector
     /// model the table, or because the scan stopped part-way through it or
     /// before reaching it.
     ///
+    /// A fourth limit is real and cannot be reported per query: only edges
+    /// spelled as handle columns are matched, so a TypeDefOrRef token carried
+    /// inside a signature blob is never found. See
+    /// <see cref="MetadataRowReferenceSet.IsComplete"/>, which does not mean
+    /// nothing points at the target.
+    ///
     /// A dangling edge is not a reference: a handle whose row lies outside its
     /// target table projects as <see cref="MetadataValue.Malformed"/>, so it
     /// cannot match. It does, however, make its row an
@@ -204,6 +210,12 @@ public static class MetadataTableProjector
     /// edge column the projection could not resolve is an edge this search
     /// cannot account for.
     /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="targetRowId"/> is less than 1. A row id past the *end* of
+    /// the table is reported through
+    /// <see cref="MetadataRowReferenceSet.TargetExists"/> rather than rejected,
+    /// because a dangling edge points at exactly such rows.
+    /// </exception>
     public static MetadataRowReferenceSet FindReferences(
         PEReader peReader,
         TableIndex targetTable,
@@ -220,9 +232,18 @@ public static class MetadataTableProjector
 
         if (!peReader.HasMetadata)
             return new MetadataRowReferenceSet(
-                target, references.ToImmutable(), unreadable.ToImmutable(), [], Truncated: false);
+                target, references.ToImmutable(), unreadable.ToImmutable(), [],
+                Truncated: false, TargetExists: false);
 
         var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+
+        // Reported rather than rejected. A row id past the end of the table is
+        // usually a typo, and answering it with a clean empty result makes that
+        // typo indistinguishable from a real row nothing points at. But it is
+        // not simply invalid input either: a dangling edge points exactly at
+        // rows that do not exist, so "what points at TypeRef[1]?" stays a
+        // legitimate question in an image whose TypeRef table is empty.
+        bool targetExists = targetRowId <= reader.GetTableRowCount(targetTable);
 
         // The scan needs edges, not text. Handle and range cells carry their
         // target table and row id independently of these budgets, so trimming the
@@ -303,14 +324,22 @@ public static class MetadataTableProjector
             }
 
             // Recorded after the row loop and only when every row the image says
-            // exists was examined. "Entered" is not the same as "searched": a
-            // loop that stopped short — the budget, or any future early exit —
-            // leaves rows unread, and an edge onto the target could sit in any
-            // of them. The check re-reads the count from the reader rather than
-            // trusting the local, so the claim "we covered this table" is
-            // anchored to the metadata instead of to a variable the loop could
-            // have narrowed.
-            if (rid > reader.GetTableRowCount(spec.Index))
+            // exists was examined in full. "Entered" is not the same as
+            // "searched", at either granularity:
+            //
+            //  - A row loop that stopped short leaves whole rows unread, so rid
+            //    never passes the count and the table is not recorded.
+            //  - The budget check sits inside the *column* loop, so truncation
+            //    on a table's final row leaves that row entered but abandoned
+            //    part-way through its columns. rid still passes the count, so
+            //    the row loop alone cannot tell. truncated does: the outer loop
+            //    breaks at the top of the next iteration, so reaching here with
+            //    truncated set means the budget stopped inside *this* table.
+            //
+            // The count is re-read from the reader rather than trusting the
+            // local, so the claim "we covered this table" is anchored to the
+            // metadata instead of to a variable the loop could have narrowed.
+            if (!truncated && rid > reader.GetTableRowCount(spec.Index))
                 visited.Add(spec.Index);
         }
 
@@ -319,7 +348,8 @@ public static class MetadataTableProjector
             references.ToImmutable(),
             unreadable.ToImmutable(),
             CollectUnscannedTables(reader, visited),
-            truncated);
+            truncated,
+            targetExists);
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -169,6 +169,128 @@ public static class MetadataTableProjector
         return BuildView(reader, spec, rowCount, options with { StartRowId = rowId, MaxRowsPerTable = 1 });
     }
 
+    /// <summary>
+    /// Finds every row that points at <paramref name="targetTable"/> row
+    /// <paramref name="targetRowId"/> — the reverse of the forward
+    /// <see cref="HandleRef"/>/<see cref="HandleRange"/> edges a projection
+    /// exposes, and the "who references this?" gesture an explorer needs.
+    ///
+    /// Both edge shapes are searched. A handle column matches when it names the
+    /// row directly; a list column matches when the target falls inside its run,
+    /// which is how ECMA-335 encodes ownership — so this answers which
+    /// <c>TypeDef</c> declares a given <c>Field</c>, <c>MethodDef</c>, or which
+    /// <c>MethodDef</c> owns a given <c>Param</c>.
+    ///
+    /// The scan always covers every supported table and ignores
+    /// <see cref="MetadataProjectionOptions.Tables"/>, because a reverse search
+    /// narrowed to part of the image could report "nothing points here" while a
+    /// pointer sat in an unsearched table. Its two blind spots are reported
+    /// instead of hidden: <see cref="MetadataRowReferenceSet.Truncated"/> when
+    /// <paramref name="maxReferences"/> stopped the scan, and
+    /// <see cref="MetadataRowReferenceSet.UnreadableRows"/> for rows that could not
+    /// be decoded and so could not be inspected.
+    ///
+    /// A dangling edge is not a reference: a handle whose row lies outside its
+    /// target table already projects as <see cref="MetadataValue.Malformed"/>,
+    /// so it cannot match.
+    /// </summary>
+    public static MetadataRowReferenceSet FindReferences(
+        PEReader peReader,
+        TableIndex targetTable,
+        int targetRowId,
+        int maxReferences = MetadataRowReferenceSet.DefaultMaxReferences)
+    {
+        ArgumentNullException.ThrowIfNull(peReader);
+        ArgumentOutOfRangeException.ThrowIfLessThan(targetRowId, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxReferences);
+
+        var target = new MetadataRowLocation(targetTable, targetRowId);
+        var references = ImmutableArray.CreateBuilder<MetadataRowReference>();
+        var unreadable = ImmutableArray.CreateBuilder<MetadataRowLocation>();
+
+        if (!peReader.HasMetadata)
+            return new MetadataRowReferenceSet(target, references.ToImmutable(), unreadable.ToImmutable(), Truncated: false);
+
+        var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+
+        // The scan needs edges, not text. Handle and range cells carry their
+        // target table and row id independently of these budgets, so trimming the
+        // heap previews cannot change which rows match — it only avoids decoding
+        // strings and blobs the result never shows.
+        var scan = new MetadataProjectionOptions { MaxStringChars = 1, MaxPreviewBytes = 0 };
+
+        bool truncated = false;
+        foreach (var spec in SupportedTables)
+        {
+            if (truncated)
+                break;
+
+            int rowCount = reader.GetTableRowCount(spec.Index);
+            for (int rid = 1; rid <= rowCount && !truncated; rid++)
+            {
+                ImmutableArray<MetadataValue> cells;
+                try
+                {
+                    cells = spec.ReadRow(reader, rid, scan);
+                }
+                catch (Exception ex) when (ex is BadImageFormatException or ArgumentException or InvalidOperationException)
+                {
+                    // The row's edges are unknowable, so record the blind spot
+                    // rather than letting a missed reference look like an absent one.
+                    unreadable.Add(new MetadataRowLocation(spec.Index, rid));
+                    continue;
+                }
+
+                for (int column = 0; column < cells.Length; column++)
+                {
+                    if (!PointsAt(cells[column], targetTable, targetRowId, out var kind))
+                        continue;
+
+                    if (references.Count >= maxReferences)
+                    {
+                        truncated = true;
+                        break;
+                    }
+
+                    references.Add(new MetadataRowReference(
+                        new MetadataRowLocation(spec.Index, rid),
+                        column,
+                        spec.Columns[column].Name,
+                        kind));
+                }
+            }
+        }
+
+        return new MetadataRowReferenceSet(target, references.ToImmutable(), unreadable.ToImmutable(), truncated);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is an edge onto the target row. A handle
+    /// names one row; a list column covers the half-open run
+    /// <c>[StartRowId, EndRowId)</c>, so membership — not equality — decides.
+    /// </summary>
+    static bool PointsAt(MetadataValue value, TableIndex table, int rowId, out MetadataRowReferenceKind kind)
+    {
+        switch (value)
+        {
+            case MetadataValue.Handle handle
+                when handle.Reference.TargetTable == table && handle.Reference.TargetRowId == rowId:
+                kind = MetadataRowReferenceKind.Handle;
+                return true;
+
+            case MetadataValue.Range range
+                when range.Reference.TargetTable == table
+                    && rowId >= range.Reference.StartRowId
+                    && rowId < range.Reference.EndRowId:
+                kind = MetadataRowReferenceKind.Range;
+                return true;
+
+            default:
+                kind = default;
+                return false;
+        }
+    }
+
     static MetadataTableView BuildView(
         MetadataReader reader,
         TableSpec spec,

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -193,8 +193,9 @@ public static class MetadataTableProjector
     /// <see cref="MetadataRowReferenceSet.UnreadableRows"/> for rows whose edges
     /// could not be fully determined, and
     /// <see cref="MetadataRowReferenceSet.UnscannedTables"/> for populated
-    /// tables no row of which was searched — because the projection does not
-    /// model the table, or because the scan stopped before covering it.
+    /// tables the scan did not read in full — because the projection does not
+    /// model the table, or because the scan stopped part-way through it or
+    /// before reaching it.
     ///
     /// A dangling edge is not a reference: a handle whose row lies outside its
     /// target table projects as <see cref="MetadataValue.Malformed"/>, so it

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -219,17 +219,18 @@ public static class MetadataTableProjector
 
         var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
 
-        // Populated tables outside the projection are never visited, so an edge
-        // living in one of them cannot be found. Report that as a blind spot
-        // rather than letting the caller read an empty result as an absent
-        // reference. Row counts only — no scanning is required to learn this.
-        var unscanned = CollectUnscannedTables(reader);
-
         // The scan needs edges, not text. Handle and range cells carry their
         // target table and row id independently of these budgets, so trimming the
         // heap previews cannot change which rows match — it only avoids decoding
         // strings and blobs the result never shows.
         var scan = new MetadataProjectionOptions { MaxStringChars = 1, MaxPreviewBytes = 0 };
+
+        // What the scan actually reached, recorded as it goes. The blind-spot
+        // report is derived from this rather than from SupportedTables, so a
+        // table the loop skips — because the projection does not model it, or
+        // because the budget stopped the scan before reaching it — cannot be
+        // declared searched by a list that disagrees with the loop.
+        var visited = new HashSet<TableIndex>();
 
         bool truncated = false;
         foreach (var spec in SupportedTables)
@@ -294,28 +295,40 @@ public static class MetadataTableProjector
                 if (blind)
                     unreadable.Add(new MetadataRowLocation(spec.Index, rid));
             }
+
+            // Recorded after the row loop, not before it, so any path that
+            // skips this table's rows also leaves it out of `visited` and it
+            // shows up as a blind spot. A budget that stopped the scan mid-table
+            // still counts as visited: the table was searched up to that point,
+            // and `Truncated` is what carries the rest.
+            visited.Add(spec.Index);
         }
 
         return new MetadataRowReferenceSet(
-            target, references.ToImmutable(), unreadable.ToImmutable(), unscanned, truncated);
+            target,
+            references.ToImmutable(),
+            unreadable.ToImmutable(),
+            CollectUnscannedTables(reader, visited),
+            truncated);
     }
 
     /// <summary>
-    /// The populated tables a reverse search cannot see, because the projection
-    /// does not model them. Empty tables are excluded: a table with no rows
-    /// cannot hold an edge onto the target, so reporting it would overstate the
-    /// blind spot.
+    /// The populated tables a reverse search did not reach — because the
+    /// projection does not model them, or because the result budget stopped the
+    /// scan first. Derived from the tables the scan actually visited, not from a
+    /// parallel declaration of what it intends to visit: the two could drift,
+    /// and a blind spot that under-reports is the bug this exists to prevent.
+    /// Empty tables are excluded: a table with no rows cannot hold an edge onto
+    /// the target, so reporting it would overstate the blind spot.
     /// </summary>
-    static ImmutableArray<TableIndex> CollectUnscannedTables(MetadataReader reader)
+    static ImmutableArray<TableIndex> CollectUnscannedTables(
+        MetadataReader reader,
+        HashSet<TableIndex> visited)
     {
-        var modeled = new HashSet<TableIndex>();
-        foreach (var spec in SupportedTables)
-            modeled.Add(spec.Index);
-
         var unscanned = ImmutableArray.CreateBuilder<TableIndex>();
         foreach (var table in Enum.GetValues<TableIndex>())
         {
-            if (modeled.Contains(table))
+            if (visited.Contains(table))
                 continue;
 
             // Every defined TableIndex is below the reader's table count, so

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -181,18 +181,23 @@ public static class MetadataTableProjector
     /// <c>TypeDef</c> declares a given <c>Field</c>, <c>MethodDef</c>, or which
     /// <c>MethodDef</c> owns a given <c>Param</c>.
     ///
-    /// The scan always covers every supported table and ignores
-    /// <see cref="MetadataProjectionOptions.Tables"/>, because a reverse search
-    /// narrowed to part of the image could report "nothing points here" while a
-    /// pointer sat in an unsearched table. Its two blind spots are reported
-    /// instead of hidden: <see cref="MetadataRowReferenceSet.Truncated"/> when
+    /// The scan always covers every supported table. It takes no
+    /// <see cref="MetadataProjectionOptions"/> at all, and in particular offers
+    /// no equivalent of <see cref="MetadataProjectionOptions.Tables"/>, because
+    /// a reverse search narrowed to part of the image could report "nothing
+    /// points here" while a pointer sat in an unsearched table. Its two blind
+    /// spots are reported instead of hidden:
+    /// <see cref="MetadataRowReferenceSet.Truncated"/> when
     /// <paramref name="maxReferences"/> stopped the scan, and
-    /// <see cref="MetadataRowReferenceSet.UnreadableRows"/> for rows that could not
-    /// be decoded and so could not be inspected.
+    /// <see cref="MetadataRowReferenceSet.UnreadableRows"/> for rows whose edges
+    /// could not be fully determined.
     ///
     /// A dangling edge is not a reference: a handle whose row lies outside its
-    /// target table already projects as <see cref="MetadataValue.Malformed"/>,
-    /// so it cannot match.
+    /// target table projects as <see cref="MetadataValue.Malformed"/>, so it
+    /// cannot match. It does, however, make its row an
+    /// <see cref="MetadataRowReferenceSet.UnreadableRows"/> entry, because an
+    /// edge column the projection could not resolve is an edge this search
+    /// cannot account for.
     /// </summary>
     public static MetadataRowReferenceSet FindReferences(
         PEReader peReader,
@@ -241,8 +246,26 @@ public static class MetadataTableProjector
                     continue;
                 }
 
+                bool blind = false;
                 for (int column = 0; column < cells.Length; column++)
                 {
+                    // A cell that failed to decode in an *edge* column may have
+                    // been an edge onto the target. The cell-level readers
+                    // contain such failures as Malformed rather than throwing, so
+                    // ReadRow succeeds and the row would otherwise pass as fully
+                    // searched. Record the blind spot instead, or a missed
+                    // reference reads as an absent one.
+                    //
+                    // The column's declared kind decides, not the cell: a
+                    // Malformed heap, scalar, or flags cell was never an edge and
+                    // cannot hide a reference.
+                    if (cells[column] is MetadataValue.Malformed
+                        && spec.Columns[column].Kind is MetadataColumnKind.Handle or MetadataColumnKind.HandleRange)
+                    {
+                        blind = true;
+                        continue;
+                    }
+
                     if (!PointsAt(cells[column], targetTable, targetRowId, out var kind))
                         continue;
 
@@ -258,6 +281,11 @@ public static class MetadataTableProjector
                         spec.Columns[column].Name,
                         kind));
                 }
+
+                // Recorded once per row, and after the column loop, so a row with
+                // one broken edge still reports the good edges it does have.
+                if (blind)
+                    unreadable.Add(new MetadataRowLocation(spec.Index, rid));
             }
         }
 

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -186,20 +186,23 @@ public static class MetadataTableProjector
     /// <see cref="MetadataProjectionOptions"/> at all, and in particular offers
     /// no equivalent of <see cref="MetadataProjectionOptions.Tables"/>, because
     /// a reverse search narrowed to part of the image could report "nothing
-    /// points here" while a pointer sat in an unsearched table. Three blind
+    /// points here" while a pointer sat in an unsearched table. Four blind
     /// spots are reported instead of hidden:
     /// <see cref="MetadataRowReferenceSet.Truncated"/> when
     /// <paramref name="maxReferences"/> stopped the scan,
     /// <see cref="MetadataRowReferenceSet.UnreadableRows"/> for rows whose edges
-    /// could not be fully determined, and
+    /// could not be fully determined,
     /// <see cref="MetadataRowReferenceSet.UnscannedTables"/> for populated
     /// tables the scan did not read in full — because the projection does not
     /// model the table, or because the scan stopped part-way through it or
-    /// before reaching it.
+    /// before reaching it — and
+    /// <see cref="MetadataRowReferenceSet.TargetExists"/> when the target row id
+    /// is past the end of its table.
     ///
-    /// A fourth limit is real and cannot be reported per query: only edges
-    /// spelled as handle columns are matched, so a TypeDefOrRef token carried
-    /// inside a signature blob is never found. See
+    /// A fifth limit is real and cannot be reported per query: only edges
+    /// spelled as handle columns are matched, so a reference carried inside a
+    /// blob is never found. It is disclosed unconditionally by the renderer
+    /// rather than through this result. See
     /// <see cref="MetadataRowReferenceSet.IsComplete"/>, which does not mean
     /// nothing points at the target.
     ///
@@ -266,6 +269,7 @@ public static class MetadataTableProjector
 
             int rowCount = reader.GetTableRowCount(spec.Index);
             int rid = 1;
+            bool abandonedMidTable = false;
             for (; rid <= rowCount && !truncated; rid++)
             {
                 ImmutableArray<MetadataValue> cells;
@@ -307,6 +311,14 @@ public static class MetadataTableProjector
                     if (references.Count >= maxReferences)
                     {
                         truncated = true;
+
+                        // Whether this table still holds anything unlooked-at:
+                        // the columns after this one on this row, or any row
+                        // after it. Stopping on the very last column of the very
+                        // last row leaves nothing unexamined, so the table was
+                        // genuinely searched in full even though the scan ended
+                        // inside it.
+                        abandonedMidTable = column + 1 < cells.Length || rid < rowCount;
                         break;
                     }
 
@@ -332,14 +344,18 @@ public static class MetadataTableProjector
             //  - The budget check sits inside the *column* loop, so truncation
             //    on a table's final row leaves that row entered but abandoned
             //    part-way through its columns. rid still passes the count, so
-            //    the row loop alone cannot tell. truncated does: the outer loop
-            //    breaks at the top of the next iteration, so reaching here with
-            //    truncated set means the budget stopped inside *this* table.
+            //    the row loop alone cannot tell.
+            //
+            // abandonedMidTable carries that column-level fact. Note it is not
+            // the same as truncated: a scan that stops on the last column of the
+            // last row examined every cell this table has, so reporting it
+            // unscanned would be a false blind spot — claiming an unread row
+            // could hide an edge when no row went unread.
             //
             // The count is re-read from the reader rather than trusting the
             // local, so the claim "we covered this table" is anchored to the
             // metadata instead of to a variable the loop could have narrowed.
-            if (!truncated && rid > reader.GetTableRowCount(spec.Index))
+            if (!abandonedMidTable && rid > reader.GetTableRowCount(spec.Index))
                 visited.Add(spec.Index);
         }
 

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -181,16 +181,20 @@ public static class MetadataTableProjector
     /// <c>TypeDef</c> declares a given <c>Field</c>, <c>MethodDef</c>, or which
     /// <c>MethodDef</c> owns a given <c>Param</c>.
     ///
-    /// The scan always covers every supported table. It takes no
+    /// The scan covers every supported table, up to the point
+    /// <paramref name="maxReferences"/> stops it. It takes no
     /// <see cref="MetadataProjectionOptions"/> at all, and in particular offers
     /// no equivalent of <see cref="MetadataProjectionOptions.Tables"/>, because
     /// a reverse search narrowed to part of the image could report "nothing
-    /// points here" while a pointer sat in an unsearched table. Its two blind
+    /// points here" while a pointer sat in an unsearched table. Its three blind
     /// spots are reported instead of hidden:
     /// <see cref="MetadataRowReferenceSet.Truncated"/> when
-    /// <paramref name="maxReferences"/> stopped the scan, and
+    /// <paramref name="maxReferences"/> stopped the scan,
     /// <see cref="MetadataRowReferenceSet.UnreadableRows"/> for rows whose edges
-    /// could not be fully determined.
+    /// could not be fully determined, and
+    /// <see cref="MetadataRowReferenceSet.UnscannedTables"/> for populated
+    /// tables no row of which was searched — because the projection does not
+    /// model the table, or because the scan stopped before covering it.
     ///
     /// A dangling edge is not a reference: a handle whose row lies outside its
     /// target table projects as <see cref="MetadataValue.Malformed"/>, so it
@@ -239,7 +243,8 @@ public static class MetadataTableProjector
                 break;
 
             int rowCount = reader.GetTableRowCount(spec.Index);
-            for (int rid = 1; rid <= rowCount && !truncated; rid++)
+            int rid = 1;
+            for (; rid <= rowCount && !truncated; rid++)
             {
                 ImmutableArray<MetadataValue> cells;
                 try
@@ -296,12 +301,16 @@ public static class MetadataTableProjector
                     unreadable.Add(new MetadataRowLocation(spec.Index, rid));
             }
 
-            // Recorded after the row loop, not before it, so any path that
-            // skips this table's rows also leaves it out of `visited` and it
-            // shows up as a blind spot. A budget that stopped the scan mid-table
-            // still counts as visited: the table was searched up to that point,
-            // and `Truncated` is what carries the rest.
-            visited.Add(spec.Index);
+            // Recorded after the row loop and only when every row the image says
+            // exists was examined. "Entered" is not the same as "searched": a
+            // loop that stopped short — the budget, or any future early exit —
+            // leaves rows unread, and an edge onto the target could sit in any
+            // of them. The check re-reads the count from the reader rather than
+            // trusting the local, so the claim "we covered this table" is
+            // anchored to the metadata instead of to a variable the loop could
+            // have narrowed.
+            if (rid > reader.GetTableRowCount(spec.Index))
+                visited.Add(spec.Index);
         }
 
         return new MetadataRowReferenceSet(

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -318,6 +318,16 @@ public static class MetadataTableProjector
                         // last row leaves nothing unexamined, so the table was
                         // genuinely searched in full even though the scan ended
                         // inside it.
+                        //
+                        // This also covers `blind` going under-determined. A
+                        // break before the last column leaves the remaining
+                        // columns unchecked for Malformed edges, so this row
+                        // might belong in unreadable without our knowing — but
+                        // that break is exactly the case where the flag is true,
+                        // so the table is disclosed as unscanned instead. When
+                        // the break is on the last column, every column was
+                        // checked and `blind` is fully determined. Either way
+                        // the gap is reported.
                         abandonedMidTable = column + 1 < cells.Length || rid < rowCount;
                         break;
                     }

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -214,9 +214,16 @@ public static class MetadataTableProjector
         var unreadable = ImmutableArray.CreateBuilder<MetadataRowLocation>();
 
         if (!peReader.HasMetadata)
-            return new MetadataRowReferenceSet(target, references.ToImmutable(), unreadable.ToImmutable(), Truncated: false);
+            return new MetadataRowReferenceSet(
+                target, references.ToImmutable(), unreadable.ToImmutable(), [], Truncated: false);
 
         var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+
+        // Populated tables outside the projection are never visited, so an edge
+        // living in one of them cannot be found. Report that as a blind spot
+        // rather than letting the caller read an empty result as an absent
+        // reference. Row counts only — no scanning is required to learn this.
+        var unscanned = CollectUnscannedTables(reader);
 
         // The scan needs edges, not text. Handle and range cells carry their
         // target table and row id independently of these budgets, so trimming the
@@ -289,7 +296,36 @@ public static class MetadataTableProjector
             }
         }
 
-        return new MetadataRowReferenceSet(target, references.ToImmutable(), unreadable.ToImmutable(), truncated);
+        return new MetadataRowReferenceSet(
+            target, references.ToImmutable(), unreadable.ToImmutable(), unscanned, truncated);
+    }
+
+    /// <summary>
+    /// The populated tables a reverse search cannot see, because the projection
+    /// does not model them. Empty tables are excluded: a table with no rows
+    /// cannot hold an edge onto the target, so reporting it would overstate the
+    /// blind spot.
+    /// </summary>
+    static ImmutableArray<TableIndex> CollectUnscannedTables(MetadataReader reader)
+    {
+        var modeled = new HashSet<TableIndex>();
+        foreach (var spec in SupportedTables)
+            modeled.Add(spec.Index);
+
+        var unscanned = ImmutableArray.CreateBuilder<TableIndex>();
+        foreach (var table in Enum.GetValues<TableIndex>())
+        {
+            if (modeled.Contains(table))
+                continue;
+
+            // Every defined TableIndex is below the reader's table count, so
+            // this is a range check plus an array index over counts parsed at
+            // MetadataReader construction. It cannot fail here.
+            if (reader.GetTableRowCount(table) > 0)
+                unscanned.Add(table);
+        }
+
+        return unscanned.ToImmutable();
     }
 
     /// <summary>

--- a/src/mdi/MdiCommand.cs
+++ b/src/mdi/MdiCommand.cs
@@ -53,6 +53,18 @@ public static class MdiCommand
         };
         startRowOption.Aliases.Add("-s");
 
+        var referencesOption = new Option<string?>("--references")
+        {
+            Description = "Instead of dumping tables, list the rows pointing at one row, given as Table:RowId (for example TypeDef:5). Includes list-column ownership, so Field:1 names its declaring type.",
+        };
+        referencesOption.Aliases.Add("-r");
+
+        var maxReferencesOption = new Option<int>("--max-references")
+        {
+            Description = $"Maximum references collected by --references before the scan stops (default {MetadataRowReferenceSet.DefaultMaxReferences}).",
+            DefaultValueFactory = _ => MetadataRowReferenceSet.DefaultMaxReferences,
+        };
+
         var maxBytesOption = new Option<int>("--max-bytes")
         {
             Description = $"Maximum blob-preview bytes per cell (default {MetadataProjectionOptions.DefaultMaxPreviewBytes}).",
@@ -71,6 +83,8 @@ public static class MdiCommand
         root.Options.Add(formatOption);
         root.Options.Add(maxRowsOption);
         root.Options.Add(startRowOption);
+        root.Options.Add(referencesOption);
+        root.Options.Add(maxReferencesOption);
         root.Options.Add(maxBytesOption);
         root.Options.Add(maxCharsOption);
 
@@ -81,6 +95,8 @@ public static class MdiCommand
             string formatText = parseResult.GetValue(formatOption)!;
             int maxRows = parseResult.GetValue(maxRowsOption);
             int startRow = parseResult.GetValue(startRowOption);
+            string? referenceSpec = parseResult.GetValue(referencesOption);
+            int maxReferences = parseResult.GetValue(maxReferencesOption);
             int maxBytes = parseResult.GetValue(maxBytesOption);
             int maxChars = parseResult.GetValue(maxCharsOption);
 
@@ -107,6 +123,24 @@ public static class MdiCommand
                 Console.Error.WriteLine(
                     $"Error: unknown table '{badName}'. Table names are members of System.Reflection.Metadata.Ecma335.TableIndex (for example TypeDef, MethodDef, Field).");
                 return 1;
+            }
+
+            if (referenceSpec is not null)
+            {
+                if (maxReferences < 0)
+                {
+                    Console.Error.WriteLine("Error: --max-references must be non-negative.");
+                    return 1;
+                }
+
+                if (!TryParseRowLocation(referenceSpec, out var targetTable, out int targetRowId, out string? specError))
+                {
+                    Console.Error.WriteLine($"Error: {specError}");
+                    return 1;
+                }
+
+                return ExecuteReferences(
+                    assembly, targetTable, targetRowId, maxReferences, format, Console.Out, Console.Error);
             }
 
             var options = new MetadataProjectionOptions
@@ -199,6 +233,71 @@ public static class MdiCommand
     }
 
     /// <summary>
+    /// Opens <paramref name="assemblyPath"/> and renders every row pointing at
+    /// <paramref name="targetTable"/>[<paramref name="targetRowId"/>]. Returns a
+    /// process exit code.
+    ///
+    /// A row id that does not exist is not an error: the answer is an empty set,
+    /// which is what the projection itself reports, since a handle pointing past
+    /// the end of a table is malformed rather than a reference.
+    /// </summary>
+    public static int ExecuteReferences(
+        string assemblyPath,
+        TableIndex targetTable,
+        int targetRowId,
+        int maxReferences,
+        MetadataTableFormat format,
+        TextWriter output,
+        TextWriter error)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        if (targetRowId < 1)
+        {
+            error.WriteLine("Error: the row id in --references must be 1 or greater (row ids are 1-based).");
+            return 1;
+        }
+
+        if (!File.Exists(assemblyPath))
+        {
+            error.WriteLine($"Error: file not found: {assemblyPath}");
+            return 1;
+        }
+
+        MetadataRowReferenceSet references;
+        try
+        {
+            using var session = AssemblyInspectionSession.Open(assemblyPath);
+            if (!session.HasMetadata)
+            {
+                error.WriteLine($"Error: '{assemblyPath}' contains no .NET metadata (not a managed assembly).");
+                return 1;
+            }
+
+            references = session.MetadataReferences(targetTable, targetRowId, maxReferences);
+        }
+        catch (Exception ex) when (IsExpectedReadFailure(ex))
+        {
+            error.WriteLine($"Error: cannot read metadata from '{assemblyPath}': {ex.Message}");
+            return 1;
+        }
+
+        MetadataProjectionRenderer.Render(references, output, format);
+
+        // Markdown renders the search's blind spots inline. The machine formats
+        // are pure row streams, so an incomplete scan would look identical to a
+        // complete one; surface the same caveats on the error writer instead.
+        if (format != MetadataTableFormat.Markdown)
+        {
+            foreach (string caveat in MetadataProjectionRenderer.Caveats(references))
+                error.WriteLine($"Note: {caveat}");
+        }
+
+        return 0;
+    }
+
+    /// <summary>
     /// Whether <paramref name="ex"/> is an expected failure of opening or reading
     /// an assembly file — a bad image, an unreadable or inaccessible file, or an
     /// invalid path — as opposed to an unexpected programming error. These are
@@ -233,8 +332,43 @@ public static class MdiCommand
         }
     }
 
-    static bool TryParseTables(string? spec, out ImmutableArray<TableIndex> tables, out string? badName)
+    /// <summary>
+    /// Parses a <c>Table:RowId</c> row reference (for example <c>TypeDef:5</c>).
+    /// The two halves are validated separately so the diagnostic names the half
+    /// that is wrong.
+    /// </summary>
+    static bool TryParseRowLocation(string spec, out TableIndex table, out int rowId, out string? error)
     {
+        table = default;
+        rowId = 0;
+
+        int separator = spec.LastIndexOf(':');
+        if (separator < 0)
+        {
+            error = $"'{spec}' is not a row reference. Use Table:RowId, for example TypeDef:5.";
+            return false;
+        }
+
+        string tableName = spec[..separator].Trim();
+        string rowText = spec[(separator + 1)..].Trim();
+
+        if (!Enum.TryParse(tableName, ignoreCase: true, out table) || !Enum.IsDefined(table))
+        {
+            error = $"unknown table '{tableName}'. Table names are members of System.Reflection.Metadata.Ecma335.TableIndex (for example TypeDef, MethodDef, Field).";
+            return false;
+        }
+
+        if (!int.TryParse(rowText, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out rowId) || rowId < 1)
+        {
+            error = $"'{rowText}' is not a row id. Row ids are 1-based positive integers.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    static bool TryParseTables(string? spec, out ImmutableArray<TableIndex> tables, out string? badName)    {
         badName = null;
 
         // A default (unset) array is the projector's signal to include every

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
@@ -296,8 +296,13 @@ public class MdiCommandTests
     }
 
     [Fact]
-    public void ExecuteReferences_NonexistentRow_IsAnEmptyAnswerNotAnError()
+    public void ExecuteReferences_NonexistentRow_QualifiesTheEmptyAnswer()
     {
+        // A row id past the end of its table is a well-formed question about a
+        // row that is not there, so it stays an answer rather than an error. It
+        // must not read as "nothing points at this row" though: no such row
+        // exists to be pointed at, and an unqualified empty answer would say the
+        // image was searched and came back clean.
         var output = new StringWriter();
         var error = new StringWriter();
         int code = MdiCommand.ExecuteReferences(
@@ -310,7 +315,7 @@ public class MdiCommandTests
             error);
 
         Assert.Equal(0, code);
-        Assert.Contains("No row points at", output.ToString());
+        Assert.Contains("past the end of its table", output.ToString());
     }
 
     [Theory]

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiCommandTests.cs
@@ -197,4 +197,151 @@ public class MdiCommandTests
         // Markdown carries truncation inline, so it does not also emit the note.
         Assert.DoesNotContain("truncated to", error.ToString());
     }
+
+    [Fact]
+    public void ExecuteReferences_SelfAssembly_FindsTheDeclaringTypeOfAField()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        // Field[1] has no back-pointer to its declaring type in ECMA-335; only a
+        // TypeDef.FieldList run covers it, so this proves range edges are searched.
+        int code = MdiCommand.ExecuteReferences(
+            SelfPath,
+            TableIndex.Field,
+            1,
+            MetadataRowReferenceSet.DefaultMaxReferences,
+            MetadataTableFormat.Markdown,
+            output,
+            error);
+
+        Assert.Equal(0, code);
+        string markdown = output.ToString();
+        Assert.Contains("## References to Field[1]", markdown);
+        Assert.Contains("FieldList", markdown);
+        Assert.Contains("Range", markdown);
+        Assert.True(string.IsNullOrWhiteSpace(error.ToString()));
+    }
+
+    [Fact]
+    public void ExecuteReferences_MachineFormat_ReportsTruncationOnError()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        int code = MdiCommand.ExecuteReferences(
+            SelfPath,
+            TableIndex.Field,
+            1,
+            maxReferences: 1,
+            MetadataTableFormat.Jsonl,
+            output,
+            error);
+
+        Assert.Equal(0, code);
+        // A pure row stream cannot show a stopped scan, so the caveat must reach stderr.
+        Assert.Contains("budget stopped this scan", error.ToString());
+    }
+
+    [Fact]
+    public void ExecuteReferences_Markdown_KeepsCaveatsInline_NotOnError()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        int code = MdiCommand.ExecuteReferences(
+            SelfPath,
+            TableIndex.Field,
+            1,
+            maxReferences: 1,
+            MetadataTableFormat.Markdown,
+            output,
+            error);
+
+        Assert.Equal(0, code);
+        Assert.Contains("budget stopped this scan", output.ToString());
+        Assert.True(string.IsNullOrWhiteSpace(error.ToString()));
+    }
+
+    [Fact]
+    public void ExecuteReferences_MissingFile_ReturnsErrorAndReports()
+    {
+        var error = new StringWriter();
+        int code = MdiCommand.ExecuteReferences(
+            "does-not-exist.dll",
+            TableIndex.TypeDef,
+            1,
+            MetadataRowReferenceSet.DefaultMaxReferences,
+            MetadataTableFormat.Markdown,
+            new StringWriter(),
+            error);
+
+        Assert.Equal(1, code);
+        Assert.Contains("file not found", error.ToString());
+    }
+
+    [Fact]
+    public void ExecuteReferences_RowIdBelowOne_IsRejectedBeforeOpeningTheFile()
+    {
+        var error = new StringWriter();
+        int code = MdiCommand.ExecuteReferences(
+            "does-not-exist.dll",
+            TableIndex.TypeDef,
+            0,
+            MetadataRowReferenceSet.DefaultMaxReferences,
+            MetadataTableFormat.Markdown,
+            new StringWriter(),
+            error);
+
+        Assert.Equal(1, code);
+        Assert.Contains("row id", error.ToString());
+    }
+
+    [Fact]
+    public void ExecuteReferences_NonexistentRow_IsAnEmptyAnswerNotAnError()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        int code = MdiCommand.ExecuteReferences(
+            SelfPath,
+            TableIndex.TypeDef,
+            int.MaxValue,
+            MetadataRowReferenceSet.DefaultMaxReferences,
+            MetadataTableFormat.Markdown,
+            output,
+            error);
+
+        Assert.Equal(0, code);
+        Assert.Contains("No row points at", output.ToString());
+    }
+
+    [Theory]
+    [InlineData("TypeDef")]
+    [InlineData("TypeDef:")]
+    [InlineData("TypeDef:0")]
+    [InlineData("TypeDef:-3")]
+    [InlineData("TypeDef:abc")]
+    [InlineData("NoSuchTable:1")]
+    public void CreateRootCommand_RejectsAMalformedReferenceSpec(string spec)
+    {
+        int code = MdiCommand.CreateRootCommand().Parse([SelfPath, "--references", spec]).Invoke();
+
+        Assert.NotEqual(0, code);
+    }
+
+    [Fact]
+    public void CreateRootCommand_RejectsANegativeMaxReferences()
+    {
+        int code = MdiCommand.CreateRootCommand()
+            .Parse([SelfPath, "--references", "TypeDef:1", "--max-references", "-1"])
+            .Invoke();
+
+        Assert.NotEqual(0, code);
+    }
+
+    [Fact]
+    public void CreateRootCommand_AcceptsAWellFormedReferenceSpec()
+    {
+        int code = MdiCommand.CreateRootCommand().Parse([SelfPath, "-r", "typedef:1"]).Invoke();
+
+        Assert.Equal(0, code);
+    }
 }

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
@@ -53,7 +53,7 @@ public class MetadataRowReferenceRendererTests
         Assert.Contains("No row points at TypeDef[5].", markdown);
         // Nothing was hidden, so no caveat may appear.
         Assert.DoesNotContain("budget", markdown);
-        Assert.DoesNotContain("could not be decoded", markdown);
+        Assert.DoesNotContain("could not be read", markdown);
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class MetadataRowReferenceRendererTests
 
         var markdown = Render(Set(unreadable: unreadable));
 
-        Assert.Contains("2 rows could not be decoded", markdown);
+        Assert.Contains("2 rows had edges that could not be read", markdown);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class MetadataRowReferenceRendererTests
 
         var markdown = Render(Set(unreadable: unreadable));
 
-        Assert.Contains("1 row could not be decoded", markdown);
+        Assert.Contains("1 row had an edge that could not be read", markdown);
         Assert.DoesNotContain("1 rows", markdown);
     }
 

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
@@ -24,7 +24,8 @@ public class MetadataRowReferenceRendererTests
         ImmutableArray<MetadataRowReference>? references = null,
         ImmutableArray<MetadataRowLocation>? unreadable = null,
         ImmutableArray<TableIndex>? unscanned = null,
-        bool truncated = false)
+        bool truncated = false,
+        bool targetExists = true)
         => new(
             new MetadataRowLocation(TableIndex.TypeDef, 5),
             references ?? ImmutableArray.Create(
@@ -35,7 +36,8 @@ public class MetadataRowReferenceRendererTests
                     MetadataRowReferenceKind.Handle)),
             unreadable ?? [],
             unscanned ?? [],
-            truncated);
+            truncated,
+            targetExists);
 
     [Fact]
     public void Markdown_NamesTargetAndCountInHeading()
@@ -49,15 +51,21 @@ public class MetadataRowReferenceRendererTests
     }
 
     [Fact]
-    public void Markdown_EmptyAndComplete_SaysNothingPointsHere()
+    public void Markdown_EmptyAndClean_QualifiesNothingPointsHere()
     {
         var markdown = Render(Set(references: []));
 
         Assert.Contains("No row points at TypeDef[5].", markdown);
-        // Nothing was hidden, so no caveat may appear.
+
+        // No detectable blind spot fired, so none of their caveats may appear...
         Assert.DoesNotContain("budget", markdown);
         Assert.DoesNotContain("could not be read", markdown);
-        Assert.DoesNotContain("not searched", markdown);
+        Assert.DoesNotContain("not searched in full", markdown);
+        Assert.DoesNotContain("past the end of its table", markdown);
+
+        // ...but the blob limit always applies, and this is the case where the
+        // bare sentence above would otherwise read as a guarantee.
+        Assert.Contains("signature blobs", markdown);
     }
 
     [Fact]
@@ -145,9 +153,19 @@ public class MetadataRowReferenceRendererTests
         Assert.True(first >= 0 && first < second && second < third);
     }
 
+    /// <summary>
+    /// The signature-blob limit is unconditional, so a search that hits no
+    /// detectable blind spot still carries exactly one caveat. A reader acting
+    /// on "No row points at X" must see it precisely in this case, because this
+    /// is when that sentence reads most like a guarantee.
+    /// </summary>
     [Fact]
-    public void Caveats_AreEmptyForACompleteSearch()
-        => Assert.Empty(MetadataProjectionRenderer.Caveats(Set()));
+    public void Caveats_ForACleanSearch_AreTheBlobLimitAlone()
+    {
+        var caveat = Assert.Single(MetadataProjectionRenderer.Caveats(Set()));
+
+        Assert.Contains("signature blobs", caveat);
+    }
 
     [Fact]
     public void Caveats_ReportEachBlindSpotIndependently()
@@ -155,9 +173,22 @@ public class MetadataRowReferenceRendererTests
         var all = Set(
             unreadable: ImmutableArray.Create(new MetadataRowLocation(TableIndex.MethodDef, 7)),
             unscanned: ImmutableArray.Create(TableIndex.NestedClass),
-            truncated: true);
+            truncated: true,
+            targetExists: false);
 
-        Assert.Equal(3, MetadataProjectionRenderer.Caveats(all).Count());
+        // Four detectable blind spots, plus the unconditional blob limit.
+        Assert.Equal(5, MetadataProjectionRenderer.Caveats(all).Count());
+    }
+
+    [Fact]
+    public void Caveats_MissingTargetRow_IsReportedNotRenderedAsAnEmptyAnswer()
+    {
+        // A row id past the end of its table is usually a typo. Answering it
+        // with a clean "nothing points here" makes the typo indistinguishable
+        // from a real row nothing points at.
+        var caveats = MetadataProjectionRenderer.Caveats(Set(references: [], targetExists: false));
+
+        Assert.Contains(caveats, c => c.Contains("past the end of its table", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
@@ -233,6 +233,13 @@ public class MetadataRowReferenceRendererTests
         Assert.Contains("Assembly", markdown);
         Assert.DoesNotContain("not modelled", markdown);
         Assert.Contains("not searched in full", markdown);
+
+        // A table lands in UnscannedTables for three reasons, and only two of
+        // them leave a whole row unread — the third stops between columns of an
+        // already-read final row. Claiming an unread row would be false there,
+        // so the caveat is worded around an unexamined cell instead.
+        Assert.Contains("cell the scan never examined", markdown);
+        Assert.DoesNotContain("row the scan never read", markdown);
     }
 
     [Fact]

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
@@ -1,0 +1,166 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata.Ecma335;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.MetadataRendering.Tests;
+
+/// <summary>
+/// Tests for rendering a <see cref="MetadataRowReferenceSet"/>. The renderer's
+/// obligation is that a reverse search's blind spots — a budget that stopped the
+/// scan, and rows that could not be decoded — survive into every format, so an
+/// empty answer is never mistaken for a confident one.
+/// </summary>
+public class MetadataRowReferenceRendererTests
+{
+    static string Render(MetadataRowReferenceSet references, MetadataTableFormat format = MetadataTableFormat.Markdown)
+    {
+        var writer = new StringWriter();
+        MetadataProjectionRenderer.Render(references, writer, format);
+        return writer.ToString();
+    }
+
+    static MetadataRowReferenceSet Set(
+        ImmutableArray<MetadataRowReference>? references = null,
+        ImmutableArray<MetadataRowLocation>? unreadable = null,
+        bool truncated = false)
+        => new(
+            new MetadataRowLocation(TableIndex.TypeDef, 5),
+            references ?? ImmutableArray.Create(
+                new MetadataRowReference(
+                    new MetadataRowLocation(TableIndex.NestedClass, 3),
+                    ColumnIndex: 1,
+                    ColumnName: "EnclosingClass",
+                    MetadataRowReferenceKind.Handle)),
+            unreadable ?? [],
+            truncated);
+
+    [Fact]
+    public void Markdown_NamesTargetAndCountInHeading()
+    {
+        var markdown = Render(Set());
+
+        Assert.Contains("## References to TypeDef[5] (1)", markdown);
+        Assert.Contains("NestedClass", markdown);
+        Assert.Contains("EnclosingClass", markdown);
+        Assert.Contains("Handle", markdown);
+    }
+
+    [Fact]
+    public void Markdown_EmptyAndComplete_SaysNothingPointsHere()
+    {
+        var markdown = Render(Set(references: []));
+
+        Assert.Contains("No row points at TypeDef[5].", markdown);
+        // Nothing was hidden, so no caveat may appear.
+        Assert.DoesNotContain("budget", markdown);
+        Assert.DoesNotContain("could not be decoded", markdown);
+    }
+
+    [Fact]
+    public void Markdown_Truncated_SaysMoreMayExist()
+    {
+        var markdown = Render(Set(truncated: true));
+
+        Assert.Contains("budget stopped this scan", markdown);
+    }
+
+    [Fact]
+    public void Markdown_UnreadableRows_AreVisibleAndCounted()
+    {
+        var unreadable = ImmutableArray.Create(
+            new MetadataRowLocation(TableIndex.MethodDef, 7),
+            new MetadataRowLocation(TableIndex.MethodDef, 8));
+
+        var markdown = Render(Set(unreadable: unreadable));
+
+        Assert.Contains("2 rows could not be decoded", markdown);
+    }
+
+    [Fact]
+    public void Markdown_SingleUnreadableRow_ReadsAsSingular()
+    {
+        var unreadable = ImmutableArray.Create(new MetadataRowLocation(TableIndex.MethodDef, 7));
+
+        var markdown = Render(Set(unreadable: unreadable));
+
+        Assert.Contains("1 row could not be decoded", markdown);
+        Assert.DoesNotContain("1 rows", markdown);
+    }
+
+    [Fact]
+    public void MachineFormats_CarryTargetColumn_SoRowsSelfIdentify()
+    {
+        // Markdown names the target once in a heading; TSV and JSONL have no
+        // heading, so the target must travel on every row.
+        var tsv = Render(Set(), MetadataTableFormat.Tsv);
+        var jsonl = Render(Set(), MetadataTableFormat.Jsonl);
+
+        Assert.Contains("TypeDef[5]", tsv);
+        Assert.Contains("TypeDef[5]", jsonl);
+        Assert.Contains("target", jsonl);
+    }
+
+    [Fact]
+    public void Jsonl_EmitsOneObjectPerReference()
+    {
+        var references = ImmutableArray.Create(
+            new MetadataRowReference(
+                new MetadataRowLocation(TableIndex.TypeDef, 4),
+                0,
+                "FieldList",
+                MetadataRowReferenceKind.Range),
+            new MetadataRowReference(
+                new MetadataRowLocation(TableIndex.NestedClass, 3),
+                1,
+                "EnclosingClass",
+                MetadataRowReferenceKind.Handle));
+
+        var jsonl = Render(Set(references), MetadataTableFormat.Jsonl);
+
+        var lines = jsonl.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.All(lines, line => Assert.StartsWith("{", line.Trim()));
+        Assert.Contains("Range", jsonl);
+        Assert.Contains("Handle", jsonl);
+    }
+
+    [Fact]
+    public void ReferenceOrder_IsPreserved()
+    {
+        var references = ImmutableArray.Create(
+            new MetadataRowReference(new MetadataRowLocation(TableIndex.TypeDef, 4), 0, "FieldList", MetadataRowReferenceKind.Range),
+            new MetadataRowReference(new MetadataRowLocation(TableIndex.MethodDef, 9), 0, "Signature", MetadataRowReferenceKind.Handle),
+            new MetadataRowReference(new MetadataRowLocation(TableIndex.NestedClass, 3), 1, "EnclosingClass", MetadataRowReferenceKind.Handle));
+
+        var tsv = Render(Set(references), MetadataTableFormat.Tsv);
+
+        int first = tsv.IndexOf("FieldList", StringComparison.Ordinal);
+        int second = tsv.IndexOf("Signature", StringComparison.Ordinal);
+        int third = tsv.IndexOf("EnclosingClass", StringComparison.Ordinal);
+
+        Assert.True(first >= 0 && first < second && second < third);
+    }
+
+    [Fact]
+    public void Caveats_AreEmptyForACompleteSearch()
+        => Assert.Empty(MetadataProjectionRenderer.Caveats(Set()));
+
+    [Fact]
+    public void Caveats_ReportBothBlindSpotsIndependently()
+    {
+        var both = Set(
+            unreadable: ImmutableArray.Create(new MetadataRowLocation(TableIndex.MethodDef, 7)),
+            truncated: true);
+
+        Assert.Equal(2, MetadataProjectionRenderer.Caveats(both).Count());
+    }
+
+    [Fact]
+    public void Render_NullArguments_Throw()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => MetadataProjectionRenderer.Render((MetadataRowReferenceSet)null!, new StringWriter()));
+        Assert.Throws<ArgumentNullException>(
+            () => MetadataProjectionRenderer.Render(Set(), null!));
+    }
+}

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
@@ -65,7 +65,7 @@ public class MetadataRowReferenceRendererTests
 
         // ...but the blob limit always applies, and this is the case where the
         // bare sentence above would otherwise read as a guarantee.
-        Assert.Contains("signature blobs", markdown);
+        Assert.Contains("Blob payloads are not searched", markdown);
     }
 
     [Fact]
@@ -164,7 +164,7 @@ public class MetadataRowReferenceRendererTests
     {
         var caveat = Assert.Single(MetadataProjectionRenderer.Caveats(Set()));
 
-        Assert.Contains("signature blobs", caveat);
+        Assert.Contains("Blob payloads are not searched", caveat);
     }
 
     [Fact]

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
@@ -7,8 +7,9 @@ namespace DotnetInspector.MetadataRendering.Tests;
 /// <summary>
 /// Tests for rendering a <see cref="MetadataRowReferenceSet"/>. The renderer's
 /// obligation is that a reverse search's blind spots — a budget that stopped the
-/// scan, and rows that could not be decoded — survive into every format, so an
-/// empty answer is never mistaken for a confident one.
+/// scan, rows that could not be decoded, and populated tables the projection
+/// never modelled — survive into every format, so an empty answer is never
+/// mistaken for a confident one.
 /// </summary>
 public class MetadataRowReferenceRendererTests
 {
@@ -22,6 +23,7 @@ public class MetadataRowReferenceRendererTests
     static MetadataRowReferenceSet Set(
         ImmutableArray<MetadataRowReference>? references = null,
         ImmutableArray<MetadataRowLocation>? unreadable = null,
+        ImmutableArray<TableIndex>? unscanned = null,
         bool truncated = false)
         => new(
             new MetadataRowLocation(TableIndex.TypeDef, 5),
@@ -32,6 +34,7 @@ public class MetadataRowReferenceRendererTests
                     ColumnName: "EnclosingClass",
                     MetadataRowReferenceKind.Handle)),
             unreadable ?? [],
+            unscanned ?? [],
             truncated);
 
     [Fact]
@@ -54,6 +57,7 @@ public class MetadataRowReferenceRendererTests
         // Nothing was hidden, so no caveat may appear.
         Assert.DoesNotContain("budget", markdown);
         Assert.DoesNotContain("could not be read", markdown);
+        Assert.DoesNotContain("not modelled by the projection", markdown);
     }
 
     [Fact]
@@ -146,13 +150,36 @@ public class MetadataRowReferenceRendererTests
         => Assert.Empty(MetadataProjectionRenderer.Caveats(Set()));
 
     [Fact]
-    public void Caveats_ReportBothBlindSpotsIndependently()
+    public void Caveats_ReportEachBlindSpotIndependently()
     {
-        var both = Set(
+        var all = Set(
             unreadable: ImmutableArray.Create(new MetadataRowLocation(TableIndex.MethodDef, 7)),
+            unscanned: ImmutableArray.Create(TableIndex.NestedClass),
             truncated: true);
 
-        Assert.Equal(2, MetadataProjectionRenderer.Caveats(both).Count());
+        Assert.Equal(3, MetadataProjectionRenderer.Caveats(all).Count());
+    }
+
+    [Fact]
+    public void Markdown_UnscannedTables_AreNamedNotJustCounted()
+    {
+        // A reader cannot judge what the search missed from a bare count, so the
+        // caveat must name the tables that went unvisited.
+        var markdown = Render(Set(
+            unscanned: ImmutableArray.Create(TableIndex.NestedClass, TableIndex.MethodSemantics)));
+
+        Assert.Contains("2 populated tables are not modelled by the projection", markdown);
+        Assert.Contains("NestedClass", markdown);
+        Assert.Contains("MethodSemantics", markdown);
+    }
+
+    [Fact]
+    public void Markdown_SingleUnscannedTable_ReadsAsSingular()
+    {
+        var markdown = Render(Set(unscanned: ImmutableArray.Create(TableIndex.NestedClass)));
+
+        Assert.Contains("1 populated table is not modelled by the projection", markdown);
+        Assert.DoesNotContain("1 populated tables", markdown);
     }
 
     [Fact]

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
@@ -187,6 +187,10 @@ public class MetadataRowReferenceRendererTests
     /// or because the budget stopped the scan first. The caveat cannot see
     /// which, so it must not assert a cause it does not know — a modelled table
     /// the budget never reached would make "not modelled" a false statement.
+    ///
+    /// It must not overstate the extent either. The budget can stop *part-way
+    /// through* a table, so a caveat claiming none of the table's rows was
+    /// searched would be false for the very table truncation landed in.
     /// </summary>
     [Fact]
     public void Markdown_UnscannedTables_DoNotClaimACause()
@@ -197,6 +201,7 @@ public class MetadataRowReferenceRendererTests
 
         Assert.Contains("Assembly", markdown);
         Assert.DoesNotContain("not modelled", markdown);
+        Assert.Contains("not searched in full", markdown);
     }
 
     [Fact]

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataRowReferenceRendererTests.cs
@@ -57,7 +57,7 @@ public class MetadataRowReferenceRendererTests
         // Nothing was hidden, so no caveat may appear.
         Assert.DoesNotContain("budget", markdown);
         Assert.DoesNotContain("could not be read", markdown);
-        Assert.DoesNotContain("not modelled by the projection", markdown);
+        Assert.DoesNotContain("not searched", markdown);
     }
 
     [Fact]
@@ -164,11 +164,11 @@ public class MetadataRowReferenceRendererTests
     public void Markdown_UnscannedTables_AreNamedNotJustCounted()
     {
         // A reader cannot judge what the search missed from a bare count, so the
-        // caveat must name the tables that went unvisited.
+        // caveat must name the tables that went unsearched.
         var markdown = Render(Set(
             unscanned: ImmutableArray.Create(TableIndex.NestedClass, TableIndex.MethodSemantics)));
 
-        Assert.Contains("2 populated tables are not modelled by the projection", markdown);
+        Assert.Contains("2 populated tables were not searched", markdown);
         Assert.Contains("NestedClass", markdown);
         Assert.Contains("MethodSemantics", markdown);
     }
@@ -178,8 +178,25 @@ public class MetadataRowReferenceRendererTests
     {
         var markdown = Render(Set(unscanned: ImmutableArray.Create(TableIndex.NestedClass)));
 
-        Assert.Contains("1 populated table is not modelled by the projection", markdown);
+        Assert.Contains("1 populated table was not searched", markdown);
         Assert.DoesNotContain("1 populated tables", markdown);
+    }
+
+    /// <summary>
+    /// A table goes unsearched either because the projection does not model it
+    /// or because the budget stopped the scan first. The caveat cannot see
+    /// which, so it must not assert a cause it does not know — a modelled table
+    /// the budget never reached would make "not modelled" a false statement.
+    /// </summary>
+    [Fact]
+    public void Markdown_UnscannedTables_DoNotClaimACause()
+    {
+        var markdown = Render(Set(
+            unscanned: ImmutableArray.Create(TableIndex.Assembly),
+            truncated: true));
+
+        Assert.Contains("Assembly", markdown);
+        Assert.DoesNotContain("not modelled", markdown);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -494,6 +494,51 @@ public class MetadataRowReferenceSearchTests
     }
 
     [Fact]
+    public void FindReferences_StoppedOnATableSVeryLastCell_IsStillCountedAsSearched()
+    {
+        // The counterpart to the test above, and the boundary between them. If
+        // the budget trips on the *last column of the last row*, every cell the
+        // table has was examined, so the table really was searched in full even
+        // though the scan ended inside it. Reporting it unscanned would be a
+        // false blind spot: it would claim an unread row could hide an edge when
+        // no row went unread.
+        using var peReader = OpenSelfFromBytes();
+        var reader = peReader.GetMetadataReader();
+
+        int typeDefRows = reader.GetTableRowCount(TableIndex.TypeDef);
+        int lastColumn = FullProjection(peReader)
+            .Tables.Single(t => t.Index == TableIndex.TypeDef)
+            .Columns.Length - 1;
+
+        // TypeDef's last column is its MethodList run, so a method owned by the
+        // last TypeDef row is pointed at from exactly that cell.
+        var lastType = reader.GetTypeDefinition(MetadataTokens.TypeDefinitionHandle(typeDefRows));
+        int methodRid = MetadataTokens.GetRowNumber(lastType.GetMethods().First());
+
+        var full = MetadataTableProjector.FindReferences(peReader, TableIndex.MethodDef, methodRid, int.MaxValue);
+        int budget = -1;
+        for (int i = 0; i < full.References.Length; i++)
+        {
+            var reference = full.References[i];
+            if (reference.Source.Table == TableIndex.TypeDef
+                && reference.Source.RowId == typeDefRows
+                && reference.ColumnIndex == lastColumn)
+            {
+                budget = i;
+                break;
+            }
+        }
+
+        Assert.True(budget >= 0, "Expected the last TypeDef row's final column to point at its own method.");
+
+        var capped = MetadataTableProjector.FindReferences(peReader, TableIndex.MethodDef, methodRid, budget);
+        Assert.True(capped.Truncated, "Expected the budget to stop this scan.");
+
+        // Stopped inside TypeDef, yet TypeDef is fully searched.
+        Assert.DoesNotContain(TableIndex.TypeDef, capped.UnscannedTables);
+    }
+
+    [Fact]
     public void FindReferences_TruncatedScan_ReportsTheTablesItNeverReached()
     {
         using var peReader = OpenSelfFromBytes();

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
@@ -347,5 +349,153 @@ public class MetadataRowReferenceSearchTests
         using var session = AssemblyInspectionSession.Open(SelfPath);
 
         Assert.Null(session.MetadataTableRow(TableIndex.TypeDef, int.MaxValue));
+    }
+
+    /// <summary>
+    /// A synthetic image whose <c>TypeDef[2].Extends</c> names a <c>TypeRef</c>
+    /// row that does not exist, and whose <c>Module[1].Mvid</c> points past the
+    /// end of the GUID heap.
+    ///
+    /// Real compilers do not emit either, which is exactly why a blind spot here
+    /// has to be constructed: the cell readers contain both failures as
+    /// <see cref="MetadataValue.Malformed"/> rather than throwing, so the row
+    /// reads successfully and would otherwise pass as fully searched.
+    /// </summary>
+    static byte[] BuildImageWithMalformedCells()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            // A broken cell in a Heap column, which was never an edge: the GUID
+            // heap holds no such index.
+            mvid: MetadataTokens.GuidHandle(9999),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+
+        // The <Module> pseudo-type must be row 1.
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        // Row 2: a dangling edge in a Handle column.
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("DanglingExtends"),
+            baseType: MetadataTokens.TypeReferenceHandle(9999),
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+
+        // One method, so TypeDef[2].MethodList is a real run rather than an
+        // empty one. TypeDef[1] and TypeDef[2] both start at MethodDef row 1, so
+        // TypeDef[1]'s run is empty and TypeDef[2]'s is [1, 2).
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature().Parameters(0, r => r.Void(), _ => { });
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Abstract,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("M"),
+            metadata.GetOrAddBlob(signature),
+            bodyOffset: -1,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var peBuilder = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            rootBuilder,
+            ilStream: new BlobBuilder());
+        var image = new BlobBuilder();
+        peBuilder.Serialize(image);
+        return image.ToArray();
+    }
+
+    [Fact]
+    public void MalformedCells_AreOnlyProducedWhereThisFixtureIntends()
+    {
+        // Guards the two tests below: if SRM ever stops producing a malformed
+        // cell here, they would silently become vacuous.
+        using var peReader = new PEReader(new MemoryStream(BuildImageWithMalformedCells()));
+        var projection = FullProjection(peReader);
+
+        var typeDefs = Assert.Single(projection.Tables, t => t.Index == TableIndex.TypeDef);
+        Assert.Equal(2, typeDefs.Rows.Length);
+        int extends = Array.FindIndex(typeDefs.Columns.ToArray(), c => c.Kind == MetadataColumnKind.Handle);
+        Assert.IsType<MetadataValue.Malformed>(typeDefs.Rows[1].Cells[extends]);
+
+        // The Heap-column counterpart, which must not be treated as a lost edge.
+        var modules = Assert.Single(projection.Tables, t => t.Index == TableIndex.Module);
+        int mvid = Array.FindIndex(modules.Columns.ToArray(), c => c.Name == "Mvid");
+        Assert.Equal(MetadataColumnKind.Heap, modules.Columns[mvid].Kind);
+        Assert.IsType<MetadataValue.Malformed>(modules.Rows[0].Cells[mvid]);
+    }
+
+    [Fact]
+    public void FindReferences_MalformedEdgeColumn_IsReportedAsABlindSpot()
+    {
+        using var peReader = new PEReader(new MemoryStream(BuildImageWithMalformedCells()));
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, 1);
+
+        // The Extends cell may or may not have been an edge onto TypeRef[1]; the
+        // search cannot tell, so it must not answer "nothing points here".
+        Assert.Empty(set.References);
+        Assert.False(set.IsComplete);
+
+        var blind = Assert.Single(set.UnreadableRows);
+        Assert.Equal(TableIndex.TypeDef, blind.Table);
+        Assert.Equal(2, blind.RowId);
+    }
+
+    [Fact]
+    public void FindReferences_MalformedHeapColumn_IsNotABlindSpot()
+    {
+        using var peReader = new PEReader(new MemoryStream(BuildImageWithMalformedCells()));
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, 1);
+
+        // Module[1].Mvid is a Heap column. It was never an edge, so it cannot
+        // hide a reference and must not be reported as one lost.
+        Assert.DoesNotContain(set.UnreadableRows, r => r.Table == TableIndex.Module);
+    }
+
+    [Fact]
+    public void FindReferences_MalformedEdge_StillReportsTheGoodEdgesOnTheSameRow()
+    {
+        using var peReader = new PEReader(new MemoryStream(BuildImageWithMalformedCells()));
+
+        // TypeDef[2] has a broken Extends *and* a valid MethodList run. The row
+        // being a blind spot must not cost the caller the edges it does have.
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.MethodDef, 1);
+
+        Assert.Contains(
+            set.References,
+            r => r.Source.Table == TableIndex.TypeDef && r.Source.RowId == 2 && r.Kind == MetadataRowReferenceKind.Range);
+        Assert.Single(set.UnreadableRows);
+    }
+
+    [Fact]
+    public void FindReferences_WellFormedImage_ReportsNoBlindSpots()
+    {
+        // The negative case for the check above: a real assembly must not start
+        // reporting blind spots just because malformed edge cells are now tracked.
+        using var peReader = OpenSelfFromBytes();
+
+        foreach (var table in new[] { TableIndex.TypeDef, TableIndex.MethodDef, TableIndex.Field, TableIndex.TypeRef })
+        {
+            var set = MetadataTableProjector.FindReferences(peReader, table, 1);
+            Assert.Empty(set.UnreadableRows);
+            Assert.True(set.IsComplete);
+        }
     }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -72,6 +72,19 @@ public class MetadataRowReferenceSearchTests
         MetadataRowReferenceSet set)
         => [.. set.References.Select(r => (r.Source.Table, r.Source.RowId, r.ColumnName, r.Kind))];
 
+    /// <summary>
+    /// The scan itself finished and read every row it visited. This is not
+    /// <see cref="MetadataRowReferenceSet.IsComplete"/>: on a real assembly that
+    /// is false because the projection models a subset of ECMA-335's tables, so
+    /// populated tables go unvisited. Tests that mean "the scan ran clean" must
+    /// say so rather than borrowing a stronger claim.
+    /// </summary>
+    static void AssertScanRanClean(MetadataRowReferenceSet set)
+    {
+        Assert.False(set.Truncated, "Expected the scan to run to completion.");
+        Assert.Empty(set.UnreadableRows);
+    }
+
     [Theory]
     [InlineData(TableIndex.TypeDef, 1)]
     [InlineData(TableIndex.TypeDef, 2)]
@@ -88,7 +101,7 @@ public class MetadataRowReferenceSearchTests
         var expected = Expected(FullProjection(peReader), table, rowId);
         var set = MetadataTableProjector.FindReferences(peReader, table, rowId, int.MaxValue);
 
-        Assert.True(set.IsComplete, "Expected a complete scan over a well-formed image.");
+        AssertScanRanClean(set);
         Assert.Equal(expected, Actual(set));
     }
 
@@ -172,7 +185,7 @@ public class MetadataRowReferenceSearchTests
     }
 
     [Fact]
-    public void FindReferences_ForARowNothingPointsAt_ReportsACompleteEmptyResult()
+    public void FindReferences_ForARowNothingPointsAt_ReportsAnEmptyResultFromACleanScan()
     {
         using var peReader = OpenSelfFromBytes();
         var typeDef = FullProjection(peReader).Tables.Single(t => t.Index == TableIndex.TypeDef);
@@ -182,7 +195,7 @@ public class MetadataRowReferenceSearchTests
         var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, typeDef.RowCount + 1_000, int.MaxValue);
 
         Assert.Empty(set.References);
-        Assert.True(set.IsComplete, "An empty result must be distinguishable from a stopped or blind scan.");
+        AssertScanRanClean(set);
     }
 
     /// <summary>
@@ -265,6 +278,82 @@ public class MetadataRowReferenceSearchTests
         Assert.Empty(set.UnreadableRows);
     }
 
+    /// <summary>
+    /// The projection models a subset of ECMA-335's tables, and a real assembly
+    /// populates tables outside that subset. The scan never visits them, so an
+    /// edge living in one is invisible — and that must be reported rather than
+    /// folded into an empty or "complete" answer.
+    /// </summary>
+    [Fact]
+    public void FindReferences_ReportsPopulatedUnmodelledTables_AsABlindSpot()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, 1, int.MaxValue);
+
+        AssertScanRanClean(set);
+        Assert.NotEmpty(set.UnscannedTables);
+        Assert.False(
+            set.IsComplete,
+            "A scan that never visited a populated table has not covered the whole image.");
+    }
+
+    /// <summary>
+    /// The blind spot must be exactly the populated tables the projection does
+    /// not model — no modelled table, and no empty table. Over-reporting would
+    /// scare a caller off a result the search actually did cover.
+    /// </summary>
+    [Fact]
+    public void FindReferences_UnscannedTables_AreExactlyThePopulatedUnmodelledOnes()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var reader = peReader.GetMetadataReader();
+
+        var projected = FullProjection(peReader).Tables.Select(t => t.Index).ToHashSet();
+        var expected = Enum.GetValues<TableIndex>()
+            .Where(t => !projected.Contains(t) && reader.GetTableRowCount(t) > 0)
+            .ToArray();
+
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, 1, int.MaxValue);
+
+        Assert.NotEmpty(expected);
+        Assert.Equal(expected, set.UnscannedTables);
+        Assert.All(set.UnscannedTables, t => Assert.DoesNotContain(t, projected));
+        Assert.All(set.UnscannedTables, t => Assert.True(reader.GetTableRowCount(t) > 0));
+    }
+
+    /// <summary>
+    /// The blind spot is not hypothetical. <c>NestedClass</c> is the only place a
+    /// nested type's declaring type is recorded, and the projection does not
+    /// model it, so the search silently misses that edge today. This test pins
+    /// the miss *and* the disclosure together: if the projection later covers
+    /// <c>NestedClass</c>, the edge must appear and the table must drop off the
+    /// blind-spot list at the same time.
+    /// </summary>
+    [Fact]
+    public void FindReferences_MissesTheDeclaringTypeOfANestedType_AndDisclosesWhy()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var reader = peReader.GetMetadataReader();
+
+        // Independent oracle: ask SRM which TypeDef is nested, rather than
+        // hardcoding a row id that recompiling this assembly would move.
+        int nestedRowId = reader.TypeDefinitions
+            .Where(h => reader.GetTypeDefinition(h).IsNested)
+            .Select(h => MetadataTokens.GetRowNumber((EntityHandle)h))
+            .First();
+
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, nestedRowId, int.MaxValue);
+
+        AssertScanRanClean(set);
+        Assert.DoesNotContain(set.References, r => r.Source.Table == TableIndex.NestedClass);
+
+        if (set.UnscannedTables.Contains(TableIndex.NestedClass))
+            Assert.False(set.IsComplete, "The missed edge must not be hidden behind a complete result.");
+        else
+            Assert.Contains(set.References, r => r.Source.Table == TableIndex.NestedClass);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
@@ -314,7 +403,8 @@ public class MetadataRowReferenceSearchTests
             direct.References.Select(r => (r.Source.Table, r.Source.RowId, r.ColumnName, r.Kind)),
             viaSession.References.Select(r => (r.Source.Table, r.Source.RowId, r.ColumnName, r.Kind)));
         Assert.Equal(direct.Target.Token, viaSession.Target.Token);
-        Assert.True(viaSession.IsComplete);
+        Assert.Equal(direct.IsComplete, viaSession.IsComplete);
+        AssertScanRanClean(viaSession);
     }
 
     [Fact]
@@ -485,17 +575,17 @@ public class MetadataRowReferenceSearchTests
     }
 
     [Fact]
-    public void FindReferences_WellFormedImage_ReportsNoBlindSpots()
+    public void FindReferences_WellFormedImage_ReportsNoUnreadableRows()
     {
         // The negative case for the check above: a real assembly must not start
-        // reporting blind spots just because malformed edge cells are now tracked.
+        // reporting unreadable rows just because malformed edge cells are now
+        // tracked.
         using var peReader = OpenSelfFromBytes();
 
         foreach (var table in new[] { TableIndex.TypeDef, TableIndex.MethodDef, TableIndex.Field, TableIndex.TypeRef })
         {
             var set = MetadataTableProjector.FindReferences(peReader, table, 1);
-            Assert.Empty(set.UnreadableRows);
-            Assert.True(set.IsComplete);
+            AssertScanRanClean(set);
         }
     }
 

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -295,7 +295,7 @@ public class MetadataRowReferenceSearchTests
         Assert.NotEmpty(set.UnscannedTables);
         Assert.False(
             set.IsComplete,
-            "A scan that never visited a populated table has not covered the whole image.");
+            "A scan that left a populated table unread, in whole or in part, has not covered the whole image.");
     }
 
     /// <summary>

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -498,4 +498,61 @@ public class MetadataRowReferenceSearchTests
             Assert.True(set.IsComplete);
         }
     }
+
+    /// <summary>
+    /// The invariant the malformed-edge gate rests on: an edge cell only ever
+    /// appears in a column declared as an edge column. If a column that can
+    /// produce a <see cref="MetadataValue.Handle"/> or
+    /// <see cref="MetadataValue.Range"/> were declared <c>Heap</c>, <c>Scalar</c>,
+    /// or <c>Flags</c>, a malformed cell there would be a lost edge the search
+    /// silently ignores — the exact bug the gate exists to prevent.
+    /// </summary>
+    [Fact]
+    public void EdgeCells_OnlyEverAppearInEdgeColumns()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var projection = FullProjection(peReader);
+
+        int inspected = 0;
+        foreach (var table in projection.Tables)
+        {
+            foreach (var row in table.Rows)
+            {
+                for (int column = 0; column < row.Cells.Length; column++)
+                {
+                    var kind = table.Columns[column].Kind;
+                    inspected++;
+
+                    if (row.Cells[column] is MetadataValue.Handle)
+                        Assert.Equal(MetadataColumnKind.Handle, kind);
+
+                    if (row.Cells[column] is MetadataValue.Range)
+                        Assert.Equal(MetadataColumnKind.HandleRange, kind);
+                }
+            }
+        }
+
+        // Guards against the loop above passing because it saw nothing.
+        Assert.True(inspected > 10_000, $"only {inspected} cells inspected");
+    }
+
+    /// <summary>
+    /// The converse: every column kind the gate treats as an edge column is
+    /// actually reachable in real metadata, so the gate is not written against
+    /// kinds that never occur.
+    /// </summary>
+    [Fact]
+    public void BothEdgeColumnKinds_OccurInRealMetadata()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var projection = FullProjection(peReader);
+
+        var kinds = projection.Tables
+            .SelectMany(t => t.Columns)
+            .Select(c => c.Kind)
+            .ToHashSet();
+
+        Assert.Contains(MetadataColumnKind.Handle, kinds);
+        Assert.Contains(MetadataColumnKind.HandleRange, kinds);
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -184,18 +184,63 @@ public class MetadataRowReferenceSearchTests
         }
     }
 
+    /// <summary>
+    /// A row that exists and that genuinely nothing points at. The row id is
+    /// derived rather than hardcoded, because which rows are unreferenced is an
+    /// artifact of how this assembly happens to be compiled.
+    ///
+    /// Deliberately not a row id past the end of the table: that is a different
+    /// answer wearing the same clothes, and conflating the two is what
+    /// <see cref="MetadataRowReferenceSet.TargetExists"/> exists to stop.
+    /// </summary>
     [Fact]
     public void FindReferences_ForARowNothingPointsAt_ReportsAnEmptyResultFromACleanScan()
     {
         using var peReader = OpenSelfFromBytes();
         var typeDef = FullProjection(peReader).Tables.Single(t => t.Index == TableIndex.TypeDef);
 
-        // A row id past the end of the table cannot be referenced: a handle that
-        // far out already projects as Malformed rather than a resolvable edge.
-        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, typeDef.RowCount + 1_000, int.MaxValue);
+        int unreferenced = Enumerable
+            .Range(1, typeDef.RowCount)
+            .First(rid => MetadataTableProjector
+                .FindReferences(peReader, TableIndex.TypeDef, rid, int.MaxValue)
+                .References.IsEmpty);
+
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, unreferenced, int.MaxValue);
 
         Assert.Empty(set.References);
+        Assert.True(set.TargetExists, "The row must exist, or this is not the case under test.");
         AssertScanRanClean(set);
+    }
+
+    [Fact]
+    public void FindReferences_ForARowPastTheEndOfItsTable_SaysTheRowIsNotThere()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var typeDef = FullProjection(peReader).Tables.Single(t => t.Index == TableIndex.TypeDef);
+
+        var set = MetadataTableProjector.FindReferences(
+            peReader, TableIndex.TypeDef, typeDef.RowCount + 1_000, int.MaxValue);
+
+        // Empty for a reason the caller must be able to tell apart from "this
+        // row exists and nothing points at it". Without TargetExists the two
+        // render identically, so a typo'd row id reads as a real answer.
+        Assert.Empty(set.References);
+        Assert.False(set.TargetExists);
+        Assert.False(set.IsComplete);
+    }
+
+    [Fact]
+    public void FindReferences_ForTheLastRowOfATable_SaysTheRowIsThere()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var typeDef = FullProjection(peReader).Tables.Single(t => t.Index == TableIndex.TypeDef);
+
+        // The boundary the off-by-one would land on: row ids are 1-based, so the
+        // last valid row is RowCount itself, not RowCount - 1.
+        var set = MetadataTableProjector.FindReferences(
+            peReader, TableIndex.TypeDef, typeDef.RowCount, int.MaxValue);
+
+        Assert.True(set.TargetExists);
     }
 
     /// <summary>
@@ -400,6 +445,55 @@ public class MetadataRowReferenceSearchTests
     }
 
     [Fact]
+    public void FindReferences_StoppedOnATableSLastRow_IsStillNotCountedAsSearched()
+    {
+        // The budget is checked inside the column loop, so a scan can enter the
+        // final row of a table and abandon it part way through its columns. The
+        // row counter still reaches RowCount + 1 on the way out, which looks
+        // exactly like an ordinary completed table. Truncation is the only thing
+        // that separates the two.
+        using var peReader = OpenSelfFromBytes();
+        var reader = peReader.GetMetadataReader();
+        int popular = MostReferencedTypeRef(FullProjection(peReader));
+
+        var full = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, int.MaxValue);
+        Assert.False(full.Truncated);
+
+        // Find a match that sits on the last row of a multi-row table. Budgeting
+        // the scan to the matches before it makes that row the one the budget
+        // trips on, so the scan stops inside the table's final row.
+        int budget = -1;
+        TableIndex stoppedIn = default;
+        for (int i = 0; i < full.References.Length; i++)
+        {
+            var source = full.References[i].Source;
+            int rowCount = reader.GetTableRowCount(source.Table);
+            if (source.RowId == rowCount && rowCount > 1)
+            {
+                budget = i;
+                stoppedIn = source.Table;
+                break;
+            }
+        }
+
+        Assert.True(budget >= 0, "No match sat on the last row of a multi-row table.");
+
+        var capped = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, budget);
+        Assert.True(capped.Truncated, "Expected the budget to stop this scan.");
+        Assert.Equal(budget, capped.References.Length);
+
+        // The last row was entered but never finished, so its columns after the
+        // stop were never compared against the target.
+        Assert.Contains(stoppedIn, ModelledTables);
+        Assert.Contains(stoppedIn, capped.UnscannedTables);
+
+        // Nothing stops the full scan, so the same table is searched there. That
+        // is what makes the blind spot evidence of the stop rather than a gap in
+        // what the projection models.
+        Assert.DoesNotContain(stoppedIn, full.UnscannedTables);
+    }
+
+    [Fact]
     public void FindReferences_TruncatedScan_ReportsTheTablesItNeverReached()
     {
         using var peReader = OpenSelfFromBytes();
@@ -556,6 +650,88 @@ public class MetadataRowReferenceSearchTests
         using var session = AssemblyInspectionSession.Open(SelfPath);
 
         Assert.Null(session.MetadataTableRow(TableIndex.TypeDef, int.MaxValue));
+    }
+
+    /// <summary>
+    /// A synthetic image every one of whose populated tables the projection
+    /// models, with no malformed cell anywhere.
+    ///
+    /// This is what makes it useful: on a real assembly a scan is incomplete for
+    /// several reasons at once, so an <c>IsComplete == false</c> assertion there
+    /// passes no matter which reason produced it. Here a clean scan is genuinely
+    /// available, so target existence can be isolated as the only thing left
+    /// that can take it away.
+    /// </summary>
+    static byte[] BuildMinimalCleanImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Clean.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Clean"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+
+        // The <Module> pseudo-type must be row 1.
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("Solo"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var peBuilder = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            rootBuilder,
+            ilStream: new BlobBuilder());
+        var image = new BlobBuilder();
+        peBuilder.Serialize(image);
+        return image.ToArray();
+    }
+
+    [Fact]
+    public void FindReferences_MissingTargetRow_IsTheOnlyThingWrongWithAnOtherwiseCleanScan()
+    {
+        using var peReader = new PEReader(new MemoryStream(BuildMinimalCleanImage()));
+        var reader = peReader.GetMetadataReader();
+        int rowCount = reader.GetTableRowCount(TableIndex.TypeDef);
+
+        // A row that is there. Every other completeness condition holds on this
+        // image, so the scan is complete — which is what licenses the comparison
+        // below to attribute the difference to target existence alone.
+        var present = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, rowCount);
+        Assert.True(
+            present.IsComplete,
+            "This fixture exists to offer a genuinely complete scan; without one the test below proves nothing.");
+
+        // The same image, the same scan, one row further on.
+        var absent = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, rowCount + 1);
+        Assert.False(absent.Truncated);
+        Assert.Empty(absent.UnreadableRows);
+        Assert.Empty(absent.UnscannedTables);
+        Assert.False(absent.TargetExists);
+
+        // So an empty result here cannot be reported as a trustworthy "nothing
+        // points at this row": there is no row for anything to point at.
+        Assert.Empty(absent.References);
+        Assert.False(absent.IsComplete);
     }
 
     /// <summary>

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -1,0 +1,351 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Tests for <see cref="MetadataTableProjector.FindReferences"/> — the reverse of
+/// the projection's forward handle edges, answering "which rows point at this
+/// row?" (issue #3341, gap 4).
+///
+/// Two edge shapes must both resolve: a handle column naming a row directly, and
+/// a list column whose contiguous run contains it. The second is the one that
+/// matters most, because ECMA-335 encodes ownership as a run on the owner rather
+/// than a back-pointer on the owned row, so it is the only way to answer "which
+/// type declares this field?".
+/// </summary>
+public class MetadataRowReferenceSearchTests
+{
+    static string SelfPath => typeof(MetadataRowReferenceSearchTests).Assembly.Location;
+
+    static PEReader OpenSelfFromBytes() => new(new MemoryStream(File.ReadAllBytes(SelfPath)));
+
+    static MetadataTableProjection FullProjection(PEReader peReader)
+        => MetadataTableProjector.Project(
+            peReader,
+            new MetadataProjectionOptions { MaxRowsPerTable = int.MaxValue });
+
+    /// <summary>
+    /// An independent restatement of the search: walk every row of a complete
+    /// projection and collect the cells that point at the target. Deliberately
+    /// re-derives the half-open run membership rather than calling the product's
+    /// helper, so a change to that rule shows up as a disagreement.
+    /// </summary>
+    static ImmutableArray<(TableIndex Table, int RowId, string Column, MetadataRowReferenceKind Kind)> Expected(
+        MetadataTableProjection projection,
+        TableIndex targetTable,
+        int targetRowId)
+    {
+        var found = ImmutableArray.CreateBuilder<(TableIndex, int, string, MetadataRowReferenceKind)>();
+        foreach (var table in projection.Tables)
+        {
+            foreach (var row in table.Rows)
+            {
+                for (int column = 0; column < row.Cells.Length; column++)
+                {
+                    switch (row.Cells[column])
+                    {
+                        case MetadataValue.Handle handle
+                            when handle.Reference.TargetTable == targetTable
+                                && handle.Reference.TargetRowId == targetRowId:
+                            found.Add((table.Index, row.RowId, table.Columns[column].Name, MetadataRowReferenceKind.Handle));
+                            break;
+
+                        case MetadataValue.Range range
+                            when range.Reference.TargetTable == targetTable
+                                && targetRowId >= range.Reference.StartRowId
+                                && targetRowId < range.Reference.EndRowId:
+                            found.Add((table.Index, row.RowId, table.Columns[column].Name, MetadataRowReferenceKind.Range));
+                            break;
+                    }
+                }
+            }
+        }
+
+        return found.ToImmutable();
+    }
+
+    static ImmutableArray<(TableIndex Table, int RowId, string Column, MetadataRowReferenceKind Kind)> Actual(
+        MetadataRowReferenceSet set)
+        => [.. set.References.Select(r => (r.Source.Table, r.Source.RowId, r.ColumnName, r.Kind))];
+
+    [Theory]
+    [InlineData(TableIndex.TypeDef, 1)]
+    [InlineData(TableIndex.TypeDef, 2)]
+    [InlineData(TableIndex.TypeRef, 1)]
+    [InlineData(TableIndex.Field, 1)]
+    [InlineData(TableIndex.MethodDef, 1)]
+    [InlineData(TableIndex.MethodDef, 7)]
+    [InlineData(TableIndex.Param, 1)]
+    [InlineData(TableIndex.AssemblyRef, 1)]
+    public void FindReferences_AgreesWithAFullScanOfTheProjection(TableIndex table, int rowId)
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var expected = Expected(FullProjection(peReader), table, rowId);
+        var set = MetadataTableProjector.FindReferences(peReader, table, rowId, int.MaxValue);
+
+        Assert.True(set.IsComplete, "Expected a complete scan over a well-formed image.");
+        Assert.Equal(expected, Actual(set));
+    }
+
+    [Fact]
+    public void FindReferences_ResolvesOwnership_ThroughAListColumnRun()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        // ECMA-335 gives a Field no back-pointer to its type; the only evidence is
+        // that some TypeDef's FieldList run covers it. Without range edges this
+        // question is unanswerable.
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.Field, 1, int.MaxValue);
+
+        var owner = Assert.Single(
+            set.References.Where(r => r.Source.Table == TableIndex.TypeDef && r.Kind == MetadataRowReferenceKind.Range));
+        Assert.Equal("FieldList", owner.ColumnName);
+
+        // The claimed owner must actually cover the field.
+        var ownerRow = MetadataTableProjector.ProjectRow(peReader, TableIndex.TypeDef, owner.Source.RowId);
+        var cell = Assert.IsType<MetadataValue.Range>(Assert.Single(ownerRow!.Rows).Cells[owner.ColumnIndex]);
+        Assert.Equal(TableIndex.Field, cell.Reference.TargetTable);
+        Assert.InRange(1, cell.Reference.StartRowId, cell.Reference.EndRowId - 1);
+    }
+
+    [Fact]
+    public void FindReferences_ResolvesTheDeclaringMethodOfAParam()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.Param, 1, int.MaxValue);
+
+        var owner = Assert.Single(
+            set.References.Where(r => r.Source.Table == TableIndex.MethodDef && r.Kind == MetadataRowReferenceKind.Range));
+        Assert.Equal("ParamList", owner.ColumnName);
+    }
+
+    [Fact]
+    public void FindReferences_ResolvesHandleEdges()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var projection = FullProjection(peReader);
+
+        // Pick a real handle edge out of the image, then look for it backwards.
+        var typeDef = projection.Tables.Single(t => t.Index == TableIndex.TypeDef);
+        int extends = typeDef.Columns.Select((c, i) => (c, i)).First(x => x.c.Name == "Extends").i;
+        var edge = typeDef.Rows
+            .Select(row => (row, cell: row.Cells[extends] as MetadataValue.Handle))
+            .First(x => x.cell is { Reference.TargetTable: TableIndex.TypeRef });
+
+        var set = MetadataTableProjector.FindReferences(
+            peReader,
+            TableIndex.TypeRef,
+            edge.cell!.Reference.TargetRowId,
+            int.MaxValue);
+
+        Assert.Contains(set.References, r =>
+            r.Source.Table == TableIndex.TypeDef
+            && r.Source.RowId == edge.row.RowId
+            && r.ColumnName == "Extends"
+            && r.Kind == MetadataRowReferenceKind.Handle);
+    }
+
+    [Fact]
+    public void FindReferences_CarriesAColumnIndexThatAlignsWithTheSourceRow()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, 1, int.MaxValue);
+        Assert.NotEmpty(set.References);
+
+        foreach (var reference in set.References)
+        {
+            // ColumnIndex must index the source table's own schema, not the
+            // target's, or a consumer highlighting the cell would point at the
+            // wrong column.
+            var view = MetadataTableProjector.ProjectRow(peReader, reference.Source.Table, reference.Source.RowId);
+            Assert.NotNull(view);
+            Assert.Equal(reference.ColumnName, view!.Columns[reference.ColumnIndex].Name);
+            Assert.InRange(reference.ColumnIndex, 0, Assert.Single(view.Rows).Cells.Length - 1);
+        }
+    }
+
+    [Fact]
+    public void FindReferences_ForARowNothingPointsAt_ReportsACompleteEmptyResult()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var typeDef = FullProjection(peReader).Tables.Single(t => t.Index == TableIndex.TypeDef);
+
+        // A row id past the end of the table cannot be referenced: a handle that
+        // far out already projects as Malformed rather than a resolvable edge.
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, typeDef.RowCount + 1_000, int.MaxValue);
+
+        Assert.Empty(set.References);
+        Assert.True(set.IsComplete, "An empty result must be distinguishable from a stopped or blind scan.");
+    }
+
+    /// <summary>
+    /// The <c>TypeRef</c> row the image points at most (in practice
+    /// <c>System.Object</c>). Derived rather than hardcoded, because which row id
+    /// is popular is an artifact of how this test assembly happens to be
+    /// compiled, not something a test should assume.
+    /// </summary>
+    static int MostReferencedTypeRef(MetadataTableProjection projection)
+    {
+        var counts = new Dictionary<int, int>();
+        foreach (var table in projection.Tables)
+        {
+            foreach (var row in table.Rows)
+            {
+                foreach (var cell in row.Cells)
+                {
+                    if (cell is MetadataValue.Handle { Reference.TargetTable: TableIndex.TypeRef } handle)
+                        counts[handle.Reference.TargetRowId] = counts.GetValueOrDefault(handle.Reference.TargetRowId) + 1;
+                }
+            }
+        }
+
+        Assert.NotEmpty(counts);
+        return counts.MaxBy(pair => pair.Value).Key;
+    }
+
+    [Fact]
+    public void FindReferences_MarksTruncation_WhenTheBudgetStopsTheScan()
+    {
+        using var peReader = OpenSelfFromBytes();
+        int popular = MostReferencedTypeRef(FullProjection(peReader));
+
+        var full = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, int.MaxValue);
+        Assert.True(full.References.Length > 1, $"Expected TypeRef[{popular}] to be referenced more than once.");
+
+        var capped = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, 1);
+
+        Assert.Single(capped.References);
+        Assert.True(capped.Truncated);
+        Assert.False(capped.IsComplete, "A stopped scan must never claim completeness.");
+        Assert.Equal(full.References[0], capped.References[0]);
+    }
+
+    [Fact]
+    public void FindReferences_WithAZeroBudget_StillReportsThatItStopped()
+    {
+        using var peReader = OpenSelfFromBytes();
+        int popular = MostReferencedTypeRef(FullProjection(peReader));
+
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, 0);
+
+        Assert.Empty(set.References);
+        // Zero results plus Truncated is the honest encoding of "there are
+        // references, you just asked for none of them".
+        Assert.True(set.Truncated);
+        Assert.False(set.IsComplete);
+    }
+
+    [Fact]
+    public void FindReferences_OrdersResultsByTableThenRow()
+    {
+        using var peReader = OpenSelfFromBytes();
+        int popular = MostReferencedTypeRef(FullProjection(peReader));
+
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, int.MaxValue);
+        Assert.True(set.References.Length > 1, "Expected more than one reference to order.");
+
+        var keys = set.References.Select(r => ((int)r.Source.Table, r.Source.RowId)).ToArray();
+        Assert.Equal(keys.OrderBy(k => k.Item1).ThenBy(k => k.Item2).ToArray(), keys);
+    }
+
+    [Fact]
+    public void FindReferences_ReportsNoBlindSpots_ForAWellFormedImage()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, 1, int.MaxValue);
+
+        Assert.Empty(set.UnreadableRows);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void FindReferences_RejectsANonPositiveTargetRowId(int rowId)
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, rowId));
+    }
+
+    [Fact]
+    public void FindReferences_RejectsANegativeBudget()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, 1, -1));
+    }
+
+    [Fact]
+    public void RowLocation_ComposesTheSameTokenTheProjectionAssignsToARow()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var row = Assert.Single(MetadataTableProjector.ProjectRow(peReader, TableIndex.TypeDef, 3)!.Rows);
+
+        Assert.Equal(row.Token, new MetadataRowLocation(TableIndex.TypeDef, 3).Token);
+    }
+
+    [Fact]
+    public void RowLocation_RejectsANonPositiveRowId()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new MetadataRowLocation(TableIndex.TypeDef, 0));
+
+    [Fact]
+    public void Session_MetadataReferencesFacet_MatchesTheProjectorDirectly()
+    {
+        // The session's contract is that callers never touch a PEReader, so the
+        // facet must be a real alternative to the projector, not a thinner view.
+        using var peReader = OpenSelfFromBytes();
+        var direct = MetadataTableProjector.FindReferences(peReader, TableIndex.Field, 1);
+
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+        var viaSession = session.MetadataReferences(TableIndex.Field, 1);
+
+        Assert.Equal(direct.References.Length, viaSession.References.Length);
+        Assert.Equal(
+            direct.References.Select(r => (r.Source.Table, r.Source.RowId, r.ColumnName, r.Kind)),
+            viaSession.References.Select(r => (r.Source.Table, r.Source.RowId, r.ColumnName, r.Kind)));
+        Assert.Equal(direct.Target.Token, viaSession.Target.Token);
+        Assert.True(viaSession.IsComplete);
+    }
+
+    [Fact]
+    public void Session_MetadataReferencesFacet_HonorsTheBudget()
+    {
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+        var bounded = session.MetadataReferences(TableIndex.Field, 1, maxReferences: 1);
+
+        Assert.Single(bounded.References);
+        Assert.True(bounded.Truncated);
+        Assert.False(bounded.IsComplete);
+    }
+
+    [Fact]
+    public void Session_MetadataTableRowFacet_MatchesTheProjectorDirectly()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var direct = MetadataTableProjector.ProjectRow(peReader, TableIndex.TypeDef, 3);
+
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+        var viaSession = session.MetadataTableRow(TableIndex.TypeDef, 3);
+
+        Assert.NotNull(direct);
+        Assert.NotNull(viaSession);
+        Assert.Equal(direct!.RowCount, viaSession!.RowCount);
+        Assert.Equal(Assert.Single(direct.Rows).Token, Assert.Single(viaSession.Rows).Token);
+    }
+
+    [Fact]
+    public void Session_MetadataTableRowFacet_ReturnsNullPastTheEndOfATable()
+    {
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+
+        Assert.Null(session.MetadataTableRow(TableIndex.TypeDef, int.MaxValue));
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -366,6 +366,39 @@ public class MetadataRowReferenceSearchTests
     /// *intends* to visit would miss them and under-report — the same failure
     /// as the unmodelled-table gap, at a smaller scale.
     /// </summary>
+    /// <summary>
+    /// Entering a table is not searching it. When the budget stops the scan
+    /// part-way through a table, the rows after the stop were never read and an
+    /// edge could sit in any of them — so that table must stay a blind spot
+    /// rather than count as covered on the strength of having been started.
+    /// </summary>
+    [Fact]
+    public void FindReferences_TableStoppedPartWayThrough_IsNotCountedAsSearched()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var reader = peReader.GetMetadataReader();
+        int popular = MostReferencedTypeRef(FullProjection(peReader));
+
+        var capped = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, 1);
+        Assert.True(capped.Truncated, "Expected the budget to stop this scan.");
+
+        // The table holding the one reference we kept is where the scan stopped.
+        var stoppedIn = Assert.Single(capped.References).Source.Table;
+
+        // It is modelled, so the only reason it can appear as unscanned is that
+        // the scan did not finish it.
+        Assert.Contains(stoppedIn, ModelledTables);
+        Assert.True(
+            reader.GetTableRowCount(stoppedIn) > 1,
+            "Need a multi-row table for 'stopped part-way' to be meaningful.");
+        Assert.Contains(stoppedIn, capped.UnscannedTables);
+
+        // The same table is fully searched when nothing stops the scan, so the
+        // blind spot is evidence of the stop and not a permanent gap.
+        var full = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, int.MaxValue);
+        Assert.DoesNotContain(stoppedIn, full.UnscannedTables);
+    }
+
     [Fact]
     public void FindReferences_TruncatedScan_ReportsTheTablesItNeverReached()
     {

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -299,9 +299,39 @@ public class MetadataRowReferenceSearchTests
     }
 
     /// <summary>
+    /// An independent restatement of the tables the projection models, spelled
+    /// out rather than read back from <c>SupportedTables</c>. Deriving the
+    /// expectation from the product would make the exactness check below
+    /// tautological: it would agree with any table list, including a wrong one.
+    /// Growing the projection is expected to fail this list — that is the point,
+    /// because the blind-spot report must move in lockstep with coverage.
+    /// </summary>
+    static readonly ImmutableArray<TableIndex> ModelledTables =
+    [
+        TableIndex.Module,
+        TableIndex.TypeRef,
+        TableIndex.TypeDef,
+        TableIndex.Field,
+        TableIndex.MethodDef,
+        TableIndex.Param,
+        TableIndex.MemberRef,
+        TableIndex.Constant,
+        TableIndex.CustomAttribute,
+        TableIndex.StandAloneSig,
+        TableIndex.MethodImpl,
+        TableIndex.TypeSpec,
+        TableIndex.Assembly,
+        TableIndex.AssemblyRef,
+        TableIndex.ExportedType,
+        TableIndex.GenericParam,
+        TableIndex.MethodSpec,
+    ];
+
+    /// <summary>
     /// The blind spot must be exactly the populated tables the projection does
     /// not model — no modelled table, and no empty table. Over-reporting would
-    /// scare a caller off a result the search actually did cover.
+    /// scare a caller off a result the search actually did cover;
+    /// under-reporting is the original bug.
     /// </summary>
     [Fact]
     public void FindReferences_UnscannedTables_AreExactlyThePopulatedUnmodelledOnes()
@@ -309,17 +339,65 @@ public class MetadataRowReferenceSearchTests
         using var peReader = OpenSelfFromBytes();
         var reader = peReader.GetMetadataReader();
 
-        var projected = FullProjection(peReader).Tables.Select(t => t.Index).ToHashSet();
+        // Guard the restatement itself: if the projection's coverage moves, this
+        // fires first and names the drift, rather than the exactness assertion
+        // failing for a reason the reader has to reverse-engineer.
+        Assert.Equal(
+            ModelledTables.Order().ToArray(),
+            FullProjection(peReader).Tables.Select(t => t.Index).Order().ToArray());
+
+        var modelled = ModelledTables.ToHashSet();
         var expected = Enum.GetValues<TableIndex>()
-            .Where(t => !projected.Contains(t) && reader.GetTableRowCount(t) > 0)
+            .Where(t => !modelled.Contains(t) && reader.GetTableRowCount(t) > 0)
             .ToArray();
 
         var set = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeDef, 1, int.MaxValue);
 
         Assert.NotEmpty(expected);
         Assert.Equal(expected, set.UnscannedTables);
-        Assert.All(set.UnscannedTables, t => Assert.DoesNotContain(t, projected));
+        Assert.All(set.UnscannedTables, t => Assert.DoesNotContain(t, modelled));
         Assert.All(set.UnscannedTables, t => Assert.True(reader.GetTableRowCount(t) > 0));
+    }
+
+    /// <summary>
+    /// A budget that stops the scan leaves modelled tables unreached, and those
+    /// are unscanned in exactly the sense the report means: the search did not
+    /// look. Deriving the blind spot from a static list of what the scan
+    /// *intends* to visit would miss them and under-report — the same failure
+    /// as the unmodelled-table gap, at a smaller scale.
+    /// </summary>
+    [Fact]
+    public void FindReferences_TruncatedScan_ReportsTheTablesItNeverReached()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var reader = peReader.GetMetadataReader();
+        int popular = MostReferencedTypeRef(FullProjection(peReader));
+
+        // One result is enough to stop the scan almost immediately, leaving most
+        // of the modelled tables unvisited.
+        var capped = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, 1);
+        Assert.True(capped.Truncated, "Expected the budget to stop this scan.");
+
+        var full = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, int.MaxValue);
+        Assert.False(full.Truncated);
+
+        // Stopping early can only widen the blind spot, never narrow it.
+        var cappedBlind = capped.UnscannedTables.ToHashSet();
+        var fullBlind = full.UnscannedTables.ToHashSet();
+        Assert.True(
+            cappedBlind.IsSupersetOf(fullBlind),
+            $"Stopped scan lost blind spots the full scan reported: {string.Join(", ", fullBlind.Except(cappedBlind))}");
+        Assert.True(
+            cappedBlind.Count > fullBlind.Count,
+            "A stopped scan left modelled tables unreached, so it must report more of them.");
+
+        // Every extra entry must be a modelled table the full scan did reach —
+        // that is what makes it evidence of truncation rather than noise.
+        foreach (var table in cappedBlind.Except(fullBlind))
+        {
+            Assert.Contains(table, ModelledTables);
+            Assert.True(reader.GetTableRowCount(table) > 0);
+        }
     }
 
     /// <summary>
@@ -403,6 +481,12 @@ public class MetadataRowReferenceSearchTests
             direct.References.Select(r => (r.Source.Table, r.Source.RowId, r.ColumnName, r.Kind)),
             viaSession.References.Select(r => (r.Source.Table, r.Source.RowId, r.ColumnName, r.Kind)));
         Assert.Equal(direct.Target.Token, viaSession.Target.Token);
+        // Comparing IsComplete alone would be vacuous: both are false on a real
+        // assembly. Compare the blind spots themselves, so the facet cannot
+        // silently report a different search than the projector ran.
+        Assert.Equal(direct.UnscannedTables, viaSession.UnscannedTables);
+        Assert.Equal(direct.UnreadableRows, viaSession.UnreadableRows);
+        Assert.Equal(direct.Truncated, viaSession.Truncated);
         Assert.Equal(direct.IsComplete, viaSession.IsComplete);
         AssertScanRanClean(viaSession);
     }


### PR DESCRIPTION
Stacked on #3345 (`feature/3341-projection-row-window`). Review only the top commit; the base branch carries the row-window work.

## What

The projection's handle edges only run forward. A browser can follow `TypeDef[5].FieldList` down to a field, but cannot answer the two questions a reader actually asks: **"what declares this?"** and **"what points here?"**

`MetadataTableProjector.FindReferences(peReader, targetTable, targetRowId, maxReferences)` inverts them, returning a `MetadataRowReferenceSet`:

```text
$ mdi ILInspector.Metadata.dll --references Field:1

## References to Field[1] (2)

| Table | # | Column | Kind |
| ----- | - | ------ | ---- |
| TypeDef | 2 | FieldList | Range |
| CustomAttribute | 1 | Parent | Handle |
```

## Why the `Range` case is load-bearing

ECMA-335 gives an owned row **no back-pointer to its owner**. A `Field` is owned by whichever `TypeDef.FieldList` run covers it; a `Param` by whichever `MethodDef.ParamList` run covers it. Reverse search over list columns is therefore *how ownership resolves at all* — not an extra convenience layered on handle search. The example above is exactly that: `Field[1]` learns its declaring type only from the `Range` edge.

## Two deliberate design points that look like oversights

- **`options.Tables` is not honored.** Like `ProjectRow`, this is a query over the whole image, not a projection of a selection. A narrowed scan could report "nothing points here" while a pointer sat in an unsearched table — worse than a slower answer. (This exact ambiguity split two reviewers on #3345, so it is stated in the XML doc and the design doc rather than left to inference.)
- **Blind spots are reported, not folded in.** `Truncated` marks a scan the result budget stopped; `UnreadableRows` lists rows that could not be decoded and therefore could not be inspected. `IsComplete` is true only when neither happened — which is what makes an empty result trustworthy. Unlike `MetadataTableTruncation`, `Truncated` carries no total: a stopped scan never learns how many references it did not reach.

## Cost

The search reuses the projection's **single row-reading path** rather than a faster private one, so a `HandleRef`/`HandleRange` means the same thing in a search result as in a rendered table. Per-query cost is therefore proportional to the whole image. Whether that needs an index is a **measurement** question, filed with the allocation work (#3341 gap 3) rather than guessed at here.

## Naming

The public type is `MetadataRowReference`, not `MetadataReference`. The latter collides with `Microsoft.CodeAnalysis.MetadataReference` (CS0104) in `DecompilerHarness` and `ILInspector.Decompiler.Tests`, which reference both. Caught by the full-solution build, not by the Metadata project alone.

## Surface

- `AssemblyInspectionSession.MetadataReferences(table, rowId, maxReferences)` — plus a `MetadataTableRow` facet for `ProjectRow`, so the session's "callers never touch a `PEReader`" contract holds for both new primitives.
- `MetadataProjectionRenderer.Render(MetadataRowReferenceSet, …)` — Markdown names the target in a `##` heading; TSV/JSONL carry a leading `Target` column so rows self-identify.
- `mdi --references|-r Table:RowId [--max-references N]`. Markdown renders the caveats inline; the machine formats report them on **stderr**, since a pure row stream cannot distinguish a complete scan from a stopped one.

## Compatibility

Purely additive. No existing signature, model shape, or rendered output changes; the base branch's row-window behavior is untouched.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release` — clean.
- `ILInspector.Metadata.Tests` — **994 / 0 failed / 0 skipped** (0 skipped means the `mdv` oracle actually ran). Includes a brute-force full-projection oracle that independently re-derives half-open run membership and is compared against the search across 8 targets.
- `DotnetInspector.MetadataRendering.Tests` — **58 / 0**.
- `mdi --references` verified end to end on `ILInspector.Metadata.dll` in `md`, `tsv`, and `jsonl`, including the truncated-scan stderr note.

Part of #3341.
