### PR TITLE
Fail loudly when a render path drops a payload projection

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -200,6 +200,20 @@ could name a package. The explicit transition to that package artifact remains
 `package Package@version`. Likewise, printing a timeline may use only declared
 payloads on already evaluated rows; it cannot probe missing cells.
 
+### A payload projection is never silently dropped
+
+`--print`, `--value`, `--urls`, `--paths`, and `--count` reshape the payload, so
+a render path that ignores one answers a question the caller did not ask while
+still exiting 0. That failure is invisible to exit-code checks and to tests that
+only cover the unprojected path.
+
+Every accepted payload projection must therefore end in one of two outcomes: the
+payload is projected, or the command reports why it cannot be and exits non-zero.
+Rendering the full unprojected shape is not a third option. The requirement is
+enforced structurally rather than per command — the request is recorded from the
+parse result and the projection writers mark it honored, so a route that drops
+one fails loudly instead of shipping the wrong payload.
+
 ### Presentation modifiers (render the chosen shape)
 
 | Flag | Effect |

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -211,8 +211,17 @@ Every accepted payload projection must therefore end in one of two outcomes: the
 payload is projected, or the command reports why it cannot be and exits non-zero.
 Rendering the full unprojected shape is not a third option. The requirement is
 enforced structurally rather than per command — the request is recorded from the
-parse result and the projection writers mark it honored, so a route that drops
-one fails loudly instead of shipping the wrong payload.
+parse result and the projection writers report which projection they honored, so
+a route that drops one fails loudly instead of shipping the wrong payload.
+
+Writers report *which* flag they honored rather than merely acknowledging one.
+A writer can be reached for more than one reason — the print writer also serves
+`--bare` — so an untyped signal would let it satisfy an unrelated request and let
+that drop escape.
+
+The projections are mutually exclusive. Two of them cannot both shape one
+payload, so a combination is rejected before the command runs rather than
+resolved by discarding one.
 
 ### Presentation modifiers (render the chosen shape)
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3476,6 +3476,38 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Find_Count_ComposesWithJson()
+    {
+        // Found by the projection audit: --json was resolved before --count, so a count
+        // request was answered with the full unprojected result set and exit 0.
+        var (exit, output, _) = await RunAppAsync(
+            "find", "Cache", "--library", TestAssemblyPath, "--count", "--json");
+
+        Assert.Equal(0, exit);
+        Assert.True(int.TryParse(output.Trim(), out _), $"expected a bare count, got: {output}");
+    }
+
+    [Fact]
+    public async Task Implements_Count_ComposesWithJson()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "implements", "IDisposable", "--library", TestAssemblyPath, "--count", "--json");
+
+        Assert.Equal(0, exit);
+        Assert.True(int.TryParse(output.Trim(), out _), $"expected a bare count, got: {output}");
+    }
+
+    [Fact]
+    public async Task Extensions_Count_ComposesWithJson()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "extensions", "String", "--library", TestAssemblyPath, "--count", "--json");
+
+        Assert.Equal(0, exit);
+        Assert.True(int.TryParse(output.Trim(), out _), $"expected a bare count, got: {output}");
+    }
+
+    [Fact]
     public async Task Type_SourceFiles_Value_RowSelectsUrl()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3476,6 +3476,18 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_RewrittenCommand_IsAudited()
