### PR TITLE
Reject duplicate JSON properties at untrusted parse boundaries, and gate JSON wire names

### DIFF
--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -254,6 +254,14 @@ only ordinary compiler output.
    attacker-authored content. Require agreement on the full resolved URL prefix
    including the commit, or derive provenance from the mapping the resolver
    actually selects, and report nothing when entries disagree.
+
+   Compare and extract on the *canonical* URL, not the literal mapping text.
+   `System.Uri` applies RFC 3986 dot-segment removal, so a value such as
+   `https://raw.githubusercontent.com/dotnet/runtime/<commit>/../../../owner/repo/<commit>/*`
+   is fetched from `owner/repo` while a regex over the raw string reports
+   `dotnet/runtime`. Canonicalize, or reject dot segments and their
+   percent-encoded equivalents, before both the comparison and the provenance
+   extraction.
 2. Fix GitHub repository provenance. The precondition tests the value for
    `github.com`, which canonical `raw.githubusercontent.com` SourceLink URLs do
    not contain, so GitHub-hosted assemblies report no repository at all. Match

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -242,26 +242,48 @@ only ordinary compiler output.
 
 ## Open work
 
-1. Unify SourceLink provenance with source resolution. `AssemblyInspector`
+1. Unify SourceLink provenance with source resolution. Today `AssemblyInspector`
    reports the repository from the first `documents` entry while
    `SourceDocumentPathResolver` selects by longest matching pattern, so a
-   well-formed map with distinct keys can resolve source from one origin while
-   provenance names another. Requiring entries to agree on the *repository* is
-   not sufficient: the reader derives `owner/repo` and discards the commit, and
-   `raw.githubusercontent.com` serves any commit reachable in a repository,
-   including the head of an unmerged pull request. Two entries naming the same
-   repository at different commits would therefore "agree" while resolving
-   attacker-authored content. Require agreement on the full resolved URL prefix
-   including the commit, or derive provenance from the mapping the resolver
-   actually selects, and report nothing when entries disagree.
+   well-formed map can resolve source from one origin while provenance names
+   another.
 
-   Compare and extract on the *canonical* URL, not the literal mapping text.
-   `System.Uri` applies RFC 3986 dot-segment removal, so a value such as
-   `https://raw.githubusercontent.com/dotnet/runtime/<commit>/../../../owner/repo/<commit>/*`
-   is fetched from `owner/repo` while a regex over the raw string reports
-   `dotnet/runtime`. Canonicalize, or reject dot segments and their
-   percent-encoded equivalents, before both the comparison and the provenance
-   extraction.
+   State the fix as an invariant rather than a list of blocked tricks, because
+   each enumerated mitigation has proven incomplete under review:
+
+   > Reported provenance must describe the origin that source content is
+   > actually fetched from, for every document the assembly resolves. When that
+   > cannot be established for all of them, report no repository.
+
+   Establish it on the **final resolved URL, after wildcard substitution and
+   canonicalization** — not on the mapping text, and not on the mapping prefix
+   alone. Four concrete ways the weaker forms fail, all reproduced:
+
+   - Agreement on `owner/repo` ignores the commit, and
+     `raw.githubusercontent.com` serves any commit reachable in a repository,
+     including the head of an unmerged pull request. Two entries on one
+     repository at different commits "agree" while serving different code.
+   - `System.Uri` applies RFC 3986 dot-segment removal, so a mapping value
+     containing `../` is fetched from the traversed-to path while a regex over
+     the raw string reports the literal one.
+   - Even a clean mapping is not enough. The wildcard suffix comes from the PDB
+     document path, which is equally attacker-controlled, and
+     `EscapeSourceLinkPath` leaves `..` intact. A benign
+     `.../dotnet/runtime/<commit>/*` resolves
+     `/_/../../../attacker/evil/main/Program.cs` to a URL that canonicalizes
+     into `attacker/evil`.
+   - `System.Uri` preserves percent-encoded separators verbatim: `..%2f` and
+     `..%5c` survive canonicalization, so a "canonicalize, then prefix-check"
+     step passes while a server that percent-decodes before resolving dot
+     segments still traverses out. Reject encoded separators and encoded dot
+     segments rather than assuming canonicalization removed them.
+
+   Checking that the canonicalized resolved URL still lies beneath the
+   canonicalized mapping prefix addresses all four, but do not take that as
+   sufficient on its own: whatever check is implemented must ship with tests
+   covering at least these cases, since each was found only by attacking a
+   previous formulation of this item.
+
 2. Fix GitHub repository provenance. The precondition tests the value for
    `github.com`, which canonical `raw.githubusercontent.com` SourceLink URLs do
    not contain, so GitHub-hosted assemblies report no repository at all. Match

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -92,6 +92,27 @@ cache entries use SHA-256-derived keys through `CoreCache`.
 Archive containment does not itself bound expanded bytes, entry count, or disk
 consumption. Resource budgets remain an open requirement below.
 
+### Untrusted JSON rejects duplicate properties
+
+JSON does not define how duplicate object keys resolve, so two readers of one payload can
+disagree. `DotnetInspector.Core.HardenedJson` (and its `ILInspector.Metadata.SourceLinkJson`
+counterpart, kept separate because Metadata sits below the Core infrastructure layer) parses with
+`AllowDuplicateProperties = false`, so such a payload fails visibly instead of binding one of
+several possible readings.
+
+This is not hypothetical for SourceLink. `SourceDocumentPathResolver` orders mappings by
+descending pattern length and takes the first match, while the repository-URL reader in
+`AssemblyInspector` takes the first value naming a known host. Given a repeated key under
+`documents`, those rules select different entries, so a hostile PDB could resolve source from one
+origin while the tool reported provenance from another. Rejecting the map closes that gap.
+
+Feed responses, package contents, `project.assets.json`, `.deps.json`, and product cache entries
+parse through the same guard. Callers that already treated malformed JSON as "no data" now treat
+duplicate-bearing JSON the same way; that is fail-closed, but it does not by itself convert those
+callers to explicit failure reporting, which remains open work below.
+
+`runfaster` still parses its trace inputs directly and is not yet covered.
+
 ### Artifact-derived source URLs use an SSRF-hardened client
 
 SourceLink and other artifact-derived fetches must use
@@ -211,22 +232,24 @@ only ordinary compiler output.
 | Resource extraction | Traversal and rooted names rejected before writes; valid nested and empty resources retained; malformed ranges rejected; separator/case aliases collide; existing file preserved; device/control names rejected |
 | Archive extraction | Zip-slip fixture; expanded-size and entry-count policy tests once budgets exist |
 | Metadata and signatures | Malformed table/blob fixtures, depth/size limits, no process crash |
-| SourceLink | Private/loopback/redirect targets rejected; allowed public target and checksum path retained |
+| SourceLink | Private/loopback/redirect targets rejected; allowed public target and checksum path retained; duplicate `documents` entries rejected rather than resolved |
+| Untrusted JSON | Duplicate properties rejected at top level, nested, and from UTF-8 bytes; case-distinct and sibling-repeated names still parse |
 | Cache paths | Traversal/separator components rejected; content-addressed keys deterministic |
 | Structured output | Untrusted delimiters/control characters cannot escape the selected format |
 
 ## Open work
 
-1. Define package, symbol, source-download, and decompressed-archive byte and
+1. Extend duplicate-property rejection to `runfaster` trace parsing.
+2. Define package, symbol, source-download, and decompressed-archive byte and
    entry-count budgets.
-2. Audit every product write against the derived-path rules, including symbol
+3. Audit every product write against the derived-path rules, including symbol
    server cache path construction.
-3. Audit Markdown, plain-text, and stderr rendering for terminal control
+4. Audit Markdown, plain-text, and stderr rendering for terminal control
    characters and structure injection.
