### PR TITLE
Fold single-use default member-value spill in object initializers (#3336)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5024,6 +5024,33 @@ public class CfgSampleClass
         using (DisposableFromObjectSpan([a, b])) { n = 1; }
         return n;
     }
+
+    // #3336 stage 1: a struct-typed member assigned `default` in an object
+    // initializer. Roslyn spills `default(InitFlag)` to a local via `initobj`
+    // (a struct has no `ldnull` default), then reads it back as the member value
+    // AFTER the `newobj` — a single-use member-value spill interleaved in the dup
+    // chain. #3272's skip guard only tolerates spills computed BEFORE the newobj,
+    // so without folding the spill the trailing member (and thus the whole
+    // initializer) stays lowered. This must fold to
+    // `new InitTargetWithFlag { X = a, Y = b, Flag = default(InitFlag) }`.
+    // Placed last (with its non-capturing helper types) so it shifts no
+    // pre-existing method's compiler-generated ordinal — the fidelity docket keys
+    // on `<>9__N`/`<>c__DisplayClassN` names (see #3129 S4, #3281).
+    public static InitTargetWithFlag MakeTargetWithDefaultStructMember(int a, int b)
+        => new InitTargetWithFlag { X = a, Y = b, Flag = default };
+
+    public struct InitFlag
+    {
+        public int First;
+        public int Second;
+    }
+
+    public sealed class InitTargetWithFlag
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+        public InitFlag Flag { get; set; }
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -536,6 +536,33 @@ public class ObjectInitializerPassTests
             CSharpPrinter.Print(function).Output);
     }
 
+    // #3336 stage 1: a single-use member-value `default` spill. Roslyn spills
+    // `default(InitFlag)` (a struct) to a local via `initobj` and reads it back as
+    // the trailing member value AFTER the `newobj`. #3272's skip guard tolerates
+    // only spills computed BEFORE the newobj, so this member — and thus the whole
+    // initializer — stayed lowered. The pass now consumes the single-use spill and
+    // inlines `default(InitFlag)` at the member, folding the entire chain.
+    [Fact]
+    public void DefaultStructMemberSpill_FoldsWholeInitializer()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeTargetWithDefaultStructMember));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.False(initializer.IsCollection);
+        Assert.Equal(["X", "Y", "Flag"], initializer.Members);
+        // The inlined member value is default(InitFlag), and the spilling initobj is gone.
+        Assert.Single(initializer.Entries[^1].Arguments.OfType<DefaultValue>());
+        Assert.Empty(function.Descendants.OfType<InitObject>());
+
+        // The whole dup chain, its version copies, and the spill local are gone.
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+
+        Assert.Contains(
+            "new InitTargetWithFlag { X = a, Y = b, Flag = default(InitFlag) }",
+            CSharpPrinter.Print(function).Output);
+    }
+
     static IrFunction FunctionWithSetter(bool generic, string propertyName = "set_Value")
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "Owner");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -187,6 +187,29 @@ public sealed class ObjectInitializerPass : IIrPass
                 continue;
             }
 
+            // A single-use member-value spill feeding the immediately-following
+            // member store: `default(T) V = default; ref.M = V`, where the compiler
+            // spills a `default(T)` (a struct-typed `initobj` into its own local)
+            // and reads it straight back as the member value. Fold both into
+            // `M = default` inlined at the member's position. Sound because the
+            // member value stays in member order at the fold site — unlike a
+            // pre-entry skip, it is never reordered across the `newobj` or other
+            // members; and `default(T)` is a pure zero-init with no side effect.
+            if (i + 1 < statements.Count
+                && !TouchesAnySlot(statement, aliasSlots)
+                && TryDefaultValueSpill(function, statement, statements[i + 1], aliasSlots) is { } spilled)
+            {
+                if (isCollection == true)
+                    break;
+                FlushPending();
+                isCollection = false;
+                entries.Add(spilled);
+                consumed.Add(statement);
+                consumed.Add(statements[i + 1]);
+                i++;   // the member store is consumed together with its spill
+                continue;
+            }
+
             // A statement interleaved before the first initializer entry that neither
             // reads nor writes the threaded reference — e.g. `t = new(); a = Other();
             // t.X = ...` where `a` is a preceding constructor argument the stackifier
@@ -529,6 +552,53 @@ public sealed class ObjectInitializerPass : IIrPass
         _ => null,
     };
 
