### PR TITLE
Describe the metadata image and read heap values by address

### DIFF
--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -346,9 +346,12 @@ inspector), a standalone tool that renders the tables the way `mdv` does:
   `MetadataProjectionOptions` and delegates all output to the renderer below.
   Surface: `mdi <assembly> [--table|-t <Names>] [--format|-f md|tsv|jsonl]
   [--max-rows|-n N] [--start-row|-s N] [--references|-r Table:RowId]
-  [--max-references N] [--max-bytes N] [--max-chars N]`. Missing
+  [--max-references N] [--overview|-i] [--heap Heap:Address]
+  [--max-bytes N] [--max-chars N]`. Missing
   files, native images, and unreadable metadata surface as visible errors, never
-  success-shaped empty output.
+  success-shaped empty output. `--references`, `--overview`, and `--heap` each
+  select a different view and are rejected in combination rather than silently
+  ranked.
 - **`src/DotnetInspector.MetadataRendering`** — a small reusable library holding
   `MetadataProjectionRenderer` (projection → Markout tables). It lives in the
   product-side `DotnetInspector.*` family, **not** in `ILInspector.Metadata`,
@@ -560,6 +563,57 @@ The renderer and `mdi` carry the blind spots into every format:
 `mdi --references TypeDef:5` prints them inline under the Markdown table, and
 the TSV/JSONL streams report them on stderr, since a pure row stream cannot
 distinguish a complete scan from a stopped one.
+
+## Implemented: the image overview and heap random access
+
+The projection covers *tables*. A metadata browser also shows the container —
+heap sizes, stream and header facts, and which tables exist at all — and needs
+to read a heap value the tables never point at. That is issue #3341's gap 5, and
+it is net-new surface rather than a change to the projection.
+
+`MetadataImageInspector.Describe(PEReader)` returns a `MetadataImageOverview`:
+the metadata root's version, kind, offset, size and whether it carries an
+assembly manifest; one `MetadataHeapSummary` per heap; one
+`MetadataTableSummary` per ECMA-335 table; and `MetadataImageHeaders` for the
+PE/CLI facts. It returns `null` for an image with no metadata, the same "not
+applicable" signal `ProjectRow` uses.
+
+Two decisions in that model are load-bearing.
+
+**Row counts cover every table, not just the projected ones.** The overview
+reports what is physically present and marks each table with `IsProjected`, so a
+table with rows the projection does not model — `NestedClass`,
+`MethodSemantics`, `Property` on a typical assembly — is visible as a coverage
+gap. Listing only the projected tables would make an unmodelled table
+indistinguishable from an empty one, which is the same success-shaped-absence
+failure the reverse search avoids.
+
+**Heap addressing is part of the model.** ECMA-335 addresses the String, Blob,
+and UserString heaps by byte offset but the GUID heap by 1-based index into a
+vector of 16-byte values, and SRM's `GetHeapOffset` follows suit, returning an
+index for a GUID handle. `MetadataHeapAddressing` states which convention a heap
+uses and `MaxAddress` applies it, so a caller cannot silently read a GUID
+address as a byte offset.
+
+`MetadataTableProjector.ReadHeapValue(peReader, heap, address, options)` is the
+heap counterpart of `ProjectRow`. The address is exactly what
+`MetadataValue.HeapReference.Offset` publishes, so a projected cell's offset
+round-trips, and the result is the same `MetadataValue` shape a projected cell
+carries — one renderer serves both. Address zero is every heap's nil value; an
+address past the end yields `Malformed` rather than an empty value. Because the
+tables never reference the `#US` heap, this is also the only way to browse the
+user strings that IL points at.
+
+What is deliberately *not* here: heap **enumeration**. SRM exposes no public way
+to walk every entry of a heap, so the surface is overview plus random access,
+and says so rather than faking a walk by scanning bytes.
+
+Both facets hang off `AssemblyInspectionSession` (`MetadataImage()`,
+`MetadataHeapValue(...)`), render through `MetadataProjectionRenderer`, and are
+reachable from `mdi --overview` and `mdi --heap Heap:Address`. The overview
+lists only tables that carry rows; the number omitted and any unmodelled table
+with rows are reported as caveats — inline in Markdown, on stderr for the
+machine formats.
 
 ## Layer placement
 

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -249,6 +249,257 @@ public static class MetadataProjectionRenderer
 
     static string Describe(MetadataRowLocation location) => $"{location.Table}[{location.RowId}]";
 
+    /// <summary>
+    /// Renders an image overview — metadata root identity, heap sizes, table row
+    /// counts, and PE/CLI header facts — to <paramref name="output"/>.
+    ///
+    /// Only tables that carry rows are listed; the number omitted is reported as
+    /// a caveat rather than left implicit, so a short list is never mistaken for
+    /// the whole of ECMA-335. A table with rows that the projection does not
+    /// model stays visible and is marked as unprojected, because that is a gap in
+    /// coverage rather than an empty table.
+    /// </summary>
+    public static void Render(
+        MetadataImageOverview overview,
+        TextWriter output,
+        MetadataTableFormat format = MetadataTableFormat.Markdown)
+    {
+        ArgumentNullException.ThrowIfNull(overview);
+        ArgumentNullException.ThrowIfNull(output);
+
+        if (format == MetadataTableFormat.Markdown)
+            RenderOverviewMarkdown(overview, output);
+        else
+            RenderOverviewTabular(overview, output, format);
+    }
+
+    static void RenderOverviewMarkdown(MetadataImageOverview overview, TextWriter output)
+    {
+        var writer = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
+
+        writer.WriteHeading(2, "Image");
+        WriteImageTable(writer, overview, identifySection: false);
+
+        writer.WriteBlankLine();
+        writer.WriteHeading(2, "Heaps");
+        WriteHeapTable(writer, overview, identifySection: false);
+
+        writer.WriteBlankLine();
+        writer.WriteHeading(2, $"Tables ({NonEmptyTables(overview).Count})");
+        WriteTableTable(writer, overview, identifySection: false);
+
+        foreach (string caveat in Caveats(overview))
+        {
+            writer.WriteBlankLine();
+            writer.WriteParagraph(caveat);
+        }
+
+        writer.Flush();
+    }
+
+    static void RenderOverviewTabular(MetadataImageOverview overview, TextWriter output, MetadataTableFormat format)
+    {
+        var options = new MarkoutWriterOptions
+        {
+            TableMode = format == MetadataTableFormat.Tsv ? MarkoutTableMode.Tsv : MarkoutTableMode.Jsonl,
+        };
+        var writer = new MarkoutWriter(output, new TableFormatter(showHeader: true), options);
+
+        // The three parts have different shapes, so each keeps its own header and
+        // carries a leading Section column, matching how the table renderer keeps
+        // machine rows self-identifying.
+        WriteImageTable(writer, overview, identifySection: true);
+        WriteHeapTable(writer, overview, identifySection: true);
+        WriteTableTable(writer, overview, identifySection: true);
+
+        writer.Flush();
+    }
+
+    static void WriteImageTable(MarkoutWriter writer, MetadataImageOverview overview, bool identifySection)
+    {
+        var rows = new List<string[]>();
+        Add("Metadata version", overview.MetadataVersion);
+        Add("Metadata kind", overview.Kind.ToString());
+        Add("Has assembly manifest", overview.IsAssembly ? "yes" : "no");
+        Add("Metadata offset", overview.MetadataOffset.ToString());
+        Add("Metadata size", $"{overview.MetadataSize} bytes");
+        Add("Machine", overview.Headers.Machine.ToString());
+        Add("Image characteristics", overview.Headers.ImageCharacteristics.ToString());
+        Add("Subsystem", overview.Headers.Subsystem.ToString());
+        Add("DLL characteristics", overview.Headers.DllCharacteristics.ToString());
+        Add("Optional header", overview.Headers.IsPE32Plus ? "PE32+" : "PE32");
+
+        if (overview.Headers.Cor is { } cor)
+        {
+            Add("CLI runtime version", $"{cor.MajorRuntimeVersion}.{cor.MinorRuntimeVersion}");
+            Add("CLI flags", cor.Flags.ToString());
+            Add("Entry point", DescribeEntryPoint(cor));
+        }
+        else
+        {
+            // Never rendered as a blank or zero: an image with no CLI header is a
+            // different fact from one whose header happens to be empty.
+            Add("CLI header", "absent");
+        }
+
+        WriteSectionTable(writer, identifySection, "image", ["Property", "Value"], ["property", "value"], rows);
+
+        void Add(string property, string value) => rows.Add([property, value]);
+    }
+
+    static string DescribeEntryPoint(MetadataCorHeaderSummary cor)
+    {
+        if (cor.EntryPointToken is { } token)
+            return $"token 0x{token:X8}";
+
+        if (cor.EntryPointTokenOrRelativeVirtualAddress == 0)
+            return "none";
+
+        return $"native RVA 0x{cor.EntryPointTokenOrRelativeVirtualAddress:X8}";
+    }
+
+    static void WriteHeapTable(MarkoutWriter writer, MetadataImageOverview overview, bool identifySection)
+    {
+        var rows = new List<string[]>(overview.Heaps.Length);
+        foreach (var heap in overview.Heaps)
+        {
+            rows.Add([
+                heap.Heap.ToString(),
+                heap.SizeInBytes.ToString(),
+                heap.Addressing == MetadataHeapAddressing.Index ? "index" : "byte offset",
+                heap.MaxAddress.ToString(),
+            ]);
+        }
+
+        WriteSectionTable(
+            writer,
+            identifySection,
+            "heap",
+            ["Heap", "Bytes", "Addressing", "Max address"],
+            ["heap", "bytes", "addressing", "maxAddress"],
+            rows);
+    }
+
+    static void WriteTableTable(MarkoutWriter writer, MetadataImageOverview overview, bool identifySection)
+    {
+        var rows = new List<string[]>();
+        foreach (var table in NonEmptyTables(overview))
+            rows.Add([table.Name, table.RowCount.ToString(), table.IsProjected ? "yes" : "no"]);
+
+        WriteSectionTable(
+            writer,
+            identifySection,
+            "table",
+            ["Table", "Rows", "Projected"],
+            ["table", "rows", "projected"],
+            rows);
+    }
+
+    static void WriteSectionTable(
+        MarkoutWriter writer,
+        bool identifySection,
+        string section,
+        string[] headers,
+        string[] headerNames,
+        List<string[]> rows)
+    {
+        if (!identifySection)
+        {
+            writer.WriteTable(headers, headerNames, rows);
+            return;
+        }
+
+        string[] prefixedHeaders = ["Section", .. headers];
+        string[] prefixedNames = ["section", .. headerNames];
+        var prefixedRows = new List<string[]>(rows.Count);
+        foreach (var row in rows)
+            prefixedRows.Add([section, .. row]);
+
+        writer.WriteTable(prefixedHeaders, prefixedNames, prefixedRows);
+    }
+
+    static List<MetadataTableSummary> NonEmptyTables(MetadataImageOverview overview)
+    {
+        var tables = new List<MetadataTableSummary>();
+        foreach (var table in overview.Tables)
+        {
+            if (table.RowCount > 0)
+                tables.Add(table);
+        }
+
+        return tables;
+    }
+
+    /// <summary>
+    /// What an image overview leaves out, as caveats a reader must see: the
+    /// tables omitted for being empty, and any table with rows the projection
+    /// does not model.
+    /// </summary>
+    public static IEnumerable<string> Caveats(MetadataImageOverview overview)
+    {
+        ArgumentNullException.ThrowIfNull(overview);
+
+        int empty = overview.Tables.Length - NonEmptyTables(overview).Count;
+        if (empty > 0)
+            yield return $"{empty} of {overview.Tables.Length} ECMA-335 tables carry no rows in this image and are not listed.";
+
+        var unprojected = new List<string>();
+        foreach (var table in NonEmptyTables(overview))
+        {
+            if (!table.IsProjected)
+                unprojected.Add(table.Name);
+        }
+
+        if (unprojected.Count > 0)
+            yield return $"{unprojected.Count} {(unprojected.Count == 1 ? "table has" : "tables have")} rows the projection does not model, so their contents cannot be dumped: {string.Join(", ", unprojected)}.";
+    }
+
+    /// <summary>
+    /// Renders a single heap value read by address to
+    /// <paramref name="output"/>. The address is echoed alongside the value so
+    /// the row identifies what was asked for, in every format.
+    /// </summary>
+    public static void Render(
+        MetadataValue value,
+        HeapKind heap,
+        int address,
+        TextWriter output,
+        MetadataTableFormat format = MetadataTableFormat.Markdown)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(output);
+
+        var heapReference = value as MetadataValue.HeapReference;
+        string[] row =
+        [
+            heap.ToString(),
+            address.ToString(),
+            heapReference is null ? string.Empty : heapReference.Length.ToString(),
+            heapReference is { Truncated: true } ? "yes" : "no",
+            FormatCell(value),
+        ];
+
+        string[] headers = ["Heap", "Address", "Length", "Truncated", "Value"];
+        string[] headerNames = ["heap", "address", "length", "truncated", "value"];
+
+        if (format == MetadataTableFormat.Markdown)
+        {
+            var markdown = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
+            markdown.WriteHeading(2, $"{heap} heap at {address}");
+            markdown.WriteTable(headers, headerNames, [row]);
+            markdown.Flush();
+            return;
+        }
+
+        var options = new MarkoutWriterOptions
+        {
+            TableMode = format == MetadataTableFormat.Tsv ? MarkoutTableMode.Tsv : MarkoutTableMode.Jsonl,
+        };
+        var writer = new MarkoutWriter(output, new TableFormatter(showHeader: true), options);
+        writer.WriteTable(headers, headerNames, [row]);
+        writer.Flush();
+    }
+
     static string HeadingText(MetadataTableView table)
     {
         if (table.Truncation is not { } truncation)

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -148,5 +148,26 @@ public sealed class AssemblyInspectionSession : IDisposable
         int maxReferences = MetadataRowReferenceSet.DefaultMaxReferences)
         => MetadataTableProjector.FindReferences(_image.PEReader, targetTable, targetRowId, maxReferences);
 
