### PR TITLE
Raise inline-Current enumerator loops to foreach (#3164)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2106,6 +2106,30 @@ public class CfgSampleClass
         return sum;
     }
 
+    // Compiler foreach whose iteration variable is used exactly once, next to a
+    // second enumerator advanced manually in the loop body. csc hoists `x =
+    // e.Current` to the loop top, but because `x` is single-use and (in the
+    // absence of a source name) inlinable, ExpressionInliningPass can fold that
+    // store into its one use before ForeachStatementPass runs — leaving the
+    // hidden enumerator referenced only by MoveNext and one inline `e.Current`.
+    // This is the shape System.Text.Json.JsonElement.DeepEquals exhibits on its
+    // Array arm (#3164): the pass must still recover the foreach by rebinding the
+    // inline Current to a fresh iteration variable.
+    public static bool ForeachSingleUseWithParallelEnumerator(
+        System.Collections.Generic.List<int> a, System.Collections.Generic.List<int> b)
+    {
+        System.Collections.Generic.List<int>.Enumerator other = b.GetEnumerator();
+        foreach (int x in a)
+        {
+            other.MoveNext();
+            if (x != other.Current)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public ref struct RefStructResource
     {
         public RefStructResource(int value) => Value = value;

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -335,6 +335,18 @@ public class FidelityGateTests
         // JsonElement structs through one such temp but cannot itself be fed to the
         // compile-back oracle (internal System.Text.Json surface).
         "SwapStructPair",
+        // #3164: the inline-Current foreach. On its Array arm DeepEquals runs a
+        // compiler `foreach` whose single-use iteration variable csc hoists as
+        // `item = e.Current`; ExpressionInliningPass folds that store into its one
+        // use before ForeachStatementPass runs, so the hidden enumerator survives
+        // referenced only by MoveNext and one inline `e.Current`. The pass rebinds
+        // that inline read to a fresh foreach variable. Because the raised
+        // `foreach` re-lowers to csc's original hoist, the transform is
+        // opcode-exact — this pins it. Mirrors System.Text.Json.JsonElement.
+        // DeepEquals, whose Array arm iterates one enumerator by `foreach` while a
+        // second is advanced manually, but which cannot itself be fed to the
+        // compile-back oracle (internal System.Text.Json surface, #3197).
+        "ForeachSingleUseWithParallelEnumerator",
         // The compile-back oracle replays the fixture's runtime-async feature,
         // so these methods must retain the same lowering rather than merely
         // remaining recompilable.

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -570,6 +570,30 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void InlineCurrentForeach_ReadInsideTryAtBodyTop_StaysUsingWhile()
+    {
+        // Exception regions emit no IL of their own, so a hand-written
+        // `try { if (e.Current == 0) ... } catch { ... }` at the loop-body top has
+        // get_Current as the first *executable* instruction (offset == body top) —
+        // the offset check alone would accept it. But the read is protected by the
+        // handler; hoisting it to the foreach header moves get_Current out of the
+        // try, so a throwing enumerator would escape the loop instead of being
+        // caught. ReadOriginatesAtLoopBodyTop rejects a read wrapped in any
+        // try/catch/finally within the body. (A real foreach whose iteration
+        // variable is used inside a try must store it — the stack-cached inline
+        // form cannot cross the region boundary — so this declines no real
+        // foreach.)
+        var function = BuildInlineCurrentReadInTryLoop();
+
+        new ForeachStatementPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Single(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
     public void InlineCurrentForeach_UnconditionalCurrentReadInsideIfCondition_RaisesToForeach()
     {
         // Positive control for the guard: the same hidden-enumerator loop, but the
@@ -750,13 +774,22 @@ public class ForeachStatementPassTests
         // it in the body, so hoisting it to the loop top would reorder get_Current
         // ahead of that statement.
         AfterSideEffect,
+        // e.Current read is the first executable instruction of the body but sits
+        // inside a try, so hoisting it to the foreach header would move it out of
+        // the protected region — the offset is body-top but the region is metadata.
+        TryProtectedBodyTop,
     }
 
     static IrFunction BuildInlineCurrentEnumeratorLoop(InlineReadPlacement placement)
     {
+        // The loop body's first IL instruction sits at this offset; the guard
+        // compares the read's origin to the body block's import-stamped StartOffset.
+        const int BodyStart = 0x10;
+
         var intType = TypeRef.CoreLib("System", "Int32");
         var boolType = TypeRef.CoreLib("System", "Boolean");
         var voidType = TypeRef.CoreLib("System", "Void");
+        var exceptionType = TypeRef.CoreLib("System", "Exception");
         var collectionType = TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1");
         var enumeratorType = TypeRef.CoreLib("System.Collections.Generic", "IEnumerator`1");
         var ownerType = TypeRef.Definition("Synthetic", "Samples", "Owner");
@@ -769,8 +802,8 @@ public class ForeachStatementPassTests
         };
 
         // Stamp source offsets in emission order: the guard recovers foreach-header
-        // provenance from them (the read is a real header only when its subtree
-        // carries the minimum IL offset in the loop body).
+        // provenance from them (the read is a real header only when its subtree's
+        // minimum offset equals the loop body's entry offset).
         static T Stamp<T>(T node, int offset) where T : IrNode
         {
             node.SetSourceOffset(offset);
@@ -780,7 +813,7 @@ public class ForeachStatementPassTests
         LoadProperty CurrentRead(int receiverOffset)
             => Stamp(new LoadProperty(current, Stamp(new LoadLocal(0, enumeratorType), receiverOffset), []), receiverOffset + 1);
 
-        var loopBody = new Block();
+        var loopBody = new Block(BodyStart);
         switch (placement)
         {
             case InlineReadPlacement.BodyTop:
@@ -788,11 +821,11 @@ public class ForeachStatementPassTests
                 // in the body (in the `if`-condition), evaluated every iteration.
                 {
                     var thenArm = new Block();
-                    thenArm.Add(Stamp(new Return(Stamp(new Constant(1, boolType), 4)), 5));
+                    thenArm.Add(Stamp(new Return(Stamp(new Constant(1, boolType), BodyStart + 4)), BodyStart + 5));
                     loopBody.Add(Stamp(new IfStatement(
-                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(0), Stamp(new Constant(0, intType), 2)), 3),
+                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(BodyStart), Stamp(new Constant(0, intType), BodyStart + 2)), BodyStart + 3),
                         thenArm,
-                        null), 3));
+                        null), BodyStart + 3));
                 }
                 break;
 
@@ -801,11 +834,11 @@ public class ForeachStatementPassTests
                 // branch is taken, and is emitted after the probe comparison.
                 {
                     var thenArm = new Block();
-                    thenArm.Add(Stamp(new Return(CurrentRead(5)), 7));
+                    thenArm.Add(Stamp(new Return(CurrentRead(BodyStart + 5)), BodyStart + 7));
                     loopBody.Add(Stamp(new IfStatement(
-                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, Stamp(new LoadArgument(1, "probe", intType), 0), Stamp(new Constant(0, intType), 1)), 2),
+                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, Stamp(new LoadArgument(1, "probe", intType), BodyStart), Stamp(new Constant(0, intType), BodyStart + 1)), BodyStart + 2),
                         thenArm,
-                        null), 2));
+                        null), BodyStart + 2));
                 }
                 break;
 
@@ -814,13 +847,40 @@ public class ForeachStatementPassTests
                 // unconditional (in the `if`-condition) but a side-effecting call
                 // was emitted first, so get_Current is not the body's first op.
                 {
-                    loopBody.Add(Stamp(new ExpressionStatement(Stamp(new Call(sideEffect, isVirtual: false, []), 0)), 0));
+                    loopBody.Add(Stamp(new ExpressionStatement(Stamp(new Call(sideEffect, isVirtual: false, []), BodyStart)), BodyStart));
                     var thenArm = new Block();
-                    thenArm.Add(Stamp(new Return(Stamp(new Constant(1, boolType), 8)), 9));
+                    thenArm.Add(Stamp(new Return(Stamp(new Constant(1, boolType), BodyStart + 8)), BodyStart + 9));
                     loopBody.Add(Stamp(new IfStatement(
-                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(5), Stamp(new Constant(0, intType), 7)), 8),
+                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(BodyStart + 5), Stamp(new Constant(0, intType), BodyStart + 7)), BodyStart + 8),
                         thenArm,