+    /// <summary>
+    /// Matches a <c>default(T)</c> member-value spill and its consuming member store:
+    /// <c>InitObject L</c> (a struct-typed <c>initobj</c> that zero-inits its own
+    /// local <c>L</c>) immediately followed by <c>ref.M = LoadLocal L</c> on a
+    /// threaded slot, where <c>L</c> is single-assignment, addressed only by this
+    /// <c>initobj</c>, and read exactly once — as that member value. Returns the
+    /// member entry with <see cref="DefaultValue"/> inlined in place of the temp so
+    /// the spill statement can be dropped. The compiler emits this shape for a
+    /// struct-typed <c>default</c> assigned to an initializer member; recovering it
+    /// lets the whole chain fold instead of leaving the trailing member lowered.
+    /// </summary>
+    static EntryPlan? TryDefaultValueSpill(IrFunction function, IrNode spill, IrNode memberStatement, HashSet<int> aliasSlots)
+    {
+        // The spill: `initobj L` writing the zero value through a local's address.
+        if (spill is not InitObject { Address: LoadLocalAddress { Index: var localIndex } } init)
+            return null;
+
+        // The consuming member store: `ref.M = LoadLocal L` on a threaded slot, with
+        // no index arguments (the value is the whole right-hand side).
+        var (member, method, fieldRef) = memberStatement switch
+        {
+            StoreProperty { HasInstance: true, Instance: LoadStackSlot slot, Value: LoadLocal use } property
+                when aliasSlots.Contains(slot.Slot) && use.Index == localIndex
+                    && property.IndexArguments.Count == 0 && IsInitializerSpellable(property)
+                => (property.PropertyName, (MethodRef?)property.Accessor, (FieldRef?)null),
+            StoreField { HasInstance: true, Instance: LoadStackSlot slot, Value: LoadLocal use } field
+                when aliasSlots.Contains(slot.Slot) && use.Index == localIndex
+                => (field.Field.Name, null, field.Field),
+            _ => ((string?)null, null, null),
+        };
+        if (member is null)
+            return null;
+
+        // The temp must belong solely to this spill/use pair: referenced or bound
+        // nowhere else, never re-stored, and addressed only by this `initobj`. That
+        // makes dropping its definition and inlining `default(T)` semantics-preserving.
+        if (!ReferenceOwnership.LocalReferencedOrBoundOnlyWithin(function, localIndex, [spill, memberStatement]))
+            return null;
+        if (function.Descendants.OfType<StoreLocal>().Any(store => store.Index == localIndex))
+            return null;
+        if (function.Descendants.OfType<LoadLocalAddress>()
+                .Any(address => address.Index == localIndex && !ReferenceEquals(address, init.Address)))
+            return null;
+
+        return new EntryPlan(member, [new DefaultValue(init.Type)], null, ConsumedMethod: method, ConsumedField: fieldRef);
+    }
+
     static EntryPlan? TryMemberStore(IrNode statement, int localIndex) => statement switch
     {
         StoreProperty { HasInstance: true, Instance: LoadLocal local } property
@@ -707,7 +777,8 @@ public sealed class ObjectInitializerPass : IIrPass
         }
 
         foreach (var leaf in LeafArguments(plan.Entries))
-            leaf.Detach();
+            if (leaf.Parent is not null)
+                leaf.Detach();   // a synthesized leaf (e.g. an inlined default) is already free
 
         var entries = plan.Entries.Select(BuildEntry).ToList();
         switch (plan.Target)


### PR DESCRIPTION
- Fixes/advances #3336
- Changes `ObjectInitializerPass` to fold an object initializer whose trailing member is a struct-typed `default(T)` spilled after the `newobj`
- Card revision: `5c1d8156`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a real corpus witness now folds to a single object initializer, the change is byte-neutral (its fixture recompiles exact), and it introduces zero new fidelity diffs versus `origin/main`.

### Benchmark target

Benchmark target: `Azure.Messaging.ServiceBus@7.20.1`

dotnet-inspect command:

```bash
dotnet-inspect member Azure.Messaging.ServiceBus.ServiceBusModelFactory NamespaceProperties -S "Decompiled Source"
```

### Original source

```csharp
public static NamespaceProperties NamespaceProperties(
    string name,
    DateTimeOffset createdTime,
    DateTimeOffset modifiedTime,
    MessagingSku messagingSku,
    int messagingUnits,
    string alias) =>
    new NamespaceProperties
    {
        Name = name,
        CreatedTime = createdTime,
        ModifiedTime = modifiedTime,
        MessagingSku = messagingSku,
        MessagingUnits = messagingUnits,
        Alias = alias,
        NamespaceType = new NamespaceType() // this cannot be created by the user
    };
```