+    /// <summary>
+    /// Image-level facts outside the table projection: metadata root identity,
+    /// heap sizes and addressing, physical row counts for every ECMA-335 table
+    /// (including tables the projection does not model), and PE/CLI header
+    /// facts. Null when the image carries no metadata.
+    /// </summary>
+    public MetadataImageOverview? MetadataImage()
+        => MetadataImageInspector.Describe(_image.PEReader);
+
+    /// <summary>
+    /// One heap value read by address, independent of any row that references
+    /// it. The address follows
+    /// <see cref="MetadataValue.HeapReference.Offset"/>, so a projected cell's
+    /// offset round-trips. Null when the image carries no metadata.
+    /// </summary>
+    public MetadataValue? MetadataHeapValue(
+        HeapKind heap,
+        int address,
+        MetadataProjectionOptions? options = null)
+        => MetadataTableProjector.ReadHeapValue(_image.PEReader, heap, address, options);
+
     public void Dispose() => _image.Dispose();
 }

--- a/src/ILInspector.Metadata/MetadataImageInspector.cs
+++ b/src/ILInspector.Metadata/MetadataImageInspector.cs
@@ -1,0 +1,145 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Describes the container a <see cref="MetadataTableProjection"/> is drawn
+/// from: metadata root identity, heap sizes and addressing, physical row counts
+/// for every ECMA-335 table, and PE/CLI header facts.
+///
+/// This is the companion to <see cref="MetadataTableProjector"/> for the parts
+/// of a metadata browser that are not tables. Like the projector it is
+/// read-only, SRM-only, and presentation-free.
+/// </summary>
+public static class MetadataImageInspector
+{
+    /// <summary>
+    /// Describes <paramref name="peReader"/>'s metadata container.
+    ///
+    /// Row counts cover every table this runtime's <see cref="TableIndex"/>
+    /// knows, not just the tables the projector models, so a caller can see
+    /// content the projection does not yet cover instead of mistaking it for an
+    /// empty table.
+    ///
+    /// Returns <see langword="null"/> when the image carries no metadata, which
+    /// is the same "not applicable" signal
+    /// <see cref="MetadataTableProjector.ProjectRow"/> uses.
+    /// </summary>
+    public static MetadataImageOverview? Describe(PEReader peReader)
+    {
+        ArgumentNullException.ThrowIfNull(peReader);
+
+        if (!peReader.HasMetadata)
+            return null;
+
+        // MetadataReaderOptions.None for the same reason the projector uses it:
+        // the default enables Windows-Runtime projection, which would rewrite the
+        // very facts this overview reports.
+        var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+        var headers = peReader.PEHeaders;
+
+        return new MetadataImageOverview(
+            reader.MetadataVersion,
+            reader.MetadataKind,
+            reader.IsAssembly,
+            headers.MetadataStartOffset,
+            headers.MetadataSize,
+            DescribeHeaps(reader),
+            DescribeTables(reader),
+            DescribeHeaders(headers));
+    }
+
+    static ImmutableArray<MetadataHeapSummary> DescribeHeaps(MetadataReader reader)
+    {
+        var heaps = ImmutableArray.CreateBuilder<MetadataHeapSummary>(HeapIndices.Length);
+        foreach ((HeapKind kind, HeapIndex index) in HeapIndices)
+        {
+            heaps.Add(new MetadataHeapSummary(kind, reader.GetHeapSize(index), Addressing(kind)));
+        }
+
+        return heaps.MoveToImmutable();
+    }
+
+    static ImmutableArray<MetadataTableSummary> DescribeTables(MetadataReader reader)
+    {
+        var projected = MetadataTableProjector.ProjectedTables;
+        var tables = ImmutableArray.CreateBuilder<MetadataTableSummary>();
+
+        foreach (var index in Enum.GetValues<TableIndex>())
+        {
+            tables.Add(new MetadataTableSummary(
+                index,
+                index.ToString(),
+                RowCount(reader, index),
+                projected.Contains(index)));
+        }
+
+        return tables.ToImmutable();
+    }
+
+    static int RowCount(MetadataReader reader, TableIndex index)
+    {
+        try
+        {
+            return reader.GetTableRowCount(index);
+        }
+        catch (Exception ex) when (ex is ArgumentOutOfRangeException or BadImageFormatException)
+        {
+            // A TableIndex this runtime declares but this metadata cannot count
+            // is reported as empty rather than aborting the whole overview; the
+            // table is still listed so its absence stays visible.
+            return 0;
+        }
+    }
+
+    static MetadataImageHeaders DescribeHeaders(PEHeaders headers)
+    {
+        var cor = headers.CorHeader is { } corHeader
+            ? new MetadataCorHeaderSummary(
+                corHeader.MajorRuntimeVersion,
+                corHeader.MinorRuntimeVersion,
+                corHeader.Flags,
+                corHeader.EntryPointTokenOrRelativeVirtualAddress)
+            : null;
+
+        var pe = headers.PEHeader;
+
+        return new MetadataImageHeaders(
+            headers.CoffHeader.Machine,
+            headers.CoffHeader.Characteristics,
+            pe?.Subsystem ?? Subsystem.Unknown,
+            pe?.DllCharacteristics ?? default,
+            pe?.Magic == PEMagic.PE32Plus,
+            cor);
+    }
+
+    static MetadataHeapAddressing Addressing(HeapKind heap)
+        => heap is HeapKind.Guid ? MetadataHeapAddressing.Index : MetadataHeapAddressing.ByteOffset;
+
+    static readonly (HeapKind Kind, HeapIndex Index)[] HeapIndices =
+    [
+        (HeapKind.String, HeapIndex.String),
+        (HeapKind.Blob, HeapIndex.Blob),
+        (HeapKind.Guid, HeapIndex.Guid),
+        (HeapKind.UserString, HeapIndex.UserString),
+    ];
+
+    /// <summary>
+    /// Maps a <see cref="HeapKind"/> to the SRM heap it names. Kept beside the
+    /// overview because both the overview and random-access heap reads must
+    /// agree on the mapping.
+    /// </summary>
+    internal static HeapIndex ToHeapIndex(HeapKind heap) => heap switch
+    {
+        HeapKind.String => HeapIndex.String,
+        HeapKind.Blob => HeapIndex.Blob,
+        HeapKind.Guid => HeapIndex.Guid,
+        HeapKind.UserString => HeapIndex.UserString,
+        _ => throw new ArgumentOutOfRangeException(nameof(heap), heap, "Unknown heap."),
+    };
+
+    internal static MetadataHeapAddressing AddressingOf(HeapKind heap) => Addressing(heap);
+}

--- a/src/ILInspector.Metadata/MetadataImageInspector.cs
+++ b/src/ILInspector.Metadata/MetadataImageInspector.cs
@@ -70,29 +70,21 @@ public static class MetadataImageInspector
 
         foreach (var index in Enum.GetValues<TableIndex>())
         {
+            // Deliberately undefended. GetTableRowCount validates the index and
+            // then indexes a row-count array that MetadataReader parsed during
+            // construction, so it cannot report a malformed image here: a corrupt
+            // table stream already threw out of GetMetadataReader. Every declared
+            // TableIndex is in range for the same assembly's TableCount. Catching
+            // and returning 0 would turn any future failure into a table that
+            // reads as legitimately empty.
             tables.Add(new MetadataTableSummary(
                 index,
                 index.ToString(),
-                RowCount(reader, index),
+                reader.GetTableRowCount(index),
                 projected.Contains(index)));
         }
 
         return tables.ToImmutable();
-    }
-
-    static int RowCount(MetadataReader reader, TableIndex index)
-    {
-        try
-        {
-            return reader.GetTableRowCount(index);
-        }
-        catch (Exception ex) when (ex is ArgumentOutOfRangeException or BadImageFormatException)
-        {
-            // A TableIndex this runtime declares but this metadata cannot count
-            // is reported as empty rather than aborting the whole overview; the
-            // table is still listed so its absence stays visible.
-            return 0;
-        }
     }
 
     static MetadataImageHeaders DescribeHeaders(PEHeaders headers)

