### PR TITLE
Make --print failures visible and remove --print-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ dotnet-inspect library MyLib.dll --il-offset 0x06000001+0x5
 
 ## Output and querying
 
-Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--bare` for one undecorated payload without changing the selected shape, `--value` for one scalar, `--urls` for URL lists, `--paths` for path lists, `--print` to materialize one printable selected-section row (`--row N` chooses a printable row), `--print-all` to materialize every printable row with separators, `--json-array` to emit projected rows as one JSON array, `--rows -n N` to cap rendered table rows, `--count` to reduce a selected section/vector to a single row count, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.
+Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--bare` for one undecorated payload without changing the selected shape, `--value` for one scalar, `--urls` for URL lists, `--paths` for path lists, `--print` to materialize one printable selected-section row (`--row N` chooses a printable row), `--json-array` to emit projected rows as one JSON array, `--rows -n N` to cap rendered table rows, `--count` to reduce a selected section/vector to a single row count, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.
 
 Sections and fields are queryable without a template language:
 
@@ -384,7 +384,7 @@ dotnet-inspect type Command --project ./src/App
 dotnet-inspect member Command --project ./src/App -S "Member Index"
 dotnet-inspect project ./src/App -S Skills
 dotnet-inspect project ./src/App -S Skills --print --row 1
-dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print-all
+dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
 dotnet-inspect type string --shape
 dotnet-inspect type --package System.Text.Json --table
 dotnet-inspect member JsonSerializer --package System.Text.Json -m Serialize

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -218,7 +218,6 @@ package payloads. Once selected, the normal output-shape rules apply:
 | `--count` | Reduce the selected Vector to a Scalar count. | None. Count the bounded, prerelease-filtered addresses already selected. |
 | `--urls` | Project URL-bearing rows to a URL Vector. | None. Valid only if the version-row schema exposes a URL. |
 | `--print` | Resolve a printable payload already referenced by one selected row. | May fetch that declared payload at the same evaluated address; must not add or evaluate another source address. |
-| `--print-all` | Resolve every declared printable row payload in stable row order. | Explicitly authorizes payload fan-out only for already selected/evaluated rows; must not evaluate source addresses. |
 | `--head N` / `--tail N` | Clip rendered output lines after projection. | None. They do not select printable rows or limit payload fetches. |
 
 Shape reducers do not revise operation arity. In particular:
@@ -229,23 +228,23 @@ Shape reducers do not revise operation arity. In particular:
 - `--urls` may expose registry URLs if version rows gain such a field, but it
   must not download package contents to manufacture them;
 - `--print` is exactly-one, not implicit-first: one printable row prints
-  directly, multiple printable rows require `--row N|first|last` or `--print-all`, and zero
-  printable rows reject;
+  directly, multiple printable rows require `--row N|first|last`, and zero
+  printable rows reject. There is no fan-out gesture, so a single `--print`
+  authorizes at most one declared payload fetch;
 - `--head N` and `--tail N` run after print selection and fetching, so
-  `--print --head 1` does not select the first printable row and
-  `--print-all --head 1` still authorizes all declared payload fetches;
+  `--print --head 1` does not select the first printable row;
 - `--rows --head N` and the symmetric `--rows --tail N` are first/last
-  table-row rendering windows and remain incompatible with `--print` and
-  `--print-all`; `--row N|first|last` selects exactly one printable row;
-- a plain version string has no printable document. `--print` and `--print-all`
+  table-row rendering windows and remain incompatible with `--print`;
+  `--row N|first|last` selects exactly one printable row;
+- a plain version string has no printable document. `--print`
   must report that the selected shape is not printable rather than silently
   transition from version-address rows to package artifact inspection. The
   explicit transition remains `package Package@version`.
 
 The same rule applies to `timeline`. `--count` can reduce an already
-assembled Timeline table; it cannot probe additional cells. `--print` and
-`--print-all` can print only payloads already carried or explicitly referenced
-by evaluated rows; they cannot turn unevaluated rows into implicit acquisition.
+assembled Timeline table; it cannot probe additional cells. `--print` can print
+only payloads already carried or explicitly referenced by evaluated rows; it
+cannot turn unevaluated rows into implicit acquisition.
 
 The current package `--versions` path is implemented as a specialized early-exit
 list writer, so some shared reducers and projectors are not yet honored

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -4,7 +4,7 @@ dotnet-inspect output narrows through a small ladder of **shapes**. Markout
 defines the shapes and produces them; dotnet-inspect flags choose which rung you
 land on. Naming the ladder gives a shared vocabulary for the output flags
 (`-S`, `--fields`/`--columns`, `--tsv`/`--jsonl`, `--count`, `-n`/`--rows`,
-`--print`, `--print-all`, `--bare`, …) and for deciding what a new flag should
+`--print`, `--bare`, …) and for deciding what a new flag should
 do.
 
 Related docs:
@@ -107,19 +107,27 @@ modifier changes how a selected payload is rendered.
 it does not mean "take the first row." Cardinality is resolved after section
 selection, filtering, and printable-capability filtering:
 
-| Printable rows | `--print` | `--print --row N\|first\|last` | `--print-all` |
-| ---: | --- | --- | --- |
-| 0 | Error: the selected shape is not printable. | Error. | Error: the selected shape is not printable. |
-| 1 | Print the one payload. | Print row `1`, `first`, or `last`; any other index is an error. | Print the one payload. |
-| More than 1 | Guidance error requiring `--row` or `--print-all`. | Print exactly the selected printable row. | Print every printable payload in stable row order. |
+| Printable rows | `--print` | `--print --row N\|first\|last` |
+| ---: | --- | --- |
+| 0 | Error: the selected shape is not printable. | Error. |
+| 1 | Print the one payload. | Print row `1`, `first`, or `last`; any other index is an error. |
+| More than 1 | Guidance error requiring `--row`. | Print exactly the selected printable row. |
+
+`--print` resolves exactly one payload. There is no fan-out gesture: printing
+more than one document at a time is not currently expressible.
 
 Numeric `--row N` is one-based and counts printable rows, not every row in the
 selected table. `first` and `last` are stable aliases for the endpoints of that
-printable-row sequence. `--print-all` cannot be combined with `--row`.
+printable-row sequence.
+
+Because `--print` is exactly-one, a payload that is declared but cannot be
+acquired is an error, not an omission. Failing to fetch the selected row's
+document reports that failure and exits non-zero; it never renders as an empty
+or short success.
 
 `-n N` / `--head N` and `--tail N` are rendered-line windows applied after
