### PR TITLE
Address rows by their displayed number, not their list position

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -140,20 +140,30 @@ modifier changes how a selected payload is rendered.
 
 `--print` projects a selected row's declared printable payload. It is unary, but
 it does not mean "take the first row." Cardinality is resolved after section
-selection, filtering, and printable-capability filtering:
+selection and filtering:
 
-| Printable rows | `--print` | `--print --row N\|first\|last` |
+| Rendered rows | `--print` | `--print --row N\|first\|last` |
 | ---: | --- | --- |
-| 0 | Error: the selected shape is not printable. | Error. |
-| 1 | Print the one payload. | Print row `1`, `first`, or `last`; any other index is an error. |
-| More than 1 | Guidance error requiring `--row`. | Print exactly the selected printable row. |
+| 0 | Error: the selected section has no rows. | Error. |
+| 1 | Print the one payload. | Print that row by its number, `first`, or `last`; any other number is an error. |
+| More than 1 | Guidance error requiring `--row`. | Print exactly the selected row. |
 
 `--print` resolves exactly one payload. There is no fan-out gesture: printing
 more than one document at a time is not currently expressible.
 
-Numeric `--row N` is one-based and counts printable rows, not every row in the
-selected table. `first` and `last` are stable aliases for the endpoints of that
-printable-row sequence.
+Numeric `--row N` addresses the row number the reader can see in the rendered
+section. It is not a position within a filtered subsequence, and in particular
+printability does not renumber anything: a row that declares no payload still
+occupies its number, and selecting it reports that it has no document rather
+than silently sliding to a neighbour. `first` and `last` are the endpoints of
+the rendered sequence, so when a projection skips rows they resolve to the
+first and last numbers actually on screen rather than to `1` and the row count.
+
+This is the one rule that makes the ordinal trustworthy. Numbering by position
+in a filtered list is wrong in the worst way available: it returns a real row,
+so nothing looks broken, and the reader has no way to see the sequence being
+indexed. Selecting by displayed number can only ever hit the intended row or
+report a miss.
 
 Because `--print` is exactly-one, failing to acquire the selected row's payload
 is an error, not an omission: it reports the failure and exits non-zero rather
@@ -162,7 +172,7 @@ selected row; whether a section producer declares a row at all is that
 producer's concern.
 
 `-n N` / `--head N` and `--tail N` are rendered-line windows applied after
-printable-row cardinality is resolved and the payload is fetched. They do not
+row cardinality is resolved and the payload is fetched. They do not
 select rows:
 
 ```text
@@ -170,7 +180,7 @@ select rows:
   multi-row selection -> error; does not choose the first row
 
 --print --row 2 --head 20
-  select printable row 2 -> fetch one payload -> render its first 20 lines
+  select row 2 -> fetch one payload -> render its first 20 lines
 ```
 
 `--rows` changes head/tail from rendered-line windows into per-table data-row
@@ -180,7 +190,7 @@ windows:
 - `--rows --tail N` keeps the last N data rows.
 
 Both row-window forms are incompatible with `--print`;
-`--row N|first|last` is the explicit printable-row selector. The CLI implements
+`--row N|first|last` is the explicit row selector. The CLI implements
 both head and tail data-row windows symmetrically.
 
 This policy deliberately rejects implicit-first behavior. Row order may change
@@ -433,12 +443,15 @@ The stable vocabulary is:
 - `--count` is a shape-reduction selector: it collapses a selected table/vector to a
   single scalar count.
 - `--print` is an exactly-one row-payload projection: it never chooses the first
-  of multiple printable rows implicitly, does not make non-printable rows
-  printable, and does not evaluate new addresses.
+  of multiple rows implicitly, does not make rows without a payload printable,
+  and does not evaluate new addresses.
 - `--head` / `--tail` are post-projection line windows: they do not select rows
   or constrain payload acquisition.
 - `--rows` promotes head/tail to first/last data-row windows, but those windows
-  remain presentation limits rather than printable-row selectors.
+  remain presentation limits rather than row selectors.
+- `--row` addresses a rendered row by its displayed number. Any future selector
+  that takes an ordinal joins this rule: the number a reader can see is the
+  number that can be addressed, and no filter may renumber it.
 - `--bare` is a presentation modifier: it strips the surrounding framing from an
   already-selected payload.
 - `--raw` / `--blob` are URL-shape modifiers: they control the form of emitted

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -151,18 +151,23 @@ selection and filtering:
 `--print` resolves exactly one payload. There is no fan-out gesture: printing
 more than one document at a time is not currently expressible.
 
-Numeric `--row N` addresses the row number the reader can see in the rendered
-section. It is not a position within a filtered subsequence, and in particular
-printability does not renumber anything: a row that declares no payload still
+Numeric `--row N` addresses a row by its position in the rendered section,
+counting from 1. Sections do not print a row-number column, so N is the number
+the reader arrives at by counting rows top to bottom — which is precisely why it
+has to be stable: it is not a position within a filtered subsequence, and
+printability does not renumber anything. A row that declares no payload still
 occupies its number, and selecting it reports that it has no document rather
 than silently sliding to a neighbour. `first` and `last` are the endpoints of
 the rendered sequence, so when a projection skips rows they resolve to the
