### PR TITLE
Require consulting both dotnet/runtime oracle facets for taste/style raises

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,16 @@ Match evidence to the claim and use the smallest existing check that proves it:
   the change explicitly intends otherwise.
 - For output changes, exercise the affected Markdown and structured modes,
   schema/query fields, ordering, and verbosity behavior.
+- For any taste- or style-oriented raise or rendering change, consult **both**
+  facets of the dotnet/runtime style oracle before landing it and record what
+  each says: the **declared** facet (`dotnet/runtime`'s `.editorconfig` and
+  enabled analyzers — quote the `dotnet_style_*`/`csharp_style_*` key or state
+  it is silent) and the **revealed** facet (the dominant form in
+  `dotnet/runtime` source, with `path/file.cs:line` witnesses). Cite the facet a
+  claim rests on; never assert "oracle approved" uncited, and never infer one
+  facet from the other. A knowing divergence is legitimate only when the
+  consultation happened and is recorded. See
+  [`docs/decompiler-taste.md`](docs/decompiler-taste.md#consulting-both-facets-is-required).
 - For corpus or performance claims, record the pinned input, command, baseline,
   and result. Static analysis proves structural evidence, not runtime heat,
   frequency, bytes, or impact; use a benchmark or profiler for runtime claims.

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -43,6 +43,36 @@ that is what runtime code writes. So "the oracle is silent" always means the
 no dominant form. A shape can be declared-silent yet revealed-endorsed — which is
 exactly the status of the fidelity-neutral formatting/synthesis knobs below.
 
+### Consulting both facets is required
+
+Because the oracle has these two facets, **every taste- or style-oriented raise
+or rendering change must consult both before it lands**, and record what each
+one says. This is a required step, not a courtesy:
+
+1. **Declared facet — `dotnet/runtime`'s `.editorconfig` and enabled analyzers.**
+   Check whether a `dotnet_style_*` / `csharp_style_*` key (or an enabled IDE
+   fixer) speaks to the shape. Quote the key and its value, or state explicitly
+   that the declared oracle is **silent** on it.
+2. **Revealed facet — `dotnet/runtime` source.** Look for the dominant form the
+   runtime's own code actually writes for the shape, with concrete
+   `path/file.cs:line` witnesses. If the corpus shows no dominant form, say so.
+
+A change may only claim oracle endorsement for the facet it actually checked:
+"the runtime writes it this way" is a *revealed* claim and needs source
+witnesses; "the `.editorconfig` prescribes it" is a *declared* claim and needs
+the key. Do not infer one facet from the other, and do not assert "oracle
+approved" without naming which facet and citing it.
+
+Consulting the oracle does not mean the tool must match it. Where we knowingly
+diverge — a compactness knob, or a terminal-oriented wrapping trigger more eager
+than the corpus's habit — the divergence is legitimate **only when the
+consultation happened and the result is recorded**, so a later reader sees a
+deliberate, cited taste choice rather than an unreviewed gap. (Example: the
+`with`/anonymous width-wrap trigger is intentionally more eager than the
+runtime's inline habit for terminal readability, recorded against its issue.)
+An unchecked or uncited taste change is incomplete regardless of how the output
+looks.
+
 ## The three-class rule
 
 Every proposed rendering falls into one of three classes, and the class decides the answer:


### PR DESCRIPTION
## What

Makes it a **required, recorded step** to consult the dotnet/runtime style oracle for every taste- or style-oriented raise/rendering change — both facets:

- **Declared** — `dotnet/runtime`'s `.editorconfig` + enabled analyzers (`dotnet_style_*`/`csharp_style_*`), or an explicit "silent".
- **Revealed** — the dominant form in `dotnet/runtime` source, with `path/file.cs:line` witnesses.

A change may only claim endorsement for the facet it actually checked, must cite it, and must not infer one facet from the other. A knowing divergence (a compactness knob, or a terminal-oriented wrap trigger more eager than the corpus habit) is legitimate **only when the consultation happened and is recorded** — so a later reader sees a deliberate, cited taste choice rather than an unreviewed gap.

## Why

The taste doc already describes the oracle's declared/revealed facets, but nothing *required* an author to consult and cite them. This closes that gap so "oracle approved" is always an auditable claim. Prompted by the #3382 `with`/anonymous width-wrap work: we consulted the oracle (runtime keeps `with` inline even at 167 cols; `.editorconfig` has no line-length rule) and chose a deliberately more-eager trigger for terminal readability — recorded in #3383. This PR makes that consult-and-record loop the standing rule.

## Changes

- `docs/decompiler-taste.md`: new **"Consulting both facets is required"** subsection under *The style oracle*.
- `AGENTS.md`: matching bullet under *Evidence and validation*, linking the taste-doc section.

## Evidence

Docs-only; no product behavior claim. `markdownlint-cli` clean on both files. Per AGENTS.md, documentation-only changes require Markdown validation, not product builds or tests.