-printable-row cardinality is resolved and payloads are fetched. They do not
-select rows or limit `--print-all` fan-out:
+printable-row cardinality is resolved and the payload is fetched. They do not
+select rows:
 
 ```text
 --print --head 1
@@ -127,9 +135,6 @@ select rows or limit `--print-all` fan-out:
 
 --print --row 2 --head 20
   select printable row 2 -> fetch one payload -> render its first 20 lines
-
---print-all --tail 20
-  fetch every declared printable payload -> render the final 20 combined lines
 ```
 
 `--rows` changes head/tail from rendered-line windows into per-table data-row
@@ -138,18 +143,17 @@ windows:
 - `--rows --head N` keeps the first N data rows;
 - `--rows --tail N` keeps the last N data rows.
 
-Both row-window forms are incompatible with `--print` and `--print-all`;
+Both row-window forms are incompatible with `--print`;
 `--row N|first|last` is the explicit printable-row selector. The CLI implements
 both head and tail data-row windows symmetrically.
 
 This policy deliberately rejects implicit-first behavior. Row order may change
 with filtering, producer evolution, or package versions, and choosing the first
 row could silently fetch the wrong document. It also rejects implicit fan-out:
-`--print-all` is the gesture that explicitly accepts every declared payload
-fetch.
+one `--print` authorizes exactly one declared payload fetch.
 
 Printability is a row capability, not a property implied by Table or Vector
-shape. Neither `--print` nor `--print-all` may:
+shape. `--print` may not:
 
 - reinterpret an address row as the artifact at that address;
 - evaluate an unevaluated address;
@@ -370,9 +374,8 @@ The stable vocabulary is:
 - `--count` is a shape-reduction selector: it collapses a selected table/vector to a
   single scalar count.
 - `--print` is an exactly-one row-payload projection: it never chooses the first
-  of multiple printable rows implicitly.
-- `--print-all` is the explicit row-payload fan-out projection: it does not make
-  non-printable rows printable or evaluate new addresses.
+  of multiple printable rows implicitly, does not make non-printable rows
+  printable, and does not evaluate new addresses.
 - `--head` / `--tail` are post-projection line windows: they do not select rows
   or constrain payload acquisition.
 - `--rows` promotes head/tail to first/last data-row windows, but those windows

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -120,10 +120,11 @@ Numeric `--row N` is one-based and counts printable rows, not every row in the
 selected table. `first` and `last` are stable aliases for the endpoints of that
 printable-row sequence.
 
-Because `--print` is exactly-one, a payload that is declared but cannot be
-acquired is an error, not an omission. Failing to fetch the selected row's
-document reports that failure and exits non-zero; it never renders as an empty
-or short success.
+Because `--print` is exactly-one, failing to acquire the selected row's payload
+is an error, not an omission: it reports the failure and exits non-zero rather
+than rendering an empty or short success. This covers acquisition for the
+selected row; whether a section producer declares a row at all is that
+producer's concern.
 
 `-n N` / `--head N` and `--tail N` are rendered-line windows applied after
 printable-row cardinality is resolved and the payload is fetched. They do not

--- a/docs/design/rendering-model.md
+++ b/docs/design/rendering-model.md
@@ -60,7 +60,6 @@ The `package` command inspects a NuGet package. Its default view is *package ide
 | `--urls` | URL projection | Prints URL-bearing selected-section rows as a URL list, JSONL rows, or a JSON array |
 | `--paths` | Path projection | Prints path-bearing selected-section rows as a path list, JSONL rows, or a JSON array |
 | `--print` | Row payload | Prints one document behind a selected printable section row; use `--row N\|first\|last` to choose the printable row when multiple printable rows exist |
-| `--print-all` | Row payloads | Prints every printable row from one selected section, using separators for text, JSONL rows, or one JSON array with `--json-array` |
 | `--versions` | Version history | Available versions from nuget.org |
 | `--library` | Library metadata | Delegates to library inspection |
 
@@ -108,7 +107,7 @@ A mode-switch flag says "show me this aspect of the subject." It does not intera
 
 ### Each lens owns its own rendering
 
-The `--files` view renders a tree. The `--readme` compatibility view renders raw markdown. The `--versions` view renders a list. `--print` projects one row of a selected printable section to the referenced document body; `--row N` chooses the Nth printable row, and multiple printable rows without `--row` produce a guidance error. `--print-all` projects every printable row and separates text payloads with `--- label ---` headers; `--jsonl` emits one object per printed row. These rendering choices are intrinsic to the lens, not controlled by verbosity. A lens may support its own sub-options (e.g. `--files --all` to include all files, not just DLLs) but those are scoped to that lens.
+The `--files` view renders a tree. The `--readme` compatibility view renders raw markdown. The `--versions` view renders a list. `--print` projects one row of a selected printable section to the referenced document body; `--row N` chooses the Nth printable row, and multiple printable rows without `--row` produce a guidance error. `--jsonl` emits the printed row as one object. These rendering choices are intrinsic to the lens, not controlled by verbosity. A lens may support its own sub-options (e.g. `--files --all` to include all files, not just DLLs) but those are scoped to that lens.
 
 ### Default rendering should be the most useful
 
@@ -119,7 +118,7 @@ When a lens has multiple possible rendering modes, the default should be the mos
 | Command | Identity (verbosity) | Lenses (mode-switch flags) |
 | ------- | -------------------- | -------------------------- |
 | `package` | Package Info, Statistics, Dependencies, Vulnerabilities | `--files`, `-S Grounding --print`, `--readme`, `--versions`, `-S Signals` |
-| `project` | — | `-S Skills`, `-S Skills --print --row N`, `-S Skills --print-all` |
+| `project` | — | `-S Skills`, `-S Skills --print --row N` |
 | `type`/`member` | Type/member identity and sectioned evidence | `-S "Source Files" --print --row N`, `-S "Source Locations" --print --row N`, `-S "Original Source" --print` |
 | `api` | Type fields, Members table | `--docs`, `--samples`, `--table`, `--tsv` |
 | `library` | Library info, PE headers | `--sourcelink`, `--references` |

--- a/docs/workflows/core/package-inspection.md
+++ b/docs/workflows/core/package-inspection.md
@@ -211,7 +211,7 @@ dotnet-inspect package Markout -S "Grounding" --print
 dotnet-inspect project ./src/App -S "Skills"
 dotnet-inspect project ./src/App -S "Skills" --paths
 dotnet-inspect project ./src/App -S "Skills" --print --row 1
-dotnet-inspect project ./src/App -S "Skills" --print-all --jsonl
+dotnet-inspect project ./src/App -S "Skills" --print --row 1 --jsonl
 dotnet-inspect package Markout -S "Markdown Files"
 dotnet-inspect package Markout --path @agents --content --frontmatter
 dotnet-inspect package Markout Polly --path @agents --path @readme --match first --content --jsonl