### Before

```csharp
public static Azure.Messaging.ServiceBus.Administration.NamespaceProperties NamespaceProperties(string name, System.DateTimeOffset createdTime, System.DateTimeOffset modifiedTime, Azure.Messaging.ServiceBus.Administration.MessagingSku messagingSku, int messagingUnits, string alias)
{
    NamespaceProperties S_256 = new();
    S_256.Name = name;
    NamespaceProperties S_257 = S_256;
    S_257.CreatedTime = createdTime;
    NamespaceProperties S_258 = S_257;
    S_258.ModifiedTime = modifiedTime;
    NamespaceProperties S_259 = S_258;
    S_259.MessagingSku = messagingSku;
    NamespaceProperties S_260 = S_259;
    S_260.MessagingUnits = messagingUnits;
    NamespaceProperties S_261 = S_260;
    S_261.Alias = alias;
    NamespaceProperties S_262 = S_261;
    NamespaceType V_0 = default;
    S_262.NamespaceType = V_0;
    return S_262;
}
```

- Valid: True
- Correct: True
- IL fidelity: True (lowered version-copy chain; not the raised endpoint)
- Taste applied: None
- Commit: `21c00743`

The trailing `NamespaceType V_0 = default; S_262.NamespaceType = V_0;` is the single-use `default(T)` member-value spill emitted after the `newobj`. #3272's skip guard only tolerated spills computed *before* the `newobj`, so this interleaved spill blocked the whole chain from folding, leaving the version-copy chain lowered.

### After

```csharp
public static Azure.Messaging.ServiceBus.Administration.NamespaceProperties NamespaceProperties(string name, System.DateTimeOffset createdTime, System.DateTimeOffset modifiedTime, Azure.Messaging.ServiceBus.Administration.MessagingSku messagingSku, int messagingUnits, string alias) => new NamespaceProperties { Name = name, CreatedTime = createdTime, ModifiedTime = modifiedTime, MessagingSku = messagingSku, MessagingUnits = messagingUnits, Alias = alias, NamespaceType = default(NamespaceType) };
```

- Valid: True
- Correct: True
- IL fidelity: True (byte-neutral: the `MakeTargetWithDefaultStructMember` fixture recompiles exact via the compile-back harness)
- Taste applied: None
- Commit: `5c1d8156`

`default(NamespaceType)` is behavior-identical to the original `new NamespaceType()` for this struct (a pure zero-init), and matches dotnet/runtime taste (`dotnet_style_object_initializer = true`).

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline (`21c00743`) | Head (`5c1d8156`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ObjectInitializerPassTests`: 35 passed | `ObjectInitializerPassTests`: 36 passed |
| Decompiler fast suite | not re-run | 4018 total, 0 failed |
| Reduced fixture validity | Pass | Pass |
| Reduced fixture fidelity | Pass (fixture recompiles exact) | Pass (fixture recompiles exact) |
| Real witness | `ServiceBusModelFactory::NamespaceProperties` unfolded | `ServiceBusModelFactory::NamespaceProperties` folded |

**Pre-existing fidelity-gate failures (unchanged by this PR).** `FidelityGateTests` and `LoweredFidelityGateTests` (Speed=Slow, compile-back) fail 3 tests on **both** `origin/main` and this branch, with the **identical** unexpected-diff sets:

- `FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket`: `MakeConsumerWithTwoLeadingArgs`, `ManualConstantOnlyComparisonFactory`, `StatementBodyLambdaInsideIf`
- `LoweredFidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket`: `EnumArgInInlineLocalFunction`, `EnumArgInLocalFunctionWithLocal`, `ManualConstantOnlyComparisonFactory`, `RecursiveLocalFunction`, `StaticLocalFunctionWithLocal`, `TwoLocalFunctionQuadrants`
- `FidelityGateTests.PinnedFixesStayExact`: `TupleRest` (`RecompileFail`, `CS0246: 'int' could not be found`)

These are environmental (this machine's SDK/Roslyn toolchain diverges from the committed docket). My change touches none of these methods: the two object-initializer methods that this pass *could* affect (`MakeConsumerWithTwoLeadingArgs`, `ObjectInitializerArgumentBeforeShortCircuit`) decompile byte-identically on both commits, and my `MakeTargetWithDefaultStructMember` fixture is absent from every diff list (recompiles exact).

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — clean.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ObjectInitializerPassTests` — 36/36.
- Fidelity gates re-run on both `origin/main` and head (full ~2h each); identical failure sets confirm no new diffs.
