### PR TITLE
Cache the whole-graph maps behind the call-tree builders (#3342)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -316,6 +316,109 @@ public class LibraryBodyIndexTests
             child.Member.Name == nameof(BodilessRootFixtures.InvokesThroughInterface));
     }
 
+    // #3342: the whole-graph maps behind the call-tree builders (definition map, distinct-caller
+    // counts, reverse edges, and the cross-assembly scope maps) are cached per index so a
+    // consumer that asks many questions of one index pays for them once. That is only sound if
+    // none of them depends on which member was selected or on a previously requested scope set.
+    // This walks one index through a sequence designed to poison a root- or scope-dependent
+    // cache, and requires every answer to match a fresh index that was asked nothing else.
+    //
+    // Scope note: this pins cache *independence*, not the bodiless-root contract itself. Serving
+    // a bodiless root from the shared grouping is a correctness fault that a fresh index would
+    // reproduce identically, so no independence test can see it;
+    // BuildCallerTree_ResolvesCallers_WhenSelectedRootIsBodilessInterfaceMethod owns that, and
+    // was confirmed to fail when the guard is removed.
+    [Fact]
+    public void CallTreeBuilders_AreUnaffectedByEarlierRequestsOnTheSameIndex()
+    {
+        string analysisPath = typeof(LibraryBodyIndex).Assembly.Location;
+        string testPath = typeof(LibraryBodyIndexTests).Assembly.Location;
+
+        // Pick a root with a genuinely branching caller tree. Comparing trees is only evidence
+        // if the trees can differ: a root with no in-assembly callers renders one leaf line, and
+        // every comparison below would hold no matter how badly a cache leaked.
+        var probe = LibraryBodyIndex.Open(analysisPath);
+        int richToken = PickRichest(probe, out int richest);
+
+        Assert.True(richest >= 4, $"expected a branching caller tree to compare; richest had {richest} nodes");
+        int otherToken = probe.Methods.First(method => method.MetadataToken != richToken).MetadataToken;
+        // A bodiless root is the one case whose caller grouping genuinely depends on the root,
+        // so it must not be served from (or poison) the shared per-index cache.
+        int bodilessToken = typeof(ICallerGraphTarget).GetMethod(nameof(ICallerGraphTarget.Target))!.MetadataToken;
+
+        // Each expectation comes from an index that has answered nothing else.
+        var expectedCallers = Describe(LibraryBodyIndex.Open(analysisPath).BuildCallerTree(richToken, maxDepth: 2, maxNodes: 50));
+        var expectedCallees = Describe(LibraryBodyIndex.Open(analysisPath).BuildCallTree(richToken, maxDepth: 2, maxNodes: 50));
+        var expectedScoped = Describe(LibraryBodyIndex.Open(analysisPath)
+            .BuildCallerTree(richToken, new[] { LibraryBodyIndex.Open(testPath) }, maxDepth: 2, maxNodes: 50));
+        var expectedUnscoped = Describe(LibraryBodyIndex.Open(analysisPath)
+            .BuildCallerTree(richToken, Array.Empty<LibraryBodyIndex>(), maxDepth: 2, maxNodes: 50));
+        var expectedBodiless = Describe(LibraryBodyIndex.Open(testPath).BuildCallerTree(bodilessToken, maxDepth: 2, maxNodes: 50));
+
+        // Scoping must actually change the answer, or the scope-set comparisons prove nothing.
+        Assert.NotEqual(expectedScoped, expectedUnscoped);
+
+        // Now ask one index everything, in an order that would expose a leaked root or scope.
+        var reused = LibraryBodyIndex.Open(analysisPath);
+        var scopeA = LibraryBodyIndex.Open(testPath);
+        reused.BuildCallerTree(otherToken, maxDepth: 2, maxNodes: 50);
+        reused.BuildCallTree(otherToken, maxDepth: 2, maxNodes: 50);
+        reused.BuildCallerTree(otherToken, new[] { scopeA }, maxDepth: 2, maxNodes: 50);
+        reused.BuildCallerTree(otherToken, Array.Empty<LibraryBodyIndex>(), maxDepth: 2, maxNodes: 50);
+
+        Assert.Equal(expectedCallers, Describe(reused.BuildCallerTree(richToken, maxDepth: 2, maxNodes: 50)));
+        Assert.Equal(expectedCallees, Describe(reused.BuildCallTree(richToken, maxDepth: 2, maxNodes: 50)));
+
+        // Alternating scope sets on one index: the empty set must not be answered from the
+        // populated set's map, nor the reverse, however many times they interleave.
+        Assert.Equal(expectedScoped, Describe(reused.BuildCallerTree(richToken, new[] { scopeA }, maxDepth: 2, maxNodes: 50)));
+        Assert.Equal(expectedUnscoped, Describe(reused.BuildCallerTree(richToken, Array.Empty<LibraryBodyIndex>(), maxDepth: 2, maxNodes: 50)));
+        Assert.Equal(expectedScoped, Describe(reused.BuildCallerTree(richToken, new[] { scopeA }, maxDepth: 2, maxNodes: 50)));
+
+        // A bodiless root asked after body-rooted requests have populated the cache.
+        var reusedTests = LibraryBodyIndex.Open(testPath);
+        int testAsmToken = PickRichest(reusedTests, out int testRichest);
+        Assert.True(testRichest >= 2, $"expected a non-leaf caller tree in the test assembly; richest had {testRichest} nodes");
+        var expectedTestAsmCallers = Describe(LibraryBodyIndex.Open(testPath).BuildCallerTree(testAsmToken, maxDepth: 2, maxNodes: 50));
+        reusedTests.BuildCallerTree(testAsmToken, maxDepth: 2, maxNodes: 50);
+        Assert.Equal(expectedBodiless, Describe(reusedTests.BuildCallerTree(bodilessToken, maxDepth: 2, maxNodes: 50)));
+
+        // ...and the bodiless request must not have written its root-dependent grouping into the
+        // shared cache, so a body-rooted request after it still answers like a fresh index.
+        Assert.Equal(expectedTestAsmCallers, Describe(reusedTests.BuildCallerTree(testAsmToken, maxDepth: 2, maxNodes: 50)));
+
+        static int PickRichest(LibraryBodyIndex index, out int richest)
+        {
+            int token = 0;
+            richest = 0;
+            foreach (var method in index.Methods.Take(150))
+            {
+                int size = Describe(index.BuildCallerTree(method.MetadataToken, maxDepth: 2, maxNodes: 50)).Count;
+                if (size > richest)
+                {
+                    richest = size;
+                    token = method.MetadataToken;
+                }
+            }
+
+            return token;
+        }
+
+        static List<string> Describe(CallTreeNode root)
+        {
+            var lines = new List<string>();
+            void Walk(CallTreeNode node, int depth)
+            {
+                lines.Add($"{depth}|{node.Member.DeclaringType.Name}.{node.Member.Name}|{node.Status}|" +
+                    $"{node.Perf?.Source ?? ""}|fanout={node.Perf?.Fanout ?? -1}|fanin={node.Perf?.Fanin ?? -1}");
+                foreach (var child in node.Children)
+                    Walk(child, depth + 1);
+            }
+            Walk(root, 0);
+            return lines;
+        }
+    }
+
     [Fact]
     public void BuildCallerTree_WithScope_IncorporatesAndTagsExternalCallers()
     {

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -339,8 +339,10 @@ public class LibraryBodyIndexTests
         // Evidence-domain caches the release methods deliberately retain.
         string[] retainedCaches =
         [
+            "_allocationFanoutOpportunities",
             "_directCallerLoops",
             "_generatedFrameworkTypes",
+            "_opportunities",
             "_rootReachByToken",
             "_signals",
             "_unsafeEvidenceByMember",
@@ -383,17 +385,31 @@ public class LibraryBodyIndexTests
             return index;
         }
 
+        // Every non-readonly instance field on this type is a lazy cache, so the filter is just
+        // "mutable state" rather than a type-shaped guess. An earlier version excluded value types
+        // and so silently missed the two ImmutableArray caches, which is the same blind spot this
+        // test exists to catch.
         static IEnumerable<FieldInfo> MutableCacheFields()
             => typeof(LibraryBodyIndex)
-                .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
-                .Where(field => field.Name.StartsWith('_') && !field.IsInitOnly && !field.FieldType.IsValueType);
+                .GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+                .Where(field => field.Name.StartsWith('_') && !field.IsInitOnly);
 
         static List<string> PopulatedCaches(LibraryBodyIndex index)
             => MutableCacheFields()
-                .Where(field => field.GetValue(index) is not null)
+                .Where(field => IsPopulated(field.GetValue(index)))
                 .Select(field => field.Name)
                 .OrderBy(name => name, StringComparer.Ordinal)
                 .ToList();
+
+        // ImmutableArray caches signal "not yet computed" with IsDefault, not with null.
+        static bool IsPopulated(object? value)
+        {
+            if (value is null)
+                return false;
+
+            var isDefault = value.GetType().GetProperty("IsDefault");
+            return isDefault is null || !(bool)isDefault.GetValue(value)!;
+        }
     }
 
     // #3342: the whole-graph maps behind the call-tree builders (definition map, distinct-caller

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -316,6 +316,86 @@ public class LibraryBodyIndexTests
             child.Member.Name == nameof(BodilessRootFixtures.InvokesThroughInterface));
     }
 
