### PR TITLE
Settle the metadata lens on a section category, not a new flag

### DIFF
--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -217,6 +217,11 @@ session-lifetime rule in
 
 ## Surface — the `metadata` table lens
 
+**Status: designed, not yet implemented.** Nothing in this section runs today;
+`-S @Metadata` currently fails with `Select value '@Metadata' not found.` The
+commands and outputs below are the intended surface, recorded so the
+implementation has a target.
+
 Each metadata table is **one section**, and the tables together form a section
 category, `@Metadata`, registered the same way `@Performance` is:
 
@@ -277,9 +282,16 @@ counts, so they remain a single `Metadata: Image` section.
 Progressive-disclosure discipline (see
 [progressive-disclosure.md](progressive-disclosure.md) and
 [section-model.md](section-model.md)): raw tables are **not** in the default
-`-v:m` view. Category membership is what keeps them out, exactly as it does for
-`@Performance`, so no section-specific special-casing is required. They are
-reached by explicit selection (`-S @Metadata` or `-S "Metadata: <Table>"`).
+`-v:m` view. Two separate mechanisms are involved, and they do different jobs:
+
+- Each metadata table descriptor sets `ExplicitOnly => true`. That is the
+  render gate — `SectionPipeline.IsRequested` returns `false` for an
+  `ExplicitOnly` entry unless it is explicitly included, so no verbosity level
+  auto-selects it. This is per-section configuration, the same as the
+  `@Performance` sections and the `--il-offset` coordinate sections.
+- The `@Metadata` category is the *selection and discovery* affordance. It lets
+  `-S @Metadata` name the whole group and gives `-D` something to list; it does
+  not by itself suppress anything.
 
 Heap **addressing** is the one place this lens does introduce a new currency: a
 heap coordinate such as `#Strings:0x1a4` is not a section name, so it needs a

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -217,34 +217,89 @@ session-lifetime rule in
 
 ## Surface — the `metadata` table lens
 
-The projection is exposed as its own table lens so it composes with the existing
-verbosity model and can be selected explicitly. It rides the `library` command
-(the assembly-oriented surface; note the deprecated `package X --metadata` alias
-already redirects there):
+Each metadata table is **one section**, and the tables together form a section
+category, `@Metadata`, registered the same way `@Performance` is:
+
+```csharp
+.AddCategory(SectionCategoryNames.Metadata, MetadataTables.Sections)
+```
+
+The lens therefore adds **no new shape flags**. Metadata tables introduce no new
+currency — they are sections, addressed by name — so they are reached with the
+existing selection vocabulary rather than a focused flag. It rides the `library`
+command (the assembly-oriented surface; note the deprecated `package X
+--metadata` alias already redirects there):
 
 ```bash
-# enumerate a single table
-dotnet-inspect library My.dll --table TypeDef
+# Document: every projected table
+dotnet-inspect library My.dll -S @Metadata
 
-# a single row with its columns and resolvable handle refs
-dotnet-inspect library My.dll --table MethodDef --row 3
+# Table: one metadata table
+dotnet-inspect library My.dll -S "Metadata: TypeRef"
+
+# Vector: one column of that table
+dotnet-inspect library My.dll -S "Metadata: TypeRef" --columns Name --tsv
+
+# Scalar: collapse to a row count
+dotnet-inspect library My.dll -S "Metadata: TypeDef" --count
+
+# a bounded window into a large table
+dotnet-inspect library My.dll -S "Metadata: MethodDef" --rows --head 20
 
 # structured, for tooling
-dotnet-inspect library My.dll --table TypeRef --jsonl
+dotnet-inspect library My.dll -S "Metadata: TypeRef" --jsonl
 ```
 
 This obeys the shape ladder in [output-shapes.md](output-shapes.md): a table is a
