### PR TITLE
Record printed character ranges in the C# printer (#3328)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
@@ -247,3 +247,65 @@ public class MixedSourceRendererTests
         Assert.Equal(left.GetHashCode(), right.GetHashCode());
     }
 }
+
+/// <summary>
+/// A derived constructor whose implicit <c>base()</c> targets a user-defined
+/// base. The chain call prints nothing, so it owns no characters, but its two
+/// opcodes still run — before the first statement. See
+/// <see cref="MixedPreambleTests"/>.
+/// </summary>
+public class MixedPreambleBase
+{
+    protected MixedPreambleBase() => Created = true;
+
+    public bool Created { get; }
+}
+
+public sealed class MixedPreambleDerived : MixedPreambleBase
+{
+    public MixedPreambleDerived(string name) => Name = name;
+
+    public string Name { get; }
+}
+
+public class MixedPreambleTests
+{
+    static string Render(Type type)
+    {
+        var source = MetadataSource.Open(type.Assembly.Location);
+        var result = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+            source, type.FullName!, ".ctor", AnnotatedSource: true)).AnnotatedSource;
+        Assert.NotNull(result?.Output);
+        return result!.Output!;
+    }
+
+    [Fact]
+    public void ImplicitBaseCall_RendersAboveTheStatementItRunsBefore()
+    {
+        // The implicit base() prints no C#, so it has no range and no line, and
+        // the interleave reaches it only through its insertion point. Two things
+        // have to hold and both have been wrong before: the opcodes must appear
+        // at all (dropping the zero-width range once removed them entirely), and
+        // they must appear *above* the first statement rather than beneath it
+        // (bucketing them onto the next statement's line once claimed that
+        // statement executed them).
+        var lines = Render(typeof(MixedPreambleDerived)).Split('\n');
+
+        int baseCall = Array.FindIndex(lines, l => l.Contains($"{nameof(MixedPreambleBase)}::.ctor()"));
+        int firstStatement = Array.FindIndex(lines, l => l.Trim().StartsWith("this.Name = name;"));
+
+        Assert.True(baseCall >= 0, $"base call IL is missing from:\n{string.Join('\n', lines)}");
+        Assert.True(firstStatement >= 0, "the constructor body should print its field store");
+        Assert.True(
+            baseCall < firstStatement,
+            $"base call IL should precede the statement it runs before:\n{string.Join('\n', lines)}");
+        Assert.StartsWith("//", lines[baseCall].TrimStart());
+
+        // The invariant is "before the first statement", not "immediately after
+        // the opening brace". An insertion point is where the node's text would
+        // have gone, and the printer may hoist synthesized local declarations to
+        // the top of the block first, in which case the preamble lands below
+        // them. Those declarations emit no IL of their own, so nothing
+        // executable is ever shown as running before the base call.
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/PrintedRangeMapTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrintedRangeMapTests.cs
@@ -10,13 +10,24 @@ namespace ILInspector.Decompiler.Tests;
 public class PrintedRangeMapTests
 {
     static (string Output, PrintedRangeMap Ranges) Print(string methodName)
+        => Print(typeof(AllocSampleClass), methodName);
+
+    static (string Output, PrintedRangeMap Ranges) Print(Type declaringType, string methodName)
     {
-        var source = MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location);
-        var function = IrImporter.Import(source, typeof(AllocSampleClass).FullName!, methodName);
+        var source = MetadataSource.Open(declaringType.Assembly.Location);
+        var function = IrImporter.Import(source, declaringType.FullName!, methodName);
         Assert.NotNull(function);
         var result = CSharpPrinter.PrintRaised(function!, out var ranges);
         Assert.NotNull(result.Output);
         return (result.Output!, ranges);
+    }
+
+    static IrFunction Import(Type declaringType, string methodName)
+    {
+        var source = MetadataSource.Open(declaringType.Assembly.Location);
+        var function = IrImporter.Import(source, declaringType.FullName!, methodName);
+        Assert.NotNull(function);
+        return function!;
     }
 
     static (int Start, int End) Offsets(PrintedRange range, int length)
@@ -39,7 +50,37 @@ public class PrintedRangeMapTests
             var (start, end) = Offsets(range, output.Length);
             Assert.InRange(start, 0, output.Length);
             Assert.InRange(end, start, output.Length);
+            Assert.True(end > start, $"{range.Node.GetType().Name} recorded an empty range");
         }
+    }
+
+    [Fact]
+    public void SuppressedChainCall_IsNotRecorded_BecauseItPrintsNothing()
+    {
+        // An implicit parameterless base() has no rendered form, so unlike a
+        // chain call with arguments — lifted onto the signature and never walked
+        // — it stays in the body and emits nothing. Recording it would stamp a
+        // zero-width range that resolves to the line of the *next* statement. A
+        // sweep found 890 of these across 9,114 methods, so the shape is
+        // ordinary rather than exotic.
+        var function = Import(typeof(PrintedRangeChainFixture), ".ctor");
+        var chainCalls = function.Body.Descendants
+            .OfType<ExpressionStatement>()
+            .Where(statement => statement.Expression is Call { Callee.Name: ".ctor" })
+            .ToList();
+        Assert.NotEmpty(chainCalls);
+
+        var result = CSharpPrinter.PrintRaised(function, out var ranges);
+        Assert.NotNull(result.Output);
+
+        foreach (var chainCall in chainCalls)
+            Assert.False(ranges.TryGetRange(chainCall, out _));
+
+        // Not vacuous by way of an empty body: the store that follows the
+        // suppressed chain call is recorded, and its range is the printed text.
+        Assert.NotEmpty(ranges);
+        var store = Assert.Single(ranges, range => range.Node is StoreField);
+        Assert.Equal("this.Name = name;", result.Output![store.Characters].Trim());
     }
 
     [Theory]
@@ -138,4 +179,17 @@ public class PrintedRangeMapTests
                 return current;
         return null;
     }
+}
+
+/// <summary>
+/// A constructor whose chain call the printer walks but never prints: the
+/// implicit <c>object::.ctor()</c> has no rendered form, so the statement
+/// stays in the body and emits nothing. See
+/// <see cref="PrintedRangeMapTests.SuppressedChainCall_IsNotRecorded_BecauseItPrintsNothing"/>.
+/// </summary>
+public sealed class PrintedRangeChainFixture
+{
+    public PrintedRangeChainFixture(string name) => Name = name;
+
+    public string Name { get; }
 }

