### PR TITLE
Wrap long object/collection initializers Allman-style (#3371)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerFormattingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerFormattingTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #3371: once a raised object initializer is long, CSharpPrinter breaks it
+// Allman-style — the `new T` head on the first line, `{`/`}` on their own lines,
+// and one `Member = value` entry per line under a continuation indent; an
+// initializer that still fits stays inline. Breaking is whitespace-only (no
+// trailing comma, same head and entry texts), so the broken body still compiles
+// and carries the same tokens as the inline form.
+public sealed class ObjectInitializerFormattingTests
+{
+    static readonly TypeRef Holder = TypeRef.Definition("synthetic", "", "Holder");
+    static readonly TypeRef Options = TypeRef.Definition("synthetic", "", "WideOptions");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
+    static readonly MethodRef Ctor = new(Options, ".ctor", Void, [], HasThis: true);
+
+    static ObjectInitializerExpression Initializer(params string[] members)
+    {
+        var creation = new NewObject(Ctor, []);
+        var entries = members.Select(m => new InitializerEntry(m, [new LoadArgument(0, ArgName(m), Int32)]));
+        return new ObjectInitializerExpression(creation, isCollection: false, entries);
+    }
+
+    static string ArgName(string member) => "value_" + member;
+
+    // Render `return <initializer>;` as the whole method body and reduce it to
+    // the raw statement/expression-body text.
+    static string Render(ObjectInitializerExpression init, PrinterOptions? options = null)
+    {
+        var block = new Block(0);
+        block.Add(new Return(init));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Options, ImmutableArray<Parameter>.Empty, HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", Holder, signature, [], container);
+        return CSharpPrinter.Print(function, options ?? PrinterOptions.Default).Output!;
+    }
+
+    // Four PascalCase members whose flat `new WideOptions { ... }` form runs past
+    // the 120-column wrap width.
+    static ObjectInitializerExpression LongInitializer()
+        => Initializer(
+            "FirstMeasuredProperty",
+            "SecondMeasuredProperty",
+            "ThirdMeasuredProperty",
+            "FourthMeasuredProperty");
+
+    [Fact]
+    public void LongInitializer_BreaksAllmanOnePerLine()
+    {
+        string body = Render(LongInitializer());
+
+        // Head, then `{`/`}` on their own lines, one entry per line, no trailing comma.
+        Assert.Contains("new WideOptions\n", body);
+        Assert.Contains("\n{\n", body);
+        Assert.Contains("    FirstMeasuredProperty = value_FirstMeasuredProperty,\n", body);
+        Assert.Contains("    FourthMeasuredProperty = value_FourthMeasuredProperty\n", body);
+        Assert.DoesNotContain("value_FourthMeasuredProperty,", body);
+        Assert.Contains("\n};", body);
+        // No flat `{ ... }` body survives.
+        Assert.DoesNotContain("{ FirstMeasuredProperty", body);
+    }
+
+    [Fact]
+    public void ShortInitializer_StaysInline()
+    {
+        string body = Render(Initializer("X", "Y"));
+
+        Assert.Contains("new WideOptions { X = value_X, Y = value_Y };", body);
+        Assert.DoesNotContain("\n{\n", body);
+    }
+
+    [Fact]
+    public void SingleEntry_StaysInline_EvenWhenLong()
+    {
+        string body = Render(Initializer("AnExtremelyLongSinglePropertyNameThatOnItsOwnExceedsTheOneHundredAndTwentyColumnWrapWidthEasilyYes"));
+
+        Assert.DoesNotContain("\n{\n", body);
+    }
+
+    // Issue #3185 parity: the general one-liner opt-out suppresses the always-on
+    // wrapper, so an over-width initializer stays on one line.
+    [Fact]
+    public void LongInitializer_DisableOneLinerWrapping_StaysInline()
+    {
+        string body = Render(LongInitializer(), PrinterOptions.Default with { DisableOneLinerWrapping = true });
+
+        Assert.Contains(
+            "new WideOptions { FirstMeasuredProperty = value_FirstMeasuredProperty,"
+                + " SecondMeasuredProperty = value_SecondMeasuredProperty,"
+                + " ThirdMeasuredProperty = value_ThirdMeasuredProperty,"
+                + " FourthMeasuredProperty = value_FourthMeasuredProperty };",
+            string.Concat(body.Split('\n').Select(line => line.Trim())));
+        Assert.DoesNotContain("\n{\n", body);
+    }
+
+    // The broken form must be a pure whitespace variant of the inline form: the
+    // same tokens, in the same order, differing only in whitespace.
+    [Fact]
+    public void BrokenForm_IsWhitespaceVariantOfInline()
+    {
+        string broken = Render(LongInitializer());
+        string inline = Render(LongInitializer(), PrinterOptions.Default with { DisableOneLinerWrapping = true });
+
+        static string Collapse(string s) => string.Concat(s.Where(c => !char.IsWhiteSpace(c)));
+
+        // Drop the trailing comma the broken form omits before `}` is irrelevant —
+        // the inline form has commas only between entries too, so collapsing
+        // whitespace yields identical token streams.
+        Assert.Equal(Collapse(inline), Collapse(broken));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -890,7 +890,61 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// A rectangular (multi-dimensional) array element/creation pseudo-member.
+    /// Renders an object/collection initializer as a wrapped Allman block — the
+    /// <c>new T(...)</c> head on the first line, <c>{</c> and <c>}</c> on their own
+    /// lines at the statement indent, and one <c>Member = value</c> / element entry
+    /// per line one continuation level deeper — when the initializer has at least
+    /// <see cref="FluentChainMinSegments"/> entries and its single-line form would
+    /// exceed <see cref="FluentChainWrapWidth"/>. Returns null (render inline)
+    /// otherwise. The wrapped form reuses the same head and entry texts the inline
+    /// <see cref="ObjectInitializerText"/> renders and carries no trailing comma, so
+    /// it is token-identical to the inline form: only whitespace differs and the IL
+    /// is unchanged. A defensive re-match against the inline text keeps the
+    /// statement inline if the reconstruction diverges rather than reshaping a token.
+    /// </summary>
+    string? ObjectInitializerLines(ObjectInitializerExpression initializer, string prefix, string suffix, int indent)
+    {
+        var entries = initializer.Entries;
+        if (entries.Count < FluentChainMinSegments)
+            return null;
+
+        string flat = ObjectInitializerText(initializer);
+        if (indent * 4 + prefix.Length + flat.Length + suffix.Length <= FluentChainWrapWidth)
+            return null;
+
+        var creation = initializer.Creation;
+        string arguments = creation.Arguments.Count == 0
+            ? string.Empty
+            : $"({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
+        string head = $"new {TypeText(creation.Constructor.DeclaringType)}{arguments}";
+
+        var entryTexts = entries
+            .Select(entry => InitializerEntryText(initializer.IsCollection, entry))
+            .ToList();
+
+        // The wrapped form must be a pure whitespace variant of the inline text.
+        // Reconstruct the inline body from the same head and entry texts and bail if
+        // it does not match exactly, so a renderer quirk keeps the statement inline
+        // rather than reshaping a token.
+        if ($"{head} {{ {string.Join(", ", entryTexts)} }}" != flat)
+            return null;
+
+        string pad = new(' ', indent * 4);
+        string continuation = pad + "    ";
+        var sb = new System.Text.StringBuilder();
+        sb.Append(pad).Append(prefix).Append(head);
+        sb.Append('\n').Append(pad).Append('{');
+        for (int i = 0; i < entryTexts.Count; i++)
+        {
+            sb.Append('\n').Append(continuation).Append(entryTexts[i]);
+            if (i < entryTexts.Count - 1)
+                sb.Append(',');
+        }
+        sb.Append('\n').Append(pad).Append('}');
+        sb.Append(suffix);
+        return sb.ToString();
+    }
+
     /// The CLR models <c>int[,]</c> element get/set/address and construction as
     /// calls to runtime-generated members named <c>Get</c>/<c>Set</c>/<c>Address</c>
     /// and a rank-shaped <c>.ctor</c> — none of which are spellable C#. The

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2020,7 +2020,8 @@ public sealed partial class CSharpPrinter
         {
             if (!TryAppendFluentChain(sb, node, line, indent)
                 && !TryAppendSplittableExpression(sb, node, line, indent)
-                && !TryAppendBitwiseChain(sb, node, line, indent))
+                && !TryAppendBitwiseChain(sb, node, line, indent)
+                && !TryAppendObjectInitializer(sb, node, line, indent))
                 sb.Append(pad).AppendLine(line);
         }
     }
@@ -2353,6 +2354,67 @@ public sealed partial class CSharpPrinter
                 return true;
             default:
                 root = null!;
+                prefix = "";
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Emits <paramref name="node"/> as a wrapped object/collection initializer —
+    /// the <c>new T(...)</c> head on the first line, an Allman <c>{</c>/<c>}</c>
+    /// pair on their own lines, and one <c>Member = value</c> / element entry per
+    /// line — when it is an initializer-valued statement whose flat single-line
+    /// form would exceed <see cref="FluentChainWrapWidth"/>, returning true after
+    /// appending; false to fall through to the flat single-line emit. The broken
+    /// form is only chosen when the flat statement <paramref name="line"/> is
+    /// exactly <c>prefix + initializer + ";"</c>, so any coercion cast the renderer
+    /// added around the initializer keeps the statement inline — breaking never
+    /// drops or reshapes a token.
+    /// </summary>
+    bool TryAppendObjectInitializer(StringBuilder sb, IrNode node, string line, int indent)
+    {
+        if (_options.DisableOneLinerWrapping)
+            return false;
+        if (!TryObjectInitializerStatement(node, out var initializer, out var prefix))
+            return false;
+        if (line != prefix + ObjectInitializerText(initializer) + ";")
+            return false;
+        if (ObjectInitializerLines(initializer, prefix, ";", indent) is not { } broken)
+            return false;
+        sb.AppendLine(broken);
+        return true;
+    }
+
+    /// <summary>
+    /// Recognizes the statement positions whose value is a bare object/collection
+    /// initializer — a <c>return</c> or a (non-ref) local or stack-slot store — and
+    /// yields the initializer plus the exact statement prefix the flat renderer
+    /// prints before it. The caller re-derives the flat text and only breaks the
+    /// initializer when it matches, so the prefix here need only cover the common
+    /// (cast-free) spelling.
+    /// </summary>
+    bool TryObjectInitializerStatement(IrNode node, out ObjectInitializerExpression initializer, out string prefix)
+    {
+        switch (node)
+        {
+            case Return { Value: ObjectInitializerExpression init }:
+                initializer = init;
+                prefix = "return ";
+                return true;
+            case StoreLocal { Type.Kind: not TypeRefKind.ByRef, Value: ObjectInitializerExpression init } store:
+                initializer = init;
+                prefix = _declaringStores.Contains(store)
+                    ? $"{DeclarationTypeText(store.Type, store.Value)} {LocalName(store.Index)} = "
+                    : $"{LocalName(store.Index)} = ";
+                return true;
+            case StoreStackSlot store when store.Value is ObjectInitializerExpression init && StackSlotTargetType(store) is { Kind: not TypeRefKind.ByRef }:
+                initializer = init;
+                prefix = _declaringStores.Contains(store)
+                    ? $"{DeclarationTypeText(StackSlotTargetType(store)!, store.Value)} {StackSlotName(store)} = "
+                    : $"{StackSlotName(store)} = ";
+                return true;
+            default:
+                initializer = null!;
                 prefix = "";
                 return false;
         }


### PR DESCRIPTION
Closes #3371.

## Summary

The C# printer rendered every raised object/collection initializer on one
physical line (`"{ " + string.Join(", ", …) + " }"`), so a many-member
initializer became a very long line. The merged #3368 witness
`ServiceBusModelFactory.NamespaceProperties` rendered as a **499-char** line
(initializer body alone 212 chars) — well past the printer's existing
120-column wrap width that already breaks long fluent chains, splittable
boolean chains, and bitwise chains one element per line.

This extends that always-on width wrapper with an initializer arm: when an
initializer-valued statement (`return`, non-ref local, or stack-slot store)
whose flat single-line form exceeds `FluentChainWrapWidth` (120), the printer
breaks it **Allman-style** — the `new T(...)` head on the first line, `{`/`}`
on their own lines at the statement indent, one `Member = value` / element
entry per line one continuation level deeper. Short initializers stay inline;
`DisableOneLinerWrapping` suppresses the wrap (issue #3185 parity).

This matches the dotnet/runtime style oracle
(`csharp_new_line_before_members_in_object_initializers=true`, Allman braces) —
the `NamespaceProperties` **Original Source** below is itself broken exactly
this way.

## Byte-neutrality

Whitespace-only. The wrapped form **reuses the same head and entry texts** the
inline renderer emits and carries **no trailing comma**, so it is a pure
whitespace variant of the inline form — token-identical, same IL. A defensive
re-match (`$"{head} {{ {join} }}" != ObjectInitializerText(init) → stay inline`)
plus the caller's `line != prefix + ObjectInitializerText(init) + ";"` guard
keep any coercion cast or renderer quirk inline rather than reshaping a token —
the same guard pattern the fluent/splittable/bitwise wrappers use.

- **IL fidelity:** True — proven by the compile-back RoundTrip area
  (`Area=RoundTrip`, incl. slow compile-back gates): all wide initializers
  recompile to identical opcodes. (The 3 `parameter-attributes`/fidelity
  `RecompileFail`s are pre-existing on base `e3040716`, reproduced there,
  unrelated to this change.)
- **Taste applied:** none — this is always-on formatting (like fluent-chain
  wrapping), not a configurable style lens; `-S "Applied Taste"` reports "No
  recorded style choices were applied" on both base and head.

## Original source

`member Azure.Messaging.ServiceBus.ServiceBusModelFactory NamespaceProperties -S "Original Source"`

```csharp
public static NamespaceProperties NamespaceProperties(
    string name,
    DateTimeOffset createdTime,
    DateTimeOffset modifiedTime,
    MessagingSku messagingSku,
    int messagingUnits,
    string alias) =>
    new NamespaceProperties
    {
        Name = name,
        CreatedTime = createdTime,
        ModifiedTime = modifiedTime,
        MessagingSku = messagingSku,
        MessagingUnits = messagingUnits,
        Alias = alias,
        NamespaceType = new NamespaceType() // this cannot be created by the user
    };
```

## Before (base `e3040716`, `-S "Decompiled Source"`)

- Valid: True — Correct: True — IL fidelity: True — Taste applied: none

```csharp
public static Azure.Messaging.ServiceBus.Administration.NamespaceProperties NamespaceProperties(string name, System.DateTimeOffset createdTime, System.DateTimeOffset modifiedTime, Azure.Messaging.ServiceBus.Administration.MessagingSku messagingSku, int messagingUnits, string alias) => new NamespaceProperties { Name = name, CreatedTime = createdTime, ModifiedTime = modifiedTime, MessagingSku = messagingSku, MessagingUnits = messagingUnits, Alias = alias, NamespaceType = default(NamespaceType) };
```

## After (head `a82bd9aa`, `-S "Decompiled Source"`)

- Valid: True — Correct: True — IL fidelity: True — Taste applied: none

```csharp
public static Azure.Messaging.ServiceBus.Administration.NamespaceProperties NamespaceProperties(string name, System.DateTimeOffset createdTime, System.DateTimeOffset modifiedTime, Azure.Messaging.ServiceBus.Administration.MessagingSku messagingSku, int messagingUnits, string alias) => new NamespaceProperties
{
    Name = name,
    CreatedTime = createdTime,
    ModifiedTime = modifiedTime,
    MessagingSku = messagingSku,
    MessagingUnits = messagingUnits,
    Alias = alias,
    NamespaceType = default(NamespaceType)
};
```

## Scope (v1)

- Handles `ObjectInitializerExpression` (object and collection form). Requires
  `>= 2` entries (parity with `FluentChainMinSegments`).
- **Deferred:** parameter-list wrapping (the signature stays flat — a separate
  concern), `WithExpression`/anonymous-object initializers (separate
  renderers), and recursive wrapping of nested initializers (a nested member
  value stays inline within its one line).

## Tests

- New `ObjectInitializerFormattingTests` (5): long initializer breaks Allman
  one-per-line with no trailing comma; short stays inline; a single long entry
  stays inline; `DisableOneLinerWrapping` stays inline; the broken form is a
  whitespace-collapse-identical variant of the inline form.
- Fast decompiler suite `-trait- "Speed=Slow"`: **4051/0**.
- Slow `Area=RoundTrip` compile-back: green (pre-existing env `RecompileFail`s
  excepted).
- CLI product-output suite (`src/dotnet-inspect.Tests`): **2229/0**.
