### PR TITLE
Document the SSCP ExternalTargets bail as a soundness guard

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
@@ -132,6 +132,15 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
         // the same contract DefiniteAssignment uses. This turns the previously
         // accidental exclusion of leave edges (a side effect of guard
         // interaction) into an explicit, pinned invariant.
+        //
+        // The ExternalTargets clause also closes a soundness hole, not just a
+        // missed optimization: the old private Successors silently dropped an
+        // unresolvable branch target (offset lookup → -1 → no edge emitted).
+        // That missing edge flowed into Predecessors, and the region-domination
+        // check reasons over predecessors, so a block with a dropped incoming
+        // edge could look dominated by the copy when it is not — propagating a
+        // value along a path that does not actually carry it. Bailing on any
+        // external target makes that unsound case unreachable by construction.
         var edges = Cfg.Build(blocks);
         if (edges.Any(edge => edge.LeavesRegion || edge.ExternalTargets.Count > 0))
             return null;


### PR DESCRIPTION
## What

Adds a comment to `StackSlotCopyPropagationPass.TryGetCopyPath` explaining that the `ExternalTargets` half of the post-#3248 CFG bail is a **soundness guard**, not just behavior-preserving housekeeping.

## Why

This captures the durable half of an adversarial-review note on #3248 that never made it into that (now-merged) PR. The existing comment explains the CFG-consolidation *mechanism* but frames the entire bail as a refactor. The `ExternalTargets` clause is stronger than that:

- The old private `Successors` silently dropped an unresolvable branch target (offset lookup → `-1` → no edge emitted).
- That missing edge fed `Predecessors`, and `RegionDominatedByCopy` (line 236) reasons over predecessors (line 238).
- So a block with a dropped incoming edge could look **dominated by the copy when it is not** — propagating a value along a path that does not actually carry it. That is an *unsound* propagation, not a merely missed one.
- Bailing on any external target makes that case unreachable by construction.

Recording the rationale in the code means the next reader — and the open #3242 retire-vs-keep decision for this CFG machinery — doesn't have to rediscover it from the #3248 review thread.

## Scope / risk

Comment-only. No behavior change. Verified against the code: the claim matches `RegionDominatedByCopy` → `Predecessors` at the cited lines. `ILInspector.Decompiler` builds clean in Release (`0 errors`).

## Review

Trivial (comment-only, no measured behavior claim) → no adversarial review.