### PR TITLE
Wrap long `with` and anonymous-object initializers Allman-style (#3371)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -6136,3 +6136,38 @@ public static class FlagsEnumAccumulatorSamples
         return (int)caps;
     }
 }
+
+// #3371 follow-up witnesses: a record `with` expression and an anonymous object
+// wide enough that the printer's brace-body width wrapper breaks them Allman-style
+// (one entry per line). New top-level types appended at end of file so they cannot
+// shift any existing CfgSampleClass generated-code ordinals.
+public sealed record MeasuredRecord(
+    int FirstMeasuredValue,
+    int SecondMeasuredValue,
+    int ThirdMeasuredValue,
+    int FourthMeasuredValue);
+
+public static class BraceBodyWrappingSamples
+{
+    // `source with { A = .., B = .., C = .., D = .. }` — flat form exceeds 120 cols.
+    public static MeasuredRecord WidenMeasuredRecord(MeasuredRecord source, int first, int second, int third, int fourth)
+        => source with
+        {
+            FirstMeasuredValue = first,
+            SecondMeasuredValue = second,
+            ThirdMeasuredValue = third,
+            FourthMeasuredValue = fourth,
+        };
+
+    // Anonymous types are reference types, so returning one as `object` needs no
+    // box/cast; the anonymous object stays the bare return value. Explicit
+    // `Name = value` form (value names differ from property names), flat > 120 cols.
+    public static object ProjectMeasuredValues(int first, int second, int third, int fourth)
+        => new
+        {
+            FirstMeasuredProjection = first,
+            SecondMeasuredProjection = second,
+            ThirdMeasuredProjection = third,
+            FourthMeasuredProjection = fourth,
+        };
+}