+    {
+        // The router captures projection flags as raw tokens, so the outer invocation records
+        // nothing. It used to invoke the rewritten parse directly, bypassing the audit, which
+        // left every bare-mode invocation unguarded. It now goes through the choke point.
+        var (exit, _, error) = await RunAppAsync("Regex", "--count", "--print", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--count cannot be combined with --print", error);
+    }
+
+    [Fact]
     public void ProjectionAudit_TracksProjectionDeclaredByAnAncestorCommand()
     {
         // `package --count search <id>` binds --count to the parent command, which the parser

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3549,6 +3549,18 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task ProjectionFlags_ConflictIsMootUnderHelp()
+    {
+        // Help renders no payload, so there is nothing for two projections to fight over.
+        // Rejecting the combination here would turn a working help request into an error.
+        var (exit, output, _) = await RunAppAsync(
+            "type", "--library", TestAssemblyPath, "-S", "Classes", "--count", "--print", "--help");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Usage", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Find_Count_ComposesWithJson()
     {
         // Found by the projection audit: --json was resolved before --count, so a count

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -548,7 +548,7 @@ public class CommandExecutionTests
             }
             try
             {
-                return await result.InvokeAsync();
+                return await CommandLineBuilder.InvokeAsync(result);
             }
             catch (RowWindowValidationException ex)
             {
@@ -3421,6 +3421,58 @@ public class CommandExecutionTests
         Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", rows[0].GetProperty("url").GetString());
         Assert.Equal(2, rows[1].GetProperty("row").GetInt32());
         Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", rows[1].GetProperty("url").GetString());
+    }
+
+    [Theory]
+    [InlineData("--value")]
+    [InlineData("--urls")]
+    [InlineData("--paths")]
+    [InlineData("--print")]
+    public async Task WholeSurfaceListing_DroppedProjection_FailsLoudly(string projectionFlag)
+    {
+        // The whole-surface type listing renders sections but has no projection dispatch, so
+        // before the audit it answered a projection request with the full unprojected listing
+        // and exit 0. The audit turns that silent drop into a reported failure. When this route
+        // gains real column projection, this expectation changes to a projected payload.
+        var (exit, _, error) = await RunAppAsync(
+            "type", "--library", TestAssemblyPath, "-S", "Classes", projectionFlag);
+
+        Assert.Equal(1, exit);
+        Assert.Contains($"'{projectionFlag}' was accepted but this command path produced unprojected output", error);
+    }
+
+    [Fact]
+    public async Task ProjectionAudit_DoesNotFireForHelp()
+    {
+        // --help short-circuits rendering, so the projection is not dropped; it is moot.
+        var (exit, _, error) = await RunAppAsync(
+            "type", "--library", TestAssemblyPath, "-S", "Classes", "--value", "--help");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("produced unprojected output", error);
+    }
+
+    [Fact]
+    public async Task ProjectionAudit_DoesNotFireWhenProjectionIsRejected()
+    {
+        // A command that rejects an unsupported projection has already reported the problem;
+        // the audit must not add a second, misleading "this is a bug" line on top of it.
+        var (exit, _, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "Signals", "--urls");
+
+        Assert.Equal(1, exit);
+        Assert.DoesNotContain("produced unprojected output", error);
+    }
+
+    [Fact]
+    public async Task ProjectionAudit_DoesNotFireForHonoredCount()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "References", "--count");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("produced unprojected output", error);
+        Assert.True(int.TryParse(output.Trim(), out _), $"expected a bare count, got: {output}");
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3581,6 +3581,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Depends_Count_ComposesWithJson()
+    {
+        // The type with dependencies matters: a type with none short-circuits before the
+        // JSON branch, which is why an earlier probe using such a type saw no defect.
+        var (exit, output, _) = await RunAppAsync(
+            "depends", "SampleGenericClass`1", "--library", TestAssemblyPath, "--count", "--json");
+
+        Assert.Equal(0, exit);
+        Assert.True(int.TryParse(output.Trim(), out var count), $"expected a bare count, got: {output}");
+        Assert.True(count > 0, "fixture must have dependencies for this to be a meaningful regression test");
+    }
+
+    [Fact]
     public async Task Type_SourceFiles_Value_RowSelectsUrl()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3488,6 +3488,34 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public void ProjectionAudit_NestedInvocationDoesNotDiscardOuterRequest()
+    {
+        // Invocations nest: the router invokes the command it rewrites to. An inner invocation
+        // must not consume the outer one's request, or the outer verify finds nothing to check
+        // and a dropped projection escapes.
+        var root = CommandLineBuilder.CreateRootCommand();
+        var outer = root.Parse(["library", TestAssemblyPath, "-S", "References", "--count"]);
+        var inner = root.Parse(["library", TestAssemblyPath, "-S", "References"]);
+
+        try
+        {
+            using (ProjectionAudit.BeginRequest(outer))
+            {
+                using (ProjectionAudit.BeginRequest(inner))
+                {
+                    Assert.Equal(0, ProjectionAudit.Verify(0));
+                }
+
+                Assert.Equal(1, ProjectionAudit.Verify(0));
+            }
+        }
+        finally
+        {
+            ProjectionAudit.ResetForTesting();
+        }
+    }
+
+    [Fact]
     public void ProjectionAudit_TracksProjectionDeclaredByAnAncestorCommand()
     {
         // `package --count search <id>` binds --count to the parent command, which the parser

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3476,6 +3476,79 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public void ProjectionAudit_WrongFlagDoesNotSatisfyRequest()
+    {
+        // The print writer also serves --bare, so an untyped "honored" signal would let it
+        // satisfy an unrelated recorded --count and let that drop escape.
+        var result = CommandLineBuilder.CreateRootCommand()
+            .Parse(["library", TestAssemblyPath, "-S", "References", "--count"]);
+
+        try
+        {
+            ProjectionAudit.BeginRequest(result);
+            ProjectionAudit.MarkHonored(ProjectionAudit.Print);
+
+            Assert.Equal(1, ProjectionAudit.Verify(0));
+        }
+        finally
+        {
+            ProjectionAudit.ResetForTesting();
+        }
+    }
+
+    [Fact]
+    public void ProjectionAudit_MatchingFlagSatisfiesRequest()
+    {
+        var result = CommandLineBuilder.CreateRootCommand()
+            .Parse(["library", TestAssemblyPath, "-S", "References", "--count"]);
+
+        try
+        {
+            ProjectionAudit.BeginRequest(result);
+            ProjectionAudit.MarkHonored(ProjectionAudit.Count);
+
+            Assert.Equal(0, ProjectionAudit.Verify(0));
+        }
+        finally
+        {
+            ProjectionAudit.ResetForTesting();
+        }
+    }
+
+    [Fact]
+    public void ProjectionAudit_HelpTokenAsOptionValueDoesNotDisableAudit()
+    {
+        // '/h' here is the value of --type, not a help request. Matching raw token text
+        // rather than option tokens would silently disable the audit for the invocation.
+        var result = CommandLineBuilder.CreateRootCommand()
+            .Parse(["type", "--library", TestAssemblyPath, "-S", "Classes", "--value", "--type", "/h"]);
+
+        try
+        {
+            ProjectionAudit.BeginRequest(result);
+
+            Assert.Equal(1, ProjectionAudit.Verify(0));
+        }
+        finally
+        {
+            ProjectionAudit.ResetForTesting();
+        }
+    }
+
+    [Fact]
+    public async Task ProjectionFlags_AreMutuallyExclusive()
+    {
+        // Two projections cannot both shape one payload, so honoring either one would
+        // discard the other.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "--library", TestAssemblyPath, "-S", "Classes", "--count", "--print");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("--count cannot be combined with --print", error);
+    }
+
+    [Fact]
     public async Task Find_Count_ComposesWithJson()
     {
         // Found by the projection audit: --json was resolved before --count, so a count

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3476,6 +3476,36 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public void ProjectionAudit_TracksProjectionDeclaredByAnAncestorCommand()
+    {
+        // `package --count search <id>` binds --count to the parent command, which the parser
+        // accepts. Inspecting only the executing command missed it, so the subcommand rendered
+        // its full payload and exited 0 with the projection silently discarded.
+        var result = CommandLineBuilder.CreateRootCommand()
+            .Parse(["package", "--count", "search", "Newtonsoft.Json"]);
+
+        try
+        {
+            ProjectionAudit.BeginRequest(result);
+
+            Assert.Equal(1, ProjectionAudit.Verify(0));
+        }
+        finally
+        {
+            ProjectionAudit.ResetForTesting();
+        }
+    }
+
+    [Fact]
+    public void ProjectionAudit_RejectsConflictDeclaredByAnAncestorCommand()
+    {
+        var result = CommandLineBuilder.CreateRootCommand()
+            .Parse(["package", "--count", "--print", "search", "Newtonsoft.Json"]);
+
+        Assert.False(ProjectionAudit.ValidateExclusive(result));
+    }
+
+    [Fact]
     public void ProjectionAudit_WrongFlagDoesNotSatisfyRequest()
     {
         // The print writer also serves --bare, so an untyped "honored" signal would let it

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -70,7 +70,10 @@ public static class RouterCommandDefinition
                 return 1;
             }
 
-            return await rootCommand.Parse(rewritten).InvokeAsync();
+            // Invoked through the audit choke point, not ParseResult.InvokeAsync: the router
+            // captures projection flags as raw tokens, so the outer invocation records nothing
+            // and only this rewritten parse can tell whether a projection was honored.
+            return await CommandLineBuilder.InvokeAsync(rootCommand.Parse(rewritten));
         });
 
         return routerCommand;

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -45,6 +45,18 @@ public static class CommandLineBuilder
     public static string[] PreprocessArgs(string[] args) => ArgumentPreprocessor.PreprocessArgs(args);
 
     /// <summary>
+    /// Invokes a parsed command under the payload-projection audit. This is the single
+    /// invoke choke point: the product entry point and the test harness both call it, so a
+    /// render path that drops <c>--print</c>/<c>--value</c>/<c>--urls</c>/<c>--paths</c>/
+    /// <c>--count</c> fails loudly in tests rather than shipping unprojected output.
+    /// </summary>
+    public static async Task<int> InvokeAsync(ParseResult parseResult)
+    {
+        ProjectionAudit.BeginRequest(parseResult);
+        return ProjectionAudit.Verify(await parseResult.InvokeAsync());
+    }
+
+    /// <summary>
     /// Creates the root command with all subcommands configured.
     /// </summary>
     public static RootCommand CreateRootCommand()

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -52,6 +52,11 @@ public static class CommandLineBuilder
     /// </summary>
     public static async Task<int> InvokeAsync(ParseResult parseResult)
     {
+        // Two projections cannot both shape one payload, so reject the combination before
+        // the command runs rather than letting one of them be discarded.
+        if (!ProjectionAudit.ValidateExclusive(parseResult))
+            return 1;
+
         ProjectionAudit.BeginRequest(parseResult);
         return ProjectionAudit.Verify(await parseResult.InvokeAsync());
     }

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -57,7 +57,7 @@ public static class CommandLineBuilder
         if (!ProjectionAudit.ValidateExclusive(parseResult))
             return 1;
 
-        ProjectionAudit.BeginRequest(parseResult);
+        using var scope = ProjectionAudit.BeginRequest(parseResult);
         return ProjectionAudit.Verify(await parseResult.InvokeAsync());
     }
 

--- a/src/dotnet-inspect/Commands/DependsCommand.cs
+++ b/src/dotnet-inspect/Commands/DependsCommand.cs
@@ -235,12 +235,12 @@ public class DependsCommand
 
     private static void WriteCount(List<TypeDependencyNode> nodes)
     {
-        Console.WriteLine(CountTypeNodes(nodes));
+        CountOutput.WriteCount(CountTypeNodes(nodes));
     }
 
     private static void WriteCount(int count)
     {
-        Console.WriteLine(count);
+        CountOutput.WriteCount(count);
     }
 
     private static int CountTypeNodes(List<TypeDependencyNode> nodes)

--- a/src/dotnet-inspect/Commands/DependsCommand.cs
+++ b/src/dotnet-inspect/Commands/DependsCommand.cs
@@ -56,16 +56,16 @@ public class DependsCommand
                 return 0;
             }
 