--- a/docs/workflows/getting-started/lap-around.md
+++ b/docs/workflows/getting-started/lap-around.md
@@ -211,7 +211,7 @@ SourceLink URLs are exposed on the command you are already using.
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --table
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --urls --json-array
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
-dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print-all --jsonl
+dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1 --jsonl
 ```
 
 ```expect

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -23,13 +23,12 @@ Default output is Markdown. Pick a machine or compact shape when you need one:
 - `--table` — compact aligned rows.
 - `--tsv` — stable snake_case headers, no embedded tabs/newlines.
 - `--jsonl` — one JSON object per row.
-- `--json-array` — one JSON array for projected rows (`--urls`, `--paths`, `--value`, `--print-all`).
+- `--json-array` — one JSON array for projected rows (`--urls`, `--paths`, `--value`, `--print`).
 - `--json` — structured documents.
 - `--bare` — one undecorated payload or URL list.
 - `--count` — a bare row count.
 - `--value` / `--urls` / `--paths` — project one selected section to scalar, URL, or path payloads.
 - `--print` — print one document behind a selected printable row; use `--row N` when multiple printable rows exist.
-- `--print-all` — print every printable row from one selected section, with text separators, `--jsonl`, or `--json-array`.
 - `--mermaid` — graph-shaped output.
 
 ## Discover and select sections

--- a/skills/sourcelink/SKILL.md
+++ b/skills/sourcelink/SKILL.md
@@ -40,7 +40,7 @@ row; add `--row N` when the selected section has multiple printable rows.
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S "Original Source"
 dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Source Locations" --print --row 1
-dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --print-all --json-array
+dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1 --json-array
 ```
 
 ## URL forms

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3467,7 +3467,7 @@ public class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains("selected section has 2 printable rows; use --row N|first|last to choose one row or --print-all", error);
+        Assert.Contains("selected section has 2 printable rows; use --row N|first|last to choose one row", error);
     }
 
     [Fact]
@@ -3516,42 +3516,22 @@ public class CommandExecutionTests
         Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", document.RootElement.GetProperty("url").GetString());
     }
 
+
     [Fact]
-    public async Task Type_SourceFiles_PrintAllJsonlFetchesAllSources()
+    public async Task Type_SourceFiles_PrintJsonArrayEmitsSelectedRowAsSingleElementArray()
     {
         var (exit, output, error) = await RunAppAsync(
             "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
-            "-S", "Source Files", "--print-all", "--jsonl", "--raw", "--tips", "q");
-
-        Assert.Equal(0, exit);
-        Assert.Empty(error);
-        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.Equal(2, lines.Length);
-        using var first = JsonDocument.Parse(lines[0]);
-        using var second = JsonDocument.Parse(lines[1]);
-        Assert.Equal(1, first.RootElement.GetProperty("row").GetInt32());
-        Assert.Equal(2, second.RootElement.GetProperty("row").GetInt32());
-        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", first.RootElement.GetProperty("url").GetString());
-        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", second.RootElement.GetProperty("url").GetString());
-    }
-
-    [Fact]
-    public async Task Type_SourceFiles_PrintAllJsonArrayFetchesAllSources()
-    {
-        var (exit, output, error) = await RunAppAsync(
-            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
-            "-S", "Source Files", "--print-all", "--json-array", "--raw", "--tips", "q");
+            "-S", "Source Files", "--print", "--row", "1", "--json-array", "--raw", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
         using var document = JsonDocument.Parse(output);
         var rows = document.RootElement.EnumerateArray().ToArray();
-        Assert.Equal(2, rows.Length);
-        Assert.Equal(1, rows[0].GetProperty("row").GetInt32());
-        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", rows[0].GetProperty("url").GetString());
-        Assert.Contains("JsonReader", rows[0].GetProperty("content").GetString());
-        Assert.Equal(2, rows[1].GetProperty("row").GetInt32());
-        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", rows[1].GetProperty("url").GetString());
+        var single = Assert.Single(rows);
+        Assert.Equal(1, single.GetProperty("row").GetInt32());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", single.GetProperty("url").GetString());
+        Assert.Contains("JsonReader", single.GetProperty("content").GetString());
     }
 
     [Fact]
@@ -3563,7 +3543,7 @@ public class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains("--json-array requires --value, --urls, --paths, --print, or --print-all", error);
+        Assert.Contains("--json-array requires --value, --urls, --paths, or --print", error);
     }
 
     [Fact]
@@ -7347,7 +7327,7 @@ public class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "library", "--platform", "System.Text.Json",
-            "--il-offset", "0x06000001+0x0", "-S", "Source Location", "--print-all", "--json-array", "--tips", "q");
+            "--il-offset", "0x06000001+0x0", "-S", "Source Location", "--print", "--json-array", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -7357,17 +7337,6 @@ public class CommandExecutionTests
         Assert.Contains("CharToHexLookup", output);
     }
 
-    [Fact]
-    public async Task LibraryCommand_IlOffsetPrintAllRejectsRow()
-    {
-        var (exit, output, error) = await RunAppAsync(
-            "library", "--platform", "System.Text.Json",
-            "--il-offset", "0x06000001+0x0", "-S", "Source Location", "--print-all", "--row", "1", "--tips", "q");
-
-        Assert.Equal(1, exit);
-        Assert.Empty(output);
-        Assert.Contains("--print-all cannot be combined with --row", error);
-    }
 
     [Fact]
     public async Task LibraryCommand_IlOffsetCountRejectsPrint()
@@ -10731,7 +10700,7 @@ public class CommandExecutionTests
 
             Assert.Equal(1, exit);
             Assert.Empty(output);
-            Assert.Contains("selected section has 2 printable rows; use --row N|first|last to choose one row or --print-all", error);
+            Assert.Contains("selected section has 2 printable rows; use --row N|first|last to choose one row", error);
         }
         finally
         {
@@ -10789,7 +10758,7 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_SkillsPrintAll_UsesSeparators()
+    public async Task Project_SkillsPrintAll_IsNoLongerRecognized()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.PrintAll.One", "1.0.0", "README.md", "readme", Skills:
@@ -10802,12 +10771,9 @@ public class CommandExecutionTests
             var (exit, output, error) = await RunAppAsync(
                 "project", projectPath, "-S", "Skills", "--print-all");
 
-            Assert.Equal(0, exit);
-            Assert.Empty(error);
-            Assert.Contains("--- Test.Project.PrintAll.One skills/one/SKILL.md ---", output);
-            Assert.Contains("--- Test.Project.PrintAll.Two skills/two/SKILL.md ---", output);
-            Assert.Contains("one", output);
-            Assert.Contains("two", output);
+            Assert.NotEqual(0, exit);
+            Assert.DoesNotContain("--- Test.Project.PrintAll.One", output);
+            Assert.Contains("--print-all", error);
         }
         finally
         {

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -448,7 +448,6 @@ public static class InspectionCommandDefinitions
                 Fields = opts.ParseFields(parseResult),
                 Count = parseResult.GetValue(opts.Count),
                 Print = parseResult.GetValue(opts.Print),
-                PrintAll = parseResult.GetValue(opts.PrintAll),
                 Value = parseResult.GetValue(opts.Value),
                 Urls = parseResult.GetValue(opts.Urls),
                 Paths = parseResult.GetValue(opts.Paths),

--- a/src/dotnet-inspect/CommandLine/Commands/ProjectCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ProjectCommandDefinitions.cs
@@ -75,7 +75,6 @@ public static class ProjectCommandDefinitions
                 AgentsIndex = parseResult.GetValue(agentsIndexOption),
                 ReadmePackageId = parseResult.GetValue(readmeOption),
                 Print = parseResult.GetValue(opts.Print),
-                PrintAll = parseResult.GetValue(opts.PrintAll),
                 PrintRow = opts.ParsePrintRow(parseResult),
                 Value = parseResult.GetValue(opts.Value),
                 Urls = parseResult.GetValue(opts.Urls),

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -283,7 +283,6 @@ public static class MemberOptionsParser
             RequestAllTaste = parseResult.GetValue(opts.Taste),
             Focus = parseResult.GetValue(opts.Focus),
             Print = parseResult.GetValue(opts.Print),
-            PrintAll = parseResult.GetValue(opts.PrintAll),
             PrintRow = opts.ParsePrintRow(parseResult),
             Value = parseResult.GetValue(opts.Value),
             Urls = parseResult.GetValue(opts.Urls),

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -137,7 +137,6 @@ public static class PackageOptionsParser
             IncludePrerelease = parseResult.GetValue(args.PrereleaseOption),
             ShowReadme = parseResult.GetValue(args.ReadmeOption),
             Print = parseResult.GetValue(opts.Print),
-            PrintAll = parseResult.GetValue(opts.PrintAll),
             PrintRow = opts.ParsePrintRow(parseResult),
             Value = parseResult.GetValue(opts.Value),
             Urls = parseResult.GetValue(opts.Urls),

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -182,7 +182,6 @@ public static class TypeOptionsParser
             Bare = parseResult.GetValue(opts.Bare),
             RequestAllTaste = parseResult.GetValue(opts.Taste),
             Print = parseResult.GetValue(opts.Print),
-            PrintAll = parseResult.GetValue(opts.PrintAll),
             PrintRow = opts.ParsePrintRow(parseResult),
             Value = parseResult.GetValue(opts.Value),
             Urls = parseResult.GetValue(opts.Urls),

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -47,7 +47,7 @@ public class ApiCommand
             NoHeader = options.NoHeader, Limit = options.Limit, MemberFilter = options.MemberFilter,
             KindFilter = options.KindFilter, UnsafeOnly = options.UnsafeOnly,
             IncludeSections = options.IncludeSections,
-            Print = options.Print, PrintAll = options.PrintAll, PrintRow = options.PrintRow,
+            Print = options.Print, PrintRow = options.PrintRow,
             Value = options.Value, Urls = options.Urls, Paths = options.Paths,
             Select = options.Select, Columns = options.Columns, Fields = options.Fields,
             Schema = options.Schema, Count = options.Count, SourceOptions = options.SourceOptions,
@@ -127,9 +127,9 @@ public class ApiCommand
             var optionName = options.Value ? "--value" : options.Urls ? "--urls" : "--paths";
             if (!ShapeProjectionOutput.ValidateSingleSection(options.IncludeSections, optionName))
                 return (null!, 1);
-            if (options.Count || options.Print || options.PrintAll)
+            if (options.Count || options.Print)
             {
-                Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count, --print, or --print-all.");
+                Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count or --print.");
                 return (null!, 1);
             }
             if (options.Rows is not null)
@@ -139,9 +139,9 @@ public class ApiCommand
             }
         }
 
-        if (options.JsonArray && shapeCount == 0 && !options.Print && !options.PrintAll)
+        if (options.JsonArray && shapeCount == 0 && !options.Print)
         {
-            Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, --print, or --print-all.");
+            Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, or --print.");
             return (null!, 1);
         }
 
@@ -151,24 +151,18 @@ public class ApiCommand
             return (null!, 1);
         }
 
-        if ((options.Print || options.PrintAll) && !ValidateApiPrintSelection(options.IncludeSections))
+        if (options.Print && !ValidateApiPrintSelection(options.IncludeSections))
             return (null!, 1);
 
-        if ((options.Print || options.PrintAll) && options.Rows is not null)
+        if (options.Print && options.Rows is not null)
         {
-            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N|first|last to choose a printed row.");
+            Console.Error.WriteLine("Error: --rows cannot be combined with --print; use --row N|first|last to choose a printed row.");
             return (null!, 1);
         }
 
         if (options.PrintRow is not null && !options.Print && shapeCount == 0)
         {
             Console.Error.WriteLine("Error: --row requires --print, --value, --urls, or --paths.");
-            return (null!, 1);
-        }
-
-        if (options.Print && options.PrintAll)
-        {
-            Console.Error.WriteLine("Error: --print cannot be combined with --print-all.");
             return (null!, 1);
         }
 
@@ -242,7 +236,7 @@ public class ApiCommand
         if (includeSections is { Count: 1 })
             return true;
 
-        Console.Error.WriteLine("Error: --print/--print-all requires -S/--select to match exactly one printable section.");
+        Console.Error.WriteLine("Error: --print requires -S/--select to match exactly one printable section.");
         return false;
     }
 
@@ -845,7 +839,7 @@ public class ApiCommand
             }
         }
 
-        if (options.Print || options.PrintAll)
+        if (options.Print)
             return await PrintApiProjectionAsync(view, options);
 
         if (options.Value || options.Urls || options.Paths)
@@ -979,7 +973,6 @@ public class ApiCommand
         return PrintProjectionOutput.Write(
             documents,
             new PrintProjectionOptions(
-                options.PrintAll,
                 options.PrintRow,
                 options.JsonOutput,
                 options.Jsonl,
@@ -1102,50 +1095,45 @@ public class ApiCommand
             .Where(row => !string.IsNullOrWhiteSpace(row.Url))
             .ToList();
         if (printableRows.Count == 0)
-            return PrintProjectionOutput.Write(
-                [],
-                new PrintProjectionOptions(options.PrintAll, null, options.JsonOutput, options.Jsonl, options.JsonArray, options.Bare, OutputPath: null));
-
-        if (!options.PrintAll)
         {
-            if (options.PrintRow is null && printableRows.Count != 1)
-            {
-                Console.Error.WriteLine($"Error: selected section has {printableRows.Count} printable rows; use --row N|first|last to choose one row or --print-all.");
-                return 1;
-            }
-
-            var targetIndex = options.PrintRow?.Resolve(printableRows.Count) ?? 1;
-            if (targetIndex < 1 || targetIndex > printableRows.Count)
-            {
-                Console.Error.WriteLine($"Error: printable row {targetIndex} is out of range. Use 1 through {printableRows.Count}, first, or last.");
-                return 1;
-            }
-
-            printableRows = [printableRows[targetIndex - 1]];
+            Console.Error.WriteLine("Error: selected section has no printable rows.");
+            return 1;
         }
 
+        if (options.PrintRow is null && printableRows.Count != 1)
+        {
+            Console.Error.WriteLine($"Error: selected section has {printableRows.Count} printable rows; use --row N|first|last to choose one row.");
+            return 1;
+        }
+
+        var targetIndex = options.PrintRow?.Resolve(printableRows.Count) ?? 1;
+        if (targetIndex < 1 || targetIndex > printableRows.Count)
+        {
+            Console.Error.WriteLine($"Error: printable row {targetIndex} is out of range. Use 1 through {printableRows.Count}, first, or last.");
+            return 1;
+        }
+
+        var selectedRow = printableRows[targetIndex - 1];
+        var rawUrl = GitHubUrlResolver.ConvertBlobToRawUrl(selectedRow.Url!);
         var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
-        List<PrintableDocument> documents = [];
-        foreach (var row in printableRows)
+        var content = await fetcher.FetchSourceAsync(rawUrl);
+        if (content == null)
         {
-            var rawUrl = GitHubUrlResolver.ConvertBlobToRawUrl(row.Url!);
-            var content = await fetcher.FetchSourceAsync(rawUrl);
-            if (content == null)
-                continue;
-
-            documents.Add(new PrintableDocument(
-                row.Row,
-                section,
-                string.IsNullOrWhiteSpace(row.Label) ? rawUrl : row.Label!,
-                null,
-                rawUrl,
-                content));
+            Console.Error.WriteLine($"Error: failed to fetch the document for printable row {targetIndex} from {rawUrl}.");
+            return 1;
         }
+
+        var document = new PrintableDocument(
+            selectedRow.Row,
+            section,
+            string.IsNullOrWhiteSpace(selectedRow.Label) ? rawUrl : selectedRow.Label!,
+            null,
+            rawUrl,
+            content);
 
         return PrintProjectionOutput.Write(
-            documents,
+            [document],
             new PrintProjectionOptions(
-                options.PrintAll,
                 Row: null,
                 options.JsonOutput,
                 options.Jsonl,

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -118,9 +118,9 @@ public class LibraryCommand
         if (options.Count && !CountOutput.ValidateSectionsSelected(options.IncludeSections))
             return 1;
 
-        if (options.Count && (options.Print || options.PrintAll))
+        if (options.Count && options.Print)
         {
-            Console.Error.WriteLine("Error: --count cannot be combined with --print or --print-all.");
+            Console.Error.WriteLine("Error: --count cannot be combined with --print.");
             return 1;
         }
 
@@ -136,9 +136,9 @@ public class LibraryCommand
             var optionName = options.Value ? "--value" : options.Urls ? "--urls" : "--paths";
             if (!ShapeProjectionOutput.ValidateSingleSection(options.IncludeSections, optionName))
                 return 1;
-            if (options.Count || options.Print || options.PrintAll)
+            if (options.Count || options.Print)
             {
-                Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count, --print, or --print-all.");
+                Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count or --print.");
                 return 1;
             }
             if (options.Rows is not null)
@@ -148,9 +148,9 @@ public class LibraryCommand
             }
         }
 
-        if (options.JsonArray && shapeCount == 0 && !options.Print && !options.PrintAll)
+        if (options.JsonArray && shapeCount == 0 && !options.Print)
         {
-            Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, --print, or --print-all.");
+            Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, or --print.");
             return 1;
         }
 
@@ -160,28 +160,16 @@ public class LibraryCommand
             return 1;
         }
 
-        if ((options.Print || options.PrintAll) && !ValidateLibraryPrintSelection(options.IncludeSections))
+        if (options.Print && !ValidateLibraryPrintSelection(options.IncludeSections))
             return 1;
 
-        if ((options.Print || options.PrintAll) && options.Rows is not null)
+        if (options.Print && options.Rows is not null)
         {
-            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N|first|last to choose a printed row.");
+            Console.Error.WriteLine("Error: --rows cannot be combined with --print; use --row N|first|last to choose a printed row.");
             return 1;
         }
 
-        if (options.Print && options.PrintAll)
-        {
-            Console.Error.WriteLine("Error: --print cannot be combined with --print-all.");
-            return 1;
-        }
-
-        if (options.PrintAll && options.PrintRow is not null)
-        {
-            Console.Error.WriteLine("Error: --print-all cannot be combined with --row.");
-            return 1;
-        }
-
-        if (options.ProjectionRow is not null && !options.Print && !options.PrintAll && shapeCount == 0)
+        if (options.ProjectionRow is not null && !options.Print && shapeCount == 0)
         {
             Console.Error.WriteLine("Error: --row requires --print, --value, --urls, or --paths.");
             return 1;
@@ -285,7 +273,7 @@ public class LibraryCommand
                     return WriteEffectiveSections(resolvedPath!, inspection, options, pipeline, userVerbosity, cache: !HasILOffsetCoordinate(options));
                 if (TryWriteLibrarySingletonCount(inspection, options))
                     return 0;
-                if (options.Print || options.PrintAll)
+                if (options.Print)
                     return await WriteLibraryPrintProjectionAsync(inspection, options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspection, options);
@@ -355,7 +343,7 @@ public class LibraryCommand
                     return WriteEffectiveSections(assemblyPaths[0], inspections[0], options, pipeline, userVerbosity, cache: !HasILOffsetCoordinate(options));
                 if (TryWriteLibrarySingletonCount(inspections[0], options))
                     return 0;
-                if (options.Print || options.PrintAll)
+                if (options.Print)
                     return await WriteLibraryPrintProjectionAsync(inspections[0], options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspections[0], options);
@@ -411,7 +399,7 @@ public class LibraryCommand
                     return WriteEffectiveSections(assemblyPath!, inspection, options, pipeline, userVerbosity, cache: !HasILOffsetCoordinate(options));
                 if (TryWriteLibrarySingletonCount(inspection, options))
                     return 0;
-                if (options.Print || options.PrintAll)
+                if (options.Print)
                     return await WriteLibraryPrintProjectionAsync(inspection, options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspection, options);
@@ -486,7 +474,6 @@ public class LibraryCommand
                 Select = [.. sections],
                 Discover = null,
                 Print = false,
-                PrintAll = false,
                 Count = false,
                 Value = false,
                 Urls = false,
@@ -871,7 +858,6 @@ public class LibraryCommand
         return PrintProjectionOutput.Write(
             projection.Documents,
             new PrintProjectionOptions(
-                options.PrintAll,
                 options.PrintRow,
                 options.JsonOutput,
                 options.Jsonl,

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -81,9 +81,9 @@ public class PackageCommand
                 var optionName = options.Value ? "--value" : options.Urls ? "--urls" : "--paths";
                 if (!ShapeProjectionOutput.ValidateSingleSection(options.IncludeSections, optionName))
                     return 1;
-                if (options.Count || options.Print || options.PrintAll)
+                if (options.Count || options.Print)
                 {
-                    Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count, --print, or --print-all.");
+                    Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count or --print.");
                     return 1;
                 }
                 if (options.Rows is not null)
@@ -93,9 +93,9 @@ public class PackageCommand
                 }
             }
 
-            if (options.JsonArray && shapeCount == 0 && !options.Print && !options.PrintAll)
+            if (options.JsonArray && shapeCount == 0 && !options.Print)
             {
-                Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, --print, or --print-all.");
+                Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, or --print.");
                 return 1;
             }
 
@@ -105,7 +105,7 @@ public class PackageCommand
                 return 1;
             }
 
-            if ((options.Print || options.PrintAll) && !ValidatePackagePrintSelection(options.IncludeSections))
+            if (options.Print && !ValidatePackagePrintSelection(options.IncludeSections))
                 return 1;
 
             if (!OutputFormatResolver.ValidateSingleSectionForTabular(options.TabularExplicitlySet, options.IncludeSections))
@@ -377,7 +377,7 @@ public class PackageCommand
             }
 
             // Handle --readme/--print mode: print the selected grounding document and exit early
-            if (options.ShowReadme || options.Print || options.PrintAll)
+            if (options.ShowReadme || options.Print)
             {
                 var packageId = nuspec?.PackageName ?? packageName;
                 var packageVersion = nuspec?.Version ?? version;
@@ -802,7 +802,6 @@ public class PackageCommand
         var multiReadmeFrontmatter = options.ShowReadme && options.ContentScope == PackageFileContentScope.Frontmatter;
         if (options.ShowReadme && !multiReadmeFrontmatter) conflicts.Add("--readme");
         if (options.Print) conflicts.Add("--print");
-        if (options.PrintAll) conflicts.Add("--print-all");
         if (multiReadmeFrontmatter && options.JsonOutput) conflicts.Add("--json");
         if (options.ShowDependencies) conflicts.Add("--dependencies");
         if (options.PackageLibrary != null) conflicts.Add("--library");
@@ -839,15 +838,9 @@ public class PackageCommand
             return false;
         }
 
-        if ((options.Print || options.PrintAll) && options.ShowContent)
+        if (options.Print && options.ShowContent)
         {
-            Console.Error.WriteLine("Error: --print/--print-all cannot be combined with --content.");
-            return false;
-        }
-
-        if (options.Print && options.PrintAll)
-        {
-            Console.Error.WriteLine("Error: --print cannot be combined with --print-all.");
+            Console.Error.WriteLine("Error: --print cannot be combined with --content.");
             return false;
         }
 
@@ -861,9 +854,9 @@ public class PackageCommand
             return false;
         }
 
-        if ((options.Print || options.PrintAll) && options.Rows is not null)
+        if (options.Print && options.Rows is not null)
         {
-            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N|first|last to choose a printed row.");
+            Console.Error.WriteLine("Error: --rows cannot be combined with --print; use --row N|first|last to choose a printed row.");
             return false;
         }
 
@@ -873,9 +866,9 @@ public class PackageCommand
             return false;
         }
 
-        if (scopedContent && !options.ShowReadme && !options.Print && !options.PrintAll && !options.ShowContent)
+        if (scopedContent && !options.ShowReadme && !options.Print && !options.ShowContent)
         {
-            Console.Error.WriteLine("Error: --frontmatter/--yaml-header and --body require --readme, --print, --print-all, or --content.");
+            Console.Error.WriteLine("Error: --frontmatter/--yaml-header and --body require --readme, --print, or --content.");
             return false;
         }
 
@@ -1779,7 +1772,6 @@ public class PackageCommand
         if (options.ListVersions) conflicts.Add("--versions/--version/--latest-version");
         if (options.ShowReadme) conflicts.Add("--readme");
         if (options.Print) conflicts.Add("--print");
-        if (options.PrintAll) conflicts.Add("--print-all");
         if (options.ShowDependencies) conflicts.Add("--dependencies");
         if (string.Equals(options.Tfm, "all", StringComparison.OrdinalIgnoreCase)) conflicts.Add("--tfm all");
 
@@ -1800,7 +1792,6 @@ public class PackageCommand
         if (options.ListVersions) conflicts.Add("--versions/--version/--latest-version");
         if (options.ShowReadme) conflicts.Add("--readme");
         if (options.Print) conflicts.Add("--print");
-        if (options.PrintAll) conflicts.Add("--print-all");
         if (options.ShowDependencies) conflicts.Add("--dependencies");
         if (options.Discover != null) conflicts.Add("-D/--discover");
         if (options.Columns != null) conflicts.Add("--columns");
@@ -2719,12 +2710,11 @@ public class PackageCommand
 
         var file = result.Files[0];
         InfoTracker.SetDetail("readme", $"{file.Path} ({file.Size.ToString(CultureInfo.InvariantCulture)} B)");
-        if (options.Print || options.PrintAll)
+        if (options.Print)
         {
             return PrintProjectionOutput.Write(
                 [new PrintableDocument(1, PackageSections.PackageReadme, file.Path, file.Path, null, file.Content)],
                 new PrintProjectionOptions(
-                    options.PrintAll,
                     options.PrintRow,
                     options.JsonOutput,
                     options.Jsonl,

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -69,9 +69,9 @@ public class ProjectCommand
             var optionName = options.Value ? "--value" : options.Urls ? "--urls" : "--paths";
             if (!ShapeProjectionOutput.ValidateSingleSection(selectResult.Sections, optionName))
                 return 1;
-            if (options.Count || options.Print || options.PrintAll)
+            if (options.Count || options.Print)
             {
-                Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count, --print, or --print-all.");
+                Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count or --print.");
                 return 1;
             }
             if (options.Rows is not null)
@@ -81,9 +81,9 @@ public class ProjectCommand
             }
         }
 
-        if (options.JsonArray && shapeCount == 0 && !options.Print && !options.PrintAll)
+        if (options.JsonArray && shapeCount == 0 && !options.Print)
         {
-            Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, --print, or --print-all.");
+            Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, or --print.");
             return 1;
         }
 
@@ -100,7 +100,7 @@ public class ProjectCommand
             return 1;
         }
 
-        if ((options.Print || options.PrintAll) && !ValidateProjectPrintSelection(selectResult.Sections))
+        if (options.Print && !ValidateProjectPrintSelection(selectResult.Sections))
             return 1;
 
         if (options.Schema && options.Discover == null)
@@ -168,21 +168,15 @@ public class ProjectCommand
             return false;
         }
 
-        if ((options.Print || options.PrintAll) && options.ReadmePackageId != null)
+        if (options.Print && options.ReadmePackageId != null)
         {
-            Console.Error.WriteLine("Error: --print/--print-all cannot be combined with --readme.");
+            Console.Error.WriteLine("Error: --print cannot be combined with --readme.");
             return false;
         }
 
-        if ((options.Print || options.PrintAll) && options.AgentsIndex)
+        if (options.Print && options.AgentsIndex)
         {
-            Console.Error.WriteLine("Error: --print/--print-all cannot be combined with --agents-index.");
-            return false;
-        }
-
-        if (options.Print && options.PrintAll)
-        {
-            Console.Error.WriteLine("Error: --print cannot be combined with --print-all.");
+            Console.Error.WriteLine("Error: --print cannot be combined with --agents-index.");
             return false;
         }
 
@@ -196,15 +190,14 @@ public class ProjectCommand
             return false;
         }
 
-        if ((options.Print || options.PrintAll) && options.Rows is not null)
+        if (options.Print && options.Rows is not null)
         {
-            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N|first|last to choose a printed row.");
+            Console.Error.WriteLine("Error: --rows cannot be combined with --print; use --row N|first|last to choose a printed row.");
             return false;
         }
 
         if ((options.FrontmatterRequested || options.BodyRequested)
             && !options.Print
-            && !options.PrintAll
             && options.ReadmePackageId == null
             && !options.AgentsIndex)
         {
@@ -343,7 +336,7 @@ public class ProjectCommand
         if (options.Value || options.Urls || options.Paths)
             return WriteSkillShapeProjection(rows, options);
 
-        if (options.Print || options.PrintAll || options.Bare)
+        if (options.Print || options.Bare)
             return PrintSkillDocument(rows, options);
 
         var output = options.Count
@@ -450,8 +443,7 @@ public class ProjectCommand
         return PrintProjectionOutput.Write(
             documents,
             new PrintProjectionOptions(
-                options.PrintAll,
-                options.Bare && !options.Print && !options.PrintAll ? RowSelector.FromIndex(1) : options.PrintRow,
+                options.Bare && !options.Print ? RowSelector.FromIndex(1) : options.PrintRow,
                 options.JsonOutput,
                 options.Jsonl,
                 options.JsonArray,

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -116,8 +116,6 @@ public partial record ApiOptions
 
     public bool Print { get; init; }
 
-    public bool PrintAll { get; init; }
-
     public RowSelector? PrintRow { get; init; }
 
     public bool Value { get; init; }
@@ -180,7 +178,7 @@ public partial record ApiOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public virtual bool IsRawOutput => Bare || Print || PrintAll || Value || Urls || Paths || JsonOutput || Tabular || Jsonl || NoHeader || Count;
+    public virtual bool IsRawOutput => Bare || Print || Value || Urls || Paths || JsonOutput || Tabular || Jsonl || NoHeader || Count;
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -109,8 +109,6 @@ public record InspectionOptions
     /// </summary>
     public bool Print { get; init; }
 
-    public bool PrintAll { get; init; }
-
     public RowSelector? PrintRow { get; init; }
 
     public bool Value { get; init; }
@@ -262,7 +260,7 @@ public record InspectionOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public bool IsRawOutput => Bare || JsonOutput || Tabular || Jsonl || JsonArray || NoHeader || ListLayout || ListTfms || ListVersions || ShowReadme || Print || PrintAll || Value || Urls || Paths || ShowContent || ShowDependencies || Count || PackageLibrary != null || AllLibraries;
+    public bool IsRawOutput => Bare || JsonOutput || Tabular || Jsonl || JsonArray || NoHeader || ListLayout || ListTfms || ListVersions || ShowReadme || Print || Value || Urls || Paths || ShowContent || ShowDependencies || Count || PackageLibrary != null || AllLibraries;
 
     /// <summary>
     /// All inspection features enabled.

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -191,8 +191,6 @@ public record LibraryOptions
 
     public bool Print { get; init; }
 
-    public bool PrintAll { get; init; }
-
     public bool Value { get; init; }
 
     public bool Urls { get; init; }

--- a/src/dotnet-inspect/Options/ProjectOptions.cs
+++ b/src/dotnet-inspect/Options/ProjectOptions.cs
@@ -13,8 +13,6 @@ public record ProjectOptions
 
     public bool Print { get; init; }
 
-    public bool PrintAll { get; init; }
-
     public RowSelector? PrintRow { get; init; }
 
     public bool Value { get; init; }

--- a/src/dotnet-inspect/Output/PrintProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/PrintProjectionOutput.cs
@@ -12,7 +12,6 @@ public sealed record PrintableDocument(
     string Content);
 
 public sealed record PrintProjectionOptions(
-    bool PrintAll,
     RowSelector? Row,
     bool JsonOutput,
     bool Jsonl,
@@ -30,24 +29,8 @@ public static class PrintProjectionOutput
             return 1;
         }
 
-        if (options.PrintAll && options.Row is not null)
-        {
-            Console.Error.WriteLine("Error: --print-all cannot be combined with --row.");
-            return 1;
-        }
-
-        IReadOnlyList<PrintableDocument> selected;
-        if (options.PrintAll)
-        {
-            if (options.Bare && !options.JsonOutput && !options.Jsonl)
-            {
-                Console.Error.WriteLine("Error: --bare cannot be combined with --print-all because multiple documents need separators.");
-                return 1;
-            }
-
-            selected = documents;
-        }
-        else if (options.Row is { } selector)
+        PrintableDocument selected;
+        if (options.Row is { } selector)
         {
             var row = selector.Resolve(documents.Count);
             if (row < 1 || row > documents.Count)
@@ -56,52 +39,40 @@ public static class PrintProjectionOutput
                 return 1;
             }
 
-            selected = [documents[row - 1]];
+            selected = documents[row - 1];
         }
         else
         {
             if (documents.Count != 1)
             {
-                Console.Error.WriteLine($"Error: selected section has {documents.Count} printable rows; use --row N|first|last to choose one row or --print-all.");
+                Console.Error.WriteLine($"Error: selected section has {documents.Count} printable rows; use --row N|first|last to choose one row.");
                 return 1;
             }
 
-            selected = [documents[0]];
+            selected = documents[0];
         }
 
         if (options.Jsonl)
         {
-            var lines = selected
-                .Select(item => JsonSerializer.Serialize(item, PrintProjectionJsonContext.Default.PrintableDocument));
-            WriteOutput(string.Join(Environment.NewLine, lines) + Environment.NewLine, options.OutputPath);
+            WriteOutput(
+                JsonSerializer.Serialize(selected, PrintProjectionJsonContext.Default.PrintableDocument) + Environment.NewLine,
+                options.OutputPath);
             return 0;
         }
 
         if (options.JsonArray)
         {
-            WriteOutput(JsonSerializer.Serialize(selected.ToArray(), PrintProjectionJsonContext.Default.PrintableDocumentArray), options.OutputPath);
+            WriteOutput(JsonSerializer.Serialize(new[] { selected }, PrintProjectionJsonContext.Default.PrintableDocumentArray), options.OutputPath);
             return 0;
         }
 
         if (options.JsonOutput)
         {
-            var json = selected.Count == 1
-                ? JsonSerializer.Serialize(selected[0], PrintProjectionJsonContext.Default.PrintableDocument)
-                : JsonSerializer.Serialize(selected.ToArray(), PrintProjectionJsonContext.Default.PrintableDocumentArray);
-            WriteOutput(json, options.OutputPath);
+            WriteOutput(JsonSerializer.Serialize(selected, PrintProjectionJsonContext.Default.PrintableDocument), options.OutputPath);
             return 0;
         }
 
-        if (selected.Count == 1)
-        {
-            WriteOutput(selected[0].Content, options.OutputPath);
-            return 0;
-        }
-
-        var rendered = string.Join(
-            Environment.NewLine + Environment.NewLine,
-            selected.Select(item => $"--- {item.Label} ---{Environment.NewLine}{item.Content.TrimEnd()}"));
-        WriteOutput(rendered + Environment.NewLine, options.OutputPath);
+        WriteOutput(selected.Content, options.OutputPath);
         return 0;
     }
 

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -38,7 +38,6 @@ public class SharedOptions
     public Option<int?> Tail { get; }
     public Option<bool> Count { get; } = new("--count") { Description = "Reduce a selected table/vector to a single row count" };
     public Option<bool> Print { get; } = new("--print") { Description = "Print one document behind a selected section row; use --row N|first|last to choose a row when multiple rows are printable" };
-    public Option<bool> PrintAll { get; } = new("--print-all") { Description = "Print all documents behind rows in the selected printable section, separated by item headers" };
     public Option<string?> Row { get; } = new("--row") { Description = "With --print or a shape projection, select a printable row: a 1-based index, first, or last" };
     public Option<bool> Value { get; } = new("--value") { Description = "Print one scalar value from a selected section; use --row N|first|last when multiple rows exist" };
     public Option<bool> Urls { get; } = new("--urls") { Description = "Project URL-bearing selected section rows to a URL list or JSONL rows" };
@@ -246,7 +245,6 @@ public class SharedOptions
     public void AddPrintOptionTo(Command command)
     {
         command.Options.Add(Print);
-        command.Options.Add(PrintAll);
         command.Options.Add(Row);
     }
 


### PR DESCRIPTION
PR 1 of the #3364 series. Fixes the acquisition-failure half of the issue and removes `--print-all`. Numbering is deliberately unchanged — renumbering `--row` over displayed rows is the next PR in the stack.

## The behavior claim

`--print` reported acquisition failures with a false diagnostic, and `--print-all` dropped them entirely.

Fixture: a compiled assembly with a hand-written SourceLink map, giving `Source Files` two printable rows where row 1 resolves and row 2 points at a URL that 404s.

**Before** (`origin/main` @ `924e6e0c`):

```console
$ ... -S "Source Files" --print --row 2
Error: selected section has no printable rows.        # exit 1
```

False. The section had two printable rows; the *fetch* failed.

```console
$ ... -S "Source Files" --print-all --jsonl
                                                      # exit 0, empty stderr
