### PR TITLE
Exclude NuGet unlisted versions from enumeration and latest resolution (#3388)

### DIFF
--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -153,6 +153,33 @@ dotnet-inspect diff --package Foo@1.4.0..1.5.0 \
 kind and producer detail establish identity, while IL offsets remain local to
 each endpoint.
 
+## Listed vs. unlisted versions
+
+NuGet lets a publisher **unlist** a version: it stays restorable by exact
+coordinate but is hidden from discovery on nuget.org. The flat-container
+`index.json` that drives version enumeration lists **every** published version
+and carries no listed flag, so it cannot distinguish an unlisted version on its
+own. Only the nuget.org **registration** index exposes the per-version
+`catalogEntry.listed` bit.
+
+Version resolution applies one shared listing-aware policy so discovery matches
+the nuget.org gallery:
+
+- **Enumeration** (`Name --versions`, wildcard resolution) and the
+  **flat-container / prerelease "latest"** paths consult the registration index
+  and drop versions whose `catalogEntry.listed` is explicitly `false`. The
+  stable "latest" path already uses the listing-aware search API and is
+  unaffected. This is nuget.org-only; other feeds have no listed concept and are
+  returned unfiltered.
+- **Explicit access is preserved.** A pinned `Name@Version` (including
+  `Name@latest` and the addressable-vector endpoints) never enumerates, so a
+  known unlisted version still resolves and loads — matching NuGet's own
+  behavior of restoring a known unlisted version.
+- **Fail-open.** If the registration index cannot be fetched or parsed, the list
+  is returned unfiltered rather than silently dropping versions; the condition
+  is logged. The filtered nuget.org list is what gets cached, so a cache hit
+  within the 1-hour TTL never re-surfaces an unlisted version.
+
 ## Cache locations
 
 | Cache | Location | TTL | Written by |

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -160,7 +160,11 @@ coordinate but is hidden from discovery on nuget.org. The flat-container
 `index.json` that drives version enumeration lists **every** published version
 and carries no listed flag, so it cannot distinguish an unlisted version on its
 own. Only the nuget.org **registration** index exposes the per-version
-`catalogEntry.listed` bit.
+`catalogEntry.listed` bit. Resolution reads the SemVer2 registration hive
+(`registration5-gz-semver2`) rather than the SemVer1 hive, because the SemVer1
+hive omits SemVer2 versions entirely — reading it would let unlisted SemVer2
+prereleases escape filtering. That hive is gzip-encoded and transparently
+decompressed by the shared HTTP client.
 
 Version resolution applies one shared listing-aware policy so discovery matches
 the nuget.org gallery:
@@ -175,10 +179,14 @@ the nuget.org gallery:
   `Name@latest` and the addressable-vector endpoints) never enumerates, so a
   known unlisted version still resolves and loads — matching NuGet's own
   behavior of restoring a known unlisted version.
-- **Fail-open.** If the registration index cannot be fetched or parsed, the list
-  is returned unfiltered rather than silently dropping versions; the condition
-  is logged. The filtered nuget.org list is what gets cached, so a cache hit
-  within the 1-hour TTL never re-surfaces an unlisted version.
+- **Fail-open.** If the registration index cannot be fetched or parsed (network
+  failure, or a valid-JSON document whose shape defies the expected schema), the
+  list is returned unfiltered rather than silently dropping versions, and the
+  condition is logged. A fail-open (unfiltered) snapshot is **not** cached, so a
+  transient registration outage cannot re-surface unlisted versions for the
+  cache TTL; only an authoritatively filtered list is persisted. For the same
+  reason, nuget.org "latest" resolution returns no result rather than falling
+  back to an unfiltered index when the listing-aware path cannot produce a list.
 
 ## Cache locations
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -179,14 +179,20 @@ the nuget.org gallery:
   `Name@latest` and the addressable-vector endpoints) never enumerates, so a
   known unlisted version still resolves and loads — matching NuGet's own
   behavior of restoring a known unlisted version.
-- **Fail-open.** If the registration index cannot be fetched or parsed (network
-  failure, or a valid-JSON document whose shape defies the expected schema), the
-  list is returned unfiltered rather than silently dropping versions, and the
-  condition is logged. A fail-open (unfiltered) snapshot is **not** cached, so a
+- **Fail-open vs. fail-closed on outage.** If the registration index cannot be
+  fetched or parsed (network failure, or a valid-JSON document whose shape
+  defies the expected schema), the condition is logged and behavior depends on
+  the caller. **Raw enumeration** (`Name --versions`) fails **open** — the
+  unfiltered list is returned rather than silently dropping real versions.
+  **Auto-selecting** callers that pick a single version — nuget.org "latest"
+  resolution and wildcard pattern resolution (`Name@3.0.*`) — fail **closed**,
+  returning no result rather than risk selecting an unlisted version from an
+  unfiltered snapshot. A fail-open (unfiltered) snapshot is **not** cached, so a
   transient registration outage cannot re-surface unlisted versions for the
-  cache TTL; only an authoritatively filtered list is persisted. For the same
-  reason, nuget.org "latest" resolution returns no result rather than falling
-  back to an unfiltered index when the listing-aware path cannot produce a list.
+  cache TTL; only an authoritatively filtered list is persisted. The version
+  cache category is versioned (`versions-v2`) so lists written by an older,
+  pre-filter build are never read after upgrading — the filter takes effect
+  immediately rather than being delayed by up to the cache TTL.
 
 ## Cache locations
 
@@ -195,7 +201,7 @@ the nuget.org gallery:
 | NuGet global cache | `~/.nuget/packages/{name}/{version}/` | Permanent | `dotnet restore`, NuGet client |
 | App package cache | `$LOCAL_APP_DATA/dotnet-inspect/package-content-v2/{name}/{version}/` | Permanent | dotnet-inspect |
 | Platform packs | `$LOCAL_APP_DATA/dotnet-inspect/packs-v2/{pack}/{version}/` | Permanent | dotnet-inspect |