+    /// <summary>
+    /// Derives this type's mutable cache fields by reflection and pins each one to a side of the
+    /// release boundary, so the two release methods are gated on the property they exist for
+    /// rather than only on staying correct. Both directions fail: a cache the doc claims to drop
+    /// but doesn't, and a cache dropped that the doc says survives. A newly added cache field
+    /// belongs to neither list and fails until someone decides which side it is on.
+    /// </summary>
+    [Fact]
+    public void ReleaseMethods_DropExactlyTheCachesTheyDocument()
+    {
+        // Dropped by ReleaseCallGraphCaches(); _scopeGraph is also dropped by ReleaseScopeGraph().
+        string[] callGraphCaches =
+        [
+            "_directCallsByCaller",
+            "_distinctCallerEdgesByCallee",
+            "_distinctCallersByCallee",
+            "_methodMap",
+            "_scopeGraph",
+        ];
+
+        // Evidence-domain caches the release methods deliberately retain.
+        string[] retainedCaches =
+        [
+            "_directCallerLoops",
+            "_generatedFrameworkTypes",
+            "_rootReachByToken",
+            "_signals",
+            "_unsafeEvidenceByMember",
+        ];
+
+        Assert.Equal(
+            callGraphCaches.Concat(retainedCaches).OrderBy(name => name, StringComparer.Ordinal),
+            MutableCacheFields().Select(field => field.Name).OrderBy(name => name, StringComparer.Ordinal));
+
+        string analysisPath = typeof(LibraryBodyIndex).Assembly.Location;
+        string testPath = typeof(LibraryBodyIndexTests).Assembly.Location;
+        var scope = LibraryBodyIndex.Open(testPath);
+
+        var index = Exercised(analysisPath, scope);
+        var before = PopulatedCaches(index);
+
+        // The gate is only meaningful if the caches under test were populated to begin with.
+        foreach (var name in callGraphCaches)
+            Assert.Contains(name, before);
+
+        index.ReleaseCallGraphCaches();
+        Assert.Equal(before.Where(name => !callGraphCaches.Contains(name)), PopulatedCaches(index));
+
+        // ReleaseScopeGraph drops the scope graph and nothing else — that is the whole point of
+        // having it separately, since the single-assembly maps are the cheap, high-value half.
+        var scopeOnly = Exercised(analysisPath, scope);
+        var beforeScopeRelease = PopulatedCaches(scopeOnly);
+        Assert.Contains("_scopeGraph", beforeScopeRelease);
+
+        scopeOnly.ReleaseScopeGraph();
+        Assert.Equal(beforeScopeRelease.Where(name => name != "_scopeGraph"), PopulatedCaches(scopeOnly));
+
+        static LibraryBodyIndex Exercised(string path, LibraryBodyIndex scope)
+        {
+            var index = LibraryBodyIndex.Open(path);
+            int token = index.Methods.First().MetadataToken;
+            index.BuildCallerTree(token, maxDepth: 2, maxNodes: 50);
+            index.BuildCallTree(token, maxDepth: 2, maxNodes: 50);
+            index.BuildCallerTree(token, new[] { scope }, maxDepth: 2, maxNodes: 50);
+            return index;
+        }
+
+        static IEnumerable<FieldInfo> MutableCacheFields()
+            => typeof(LibraryBodyIndex)
+                .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(field => field.Name.StartsWith('_') && !field.IsInitOnly && !field.FieldType.IsValueType);
+
+        static List<string> PopulatedCaches(LibraryBodyIndex index)
+            => MutableCacheFields()
+                .Where(field => field.GetValue(index) is not null)
+                .Select(field => field.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToList();
+    }
+
     // #3342: the whole-graph maps behind the call-tree builders (definition map, distinct-caller
     // counts, reverse edges, and the cross-assembly scope maps) are cached per index so a
     // consumer that asks many questions of one index pays for them once. That is only sound if

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -322,6 +322,10 @@ public class LibraryBodyIndexTests
     /// rather than only on staying correct. Both directions fail: a cache the doc claims to drop
     /// but doesn't, and a cache dropped that the doc says survives. A newly added cache field
     /// belongs to neither list and fails until someone decides which side it is on.
+    /// <para>
+    /// Known boundary: this compares populated-ness, so it would not see a future release method
+    /// that empties a readonly collection in place instead of nulling a field.
+    /// </para>
     /// </summary>
     [Fact]
     public void ReleaseMethods_DropExactlyTheCachesTheyDocument()
@@ -360,7 +364,9 @@ public class LibraryBodyIndexTests
         var before = PopulatedCaches(index);
 
         // The gate is only meaningful if the caches under test were populated to begin with.
-        foreach (var name in callGraphCaches)
+        // Both halves need this: an unpopulated cache is absent from `before` and from `after`,
+        // so the set comparison would hold no matter what the release methods did to it.
+        foreach (var name in callGraphCaches.Concat(retainedCaches))
             Assert.Contains(name, before);
 
         index.ReleaseCallGraphCaches();
@@ -382,6 +388,15 @@ public class LibraryBodyIndexTests
             index.BuildCallerTree(token, maxDepth: 2, maxNodes: 50);
             index.BuildCallTree(token, maxDepth: 2, maxNodes: 50);
             index.BuildCallerTree(token, new[] { scope }, maxDepth: 2, maxNodes: 50);
+
+            // The retained half of the contract is only gated on caches this workload actually
+            // populates, and the call-tree builders alone reach just one of the seven. Touch the
+            // evidence-domain producers too; OptimizationOpportunities is what pulls in
+            // _directCallerLoops and _rootReachByToken, which have no direct test access.
+            _ = index.OptimizationOpportunities;
+            _ = index.AllocationFanoutOpportunities;
+            _ = index.GetUnsafeEvidenceByMember();
+            _ = index.GeneratedFrameworkTypeNames;
             return index;
         }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -387,6 +387,32 @@ public class LibraryBodyIndexTests
         // shared cache, so a body-rooted request after it still answers like a fresh index.
         Assert.Equal(expectedTestAsmCallers, Describe(reusedTests.BuildCallerTree(testAsmToken, maxDepth: 2, maxNodes: 50)));
 