-                        null), 8));
+                        null), BodyStart + 8));
+                }
+                break;
+
+            case InlineReadPlacement.TryProtectedBodyTop:
+                // try { if (e.Current == 0) return true; } catch { return false; }
+                // — get_Current is the first executable instruction (offset ==
+                // body top), but it is inside the try's protected region, which
+                // emits no IL of its own. Hoisting it to the foreach header would
+                // move it out of the handler's scope.
+                {
+                    var thenArm = new Block();
+                    thenArm.Add(Stamp(new Return(Stamp(new Constant(1, boolType), BodyStart + 4)), BodyStart + 5));
+                    var tryInner = new Block(BodyStart);
+                    tryInner.Add(Stamp(new IfStatement(
+                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(BodyStart), Stamp(new Constant(0, intType), BodyStart + 2)), BodyStart + 3),
+                        thenArm,
+                        null), BodyStart + 3));
+                    var tryBody = new BlockContainer();
+                    tryBody.Add(tryInner);
+
+                    var catchInner = new Block(BodyStart + 0x10);
+                    catchInner.Add(Stamp(new Return(Stamp(new Constant(0, boolType), BodyStart + 0x11)), BodyStart + 0x12));
+                    var catchBody = new BlockContainer();
+                    catchBody.Add(catchInner);
+                    var catchClause = new CatchClause(exceptionType, catchBody);
+
+                    loopBody.Add(Stamp(new TryCatch(tryBody, [catchClause]), BodyStart));
                 }
                 break;
         }
@@ -850,6 +910,9 @@ public class ForeachStatementPassTests
 
     static IrFunction BuildInlineCurrentReadAfterSideEffectLoop()
         => BuildInlineCurrentEnumeratorLoop(InlineReadPlacement.AfterSideEffect);
+
+    static IrFunction BuildInlineCurrentReadInTryLoop()
+        => BuildInlineCurrentEnumeratorLoop(InlineReadPlacement.TryProtectedBodyTop);
 
     static IrFunction BuildStructCollectionEnumeratorUsingWhile()
     {

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -530,13 +530,36 @@ public class ForeachStatementPassTests
         // reached conditionally (here, inside an `if`-then), the shape a
         // hand-written `while` produces when it reads Current only some
         // iterations — e.g. Enumerable.ElementAt's `if (index == 0) return
-        // e.Current;`. Re-hoisting that read to a foreach header would run
+        // e.Current;`. csc emits that read after the branch test, so its source
+        // offset is not the loop body's minimum; ReadOriginatesAtLoopBodyTop
+        // therefore declines it. Re-hoisting it to a foreach header would run
         // get_Current every iteration, changing how often it executes (and, for a
         // throwing/side-effecting enumerator, observable behavior). The
         // enumerator is a hidden slot over a supported IEnumerable<int>, so the
         // symbol/collection gate passes and the decision rests entirely on the
-        // unconditional-read guard.
+        // provenance guard.
         var function = BuildInlineConditionalCurrentEnumeratorLoop();
+
+        new ForeachStatementPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Single(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
+    public void InlineCurrentForeach_UnconditionalReadAfterSideEffect_StaysUsingWhile()
+    {
+        // Reorder guard: the single `e.Current` read is unconditional (it sits in
+        // the loop-body `if`-*condition*, evaluated every iteration), so a
+        // frequency-only check would wrongly accept it — but a side-effecting
+        // `SideEffect()` call was emitted before it. Hoisting get_Current to the
+        // foreach header would move it ahead of that call, changing their order
+        // (observable if either throws or mutates shared state). The read's source
+        // offset is not the loop body's minimum (the call's is), so
+        // ReadOriginatesAtLoopBodyTop declines and the loop stays lowered.
+        var function = BuildInlineCurrentReadAfterSideEffectLoop();
 
         new ForeachStatementPass().Run(function, PassContext.None);
         function.CheckInvariant();
@@ -550,9 +573,10 @@ public class ForeachStatementPassTests
     public void InlineCurrentForeach_UnconditionalCurrentReadInsideIfCondition_RaisesToForeach()
     {
         // Positive control for the guard: the same hidden-enumerator loop, but the
-        // single `e.Current` read sits in the loop-body `if`-*condition*, which is
-        // evaluated on every iteration. That is unconditional, so the raise is
-        // sound and the inline matcher recovers the foreach.
+        // single `e.Current` read sits in the loop-body `if`-*condition* as the
+        // first operation, so its source offset is the loop body's minimum — the
+        // provenance of a real foreach header. The inline matcher recovers the
+        // foreach.
         var function = BuildInlineUnconditionalCurrentEnumeratorLoop();
 
         new ForeachStatementPass().Run(function, PassContext.None);
@@ -716,43 +740,89 @@ public class ForeachStatementPassTests
     // <paramref name="conditional"/> is false the read instead sits in the
     // loop-body `if`-condition (evaluated every iteration), the safe shape the
     // matcher raises.
-    static IrFunction BuildInlineCurrentEnumeratorLoop(bool conditional)
+    enum InlineReadPlacement
+    {
+        // e.Current read is the first operation of the loop body (foreach header).
+        BodyTop,
+        // e.Current read sits inside an `if`-then, reached only some iterations.
+        ConditionalThen,
+        // e.Current read is unconditional but a side-effecting statement precedes
+        // it in the body, so hoisting it to the loop top would reorder get_Current
+        // ahead of that statement.
+        AfterSideEffect,
+    }
+
+    static IrFunction BuildInlineCurrentEnumeratorLoop(InlineReadPlacement placement)
     {
         var intType = TypeRef.CoreLib("System", "Int32");
         var boolType = TypeRef.CoreLib("System", "Boolean");
+        var voidType = TypeRef.CoreLib("System", "Void");
         var collectionType = TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1");
         var enumeratorType = TypeRef.CoreLib("System.Collections.Generic", "IEnumerator`1");
+        var ownerType = TypeRef.Definition("Synthetic", "Samples", "Owner");
         var getEnumerator = new MethodRef(collectionType, "GetEnumerator", enumeratorType, [], HasThis: true);
         var moveNext = new MethodRef(enumeratorType, "MoveNext", boolType, [], HasThis: true);
+        var sideEffect = new MethodRef(ownerType, "SideEffect", voidType, [], HasThis: false);
         var current = new MethodRef(enumeratorType, "get_Current", intType, [], HasThis: true)
         {
             IsSpecialName = true,
         };
 
-        IrExpression CurrentRead() => new LoadProperty(current, new LoadLocal(0, enumeratorType), []);
+        // Stamp source offsets in emission order: the guard recovers foreach-header
+        // provenance from them (the read is a real header only when its subtree
+        // carries the minimum IL offset in the loop body).
+        static T Stamp<T>(T node, int offset) where T : IrNode
+        {
+            node.SetSourceOffset(offset);
+            return node;
+        }
+
+        LoadProperty CurrentRead(int receiverOffset)
+            => Stamp(new LoadProperty(current, Stamp(new LoadLocal(0, enumeratorType), receiverOffset), []), receiverOffset + 1);
 
         var loopBody = new Block();
-        if (conditional)
+        switch (placement)
         {
-            // if (probe == 0) return e.Current;  — the read runs only when the
-            // branch is taken.
-            var thenArm = new Block();
-            thenArm.Add(new Return(CurrentRead()));
-            loopBody.Add(new IfStatement(
-                new Comparison(ComparisonKind.Equal, isUnsigned: false, new LoadArgument(1, "probe", intType), new Constant(0, intType)),
-                thenArm,
-                null));
-        }
-        else
-        {
-            // if (e.Current == 0) return true;  — the read is in the condition,
-            // evaluated every iteration.
-            var thenArm = new Block();
-            thenArm.Add(new Return(new Constant(1, boolType)));
-            loopBody.Add(new IfStatement(
-                new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(), new Constant(0, intType)),
-                thenArm,
-                null));
+            case InlineReadPlacement.BodyTop:
+                // if (e.Current == 0) return true;  — the read is the first thing
+                // in the body (in the `if`-condition), evaluated every iteration.
+                {
+                    var thenArm = new Block();
+                    thenArm.Add(Stamp(new Return(Stamp(new Constant(1, boolType), 4)), 5));
+                    loopBody.Add(Stamp(new IfStatement(
+                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(0), Stamp(new Constant(0, intType), 2)), 3),
+                        thenArm,
+                        null), 3));
+                }
+                break;
+
+            case InlineReadPlacement.ConditionalThen:
+                // if (probe == 0) return e.Current;  — the read runs only when the
+                // branch is taken, and is emitted after the probe comparison.
+                {
+                    var thenArm = new Block();
+                    thenArm.Add(Stamp(new Return(CurrentRead(5)), 7));
+                    loopBody.Add(Stamp(new IfStatement(
+                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, Stamp(new LoadArgument(1, "probe", intType), 0), Stamp(new Constant(0, intType), 1)), 2),
+                        thenArm,
+                        null), 2));
+                }
+                break;
+
+            case InlineReadPlacement.AfterSideEffect:
+                // SideEffect(); if (e.Current == 0) return true;  — the read is
+                // unconditional (in the `if`-condition) but a side-effecting call
+                // was emitted first, so get_Current is not the body's first op.
+                {
+                    loopBody.Add(Stamp(new ExpressionStatement(Stamp(new Call(sideEffect, isVirtual: false, []), 0)), 0));
+                    var thenArm = new Block();
+                    thenArm.Add(Stamp(new Return(Stamp(new Constant(1, boolType), 8)), 9));
+                    loopBody.Add(Stamp(new IfStatement(
+                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(5), Stamp(new Constant(0, intType), 7)), 8),
+                        thenArm,
+                        null), 8));
+                }
+                break;
         }
 
         var usingBody = new BlockContainer();