-| Version resolution | `$LOCAL_APP_DATA/dotnet-inspect/versions/` | 1 hour | dotnet-inspect |
+| Version resolution | `$LOCAL_APP_DATA/dotnet-inspect/versions-v2/` | 1 hour | dotnet-inspect |
 | Package metadata | `$LOCAL_APP_DATA/dotnet-inspect/metadata/` | 1 hour | dotnet-inspect |
 | Symbol miss markers | `$LOCAL_APP_DATA/dotnet-inspect/symbol-misses/` | 1 day | dotnet-inspect |
 | SourceLink availability markers | `$LOCAL_APP_DATA/dotnet-inspect/source-audit/` | Permanent for hits, 1 day for misses | dotnet-inspect |

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -970,14 +970,16 @@ public static class PackageExtractor
         }
 
         // For nuget.org, the flat-container/prerelease path must exclude unlisted versions.
-        // FetchListedVersionsFromSourceAsync consults the registration index; its result is
-        // authoritative for nuget.org, so do not fall through to the unfiltered index below —
-        // returning null (couldn't determine a latest) is safer than an unfiltered latest that
-        // could be an unlisted version.
+        // FetchListedVersionsFromSourceAsync consults the registration index; only an
+        // authoritative result (registration index read successfully) is trustworthy. If the
+        // registration index is unavailable the method fails open to an UNFILTERED list flagged
+        // Authoritative=false; picking a "latest" from that could surface an unlisted version, so
+        // return null (couldn't determine a latest) instead of falling through to the unfiltered
+        // index below.
         if (source.IsNuGetOrg)
         {
-            var (listed, _) = await FetchListedVersionsFromSourceAsync(client, packageName, source, log).ConfigureAwait(false);
-            if (listed != null)
+            var (listed, authoritative) = await FetchListedVersionsFromSourceAsync(client, packageName, source, log).ConfigureAwait(false);
+            if (listed != null && authoritative)
                 return PickLatest(listed, includePrerelease);
             return null;
         }

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -644,7 +644,20 @@ public static class PackageExtractor
     }
 
     private static readonly TimeSpan VersionCacheTtl = TimeSpan.FromHours(1);