-**Table**, one column is a **Vector**, `--count` / one row is a **Scalar**. Each
-metadata table is one section; a `HandleRef` cell renders as its token +
-optional label in Markdown and as structured fields in JSON/JSONL.
+**Table**, one column is a **Vector**, and `--count` is a **Scalar**. A
+`HandleRef` cell renders as its token + optional label in Markdown and as
+structured fields in JSON/JSONL.
+
+Because `--count` reduces *each* selected section to a count, the category
+selection doubles as the table-stream overview, with no separate rendering path:
+
+```bash
+dotnet-inspect library My.dll -S @Metadata --count
+```
+
+```md
+| Section | Count |
+| ------- | ----- |
+| Metadata: TypeRef | 309 |
+| Metadata: TypeDef | 118 |
+| Metadata: MethodDef | 1204 |
+```
+
+The parts of the image that are not rows of a table — stream sizes, the
+table-present bitmask, the metadata version string — are not expressible as row
+counts, so they remain a single `Metadata: Image` section.
 
 Progressive-disclosure discipline (see
 [progressive-disclosure.md](progressive-disclosure.md) and
 [section-model.md](section-model.md)): raw tables are **not** in the default
-`-v:m` view. They are reached by explicit selection (`--table <Name>` or
-`-S`), following the same focused-flag-promotes-sections pattern that
-`library --il-offset` uses to add its coordinate-scoped sections. Heap dumps are
-a further explicit opt-in on top of that.
+`-v:m` view. Category membership is what keeps them out, exactly as it does for
+`@Performance`, so no section-specific special-casing is required. They are
+reached by explicit selection (`-S @Metadata` or `-S "Metadata: <Table>"`).
+
+Heap **addressing** is the one place this lens does introduce a new currency: a
+heap coordinate such as `#Strings:0x1a4` is not a section name, so it needs a
+carrier. `--heap` is that carrier, and it behaves like `--il-offset` — it makes a
+coordinate-scoped section available and discoverable only when present (see the
+coordinate-carrier family in [output-shapes.md](output-shapes.md)):
+
+```bash
+# bounded heap preview — just a section
+dotnet-inspect library My.dll -S "Metadata: #Strings"
+
+# one address — a coordinate
+dotnet-inspect library My.dll --heap "#Strings:0x1a4"
+```
+
+Deep paging into the middle of a table is deliberately **not** a CLI gesture.
+`--head`/`--tail` are presentation limits rather than row selectors, and a
+start-row flag would blend those concepts. Random access at an arbitrary row
+stays a library concern, served by `ProjectRow` and the row window for the
+explorer host.
 
 ## Safety
 
@@ -822,10 +877,19 @@ via the existing section pipeline and `OutputFormatter`.
 
 - **`HandleRef` shape.** Exact fields and whether `Display` is always populated
   or lazily resolved. Decide before code, since the explorer's value rests on it.
-- **Lens home.** A focused `--table <Name>` flag on `library`, a `-S` section
-  group ("Metadata Tables"), or a dedicated `metadata` command. Leaning toward a
-  `library` flag to reuse assembly acquisition and the section pipeline.
-- **Heap surfacing flags.** The exact opt-in gesture(s) for dumping string / blob
-  / user-string / guid heaps, and their bounded-preview defaults.
-- **Table selection grammar.** Whether tables are addressed by ECMA name
-  (`TypeDef`), by index (`0x02`), or both.
+- **Row addressing.** `--row` is currently a *printable-row* selector, not a
+  row-id addressor, so it cannot name `MethodDef[3]`; `--where` carries that
+  today. Reworking `--row` into a row-id addressor is a known weak point but is
+  deliberately out of scope for this series.
+
+Resolved:
+
+- **Lens home.** A `@Metadata` section category, not a focused flag and not a
+  dedicated command. Metadata tables introduce no new currency, so section
+  selection already addresses them. This also avoids a collision: `--table` is
+  already taken as a presentation modifier ("render as a pretty table").
+- **Heap surfacing flags.** Bounded per-heap previews are ordinary sections
+  (`Metadata: #Strings`). Reading a specific address is a coordinate, so it gets
+  a carrier: `--heap "#Strings:0x1a4"`.
+- **Table selection grammar.** Both, since output already prints hex tokens and
+  users will paste them: `TypeDef` and `0x02` address the same table.

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -309,11 +309,12 @@ dotnet-inspect library My.dll --heap "#Strings:0x1a4"
 
 Deep paging into the middle of a table needs no metadata-specific gesture. It is
 a general row-selection concern, and `--row`/`--rows` are being reworked to
