### PR TITLE
Match SourceLink document keys by prefix, not by regex

### DIFF
--- a/src/SourceLinkFetch/SourceLinkFetch.csproj
+++ b/src/SourceLinkFetch/SourceLinkFetch.csproj
@@ -13,4 +13,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ILInspector.Metadata.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/SourceLinkFetch/SourceLinkResolver.cs
+++ b/src/SourceLinkFetch/SourceLinkResolver.cs
@@ -14,7 +14,7 @@ public class SourceLinkResolver
 
     private readonly Dictionary<string, string> _documentMappings;
 
-    private SourceLinkResolver(Dictionary<string, string> documentMappings)
+    internal SourceLinkResolver(Dictionary<string, string> documentMappings)
     {
         _documentMappings = documentMappings;
     }
@@ -45,16 +45,20 @@ public class SourceLinkResolver
 
         foreach (var (pattern, urlTemplate) in _documentMappings)
         {
-            if (pattern.Contains('*'))
+            int star = pattern.IndexOf('*');
+            if (star >= 0)
             {
-                string regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", "(.*)") + "$";
-                var match = Regex.Match(filePath, regexPattern);
+                // SourceLink allows a key at most one '*', and requires it to be the final
+                // character, so a conformant key is a prefix and the match is a prefix test.
+                // Testing the first '*' for finality rejects both violations at once: a second
+                // '*' leaves the first one non-final. A key we reject is one no conformant
+                // producer emits and one we could not honor unambiguously anyway.
+                if (star != pattern.Length - 1)
+                    continue;
 
-                if (match.Success && match.Groups.Count > 1)
-                {
-                    string captured = match.Groups[1].Value;
-                    return urlTemplate.Replace("*", captured);
-                }
+                string prefix = pattern[..^1];
+                if (filePath.StartsWith(prefix, StringComparison.Ordinal))
+                    return urlTemplate.Replace("*", filePath[prefix.Length..]);
             }
             else if (filePath == pattern)
             {

--- a/tests/ILInspector.Metadata.Tests/SourceLinkUrlResolutionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SourceLinkUrlResolutionTests.cs
@@ -1,0 +1,130 @@
+using System.Diagnostics;
+using SLF = SourceLinkFetch;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Covers <see cref="SLF.SourceLinkResolver.ResolveUrl"/>, which maps a PDB document path to a
+/// source URL using the SourceLink document keys embedded in that PDB. Those keys are
+/// attacker-controlled: they arrive inside the assembly under inspection, which the user does
+/// not necessarily trust (see docs/design/untrusted-data-threat-model.md).
+/// </summary>
+public class SourceLinkUrlResolutionTests
+{
+    private static SLF.SourceLinkResolver For(params (string Pattern, string Url)[] mappings)
+        => new SLF.SourceLinkResolver(mappings.ToDictionary(m => m.Pattern, m => m.Url));
+
+    [Fact]
+    public void ATrailingWildcard_MapsThePathSuffixIntoTheUrl()
+    {
+        var resolver = For(("/_/src/*", "https://raw.githubusercontent.com/o/r/abc/*"));
+
+        Assert.Equal(
+            "https://raw.githubusercontent.com/o/r/abc/System/Text/Json/Utf8JsonReader.cs",
+            resolver.ResolveUrl("/_/src/System/Text/Json/Utf8JsonReader.cs"));
+    }
+
+    [Fact]
+    public void AWildcardKey_MatchesTheEmptySuffix()
+    {
+        var resolver = For(("/_/*", "https://example.test/*"));
+
+        Assert.Equal("https://example.test/", resolver.ResolveUrl("/_/"));
+    }
+
+    [Fact]
+    public void AWildcardKey_DoesNotMatchAPathOutsideItsPrefix()
+    {
+        var resolver = For(("/_/src/*", "https://example.test/*"));
+
+        Assert.Null(resolver.ResolveUrl("/other/src/File.cs"));
+    }
+
+    [Fact]
+    public void AKeyWithoutAWildcard_MatchesOnlyThatExactPath()
+    {
+        var resolver = For(("/_/src/File.cs", "https://example.test/File.cs"));
+
+        Assert.Equal("https://example.test/File.cs", resolver.ResolveUrl("/_/src/File.cs"));
+        Assert.Null(resolver.ResolveUrl("/_/src/File.cs.bak"));
+    }
+
+    [Fact]
+    public void ABackslashPath_IsNormalizedBeforeMatching()
+    {
+        var resolver = For((@"/_/src/*", "https://example.test/*"));
+
+        Assert.Equal("https://example.test/a/b.cs", resolver.ResolveUrl(@"\_\src\a\b.cs"));
+    }
+
+    /// <summary>
+    /// SourceLink requires a key to carry at most one '*' and requires that '*' to be the final
+    /// character. A key that breaks either rule cannot be honored unambiguously, and honoring it
+    /// is what previously created the denial of service pinned by
+    /// <see cref="AKeyWithManyWildcards_ResolvesPromptly_AndDoesNotBacktrack"/>.
+    /// </summary>
+    [Theory]
+    [InlineData("/_/*/src/*")]      // two wildcards
+    [InlineData("/_/*/src")]        // one wildcard, not final
+    [InlineData("/*/*/*/*/*/*a")]   // the denial-of-service shape
+    public void ANonConformantKey_IsIgnored(string pattern)
+    {
+        var resolver = For((pattern, "https://example.test/*"));
+
+        Assert.Null(resolver.ResolveUrl("/_/a/src/b.cs"));
+    }
+
+    [Fact]
+    public void ANonConformantKey_DoesNotShadowAConformantOne()
+    {
+        var resolver = For(
+            ("/_/*/bad/*", "https://wrong.test/*"),
+            ("/_/src/*", "https://right.test/*"));
+
+        Assert.Equal("https://right.test/a.cs", resolver.ResolveUrl("/_/src/a.cs"));
+    }
+
+    /// <summary>
+    /// The previous implementation built a regex by replacing every '*' in the key with the
+    /// greedy group "(.*)", then matched with no timeout. Adjacent greedy groups over a
+    /// separator-rich path backtrack exponentially: measured on the pre-fix code, twelve
+    /// wildcards against a 62-character path took 14.3 seconds, roughly doubling per added
+    /// wildcard, from a key an attacker supplies inside a PDB.
+    ///
+    /// Prefix matching cannot backtrack, so this asserts a bound rather than pinning a shape.
+    /// The bound is deliberately loose: it must fail on exponential behavior and never on a
+    /// slow machine. The pre-fix code exceeds it by more than three orders of magnitude.
+    /// </summary>
+    [Fact]
+    public void AKeyWithManyWildcards_ResolvesPromptly_AndDoesNotBacktrack()
+    {
+        string pattern = string.Concat(Enumerable.Repeat("/*", 24)) + "a";
+        string filePath = string.Concat(Enumerable.Repeat("/a", 40)) + "/b";
+        var resolver = For((pattern, "https://example.test/*"));
+
+        var stopwatch = Stopwatch.StartNew();
+        string? resolved = resolver.ResolveUrl(filePath);
+        stopwatch.Stop();
+
+        Assert.Null(resolved);
+        Assert.True(
+            stopwatch.ElapsedMilliseconds < 1000,
+            $"resolution took {stopwatch.ElapsedMilliseconds}ms, which indicates backtracking");
+    }
+
+    /// <summary>
+    /// Every SourceLink document key in the 1,452 PDBs cached locally when this fix was written
+    /// carried exactly one '*' in the final position -- 1,584 keys, no exceptions. This pins the
+    /// shape that survey found, so that the conformant path stays exercised by a real-world key
+    /// rather than only by hand-written ones.
+    /// </summary>
+    [Fact]
+    public void TheKeyShapeRealPdbsEmit_Resolves()
+    {
+        var resolver = For(("/_/*", "https://raw.githubusercontent.com/dotnet/dotnet/f7d9079/*"));
+
+        Assert.Equal(
+            "https://raw.githubusercontent.com/dotnet/dotnet/f7d9079/src/libraries/a.cs",
+            resolver.ResolveUrl("/_/src/libraries/a.cs"));
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/SourceLinkUrlResolutionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SourceLinkUrlResolutionTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using SLF = SourceLinkFetch;
 
 namespace ILInspector.Metadata.Tests;
@@ -65,23 +66,53 @@ public class SourceLinkUrlResolutionTests
     /// </summary>
     [Theory]
     [InlineData("/_/*/src/*")]      // two wildcards
-    [InlineData("/_/*/src")]        // one wildcard, not final
-    [InlineData("/*/*/*/*/*/*a")]   // the denial-of-service shape
+    [InlineData("/_/*/src/b.cs")]   // one wildcard, not final
+    [InlineData("/*/*/*/*s")]       // the denial-of-service shape
     public void ANonConformantKey_IsIgnored(string pattern)
     {
+        AssertTheReplacedImplementationWouldHaveResolved(pattern, NonConformantPath);
+
         var resolver = For((pattern, "https://example.test/*"));
 
-        Assert.Null(resolver.ResolveUrl("/_/a/src/b.cs"));
+        Assert.Null(resolver.ResolveUrl(NonConformantPath));
     }
 
     [Fact]
     public void ANonConformantKey_DoesNotShadowAConformantOne()
     {
+        // The non-conformant key is listed first and, under the replaced implementation, matches
+        // this path and wins. Ignoring it must not merely be silent; the conformant key behind it
+        // must still resolve.
+        AssertTheReplacedImplementationWouldHaveResolved("/_/*/a.cs", "/_/src/a.cs");
+
         var resolver = For(
-            ("/_/*/bad/*", "https://wrong.test/*"),
+            ("/_/*/a.cs", "https://wrong.test/*"),
             ("/_/src/*", "https://right.test/*"));
 
         Assert.Equal("https://right.test/a.cs", resolver.ResolveUrl("/_/src/a.cs"));
+    }
+
+    private const string NonConformantPath = "/_/a/src/b.cs";
+
+    /// <summary>
+    /// Guards the negative tests above against going vacuous. Each asserts that a non-conformant
+    /// key resolves to nothing, but that assertion only means something if the key is one the
+    /// replaced implementation would have accepted. A key the old regex never matched would pass
+    /// those tests against the vulnerable code too, proving nothing.
+    ///
+    /// This reconstructs the replaced matcher — build "^" + escaped key with every '*' as the
+    /// greedy group "(.*)" + "$" — and requires it to match. Changing an <c>InlineData</c> row to
+    /// a key the old code ignored therefore fails here rather than silently weakening the suite.
+    /// </summary>
+    private static void AssertTheReplacedImplementationWouldHaveResolved(string pattern, string path)
+    {
+        string asRegex = "^" + Regex.Escape(pattern).Replace("\\*", "(.*)") + "$";
+
+        Assert.True(
+            Regex.IsMatch(path, asRegex, RegexOptions.None, TimeSpan.FromSeconds(10)),
+            $"Vacuous case: the replaced implementation ignored key '{pattern}' for path " +
+            $"'{path}', so asserting that the current implementation ignores it proves nothing. " +
+            "Choose a key the old regex matched.");
     }
 
     /// <summary>


### PR DESCRIPTION
Stacked on #3367. GitHub will retarget this to `main` when #3367 merges.

## What is wrong

`SourceLinkResolver.ResolveUrl` built a regex from a SourceLink document key and matched with **no timeout**:

```csharp
string regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", "(.*)") + "$";
var match = Regex.Match(filePath, regexPattern);
```

Those keys come from the SourceLink JSON embedded in the PDB of the assembly being inspected, so **an attacker chooses them** — squarely inside `docs/design/untrusted-data-threat-model.md`. Every `*` becomes another adjacent greedy group, and adjacent greedy groups over a separator-rich path backtrack exponentially.

Measured on the pre-fix code, matching a path of only 62 characters:

| wildcards | 5 | 7 | 9 | 11 | 12 |
| --- | --- | --- | --- | --- | --- |
| match time (ms) | 12 | 253 | 2,109 | 6,575 | **14,298** |

Roughly doubling per added wildcard, from a key inside a PDB. Real source paths are far longer than 62 characters.

Found by a Gemini Pro adversarial review of #3367. **Pre-existing** — it shipped in the `SourceLinkFetch` 0.1.0 package that `main` already consumes, so this is not a regression from adopting the source. Adopting the source is what makes it fixable.

## The fix removes the regex rather than bounding it

The SourceLink specification allows a key **at most one `*`**, and requires that `*` to be the **final character**. A conformant key is therefore a prefix, and the match is a prefix test — no regex, no backtracking, and the vulnerability becomes unrepresentable rather than merely timed out.

Testing the *first* `*` for finality rejects both violations at once: a second `*` necessarily leaves the first one non-final.

## Evidence that rejecting non-conformant keys is safe

I surveyed every Portable PDB in the local `dotnet-inspect` cache:

```
pdb files scanned : 1626
with SourceLink   : 1452
document keys     : 1584
--- key shapes ---
  1584  one '*', final char (spec-conformant)
```

**1,584 keys, 100% conformant, no exceptions.** No real producer emits a key this rejects. Rejecting one is also the only safe reading — a key we cannot honor unambiguously is exactly the key that hangs us.

## The new test is not vacuous

`AKeyWithManyWildcards_ResolvesPromptly_AndDoesNotBacktrack` asserts a loose 1-second bound. On its exact inputs:

```
AFTER  (prefix match) : 1 ms, result=null
BEFORE (regex)        : STILL RUNNING after 30s -- aborted by an artificial
                        timeout the product code did NOT have
```

Three orders of magnitude of headroom, so it fails on exponential behavior and never on a slow machine.

11 tests added covering suffix mapping, empty suffix, prefix misses, exact keys, backslash normalization, the three non-conformant key shapes, non-conformant keys not shadowing conformant ones, the denial-of-service bound, and the real-world key shape the PDB survey found.

## Validation

| Suite | Result |
| --- | --- |
| Metadata | **1233** pass (1222 + 11 new) |
| Services | **319** pass |
| CLI | **2233** pass |

## Behavior note

A key with `*` in a non-final position previously matched via regex and is now ignored. That shape is non-conformant, absent from all 1,584 surveyed keys, and is the shape that causes the hang. Called out explicitly rather than buried.

Adjacent and **not** addressed here: `src/ILInspector.Metadata/TypeMatcher.cs:367` uses the same `Regex.Escape(p).Replace("\\*", ".*")` shape with no timeout. Narrower vector — the pattern is the user's own CLI glob, though the matched text is an attacker-supplied type name.