### PR TITLE
Make --json compose with print and shape projections

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -205,7 +205,7 @@ payloads on already evaluated rows; it cannot probe missing cells.
 | Flag | Effect |
 | --- | --- |
 | `--markdown` | force the full Markdown Document format |
-| `--json` | the whole Document as one JSON object |
+| `--json` | render the selected shape as JSON: the whole Document when no narrower shape is selected, otherwise the projected payload (`--print`, `--value`, `--urls`, `--paths`) |
 | `--tsv` / `--jsonl` | render the single selected section as TSV / JSON Lines (a Table or Vector) |
 | `--table` | render the single selected section as a space-padded pretty table |
 | `--no-header` (`--no-headers`) | drop the Table header row |

--- a/src/DotnetInspector.Core/HttpClientFactory.cs
+++ b/src/DotnetInspector.Core/HttpClientFactory.cs
@@ -14,6 +14,7 @@ public static class HttpClientFactory
     private static bool _offline;
     private static HttpClient? _shared;
     private static HttpClient? _sharedUntrustedFetch;
+    private static HttpClient? _untrustedFetchOverride;
     private static IDisposable? _networkTrafficLoggingSubscription;
 
     /// <summary>
@@ -55,6 +56,7 @@ public static class HttpClientFactory
     {
         _shared = null;
         _sharedUntrustedFetch = null;
+        _untrustedFetchOverride = null;
         _networkTrafficLoggingSubscription?.Dispose();
         _networkTrafficLoggingSubscription = null;
     }
@@ -70,7 +72,15 @@ public static class HttpClientFactory
     /// in untrusted artifacts (SourceLink URLs embedded in a PDB, etc.). Use this — not <see cref="Shared"/> —
     /// for any URL that came from inspected package/PDB data. Do not dispose.
     /// </summary>
-    public static HttpClient SharedUntrustedFetch => _sharedUntrustedFetch ??= CreateUntrustedFetchClient();
+    public static HttpClient SharedUntrustedFetch => _untrustedFetchOverride ?? (_sharedUntrustedFetch ??= CreateUntrustedFetchClient());
+
+    /// <summary>
+    /// Test-only: substitutes the transport used by untrusted-source fetches so acquisition
+    /// paths (including failure) can be exercised without network access. This replaces only
+    /// the transport; callers still run the real <c>SourceFetcher</c>, so scheme restriction,
+    /// caching, and status handling stay under test. Pass null to restore the real client.
+    /// </summary>
+    internal static void SetUntrustedFetchForTesting(HttpClient? client) => _untrustedFetchOverride = client;
 
     /// <summary>
     /// Whether <paramref name="url"/> is an absolute http/https URL. Untrusted-source fetches restrict

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3534,6 +3534,151 @@ public class CommandExecutionTests
         Assert.Contains("JsonReader", single.GetProperty("content").GetString());
     }
 