-4. Implement the [bounded metadata traversal](bounded-metadata-traversal.md)
+5. Implement the [bounded metadata traversal](bounded-metadata-traversal.md)
    migration and expand malformed PE/PDB product-entry-point coverage around
    graph depth, row count, and allocation limits.
-5. Migrate legacy metadata scanners that collapse malformed reads into empty or
+6. Migrate legacy metadata scanners that collapse malformed reads into empty or
    zero-valued results onto explicit failure-bearing outcomes.
-6. Revisit filesystem containment if .NET exposes a portable atomic
+7. Revisit filesystem containment if .NET exposes a portable atomic
    no-follow/open-beneath primitive.

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -246,8 +246,14 @@ only ordinary compiler output.
    reports the repository from the first `documents` entry while
    `SourceDocumentPathResolver` selects by longest matching pattern, so a
    well-formed map with distinct keys can resolve source from one origin while
-   provenance names another. Report no repository when entries disagree on
-   origin.
+   provenance names another. Requiring entries to agree on the *repository* is
+   not sufficient: the reader derives `owner/repo` and discards the commit, and
+   `raw.githubusercontent.com` serves any commit reachable in a repository,
+   including the head of an unmerged pull request. Two entries naming the same
+   repository at different commits would therefore "agree" while resolving
+   attacker-authored content. Require agreement on the full resolved URL prefix
+   including the commit, or derive provenance from the mapping the resolver
+   actually selects, and report nothing when entries disagree.
 2. Fix GitHub repository provenance. The precondition tests the value for
    `github.com`, which canonical `raw.githubusercontent.com` SourceLink URLs do
    not contain, so GitHub-hosted assemblies report no repository at all. Match

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -278,11 +278,13 @@ only ordinary compiler output.
      segments still traverses out. Reject encoded separators and encoded dot
      segments rather than assuming canonicalization removed them.
 
-   Checking that the canonicalized resolved URL still lies beneath the
-   canonicalized mapping prefix addresses all four, but do not take that as
-   sufficient on its own: whatever check is implemented must ship with tests
-   covering at least these cases, since each was found only by attacking a
-   previous formulation of this item.
+   These four are evidence that the weaker forms fail, not a specification of
+   what to block; each was found only by attacking a previous formulation of
+   this item, and no formulation reviewed so far has survived contact with the
+   next reviewer. Treat the invariant as the requirement and this list as a
+   regression floor: whatever check is implemented must ship with tests
+   covering at least these cases, and passing them is not evidence that the
+   invariant holds.
 
 2. Fix GitHub repository provenance. The precondition tests the value for
    `github.com`, which canonical `raw.githubusercontent.com` SourceLink URLs do

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -100,11 +100,14 @@ counterpart, kept separate because Metadata sits below the Core infrastructure l
 `AllowDuplicateProperties = false`, so such a payload fails visibly instead of binding one of
 several possible readings.
 
-This is not hypothetical for SourceLink. `SourceDocumentPathResolver` orders mappings by
-descending pattern length and takes the first match, while the repository-URL reader in
-`AssemblyInspector` takes the first value naming a known host. Given a repeated key under
-`documents`, those rules select different entries, so a hostile PDB could resolve source from one
-origin while the tool reported provenance from another. Rejecting the map closes that gap.
+This is generic hardening, not a fix for a known divergence. It does **not** close the SourceLink
+provenance gap. The repository-URL reader in `AssemblyInspector` stops at the first `documents`
+entry, while `SourceDocumentPathResolver` orders mappings by descending pattern length and takes
+the first match. A duplicated key keeps document order under a stable sort, so both readers land on
+the same entry and duplication alone cannot make them disagree. They diverge on **distinct** keys,
+which are well-formed and still accepted: a map whose first entry names a trusted host and whose
+longer-matching entry names another origin reports the trusted repository while resolving source
+from the other. That gap is open work below.
 
 Feed responses, package contents, `project.assets.json`, `.deps.json`, and product cache entries
 parse through the same guard. Callers that already treated malformed JSON as "no data" now treat
@@ -232,24 +235,34 @@ only ordinary compiler output.
 | Resource extraction | Traversal and rooted names rejected before writes; valid nested and empty resources retained; malformed ranges rejected; separator/case aliases collide; existing file preserved; device/control names rejected |
 | Archive extraction | Zip-slip fixture; expanded-size and entry-count policy tests once budgets exist |
 | Metadata and signatures | Malformed table/blob fixtures, depth/size limits, no process crash |
-| SourceLink | Private/loopback/redirect targets rejected; allowed public target and checksum path retained; duplicate `documents` entries rejected rather than resolved |
+| SourceLink | Private/loopback/redirect targets rejected; allowed public target and checksum path retained; a duplicate `documents` key fails the parse rather than binding one of its values |
 | Untrusted JSON | Duplicate properties rejected at top level, nested, and from UTF-8 bytes; case-distinct and sibling-repeated names still parse |
 | Cache paths | Traversal/separator components rejected; content-addressed keys deterministic |
 | Structured output | Untrusted delimiters/control characters cannot escape the selected format |
 
 ## Open work
 
-1. Extend duplicate-property rejection to `runfaster` trace parsing.
-2. Define package, symbol, source-download, and decompressed-archive byte and
+1. Unify SourceLink provenance with source resolution. `AssemblyInspector`
+   reports the repository from the first `documents` entry while
+   `SourceDocumentPathResolver` selects by longest matching pattern, so a
+   well-formed map with distinct keys can resolve source from one origin while
+   provenance names another. Report no repository when entries disagree on
+   origin.
+2. Fix GitHub repository provenance. The precondition tests the value for
+   `github.com`, which canonical `raw.githubusercontent.com` SourceLink URLs do
+   not contain, so GitHub-hosted assemblies report no repository at all. Match
+   the URI host instead of a substring.
+3. Extend duplicate-property rejection to `runfaster` trace parsing.
+4. Define package, symbol, source-download, and decompressed-archive byte and
    entry-count budgets.
-3. Audit every product write against the derived-path rules, including symbol
+5. Audit every product write against the derived-path rules, including symbol
    server cache path construction.
-4. Audit Markdown, plain-text, and stderr rendering for terminal control
+6. Audit Markdown, plain-text, and stderr rendering for terminal control
    characters and structure injection.
-5. Implement the [bounded metadata traversal](bounded-metadata-traversal.md)
+7. Implement the [bounded metadata traversal](bounded-metadata-traversal.md)
    migration and expand malformed PE/PDB product-entry-point coverage around
    graph depth, row count, and allocation limits.
-6. Migrate legacy metadata scanners that collapse malformed reads into empty or
+8. Migrate legacy metadata scanners that collapse malformed reads into empty or
    zero-valued results onto explicit failure-bearing outcomes.
-7. Revisit filesystem containment if .NET exposes a portable atomic
+9. Revisit filesystem containment if .NET exposes a portable atomic
    no-follow/open-beneath primitive.

