### PR TITLE
Add an opt-in taste lens folding `(long)N` to the `NL` long literal

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LongLiteralFoldFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/LongLiteralFoldFixture.cs
@@ -1,0 +1,74 @@
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Long-constant shapes for the opt-in
+/// <see cref="ILInspector.Decompiler.Pipeline.PrinterOptions.PreferLongLiteralSuffix"/>
+/// style lens (#3347). The lens folds the IR shape
+/// <c>Convert(→Int64, Int32 Constant)</c> — what csc's <c>ldc.i4(.s) N; conv.i8</c>
+/// imports as — into the idiomatic <c>NL</c> literal, and must leave a genuine
+/// <c>ldc.i8</c> (a bare <c>Int64</c> constant, no <c>Convert</c> over it) alone.
+///
+/// <para>The split between the two IL encodings is a property of csc's own literal
+/// emission, not of the decompiler: csc uses <c>ldc.i4</c>+<c>conv.i8</c> for any
+/// <c>long</c> constant whose value fits in an <see cref="int"/> and <c>ldc.i8</c>
+/// for one that does not. That is why every method below is authored as a plain
+/// C# constant — the compiler, not the fixture, chooses the opcode, so the
+/// fixture is a real compiled canary for the shape rather than an assumption
+/// about it. The value at the int/long boundary is covered from both sides
+/// (<see cref="IntMaxValue"/> is the last <c>ldc.i4</c>,
+/// <see cref="JustPastIntMaxValue"/> the first <c>ldc.i8</c>), and the small
+/// <c>ldc.i8</c> case C# cannot author at all is pinned synthetically in
+/// <c>LongLiteralFoldTests</c>.</para>
+/// </summary>
+public static class LongLiteralFoldFixture
+{
+    // --- conv.i8 sources: the lens folds these ---
+
+    // The reference witness's shape (CfgSampleClass.InlineArraySpanTernaryConditionValue),
+    // reduced: two `ldc.i4.s N; conv.i8` arms feeding an `add`, which is what keeps the
+    // join a real `?:` — a bare `return c ? 10L : 20L;` compiles to two returns and
+    // never reaches the conditional-arm seam at all.
+    public static long TernaryArms(bool c, long tail) => (c ? 10L : 20L) + tail;
+
+    // Return position: the value flows through the return sink's coercion, not an
+    // arm join. `ldc.i4.s 42; conv.i8; ret`.
+    public static long SmallReturn() => 42L;
+
+    // Argument position: the coercion sink is the parameter type, and the folded
+    // literal has to stay a well-formed argument.
+    public static long SmallArgument() => Consume(7L);
+
+    // Binary operand: exercises precedence. A cast operand and a literal operand
+    // report different precedences, so the fold must carry its own rather than
+    // inherit the cast's.
+    public static long BinaryOperand(long x) => x * 3L;
+
+    // Negative literal operand — the fold's text starts with a unary `-`, so this is
+    // the precedence case a bare Primary claim would get wrong.
+    public static long NegativeBinaryOperand(long x) => x * -1L;
+
+    // Boundary and sign coverage, all still `ldc.i4*; conv.i8`.
+    public static long Zero() => 0L;
+
+    public static long MinusOne() => -1L;
+
+    public static long IntMinValue() => int.MinValue;
+
+    // The largest long constant csc still encodes as `ldc.i4`.
+    public static long IntMaxValue() => int.MaxValue;
+
+    // --- genuine ldc.i8 sources: the lens must leave these exactly as they are ---
+
+    // One past int.MaxValue: the first value csc encodes as `ldc.i8`. Arrives at the
+    // printer as a bare Int64 Constant, so it cannot match the fold.
+    public static long JustPastIntMaxValue() => 2147483648L;
+
+    // A comfortably large `ldc.i8`, the issue's own example.
+    public static long LargeReturn() => 5_000_000_000L;
+
+    // An `ldc.i8` in the same ternary-arm position the fold fires in, so the close
+    // negative is pinned at the seam and not only at a return.
+    public static long LargeTernaryArms(bool c, long tail) => (c ? 5_000_000_000L : 6_000_000_000L) + tail;
+
+    public static long Consume(long value) => value;
+}