--- a/src/ILInspector.Metadata/MetadataImageOverview.cs
+++ b/src/ILInspector.Metadata/MetadataImageOverview.cs
@@ -1,0 +1,263 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Image-level facts that sit outside a <see cref="MetadataTableProjection"/>:
+/// the metadata root's identity, the size and addressing of each heap, the
+/// physical row count of every ECMA-335 table (including tables the projection
+/// does not model), and the PE/COR header facts a metadata browser shows
+/// alongside the tables.
+///
+/// This is a description of the container, not a projection of its values. It
+/// deliberately reports what is physically present rather than what the
+/// projection covers, so a consumer can tell "this table is empty" apart from
+/// "this table is not projected".
+/// </summary>
+public sealed record MetadataImageOverview
+{
+    public MetadataImageOverview(
+        string MetadataVersion,
+        MetadataKind Kind,
+        bool IsAssembly,
+        int MetadataOffset,
+        int MetadataSize,
+        ImmutableArray<MetadataHeapSummary> Heaps,
+        ImmutableArray<MetadataTableSummary> Tables,
+        MetadataImageHeaders Headers)
+    {
+        ArgumentNullException.ThrowIfNull(MetadataVersion);
+        ArgumentOutOfRangeException.ThrowIfNegative(MetadataOffset);
+        ArgumentOutOfRangeException.ThrowIfNegative(MetadataSize);
+        ArgumentNullException.ThrowIfNull(Headers);
+        if (Heaps.IsDefault)
+            throw new ArgumentException("Heaps must be initialized.", nameof(Heaps));
+        if (Tables.IsDefault)
+            throw new ArgumentException("Tables must be initialized.", nameof(Tables));
+
+        this.MetadataVersion = MetadataVersion;
+        this.Kind = Kind;
+        this.IsAssembly = IsAssembly;
+        this.MetadataOffset = MetadataOffset;
+        this.MetadataSize = MetadataSize;
+        this.Heaps = Heaps;
+        this.Tables = Tables;
+        this.Headers = Headers;
+    }
+
+    /// <summary>
+    /// The metadata root's version string (for example <c>v4.0.30319</c>). This
+    /// is the metadata format stamp, not the assembly's target framework.
+    /// </summary>
+    public string MetadataVersion { get; }
+
+    /// <summary>Whether the metadata is plain ECMA-335 or a Windows-Runtime flavour.</summary>
+    public MetadataKind Kind { get; }
+
+    /// <summary>True when the image carries an <c>Assembly</c> row (a manifest), false for a bare module.</summary>
+    public bool IsAssembly { get; }
+
+    /// <summary>The metadata root's offset from the start of the image, in bytes.</summary>
+    public int MetadataOffset { get; }
+
+    /// <summary>The total size of the metadata root, in bytes: all streams plus the root header.</summary>
+    public int MetadataSize { get; }
+
+    /// <summary>
+    /// One entry per metadata heap, in <see cref="HeapKind"/> order. A heap that
+    /// is absent from the image is reported with a zero size rather than omitted,
+    /// so the set of heaps is always the same shape.
+    /// </summary>
+    public ImmutableArray<MetadataHeapSummary> Heaps { get; }
+
+    /// <summary>
+    /// One entry per ECMA-335 table known to this runtime's
+    /// <see cref="TableIndex"/>, in table order, whether or not the table has
+    /// rows and whether or not the projection models it.
+    /// </summary>
+    public ImmutableArray<MetadataTableSummary> Tables { get; }
+
+    /// <summary>PE and CLI header facts for the containing image.</summary>
+    public MetadataImageHeaders Headers { get; }
+}
+
+/// <summary>
+/// The size and addressing of a single metadata heap.
+/// </summary>
+public sealed record MetadataHeapSummary
+{
+    public MetadataHeapSummary(HeapKind Heap, int SizeInBytes, MetadataHeapAddressing Addressing)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(SizeInBytes);
+        this.Heap = Heap;
+        this.SizeInBytes = SizeInBytes;
+        this.Addressing = Addressing;
+    }
+
+    /// <summary>Which heap this describes.</summary>
+    public HeapKind Heap { get; }
+
+    /// <summary>
+    /// The heap's size in bytes, or zero when the image carries no such heap.
+    /// This is always a byte count, even for an index-addressed heap.
+    /// </summary>
+    public int SizeInBytes { get; }
+
+    /// <summary>How a <see cref="MetadataValue.HeapReference.Offset"/> into this heap is interpreted.</summary>
+    public MetadataHeapAddressing Addressing { get; }
+
+    /// <summary>
+    /// The largest addressable value for this heap: the last valid byte offset,
+    /// or the last valid 1-based index for an index-addressed heap. Zero when the
+    /// heap is empty, since zero always addresses the nil value.
+    /// </summary>
+    public int MaxAddress => Addressing switch
+    {
+        MetadataHeapAddressing.Index => SizeInBytes / MetadataHeapAddressingSizes.GuidSize,
+        _ => SizeInBytes == 0 ? 0 : SizeInBytes - 1,
+    };
+}
+
+/// <summary>
+/// How a heap address is interpreted. ECMA-335 addresses the String, Blob, and
+/// UserString heaps by byte offset, but the GUID heap by 1-based index into a
+/// vector of 16-byte values — and SRM's <c>GetHeapOffset</c> follows suit,
+/// returning an index for a GUID handle. Making that difference part of the
+/// model keeps a caller from treating a GUID address as a byte offset.
+/// </summary>
+public enum MetadataHeapAddressing
+{
+    /// <summary>The address is a byte offset from the start of the heap.</summary>
+    ByteOffset,
+
+    /// <summary>The address is a 1-based index into a vector of fixed-size entries.</summary>
+    Index,
+}
+
+/// <summary>Fixed sizes used by index-addressed heaps.</summary>
+public static class MetadataHeapAddressingSizes
+{
+    /// <summary>The size of a single GUID-heap entry, in bytes.</summary>
+    public const int GuidSize = 16;
+}
+
+/// <summary>
+/// The physical size of a single ECMA-335 table, and whether the projection
+/// models it.
+/// </summary>
+public sealed record MetadataTableSummary
+{
+    public MetadataTableSummary(TableIndex Index, string Name, int RowCount, bool IsProjected)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(Name);
+        ArgumentOutOfRangeException.ThrowIfNegative(RowCount);
+        this.Index = Index;
+        this.Name = Name;
+        this.RowCount = RowCount;
+        this.IsProjected = IsProjected;
+    }
+
+    /// <summary>The ECMA-335 table.</summary>
+    public TableIndex Index { get; }
+
+    /// <summary>The table's canonical name (for example <c>TypeDef</c>).</summary>
+    public string Name { get; }
+
+    /// <summary>The physical row count reported by the metadata, before any row budget.</summary>
+    public int RowCount { get; }
+
+    /// <summary>
+    /// True when <see cref="MetadataTableProjector"/> models this table. A table
+    /// with rows but <see langword="false"/> here is real content the projection
+    /// does not yet cover — a visible gap rather than an empty table.
+    /// </summary>
+    public bool IsProjected { get; }
+}
+
+/// <summary>PE and CLI header facts for a managed image.</summary>
+public sealed record MetadataImageHeaders
+{
+    public MetadataImageHeaders(
+        Machine Machine,
+        Characteristics ImageCharacteristics,
+        Subsystem Subsystem,
+        DllCharacteristics DllCharacteristics,
+        bool IsPE32Plus,
+        MetadataCorHeaderSummary? Cor)
+    {
+        this.Machine = Machine;
+        this.ImageCharacteristics = ImageCharacteristics;
+        this.Subsystem = Subsystem;
+        this.DllCharacteristics = DllCharacteristics;
+        this.IsPE32Plus = IsPE32Plus;
+        this.Cor = Cor;
+    }
+
+    /// <summary>The COFF machine type.</summary>
+    public Machine Machine { get; }
+
+    /// <summary>The COFF image characteristics.</summary>
+    public Characteristics ImageCharacteristics { get; }
+
+    /// <summary>The optional header's subsystem.</summary>
+    public Subsystem Subsystem { get; }
+
+    /// <summary>The optional header's DLL characteristics.</summary>
+    public DllCharacteristics DllCharacteristics { get; }
+
+    /// <summary>True for a PE32+ (64-bit) optional header, false for PE32.</summary>
+    public bool IsPE32Plus { get; }
+
+    /// <summary>
+    /// The CLI header, or <see langword="null"/> when the image has none. An
+    /// image with metadata always has one; the nullability keeps a native or
+    /// malformed image describable rather than throwing.
+    /// </summary>
+    public MetadataCorHeaderSummary? Cor { get; }
+}
+
+/// <summary>The CLI (COR) header facts a metadata browser shows.</summary>
+public sealed record MetadataCorHeaderSummary
+{
+    public MetadataCorHeaderSummary(
+        ushort MajorRuntimeVersion,
+        ushort MinorRuntimeVersion,
+        CorFlags Flags,
+        int EntryPointTokenOrRelativeVirtualAddress)
+    {
+        this.MajorRuntimeVersion = MajorRuntimeVersion;
+        this.MinorRuntimeVersion = MinorRuntimeVersion;
+        this.Flags = Flags;
+        this.EntryPointTokenOrRelativeVirtualAddress = EntryPointTokenOrRelativeVirtualAddress;
+    }
+
+    /// <summary>The CLI header's major runtime version.</summary>
+    public ushort MajorRuntimeVersion { get; }
+
+    /// <summary>The CLI header's minor runtime version.</summary>
+    public ushort MinorRuntimeVersion { get; }
+
+    /// <summary>The CLI header flags (IL-only, 32-bit preference, strong-name signed, …).</summary>
+    public CorFlags Flags { get; }
+
+    /// <summary>
+    /// The managed entry-point token, or a native entry-point RVA when
+    /// <see cref="Flags"/> has <see cref="CorFlags.NativeEntryPoint"/>. Zero when
+    /// the image has no entry point.
+    /// </summary>
+    public int EntryPointTokenOrRelativeVirtualAddress { get; }
+
+    /// <summary>
+    /// The entry-point token when the header carries a managed one, otherwise
+    /// <see langword="null"/>. Reading
+    /// <see cref="EntryPointTokenOrRelativeVirtualAddress"/> as a token without
+    /// this check would misreport a native entry-point RVA as a row id.
+    /// </summary>
+    public int? EntryPointToken
+        => EntryPointTokenOrRelativeVirtualAddress != 0 && !Flags.HasFlag(CorFlags.NativeEntryPoint)
+            ? EntryPointTokenOrRelativeVirtualAddress
+            : null;
+}

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -76,6 +76,15 @@ public static class MetadataTableProjector
     ];
 
     /// <summary>
+    /// The tables this projector models, in ECMA-335 table order. A table absent
+    /// from this set is not projected at all, which is a different fact from a
+    /// table that is projected and empty — see
+    /// <see cref="MetadataTableSummary.IsProjected"/>.
+    /// </summary>
+    public static ImmutableArray<TableIndex> ProjectedTables { get; } =
+        [.. SupportedTables.Select(static spec => spec.Index)];
+
+    /// <summary>
     /// Projects the supported metadata tables of <paramref name="peReader"/>.
     /// Returns an empty projection when the image carries no metadata.
     /// </summary>
@@ -405,6 +414,78 @@ public static class MetadataTableProjector
         }
 
         return unscanned.ToImmutable();