-    private const string VersionCacheCategory = "versions";
+
+    // Bumped to -v2 for #3388: the pre-fix tool populated this category from the UNFILTERED
+    // flat-container, so entries written by an older build may include unlisted versions. A new
+    // category name means those stale entries are never read after upgrading, so the listed-status
+    // filter takes effect immediately rather than being delayed by up to the cache TTL.
+    private const string VersionCacheCategory = "versions-v2";
+    private const string VersionCacheCategoryPrefix = "versions-v";
+
+    static PackageExtractor()
+    {
+        CoreCache.RegisterVersionedCategory(
+            VersionCacheCategoryPrefix,
+            VersionCacheCategory);
+    }
 
     public static async Task<string?> GetLatestVersionAsync(
         HttpClient client,
@@ -710,10 +723,20 @@ public static class PackageExtractor
         string? bestOriginal = null;
 
         var versions = await GetAllVersionsWithCacheAsync(client, normalizedName, sources, log).ConfigureAwait(false);
-        if (versions == null)
+        if (versions.Versions == null)
             return null;
 
-        foreach (var ver in versions)
+        // Wildcard resolution auto-selects a single "latest matching" version. If the list is a
+        // fail-open snapshot (nuget.org registration index unavailable) it may contain unlisted
+        // versions, and we cannot tell which — so refuse to resolve rather than risk selecting an
+        // unlisted version. Raw enumeration (GetVersionsAsync) intentionally still fails open.
+        if (!versions.Authoritative)
+        {
+            log?.Invoke($"Could not resolve pattern '{pattern}': listing status unavailable");
+            return null;
+        }
+
+        foreach (var ver in versions.Versions)
         {
             if (ver.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
                 && NuGet.Versioning.NuGetVersion.TryParse(ver, out var parsed)
@@ -1093,12 +1116,14 @@ public static class PackageExtractor
         var sources = NuGetSourceResolver.ResolveSources(sourceOptions);
 
         var allVersions = await GetAllVersionsWithCacheAsync(client, normalizedName, sources, log).ConfigureAwait(false);
-        if (allVersions == null)
+        if (allVersions.Versions == null)
             return null;
 
+        // Raw enumeration fails open: showing the unfiltered list during a registration outage is
+        // preferable to dropping real versions. (Auto-selecting callers fail closed instead.)
         var filtered = includePrerelease
-            ? allVersions
-            : allVersions.Where(v => !v.Contains('-')).ToList();
+            ? allVersions.Versions
+            : allVersions.Versions.Where(v => !v.Contains('-')).ToList();
 
         // Newest first, with optional limit
         List<string> result = [];
@@ -1112,7 +1137,7 @@ public static class PackageExtractor
         return result;
     }
 
-    private static async Task<List<string>?> GetAllVersionsWithCacheAsync(
+    private static async Task<(List<string>? Versions, bool Authoritative)> GetAllVersionsWithCacheAsync(
         HttpClient client,
         string normalizedName,
         List<NuGetSource> sources,
@@ -1125,10 +1150,17 @@ public static class PackageExtractor
         var merged = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         bool anyFound = false;
 
+        // The merged list is authoritative unless a nuget.org source failed open (registration
+        // index unavailable), in which case it may contain unlisted versions. Callers that
+        // auto-select a single version (e.g. wildcard resolution) must treat a non-authoritative
+        // list as "cannot determine safely"; raw enumeration may still fail open.
+        bool authoritative = true;
+
         foreach (var source in sources)
         {
             List<string>? versions = null;
             bool fetchedAuthoritative = false;
+            bool fromCache = false;
 
             if (source.IsNuGetOrg && canCacheNuGetOrg)
             {
@@ -1137,6 +1169,7 @@ public static class PackageExtractor
                 {
                     log?.Invoke("Using cached version list");
                     versions = [.. cached.Split('\n', StringSplitOptions.RemoveEmptyEntries)];
+                    fromCache = true;
                 }
             }
 
@@ -1144,6 +1177,12 @@ public static class PackageExtractor
                 (versions, fetchedAuthoritative) = await FetchListedVersionsFromSourceAsync(client, normalizedName, source, log).ConfigureAwait(false);
             if (versions == null)
                 continue;
+
+            // A cache hit is authoritative (only an authoritatively filtered list is ever
+            // persisted). A fresh fetch reports authoritativeness itself (false only on a
+            // nuget.org registration fail-open).
+            if (!fromCache && !fetchedAuthoritative)
+                authoritative = false;
 
             anyFound = true;
             merged.UnionWith(versions);
@@ -1158,7 +1197,7 @@ public static class PackageExtractor
         }
 
         if (!anyFound)
-            return null;
+            return (null, authoritative);
 
         // Sort ascending by SemVer (newest last) so callers that assume ordered input
         // (e.g. GetVersionsAsync) stay correct across merged feeds; unparseable entries sort last.
@@ -1173,7 +1212,7 @@ public static class PackageExtractor
         }
 
         parseable.Sort((a, b) => a.Parsed.CompareTo(b.Parsed));
-        return [.. parseable.Select(p => p.Original), .. unparseable];
+        return ([.. parseable.Select(p => p.Original), .. unparseable], authoritative);
     }
 
     /// <summary>

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -801,8 +801,12 @@ public static class PackageExtractor
 
     // nuget.org registration index — the only nuget.org endpoint that carries the
     // per-version `catalogEntry.listed` flag. The flat-container index.json omits it.
+    // The gz-semver2 hive is used (not semver1) because the semver1 hive omits SemVer2
+    // versions entirely, which would let unlisted SemVer2 prereleases escape filtering.
+    // Its responses are gzip-encoded and transparently decompressed by the shared
+    // HttpClient (HttpClientFactory sets AutomaticDecompression = DecompressionMethods.All).
     private const string NuGetOrgRegistrationBase =
-        "https://api.nuget.org/v3/registration5-semver1";
+        "https://api.nuget.org/v3/registration5-gz-semver2";
 
     /// <summary>
     /// Fetches all version strings for a package from a single source, then removes NuGet
@@ -810,8 +814,16 @@ public static class PackageExtractor
     /// surfaces a version hidden on nuget.org. Only nuget.org exposes a listed flag (via the
     /// registration index); other feeds are returned unfiltered. Explicit <c>Package@Version</c>
     /// access does not enumerate, so it still resolves and loads a known unlisted version.
+    /// <para>
+    /// <c>Authoritative</c> is <see langword="true"/> when the returned list reflects a definitive
+    /// listing decision — a successful registration read (nuget.org) or a feed with no listed
+    /// concept (other feeds). It is <see langword="false"/> only when nuget.org's registration index
+    /// could not be read and the list is therefore a fail-open, <em>unfiltered</em> snapshot;
+    /// callers must not persist such a snapshot, or a transient registration outage would re-surface
+    /// unlisted versions for the whole cache TTL.
+    /// </para>
     /// </summary>
-    private static async Task<List<string>?> FetchListedVersionsFromSourceAsync(
+    private static async Task<(List<string>? Versions, bool Authoritative)> FetchListedVersionsFromSourceAsync(
         HttpClient client,
         string packageName,
         NuGetSource source,
@@ -819,17 +831,19 @@ public static class PackageExtractor
     {
         var versions = await FetchAllVersionsFromSourceAsync(client, packageName, source, log).ConfigureAwait(false);
         if (versions == null || !source.IsNuGetOrg)
-            return versions;
+            return (versions, Authoritative: true);
 
         var unlisted = await FetchUnlistedVersionsFromNuGetOrgAsync(client, packageName, log).ConfigureAwait(false);
-        if (unlisted == null || unlisted.Count == 0)
-            return versions;
+        if (unlisted == null)
+            return (versions, Authoritative: false);
+        if (unlisted.Count == 0)
+            return (versions, Authoritative: true);
 
         var filtered = versions.Where(v => !IsUnlisted(v, unlisted)).ToList();
         int removed = versions.Count - filtered.Count;
         if (removed > 0)
             log?.Invoke($"Excluded {removed} unlisted version(s) from enumeration");
-        return filtered;
+        return (filtered, Authoritative: true);
     }
 
     private static bool IsUnlisted(string version, HashSet<NuGet.Versioning.NuGetVersion> unlisted) =>
@@ -884,8 +898,11 @@ public static class PackageExtractor
                 }
             }
         }
-        catch (System.Text.Json.JsonException ex)
+        catch (Exception ex) when (ex is System.Text.Json.JsonException or InvalidOperationException)
         {
+            // Fail open on any malformed or unexpectedly shaped registration document
+            // (JsonException = invalid JSON; InvalidOperationException = valid JSON whose
+            // shape defies the accessors, e.g. `items` not an array or `version` not a string).
             log?.Invoke($"Could not parse listing status: {ex.Message}");
             return null;
         }
@@ -954,12 +971,15 @@ public static class PackageExtractor
 
         // For nuget.org, the flat-container/prerelease path must exclude unlisted versions.
         // FetchListedVersionsFromSourceAsync consults the registration index; its result is
-        // authoritative for nuget.org, so do not fall through to the unfiltered index below.
+        // authoritative for nuget.org, so do not fall through to the unfiltered index below —
+        // returning null (couldn't determine a latest) is safer than an unfiltered latest that
+        // could be an unlisted version.
         if (source.IsNuGetOrg)
         {
-            var listed = await FetchListedVersionsFromSourceAsync(client, packageName, source, log).ConfigureAwait(false);
+            var (listed, _) = await FetchListedVersionsFromSourceAsync(client, packageName, source, log).ConfigureAwait(false);
             if (listed != null)
                 return PickLatest(listed, includePrerelease);
+            return null;
         }
 
         // Fall back to flat-container index (enumerates all versions)
@@ -1106,6 +1126,7 @@ public static class PackageExtractor
         foreach (var source in sources)
         {
             List<string>? versions = null;
+            bool fetchedAuthoritative = false;
 
             if (source.IsNuGetOrg && canCacheNuGetOrg)
             {
@@ -1117,7 +1138,8 @@ public static class PackageExtractor
                 }
             }
 
-            versions ??= await FetchListedVersionsFromSourceAsync(client, normalizedName, source, log).ConfigureAwait(false);
+            if (versions == null)
+                (versions, fetchedAuthoritative) = await FetchListedVersionsFromSourceAsync(client, normalizedName, source, log).ConfigureAwait(false);
             if (versions == null)
                 continue;
 
@@ -1125,9 +1147,11 @@ public static class PackageExtractor
             merged.UnionWith(versions);
 
             // Persist nuget.org's list (not the merged set) so private-feed versions don't
-            // pollute the shared, name-keyed cache. The list is already listing-filtered, so the
-            // cache never re-surfaces an unlisted version within its TTL.
-            if (source.IsNuGetOrg && canCacheNuGetOrg)
+            // pollute the shared, name-keyed cache. Only cache a freshly fetched, authoritatively
+            // filtered list: a fail-open snapshot taken while the registration index was
+            // unavailable is unfiltered, so caching it would re-surface unlisted versions for the
+            // whole TTL. A list served from cache is already persisted and need not be rewritten.
+            if (source.IsNuGetOrg && canCacheNuGetOrg && fetchedAuthoritative)
                 CoreCache.Set(VersionCacheCategory, $"{normalizedName}-all", string.Join('\n', versions), extension: "txt");
         }
 

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -941,9 +941,21 @@ public static class PackageExtractor
         {
             if (!item.TryGetProperty("catalogEntry", out var entry))
                 continue;
-            if (!entry.TryGetProperty("listed", out var listedElement)
-                || listedElement.ValueKind != System.Text.Json.JsonValueKind.False)
-                continue;
+            if (!entry.TryGetProperty("listed", out var listedElement))
+                continue; // absent -> listed by default (matches NuGet's own default)
+            if (listedElement.ValueKind == System.Text.Json.JsonValueKind.True)
+                continue; // explicitly listed
+            if (listedElement.ValueKind != System.Text.Json.JsonValueKind.False)
+            {
+                // A present-but-non-boolean `listed` (e.g. the string "false") is a schema
+                // violation. Rather than silently treating the entry as listed — which would let a
+                // hostile or buggy feed smuggle an unlisted version through as "latest" — fail the
+                // whole parse. The caller catches this and returns no filter (non-authoritative),
+                // so enumeration fails open and auto-selecting callers fail closed, consistent with
+                // how every other malformed registration shape is handled.
+                throw new InvalidOperationException(
+                    $"Unexpected 'listed' value kind '{listedElement.ValueKind}' in registration entry");
+            }
             if (entry.TryGetProperty("version", out var versionElement)
                 && versionElement.GetString() is string version
                 && NuGet.Versioning.NuGetVersion.TryParse(version, out var parsed))

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -799,6 +799,142 @@ public static class PackageExtractor
         return null;
     }
 