--- a/src/ILInspector.Decompiler.Tests/WithAndAnonymousWrappingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WithAndAnonymousWrappingTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #3371 follow-up: the always-on brace-body width wrapper that breaks long object
+// initializers Allman-style (#3377) also covers record `with` expressions and
+// anonymous objects — the same head + one-entry-per-line shape, no trailing
+// comma, so breaking stays whitespace-only and token-identical to the inline form.
+public sealed class WithAndAnonymousWrappingTests
+{
+    static readonly TypeRef Holder = TypeRef.Definition("synthetic", "", "Holder");
+    static readonly TypeRef Record = TypeRef.Definition("synthetic", "", "MeasuredRecord");
+    static readonly TypeRef Anon = TypeRef.Definition("synthetic", "", "<>f__AnonymousType0");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    static string Render(IrExpression value, TypeRef returnType, PrinterOptions? options = null)
+    {
+        var block = new Block(0);
+        block.Add(new Return(value));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(returnType, ImmutableArray<Parameter>.Empty, HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", Holder, signature, [], container);
+        return CSharpPrinter.Print(function, options ?? PrinterOptions.Default).Output!;
+    }
+
+    static WithExpression With(params string[] members)
+    {
+        var receiver = new LoadArgument(0, "original", Record);
+        var entries = members.Select(m => new InitializerEntry(m, [new LoadArgument(1, "value_" + m, Int32)]));
+        return new WithExpression(receiver, entries);
+    }
+
+    static WithExpression LongWith()
+        => With("FirstMeasuredProperty", "SecondMeasuredProperty", "ThirdMeasuredProperty", "FourthMeasuredProperty");
+
+    static AnonymousObject Anonymous(params string[] names)
+    {
+        var values = names.Select(n => (IrExpression)new LoadArgument(1, "value_" + n, Int32));
+        return new AnonymousObject(Anon, [.. names], values);
+    }
+
+    static AnonymousObject LongAnonymous()
+        => Anonymous("FirstMeasuredProperty", "SecondMeasuredProperty", "ThirdMeasuredProperty", "FourthMeasuredProperty");
+
+    [Fact]
+    public void LongWith_BreaksAllmanOnePerLine()
+    {
+        string body = Render(LongWith(), Record);
+
+        Assert.Contains("original with\n", body);
+        Assert.Contains("\n{\n", body);
+        Assert.Contains("    FirstMeasuredProperty = value_FirstMeasuredProperty,\n", body);
+        Assert.Contains("    FourthMeasuredProperty = value_FourthMeasuredProperty\n", body);
+        Assert.DoesNotContain("value_FourthMeasuredProperty,", body);
+        Assert.Contains("\n};", body);
+        Assert.DoesNotContain("with { FirstMeasuredProperty", body);
+    }
+
+    [Fact]
+    public void ShortWith_StaysInline()
+    {
+        string body = Render(With("X", "Y"), Record);
+
+        Assert.Contains("original with { X = value_X, Y = value_Y };", body);
+        Assert.DoesNotContain("\n{\n", body);
+    }
+
+    [Fact]
+    public void LongWith_DisableOneLinerWrapping_StaysInline()
+    {
+        string body = Render(LongWith(), Record, PrinterOptions.Default with { DisableOneLinerWrapping = true });
+
+        Assert.DoesNotContain("\n{\n", body);
+        Assert.Contains("original with { FirstMeasuredProperty = value_FirstMeasuredProperty,",
+            string.Concat(body.Split('\n').Select(line => line.Trim())).Replace("  ", " "));
+    }
+
+    [Fact]
+    public void LongAnonymous_BreaksAllmanOnePerLine()
+    {
+        string body = Render(LongAnonymous(), Anon);
+
+        Assert.Contains("new\n", body);
+        Assert.Contains("\n{\n", body);
+        Assert.Contains("    FirstMeasuredProperty = value_FirstMeasuredProperty,\n", body);
+        Assert.Contains("    FourthMeasuredProperty = value_FourthMeasuredProperty\n", body);
+        Assert.DoesNotContain("value_FourthMeasuredProperty,", body);
+        Assert.Contains("\n};", body);
+        Assert.DoesNotContain("new { FirstMeasuredProperty", body);
+    }
+
+    [Fact]
+    public void ShortAnonymous_StaysInline()
+    {
+        string body = Render(Anonymous("X", "Y"), Anon);
+
+        Assert.Contains("new { X = value_X, Y = value_Y };", body);
+        Assert.DoesNotContain("\n{\n", body);
+    }
+
+    // Both broken forms must be pure whitespace variants of their inline forms.
+    [Fact]
+    public void BrokenForms_AreWhitespaceVariantsOfInline()
+    {
+        static string Collapse(string s) => string.Concat(s.Where(c => !char.IsWhiteSpace(c)));
+
+        string brokenWith = Render(LongWith(), Record);
+        string inlineWith = Render(LongWith(), Record, PrinterOptions.Default with { DisableOneLinerWrapping = true });
+        Assert.Equal(Collapse(inlineWith), Collapse(brokenWith));
+
+        string brokenAnon = Render(LongAnonymous(), Anon);
+        string inlineAnon = Render(LongAnonymous(), Anon, PrinterOptions.Default with { DisableOneLinerWrapping = true });
+        Assert.Equal(Collapse(inlineAnon), Collapse(brokenAnon));
+    }
+}
+
+// Real compiler-produced witnesses (imported from compiled fixtures, raised, then
+// printed) confirming the brace-body wrapper folds a wide record `with` expression
+// and a wide anonymous object end-to-end, not just synthetic IR.
+public sealed class WithAndAnonymousWrappingFixtureTests
+{
+    static string Print(Type sampleType, string methodName)
+    {
+        using var source = MetadataSource.Open(sampleType.Assembly.Location);
+        var function = IrImporter.Import(source, sampleType.FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void WideWithExpression_FoldsMultiLine()
+    {
+        string output = Print(typeof(BraceBodyWrappingSamples), nameof(BraceBodyWrappingSamples.WidenMeasuredRecord));
+
+        // Raised to a multi-entry `with`, then broken Allman one-per-line.
+        Assert.Contains(" with\n", output);
+        Assert.Contains("    FirstMeasuredValue = ", output);
+        Assert.Contains("    FourthMeasuredValue = ", output);
+        Assert.DoesNotContain("with { FirstMeasuredValue", output);
+        // No trailing comma before the closing brace.
+        Assert.DoesNotContain(",\n};", output.Replace("\r", ""));
+    }
+
+    [Fact]
+    public void WideAnonymousObject_FoldsMultiLine()
+    {
+        string output = Print(typeof(BraceBodyWrappingSamples), nameof(BraceBodyWrappingSamples.ProjectMeasuredValues));
+
+        Assert.Contains("new\n", output);
+        Assert.Contains("    FirstMeasuredProjection = ", output);
+        Assert.Contains("    FourthMeasuredProjection = ", output);
+        Assert.DoesNotContain("new { FirstMeasuredProjection", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -890,37 +890,26 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// Renders an object/collection initializer as a wrapped Allman block — the
-    /// <c>new T(...)</c> head on the first line, <c>{</c> and <c>}</c> on their own
-    /// lines at the statement indent, and one <c>Member = value</c> / element entry
-    /// per line one continuation level deeper — when the initializer has at least
-    /// <see cref="FluentChainMinSegments"/> entries and its single-line form would
-    /// exceed <see cref="FluentChainWrapWidth"/>. Returns null (render inline)
-    /// otherwise. The wrapped form reuses the same head and entry texts the inline
-    /// <see cref="ObjectInitializerText"/> renders and carries no trailing comma, so
-    /// it is token-identical to the inline form: only whitespace differs and the IL
-    /// is unchanged. A defensive re-match against the inline text keeps the
-    /// statement inline if the reconstruction diverges rather than reshaping a token.
+    /// Renders a brace-bodied expression — an object/collection initializer, a
+    /// record <c>with</c> expression, or an anonymous object — as a wrapped Allman
+    /// block: <paramref name="head"/> on the first line, <c>{</c> and <c>}</c> on
+    /// their own lines at the statement indent, and one entry per line one
+    /// continuation level deeper. Returns null (render inline) when the body has
+    /// fewer than <see cref="FluentChainMinSegments"/> entries or its single-line
+    /// form fits within <see cref="FluentChainWrapWidth"/>. The wrapped form reuses
+    /// the same <paramref name="head"/> and <paramref name="entryTexts"/> the inline
+    /// renderer emits and carries no trailing comma, so it is token-identical to the
+    /// inline form: only whitespace differs and the IL is unchanged. A defensive
+    /// re-match against the inline <paramref name="flat"/> text keeps the statement
+    /// inline if the reconstruction diverges rather than reshaping a token.
     /// </summary>
-    string? ObjectInitializerLines(ObjectInitializerExpression initializer, string prefix, string suffix, int indent)
+    string? BraceBodyLines(string head, IReadOnlyList<string> entryTexts, string flat, string prefix, string suffix, int indent)
     {
-        var entries = initializer.Entries;
-        if (entries.Count < FluentChainMinSegments)
+        if (entryTexts.Count < FluentChainMinSegments)
             return null;
 
-        string flat = ObjectInitializerText(initializer);
         if (indent * 4 + prefix.Length + flat.Length + suffix.Length <= FluentChainWrapWidth)
             return null;
-
-        var creation = initializer.Creation;
-        string arguments = creation.Arguments.Count == 0
-            ? string.Empty
-            : $"({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
-        string head = $"new {TypeText(creation.Constructor.DeclaringType)}{arguments}";
-
-        var entryTexts = entries
-            .Select(entry => InitializerEntryText(initializer.IsCollection, entry))
-            .ToList();
 
         // The wrapped form must be a pure whitespace variant of the inline text.
         // Reconstruct the inline body from the same head and entry texts and bail if
@@ -943,6 +932,48 @@ public sealed partial class CSharpPrinter
         sb.Append('\n').Append(pad).Append('}');
         sb.Append(suffix);
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Wraps an object/collection initializer (<c>new T(...) { ... }</c>) through
+    /// <see cref="BraceBodyLines"/>, reusing the same head and entry texts the inline
+    /// <see cref="ObjectInitializerText"/> renders.
+    /// </summary>
+    string? ObjectInitializerLines(ObjectInitializerExpression initializer, string prefix, string suffix, int indent)
+    {
+        var creation = initializer.Creation;
+        string arguments = creation.Arguments.Count == 0
+            ? string.Empty
+            : $"({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
+        string head = $"new {TypeText(creation.Constructor.DeclaringType)}{arguments}";
+        var entryTexts = initializer.Entries
+            .Select(entry => InitializerEntryText(initializer.IsCollection, entry))
+            .ToList();
+        return BraceBodyLines(head, entryTexts, ObjectInitializerText(initializer), prefix, suffix, indent);
+    }
+
+    /// <summary>
+    /// Wraps a record <c>with</c> expression (<c>receiver with { ... }</c>) through
+    /// <see cref="BraceBodyLines"/>, reusing the same head and entry texts the inline
+    /// <see cref="WithExpressionText"/> renders.
+    /// </summary>
+    string? WithExpressionLines(WithExpression node, string prefix, string suffix, int indent)
+    {
+        string head = $"{Operand(node.Receiver)} with";
+        var entryTexts = node.Entries.Select(WithExpressionEntryText).ToList();
+        return BraceBodyLines(head, entryTexts, WithExpressionText(node), prefix, suffix, indent);
+    }
+
+    /// <summary>
+    /// Wraps an anonymous object (<c>new { ... }</c>) through
+    /// <see cref="BraceBodyLines"/>, reusing the same projection parts the inline
+    /// <see cref="AnonymousObjectText"/> renders.
+    /// </summary>
+    string? AnonymousObjectLines(AnonymousObject node, string prefix, string suffix, int indent)
+    {
+        if (node.Values.Count == 0)
+            return null;
+        return BraceBodyLines("new", AnonymousObjectParts(node), AnonymousObjectText(node), prefix, suffix, indent);
     }
 
     /// The CLR models <c>int[,]</c> element get/set/address and construction as

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -70,6 +70,17 @@ public sealed partial class CSharpPrinter
     {
         if (anonymous.Values.Count == 0)
             return "new { }";
+        return $"new {{ {string.Join(", ", AnonymousObjectParts(anonymous))} }}";
+    }
+
+    /// <summary>
+    /// Renders each anonymous-object projection part (<c>x</c> / <c>obj.Member</c>
+    /// shorthand where the value's own member name matches, else <c>Name = value</c>),
+    /// shared by the inline <see cref="AnonymousObjectText"/> and the wrapped
+    /// <c>AnonymousObjectLines</c> so both spell identical tokens.
+    /// </summary>
+    List<string> AnonymousObjectParts(AnonymousObject anonymous)
+    {
         var parts = new List<string>(anonymous.Values.Count);
         for (int i = 0; i < anonymous.Values.Count; i++)
         {
@@ -82,7 +93,7 @@ public sealed partial class CSharpPrinter
                 || (value is LoadProperty property && property.PropertyName == name && text.EndsWith("." + escapedName, StringComparison.Ordinal));
             parts.Add(shorthand ? text : $"{escapedName} = {text}");
         }
-        return $"new {{ {string.Join(", ", parts)} }}";
+        return parts;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2021,7 +2021,7 @@ public sealed partial class CSharpPrinter
             if (!TryAppendFluentChain(sb, node, line, indent)
                 && !TryAppendSplittableExpression(sb, node, line, indent)
                 && !TryAppendBitwiseChain(sb, node, line, indent)
-                && !TryAppendObjectInitializer(sb, node, line, indent))
+                && !TryAppendBraceBody(sb, node, line, indent))
                 sb.Append(pad).AppendLine(line);
         }
     }
@@ -2360,61 +2360,77 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// Emits <paramref name="node"/> as a wrapped object/collection initializer —
-    /// the <c>new T(...)</c> head on the first line, an Allman <c>{</c>/<c>}</c>
-    /// pair on their own lines, and one <c>Member = value</c> / element entry per
-    /// line — when it is an initializer-valued statement whose flat single-line
-    /// form would exceed <see cref="FluentChainWrapWidth"/>, returning true after
-    /// appending; false to fall through to the flat single-line emit. The broken
-    /// form is only chosen when the flat statement <paramref name="line"/> is
-    /// exactly <c>prefix + initializer + ";"</c>, so any coercion cast the renderer
-    /// added around the initializer keeps the statement inline — breaking never
-    /// drops or reshapes a token.
+    /// Emits <paramref name="node"/> as a wrapped brace-bodied expression — an
+    /// object/collection initializer (<c>new T(...) { ... }</c>), a record
+    /// <c>with</c> expression (<c>receiver with { ... }</c>), or an anonymous object
+    /// (<c>new { ... }</c>) — with the head on the first line, an Allman <c>{</c>/<c>}</c>
+    /// pair on their own lines, and one entry per line, when it is a brace-bodied
+    /// statement whose flat single-line form would exceed
+    /// <see cref="FluentChainWrapWidth"/>, returning true after appending; false to
+    /// fall through to the flat single-line emit. The broken form is only chosen
+    /// when the flat statement <paramref name="line"/> is exactly
+    /// <c>prefix + body + ";"</c>, so any coercion cast the renderer added around the
+    /// body keeps the statement inline — breaking never drops or reshapes a token.
     /// </summary>
-    bool TryAppendObjectInitializer(StringBuilder sb, IrNode node, string line, int indent)
+    bool TryAppendBraceBody(StringBuilder sb, IrNode node, string line, int indent)
     {
         if (_options.DisableOneLinerWrapping)
             return false;
-        if (!TryObjectInitializerStatement(node, out var initializer, out var prefix))
+        if (!TryBraceBodyStatement(node, out var value, out var prefix))
             return false;
-        if (line != prefix + ObjectInitializerText(initializer) + ";")
+        string flat = value switch
+        {
+            ObjectInitializerExpression initializer => ObjectInitializerText(initializer),
+            WithExpression with => WithExpressionText(with),
+            AnonymousObject anonymous => AnonymousObjectText(anonymous),
+            _ => null!,
+        };
+        if (line != prefix + flat + ";")
             return false;
-        if (ObjectInitializerLines(initializer, prefix, ";", indent) is not { } broken)
+        string? broken = value switch
+        {
+            ObjectInitializerExpression initializer => ObjectInitializerLines(initializer, prefix, ";", indent),
+            WithExpression with => WithExpressionLines(with, prefix, ";", indent),
+            AnonymousObject anonymous => AnonymousObjectLines(anonymous, prefix, ";", indent),
+            _ => null,
+        };
+        if (broken is null)
             return false;
         sb.AppendLine(broken);
         return true;
     }
 
     /// <summary>
-    /// Recognizes the statement positions whose value is a bare object/collection
-    /// initializer — a <c>return</c> or a (non-ref) local or stack-slot store — and
-    /// yields the initializer plus the exact statement prefix the flat renderer
-    /// prints before it. The caller re-derives the flat text and only breaks the
-    /// initializer when it matches, so the prefix here need only cover the common
+    /// Recognizes the statement positions whose value is a bare brace-bodied
+    /// expression — an object/collection initializer, a record <c>with</c>
+    /// expression, or an anonymous object — in a <c>return</c> or a (non-ref) local
+    /// or stack-slot store, and yields the value plus the exact statement prefix the
+    /// flat renderer prints before it. The caller re-derives the flat text and only
+    /// breaks the body when it matches, so the prefix here need only cover the common
     /// (cast-free) spelling.
     /// </summary>
-    bool TryObjectInitializerStatement(IrNode node, out ObjectInitializerExpression initializer, out string prefix)
+    bool TryBraceBodyStatement(IrNode node, out IrExpression value, out string prefix)
     {
         switch (node)
         {
-            case Return { Value: ObjectInitializerExpression init }:
-                initializer = init;
+            case Return { Value: ObjectInitializerExpression or WithExpression or AnonymousObject } ret:
+                value = ret.Value!;
                 prefix = "return ";
                 return true;
-            case StoreLocal { Type.Kind: not TypeRefKind.ByRef, Value: ObjectInitializerExpression init } store:
-                initializer = init;
+            case StoreLocal { Type.Kind: not TypeRefKind.ByRef, Value: ObjectInitializerExpression or WithExpression or AnonymousObject } store:
+                value = store.Value;
                 prefix = _declaringStores.Contains(store)
                     ? $"{DeclarationTypeText(store.Type, store.Value)} {LocalName(store.Index)} = "
                     : $"{LocalName(store.Index)} = ";
                 return true;
-            case StoreStackSlot store when store.Value is ObjectInitializerExpression init && StackSlotTargetType(store) is { Kind: not TypeRefKind.ByRef }:
-                initializer = init;
+            case StoreStackSlot store when store.Value is (ObjectInitializerExpression or WithExpression or AnonymousObject) && StackSlotTargetType(store) is { Kind: not TypeRefKind.ByRef }:
+                value = store.Value;
                 prefix = _declaringStores.Contains(store)
                     ? $"{DeclarationTypeText(StackSlotTargetType(store)!, store.Value)} {StackSlotName(store)} = "
                     : $"{StackSlotName(store)} = ";
                 return true;
             default:
-                initializer = null!;
+                value = null!;
                 prefix = "";
                 return false;
         }


### PR DESCRIPTION
Closes #3371 (follow-up to #3377).

## Summary

#3377 broke long **object/collection** initializers Allman-style via an always-on
brace-body width wrapper, but deferred two sibling forms that render through the
same `head { e0, e1 }` shape and hit the same long-line problem:

- record **`with`** expressions — `receiver with { A = x, B = y, … }`
- **anonymous objects** — `new { Name = value, … }`

This extends the wrapper to both, and refactors #3377's initializer-specific code
into a shared core rather than adding parallel abstractions.

## Change

- **Extract** the width-check / whitespace-variant-guard / Allman-emit body of
  #3377's `ObjectInitializerLines` into `BraceBodyLines(head, entryTexts, flat, prefix, suffix, indent)`.
- **Three thin callers** feed it the head + entry texts the inline renderers already
  emit: `ObjectInitializerLines` (unchanged behavior), `WithExpressionLines`
  (head `receiver with`), `AnonymousObjectLines` (head `new`). The anonymous
  projection parts are factored into a shared `AnonymousObjectParts` so the inline
  and wrapped forms spell identical tokens.
- **Unify** the statement recognizer/caller: `TryObjectInitializerStatement` /
  `TryAppendObjectInitializer` → `TryBraceBodyStatement` / `TryAppendBraceBody`,
  matching `ObjectInitializerExpression`, `WithExpression`, and `AnonymousObject`
  in `return` / non-ref local or stack-slot store position and dispatching per
  value type.

## Byte-neutrality

Whitespace-only, same as #3377. A wrapped form is admitted only when **both** guards
hold: the caller's exact-match `line == prefix + <inline body> + ";"` (so a coercion
cast keeps it inline) and `BraceBodyLines`'s reconstruction `head + "{ " + join + " }" == inline`.
No trailing comma. The object-initializer path is the same shared core, so its
compile-back RoundTrip gates cover the core; the whitespace-variant tests prove the
two new arms are token-identical to their inline forms.

- **IL fidelity:** True — object-initializer compile-back RoundTrip gates unchanged;
  the two new arms are proven pure whitespace variants. (The 3 `parameter-attributes` /
  record-helper / lowering-frontier `RecompileFail`s in `Area=RoundTrip` are
  pre-existing/environmental, same set #3377's reviewers confirmed on base.)
- **Taste applied:** none — always-on formatting, not a style lens.

## After (verbatim product output at head `8512014b`)

Real compiled fixtures (`BraceBodyWrappingSamples`, appended at end of the fixture
file so no generated-code ordinals shift), `-S "Decompiled Source"`:

Record `with` (`WidenMeasuredRecord`):

```csharp
public static ILInspector.Decompiler.Tests.MeasuredRecord WidenMeasuredRecord(ILInspector.Decompiler.Tests.MeasuredRecord source, int first, int second, int third, int fourth) => source with
{
    FirstMeasuredValue = first,
    SecondMeasuredValue = second,
    ThirdMeasuredValue = third,
    FourthMeasuredValue = fourth
};
```

Anonymous object (`ProjectMeasuredValues`):

```csharp
public static object ProjectMeasuredValues(int first, int second, int third, int fourth) => new
{
    FirstMeasuredProjection = first,
    SecondMeasuredProjection = second,
    ThirdMeasuredProjection = third,
    FourthMeasuredProjection = fourth
};
```

## Before (pre-change behavior)

Each rendered as a single flat line (the inline `WithExpressionText` /
`AnonymousObjectText` join, which `DisableOneLinerWrapping` still produces) — e.g.:

```csharp
... WidenMeasuredRecord(...) => source with { FirstMeasuredValue = first, SecondMeasuredValue = second, ThirdMeasuredValue = third, FourthMeasuredValue = fourth };
... ProjectMeasuredValues(...) => new { FirstMeasuredProjection = first, SecondMeasuredProjection = second, ThirdMeasuredProjection = third, FourthMeasuredProjection = fourth };
```

- Valid: True — Correct: True — IL fidelity: True — Taste applied: none (both Before and After)

## Tests

- `WithAndAnonymousWrappingTests` (hand-built IR): break / inline / single-long /
  `DisableOneLinerWrapping` / whitespace-variant, for both `with` and anonymous.
- `WithAndAnonymousWrappingFixtureTests` (real compiled fixtures): both fold
  multi-line end-to-end (the `with` raises to a 4-entry `WithExpression`).
- Existing #3377 `ObjectInitializerFormattingTests`: unchanged, still green (refactor
  is behavior-preserving).
- Fast decompiler suite (`-trait- "Speed=Slow"`): **4059/0**.
- Slow `Area=RoundTrip`: only the 3 known pre-existing env failures.

## Scope

Completes the initializer-family wrapping. Still deferred (separate concerns):
method/parameter-list signature wrapping; recursive wrapping of nested initializers.