+    }
+
+    /// <summary>
+    /// Reads one heap value by address, independent of any table row that
+    /// references it. This is the heap counterpart of
+    /// <see cref="ProjectRow"/>: a <see cref="MetadataValue.HeapReference"/> cell
+    /// carries a bounded preview plus an <see cref="MetadataValue.HeapReference.Offset"/>,
+    /// and this resolves that address back to a value so a browser can show the
+    /// whole entry, or browse a heap the tables never point into at all (the
+    /// UserString heap is referenced only from IL).
+    ///
+    /// <paramref name="address"/> uses the same convention as
+    /// <see cref="MetadataValue.HeapReference.Offset"/>, so a value read from a
+    /// projected cell round-trips: a byte offset for the String, Blob, and
+    /// UserString heaps, but a 1-based index for the GUID heap. See
+    /// <see cref="MetadataHeapAddressing"/>. Address zero is the nil value of
+    /// every heap and reads as <see cref="MetadataValue.Nil"/>.
+    ///
+    /// The result is shaped exactly like the projected cell for the same value,
+    /// so one renderer serves both. An address past the end of the heap yields
+    /// <see cref="MetadataValue.Malformed"/> rather than an empty value.
+    ///
+    /// Returns <see langword="null"/> when the image carries no metadata.
+    /// </summary>
+    public static MetadataValue? ReadHeapValue(
+        PEReader peReader,
+        HeapKind heap,
+        int address,
+        MetadataProjectionOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(peReader);
+        ArgumentOutOfRangeException.ThrowIfNegative(address);
+        options ??= new MetadataProjectionOptions();
+
+        if (!peReader.HasMetadata)
+            return null;
+
+        var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+
+        // Address zero is nil in every heap, including an absent one, so it is
+        // answered before the bounds check rather than reported out of range.
+        if (address == 0)
+            return new MetadataValue.Nil();
+
+        int size = reader.GetHeapSize(MetadataImageInspector.ToHeapIndex(heap));
+        bool addressable = MetadataImageInspector.AddressingOf(heap) is MetadataHeapAddressing.Index
+            ? address <= size / MetadataHeapAddressingSizes.GuidSize
+            : address < size;
+
+        if (!addressable)
+            return new MetadataValue.Malformed(
+                $"{heap} heap address {address} is past the end of a {size}-byte heap.");
+
+        try
+        {
+            return heap switch
+            {
+                HeapKind.String => StringCell(reader, MetadataTokens.StringHandle(address), options),
+                HeapKind.Blob => BlobCell(reader, MetadataTokens.BlobHandle(address), options),
+                HeapKind.Guid => GuidCell(reader, MetadataTokens.GuidHandle(address)),
+                HeapKind.UserString => UserStringCell(reader, MetadataTokens.UserStringHandle(address), options),
+                _ => throw new System.Diagnostics.UnreachableException($"Unhandled heap {heap}."),
+            };
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            // Handle construction happens outside the cell readers' own guards,
+            // so a rejected address is contained here rather than escaping as a
+            // throw from a read-only query. An unknown HeapKind is not caught
+            // here: ToHeapIndex above already rejected it.
+            return new MetadataValue.Malformed($"{heap} heap read failed: {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -842,6 +923,24 @@ public static class MetadataTableProjector
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
             return new MetadataValue.Malformed($"String heap read failed: {ex.Message}");
+        }
+    }
+
+    static MetadataValue UserStringCell(MetadataReader reader, UserStringHandle handle, MetadataProjectionOptions options)
+    {
+        if (handle.IsNil)
+            return new MetadataValue.Nil();
+
+        try
+        {
+            string raw = reader.GetUserString(handle);
+            string text = EscapeText(raw, options.MaxStringChars, out bool truncated);
+            return new MetadataValue.HeapReference(
+                HeapKind.UserString, MetadataTokens.GetHeapOffset(handle), raw.Length, text, text, truncated);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return new MetadataValue.Malformed($"UserString heap read failed: {ex.Message}");
         }
     }
 

--- a/src/mdi/MdiCommand.cs
+++ b/src/mdi/MdiCommand.cs
@@ -65,6 +65,17 @@ public static class MdiCommand
             DefaultValueFactory = _ => MetadataRowReferenceSet.DefaultMaxReferences,
         };
 
+        var overviewOption = new Option<bool>("--overview")
+        {
+            Description = "Instead of dumping tables, describe the image: metadata root, heap sizes, row counts for every ECMA-335 table, and PE/CLI header facts.",
+        };
+        overviewOption.Aliases.Add("-i");
+
+        var heapOption = new Option<string?>("--heap")
+        {
+            Description = "Instead of dumping tables, read one heap value, given as Heap:Address (for example String:1234 or Guid:1). Addresses match a cell's offset: a byte offset, except the Guid heap's 1-based index.",
+        };
+
         var maxBytesOption = new Option<int>("--max-bytes")
         {
             Description = $"Maximum blob-preview bytes per cell (default {MetadataProjectionOptions.DefaultMaxPreviewBytes}).",
@@ -85,6 +96,8 @@ public static class MdiCommand
         root.Options.Add(startRowOption);
         root.Options.Add(referencesOption);
         root.Options.Add(maxReferencesOption);
+        root.Options.Add(overviewOption);
+        root.Options.Add(heapOption);
         root.Options.Add(maxBytesOption);
         root.Options.Add(maxCharsOption);
 
@@ -97,6 +110,8 @@ public static class MdiCommand
             int startRow = parseResult.GetValue(startRowOption);
             string? referenceSpec = parseResult.GetValue(referencesOption);
             int maxReferences = parseResult.GetValue(maxReferencesOption);
+            bool overview = parseResult.GetValue(overviewOption);
+            string? heapSpec = parseResult.GetValue(heapOption);
             int maxBytes = parseResult.GetValue(maxBytesOption);
             int maxChars = parseResult.GetValue(maxCharsOption);
 
@@ -123,6 +138,49 @@ public static class MdiCommand
                 Console.Error.WriteLine(
                     $"Error: unknown table '{badName}'. Table names are members of System.Reflection.Metadata.Ecma335.TableIndex (for example TypeDef, MethodDef, Field).");
                 return 1;
+            }
+
+            // The three query modes answer different questions and cannot be
+            // combined; picking one silently would answer a question the caller
+            // did not ask.
+            var modes = new List<string>();
+            if (referenceSpec is not null)
+                modes.Add("--references");
+            if (overview)
+                modes.Add("--overview");
+            if (heapSpec is not null)
+                modes.Add("--heap");
+
+            if (modes.Count > 1)
+            {
+                Console.Error.WriteLine($"Error: {string.Join(" and ", modes)} cannot be combined; each selects a different view.");
+                return 1;
+            }
+
+            if (overview)
+                return ExecuteOverview(assembly, format, Console.Out, Console.Error);
+
+            if (heapSpec is not null)
+            {
+                if (!TryParseHeapLocation(heapSpec, out var heap, out int address, out string? heapError))
+                {
+                    Console.Error.WriteLine($"Error: {heapError}");
+                    return 1;
+                }
+
+                if (maxBytes < 0 || maxChars < 0)
+                {
+                    Console.Error.WriteLine("Error: --max-bytes and --max-chars must be non-negative.");
+                    return 1;
+                }
+
+                var heapOptions = new MetadataProjectionOptions
+                {
+                    MaxPreviewBytes = maxBytes,
+                    MaxStringChars = maxChars,
+                };
+
+                return ExecuteHeapValue(assembly, heap, address, heapOptions, format, Console.Out, Console.Error);
             }
 
             if (referenceSpec is not null)
@@ -298,6 +356,120 @@ public static class MdiCommand
     }
 
     /// <summary>