+    // nuget.org registration index — the only nuget.org endpoint that carries the
+    // per-version `catalogEntry.listed` flag. The flat-container index.json omits it.
+    private const string NuGetOrgRegistrationBase =
+        "https://api.nuget.org/v3/registration5-semver1";
+
+    /// <summary>
+    /// Fetches all version strings for a package from a single source, then removes NuGet
+    /// <em>unlisted</em> versions so that discovery (enumeration and "latest" resolution) never
+    /// surfaces a version hidden on nuget.org. Only nuget.org exposes a listed flag (via the
+    /// registration index); other feeds are returned unfiltered. Explicit <c>Package@Version</c>
+    /// access does not enumerate, so it still resolves and loads a known unlisted version.
+    /// </summary>
+    private static async Task<List<string>?> FetchListedVersionsFromSourceAsync(
+        HttpClient client,
+        string packageName,
+        NuGetSource source,
+        Action<string>? log)
+    {
+        var versions = await FetchAllVersionsFromSourceAsync(client, packageName, source, log).ConfigureAwait(false);
+        if (versions == null || !source.IsNuGetOrg)
+            return versions;
+
+        var unlisted = await FetchUnlistedVersionsFromNuGetOrgAsync(client, packageName, log).ConfigureAwait(false);
+        if (unlisted == null || unlisted.Count == 0)
+            return versions;
+
+        var filtered = versions.Where(v => !IsUnlisted(v, unlisted)).ToList();
+        int removed = versions.Count - filtered.Count;
+        if (removed > 0)
+            log?.Invoke($"Excluded {removed} unlisted version(s) from enumeration");
+        return filtered;
+    }
+
+    private static bool IsUnlisted(string version, HashSet<NuGet.Versioning.NuGetVersion> unlisted) =>
+        NuGet.Versioning.NuGetVersion.TryParse(version, out var parsed) && unlisted.Contains(parsed);
+
+    /// <summary>
+    /// Reads the nuget.org registration index and returns the set of versions whose
+    /// <c>catalogEntry.listed</c> is explicitly <c>false</c>. A missing <c>listed</c> property is
+    /// treated as listed (older catalog entries omit it). Returns <c>null</c> when the index cannot
+    /// be fetched or parsed, so callers fail open (no filtering) rather than dropping real versions.
+    /// </summary>
+    private static async Task<HashSet<NuGet.Versioning.NuGetVersion>?> FetchUnlistedVersionsFromNuGetOrgAsync(
+        HttpClient client,
+        string packageName,
+        Action<string>? log)
+    {
+        string indexUrl = $"{NuGetOrgRegistrationBase}/{packageName}/index.json";
+        log?.Invoke($"Fetching listing status from: {indexUrl}");
+
+        string? json = await HttpRetryHelper.GetStringWithRetryAsync(
+            client, indexUrl,
+            trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
+        if (json == null)
+            return null;
+
+        var unlisted = new HashSet<NuGet.Versioning.NuGetVersion>();
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("items", out var pages))
+                return null;
+
+            foreach (var page in pages.EnumerateArray())
+            {
+                // A page either inlines its entries under "items" or points at a URL that must be
+                // fetched separately (registration pages are split for large version histories).
+                if (page.TryGetProperty("items", out var inlineItems))
+                {
+                    CollectUnlisted(inlineItems, unlisted);
+                }
+                else if (page.TryGetProperty("@id", out var pageIdElement)
+                    && pageIdElement.GetString() is string pageUrl)
+                {
+                    string? pageJson = await HttpRetryHelper.GetStringWithRetryAsync(
+                        client, pageUrl,
+                        trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
+                    if (pageJson == null)
+                        return null;
+                    using var pageDoc = System.Text.Json.JsonDocument.Parse(pageJson);
+                    if (pageDoc.RootElement.TryGetProperty("items", out var pageItems))
+                        CollectUnlisted(pageItems, unlisted);
+                }
+            }
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            log?.Invoke($"Could not parse listing status: {ex.Message}");
+            return null;
+        }
+
+        return unlisted;
+    }
+
+    private static void CollectUnlisted(
+        System.Text.Json.JsonElement items,
+        HashSet<NuGet.Versioning.NuGetVersion> unlisted)
+    {
+        foreach (var item in items.EnumerateArray())
+        {
+            if (!item.TryGetProperty("catalogEntry", out var entry))
+                continue;
+            if (!entry.TryGetProperty("listed", out var listedElement)
+                || listedElement.ValueKind != System.Text.Json.JsonValueKind.False)
+                continue;
+            if (entry.TryGetProperty("version", out var versionElement)
+                && versionElement.GetString() is string version
+                && NuGet.Versioning.NuGetVersion.TryParse(version, out var parsed))
+            {
+                unlisted.Add(parsed);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Selects the newest version from a set of version strings. When
+    /// <paramref name="includePrerelease"/> is false, prefers the newest stable version and only
+    /// falls back to a prerelease when no stable version exists. Unparseable entries are ignored.
+    /// </summary>
+    private static string? PickLatest(IEnumerable<string?> versions, bool includePrerelease)
+    {
+        NuGet.Versioning.NuGetVersion? latestStable = null;
+        NuGet.Versioning.NuGetVersion? latestAny = null;
+        foreach (var ver in versions)
+        {
+            if (ver != null && NuGet.Versioning.NuGetVersion.TryParse(ver, out var parsed))
+            {
+                if (latestAny == null || parsed > latestAny)
+                    latestAny = parsed;
+                if (!parsed.IsPrerelease && (latestStable == null || parsed > latestStable))
+                    latestStable = parsed;
+            }
+        }
+        return (includePrerelease ? latestAny : latestStable ?? latestAny)?.OriginalVersion;
+    }
+
     private static async Task<string?> GetLatestVersionFromSourceAsync(
         HttpClient client,
         string packageName,
@@ -814,6 +950,16 @@ public static class PackageExtractor
             var version = await GetLatestVersionFromSearchAsync(client, packageName, log).ConfigureAwait(false);
             if (version != null)
                 return version;
+        }
+
+        // For nuget.org, the flat-container/prerelease path must exclude unlisted versions.
+        // FetchListedVersionsFromSourceAsync consults the registration index; its result is
+        // authoritative for nuget.org, so do not fall through to the unfiltered index below.
+        if (source.IsNuGetOrg)
+        {
+            var listed = await FetchListedVersionsFromSourceAsync(client, packageName, source, log).ConfigureAwait(false);
+            if (listed != null)
+                return PickLatest(listed, includePrerelease);
         }
 
         // Fall back to flat-container index (enumerates all versions)
@@ -900,20 +1046,9 @@ public static class PackageExtractor
             {
                 // Use NuGetVersion for proper comparison — feeds may return
                 // versions in any order (nuget.org ascending, Azure DevOps descending).
-                NuGet.Versioning.NuGetVersion? latestStable = null;
-                NuGet.Versioning.NuGetVersion? latestAny = null;
-                foreach (var v in versions.EnumerateArray())
-                {
-                    var ver = v.GetString();
-                    if (ver != null && NuGet.Versioning.NuGetVersion.TryParse(ver, out var parsed))
-                    {
-                        if (latestAny == null || parsed > latestAny)
-                            latestAny = parsed;
-                        if (!parsed.IsPrerelease && (latestStable == null || parsed > latestStable))
-                            latestStable = parsed;
-                    }
-                }
-                return (includePrerelease ? latestAny : latestStable ?? latestAny)?.OriginalVersion;
+                return PickLatest(
+                    versions.EnumerateArray().Select(v => v.GetString()),
+                    includePrerelease);
             }
         }
         catch (System.Text.Json.JsonException)
@@ -982,7 +1117,7 @@ public static class PackageExtractor
                 }
             }
 