--- a/src/ILInspector.Decompiler.Tests/LongLiteralFoldTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LongLiteralFoldTests.cs
@@ -1,0 +1,316 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The opt-in byte-divergent style lens
+/// <see cref="PrinterOptions.PreferLongLiteralSuffix"/> (#3347): a <c>long</c>
+/// constant csc emits as <c>ldc.i4(.s) N; conv.i8</c> renders as the idiomatic
+/// <c>NL</c> literal instead of the <c>(long)N</c> cast the default view spells.
+/// This is a raise-completeness gap, not a fidelity gap — the cast is already
+/// opcode-faithful and round-trips; it is simply not fully raised.
+///
+/// <para>Three claims are pinned here, in the order they matter:</para>
+/// <list type="number">
+/// <item><description>
+/// <b>Default unchanged.</b> Every fixture method and the reference witness
+/// <c>CfgSampleClass.InlineArraySpanTernaryConditionValue</c> render exactly
+/// today's text with the knob off — the lens is opt-in and the shipped view stays
+/// byte-faithful.
+/// </description></item>
+/// <item><description>
+/// <b>The fold fires on exactly the <c>conv.i8</c> shape.</b> With the knob on, a
+/// <c>Convert(→Int64, Int32 Constant)</c> becomes <c>NL</c> at a ternary arm, a
+/// return, an argument, and a binary operand (including a negative literal, whose
+/// unary precedence the fold has to carry itself).
+/// </description></item>
+/// <item><description>
+/// <b>The close negative: a genuine <c>ldc.i8</c> is untouched.</b> That shape
+/// reaches the printer as a bare <c>Int64</c> <see cref="Constant"/> with no
+/// <see cref="Convert"/> over it, so it cannot match the fold. csc will not emit
+/// <c>ldc.i8</c> for a small value, so the small-<c>ldc.i8</c> case is pinned on a
+/// hand-built IR function, and the compiled fixture covers the large values csc
+/// does encode that way (including one in the very ternary-arm seam the fold fires
+/// in). Both must render identically knob-on and knob-off.
+/// </description></item>
+/// </list>
+///
+/// <para>The lens is <see cref="StyleOptionDescriptor.ByteDivergent"/>, so it is
+/// excluded from <see cref="ByteNeutralityGateTests"/> by construction. Its
+/// fidelity claim is narrower and is proven directly: because the fold is
+/// opcode-neutral <em>for csc output</em>, the knob-on render of every folded
+/// specimen must still compile back <c>Exact</c> — the same anchor the knob-off
+/// render earns. That is measured with the product's own compile-back harness
+/// (<see cref="FidelityCheck.EvaluateTargets(IReadOnlyList{string}, IReadOnlyList{FidelityCheck.CompileBackTarget}, bool, PrinterOptions?)"/>),
+/// not a harness-side reimplementation.</para>
+/// </summary>
+[Trait("Area", "RoundTrip")]
+public sealed class LongLiteralFoldTests
+{
+    const string KnobId = "prefer-long-literal-suffix";
+
+    static string AssemblyPath => typeof(LongLiteralFoldTests).Assembly.Location;
+
+    static StyleOptionDescriptor Knob => StyleOptionCatalog.Options.Single(o => o.Id == KnobId);
+
+    // Built through the catalog descriptor rather than a raw property set, so these
+    // tests exercise the same value-domain plumbing the CLI config resolver uses.
+    static PrinterOptions LensOptions => Knob.WithValue(PrinterOptions.Default, "true");
+
+    static string Render(System.Type declaringType, string memberName, PrinterOptions? options = null)
+    {
+        using var pe = new PEReader(File.OpenRead(AssemblyPath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == declaringType.FullName);
+        var member = Assert.Single(type.Members, m => m.Name == memberName);
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null, printerOptions: options);
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.NotNull(rendered.Text);
+        return rendered.Text!.Trim();
+    }
+
+    static string Fixture(string memberName, PrinterOptions? options = null)
+        => Render(typeof(LongLiteralFoldFixture), memberName, options);
+
+    // ---- 1. the default view is unchanged ----
+
+    public static TheoryData<string, string> DefaultRenders() => new()
+    {
+        { nameof(LongLiteralFoldFixture.TernaryArms), "public static long TernaryArms(bool c, long tail) => (c ? ((long)10) : ((long)20)) + tail;" },
+        { nameof(LongLiteralFoldFixture.SmallReturn), "public static long SmallReturn() => (long)42;" },
+        { nameof(LongLiteralFoldFixture.SmallArgument), "public static long SmallArgument() => Consume((long)7);" },
+        { nameof(LongLiteralFoldFixture.BinaryOperand), "public static long BinaryOperand(long x) => x * (long)3;" },
+        { nameof(LongLiteralFoldFixture.NegativeBinaryOperand), "public static long NegativeBinaryOperand(long x) => x * (long)-1;" },
+        { nameof(LongLiteralFoldFixture.Zero), "public static long Zero() => (long)0;" },
+        { nameof(LongLiteralFoldFixture.MinusOne), "public static long MinusOne() => (long)-1;" },
+        { nameof(LongLiteralFoldFixture.IntMinValue), "public static long IntMinValue() => (long)-2147483648;" },
+        { nameof(LongLiteralFoldFixture.IntMaxValue), "public static long IntMaxValue() => (long)2147483647;" },
+        { nameof(LongLiteralFoldFixture.LargeReturn), "public static long LargeReturn() => 5000000000;" },
+        { nameof(LongLiteralFoldFixture.LargeTernaryArms), "public static long LargeTernaryArms(bool c, long tail) => (c ? 5000000000 : 6000000000) + tail;" },
+    };
+
+    [Theory]
+    [MemberData(nameof(DefaultRenders))]
+    public void Default_IsUnchanged(string member, string expected)
+    {
+        // The knob defaults to false, so PrinterOptions.Default and "no options at all"
+        // must both produce today's text — the opt-in contract, pinned as exact text
+        // rather than a containment check so a stray space or paren fails here.
+        Assert.Equal(expected, Fixture(member));
+        Assert.Equal(expected, Fixture(member, PrinterOptions.Default));
+    }
+
+    [Fact]
+    public void ReferenceWitness_Default_IsUnchanged()
+    {
+        Assert.Equal(
+            "public static long InlineArraySpanTernaryConditionValue(object a, object b) "
+            + "=> (AnyObjectSpan([a, b]) ? ((long)10) : ((long)20)) + Environment.TickCount64;",
+            Render(typeof(CfgSampleClass), nameof(CfgSampleClass.InlineArraySpanTernaryConditionValue)));
+    }
+
+    // ---- 2. the lens folds exactly the conv.i8-sourced constants ----
+
+    public static TheoryData<string, string> LensRenders() => new()
+    {
+        // The reference witness's shape: both arms fold, and the folded literal drops
+        // the arm parentheses the cast needed without disturbing the enclosing `+`.
+        { nameof(LongLiteralFoldFixture.TernaryArms), "public static long TernaryArms(bool c, long tail) => (c ? 10L : 20L) + tail;" },
+        { nameof(LongLiteralFoldFixture.SmallReturn), "public static long SmallReturn() => 42L;" },
+        { nameof(LongLiteralFoldFixture.SmallArgument), "public static long SmallArgument() => Consume(7L);" },
+        { nameof(LongLiteralFoldFixture.BinaryOperand), "public static long BinaryOperand(long x) => x * 3L;" },
+        // `-1L` is a UNARY expression, not a primary one; at the right operand of `*`
+        // the demand is exactly Unary, so it stays bare and still binds correctly.
+        { nameof(LongLiteralFoldFixture.NegativeBinaryOperand), "public static long NegativeBinaryOperand(long x) => x * -1L;" },
+        { nameof(LongLiteralFoldFixture.Zero), "public static long Zero() => 0L;" },
+        { nameof(LongLiteralFoldFixture.MinusOne), "public static long MinusOne() => -1L;" },
+        { nameof(LongLiteralFoldFixture.IntMinValue), "public static long IntMinValue() => -2147483648L;" },
+        { nameof(LongLiteralFoldFixture.IntMaxValue), "public static long IntMaxValue() => 2147483647L;" },
+    };
+
+    [Theory]
+    [MemberData(nameof(LensRenders))]
+    public void Lens_FoldsConvI8Constants(string member, string expected)
+        => Assert.Equal(expected, Fixture(member, LensOptions));
+
+    [Fact]
+    public void ReferenceWitness_Lens_FoldsBothArms()
+    {
+        // The endpoint the issue names.
+        Assert.Equal(
+            "public static long InlineArraySpanTernaryConditionValue(object a, object b) "
+            + "=> (AnyObjectSpan([a, b]) ? 10L : 20L) + Environment.TickCount64;",
+            Render(typeof(CfgSampleClass), nameof(CfgSampleClass.InlineArraySpanTernaryConditionValue), LensOptions));
+    }
+
+    // ---- 3. the close negative: a genuine ldc.i8 source is untouched ----
+
+    [Theory]
+    [InlineData(nameof(LongLiteralFoldFixture.LargeReturn))]
+    [InlineData(nameof(LongLiteralFoldFixture.LargeTernaryArms))]
+    [InlineData(nameof(LongLiteralFoldFixture.JustPastIntMaxValue))]
+    public void LdcI8Sources_RenderIdenticallyWithTheLensOnOrOff(string member)
+    {
+        // `LargeReturn`/`LargeTernaryArms` are real `ldc.i8` bodies; `JustPastIntMaxValue`
+        // is csc's `ldc.i4 <int.MinValue bits>; conv.u8` zero-extension trick, whose target
+        // is UInt64 and so is not the fold's shape either. None may change, and equality —
+        // not an expected-text pin — is the claim, so this stays honest even where the
+        // shipped render of a shape is imperfect (the conv.u8 body is such a case; its
+        // pre-existing spelling is out of this lens's scope).
+        Assert.Equal(Fixture(member), Fixture(member, LensOptions));
+    }
+
+    [Fact]
+    public void SmallLdcI8_RendersIdenticallyWithTheLensOnOrOff()
+    {
+        // The case the corpus cannot supply: csc never encodes a SMALL long constant as
+        // `ldc.i8`, but a hand-authored or non-csc assembly can, and that is a distinct
+        // opcode from `ldc.i4.s; conv.i8`. Such a body reaches the printer as a bare
+        // Int64 Constant with no Convert over it, so the fold cannot see it — this is the
+        // opcode-fidelity guard the issue asks for, and it is structural, not heuristic.
+        var off = Print(SmallInt64ConstantReturn(), options: null);
+        var on = Print(SmallInt64ConstantReturn(), LensOptions);
+
+        Assert.Equal(off, on);
+        Assert.Contains("return 10;", off);
+        Assert.DoesNotContain("10L", on);
+    }
+
+    [Fact]
+    public void SyntheticConvI8_Folds_ProvingTheLdcI8PinIsNotVacuous()
+    {
+        // Non-vacuity partner of the pin above: the SAME hand-built shape with the
+        // `conv.i8` widening in place DOES fold, so the identical-render assertion there
+        // is a real discrimination between the two opcode sources rather than a lens that
+        // silently does nothing on synthetic input.
+        Assert.Contains("return (long)10;", Print(SmallConvertedInt32ConstantReturn(), options: null));
+        Assert.Contains("return 10L;", Print(SmallConvertedInt32ConstantReturn(), LensOptions));
+    }
+
+    static string Print(IrFunction function, PrinterOptions? options)
+    {
+        function.CheckInvariant();
+        var result = CSharpPrinter.Print(function, options);
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+
+    // `return <Int64 Constant 10>;` — the IR shape a genuine `ldc.i8 10` imports as.
+    static IrFunction SmallInt64ConstantReturn()
+        => Int64ReturningFunction("SmallLdcI8", new Constant(10L, TypeRef.CoreLib("System", "Int64")));
+
+    // `return <Convert(Int64, Int32 Constant 10)>;` — the shape `ldc.i4.s 10; conv.i8`
+    // imports as, and the only one the fold accepts.
+    static IrFunction SmallConvertedInt32ConstantReturn()
+        => Int64ReturningFunction(
+            "SmallConvI8",
+            new Pipeline.Convert(
+                TypeRef.CoreLib("System", "Int64"),
+                isChecked: false,
+                isUnsigned: false,
+                new Constant(10, TypeRef.CoreLib("System", "Int32"))));
+
+    static IrFunction Int64ReturningFunction(string name, IrExpression value)
+    {
+        var int64 = TypeRef.CoreLib("System", "Int64");
+        var holder = TypeRef.Definition("Synthetic", "Samples", "LongLiterals");
+        var body = new BlockContainer();
+        var block = new Block();
+        body.Add(block);
+        block.Add(new Return(value));
+        // No locals are declared because none are referenced: a hand-built function must
+        // carry the local table its body indexes (AGENTS.md, semantic IR invariants).
+        return new IrFunction(
+            name,
+            holder,
+            new MethodSignature(int64, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    // ---- catalog wiring ----
+
+    [Fact]
+    public void Knob_IsRegisteredAsANonEndorsedLensWithAToolOwnedConfigKey()
+    {
+        var knob = Knob;
+
+        Assert.Equal(StyleOptionTier.Lens, knob.Tier);
+        Assert.True(knob.ByteDivergent);
+        Assert.False(knob.OracleEndorsed);
+        Assert.False(knob.CorpusEndorsed);
+        Assert.Equal("false", knob.DefaultValue);
+        Assert.False(PrinterOptions.Default.PreferLongLiteralSuffix);
+
+        // Tool-owned vocabulary: `dotnet_style_*` is reserved for oracle-endorsed values
+        // (StyleOptionCatalogTests.EndorsedValuesWithAConfigKey_UseTheEditorconfigVocabulary).
+        Assert.Equal("dotnet_inspect_style_prefer_long_literal_suffix", knob.ConfigKey);
+        Assert.True(LensOptions.PreferLongLiteralSuffix);
+
+        // Not part of the "full taste" aggregate, since no value on the axis is endorsed.
+        Assert.False(StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default).PreferLongLiteralSuffix);
+    }
+
+    // ---- compile-back: the folded NL output round-trips ----
+
+    // Every specimen the fold fires on, with the harness signature that identifies it.
+    static readonly IReadOnlyList<(string Method, string Signature)> FoldedSpecimens =
+    [
+        (nameof(LongLiteralFoldFixture.TernaryArms), "(corelib:System.Boolean, corelib:System.Int64) -> corelib:System.Int64"),
+        (nameof(LongLiteralFoldFixture.SmallReturn), "() -> corelib:System.Int64"),
+        (nameof(LongLiteralFoldFixture.SmallArgument), "() -> corelib:System.Int64"),
+        (nameof(LongLiteralFoldFixture.BinaryOperand), "(corelib:System.Int64) -> corelib:System.Int64"),
+        (nameof(LongLiteralFoldFixture.NegativeBinaryOperand), "(corelib:System.Int64) -> corelib:System.Int64"),
+        (nameof(LongLiteralFoldFixture.Zero), "() -> corelib:System.Int64"),
+        (nameof(LongLiteralFoldFixture.MinusOne), "() -> corelib:System.Int64"),
+        (nameof(LongLiteralFoldFixture.IntMinValue), "() -> corelib:System.Int64"),
+        (nameof(LongLiteralFoldFixture.IntMaxValue), "() -> corelib:System.Int64"),
+    ];
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void FoldedOutput_CompilesBackExactly()
+    {
+        // The lens is byte-divergent as a CLASSIFICATION — a non-csc `ldc.i8 <small>`
+        // source would make `NL` and the source opcode disagree — but on csc output the
+        // fold is opcode-neutral, and that is the property this proves: the knob-on render
+        // recompiles to the original IL exactly, the same anchor the knob-off render earns.
+        // Measured with the product's own compile-back harness (the seam the byte-neutrality
+        // gate uses), never a harness-side reimplementation.
+        var targets = FoldedSpecimens
+            .Select(s => new FidelityCheck.CompileBackTarget(
+                AssemblyPath, typeof(LongLiteralFoldFixture).FullName!, s.Method, Overload: 0, Signature: s.Signature))
+            .ToArray();
+
+        var off = Evaluate(targets, options: null);
+        var on = Evaluate(targets, LensOptions);
+
+        foreach (var (method, _) in FoldedSpecimens)
+        {
+            Assert.True(off[method].Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{method}: knob-off compile-back is {off[method].Status} ({off[method].Detail}); the baseline anchor must be Exact.");
+            Assert.True(on[method].Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{method}: knob-on compile-back is {on[method].Status} ({on[method].Detail}); the folded NL literal did not round-trip.");
+
+            // Byte identity of the two recompiled bodies, so "both Exact" cannot be two
+            // different exactness verdicts against different originals.
+            Assert.Equal(off[method].RecompiledOpcodes, on[method].RecompiledOpcodes);
+        }
+
+        // Non-vacuity: the knob-on renders must actually differ from knob-off, otherwise
+        // this would be comparing a render with itself.
+        Assert.All(FoldedSpecimens, s => Assert.NotEqual(Fixture(s.Method), Fixture(s.Method, LensOptions)));
+    }
+
+    static IReadOnlyDictionary<string, FidelityCheck.CompileBackResult> Evaluate(
+        IReadOnlyList<FidelityCheck.CompileBackTarget> targets, PrinterOptions? options)
+        => FidelityCheck.EvaluateTargets([AssemblyPath], targets, lowered: false, options)
+            .ToDictionary(r => r.Method, r => r, StringComparer.Ordinal);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1007,6 +1007,17 @@ public sealed partial class CSharpPrinter
         // so demand the next-tighter level there. The left side can associate
         // bare at equal precedence (`(a - b) - c`).
         var demand = rightSide ? TighterThan(parentPrecedence) : parentPrecedence;
+        // The long-literal lens (#3347) at an operator operand. The folded literal
+        // carries its own precedence — Primary for `10L`, Unary for `-1L`, the same
+        // level the `(long)-1` cast it replaces reports — so the demand still decides
+        // the parentheses and no context can misbind.
+        if (TryLongLiteralText(operand) is { } longOperandLiteral)
+        {
+            return new Rendered(
+                longOperandLiteral,
+                longOperandLiteral[0] == '-' ? Precedence.Unary : Precedence.Primary).At(demand);
+        }
+
         return RenderedExpression(operand).At(demand);
     }
 
@@ -1751,6 +1762,12 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string CoerceText(IrExpression value, TypeRef? target)
     {
+        // The long-literal lens (#3347) at a value sink — a return, an argument, an
+        // assignment, a field/array store, a box. Gated on an Int64 sink so the fold
+        // only ever replaces a rendering that was already the bare `(long)N` cast;
+        // a wider or differently-typed sink keeps whichever coercion cast it needs.
+        if (IsCoreInt64(target) && TryLongLiteralText(value) is { } longSinkLiteral)
+            return longSinkLiteral;
         if (target is { } nativeTarget
             && IsNativeInteger(nativeTarget)
             && AddressOfValue(value) is { } address)
@@ -2110,7 +2127,15 @@ public sealed partial class CSharpPrinter
             && IsBooleanLike(conditional.WhenTrue);
 
     string ConditionalArm(IrExpression arm, TypeRef? target, TypeRef? primitiveCoercionSourceType = null, bool joinHasExactTypedArm = true)
-        => target is { } charTarget && IsCoreChar(charTarget) && TryCharConstantText(arm, out var charText)
+        // The long-literal lens (#3347). Only at a join whose target is Int64 or
+        // neutralized (EffectiveJoinTarget returns null when the arms already render
+        // bare at the target — the reference witness's case): the folded literal is
+        // long-typed exactly as the `(long)N` cast it replaces, so the join's natural
+        // type is unchanged. A join distributing some OTHER target still needs its own
+        // coercion cast and falls through untouched.
+        => (target is null || IsCoreInt64(target)) && TryLongLiteralText(arm) is { } longArmLiteral
+            ? longArmLiteral
+            : target is { } charTarget && IsCoreChar(charTarget) && TryCharConstantText(arm, out var charText)
             ? charText
             // An integer arm flowing into an enum-typed conditional (`ci ? 4 : raw`
             // into StringComparison) is CS0266 — int does not convert to the enum.
@@ -2389,6 +2414,47 @@ public sealed partial class CSharpPrinter
 
     static bool IsCoreChar(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Char" };
+
+    static bool IsCoreInt64(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Int64" };
+
+    /// <summary>
+    /// The opt-in long-literal fold (#3347), gated on
+    /// <see cref="PrinterOptions.PreferLongLiteralSuffix"/>: the <c>NL</c> spelling
+    /// of a <c>Convert(→Int64, Int32 Constant)</c> — the IR shape csc's
+    /// <c>ldc.i4(.s) N; conv.i8</c> produces for every small <c>long</c> literal —
+    /// or <see langword="null"/> when the lens is off or the node does not qualify.
+    /// Returns a bare literal, so the caller may place it wherever it would have
+    /// placed the <c>(long)N</c> cast: <c>NL</c> is a primary expression and a
+    /// negative one is unary, exactly the cast's own precedence.
+    ///
+    /// <para>The opcode-fidelity guard is the node shape itself, not a heuristic. A
+    /// genuine <c>ldc.i8</c> reaches the printer as a bare <see cref="Constant"/>
+    /// carrying a <c>long</c> payload with no <see cref="Convert"/> over it, so it
+    /// cannot match here and keeps its current spelling with the lens on or off.
+    /// Only the plain widening <c>conv.i8</c> qualifies: <c>conv.ovf.i8</c>
+    /// (<see cref="Convert.IsChecked"/>) and the <c>.un</c> forms
+    /// (<see cref="Convert.IsUnsigned"/>) are distinct opcodes and are declined, as
+    /// is any operand that is not an <c>Int32</c>-typed constant — a bool, char, or
+    /// enum-retyped constant spells a keyword or a member name that a bare integer
+    /// literal would silently drop.</para>
+    /// </summary>
+    string? TryLongLiteralText(IrExpression expression)
+        => _options.PreferLongLiteralSuffix
+            && expression is Convert
+            {
+                IsChecked: false,
+                IsUnsigned: false,
+                Target: { } convertTarget,
+                Operand: Constant
+                {
+                    Value: int payload,
+                    Type: { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Int32" },
+                },
+            }
+            && IsCoreInt64(convertTarget)
+                ? $"{payload.ToString(System.Globalization.CultureInfo.InvariantCulture)}L"
+                : null;
 
     static bool TryCharConstantText(IrExpression expression, out string text)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -179,6 +179,27 @@ public sealed record PrinterOptions
     /// </summary>
     public bool PreferBranchlessBoolean { get; init; }
 
+    /// <summary>
+    /// When set, a <c>long</c> constant the IL spells <c>ldc.i4(.s) N; conv.i8</c> —
+    /// the widening the printer sees as <c>Convert(→Int64, Int32 Constant)</c>, and
+    /// the shape csc emits for every small <c>long</c> literal — renders as the
+    /// idiomatic <c>NL</c> literal (<c>10L</c>) instead of the <c>(long)N</c> cast
+    /// the default view spells (#3347). A raise-completeness gap, not a fidelity
+    /// gap: the cast is already opcode-faithful, it is simply not fully raised.
+    ///
+    /// <para>Like the guarded-return lenses this is a <b>byte-divergent</b> opt-in
+    /// <b>style lens</b>, and for a specific reason: the fold is opcode-neutral for
+    /// <em>csc</em> output (<c>10L</c> and <c>(long)10</c> compile to the same
+    /// <c>ldc.i4.s 10; conv.i8</c>), but a hand-authored or non-csc assembly may
+    /// encode the same value as <c>ldc.i8 &lt;small&gt;</c> — a distinct opcode —
+    /// and a blanket default fold would put the two shapes on one spelling. The
+    /// printer keeps them apart structurally: a genuine <c>ldc.i8</c> arrives as a
+    /// bare <c>Int64</c> <c>Constant</c> with no <c>Convert</c> over it, so it can
+    /// never match the fold and renders exactly as today with the lens on or off.
+    /// Off by default; the default view stays byte-faithful.</para>
+    /// </summary>
+    public bool PreferLongLiteralSuffix { get; init; }
+
     /// <summary>The shipped defaults — every knob off.</summary>
     public static PrinterOptions Default { get; } = new();
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -352,6 +352,16 @@ public static class StyleOptionCatalog
             with: static (o, v) => o with { QualifyEventAccess = v }),
         GuardedBooleanReturnStyle(),
         VarSpellingStyle(),
+        Boolean(
+            id: "prefer-long-literal-suffix",
+            title: "Long literal suffix (10L)",
+            summary: "Render a long constant the IL spells `ldc.i4(.s) N; conv.i8` as the idiomatic NL literal instead of the (long)N cast; a genuine ldc.i8 source keeps its current spelling.",
+            tier: StyleOptionTier.Lens,
+            byteDivergent: true,
+            oracleEndorsed: false,
+            configKey: "dotnet_inspect_style_prefer_long_literal_suffix",
+            get: static o => o.PreferLongLiteralSuffix,
+            with: static (o, v) => o with { PreferLongLiteralSuffix = v }),
     ];
 
     /// <summary>


### PR DESCRIPTION
- Fixes/advances #3347
- Changes: adds an opt-in, non-default C# taste lens that renders a `long`
  constant csc emits as `ldc.i4(.s) N; conv.i8` as the idiomatic `NL` literal
  (`(long)10` → `10L`) instead of the `(long)N` cast. Default output is
  unchanged.
- Card revision: `67d261f2`

## Change

> Should we accept this change?

**Conclusion:** **REVIEW** — the fold is structurally guarded (it can only match
`Convert(→Int64, Int32 Constant)`, never a genuine `ldc.i8`) and every folded
specimen compiles back `Exact`, but the lens records no `style-lens.*` decision,
so a byte-divergent-classified render is invisible to `-S "Applied Taste"` and
still gets interleaved IL in Annotated Source. See the review comment on this PR.

### Benchmark target

Benchmark target: this repository's decompiler fixture assembly,
`artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll`,
built at head `67d261f2`. The reference witness is the one #3347 names,
`CfgSampleClass.InlineArraySpanTernaryConditionValue`. The **same** fixture
binary is inspected by both the base and head tool builds, so the only variable
across Before/After is `dotnet-inspect` itself.

dotnet-inspect command:

```bash
dotnet-inspect member \
  --library artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll \
  CfgSampleClass -m InlineArraySpanTernaryConditionValue --all \
  -S "Decompiled Source"
```

The lens is off unless requested. The After (lens on) render below was taken in
a directory holding:

```ini
root = true
dotnet_inspect_style_prefer_long_literal_suffix = true
```

### Original source

Acquired with `-S "Original Source"` (SourceLink-backed C#) at head:

```csharp
public static long InlineArraySpanTernaryConditionValue(object a, object b)
    => (AnyObjectSpan([a, b]) ? 10L : 20L) + System.Environment.TickCount64;
```

The IL the two `long` constants compile to (`-S "IL"`), which is the shape the
fold keys on:

```il
IL_0029: brtrue.s     IL_0030
IL_002B: ldc.i4.s     20
IL_002D: conv.i8
IL_002E: br.s         IL_0033
IL_0030: ldc.i4.s     10
IL_0032: conv.i8
```

### Before

`-S "Decompiled Source"` at base `21c00743`:

```csharp
public static long InlineArraySpanTernaryConditionValue(object a, object b) => (AnyObjectSpan([a, b]) ? ((long)10) : ((long)20)) + Environment.TickCount64;
```

- Valid: True
- Correct: True
- IL fidelity: True — `-S "Fidelity Causes"` reports `No fidelity causes;
  decompiler fidelity is Full.`
- Taste applied: None (`-S "Applied Taste"`: no recorded style choices)
- Commit: `21c00743`

Already `Full` fidelity and opcode-faithful; the gap is raise-completeness, not
fidelity — `(long)10` is the cast spelling of a value C# spells `10L`.

### After

`-S "Decompiled Source"` at head `67d261f2` with
`dotnet_inspect_style_prefer_long_literal_suffix = true`:

```csharp
public static long InlineArraySpanTernaryConditionValue(object a, object b) => (AnyObjectSpan([a, b]) ? 10L : 20L) + Environment.TickCount64;
```

- Valid: True
- Correct: True
- IL fidelity: True for csc-emitted shapes — all nine folded specimens compile
  back `Exact` both lens-on and lens-off with **identical** recompiled opcodes,
  measured through the product harness (`FidelityCheck.EvaluateTargets` in
  `LongLiteralFoldTests.FoldedOutput_CompilesBackExactly`). This witness itself
  is not in the compile-back set (inline-array body); `-S "Fidelity Causes"`
  reports `Full` for it at head with the lens on.
- Taste applied: **None recorded — this is a defect, not a property.** The knob
  is registered `ByteDivergent = true`, and the two existing byte-divergent
  lenses emit a `style-lens.*` `DecompilerDecision` so `-S "Applied Taste"`
  can account for them; this lens emits none, so the section renders `No
  recorded style choices were applied to this member.` on the render above.
  A consequence follows in Annotated Source, which suppresses interleaved IL
  only when an applied byte-divergent lens is recorded: it renders the folded
  `10L` text *and* the original `ldc.i4.s 10; conv.i8` listing side by side with
  no taste annotation on the signature.
- Commit: `67d261f2`

The default view at head is byte-identical to Before — the opt-in contract:

```csharp
public static long InlineArraySpanTernaryConditionValue(object a, object b) => (AnyObjectSpan([a, b]) ? ((long)10) : ((long)20)) + Environment.TickCount64;
```

### Fully raised

The After (lens-on) decompilation is in the fully raised state: it is textually
identical to the authored original source expression, `(AnyObjectSpan([a, b]) ?
10L : 20L) + Environment.TickCount64`.

The default view deliberately stays at `(long)N`. That is the byte-faithful
default, not an unraised remainder: the fully raised endpoint here is reachable
only behind the opt-in lens, because a non-csc assembly can encode the same
value as `ldc.i8 <small>` — a distinct opcode that must keep the cast spelling.

## Evidence

Release build, base `21c00743` (Baseline) vs head `67d261f2` (Head). Both trees
built with `dotnet build dotnet-inspect.slnx -c Release` before the runs, so no
fixture assembly is missing.

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `LongLiteralFoldTests`: not present (added here) | `LongLiteralFoldTests`: 29 passed, 0 failed |
| Decompiler fast suite (`-trait- Speed=Slow`) | 4017 total, 0 failed | 4045 total, 0 failed |
| Decompiler `Area=Corpus` | 83 total, 0 failed | 83 total, 0 failed |
| Reduced fixture validity | not applicable (no raising change; printer-only fold) | not applicable |
| Reduced fixture fidelity | 9 specimens `Exact` (lens absent) | 9 specimens `Exact` lens-on **and** lens-off, identical recompiled opcodes |
| Real witness | `CfgSampleClass::InlineArraySpanTernaryConditionValue` renders `(long)10` | renders `10L` with the lens on; byte-identical to Baseline with the lens off |

No Baseline failures. An earlier draft of this description reported "three
pre-existing `GeneratedFixtureCatalogTests.*` failures"; that was an artifact of
running the suite after building only the test project (a fixture binary was
missing). After a full `dotnet-inspect.slnx` build, both ends are 0 failed.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the corpus renders with `PrinterOptions.Default`, in
which `PreferLongLiteralSuffix` is `false`, and every touched printer path is
gated on that flag, so no corpus metric can move. Held up by measurement rather
than assertion on two sides: `Area=Corpus` is 83/0 failed at both ends, and
`LongLiteralFoldTests.Default_IsUnchanged` pins the exact default text of all
eleven fixture methods plus the reference witness
(`ReferenceWitness_Default_IsUnchanged`) against `PrinterOptions.Default` *and*
against "no options at all".

The quick-gate and aggregate metric tables are omitted for that reason: with the
default render provably unchanged, there is no delta to report.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -class "ILInspector.Decompiler.Tests.LongLiteralFoldTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -trait "Area=Corpus"
```

Fixes: #3347
Nightshift-Order: /plan/pilot/order/long-literal