--- a/src/DotnetInspector.Core/HardenedJson.cs
+++ b/src/DotnetInspector.Core/HardenedJson.cs
@@ -24,11 +24,7 @@ namespace DotnetInspector.Core;
 /// </remarks>
 public static class HardenedJson
 {
-    /// <summary>
-    /// Document options that reject duplicate property names. Use this only for parses that cannot
-    /// go through <see cref="Parse(string)"/>, such as a <see cref="Utf8JsonReader"/> loop.
-    /// </summary>
-    public static JsonDocumentOptions DocumentOptions => new() { AllowDuplicateProperties = false };
+    private static JsonDocumentOptions DocumentOptions => new() { AllowDuplicateProperties = false };
 
     /// <summary>Parses a <see cref="JsonDocument"/>, rejecting duplicate property names.</summary>
     /// <exception cref="JsonException">The input is malformed or contains a duplicate property name.</exception>

--- a/src/DotnetInspector.Core/HardenedJson.cs
+++ b/src/DotnetInspector.Core/HardenedJson.cs
@@ -9,11 +9,13 @@ namespace DotnetInspector.Core;
 /// <remarks>
 /// <para>
 /// JSON does not define how duplicate object keys are resolved, so independent readers of the same
-/// payload can disagree. <c>JsonElement.TryGetProperty</c> returns the first match while
-/// <c>JsonElement.EnumerateObject</c> yields every occurrence, and any two readers that filter or
-/// order that set differently can end up on different values. The disagreement is exploitable
-/// whenever one reader decides policy and another decides what is shown or acted on, letting a
-/// single document present two views of itself. See CVE-2017-12635 for the canonical instance.
+/// payload can disagree. <c>JsonElement.TryGetProperty</c> resolves to the <em>last</em>
+/// occurrence, while <c>JsonElement.EnumerateObject</c> yields every occurrence in document order,
+/// so a reader that takes the first enumerated match already disagrees with a reader that looks
+/// the name up. Any two readers that filter or order that set differently can end up on different
+/// values. The disagreement is exploitable whenever one reader decides policy and another decides
+/// what is shown or acted on, letting a single document present two views of itself. See
+/// CVE-2017-12635 for the canonical instance.
 /// </para>
 /// <para>
 /// This mirrors <see cref="HardenedXml"/>: parsing untrusted input goes through a named, hardened

--- a/src/DotnetInspector.Core/HardenedJson.cs
+++ b/src/DotnetInspector.Core/HardenedJson.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+
+namespace DotnetInspector.Core;
+
+/// <summary>
+/// Parses JSON from untrusted sources (NuGet feed responses, package contents, restored project
+/// inputs, product caches) with duplicate property names rejected.
+/// </summary>
+/// <remarks>
+/// <para>
+/// JSON does not define how duplicate object keys are resolved, so independent readers of the same
+/// payload can disagree. <c>JsonElement.TryGetProperty</c> returns the first match while
+/// <c>JsonElement.EnumerateObject</c> yields every occurrence, and any two readers that filter or
+/// order that set differently can end up on different values. The disagreement is exploitable
+/// whenever one reader decides policy and another decides what is shown or acted on, letting a
+/// single document present two views of itself. See CVE-2017-12635 for the canonical instance.
+/// </para>
+/// <para>
+/// This mirrors <see cref="HardenedXml"/>: parsing untrusted input goes through a named, hardened
+/// entry point rather than through per-call-site options that are easy to omit. Malformed and
+/// duplicate-bearing input surfaces as <see cref="JsonException"/> so callers fail visibly instead
+/// of silently binding one of several possible readings.
+/// </para>
+/// </remarks>
+public static class HardenedJson
+{
+    /// <summary>
+    /// Document options that reject duplicate property names. Use this only for parses that cannot
+    /// go through <see cref="Parse(string)"/>, such as a <see cref="Utf8JsonReader"/> loop.
+    /// </summary>
+    public static JsonDocumentOptions DocumentOptions => new() { AllowDuplicateProperties = false };
+
+    /// <summary>Parses a <see cref="JsonDocument"/>, rejecting duplicate property names.</summary>
+    /// <exception cref="JsonException">The input is malformed or contains a duplicate property name.</exception>
+    public static JsonDocument Parse(string json) => JsonDocument.Parse(json, DocumentOptions);
+
+    /// <summary>Parses a <see cref="JsonDocument"/> from UTF-8 bytes, rejecting duplicate property names.</summary>
+    /// <exception cref="JsonException">The input is malformed or contains a duplicate property name.</exception>
+    public static JsonDocument Parse(ReadOnlyMemory<byte> utf8Json) => JsonDocument.Parse(utf8Json, DocumentOptions);
+}

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -560,7 +560,7 @@ public static class PackageExtractor
 
         try
         {
-            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
             var resources = doc.RootElement.GetProperty("resources");
 
             foreach (var resource in resources.EnumerateArray())
@@ -781,7 +781,7 @@ public static class PackageExtractor
 
         try
         {
-            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
             if (doc.RootElement.TryGetProperty("versions", out var versions))
             {
                 return versions.EnumerateArray()
@@ -862,7 +862,7 @@ public static class PackageExtractor
             if (json == null)
                 return null;
 
-            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
             if (doc.RootElement.TryGetProperty("data", out var data) &&
                 data.GetArrayLength() > 0)
             {
@@ -894,7 +894,7 @@ public static class PackageExtractor
 
         try
         {
-            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
             var versions = doc.RootElement.GetProperty("versions");
             if (versions.GetArrayLength() > 0)
             {

--- a/src/DotnetInspector.Services.Tests/HardenedJsonTests.cs
+++ b/src/DotnetInspector.Services.Tests/HardenedJsonTests.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using DotnetInspector.Core;
+
+namespace DotnetInspector.Services.Tests;
+
+/// <summary>
+/// Negative fixtures for <see cref="HardenedJson"/>. JSON leaves duplicate-key resolution
+/// undefined, so two readers of one payload can disagree; these pin that the product rejects such
+/// payloads instead of silently binding one of the possible readings.
+/// </summary>
+public class HardenedJsonTests
+{
+    [Fact]
+    public void Parse_RejectsDuplicateTopLevelProperty()
+    {
+        const string json = """{"id":"first","id":"second"}""";
+
+        // Baseline: the unhardened parser accepts this and silently keeps one reading.
+        using (var permissive = JsonDocument.Parse(json))
+        {
+            Assert.Equal("second", permissive.RootElement.GetProperty("id").GetString());
+        }
+
+        Assert.Throws<JsonException>(() => HardenedJson.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_RejectsDuplicateNestedProperty()
+    {
+        const string json = """{"outer":{"value":1,"value":2}}""";
+
+        Assert.Throws<JsonException>(() => HardenedJson.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_RejectsDuplicatePropertyFromUtf8Bytes()
+    {
+        byte[] utf8 = "{\"id\":\"first\",\"id\":\"second\"}"u8.ToArray();
+
+        Assert.Throws<JsonException>(() => HardenedJson.Parse(utf8.AsMemory()));
+    }
+
+    [Fact]
+    public void Parse_AcceptsDistinctPropertiesThatDifferOnlyByCase()
+    {
+        // Duplicate detection is ordinal. Case-distinct names are distinct JSON members and must
+        // keep parsing, otherwise the guard would reject ordinary payloads.
+        using var doc = HardenedJson.Parse("""{"id":"a","Id":"b"}""");
+
+        Assert.Equal("a", doc.RootElement.GetProperty("id").GetString());
+        Assert.Equal("b", doc.RootElement.GetProperty("Id").GetString());
+    }
+
+    [Fact]
+    public void Parse_AcceptsRepeatedNamesInSiblingObjects()
+    {
+        // The same name in different objects is not a duplicate.
+        using var doc = HardenedJson.Parse("""{"a":{"name":1},"b":{"name":2}}""");
+
+        Assert.Equal(1, doc.RootElement.GetProperty("a").GetProperty("name").GetInt32());
+        Assert.Equal(2, doc.RootElement.GetProperty("b").GetProperty("name").GetInt32());
+    }
+
+    [Fact]
+    public void Parse_AcceptsWellFormedDocument()
+    {
+        using var doc = HardenedJson.Parse("""{"runtimeTarget":{"name":".NETCoreApp,Version=v10.0"}}""");
+
+        Assert.Equal(
+            ".NETCoreApp,Version=v10.0",
+            doc.RootElement.GetProperty("runtimeTarget").GetProperty("name").GetString());
+    }
+}

--- a/src/DotnetInspector.Services.Tests/HardenedJsonTests.cs
+++ b/src/DotnetInspector.Services.Tests/HardenedJsonTests.cs
@@ -70,4 +70,26 @@ public class HardenedJsonTests
             ".NETCoreApp,Version=v10.0",
             doc.RootElement.GetProperty("runtimeTarget").GetProperty("name").GetString());
     }
+
+    /// <summary>
+    /// Pins the permissive-parsing behavior that motivates <see cref="HardenedJson"/>, because it
+    /// is easy to state backwards: a name lookup resolves to the <em>last</em> duplicate, while
+    /// enumeration yields every occurrence in document order. A reader that takes the first
+    /// enumerated match therefore disagrees with a reader that looks the name up, on the same
+    /// document. If a future runtime changes this, the rationale in that class needs rewriting.
+    /// </summary>
+    [Fact]
+    public void PermissiveParsing_ResolvesANameLookupToTheLastDuplicate()
+    {
+        using var doc = JsonDocument.Parse("""{"id":"first","other":1,"id":"second"}""");
+
+        Assert.True(doc.RootElement.TryGetProperty("id", out var looked));
+        Assert.Equal("second", looked.GetString());
+
+        Assert.Equal(
+            ["first", "second"],
+            doc.RootElement.EnumerateObject()
+                .Where(static p => p.Name == "id")
+                .Select(static p => p.Value.GetString()));
+    }
 }

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Xml.Linq;
 using System.Runtime.InteropServices;
+using DotnetInspector.Core;
 using DotnetInspector.Packages;
 using ILInspector.Metadata;
 using NuGet.Versioning;
@@ -660,7 +661,7 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
 
         try
         {
-            using var doc = JsonDocument.Parse(File.ReadAllText(depsPath));
+            using var doc = HardenedJson.Parse(File.ReadAllText(depsPath));
             var root = doc.RootElement;
             if (!root.TryGetProperty("targets", out var targets) ||
                 targets.ValueKind != JsonValueKind.Object ||

--- a/src/DotnetInspector.Services/DepsJsonParser.cs
+++ b/src/DotnetInspector.Services/DepsJsonParser.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using DotnetInspector.Core;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Services;
@@ -15,7 +16,7 @@ public static class DepsJsonParser
         try
         {
             string json = File.ReadAllText(depsPath);
-            using var doc = JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
 
             // Get runtime target
             if (doc.RootElement.TryGetProperty("runtimeTarget", out var runtimeTarget))

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -46,7 +46,7 @@ public static class PackageMetadataService
             if (json == null)
                 return null;
 
-            using var doc = JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
             if (doc.RootElement.TryGetProperty("published", out var publishedElement))
             {
                 if (DateTimeOffset.TryParse(publishedElement.GetString(), out var published))
@@ -142,7 +142,7 @@ public static class PackageMetadataService
                 trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
             if (json != null)
             {
-                using var doc = JsonDocument.Parse(json);
+                using var doc = HardenedJson.Parse(json);
                 var root = doc.RootElement;
 
                 if (root.TryGetProperty("published", out var publishedElement))
@@ -176,7 +176,7 @@ public static class PackageMetadataService
                     trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
                 if (catalogJson != null)
                 {
-                    using var doc = JsonDocument.Parse(catalogJson);
+                    using var doc = HardenedJson.Parse(catalogJson);
                     var root = doc.RootElement;
 
                     if (root.TryGetProperty("deprecation", out var deprecationElement) &&
@@ -204,7 +204,7 @@ public static class PackageMetadataService
                 trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
             if (json != null)
             {
-                using var doc = JsonDocument.Parse(json);
+                using var doc = HardenedJson.Parse(json);
                 if (doc.RootElement.TryGetProperty("data", out var data) &&
                     data.GetArrayLength() > 0)
                 {
@@ -340,7 +340,7 @@ public static class PackageMetadataService
         if (indexJson == null)
             return result;
 
-        using var indexDoc = JsonDocument.Parse(indexJson);
+        using var indexDoc = HardenedJson.Parse(indexJson);
         var pages = indexDoc.RootElement.EnumerateArray()
             .Select(e => e.GetProperty("@id").GetString())
             .Where(url => url != null)
@@ -356,7 +356,7 @@ public static class PackageMetadataService
                 trafficKind: NetworkTrafficKind.VulnerabilityData).ConfigureAwait(false);
             if (pageJson == null) continue;
 
-            using var pageDoc = JsonDocument.Parse(pageJson);
+            using var pageDoc = HardenedJson.Parse(pageJson);
 
             if (pageDoc.RootElement.TryGetProperty(packageName, out var vulnArray))
             {
@@ -419,7 +419,7 @@ public static class PackageMetadataService
             }
 
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            using var doc = JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
             var root = doc.RootElement;
 
             if (root.TryGetProperty("cve_id", out var cveId) && cveId.ValueKind == JsonValueKind.String)

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Enumeration;
 using System.Text.Json;
+using DotnetInspector.Core;
 using DotnetInspector.Packages;
 using NuGetFetch;
 
@@ -149,7 +150,7 @@ public static class ProjectAssetsParser
         try
         {
             var json = File.ReadAllText(assetsPath);
-            using var doc = JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
 
             if (!doc.RootElement.TryGetProperty("targets", out var targets))
                 return results;
@@ -224,7 +225,7 @@ public static class ProjectAssetsParser
         try
         {
             var json = File.ReadAllText(assetsPath);
-            using var doc = JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
 
             if (!doc.RootElement.TryGetProperty("targets", out var targets))
                 return results;
@@ -288,7 +289,7 @@ public static class ProjectAssetsParser
         try
         {
             var json = File.ReadAllText(assetsPath);
-            using var doc = JsonDocument.Parse(json);
+            using var doc = HardenedJson.Parse(json);
 
             if (!doc.RootElement.TryGetProperty("targets", out var targets))
                 return results;

--- a/src/ILInspector.Metadata/AssemblyInspector.cs
+++ b/src/ILInspector.Metadata/AssemblyInspector.cs
@@ -402,7 +402,7 @@ public static class AssemblyInspector
         List<string> nonNormalizedPaths = [];
         try
         {
-            using var doc = System.Text.Json.JsonDocument.Parse(sourceLink);
+            using var doc = SourceLinkJson.Parse(sourceLink);
             if (doc.RootElement.TryGetProperty("documents", out var documents))
             {
                 foreach (var prop in documents.EnumerateObject())
@@ -425,7 +425,7 @@ public static class AssemblyInspector
     {
         try
         {
-            using var doc = System.Text.Json.JsonDocument.Parse(sourceLink);
+            using var doc = SourceLinkJson.Parse(sourceLink);
             if (doc.RootElement.TryGetProperty("documents", out var documents))
             {
                 foreach (var prop in documents.EnumerateObject())

--- a/src/ILInspector.Metadata/SourceDocumentPath.cs
+++ b/src/ILInspector.Metadata/SourceDocumentPath.cs
@@ -38,7 +38,7 @@ internal sealed class SourceDocumentPathResolver
 
         try
         {
-            using var document = JsonDocument.Parse(sourceLinkJson);
+            using var document = SourceLinkJson.Parse(sourceLinkJson);
             if (document.RootElement.ValueKind != JsonValueKind.Object
                 || !document.RootElement.TryGetProperty("documents", out var mappings)
                 || mappings.ValueKind != JsonValueKind.Object)

--- a/src/ILInspector.Metadata/SourceLinkJson.cs
+++ b/src/ILInspector.Metadata/SourceLinkJson.cs
@@ -14,13 +14,15 @@ namespace ILInspector.Metadata;
 /// into the SRM layer and invert the ownership documented in <c>docs/overview.md</c>.
 /// </para>
 /// <para>
-/// The duplicate-key hazard is concrete here. <see cref="SourceDocumentPathResolver"/> and the
-/// SourceLink readers in <see cref="AssemblyInspector"/> parse the same attacker-controlled map,
-/// and they select differently over a duplicated <c>documents</c> entry: the resolver orders
-/// mappings by descending pattern length and takes the first match, while the repository-URL
-/// reader takes the first entry whose value mentions a known host. Given two entries under one
-/// key, those rules pick different values, so a hostile PDB can resolve source from one origin
-/// while the tool reports provenance from another.
+/// This is generic fail-visible hardening for an attacker-controlled map, not a fix for a known
+/// divergence. It deliberately does <em>not</em> close the SourceLink provenance gap: the
+/// repository-URL reader in <see cref="AssemblyInspector"/> stops at the first <c>documents</c>
+/// entry, while <see cref="SourceDocumentPathResolver"/> orders mappings by descending pattern
+/// length and takes the first match. Because a duplicated key keeps document order under a stable
+/// sort, both readers land on the same first entry, so duplication alone cannot make them
+/// disagree. They diverge on maps with <em>distinct</em> keys, which are well-formed and remain
+/// accepted. That gap is tracked separately; see the SourceLink entry in
+/// <c>docs/design/untrusted-data-threat-model.md</c>.
 /// </para>
 /// </remarks>
 internal static class SourceLinkJson

--- a/src/ILInspector.Metadata/SourceLinkJson.cs
+++ b/src/ILInspector.Metadata/SourceLinkJson.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Parses JSON from untrusted assembly-derived sources (SourceLink maps recovered from portable
+/// PDBs) with duplicate property names rejected.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This mirrors <c>DotnetInspector.Core.HardenedJson</c> deliberately. Metadata sits below the
+/// Core infrastructure layer and references only Findings, MetadataPrimitives, and Text; taking a
+/// dependency on Core to share ten lines would pull HTTP, caching, and download infrastructure
+/// into the SRM layer and invert the ownership documented in <c>docs/overview.md</c>.
+/// </para>
+/// <para>
+/// The duplicate-key hazard is concrete here. <see cref="SourceDocumentPathResolver"/> and the
+/// SourceLink readers in <see cref="AssemblyInspector"/> parse the same attacker-controlled map,
+/// and they select differently over a duplicated <c>documents</c> entry: the resolver orders
+/// mappings by descending pattern length and takes the first match, while the repository-URL
+/// reader takes the first entry whose value mentions a known host. Given two entries under one
+/// key, those rules pick different values, so a hostile PDB can resolve source from one origin
+/// while the tool reports provenance from another.
+/// </para>
+/// </remarks>
+internal static class SourceLinkJson
+{
+    private static JsonDocumentOptions DocumentOptions => new() { AllowDuplicateProperties = false };
+
+    /// <summary>Parses a <see cref="JsonDocument"/>, rejecting duplicate property names.</summary>
+    /// <exception cref="JsonException">The input is malformed or contains a duplicate property name.</exception>
+    public static JsonDocument Parse(string json) => JsonDocument.Parse(json, DocumentOptions);
+}

--- a/src/ILInspector.Metadata/SourceLinkService.cs
+++ b/src/ILInspector.Metadata/SourceLinkService.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 namespace ILInspector.Metadata;
 
 [JsonSerializable(typeof(Dictionary<string, string[]>))]
+[JsonSourceGenerationOptions(AllowDuplicateProperties = false)]
 internal partial class SourceLinkJsonContext : JsonSerializerContext;
 
 /// <summary>

--- a/src/dotnet-inspect.Tests/JsonWireNameGateTests.cs
+++ b/src/dotnet-inspect.Tests/JsonWireNameGateTests.cs
@@ -93,7 +93,20 @@ public class JsonWireNameGateTests
     /// change that discovered it. <see cref="KnownPascalCaseDeviations_StillDeviate"/> fails if it
     /// is fixed, forcing this entry to be removed with the fix.
     /// </summary>
-    private static readonly string[] KnownPascalCaseContexts = ["TimelineJsonContext"];
+    /// <remarks>
+    /// The value pins the exact wire names that deviate, not merely that some name deviates, so a
+    /// partial correction fails this gate instead of passing while the context is left in a mixed
+    /// state.
+    /// </remarks>
+    private static readonly Dictionary<string, string[]> KnownPascalCaseContexts = new()
+    {
+        ["TimelineJsonContext"] =
+        [
+            "Address", "Detail", "Evaluations", "Finding", "Findings", "From", "Member", "Range",
+            "Recommendation", "Span", "State", "Target", "Title", "To", "Transition", "Transitions",
+            "Type", "Version",
+        ],
+    };
 
     /// <summary>
     /// Every wire name must match the shape its context declares. A context that omits
@@ -107,7 +120,7 @@ public class JsonWireNameGateTests
         foreach (var context in Contexts)
         {
             var contextType = context.GetType();
-            if (KnownPascalCaseContexts.Contains(contextType.Name))
+            if (KnownPascalCaseContexts.ContainsKey(contextType.Name))
             {
                 continue;
             }
@@ -137,17 +150,24 @@ public class JsonWireNameGateTests
     [Fact]
     public void KnownPascalCaseDeviations_StillDeviate()
     {
-        foreach (string contextName in KnownPascalCaseContexts)
+        foreach (var (contextName, expectedDeviations) in KnownPascalCaseContexts)
         {
             var context = Assert.Single(Contexts, c => c.GetType().Name == contextName);
 
-            bool deviates = WireNamesByType(context)
+            string[] deviating = WireNamesByType(context)
                 .SelectMany(static shape => shape.Names)
-                .Any(static name => !MatchesPolicy(name, JsonKnownNamingPolicy.Unspecified));
+                .Where(static name => !MatchesPolicy(name, JsonKnownNamingPolicy.Unspecified))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(static name => name, StringComparer.Ordinal)
+                .ToArray();
 
             Assert.True(
-                deviates,
+                deviating.Length > 0,
                 $"{contextName} now matches the snake_case contract. Remove it from {nameof(KnownPascalCaseContexts)}.");
+
+            Assert.Equal(
+                expectedDeviations.OrderBy(static name => name, StringComparer.Ordinal).ToArray(),
+                deviating);
         }
     }
 

--- a/src/dotnet-inspect.Tests/JsonWireNameGateTests.cs
+++ b/src/dotnet-inspect.Tests/JsonWireNameGateTests.cs
@@ -1,0 +1,258 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Pins JSON wire names across every <see cref="JsonSerializerContext"/> in the product.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Naming is declared per context, not per model, and several model types are serialized by more
+/// than one context (the indented/compact pairs, and rows shared between a document context and a
+/// JSONL context). Nothing in the compiler ties those declarations together, so a context added
+/// without <c>PropertyNamingPolicy</c> would silently emit a second spelling of an existing shape.
+/// These are the gate for that: <see cref="Contexts"/> is discovered by reflection rather than
+/// listed, so a new context is covered the moment it is declared.
+/// </para>
+/// <para>
+/// The output contract itself lives in <c>docs/design/output-shapes.md</c>.
+/// </para>
+/// </remarks>
+public class JsonWireNameGateTests
+{
+    private static readonly Assembly[] ProductAssemblies =
+    [
+        typeof(DotnetInspector.JsonContext).Assembly,
+        typeof(DotnetInspector.Services.DepsJsonParser).Assembly,
+        typeof(ILInspector.Metadata.SourceDocumentPath).Assembly,
+    ];
+
+    /// <summary>Every concrete generated context in the product, discovered rather than listed.</summary>
+    private static IReadOnlyList<JsonSerializerContext> Contexts { get; } = ProductAssemblies
+        .Distinct()
+        .SelectMany(static a => a.GetTypes())
+        .Where(static t => typeof(JsonSerializerContext).IsAssignableFrom(t) && !t.IsAbstract)
+        .Select(static t => t.GetProperty("Default", BindingFlags.Public | BindingFlags.Static))
+        .Where(static p => p is not null)
+        .Select(static p => (JsonSerializerContext)p!.GetValue(null)!)
+        .ToArray();
+
+    [Fact]
+    public void Gate_IsNotVacuous()
+    {
+        // If discovery breaks, every other test here passes over an empty set.
+        Assert.True(Contexts.Count >= 20, $"Expected the product's generated contexts to be discovered; found {Contexts.Count}.");
+        Assert.Contains(Contexts, static c => c is DotnetInspector.JsonContext);
+
+        var shapes = Contexts.SelectMany(WireNamesByType).ToArray();
+        Assert.True(shapes.Length >= 50, $"Expected a substantial serializable graph; found {shapes.Length} object shapes.");
+    }
+
+    /// <summary>
+    /// A model type serialized by two contexts must present one spelling. This is the drift the
+    /// per-context naming declaration cannot prevent on its own.
+    /// </summary>
+    [Fact]
+    public void SharedTypes_HaveOneSpellingAcrossEveryContext()
+    {
+        var byType = new Dictionary<Type, (string Context, string[] Names)>();
+        var divergences = new List<string>();
+
+        foreach (var context in Contexts)
+        {
+            string contextName = context.GetType().Name;
+            foreach (var (type, names) in WireNamesByType(context))
+            {
+                if (!byType.TryGetValue(type, out var seen))
+                {
+                    byType[type] = (contextName, names);
+                    continue;
+                }
+
+                if (!seen.Names.SequenceEqual(names))
+                {
+                    divergences.Add(
+                        $"{type.FullName}: {seen.Context} emits [{string.Join(", ", seen.Names)}] " +
+                        $"but {contextName} emits [{string.Join(", ", names)}]");
+                }
+            }
+        }
+
+        Assert.True(divergences.Count == 0, string.Join(Environment.NewLine, divergences));
+    }
+
+    /// <summary>
+    /// <c>TimelineJsonContext</c> declares no naming policy and its views carry no
+    /// <see cref="JsonPropertyNameAttribute"/>, so <c>timeline --json</c> emits CLR PascalCase
+    /// spelling while every other command emits snake_case. This gate found that; it is a
+    /// pre-existing deviation from the output contract, not a sanctioned style. Correcting it
+    /// changes a shipped wire format, so it is tracked separately rather than folded into the
+    /// change that discovered it. <see cref="KnownPascalCaseDeviations_StillDeviate"/> fails if it
+    /// is fixed, forcing this entry to be removed with the fix.
+    /// </summary>
+    private static readonly string[] KnownPascalCaseContexts = ["TimelineJsonContext"];
+
+    /// <summary>
+    /// Every wire name must match the shape its context declares. A context that omits
+    /// <c>PropertyNamingPolicy</c> falls back to CLR PascalCase spelling and fails here.
+    /// </summary>
+    [Fact]
+    public void EveryWireName_MatchesItsDeclaredNamingPolicy()
+    {
+        var violations = new List<string>();
+
+        foreach (var context in Contexts)
+        {
+            var contextType = context.GetType();
+            if (KnownPascalCaseContexts.Contains(contextType.Name))
+            {
+                continue;
+            }
+
+            var policy = contextType
+                .GetCustomAttribute<JsonSourceGenerationOptionsAttribute>()?.PropertyNamingPolicy
+                ?? JsonKnownNamingPolicy.Unspecified;
+
+            foreach (var (type, names) in WireNamesByType(context))
+            {
+                foreach (string name in names)
+                {
+                    if (!MatchesPolicy(name, policy))
+                    {
+                        violations.Add($"{contextType.Name} declares {policy} but {type.FullName}.{name} does not match it.");
+                    }
+                }
+            }
+        }
+
+        Assert.True(violations.Count == 0, string.Join(Environment.NewLine, violations));
+    }
+
+    /// <summary>
+    /// Pins the exemption above so it cannot outlive the deviation it describes.
+    /// </summary>
+    [Fact]
+    public void KnownPascalCaseDeviations_StillDeviate()
+    {
+        foreach (string contextName in KnownPascalCaseContexts)
+        {
+            var context = Assert.Single(Contexts, c => c.GetType().Name == contextName);
+
+            bool deviates = WireNamesByType(context)
+                .SelectMany(static shape => shape.Names)
+                .Any(static name => !MatchesPolicy(name, JsonKnownNamingPolicy.Unspecified));
+
+            Assert.True(
+                deviates,
+                $"{contextName} now matches the snake_case contract. Remove it from {nameof(KnownPascalCaseContexts)}.");
+        }
+    }
+
+    /// <summary>
+    /// Contexts that emit a wire style other than the product's snake_case default are making a
+    /// deliberate contract choice, so they are enumerated rather than inferred.
+    /// </summary>
+    [Fact]
+    public void OnlyKnownContextsOptOutOfSnakeCase()
+    {
+        string[] expectedCamelCase = ["CorpusManifestJsonContext", "DiscoveryJsonContext"];
+
+        var actual = Contexts
+            .Select(static c => c.GetType())
+            .Where(static t => t.GetCustomAttribute<JsonSourceGenerationOptionsAttribute>()?.PropertyNamingPolicy
+                is JsonKnownNamingPolicy.CamelCase)
+            .Select(static t => t.Name)
+            .OrderBy(static n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(expectedCamelCase.OrderBy(static n => n, StringComparer.Ordinal).ToArray(), actual);
+    }
+
+    private static bool MatchesPolicy(string name, JsonKnownNamingPolicy policy) => policy switch
+    {
+        JsonKnownNamingPolicy.CamelCase =>
+            name.Length == 0 || !char.IsAsciiLetterUpper(name[0]),
+
+        // SnakeCaseLower is the product's structured-output contract. A context that declares no
+        // policy pins its names with [JsonPropertyName] instead, and those names are held to the
+        // same contract -- otherwise the hand-written spellings would be the one unchecked path.
+        _ => name.All(static c => char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c) || c == '_'),
+    };
+
+    /// <summary>
+    /// Walks everything a context can serialize, including nested and element types, and returns
+    /// the wire names of each object shape. Naming attributes are not transitive, so the nested
+    /// types are exactly where a spelling change would otherwise go unnoticed.
+    /// </summary>
+    private static List<(Type Type, string[] Names)> WireNamesByType(JsonSerializerContext context)
+    {
+        var results = new List<(Type, string[])>();
+        var visited = new HashSet<Type>();
+
+        foreach (var type in SerializableTypes(context.GetType()))
+        {
+            Walk(context, type, visited, results);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// <see cref="JsonSerializableAttribute"/> does not surface its type as a property, so the
+    /// registration is read from the constructor argument.
+    /// </summary>
+    private static IEnumerable<Type> SerializableTypes(Type contextType) => contextType
+        .GetCustomAttributesData()
+        .Where(static d => d.AttributeType == typeof(JsonSerializableAttribute))
+        .Select(static d => d.ConstructorArguments.Count > 0 ? d.ConstructorArguments[0].Value as Type : null)
+        .Where(static t => t is not null)
+        .Select(static t => t!);
+
+    private static void Walk(JsonSerializerContext context, Type type, HashSet<Type> visited, List<(Type, string[])> results)
+    {
+        if (!visited.Add(type))
+        {
+            return;
+        }
+
+        JsonTypeInfo? info;
+        try
+        {
+            info = context.GetTypeInfo(type);
+        }
+        catch (InvalidOperationException)
+        {
+            // Not registered on this context; nothing to pin.
+            return;
+        }
+
+        if (info is null)
+        {
+            return;
+        }
+
+        switch (info.Kind)
+        {
+            case JsonTypeInfoKind.Object:
+                results.Add((type, info.Properties.Select(static p => p.Name).ToArray()));
+                foreach (var property in info.Properties)
+                {
+                    Walk(context, property.PropertyType, visited, results);
+                }
+
+                break;
+
+            case JsonTypeInfoKind.Enumerable:
+            case JsonTypeInfoKind.Dictionary:
+                if (info.ElementType is { } element)
+                {
+                    Walk(context, element, visited, results);
+                }
+
+                break;
+        }
+    }
+}

--- a/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
+++ b/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
@@ -271,7 +271,7 @@ internal static class PackageIndexCache
 
     internal static DependencyGroup DeserializeDependencyGroup(string raw)
     {
-        using var document = JsonDocument.Parse(raw);
+        using var document = HardenedJson.Parse(raw);
         var root = document.RootElement;
         var dependencies = new List<PackageDependency>();
         foreach (var dependency in root.GetProperty("dependencies").EnumerateArray())

--- a/tests/ILInspector.Metadata.Tests/SourceLinkDuplicateDocumentTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SourceLinkDuplicateDocumentTests.cs
@@ -108,6 +108,27 @@ public class SourceLinkDuplicateDocumentTests
             () => JsonSerializer.Deserialize(cached, SourceLinkJsonContext.Default.DictionaryStringStringArray));
     }
 
+    /// <summary>
+    /// The cache is written and read by the same context, so hardening the reader must not break
+    /// the write/read round trip that source lookup depends on.
+    /// </summary>
+    [Fact]
+    public void TypeFileIndexCache_RoundTripsWhatItWrites()
+    {
+        var index = new Dictionary<string, string[]>
+        {
+            ["A.B"] = ["one.cs", "two.cs"],
+            ["A.C"] = [],
+        };
+
+        string written = JsonSerializer.Serialize(index, SourceLinkJsonContext.Default.DictionaryStringStringArray);
+        var read = JsonSerializer.Deserialize(written, SourceLinkJsonContext.Default.DictionaryStringStringArray);
+
+        Assert.NotNull(read);
+        Assert.Equal(["one.cs", "two.cs"], read["A.B"]);
+        Assert.Empty(read["A.C"]);
+    }
+
     [Fact]
     public void TypeFileIndexCache_StillReadsDistinctKeys()
     {

--- a/tests/ILInspector.Metadata.Tests/SourceLinkDuplicateDocumentTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SourceLinkDuplicateDocumentTests.cs
@@ -1,0 +1,87 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// SourceLink maps are recovered from portable PDBs, which are untrusted artifact content. A map
+/// that repeats a key under <c>documents</c> is read by more than one product reader, and those
+/// readers select differently over the duplicate set: <see cref="SourceDocumentPathResolver"/>
+/// orders by descending pattern length and takes the first match, while the repository-URL reader
+/// in <c>AssemblyInspector</c> takes the first value mentioning a known host. Under permissive
+/// parsing those rules can land on different origins, which is the spoofed-provenance case in
+/// <c>docs/design/untrusted-data-threat-model.md</c>.
+/// </summary>
+public class SourceLinkDuplicateDocumentTests
+{
+    private const string DuplicateEntryMap = """
+        {"documents":{"/_/*":"https://evil.example/raw/*","/_/*":"https://github.com/o/r/raw/*"}}
+        """;
+
+    [Fact]
+    public void Resolve_DoesNotMapThroughADuplicatedDocumentsEntry()
+    {
+        var resolution = SourceDocumentPath.Resolve("/_/src/Program.cs", DuplicateEntryMap);
+
+        // Fail closed: no mapping at all, rather than silently binding one of the two origins.
+        Assert.False(resolution.IsMapped);
+        Assert.Null(resolution.ResolvedUrl);
+    }
+
+    [Fact]
+    public void Resolve_DoesNotYieldTheAttackerOriginFromADuplicatedEntry()
+    {
+        var resolution = SourceDocumentPath.Resolve("/_/src/Program.cs", DuplicateEntryMap);
+
+        Assert.DoesNotContain("evil.example", resolution.ResolvedUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Resolve_RejectsADuplicatedTopLevelDocumentsObject()
+    {
+        const string map = """
+            {"documents":{"/_/*":"https://github.com/o/r/raw/*"},"documents":{"/_/*":"https://evil.example/raw/*"}}
+            """;
+
+        var resolution = SourceDocumentPath.Resolve("/_/src/Program.cs", map);
+
+        Assert.False(resolution.IsMapped);
+        Assert.Null(resolution.ResolvedUrl);
+    }
+
+    [Fact]
+    public void Resolve_StillMapsAWellFormedSourceLinkDocument()
+    {
+        const string map = """
+            {"documents":{"/_/*":"https://raw.githubusercontent.com/o/r/abc123/*"}}
+            """;
+
+        var resolution = SourceDocumentPath.Resolve("/_/src/Program.cs", map);
+
+        Assert.True(resolution.IsMapped);
+        Assert.Equal("src/Program.cs", resolution.CanonicalPath);
+        Assert.Equal("https://raw.githubusercontent.com/o/r/abc123/src/Program.cs", resolution.ResolvedUrl);
+    }
+
+    [Fact]
+    public void Resolve_StillMapsAMapWithSeveralDistinctPatterns()
+    {
+        // Distinct keys are not duplicates; multi-root maps must keep working.
+        const string map = """
+            {"documents":{"/_/*":"https://host.example/a/*","/_/sub/*":"https://host.example/b/*"}}
+            """;
+
+        var resolution = SourceDocumentPath.Resolve("/_/sub/File.cs", map);
+
+        Assert.True(resolution.IsMapped);
+        Assert.Equal("https://host.example/b/File.cs", resolution.ResolvedUrl);
+    }
+
+    [Fact]
+    public void Resolve_LeavesUnmappedPathsUnmappedWithoutASourceLinkMap()
+    {
+        var resolution = SourceDocumentPath.Resolve("/_/src/Program.cs", sourceLinkJson: null);
+
+        Assert.False(resolution.IsMapped);
+        Assert.Equal("src/Program.cs", resolution.CanonicalPath);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/SourceLinkDuplicateDocumentTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SourceLinkDuplicateDocumentTests.cs
@@ -1,16 +1,22 @@
+using System.Text.Json;
 using ILInspector.Metadata;
 
 namespace ILInspector.Metadata.Tests;
 
 /// <summary>
-/// SourceLink maps are recovered from portable PDBs, which are untrusted artifact content. A map
-/// that repeats a key under <c>documents</c> is read by more than one product reader, and those
-/// readers select differently over the duplicate set: <see cref="SourceDocumentPathResolver"/>
-/// orders by descending pattern length and takes the first match, while the repository-URL reader
-/// in <c>AssemblyInspector</c> takes the first value mentioning a known host. Under permissive
-/// parsing those rules can land on different origins, which is the spoofed-provenance case in
-/// <c>docs/design/untrusted-data-threat-model.md</c>.
+/// SourceLink maps are recovered from portable PDBs, which are untrusted artifact content. JSON
+/// leaves duplicate object keys undefined, so a map that repeats a key under <c>documents</c> has
+/// more than one valid reading. These tests pin that such a map fails the parse rather than
+/// binding one of its readings.
 /// </summary>
+/// <remarks>
+/// This is fail-visible hardening, not a fix for a reader divergence. Both product readers happen
+/// to select the first entry for a duplicated key — <c>AssemblyInspector</c> stops at the first
+/// <c>documents</c> entry, and <see cref="SourceDocumentPathResolver"/>'s descending pattern-length
+/// sort is stable, so equal-length duplicates keep document order. They diverge only on maps with
+/// <em>distinct</em> keys, which stay well-formed and accepted; see the SourceLink open-work entry
+/// in <c>docs/design/untrusted-data-threat-model.md</c>.
+/// </remarks>
 public class SourceLinkDuplicateDocumentTests
 {
     private const string DuplicateEntryMap = """
@@ -83,5 +89,36 @@ public class SourceLinkDuplicateDocumentTests
 
         Assert.False(resolution.IsMapped);
         Assert.Equal("src/Program.cs", resolution.CanonicalPath);
+    }
+
+    /// <summary>
+    /// The source-generated cache reader is a separate parse path from <c>SourceLinkJson</c>, so it
+    /// needs its own duplicate rejection. This gates the "product cache entries parse through the
+    /// same guard" claim in <c>docs/design/untrusted-data-threat-model.md</c>; without
+    /// <c>AllowDuplicateProperties = false</c> on the context the last value would silently win.
+    /// </summary>
+    [Fact]
+    public void TypeFileIndexCache_RejectsDuplicateKeys()
+    {
+        const string cached = """
+            {"A.B":["first.cs"],"A.B":["second.cs"]}
+            """;
+
+        Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize(cached, SourceLinkJsonContext.Default.DictionaryStringStringArray));
+    }
+
+    [Fact]
+    public void TypeFileIndexCache_StillReadsDistinctKeys()
+    {
+        const string cached = """
+            {"A.B":["first.cs"],"A.C":["second.cs"]}
+            """;
+
+        var index = JsonSerializer.Deserialize(cached, SourceLinkJsonContext.Default.DictionaryStringStringArray);
+
+        Assert.NotNull(index);
+        Assert.Equal(["first.cs"], index["A.B"]);
+        Assert.Equal(["second.cs"], index["A.C"]);
     }
 }


### PR DESCRIPTION
## Summary

Two related changes from a review of the System.Text.Json additions in .NET 10 and .NET 11.

**Adopted, from .NET 10:** `AllowDuplicateProperties = false` at untrusted JSON parse boundaries.

**Not adopted, from .NET 11:** nothing. Details below, since the investigation was the point of the exercise.

## The duplicate-property hardening

JSON does not define how duplicate object keys resolve, so two readers of one payload can disagree. SourceLink is a live instance rather than a hypothetical:

- `SourceDocumentPathResolver.Create` orders mappings by descending pattern length and takes the first match.
- The repository-URL reader in `AssemblyInspector` takes the first value naming a known host.

Given a repeated key under `documents`, those two rules select different entries. Measured on the pre-change readers:

```
mappings seen: 2
Reader A (resolved source URL): https://evil.example/raw/*
Reader B (reported repo URL):   https://github.com/o/r/raw/*
```

A hostile PDB could therefore resolve source from one origin while the tool reported provenance from another — the spoofed-provenance case in `docs/design/untrusted-data-threat-model.md`.

Adds `HardenedJson` to `DotnetInspector.Core`, directly alongside the existing `HardenedXml`. Twenty parse sites move onto it: SourceLink maps, package contents, feed responses, `project.assets.json`, `.deps.json`, and the package index cache.

**Layering note for reviewers.** `ILInspector.Metadata` gets its own `SourceLinkJson` rather than a `DotnetInspector.Core` reference. Metadata references only Findings, MetadataPrimitives, and Text; depending on Core to share ten lines would pull HTTP, caching, and download infrastructure into the SRM layer and invert the ownership documented in `docs/overview.md`. The duplication is deliberate — please push back if you disagree.

## Compatibility boundary

Callers that already treated malformed JSON as "no data" now treat duplicate-bearing JSON the same way. That is fail-closed and consistent with their existing malformed-input handling, but it does **not** convert them to explicit failure reporting, which remains open work item 6 in the threat model. NuGet-produced `deps.json` and `project.assets.json` do not legitimately contain duplicate keys, so real-world impact should be nil.

`runfaster` still parses its trace inputs directly; recorded as open work item 1 rather than silently expanded into this change.

## The wire-name gate

Naming is declared per context, not per model. Twenty-eight contexts repeat the declaration by hand, and several model types are serialized by more than one context (the indented/compact pairs; rows shared between a document context and a JSONL context). Nothing ties those declarations together, so a context added without `PropertyNamingPolicy` would silently emit a second spelling of an existing shape.

The gate discovers contexts by reflection rather than listing them, so a new context is covered the moment it is declared, and walks each graph transitively — naming attributes are not transitive, so nested types are exactly where a spelling change would go unnoticed.

**Evidence it is not vacuous.** Both assertions were verified against tampered builds:

| Tamper | Result |
| --- | --- |
| Remove `PropertyNamingPolicy` from `PackageFileJsonRowContext` | `EveryWireName_MatchesItsDeclaredNamingPolicy` fails, naming `PackageFileJsonRow.Path`, `.Size` |
| Flip `ApiTypeCompactJsonContext` to CamelCase | `SharedTypes_HaveOneSpellingAcrossEveryContext` fails, naming `ApiType` plus nested `TypeParameter`, `ApiMember`, `SampleReference`, `PartialSourceFileInfo` |

A `Gate_IsNotVacuous` test fails if discovery stops finding contexts.

## The gate found a real deviation

`TimelineJsonContext` declares no naming policy and its views carry no `[JsonPropertyName]`, so **`timeline --json` emits CLR PascalCase** (`Member`, `Finding`, `Address`, …) while every other command emits snake_case.

Correcting it changes a shipped wire format, so this PR does not do it. It is recorded as a named exception, and `KnownPascalCaseDeviations_StillDeviate` fails once it is fixed, forcing the exception to be deleted alongside the fix. Happy to follow up separately if you want the wire format aligned.

## Why no .NET 11 features

`JsonNamingPolicyAttribute` was the only serious candidate — it would let naming live on the model instead of being copy-pasted across contexts. It does not hold up: the attribute overrides a context policy for a type's own properties but is **not transitive**.

```
ctx=SnakeCase, Outer=[CamelCase]: {"outerProp":"a","nested":{"nested_prop":"b"}}
                                                  nested type ignored the attribute
```

Making naming genuinely intrinsic would mean attributing every type in the transitive graph (~100+), which is more duplication than the 22 context lines it removes, with silent wire-name changes on any miss. The gate above addresses the same drift hazard directly and needs no new dependency.

Also assessed and rejected: `CreateIReadOnlySetInfo` (all `IReadOnlySet` uses are method parameters, never serialized properties), `GetTypeInfo<T>`/`TryGetTypeInfo<T>` (contexts already thread `JsonTypeInfo<T>` explicitly), unions and `JsonTypeClassifier` (no polymorphic serialization; `UnionTypeInfo` is a *detected* .NET union, an unrelated feature), `Utf8JsonWriter.Reset` (no hot-loop writer reuse), and `SerializeAsyncEnumerable(topLevelValues: true)` (fits the three per-row JSONL sites, but they would have to go async and the primary JSONL path goes through Markout's table writer, not STJ).

Worth recording: a preview STJ package **would** have worked. Verified that a net10.0 app referencing `System.Text.Json 11.0.0-preview.6` loads app-local `System.Text.Json.dll` v11.0.0.0 on the .NET 10.0.8 runtime, with the net11-only APIs functioning and the source generator honoring them. The out-of-band package is not blocked by the LTS-floor TFM of the shipped "any" package. It simply is not needed.

## Validation

Release, per the repo's fixture-fidelity rule.

| Suite | Result |
| --- | --- |
| `dotnet-inspect.Tests` | 2238 passed, 0 failed, 14 skipped |
| `DotnetInspector.Services.Tests` | 325 passed, 0 failed |
| `ILInspector.Metadata.Tests` | 953 passed, 0 failed, 5 skipped |
| `ILInspector.Analysis.Tests` | 554 passed, 0 failed |
| `ILInspector.Decompiler.Tests --gate fast` | 4059 passed, 0 failed |

`markdownlint` clean on the changed doc. Suites re-run after merging `origin/main`.

Not yet ready to merge — adversarial review pending.