+    /// Opens <paramref name="assemblyPath"/> and renders its image overview.
+    /// Returns a process exit code.
+    /// </summary>
+    public static int ExecuteOverview(
+        string assemblyPath,
+        MetadataTableFormat format,
+        TextWriter output,
+        TextWriter error)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        if (!File.Exists(assemblyPath))
+        {
+            error.WriteLine($"Error: file not found: {assemblyPath}");
+            return 1;
+        }
+
+        MetadataImageOverview? overview;
+        try
+        {
+            using var session = AssemblyInspectionSession.Open(assemblyPath);
+            overview = session.MetadataImage();
+        }
+        catch (Exception ex) when (IsExpectedReadFailure(ex))
+        {
+            error.WriteLine($"Error: cannot read metadata from '{assemblyPath}': {ex.Message}");
+            return 1;
+        }
+
+        if (overview is null)
+        {
+            error.WriteLine($"Error: '{assemblyPath}' contains no .NET metadata (not a managed assembly).");
+            return 1;
+        }
+
+        MetadataProjectionRenderer.Render(overview, output, format);
+
+        // Markdown carries the overview's caveats inline. The machine formats are
+        // pure row streams, so the same facts go to the error writer rather than
+        // being dropped.
+        if (format != MetadataTableFormat.Markdown)
+        {
+            foreach (string caveat in MetadataProjectionRenderer.Caveats(overview))
+                error.WriteLine($"Note: {caveat}");
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Opens <paramref name="assemblyPath"/> and renders one heap value read by
+    /// address. Returns a process exit code.
+    ///
+    /// An address past the end of the heap is not a command failure: the value
+    /// renders as malformed, which is the projection's own answer for an
+    /// unreadable heap reference, and is reported as such rather than as an empty
+    /// result.
+    /// </summary>
+    public static int ExecuteHeapValue(
+        string assemblyPath,
+        HeapKind heap,
+        int address,
+        MetadataProjectionOptions options,
+        MetadataTableFormat format,
+        TextWriter output,
+        TextWriter error)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        if (address < 0)
+        {
+            error.WriteLine("Error: the address in --heap must be zero or greater.");
+            return 1;
+        }
+
+        if (!File.Exists(assemblyPath))
+        {
+            error.WriteLine($"Error: file not found: {assemblyPath}");
+            return 1;
+        }
+
+        MetadataValue? value;
+        try
+        {
+            using var session = AssemblyInspectionSession.Open(assemblyPath);
+            value = session.MetadataHeapValue(heap, address, options);
+        }
+        catch (Exception ex) when (IsExpectedReadFailure(ex))
+        {
+            error.WriteLine($"Error: cannot read metadata from '{assemblyPath}': {ex.Message}");
+            return 1;
+        }
+
+        if (value is null)
+        {
+            error.WriteLine($"Error: '{assemblyPath}' contains no .NET metadata (not a managed assembly).");
+            return 1;
+        }
+
+        MetadataProjectionRenderer.Render(value, heap, address, output, format);
+
+        if (value is MetadataValue.Malformed malformed)
+        {
+            error.WriteLine($"Note: {malformed.Detail}");
+            return 0;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
     /// Whether <paramref name="ex"/> is an expected failure of opening or reading
     /// an assembly file — a bad image, an unreadable or inaccessible file, or an
     /// invalid path — as opposed to an unexpected programming error. These are
@@ -361,6 +533,42 @@ public static class MdiCommand
         if (!int.TryParse(rowText, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out rowId) || rowId < 1)
         {
             error = $"'{rowText}' is not a row id. Row ids are 1-based positive integers.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a <c>Heap:Address</c> heap reference (for example
+    /// <c>String:1234</c>). The two halves are validated separately so the
+    /// diagnostic names the half that is wrong.
+    /// </summary>
+    internal static bool TryParseHeapLocation(string spec, out HeapKind heap, out int address, out string? error)
+    {
+        heap = default;
+        address = 0;
+
+        int separator = spec.LastIndexOf(':');
+        if (separator < 0)
+        {
+            error = $"'{spec}' is not a heap reference. Use Heap:Address, for example String:1234.";
+            return false;
+        }
+
+        string heapName = spec[..separator].Trim();
+        string addressText = spec[(separator + 1)..].Trim();
+
+        if (!Enum.TryParse(heapName, ignoreCase: true, out heap) || !Enum.IsDefined(heap))
+        {
+            error = $"unknown heap '{heapName}'. Use String, Blob, Guid, or UserString.";
+            return false;
+        }
+
+        if (!int.TryParse(addressText, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out address))
+        {
+            error = $"'{addressText}' is not a heap address. Addresses are non-negative integers.";
             return false;
         }
 

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
@@ -1,0 +1,448 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+using Mdi;
+
+namespace DotnetInspector.MetadataRendering.Tests;
+
+/// <summary>
+/// Tests for rendering an image overview and a single heap value, and for the
+/// <c>mdi</c> flags that select them (issue #3341, gap 5).
+///
+/// The rendering claim under test is the same one the table renderer makes: a
+/// limit is never silent. An overview lists only tables that carry rows, so the
+/// count it omitted and any table it cannot dump must both surface as caveats —
+/// inline in Markdown, and on the error writer for the machine formats, which
+/// are pure row streams with nowhere to put prose.
+/// </summary>
+public class MetadataImageOverviewRendererTests
+{
+    static readonly string SelfPath = typeof(MetadataImageOverviewRendererTests).Assembly.Location;
+
+    static MetadataImageOverview SelfOverview()
+    {
+        using var peReader = new PEReader(new MemoryStream(File.ReadAllBytes(SelfPath)));
+        var overview = MetadataImageInspector.Describe(peReader);
+        Assert.NotNull(overview);
+        return overview;
+    }
+
+    static string Render(MetadataImageOverview overview, MetadataTableFormat format)
+    {
+        var output = new StringWriter();
+        MetadataProjectionRenderer.Render(overview, output, format);
+        return output.ToString();
+    }
+
+    // --- Overview rendering ------------------------------------------------
+
+    [Fact]
+    public void Markdown_RendersASectionForEachPart()
+    {
+        string markdown = Render(SelfOverview(), MetadataTableFormat.Markdown);
+
+        Assert.Contains("## Image", markdown);
+        Assert.Contains("## Heaps", markdown);
+        Assert.Contains("## Tables", markdown);
+        Assert.Contains("Metadata version", markdown);
+    }
+
+    [Fact]
+    public void Markdown_NamesTheGuidHeapsAddressingSoAnAddressIsNotMisread()
+    {
+        string markdown = Render(SelfOverview(), MetadataTableFormat.Markdown);
+
+        Assert.Contains("| Guid | ", markdown);
+        Assert.Contains("index", markdown);
+        Assert.Contains("byte offset", markdown);
+    }
+
+    [Fact]
+    public void Markdown_CarriesTheOmittedTableCountInline()
+    {
+        var overview = SelfOverview();
+        string markdown = Render(overview, MetadataTableFormat.Markdown);
+
+        int empty = overview.Tables.Count(static table => table.RowCount == 0);
+        Assert.True(empty > 0, "this assembly leaves no table empty, so the caveat cannot be exercised");
+        Assert.Contains($"{empty} of {overview.Tables.Length} ECMA-335 tables carry no rows", markdown);
+    }
+
+    [Fact]
+    public void Markdown_NamesTablesWithRowsTheProjectionCannotDump()
+    {
+        var overview = SelfOverview();
+        string markdown = Render(overview, MetadataTableFormat.Markdown);
+
+        var unprojected = overview.Tables
+            .Where(static table => table.RowCount > 0 && !table.IsProjected)
+            .Select(static table => table.Name)
+            .ToList();
+
+        Assert.NotEmpty(unprojected);
+        foreach (string name in unprojected)
+            Assert.Contains(name, markdown);
+    }
+
+    [Fact]
+    public void Markdown_ListsEveryTableThatCarriesRows()
+    {
+        var overview = SelfOverview();
+        string markdown = Render(overview, MetadataTableFormat.Markdown);
+
+        var withRows = overview.Tables.Where(static table => table.RowCount > 0).ToList();
+        Assert.NotEmpty(withRows);
+
+        foreach (var table in withRows)
+            Assert.Contains($"| {table.Name} | {table.RowCount} |", markdown);
+    }
+
+    [Fact]
+    public void Markdown_OmitsEmptyTablesFromTheTableList()
+    {
+        var overview = SelfOverview();
+        string markdown = Render(overview, MetadataTableFormat.Markdown);
+
+        var empty = overview.Tables.First(static table => table.RowCount == 0);
+
+        Assert.DoesNotContain($"| {empty.Name} | 0 |", markdown);
+    }
+
+    [Theory]
+    [InlineData(MetadataTableFormat.Tsv)]
+    [InlineData(MetadataTableFormat.Jsonl)]
+    public void MachineFormats_KeepEveryRowSelfIdentifying(MetadataTableFormat format)
+    {
+        string rendered = Render(SelfOverview(), format);
+
+        Assert.Contains("image", rendered);
+        Assert.Contains("heap", rendered);
+        Assert.Contains("table", rendered);
+
+        if (format == MetadataTableFormat.Jsonl)
+        {
+            foreach (string line in rendered.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                Assert.Contains("\"section\":", line);
+        }
+    }
+
+    [Fact]
+    public void Jsonl_EmitsOneObjectPerHeapAndPopulatedTable()
+    {
+        var overview = SelfOverview();
+        string jsonl = Render(overview, MetadataTableFormat.Jsonl);
+
+        var lines = jsonl.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(overview.Heaps.Length, lines.Count(static line => line.Contains("\"section\":\"heap\"")));
+        Assert.Equal(
+            overview.Tables.Count(static table => table.RowCount > 0),
+            lines.Count(static line => line.Contains("\"section\":\"table\"")));
+    }
+
+    [Fact]
+    public void Caveats_AreEmptyOnlyWhenNothingWasLeftOut()
+    {
+        var complete = new MetadataImageOverview(
+            "v4.0.30319",
+            MetadataKind.Ecma335,
+            IsAssembly: true,
+            MetadataOffset: 1,
+            MetadataSize: 2,
+            [new MetadataHeapSummary(HeapKind.String, 4, MetadataHeapAddressing.ByteOffset)],
+            [new MetadataTableSummary(TableIndex.TypeDef, "TypeDef", 3, IsProjected: true)],
+            new MetadataImageHeaders(
+                Machine.Amd64,
+                Characteristics.Dll,
+                Subsystem.WindowsCui,
+                DllCharacteristics.DynamicBase,
+                IsPE32Plus: true,
+                new MetadataCorHeaderSummary(2, 5, CorFlags.ILOnly, 0)));
+
+        Assert.Empty(MetadataProjectionRenderer.Caveats(complete));
+    }
+
+    [Fact]
+    public void Markdown_ReportsAnAbsentCliHeaderRatherThanBlankFields()
+    {
+        var native = new MetadataImageOverview(
+            "v4.0.30319",
+            MetadataKind.Ecma335,
+            IsAssembly: false,
+            MetadataOffset: 1,
+            MetadataSize: 2,
+            [new MetadataHeapSummary(HeapKind.String, 4, MetadataHeapAddressing.ByteOffset)],
+            [new MetadataTableSummary(TableIndex.TypeDef, "TypeDef", 3, IsProjected: true)],
+            new MetadataImageHeaders(
+                Machine.Amd64,
+                Characteristics.Dll,
+                Subsystem.WindowsCui,
+                DllCharacteristics.DynamicBase,
+                IsPE32Plus: true,
+                Cor: null));
+
+        string markdown = Render(native, MetadataTableFormat.Markdown);
+
+        Assert.Contains("| CLI header | absent |", markdown);
+        Assert.DoesNotContain("CLI flags", markdown);
+    }
+
+    [Theory]
+    [InlineData(0, CorFlags.ILOnly, "none")]
+    [InlineData(0x06000001, CorFlags.ILOnly, "token 0x06000001")]
+    [InlineData(0x00001234, CorFlags.NativeEntryPoint, "native RVA 0x00001234")]
+    public void Markdown_DistinguishesAManagedEntryPointFromANativeOne(int raw, CorFlags flags, string expected)
+    {
+        var overview = new MetadataImageOverview(
+            "v4.0.30319",
+            MetadataKind.Ecma335,
+            IsAssembly: true,
+            MetadataOffset: 1,
+            MetadataSize: 2,
+            [new MetadataHeapSummary(HeapKind.String, 4, MetadataHeapAddressing.ByteOffset)],
+            [new MetadataTableSummary(TableIndex.TypeDef, "TypeDef", 3, IsProjected: true)],
+            new MetadataImageHeaders(
+                Machine.Amd64,
+                Characteristics.Dll,
+                Subsystem.WindowsCui,
+                DllCharacteristics.DynamicBase,
+                IsPE32Plus: true,
+                new MetadataCorHeaderSummary(2, 5, flags, raw)));
+
+        Assert.Contains($"| Entry point | {expected} |", Render(overview, MetadataTableFormat.Markdown));
+    }
+
+    [Fact]
+    public void Render_RejectsNullArguments()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => MetadataProjectionRenderer.Render((MetadataImageOverview)null!, new StringWriter()));
+        Assert.Throws<ArgumentNullException>(() => MetadataProjectionRenderer.Render(SelfOverview(), null!));
+    }
+
+    // --- Heap value rendering ----------------------------------------------
+
+    static string RenderHeap(MetadataValue value, HeapKind heap, int address, MetadataTableFormat format)
+    {
+        var output = new StringWriter();
+        MetadataProjectionRenderer.Render(value, heap, address, output, format);
+        return output.ToString();
+    }
+
+    [Fact]
+    public void HeapValue_MarkdownEchoesTheAddressItAnswered()
+    {
+        var value = new MetadataValue.HeapReference(HeapKind.String, 42, 5, "hello", "hello", Truncated: false);
+
+        string markdown = RenderHeap(value, HeapKind.String, 42, MetadataTableFormat.Markdown);
+
+        Assert.Contains("## String heap at 42", markdown);
+        Assert.Contains("| String | 42 | 5 | no | hello |", markdown);
+    }
+
+    [Fact]
+    public void HeapValue_MarksATruncatedPreviewSoItIsNotReadAsWhole()
+    {
+        var value = new MetadataValue.HeapReference(HeapKind.Blob, 7, 64, null, "0011", Truncated: true);
+
+        string markdown = RenderHeap(value, HeapKind.Blob, 7, MetadataTableFormat.Markdown);
+
+        Assert.Contains("| Blob | 7 | 64 | yes |", markdown);
+        Assert.Contains("0011\u2026", markdown);
+    }
+
+    [Fact]
+    public void HeapValue_KeepsAMalformedReadVisible()
+    {
+        var value = new MetadataValue.Malformed("past the end");
+
+        string markdown = RenderHeap(value, HeapKind.Guid, 99, MetadataTableFormat.Markdown);
+
+        Assert.Contains("!malformed: past the end", markdown);
+    }
+
+    [Fact]
+    public void HeapValue_RendersNilWithoutClaimingALength()
+    {
+        string tsv = RenderHeap(new MetadataValue.Nil(), HeapKind.String, 0, MetadataTableFormat.Tsv);
+
+        Assert.Contains("nil", tsv);
+        Assert.Contains("String\t0\t\tno\tnil", tsv);
+    }
+
+    [Fact]
+    public void HeapValue_JsonlIsSelfDescribing()
+    {
+        var value = new MetadataValue.HeapReference(HeapKind.UserString, 1, 3, "abc", "abc", Truncated: false);
+
+        string jsonl = RenderHeap(value, HeapKind.UserString, 1, MetadataTableFormat.Jsonl);
+
+        Assert.Contains("\"heap\":\"UserString\"", jsonl);
+        Assert.Contains("\"address\":\"1\"", jsonl);
+        Assert.Contains("\"value\":\"abc\"", jsonl);
+    }
+
+    // --- mdi wiring --------------------------------------------------------
+
+    [Fact]
+    public void ExecuteOverview_RendersTheImage()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        int code = MdiCommand.ExecuteOverview(SelfPath, MetadataTableFormat.Markdown, output, error);
+
+        Assert.Equal(0, code);
+        Assert.Contains("## Image", output.ToString());
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public void ExecuteOverview_MovesCaveatsToTheErrorWriterForMachineFormats()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        int code = MdiCommand.ExecuteOverview(SelfPath, MetadataTableFormat.Jsonl, output, error);
+
+        Assert.Equal(0, code);
+        Assert.Contains("Note:", error.ToString());
+        Assert.Contains("carry no rows", error.ToString());
+        Assert.DoesNotContain("Note:", output.ToString());
+    }
+
+    [Fact]
+    public void ExecuteOverview_MissingFile_ReturnsErrorAndReports()
+    {
+        var error = new StringWriter();
+
+        int code = MdiCommand.ExecuteOverview(
+            "does-not-exist.dll", MetadataTableFormat.Markdown, new StringWriter(), error);
+
+        Assert.Equal(1, code);
+        Assert.Contains("file not found", error.ToString());
+    }
+
+    [Fact]
+    public void ExecuteOverview_NonManagedFile_ReportsFailureWithoutOutput()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "this is not a PE image");
+
+            var output = new StringWriter();
+            var error = new StringWriter();
+
+            int code = MdiCommand.ExecuteOverview(path, MetadataTableFormat.Markdown, output, error);
+
+            Assert.Equal(1, code);
+            Assert.False(string.IsNullOrWhiteSpace(error.ToString()));
+            Assert.Equal(string.Empty, output.ToString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ExecuteHeapValue_ReadsAGuidByIndex()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        int code = MdiCommand.ExecuteHeapValue(
+            SelfPath, HeapKind.Guid, 1, new MetadataProjectionOptions(), MetadataTableFormat.Markdown, output, error);
+
+        Assert.Equal(0, code);
+        Assert.Contains("## Guid heap at 1", output.ToString());
+        Assert.DoesNotContain("malformed", output.ToString());
+    }
+
+    [Fact]
+    public void ExecuteHeapValue_ReportsAnUnreadableAddressWithoutFailingTheCommand()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        int code = MdiCommand.ExecuteHeapValue(
+            SelfPath, HeapKind.Guid, 9999, new MetadataProjectionOptions(), MetadataTableFormat.Markdown, output, error);
+
+        // An unreadable address is an answer, not a command failure — but it must
+        // never render as an empty success.
+        Assert.Equal(0, code);
+        Assert.Contains("!malformed", output.ToString());
+        Assert.Contains("Note:", error.ToString());
+    }
+
+    [Fact]
+    public void ExecuteHeapValue_RejectsANegativeAddress()
+    {
+        var error = new StringWriter();
+
+        int code = MdiCommand.ExecuteHeapValue(
+            SelfPath, HeapKind.String, -1, new MetadataProjectionOptions(), MetadataTableFormat.Markdown, new StringWriter(), error);
+
+        Assert.Equal(1, code);
+        Assert.Contains("must be zero or greater", error.ToString());
+    }
+
+    [Theory]
+    [InlineData("String:1234", HeapKind.String, 1234)]
+    [InlineData("guid:1", HeapKind.Guid, 1)]
+    [InlineData(" UserString : 0 ", HeapKind.UserString, 0)]
+    [InlineData("Blob:0", HeapKind.Blob, 0)]
+    public void TryParseHeapLocation_AcceptsAHeapAndAddress(string spec, HeapKind heap, int address)
+    {
+        Assert.True(MdiCommand.TryParseHeapLocation(spec, out var parsedHeap, out int parsedAddress, out string? error));
+        Assert.Equal(heap, parsedHeap);
+        Assert.Equal(address, parsedAddress);
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData("String", "not a heap reference")]
+    [InlineData("Nope:1", "unknown heap")]
+    [InlineData("String:abc", "not a heap address")]
+    [InlineData("String:-1", "not a heap address")]
+    public void TryParseHeapLocation_NamesTheHalfThatIsWrong(string spec, string expected)
+    {
+        Assert.False(MdiCommand.TryParseHeapLocation(spec, out _, out _, out string? error));
+        Assert.NotNull(error);
+        Assert.Contains(expected, error);
+    }
+
+    [Fact]
+    public void RootCommand_ExposesTheOverviewAndHeapOptions()
+    {
+        var root = MdiCommand.CreateRootCommand();
+
+        var names = root.Options.SelectMany(option => new[] { option.Name }.Concat(option.Aliases)).ToList();
+
+        Assert.Contains("--overview", names);
+        Assert.Contains("-i", names);
+        Assert.Contains("--heap", names);
+    }
+
+    [Fact]
+    public void RootCommand_RejectsCombiningTheQueryModes()
+    {
+        var root = MdiCommand.CreateRootCommand();
+        var error = new StringWriter();
+        var original = Console.Error;
+        try
+        {
+            Console.SetError(error);
+            int code = root.Parse([SelfPath, "--overview", "--heap", "Guid:1"]).Invoke();
+
+            Assert.Equal(1, code);
+            Assert.Contains("cannot be combined", error.ToString());
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataImageOverviewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataImageOverviewTests.cs
@@ -1,0 +1,578 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Tests for <see cref="MetadataImageInspector.Describe"/> and
+/// <see cref="MetadataTableProjector.ReadHeapValue"/> — the image-level facts and
+/// heap random access a metadata browser needs alongside the table projection
+/// (issue #3341, gap 5).
+///
+/// Two claims carry most of the weight here. First, the overview reports what is
+/// physically present rather than what the projection covers, so an unmodelled
+/// table with rows is visible as a gap instead of reading as empty. Second, a
+/// heap address round-trips: the address a projected cell publishes is the
+/// address this reader accepts, which is only true if the GUID heap's 1-based
+/// index addressing is respected rather than treated as a byte offset.
+/// </summary>
+public class MetadataImageOverviewTests
+{
+    static string SelfPath => typeof(MetadataImageOverviewTests).Assembly.Location;
+
+    static PEReader OpenSelfFromBytes() => new(new MemoryStream(File.ReadAllBytes(SelfPath)));
+
+    static MetadataImageOverview DescribeSelf(PEReader peReader)
+    {
+        var overview = MetadataImageInspector.Describe(peReader);
+        Assert.NotNull(overview);
+        return overview;
+    }
+
+    static MetadataTableProjection FullProjection(PEReader peReader)
+        => MetadataTableProjector.Project(
+            peReader,
+            new MetadataProjectionOptions { MaxRowsPerTable = int.MaxValue });
+
+    /// <summary>
+    /// A copy of this assembly with the CLI (COR20) data directory zeroed, which
+    /// is how a PE stops being a managed image. Used to exercise the "no
+    /// metadata" contract on a real image rather than asserting it in theory.
+    /// </summary>
+    static byte[] SelfWithoutCliHeader()
+    {
+        byte[] bytes = File.ReadAllBytes(SelfPath);
+
+        using var peReader = new PEReader(new MemoryStream(bytes));
+        var peHeader = peReader.PEHeaders.PEHeader!;
+
+        // The data directories follow the optional header's fixed part, whose
+        // size differs between PE32 and PE32+. COR20 is directory 14.
+        int directoryBase = peReader.PEHeaders.PEHeaderStartOffset + (peHeader.Magic == PEMagic.PE32Plus ? 112 : 96);
+        Array.Clear(bytes, directoryBase + (14 * 8), 8);
+
+        return bytes;
+    }
+
+    // --- Metadata root -----------------------------------------------------
+
+    [Fact]
+    public void Describe_ReportsTheMetadataRootIdentity()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+
+        Assert.StartsWith("v", overview.MetadataVersion);
+        Assert.Equal(MetadataKind.Ecma335, overview.Kind);
+        Assert.True(overview.IsAssembly);
+    }
+
+    [Fact]
+    public void Describe_ReportsAMetadataExtentThatContainsEveryHeap()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+
+        Assert.True(overview.MetadataOffset > 0);
+
+        // The heaps are streams inside the metadata root, so their total can
+        // never exceed it. This catches an offset/size pair read from the wrong
+        // header far more cheaply than restating the header layout.
+        long heapBytes = overview.Heaps.Sum(static heap => (long)heap.SizeInBytes);
+        Assert.True(
+            heapBytes < overview.MetadataSize,
+            $"heaps total {heapBytes} bytes but the metadata root is only {overview.MetadataSize}");
+    }
+
+    [Fact]
+    public void Describe_MatchesTheReaderItDescribes()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+
+        var overview = DescribeSelf(peReader);
+
+        Assert.Equal(reader.MetadataVersion, overview.MetadataVersion);
+        Assert.Equal(peReader.PEHeaders.MetadataStartOffset, overview.MetadataOffset);
+        Assert.Equal(peReader.PEHeaders.MetadataSize, overview.MetadataSize);
+    }
+
+    // --- Heaps -------------------------------------------------------------
+
+    [Fact]
+    public void Describe_ReportsEveryHeapExactlyOnce()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+
+        Assert.Equal(Enum.GetValues<HeapKind>(), overview.Heaps.Select(static heap => heap.Heap));
+    }
+
+    [Fact]
+    public void Describe_ReportsHeapSizesInBytes()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+
+        var overview = DescribeSelf(peReader);
+
+        Assert.Equal(reader.GetHeapSize(HeapIndex.String), Size(overview, HeapKind.String));
+        Assert.Equal(reader.GetHeapSize(HeapIndex.Blob), Size(overview, HeapKind.Blob));
+        Assert.Equal(reader.GetHeapSize(HeapIndex.Guid), Size(overview, HeapKind.Guid));
+        Assert.Equal(reader.GetHeapSize(HeapIndex.UserString), Size(overview, HeapKind.UserString));
+
+        // A real assembly must exercise the heaps the round-trip tests below
+        // walk, or those tests could pass over nothing.
+        Assert.True(Size(overview, HeapKind.String) > 0);
+        Assert.True(Size(overview, HeapKind.Blob) > 0);
+        Assert.True(Size(overview, HeapKind.Guid) > 0);
+
+        static int Size(MetadataImageOverview overview, HeapKind heap)
+            => overview.Heaps.Single(entry => entry.Heap == heap).SizeInBytes;
+    }
+
+    [Fact]
+    public void Describe_MarksOnlyTheGuidHeapAsIndexAddressed()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+
+        foreach (var heap in overview.Heaps)
+        {
+            var expected = heap.Heap is HeapKind.Guid
+                ? MetadataHeapAddressing.Index
+                : MetadataHeapAddressing.ByteOffset;
+
+            Assert.Equal(expected, heap.Addressing);
+        }
+    }
+
+    [Fact]
+    public void GuidHeapSize_IsAWholeNumberOfEntries()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var guid = DescribeSelf(peReader).Heaps.Single(static heap => heap.Heap == HeapKind.Guid);
+
+        Assert.Equal(0, guid.SizeInBytes % MetadataHeapAddressingSizes.GuidSize);
+        Assert.Equal(guid.SizeInBytes / MetadataHeapAddressingSizes.GuidSize, guid.MaxAddress);
+    }
+
+    [Theory]
+    [InlineData(HeapKind.String, 0, 0)]
+    [InlineData(HeapKind.String, 64, 63)]
+    [InlineData(HeapKind.Blob, 1, 0)]
+    [InlineData(HeapKind.Guid, 0, 0)]
+    [InlineData(HeapKind.Guid, 16, 1)]
+    [InlineData(HeapKind.Guid, 48, 3)]
+    public void MaxAddress_FollowsTheHeapAddressing(HeapKind heap, int sizeInBytes, int expected)
+    {
+        var addressing = heap is HeapKind.Guid
+            ? MetadataHeapAddressing.Index
+            : MetadataHeapAddressing.ByteOffset;
+
+        Assert.Equal(expected, new MetadataHeapSummary(heap, sizeInBytes, addressing).MaxAddress);
+    }
+
+    // --- Tables ------------------------------------------------------------
+
+    [Fact]
+    public void Describe_ReportsEveryTableInTableOrder()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+
+        Assert.Equal(Enum.GetValues<TableIndex>(), overview.Tables.Select(static table => table.Index));
+    }
+
+    [Fact]
+    public void Describe_ReportsPhysicalRowCountsMatchingTheProjection()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+        var projection = FullProjection(peReader);
+
+        Assert.NotEmpty(projection.Tables);
+
+        foreach (var view in projection.Tables)
+        {
+            var summary = overview.Tables.Single(table => table.Index == view.Index);
+
+            Assert.Equal(view.RowCount, summary.RowCount);
+            Assert.Equal(view.Name, summary.Name);
+            Assert.True(summary.IsProjected);
+        }
+    }
+
+    [Fact]
+    public void IsProjected_AgreesWithTheProjectorsOwnTableSet()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+
+        foreach (var table in overview.Tables)
+        {
+            Assert.Equal(MetadataTableProjector.ProjectedTables.Contains(table.Index), table.IsProjected);
+        }
+    }
+
+    /// <summary>
+    /// The reason the overview lists every table rather than only the projected
+    /// ones: real assemblies carry content the projection does not yet model, and
+    /// a browser must be able to tell that gap apart from an empty table.
+    /// </summary>
+    [Fact]
+    public void UnprojectedTablesWithRows_AreVisibleAsAGap()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+
+        var gaps = overview.Tables
+            .Where(static table => table.RowCount > 0 && !table.IsProjected)
+            .Select(static table => table.Name)
+            .ToImmutableArray();
+
+        Assert.NotEmpty(gaps);
+        Assert.Contains(nameof(TableIndex.NestedClass), gaps);
+        Assert.Contains(nameof(TableIndex.MethodSemantics), gaps);
+    }
+
+    [Fact]
+    public void ProjectedTables_IsTheProjectorsSupportedSet()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var projected = MetadataTableProjector.ProjectedTables;
+
+        Assert.NotEmpty(projected);
+        Assert.Equal(projected.Distinct().Count(), projected.Length);
+
+        // Every table the projector actually emits must be in the advertised set.
+        foreach (var view in FullProjection(peReader).Tables)
+        {
+            Assert.Contains(view.Index, projected);
+        }
+    }
+
+    // --- Headers -----------------------------------------------------------
+
+    [Fact]
+    public void Describe_ReportsPeAndCliHeaderFacts()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var headers = peReader.PEHeaders;
+
+        var actual = DescribeSelf(peReader).Headers;
+
+        Assert.Equal(headers.CoffHeader.Machine, actual.Machine);
+        Assert.Equal(headers.CoffHeader.Characteristics, actual.ImageCharacteristics);
+        Assert.Equal(headers.PEHeader!.Subsystem, actual.Subsystem);
+        Assert.Equal(headers.PEHeader.DllCharacteristics, actual.DllCharacteristics);
+        Assert.Equal(headers.PEHeader.Magic == PEMagic.PE32Plus, actual.IsPE32Plus);
+
+        Assert.NotNull(actual.Cor);
+        Assert.Equal(headers.CorHeader!.Flags, actual.Cor.Flags);
+        Assert.Equal(headers.CorHeader.MajorRuntimeVersion, actual.Cor.MajorRuntimeVersion);
+        Assert.Equal(
+            headers.CorHeader.EntryPointTokenOrRelativeVirtualAddress,
+            actual.Cor.EntryPointTokenOrRelativeVirtualAddress);
+    }
+
+    [Fact]
+    public void Describe_ReportsAManagedImageAsIlOnly()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var cor = DescribeSelf(peReader).Headers.Cor;
+
+        Assert.NotNull(cor);
+        Assert.True(cor.Flags.HasFlag(CorFlags.ILOnly));
+    }
+
+    [Theory]
+    [InlineData(0, CorFlags.ILOnly, null)]
+    [InlineData(0x06000001, CorFlags.ILOnly, 0x06000001)]
+    [InlineData(0x00001234, CorFlags.NativeEntryPoint, null)]
+    public void EntryPointToken_IsNullUnlessTheHeaderCarriesAManagedOne(
+        int raw,
+        CorFlags flags,
+        int? expected)
+    {
+        var cor = new MetadataCorHeaderSummary(2, 5, flags, raw);
+
+        Assert.Equal(expected, cor.EntryPointToken);
+    }
+
+    // --- No metadata -------------------------------------------------------
+
+    [Fact]
+    public void Describe_ReturnsNullForAnImageWithoutMetadata()
+    {
+        using var peReader = new PEReader(new MemoryStream(SelfWithoutCliHeader()));
+
+        // Canary: if zeroing the CLI directory ever stops producing an image
+        // without metadata, the assertion below would pass for the wrong reason.
+        Assert.False(peReader.HasMetadata);
+
+        Assert.Null(MetadataImageInspector.Describe(peReader));
+    }
+
+    [Fact]
+    public void ReadHeapValue_ReturnsNullForAnImageWithoutMetadata()
+    {
+        using var peReader = new PEReader(new MemoryStream(SelfWithoutCliHeader()));
+
+        Assert.False(peReader.HasMetadata);
+
+        Assert.Null(MetadataTableProjector.ReadHeapValue(peReader, HeapKind.String, 1));
+    }
+
+    [Fact]
+    public void Describe_RejectsANullReader()
+        => Assert.Throws<ArgumentNullException>(() => MetadataImageInspector.Describe(null!));
+
+    // --- Heap random access ------------------------------------------------
+
+    /// <summary>
+    /// The load-bearing round trip: every heap address the projection publishes
+    /// must read back through <see cref="MetadataTableProjector.ReadHeapValue"/>
+    /// as the same value. This is what makes a cell's offset a usable address
+    /// rather than a display detail.
+    ///
+    /// Note what this cannot prove on its own: both sides construct their handle
+    /// from the same address, so a round trip stays green even if that shared
+    /// convention were wrong. <see cref="ReadHeapValue_ReadsTheGuidHeapByIndexNotByteOffset"/>
+    /// anchors the GUID convention to an externally-known value for that reason.
+    /// </summary>
+    [Fact]
+    public void ReadHeapValue_RoundTripsEveryProjectedHeapAddress()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var options = new MetadataProjectionOptions { MaxRowsPerTable = int.MaxValue };
+
+        int checkedCells = 0;
+        var seenHeaps = new HashSet<HeapKind>();
+
+        foreach (var view in MetadataTableProjector.Project(peReader, options).Tables)
+        {
+            foreach (var row in view.Rows)
+            {
+                foreach (var cell in row.Cells)
+                {
+                    if (cell is not MetadataValue.HeapReference expected)
+                        continue;
+
+                    var actual = MetadataTableProjector.ReadHeapValue(
+                        peReader, expected.Heap, expected.Offset, options);
+
+                    var reread = Assert.IsType<MetadataValue.HeapReference>(actual);
+
+                    Assert.Equal(expected.Heap, reread.Heap);
+                    Assert.Equal(expected.Offset, reread.Offset);
+                    Assert.Equal(expected.Length, reread.Length);
+                    Assert.Equal(expected.Text, reread.Text);
+                    Assert.Equal(expected.Preview, reread.Preview);
+                    Assert.Equal(expected.Truncated, reread.Truncated);
+
+                    seenHeaps.Add(expected.Heap);
+                    checkedCells++;
+                }
+            }
+        }
+
+        // Floor and coverage guards: without them a projection that stopped
+        // emitting heap cells, or one that only ever emitted strings, would let
+        // this walk pass without exercising the addressing rule it exists to pin.
+        Assert.True(checkedCells > 1_000, $"only {checkedCells} heap cells were round-tripped");
+        Assert.Contains(HeapKind.String, seenHeaps);
+        Assert.Contains(HeapKind.Blob, seenHeaps);
+        Assert.Contains(HeapKind.Guid, seenHeaps);
+    }
+
+    [Fact]
+    public void ReadHeapValue_ReadsTheUserStringHeapTheTablesNeverPointAt()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+        int size = overview.Heaps.Single(static heap => heap.Heap == HeapKind.UserString).SizeInBytes;
+
+        // The #US heap opens with a single nil byte, so the first literal starts
+        // at offset 1. Guard the premise rather than assume it.
+        Assert.True(size > 1, "this assembly carries no user strings to read");
+
+        var value = MetadataTableProjector.ReadHeapValue(peReader, HeapKind.UserString, 1);
+
+        var heapValue = Assert.IsType<MetadataValue.HeapReference>(value);
+        Assert.Equal(HeapKind.UserString, heapValue.Heap);
+        Assert.Equal(1, heapValue.Offset);
+        Assert.NotNull(heapValue.Text);
+        Assert.NotEmpty(heapValue.Text);
+    }
+
+    [Theory]
+    [InlineData(HeapKind.String)]
+    [InlineData(HeapKind.Blob)]
+    [InlineData(HeapKind.Guid)]
+    [InlineData(HeapKind.UserString)]
+    public void ReadHeapValue_TreatsAddressZeroAsNil(HeapKind heap)
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        Assert.IsType<MetadataValue.Nil>(MetadataTableProjector.ReadHeapValue(peReader, heap, 0));
+    }
+
+    [Theory]
+    [InlineData(HeapKind.String)]
+    [InlineData(HeapKind.Blob)]
+    [InlineData(HeapKind.Guid)]
+    [InlineData(HeapKind.UserString)]
+    public void ReadHeapValue_ReportsAnAddressPastTheEndAsMalformed(HeapKind heap)
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var overview = DescribeSelf(peReader);
+        int beyond = overview.Heaps.Single(entry => entry.Heap == heap).MaxAddress + 1;
+
+        var value = MetadataTableProjector.ReadHeapValue(peReader, heap, beyond);
+
+        Assert.IsType<MetadataValue.Malformed>(value);
+    }
+
+    /// <summary>
+    /// Anchors the GUID heap's addressing to a value known independently of the
+    /// projection: the module's MVID, read through SRM's typed API. A reader that
+    /// treated the address as a byte offset would resolve a different (or
+    /// unreadable) entry here, which no round trip against the projection could
+    /// detect, since both sides of that round trip share one convention.
+    /// </summary>
+    [Fact]
+    public void ReadHeapValue_ReadsTheGuidHeapByIndexNotByteOffset()
+    {
+        using var peReader = OpenSelfFromBytes();
+        var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+
+        var mvid = reader.GetModuleDefinition().Mvid;
+        int address = MetadataTokens.GetHeapOffset(mvid);
+
+        // The premise of the byte-offset confusion: the MVID sits at address 1,
+        // which is entry one, not byte one.
+        Assert.Equal(1, address);
+
+        var value = MetadataTableProjector.ReadHeapValue(peReader, HeapKind.Guid, address);
+
+        var heapValue = Assert.IsType<MetadataValue.HeapReference>(value);
+        Assert.Equal(reader.GetGuid(mvid).ToString(), heapValue.Text);
+        Assert.NotEqual(Guid.Empty.ToString(), heapValue.Text);
+    }
+
+    /// <summary>
+    /// The GUID heap is the one place where an address can look valid under the
+    /// wrong convention: on a single-entry heap, index 2 is past the end while
+    /// byte offset 2 is well inside. Both the overview's declared
+    /// <see cref="MetadataHeapSummary.MaxAddress"/> and the read itself must
+    /// treat those addresses as out of range.
+    /// </summary>
+    [Fact]
+    public void ReadHeapValue_RejectsAGuidIndexPastTheEndOfAByteAddressableRange()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var guid = DescribeSelf(peReader).Heaps.Single(static heap => heap.Heap == HeapKind.Guid);
+        Assert.Equal(MetadataHeapAddressingSizes.GuidSize, guid.SizeInBytes);
+        Assert.Equal(1, guid.MaxAddress);
+
+        Assert.IsType<MetadataValue.HeapReference>(
+            MetadataTableProjector.ReadHeapValue(peReader, HeapKind.Guid, 1));
+
+        // Byte-offset thinking would accept 2 through 15 here.
+        for (int address = 2; address < MetadataHeapAddressingSizes.GuidSize; address++)
+        {
+            Assert.IsType<MetadataValue.Malformed>(
+                MetadataTableProjector.ReadHeapValue(peReader, HeapKind.Guid, address));
+        }
+    }
+
+    [Fact]
+    public void ReadHeapValue_HonoursTheBlobPreviewBudget()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        var options = new MetadataProjectionOptions { MaxRowsPerTable = int.MaxValue };
+        var large = MetadataTableProjector.Project(peReader, options).Tables
+            .SelectMany(static view => view.Rows)
+            .SelectMany(static row => row.Cells)
+            .OfType<MetadataValue.HeapReference>()
+            .Where(static cell => cell.Heap == HeapKind.Blob && cell.Length > 8)
+            .First();
+
+        var bounded = Assert.IsType<MetadataValue.HeapReference>(
+            MetadataTableProjector.ReadHeapValue(
+                peReader, HeapKind.Blob, large.Offset, new MetadataProjectionOptions { MaxPreviewBytes = 4 }));
+
+        Assert.True(bounded.Truncated);
+        Assert.Equal(8, bounded.Preview.Length);
+        Assert.Equal(large.Length, bounded.Length);
+
+        var whole = Assert.IsType<MetadataValue.HeapReference>(
+            MetadataTableProjector.ReadHeapValue(
+                peReader, HeapKind.Blob, large.Offset, new MetadataProjectionOptions { MaxPreviewBytes = int.MaxValue }));
+
+        Assert.False(whole.Truncated);
+        Assert.Equal(large.Length * 2, whole.Preview.Length);
+    }
+
+    [Fact]
+    public void ReadHeapValue_RejectsANegativeAddress()
+    {
+        using var peReader = OpenSelfFromBytes();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => MetadataTableProjector.ReadHeapValue(peReader, HeapKind.String, -1));
+    }
+
+    [Fact]
+    public void ReadHeapValue_RejectsANullReader()
+        => Assert.Throws<ArgumentNullException>(
+            () => MetadataTableProjector.ReadHeapValue(null!, HeapKind.String, 1));
+
+    // --- Session facets ----------------------------------------------------
+
+    [Fact]
+    public void SessionExposesTheImageOverview()
+    {
+        using var peReader = OpenSelfFromBytes();
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+
+        var direct = DescribeSelf(peReader);
+        var viaSession = session.MetadataImage();
+
+        Assert.NotNull(viaSession);
+        Assert.Equal(direct.MetadataVersion, viaSession.MetadataVersion);
+        Assert.Equal(direct.Tables.Length, viaSession.Tables.Length);
+        Assert.Equal(direct.Heaps, viaSession.Heaps);
+    }
+
+    [Fact]
+    public void SessionExposesHeapRandomAccess()
+    {
+        using var peReader = OpenSelfFromBytes();
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+
+        var direct = MetadataTableProjector.ReadHeapValue(peReader, HeapKind.Guid, 1);
+        var viaSession = session.MetadataHeapValue(HeapKind.Guid, 1);
+
+        Assert.Equal(direct, viaSession);
+        Assert.IsType<MetadataValue.HeapReference>(viaSession);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataImageOverviewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataImageOverviewTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Text;
 
 namespace ILInspector.Metadata.Tests;
 
@@ -55,6 +56,50 @@ public class MetadataImageOverviewTests
 
         return bytes;
     }