@@ -766,17 +836,20 @@ public class ForeachStatementPassTests
         body.Add(entry);
         return new IrFunction(
             "M",
-            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            ownerType,
             new MethodSignature(boolType, [new Parameter("items", collectionType), new Parameter("probe", intType)], HasThis: false, GenericParameterCount: 0),
             [enumeratorType],
             body);
     }
 
     static IrFunction BuildInlineConditionalCurrentEnumeratorLoop()
-        => BuildInlineCurrentEnumeratorLoop(conditional: true);
+        => BuildInlineCurrentEnumeratorLoop(InlineReadPlacement.ConditionalThen);
 
     static IrFunction BuildInlineUnconditionalCurrentEnumeratorLoop()
-        => BuildInlineCurrentEnumeratorLoop(conditional: false);
+        => BuildInlineCurrentEnumeratorLoop(InlineReadPlacement.BodyTop);
+
+    static IrFunction BuildInlineCurrentReadAfterSideEffectLoop()
+        => BuildInlineCurrentEnumeratorLoop(InlineReadPlacement.AfterSideEffect);
 
     static IrFunction BuildStructCollectionEnumeratorUsingWhile()
     {

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -570,6 +570,28 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void InlineCurrentForeach_ReadInsideNestedLoopAtBodyTop_StaysUsingWhile()
+    {
+        // A nested loop contributes no distinguishing leading IL, so a
+        // `do { if (e.Current == 0) ... } while (...)` at the loop-body top has
+        // get_Current as the first executable instruction (offset == body top) —
+        // the offset check alone would accept it. But the read runs once per inner
+        // iteration, i.e. many times per outer iteration; hoisting it to the
+        // foreach header would run it exactly once, changing execution count.
+        // ReadOriginatesAtLoopBodyTop rejects a read wrapped in any nested loop.
+        // (A real foreach whose iteration variable is used inside a nested loop
+        // must store it — the stack-cached inline form cannot cross the loop
+        // boundary — so this declines no real foreach.)
+        var function = BuildInlineCurrentReadInNestedLoop();
+
+        new ForeachStatementPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Single(function.Descendants.OfType<UsingStatement>());
+    }
+
+    [Fact]
     public void InlineCurrentForeach_ReadInsideTryAtBodyTop_StaysUsingWhile()
     {
         // Exception regions emit no IL of their own, so a hand-written
@@ -778,6 +800,10 @@ public class ForeachStatementPassTests
         // inside a try, so hoisting it to the foreach header would move it out of
         // the protected region — the offset is body-top but the region is metadata.
         TryProtectedBodyTop,
+        // e.Current read is the first executable instruction of the body but sits
+        // inside a nested do-loop at the body top, so it runs many times per outer
+        // iteration; hoisting to the header would run it once.
+        NestedLoopBodyTop,
     }
 
     static IrFunction BuildInlineCurrentEnumeratorLoop(InlineReadPlacement placement)
@@ -883,6 +909,26 @@ public class ForeachStatementPassTests
                     loopBody.Add(Stamp(new TryCatch(tryBody, [catchClause]), BodyStart));
                 }
                 break;
+
+            case InlineReadPlacement.NestedLoopBodyTop:
+                // do { if (e.Current == 0) return true; } while (probe == 0);
+                // — get_Current is the first executable instruction (offset ==
+                // body top), but it is inside a nested do-loop, so it runs once
+                // per inner iteration, many times per outer iteration.
+                {
+                    var thenArm = new Block();
+                    thenArm.Add(Stamp(new Return(Stamp(new Constant(1, boolType), BodyStart + 4)), BodyStart + 5));
+                    var doInner = new Block(BodyStart);
+                    doInner.Add(Stamp(new IfStatement(
+                        Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(BodyStart), Stamp(new Constant(0, intType), BodyStart + 2)), BodyStart + 3),
+                        thenArm,
+                        null), BodyStart + 3));
+                    var doBody = new BlockContainer();
+                    doBody.Add(doInner);
+                    var condition = Stamp(new Comparison(ComparisonKind.Equal, isUnsigned: false, Stamp(new LoadArgument(1, "probe", intType), BodyStart + 8), Stamp(new Constant(0, intType), BodyStart + 9)), BodyStart + 10);
+                    loopBody.Add(Stamp(new DoWhileLoop(doBody, condition), BodyStart));
+                }
+                break;
         }
 
         var usingBody = new BlockContainer();
@@ -913,6 +959,9 @@ public class ForeachStatementPassTests
 
     static IrFunction BuildInlineCurrentReadInTryLoop()
         => BuildInlineCurrentEnumeratorLoop(InlineReadPlacement.TryProtectedBodyTop);