-carry it: a row range such as `--rows 40000..40099` addresses an arbitrary
-window in any section, metadata tables included. This lens therefore adds
-nothing for paging and inherits whatever that work lands. Random access from a
-host that is not the CLI stays a library concern, served by `ProjectRow` and the
-row window.
+carry it ([#3364](https://github.com/richlander/dotnet-inspect/issues/3364)):
+once that lands, a row range such as `--rows 40000..40099` will address an
+arbitrary window in any section, metadata tables included. Neither spelling
+parses a range today. This lens therefore adds nothing for paging and inherits
+whatever that work lands. Random access from a host that is not the CLI stays a
+library concern, served by `ProjectRow` and the row window.
 
 ## Safety
 
@@ -894,10 +895,14 @@ via the existing section pipeline and `OutputFormatter`.
 - **Row addressing.** `--row` currently selects the Nth row that survived an
   invisible printability filter, so it neither names `MethodDef[3]` nor matches
   the row a reader counted in the output; `--where` carries row addressing
-  today. A general rework is designed — `-n` carries the count, `--rows` selects
-  the unit, `--tail` selects the direction, and `--rows` accepts `N`, `N..M`
-  (inclusive), and `N+K` (start plus count) — but it is a CLI-wide change and is
-  out of scope for this series. This lens inherits it.
+  today. Part of the shape is already in place: `-n`/`--head` and `--tail` take
+  a count, and `--rows` is a boolean that switches their unit from output lines
+  to data rows. What is missing is range addressing — neither `--row` nor
+  `--rows` parses a range today. The rework designed in
+  [#3364](https://github.com/richlander/dotnet-inspect/issues/3364) would give
+  `--rows` a value of `N`, `N..M` (inclusive), or `N+K` (start plus count), but
+  it is a CLI-wide change and is out of scope for this series. This lens
+  inherits it.
 
 Resolved:
 

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -307,11 +307,13 @@ dotnet-inspect library My.dll -S "Metadata: #Strings"
 dotnet-inspect library My.dll --heap "#Strings:0x1a4"
 ```
 
-Deep paging into the middle of a table is deliberately **not** a CLI gesture.
-`--head`/`--tail` are presentation limits rather than row selectors, and a
-start-row flag would blend those concepts. Random access at an arbitrary row
-stays a library concern, served by `ProjectRow` and the row window for the
-explorer host.
+Deep paging into the middle of a table needs no metadata-specific gesture. It is
+a general row-selection concern, and `--row`/`--rows` are being reworked to
+carry it: a row range such as `--rows 40000..40099` addresses an arbitrary
+window in any section, metadata tables included. This lens therefore adds
+nothing for paging and inherits whatever that work lands. Random access from a
+host that is not the CLI stays a library concern, served by `ProjectRow` and the
+row window.
 
 ## Safety
 
@@ -889,10 +891,13 @@ via the existing section pipeline and `OutputFormatter`.
 
 - **`HandleRef` shape.** Exact fields and whether `Display` is always populated
   or lazily resolved. Decide before code, since the explorer's value rests on it.
-- **Row addressing.** `--row` is currently a *printable-row* selector, not a
-  row-id addressor, so it cannot name `MethodDef[3]`; `--where` carries that
-  today. Reworking `--row` into a row-id addressor is a known weak point but is
-  deliberately out of scope for this series.
+- **Row addressing.** `--row` currently selects the Nth row that survived an
+  invisible printability filter, so it neither names `MethodDef[3]` nor matches
+  the row a reader counted in the output; `--where` carries row addressing
+  today. A general rework is designed — `-n` carries the count, `--rows` selects
+  the unit, `--tail` selects the direction, and `--rows` accepts `N`, `N..M`
+  (inclusive), and `N+K` (start plus count) — but it is a CLI-wide change and is
+  out of scope for this series. This lens inherits it.
 
 Resolved:
 

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -55,7 +55,10 @@ A flag can contribute in one of three ways:
 
 A fourth kind of flag does not walk the ladder at all: it *supplies an input the
 command has no other way to express*, and in doing so changes which sections
-exist to be selected. `--il-offset` and `--heap` are the members of this family.
+exist to be selected. `--il-offset` is the family's one implemented member;
+`--heap` (see
+[metadata-table-projection.md](metadata-table-projection.md)) is designed to be
+the second.
 
 A coordinate carrier is the right shape for a flag only when the input is a
 genuinely new currency — a value that is not a section name, a column name, or a
@@ -412,8 +415,9 @@ The stable vocabulary is:
   GitHub links, not the shape of the payload itself.
 - `--plaintext` remains distinct from `--bare`; if it stays in the product, it is
   a whole-document plain-text rendering mode rather than a bare-payload mode.
-- `--il-offset` / `--heap` are coordinate carriers: they supply an input that has
-  no other expression and gate the sections it makes meaningful. They do not
-  narrow a shape, and a flag qualifies only if its input is a new currency.
+- `--il-offset` is a coordinate carrier: it supplies an input that has no other
+  expression and gates the sections it makes meaningful. It does not narrow a
+  shape, and a flag qualifies for this family only if its input is a new
+  currency. `--heap` is the designed second member.
 
 New flags should fit one of those buckets rather than blending concepts.

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -39,9 +39,10 @@ Most sections are Tables, but a section can also be a key-value field set, a
 list, a code/text blob, or a tree (for example a call graph). Those are still
 "one section" — the Table rung — and they collapse to Scalars the same way.
 
-## Three flag families
+## Flag families
 
-A flag can contribute in one of three ways:
+Three families walk the shape ladder, and a fourth sits before it. A flag in one
+of the ladder families contributes in one of three ways:
 
 - **Shape selectors** narrow the requested shape (`-S`, `--fields`/`--columns`,
   `--count`, `-n 1`).

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -56,10 +56,16 @@ of the ladder families contributes in one of three ways:
 
 A fourth kind of flag does not walk the ladder at all: it *supplies an input the
 command has no other way to express*, and in doing so changes which sections
-exist to be selected. `--il-offset` is the family's one implemented member;
-`--heap` (see
+exist to be selected. The IL coordinate is the family's one implemented
+currency; `--heap` (see
 [metadata-table-projection.md](metadata-table-projection.md)) is designed to be
 the second.
+
+The family is counted in currencies, not flags, because one currency can have
+more than one spelling. The IL coordinate has two: `--il-offset` takes a single
+coordinate, and `--il-offsets` takes a file of them for batch reporting. They
+are mutually exclusive (`--il-offset cannot be combined with --il-offsets`) and
+carry the same currency, so they are one member of this family rather than two.
 
 A coordinate carrier is the right shape for a flag only when the input is a
 genuinely new currency — a value that is not a section name, a column name, or a
@@ -416,9 +422,10 @@ The stable vocabulary is:
   GitHub links, not the shape of the payload itself.
 - `--plaintext` remains distinct from `--bare`; if it stays in the product, it is
   a whole-document plain-text rendering mode rather than a bare-payload mode.
-- `--il-offset` is a coordinate carrier: it supplies an input that has no other
-  expression and gates the sections it makes meaningful. It does not narrow a
-  shape, and a flag qualifies for this family only if its input is a new
-  currency. `--heap` is the designed second member.
+- `--il-offset` / `--il-offsets` are coordinate carriers: they supply an input
+  that has no other expression and gate the sections it makes meaningful. They
+  do not narrow a shape, and a flag qualifies for this family only if its input
+  is a new currency. Both spell the same currency, so they are one member;
+  `--heap` is the designed second.
 
 New flags should fit one of those buckets rather than blending concepts.

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -51,6 +51,31 @@ A flag can contribute in one of three ways:
 - **URL-shape modifiers** change only the form of GitHub URLs emitted as data
   (`--raw`, `--blob`). They are orthogonal to the output-shape ladder.
 
+### Coordinate carriers sit before the ladder
+
+A fourth kind of flag does not walk the ladder at all: it *supplies an input the
+command has no other way to express*, and in doing so changes which sections
+exist to be selected. `--il-offset` and `--heap` are the members of this family.
+
+A coordinate carrier is the right shape for a flag only when the input is a
+genuinely new currency — a value that is not a section name, a column name, or a
+row. An IL coordinate (`0x06000002+0x1`) and a heap address (`#Strings:0x1a4`)
+qualify; a table name does not, because a table is already a section and `-S`
+already addresses sections.
+
+Carriers behave consistently:
+
+- The sections they enable are **discoverable only when the carrier is present**,
+  so `-D` reflects the carrier (see the IL-offset case study below).
+- Absent the carrier, requesting a coordinate-scoped section is an error that
+  names the missing carrier, for example
+  `IL coordinate sections require --il-offset`.
+- Once the carrier resolves, its sections are ordinary sections: they obey `-S`,
+  `--columns`, `--count`, and the rest of the ladder like any other.
+
+Prefer a section, a category, or `--where` before reaching for a new carrier.
+The bar is a new currency, not merely a new thing to look at.
+
 ## How Markout produces the shapes
 
 Markout serializes a view object into a **Document** of **Sections** and renders
@@ -387,5 +412,8 @@ The stable vocabulary is:
   GitHub links, not the shape of the payload itself.
 - `--plaintext` remains distinct from `--bare`; if it stays in the product, it is
   a whole-document plain-text rendering mode rather than a bare-payload mode.
+- `--il-offset` / `--heap` are coordinate carriers: they supply an input that has
+  no other expression and gate the sections it makes meaningful. They do not
+  narrow a shape, and a flag qualifies only if its input is a new currency.
 
 New flags should fit one of those buckets rather than blending concepts.


### PR DESCRIPTION
Fifth in the #3341 stack, on top of #3352. Docs only -- no product code.

## The correction

The design doc proposed `library My.dll --table TypeDef`. That flag cannot exist: `--table` is already a presentation modifier ("render the selected section as a space-padded pretty table"), verified in `library --help` and in the output-shapes flag tables.

The deeper point is that no flag was needed. A metadata table **is** a section, addressed by name, so `-S` already reaches it. Tables become a `@Metadata` category registered the way `@Performance` is:

```csharp
.AddCategory(SectionCategoryNames.Metadata, MetadataTables.Sections)
```

Category membership is also what supplies progressive disclosure -- it is what keeps raw tables out of the default `-v:m` view, with no section-specific special-casing.

## What that collapses

`-S @Metadata --count` already renders a Section/Count table, so it **is** the table-stream overview. Verified against the existing category:

```console
$ dotnet-inspect library System.Text.Json.dll -S @Performance --count
| Section | Count |
| ------- | ----- |
| Performance: Boxing | 51 |
| Performance: Arrays | 48 |
```

Only the non-row parts of the image -- stream sizes, table-present bitmask, version string -- still need a `Metadata: Image` section.

Deep paging is dropped rather than designed. `--head`/`--tail` are documented as presentation limits, not row selectors, so a start-row flag would blend concepts in exactly the way the doc's own discipline section prohibits. Arbitrary-row access stays a library concern, served by `ProjectRow` and the row window from #3345 for the explorer host.

## The one new flag, and the family it belongs to

Heap addressing is a genuinely new currency: `#Strings:0x1a4` is not a section name. It gets a carrier, `--heap`, behaving like `--il-offset`.

That pattern was load-bearing but unnamed. `--il-offset` appears in **none** of the three flag families in `output-shapes.md` despite having its own case study there. This names a fourth family -- coordinate carriers -- and states the bar: a new currency, not merely a new thing to look at. The next flag now has a rule to follow instead of a precedent to copy.

## Open questions resolved

Lens home, heap surfacing, and table selection grammar (both `TypeDef` and `0x02`, since output already prints hex tokens).

Reworking `--row` from a printable-row selector into a row-id addressor is recorded as a known weak point and explicitly out of scope for this series.

## Validation

Markdown structural checks (MD009/MD012/MD022/MD047) clean on both files; `markdownlint` proper is unavailable locally (no Node). No behaviour claim, so no product build or test is implicated.