+
+    /// <summary>
+    /// A copy of this assembly whose <c>#~</c> stream is declared too small to
+    /// hold its own table header. The CLI header is left intact, so this is a
+    /// corrupt table stream rather than an absent one.
+    /// </summary>
+    static byte[] SelfWithCorruptTableStream()
+    {
+        byte[] bytes = File.ReadAllBytes(SelfPath);
+
+        int metadataStart;
+        using (var peReader = new PEReader(new MemoryStream(bytes)))
+        {
+            metadataStart = peReader.PEHeaders.MetadataStartOffset;
+        }
+
+        // Metadata root: signature, version pair and reserved (12 bytes), then a
+        // length-prefixed version string padded to 4, then flags and stream count.
+        int versionLength = BitConverter.ToInt32(bytes, metadataStart + 12);
+        int cursor = metadataStart + 16 + AlignTo4(versionLength);
+        int streamCount = BitConverter.ToUInt16(bytes, cursor + 2);
+        cursor += 4;
+
+        for (int i = 0; i < streamCount; i++)
+        {
+            // Stream header: offset, size, then a null-terminated name padded to 4.
+            int sizeOffset = cursor + 4;
+            int nameStart = cursor + 8;
+            int nameEnd = Array.IndexOf(bytes, (byte)0, nameStart);
+            string name = Encoding.ASCII.GetString(bytes, nameStart, nameEnd - nameStart);
+
+            if (name == "#~")
+            {
+                BitConverter.GetBytes(4).CopyTo(bytes, sizeOffset);
+                return bytes;
+            }
+
+            cursor = nameStart + AlignTo4(nameEnd - nameStart + 1);
+        }
+
+        throw new InvalidOperationException("This assembly has no #~ stream to corrupt.");
+    }
+
+    static int AlignTo4(int value) => (value + 3) & ~3;
 
     // --- Metadata root -----------------------------------------------------
 