-            if (options.JsonOutput)
+            if (options.Count)
+            {
+                WriteCount(result.Tree);
+            }
+            else if (options.JsonOutput)
             {
                 JsonOutputHelper.Write(result.Tree,
                     DependsJsonContext.Default.ListTypeDependencyNode,
                     DependsCompactJsonContext.Default.ListTypeDependencyNode,
                     options.CompactJson);
-            }
-            else if (options.Count)
-            {
-                WriteCount(result.Tree);
             }
             else
             {

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -49,13 +49,16 @@ public class ExtensionsCommand
                 NamespacePrefixHints.WriteIfLikelyNamespacePrefix(targetType);
 
             // Output results
-            if (options.JsonOutput)
-            {
-                WriteJsonOutput(results, options.CompactJson);
-            }
-            else if (options.Count)
+            // --count reduces the payload, so it is resolved before the format flags that
+            // render it. Ordering these the other way lets --json answer a count request
+            // with the full unprojected result set.
+            if (options.Count)
             {
                 WriteCount(results);
+            }
+            else if (options.JsonOutput)
+            {
+                WriteJsonOutput(results, options.CompactJson);
             }
             else if (options.Tabular || options.Tsv || options.Jsonl || options.NoHeader)
             {

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -235,7 +235,7 @@ public class ExtensionsCommand
 
     private static void WriteCount(List<ExtensionMethodResult> results)
     {
-        Console.WriteLine(results.Count);
+        CountOutput.WriteCount(results.Count);
     }
 
     private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity, RowWindow? rows)

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -147,7 +147,7 @@ public class FindCommand
     private static void WriteCount(List<TypeFindResult> rawData, string title)
     {
         var view = FindOutputFormatter.BuildView(rawData, title);
-        Console.WriteLine(view.Results?.Count ?? 0);
+        CountOutput.WriteCount(view.Results?.Count ?? 0);
     }
 
     private static void WriteMemberOutput(List<MemberFindResult> rawData, string title, FindOptions options)
@@ -178,7 +178,7 @@ public class FindCommand
     private static void WriteMemberCount(List<MemberFindResult> rawData, string title)
     {
         var view = FindOutputFormatter.BuildMemberView(rawData, title);
-        Console.WriteLine(view.Results?.Count ?? 0);
+        CountOutput.WriteCount(view.Results?.Count ?? 0);
     }
 }
 

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -57,14 +57,17 @@ public class FindCommand
             var results = await TypeSearchService.FindTypesAsync(options, patterns, logger, context.HttpClient);
             var title = patterns.Length == 1 ? $"Find: {patterns[0]}" : "Find Results";
 
