### PR TITLE
Add the --rows range grammar as a parsed value type

### DIFF
--- a/src/dotnet-inspect.Tests/RowSpecGrammarTests.cs
+++ b/src/dotnet-inspect.Tests/RowSpecGrammarTests.cs
@@ -1,0 +1,204 @@
+using DotnetInspector.Output;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Pins the <c>--rows</c> grammar.
+///
+/// The central claim is that identical digits mean different things in different
+/// forms -- <c>2..10</c> is nine rows and <c>2+10</c> is ten -- so the tests
+/// assert the resolved extent rather than just that parsing succeeded. A parser
+/// that accepted every form but conflated two of them would satisfy a
+/// "parses without error" suite while still selecting the wrong rows, which is
+/// the failure mode this flag exists to remove.
+/// </summary>
+public class RowSpecGrammarTests
+{
+    [Fact]
+    public void BareNumber_IsACount_NotARange()
+    {
+        Assert.True(RowSpec.TryParse("6", out var spec, out var error));
+        Assert.Null(error);
+
+        Assert.Equal(RowSpecKind.Count, spec.Kind);
+        Assert.Equal(6, spec.Count);
+        Assert.False(spec.IsRange);
+
+        // A count has no absolute extent until a direction and a section supply
+        // one, so it deliberately does not answer Contains.
+        Assert.False(spec.Contains(1));
+        Assert.Null(spec.RowCount);
+    }
+
+    [Fact]
+    public void DotDotRange_IsInclusive_AtBothEnds()
+    {
+        Assert.True(RowSpec.TryParse("2..10", out var spec, out var error));
+        Assert.Null(error);
+
+        Assert.Equal(RowSpecKind.Range, spec.Kind);
+        Assert.Equal(2, spec.Start);
+        Assert.Equal(10, spec.End);
+
+        // Inclusive at both ends: 2 through 10 is nine rows, not eight.
+        Assert.Equal(9, spec.RowCount);
+        Assert.True(spec.Contains(2));
+        Assert.True(spec.Contains(10));
+        Assert.False(spec.Contains(1));
+        Assert.False(spec.Contains(11));
+    }
+
+    [Fact]
+    public void PlusRange_IsStartPlusCount()
+    {
+        Assert.True(RowSpec.TryParse("2+10", out var spec, out var error));
+        Assert.Null(error);
+
+        Assert.Equal(RowSpecKind.Range, spec.Kind);
+        Assert.Equal(2, spec.Start);
+
+        // Ten rows starting at 2 ends at 11, not 12.
+        Assert.Equal(11, spec.End);
+        Assert.Equal(10, spec.RowCount);
+        Assert.True(spec.Contains(11));
+        Assert.False(spec.Contains(12));
+    }
+
+    [Fact]
+    public void SameDigits_SelectDifferentRows_AcrossTheTwoRangeForms()
+    {
+        Assert.True(RowSpec.TryParse("2..10", out var inclusive, out _));
+        Assert.True(RowSpec.TryParse("2+10", out var startPlusCount, out _));
+
+        // The whole reason both forms exist: the digits are read differently, so
+        // conflating them silently shifts the selection by one row at the end.
+        Assert.Equal(9, inclusive.RowCount);
+        Assert.Equal(10, startPlusCount.RowCount);
+        Assert.NotEqual(inclusive.End, startPlusCount.End);
+    }
+
+    [Fact]
+    public void OpenRange_RunsToTheEndOfTheSection()
+    {
+        Assert.True(RowSpec.TryParse("10..", out var spec, out var error));
+        Assert.Null(error);
+
+        Assert.Equal(RowSpecKind.Range, spec.Kind);
+        Assert.Equal(10, spec.Start);
+        Assert.Null(spec.End);
+        Assert.True(spec.IsOpenEnded);
+
+        // The extent depends on the section, so the count is unknown here, but
+        // membership above the start is still decidable.
+        Assert.Null(spec.RowCount);
+        Assert.True(spec.Contains(10));
+        Assert.True(spec.Contains(40_000));
+        Assert.False(spec.Contains(9));
+    }
+
+    [Fact]
+    public void SingleRowRange_IsOneRow()
+    {
+        Assert.True(RowSpec.TryParse("7..7", out var spec, out _));
+        Assert.Equal(1, spec.RowCount);
+        Assert.True(spec.Contains(7));
+        Assert.False(spec.Contains(8));
+    }
+
+    [Fact]
+    public void ColonForm_IsRejected_WithAnExplanationRatherThanAParseError()
+    {
+        Assert.False(RowSpec.TryParse("2:10", out _, out var error));
+
+        // A colon form would be read as a Python slice (0-based, end-exclusive),
+        // so for the same digits it names a different set of rows. Rejecting it
+        // generically would leave the user to rediscover that difference.
+        Assert.NotNull(error);
+        Assert.Contains("':'", error);
+        Assert.Contains("2..10", error);
+        Assert.Contains("2+10", error);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void MissingValue_IsRejected(string? token)
+    {
+        Assert.False(RowSpec.TryParse(token, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("0")]           // rows are 1-based
+    [InlineData("-1")]          // a leading sign is not part of the grammar
+    [InlineData("0..5")]
+    [InlineData("2..0")]
+    [InlineData("0+3")]
+    [InlineData("2+0")]
+    [InlineData("abc")]
+    [InlineData("2..abc")]
+    [InlineData("abc..2")]
+    [InlineData("..5")]         // an open range still needs a start
+    [InlineData("2..10..3")]    // one range operator only
+    [InlineData("2+10+3")]
+    [InlineData("2..-1")]
+    [InlineData("+5")]
+    [InlineData("2 .. 10")]     // internal spaces are not part of the grammar
+    [InlineData("1e3")]
+    [InlineData("99999999999999999999")]
+    public void MalformedTokens_AreRejected(string token)
+    {
+        Assert.False(RowSpec.TryParse(token, out _, out var error));
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    [Fact]
+    public void DescendingRange_IsRejected_AndSuggestsTheAscendingForm()
+    {
+        Assert.False(RowSpec.TryParse("10..2", out _, out var error));
+
+        Assert.NotNull(error);
+        Assert.Contains("2..10", error);
+    }
+
+    [Fact]
+    public void StartPlusCount_PastTheLargestRow_IsReportedRatherThanWrapped()
+    {
+        // start + count - 1 overflows int here; computing it in int would wrap to
+        // a negative end and produce a range that silently selects nothing.
+        Assert.False(RowSpec.TryParse($"{int.MaxValue}+2", out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void SurroundingWhitespace_IsTolerated()
+    {
+        Assert.True(RowSpec.TryParse("  2..10  ", out var spec, out _));
+        Assert.Equal(2, spec.Start);
+        Assert.Equal(10, spec.End);
+    }
+
+    [Theory]
+    [InlineData("6", "6")]
+    [InlineData("2..10", "2..10")]
+    [InlineData("10..", "10..")]
+    [InlineData("2+10", "2..11")]   // normalized to the inclusive spelling
+    public void ToString_RoundTripsThroughTheGrammar(string token, string expected)
+    {
+        Assert.True(RowSpec.TryParse(token, out var spec, out _));
+        Assert.Equal(expected, spec.ToString());
+
+        // Whatever ToString produces must itself parse, and to the same spec.
+        Assert.True(RowSpec.TryParse(spec.ToString(), out var reparsed, out _));
+        Assert.Equal(spec, reparsed);
+    }
+
+    [Fact]
+    public void FactoryMethods_RejectOutOfRangeInput()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => RowSpec.FromCount(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => RowSpec.FromRange(0, 5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => RowSpec.FromRange(5, 4));
+    }
+}

--- a/src/dotnet-inspect.Tests/RowSpecGrammarTests.cs
+++ b/src/dotnet-inspect.Tests/RowSpecGrammarTests.cs
@@ -23,11 +23,31 @@ public class RowSpecGrammarTests
         Assert.Equal(RowSpecKind.Count, spec.Kind);
         Assert.Equal(6, spec.Count);
         Assert.False(spec.IsRange);
+        Assert.False(spec.IsOpenEnded);
 
-        // A count has no absolute extent until a direction and a section supply
-        // one, so it deliberately does not answer Contains.
-        Assert.False(spec.Contains(1));
-        Assert.Null(spec.RowCount);
+        // A count knows how many rows it takes, just not which ones.
+        Assert.Equal(6, spec.RowCount);
+    }
+
+    [Fact]
+    public void CountSpec_RefusesTheRangeMembers_RatherThanAnsweringWithADefault()
+    {
+        Assert.True(RowSpec.TryParse("6", out var spec, out _));
+
+        // Contains is the dangerous one: false is exactly what a genuine miss
+        // looks like, so a caller filtering rows through it would select nothing
+        // and see no error. Start would hand back 0, which is not a row.
+        Assert.Throws<InvalidOperationException>(() => spec.Contains(1));
+        Assert.Throws<InvalidOperationException>(() => spec.Start);
+        Assert.Throws<InvalidOperationException>(() => spec.End);
+    }
+
+    [Fact]
+    public void RangeSpec_RefusesTheCountMember()
+    {
+        Assert.True(RowSpec.TryParse("2..10", out var spec, out _));
+
+        Assert.Throws<InvalidOperationException>(() => spec.Count);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Output/RowSpec.cs
+++ b/src/dotnet-inspect/Output/RowSpec.cs
@@ -1,0 +1,297 @@
+using System.Globalization;
+
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// How a <see cref="RowSpec"/> addresses rows.
+/// </summary>
+public enum RowSpecKind
+{
+    /// <summary>
+    /// A relative count of rows (<c>6</c>), anchored by a direction the spec
+    /// does not itself carry: <c>--head</c> takes the first N, <c>--tail</c> the
+    /// last N.
+    /// </summary>
+    Count,
+
+    /// <summary>
+    /// An absolute row range (<c>2..10</c>, <c>2+10</c>, <c>10..</c>). A range
+    /// names rows outright, so it is complete on its own and a direction applied
+    /// to it is incoherent.
+    /// </summary>
+    Range,
+}
+
+/// <summary>
+/// A row selection parsed from <c>--rows</c>.
+///
+/// The grammar has exactly four forms, and the distinction between the first
+/// and the rest is the point:
+///
+/// <list type="bullet">
+///   <item><description><c>N</c> — a <see cref="RowSpecKind.Count"/> of N rows, like <c>head -n</c>. The digits are a quantity.</description></item>
+///   <item><description><c>N..M</c> — an inclusive <see cref="RowSpecKind.Range"/>. The digits are positions, so <c>2..10</c> is nine rows.</description></item>
+///   <item><description><c>N+K</c> — a range written as start plus count: K rows beginning at N.</description></item>
+///   <item><description><c>N..</c> — a range from N to the end of the section.</description></item>
+/// </list>
+///
+/// So <c>6</c> and <c>6..</c> both mention six but mean different things: the
+/// first is "six rows", the second is "from row six". That is inherent to
+/// offering both a count and a range in one flag, and is why the two forms parse
+/// into different <see cref="RowSpecKind"/>s rather than into one normalized
+/// shape — a caller that must reject one of them (a direction cannot apply to an
+/// absolute range) has to be able to tell them apart.
+/// </summary>
+public readonly record struct RowSpec
+{
+    private RowSpec(RowSpecKind kind, int count, int start, int? end)
+    {
+        Kind = kind;
+        Count = count;
+        Start = start;
+        End = end;
+    }
+
+    /// <summary>Which of the two addressing modes this spec uses.</summary>
+    public RowSpecKind Kind { get; }
+
+    /// <summary>
+    /// For <see cref="RowSpecKind.Count"/>, the number of rows requested.
+    /// Meaningless for a range; use <see cref="Start"/>/<see cref="End"/>.
+    /// </summary>
+    public int Count { get; }
+
+    /// <summary>
+    /// For <see cref="RowSpecKind.Range"/>, the 1-based first row, inclusive.
+    /// </summary>
+    public int Start { get; }
+
+    /// <summary>
+    /// For <see cref="RowSpecKind.Range"/>, the 1-based last row, inclusive, or
+    /// <see langword="null"/> when the range runs to the end of the section
+    /// (<c>N..</c>).
+    /// </summary>
+    public int? End { get; }
+
+    /// <summary>True when this spec names an absolute range rather than a count.</summary>
+    public bool IsRange => Kind == RowSpecKind.Range;
+
+    /// <summary>True for <c>N..</c>, whose end is whatever the section renders.</summary>
+    public bool IsOpenEnded => Kind == RowSpecKind.Range && End is null;
+
+    /// <summary>A count of N rows, anchored by a separate direction.</summary>
+    public static RowSpec FromCount(int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(count, 1);
+        return new RowSpec(RowSpecKind.Count, count, 0, null);
+    }
+
+    /// <summary>An inclusive range. A null <paramref name="end"/> runs to the end of the section.</summary>
+    public static RowSpec FromRange(int start, int? end)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(start, 1);
+        if (end is { } e)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(e, start);
+        }
+
+        return new RowSpec(RowSpecKind.Range, 0, start, end);
+    }
+
+    /// <summary>
+    /// The number of rows this range covers, or <see langword="null"/> when that
+    /// depends on the section (an open-ended range, or a count whose direction
+    /// the spec does not carry).
+    /// </summary>
+    public int? RowCount => Kind == RowSpecKind.Range && End is { } e ? e - Start + 1 : null;
+
+    /// <summary>
+    /// True when <paramref name="rowNumber"/> falls inside this range. Only
+    /// meaningful for <see cref="RowSpecKind.Range"/>; a count has no absolute
+    /// extent until a direction and a section are supplied.
+    /// </summary>
+    public bool Contains(int rowNumber)
+        => Kind == RowSpecKind.Range && rowNumber >= Start && (End is not { } e || rowNumber <= e);
+
+    /// <summary>
+    /// Parses a <c>--rows</c> token. Returns false with a caller-renderable
+    /// <paramref name="error"/> describing the grammar violation.
+    ///
+    /// The grammar is deliberately closed: anything outside the four documented
+    /// forms is rejected rather than guessed at. Row selection that quietly
+    /// reinterprets its input is the defect this flag exists to replace.
+    /// </summary>
+    public static bool TryParse(string? text, out RowSpec spec, out string? error)
+    {
+        spec = default;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            error = "a row selection is required, such as 6, 2..10, 2+10, or 10..";
+            return false;
+        }
+
+        var token = text.Trim();
+
+        // A colon form is rejected outright rather than left to fail as a generic
+        // parse error. `2:10` is a slice in Python's sense -- 0-based and
+        // end-exclusive -- so for identical digits it would name a different set
+        // of rows than `2..10` by exactly one row at each edge. Silently accepting
+        // it under `..` semantics, or rejecting it without explanation, both leave
+        // the user to discover the discrepancy from the output.
+        if (token.Contains(':', StringComparison.Ordinal))
+        {
+            error = $"'{token}' uses ':' which is not a row range. Use '..' for an inclusive range (2..10 is nine rows) or '+' for start plus count (2+10 is ten rows).";
+            return false;
+        }
+
+        var rangeIndex = token.IndexOf("..", StringComparison.Ordinal);
+        if (rangeIndex >= 0)
+            return TryParseRange(token, rangeIndex, ref spec, ref error);
+
+        var plusIndex = token.IndexOf('+', StringComparison.Ordinal);
+        if (plusIndex > 0)
+            return TryParseStartPlusCount(token, plusIndex, ref spec, ref error);
+
+        if (!TryParseComponent(token, out var count))
+        {
+            error = $"'{token}' is not a row selection. Use a count (6), an inclusive range (2..10), a start plus count (2+10), or an open range (10..).";
+            return false;
+        }
+
+        if (count < 1)
+        {
+            error = $"a row count must be 1 or greater (got {count}).";
+            return false;
+        }
+
+        spec = FromCount(count);
+        return true;
+    }
+
+    private static bool TryParseRange(string token, int rangeIndex, ref RowSpec spec, ref string? error)
+    {
+        var startText = token[..rangeIndex];
+        var endText = token[(rangeIndex + 2)..];
+
+        if (endText.Contains("..", StringComparison.Ordinal) || endText.Contains('+', StringComparison.Ordinal))
+        {
+            error = $"'{token}' has more than one range operator. Use a single range such as 2..10.";
+            return false;
+        }
+
+        if (startText.Length == 0)
+        {
+            error = $"'{token}' has no start row. An open range needs a start, as in 10.. ; to begin at the first row use 1..{endText}.";
+            return false;
+        }
+
+        if (!TryParseComponent(startText, out var start))
+        {
+            error = $"'{startText}' is not a row number in '{token}'.";
+            return false;
+        }
+
+        if (start < 1)
+        {
+            error = $"row numbers start at 1 (got {start} in '{token}').";
+            return false;
+        }
+
+        // `N..` is open-ended: the end is whatever the section renders.
+        if (endText.Length == 0)
+        {
+            spec = FromRange(start, null);
+            return true;
+        }
+
+        if (!TryParseComponent(endText, out var end))
+        {
+            error = $"'{endText}' is not a row number in '{token}'.";
+            return false;
+        }
+
+        if (end < start)
+        {
+            error = $"'{token}' ends before it starts. A range is inclusive and ascending, so use {end}..{start} to select those rows.";
+            return false;
+        }
+
+        spec = FromRange(start, end);
+        return true;
+    }
+
+    private static bool TryParseStartPlusCount(string token, int plusIndex, ref RowSpec spec, ref string? error)
+    {
+        var startText = token[..plusIndex];
+        var countText = token[(plusIndex + 1)..];
+
+        if (countText.Contains('+', StringComparison.Ordinal))
+        {
+            error = $"'{token}' has more than one '+'. Use a single start plus count such as 2+10.";
+            return false;
+        }
+
+        if (!TryParseComponent(startText, out var start) || !TryParseComponent(countText, out var count))
+        {
+            error = $"'{token}' is not a start plus count. Use two row numbers such as 2+10.";
+            return false;
+        }
+
+        if (start < 1)
+        {
+            error = $"row numbers start at 1 (got {start} in '{token}').";
+            return false;
+        }
+
+        if (count < 1)
+        {
+            error = $"a row count must be 1 or greater (got {count} in '{token}').";
+            return false;
+        }
+
+        // Computed in long so a start plus count that lands past int.MaxValue is
+        // reported as out of range rather than wrapping into a valid-looking row.
+        var end = (long)start + count - 1;
+        if (end > int.MaxValue)
+        {
+            error = $"'{token}' selects rows past the largest addressable row.";
+            return false;
+        }
+
+        spec = FromRange(start, (int)end);
+        return true;
+    }
+
+    /// <summary>
+    /// Parses one digits-only component. A leading sign is rejected here rather
+    /// than parsed and range-checked later, so that <c>2..-1</c> reads as a
+    /// malformed range instead of silently becoming an empty one.
+    /// </summary>
+    private static bool TryParseComponent(string text, out int value)
+    {
+        value = 0;
+        if (text.Length == 0)
+            return false;
+
+        foreach (var c in text)
+        {
+            if (!char.IsAsciiDigit(c))
+                return false;
+        }
+
+        return int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value);
+    }
+
+    /// <summary>
+    /// Renders this spec back into its canonical token, so an error or an echo
+    /// shows the same spelling the grammar accepts.
+    /// </summary>
+    public override string ToString() => Kind switch
+    {
+        RowSpecKind.Count => Count.ToString(CultureInfo.InvariantCulture),
+        _ when End is null => $"{Start}..",
+        _ => $"{Start}..{End}",
+    };
+}

--- a/src/dotnet-inspect/Output/RowSpec.cs
+++ b/src/dotnet-inspect/Output/RowSpec.cs
@@ -44,12 +44,16 @@ public enum RowSpecKind
 /// </summary>
 public readonly record struct RowSpec
 {
+    private readonly int _count;
+    private readonly int _start;
+    private readonly int? _end;
+
     private RowSpec(RowSpecKind kind, int count, int start, int? end)
     {
         Kind = kind;
-        Count = count;
-        Start = start;
-        End = end;
+        _count = count;
+        _start = start;
+        _end = end;
     }
 
     /// <summary>Which of the two addressing modes this spec uses.</summary>
@@ -57,27 +61,52 @@ public readonly record struct RowSpec
 
     /// <summary>
     /// For <see cref="RowSpecKind.Count"/>, the number of rows requested.
-    /// Meaningless for a range; use <see cref="Start"/>/<see cref="End"/>.
+    /// Throws for a range, which has no single count to report; use
+    /// <see cref="Start"/>/<see cref="End"/>, or <see cref="RowCount"/> for the
+    /// extent either kind covers.
     /// </summary>
-    public int Count { get; }
+    public int Count => Kind == RowSpecKind.Count
+        ? _count
+        : throw WrongKind(nameof(Count), RowSpecKind.Count);
 
     /// <summary>
     /// For <see cref="RowSpecKind.Range"/>, the 1-based first row, inclusive.
+    /// Throws for a count, whose first row is not known until a direction and a
+    /// section supply one.
     /// </summary>
-    public int Start { get; }
+    public int Start => Kind == RowSpecKind.Range
+        ? _start
+        : throw WrongKind(nameof(Start), RowSpecKind.Range);
 
     /// <summary>
     /// For <see cref="RowSpecKind.Range"/>, the 1-based last row, inclusive, or
     /// <see langword="null"/> when the range runs to the end of the section
-    /// (<c>N..</c>).
+    /// (<c>N..</c>). Throws for a count, so that a caller cannot read the
+    /// open-ended <see langword="null"/> out of a spec that is not a range at all.
     /// </summary>
-    public int? End { get; }
+    public int? End => Kind == RowSpecKind.Range
+        ? _end
+        : throw WrongKind(nameof(End), RowSpecKind.Range);
+
+    /// <summary>
+    /// The kind-specific members throw rather than returning a default, because
+    /// every default available here is a lie a caller would act on: a
+    /// <see cref="Start"/> of 0 is not a row, and a <see cref="Contains"/> of
+    /// false is indistinguishable from a genuine miss. A spec is a two-case
+    /// union, so reading the wrong case is a caller bug, and it should surface
+    /// where it happens rather than as rows quietly going missing downstream.
+    /// </summary>
+    private InvalidOperationException WrongKind(string member, RowSpecKind required)
+        => new($"{member} is only meaningful for a {required} row spec; this spec is {Kind}. Check {nameof(Kind)} first.");
 
     /// <summary>True when this spec names an absolute range rather than a count.</summary>
     public bool IsRange => Kind == RowSpecKind.Range;
 
-    /// <summary>True for <c>N..</c>, whose end is whatever the section renders.</summary>
-    public bool IsOpenEnded => Kind == RowSpecKind.Range && End is null;
+    /// <summary>
+    /// True for <c>N..</c>, whose end is whatever the section renders. False for
+    /// a count, which is not a range at all.
+    /// </summary>
+    public bool IsOpenEnded => Kind == RowSpecKind.Range && _end is null;
 
     /// <summary>A count of N rows, anchored by a separate direction.</summary>
     public static RowSpec FromCount(int count)
@@ -99,19 +128,34 @@ public readonly record struct RowSpec
     }
 
     /// <summary>
-    /// The number of rows this range covers, or <see langword="null"/> when that
-    /// depends on the section (an open-ended range, or a count whose direction
-    /// the spec does not carry).
+    /// The number of rows this spec selects at most, or <see langword="null"/>
+    /// only when that genuinely depends on the section — an open-ended
+    /// <c>N..</c>. A count knows its own extent (<c>6</c> selects six rows
+    /// whichever direction anchors it), so it reports it rather than pleading
+    /// ignorance; what a count does not know is *which* rows, not how many.
     /// </summary>
-    public int? RowCount => Kind == RowSpecKind.Range && End is { } e ? e - Start + 1 : null;
+    public int? RowCount => Kind switch
+    {
+        RowSpecKind.Count => _count,
+        _ => _end is { } e ? e - _start + 1 : null,
+    };
 
     /// <summary>
-    /// True when <paramref name="rowNumber"/> falls inside this range. Only
-    /// meaningful for <see cref="RowSpecKind.Range"/>; a count has no absolute
-    /// extent until a direction and a section are supplied.
+    /// True when <paramref name="rowNumber"/> falls inside this range.
+    ///
+    /// Throws for a count. Returning false there would answer a question the
+    /// spec cannot answer — a count names no absolute rows until a direction and
+    /// a section supply them — and would do it in the one way a caller cannot
+    /// detect, since a false is exactly what a genuine miss looks like. A caller
+    /// that filters rows through this would silently select nothing.
     /// </summary>
     public bool Contains(int rowNumber)
-        => Kind == RowSpecKind.Range && rowNumber >= Start && (End is not { } e || rowNumber <= e);
+    {
+        if (Kind != RowSpecKind.Range)
+            throw WrongKind(nameof(Contains), RowSpecKind.Range);
+
+        return rowNumber >= _start && (_end is not { } e || rowNumber <= e);
+    }
 
     /// <summary>
     /// Parses a <c>--rows</c> token. Returns false with a caller-renderable
@@ -290,8 +334,8 @@ public readonly record struct RowSpec
     /// </summary>
     public override string ToString() => Kind switch
     {
-        RowSpecKind.Count => Count.ToString(CultureInfo.InvariantCulture),
-        _ when End is null => $"{Start}..",
-        _ => $"{Start}..{End}",
+        RowSpecKind.Count => _count.ToString(CultureInfo.InvariantCulture),
+        _ when _end is null => $"{_start}..",
+        _ => $"{_start}..{_end}",
     };
 }


### PR DESCRIPTION
First half of the #3364 redesign. **Grammar only** -- `RowSpec` is not referenced by any product path yet (`grep` finds it in its own file and its test file, nowhere else), so no user-visible behaviour changes. Wiring it to the flag is the next PR.

## The grammar

| Form | Meaning | Rows |
| --- | --- | --- |
| `6` | a count, like `head -n` | six rows |
| `2..10` | inclusive range | **nine** rows |
| `2+10` | start plus count | **ten** rows |
| `10..` | from row ten to the end | depends on the section |

`6` and `6..` both mention six and mean different things: the first is a quantity, the second a position. That is inherent to offering a count and a range through one flag, so the two parse into different `RowSpecKind`s rather than into one normalized shape -- the caller that must reject a direction applied to an absolute range has to be able to tell them apart.

## Two decisions worth review

**The colon form is rejected with an explanation, not a generic parse error.** `2:10` carries Python slice heritage (0-based, end-exclusive), so for identical digits it names a different set of rows than `2..10` by one row at each edge. Failing it silently, or failing it without saying why, leaves the user to rediscover that from the output.

**The grammar is closed.** Anything outside the four forms is rejected rather than guessed at, including a leading sign -- parsing `2..-1` and range-checking it later would turn a malformed range into a silently empty one. Start-plus-count is computed in `long`, so a start plus count landing past `int.MaxValue` is reported rather than wrapping into a negative end that selects nothing.

## Evidence

35 tests. They assert **resolved extents**, not merely that parsing succeeded: a parser that accepted all four forms while conflating two of them would pass a "parses without error" suite and still select the wrong rows.

Non-vacuity checked with two mutations:

| Mutation | Result |
| --- | --- |
| make `..` end-exclusive (`FromRange(start, end - 1)`) | **6 fail**, including inclusivity, single-row, same-digits, and `ToString` round-trip |
| off-by-one in `+` (`start + count` instead of `start + count - 1`) | **3 fail**, including `PlusRange_IsStartPlusCount` and same-digits |

## Suite status, including something that needs its own issue

Full suite: **2309 tests, 1 failure** -- `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden`, which reproduces on unmodified `origin/main` locally and does not occur in CI at all.

Two *other* tests failed intermittently across my runs, and I could not attribute them to this change:

| Run | Failures |
| --- | --- |
| clean `main`, files removed | 1 |
| with this change | 3 (`WriteTips_WithMinimalLevel_WritesTips`, `DiffCommandTests.ExecuteAsync_AllocationFindingTransitions_ComposesJson`) |
| with this change | 3 (`WriteTips_...`, `DiffCommandTests.BuildApiDiff_TypeFilterWithNoChangedTypesAndMemberFilter_ReportsTypeFilter`) |
| with this change | 1 |

The `DiffCommandTests` failure was a **different test each time**, and both classes pass in isolation (295 tests, 0 failures). Since `RowSpec` is called by no product path, the only mechanism available to it is shifting test scheduling -- which points at pre-existing shared state or a parallelism race in the suite that adding 35 tests perturbs. I have not tried to fix that here; it wants its own issue and is not this PR's to carry.

## Not in this PR

The flag wiring, `-r`, the `--head`/`--tail` direction split, and the `output-shapes.md` rewrite. The open compatibility question -- whether bare `--rows` keeps its current meaning ("interpret `-n` as data rows", load-bearing in ~70 test call sites, `README.md`, and four skill docs) -- is settled there, not here.