@@ -335,6 +380,31 @@ public class MetadataImageOverviewTests
         Assert.False(peReader.HasMetadata);
 
         Assert.Null(MetadataTableProjector.ReadHeapValue(peReader, HeapKind.String, 1));
+    }
+
+    /// <summary>
+    /// Corrupt metadata must fail visibly. The failure mode this guards against
+    /// is an overview that reports every table as zero rows, which is
+    /// indistinguishable from a legitimately empty image and so hides the
+    /// corruption completely. "No metadata" is null; "unreadable metadata" throws.
+    /// </summary>
+    [Fact]
+    public void Describe_FailsVisiblyForACorruptTableStream()
+    {
+        using (var intact = OpenSelfFromBytes())
+        {
+            // Canary: the intact image has rows that a zero-row overview would lose.
+            var typeDef = DescribeSelf(intact).Tables.Single(table => table.Index == TableIndex.TypeDef);
+            Assert.True(typeDef.RowCount > 0, "The intact image should report TypeDef rows.");
+        }
+
+        using var peReader = new PEReader(new MemoryStream(SelfWithCorruptTableStream()));
+
+        // Canary: the CLI header is still intact, so this is corruption rather
+        // than the absent-metadata case covered above.
+        Assert.True(peReader.HasMetadata);
+
+        Assert.Throws<BadImageFormatException>(() => MetadataImageInspector.Describe(peReader));
     }
 
     [Fact]