--- a/src/ILInspector.Decompiler.Tests/PrintedRangeMapTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrintedRangeMapTests.cs
@@ -1,0 +1,141 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// The printer is the only component that can say which characters belong to
+// which node, so these pin the recording itself: bounds, the line projection
+// that replaced the old per-statement rescan, and the nesting that a wrapper
+// around the emission body is what makes correct.
+[Trait("Area", "Printer")]
+public class PrintedRangeMapTests
+{
+    static (string Output, PrintedRangeMap Ranges) Print(string methodName)
+    {
+        var source = MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(AllocSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        var result = CSharpPrinter.PrintRaised(function!, out var ranges);
+        Assert.NotNull(result.Output);
+        return (result.Output!, ranges);
+    }
+
+    static (int Start, int End) Offsets(PrintedRange range, int length)
+        => (range.Characters.Start.GetOffset(length), range.Characters.End.GetOffset(length));
+
+    [Theory]
+    [InlineData(nameof(AllocSampleClass.SumList))]
+    [InlineData(nameof(AllocSampleClass.SumEnumerable))]
+    [InlineData(nameof(AllocSampleClass.MakeArray))]
+    public void EveryRange_LiesInsideTheOutputItIndexes(string methodName)
+    {
+        // Nothing clamps ranges to the returned string, because a sweep of 62,838
+        // ranges found none that overruns it. This is the invariant that lets
+        // consumers slice without checking, so it is pinned rather than assumed.
+        var (output, ranges) = Print(methodName);
+        Assert.NotEmpty(ranges);
+
+        foreach (var range in ranges)
+        {
+            var (start, end) = Offsets(range, output.Length);
+            Assert.InRange(start, 0, output.Length);
+            Assert.InRange(end, start, output.Length);
+        }
+    }
+
+    [Theory]
+    [InlineData(nameof(AllocSampleClass.SumList))]
+    [InlineData(nameof(AllocSampleClass.SumEnumerable))]
+    public void TryGetLine_AgreesWithCountingNewlinesIndependently(string methodName)
+    {
+        // The line is now a projection of the range rather than separately
+        // recorded, so it has to reproduce what the old scan computed.
+        var (output, ranges) = Print(methodName);
+
+        foreach (var range in ranges)
+        {
+            var (start, _) = Offsets(range, output.Length);
+            int expected = output[..start].Count(c => c == '\n');
+            Assert.True(ranges.TryGetLine(range.Node, out int line));
+            Assert.Equal(expected, line);
+        }
+    }
+
+    [Theory]
+    [InlineData(nameof(AllocSampleClass.SumList))]
+    [InlineData(nameof(AllocSampleClass.SumEnumerable))]
+    public void RangeText_StartsAtTheStatementOnItsOwnLine(string methodName)
+    {
+        // Catches an off-by-N start: the recorded slice, once its leading indent
+        // is dropped, must be what the line at that position actually reads.
+        var (output, ranges) = Print(methodName);
+        var lines = output.Replace("\r\n", "\n").Split('\n');
+
+        foreach (var range in ranges)
+        {
+            var (start, end) = Offsets(range, output.Length);
+            string slice = output[start..end].TrimStart();
+            if (slice.Length == 0)
+                continue;
+            Assert.True(ranges.TryGetLine(range.Node, out int line));
+            string firstSliceLine = slice.Replace("\r\n", "\n").Split('\n')[0];
+            Assert.Equal(lines[line].TrimStart(), firstSliceLine);
+        }
+    }
+
+    [Fact]
+    public void NestedStatement_IsContainedByItsPrintedAncestor()
+    {
+        // A foreach body sits inside the loop's own printed range. This is the
+        // property a wrapper around the emission body buys and an inline record
+        // at the top of that body cannot.
+        var (output, ranges) = Print(nameof(AllocSampleClass.SumList));
+
+        var contained = ranges
+            .Where(range => NearestRecordedAncestor(range.Node, ranges) is not null)
+            .ToList();
+        Assert.NotEmpty(contained);
+
+        foreach (var range in contained)
+        {
+            var ancestor = NearestRecordedAncestor(range.Node, ranges)!;
+            Assert.True(ranges.TryGetRange(ancestor, out var outer));
+            var (start, end) = Offsets(range, output.Length);
+            int outerStart = outer.Start.GetOffset(output.Length);
+            int outerEnd = outer.End.GetOffset(output.Length);
+            Assert.InRange(start, outerStart, outerEnd);
+            Assert.InRange(end, start, outerEnd);
+        }
+    }
+
+    [Fact]
+    public void EnumerationOrder_IsEmissionCompletion_SoAncestorsFollowDescendants()
+    {
+        // The documented contract. Ordering by start position is deliberately not
+        // promised, so this pins what is promised instead.
+        var (_, ranges) = Print(nameof(AllocSampleClass.SumList));
+
+        var position = new Dictionary<IrNode, int>();
+        for (int i = 0; i < ranges.Count; i++)
+            position[ranges[i].Node] = i;
+
+        foreach (var (node, _) in ranges)
+            if (NearestRecordedAncestor(node, ranges) is { } ancestor)
+                Assert.True(position[node] < position[ancestor]);
+    }
+
+    [Fact]
+    public void FailedPrint_YieldsAnEmptyMapRatherThanRangesIntoNothing()
+    {
+        Assert.Empty(PrintedRangeMap.Empty);
+        Assert.Equal("", PrintedRangeMap.Empty.Output);
+        Assert.False(PrintedRangeMap.Empty.TryGetLine(new Return(null), out _));
+    }
+
+    static IrNode? NearestRecordedAncestor(IrNode node, PrintedRangeMap ranges)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (ranges.TryGetRange(current, out _))
+                return current;
+        return null;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/PrintedRangeMapTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrintedRangeMapTests.cs
@@ -83,6 +83,47 @@ public class PrintedRangeMapTests
         Assert.Equal("this.Name = name;", result.Output![store.Characters].Trim());
     }
 
+    [Fact]
+    public void SuppressedChainCall_KeepsItsInsertionPoint_SoItsIlStillHasSomewhereToGo()
+    {
+        // Printing nothing makes "which characters did this node emit" undefined,
+        // but it leaves "where in emission order does it sit" perfectly defined.
+        // Those are separate questions and get separate members, because the
+        // node's own opcodes have no other owner: without the insertion point the
+        // mixed IL view has no line to render them against and drops them.
+        var function = Import(typeof(PrintedRangeChainFixture), ".ctor");
+        var chainCall = Assert.Single(
+            function.Body.Descendants.OfType<ExpressionStatement>(),
+            statement => statement.Expression is Call { Callee.Name: ".ctor" });
+
+        var result = CSharpPrinter.PrintRaised(function, out var ranges);
+        Assert.NotNull(result.Output);
+
+        Assert.False(ranges.TryGetRange(chainCall, out _));
+        Assert.False(ranges.TryGetLine(chainCall, out _));
+        Assert.True(ranges.TryGetInsertionLine(chainCall, out int line));
+
+        // The implicit base() runs before the first statement, so it inserts at
+        // the line that statement prints on — IL placed against it belongs above.
+        Assert.Equal(0, line);
+        var store = Assert.Single(ranges, range => range.Node is StoreField);
+        Assert.True(ranges.TryGetLine(store.Node, out int storeLine));
+        Assert.Equal(storeLine, line);
+    }
+
+    [Fact]
+    public void PrintedNode_HasNoInsertionPoint_BecauseItHasARange()
+    {
+        // The two channels are disjoint: asking for an insertion point on a node
+        // that printed text is a category error, and answering it would let a
+        // consumer take a position where it should have taken a range.
+        var (_, ranges) = Print(nameof(AllocSampleClass.SumList));
+
+        Assert.NotEmpty(ranges);
+        foreach (var range in ranges)
+            Assert.False(ranges.TryGetInsertionLine(range.Node, out _));
+    }
+
     [Theory]
     [InlineData(nameof(AllocSampleClass.SumList))]
     [InlineData(nameof(AllocSampleClass.SumEnumerable))]

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -103,11 +103,11 @@ public static class AnnotationAnchor
     /// </summary>
     public static bool TryGetPrintedLine(
         IrNode owner,
-        IReadOnlyDictionary<IrNode, int> statementLines,
+        PrintedRangeMap printedRanges,
         out int line)
     {
         for (var current = owner; current is not null; current = current.Parent)
-            if (statementLines.TryGetValue(current, out line))
+            if (printedRanges.TryGetLine(current, out line))
                 return true;
         line = 0;
         return false;

--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -482,9 +482,9 @@ public static class CSharpBodyDiff
         if (function is null)
             return new CSharpMethodRender(CSharpRenderState.Absent, [new SourceLine("/* no method body */", -1)], DecompilationFidelity.IlOnly);
 
-        var result = CSharpPrinter.PrintRaised(function, out var statementLines);
+        var result = CSharpPrinter.PrintRaised(function, out var printedRanges);
         return result.Succeeded
-            ? new CSharpMethodRender(CSharpRenderState.Rendered, BuildSourceLines(result.Output, statementLines), result.Fidelity)
+            ? new CSharpMethodRender(CSharpRenderState.Rendered, BuildSourceLines(result.Output, printedRanges), result.Fidelity)
             : new CSharpMethodRender(
                 CSharpRenderState.Failed,
                 [new SourceLine($"/* decompile failed: {string.Join("; ", result.Diagnostics.Select(diagnostic => diagnostic.Message))} */", -1)],
@@ -495,13 +495,13 @@ public static class CSharpBodyDiff
     // diff aligns over: text is the exact SplitLines rendering (untrimmed, so line
     // identity and LCS stay unchanged), and each line carries the smallest source
     // offset among the statements that start on it (-1 when the line owns none).
-    static IReadOnlyList<SourceLine> BuildSourceLines(string? output, IReadOnlyDictionary<IrNode, int> statementLines)
+    static IReadOnlyList<SourceLine> BuildSourceLines(string? output, PrintedRangeMap printedRanges)
     {
         var lineOffsets = new Dictionary<int, int>();
-        foreach (var (node, line) in statementLines)
+        foreach (var (node, _) in printedRanges)
         {
             int start = StatementStartOffset(node);
-            if (start < 0)
+            if (start < 0 || !printedRanges.TryGetLine(node, out int line))
                 continue;
             lineOffsets[line] = lineOffsets.TryGetValue(line, out int existing)
                 ? Math.Min(existing, start)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -178,16 +178,16 @@ public sealed partial class CSharpPrinter
             };
 
     /// <summary>
-    /// The product path with a statement line map: same output as
-    /// <see cref="PrintRaised(IrFunction)"/>, plus a table from each top-level
-    /// statement node to its 0-based start line. Line-anchored overlays (the
-    /// annotated C# view) splice onto those lines; the printer itself stays
-    /// annotation-agnostic. The map is empty on failure.
+    /// The product path with a printed-range map: same output as
+    /// <see cref="PrintRaised(IrFunction)"/>, plus a record of which characters
+    /// of that output each statement node emitted. Line- and range-anchored
+    /// overlays (the annotated C# view) splice onto those positions; the printer
+    /// itself stays annotation-agnostic. The map is empty on failure.
     /// </summary>
-    public static DecompilerResult PrintRaised(IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines)
-        => PrintRaised(function, out statementLines, importMethodBody: null);
+    public static DecompilerResult PrintRaised(IrFunction function, out PrintedRangeMap printedRanges)
+        => PrintRaised(function, out printedRanges, importMethodBody: null);
 
-    /// <inheritdoc cref="PrintRaised(IrFunction, out IReadOnlyDictionary{IrNode, int})"/>
+    /// <inheritdoc cref="PrintRaised(IrFunction, out PrintedRangeMap)"/>
     /// <remarks>
     /// <paramref name="options"/> applies the same taste as the plain
     /// <see cref="PrintRaised(IrFunction, Func{MethodRef, IrFunction}, PrinterOptions, Func{TypeRef, TypeRef, bool})"/>
@@ -200,11 +200,11 @@ public sealed partial class CSharpPrinter
     /// corresponding.
     /// </remarks>
     public static DecompilerResult PrintRaised(
-        IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines, Func<MethodRef, IrFunction?>? importMethodBody,
+        IrFunction function, out PrintedRangeMap printedRanges, Func<MethodRef, IrFunction?>? importMethodBody,
         Func<TypeRef, TypeRef, bool>? typesProvablyDisjoint = null,
         PrinterOptions? options = null)
     {
-        statementLines = new Dictionary<IrNode, int>();
+        printedRanges = PrintedRangeMap.Empty;
         List<DecompilerDecision> appliedLenses;
         try
         {
@@ -217,10 +217,10 @@ public sealed partial class CSharpPrinter
 
         try
         {
-            var sink = new Dictionary<IrNode, int>();
-            var printer = new CSharpPrinter(function, options) { _statementLines = sink };
+            var sink = new PrintedRangeMap();
+            var printer = new CSharpPrinter(function, options) { _printedRanges = sink };
             string output = printer.PrintBody(function);
-            statementLines = sink;
+            printedRanges = sink.Complete(output);
             return WithAppliedLenses(printer.Result(output, function), appliedLenses);
         }
         catch (Exception ex)
@@ -257,12 +257,12 @@ public sealed partial class CSharpPrinter
     /// As <see cref="PrintLowered(IrFunction)"/>, but also yields the
     /// statement-to-output-line table the mixed-source view uses to anchor fact
     /// comments and interleaved IL onto the lowered C# (the lowered analogue of
-    /// <see cref="PrintRaised(IrFunction, out IReadOnlyDictionary{IrNode, int})"/>).
+    /// <see cref="PrintRaised(IrFunction, out PrintedRangeMap)"/>).
     /// </summary>
-    public static DecompilerResult PrintLowered(IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines)
-        => PrintLowered(function, out statementLines, importMethodBody: null);
+    public static DecompilerResult PrintLowered(IrFunction function, out PrintedRangeMap printedRanges)
+        => PrintLowered(function, out printedRanges, importMethodBody: null);
 
-    /// <inheritdoc cref="PrintLowered(IrFunction, out IReadOnlyDictionary{IrNode, int})"/>
+    /// <inheritdoc cref="PrintLowered(IrFunction, out PrintedRangeMap)"/>
     /// <remarks>
     /// <paramref name="options"/> applies the printer's byte-preserving spelling
     /// and layout knobs so the lowered annotated view spells a member the same way
@@ -271,10 +271,10 @@ public sealed partial class CSharpPrinter
     /// show the shape below that sugar.
     /// </remarks>
     public static DecompilerResult PrintLowered(
-        IrFunction function, out IReadOnlyDictionary<IrNode, int> statementLines, Func<MethodRef, IrFunction?>? importMethodBody,
+        IrFunction function, out PrintedRangeMap printedRanges, Func<MethodRef, IrFunction?>? importMethodBody,
         PrinterOptions? options = null)
     {
-        statementLines = new Dictionary<IrNode, int>();
+        printedRanges = PrintedRangeMap.Empty;
         try
         {
             IrPasses.Run(function, IrPasses.Lowered, RaiseContext(importMethodBody));
@@ -286,10 +286,10 @@ public sealed partial class CSharpPrinter
 
         try
         {
-            var sink = new Dictionary<IrNode, int>();
-            var printer = new CSharpPrinter(function, options) { _statementLines = sink };
+            var sink = new PrintedRangeMap();
+            var printer = new CSharpPrinter(function, options) { _printedRanges = sink };
             string output = printer.PrintBody(function);
-            statementLines = sink;
+            printedRanges = sink.Complete(output);
             return printer.Result(output, function);
         }
         catch (Exception ex)
@@ -505,8 +505,8 @@ public sealed partial class CSharpPrinter
     /// <summary>Ref-struct locals whose hoisted declaration must spell <c>scoped</c>: a <c>stackalloc</c>-initialized span whose declaration was split from its assignment (out of the unsafe block) would otherwise warn CS9081. A stackalloc result is always scoped, so this is faithful, not a guess.</summary>
     readonly HashSet<int> _scopedLocals = [];
 
-    /// <summary>Optional sink mapping each printed top-level statement node to its 0-based start line in the output; null on the shipped print path. Drives line-anchored overlays (annotated views) without the printer knowing what they are.</summary>
-    Dictionary<IrNode, int>? _statementLines;
+    /// <summary>Optional sink recording which characters of the output each printed statement node emitted; null on the shipped print path. Drives line-anchored and range-anchored overlays (annotated views) without the printer knowing what they are.</summary>
+    PrintedRangeMap? _printedRanges;
 
     readonly record struct StackSlotRenderKey(int Slot, string TypeKey);
 
@@ -1692,18 +1692,29 @@ public sealed partial class CSharpPrinter
             sb.Append(pad).AppendLine(line);
     }
 
-    /// <summary>Recursive statement emission with indentation — structured nodes (IfStatement) nest, flat statements render through <see cref="Statement"/>.</summary>
+    /// <summary>
+    /// Records the characters <paramref name="node"/> emits, then emits them.
+    /// The range is taken from the builder's length either side of the call, so
+    /// it costs nothing to capture and is exact by construction; recovering it
+    /// afterwards would mean guessing. Wrapping rather than recording inline is
+    /// what makes the end offset correct across every exit of the emission body.
+    /// </summary>
     void AppendStatement(StringBuilder sb, IrNode node, int indent)
     {
-        _statementIndent = indent;
-        if (_statementLines is not null)
+        if (_printedRanges is null)
         {
-            int startLine = 0;
-            for (int c = 0; c < sb.Length; c++)
-                if (sb[c] == '\n')
-                    startLine++;
-            _statementLines.TryAdd(node, startLine);
+            AppendStatementCore(sb, node, indent);
+            return;
         }
+        int start = sb.Length;
+        AppendStatementCore(sb, node, indent);
+        _printedRanges.Record(node, start, sb.Length);
+    }
+
+    /// <summary>Recursive statement emission with indentation — structured nodes (IfStatement) nest, flat statements render through <see cref="Statement"/>.</summary>
+    void AppendStatementCore(StringBuilder sb, IrNode node, int indent)
+    {
+        _statementIndent = indent;
         string pad = new(' ', indent * 4);
         if (node is LocalFunctionStatement localFunction)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrintedRangeMap.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrintedRangeMap.cs
@@ -32,21 +32,29 @@ public readonly record struct PrintedRange(IrNode Node, Range Characters);
 /// </para>
 /// <para>
 /// Every recorded range is <em>non-empty</em>: a node the printer visits but
-/// which emits nothing has no entry, because there is no printed text to point
+/// which emits nothing has no range, because there is no printed text to point
 /// at. The implicit parameterless <c>base()</c> chain call is the case that
 /// makes this real — <c>ConstructorChainText</c> gives it no rendered form, so
 /// unlike a chain call with arguments (which is lifted out of the body onto the
 /// signature and never walked) it stays in the body and prints nothing.
-/// Recording it would stamp a zero-width range at whatever position emission
-/// had reached, which reads as "this node printed here" while resolving to the
-/// line of the <em>next</em> statement. Measured over 63,722 ranges from 9,114
-/// printed methods, 890 such degenerate entries arose, every one of them an
-/// implicit chain call. Dropping them is what lets a caller slice or place a
-/// caret on any range in this map without a width guard. The visible
-/// consequence is that IL owned only by such a node — the implicit base call's
-/// own opcodes — no longer buckets onto a C# line in the mixed IL view. That is
-/// the honest outcome: it joins the IL that already has no C# line to sit
-/// beside, rather than being attributed to the statement printed after it.
+/// Recording a range for it would stamp a zero-width range at whatever position
+/// emission had reached, which reads as "this node printed here" while
+/// resolving to the line of the <em>next</em> statement. Measured over 63,722
+/// ranges from 9,114 printed methods, 890 such degenerate entries arose, every
+/// one of them an implicit chain call. Dropping them is what lets a caller
+/// slice or place a caret on any range in this map without a width guard.
+/// </para>
+/// <para>
+/// What such a node does still have is a <em>position</em> — where its text
+/// would have gone — and that is kept separately, as an insertion point. The
+/// two are different questions and are answered by different members on
+/// purpose: <see cref="TryGetRange"/> and <see cref="TryGetLine"/> are about
+/// printed characters and stay silent here, while
+/// <see cref="TryGetInsertionLine"/> is about emission order. Only a consumer
+/// that genuinely needs the second should reach for it. The mixed IL view is
+/// the one that does: the implicit base call's own opcodes have no other owner,
+/// and an insertion point is enough to render them above the statement that
+/// follows them, which is where they run.
 /// </para>
 /// <para>
 /// A <see cref="Range"/> is only meaningful against the exact string it was
@@ -64,6 +72,7 @@ public sealed class PrintedRangeMap : IReadOnlyList<PrintedRange>
 
     readonly List<PrintedRange> _ranges = [];
     readonly Dictionary<IrNode, int> _index = [];
+    readonly Dictionary<IrNode, int> _insertionPoints = [];
     int[]? _lineStarts;
 
     /// <summary>The printed text every <see cref="PrintedRange"/> here indexes.</summary>
@@ -110,14 +119,48 @@ public sealed class PrintedRangeMap : IReadOnlyList<PrintedRange>
     }
 
     /// <summary>
+    /// Where <paramref name="node"/> would have printed had it emitted anything:
+    /// the 0-based output line that the text following it begins on. Defined only
+    /// for a node the printer walked and which emitted nothing; a node with a
+    /// range is not here, and vice versa.
+    /// </summary>
+    /// <remarks>
+    /// This answers "where does this node sit in emission order", which is a
+    /// different question from "which characters did this node print", and it is
+    /// separate precisely because a consumer that wants the second must not be
+    /// silently handed the first. A caret or a slice needs printed text and gets
+    /// nothing here; the mixed IL view needs somewhere to put opcodes whose only
+    /// owner printed nothing, and a position is exactly enough for that. The
+    /// line returned is the one the node's text would have started, so IL placed
+    /// against it belongs <em>above</em> that line — the implicit <c>base()</c>
+    /// runs before the first statement, not after it.
+    /// </remarks>
+    public bool TryGetInsertionLine(IrNode node, out int line)
+    {
+        if (!_insertionPoints.TryGetValue(node, out int position))
+        {
+            line = 0;
+            return false;
+        }
+        line = LineAt(position);
+        return true;
+    }
+
+    /// <summary>
     /// Records what <paramref name="node"/> emitted, between the output lengths
     /// captured either side of its emission. A node that emitted nothing
-    /// (<paramref name="end"/> equal to <paramref name="start"/>) is not
-    /// recorded: it printed no text, so it owns no range and no line.
+    /// (<paramref name="end"/> equal to <paramref name="start"/>) gets no range —
+    /// it printed no text, so it owns no characters and no line — but keeps its
+    /// position as an insertion point, which is the part that stays knowable.
     /// </summary>
     internal void Record(IrNode node, int start, int end)
     {
-        if (end <= start || _index.ContainsKey(node))
+        if (end <= start)
+        {
+            _insertionPoints.TryAdd(node, start);
+            return;
+        }
+        if (_index.ContainsKey(node))
             return;
         _index[node] = _ranges.Count;
         _ranges.Add(new PrintedRange(node, start..end));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrintedRangeMap.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrintedRangeMap.cs
@@ -6,6 +6,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// One node's contribution to the printer's output: the characters it emitted.
 /// <see cref="Characters"/> indexes <see cref="PrintedRangeMap.Output"/>, so
 /// <c>map.Output[range.Characters]</c> is the exact printed text of the node.
+/// Always a non-empty slice — see <see cref="PrintedRangeMap"/>.
 /// </summary>
 public readonly record struct PrintedRange(IrNode Node, Range Characters);
 
@@ -28,6 +29,24 @@ public readonly record struct PrintedRange(IrNode Node, Range Characters);
 /// is deliberately <em>not</em> part of this contract: promising it would force
 /// a sort that no current consumer needs. Anything requiring sorted or
 /// containment-ordered access should say so explicitly at its own call site.
+/// </para>
+/// <para>
+/// Every recorded range is <em>non-empty</em>: a node the printer visits but
+/// which emits nothing has no entry, because there is no printed text to point
+/// at. The implicit parameterless <c>base()</c> chain call is the case that
+/// makes this real — <c>ConstructorChainText</c> gives it no rendered form, so
+/// unlike a chain call with arguments (which is lifted out of the body onto the
+/// signature and never walked) it stays in the body and prints nothing.
+/// Recording it would stamp a zero-width range at whatever position emission
+/// had reached, which reads as "this node printed here" while resolving to the
+/// line of the <em>next</em> statement. Measured over 63,722 ranges from 9,114
+/// printed methods, 890 such degenerate entries arose, every one of them an
+/// implicit chain call. Dropping them is what lets a caller slice or place a
+/// caret on any range in this map without a width guard. The visible
+/// consequence is that IL owned only by such a node — the implicit base call's
+/// own opcodes — no longer buckets onto a C# line in the mixed IL view. That is
+/// the honest outcome: it joins the IL that already has no C# line to sit
+/// beside, rather than being attributed to the statement printed after it.
 /// </para>
 /// <para>
 /// A <see cref="Range"/> is only meaningful against the exact string it was
@@ -90,9 +109,15 @@ public sealed class PrintedRangeMap : IReadOnlyList<PrintedRange>
         return true;
     }
 
+    /// <summary>
+    /// Records what <paramref name="node"/> emitted, between the output lengths
+    /// captured either side of its emission. A node that emitted nothing
+    /// (<paramref name="end"/> equal to <paramref name="start"/>) is not
+    /// recorded: it printed no text, so it owns no range and no line.
+    /// </summary>
     internal void Record(IrNode node, int start, int end)
     {
-        if (_index.ContainsKey(node))
+        if (end <= start || _index.ContainsKey(node))
             return;
         _index[node] = _ranges.Count;
         _ranges.Add(new PrintedRange(node, start..end));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrintedRangeMap.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrintedRangeMap.cs
@@ -1,0 +1,136 @@
+using System.Collections;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// One node's contribution to the printer's output: the characters it emitted.
+/// <see cref="Characters"/> indexes <see cref="PrintedRangeMap.Output"/>, so
+/// <c>map.Output[range.Characters]</c> is the exact printed text of the node.
+/// </summary>
+public readonly record struct PrintedRange(IrNode Node, Range Characters);
+
+/// <summary>
+/// Which characters of the printer's own output each IR node emitted, recorded
+/// during emission. Nothing can re-derive this once the string exists — the
+/// printer is the only component that knows which characters belong to which
+/// node — so it is captured as the text is built rather than recovered after.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both access patterns this serves are real, so it is a lookup that also
+/// enumerates, in the tradition of <see cref="IReadOnlyDictionary{K, V}"/> and
+/// <c>ILookup</c>: annotation anchoring walks the parent chain doing keyed
+/// lookups, while the correlation seams enumerate to build line tables.
+/// </para>
+/// <para>
+/// Enumeration order is <em>emission-completion</em> order — a node completes
+/// after its children, so nesting reads post-order. Ordering by start position
+/// is deliberately <em>not</em> part of this contract: promising it would force
+/// a sort that no current consumer needs. Anything requiring sorted or
+/// containment-ordered access should say so explicitly at its own call site.
+/// </para>
+/// <para>
+/// A <see cref="Range"/> is only meaningful against the exact string it was
+/// measured from, which is why <see cref="Complete"/> binds
+/// <see cref="Output"/> and the two travel together. Any transform applied to
+/// the text after printing invalidates every range that follows the edit, so
+/// display concerns such as escaping must happen during emission, never as a
+/// post-pass over the finished string.
+/// </para>
+/// </remarks>
+public sealed class PrintedRangeMap : IReadOnlyList<PrintedRange>
+{
+    /// <summary>The map a failed print yields: no ranges, no text.</summary>
+    public static PrintedRangeMap Empty { get; } = new();
+
+    readonly List<PrintedRange> _ranges = [];
+    readonly Dictionary<IrNode, int> _index = [];
+    int[]? _lineStarts;
+
+    /// <summary>The printed text every <see cref="PrintedRange"/> here indexes.</summary>
+    public string Output { get; private set; } = "";
+
+    public int Count => _ranges.Count;
+
+    public PrintedRange this[int index] => _ranges[index];
+
+    /// <summary>Struct enumerator, so <c>foreach</c> over this map allocates nothing.</summary>
+    public List<PrintedRange>.Enumerator GetEnumerator() => _ranges.GetEnumerator();
+
+    IEnumerator<PrintedRange> IEnumerable<PrintedRange>.GetEnumerator() => _ranges.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _ranges.GetEnumerator();
+
+    /// <summary>The characters <paramref name="node"/> emitted, if it was recorded.</summary>
+    public bool TryGetRange(IrNode node, out Range range)
+    {
+        if (_index.TryGetValue(node, out int slot))
+        {
+            range = _ranges[slot].Characters;
+            return true;
+        }
+        range = default;
+        return false;
+    }
+
+    /// <summary>
+    /// The 0-based output line <paramref name="node"/> starts on — a projection
+    /// of its recorded range, not separately stored. The line index table is
+    /// built once on first use and reused, so this is a binary search per query
+    /// rather than a scan of the whole text per node.
+    /// </summary>
+    public bool TryGetLine(IrNode node, out int line)
+    {
+        if (!TryGetRange(node, out var range))
+        {
+            line = 0;
+            return false;
+        }
+        line = LineAt(range.Start.GetOffset(Output.Length));
+        return true;
+    }
+
+    internal void Record(IrNode node, int start, int end)
+    {
+        if (_index.ContainsKey(node))
+            return;
+        _index[node] = _ranges.Count;
+        _ranges.Add(new PrintedRange(node, start..end));
+    }
+
+    /// <summary>
+    /// Binds the text the ranges were measured against, so a range and the
+    /// string it indexes always travel together.
+    /// </summary>
+    /// <remarks>
+    /// <c>PrintBody</c> trims trailing whitespace before returning, which shifts
+    /// nothing earlier in the text. Measured over 62,838 ranges across 8,618
+    /// printed methods, no recorded range ends past the returned string and no
+    /// empty-output method had recorded ranges at all, so nothing is clamped or
+    /// dropped here. If that ever stops holding, a consumer slicing the output
+    /// throws rather than reading a quietly wrong span, which is the failure
+    /// worth having.
+    /// </remarks>
+    internal PrintedRangeMap Complete(string output)
+    {
+        Output = output;
+        _lineStarts = null;
+        return this;
+    }
+
+    int LineAt(int position)
+    {
+        var starts = _lineStarts ??= BuildLineStarts(Output);
+        int found = Array.BinarySearch(starts, position);
+        return found >= 0 ? found : ~found - 1;
+    }
+
+    static int[] BuildLineStarts(string output)
+    {
+        var starts = new List<int> { 0 };
+        for (int i = 0; i < output.Length; i++)
+            if (output[i] == '\n')
+                starts.Add(i + 1);
+        return [.. starts];
+    }
+}

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -323,14 +323,26 @@ public static partial class ResearchViews
 
         var factsByOffset = FactsByOffset(annotations);
         var ilByLine = new Dictionary<int, List<(int Offset, string Text)>>();
+        var ilBeforeLine = new Dictionary<int, List<(int Offset, string Text)>>();
         foreach (var instr in annotatedInstrLines)
         {
             if (AnnotationAnchor.Best(spans, instr.Offset) is not { } owner)
                 continue;
-            if (!AnnotationAnchor.TryGetPrintedLine(owner, printedRanges, out int line))
+            // An owner that printed nothing still has a place in emission order,
+            // and its opcodes have nowhere else to go. Taking the insertion point
+            // here and not in TryGetPrintedLine is the point: an annotation whose
+            // owner is silent must stay unplaced rather than claim a line it did
+            // not print, but IL only has to be rendered in the right order.
+            Dictionary<int, List<(int Offset, string Text)>> bucket;
+            int line;
+            if (AnnotationAnchor.TryGetPrintedLine(owner, printedRanges, out line))
+                bucket = ilByLine;
+            else if (printedRanges.TryGetInsertionLine(owner, out line))
+                bucket = ilBeforeLine;
+            else
                 continue;
-            if (!ilByLine.TryGetValue(line, out var list))
-                ilByLine[line] = list = [];
+            if (!bucket.TryGetValue(line, out var list))
+                bucket[line] = list = [];
             list.Add((instr.Offset, AddFactsToAnnotatedLine(instr.Text, factsByOffset.GetValueOrDefault(instr.Offset))));
         }
 
@@ -338,6 +350,10 @@ public static partial class ResearchViews
         var stream = new List<AnnotatedSourceLine>(csLines.Count);
         for (int i = 0; i < csLines.Count; i++)
         {
+            if (ilBeforeLine.TryGetValue(i, out var preamble))
+                foreach (var (offset, text) in preamble)
+                    stream.Add(new AnnotatedSourceLine(text, offset, SourceLineKind.Il));
+
             var csLine = csLines[i];
             var lineAnnotations = annotationsByLine.TryGetValue(i, out var annos)
                 ? (IReadOnlyList<IAnnotation>)annos

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -261,8 +261,8 @@ public static partial class ResearchViews
 
         IrFunction? ImportMethodBody(MethodRef target) => IrImporter.Import(source, target);
         var csResult = stage == AnnotationStage.Lowered
-            ? CSharpPrinter.PrintLowered(imported, out var statementLines, importMethodBody: ImportMethodBody, options: printerOptions)
-            : CSharpPrinter.PrintRaised(imported, out statementLines, importMethodBody: ImportMethodBody, typesProvablyDisjoint: source.AreProvablyDisjoint, options: printerOptions);
+            ? CSharpPrinter.PrintLowered(imported, out var printedRanges, importMethodBody: ImportMethodBody, options: printerOptions)
+            : CSharpPrinter.PrintRaised(imported, out printedRanges, importMethodBody: ImportMethodBody, typesProvablyDisjoint: source.AreProvablyDisjoint, options: printerOptions);
         if (csResult.Output is not { } csText)
             return csResult;
 
@@ -289,7 +289,7 @@ public static partial class ResearchViews
                 ? IlProjection.RenderIlBodyLines(source, type, method, overloadIndex, publicOnly)
                 : IlProjection.RenderIlBodyLines(source, methodToken.Value);
 
-        var stream = CorrelateMixedSource(imported, csText, statementLines, annotations, annotatedInstrLines);
+        var stream = CorrelateMixedSource(imported, csText, printedRanges, annotations, annotatedInstrLines);
         return csResult with { Output = RenderMixedStream(stream, gestures ?? AnnotationGestureSelector.SideOnly) };
     }
 
@@ -303,7 +303,7 @@ public static partial class ResearchViews
     static IReadOnlyList<AnnotatedSourceLine> CorrelateMixedSource(
         IrFunction imported,
         string csText,
-        IReadOnlyDictionary<IrNode, int> statementLines,
+        PrintedRangeMap printedRanges,
         IReadOnlyList<IAnnotation> annotations,
         IReadOnlyList<SourceLine> annotatedInstrLines)
     {
@@ -314,7 +314,7 @@ public static partial class ResearchViews
         {
             if (AnnotationAnchor.Best(spans, annotation.SourceOffset) is not { } owner)
                 continue;
-            if (!AnnotationAnchor.TryGetPrintedLine(owner, statementLines, out int line))
+            if (!AnnotationAnchor.TryGetPrintedLine(owner, printedRanges, out int line))
                 continue;
             if (!annotationsByLine.TryGetValue(line, out var list))
                 annotationsByLine[line] = list = [];
@@ -327,14 +327,14 @@ public static partial class ResearchViews
         {
             if (AnnotationAnchor.Best(spans, instr.Offset) is not { } owner)
                 continue;
-            if (!AnnotationAnchor.TryGetPrintedLine(owner, statementLines, out int line))
+            if (!AnnotationAnchor.TryGetPrintedLine(owner, printedRanges, out int line))
                 continue;
             if (!ilByLine.TryGetValue(line, out var list))
                 ilByLine[line] = list = [];
             list.Add((instr.Offset, AddFactsToAnnotatedLine(instr.Text, factsByOffset.GetValueOrDefault(instr.Offset))));
         }
 
-        var csLines = RenderCSharpBodyLines(csText, statementLines);
+        var csLines = RenderCSharpBodyLines(csText, printedRanges);
         var stream = new List<AnnotatedSourceLine>(csLines.Count);
         for (int i = 0; i < csLines.Count; i++)
         {
@@ -363,12 +363,12 @@ public static partial class ResearchViews
     // it directly for line-addressable diff and body-subset anchoring.
     static IReadOnlyList<SourceLine> RenderCSharpBodyLines(
         string csText,
-        IReadOnlyDictionary<IrNode, int> statementLines)
+        PrintedRangeMap printedRanges)
     {
         var lineOffsets = new Dictionary<int, int>();
-        foreach (var (node, line) in statementLines)
+        foreach (var (node, _) in printedRanges)
         {
-            if (node.SourceOffset < 0)
+            if (node.SourceOffset < 0 || !printedRanges.TryGetLine(node, out int line))
                 continue;
             lineOffsets[line] = lineOffsets.TryGetValue(line, out int existing)
                 ? Math.Min(existing, node.SourceOffset)
@@ -414,12 +414,12 @@ public static partial class ResearchViews
 
     static DecompilerResult RenderRaisedOverlay(IrFunction imported, IReadOnlyList<IAnnotation> annotations, MetadataSource source, AnnotationGestureSelector? gestures = null)
     {
-        var result = CSharpPrinter.PrintRaised(imported, out var statementLines, importMethodBody: null, typesProvablyDisjoint: source.AreProvablyDisjoint);
+        var result = CSharpPrinter.PrintRaised(imported, out var printedRanges, importMethodBody: null, typesProvablyDisjoint: source.AreProvablyDisjoint);
         if (result.Output is not { } output)
             return result;
         var projected = annotations.Count == 0
             ? output
-            : AddTrailingComments(imported, output, statementLines, annotations, gestures ?? AnnotationGestureSelector.SideOnly);
+            : AddTrailingComments(imported, output, printedRanges, annotations, gestures ?? AnnotationGestureSelector.SideOnly);
         return result with { Output = projected };
     }
 
@@ -463,11 +463,11 @@ public static partial class ResearchViews
     static string AddTrailingComments(
         IrFunction raised,
         string output,
-        IReadOnlyDictionary<IrNode, int> statementLines,
+        PrintedRangeMap printedRanges,
         IReadOnlyList<IAnnotation> annotations,
         AnnotationGestureSelector gestures)
     {
-        var stream = CorrelateOverlay(raised, output, statementLines, annotations);
+        var stream = CorrelateOverlay(raised, output, printedRanges, annotations);
         return RenderOverlayStream(output, stream, gestures);
     }
 
@@ -480,18 +480,18 @@ public static partial class ResearchViews
     static IReadOnlyList<AnnotatedSourceLine> CorrelateOverlay(
         IrFunction raised,
         string output,
-        IReadOnlyDictionary<IrNode, int> statementLines,
+        PrintedRangeMap printedRanges,
         IReadOnlyList<IAnnotation> annotations)
     {
         var annotationsByLine = new Dictionary<int, IReadOnlyList<IAnnotation>>();
         foreach (var (statement, facts) in AnnotationAnchor.Anchor(raised, annotations))
-            if (AnnotationAnchor.TryGetPrintedLine(statement, statementLines, out int line))
+            if (AnnotationAnchor.TryGetPrintedLine(statement, printedRanges, out int line))
                 annotationsByLine[line] = facts;
 
         var lineOffsets = new Dictionary<int, int>();
-        foreach (var (node, line) in statementLines)
+        foreach (var (node, _) in printedRanges)
         {
-            if (node.SourceOffset < 0)
+            if (node.SourceOffset < 0 || !printedRanges.TryGetLine(node, out int line))
                 continue;
             lineOffsets[line] = lineOffsets.TryGetValue(line, out int existing)
                 ? Math.Min(existing, node.SourceOffset)
@@ -566,7 +566,7 @@ public static partial class ResearchViews
 
     static Dictionary<IAnnotation, int> CSharpLinesByFact(IrFunction imported, IReadOnlyList<IAnnotation> facts, MetadataSource source)
     {
-        var result = CSharpPrinter.PrintRaised(imported, out var statementLines, importMethodBody: null, typesProvablyDisjoint: source.AreProvablyDisjoint);
+        var result = CSharpPrinter.PrintRaised(imported, out var printedRanges, importMethodBody: null, typesProvablyDisjoint: source.AreProvablyDisjoint);
         if (result.Output is null || facts.Count == 0)
             return [];
         var spans = AnnotationAnchor.ComputeSpans(imported);
@@ -574,7 +574,7 @@ public static partial class ResearchViews
         foreach (var fact in facts)
         {
             if (AnnotationAnchor.Best(spans, fact.SourceOffset) is { } owner
-                && AnnotationAnchor.TryGetPrintedLine(owner, statementLines, out int line))
+                && AnnotationAnchor.TryGetPrintedLine(owner, printedRanges, out int line))
             {
                 lines[fact] = line;
             }


### PR DESCRIPTION
Phase 1 of #3328, plus the two corrections that fell out of verifying it.

Annotations can currently only underline a *whole statement*, because nothing in
the pipeline records which characters of a printed line a fact refers to. The
progression below is the point of the work; all three views are of the same
method, `CommandCaretGestureFixture.Pump`.

### Where it started: facts as trailing comments

Every fact rides on the end of the line it belongs to. Nothing is claimed about
*where* in the statement the fact lives, so nothing is wrong — but a long fact
pushes the code off screen, and two facts on one line have to share.

```csharp
    List<object> sink = new();  // alloc.new(List<object>; alloc=System.Collections.Generic.List<System.Object>; path=straight-line; path-confidence=dominates-return; multiplicity=once; churned=System.Object[])
        // IL_0000: newobj       List<object>::.ctor()
        // IL_0005: stloc.0
    ...
        sink.Add(new object());  // alloc.new(object; alloc=System.Object; path=loop-body; path-confidence=behind-branch; multiplicity=loop)
            // IL_000A: ldloc.0
            // IL_000B: newobj       object::.ctor()
            // IL_0010: callvirt     List<object>::Add(object)
```

### Today: the caret exists, but points at the whole statement

`--focus allocation` promotes the fact to a caret gesture. The fact now has room
to wrap and read properly. But the caret spans the entire statement, which
asserts something false — and does so directly above the IL that shows the
truth:

```csharp
    List<object> sink = new();
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ alloc.new(List<object>;
//                             alloc=System.Collections.Generic.List<System.Object>;
//                             path=straight-line; path-confidence=dominates-return;
//                             multiplicity=once; churned=System.Object[])
        // IL_0000: newobj       List<object>::.ctor()
        // IL_0005: stloc.0
    ...
        sink.Add(new object());
//      ^^^^^^^^^^^^^^^^^^^^^^^ alloc.new(object; alloc=System.Object; path=loop-body;
//                              path-confidence=behind-branch; multiplicity=loop)
            // IL_000A: ldloc.0
            // IL_000B: newobj       object::.ctor()
            // IL_0010: callvirt     List<object>::Add(object)
```

The `List<object> sink =` part does not allocate; `new()` does. `sink.Add` does not
allocate; `new object()` does. In both cases the caret underlines the local, the
receiver and the method call and claims they allocate, and the reader can see
`newobj` sitting on its own line immediately below.

Both blocks above are real output. Abridged in two ways: the loop header and
its IL are elided (`...`), and the trailing `// alloc...` / `stack:` annotations
that each IL line also carries are trimmed. The C# lines, carets and fact text
are verbatim.

### The target — **not in this PR**

```csharp
    List<object> sink = new();
//                      ^^^^^ alloc.new(List<object>; ...)
        // IL_0000: newobj       List<object>::.ctor()
    ...
        sink.Add(new object());
//               ^^^^^^^^^^^^ alloc.new(object; ...)
            // IL_000B: newobj       object::.ctor()
```

This block is a mockup, not captured output. Reaching it needs three more
phases: carry the range to `AnnotatedSourceLine` (the caret renderer currently
receives no map, no offset and no column, so a range cannot reach it at all),
record expression nodes and not just statements, then select the narrowest node
covering the fact's IL offset and fall back to the whole statement rather than
guess.

### Why the printer has to be the one to do it

The precision was never missing. `AllocationOccurrence` carries an exact
`ILOffset`, and `AnnotationAnchor.Best` already resolves that offset to the
owning IR node. What is missing is the last hop: which *characters* of the
printed line that node produced. Only the printer knows, and once the string
exists the information is unrecoverable — the repo's own harness
(`tools/DecompilerHarness/SpanAttribution.cs`) re-parses decompiled C# with
Roslyn to recover even a coarse body span.

This PR captures it at the one place it is free: the builder's length either
side of a node's emission. It does **not** narrow any caret.

## What is here

**`PrintedRangeMap`** replaces the statement-line dictionary. A lookup that also
enumerates, because both patterns are real: annotation anchoring walks the parent
chain doing keyed lookups, the correlation seams enumerate to build line tables.
Lines became a projection of the range rather than a separate recording, which
removes a per-statement rescan of the whole builder — not measurable today,
but it
is what would have gone quadratic once expression nodes are recorded.

Ranges are captured by wrapping the emission body rather than recording inside it,
which is what makes the end offset correct across every exit of a 340-line method.

**Two invariants, arrived at by breaking things:**

*Every range is non-empty.* A node the printer walks but which emits nothing was
being recorded with a zero-width range at whatever position emission had
reached —
reading as "this node printed here" while resolving to the line of the *next*
statement. 890 of these across 9,114 methods, every one an implicit parameterless
`base()`. Dropping them lets a consumer slice or place a caret without a width
guard.

*A silent node keeps its position.* Dropping the range took something else
with it:
"where does this node sit in emission order" is perfectly well defined at
offset 0,
and the mixed IL view was the consumer relying on it. Its opcodes lost their only
bucket and vanished from the interleave. So the two questions are now separate
members — `TryGetRange`/`TryGetLine` for printed characters, `TryGetInsertionLine`
for emission order — and the channels are disjoint, asserted by a test. A caret
still cannot reach a node that printed nothing.

Only the IL path takes the insertion-point fallback. An annotation whose owner is
silent stays unplaced rather than claiming a line it did not print: a fact asserts
something about the line it sits on, an opcode only has to render in the right
order.

## This ends up ahead of where it started

Placing against an insertion point renders preamble IL *above* the line — for a
constructor, above the first statement of the body, which is when it runs.
`main` rendered it *below* that statement, simultaneously claiming the statement
executed the base call and showing it executing afterward:

```csharp
public Constant(object? value, TypeRef type)
{
        // IL_0000: ldarg.0
        // IL_0001: call         IrExpression::.ctor()
    this.Value = value;
        // IL_0006: ldarg.0
        // IL_0008: stfld        object Constant::<Value>k__BackingField
}
```

Where the printer hoists synthesized local declarations to the top of a block,
the insertion point falls below them rather than immediately after the opening
brace. That is what an insertion point *is* — the declarations would have printed
first — and they emit no IL of their own, so nothing executable is ever shown as
running before the base call. Called out because an earlier draft of this
description claimed "immediately after the opening brace", which is only true for
bodies with no hoisted declarations.

## Verified rather than assumed

| | |
| --- | --- |
| Renders vs `main`, 9,195 methods | 900 changed, **0 by content** (ordering + 609 stray blanks removed) |
| IL lines with no C# line to sit beside | 4,596 → **2,796** |
| Facts with no printed line | 56 → 56 — none lost |
| Range overruns of the returned string | 0 of 62,838, so the defensive clamp was dead and is deleted rather than shipped unproven |
| Print time, best-of-6 over 9,122 methods | 5,236 ms → 5,205 ms — below per-round variance, so "no change", not a win |

**Gates proven non-vacuous by breaking what they cover:** an off-by-one start fails
the text-alignment test; a zero-width range fails containment; removing the
insertion-point fallback fails the preamble test; bucketing after the line instead
of before fails it; recording insertion points for printed nodes fails disjointness.

Two of my own gates were vacuous when first written and were rebuilt — the
suppressed-chain fixture originally used an explicit `: base(seed)`, which is the
*lifted* case that is never walked at all.

## Suites

`ILInspector.Decompiler.Tests` 4,261 · `ILInspector.Research.Tests` 132 ·
`dotnet-inspect.Tests` 1,638 · `CommandExecutionTests` 595.

Seven decompiler failures reproduce on the unmodified base commit with identical
messages — three generated-fixture catalogs, three fidelity gates, and the pinned
missing-return list. None touch this code.

## Follow-ups

Issue #3338 keeps the remaining 2,796 unanchorable IL lines and the
declaration line as
the more precise home for preamble IL. The 56 homeless facts are field-initializer
stores lifted onto declarations — a separate gap.

Phases 2-4 (carry the range to `AnnotatedSourceLine`, record expression nodes,
narrow the caret) are what actually fix the render at the top of this description.