+
+    static IrFunction BuildInlineCurrentReadInNestedLoop()
+        => BuildInlineCurrentEnumeratorLoop(InlineReadPlacement.NestedLoopBodyTop);
 
     static IrFunction BuildStructCollectionEnumeratorUsingWhile()
     {

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -524,6 +524,46 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void InlineCurrentForeach_ConditionalCurrentRead_StaysUsingWhile()
+    {
+        // The inline matcher must decline a loop whose single `e.Current` read is
+        // reached conditionally (here, inside an `if`-then), the shape a
+        // hand-written `while` produces when it reads Current only some
+        // iterations — e.g. Enumerable.ElementAt's `if (index == 0) return
+        // e.Current;`. Re-hoisting that read to a foreach header would run
+        // get_Current every iteration, changing how often it executes (and, for a
+        // throwing/side-effecting enumerator, observable behavior). The
+        // enumerator is a hidden slot over a supported IEnumerable<int>, so the
+        // symbol/collection gate passes and the decision rests entirely on the
+        // unconditional-read guard.
+        var function = BuildInlineConditionalCurrentEnumeratorLoop();
+
+        new ForeachStatementPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<ForeachStatement>());
+        Assert.Single(function.Descendants.OfType<UsingStatement>());
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
+    public void InlineCurrentForeach_UnconditionalCurrentReadInsideIfCondition_RaisesToForeach()
+    {
+        // Positive control for the guard: the same hidden-enumerator loop, but the
+        // single `e.Current` read sits in the loop-body `if`-*condition*, which is
+        // evaluated on every iteration. That is unconditional, so the raise is
+        // sound and the inline matcher recovers the foreach.
+        var function = BuildInlineUnconditionalCurrentEnumeratorLoop();
+
+        new ForeachStatementPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<ForeachStatement>());
+        Assert.Empty(function.Descendants.OfType<UsingStatement>());
+        Assert.Empty(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
     public void HandWrittenEnumeratorUsingLoop_WithoutSymbols_StaysUsingWhile()
     {
         var function = RaisedWithoutSymbols(nameof(CfgSampleClass.StructUsing));
@@ -668,6 +708,75 @@ public class ForeachStatementPassTests
             [enumeratorType, intType],
             body);
     }
+
+    // A compiler foreach over IEnumerable<int> whose single-use iteration
+    // variable's `e.Current` read was inlined by ExpressionInliningPass — but
+    // into an `if` branch, so the read is reached only some iterations. Models
+    // the Enumerable.ElementAt shape the inline matcher must decline. When
+    // <paramref name="conditional"/> is false the read instead sits in the
+    // loop-body `if`-condition (evaluated every iteration), the safe shape the
+    // matcher raises.
+    static IrFunction BuildInlineCurrentEnumeratorLoop(bool conditional)
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var collectionType = TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1");
+        var enumeratorType = TypeRef.CoreLib("System.Collections.Generic", "IEnumerator`1");
+        var getEnumerator = new MethodRef(collectionType, "GetEnumerator", enumeratorType, [], HasThis: true);
+        var moveNext = new MethodRef(enumeratorType, "MoveNext", boolType, [], HasThis: true);
+        var current = new MethodRef(enumeratorType, "get_Current", intType, [], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+
+        IrExpression CurrentRead() => new LoadProperty(current, new LoadLocal(0, enumeratorType), []);
+
+        var loopBody = new Block();
+        if (conditional)
+        {
+            // if (probe == 0) return e.Current;  — the read runs only when the
+            // branch is taken.
+            var thenArm = new Block();
+            thenArm.Add(new Return(CurrentRead()));
+            loopBody.Add(new IfStatement(
+                new Comparison(ComparisonKind.Equal, isUnsigned: false, new LoadArgument(1, "probe", intType), new Constant(0, intType)),
+                thenArm,
+                null));
+        }
+        else
+        {
+            // if (e.Current == 0) return true;  — the read is in the condition,
+            // evaluated every iteration.
+            var thenArm = new Block();
+            thenArm.Add(new Return(new Constant(1, boolType)));
+            loopBody.Add(new IfStatement(
+                new Comparison(ComparisonKind.Equal, isUnsigned: false, CurrentRead(), new Constant(0, intType)),
+                thenArm,
+                null));
+        }
+
+        var usingBody = new BlockContainer();
+        var usingBlock = new Block();
+        usingBlock.Add(new WhileLoop(new Call(moveNext, isVirtual: true, [new LoadLocal(0, enumeratorType)]), loopBody));
+        usingBody.Add(usingBlock);
+
+        var entry = new Block();
+        entry.Add(new UsingStatement(0, enumeratorType, new Call(getEnumerator, isVirtual: true, [new LoadArgument(0, "items", collectionType)]), usingBody));
+        var body = new BlockContainer();
+        body.Add(entry);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(boolType, [new Parameter("items", collectionType), new Parameter("probe", intType)], HasThis: false, GenericParameterCount: 0),
+            [enumeratorType],
+            body);
+    }
+
+    static IrFunction BuildInlineConditionalCurrentEnumeratorLoop()
+        => BuildInlineCurrentEnumeratorLoop(conditional: true);
+
+    static IrFunction BuildInlineUnconditionalCurrentEnumeratorLoop()
+        => BuildInlineCurrentEnumeratorLoop(conditional: false);
 
     static IrFunction BuildStructCollectionEnumeratorUsingWhile()
     {

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -472,6 +472,58 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void InlineCurrentForeach_RaisesToForeach()
+    {
+        // The single-use iteration variable is folded into its one use by
+        // ExpressionInliningPass before this pass runs, so no `item = e.Current`
+        // store survives — the hidden enumerator is referenced only by MoveNext
+        // and one inline `e.Current`. The pass rebinds that inline read to a
+        // fresh foreach variable. (JsonElement.DeepEquals Array arm, #3164.)
+        var function = Raised(nameof(CfgSampleClass.ForeachSingleUseWithParallelEnumerator));
+
+        var foreachStatement = Assert.Single(function.Descendants.OfType<ForeachStatement>());
+        Assert.Equal("int", foreachStatement.LocalType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<UsingStatement>());
+        // Only the manually advanced parallel enumerator's while loop is gone;
+        // the foreach replaced the compiler loop, leaving no WhileLoop behind.
+        Assert.Empty(function.Descendants.OfType<WhileLoop>());
+        Assert.Contains(foreachStatement.ConsumedMemberRefs, method => method.Name == "get_Current");
+        Assert.Contains(foreachStatement.ConsumedMemberRefs, method => method.Name == "MoveNext");
+    }
+
+    [Fact]
+    public void InlineCurrentForeach_PrintRaised_RendersForeachWithInlineCurrentRebound()
+    {
+        var output = CSharpPrinter.Print(
+            Raised(nameof(CfgSampleClass.ForeachSingleUseWithParallelEnumerator))).Output;
+
+        Assert.NotNull(output);
+        // The foreach header binds a fresh variable and the inline use is rebound
+        // to it; the parallel manual enumerator keeps its own MoveNext/Current.
+        Assert.Contains("foreach (int ", output);
+        Assert.Contains("in a)", output);
+        Assert.Contains("other.MoveNext();", output);
+        // No compiler enumerator loop survives: the foreach's own
+        // GetEnumerator/MoveNext are consumed (the parallel `other` enumerator
+        // keeps its own, which is expected).
+        Assert.DoesNotContain("using (", output);
+        Assert.DoesNotContain(".MoveNext())", output);
+    }
+
+    [Fact]
+    public void InlineCurrentForeach_WithoutSymbols_StaysUsingWhile()
+    {
+        // Same discriminator as the hoisted enumerator form: without the hidden
+        // enumerator slot the compiler foreach cannot be told from a hand-written
+        // using/while, so it declines and the loop stays lowered.
+        var function = RaisedWithoutSymbols(
+            nameof(CfgSampleClass.ForeachSingleUseWithParallelEnumerator));
+
+        Assert.DoesNotContain(function.Descendants.OfType<ForeachStatement>(), _ => true);
+        Assert.Single(function.Descendants.OfType<UsingStatement>());
+    }
+
+    [Fact]
     public void HandWrittenEnumeratorUsingLoop_WithoutSymbols_StaysUsingWhile()
     {
         var function = RaisedWithoutSymbols(nameof(CfgSampleClass.StructUsing));

--- a/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringDiagnosticsTests.cs
@@ -231,9 +231,13 @@ public class StructuringDiagnosticsTests
     [Fact]
     public void EarlyBreakFromInnerTry_RaisesWithoutLeaveGoto()
     {
-        // The readability win: the inner try body and its post-finally
-        // continuation structure without either flat goto soup or a surviving
-        // `goto ...; // leave`.
+        // The readability win: the inner enumerator's try/finally (the foreach
+        // Dispose) and its post-finally continuation structure without either flat
+        // goto soup or a surviving `goto ...; // leave`. Both the outer and inner
+        // loops are genuine compiler foreach loops whose single-use iteration
+        // variable is read unconditionally at the body top, so ForeachStatementPass
+        // (#3164) now recovers both: the inner loop no longer stays a
+        // `using`/`while (e.MoveNext())` enumerator loop.
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.AllOuterMatchInner));
         Assert.NotNull(function);
@@ -243,7 +247,8 @@ public class StructuringDiagnosticsTests
         Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
 
         var output = result.Output!.ReplaceLineEndings("\n");
-        Assert.Contains("while (", output);
+        Assert.Equal(2, output.Split("foreach (").Length - 1);
+        Assert.DoesNotContain("while (", output);
         Assert.DoesNotContain("// leave", output);
     }
 

--- a/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
@@ -20,6 +20,10 @@ public class SubstratePredicateCensusTests
             "Pass-local side-effect-free place equality composing PlaceIdentity.SameOperand/SameStackSlot with field-rooted recursion, for the user-defined ++/-- self-update lvalue.",
         [new("ExpressionInliningPass.cs", "IsInsideCatchFilter")] =
             "Inlining-specific EH guard that first finds the containing catch clause before using ReferenceOwnership.IsInside on its filter.",
+        [new("ForeachStatementPass.cs", "IsInsideNestedFunction")] =
+            "Foreach-recovery guard: an ancestor-kind scan that declines an inline Current read nested in a Lambda/LocalFunctionStatement within the loop body, since such a read is not the enclosing loop's foreach header. Node-kind ancestor containment, distinct from ReferenceOwnership.IsInside place/subtree identity.",
+        [new("ForeachStatementPass.cs", "IsInsideNestedLoopOrExceptionRegion")] =
+            "Foreach-recovery guard: an ancestor-kind scan that declines an inline Current read wrapped in a nested loop or EH region between the read and the loop body. Such a region repeats or protects a body-top read invisibly to the Block.StartOffset ordering check, so it must be rejected structurally. Node-kind ancestor containment, distinct from ReferenceOwnership.IsInside.",
         [new("ExpressionInliningPass.cs", "SameRegions")] =
             "Inlining-specific EH range equality for candidate movement; the predicate is over function region spans, not IR identity.",
         [new("FixedArrayRaising.cs", "SameLoadPlace")] =

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -547,48 +547,39 @@ public sealed class ForeachStatementPass : IIrPass
         return false;
     }
 