-first and last numbers actually on screen rather than to `1` and the row count.
+first and last numbers actually present rather than to `1` and the row count.
+Structured output makes the number explicit — `--jsonl` and `--json` emit it as
+`row` — and error messages name the addressable numbers, so a projection with
+gaps stays navigable.
 
 This is the one rule that makes the ordinal trustworthy. Numbering by position
 in a filtered list is wrong in the worst way available: it returns a real row,
-so nothing looks broken, and the reader has no way to see the sequence being
-indexed. Selecting by displayed number can only ever hit the intended row or
+so nothing looks broken, and the reader has no way to recover the sequence being
+indexed. Addressing by rendered position can only ever hit the intended row or
 report a miss.
 
 Because `--print` is exactly-one, failing to acquire the selected row's payload
@@ -449,9 +454,10 @@ The stable vocabulary is:
   or constrain payload acquisition.
 - `--rows` promotes head/tail to first/last data-row windows, but those windows
   remain presentation limits rather than row selectors.
-- `--row` addresses a rendered row by its displayed number. Any future selector
-  that takes an ordinal joins this rule: the number a reader can see is the
-  number that can be addressed, and no filter may renumber it.
+- `--row` addresses a rendered row by its position in the section, counting from
+  1. Any future selector that takes an ordinal joins this rule: the number a
+  reader arrives at by counting rows is the number that can be addressed, and no
+  filter may renumber it.
 - `--bare` is a presentation modifier: it strips the surrounding framing from an
   already-selected payload.
 - `--raw` / `--blob` are URL-shape modifiers: they control the form of emitted

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3719,7 +3719,7 @@ public class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains("selected section has 2 printable rows; use --row N|first|last to choose one row", error);
+        Assert.Contains("selected section has 2 rows; use --row N|first|last to choose one row", error);
     }
 
     [Fact]
@@ -3821,7 +3821,7 @@ public class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains("selected section has 2 printable rows; use --row N|first|last to choose one row", error);
+        Assert.Contains("selected section has 2 rows; use --row N|first|last to choose one row", error);
     }
 
     [Fact]
@@ -3876,7 +3876,7 @@ public class CommandExecutionTests
 
             Assert.Equal(1, exit);
             Assert.Empty(output);
-            Assert.Contains("failed to fetch the document for printable row 2 from", error);
+            Assert.Contains("failed to fetch the document for row 2 from", error);
             Assert.Contains("/Src/Newtonsoft.Json/JsonReader.Async.cs", error);
         }
         finally
@@ -3909,7 +3909,7 @@ public class CommandExecutionTests
 
             Assert.Equal(1, exit);
             Assert.Empty(output);