-            versions ??= await FetchAllVersionsFromSourceAsync(client, normalizedName, source, log).ConfigureAwait(false);
+            versions ??= await FetchListedVersionsFromSourceAsync(client, normalizedName, source, log).ConfigureAwait(false);
             if (versions == null)
                 continue;
 
@@ -990,7 +1125,8 @@ public static class PackageExtractor
             merged.UnionWith(versions);
 
             // Persist nuget.org's list (not the merged set) so private-feed versions don't
-            // pollute the shared, name-keyed cache.
+            // pollute the shared, name-keyed cache. The list is already listing-filtered, so the
+            // cache never re-surfaces an unlisted version within its TTL.
             if (source.IsNuGetOrg && canCacheNuGetOrg)
                 CoreCache.Set(VersionCacheCategory, $"{normalizedName}-all", string.Join('\n', versions), extension: "txt");
         }

--- a/src/DotnetInspector.Services.Tests/LocalFolderSourceTests.cs
+++ b/src/DotnetInspector.Services.Tests/LocalFolderSourceTests.cs
@@ -17,7 +17,7 @@ namespace DotnetInspector.Services.Tests;
 [Collection(CoreCacheCollection.Name)]
 public class LocalFolderSourceTests : IDisposable
 {
-    private const string VersionCacheCategory = "versions";
+    private const string VersionCacheCategory = "versions-v2";
 
     public LocalFolderSourceTests()
     {

--- a/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
+++ b/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
@@ -15,7 +15,7 @@ namespace DotnetInspector.Services.Tests;
 [Collection(CoreCacheCollection.Name)]
 public class UnlistedVersionTests : IDisposable
 {
-    private const string VersionCacheCategory = "versions";
+    private const string VersionCacheCategory = "versions-v2";
     private static readonly NuGetSource NuGetOrgSource = NuGetSource.NuGetOrg;
 
     public UnlistedVersionTests()
@@ -84,6 +84,22 @@ public class UnlistedVersionTests : IDisposable
 
         // 2.0.0 (unlisted) is excluded, so the only 2.0.* match is the listed prerelease.
         Assert.Equal("2.0.0-beta.1", result);
+    }
+
+    [Fact]
+    public async Task ResolveVersionPattern_ReturnsNull_WhenRegistrationUnavailable()
+    {
+        // Wildcard resolution auto-selects a single "latest matching" version. When the
+        // registration index is unavailable the list is an unfiltered fail-open snapshot, so we
+        // cannot tell which matches are unlisted — resolution must refuse (null) rather than
+        // auto-select the unlisted 3.0.0-beta.1. (Raw enumeration still fails open; only
+        // auto-selecting callers fail closed.)
+        using var client = new HttpClient(new NuGetOrgHandler("unlistedpkg", Registry, serveRegistration: false));
+
+        var result = await PackageExtractor.ResolveVersionPatternAsync(
+            client, "UnlistedPkg", "3.0.*", [NuGetOrgSource], log: null);
+
+        Assert.Null(result);
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
+++ b/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
@@ -99,6 +99,51 @@ public class UnlistedVersionTests : IDisposable
         Assert.Equal(["2.0.0", "1.5.0", "1.0.0"], result);
     }
 
+    [Fact]
+    public async Task GetVersions_FailsOpen_WhenRegistrationMalformed()
+    {
+        // Registration returns valid JSON whose shape defies the accessors (`items` is a number,
+        // not an array). Parsing must fail open (no crash) rather than throw InvalidOperationException.
+        using var client = new HttpClient(new NuGetOrgHandler(
+            "unlistedpkg", Registry, registrationBodyOverride: "{\"items\":42}"));
+
+        var result = await PackageExtractor.GetVersionsAsync(
+            client, "UnlistedPkg", includePrerelease: false, limit: null, log: null);
+
+        // Could not determine listing → unfiltered (unlisted 2.0.0 retained), no exception thrown.
+        Assert.Equal(["2.0.0", "1.5.0", "1.0.0"], result);
+    }
+
+    [Fact]
+    public async Task GetVersions_FailOpenResult_IsNotCached()
+    {
+        // When registration is unavailable the returned list is an unfiltered fail-open snapshot;
+        // it must NOT be persisted, or a transient registration outage would re-surface unlisted
+        // versions for the whole cache TTL.
+        using var client = new HttpClient(new NuGetOrgHandler("unlistedpkg", Registry, serveRegistration: false));
+
+        var result = await PackageExtractor.GetVersionsAsync(
+            client, "UnlistedPkg", includePrerelease: false, limit: null, log: null);
+
+        Assert.Equal(["2.0.0", "1.5.0", "1.0.0"], result);   // fail-open, unfiltered
+        Assert.Null(CoreCache.TryGet(VersionCacheCategory, "unlistedpkg-all", TimeSpan.FromHours(1), extension: "txt"));
+    }
+
+    [Fact]
+    public async Task GetLatestVersion_Prerelease_DoesNotFallThroughToUnfiltered_OnTransientFlatContainerFailure()
+    {
+        // The registration path is authoritative for nuget.org. If the flat-container read fails
+        // (so no listed list can be produced), latest resolution must return null rather than
+        // falling through and re-reading the flat-container UNFILTERED — which on a transient
+        // recovery would surface the unlisted 3.0.0-beta.1 as prerelease "latest".
+        using var client = new HttpClient(new NuGetOrgHandler("unlistedpkg", Registry, failFlatContainerFirstCall: true));
+
+        var result = await PackageExtractor.GetLatestVersionAsync(
+            client, "UnlistedPkg", [NuGetOrgSource], log: null, includePrerelease: true);
+
+        Assert.Null(result);
+    }
+
     /// <summary>
     /// Serves the three nuget.org endpoints version resolution touches: the flat-container version
     /// list (no listed flag), the registration index (single inline page carrying listed flags),
@@ -107,9 +152,13 @@ public class UnlistedVersionTests : IDisposable
     private sealed class NuGetOrgHandler(
         string packageId,
         (string Version, bool Listed)[] registry,
-        bool serveRegistration = true)
+        bool serveRegistration = true,
+        string? registrationBodyOverride = null,
+        bool failFlatContainerFirstCall = false)
         : HttpMessageHandler
     {
+        private int _flatContainerCalls;
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -118,16 +167,28 @@ public class UnlistedVersionTests : IDisposable
 
             if (string.Equals(url, $"https://api.nuget.org/v3-flatcontainer/{packageId}/index.json", StringComparison.OrdinalIgnoreCase))
             {
+                // Simulate a transient (non-retryable 404) failure on the first read so a caller
+                // that wrongly falls through would see the endpoint recover on a later read.
+                if (failFlatContainerFirstCall && ++_flatContainerCalls == 1)
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
                 string versions = string.Join(",", registry.Select(r => "\"" + r.Version + "\""));
                 body = "{\"versions\":[" + versions + "]}";
             }
             else if (serveRegistration &&
-                string.Equals(url, $"https://api.nuget.org/v3/registration5-semver1/{packageId}/index.json", StringComparison.OrdinalIgnoreCase))
+                string.Equals(url, $"https://api.nuget.org/v3/registration5-gz-semver2/{packageId}/index.json", StringComparison.OrdinalIgnoreCase))
             {
-                string items = string.Join(",", registry.Select(r =>
-                    "{\"catalogEntry\":{\"version\":\"" + r.Version + "\",\"listed\":"
-                        + (r.Listed ? "true" : "false") + "}}"));
-                body = "{\"items\":[{\"items\":[" + items + "]}]}";
+                if (registrationBodyOverride != null)
+                {
+                    body = registrationBodyOverride;
+                }
+                else
+                {
+                    string items = string.Join(",", registry.Select(r =>
+                        "{\"catalogEntry\":{\"version\":\"" + r.Version + "\",\"listed\":"
+                            + (r.Listed ? "true" : "false") + "}}"));
+                    body = "{\"items\":[{\"items\":[" + items + "]}]}";
+                }
             }
             else if (url.StartsWith("https://azuresearch-usnc.nuget.org/query", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
+++ b/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
@@ -131,6 +131,30 @@ public class UnlistedVersionTests : IDisposable
     }
 
     [Fact]
+    public async Task GetLatestVersion_ReturnsNull_WhenListedValueIsMalformed()
+    {
+        // A present-but-non-boolean `listed` ("false" as a JSON string, not the boolean false) is a
+        // schema violation. Parsing must fail open (non-authoritative) so latest resolution fails
+        // closed rather than silently treating the malformed entry as listed and surfacing the
+        // unlisted 3.0.0-beta.1 as prerelease "latest". (Pre-fix code returned 3.0.0-beta.1.)
+        const string malformed =
+            "{\"items\":[{\"items\":["
+            + "{\"catalogEntry\":{\"version\":\"1.0.0\",\"listed\":true}},"
+            + "{\"catalogEntry\":{\"version\":\"1.5.0\",\"listed\":true}},"
+            + "{\"catalogEntry\":{\"version\":\"2.0.0\",\"listed\":false}},"
+            + "{\"catalogEntry\":{\"version\":\"2.0.0-beta.1\",\"listed\":true}},"
+            + "{\"catalogEntry\":{\"version\":\"3.0.0-beta.1\",\"listed\":\"false\"}}"
+            + "]}]}";
+        using var client = new HttpClient(new NuGetOrgHandler(
+            "unlistedpkg", Registry, registrationBodyOverride: malformed));
+
+        var result = await PackageExtractor.GetLatestVersionAsync(
+            client, "UnlistedPkg", [NuGetOrgSource], log: null, includePrerelease: true);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
     public async Task GetVersions_FailOpenResult_IsNotCached()
     {
         // When registration is unavailable the returned list is an unfiltered fail-open snapshot;

--- a/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
+++ b/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using DotnetInspector.Core;
+using DotnetInspector.Packages;
+using NuGetSource = NuGetFetch.PackageSource;
+using PackageExtractor = DotnetInspector.Packages.PackageExtractor;
+
+namespace DotnetInspector.Services.Tests;
+
+/// <summary>
+/// Regression tests for issue #3388: NuGet unlisted versions must not surface during discovery
+/// (enumeration and "latest" resolution). The flat-container index.json includes unlisted versions
+/// with no listed flag; only the registration index exposes <c>catalogEntry.listed</c>, so version
+/// resolution must consult it and filter unlisted versions in one shared place.
+/// </summary>
+[Collection(CoreCacheCollection.Name)]
+public class UnlistedVersionTests : IDisposable
+{
+    private const string VersionCacheCategory = "versions";
+    private static readonly NuGetSource NuGetOrgSource = NuGetSource.NuGetOrg;
+
+    public UnlistedVersionTests()
+    {
+        CoreCache.Initialize("dotnet-inspect-test");
+        CoreCache.Clear(VersionCacheCategory);
+    }
+
+    public void Dispose() => CoreCache.Clear(VersionCacheCategory);
+
+    // Version history shared by the enumeration/resolution tests: two unlisted versions
+    // (a stable 2.0.0 and a prerelease 3.0.0-beta.1) interleaved with listed versions.
+    private static readonly (string Version, bool Listed)[] Registry =
+    [
+        ("1.0.0", true),
+        ("1.5.0", true),
+        ("2.0.0", false),          // unlisted stable — must never appear or become "latest"
+        ("2.0.0-beta.1", true),
+        ("3.0.0-beta.1", false),   // unlisted prerelease — must never become prerelease "latest"
+    ];
+
+    [Fact]
+    public async Task GetVersions_Stable_ExcludesUnlisted()
+    {
+        using var client = new HttpClient(new NuGetOrgHandler("unlistedpkg", Registry));
+
+        var result = await PackageExtractor.GetVersionsAsync(
+            client, "UnlistedPkg", includePrerelease: false, limit: null, log: null);
+
+        // 2.0.0 is unlisted and must be excluded; newest-first ordering.
+        Assert.Equal(["1.5.0", "1.0.0"], result);
+    }
+
+    [Fact]
+    public async Task GetVersions_Prerelease_ExcludesUnlisted()
+    {
+        using var client = new HttpClient(new NuGetOrgHandler("unlistedpkg", Registry));
+
+        var result = await PackageExtractor.GetVersionsAsync(
+            client, "UnlistedPkg", includePrerelease: true, limit: null, log: null);
+
+        // Both unlisted versions (2.0.0 and 3.0.0-beta.1) excluded; newest-first.
+        Assert.Equal(["2.0.0-beta.1", "1.5.0", "1.0.0"], result);
+    }
+
+    [Fact]
+    public async Task GetLatestVersion_Prerelease_SkipsUnlistedHead()
+    {
+        using var client = new HttpClient(new NuGetOrgHandler("unlistedpkg", Registry));
+
+        var result = await PackageExtractor.GetLatestVersionAsync(
+            client, "UnlistedPkg", [NuGetOrgSource], log: null, includePrerelease: true);
+
+        // The newest version overall is the unlisted 3.0.0-beta.1; latest must be the newest
+        // listed version instead. This is the core prerelease-path defect from #3388.
+        Assert.Equal("2.0.0-beta.1", result);
+    }
+
+    [Fact]
+    public async Task ResolveVersionPattern_SkipsUnlistedMatch()
+    {
+        using var client = new HttpClient(new NuGetOrgHandler("unlistedpkg", Registry));
+
+        var result = await PackageExtractor.ResolveVersionPatternAsync(
+            client, "UnlistedPkg", "2.0.*", [NuGetOrgSource], log: null);
+
+        // 2.0.0 (unlisted) is excluded, so the only 2.0.* match is the listed prerelease.
+        Assert.Equal("2.0.0-beta.1", result);
+    }
+
+    [Fact]
+    public async Task GetVersions_FailsOpen_WhenRegistrationUnavailable()
+    {
+        // Registration index 404s → we cannot determine listed status → do not drop versions.
+        using var client = new HttpClient(new NuGetOrgHandler("unlistedpkg", Registry, serveRegistration: false));
+
+        var result = await PackageExtractor.GetVersionsAsync(
+            client, "UnlistedPkg", includePrerelease: false, limit: null, log: null);
+
+        // Unfiltered: the unlisted 2.0.0 is retained rather than silently disappearing.
+        Assert.Equal(["2.0.0", "1.5.0", "1.0.0"], result);
+    }
+
+    /// <summary>
+    /// Serves the three nuget.org endpoints version resolution touches: the flat-container version
+    /// list (no listed flag), the registration index (single inline page carrying listed flags),
+    /// and the search API (listing-aware stable latest). Any other URL returns 404.
+    /// </summary>
+    private sealed class NuGetOrgHandler(
+        string packageId,
+        (string Version, bool Listed)[] registry,
+        bool serveRegistration = true)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string url = request.RequestUri!.ToString();
+            string? body = null;
+
+            if (string.Equals(url, $"https://api.nuget.org/v3-flatcontainer/{packageId}/index.json", StringComparison.OrdinalIgnoreCase))
+            {
+                string versions = string.Join(",", registry.Select(r => "\"" + r.Version + "\""));
+                body = "{\"versions\":[" + versions + "]}";
+            }
+            else if (serveRegistration &&
+                string.Equals(url, $"https://api.nuget.org/v3/registration5-semver1/{packageId}/index.json", StringComparison.OrdinalIgnoreCase))
+            {
+                string items = string.Join(",", registry.Select(r =>
+                    "{\"catalogEntry\":{\"version\":\"" + r.Version + "\",\"listed\":"
+                        + (r.Listed ? "true" : "false") + "}}"));
+                body = "{\"items\":[{\"items\":[" + items + "]}]}";
+            }
+            else if (url.StartsWith("https://azuresearch-usnc.nuget.org/query", StringComparison.OrdinalIgnoreCase))
+            {
+                // Search API is listing-aware: report the newest listed stable version.
+                string latestStable = registry.Where(r => r.Listed && !r.Version.Contains('-'))
+                    .Select(r => r.Version).Last();
+                body = "{\"data\":[{\"version\":\"" + latestStable + "\"}]}";
+            }
+
+            var response = body != null
+                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) }
+                : new HttpResponseMessage(HttpStatusCode.NotFound);
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
+++ b/src/DotnetInspector.Services.Tests/UnlistedVersionTests.cs
@@ -144,6 +144,21 @@ public class UnlistedVersionTests : IDisposable
         Assert.Null(result);
     }
 
+    [Fact]
+    public async Task GetLatestVersion_Prerelease_ReturnsNull_WhenRegistrationUnavailable()
+    {
+        // Flat-container is healthy but the registration index (the authoritative source of listed
+        // status) is unavailable, so the listed list is a fail-open UNFILTERED snapshot flagged
+        // non-authoritative. Latest resolution must NOT pick from it — otherwise the unlisted head
+        // 3.0.0-beta.1 would surface as prerelease "latest" during a transient registration outage.
+        using var client = new HttpClient(new NuGetOrgHandler("unlistedpkg", Registry, serveRegistration: false));
+
+        var result = await PackageExtractor.GetLatestVersionAsync(
+            client, "UnlistedPkg", [NuGetOrgSource], log: null, includePrerelease: true);
+
+        Assert.Null(result);
+    }
+
     /// <summary>
     /// Serves the three nuget.org endpoints version resolution touches: the flat-container version
     /// list (no listed flag), the registration index (single inline page carrying listed flags),

--- a/src/DotnetInspector.Services.Tests/VersionCacheTests.cs
+++ b/src/DotnetInspector.Services.Tests/VersionCacheTests.cs
@@ -13,7 +13,7 @@ namespace DotnetInspector.Services.Tests;
 [Collection(CoreCacheCollection.Name)]
 public class VersionCacheTests : IDisposable
 {
-    private const string VersionCacheCategory = "versions";
+    private const string VersionCacheCategory = "versions-v2";
 
     /// <summary>
     /// An HttpClient that throws on any request — proves cache prevented network access.

--- a/src/dotnet-inspect.Tests/RouterVersionTests.cs
+++ b/src/dotnet-inspect.Tests/RouterVersionTests.cs
@@ -10,7 +10,7 @@ namespace DotnetInspector.Tests;
 [Collection("Console")]
 public class RouterVersionTests
 {
-    private const string VersionCacheCategory = "versions";
+    private const string VersionCacheCategory = "versions-v2";
 
     public RouterVersionTests()
     {


### PR DESCRIPTION
## Summary

Fixes #3388. NuGet's flat-container `index.json` lists **every** version including **unlisted** ones, with no `listed` flag. Previously, unlisted versions leaked into enumeration and — worse — could be auto-selected as "latest". This PR makes version resolution **listing-aware**: unlisted versions are excluded from enumeration and from flat-container/prerelease latest selection, using nuget.org's registration index as the authoritative source of the `listed` bit.

## Behavioral change

- **Enumeration & raw listing** (`GetVersionsAsync`, `package Name --versions`): unlisted versions are filtered out. If the nuget.org registration read fails, this path **fails open** (returns the unfiltered list) — better to show a real version than to drop it during a transient outage.
- **Auto-selecting paths** (`GetLatestVersionFromSourceAsync`, wildcard `ResolveVersionPatternAsync`): these **fail closed** (return null) when the version list is non-authoritative. Silently resolving to an unlisted version is the actual #3388 harm, so we refuse rather than guess.
- **Explicit pinned access preserved**: a fully-pinned coordinate (`pkg@X`) still resolves even if that version is unlisted — explicit access is not discovery.
- **Non-nuget.org sources unchanged**: filtering only applies where nuget.org's registration provides an authoritative `listed` bit.

## Implementation notes

- `GetAllVersionsWithCacheAsync` now returns `(List<string>? Versions, bool Authoritative)`; only authoritative (filtered) lists are cached.
- Uses the SemVer2 registration hive (`registration5-gz-semver2`) so unlisted SemVer2 prereleases are also detected.
- `CollectUnlisted` treats absent/`true` `listed` as listed, `false` as unlisted, and **throws** on any other JSON value kind (string, number, null, object, array) — a malformed/hostile feed thus fails open, and the auto-select path then fails closed.
- Version cache category bumped `versions` → `versions-v2` so pre-upgrade unfiltered entries are never trusted.

## Evidence

- Services tests: 330 pass. CLI suite: green.
- New regression tests: `ResolveVersionPattern_ReturnsNull_WhenRegistrationUnavailable`, `GetLatestVersion_ReturnsNull_WhenListedValueIsMalformed`, plus fail-open/fail-closed vectors in `UnlistedVersionTests`.
- Live-verified against System.CommandLine unlisted SemVer2 prerelease `2.0.0-beta3.22101.1`.

## Adversarial review

High-risk change; reviewed across five rounds by two model families per round (Gemini + GPT). Full reconciliation posted as a follow-up comment.