+        // The scope cache keys on the caller's collection, which the caller still owns and may
+        // mutate. Holding that live list would make the key compare equal to itself while the
+        // built maps still describe the old contents, so the scope references are snapshotted.
+        var mutableScopes = new List<LibraryBodyIndex> { scopeA };
+        var mutated = LibraryBodyIndex.Open(analysisPath);
+        mutated.BuildCallerTree(richToken, mutableScopes, maxDepth: 2, maxNodes: 50);
+        mutableScopes[0] = LibraryBodyIndex.Open(analysisPath);
+        var expectedAfterMutation = Describe(LibraryBodyIndex.Open(analysisPath)
+            .BuildCallerTree(richToken, mutableScopes, maxDepth: 2, maxNodes: 50));
+
+        // Swapping the element must actually change the answer, or this proves nothing.
+        Assert.NotEqual(expectedScoped, expectedAfterMutation);
+        Assert.Equal(expectedAfterMutation, Describe(mutated.BuildCallerTree(richToken, mutableScopes, maxDepth: 2, maxNodes: 50)));
+
+        // Releasing the caches is a memory/time trade only: answers after a release must still
+        // match a fresh index, and must not be served from a map that was supposedly dropped.
+        var released = LibraryBodyIndex.Open(analysisPath);
+        released.BuildCallerTree(richToken, new[] { scopeA }, maxDepth: 2, maxNodes: 50);
+        released.BuildCallTree(richToken, maxDepth: 2, maxNodes: 50);
+        released.ReleaseScopeGraph();
+        Assert.Equal(expectedScoped, Describe(released.BuildCallerTree(richToken, new[] { scopeA }, maxDepth: 2, maxNodes: 50)));
+        released.ReleaseCallGraphCaches();
+        Assert.Equal(expectedCallers, Describe(released.BuildCallerTree(richToken, maxDepth: 2, maxNodes: 50)));
+        Assert.Equal(expectedCallees, Describe(released.BuildCallTree(richToken, maxDepth: 2, maxNodes: 50)));
+        Assert.Equal(expectedScoped, Describe(released.BuildCallerTree(richToken, new[] { scopeA }, maxDepth: 2, maxNodes: 50)));
+
         static int PickRichest(LibraryBodyIndex index, out int richest)
         {
             int token = 0;

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1106,6 +1106,14 @@ public sealed class LibraryBodyIndex
         Dictionary<string, List<ReverseCallerEdge>>? _reverse;
 
         /// <summary>True when this cache was built for exactly the same scope instances, in order.</summary>
+        /// <remarks>
+        /// The root is part of the key because it is itself a graph participant, not merely the
+        /// object holding the cache. That clause cannot currently fail — the only storage is
+        /// <c>_scopeGraph</c> on the same instance <c>ScopeGraphFor</c> passes as <c>this</c> — so it
+        /// is an uncoverable branch, worth knowing if branch coverage here is ever read as
+        /// meaningful. It stays because dropping it would leave the key incomplete rather than
+        /// simplified, and silently wrong if a graph were ever cached anywhere but its own root.
+        /// </remarks>
         public bool Matches(LibraryBodyIndex requestRoot, IReadOnlyList<LibraryBodyIndex> requested)
         {
             if (!ReferenceEquals(root, requestRoot) || _scopes.Length != requested.Count)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -36,7 +36,15 @@ public enum LibraryBodyAnalysisFeatures
     All = Default | LeakTriage,
 }
 
-/// <summary>Materialized IL body evidence for one assembly.</summary>
+/// <summary>
+/// Materialized IL body evidence for one assembly.
+/// <para>
+/// Derived call-graph maps are populated lazily on first use and then retained, so an instance is
+/// not safe for concurrent use without external synchronization — the same as the evidence
+/// accessors that already cached this way. Use <see cref="ReleaseScopeGraph"/> or
+/// <see cref="ReleaseCallGraphCaches"/> to hand that memory back.
+/// </para>
+/// </summary>
 public sealed class LibraryBodyIndex
 {
     LibraryBodyIndex(
@@ -127,6 +135,36 @@ public sealed class LibraryBodyIndex
     IReadOnlyDictionary<int, int>? _distinctCallersByCallee;
     IReadOnlyDictionary<int, ImmutableArray<DirectCall>>? _distinctCallerEdgesByCallee;
     ScopeGraph? _scopeGraph;
+
+    /// <summary>
+    /// Drops the cross-assembly maps cached for the last-requested scope set.
+    /// <para>
+    /// These are by far the largest thing this index retains — indexing one root plus 22 scopes
+    /// holds roughly 370 MB — and they are specific to one scope set, so a consumer that has
+    /// finished rendering for a scope (or is moving to a different one) can release them without
+    /// giving up the single-assembly caches. Everything rebuilds on next use; this only trades
+    /// time for memory.
+    /// </para>
+    /// </summary>
+    public void ReleaseScopeGraph() => _scopeGraph = null;
+
+    /// <summary>
+    /// Drops every derived call-graph map this index has cached, including the scope graph.
+    /// <para>
+    /// For a consumer under a hard memory ceiling that is done asking call-graph questions.
+    /// Prefer <see cref="ReleaseScopeGraph"/> between renders that keep visiting members of this
+    /// same assembly: the single-assembly maps are comparatively small and are what make repeated
+    /// requests cheap. Everything rebuilds on next use.
+    /// </para>
+    /// </summary>
+    public void ReleaseCallGraphCaches()
+    {
+        _scopeGraph = null;
+        _methodMap = null;
+        _distinctCallersByCallee = null;
+        _distinctCallerEdgesByCallee = null;
+        _directCallsByCaller = null;
+    }
 
     /// <summary>
     /// Source/IL optimization opportunities, each enriched with the containing method's
@@ -1047,6 +1085,12 @@ public sealed class LibraryBodyIndex
     /// </summary>
     sealed class ScopeGraph(LibraryBodyIndex root, IReadOnlyList<LibraryBodyIndex> scopes)
     {
+        // Snapshot the scope references. The caller owns the list it passed and may mutate or reuse
+        // it, and Participants() is a lazy iterator, so holding the live list would let a later
+        // mutation both invalidate Matches (it would compare the list against itself) and change
+        // which assemblies get indexed after the fact.
+        readonly ImmutableArray<LibraryBodyIndex> _scopes = [.. scopes];
+
         Dictionary<string, List<ForwardCalleeEdge>>? _forward;
         Dictionary<string, HashSet<string>>? _incoming;
         Dictionary<string, (string Assembly, MethodSignals Signals)>? _definitions;
@@ -1055,11 +1099,11 @@ public sealed class LibraryBodyIndex
         /// <summary>True when this cache was built for exactly the same scope instances, in order.</summary>
         public bool Matches(LibraryBodyIndex requestRoot, IReadOnlyList<LibraryBodyIndex> requested)
         {
-            if (!ReferenceEquals(root, requestRoot) || scopes.Count != requested.Count)
+            if (!ReferenceEquals(root, requestRoot) || _scopes.Length != requested.Count)
                 return false;
-            for (int i = 0; i < scopes.Count; i++)
+            for (int i = 0; i < _scopes.Length; i++)
             {
-                if (!ReferenceEquals(scopes[i], requested[i]))
+                if (!ReferenceEquals(_scopes[i], requested[i]))
                     return false;
             }
 
@@ -1140,7 +1184,7 @@ public sealed class LibraryBodyIndex
         IEnumerable<LibraryBodyIndex> Participants()
         {
             yield return root;
-            foreach (var scope in scopes)
+            foreach (var scope in _scopes)
                 yield return scope;
         }
     }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -123,6 +123,10 @@ public sealed class LibraryBodyIndex
     Dictionary<int, int>? _rootReachByToken;
     IReadOnlyDictionary<int, ImmutableArray<DirectCall>>? _directCallsByCaller;
     IReadOnlyDictionary<int, ImmutableArray<UnsafeEvidence>>? _unsafeEvidenceByMember;
+    MethodDefinitionMap? _methodMap;
+    IReadOnlyDictionary<int, int>? _distinctCallersByCallee;
+    IReadOnlyDictionary<int, ImmutableArray<DirectCall>>? _distinctCallerEdgesByCallee;
+    ScopeGraph? _scopeGraph;
 
     /// <summary>
     /// Source/IL optimization opportunities, each enriched with the containing method's
@@ -983,6 +987,178 @@ public sealed class LibraryBodyIndex
             .GroupBy(call => call.Caller.MetadataToken)
             .ToDictionary(group => group.Key, group => group.ToImmutableArray());
 
+    /// <summary>
+    /// Token/signature resolution over this assembly's defined methods. Depends only on
+    /// <see cref="Methods"/>, so it is built once instead of per call-tree request: a single
+    /// progressive render asks for several trees over the same index.
+    /// </summary>
+    MethodDefinitionMap MethodMap => _methodMap ??= MethodDefinitionMap.Create(Methods);
+
+    /// <summary>
+    /// Distinct callers per callee definition token, over the whole assembly.
+    ///
+    /// Fan-in is the <em>true</em> inbound degree, not the degree of the drawn subgraph: a bounded
+    /// tree visits at most <c>maxNodes</c> nodes, but the annotation means "how many members depend
+    /// on this one", so it must count callers the tree never expanded. That is why this is a
+    /// whole-graph quantity and cannot be narrowed to the visited set — it is cached per index
+    /// instead, so the cost is paid once rather than on every request.
+    /// </summary>
+    IReadOnlyDictionary<int, int> DistinctCallersByCallee()
+        => _distinctCallersByCallee ??= DirectCalls
+            .GroupBy(call => MethodMap.Resolve(call))
+            .Where(group => group.Key != 0)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(call => call.Caller.MetadataToken).Distinct().Count(),
+                EqualityComparer<int>.Default);
+
+    /// <summary>
+    /// Inbound call edges per callee definition token, collapsed to one edge per distinct caller
+    /// method and preserving an in-loop call site when the same caller has one.
+    ///
+    /// Keyed by <see cref="MethodDefinitionMap.Resolve"/>, which is root-independent. The caller
+    /// tree's own resolution additionally maps any edge whose callee definition token equals the
+    /// requested root onto that root, which matters only when the root is bodiless
+    /// (abstract/interface/extern) and therefore absent from <see cref="Methods"/>; for a root with
+    /// a body <c>Resolve</c> already returns that same token. <see cref="BuildCallerTree(int, int,
+    /// int)"/> therefore uses this cache only for rooted-in-a-body requests and builds its own map
+    /// for the bodiless case, rather than caching a map that silently depends on the root.
+    /// </summary>
+    IReadOnlyDictionary<int, ImmutableArray<DirectCall>> DistinctCallerEdgesByCallee()
+        => _distinctCallerEdgesByCallee ??= DirectCalls
+            .GroupBy(call => MethodMap.Resolve(call))
+            .Where(group => group.Key != 0)
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .GroupBy(call => call.Caller.MetadataToken)
+                    .Select(callerGroup => callerGroup.FirstOrDefault(call => call.InLoop) ?? callerGroup.First())
+                    .ToImmutableArray(),
+                EqualityComparer<int>.Default);
+
+    /// <summary>
+    /// The cross-assembly structural maps for one caller/callee scope set, cached on the index
+    /// that roots the request.
+    ///
+    /// Both directions are keyed by <c>CallerGraphKey</c> and depend only on the participating
+    /// assemblies' calls, methods and signals — never on which member was selected — so a scope set
+    /// can be indexed once and reused across requests. Each direction is built on first use, so a
+    /// caller-only or callee-only consumer never pays for the other.
+    /// </summary>
+    sealed class ScopeGraph(LibraryBodyIndex root, IReadOnlyList<LibraryBodyIndex> scopes)
+    {
+        Dictionary<string, List<ForwardCalleeEdge>>? _forward;
+        Dictionary<string, HashSet<string>>? _incoming;
+        Dictionary<string, (string Assembly, MethodSignals Signals)>? _definitions;
+        Dictionary<string, List<ReverseCallerEdge>>? _reverse;
+
+        /// <summary>True when this cache was built for exactly the same scope instances, in order.</summary>
+        public bool Matches(LibraryBodyIndex requestRoot, IReadOnlyList<LibraryBodyIndex> requested)
+        {
+            if (!ReferenceEquals(root, requestRoot) || scopes.Count != requested.Count)
+                return false;
+            for (int i = 0; i < scopes.Count; i++)
+            {
+                if (!ReferenceEquals(scopes[i], requested[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public (Dictionary<string, List<ForwardCalleeEdge>> Forward,
+                Dictionary<string, HashSet<string>> Incoming,
+                Dictionary<string, (string Assembly, MethodSignals Signals)> Definitions) ForwardMaps()
+        {
+            if (_forward is not null && _incoming is not null && _definitions is not null)
+                return (_forward, _incoming, _definitions);
+
+            var forward = new Dictionary<string, List<ForwardCalleeEdge>>(StringComparer.Ordinal);
+            var incoming = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+            var definitions = new Dictionary<string, (string Assembly, MethodSignals Signals)>(StringComparer.Ordinal);
+            foreach (var assembly in Participants())
+            {
+                var signals = assembly.Signals;
+                foreach (var call in assembly.DirectCalls)
+                {
+                    if (call.Callee.Kind == MemberKind.Unsupported)
+                        continue;
+                    var callerKey = CallerGraphKey(call.Caller);
+                    var calleeKey = CallerGraphKey(call.Callee);
+                    var edge = new ForwardCalleeEdge(call.Callee, calleeKey, call.Kind, call.InLoop);
+                    if (forward.TryGetValue(callerKey, out var list))
+                        list.Add(edge);
+                    else
+                        forward[callerKey] = [edge];
+                    if (incoming.TryGetValue(calleeKey, out var callers))
+                        callers.Add(callerKey);
+                    else
+                        incoming[calleeKey] = new HashSet<string>(StringComparer.Ordinal) { callerKey };
+                }
+
+                foreach (var method in assembly.Methods)
+                {
+                    var key = CallerGraphKey(method);
+                    if (!definitions.ContainsKey(key))
+                        definitions[key] = (method.AssemblyName, signals.GetValueOrDefault(method.MetadataToken, MethodSignals.None));
+                }
+            }
+
+            _forward = forward;
+            _incoming = incoming;
+            _definitions = definitions;
+            return (forward, incoming, definitions);
+        }
+
+        public Dictionary<string, List<ReverseCallerEdge>> ReverseMap()
+        {
+            if (_reverse is not null)
+                return _reverse;
+
+            var reverse = new Dictionary<string, List<ReverseCallerEdge>>(StringComparer.Ordinal);
+            foreach (var assembly in Participants())
+            {
+                var signals = assembly.Signals;
+                foreach (var call in assembly.DirectCalls)
+                {
+                    if (call.Callee.Kind == MemberKind.Unsupported)
+                        continue;
+                    var calleeKey = CallerGraphKey(call.Callee);
+                    var caller = call.Caller;
+                    var callerKey = CallerGraphKey(caller);
+                    var edge = new ReverseCallerEdge(caller, callerKey, signals.GetValueOrDefault(caller.MetadataToken, MethodSignals.None), call.InLoop);
+                    if (reverse.TryGetValue(calleeKey, out var list))
+                        list.Add(edge);
+                    else
+                        reverse[calleeKey] = [edge];
+                }
+            }
+
+            return _reverse = reverse;
+        }
+
+        IEnumerable<LibraryBodyIndex> Participants()
+        {
+            yield return root;
+            foreach (var scope in scopes)
+                yield return scope;
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="ScopeGraph"/> for <paramref name="scopes"/>, reusing the cached one when the
+    /// same scope instances are requested again. A progressive render asks for the same scope set
+    /// in both directions, and indexing it is proportional to every edge in every participating
+    /// assembly.
+    /// </summary>
+    ScopeGraph ScopeGraphFor(IReadOnlyList<LibraryBodyIndex> scopes)
+    {
+        if (_scopeGraph is { } cached && cached.Matches(this, scopes))
+            return cached;
+
+        return _scopeGraph = new ScopeGraph(this, scopes);
+    }
+
     public IReadOnlyDictionary<int, ImmutableArray<UnsafeEvidence>> GetUnsafeEvidenceByMember()
         => _unsafeEvidenceByMember ??= UnsafeEvidence
             .GroupBy(evidence => evidence.Member.MetadataToken)
@@ -1334,11 +1510,9 @@ public sealed class LibraryBodyIndex
             ? new MemberRef(identity.DeclaringType, identity.Name, identity.ParameterTypes, identity.ReturnType, MemberKind.Method)
             : MemberRef.Unsupported($"method token 0x{rootMethodToken:X8}");
 
-        var callsByCaller = DirectCalls
-            .GroupBy(call => call.Caller.MetadataToken)
-            .ToDictionary(group => group.Key, group => group.ToList());
+        var callsByCaller = GetDirectCallsByCaller();
 
-        var methodMap = MethodDefinitionMap.Create(Methods);
+        var methodMap = MethodMap;
 
         int budget = Math.Max(1, maxNodes);
         int created = 1;
@@ -1349,14 +1523,9 @@ public sealed class LibraryBodyIndex
 
         // Fan-in counts distinct callers, not call sites: it is a leverage cue ("how many
         // members depend on this one"), and the reverse graph draws one edge per distinct
-        // caller, so the annotation has to agree with the picture it annotates.
-        var incomingCounts = DirectCalls
-            .GroupBy(call => ResolveCallee(call))
-            .Where(group => group.Key != 0)
-            .ToDictionary(
-                group => group.Key,
-                group => group.Select(call => call.Caller.MetadataToken).Distinct().Count(),
-                EqualityComparer<int>.Default);
+        // caller, so the annotation has to agree with the picture it annotates. Cached on the
+        // index because it is a whole-graph quantity that every request would otherwise rebuild.
+        var incomingCounts = DistinctCallersByCallee();
 
         CallTreeNode Build(MemberRef member, CallKind? kind, int token, int depth, bool inLoop = false)
         {
@@ -1371,7 +1540,7 @@ public sealed class LibraryBodyIndex
             // tree expanded. CallTreeStatus separately conveys why expansion stopped,
             // so depth-limited/already-shown/truncated nodes still report their real
             // fan-out instead of reading like leaves.
-            var fanout = edges.Count;
+            var fanout = edges.Length;
             if (depth >= maxDepth)
                 return new CallTreeNode(member, kind, CallTreeStatus.DepthLimited, [], new CallTreePerf(fanout, incomingCounts.TryGetValue(token, out var incomingDepth) ? incomingDepth : 0, 1, inLoop, inLoop ? "loop" : null, null, sig));
 
@@ -1421,7 +1590,7 @@ public sealed class LibraryBodyIndex
                 ? resolvedCallee
                 : MemberRef.Unsupported($"method token 0x{rootMethodToken:X8}");
 
-        var methodMap = MethodDefinitionMap.Create(Methods);
+        var methodMap = MethodMap;
 
         int ResolveCalleeToken(DirectCall call)
         {
@@ -1441,16 +1610,25 @@ public sealed class LibraryBodyIndex
         // method (the section reports callers, not call sites). Preserve the in-loop signal:
         // if any call site from a caller hits the target inside a loop, keep that edge so the
         // loop annotation survives deduplication.
-        var reverseEdges = DirectCalls
-            .GroupBy(call => ResolveCalleeToken(call))
-            .Where(group => group.Key != 0)
-            .ToDictionary(
-                group => group.Key,
-                group => group
-                    .GroupBy(call => call.Caller.MetadataToken)
-                    .Select(callerGroup => callerGroup.FirstOrDefault(call => call.InLoop) ?? callerGroup.First())
-                    .ToList(),
-                EqualityComparer<int>.Default);
+        //
+        // When the root has a body, ResolveCalleeToken agrees with MethodDefinitionMap.Resolve
+        // for every edge — Resolve returns CalleeDefinitionToken whenever that token is a defined
+        // method — so the shared per-index cache applies. A bodiless root is the one case where
+        // the grouping genuinely depends on the root, because edges naming it would otherwise be
+        // resolved onto some other defined method; that case builds its own map.
+        IReadOnlyDictionary<int, ImmutableArray<DirectCall>> reverseEdges =
+            methodMap.ContainsToken(rootMethodToken)
+                ? DistinctCallerEdgesByCallee()
+                : DirectCalls
+                    .GroupBy(call => ResolveCalleeToken(call))
+                    .Where(group => group.Key != 0)
+                    .ToDictionary(
+                        group => group.Key,
+                        group => group
+                            .GroupBy(call => call.Caller.MetadataToken)
+                            .Select(callerGroup => callerGroup.FirstOrDefault(call => call.InLoop) ?? callerGroup.First())
+                            .ToImmutableArray(),
+                        EqualityComparer<int>.Default);
 
         int budget = Math.Max(1, maxNodes);
         int created = 1;
@@ -1474,7 +1652,7 @@ public sealed class LibraryBodyIndex
                 return new CallTreeNode(member, null, leafStatus, [], new CallTreePerf(0, 0, 1, inLoop, loopHint, classification, sig));
             }
 
-            var fanin = edges.Count;
+            var fanin = edges.Length;
             if (depth >= maxDepth)
                 return new CallTreeNode(member, null, CallTreeStatus.DepthLimited, [], new CallTreePerf(0, fanin, 1, inLoop, loopHint, classification, sig));
 
@@ -1559,27 +1737,8 @@ public sealed class LibraryBodyIndex
         // Structural reverse map across the selected member's assembly plus the caller scopes:
         // callee structural key -> inbound caller edges (each carrying the caller's own-assembly
         // signals captured at index time, since signal tables are assembly-local by token).
-        var reverse = new Dictionary<string, List<ReverseCallerEdge>>(StringComparer.Ordinal);
-        void IndexAssembly(LibraryBodyIndex assembly)
-        {
-            var signals = assembly.Signals;
-            foreach (var call in assembly.DirectCalls)
-            {
-                if (call.Callee.Kind == MemberKind.Unsupported)
-                    continue;
-                var calleeKey = CallerGraphKey(call.Callee);
-                var caller = call.Caller;
-                var callerKey = CallerGraphKey(caller);
-                var edge = new ReverseCallerEdge(caller, callerKey, signals.GetValueOrDefault(caller.MetadataToken, MethodSignals.None), call.InLoop);
-                if (reverse.TryGetValue(calleeKey, out var list))
-                    list.Add(edge);
-                else
-                    reverse[calleeKey] = [edge];
-            }
-        }
-        IndexAssembly(this);
-        foreach (var scope in callerScopes)
-            IndexAssembly(scope);
+        // Cached per scope set: it depends on the participating assemblies, not on the selection.
+        var reverse = ScopeGraphFor(callerScopes).ReverseMap();
 
         int budget = Math.Max(1, maxNodes);
         int created = 1;
@@ -1696,40 +1855,10 @@ public sealed class LibraryBodyIndex
         // caller structural key -> outbound callee edges. A companion definition map records each
         // decoded method's home assembly and signals (both assembly-local by token), so an expanded
         // callee reports its source assembly and perf signals from wherever it is actually defined.
-        var forward = new Dictionary<string, List<ForwardCalleeEdge>>(StringComparer.Ordinal);
         // Distinct callers per callee, not call sites — same leverage semantics as the
         // single-assembly builder and as the reverse graph's one-edge-per-caller shape.
-        var incoming = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
-        var definitions = new Dictionary<string, (string Assembly, MethodSignals Signals)>(StringComparer.Ordinal);
-        void IndexAssembly(LibraryBodyIndex assembly)
-        {
-            var signals = assembly.Signals;
-            foreach (var call in assembly.DirectCalls)
-            {
-                if (call.Callee.Kind == MemberKind.Unsupported)
-                    continue;
-                var callerKey = CallerGraphKey(call.Caller);
-                var calleeKey = CallerGraphKey(call.Callee);
-                var edge = new ForwardCalleeEdge(call.Callee, calleeKey, call.Kind, call.InLoop);
-                if (forward.TryGetValue(callerKey, out var list))
-                    list.Add(edge);
-                else
-                    forward[callerKey] = [edge];
-                if (incoming.TryGetValue(calleeKey, out var callers))
-                    callers.Add(callerKey);
-                else
-                    incoming[calleeKey] = new HashSet<string>(StringComparer.Ordinal) { callerKey };
-            }
-            foreach (var method in assembly.Methods)
-            {
-                var key = CallerGraphKey(method);
-                if (!definitions.ContainsKey(key))
-                    definitions[key] = (method.AssemblyName, signals.GetValueOrDefault(method.MetadataToken, MethodSignals.None));
-            }
-        }
-        IndexAssembly(this);
-        foreach (var scope in calleeScopes)
-            IndexAssembly(scope);
+        // Cached per scope set: these depend on the participating assemblies, not the selection.
+        var (forward, incoming, definitions) = ScopeGraphFor(calleeScopes).ForwardMaps();
 
         int budget = Math.Max(1, maxNodes);
         int created = 1;

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -149,12 +149,20 @@ public sealed class LibraryBodyIndex
     public void ReleaseScopeGraph() => _scopeGraph = null;
 
     /// <summary>
-    /// Drops every derived call-graph map this index has cached, including the scope graph.
+    /// Drops the maps that back the call-tree builders: the scope graph, the definition map, the
+    /// distinct-caller counts and edges, and the direct-call grouping.
     /// <para>
-    /// For a consumer under a hard memory ceiling that is done asking call-graph questions.
-    /// Prefer <see cref="ReleaseScopeGraph"/> between renders that keep visiting members of this
-    /// same assembly: the single-assembly maps are comparatively small and are what make repeated
-    /// requests cheap. Everything rebuilds on next use.
+    /// For a consumer under a hard memory ceiling that is done asking call-graph questions. This
+    /// deliberately does <em>not</em> drop the evidence-domain caches — method signals, caller-loop
+    /// evidence, root-reach roll-ups, unsafe-evidence grouping — which serve other producers and
+    /// together retain well under a megabyte. Prefer <see cref="ReleaseScopeGraph"/> between
+    /// renders that keep visiting members of this same assembly: the single-assembly maps are
+    /// comparatively small and are what make repeated requests cheap. Everything rebuilds on next
+    /// use, so this only trades time for memory.
+    /// </para>
+    /// <para>
+    /// <c>ReleaseMethods_DropExactlyTheCachesTheyDocument</c> derives this type's cache fields by
+    /// reflection and fails if one is added, or moved across that boundary, without updating it.
     /// </para>
     /// </summary>
     public void ReleaseCallGraphCaches()

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -154,8 +154,9 @@ public sealed class LibraryBodyIndex
     /// <para>
     /// For a consumer under a hard memory ceiling that is done asking call-graph questions. This
     /// deliberately does <em>not</em> drop the evidence-domain caches — method signals, caller-loop
-    /// evidence, root-reach roll-ups, unsafe-evidence grouping — which serve other producers and
-    /// together retain well under a megabyte. Prefer <see cref="ReleaseScopeGraph"/> between
+    /// evidence, root-reach roll-ups, unsafe-evidence grouping, generated-framework type sets, and
+    /// the optimization-opportunity arrays — which serve other producers and together retain well
+    /// under a megabyte. Prefer <see cref="ReleaseScopeGraph"/> between
     /// renders that keep visiting members of this same assembly: the single-assembly maps are
     /// comparatively small and are what make repeated requests cheap. Everything rebuilds on next
     /// use, so this only trades time for memory.


### PR DESCRIPTION
Closes #3342.

Every call-tree request rebuilt the whole-assembly maps it needs, even though a bounded tree (`maxDepth 3`, `maxNodes 25`) only visits a few dozen nodes. Those maps are pure functions of `DirectCalls`/`Methods` — and, for the cross-assembly path, of the scope set — so they are now lazily cached on the index. A consumer that asks many questions of one index now pays for the graph once.

## Measured

One index, many requests — the shape the wasm consumer has. Output checksums identical in every row.

| shape | base | head |
| --- | --- | --- |
| 60 members, single assembly | 21246 ms / 13388 MB alloc | **230 ms / 93 MB** |
| 300 members, single assembly | 106445 ms / 66943 MB alloc | **262 ms / 95 MB** |
| 20 members, 22 scopes | 63681 ms / 29419 MB alloc / 1015 MB peak | **3341 ms / 1351 MB alloc / 789 MB peak** |

Base scales exactly linearly in member count (5x members -> 5.0x time); head is flat.

**A single CLI invocation shows no win** — 4681 ms -> 4617 ms, 340 -> 345 MB, output byte-identical. There the cost is decoding 23 assemblies, not rebuilding maps. The win is entirely in the repeated-request shape, so measuring this through the CLI alone would have shown nothing.

## What changed

`LibraryBodyIndex` gains four lazy caches using the same `_field ??= ...` pattern `GetDirectCallsByCaller()` already used: the definition map, distinct callers by callee, distinct caller edges by callee, and a scope-keyed `ScopeGraph` for the cross-assembly forward/reverse maps. `BuildCallTree` also stopped rebuilding a grouping `GetDirectCallsByCaller()` already provides.

## New public surface

Two methods on `LibraryBodyIndex`, added in `ac557157` in response to round-1 review:

| Method | Drops |
| --- | --- |
| `ReleaseScopeGraph()` | the cross-assembly scope graph only |
| `ReleaseCallGraphCaches()` | that, plus the definition map, distinct-caller counts and edges, and the direct-call grouping |

They are separate because the two halves have opposite economics. The single-assembly caches retain ~75 MB and take peak working set *below* base (451 vs 471 MB) while being 34x faster; the cross-assembly graph is the only real memory trade, and one root plus 22 scopes retains ~370 MB of it. A consumer that keeps visiting members of one assembly wants `ReleaseScopeGraph()` between renders, not the full drop.

Everything rebuilds on next use, so both only trade time for memory. `ReleaseScopeGraph()` returns live bytes to 2.1 MB — exactly base — with output checksums identical.

`ReleaseMethods_DropExactlyTheCachesTheyDocument` derives the type's twelve mutable cache fields by reflection and pins each to a side of that boundary, so the doc cannot drift from the code and a newly added cache fails until someone decides which side it is on.
## The one case deliberately left uncached

A **bodiless root** is absent from `Methods`, so edges naming it resolve onto a *different* defined method and never land in a bucket keyed by the root. `BuildCallerTree` therefore uses the shared reverse index only when `methodMap.ContainsToken(rootMethodToken)`, and builds its own map otherwise.

Mutation-tested: removing that guard leaves the new test green but fails the pre-existing `BuildCallerTree_ResolvesCallers_WhenSelectedRootIsBodilessInterfaceMethod`. That split is correct and is now stated in the new test's comment — serving a bodiless root from the shared grouping is a *correctness* fault that a fresh index reproduces identically, so no cache-independence test can see it.

I also checked the reverse direction, where a bodiless request *poisons* the shared cache. That mutation survives, and it is an **equivalent mutant**: the definition-map key includes the declaring type, so `Resolve` always returns 0 for a bodiless callee and the leaked entry is purely additive. Predicted from the key structure, then confirmed empirically rather than assumed.

## Two corrections to the issue

1. **Not superlinear.** The issue calls the cost superlinear, but its own numbers are sublinear per method (167 ms/method at 60, 117 at 300). My scaling run confirms base is *linear* in member count. The problem is the constant factor, not the growth rate.
2. **Option 2 as written is a trap.** Narrowing fan-in to the visited subset would silently redefine the metric. Fan-in must remain true whole-graph inbound degree, mirroring fan-out's existing contract ("independent of how far the bounded tree expanded"). This PR keeps the metric identical and only removes recomputation.

The issue also **understates scope**: all four builders rebuild whole-graph state, and the two most expensive were not listed.

## Test

`CallTreeBuilders_AreUnaffectedByEarlierRequestsOnTheSameIndex` walks one index through a sequence designed to poison a root- or scope-dependent cache and requires every answer to match a fresh index asked nothing else.

It is written to resist going vacuous, because **my first version did**: it compared `LibraryBodyIndex.Open`, which has no in-assembly callers, so it rendered one leaf line and would have held no matter how badly a cache leaked. It now self-calibrates — it scans for a root with a genuinely branching tree and asserts `richest >= 4` — and it asserts `expectedScoped != expectedUnscoped` so the scope comparisons cannot pass by both sides being equally empty.

Mutation-tested: forcing `ScopeGraph.Matches` to `return true` fails it.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — 0 Error(s)
- Analysis: **556 / 1 failed** — `CrossAssemblyMetadataResolver_ResolvesFrameworkTypeDefinition`, verified pre-existing on base `d4002cf1` by building and running that commit
- CLI: **2229 / 1 failed / 10 skipped** — baseline
- CLI output byte-identical base vs head for `open` (63 lines) and the caller-graph key case (64 lines)