+    /// <summary>
+    /// <c>--json</c> selects an output format and <c>--print</c> selects an output shape,
+    /// so they compose: the projection owns the request and the plain type surface must not
+    /// claim it. Regression for #3379, where the type-surface early return preceded the
+    /// projection dispatch and silently discarded <c>--print</c> with exit 0.
+    /// </summary>
+    [Fact]
+    public async Task Type_SourceFiles_PrintJson_EmitsSelectedDocumentNotTypeSurface()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--print", "--row", "1", "--json", "--raw", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        Assert.Equal(1, document.RootElement.GetProperty("row").GetInt32());
+        Assert.Equal("Source Files", document.RootElement.GetProperty("section").GetString());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", document.RootElement.GetProperty("url").GetString());
+        Assert.Contains("JsonReader", document.RootElement.GetProperty("content").GetString());
+        Assert.False(document.RootElement.TryGetProperty("metadata_name", out _));
+    }
+
+    /// <summary>
+    /// Cardinality validation belongs to the projection, so it must run under <c>--json</c> too.
+    /// </summary>
+    [Fact]
+    public async Task Type_SourceFiles_PrintJson_RequiresRowWhenMultipleUrls()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--print", "--json", "--raw", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("selected section has 2 printable rows; use --row N|first|last to choose one row", error);
+    }
+
+    [Fact]
+    public async Task Type_SourceFiles_UrlsJson_EmitsProjectedRowsNotTypeSurface()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--urls", "--json", "--raw", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        var rows = document.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(2, rows.Length);
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", rows[0].GetProperty("url").GetString());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", rows[1].GetProperty("url").GetString());
+    }
+
+    [Fact]
+    public async Task Type_SourceFiles_ValueJson_EmitsSelectedRowNotTypeSurface()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--value", "--row", "2", "--json", "--raw", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        Assert.Equal(2, document.RootElement.GetProperty("row").GetInt32());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", document.RootElement.GetProperty("value").GetString());
+    }
+
+    /// <summary>
+    /// A failed acquisition of the selected row must stay visible rather than degrade into
+    /// success-shaped output. Only the transport is substituted, so the real SourceFetcher
+    /// still applies scheme restriction, caching, and status handling.
+    /// </summary>
+    [Fact]
+    public async Task Type_SourceFiles_PrintRow_FetchFailureIsHardError()
+    {
+        using var client = new HttpClient(new NotFoundHandler());
+        DotnetInspector.Core.HttpClientFactory.SetUntrustedFetchForTesting(client);
+        string cacheDir = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-fetch-failure-{Guid.NewGuid():N}");
+        NuGetCache.Initialize("dotnet-inspect", basePath: cacheDir);
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+                "-S", "Source Files", "--print", "--row", "2", "--raw", "--tips", "q");
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains("failed to fetch the document for printable row 2 from", error);
+            Assert.Contains("/Src/Newtonsoft.Json/JsonReader.Async.cs", error);
+        }
+        finally
+        {
+            DotnetInspector.Core.HttpClientFactory.SetUntrustedFetchForTesting(null);
+            NuGetCache.Initialize("dotnet-inspect");
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The acquisition guarantee must hold under <c>--json</c> as well; before #3379 this
+    /// combination exited 0 with the type surface and never attempted the fetch.
+    /// </summary>
+    [Fact]
+    public async Task Type_SourceFiles_PrintRowJson_FetchFailureIsHardError()
+    {
+        using var client = new HttpClient(new NotFoundHandler());
+        DotnetInspector.Core.HttpClientFactory.SetUntrustedFetchForTesting(client);
+        string cacheDir = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-fetch-failure-json-{Guid.NewGuid():N}");
+        NuGetCache.Initialize("dotnet-inspect", basePath: cacheDir);
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+                "-S", "Source Files", "--print", "--row", "2", "--json", "--raw", "--tips", "q");
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains("failed to fetch the document for printable row 2 from", error);
+        }
+        finally
+        {
+            DotnetInspector.Core.HttpClientFactory.SetUntrustedFetchForTesting(null);
+            NuGetCache.Initialize("dotnet-inspect");
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    private sealed class NotFoundHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.NotFound)
+            {
+                RequestMessage = request,
+            });
+    }
+
     [Fact]
     public async Task Type_JsonArrayRequiresProjectionShape()
     {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3611,13 +3611,13 @@ public class CommandExecutionTests
     public async Task Type_SourceFiles_PrintRow_FetchFailureIsHardError()
     {
         using var client = new HttpClient(new NotFoundHandler());
-        DotnetInspector.Core.HttpClientFactory.SetUntrustedFetchForTesting(client);
         string cacheDir = Path.Combine(
             Path.GetTempPath(),
             $"dotnet-inspect-fetch-failure-{Guid.NewGuid():N}");
-        NuGetCache.Initialize("dotnet-inspect", basePath: cacheDir);
         try
         {
+            DotnetInspector.Core.HttpClientFactory.SetUntrustedFetchForTesting(client);
+            NuGetCache.Initialize("dotnet-inspect", basePath: cacheDir);
             var (exit, output, error) = await RunAppAsync(
                 "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
                 "-S", "Source Files", "--print", "--row", "2", "--raw", "--tips", "q");
@@ -3644,13 +3644,13 @@ public class CommandExecutionTests
     public async Task Type_SourceFiles_PrintRowJson_FetchFailureIsHardError()
     {
         using var client = new HttpClient(new NotFoundHandler());
-        DotnetInspector.Core.HttpClientFactory.SetUntrustedFetchForTesting(client);
         string cacheDir = Path.Combine(
             Path.GetTempPath(),
             $"dotnet-inspect-fetch-failure-json-{Guid.NewGuid():N}");
-        NuGetCache.Initialize("dotnet-inspect", basePath: cacheDir);
         try
         {
+            DotnetInspector.Core.HttpClientFactory.SetUntrustedFetchForTesting(client);
+            NuGetCache.Initialize("dotnet-inspect", basePath: cacheDir);
             var (exit, output, error) = await RunAppAsync(
                 "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
                 "-S", "Source Files", "--print", "--row", "2", "--json", "--raw", "--tips", "q");

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -654,6 +654,12 @@ public class ApiCommand
 
     // ===== Single Type Rendering =====
 
+    // --json selects an output format; --print/--value/--urls/--paths select an
+    // output shape. They compose, so the plain type-surface serializer must not
+    // claim a request that a projection owns.
+    private static bool IsProjectionRequested(ApiOptions options)
+        => options.Print || options.Value || options.Urls || options.Paths;
+
     internal static async Task<int> WriteTypeOutputAsync(ApiType type, string? foundIn, string? packageName, string? packageVersion, string? apiSource, string? selectedTfm, ApiOptions options, TextWriter? output = null)
     {
         var sink = output ?? Console.Out;
@@ -664,7 +670,7 @@ public class ApiCommand
             return 0;
         }
 
-        if (options.JsonOutput && !options.Count)
+        if (options.JsonOutput && !options.Count && !IsProjectionRequested(options))
         {
             WriteJsonTypeOutput(type, options);
             return 0;


### PR DESCRIPTION
Fixes #3379. Second PR in the #3364 stack, on top of #3373.

`--json` selects an output *format*; `--print`, `--value`, `--urls`, and `--paths` select an output *shape*. On `type` and `member` they did not compose — the type-surface early return at `ApiCommand.cs:649` preceded the projection dispatch ~190 lines later, so `--json` silently discarded the projection and exited 0.

This is the same failure class #3373 just fixed: a projection request accepted and then dropped without a word. It also defeated that PR's acquisition guarantee, since neither cardinality validation nor the fetch ever ran under `--json`.

## Why compose rather than reject

This is not a new design decision. Both projection writers already implement JSON serialization (`PrintProjectionOutput.cs:69`, `ShapeProjectionOutput.cs:87`), and the sibling format flags already compose today:

| Flag | With `--print` on `type` (before) | Why |
| --- | --- | --- |
| `--jsonl` | works | not in the early-return guard |
| `--json-array` | works | not in the guard; `:142` *requires* a projection |
| `--json` | **silently bypassed** | type JSON returned first |
| `--count` | works | explicit `&& !options.Count` guard |

`--json` was the lone outlier among four format flags. Rejecting the combination would mean refusing something the code already knows how to serialize, and would make `--json` gratuitously different from `--jsonl`. The fix makes the existing intended shape reachable.

## Change

The guard now mirrors how `--count` already exempts itself:

```csharp
if (options.JsonOutput && !options.Count && !IsProjectionRequested(options))
```

Flow then falls through to the existing dispatch. I deliberately did not hoist the dispatch instead: the projections need `view`, which is not built until `:655`, so reordering would drag view construction along for no behavioral gain.

## Evidence

Real runs against a compiled two-row SourceLink fixture whose second row 404s, baseline `729f97bf` vs head:

| Command | Baseline | Head |
| --- | --- | --- |
| `--print --json` (2 rows) | type JSON, **exit 0** | `selected section has 2 printable rows`, exit 1 |
| `--print --row 2 --json` (404) | type JSON, **exit 0** | `failed to fetch the document for printable row 2 from <url>`, exit 1 |
| `--urls --json` | type JSON, exit 0 | projected rows array, exit 0 |

Untouched paths are byte-identical to baseline (md5-compared): plain `--json`, `--count --json`, and `--print` without `--json`.

Each of the five `--json` tests was confirmed to **fail** with the guard reverted and pass with it restored, so they pin the behavior rather than merely describing it.

`Total: 2233, Errors: 0, Failed: 0` (CLI) and `Total: 319, Errors: 0, Failed: 0` (services). markdownlint clean.

## Test seam

#3373 shipped with a declared gap: no automated coverage of the fetch-failure branch, because `PrintUrlProjectionAsync` builds its `SourceFetcher` from the static `HttpClientFactory.SharedUntrustedFetch`. This PR closes it with `SetUntrustedFetchForTesting`, following the `ResetSharedForTesting` convention already in that file.

The seam substitutes **only the transport**, so tests still exercise the real `SourceFetcher` — scheme restriction, caching, and status handling all stay under test. That matches the harness-boundary rule in `AGENTS.md`: the harness supplies a fixture, not a second implementation. `Type_SourceFiles_PrintRow_FetchFailureIsHardError` passes on baseline by design; it covers PR 1's branch rather than new behavior.

## Scope

`LibraryCommand.cs:603` and `PackageCommand.cs:660` look like the same pattern but are unrelated helpers (an IL-coordinate batch writer and the multi-package path); neither precedes a projection dispatch. `type` and `member` share the fixed method, so one guard covers both.

Docs: the `--json` row in `output-shapes.md` said "the whole Document as one JSON object", which is only true when the Document *is* the selected shape. Reworded to match the model the same document already states. This aligns the doc with its own framing rather than weakening it to fit behavior.

## Adversarial review

Behavior change to output composition on two commands — needs two-model review.