-    // True iff <paramref name="node"/> is reached exactly once on every iteration
-    // of the loop whose body is <paramref name="loopBody"/> — i.e. control from
-    // the loop-body entry always flows through it, with no branch, nested loop,
-    // handler, or short-circuit that could skip or repeat it. Walk the ancestor
-    // chain to the body and reject the moment a step enters a conditional slot:
-    // an `if`/ternary arm (only the condition is unconditional), the right side
-    // of `&&`/`||`/`??`, a `?.` continuation, a switch section, a catch/finally,
-    // or any nested loop body/condition. Every other container (blocks,
-    // statements, and non-short-circuit expression operands) is straight-line, so
-    // reaching it keeps the node unconditional.
-    // The inline Current read is a genuine foreach header only when csc emitted
-    // its `get_Current` as the first operation of the loop body. We recover that
-    // provenance from source offsets (preserved through the Call→LoadProperty
-    // raise via InheritSourceOffset): the read's subtree must carry the *minimum*
-    // IL offset of every operation in the loop body's own scope — excluding
-    // nested lambdas/local functions, which run at a different time and carry
-    // their own offset space. If any sibling operation was emitted earlier — a
-    // preceding side-effecting statement, an `if`/`??=` guard, or ElementAt's
-    // conditional `return e.Current` — the read is not the minimum and we
-    // decline, because re-hoisting it to the loop top would move `get_Current`
-    // ahead of that operation, changing both how often it runs and its order
-    // (observable if either throws or mutates shared state). Requiring provenance
-    // at the body top preserves execution frequency and ordering at once, and
-    // fails closed when the read carries no offset.
+    // True iff the inline `e.Current` read is a genuine compiler foreach header:
+    // csc emits a foreach header's `get_Current` as the *first instruction of the
+    // loop body*, leaving the value live until the live-range inliner sinks it to
+    // its one use. We prove that origin from the loop body block's import-stamped
+    // entry offset (Block.StartOffset — the IL offset of its first instruction,
+    // fixed at import and immune to later passes that erase interior node
+    // offsets, e.g. NullCoalescingAssignmentPass dropping the `??=` null-check's
+    // offset): the read's subtree must carry exactly that entry offset. A
+    // conditional read (ElementAt's `if (index == 0) return e.Current;`), a `??=`
+    // read, or a read after any preceding statement starts later than the entry,
+    // so it is declined — re-hoisting it would move `get_Current` ahead of that
+    // operation, changing how often it runs and its order (observable if either
+    // throws or mutates shared state). Fails closed when the read carries no
+    // offset. Exception regions carry no IL of their own (they are pure PE
+    // metadata), so a hand-written `try { x = e.Current; }` at the body top has
+    // `get_Current` as the first *executable* instruction yet is protected by the
+    // handler; the offset check cannot see that, so we additionally reject a read
+    // wrapped in any try/catch/finally within the body. (A real foreach whose
+    // iteration variable is used inside a `try` must *store* it — crossing the
+    // region boundary forbids the stack-cached single-use form — so it takes the
+    // hoisted matcher, never this inline path; declining here loses no real
+    // foreach.) A read inside a nested lambda/local function runs at a different
+    // time, so it is excluded too.
     static bool ReadOriginatesAtLoopBodyTop(LoadProperty inlineCurrent, Block loopBody)
     {
+        if (IsInsideExceptionRegion(inlineCurrent, loopBody))
+            return false;
+
         int readMin = MinOffset(inlineCurrent);
         if (readMin == int.MaxValue)
             return false;
 
-        int bodyMin = int.MaxValue;
-        foreach (var node in loopBody.Descendants)
-        {
-            if (node.SourceOffset >= 0
-                && node.SourceOffset < bodyMin
-                && !IsInsideNestedFunction(node, loopBody))
-            {
-                bodyMin = node.SourceOffset;
-            }
-        }
-
-        return readMin == bodyMin;
+        return readMin == loopBody.StartOffset;
 
         static int MinOffset(IrNode node)
         {
@@ -598,6 +589,18 @@ public sealed class ForeachStatementPass : IIrPass
                     min = descendant.SourceOffset;
             return min;
         }
+    }
+
+    // Walk the ancestor chain from the read up to (but excluding) the loop body,
+    // reporting whether any step passes through an exception region. Such regions
+    // emit no IL, so an offset comparison alone cannot tell a body-top read that
+    // is protected by a handler from one that is not.
+    static bool IsInsideExceptionRegion(IrNode node, Block loopBody)
+    {
+        for (var current = node.Parent; current is not null && !ReferenceEquals(current, loopBody); current = current.Parent)
+            if (current is TryCatch or TryFinally or CatchClause)
+                return true;
+        return false;
     }
 
     sealed record PatternMatch(

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -100,10 +100,29 @@ public sealed class ForeachStatementPass : IIrPass
             var collection = match.Collection;
             if (collection.Parent is not null)
                 collection.Detach();
-            match.CurrentStore.Detach();
+
+            int localIndex;
+            if (match.HoistedCurrentStore is { } hoisted)
+            {
+                localIndex = hoisted.Index;
+                hoisted.Detach();
+            }
+            else
+            {
+                // The single-use iteration variable was folded into its one use
+                // before this pass ran (ExpressionInliningPass), so no `item =
+                // e.Current` store survives to carry the slot. Allocate a fresh
+                // foreach variable and rebind the inline Current read to it. The
+                // enumerator is advanced only by the loop condition, so the read
+                // is invariant across the body — hoisting it to the foreach
+                // header is the exact inverse of the earlier inline.
+                localIndex = function.AddLocal(match.LocalType);
+                match.InlineCurrent!.ReplaceWith(new LoadLocal(localIndex, match.LocalType));
+            }
+
             var body = match.Loop.Body;
             body.Detach();
-            var foreachStatement = new ForeachStatement(match.CurrentStore.Index, match.CurrentStore.Type, collection, body, match.ConsumedMemberRefs);
+            var foreachStatement = new ForeachStatement(localIndex, match.LocalType, collection, body, match.ConsumedMemberRefs);
             context.Stepper.StepOver("raise enumerator loop to foreach", usingStatement);
             usingStatement.ReplaceWith(foreachStatement);
         }
@@ -200,7 +219,9 @@ public sealed class ForeachStatementPass : IIrPass
     sealed record EnumeratorMatch(
         IrExpression Collection,
         WhileLoop Loop,
-        StoreLocal CurrentStore,
+        TypeRef LocalType,
+        StoreLocal? HoistedCurrentStore,
+        LoadProperty? InlineCurrent,
         ImmutableArray<MethodRef> ConsumedMemberRefs);
 
     sealed record AsyncEnumeratorMatch(
@@ -424,21 +445,91 @@ public sealed class ForeachStatementPass : IIrPass
         }
 
         if (usingStatement.Body.Blocks is not [{ Children: [WhileLoop loop] }]
-            || !IsMoveNextOn(loop.Condition, enumeratorIndex)
-            || loop.Body.Children is not [StoreLocal { Value: LoadProperty current } currentStore, ..]
-            || !IsCurrentOn(current, enumeratorIndex))
+            || !IsMoveNextOn(loop.Condition, enumeratorIndex))
         {
             return null;
         }
 
-        if (loop.Body.Children.Skip(1).Any(child => ReferencesLocal(child, enumeratorIndex)))
-            return null;
+        var moveNext = (Call)loop.Condition;
+        var collection = CollectionValue(getEnumerator.Arguments[0]);
 
