### PR TITLE
Narrow the Callers scope by direct type reference

### DIFF
--- a/src/ILInspector.Analysis.Tests/CallerScopeTypeFilterTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeTypeFilterTests.cs
@@ -321,10 +321,18 @@ public class CallerScopeTypeFilterTests
     /// produces. Only the metadata blob is built, because <see cref="CallerScopeTypeFilter"/>
     /// decides from a <see cref="MetadataReader"/> and never needs the surrounding PE.
     ///
-    /// The assertions below pin the two properties that make this stand in for a compiled
-    /// netmodule, so the fixture cannot quietly stop being one: the reader is not an assembly, and
-    /// the decoder gives its definitions the empty assembly name. Both were confirmed against an
-    /// actual <c>csc -target:module</c> output before this test was written.
+    /// The corelib reference and <c>System.Object</c> base type are not decoration: a real
+    /// <c>csc -target:module</c> output carries exactly them, and a fixture without them would let
+    /// a negative test "rule out" <c>System.Object</c>, which no real module would allow. Verified
+    /// against an actual netmodule, whose entire TypeRef table is:
+    /// <code>
+    /// System.Runtime.CompilerServices.RefSafetyRulesAttribute -> asmref:System.Private.CoreLib
+    /// System.Object                                           -> asmref:System.Private.CoreLib
+    /// </code>
+    ///
+    /// The assertions in the tests below pin the two properties that make this stand in for a
+    /// compiled netmodule, so the fixture cannot quietly stop being one: the reader is not an
+    /// assembly, and the decoder gives its definitions the empty assembly name.
     /// </summary>
     static MetadataReaderProvider BuildModuleMetadata(string ns, string typeName)
     {
@@ -335,6 +343,18 @@ public class CallerScopeTypeFilterTests
             builder.GetOrAddGuid(Guid.NewGuid()),
             default,
             default);
+
+        var corelib = builder.AddAssemblyReference(
+            builder.GetOrAddString("System.Private.CoreLib"),
+            new Version(9, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        var objectRef = builder.AddTypeReference(
+            corelib,
+            builder.GetOrAddString("System"),
+            builder.GetOrAddString("Object"));
 
         // Row 1 is always <Module>; the real type follows it, exactly as a compiler emits.
         builder.AddTypeDefinition(
@@ -348,7 +368,7 @@ public class CallerScopeTypeFilterTests
             TypeAttributes.Public,
             builder.GetOrAddString(ns),
             builder.GetOrAddString(typeName),
-            baseType: default,
+            baseType: objectRef,
             fieldList: MetadataTokens.FieldDefinitionHandle(1),
             methodList: MetadataTokens.MethodDefinitionHandle(1));
 
@@ -391,6 +411,12 @@ public class CallerScopeTypeFilterTests
     /// <summary>
     /// The same module must still be ruled out for a type it does not declare, or the test above
     /// would be satisfied by a filter that simply kept every module.
+    ///
+    /// The foreign type has to be one a real module would genuinely not name. <c>System.Object</c>
+    /// is the wrong choice and was the original mistake here: every compiled module references it
+    /// as a base type, so ruling it out would have been a claim no real netmodule could satisfy —
+    /// the assertion only held because the fixture was less faithful than the thing it stood for.
+    /// It is now asserted in the other direction, as a positive control.
     /// </summary>
     [Fact]
     public void ModuleWithoutAnAssemblyManifestIsStillRuledOutForAForeignType()
@@ -400,6 +426,14 @@ public class CallerScopeTypeFilterTests
 
         Assert.Equal(
             CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+            CallerScopeTypeFilter.Classify(
+                reader,
+                TypeRef.Definition("System.Net.Sockets", "System.Net.Sockets", "Socket")));
+
+        // Positive control: the type the module really does reference is found through the
+        // TypeRef table, so the negative above is a property of this type and not of modules.
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Names,
             CallerScopeTypeFilter.Classify(reader, TypeRef.CoreLib("System", "Object")));
     }
 