-            Assert.Contains("failed to fetch the document for printable row 2 from", error);
+            Assert.Contains("failed to fetch the document for row 2 from", error);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1522,7 +1522,7 @@ public class OutputFormatterTests
     [Fact]
     public void RowSelector_ResolvesEndpointsOfGappedRows()
     {
-        // first/last name the endpoints the reader can see, not 1 and the count.
+        // first/last name the endpoints of the rendered sequence, not 1 and the count.
         int[] gapped = [2, 5, 9];
         Assert.Equal(2, RowSelector.First.Resolve(gapped));
         Assert.Equal(9, RowSelector.Last.Resolve(gapped));

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1513,9 +1513,37 @@ public class OutputFormatterTests
     [Fact]
     public void RowSelector_ResolvesFirstLastAndIndex()
     {
-        Assert.Equal(1, RowSelector.First.Resolve(7));
-        Assert.Equal(7, RowSelector.Last.Resolve(7));
-        Assert.Equal(3, RowSelector.FromIndex(3).Resolve(7));
+        int[] contiguous = [1, 2, 3, 4, 5, 6, 7];
+        Assert.Equal(1, RowSelector.First.Resolve(contiguous));
+        Assert.Equal(7, RowSelector.Last.Resolve(contiguous));
+        Assert.Equal(3, RowSelector.FromIndex(3).Resolve(contiguous));
+    }
+
+    [Fact]
+    public void RowSelector_ResolvesEndpointsOfGappedRows()
+    {
+        // first/last name the endpoints the reader can see, not 1 and the count.
+        int[] gapped = [2, 5, 9];
+        Assert.Equal(2, RowSelector.First.Resolve(gapped));
+        Assert.Equal(9, RowSelector.Last.Resolve(gapped));
+        Assert.Equal(5, RowSelector.FromIndex(5).Resolve(gapped));
+    }
+
+    [Fact]
+    public void RowNumbering_DescribesContiguousAndGappedRows()
+    {
+        Assert.Equal("1 through 4", RowNumbering.Describe([1, 2, 3, 4]));
+        Assert.Equal("2, 5, 9", RowNumbering.Describe([2, 5, 9]));
+        Assert.Equal("7", RowNumbering.Describe([7]));
+        Assert.Equal("none", RowNumbering.Describe([]));
+    }
+
+    [Fact]
+    public void RowNumbering_IndexOfFindsRowByDisplayedNumber()
+    {
+        int[] gapped = [2, 5, 9];
+        Assert.Equal(1, RowNumbering.IndexOf(gapped, 5));
+        Assert.Equal(-1, RowNumbering.IndexOf(gapped, 3));
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/RowSelectionNumberingTests.cs
+++ b/src/dotnet-inspect.Tests/RowSelectionNumberingTests.cs
@@ -1,16 +1,17 @@
 using System.Text.Json;
+using DotnetInspector.Commands;
 using DotnetInspector.Output;
 
 namespace DotnetInspector.Tests;
 
 /// <summary>
-/// Pins the numbering contract for <c>--row</c>: the ordinal addresses the row
-/// number the reader can see in the rendered table, not the position of that row
+/// Pins the numbering contract for <c>--row</c>: the ordinal addresses a row by
+/// its position in the rendered section, not the position of that row
 /// inside whatever list the projection happens to have built.
 ///
 /// The two numbering systems only diverge when a projection skips rows, which is
 /// exactly when the reader cannot compensate: a section that drops rows carrying
-/// no value leaves gaps, so list position and displayed number differ by however
+/// no value leaves gaps, so list position and rendered number differ by however
 /// many rows were skipped before the target. Rows are constructed here with
 /// deliberate gaps (2 and 5, as a source-location projection produces when rows
 /// 1, 3, and 4 carry no value) because contiguous rows cannot tell a correct
@@ -46,7 +47,7 @@ public class RowSelectionNumberingTests
         var (exit, output, error) = await ConsoleCapture.RunAsync(() =>
             Task.FromResult(ShapeProjectionOutput.Write(GappedRows(), Options(RowSelector.FromIndex(5)))));
 
-        // Row 5 is on screen, so it is addressable, even though the list holds
+        // Row 5 was rendered, so it is addressable, even though the list holds
         // only two entries and a positional bound check would reject it.
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -96,5 +97,92 @@ public class RowSelectionNumberingTests
         Assert.Equal(0, exit);
         using var document = JsonDocument.Parse(output);
         Assert.Equal(5, document.RootElement.GetProperty("row").GetInt32());
+    }
+
+    // --- the --print selection path -------------------------------------------
+    //
+    // These exercise ApiCommand.SelectPrintableRow directly. The end-to-end
+    // --print tests need a package restore and a network fetch, and none of the
+    // packages they use has a source-location row that lacks a URL, so the case
+    // that motivated the whole change cannot be reached from there.
+
+    private static List<(int Row, string? Label, string? Url)> RowsWithAGap() =>
+    [
+        (1, "first", null),
+        (2, "second", "https://example.invalid/second.cs"),
+        (3, "third", null),
+    ];
+
+    [Fact]
+    public void PrintSelection_AddressesRowsThatCarryNoPayload()
+    {
+        var selected = ApiCommand.SelectPrintableRow(RowsWithAGap(), RowSelector.FromIndex(2), out var error);
+
+        Assert.NotNull(selected);
+        Assert.Equal(2, selected!.Value.Row);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public void PrintSelection_ReportsRowWithNoPayloadInsteadOfSliding()
+    {
+        // Row 1 exists and was addressed correctly; it simply has nothing behind
+        // it. Before this contract, numbering skipped it and --row 1 returned
+        // row 2's document without saying so.
+        var selected = ApiCommand.SelectPrintableRow(RowsWithAGap(), RowSelector.FromIndex(1), out var error);
+
+        Assert.Null(selected);
+        Assert.Equal("Error: row 1 has no printable document.", error);
+    }
+
+    [Fact]
+    public void PrintSelection_LastMeansTheLastRenderedRow_NotTheLastPrintableOne()
+    {
+        // 'last' is an endpoint of the rendered section. Row 3 carries no
+        // payload, so the honest answer is to say so rather than to fall back to
+        // row 2, which the reader did not ask for.
+        var selected = ApiCommand.SelectPrintableRow(RowsWithAGap(), RowSelector.Last, out var error);
+
+        Assert.Null(selected);
+        Assert.Equal("Error: row 3 has no printable document.", error);
+    }
+
+    [Fact]
+    public void PrintSelection_RejectsRowNumbersThatWereNeverRendered()
+    {
+        var selected = ApiCommand.SelectPrintableRow(RowsWithAGap(), RowSelector.FromIndex(9), out var error);
+
+        Assert.Null(selected);
+        Assert.Equal("Error: row 9 is not in this section. Use --row 1 through 3, first, or last.", error);
+    }
+
+    [Fact]
+    public void PrintSelection_RequiresRowWhenSectionHasMany()
+    {
+        var selected = ApiCommand.SelectPrintableRow(RowsWithAGap(), selector: null, out var error);
+
+        Assert.Null(selected);
+        Assert.Equal("Error: selected section has 3 rows; use --row N|first|last to choose one row.", error);
+    }
+
+    [Fact]
+    public void PrintSelection_CountsEveryRenderedRow_NotJustPrintableOnes()
+    {
+        // The guidance error has to count what the section rendered. Counting only
+        // printable rows would say "1 row" for a three-row section and then
+        // print it without being asked.
+        var selected = ApiCommand.SelectPrintableRow(RowsWithAGap(), selector: null, out var error);
+
+        Assert.Null(selected);
+        Assert.Contains("has 3 rows", error);
+    }
+
+    [Fact]
+    public void PrintSelection_ReportsEmptySection()
+    {
+        var selected = ApiCommand.SelectPrintableRow([], RowSelector.First, out var error);
+
+        Assert.Null(selected);
+        Assert.Equal("Error: selected section has no rows.", error);
     }
 }

--- a/src/dotnet-inspect.Tests/RowSelectionNumberingTests.cs
+++ b/src/dotnet-inspect.Tests/RowSelectionNumberingTests.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using DotnetInspector.Output;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Pins the numbering contract for <c>--row</c>: the ordinal addresses the row
+/// number the reader can see in the rendered table, not the position of that row
+/// inside whatever list the projection happens to have built.
+///
+/// The two numbering systems only diverge when a projection skips rows, which is
+/// exactly when the reader cannot compensate: a section that drops rows carrying
+/// no value leaves gaps, so list position and displayed number differ by however
+/// many rows were skipped before the target. Rows are constructed here with
+/// deliberate gaps (2 and 5, as a source-location projection produces when rows
+/// 1, 3, and 4 carry no value) because contiguous rows cannot tell a correct
+/// implementation from a positional one.
+/// </summary>
+public class RowSelectionNumberingTests
+{
+    private static IReadOnlyList<ShapeProjectionRow> GappedRows() =>
+    [
+        new ShapeProjectionRow(2, "Source Locations", "alpha"),
+        new ShapeProjectionRow(5, "Source Locations", "beta"),
+    ];
+
+    private static ShapeProjectionOptions Options(RowSelector? row) =>
+        new(ShapeProjectionKind.Value, row, JsonOutput: false, Jsonl: false, JsonArray: false);
+
+    [Fact]
+    public async Task Row_SelectsDisplayedNumber_NotListPosition()
+    {
+        var (exit, output, error) = await ConsoleCapture.RunAsync(() =>
+            Task.FromResult(ShapeProjectionOutput.Write(GappedRows(), Options(RowSelector.FromIndex(2)))));
+
+        // Row 2 is displayed as row 2. Selecting it positionally would return
+        // "beta", the row displayed as 5, and would do so silently.
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("alpha", output.Trim());
+    }
+
+    [Fact]
+    public async Task Row_AddressesDisplayedNumberBeyondListCount()
+    {
+        var (exit, output, error) = await ConsoleCapture.RunAsync(() =>
+            Task.FromResult(ShapeProjectionOutput.Write(GappedRows(), Options(RowSelector.FromIndex(5)))));
+
+        // Row 5 is on screen, so it is addressable, even though the list holds
+        // only two entries and a positional bound check would reject it.
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("beta", output.Trim());
+    }
+
+    [Fact]
+    public async Task Row_ThatIsNotDisplayed_IsRejectedByNumber()
+    {
+        var (exit, output, error) = await ConsoleCapture.RunAsync(() =>
+            Task.FromResult(ShapeProjectionOutput.Write(GappedRows(), Options(RowSelector.FromIndex(3)))));
+
+        // Row 3 carries no value in this section, so it is absent from the
+        // projection. The error has to name the rows that do exist rather than
+        // quote a 1..N range that includes 3 and excludes 5.
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("row 3", error);
+        Assert.Contains("2, 5", error);
+    }
+
+    [Fact]
+    public async Task First_And_Last_ResolveToDisplayedEndpoints()
+    {
+        var (firstExit, firstOutput, _) = await ConsoleCapture.RunAsync(() =>
+            Task.FromResult(ShapeProjectionOutput.Write(GappedRows(), Options(RowSelector.First))));
+        var (lastExit, lastOutput, _) = await ConsoleCapture.RunAsync(() =>
+            Task.FromResult(ShapeProjectionOutput.Write(GappedRows(), Options(RowSelector.Last))));
+
+        Assert.Equal(0, firstExit);
+        Assert.Equal("alpha", firstOutput.Trim());
+        Assert.Equal(0, lastExit);
+        Assert.Equal("beta", lastOutput.Trim());
+    }
+
+    [Fact]
+    public async Task SelectedRow_ReportsItsDisplayedNumberInJson()
+    {
+        var options = new ShapeProjectionOptions(
+            ShapeProjectionKind.Value, RowSelector.FromIndex(5),
+            JsonOutput: true, Jsonl: false, JsonArray: false);
+        var (exit, output, _) = await ConsoleCapture.RunAsync(() =>
+            Task.FromResult(ShapeProjectionOutput.Write(GappedRows(), options)));
+
+        // The payload's row number and the number used to select it must agree,
+        // so that a scripted round-trip through --row is stable.
+        Assert.Equal(0, exit);
+        using var document = JsonDocument.Parse(output);
+        Assert.Equal(5, document.RootElement.GetProperty("row").GetInt32());
+    }
+}

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1036,16 +1036,19 @@ public class ApiCommand
 
     private static List<ShapeProjectionRow> ProjectTypeSourceFiles(TypeView view, string section, ShapeProjectionKind kind)
     {
+        // Number by position in the rendered section, then drop valueless rows.
+        // Renumbering after the filter would relabel the survivors 1..N and break
+        // the correspondence with the table the reader is looking at.
         return (view.SourceFileRows ?? [])
-            .Select((row, index) => row.Url)
-            .Where(url => !string.IsNullOrWhiteSpace(url))
-            .Select((url, index) =>
+            .Select((row, index) => (Number: index + 1, row.Url))
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Url))
+            .Select(entry =>
             {
-                var value = url!;
+                var value = entry.Url!;
                 return kind switch
                 {
                     ShapeProjectionKind.Urls or ShapeProjectionKind.Value =>
-                        new ShapeProjectionRow(index + 1, section, value, Url: value),
+                        new ShapeProjectionRow(entry.Number, section, value, Url: value),
                     _ => null
                 };
             })
@@ -1121,35 +1124,51 @@ public class ApiCommand
         IEnumerable<(int Row, string? Label, string? Url)>? rows,
         ApiOptions options)
     {
-        var printableRows = (rows ?? [])
-            .Where(row => !string.IsNullOrWhiteSpace(row.Url))
-            .ToList();
-        if (printableRows.Count == 0)
+        // Numbering covers every row the section rendered. Filtering to rows that
+        // carry a payload and then indexing that shorter list positionally is how
+        // --row came to address a sequence the reader cannot see: with rows 1-2
+        // carrying no URL, --row 1 returned the row displayed as 3. Printability
+        // is checked after selection, against the row the caller actually named.
+        var allRows = (rows ?? []).ToList();
+        if (allRows.Count == 0)
         {
-            Console.Error.WriteLine("Error: selected section has no printable rows.");
+            Console.Error.WriteLine("Error: selected section has no rows.");
             return 1;
         }
 
-        if (options.PrintRow is null && printableRows.Count != 1)
+        if (options.PrintRow is null && allRows.Count != 1)
         {
-            Console.Error.WriteLine($"Error: selected section has {printableRows.Count} printable rows; use --row N|first|last to choose one row.");
+            Console.Error.WriteLine($"Error: selected section has {allRows.Count} rows; use --row N|first|last to choose one row.");
             return 1;
         }
 
-        var targetIndex = options.PrintRow?.Resolve(printableRows.Count) ?? 1;
-        if (targetIndex < 1 || targetIndex > printableRows.Count)
+        var rowNumbers = allRows.Select(row => row.Row).ToList();
+        var targetRow = options.PrintRow?.Resolve(rowNumbers) ?? rowNumbers[0];
+        var position = RowNumbering.IndexOf(rowNumbers, targetRow);
+        if (position < 0)
         {
-            Console.Error.WriteLine($"Error: printable row {targetIndex} is out of range. Use 1 through {printableRows.Count}, first, or last.");
+            Console.Error.WriteLine(
+                $"Error: row {targetRow} is not in this section. Use --row {RowNumbering.Describe(rowNumbers)}, first, or last.");
             return 1;
         }
 
-        var selectedRow = printableRows[targetIndex - 1];
+        var selectedRow = allRows[position];
+        if (string.IsNullOrWhiteSpace(selectedRow.Url))
+        {
+            // The row exists and was addressed correctly; it simply has nothing
+            // behind it. Reporting that is what keeps the ordinal trustworthy —
+            // skipping to a neighbouring row would silently answer a different
+            // question.
+            Console.Error.WriteLine($"Error: row {targetRow} has no printable document.");
+            return 1;
+        }
+
         var rawUrl = GitHubUrlResolver.ConvertBlobToRawUrl(selectedRow.Url!);
         var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
         var content = await fetcher.FetchSourceAsync(rawUrl);
         if (content == null)
         {
-            Console.Error.WriteLine($"Error: failed to fetch the document for printable row {targetIndex} from {rawUrl}.");
+            Console.Error.WriteLine($"Error: failed to fetch the document for row {targetRow} from {rawUrl}.");
             return 1;
         }
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1119,47 +1119,63 @@ public class ApiCommand
             ? []
             : [new PrintableDocument(1, section, label, null, url, content)];
 
+    /// <summary>
+    /// Selects the row addressed by <paramref name="selector"/> from the rows a
+    /// section rendered, or explains why no row could be selected.
+    ///
+    /// Numbering covers every rendered row. Filtering to rows that carry a
+    /// payload and then indexing that shorter list positionally is how --row came
+    /// to address a sequence the reader cannot count: with rows 1-2 carrying no
+    /// URL, --row 1 returned the row displayed third. Printability is therefore
+    /// checked last, against the row the caller actually named, so a row with
+    /// nothing behind it reports that rather than yielding its neighbour.
+    /// </summary>
+    internal static (int Row, string? Label, string? Url)? SelectPrintableRow(
+        IReadOnlyList<(int Row, string? Label, string? Url)> rows,
+        RowSelector? selector,
+        out string error)
+    {
+        error = "";
+        if (rows.Count == 0)
+        {
+            error = "Error: selected section has no rows.";
+            return null;
+        }
+
+        if (selector is null && rows.Count != 1)
+        {
+            error = $"Error: selected section has {rows.Count} rows; use --row N|first|last to choose one row.";
+            return null;
+        }
+
+        var rowNumbers = rows.Select(row => row.Row).ToList();
+        var targetRow = selector?.Resolve(rowNumbers) ?? rowNumbers[0];
+        var position = RowNumbering.IndexOf(rowNumbers, targetRow);
+        if (position < 0)
+        {
+            error = $"Error: row {targetRow} is not in this section. Use --row {RowNumbering.Describe(rowNumbers)}, first, or last.";
+            return null;
+        }
+
+        var selected = rows[position];
+        if (string.IsNullOrWhiteSpace(selected.Url))
+        {
+            error = $"Error: row {targetRow} has no printable document.";
+            return null;
+        }
+
+        return selected;
+    }
+
     private static async Task<int> PrintUrlProjectionAsync(
         string section,
         IEnumerable<(int Row, string? Label, string? Url)>? rows,
         ApiOptions options)
     {
-        // Numbering covers every row the section rendered. Filtering to rows that
-        // carry a payload and then indexing that shorter list positionally is how
-        // --row came to address a sequence the reader cannot see: with rows 1-2
-        // carrying no URL, --row 1 returned the row displayed as 3. Printability
-        // is checked after selection, against the row the caller actually named.
-        var allRows = (rows ?? []).ToList();
-        if (allRows.Count == 0)
+        var selection = SelectPrintableRow((rows ?? []).ToList(), options.PrintRow, out var selectionError);
+        if (selection is not { } selectedRow)
         {
-            Console.Error.WriteLine("Error: selected section has no rows.");
-            return 1;
-        }
-
-        if (options.PrintRow is null && allRows.Count != 1)
-        {
-            Console.Error.WriteLine($"Error: selected section has {allRows.Count} rows; use --row N|first|last to choose one row.");
-            return 1;
-        }
-
-        var rowNumbers = allRows.Select(row => row.Row).ToList();
-        var targetRow = options.PrintRow?.Resolve(rowNumbers) ?? rowNumbers[0];
-        var position = RowNumbering.IndexOf(rowNumbers, targetRow);
-        if (position < 0)
-        {
-            Console.Error.WriteLine(
-                $"Error: row {targetRow} is not in this section. Use --row {RowNumbering.Describe(rowNumbers)}, first, or last.");
-            return 1;
-        }
-
-        var selectedRow = allRows[position];
-        if (string.IsNullOrWhiteSpace(selectedRow.Url))
-        {
-            // The row exists and was addressed correctly; it simply has nothing
-            // behind it. Reporting that is what keeps the ordinal trustworthy —
-            // skipping to a neighbouring row would silently answer a different
-            // question.
-            Console.Error.WriteLine($"Error: row {targetRow} has no printable document.");
+            Console.Error.WriteLine(selectionError);
             return 1;
         }
 
@@ -1168,7 +1184,7 @@ public class ApiCommand
         var content = await fetcher.FetchSourceAsync(rawUrl);
         if (content == null)
         {
-            Console.Error.WriteLine($"Error: failed to fetch the document for row {targetRow} from {rawUrl}.");
+            Console.Error.WriteLine($"Error: failed to fetch the document for row {selectedRow.Row} from {rawUrl}.");
             return 1;
         }
 

--- a/src/dotnet-inspect/Output/PrintProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/PrintProjectionOutput.cs
@@ -34,14 +34,19 @@ public static class PrintProjectionOutput
         PrintableDocument selected;
         if (options.Row is { } selector)
         {
-            var row = selector.Resolve(documents.Count);
-            if (row < 1 || row > documents.Count)
+            // Same rule as the shape projections: the ordinal names the row the
+            // reader saw, and every document already carries that number.
+            var rowNumbers = documents.Select(document => document.Row).ToList();
+            var row = selector.Resolve(rowNumbers);
+            var position = RowNumbering.IndexOf(rowNumbers, row);
+            if (position < 0)
             {
-                Console.Error.WriteLine($"Error: printable row {row} is out of range. Use 1 through {documents.Count}, first, or last.");
+                Console.Error.WriteLine(
+                    $"Error: row {row} is not in this section. Use --row {RowNumbering.Describe(rowNumbers)}, first, or last.");
                 return 1;
             }
 
-            selected = documents[row - 1];
+            selected = documents[position];
         }
         else
         {

--- a/src/dotnet-inspect/Output/RowSelection.cs
+++ b/src/dotnet-inspect/Output/RowSelection.cs
@@ -42,16 +42,29 @@ public readonly record struct RowSelector
     public static RowSelector FromIndex(int index) => new(RowSelectorKind.Index, index);
 
     /// <summary>
-    /// Resolves this selector to a 1-based row index against a known row count:
-    /// <c>first</c> → 1, <c>last</c> → <paramref name="count"/>, and an explicit
-    /// index passes through unchanged (still range-checked by the caller).
+    /// Resolves this selector to the row number it addresses, given the row
+    /// numbers a projection actually rendered, in render order.
+    ///
+    /// This deliberately takes the rendered numbers rather than a count. A
+    /// projection that drops rows carrying no value leaves gaps, so the Nth
+    /// entry of the list and the row labelled N are different rows, and a count
+    /// cannot tell them apart. <c>first</c>/<c>last</c> are the endpoints of the
+    /// rendered sequence — the first and last numbers a reader can see — not 1
+    /// and <c>count</c>. An explicit index passes through as the displayed
+    /// number it names; the caller looks it up and reports a miss.
     /// </summary>
-    public int Resolve(int count) => Kind switch
+    public int Resolve(IReadOnlyList<int> rowNumbers)
     {
-        RowSelectorKind.First => 1,
-        RowSelectorKind.Last => count,
-        _ => _index,
-    };
+        ArgumentNullException.ThrowIfNull(rowNumbers);
+        ArgumentOutOfRangeException.ThrowIfZero(rowNumbers.Count);
+
+        return Kind switch
+        {
+            RowSelectorKind.First => rowNumbers[0],
+            RowSelectorKind.Last => rowNumbers[^1],
+            _ => _index,
+        };
+    }
 
     /// <summary>
     /// Parses a <c>--row</c> token: a case-insensitive <c>first</c>/<c>last</c>
@@ -91,4 +104,70 @@ public enum RowSelectorKind
     Index,
     First,
     Last,
+}
+
+/// <summary>
+/// Helpers for addressing rendered rows by the number the reader sees.
+///
+/// Selection and identity are the same concern here: a projection carries the
+/// row number it rendered on every row, so selection looks that number up
+/// instead of indexing the list positionally. Positional indexing is what made
+/// <c>--row</c> address an invisible sequence, and it fails silently — it
+/// returns a real row, just not the requested one.
+/// </summary>
+public static class RowNumbering
+{
+    /// <summary>
+    /// Returns the position in <paramref name="rowNumbers"/> of the row labelled
+    /// <paramref name="rowNumber"/>, or -1 when no rendered row carries it.
+    /// </summary>
+    public static int IndexOf(IReadOnlyList<int> rowNumbers, int rowNumber)
+    {
+        ArgumentNullException.ThrowIfNull(rowNumbers);
+
+        for (var i = 0; i < rowNumbers.Count; i++)
+        {
+            if (rowNumbers[i] == rowNumber)
+                return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Describes the addressable rows for an error message. A contiguous run
+    /// reads as a range; a gapped sequence is listed explicitly, because the
+    /// gaps are the whole reason the requested number missed and a range would
+    /// name rows that cannot be selected. Long lists are elided in the middle so
+    /// the message stays one line while still showing both endpoints.
+    /// </summary>
+    public static string Describe(IReadOnlyList<int> rowNumbers)
+    {
+        ArgumentNullException.ThrowIfNull(rowNumbers);
+
+        if (rowNumbers.Count == 0)
+            return "none";
+        if (rowNumbers.Count == 1)
+            return rowNumbers[0].ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        var contiguous = true;
+        for (var i = 1; i < rowNumbers.Count; i++)
+        {
+            if (rowNumbers[i] != rowNumbers[i - 1] + 1)
+            {
+                contiguous = false;
+                break;
+            }
+        }
+
+        if (contiguous)
+            return $"{rowNumbers[0]} through {rowNumbers[^1]}";
+
+        const int shown = 8;
+        if (rowNumbers.Count <= shown)
+            return string.Join(", ", rowNumbers);
+
+        var head = string.Join(", ", rowNumbers.Take(shown - 1));
+        return $"{head}, … , {rowNumbers[^1]}";
+    }
 }

--- a/src/dotnet-inspect/Output/RowSelection.cs
+++ b/src/dotnet-inspect/Output/RowSelection.cs
@@ -49,9 +49,9 @@ public readonly record struct RowSelector
     /// projection that drops rows carrying no value leaves gaps, so the Nth
     /// entry of the list and the row labelled N are different rows, and a count
     /// cannot tell them apart. <c>first</c>/<c>last</c> are the endpoints of the
-    /// rendered sequence — the first and last numbers a reader can see — not 1
-    /// and <c>count</c>. An explicit index passes through as the displayed
-    /// number it names; the caller looks it up and reports a miss.
+    /// rendered sequence — the first and last rows a reader would count — not 1
+    /// and <c>count</c>. An explicit index passes through as the row number it
+    /// names; the caller looks it up and reports a miss.
     /// </summary>
     public int Resolve(IReadOnlyList<int> rowNumbers)
     {
@@ -107,13 +107,14 @@ public enum RowSelectorKind
 }
 
 /// <summary>
-/// Helpers for addressing rendered rows by the number the reader sees.
+/// Helpers for addressing rendered rows by the number a reader arrives at when
+/// counting them.
 ///
 /// Selection and identity are the same concern here: a projection carries the
 /// row number it rendered on every row, so selection looks that number up
 /// instead of indexing the list positionally. Positional indexing is what made
-/// <c>--row</c> address an invisible sequence, and it fails silently — it
-/// returns a real row, just not the requested one.
+/// <c>--row</c> address a sequence the reader cannot reconstruct, and it fails
+/// silently — it returns a real row, just not the requested one.
 /// </summary>
 public static class RowNumbering
 {

--- a/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
@@ -62,14 +62,20 @@ public static class ShapeProjectionOutput
         IReadOnlyList<ShapeProjectionRow> selected = rows;
         if (options.Row is { } selector)
         {
-            var row = selector.Resolve(rows.Count);
-            if (row < 1 || row > rows.Count)
+            // Address the row by the number it was rendered with. Indexing the
+            // list positionally would return a different row whenever the
+            // projection skipped one, and would do so without complaint.
+            var rowNumbers = rows.Select(row => row.Row).ToList();
+            var row = selector.Resolve(rowNumbers);
+            var position = RowNumbering.IndexOf(rowNumbers, row);
+            if (position < 0)
             {
-                Console.Error.WriteLine($"Error: row {row} is out of range. Use --row 1 through {rows.Count}, first, or last.");
+                Console.Error.WriteLine(
+                    $"Error: row {row} is not in this section. Use --row {RowNumbering.Describe(rowNumbers)}, first, or last.");
                 return 1;
             }
 
-            selected = [rows[row - 1]];
+            selected = [rows[position]];
         }
 
         if (options.Kind == ShapeProjectionKind.Value && selected.Count != 1)


### PR DESCRIPTION
Fixes the bugfix half of #3364. The range grammar (`--rows 2..10`) stays open.

## Problem

`--row` did not select the row a reader counted in the output, and the failure was silent.

Four call sites filtered rows by payload availability -- or projected a filtered subset -- and then indexed that shorter list **positionally**, while every row already carried the number it was rendered with:

| Site | Defect |
| --- | --- |
| `ApiCommand.PrintUrlProjectionAsync` | filtered on `!IsNullOrWhiteSpace(row.Url)`, then indexed by position |
| `ShapeProjectionOutput.Write` | `rows[row - 1]` while each row carries `.Row` |
| `PrintProjectionOutput.Write` | `documents[row - 1]` while each carries `.Row` |
| `ApiCommand.ProjectTypeSourceFiles` | renumbered survivors `1..N` after filtering |

With rows 1-2 carrying no URL, `--row 1` returned the row displayed as 3. It returns a *real* row, so nothing looks broken.

## Change

`RowSelector.Resolve(int count)` is replaced by `Resolve(IReadOnlyList<int> rowNumbers)`. A count cannot distinguish the Nth entry of a list from the row labelled N, so removing the overload makes the mistake **unrepresentable** rather than merely fixed -- there is no longer a way to ask the question that produced the bug.

Consequences:

- `first`/`last` resolve to the endpoints of the *rendered* sequence, not `1` and the count.
- `RowNumbering.IndexOf`/`Describe` add the lookup and the error vocabulary. Errors now name the addressable rows (`Use --row 2, 5, first, or last`) instead of quoting a `1..N` range that includes rows that cannot be selected and excludes rows that can.
- **Printability never affects numbering.** A row that declares no payload keeps its number; selecting it reports `row N has no printable document` rather than sliding to a neighbour.

## Evidence

New `RowSelectionNumberingTests` builds rows numbered **2 and 5** -- contiguous rows cannot distinguish a correct implementation from a positional one. **4 of its 5 cases fail before this change**, including the silent wrong answer:

```
Row_SelectsDisplayedNumber_NotListPosition
  Expected: "alpha"   (row 2)
  Actual:   "beta"    (row 5)
```

Full CLI suite at the head commit: **2267 tests, 1 failure**, `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden`. That failure **reproduces on unmodified `origin/main` at 44f2832a** (verified in a separate clean worktree) and is unrelated to row selection.

## Compatibility

User-visible error text changed on the `--print` URL path, and four existing assertions were updated:

- `selected section has N printable rows` -> `selected section has N rows`
- `failed to fetch the document for printable row N` -> `... for row N`

The count is unchanged for `Source Files` (`TypeSourceFileRow.Url` is non-nullable, so every row is printable there). `PrintProjectionOutput`'s `printable rows` wording is deliberately **kept**: those documents are printable by construction, so the term is accurate there.

Behaviour changes only where displayed and positional numbering diverged -- i.e. only where `--row` was returning the wrong row.