### PR DESCRIPTION
Stacked on #3348 (which is stacked on #3345). Review only the top commit; the base will be retargeted to `main` as the stack lands.

Closes the last explorer-enabling gap in #3341 that is not measurement-gated: **gap 5, heaps and headers**.

## What this adds

The projection covers *tables*. A metadata browser also shows the container it sits in, and needs to read a heap value the tables never point at.

- `MetadataImageInspector.Describe(PEReader)` → `MetadataImageOverview`: metadata root version/kind/offset/size and manifest flag, one summary per heap, one summary per ECMA-335 table, and PE/CLI header facts. Returns `null` for an image with no metadata — the same "not applicable" signal `ProjectRow` uses.
- `MetadataTableProjector.ReadHeapValue(peReader, heap, address, options)` — the heap counterpart of `ProjectRow`.
- Session facets `MetadataImage()` and `MetadataHeapValue(...)`, renderer support, and `mdi --overview` / `mdi --heap Heap:Address`.

## The two decisions worth attacking

**1. Row counts cover every table, not just the projected ones.**

Each entry carries `IsProjected`. A table with rows the projection does not model — `NestedClass`, `MethodSemantics`, `Property` on a typical assembly — stays visible as a coverage gap rather than being indistinguishable from an empty table. Listing only projected tables would reproduce the success-shaped-absence failure the reverse search in #3348 exists to avoid.

**2. Heap addressing is part of the model, not a doc footnote.**

ECMA-335 addresses String, Blob, and UserString by byte offset, but the GUID heap by **1-based index** into a vector of 16-byte values — and SRM's `GetHeapOffset` follows suit, returning an index for a GUID handle. I verified this against SRM before designing the API: on a 16-byte GUID heap, `GetHeapOffset(mvid)` returns `1`, not `0`.

`MetadataHeapAddressing` states which convention a heap uses and `MaxAddress` applies it, so a caller cannot silently read a GUID address as a byte offset. `ReadHeapValue`'s address is exactly what `MetadataValue.HeapReference.Offset` publishes, so a projected cell's offset round-trips, and the result is the same `MetadataValue` shape a projected cell carries — one renderer serves both.

Address zero is every heap's nil value. An address past the end yields `Malformed`, not an empty value. Because the tables never reference `#US`, this is also the only way to browse the user strings IL points at.

## Deliberately not here

**Heap enumeration.** SRM exposes no public way to walk every entry of a heap. The surface is overview plus random access, and the design doc says so rather than faking a walk by scanning bytes.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release` — clean.
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — **1044 passed, 0 failed, 0 skipped** (zero skipped means the mdv oracle ran).
- `dotnet run --project tests/DotnetInspector.MetadataRendering.Tests -c Release` — **95 passed, 0 failed** (was 58).
- `dotnet run --project src/dotnet-inspect.Tests -c Release` — 2216 total, 10 skipped (ilasm/ildasm absent), **1 failure: `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden`**. Confirmed **pre-existing**: it fails identically on the unmodified base commit `a1ea72c4`. Unrelated to metadata; not fixed here.
- `mdi --overview` and `mdi --heap` verified end to end in md, tsv, and jsonl, including the stderr caveat path for machine formats and the mode-conflict error.

**Mutation-checked.** Forcing the GUID heap to byte-offset addressing fails three tests. Note what the round-trip test *cannot* prove: both sides construct their handle from the same address, so a shared-but-wrong convention would survive it. A separate test therefore anchors the GUID address to the module MVID read through SRM's typed API, and the round-trip test's own doc comment says so rather than overclaiming.

The "no metadata" contract is exercised on a real image — a copy of the test assembly with its CLI data directory zeroed — guarded by a canary asserting `HasMetadata` is actually false, so the null assertion cannot pass for the wrong reason.

## Compatibility

Purely additive. No existing model, CLI, or `mdi` behaviour changes; the projection's shape is untouched. `MetadataTableProjector.ProjectedTables` is new public surface (the projector's own supported-table set), used by the overview and pinned by a test so the two cannot drift.