--- a/src/ILInspector.Analysis.Tests/CallerScopeTypeFilterTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeTypeFilterTests.cs
@@ -1,0 +1,315 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Fixtures;
+using ILInspector.Analysis;
+
+namespace ILInspector.Analysis.Tests;
+
+/// <summary>
+/// <see cref="CallerScopeTypeFilter"/> decides, from an assembly's <c>TypeRef</c> table alone,
+/// whether it could contain a <em>direct</em> caller of a member declared by a given type. Its
+/// correctness obligation is the same shape as <see cref="CallerScopeFilter"/>'s and no weaker: it
+/// must never rule out an assembly whose call sites
+/// <see cref="MemberPattern.MatchesCrossAssembly"/> would have matched.
+///
+/// The tests that matter are the ones distinguishing it from its sibling. <see cref="CallerScopeFilter"/>
+/// asks whether an assembly could reach the target <em>assembly</em>, transitively; this asks
+/// whether it names the target <em>type</em>, directly. Every case below where the two disagree is
+/// a real compiled fixture, because the saving this filter exists for is exactly the size of that
+/// disagreement.
+/// </summary>
+public class CallerScopeTypeFilterTests
+{
+    static string Target => FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+    static string Caller => FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath();
+    static string Twin => FixtureCatalog.AnalysisCallerGraphCallerTwin.AssemblyPath();
+    static string Indirect => FixtureCatalog.AnalysisCallerGraphIndirectCaller.AssemblyPath();
+    static string Lookalike => FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath();
+
+    /// <summary>
+    /// The declaring type of a real method in the target fixture, taken from the index rather than
+    /// spelled by hand so the expected value is the one the matcher actually compares against.
+    /// </summary>
+    static TypeRef DeclaringTypeOf(string typeName, string methodName)
+    {
+        var index = LibraryBodyIndex.Open(Target);
+        var method = index.Methods.First(m => m.DeclaringType.Name == typeName && m.Name == methodName);
+        return GenericMemberIdentity.OpenDeclaringType(method.DeclaringType);
+    }
+
+    static CallerScopeTypeFilter.TypeReferenceState Classify(string candidatePath, TypeRef declaringType)
+        => CallerScopeTypeFilter.Classify(candidatePath, declaringType);
+
+    /// <summary>
+    /// Whether <see cref="CallerScopeFilter"/> — the transitive, assembly-level sibling — keeps a
+    /// candidate. Used to assert that this filter is strictly narrower on the same input, which is
+    /// the entire reason it exists.
+    ///
+    /// The whole scope is supplied, not just the candidate under test: the closure closes over the
+    /// scope rather than the machine, so an assembly whose only bridge to the target is another
+    /// scope member is only kept when that member is present.
+    /// </summary>
+    static bool AssemblyFilterKeeps(string candidatePath)
+    {
+        static ILInspector.Metadata.AssemblyIdentityNames Identity(string path)
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            return ILInspector.Metadata.AssemblyIdentityScanner.Scan(peReader);
+        }
+
+        string[] scope = [Caller, Twin, Indirect, Lookalike];
+        var candidates = scope
+            .Select(path =>
+            {
+                var identity = Identity(path);
+                return CallerScopeFilter.Candidate.Known(identity.Name, identity.ReferenceNames);
+            })
+            .ToArray();
+
+        var selected = CallerScopeFilter.SelectCouldReach(Identity(Target).Name, candidates);
+        return selected[Array.IndexOf(scope, candidatePath)];
+    }
+
+    // The real caller calls Target.Api.Ping, so its TypeRef table names Target.Api and it must be
+    // kept. This is the assembly the caller-edge tests prove does contribute edges.
+    [Fact]
+    public void AssemblyNamingTheDeclaringTypeIsKept()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Names,
+            Classify(Caller, DeclaringTypeOf("Api", "Ping")));
+    }
+
+    // THE case this filter exists for. The twin references the target assembly and calls
+    // Target.Api.Ping, so the assembly-level filter keeps it for every target in that assembly.
+    // But it never mentions Target.Box`1, so no call site in it can produce a callee whose
+    // declaring type matches Box`1, and opening it to discover that is pure cost.
+    //
+    // The two assertions are one claim: the filters disagree, and the disagreement is the saving.
+    [Fact]
+    public void AssemblyNamingTheTargetAssemblyButNotTheTypeIsRuledOut()
+    {
+        Assert.True(AssemblyFilterKeeps(Twin));
+
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+            Classify(Twin, DeclaringTypeOf("Box`1", "Store")));
+    }
+
+    // Same assembly, same scan, a type it does reference: without this the test above would pass
+    // for an assembly the filter simply cannot read.
+    [Fact]
+    public void TheSameAssemblyIsKeptForATypeItDoesName()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Names,
+            Classify(Twin, DeclaringTypeOf("Api", "Ping")));
+    }
+
+    // The transitive obligation that binds CallerScopeFilter does NOT bind this one, and that is a
+    // deliberate difference rather than an oversight. The indirect fixture references only the
+    // caller assembly, so it belongs in a caller *graph* rooted at Ping (two hops) and the
+    // assembly-level filter correctly keeps it. It has no call site targeting Ping itself, so it
+    // contributes no inbound *edge* and the single-hop consumer must not pay to open it.
+    [Fact]
+    public void TransitiveOnlyCallerIsRuledOutForDirectEdges()
+    {
+        Assert.True(AssemblyFilterKeeps(Indirect));
+
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+            Classify(Indirect, DeclaringTypeOf("Api", "Ping")));
+    }
+
+    // The lookalike declares its own Target.Api.Ping and calls that, so its calls resolve to its
+    // own TypeDef and the matcher already excludes it. Ruling it out here matches that.
+    //
+    // Note what this does NOT pin, because the name invites the stronger reading: the lookalike
+    // never references the target assembly at all, so it carries no TypeRef row for Target.Api in
+    // any assembly. Mutation-tested — an assembly-insensitive comparison still rules it out, so
+    // this case cannot certify assembly sensitivity. FrameworkTypeMatchesOnlyUnderItsOwnAssembly
+    // is the test that does, and it is the one that kills that mutant.
+    [Fact]
+    public void SameNamedTypeInAnotherAssemblyIsRuledOut()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+            Classify(Lookalike, DeclaringTypeOf("Api", "Ping")));
+    }
+
+    // A callee declared by a TypeDef carries the defining assembly's own name and appears in no
+    // TypeRef row, so the target assembly has to be kept without scanning for it.
+    [Fact]
+    public void TargetAssemblyItselfIsKept()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Names,
+            Classify(Target, DeclaringTypeOf("Api", "Ping")));
+    }
+
+    // A constructed instantiation reaches its declaring type through a TypeSpec whose signature
+    // bottoms out at the open definition's TypeRef row, so scanning that table sees it. The caller
+    // fixture only ever spells Box<int>, never the open Box`1.
+    [Fact]
+    public void ConstructedGenericCallerNamesTheOpenDefinition()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Names,
+            Classify(Caller, DeclaringTypeOf("Box`1", "Store")));
+    }
+
+    // Generic arity is part of type identity, so Box`1 and Box`2 are different types. The caller
+    // references both; the twin references neither. Pinning both directions keeps a filter that
+    // strips arity from passing.
+    [Fact]
+    public void GenericArityIsPartOfTheIdentity()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Names,
+            Classify(Caller, DeclaringTypeOf("Box`2", "Store")));
+
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+            Classify(Twin, DeclaringTypeOf("Box`2", "Store")));
+    }
+
+    // Corelib facade canonicalization, the same property that makes CallerScopeFilter safe. The
+    // fixtures reference System.Runtime and none references System.Private.CoreLib by name, so a
+    // raw name comparison would rule out every caller of a corelib type.
+    [Fact]
+    public void CorelibTypeIsFoundThroughTheFacadeReference()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Names,
+            Classify(Caller, TypeRef.CoreLib("System", "Object")));
+    }
+
+    // A corelib type nothing in the fixture uses. Without this the facade test above would pass
+    // for a filter that keeps any assembly referencing corelib at all — which is every assembly,
+    // and is precisely the over-selection this filter removes.
+    [Fact]
+    public void UnreferencedCorelibTypeIsRuledOut()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+            Classify(Caller, TypeRef.CoreLib("System.Net.Sockets", "Socket")));
+    }
+
+    // Assembly sensitivity on a framework type the fixture really does call, and the reason
+    // canonicalization must not be mistaken for "any framework assembly will do". The caller
+    // constructs a List<int>, and that callee's declaring type resolves to System.Collections —
+    // NOT to the corelib alias set. Spelling the same namespace and name against corelib must
+    // therefore miss, exactly as the matcher does, which compares the same value.
+    [Fact]
+    public void FrameworkTypeMatchesOnlyUnderItsOwnAssembly()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Names,
+            Classify(Caller, TypeRef.Definition("System.Collections", "System.Collections.Generic", "List`1")));
+
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+            Classify(Caller, TypeRef.CoreLib("System.Collections.Generic", "List`1")));
+    }
+
+    // A declaring type that is not a plain definition has no assembly-qualified identity to filter
+    // on, so the filter declines to decide rather than ruling the candidate out.
+    [Fact]
+    public void NonDefinitionDeclaringTypeIsUndecidable()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Undecidable,
+            Classify(Caller, TypeRef.SzArray(TypeRef.CoreLib("System", "Int32"))));
+    }
+
+    // A file that is not a readable managed image could not have contributed edges either, so it
+    // is ruled out rather than treated as undecidable — the same reasoning that keeps the
+    // assembly-level filter from being disabled by one native DLL in a --bin directory.
+    [Fact]
+    public void UnreadableImageIsRuledOut()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"cstf-{Guid.NewGuid():N}.dll");
+        File.WriteAllBytes(path, [0x4D, 0x5A, 0x00, 0x00]);
+        try
+        {
+            Assert.Equal(
+                CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+                Classify(path, DeclaringTypeOf("Api", "Ping")));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void MissingFileIsRuledOut()
+    {
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+            Classify(Path.Combine(Path.GetTempPath(), $"absent-{Guid.NewGuid():N}.dll"),
+                DeclaringTypeOf("Api", "Ping")));
+    }
+
+    /// <summary>
+    /// The soundness obligation stated directly, over every fixture and every declaring type in the
+    /// target: an assembly ruled out here must contribute no matching call site.
+    ///
+    /// This is the test that would catch a filter narrower than the matcher, which is the only
+    /// failure mode that changes output rather than cost. It compares against the matcher itself
+    /// rather than against a golden list, so it cannot drift from the behavior it guards, and it
+    /// asserts its own non-vacuity: a run in which nothing is ever ruled out, or in which no ruled-in
+    /// assembly ever matches, would prove nothing.
+    /// </summary>
+    [Fact]
+    public void NothingRuledOutEverContributesAMatchingCallSite()
+    {
+        var targetIndex = LibraryBodyIndex.Open(Target);
+        var declaringTypes = targetIndex.Methods
+            .Select(m => GenericMemberIdentity.OpenDeclaringType(m.DeclaringType))
+            .Distinct()
+            .ToList();
+
+        var candidates = new[] { Caller, Twin, Indirect, Lookalike, Target };
+        int ruledOut = 0;
+        int matchedWhenKept = 0;
+
+        foreach (var declaringType in declaringTypes)
+        {
+            foreach (var method in targetIndex.Methods
+                         .Where(m => GenericMemberIdentity.OpenDeclaringType(m.DeclaringType).Equals(declaringType)))
+            {
+                var pattern = MemberPattern.Method(method.DeclaringType, method.Name, method.ParameterTypes);
+
+                foreach (string candidate in candidates)
+                {
+                    bool kept = Classify(candidate, declaringType)
+                        is not CallerScopeTypeFilter.TypeReferenceState.DoesNotName;
+
+                    bool matches = LibraryBodyIndex.Open(candidate).DirectCalls
+                        .Any(call => pattern.MatchesCrossAssembly(call.Callee));
+
+                    if (kept)
+                    {
+                        if (matches)
+                            matchedWhenKept++;
+                        continue;
+                    }
+
+                    ruledOut++;
+                    Assert.False(
+                        matches,
+                        $"{Path.GetFileNameWithoutExtension(candidate)} was ruled out for "
+                        + $"{declaringType.ToQualifiedDisplayString()} but matches {method.Name}");
+                }
+            }
+        }
+
+        // Non-vacuity, over both classifications. Without the first the filter could rule nothing
+        // out; without the second the matcher could match nothing and the assertion above would
+        // hold for any filter at all.
+        Assert.True(ruledOut > 0, "no candidate was ever ruled out, so the assertion proved nothing");
+        Assert.True(matchedWhenKept > 0, "no kept candidate ever matched, so the matcher proved nothing");
+    }
+}