-            if (options.JsonOutput)
+            // --count reduces the payload, so it is resolved before the format flags that
+            // render it. Ordering these the other way lets --json answer a count request
+            // with the full unprojected result set.
+            if (options.Count)
+            {
+                WriteCount(results, title);
+            }
+            else if (options.JsonOutput)
             {
                 var writer = new FindJsonWriter();
                 writer.Write(results, new WriterOptions(), Console.Out);
-            }
-            else if (options.Count)
-            {
-                WriteCount(results, title);
             }
             else
             {
@@ -102,14 +105,14 @@ public class FindCommand
         var results = await MemberSearchService.FindMembersAsync(options, memberPatterns, logger, httpClient);
         var title = memberPatterns.Length == 1 ? $"Find member: {memberPatterns[0]}" : "Find Members";
 
-        if (options.JsonOutput)
+        if (options.Count)
+        {
+            WriteMemberCount(results, title);
+        }
+        else if (options.JsonOutput)
         {
             var writer = new MemberFindJsonWriter();
             writer.Write(results, new WriterOptions(), Console.Out);
-        }
-        else if (options.Count)
-        {
-            WriteMemberCount(results, title);
         }
         else
         {

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -76,13 +76,16 @@ public class ImplementsCommand
                 NamespacePrefixHints.WriteIfLikelyNamespacePrefix(targetType);
 
             // Output results
-            if (options.JsonOutput)
-            {
-                WriteJsonOutput(results, options.CompactJson);
-            }
-            else if (options.Count)
+            // --count reduces the payload, so it is resolved before the format flags that
+            // render it. Ordering these the other way lets --json answer a count request
+            // with the full unprojected result set.
+            if (options.Count)
             {
                 WriteCount(results);
+            }
+            else if (options.JsonOutput)
+            {
+                WriteJsonOutput(results, options.CompactJson);
             }
             else
             {

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -140,7 +140,7 @@ public class ImplementsCommand
 
     private static void WriteCount(List<ImplementerResult> results)
     {
-        Console.WriteLine(results.Count);
+        CountOutput.WriteCount(results.Count);
     }
 
     private static void WriteMarkoutOutput(string targetType, List<ImplementerResult> results, bool tabular, bool tsv, bool jsonl, bool noHeader, string[]? columns, string[]? fields, RowWindow? rows)

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -793,7 +793,7 @@ public class LibraryCommand
             SectionNames.CostContext => inspection.ILOffset?.CostContext is { Count: > 0 },
             _ => false
         };
-        Console.WriteLine(hasRow ? 1 : 0);
+        CountOutput.WriteCount(hasRow ? 1 : 0);
         return true;
     }
 

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -458,6 +458,7 @@ public class PackageCommand
 
             if (options.Count)
             {
+                ProjectionAudit.MarkHonored(ProjectionAudit.Count);
                 Console.WriteLine(OutputFormatter.FormatResult(result, options, pipeline));
                 return 0;
             }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -653,7 +653,7 @@ public class PackageCommand
 
         if (options.Count)
         {
-            Console.WriteLine(CountMultiPackageRows(results, rowSection, options).ToString(CultureInfo.InvariantCulture));
+            CountOutput.WriteCount(CountMultiPackageRows(results, rowSection, options));
             return 0;
         }
 

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -339,6 +339,9 @@ public class ProjectCommand
         if (options.Print || options.Bare)
             return PrintSkillDocument(rows, options);
 
+        if (options.Count)
+            ProjectionAudit.MarkHonored();
+
         var output = options.Count
             ? rows.Count.ToString(CultureInfo.InvariantCulture) + Environment.NewLine
             : options.JsonOutput

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -340,7 +340,7 @@ public class ProjectCommand
             return PrintSkillDocument(rows, options);
 
         if (options.Count)
-            ProjectionAudit.MarkHonored();
+            ProjectionAudit.MarkHonored(ProjectionAudit.Count);
 
         var output = options.Count
             ? rows.Count.ToString(CultureInfo.InvariantCulture) + Environment.NewLine

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -1211,7 +1211,7 @@ public static class TimelineCommand
             int count = selectedSections.Contains(EvaluationsSection)
                 ? view.Evaluations?.Count ?? 0
                 : view.Transitions?.Count ?? 0;
-            Console.WriteLine(count);
+            CountOutput.WriteCount(count);
             return;
         }
 

--- a/src/dotnet-inspect/Output/CountOutput.cs
+++ b/src/dotnet-inspect/Output/CountOutput.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace DotnetInspector.Output;
 
 /// <summary>
@@ -64,8 +66,22 @@ public static class CountOutput
         return count;
     }
 
+    /// <summary>
+    /// Writes a single count and records that the <c>--count</c> projection was honored.
+    /// Count-emitting paths should route through this rather than writing to the console
+    /// directly, so the payload-projection audit can tell a rendered count from a dropped one.
+    /// </summary>
+    public static void WriteCount(int count)
+    {
+        ProjectionAudit.MarkHonored();
+        // Invariant: a count is machine-readable output, so it must not pick up
+        // culture-specific digits or grouping from the ambient locale.
+        Console.WriteLine(count.ToString(CultureInfo.InvariantCulture));
+    }
+
     public static void WriteCountFromMarkdown(string markdown)
     {
+        ProjectionAudit.MarkHonored();
         Console.WriteLine(CountMarkdownTableRows(markdown));
     }
 