-        return new EnumeratorMatch(
-            CollectionValue(getEnumerator.Arguments[0]),
-            loop,
-            currentStore,
-            [getEnumerator.Callee, ((Call)loop.Condition).Callee, current.Accessor, .. usingStatement.ConsumedMemberRefs]);
+        // Hoisted form: the loop body opens with `item = e.Current` — the
+        // canonical compiler foreach lowering — and the enumerator is otherwise
+        // unreferenced across the body.
+        if (loop.Body.Children is [StoreLocal { Value: LoadProperty current } currentStore, ..]
+            && IsCurrentOn(current, enumeratorIndex)
+            && !loop.Body.Children.Skip(1).Any(child => ReferencesLocal(child, enumeratorIndex)))
+        {
+            return new EnumeratorMatch(
+                collection,
+                loop,
+                currentStore.Type,
+                currentStore,
+                InlineCurrent: null,
+                [getEnumerator.Callee, moveNext.Callee, current.Accessor, .. usingStatement.ConsumedMemberRefs]);
+        }
+
+        // Inline form: the iteration variable was used exactly once, so
+        // ExpressionInliningPass folded its `item = e.Current` store into that use
+        // before this pass ran (e.g. JsonElement.DeepEquals, #3164). No hoisted
+        // store survives; the enumerator is then referenced only by the condition
+        // MoveNext and one `e.Current` read somewhere in the body. Because the
+        // enumerator is advanced only by the condition, that read is invariant
+        // across the body, so hoisting it back to a fresh foreach variable is the
+        // exact inverse of the inline. Require the single read to sit directly in
+        // the loop body (not inside a nested lambda/local function, where a
+        // hoist would change when it runs).
+        var currentReads = loop.Body.Descendants.OfType<LoadProperty>()
+            .Where(p => IsCurrentOn(p, enumeratorIndex))
+            .ToList();
+        if (currentReads is [var inlineCurrent]
+            && !IsInsideNestedFunction(inlineCurrent, loop.Body)
+            && EnumeratorReferencedOnlyWithinLoopBy(loop, enumeratorIndex, moveNext, inlineCurrent))
+        {
+            return new EnumeratorMatch(
+                collection,
+                loop,
+                inlineCurrent.Accessor.ReturnType,
+                HoistedCurrentStore: null,
+                inlineCurrent,
+                [getEnumerator.Callee, moveNext.Callee, inlineCurrent.Accessor, .. usingStatement.ConsumedMemberRefs]);
+        }
+
+        return null;
+    }
+
+    // Within the loop (condition + body), the enumerator slot may be referenced
+    // only by the MoveNext receiver and the single inline Current receiver — any
+    // other read/write means the slot is not pure foreach scaffolding.
+    static bool EnumeratorReferencedOnlyWithinLoopBy(
+        WhileLoop loop, int enumeratorIndex, Call moveNext, LoadProperty inlineCurrent)
+    {
+        var allowed = new HashSet<IrNode>(ReferenceEqualityComparer.Instance);
+        if (moveNext.Arguments is [var moveNextReceiver])
+            allowed.Add(moveNextReceiver);
+        if (inlineCurrent.Instance is { } currentReceiver)
+            allowed.Add(currentReceiver);
+        foreach (var node in loop.Descendants)
+        {
+            bool references = node switch
+            {
+                LoadLocal load => load.Index == enumeratorIndex,
+                LoadLocalAddress address => address.Index == enumeratorIndex,
+                StoreLocal store => store.Index == enumeratorIndex,
+                _ => false,
+            };
+            if (references && !allowed.Contains(node))
+                return false;
+        }
+        return true;
+    }
+
+    static bool IsInsideNestedFunction(IrNode node, Block boundary)
+    {
+        for (var current = node.Parent; current is not null && current != boundary; current = current.Parent)
+            if (current is Lambda or LocalFunctionStatement)
+                return true;
+        return false;
     }
 
     sealed record PatternMatch(

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -475,29 +475,30 @@ public sealed class ForeachStatementPass : IIrPass
         // store survives; the enumerator is then referenced only by the condition
         // MoveNext and one `e.Current` read somewhere in the body.
         //
-        // The single read must be evaluated *unconditionally on every iteration*
-        // for the raise to be sound. csc emits a foreach header's `get_Current`
-        // as the first thing in the loop body, leaving the value live across the
-        // rest of the iteration; the live-range inliner then sinks that read to
-        // its one use. Re-hoisting it to a fresh foreach variable at the loop top
-        // is the exact inverse of that sink and re-lowers opcode-identically —
-        // but only because the original read ran every iteration. A hand-written
-        // `while` that reads `e.Current` inside an `if` (so `get_Current` runs
-        // only some iterations — e.g. Enumerable.ElementAt's `if (index == 0)
-        // return e.Current;`) is byte-for-byte identical here after inlining, yet
-        // hoisting it to the loop top would run `get_Current` on every iteration,
-        // changing how often it executes (and, for a throwing/side-effecting
-        // enumerator, observable behavior). IsUnconditionalEveryIteration rejects
-        // any read nested under a branch, nested loop, switch section, handler,
-        // short-circuit, or ternary/`??`/`?.` arm within the body. Also require
-        // the read to sit outside any nested lambda/local function, where a hoist
-        // would change when it runs.
+        // The single read is only a real foreach header when csc emitted its
+        // `get_Current` as the *first operation of the loop body*, leaving the
+        // value live across the rest of the iteration; the live-range inliner
+        // then sinks that read to its one use. Re-hoisting it to a fresh foreach
+        // variable at the loop top is the exact inverse of that sink and
+        // re-lowers opcode-identically — but only because the original read ran
+        // first, every iteration. A hand-written `while` that reads `e.Current`
+        // later in the body — inside an `if` (e.g. Enumerable.ElementAt's
+        // `if (index == 0) return e.Current;`), on the right of `??=`, or after
+        // any preceding side-effecting statement — is byte-for-byte identical
+        // here after inlining, yet hoisting it to the loop top would change how
+        // often `get_Current` runs and reorder it ahead of those operations
+        // (observable if either throws or mutates shared state).
+        // ReadOriginatesAtLoopBodyTop recovers that provenance from source
+        // offsets: the read's subtree must carry the minimum IL offset of every
+        // operation in the loop body's own scope. Also require the read to sit
+        // outside any nested lambda/local function, where a hoist would change
+        // when it runs.
         var currentReads = loop.Body.Descendants.OfType<LoadProperty>()
             .Where(p => IsCurrentOn(p, enumeratorIndex))
             .ToList();
         if (currentReads is [var inlineCurrent]
             && !IsInsideNestedFunction(inlineCurrent, loop.Body)
-            && IsUnconditionalEveryIteration(inlineCurrent, loop.Body)
+            && ReadOriginatesAtLoopBodyTop(inlineCurrent, loop.Body)
             && EnumeratorReferencedOnlyWithinLoopBy(loop, enumeratorIndex, moveNext, inlineCurrent))
         {
             return new EnumeratorMatch(
@@ -556,41 +557,47 @@ public sealed class ForeachStatementPass : IIrPass
     // or any nested loop body/condition. Every other container (blocks,
     // statements, and non-short-circuit expression operands) is straight-line, so
     // reaching it keeps the node unconditional.
-    static bool IsUnconditionalEveryIteration(IrNode node, Block loopBody)
+    // The inline Current read is a genuine foreach header only when csc emitted
+    // its `get_Current` as the first operation of the loop body. We recover that
+    // provenance from source offsets (preserved through the Call→LoadProperty
+    // raise via InheritSourceOffset): the read's subtree must carry the *minimum*
+    // IL offset of every operation in the loop body's own scope — excluding
+    // nested lambdas/local functions, which run at a different time and carry
+    // their own offset space. If any sibling operation was emitted earlier — a
+    // preceding side-effecting statement, an `if`/`??=` guard, or ElementAt's
+    // conditional `return e.Current` — the read is not the minimum and we
+    // decline, because re-hoisting it to the loop top would move `get_Current`
+    // ahead of that operation, changing both how often it runs and its order
+    // (observable if either throws or mutates shared state). Requiring provenance
+    // at the body top preserves execution frequency and ordering at once, and
+    // fails closed when the read carries no offset.
+    static bool ReadOriginatesAtLoopBodyTop(LoadProperty inlineCurrent, Block loopBody)
     {
-        for (var current = node; current is not null; current = current.Parent)
-        {
-            var parent = current.Parent;
-            if (parent is null)
-                return false;
-            if (ReferenceEquals(parent, loopBody))
-                return true;
+        int readMin = MinOffset(inlineCurrent);
+        if (readMin == int.MaxValue)
+            return false;
 
-            switch (parent)
+        int bodyMin = int.MaxValue;
+        foreach (var node in loopBody.Descendants)
+        {
+            if (node.SourceOffset >= 0
+                && node.SourceOffset < bodyMin
+                && !IsInsideNestedFunction(node, loopBody))
             {
-                case IfStatement ifs when !ReferenceEquals(current, ifs.Condition):
-                    return false;
-                case Conditional cond when !ReferenceEquals(current, cond.Condition):
-                    return false;
-                case LogicalBinary logical when ReferenceEquals(current, logical.Right):
-                    return false;
-                case Coalesce coalesce when ReferenceEquals(current, coalesce.Right):
-                    return false;
-                case NullConditional:
-                case WhileLoop:
-                case DoWhileLoop:
-                case ForLoop:
-                case ForeachStatement:
-                case SwitchSection:
-                case TryCatch:
-                case TryFinally:
-                case CatchClause:
-                case Lambda:
-                case LocalFunctionStatement:
-                    return false;
+                bodyMin = node.SourceOffset;
             }
         }
-        return false;
+
+        return readMin == bodyMin;
+
+        static int MinOffset(IrNode node)
+        {
+            int min = node.SourceOffset >= 0 ? node.SourceOffset : int.MaxValue;
+            foreach (var descendant in node.Descendants)
+                if (descendant.SourceOffset >= 0 && descendant.SourceOffset < min)
+                    min = descendant.SourceOffset;
+            return min;
+        }
     }
 
     sealed record PatternMatch(

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -550,29 +550,41 @@ public sealed class ForeachStatementPass : IIrPass
     // True iff the inline `e.Current` read is a genuine compiler foreach header:
     // csc emits a foreach header's `get_Current` as the *first instruction of the
     // loop body*, leaving the value live until the live-range inliner sinks it to
-    // its one use. We prove that origin from the loop body block's import-stamped
-    // entry offset (Block.StartOffset — the IL offset of its first instruction,
-    // fixed at import and immune to later passes that erase interior node
-    // offsets, e.g. NullCoalescingAssignmentPass dropping the `??=` null-check's
-    // offset): the read's subtree must carry exactly that entry offset. A
-    // conditional read (ElementAt's `if (index == 0) return e.Current;`), a `??=`
-    // read, or a read after any preceding statement starts later than the entry,
-    // so it is declined — re-hoisting it would move `get_Current` ahead of that
-    // operation, changing how often it runs and its order (observable if either
-    // throws or mutates shared state). Fails closed when the read carries no
-    // offset. Exception regions carry no IL of their own (they are pure PE
-    // metadata), so a hand-written `try { x = e.Current; }` at the body top has
-    // `get_Current` as the first *executable* instruction yet is protected by the
-    // handler; the offset check cannot see that, so we additionally reject a read
-    // wrapped in any try/catch/finally within the body. (A real foreach whose
-    // iteration variable is used inside a `try` must *store* it — crossing the
-    // region boundary forbids the stack-cached single-use form — so it takes the
-    // hoisted matcher, never this inline path; declining here loses no real
-    // foreach.) A read inside a nested lambda/local function runs at a different
-    // time, so it is excluded too.
+    // its one use. Two conditions must hold, and neither alone is sufficient:
+    //
+    // Ordering — the read must originate at the body top. We prove that from the
+    // loop body block's import-stamped entry offset (Block.StartOffset, the IL
+    // offset of its first instruction, fixed at import and immune to later passes
+    // that erase interior node offsets — e.g. NullCoalescingAssignmentPass
+    // dropping the `??=` null-check's offset): the read's subtree must carry
+    // exactly that entry offset. A conditional read (ElementAt's `if (index == 0)
+    // return e.Current;`), a `??=` read, or a read after any preceding statement
+    // starts later than the entry and is declined — re-hoisting it would move
+    // `get_Current` ahead of that operation, changing its order (observable if
+    // either throws or mutates shared state). Fails closed when the read has no
+    // offset.
+    //
+    // Frequency and placement — being the first *instruction* does not by itself
+    // mean the read runs exactly once per iteration in an unprotected position,
+    // because two constructs contribute no distinguishing leading IL of their own:
+    //   * A nested loop whose body begins at the outer body top (`do { use(
+    //     e.Current); } while (...)`) makes the read the first instruction yet
+    //     runs it many times per outer iteration; hoisting to the header would run
+    //     it once.
+    //   * An exception region is pure PE metadata (`try { x = e.Current; }` at the
+    //     body top has `get_Current` first, but the handler protects it); hoisting
+    //     to the header moves the read out of the try, so a throwing enumerator
+    //     escapes instead of being caught.
+    // The offset check cannot see either, so we also reject a read wrapped in any
+    // nested loop or try/catch/finally within the body. (A real foreach whose
+    // iteration variable is used inside a nested loop or a `try` must *store* it —
+    // crossing that boundary forbids the stack-cached single-use form — so it
+    // takes the hoisted matcher, never this inline path; declining here loses no
+    // real foreach.) A read inside a nested lambda/local function is excluded at
+    // the call site for the same reason.
     static bool ReadOriginatesAtLoopBodyTop(LoadProperty inlineCurrent, Block loopBody)
     {
-        if (IsInsideExceptionRegion(inlineCurrent, loopBody))
+        if (IsInsideNestedLoopOrExceptionRegion(inlineCurrent, loopBody))
             return false;
 
         int readMin = MinOffset(inlineCurrent);
@@ -592,13 +604,16 @@ public sealed class ForeachStatementPass : IIrPass
     }
 
     // Walk the ancestor chain from the read up to (but excluding) the loop body,
-    // reporting whether any step passes through an exception region. Such regions
-    // emit no IL, so an offset comparison alone cannot tell a body-top read that
-    // is protected by a handler from one that is not.
-    static bool IsInsideExceptionRegion(IrNode node, Block loopBody)
+    // reporting whether any step passes through a nested loop or an exception
+    // region. A nested loop can execute a body-top read multiple times per outer
+    // iteration; an exception region (pure metadata, no IL of its own) protects or
+    // relocates it. Neither is visible to the body-top offset comparison, so both
+    // must be rejected structurally.
+    static bool IsInsideNestedLoopOrExceptionRegion(IrNode node, Block loopBody)
     {
         for (var current = node.Parent; current is not null && !ReferenceEquals(current, loopBody); current = current.Parent)
-            if (current is TryCatch or TryFinally or CatchClause)
+            if (current is WhileLoop or DoWhileLoop or ForLoop or ForeachStatement
+                or TryCatch or TryFinally or CatchClause)
                 return true;
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -473,17 +473,31 @@ public sealed class ForeachStatementPass : IIrPass
         // ExpressionInliningPass folded its `item = e.Current` store into that use
         // before this pass ran (e.g. JsonElement.DeepEquals, #3164). No hoisted
         // store survives; the enumerator is then referenced only by the condition
-        // MoveNext and one `e.Current` read somewhere in the body. Because the
-        // enumerator is advanced only by the condition, that read is invariant
-        // across the body, so hoisting it back to a fresh foreach variable is the
-        // exact inverse of the inline. Require the single read to sit directly in
-        // the loop body (not inside a nested lambda/local function, where a
-        // hoist would change when it runs).
+        // MoveNext and one `e.Current` read somewhere in the body.
+        //
+        // The single read must be evaluated *unconditionally on every iteration*
+        // for the raise to be sound. csc emits a foreach header's `get_Current`
+        // as the first thing in the loop body, leaving the value live across the
+        // rest of the iteration; the live-range inliner then sinks that read to
+        // its one use. Re-hoisting it to a fresh foreach variable at the loop top
+        // is the exact inverse of that sink and re-lowers opcode-identically —
+        // but only because the original read ran every iteration. A hand-written
+        // `while` that reads `e.Current` inside an `if` (so `get_Current` runs
+        // only some iterations — e.g. Enumerable.ElementAt's `if (index == 0)
+        // return e.Current;`) is byte-for-byte identical here after inlining, yet
+        // hoisting it to the loop top would run `get_Current` on every iteration,
+        // changing how often it executes (and, for a throwing/side-effecting
+        // enumerator, observable behavior). IsUnconditionalEveryIteration rejects
+        // any read nested under a branch, nested loop, switch section, handler,
+        // short-circuit, or ternary/`??`/`?.` arm within the body. Also require
+        // the read to sit outside any nested lambda/local function, where a hoist
+        // would change when it runs.
         var currentReads = loop.Body.Descendants.OfType<LoadProperty>()
             .Where(p => IsCurrentOn(p, enumeratorIndex))
             .ToList();
         if (currentReads is [var inlineCurrent]
             && !IsInsideNestedFunction(inlineCurrent, loop.Body)
+            && IsUnconditionalEveryIteration(inlineCurrent, loop.Body)
             && EnumeratorReferencedOnlyWithinLoopBy(loop, enumeratorIndex, moveNext, inlineCurrent))
         {
             return new EnumeratorMatch(
@@ -529,6 +543,53 @@ public sealed class ForeachStatementPass : IIrPass
         for (var current = node.Parent; current is not null && current != boundary; current = current.Parent)
             if (current is Lambda or LocalFunctionStatement)
                 return true;
+        return false;
+    }
+
+    // True iff <paramref name="node"/> is reached exactly once on every iteration
+    // of the loop whose body is <paramref name="loopBody"/> — i.e. control from
+    // the loop-body entry always flows through it, with no branch, nested loop,
+    // handler, or short-circuit that could skip or repeat it. Walk the ancestor
+    // chain to the body and reject the moment a step enters a conditional slot:
+    // an `if`/ternary arm (only the condition is unconditional), the right side
+    // of `&&`/`||`/`??`, a `?.` continuation, a switch section, a catch/finally,
+    // or any nested loop body/condition. Every other container (blocks,
+    // statements, and non-short-circuit expression operands) is straight-line, so
+    // reaching it keeps the node unconditional.
+    static bool IsUnconditionalEveryIteration(IrNode node, Block loopBody)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            var parent = current.Parent;
+            if (parent is null)
+                return false;
+            if (ReferenceEquals(parent, loopBody))
+                return true;
+
+            switch (parent)
+            {
+                case IfStatement ifs when !ReferenceEquals(current, ifs.Condition):
+                    return false;
+                case Conditional cond when !ReferenceEquals(current, cond.Condition):
+                    return false;
+                case LogicalBinary logical when ReferenceEquals(current, logical.Right):
+                    return false;
+                case Coalesce coalesce when ReferenceEquals(current, coalesce.Right):
+                    return false;
+                case NullConditional:
+                case WhileLoop:
+                case DoWhileLoop:
+                case ForLoop:
+                case ForeachStatement:
+                case SwitchSection:
+                case TryCatch:
+                case TryFinally:
+                case CatchClause:
+                case Lambda:
+                case LocalFunctionStatement:
+                    return false;
+            }
+        }
         return false;
     }
 


### PR DESCRIPTION
- Fixes #3164
- Changes the `JsonElement.DeepEquals` `Array` arm (and any single-use-`Current` enumerator loop) to render as `foreach` instead of an open-coded `using`/`while` enumerator pattern.
- Card revision: `8a100bef572980421dfaff2f01cabf1066e87aed`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the enumerator is advanced only by the loop condition, so the single inline `e.Current` read is invariant across the body; hoisting it to a fresh `foreach` variable is the exact inverse of the earlier single-use inline and re-lowers opcode-identically, witnessed by a compile-back **Exact** fixture.

### Benchmark target

Benchmark target: `System.Text.Json` (platform, net11.0)

dotnet-inspect command:

```bash
dotnet-inspect member System.Text.Json.JsonElement.DeepEquals -S "Decompiled Source"
```

### Original source

```csharp
case JsonValueKind.Array:
    if (element1.GetArrayLength() != element2.GetArrayLength())
    {
        return false;
    }

    ArrayEnumerator arrayEnumerator2 = element2.EnumerateArray();
    foreach (JsonElement e1 in element1.EnumerateArray())
    {
        bool success = arrayEnumerator2.MoveNext();
        Debug.Assert(success, "enumerators must have matching length");

        if (!DeepEquals(e1, arrayEnumerator2.Current))
        {
            return false;
        }
    }

    Debug.Assert(!arrayEnumerator2.MoveNext());
    return true;
```

The authored source uses a `foreach` over `element1.EnumerateArray()` while advancing a second enumerator (`arrayEnumerator2`) manually in parallel.

### Before

```csharp
arrayEnumerator2 = element2.EnumerateArray();
using (ArrayEnumerator V_6 = element1.EnumerateArray().GetEnumerator())
{
    while (V_6.MoveNext())
    {
        arrayEnumerator2.MoveNext();
        if (!DeepEquals(V_6.Current, arrayEnumerator2.Current))
        {
            return false;
        }
    }
}
return true;
```

- Valid: True
- Correct: True
- IL fidelity: True (the `using`/`while` enumerator pattern is opcode-faithful; it is simply lower-level than the source's `foreach`)
- Taste applied: None (`-S "Applied Taste"` reports no recorded style choices)
- Commit: `21c007435eca34e0887705a39ee86fbddfc0fd85`

The pre-change render exposes the compiler's open-coded enumerator scaffolding (`using`/`while`/`V_6.Current`) instead of the source's `foreach`. The iteration variable was folded into its one use by `ExpressionInliningPass` before the foreach matcher ran, so the matcher's "first body statement is `item = e.Current`" invariant no longer held and the loop was left un-raised.

### After

```csharp
arrayEnumerator2 = element2.EnumerateArray();
foreach (JsonElement V_11 in element1.EnumerateArray())
{
    arrayEnumerator2.MoveNext();
    if (!DeepEquals(V_11, arrayEnumerator2.Current))
    {
        return false;
    }
}
return true;
```

- Valid: True
- Correct: True
- IL fidelity: True — witnessed by the pinned `CfgSampleClass.ForeachSingleUseWithParallelEnumerator` fixture (compile-back **Exact**; see below). DeepEquals itself is not directly compile-back-checkable (internal platform surface, per #3197), but the raised shape is proven opcode-exact by the fixture.
- Taste applied: None
- Commit: `8a100bef572980421dfaff2f01cabf1066e87aed`

The After render reproduces the source's `foreach (… in element1.EnumerateArray())` with the parallel `arrayEnumerator2.MoveNext()` preserved. The synthesized `V_11` loop variable (vs. the original PDB name `e1`) reflects that the single-use variable had been inlined away — the pass allocates a fresh `foreach` variable via `IrFunction.AddLocal` and rebinds the one inline `Current` read to it. Variable names do not affect IL. The `Object` arm's `while (objectEnumerator1.MoveNext())` is a genuine source-named, non-`using` open-coded loop and is correctly left untouched (tracked separately under #3165).

**Witness fixture** — `CfgSampleClass.ForeachSingleUseWithParallelEnumerator` (a single-use `foreach` iteration variable plus a parallel manually-advanced enumerator, the shape that triggers the inline) renders through the new path as:

```csharp
List<int>.Enumerator other = b.GetEnumerator();
foreach (int V_3 in a)
{
    other.MoveNext();
    // ...
}
```

It is **compile-back Exact** — pinned in `FidelityGateTests.PinnedExact` and absent from the entire fidelity diff set on head.

### Fully raised

The After decompilation is in the fully raised state for the `Array` arm's enumerator loop.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | n/a (new tests) | `ForeachStatementPassTests`: 49 passed |
| Decompiler fast suite | 328 RoundTrip passed | 328 RoundTrip passed; `Area=Pass`: 1393 passed |
| Reduced fixture validity | Pass | Pass |
| Reduced fixture fidelity | not applicable (fixture new) | `ForeachSingleUseWithParallelEnumerator`: compile-back **Exact** |
| Real witness | `JsonElement::DeepEquals` Array arm renders `using (ArrayEnumerator V_6 …) { while (…) }` | `JsonElement::DeepEquals` Array arm renders `foreach (JsonElement V_11 in element1.EnumerateArray())` |

The change is a foreach-only matcher extension in `ForeachStatementPass`: it is a structural no-op on any method without an enumerator `while`-loop.

Pre-existing baseline fidelity failures on this workstation, unchanged by this PR (all non-`foreach` fixtures, so a foreach-only pass is a no-op on each; they pass in CI's environment): `MakeConsumerWithTwoLeadingArgs` (OpcodeDiff, recompiler temp-spill `stloc`/`ldloc`), `ManualConstantOnlyComparisonFactory` (OpcodeDiff, expr-tree factory temp spill), `StatementBodyLambdaInsideIf` (OperandDiff, csc lambda-ordinal drift), `TupleRest` (RecompileFail CS0246, environmental). The new fixture is absent from the entire diff set; CI's fidelity gate is authoritative.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/ForeachStatementPassTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=RoundTrip" -trait- "Speed=Slow"
```