--- a/src/ILInspector.Analysis.Tests/CallerScopeTypeFilterTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeTypeFilterTests.cs
@@ -1,4 +1,7 @@
 using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Fixtures;
 using ILInspector.Analysis;
@@ -311,5 +314,145 @@ public class CallerScopeTypeFilterTests
         // hold for any filter at all.
         Assert.True(ruledOut > 0, "no candidate was ever ruled out, so the assertion proved nothing");
         Assert.True(matchedWhenKept > 0, "no kept candidate ever matched, so the matcher proved nothing");
+    }
+
+    /// <summary>
+    /// Metadata for a module with no assembly manifest — the shape <c>csc -target:module</c>
+    /// produces. Only the metadata blob is built, because <see cref="CallerScopeTypeFilter"/>
+    /// decides from a <see cref="MetadataReader"/> and never needs the surrounding PE.
+    ///
+    /// The assertions below pin the two properties that make this stand in for a compiled
+    /// netmodule, so the fixture cannot quietly stop being one: the reader is not an assembly, and
+    /// the decoder gives its definitions the empty assembly name. Both were confirmed against an
+    /// actual <c>csc -target:module</c> output before this test was written.
+    /// </summary>
+    static MetadataReaderProvider BuildModuleMetadata(string ns, string typeName)
+    {
+        var builder = new MetadataBuilder();
+        builder.AddModule(
+            generation: 0,
+            builder.GetOrAddString("ModOnly.netmodule"),
+            builder.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+
+        // Row 1 is always <Module>; the real type follows it, exactly as a compiler emits.
+        builder.AddTypeDefinition(
+            default,
+            default,
+            builder.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        builder.AddTypeDefinition(
+            TypeAttributes.Public,
+            builder.GetOrAddString(ns),
+            builder.GetOrAddString(typeName),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var root = new MetadataRootBuilder(builder);
+        var blob = new BlobBuilder();
+        root.Serialize(blob, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
+        return MetadataReaderProvider.FromMetadataImage(blob.ToImmutableArray());
+    }
+
+    /// <summary>
+    /// A type defined by a module with no assembly manifest decodes to the empty assembly name,
+    /// and <see cref="MemberPattern.MatchesCrossAssembly"/> compares that name like any other. The
+    /// filter therefore has to recognise it as the module's own identity and keep the candidate.
+    ///
+    /// Deriving the answer by hand from <c>reader.IsAssembly</c> gets this wrong: the guard skips
+    /// the whole own-identity check for module metadata, the type appears in no <c>TypeRef</c> row
+    /// because it is defined here, and the module is ruled out despite declaring the very type
+    /// being searched for. Asking <see cref="TypeRefDecoder"/> instead cannot drift from what the
+    /// matcher compares.
+    /// </summary>
+    [Fact]
+    public void ModuleWithoutAnAssemblyManifestIsNotRuledOutForItsOwnTypes()
+    {
+        using var provider = BuildModuleMetadata("Sample", "ModTarget");
+        var reader = provider.GetMetadataReader();
+
+        Assert.False(reader.IsAssembly);
+
+        var declaringType = reader.TypeDefinitions
+            .Select(h => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, h, 0))
+            .First(t => t.Name == "ModTarget");
+
+        Assert.Equal(string.Empty, declaringType.Assembly);
+
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Names,
+            CallerScopeTypeFilter.Classify(reader, declaringType));
+    }
+
+    /// <summary>
+    /// The same module must still be ruled out for a type it does not declare, or the test above
+    /// would be satisfied by a filter that simply kept every module.
+    /// </summary>
+    [Fact]
+    public void ModuleWithoutAnAssemblyManifestIsStillRuledOutForAForeignType()
+    {
+        using var provider = BuildModuleMetadata("Sample", "ModTarget");
+        var reader = provider.GetMetadataReader();
+
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.DoesNotName,
+            CallerScopeTypeFilter.Classify(reader, TypeRef.CoreLib("System", "Object")));
+    }
+
+    /// <summary>
+    /// A <c>TypeRef</c> row the decoder cannot project is not evidence of absence: the rows that
+    /// did decode do not speak for it, so the candidate has to be kept. The row here nests
+    /// resolution scopes deeper than <c>MetadataSafetyPolicy</c> allows the traversal to walk,
+    /// which is the cheapest way to make the real decoder return <c>Unsupported</c> without
+    /// corrupting anything else.
+    /// </summary>
+    [Fact]
+    public void AnUndecodableTypeReferenceRowLeavesTheCandidateUndecided()
+    {
+        var builder = new MetadataBuilder();
+        builder.AddModule(
+            generation: 0,
+            builder.GetOrAddString("Deep.dll"),
+            builder.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        builder.AddTypeDefinition(
+            default,
+            default,
+            builder.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        // Each row's resolution scope is the row above it, so the chain never terminates in an
+        // AssemblyRef and its length is bounded only by the row count.
+        int depth = ILInspector.Metadata.MetadataSafetyPolicy.MaxRelationshipNodes + 2;
+        for (int i = 1; i <= depth; i++)
+        {
+            builder.AddTypeReference(
+                MetadataTokens.TypeReferenceHandle(i == 1 ? depth : i - 1),
+                builder.GetOrAddString(""),
+                builder.GetOrAddString($"Nested{i}"));
+        }
+
+        var root = new MetadataRootBuilder(builder);
+        var blob = new BlobBuilder();
+        root.Serialize(blob, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
+        using var provider = MetadataReaderProvider.FromMetadataImage(blob.ToImmutableArray());
+        var reader = provider.GetMetadataReader();
+
+        // The premise: the decoder really does fail on this table. Without it the test would pass
+        // for a filter that never returns Undecidable at all.
+        Assert.Contains(
+            reader.TypeReferences,
+            h => TypeRefDecoder.Instance.GetTypeFromReference(reader, h, 0).Kind == TypeRefKind.Unsupported);
+
+        Assert.Equal(
+            CallerScopeTypeFilter.TypeReferenceState.Undecidable,
+            CallerScopeTypeFilter.Classify(reader, TypeRef.CoreLib("System", "Object")));
     }
 }

--- a/src/ILInspector.Analysis/CallerScopeTypeFilter.cs
+++ b/src/ILInspector.Analysis/CallerScopeTypeFilter.cs
@@ -1,0 +1,150 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Whether an assembly could contain a <em>direct</em> caller of a member declared by a given type,
+/// decided from its <c>TypeRef</c> table alone.
+///
+/// This is the narrower sibling of <see cref="CallerScopeFilter"/>, and the two answer genuinely
+/// different questions because their consumers walk differently. A caller <em>graph</em> is
+/// transitive, so it must select the reverse-reference closure over the scope — an assembly that
+/// never names the target still belongs in the graph if it calls something that does. Inbound
+/// <em>edges</em> are not transitive: the consumer scans each scope for call sites whose callee
+/// matches the target and stops there. Nothing upstream is ever asked for, so nothing upstream
+/// needs to be opened, and the closure that the graph requires is pure cost for the edge list.
+///
+/// The saving is the whole point. Reference closure over a framework-shaped scope selects nearly
+/// everything — every assembly reaches the core library in one hop, so transitivity makes almost
+/// any in-graph target select almost every candidate. Direct type reference does not: on a
+/// 182-assembly framework scope, a target in <c>System.Collections.Immutable</c> goes from 169
+/// selected candidates to 3. Each candidate ruled out here is a full method-body decode not paid.
+///
+/// <para><b>Why this is exactly as permissive as the matcher.</b>
+/// <see cref="MemberPattern.MatchesCrossAssembly"/> requires the candidate callee's open declaring
+/// type to be <see cref="TypeRef.Equals"/> to the target's, and that equality includes
+/// <see cref="TypeRef.Assembly"/>. A cross-assembly callee reaches its declaring type either
+/// through the <c>TypeRef</c> table directly or through a <c>TypeSpec</c> whose signature bottoms
+/// out at a <c>TypeRef</c> — <see cref="GenericMemberIdentity.OpenDeclaringType"/> reduces a
+/// constructed instantiation back to that row. So every declaring type a candidate can spell at a
+/// call site is the decoding of one of the rows scanned here.</para>
+///
+/// <para>That equivalence is by construction rather than by argument: this scan decodes each row
+/// with the same <see cref="TypeRefDecoder"/> the call-site decoding uses, so nested-type naming,
+/// generic arity, module-scoped and nil resolution scopes, and core-library facade canonicalization
+/// are not re-derived here and cannot drift from it.</para>
+///
+/// <para><b>Types the candidate defines itself.</b> A callee declared by a <c>TypeDef</c> is
+/// decoded against the defining assembly's own name and appears in no <c>TypeRef</c> row, so an
+/// assembly whose own identity canonicalizes to the target's is kept without scanning. This is the
+/// scope-contains-a-copy-of-the-target case.</para>
+///
+/// <para><b>Undecidable is kept.</b> A row that cannot be read, or a target that is not a plain
+/// type definition, yields <see cref="TypeReferenceState.Undecidable"/> and the candidate stays in
+/// the scope. Ruling out on unread metadata would drop callers the matcher would have found.</para>
+///
+/// Wider type forwarding — a candidate reaching the target only through a facade outside the
+/// core-library alias set — is not modelled here for the same reason
+/// <see cref="CallerScopeFilter"/> does not model it: the matcher already misses those callers, so
+/// this filter stays exactly as permissive as the behavior it guards.
+/// </summary>
+public static class CallerScopeTypeFilter
+{
+    /// <summary>Whether an image can spell a given declaring type at a call site.</summary>
+    public enum TypeReferenceState
+    {
+        /// <summary>The image names the type, or defines it. It stays in the scope.</summary>
+        Names,
+
+        /// <summary>
+        /// Every reference was read and none names the type, so no call site in this image can
+        /// produce a matching callee. The image is ruled out without decoding its bodies.
+        /// </summary>
+        DoesNotName,
+
+        /// <summary>
+        /// The question could not be decided. Kept, because an unread row could have been the one
+        /// naming the target.
+        /// </summary>
+        Undecidable,
+    }
+
+    /// <summary>
+    /// Classifies one candidate image against the open declaring type of the target member.
+    /// <paramref name="openDeclaringType"/> must be the same value
+    /// <see cref="MemberPattern.MatchesCrossAssembly"/> compares against — see
+    /// <see cref="GenericMemberIdentity.OpenDeclaringType"/>.
+    /// </summary>
+    public static TypeReferenceState Classify(MetadataReader reader, TypeRef openDeclaringType)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(openDeclaringType);
+
+        // Only a plain type definition has an assembly-qualified identity to filter on. Anything
+        // else (an array, a pointer, an undecoded reference) is not a shape the matcher's declaring
+        // type takes, so the filter declines to decide rather than guessing at it.
+        if (openDeclaringType.Kind != TypeRefKind.Definition)
+            return TypeReferenceState.Undecidable;
+
+        try
+        {
+            if (reader.IsAssembly)
+            {
+                string own = reader.GetString(reader.GetAssemblyDefinition().Name);
+                if (TypeRef.CanonicalAssembly(own) == openDeclaringType.Assembly)
+                    return TypeReferenceState.Names;
+            }
+
+            foreach (var handle in reader.TypeReferences)
+            {
+                var decoded = TypeRefDecoder.Instance.GetTypeFromReference(reader, handle, 0);
+
+                // A row that would not decode at a call site either cannot be ruled out on its
+                // own contents, and the rows that did decode do not speak for it.
+                if (decoded.Kind == TypeRefKind.Unsupported)
+                    return TypeReferenceState.Undecidable;
+
+                if (decoded.Equals(openDeclaringType))
+                    return TypeReferenceState.Names;
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            return TypeReferenceState.Undecidable;
+        }
+
+        return TypeReferenceState.DoesNotName;
+    }
+
+    /// <summary>
+    /// Classifies an image on disk. Opens the PE image for metadata only — no method bodies are
+    /// decoded, which is the cost this filter exists to avoid paying for images that cannot match.
+    /// An image that cannot be opened or carries no metadata is
+    /// <see cref="TypeReferenceState.DoesNotName"/>: analysis opens the same path the same way, so
+    /// it could not have contributed edges either.
+    /// </summary>
+    public static TypeReferenceState Classify(string path, TypeRef openDeclaringType)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return TypeReferenceState.DoesNotName;
+
+            return Classify(peReader.GetMetadataReader(), openDeclaringType);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException
+                                      or IOException
+                                      or UnauthorizedAccessException)
+        {
+            return TypeReferenceState.DoesNotName;
+        }
+        catch
+        {
+            // An unanticipated failure says nothing about whether analysis could read the image.
+            return TypeReferenceState.Undecidable;
+        }
+    }
+}

--- a/src/ILInspector.Analysis/CallerScopeTypeFilter.cs
+++ b/src/ILInspector.Analysis/CallerScopeTypeFilter.cs
@@ -36,9 +36,17 @@ namespace ILInspector.Analysis;
 /// are not re-derived here and cannot drift from it.</para>
 ///
 /// <para><b>Types the candidate defines itself.</b> A callee declared by a <c>TypeDef</c> is
-/// decoded against the defining assembly's own name and appears in no <c>TypeRef</c> row, so an
-/// assembly whose own identity canonicalizes to the target's is kept without scanning. This is the
-/// scope-contains-a-copy-of-the-target case.</para>
+/// decoded against the defining image's own name and appears in no <c>TypeRef</c> row, so an image
+/// whose own identity equals the target's is kept without scanning. This is the
+/// scope-contains-a-copy-of-the-target case.
+///
+/// That identity is asked of <see cref="TypeRefDecoder"/> rather than recomputed here, for the
+/// same reason the row scan reuses it. Deriving it by hand got it wrong: an image with no assembly
+/// manifest gives its definitions the <em>empty</em> assembly name, which
+/// <see cref="MemberPattern.MatchesCrossAssembly"/> compares like any other, so a
+/// <c>reader.IsAssembly</c> guard skipped the check entirely and ruled such a module out even for
+/// a type it declares itself. Every definition in an image carries the same assembly identity, so
+/// one row answers for all of them.</para>
 ///
 /// <para><b>Undecidable is kept.</b> A row that cannot be read, or a target that is not a plain
 /// type definition, yields <see cref="TypeReferenceState.Undecidable"/> and the candidate stays in

--- a/src/ILInspector.Analysis/CallerScopeTypeFilter.cs
+++ b/src/ILInspector.Analysis/CallerScopeTypeFilter.cs
@@ -89,11 +89,23 @@ public static class CallerScopeTypeFilter
 
         try
         {
-            if (reader.IsAssembly)
+            // The identity that this image's own definitions carry is asked of the decoder rather
+            // than recomputed here. Restating it is what made this branch disagree with the matcher
+            // for module metadata: a definition in an image with no assembly manifest decodes to
+            // the empty assembly name, which a hand-written `reader.IsAssembly` guard skips over
+            // entirely while MatchesCrossAssembly happily compares it.
+            foreach (var definitionHandle in reader.TypeDefinitions)
             {
-                string own = reader.GetString(reader.GetAssemblyDefinition().Name);
-                if (TypeRef.CanonicalAssembly(own) == openDeclaringType.Assembly)
+                var own = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, definitionHandle, 0);
+                if (own.Kind == TypeRefKind.Unsupported)
+                    return TypeReferenceState.Undecidable;
+
+                if (own.Assembly == openDeclaringType.Assembly)
                     return TypeReferenceState.Names;
+
+                // Every definition in an image carries the same assembly identity, so one answers
+                // for all of them.
+                break;
             }
 
             foreach (var handle in reader.TypeReferences)

--- a/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
+++ b/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
@@ -264,6 +264,119 @@ public class ApiMemberAnalysisInspectionTests
         return ILInspector.Metadata.AssemblyIdentityScanner.Scan(reader).ReferenceNames;
     }
 