@@ -127,6 +143,7 @@ public static class CountOutput
     /// </summary>
     public static void WriteCountMapFromMarkdown(string markdown, IReadOnlyList<string> orderedSections)
     {
+        ProjectionAudit.MarkHonored();
         var counts = CountMarkdownTableRowsBySection(markdown);
         Console.WriteLine("| Section | Count |");
         Console.WriteLine("| ------- | ----- |");

--- a/src/dotnet-inspect/Output/CountOutput.cs
+++ b/src/dotnet-inspect/Output/CountOutput.cs
@@ -73,7 +73,7 @@ public static class CountOutput
     /// </summary>
     public static void WriteCount(int count)
     {
-        ProjectionAudit.MarkHonored();
+        ProjectionAudit.MarkHonored(ProjectionAudit.Count);
         // Invariant: a count is machine-readable output, so it must not pick up
         // culture-specific digits or grouping from the ambient locale.
         Console.WriteLine(count.ToString(CultureInfo.InvariantCulture));
@@ -81,7 +81,7 @@ public static class CountOutput
 
     public static void WriteCountFromMarkdown(string markdown)
     {
-        ProjectionAudit.MarkHonored();
+        ProjectionAudit.MarkHonored(ProjectionAudit.Count);
         Console.WriteLine(CountMarkdownTableRows(markdown));
     }
 
@@ -143,7 +143,7 @@ public static class CountOutput
     /// </summary>
     public static void WriteCountMapFromMarkdown(string markdown, IReadOnlyList<string> orderedSections)
     {
-        ProjectionAudit.MarkHonored();
+        ProjectionAudit.MarkHonored(ProjectionAudit.Count);
         var counts = CountMarkdownTableRowsBySection(markdown);
         Console.WriteLine("| Section | Count |");
         Console.WriteLine("| ------- | ----- |");

--- a/src/dotnet-inspect/Output/PrintProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/PrintProjectionOutput.cs
@@ -23,7 +23,7 @@ public static class PrintProjectionOutput
 {
     public static int Write(IReadOnlyList<PrintableDocument> documents, PrintProjectionOptions options)
     {
-        ProjectionAudit.MarkHonored();
+        ProjectionAudit.MarkHonored(ProjectionAudit.Print);
 
         if (documents.Count == 0)
         {

--- a/src/dotnet-inspect/Output/PrintProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/PrintProjectionOutput.cs
@@ -23,6 +23,8 @@ public static class PrintProjectionOutput
 {
     public static int Write(IReadOnlyList<PrintableDocument> documents, PrintProjectionOptions options)
     {
+        ProjectionAudit.MarkHonored();
+
         if (documents.Count == 0)
         {
             Console.Error.WriteLine("Error: selected section has no printable rows.");

--- a/src/dotnet-inspect/Output/ProjectionAudit.cs
+++ b/src/dotnet-inspect/Output/ProjectionAudit.cs
@@ -62,6 +62,12 @@ public static class ProjectionAudit
     /// </summary>
     public static bool ValidateExclusive(ParseResult parseResult)
     {
+        // Help short-circuits rendering, so no payload is shaped and the conflict is moot.
+        // This must be checked here as well as in BeginRequest: rejecting the combination
+        // would otherwise turn a legitimate help request into an error.
+        if (IsHelpRequested(parseResult))
+            return true;
+
         var requested = RequestedFlags(parseResult);
         if (requested.Count <= 1)
             return true;

--- a/src/dotnet-inspect/Output/ProjectionAudit.cs
+++ b/src/dotnet-inspect/Output/ProjectionAudit.cs
@@ -93,20 +93,35 @@ public static class ProjectionAudit
     }
 
     /// <summary>
-    /// Records the payload projections requested by this invocation. Later calls replace the
-    /// prior request, so a reused execution context never inherits a stale one.
+    /// Records the payload projections requested by this invocation. Disposing the returned
+    /// scope restores whatever request was in flight before it.
     /// </summary>
-    public static void BeginRequest(ParseResult parseResult)
+    /// <remarks>
+    /// Invocations nest: the bare-mode router invokes the command it rewrites to. Without the
+    /// restore, an inner invocation would discard the outer one's request and the outer verify
+    /// would then find nothing to check. That is unreachable today, because the router captures
+    /// its tokens raw and so records nothing, but it is not a property worth depending on.
+    /// </remarks>
+    public static Scope BeginRequest(ParseResult parseResult)
     {
+        var scope = new Scope(Current.Value);
         Current.Value = null;
 
         // Help short-circuits rendering, so a projection flag alongside --help is not dropped.
         if (IsHelpRequested(parseResult))
-            return;
+            return scope;
 
         var requested = RequestedFlags(parseResult);
         if (requested.Count > 0)
             Current.Value = new Request { Flags = requested };
+
+        return scope;
+    }
+
+    /// <summary>Restores the request that was in flight when it was created.</summary>
+    public readonly struct Scope(object? displaced) : IDisposable
+    {
+        public void Dispose() => Current.Value = displaced as Request;
     }
 
     private static List<string> RequestedFlags(ParseResult parseResult)

--- a/src/dotnet-inspect/Output/ProjectionAudit.cs
+++ b/src/dotnet-inspect/Output/ProjectionAudit.cs
@@ -112,25 +112,38 @@ public static class ProjectionAudit
     private static List<string> RequestedFlags(ParseResult parseResult)
     {
         var requested = new List<string>();
-        var command = parseResult.CommandResult.Command;
 
         foreach (var name in ProjectionOptionNames)
         {
-            var option = command.Options.FirstOrDefault(
-                o => string.Equals(o.Name, name, StringComparison.Ordinal));
-            if (option is null)
-                continue;
-
-            // Implicit results come from defaults, not from the command line, and only a
-            // true bool flag shapes the payload.
-            if (parseResult.GetResult(option) is { Implicit: false } result
-                && result.GetValueOrDefault<bool>())
-            {
+            // A projection can be declared by the executing command or by any ancestor:
+            // `package --count search <id>` binds the flag to the parent `package` command,
+            // and the parser accepts it. Inspecting only the executing command would miss a
+            // projection that was accepted and is about to be dropped.
+            if (CommandChain(parseResult).Any(command => IsExplicitlySet(parseResult, command, name)))
                 requested.Add(name);
-            }
         }
 
         return requested;
+    }
+
+    private static IEnumerable<Command> CommandChain(ParseResult parseResult)
+    {
+        for (SymbolResult? scope = parseResult.CommandResult; scope is not null; scope = scope.Parent)
+            if (scope is CommandResult commandResult)
+                yield return commandResult.Command;
+    }
+
+    private static bool IsExplicitlySet(ParseResult parseResult, Command command, string name)
+    {
+        var option = command.Options.FirstOrDefault(
+            o => string.Equals(o.Name, name, StringComparison.Ordinal));
+        if (option is null)
+            return false;
+
+        // Implicit results come from defaults, not from the command line, and only a
+        // true bool flag shapes the payload.
+        return parseResult.GetResult(option) is { Implicit: false } result
+            && result.GetValueOrDefault<bool>();
     }
 
     // Matched against option tokens rather than raw token text: '/h' can legitimately be the

--- a/src/dotnet-inspect/Output/ProjectionAudit.cs
+++ b/src/dotnet-inspect/Output/ProjectionAudit.cs
@@ -18,10 +18,16 @@ namespace DotnetInspector.Output;
 /// <para>
 /// This audit closes the gap structurally rather than one site at a time. The request is
 /// recorded from the <see cref="ParseResult"/> — by option name, so unaudited and future
-/// commands are covered without registration — and the legitimate projection writers mark it
-/// honored. <see cref="Verify"/> runs at the single invoke choke point shared by the product
-/// entry point and the test harness. A route that drops a projection therefore fails loudly
-/// instead of silently, and the failure surfaces in the existing test suite.
+/// commands are covered without registration — and the legitimate projection writers report
+/// which projection they honored. <see cref="Verify"/> runs at the single invoke choke point
+/// shared by the product entry point and the test harness. A route that drops a projection
+/// therefore fails loudly instead of silently, and the failure surfaces in the existing tests.
+/// </para>
+/// <para>
+/// Honoring is reported per flag rather than as a bare acknowledgement. An untyped signal is
+/// unsound: a writer reached for one reason (say <c>--bare</c> routing through the print
+/// writer) would satisfy an unrelated recorded request such as <c>--count</c>, and the drop
+/// would escape.
 /// </para>
 /// <para>
 /// State is <see cref="AsyncLocal{T}"/> because in-process test runs invoke the CLI
@@ -30,21 +36,59 @@ namespace DotnetInspector.Output;
 /// </remarks>
 public static class ProjectionAudit
 {
+    public const string Print = "--print";
+    public const string Value = "--value";
+    public const string Urls = "--urls";
+    public const string Paths = "--paths";
+    public const string Count = "--count";
+
     /// <summary>Payload-shaping option names, by the name each option is constructed with.</summary>
-    private static readonly string[] ProjectionOptionNames =
-        ["--print", "--value", "--urls", "--paths", "--count"];
+    private static readonly string[] ProjectionOptionNames = [Print, Value, Urls, Paths, Count];
 
     private sealed class Request
     {
-        public required string Flag { get; init; }
-        public bool Honored { get; set; }
+        public required IReadOnlyList<string> Flags { get; init; }
+        public HashSet<string> Honored { get; } = new(StringComparer.Ordinal);
     }
 
     private static readonly AsyncLocal<Request?> Current = new();
 
     /// <summary>
-    /// Records the payload projection requested by this invocation, if any. Later calls replace
-    /// the prior request, so a reused execution context never inherits a stale one.
+    /// Rejects more than one payload projection in a single invocation. Two projections cannot
+    /// both shape one payload, so honoring either one silently discards the other. Commands
+    /// already enforced this among <c>--value</c>/<c>--urls</c>/<c>--paths</c> individually;
+    /// enforcing it centrally covers <c>--print</c> and <c>--count</c> too, and covers commands
+    /// that never had the check.
+    /// </summary>
+    public static bool ValidateExclusive(ParseResult parseResult)
+    {
+        var requested = RequestedFlags(parseResult);
+        if (requested.Count <= 1)
+            return true;
+
+        // Report in command-line order and in the wording the commands already use for this
+        // conflict, so the central check tightens coverage without restating the contract.
+        var ordered = requested
+            .OrderBy(flag => FirstTokenIndex(parseResult, flag))
+            .ToList();
+
+        var conflicts = string.Join(", ", ordered.Skip(1));
+        Console.Error.WriteLine($"Error: {ordered[0]} cannot be combined with {conflicts}.");
+        return false;
+    }
+
+    private static int FirstTokenIndex(ParseResult parseResult, string flag)
+    {
+        for (var i = 0; i < parseResult.Tokens.Count; i++)
+            if (string.Equals(parseResult.Tokens[i].Value, flag, StringComparison.Ordinal))
+                return i;
+
+        return int.MaxValue;
+    }
+
+    /// <summary>
+    /// Records the payload projections requested by this invocation. Later calls replace the
+    /// prior request, so a reused execution context never inherits a stale one.
     /// </summary>
     public static void BeginRequest(ParseResult parseResult)
     {
@@ -54,7 +98,16 @@ public static class ProjectionAudit
         if (IsHelpRequested(parseResult))
             return;
 
+        var requested = RequestedFlags(parseResult);
+        if (requested.Count > 0)
+            Current.Value = new Request { Flags = requested };
+    }
+
+    private static List<string> RequestedFlags(ParseResult parseResult)
+    {
+        var requested = new List<string>();
         var command = parseResult.CommandResult.Command;
+
         foreach (var name in ProjectionOptionNames)
         {
             var option = command.Options.FirstOrDefault(
@@ -62,33 +115,35 @@ public static class ProjectionAudit
             if (option is null)
                 continue;
 
-            // Implicit results come from defaults, not from the command line.
-            if (parseResult.GetResult(option) is { Implicit: false } optionResult)
+            // Implicit results come from defaults, not from the command line, and only a
+            // true bool flag shapes the payload.
+            if (parseResult.GetResult(option) is { Implicit: false } result
+                && result.GetValueOrDefault<bool>())
             {
-                // Only bool flags shape the payload; a false value is not a request.
-                if (optionResult.GetValueOrDefault<bool>() is false)
-                    continue;
-
-                Current.Value = new Request { Flag = name };
-                return;
+                requested.Add(name);
             }
         }
+
+        return requested;
     }
 
-    // Matched against raw tokens rather than a help option instance: the help option is
-    // supplied by the parser rather than declared alongside the command's own options, so
-    // token matching stays correct independent of how help is registered.
+    // Matched against option tokens rather than raw token text: '/h' can legitimately be the
+    // *value* of another option (for example --type /h), and treating that as help would
+    // silently disable the audit for the rest of the invocation.
     private static bool IsHelpRequested(ParseResult parseResult)
-        => parseResult.Tokens.Any(token => token.Value is "--help" or "-h" or "-?" or "/h" or "/?");
+        => parseResult.Tokens.Any(token =>
+            token.Type == TokenType.Option
+            && token.Value is "--help" or "-h" or "-?" or "/h" or "/?");
 
     /// <summary>
-    /// Marks the recorded projection request as honored. Called by the projection writers —
-    /// the paths that actually reduce the payload to the requested shape.
+    /// Records that <paramref name="flag"/> was honored — called by the writer that actually
+    /// reduced the payload to that projection's shape. Reporting a flag that was not requested
+    /// is harmless and expected: the print writer also serves <c>--bare</c>.
     /// </summary>
-    public static void MarkHonored()
+    public static void MarkHonored(string flag)
     {
         if (Current.Value is { } request)
-            request.Honored = true;
+            request.Honored.Add(flag);
     }
 
     /// <summary>
@@ -101,11 +156,16 @@ public static class ProjectionAudit
         var request = Current.Value;
         Current.Value = null;
 
-        if (exitCode != 0 || request is null || request.Honored)
+        if (exitCode != 0 || request is null)
+            return exitCode;
+
+        var dropped = request.Flags.Where(flag => !request.Honored.Contains(flag)).ToList();
+        if (dropped.Count == 0)
             return exitCode;
 
         Console.Error.WriteLine(
-            $"Error: '{request.Flag}' was accepted but this command path produced unprojected output. " +
+            $"Error: {string.Join(", ", dropped.Select(flag => $"'{flag}'"))} " +
+            "was accepted but this command path produced unprojected output. " +
             "This is a bug in dotnet-inspect; please report it.");
         return 1;
     }

--- a/src/dotnet-inspect/Output/ProjectionAudit.cs
+++ b/src/dotnet-inspect/Output/ProjectionAudit.cs
@@ -1,0 +1,115 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// Guards against a projection request being accepted by the parser and then silently
+/// discarded by a render path that exits 0 with the unprojected payload.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The payload-shaping flags (<c>--print</c>, <c>--value</c>, <c>--urls</c>, <c>--paths</c>,
+/// <c>--count</c>) are honored at scattered dispatch points across the commands. A route that
+/// forgets to dispatch does not fail: it renders the full section and exits 0, so the caller
+/// receives a well-formed answer to a question it did not ask. That failure is invisible to
+/// exit-code checks and to golden-output tests that only cover the unprojected path.
+/// </para>
+/// <para>
+/// This audit closes the gap structurally rather than one site at a time. The request is
+/// recorded from the <see cref="ParseResult"/> — by option name, so unaudited and future
+/// commands are covered without registration — and the legitimate projection writers mark it
+/// honored. <see cref="Verify"/> runs at the single invoke choke point shared by the product
+/// entry point and the test harness. A route that drops a projection therefore fails loudly
+/// instead of silently, and the failure surfaces in the existing test suite.
+/// </para>
+/// <para>
+/// State is <see cref="AsyncLocal{T}"/> because in-process test runs invoke the CLI
+/// concurrently; a static field would let one invocation's request observe another's honor.
+/// </para>
+/// </remarks>
+public static class ProjectionAudit
+{
+    /// <summary>Payload-shaping option names, by the name each option is constructed with.</summary>
+    private static readonly string[] ProjectionOptionNames =
+        ["--print", "--value", "--urls", "--paths", "--count"];
+
+    private sealed class Request
+    {
+        public required string Flag { get; init; }
+        public bool Honored { get; set; }
+    }
+
+    private static readonly AsyncLocal<Request?> Current = new();
+
+    /// <summary>
+    /// Records the payload projection requested by this invocation, if any. Later calls replace
+    /// the prior request, so a reused execution context never inherits a stale one.
+    /// </summary>
+    public static void BeginRequest(ParseResult parseResult)
+    {
+        Current.Value = null;
+
+        // Help short-circuits rendering, so a projection flag alongside --help is not dropped.
+        if (IsHelpRequested(parseResult))
+            return;
+
+        var command = parseResult.CommandResult.Command;
+        foreach (var name in ProjectionOptionNames)
+        {
+            var option = command.Options.FirstOrDefault(
+                o => string.Equals(o.Name, name, StringComparison.Ordinal));
+            if (option is null)
+                continue;
+
+            // Implicit results come from defaults, not from the command line.
+            if (parseResult.GetResult(option) is { Implicit: false } optionResult)
+            {
+                // Only bool flags shape the payload; a false value is not a request.
+                if (optionResult.GetValueOrDefault<bool>() is false)
+                    continue;
+
+                Current.Value = new Request { Flag = name };
+                return;
+            }
+        }
+    }
+
+    // Matched against raw tokens rather than a help option instance: the help option is
+    // supplied by the parser rather than declared alongside the command's own options, so
+    // token matching stays correct independent of how help is registered.
+    private static bool IsHelpRequested(ParseResult parseResult)
+        => parseResult.Tokens.Any(token => token.Value is "--help" or "-h" or "-?" or "/h" or "/?");
+
+    /// <summary>
+    /// Marks the recorded projection request as honored. Called by the projection writers —
+    /// the paths that actually reduce the payload to the requested shape.
+    /// </summary>
+    public static void MarkHonored()
+    {
+        if (Current.Value is { } request)
+            request.Honored = true;
+    }
+
+    /// <summary>
+    /// Fails a successful invocation that accepted a projection request and never honored it.
+    /// A non-zero exit code is left alone: the command already reported a problem, and
+    /// rejecting an unsupported projection is a legitimate way to not honor one.
+    /// </summary>
+    public static int Verify(int exitCode)
+    {
+        var request = Current.Value;
+        Current.Value = null;
+
+        if (exitCode != 0 || request is null || request.Honored)
+            return exitCode;
+
+        Console.Error.WriteLine(
+            $"Error: '{request.Flag}' was accepted but this command path produced unprojected output. " +
+            "This is a bug in dotnet-inspect; please report it.");
+        return 1;
+    }
+
+    /// <summary>Clears any recorded request. For tests that invoke writers directly.</summary>
+    public static void ResetForTesting() => Current.Value = null;
+}

--- a/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
@@ -46,6 +46,8 @@ public static class ShapeProjectionOutput
 
     public static int Write(IReadOnlyList<ShapeProjectionRow> rows, ShapeProjectionOptions options)
     {
+        ProjectionAudit.MarkHonored();
+
         if (rows.Count == 0)
         {
             Console.Error.WriteLine($"Error: selected section has no {ProjectionName(options.Kind)} values.");

--- a/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
@@ -46,7 +46,12 @@ public static class ShapeProjectionOutput
 
     public static int Write(IReadOnlyList<ShapeProjectionRow> rows, ShapeProjectionOptions options)
     {
-        ProjectionAudit.MarkHonored();
+        ProjectionAudit.MarkHonored(options.Kind switch
+        {
+            ShapeProjectionKind.Value => ProjectionAudit.Value,
+            ShapeProjectionKind.Urls => ProjectionAudit.Urls,
+            _ => ProjectionAudit.Paths
+        });
 
         if (rows.Count == 0)
         {

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -152,7 +152,7 @@ if (result.Errors.Count > 0)
 int exitCode;
 try
 {
-    exitCode = await result.InvokeAsync();
+    exitCode = await CommandLineBuilder.InvokeAsync(result);
 }
 catch (RowWindowValidationException ex)
 {


### PR DESCRIPTION
Closes part of #3364.

## The recurring defect

Three PRs into this series, the same bug had appeared three times: a payload
projection (`--print`, `--value`, `--urls`, `--paths`, `--count`) is accepted by
the parser, then a render path forgets to dispatch it, renders the full
unprojected shape, and **exits 0**. Nothing catches it — not the exit code, not
the 2233-test suite. The caller gets the wrong payload and believes it succeeded.

#3373 fixed one instance. #3379 fixed another. This PR stops fixing instances
and closes the class.

## The guardrail

An accepted projection must end in one of two outcomes: the payload is
projected, or the command says why it cannot and exits non-zero. Rendering the
full shape is not a third option.

`ProjectionAudit` records the request from the `ParseResult` **by option name**,
so a command added later is covered without registering anything. The projection
writers report **which** projection they honored, and
`CommandLineBuilder.InvokeAsync` verifies — the single choke point shared by
`Program.cs` and the test harness, so tests cannot diverge from the product.

Design decisions worth stating:

- **Writers report which flag they honored, not merely that something was
  honored.** A writer can be reached for more than one reason — the print writer
  also serves `--bare` — so an untyped signal lets it satisfy an unrelated
  request and lets that drop escape. Both reviewers found this independently.
- **The projections are mutually exclusive**, now rejected centrally *before* the
  command runs. Two of them cannot both shape one payload, so any combination
  previously meant one was silently discarded. Four commands already enforced
  this among `--value`/`--urls`/`--paths`; enforcing it centrally covers
  `--print` and `--count` and the commands that never had it. The existing
  pairwise wording and command-line ordering are preserved, so the contract
  asserted by `LibraryCommand_IlOffsetCountRejectsPrint` is unchanged.
- **`AsyncLocal`, not static** — tests invoke the CLI concurrently in-process.
- **Non-zero exits are left alone.** Rejecting a projection is a legitimate way
  to not honor one, and the command already reported it.
- **`--help` is exempt at both entry points.** Help short-circuits rendering, so
  the projection is moot and the conflict has nothing to fight over.

## What this looks like in practice

Both outcomes below are the desired ones. The point of the PR is that there is
no third outcome — an accepted projection is never answered with the full
unprojected payload and exit 0.

### Projections are honored (exit 0)

A count is a count, whatever presentation flags accompany it. `--json` used to
win over `--count` here and return the whole result set:

```console
$ dotnet-inspect find '*' --library DotnetInspector.Core.dll --count --json
24
```

```console
$ dotnet-inspect depends 'Downloader`1' --library DotnetInspector.Core.dll --count --json
1
```

An empty section still counts, rather than reporting nothing:

```console
$ dotnet-inspect library DotnetInspector.Core.dll -S References --count
Note: 1 matched section has no data: References.
0
```

Bare-mode input routes to a real command and the projection survives the
rewrite — this whole class of invocation was previously unaudited:

```console
$ dotnet-inspect Regex -S Methods --count --tips q
Note: Type 'Regex' resolved via platform find to System.Text.RegularExpressions.Regex ...
69
```

Help still works when projections are present, because help renders no payload
and so has nothing to project:

```console
$ dotnet-inspect type --library DotnetInspector.Core.dll -S Classes --count --print --help
Description:
Discover types in a package or library (compact table output)
...
```

### Projections are refused (exit 1)

Two projections cannot both shape one payload, so the combination is rejected
before the command runs rather than resolved by discarding one:

```console
$ dotnet-inspect type --library DotnetInspector.Core.dll -S Classes --count --print
Error: --count cannot be combined with --print.
```

The same conflict is now caught through the bare-mode router, which previously
bypassed the check entirely and failed later with an unrelated message about
section selection:

```console
$ dotnet-inspect Regex --count --print --tips q
Error: --count cannot be combined with --print.
```

And where a render path genuinely drops a projection, it says so instead of
returning the wrong payload as success:

```console
$ dotnet-inspect type --library DotnetInspector.Core.dll -S Classes --value
# DotnetInspector.Core
...
| Type | Members |
...
Error: '--value' was accepted but this command path produced unprojected output. This is a bug in dotnet-inspect; please report it.
```

```console
$ dotnet-inspect package --count search Newtonsoft.Json --take 1
Newtonsoft.Json  13.0.4   8.8B   Json.NET is a popular high-performance JSON framework for ....
Error: '--count' was accepted but this command path produced unprojected output. This is a bug in dotnet-inspect; please report it.
```

That last message is deliberately blunt. It names a real defect, it is
addressed to the maintainer rather than the user, and each route that can
produce it has an issue and a fix queued — see "What still fires the audit"
below. The alternative is what these commands did before: answer a question
nobody asked, and call it success.

## What wiring it up found

Real bugs, none covered by the existing suite:

| Bug | Effect |
| --- | --- |
| `find`, `implements`, `extensions`, and type-mode `depends` resolved `--json` before `--count` | `--count --json` returned the full result set, exit 0 |
| `package -S Files --count` computed its count via `FormatResult` | correct count, but exit 1 |
| `timeline --count` wrote the count directly | correct count, but exit 1 |

Plus every bespoke `--count` emitter that bypassed `CountOutput` (17 tests'
worth), now converged onto a shared `CountOutput.WriteCount` — which also fixed
an ambient-locale vs `InvariantCulture` inconsistency.

### Ways the guardrail itself could be evaded

Each was found by review, and each would have made the guardrail
partial — which is worse than no guardrail, because it invites trust:

| Escape | Effect |
| --- | --- |
| Only the first requested flag was tracked, and honoring was untyped | a second projection could still be dropped, and `--bare` could satisfy a recorded `--count` |
| `/h` as the *value* of another option (`--type /h`) | audit disabled for the whole invocation |
| Projections declared by an ancestor (`package --count search <id>`) | accepted by the parser, invisible to the audit |
| The bare-mode router invoked its rewritten parse directly | **every** bare-mode invocation unguarded; `Newtonsoft.Json --count --print -S Grounding -n 1` returned the wrong payload with exit 0 |

The router fix yields the property that makes the guardrail total rather than
best-effort: **`ParseResult.InvokeAsync` is no longer called anywhere outside the
choke point.** Because invocations now nest, `BeginRequest` returns a scope that
restores the request it displaced, so the guarantee does not rest on the router
happening to record nothing of its own.

## What still fires the audit

Three routes render an unprojected payload and now fail loudly. All three were
already broken — they returned the wrong payload with exit 0 — so this is
existing breakage made visible, not new breakage. Each has a follow-up issue and
will be fixed in an immediate stacked PR:

| Route | Issue |
| --- | --- |
| Whole-surface `type` listing — no projection dispatch at all | part of #3364 |
| `library --il-offsets` — batch path ignores all four projections | #3395 |
| `package --versions` / `--layout` / `--tfms` — lens modes ignore `-S` and every projection | #3396 |
| `-D`/`--discover` on every command that supports it — discovery listing skips projection dispatch | #3398 |

Separately, `package` exposes projections its `search` subcommand cannot honor
(#3393). The audit makes that reachable case loud too.

Three of these four share one shape — an early-branching render path that skips
the section pipeline, and therefore skips projection dispatch. That is a useful
result on its own: it says the follow-up is one dispatch seam rather than a dozen
scattered fixes.

## A note on the `depends` instance

GPT reported this in the first review; I could not reproduce it and had planned
to dismiss it. The dismissal was wrong, and the reason generalizes: I probed
with a type that has **no dependencies**, which returns early through a separate
branch that already handles `--count`. Only a type with at least one dependency
reaches the ordering defect.

My whole sweep had the same flaw — empty result sets short-circuit before the
defective dispatch. The re-sweep uses deliberately non-empty results, and the
regression test asserts the fixture's count is greater than zero so it cannot
decay back into the branch that hid the bug.

## Evidence

- Sweep of 10 command shapes x 5 projection flags x 7 format flags with
  **non-empty** result sets: no false positive. A further sweep of 14 `package`
  sections x 3 lens modes x 5 projections isolated #3396 as a single structural
  defect rather than a per-section one.
- 15 untouched paths byte-identical to base `164c6ae1`, compared against a
  **fixed base-built input assembly**. Comparing against the repo's own live
  assemblies gives a false diff: they change as tests are added and embed the
  commit SHA.
- CLI 2253 pass / 0 fail / 14 skipped; services 319 pass / 0 fail; lint clean.

## Review

Adversarially reviewed by Gemini 3.1 Pro and GPT-5.6 in isolated worktrees over
four fixed-head rounds. Both independently found the same soundness hole in the
first head, which is why it was treated as decisive, and both independently
found the `depends` instance. Every round produced a distinct real escape, and
the last three of the six bugs above came from review rather than from my own
sweeps. Reconciliation is in a PR comment.