```

2 printable rows in, **1 document out, exit 0, no diagnostic** — an acquisition failure rendered as success-shaped empty output, which `AGENTS.md` forbids.

**After:**

```console
$ ... -S "Source Files" --print --row 2
Error: failed to fetch the document for printable row 2 from
https://raw.githubusercontent.com/.../NO-SUCH-FILE-3364.md    # exit 1

$ ... -S "Source Files" --print-all
Error: Unrecognized option '--print-all'.                     # exit 1
```

## Why removing `--print-all` is the fix, not a separate change

The silent drop was only representable because `--print-all` made partial success a legal outcome: N rows in, fewer documents out, still exit 0. Removing it makes `--print` strictly exactly-one, so a declared payload that cannot be acquired has no way to degrade into a shorter success — it must be an error. The loop in `PrintUrlProjectionAsync` collapses to a single fetch whose failure is fatal, and `PrintProjectionOutput.Write` selects exactly one document.

That also retires ~15 combinatorial validation branches (`--print` vs `--print-all`, `--print-all` vs `--row`, `--print-all` vs `--bare`) and the multi-document separator rendering path.

## Compatibility

`--print-all` is removed outright, so multi-payload printing is unavailable until the bounded `--rows N..M` grammar lands later in this series. That is deliberate: the issue's design already supersedes blanket fan-out, and an explicit range is a tighter acquisition-consent gesture than "all". The fan-out authorization role documented in `command-transition-model.md` is retired here and returns bounded.

Printable-row numbering is untouched — `--row N` still counts printable rows. The `--row first|last` aliases are untouched.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — clean.
- `dotnet run --project src/dotnet-inspect.Tests -c Release` — **2227 passed, 0 failed**, 14 pre-existing environment skips.
- Before/after captured against a real compiled artifact on both `origin/main` and this head (above).
- `npx markdownlint-cli` clean on all six changed Markdown files.

Test changes: guidance/`--json-array` message assertions updated; the two `--print-all` fan-out tests and the `--print-all`-vs-`--row` conflict test removed with the behavior; `Type_SourceFiles_PrintAllJsonArrayFetchesAllSources` converted to prove `--json-array` still emits a single-element array; `Project_SkillsPrintAll_UsesSeparators` converted to assert `--print-all` is no longer recognized.

No automated test covers the fetch-failure branch: `PrintUrlProjectionAsync` builds its `SourceFetcher` from `HttpClientFactory.SharedUntrustedFetch` with no injection seam, and per the `AGENTS.md` harness boundary I did not add harness-side machinery to work around that. The branch is verified by the real-artifact run above. A test seam is worth considering in the follow-up.

Refs #3364