+    // --- #3333 increment 2: narrowing the single-hop Callers path ---
+
+    static ApiMemberAnalysisInspection CreateForCallers(string assemblyPath, IReadOnlyList<string>? scope)
+        => new(assemblyPath, [], new HashSet<string> { SectionNames.Callers }, scope, null);
+
+    static int TokenOf(string assemblyPath, string declaringTypeName, string methodName)
+        => ILInspector.Analysis.LibraryBodyIndex.Open(assemblyPath).Methods
+            .First(m => m.DeclaringType.Name == declaringTypeName && m.Name == methodName)
+            .MetadataToken;
+
+    static string[] FullScope =>
+    [
+        FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath(),
+        FixtureCatalog.AnalysisCallerGraphCallerTwin.AssemblyPath(),
+        FixtureCatalog.AnalysisCallerGraphIndirectCaller.AssemblyPath(),
+        FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath(),
+    ];
+
+    // The Callers table is built from strictly single-hop edges, so it needs the assemblies that
+    // name the declaring type, not the transitive closure the Call Graph needs. Box`1 is declared
+    // by the target and referenced only by the caller fixture: the twin references the target
+    // assembly but never Box`1, and the indirect fixture reaches the target only through the
+    // caller. The closure keeps all three; only one can contribute an edge.
+    [Fact]
+    public void DirectCallerScopes_NarrowsToAssembliesNamingTheDeclaringType()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        int store = TokenOf(target, "Box`1", "Store");
+
+        var wide = CreateForCallers(target, FullScope).CallerScopes(includeAllocations: false);
+        var narrow = CreateForCallers(target, FullScope).DirectCallerScopes(store);
+
+        Assert.NotNull(wide);
+        Assert.NotNull(narrow);
+
+        // Non-vacuity: the narrowing has to be a real reduction, or the equivalence test below
+        // would be comparing a scope against itself.
+        Assert.Equal(3, wide.Count);
+        Assert.Equal(
+            ["ILInspector.Analysis.CallerGraphCaller"],
+            narrow.Select(s => s.SourceName).OrderBy(n => n, StringComparer.Ordinal));
+    }
+
+    // The obligation: narrowing changes how many assemblies are opened, never the answer. Every
+    // method in the target fixture is compared, with the un-narrowed scope as the control.
+    //
+    // The control is obtained by resolving the graph lens first, which makes DirectCallerScopes
+    // reuse that wider set — so this exercises the reuse branch as well as pinning equivalence.
+    [Fact]
+    public void CallerEdges_AreUnchangedByNarrowing()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        var index = ILInspector.Analysis.LibraryBodyIndex.Open(target);
+
+        int compared = 0;
+        int withEdges = 0;
+        foreach (var method in index.Methods)
+        {
+            var narrowed = CreateForCallers(target, FullScope);
+
+            var control = CreateForCallers(target, FullScope);
+            Assert.NotNull(control.CallerScopes(includeAllocations: true));
+
+            string[] Render(ApiMemberAnalysisInspection inspection) => inspection
+                .CallerEdges(method.MetadataToken)
+                .Select(edge => $"{edge.Source}|{edge.Call.Caller.Name}|{edge.Call.ILOffset}")
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray();
+
+            var expected = Render(control);
+            Assert.Equal(expected, Render(narrowed));
+
+            compared++;
+            if (expected.Length > 0)
+                withEdges++;
+        }
+
+        // Without these the comparison could hold by both sides always being empty, which is what
+        // a filter that ruled everything out would produce.
+        Assert.True(compared > 0, "no member was compared");
+        Assert.True(withEdges > 0, "no member had any cross-assembly caller, so nothing was proven");
+    }
+
+    // Narrowing must never reach the Call Graph, which is transitive and would be truncated by it.
+    // The indirect fixture is the case that distinguishes them: it belongs in the graph and cannot
+    // contribute a direct edge.
+    //
+    // The lens asked for here is deliberately includeAllocations: false, because that is the one
+    // that shares a cache with the path CallerEdges used to take. Asking the allocations lens would
+    // read the other cache and so could not observe a narrow set leaking into the graph. Narrowing
+    // is resolved first, so a leak is present before the graph asks.
+    [Fact]
+    public void CallerScopes_ForTheGraphIsNotNarrowed()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        int store = TokenOf(target, "Box`1", "Store");
+
+        var inspection = CreateForCallers(target, FullScope);
+        var narrow = inspection.DirectCallerScopes(store);
+
+        Assert.NotNull(narrow);
+        Assert.DoesNotContain(
+            "ILInspector.Analysis.CallerGraphIndirectCaller",
+            narrow.Select(s => s.SourceName));
+
+        var graph = inspection.CallerScopes(includeAllocations: false);
+
+        Assert.NotNull(graph);
+        Assert.Contains(
+            "ILInspector.Analysis.CallerGraphIndirectCaller",
+            graph.Select(s => s.SourceName));
+    }
+
     static string? FindNativeImage()
     {
         foreach (string path in Directory.EnumerateFiles(

--- a/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
+++ b/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
@@ -377,6 +377,40 @@ public class ApiMemberAnalysisInspectionTests
             graph.Select(s => s.SourceName));
     }
 
+    // The narrow scope is cached per declaring type, so a second member with a *different*
+    // declaring type must not be answered from the first one's entry. Box`1 and Api are declared by
+    // the same fixture but named by different callers, so a single shared cache entry would hand
+    // one of them the other's scope.
+    [Fact]
+    public void DirectCallerScopes_AreCachedPerDeclaringType()
+    {
+        string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();
+        int store = TokenOf(target, "Box`1", "Store");
+        int ping = TokenOf(target, "Api", "Ping");
+
+        static string[] Names(IReadOnlyList<MethodBodyInspectionSession>? scopes) => scopes!
+            .Select(s => s.SourceName)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        var forward = CreateForCallers(target, FullScope);
+        var storeFirst = Names(forward.DirectCallerScopes(store));
+        var pingSecond = Names(forward.DirectCallerScopes(ping));
+
+        // The reverse order must produce the same two answers, or the first call is poisoning the
+        // second through the cache.
+        var reverse = CreateForCallers(target, FullScope);
+        var pingFirst = Names(reverse.DirectCallerScopes(ping));
+        var storeSecond = Names(reverse.DirectCallerScopes(store));
+
+        Assert.Equal(storeFirst, storeSecond);
+        Assert.Equal(pingFirst, pingSecond);
+
+        // Non-vacuity: if the two declaring types selected the same assemblies, a shared cache
+        // entry would satisfy the assertions above and prove nothing.
+        Assert.NotEqual(storeFirst, pingFirst);
+    }
+
     static string? FindNativeImage()
     {
         foreach (string path in Directory.EnumerateFiles(

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -28,6 +28,7 @@ internal sealed class ApiMemberAnalysisInspection
     bool _targetAssemblyNameResolved;
     IReadOnlyList<string>? _selectedScopePaths;
     bool _ruledOutScopeIsOpenable;
+    readonly Dictionary<Analysis.TypeRef, List<MethodBodyInspectionSession>> _directCallerScopes = [];
 
     internal ApiMemberAnalysisInspection(
         string assemblyPath,
@@ -70,7 +71,7 @@ internal sealed class ApiMemberAnalysisInspection
     }
 
     internal ImmutableArray<CallerEdge> CallerEdges(int methodToken)
-        => Session.CallerEdges(methodToken, CallerScopes(includeAllocations: false));
+        => Session.CallerEdges(methodToken, DirectCallerScopes(methodToken));
 
     internal Analysis.CallTreeNode BuildCallTree(int methodToken)
         => BodyIndex.BuildCallTree(methodToken);
@@ -170,6 +171,85 @@ internal sealed class ApiMemberAnalysisInspection
 
         cached = opened;
         return cached;
+    }
+
+    /// <summary>
+    /// The caller-scope sessions for the <c>Callers</c> table, narrowed to the assemblies that
+    /// could contain a <em>direct</em> caller of a member declared by <paramref name="methodToken"/>'s
+    /// type. Returns <see langword="null"/> when no cross-assembly scope was requested at all,
+    /// matching <see cref="CallerScopes"/>.
+    ///
+    /// The two consumers of a caller scope walk it differently and therefore need different
+    /// selections. <c>Call Graph</c> is transitive, so it needs the reverse-reference closure that
+    /// <see cref="CallerScopes"/> computes: an assembly naming nothing relevant still belongs in
+    /// the graph if it calls something that does. <see cref="MethodBodyInspectionSession.CallerEdges"/>
+    /// is strictly single-hop — it scans each scope for call sites whose callee matches the target
+    /// and never asks what calls those — so the closure is pure cost for it.
+    ///
+    /// On a framework-shaped scope that cost dominates. Reference closure selects nearly every
+    /// candidate, because everything reaches the core library in one hop and transitivity does the
+    /// rest, while direct type reference selects a handful. Every candidate ruled out here is a
+    /// full method-body decode not paid.
+    ///
+    /// Narrowing is deliberately <em>not</em> folded into <see cref="CallerScopes"/>. Its two lenses
+    /// share a cache when allocations are not requested, so narrowing there would silently narrow
+    /// the transitive graph as well and truncate it — the defect this filter's sibling was written
+    /// to avoid.
+    ///
+    /// When the graph lens has already opened its wider scope, that set is reused as-is. Narrowing
+    /// only avoids <em>opening</em> assemblies; re-deciding sessions whose body decode is already
+    /// paid for would cost a metadata read to save nothing. The extra edges this could admit are
+    /// not a behavior difference: an assembly that cannot name the declaring type produces no
+    /// match, which is exactly why it was safe to rule out.
+    /// </summary>
+    internal IReadOnlyList<MethodBodyInspectionSession>? DirectCallerScopes(int methodToken)
+    {
+        if (_callerScopeAssemblies is not { Count: > 0 })
+            return null;
+
+        if (_graphScopesResolved && _graphScopes is not null)
+            return _graphScopes;
+        if (_callerScopesResolved && _callerScopes is not null)
+            return _callerScopes;
+
+        var declaringType = Session.BodyIndex.Methods
+            .FirstOrDefault(m => m.MetadataToken == methodToken)?.DeclaringType;
+
+        // Without a typed declaring identity there is nothing to narrow on, and the matcher falls
+        // back to comparing display names, which are not assembly-qualified — an assembly-qualified
+        // filter would then be stricter than the matcher and drop real callers.
+        if (declaringType is null)
+            return CallerScopes(includeAllocations: false);
+
+        var openDeclaringType = Analysis.GenericMemberIdentity.OpenDeclaringType(declaringType);
+        if (_directCallerScopes.TryGetValue(openDeclaringType, out var cached))
+            return cached;
+
+        var opened = new List<MethodBodyInspectionSession>();
+        foreach (string scopePath in SelectedScopePaths())
+        {
+            if (Analysis.CallerScopeTypeFilter.Classify(scopePath, openDeclaringType)
+                is Analysis.CallerScopeTypeFilter.TypeReferenceState.DoesNotName)
+            {
+                continue;
+            }
+
+            try
+            {
+                opened.Add(MethodBodyInspectionSession.Open(
+                    scopePath,
+                    ApiAnalysisInspection.CreateReferenceResolver(scopePath, _options),
+                    includeAllocations: false,
+                    includeOpportunities: false));
+            }
+            catch
+            {
+                // Caller scope is best-effort; unreadable assemblies do not contribute edges.
+            }
+        }
+
+        _directCallerScopes[openDeclaringType] = opened;
+        return opened;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes part of #3333 (increment 2).

## The increment was redirected by a negative measurement

#3333''s increment 2 proposed narrowing candidates by **TypeRef** instead of AssemblyRef. That is
the right idea, but it has to be applied somewhere, and the two consumers of the candidate set
differ:

### Why it cannot go in the transitive graph — worked

Let `foo` live in assembly F, `bar` in B, `prebar` in A, with `prebar` -> `bar` -> `foo`.

- **B** calls `foo`, so B''s `TypeRef` table must carry a row naming `foo`''s declaring type.
  `CallerScopeTypeFilter` keeps B. Correct at depth 1.
- **A** calls `bar`, and references B. A may never mention `foo`''s declaring type at all.
  `CallerScopeTypeFilter` rules A out — so at depth 2 `prebar` disappears and the tree silently
  comes back one level short.

This is not hypothetical. For `ImmutableArray<T>.Length` the assemblies carrying an
`ImmutableArray` 1 `TypeRef` row are exactly `System.Collections.Immutable`,
`System.Diagnostics.StackTrace`, `System.Reflection.Emit` and `System.Reflection.Metadata`.
`System.Private.Xml` references one of those four but names `ImmutableArray` 1 nowhere, so it
enters the reverse-reference closure at hop 2. It is `prebar`''s assembly.

The reverse-reference closure exists precisely to cover that case, and does so correctly. That is
why this PR leaves it alone.
**It cannot be applied to the transitive `Call Graph` at all.** `CallerScopeFilter`''s own contract
says why: an assembly that never names the target can still appear in the tree by calling something
that does, so "testing a direct reference alone drops those upstream callers and silently shortens
the tree." The only *sound* place to put TypeRef information into a transitive closure is its
**seed** — and a closure''s fixpoint does not depend on its seed once the seed reaches a hub. That
is not a near-tie that measurement resolved narrowly; it is the same set by construction, hence
exactly 0%, hence increment 2b is **withdrawn**. The mechanism is traced under
[Why the win varies](#why-the-win-varies-so-much-between-cases): seeding with 4 candidates instead
of 169 still saturates at 169 by hop 3, because hop 2 lands on a corelib-canonical facade and 168
of 169 assemblies reference one.

**Where it can be applied, it is worth a lot.** `Callers` is strictly single-hop, so it has no
upstream to lose — the soundness objection above simply does not arise. This PR applies it there
and nowhere else.

What the measurement *did* find is that the `Callers` section never needed a closure at all.

## What changed

`MethodBodyInspectionSession.CallerEdges` is **strictly single-hop** — it scans each scope assembly for call sites whose callee matches the target and never asks what calls those. It was being handed `CallerScopes`, the closure computed for the transitive `Call Graph`. So rendering `Callers` on a framework scope opened **169** assemblies to answer a question that only the few naming the declaring type can possibly answer — measured, **2 to 44** of them.

`CallerScopeTypeFilter` (new, Analysis) answers the narrower question: does this candidate name the target's declaring type at all?

- It decodes the candidate's `TypeRef` rows with **the same `TypeRefDecoder`** the matcher's `TypeRef` values come from. Equivalence with `MemberPattern.MatchesCrossAssembly` is therefore **by construction**: nested naming (`Outer+Inner`), generic arity, ModuleRef/nil resolution scopes and corelib canonicalization cannot drift.
- A callee declared by a **TypeDef** carries its own assembly's name and appears in no TypeRef row, so an assembly whose canonical identity equals the target's is kept without scanning.
- Anything undecidable (unreadable image, `Unsupported` TypeRef row, no typed declaring identity) is **kept**.

`DirectCallerScopes` is a **separate path with its own cache**, deliberately. `CallerScopes`' two lenses share a cache when allocations are not requested, so narrowing in place would silently narrow the transitive graph and truncate it — the #3331 round-3 defect. When the graph lens has already opened its wider set, that set is reused as-is: narrowing only avoids *opening*, so re-deciding already-paid sessions saves nothing.

## Measured — output byte-identical in all nine cases

Base `44f2832a`. Time and peak working set.

| case | base | head |
| --- | --- | --- |
| 1 `ImmutableArray<T>.Length` | 8458 ms / 685 MB | **989 ms / 96 MB** |
| 2 corelib facade `StringBuilder.Append:1` | 8696 ms / 721 MB | 7222 ms / 628 MB |
| 3 `Regex.IsMatch:1` | 6915 ms / 680 MB | **3018 ms / 286 MB** |
| 4 `JsonSerializer.Serialize:1` (miss) | 917 ms / 98 MB | 903 ms / 98 MB |
| 5 unscoped | 3987 ms / 283 MB | 3674 ms / 283 MB |
| 6 both sections | 10692 ms / 939 MB | 17359 ms / 948 MB &dagger; |
| 7 `Call Graph` only | 14764 ms / 936 MB | 13181 ms / 951 MB &dagger; |
| 8 `List<T>.Add` | 8882 ms / 723 MB | **4499 ms / 314 MB** |
| 9 nested `List<T>+Enumerator.MoveNext` | 9684 ms / 719 MB | **5639 ms / 309 MB** |

Best case is **8.6x faster** and uses **7.1x less peak memory** (case 1: 8458 ms -> 989 ms, 685 MB -> 96 MB). Ratios below are base/head, so larger is better.

&dagger; **The peak-WS polling loop in the harness was itself distorting the near-tie rows.** Re-measured without it, 5-6 alternating reps, medians:

| case | base | head | |
| --- | --- | --- | --- |
| 5 unscoped | 3652 ms | 3706 ms | +1.5%, noise |
| 6 both sections | 9635 ms | 9967 ms | **+3.4%, real** |
| 7 `Call Graph` only | 9787 ms | 9672 ms | -1.2%, noise |

Case 6 is a genuine small cost and it is the predicted one: when `Callers` renders before `Call Graph`, it opens ~3 narrow sessions that the graph then re-opens as its own, plus 169 cheap metadata classifications — about 2% of 169 body decodes. Reported rather than smoothed away.

## Why the win varies so much between cases

The saving is the ratio of two independently varying quantities, both measured here by calling
the product''s own `CallerScopeFilter.SelectCouldReach` and the new `CallerScopeTypeFilter` over
the same 182-file scope:

| case | base opens | base MB | head opens | head MB | time | peak WS |
| --- | --- | --- | --- | --- | --- | --- |
| 1 `ImmutableArray<T>.Length` | 169 | 57 | **4** | **2** | 8.6x | 7.1x |
| 2 `StringBuilder.Append:1` | 169 | 57 | 38 | 46 | 1.2x | 1.15x |
| 3 `Regex.IsMatch:1` | 169 | 57 | 9 | 17 | 2.3x | 2.4x |
| 4 `JsonSerializer.Serialize:1` | **2** | 1 | 2 | 1 | 1.0x | 1.0x |
| 8 `List<T>.Add` | 169 | 57 | 44 | 33 | 2.0x | 2.3x |
| 9 `List<T>+Enumerator.MoveNext` | 169 | 57 | 32 | 29 | 1.7x | 2.3x |

**Base saturates because the corelib facades are a hub.** `mscorlib`, `netstandard` and
`System.Runtime.Extensions` all canonicalize to `System.Private.CoreLib`, and **168 of 169**
readable framework assemblies reference a corelib facade. So as soon as the reverse-reference
closure selects any facade, that facade republishes itself under the corelib name and the next
hop takes everything. Traced for case 1, which no facade references directly:

```text
=== System.Collections.Immutable ===
  hop 1: +4   -> 4     System.Collections.Immutable, System.Diagnostics.StackTrace,
                       System.Reflection.Emit, System.Reflection.Metadata
  hop 2: +6   -> 10    ... including two corelib-canonical assemblies
  hop 3: +159 -> 169   saturated
=== System.Text.Json ===
  hop 1: +2   -> 2     System.Net.Http.Json, System.Text.Json
  hop 2: +0   -> 2     stops
```

`System.Text.Json` postdates the netstandard surface, so nothing forwards it and no facade
references it — the only case where base was already tight, and correctly the only case with no
win. **This is also the mechanism behind the 0% result above**: seeding the closure with narrowed
candidates cannot help when the closure saturates two hops later regardless of its seed.

**Head varies with how popular the declaring type is**, which is a completely different question
from how popular its assembly is. `ImmutableArray<T>` is named by 4 assemblies; `List<T>` by 44.

**The cost driver is IL bytes decoded, not assembly count.** Case 2 drops 169 -> 38 assemblies but
only 57 MB -> 46 MB, because the survivors are the large ones (corelib itself, `System.Private.Xml`,
`System.Linq.Expressions`) — and it is the byte ratio, not the count ratio, that the observed 1.2x
matches. Case 1 is the reverse: 25x fewer bytes but 8.6x faster, because it has hit the floor.
Case 4 measures that floor at ~900 ms / ~98 MB, and case 1''s head is 989 ms / 96 MB — startup plus
the target assembly, with essentially nothing left to remove.
## The transitive graph is untouched, and that is checked directly

`-s "Call Graph"` does **not** suppress the auto-included `Callers` section, so a whole-file diff on such a run is not evidence about the graph. Extracting `## Call Graph` alone: **51 lines, 0 diffs** across base, head, **and** a deliberately over-narrowing mutant.

## Evidence

**18 new tests** (15 Analysis, 3 CLI), all on real compiled fixtures. The load-bearing ones:

- `AssemblyNamingTheTargetAssemblyButNotTheTypeIsRuledOut` — asserts **both** filters, so the disagreement between them is the claim. `CallerGraphCallerTwin` references the target *assembly* (it calls `Target.Api.Ping`) but never `Box\`1`, with zero fixture churn.
- `FrameworkTypeMatchesOnlyUnderItsOwnAssembly` — pins assembly sensitivity in both directions on a real artifact.
- `NothingRuledOutEverContributesAMatchingCallSite` — soundness over every fixture x declaring type, compared against **the matcher itself**, with two non-vacuity guards.
- `CallerEdges_AreUnchangedByNarrowing` — every method of the target fixture, un-narrowed scope as control, plus guards that at least one member actually had cross-assembly callers.

**Every new test was mutation-tested.** Six mutants, all killed:

| mutant | killed by |
| --- | --- |
| assembly-insensitive comparison | `FrameworkTypeMatchesOnlyUnderItsOwnAssembly` |
| drop the own-assembly TypeDef check | `TargetAssemblyItselfIsKept` |
| no-op filter (never rule out) | 7 tests, incl. the non-vacuity guard |
| over-narrow (rule out everything) | all 3 CLI tests |
| narrow set leaked into the shared `_callerScopes` | `CallerScopes_ForTheGraphIsNotNarrowed` |

Two of those found defects **in my own tests** rather than in the product:

1. `SameNamedTypeInAnotherAssemblyIsRuledOut` **survived** the assembly-insensitive mutant, so it does not pin assembly sensitivity as its comment claimed (the lookalike has no such TypeRef row at all). Comment corrected to say what it actually pins and to name the test that does.
2. `CallerScopes_ForTheGraphIsNotNarrowed` originally asked the **allocations** lens, which reads the *other* cache — so it could not observe a narrow set leaking into the graph, which is the single hazard it exists to gate. Switched to `includeAllocations: false` and re-verified: the leak mutant now kills it, and kills nothing else.

Two of my Analysis test failures were also the tests, not the product: `SelectCouldReach` closes over the supplied *scope* (so an indirect candidate needs its bridge present), and `List<T>` resolves to assembly **`System.Collections`**, not corelib — `System.Object` is the genuine corelib-facade case. The second became a stronger test rather than a weakened one.

## Validation

- Build `0 Error(s)`.
- Analysis **571 / 1** — only the known #3400 `CrossAssemblyMetadataResolver_ResolvesFrameworkTypeDefinition`.
- CLI **2262 / 1 / 10 skipped** — only the known `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden`, re-confirmed with a **committed** tree (an uncommitted tree suppresses SourceLink and produces the same failure for a different reason).


