### PR TITLE
Wire readable-local-names to a --readable-names flag and config key

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -629,7 +629,7 @@ show the shape beneath that sugar.
 
 ## Names
 
-Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL view — the two views stay name-aligned by construction. With a PDB, source names are used. Synthesizing readable names (`size`, `array`, `item`) where no PDB exists is an open design question: it is the largest remaining cosmetic gap against source, but it would break view alignment unless opt-in.
+Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL view — the two views stay name-aligned by construction. With a PDB, source names are used. Synthesizing readable names (`text`, `items`, `stringBuilder`) where no PDB source name exists is the largest remaining cosmetic gap against source, so it is exposed as an **opt-in** knob rather than a default: turning it on for every render would break the slot-name alignment the Annotated IL view relies on and churn the corpus. It rests only on evidence already in the IR (a local's type, and whether it is a loop counter) and falls back to `V_index` when no honest name applies (see `docs/design/readable-local-names.md`). Select it per run with `--readable-names` on `member`/`type`, or persistently with `dotnet_inspect_style_readable_local_names = true`. It is byte-preserving (names do not affect IL), so it is not part of the oracle-endorsed [taste](#style-configuration) aggregate and carries its own tool-owned key.
 
 ## Style configuration
 
@@ -670,9 +670,12 @@ dotnet_style_prefer_conditional_expression_over_return = true
 - Recognized keys map to `PrinterOptions`: the four `this`-qualification keys
   above (field, property, method, event — byte-preserving class-3 spellings),
   `dotnet_style_prefer_conditional_expression_over_return` (the oracle-endorsed
-  ternary [style lens](#style-lenses-behavior-faithful-byte-divergent)), and
+  ternary [style lens](#style-lenses-behavior-faithful-byte-divergent)),
   `dotnet_inspect_style_prefer_branchless_boolean` (the non-oracle-endorsed
-  branchless lens, under a tool-owned key). The set grows as more knobs ship.
+  branchless lens, under a tool-owned key), and
+  `dotnet_inspect_style_readable_local_names` (byte-preserving readable-name
+  synthesis for slot locals — see [Names](#names) — under a tool-owned key). The
+  set grows as more knobs ship.
 - `dotnet_inspect_style_full_taste = true` is a tool-owned **aggregate** key: it
   enables the whole oracle-endorsed subset at once (the four `this`-qualifications
   and the ternary lens — everything the runtime `.editorconfig`/IDE oracle

--- a/docs/design/readable-local-names.md
+++ b/docs/design/readable-local-names.md
@@ -54,7 +54,21 @@ A readable name is only as honest as the role it rests on. The synthesizer takes
 When no evidence supports a readable name, it falls back to `V_index` rather than
 fabricating — honest degradation, same as the rest of the pipeline.
 
-## Open fork (needs a decision before wiring)
+## Wiring decision (resolved)
+
+Of the fork below, **option A (printer option)** was taken. The library already
+carries `PrinterOptions.ReadableLocalNames` (default off) and consumes it in
+`CSharpPrinter.LocalName`; the CLI exposes it as the api-surface flag
+`--readable-names` on the `member` and `type` commands. The flag is threaded as
+`ApiOptions.RequestReadableLocalNames` and applied at the CLI edge in
+`ApiCommand` on top of the resolved `.dotnet-inspectconfig`/`--taste` render
+options — it is orthogonal to those style axes (a name synthesis, not a
+byte-divergent lens), so it never has to be reconciled against them and leaves
+the Annotated view's interleaved IL intact. The mode has no config key and is
+not oracle-endorsed, so a checked-in config and `--taste` never turn it on;
+only the explicit flag does. Default output stays byte-identical `V_index`.
+
+## Open fork (historical — resolved above)
 
 Where the opt-in lives:
 

--- a/docs/design/readable-local-names.md
+++ b/docs/design/readable-local-names.md
@@ -64,9 +64,12 @@ carries `PrinterOptions.ReadableLocalNames` (default off) and consumes it in
 `ApiCommand` on top of the resolved `.dotnet-inspectconfig`/`--taste` render
 options — it is orthogonal to those style axes (a name synthesis, not a
 byte-divergent lens), so it never has to be reconciled against them and leaves
-the Annotated view's interleaved IL intact. The mode has no config key and is
-not oracle-endorsed, so a checked-in config and `--taste` never turn it on;
-only the explicit flag does. Default output stays byte-identical `V_index`.
+the Annotated view's interleaved IL intact. For a persistent form the catalog
+entry also carries the tool-owned config key
+`dotnet_inspect_style_readable_local_names`. Because the mode is byte-preserving
+(names do not affect IL) it is **not** oracle-endorsed, so the `--taste` /
+`dotnet_inspect_style_full_taste` aggregate never turns it on; only the explicit
+flag or its own key does. Default output stays byte-identical `V_index`.
 
 ## Open fork (historical — resolved above)
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -276,7 +276,7 @@ public static class StyleOptionCatalog
             tier: StyleOptionTier.Synthesis,
             byteDivergent: false,
             oracleEndorsed: false,
-            configKey: null,
+            configKey: "dotnet_inspect_style_readable_local_names",
             get: static o => o.ReadableLocalNames,
             with: static (o, v) => o with { ReadableLocalNames = v }),
         Boolean(

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -63,6 +63,35 @@ public class CommandLineTests
                 .Any(o => o.Name == "--taste");
     }
 
+    // --readable-names, like --taste, is an api-surface gesture: it only means
+    // something where RenderOptions is consumed to render member source.
+
+    [Theory]
+    [InlineData("member")]
+    [InlineData("type")]
+    public void ApiCommands_AcceptReadableNamesGesture(string command)
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse([command, "System.Math", "--readable-names"]);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void NonApiCommand_DoesNotDeclareReadableNamesGesture()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        Assert.True(DeclaresReadableNames(root, "member"));
+        Assert.True(DeclaresReadableNames(root, "type"));
+        Assert.False(DeclaresReadableNames(root, "package"));
+
+        static bool DeclaresReadableNames(Command root, string name) =>
+            root.Subcommands
+                .Single(c => c.Name == name)
+                .Options
+                .Any(o => o.Name == "--readable-names");
+    }
+
     [Fact]
     public void RootCommand_WithInvalidVerbosity_ReportsParseError()
     {

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -69,6 +69,7 @@ public class MemberOptionsParserTests
         memberCommand.Options.Add(opts.Markdown);
         memberCommand.Options.Add(opts.PlainText);
         memberCommand.Options.Add(opts.Bare);
+        memberCommand.Options.Add(opts.ReadableNames);
         opts.AddOutputOptionsTo(memberCommand);
         opts.AddNuGetOptionsTo(memberCommand);
 
@@ -194,6 +195,22 @@ public class MemberOptionsParserTests
         Assert.Empty(options.CallerScopeProjects);
         Assert.Empty(options.CallerScopePackages);
         Assert.False(options.HasCallerScope);
+    }
+
+    [Fact]
+    public async Task ReadableNamesFlag_SetsRequestReadableLocalNames()
+    {
+        var options = await ParseSuccessAsync("member", "JsonSerializer", "--package", "System.Text.Json", "--readable-names");
+
+        Assert.True(options.RequestReadableLocalNames);
+    }
+
+    [Fact]
+    public async Task WithoutReadableNamesFlag_RequestReadableLocalNamesIsFalse()
+    {
+        var options = await ParseSuccessAsync("member", "JsonSerializer", "--package", "System.Text.Json");
+
+        Assert.False(options.RequestReadableLocalNames);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -967,14 +967,35 @@ public class RenderStyleConfigTests
     [Fact]
     public void ApiOnlyCatalogKnobs_HaveNoConfigKey()
     {
-        // Knobs with no config key (formatting/synthesis) are API-only and must not
-        // be reachable through the file vocabulary; a made-up key still warns.
+        // Knobs with no config key (formatting) are API-only and must not be
+        // reachable through the file vocabulary; a made-up key still warns. The
+        // whitespace-only wrappers are the standing API-only examples (synthesis's
+        // readable-local-names is now file-reachable under a tool-owned key).
         var apiOnly = StyleOptionCatalog.Options.Where(o => o.ConfigKey is null).ToArray();
-        Assert.Contains(apiOnly, o => o.Id == "readable-local-names");
+        Assert.Contains(apiOnly, o => o.Id == "wrap-splittable-expressions");
+        Assert.Contains(apiOnly, o => o.Id == "disable-one-liner-wrapping");
 
-        var result = RenderStyleConfig.Parse("readable_local_names = true", origin: "cfg");
-        Assert.False(result.Options.ReadableLocalNames);
+        var result = RenderStyleConfig.Parse("wrap_splittable_expressions = true", origin: "cfg");
+        Assert.False(result.Options.WrapSplittableExpressions);
         Assert.Contains(result.Warnings, w => w.Contains("unknown key"));
+    }
+
+    [Fact]
+    public void ReadableLocalNamesConfigKey_RoundTrips()
+    {
+        // readable-local-names is byte-preserving synthesis, so it is not in the
+        // oracle-endorsed taste aggregate; it carries its own tool-owned key.
+        var on = RenderStyleConfig.Parse("dotnet_inspect_style_readable_local_names = true", origin: "cfg");
+        Assert.Empty(on.Warnings);
+        Assert.True(on.Options.ReadableLocalNames);
+
+        var off = RenderStyleConfig.Parse("dotnet_inspect_style_readable_local_names = false", origin: "cfg");
+        Assert.Empty(off.Warnings);
+        Assert.False(off.Options.ReadableLocalNames);
+
+        // The aggregate must not turn it on (it is not oracle-endorsed).
+        var taste = RenderStyleConfig.Parse("dotnet_inspect_style_full_taste = true", origin: "cfg");
+        Assert.False(taste.Options.ReadableLocalNames);
     }
 
     private static string CreateTempDirectory()

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -104,6 +104,7 @@ public static class ApiCommandDefinitions
         typeCommand.Options.Add(opts.PlainText);
         typeCommand.Options.Add(opts.Bare);
         typeCommand.Options.Add(opts.Taste);
+        typeCommand.Options.Add(opts.ReadableNames);
         opts.AddOutputOptionsTo(typeCommand);
         opts.AddNuGetOptionsTo(typeCommand);
 
@@ -244,6 +245,7 @@ public static class ApiCommandDefinitions
         memberCommand.Options.Add(opts.PlainText);
         memberCommand.Options.Add(opts.Bare);
         memberCommand.Options.Add(opts.Taste);
+        memberCommand.Options.Add(opts.ReadableNames);
         memberCommand.Options.Add(opts.Focus);
         opts.AddOutputOptionsTo(memberCommand);
         opts.AddNuGetOptionsTo(memberCommand);

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -281,6 +281,7 @@ public static class MemberOptionsParser
             PlainText = parseResult.GetValue(opts.PlainText),
             Bare = parseResult.GetValue(opts.Bare),
             RequestAllTaste = parseResult.GetValue(opts.Taste),
+            RequestReadableLocalNames = parseResult.GetValue(opts.ReadableNames),
             Focus = parseResult.GetValue(opts.Focus),
             Print = parseResult.GetValue(opts.Print),
             PrintRow = opts.ParsePrintRow(parseResult),

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -181,6 +181,7 @@ public static class TypeOptionsParser
             PlainText = parseResult.GetValue(opts.PlainText),
             Bare = parseResult.GetValue(opts.Bare),
             RequestAllTaste = parseResult.GetValue(opts.Taste),
+            RequestReadableLocalNames = parseResult.GetValue(opts.ReadableNames),
             Print = parseResult.GetValue(opts.Print),
             PrintRow = opts.ParsePrintRow(parseResult),
             Value = parseResult.GetValue(opts.Value),

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -208,6 +208,11 @@ public class ApiCommand
         var renderOptions = options.RequestAllTaste
             ? ILInspector.Decompiler.Pipeline.StyleOptionCatalog.ApplyFullTaste(renderStyle.Options)
             : renderStyle.Options;
+        // --readable-names is orthogonal to the style axes the config/--taste cover
+        // (it names V_index locals, not a byte-divergent lens), so it applies on top
+        // of whatever those resolved and never has to be re-checked against them.
+        if (options.RequestReadableLocalNames)
+            renderOptions = renderOptions with { ReadableLocalNames = true };
         options = options with
         {
             RenderOptions = renderOptions,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -51,7 +51,9 @@ public class ApiCommand
             Value = options.Value, Urls = options.Urls, Paths = options.Paths,
             Select = options.Select, Columns = options.Columns, Fields = options.Fields,
             Schema = options.Schema, Count = options.Count, SourceOptions = options.SourceOptions,
-            TipLevel = options.TipLevel, RenderOptions = options.RenderOptions
+            TipLevel = options.TipLevel, RenderOptions = options.RenderOptions,
+            RequestAllTaste = options.RequestAllTaste,
+            RequestReadableLocalNames = options.RequestReadableLocalNames
         })
     };
 

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -78,6 +78,19 @@ public partial record ApiOptions
     public bool RequestAllTaste { get; init; }
 
     /// <summary>
+    /// The <c>--readable-names</c> gesture: for this run, synthesize a readable
+    /// identifier (from a local's type and role) for any local that has no usable
+    /// PDB source name, instead of the <c>V_index</c> fallback (see
+    /// <see cref="ILInspector.Decompiler.Pipeline.LocalNameSynthesizer"/> and
+    /// <c>docs/design/readable-local-names.md</c>). Byte-preserving — local names
+    /// do not affect IL, so it is not a byte-divergent lens and leaves the
+    /// Annotated view's interleaved IL intact. Applied on top of the resolved
+    /// <c>.dotnet-inspectconfig</c>/<c>--taste</c> options, since it is orthogonal
+    /// to the style axes those cover.
+    /// </summary>
+    public bool RequestReadableLocalNames { get; init; }
+
+    /// <summary>
     /// Pending <c>.dotnet-inspectconfig</c> parse/read warnings, emitted to stderr
     /// exactly once at the point a decompiled-source render consumes
     /// <see cref="RenderOptions"/> (see

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -22,6 +22,7 @@ public class SharedOptions
     public Option<bool> BrowsableUrls { get; } = new("--blob") { Description = "Emit GitHub URLs as browser-friendly /blob/ URLs (URL-shape modifier, not an output-shape modifier)" };
     public Option<bool> Mermaid { get; } = new("--mermaid") { Description = "Output as mermaid diagram (standalone or with --markdown for embedded)" };
     public Option<bool> Taste { get; } = new("--taste") { Description = "Render source with the full oracle-endorsed style set (includes byte-divergent lenses); Annotated Source names the applied knobs on the signature" };
+    public Option<bool> ReadableNames { get; } = new("--readable-names") { Description = "Synthesize readable names (from a local's type/role) for locals that have no usable PDB source name, instead of the V_index fallback; byte-preserving (names do not affect IL)" };
     public Option<string?> Focus { get; } = new("--focus") { Description = "Report a fact family with the caret gesture (underlined beneath the statement) instead of a trailing comment: a category (allocation), a descriptor id (alloc.box), or an id prefix (alloc). Promotes, never filters: unmatched facts keep their trailing comment", Arity = ArgumentArity.ExactlyOne };
     public Option<bool> Table { get; } = new("--table") { Description = "Output as a pretty table (space-padded columns)" };
     public Option<bool> Tsv { get; } = new("--tsv") { Description = "Output as normalized tab-separated values" };


### PR DESCRIPTION
## Summary

Wire the existing but unreachable **readable-local-names** synthesis mode to a user surface. The decompiler already had `PrinterOptions.ReadableLocalNames` (default off, consumed by `CSharpPrinter.LocalName` via `LocalNameSynthesizer`) and a catalog entry, but no way to turn it on: `--taste` skips it (`oracleEndorsed: false`) and `.dotnet-inspectconfig` skipped it (`configKey: null`). Its design note had already chosen **option A** (a printer option with a `--readable-names` flag); this completes that wiring and adds a persistent config key.

Without it, a nameless local (e.g. a record's compiler-synthesized `ToString`, whose PDB carries no local names) renders as `StringBuilder V_0`; with it, `StringBuilder stringBuilder`.

## Change

- **CLI flag `--readable-names`** on `member` and `type`, threaded as `ApiOptions.RequestReadableLocalNames` and applied at the CLI edge in `ApiCommand` on top of the resolved `.dotnet-inspectconfig` / `--taste` render options.
- **Config key `dotnet_inspect_style_readable_local_names`** on the catalog entry, mirroring the branchless-lens precedent (a byte-preserving, non-oracle-endorsed knob uses a tool-owned `dotnet_inspect_style_*` key, not a `dotnet_style_*` editorconfig one).

### Invariants preserved

- **Default output stays byte-identical `V_index`** — neither surface touches the default path, the `--skip-pdb` deterministic diff path, the fidelity gate, or Annotated-IL alignment.
- **Byte-preserving** (local names do not affect IL) → `byteDivergent: false`, so it is deliberately **not** oracle-endorsed and the `--taste` / `dotnet_inspect_style_full_taste` aggregate never enables it. Only the explicit flag or its own key does.
- The direct `ApiCommand.ExecuteAsync(ApiOptions)` compatibility shim now flows both `RequestReadableLocalNames` and (pre-existing gap, same reconstruction) `RequestAllTaste`.

## Evidence

| Check | Result |
| --- | --- |
| End-to-end (`Markout.CodeSection.ToString`) | default `V_0`; `--readable-names` → `stringBuilder`; config key → `stringBuilder`; misspelled key warns + stays `V_0` |
| CLI suite (`RenderStyleConfigTests`, `CommandLineTests`, `MemberOptionsParserTests`) | 346 passed |
| `CommandExecutionTests` (exercise the shim) | 595 passed |
| `StyleOptionCatalogTests` + `ByteNeutralityGateTests` | 34 passed |
| markdownlint | clean |

New tests: `ApiCommands_Accept/NonApiCommand_DoesNotDeclare` for `--readable-names`, `MemberOptionsParserTests` (flag → `RequestReadableLocalNames`), `RenderStyleConfigTests.ReadableLocalNamesConfigKey_RoundTrips` (key true/false round-trip, aggregate leaves it off), and retargeted `ApiOnlyCatalogKnobs_HaveNoConfigKey`.

Docs: `docs/decompiler-taste.md` Names section (open question → wired opt-in) + config-key list; `docs/design/readable-local-names.md` wiring note.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release
dotnet run --project src/dotnet-inspect.Tests -c Release -- -class "DotnetInspector.Tests.RenderStyleConfigTests" -class "DotnetInspector.Tests.CommandLineTests" -class "DotnetInspector.Tests.Parsers.MemberOptionsParserTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.StyleOptionCatalogTests"
```
