### PR TITLE
Follow type forwarders when resolving cross-assembly TypeRefs

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -135,6 +135,87 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void CrossAssemblyMetadataResolver_FollowsForwardersToDefiningAssembly()
+    {
+        // A framework TypeRef names the assembly the compiler bound against, which is a
+        // facade that defines nothing and forwards to the definer. This resolver hands back
+        // exactly the assembly a TypeRef names -- no implementation-preference redirect --
+        // so the definition is reachable only by following the facade's ExportedType
+        // forwarder. Dropping that hop makes this return null, which was the #3400 bug.
+        string frameworkDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        string targetPath = typeof(Console).Assembly.Location;
+
+        using var stream = File.OpenRead(targetPath);
+        using var peReader = new PEReader(stream);
+        Assert.True(peReader.HasMetadata);
+        var reader = peReader.GetMetadataReader();
+        using var builder = new LibraryBodyIndex.IndexBuilder(
+            targetPath, reader, peReader, new FrameworkDirectoryResolver(frameworkDir));
+
+        bool exercisedForwarder = false;
+        foreach (var handle in reader.TypeReferences)
+        {
+            var typeReference = reader.GetTypeReference(handle);
+            if (typeReference.ResolutionScope.Kind != HandleKind.AssemblyReference)
+                continue;
+
+            string referencedName = reader.GetString(
+                reader.GetAssemblyReference((AssemblyReferenceHandle)typeReference.ResolutionScope).Name);
+            string ns = reader.GetString(typeReference.Namespace);
+            string name = reader.GetString(typeReference.Name);
+            string fullTypeName = ns.Length == 0 ? name : $"{ns}.{name}";
+            string namedPath = Path.Combine(frameworkDir, referencedName + ".dll");
+
+            // Only a TypeRef whose named assembly forwards rather than defines exercises the hop.
+            if (!File.Exists(namedPath) || !TypeForwardResolver.ForwardsType(namedPath, fullTypeName))
+                continue;
+
+            var definition = builder.TryResolveExternalTypeDefinition(handle);
+            Assert.True(
+                definition is not null,
+                $"{fullTypeName} is forwarded by {referencedName} and must resolve through that forwarder");
+
+            var definingReader = definition!.Value.DefiningReader;
+            string definingName = definingReader.GetString(definingReader.GetAssemblyDefinition().Name);
+            Assert.NotEqual(referencedName, definingName);
+            Assert.True(
+                TypeForwardResolver.DefinesType(Path.Combine(frameworkDir, definingName + ".dll"), fullTypeName),
+                $"{definingName} should define {fullTypeName}");
+            Assert.Equal(name, definingReader.GetString(
+                definingReader.GetTypeDefinition(definition.Value.Definition).Name));
+
+            exercisedForwarder = true;
+            break;
+        }
+
+        Assert.True(exercisedForwarder, "expected a framework TypeRef whose named assembly forwards the type");
+    }
+
+    [Fact]
+    public void CrossAssemblyMetadataResolver_ForwarderCycleTerminatesWithoutResolving()
+    {
+        // Answering every identity with the same facade turns the forwarder chain into a
+        // cycle. Resolution must terminate and report nothing rather than spin or invent
+        // a definition.
+        string frameworkDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        string facade = Path.Combine(frameworkDir, "netstandard.dll");
+        Assert.True(File.Exists(facade));
+        Assert.True(TypeForwardResolver.ForwardsType(facade, "System.Object"));
+
+        string targetPath = typeof(Console).Assembly.Location;
+        using var stream = File.OpenRead(targetPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        using var builder = new LibraryBodyIndex.IndexBuilder(
+            targetPath, reader, peReader, new ConstantResolver(facade));
+
+        var objectReference = FindExternalTypeReference(reader, "System", "Object");
+        Assert.False(objectReference.IsNil, "System.Console should reference System.Object");
+
+        Assert.True(builder.TryResolveExternalTypeDefinition(objectReference) is null);
+    }
+
+    [Fact]
     public void CrossAssemblyMetadataResolver_NullResolverFailsHonest()
     {
         string targetPath = typeof(Console).Assembly.Location;
@@ -180,6 +261,40 @@ public class LibraryBodyIndexTests
         }
 
         throw new InvalidOperationException("Expected at least one external TypeRef.");
+    }
+
+    static TypeReferenceHandle FindExternalTypeReference(MetadataReader reader, string ns, string name)
+    {
+        foreach (var handle in reader.TypeReferences)
+        {
+            var typeReference = reader.GetTypeReference(handle);
+            if (typeReference.ResolutionScope.Kind != HandleKind.AssemblyReference)
+                continue;
+            if (reader.StringComparer.Equals(typeReference.Namespace, ns)
+                && reader.StringComparer.Equals(typeReference.Name, name))
+                return handle;
+        }
+
+        return default;
+    }
+
+    /// <summary>Resolves an identity to the same-named assembly in a directory, with no redirect.</summary>
+    sealed class FrameworkDirectoryResolver(string directory) : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+        {
+            string candidate = Path.Combine(directory, identity.Name + ".dll");
+            return File.Exists(candidate)
+                ? new ResolvedAssemblyReference(identity, candidate, () => File.OpenRead(candidate), "test")
+                : null;
+        }
+    }
+
+    /// <summary>Answers every identity with one assembly, so any forwarder chain cycles.</summary>
+    sealed class ConstantResolver(string path) : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+            => new(identity, path, () => File.OpenRead(path), "test");
     }
 
     sealed class CountingResolver : IAssemblyReferenceResolver

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -178,9 +178,6 @@ public class LibraryBodyIndexTests
             var definingReader = definition!.Value.DefiningReader;
             string definingName = definingReader.GetString(definingReader.GetAssemblyDefinition().Name);
             Assert.NotEqual(referencedName, definingName);
-            Assert.True(
-                TypeForwardResolver.DefinesType(Path.Combine(frameworkDir, definingName + ".dll"), fullTypeName),
-                $"{definingName} should define {fullTypeName}");
             Assert.Equal(name, definingReader.GetString(
                 definingReader.GetTypeDefinition(definition.Value.Definition).Name));
 
@@ -263,6 +260,71 @@ public class LibraryBodyIndexTests
         throw new InvalidOperationException("Expected at least one external TypeRef.");
     }
 
+    [Fact]
+    public void CrossAssemblyMetadataResolver_ResolvesEveryForwarderHopUnderPlatformScope()
+    {
+        // Every hop of a framework forwarder chain must stay Platform-scoped. Resolving a
+        // hop under Any would let a confusable local copy satisfy it -- see
+        // ILInspector.Analysis.SpoofRuntimeFixtures, an unsigned assembly literally named
+        // System.Runtime.
+        string frameworkDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        string targetPath = typeof(Console).Assembly.Location;
+        var recorder = new RecordingResolver(new FrameworkDirectoryResolver(frameworkDir));
+
+        using var stream = File.OpenRead(targetPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        using var builder = new LibraryBodyIndex.IndexBuilder(targetPath, reader, peReader, recorder);
+
+        var objectReference = FindExternalTypeReference(reader, "System", "Object");
+        Assert.False(objectReference.IsNil, "System.Console should reference System.Object");
+        Assert.True(builder.TryResolveExternalTypeDefinition(objectReference) is not null);
+
+        Assert.True(
+            recorder.Requests.Count > 1,
+            $"resolving System.Object should take at least one forwarder hop, saw: {string.Join(", ", recorder.Requests)}");
+        Assert.All(recorder.Requests, request =>
+            Assert.Equal(AssemblyResolutionScope.Platform, request.Scope));
+    }
+
+    [Theory]
+    [InlineData("7cec85d7bea7798e")] // System.Private.CoreLib
+    [InlineData("b03f5f7f11d50a3a")] // System.* contracts
+    [InlineData("cc7b13ffcd2ddd51")] // netstandard
+    public void NextHopScope_AnyForwardedToFrameworkSignedAssembly_TightensToPlatform(string token)
+    {
+        var forwarded = new AssemblyReferenceIdentity("System.Private.CoreLib", Version: null, Culture: null, token);
+
+        Assert.Equal(
+            AssemblyResolutionScope.Platform,
+            LibraryBodyIndex.IndexBuilder.NextHopScope(AssemblyResolutionScope.Any, forwarded));
+    }
+
+    [Theory]
+    [InlineData(null)] // unsigned -- the SpoofRuntimeFixtures adversary
+    [InlineData("1234567890abcdef")] // signed, but not a framework key
+    public void NextHopScope_AnyForwardedToUnsignedOrThirdPartyAssembly_StaysAny(string? token)
+    {
+        var forwarded = new AssemblyReferenceIdentity("System.Runtime", Version: null, Culture: null, token);
+
+        Assert.Equal(
+            AssemblyResolutionScope.Any,
+            LibraryBodyIndex.IndexBuilder.NextHopScope(AssemblyResolutionScope.Any, forwarded));
+    }
+
+    [Fact]
+    public void NextHopScope_PlatformIsNeverDowngraded()
+    {
+        foreach (string? token in new[] { null, "1234567890abcdef", "7cec85d7bea7798e" })
+        {
+            var forwarded = new AssemblyReferenceIdentity("Whatever", Version: null, Culture: null, token);
+
+            Assert.Equal(
+                AssemblyResolutionScope.Platform,
+                LibraryBodyIndex.IndexBuilder.NextHopScope(AssemblyResolutionScope.Platform, forwarded));
+        }
+    }
+
     static TypeReferenceHandle FindExternalTypeReference(MetadataReader reader, string ns, string name)
     {
         foreach (var handle in reader.TypeReferences)
@@ -295,6 +357,18 @@ public class LibraryBodyIndexTests
     {
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
             => new(identity, path, () => File.OpenRead(path), "test");
+    }
+
+    /// <summary>Records every identity and scope the builder asks for.</summary>
+    sealed class RecordingResolver(IAssemblyReferenceResolver inner) : IAssemblyReferenceResolver
+    {
+        public List<(string Name, AssemblyResolutionScope Scope)> Requests { get; } = [];
+
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+        {
+            Requests.Add((identity.Name, scope));
+            return inner.Resolve(identity, scope);
+        }
     }
 
     sealed class CountingResolver : IAssemblyReferenceResolver

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -260,11 +261,18 @@ public class LibraryBodyIndexTests
         throw new InvalidOperationException("Expected at least one external TypeRef.");
     }
 
+    /// <summary>
+    /// A chain that starts Platform-scoped stays Platform-scoped for every hop. This gates the
+    /// non-downgrade half of <see cref="LibraryBodyIndex.IndexBuilder.NextHopScope"/> against a
+    /// real framework forwarder chain; it does NOT gate tightening, because a framework TypeRef
+    /// makes <c>ScopeForReference</c> return Platform at hop 0 and the chain never starts at Any.
+    /// <see cref="ForwarderIntoFrameworkSignedAssemblyIsResolvedUnderPlatformScope"/> is the
+    /// tightening gate.
+    /// </summary>
     [Fact]
     public void CrossAssemblyMetadataResolver_ResolvesEveryForwarderHopUnderPlatformScope()
     {
-        // Every hop of a framework forwarder chain must stay Platform-scoped. Resolving a
-        // hop under Any would let a confusable local copy satisfy it -- see
+        // Resolving a hop under Any would let a confusable local copy satisfy it -- see
         // ILInspector.Analysis.SpoofRuntimeFixtures, an unsigned assembly literally named
         // System.Runtime.
         string frameworkDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
@@ -280,11 +288,146 @@ public class LibraryBodyIndexTests
         Assert.False(objectReference.IsNil, "System.Console should reference System.Object");
         Assert.True(builder.TryResolveExternalTypeDefinition(objectReference) is not null);
 
-        Assert.True(
-            recorder.Requests.Count > 1,
-            $"resolving System.Object should take at least one forwarder hop, saw: {string.Join(", ", recorder.Requests)}");
+        // Non-empty rather than "> 1": whether System.Object takes a forwarder hop from
+        // System.Console depends on the framework layout, but that this test observed real
+        // resolution at all does not.
+        Assert.NotEmpty(recorder.Requests);
         Assert.All(recorder.Requests, request =>
             Assert.Equal(AssemblyResolutionScope.Platform, request.Scope));
+    }
+
+    /// <summary>
+    /// The tightening gate, and the only test that fails if the <c>scope = NextHopScope(...)</c>
+    /// call is deleted from the forwarder loop: the unit tests below cover the function in
+    /// isolation and would all still pass with the wiring removed.
+    ///
+    /// The chain is synthetic because no natural artifact pairs an Any-scoped TypeRef with a
+    /// framework-signed forwarder target -- a real framework TypeRef is already Platform at hop 0.
+    /// Contoso.App references unsigned Contoso.Facade (Any), which forwards Sample.Widget to a
+    /// framework-signed identity. That hop must be requested under Platform, or a confusable
+    /// local copy could answer for a framework-signed name.
+    /// </summary>
+    [Fact]
+    public void ForwarderIntoFrameworkSignedAssemblyIsResolvedUnderPlatformScope()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "fwd-scope-" + Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            // 7cec85d7bea7798e is System.Private.CoreLib's key, so the forwarded identity is
+            // framework-signed while nothing else in the chain is.
+            byte[] frameworkToken = Convert.FromHexString("7cec85d7bea7798e");
+            string appPath = Path.Combine(directory, "Contoso.App.dll");
+            string facadePath = Path.Combine(directory, "Contoso.Facade.dll");
+            string corelibPath = Path.Combine(directory, "Fake.CoreLib.dll");
+
+            File.WriteAllBytes(appPath, EmitAssembly("Contoso.App", metadata =>
+            {
+                var facadeReference = metadata.AddAssemblyReference(
+                    metadata.GetOrAddString("Contoso.Facade"),
+                    new Version(1, 0, 0, 0),
+                    culture: default,
+                    publicKeyOrToken: default, // unsigned -> ScopeForReference yields Any
+                    flags: default,
+                    hashValue: default);
+                metadata.AddTypeReference(
+                    facadeReference,
+                    metadata.GetOrAddString("Sample"),
+                    metadata.GetOrAddString("Widget"));
+            }));
+
+            File.WriteAllBytes(facadePath, EmitAssembly("Contoso.Facade", metadata =>
+            {
+                var corelibReference = metadata.AddAssemblyReference(
+                    metadata.GetOrAddString("Fake.CoreLib"),
+                    new Version(1, 0, 0, 0),
+                    culture: default,
+                    publicKeyOrToken: metadata.GetOrAddBlob(frameworkToken),
+                    flags: default,
+                    hashValue: default);
+                metadata.AddExportedType(
+                    // tdForwarder (ECMA-335 II.23.1.15); not named in System.Reflection.TypeAttributes.
+                    (TypeAttributes)0x00200000,
+                    metadata.GetOrAddString("Sample"),
+                    metadata.GetOrAddString("Widget"),
+                    corelibReference,
+                    typeDefinitionId: 0);
+            }));
+
+            File.WriteAllBytes(corelibPath, EmitAssembly("Fake.CoreLib", metadata =>
+                metadata.AddTypeDefinition(
+                    TypeAttributes.Public,
+                    metadata.GetOrAddString("Sample"),
+                    metadata.GetOrAddString("Widget"),
+                    baseType: default,
+                    fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                    methodList: MetadataTokens.MethodDefinitionHandle(1))));
+
+            var recorder = new RecordingResolver(new FrameworkDirectoryResolver(directory));
+
+            using var stream = File.OpenRead(appPath);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            using var builder = new LibraryBodyIndex.IndexBuilder(appPath, reader, peReader, recorder);
+
+            var widgetReference = FindExternalTypeReference(reader, "Sample", "Widget");
+            Assert.False(widgetReference.IsNil);
+            Assert.NotNull(builder.TryResolveExternalTypeDefinition(widgetReference));
+
+            // The premise: the chain really does start unconstrained. Without this the test
+            // would pass for an implementation that scoped everything Platform from hop 0.
+            Assert.Equal(
+                AssemblyResolutionScope.Any,
+                Assert.Single(recorder.Requests, request => request.Name == "Contoso.Facade").Scope);
+
+            // The property.
+            Assert.Equal(
+                AssemblyResolutionScope.Platform,
+                Assert.Single(recorder.Requests, request => request.Name == "Fake.CoreLib").Scope);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>Emits a minimal unsigned assembly whose only content is what <paramref name="addContent"/> adds.</summary>
+    static byte[] EmitAssembly(string name, Action<MetadataBuilder> addContent)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            metadata.GetOrAddString(name + ".dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(name),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: System.Reflection.AssemblyHashAlgorithm.Sha1);
+
+        // Row 1 is always <Module>, exactly as a compiler emits.
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        addContent(metadata);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
     }
 
     [Theory]

--- a/src/ILInspector.Analysis/FrameworkAssemblyKeys.cs
+++ b/src/ILInspector.Analysis/FrameworkAssemblyKeys.cs
@@ -33,6 +33,15 @@ public static class FrameworkAssemblyKeys
             isFullKey: (reference.Flags & AssemblyFlags.PublicKey) != 0);
     }
 
+    /// <summary>
+    /// True if a lowercase-hex public-key token (as carried by
+    /// <see cref="ILInspector.Metadata.AssemblyReferenceIdentity.PublicKeyToken"/>)
+    /// is a .NET framework key. Use when only the identity is in hand and the
+    /// declaring <see cref="MetadataReader"/> is not.
+    /// </summary>
+    public static bool IsFrameworkToken(string? publicKeyToken)
+        => publicKeyToken is not null && s_frameworkTokens.Contains(publicKeyToken);
+
     public static bool IsFrameworkDefinition(MetadataReader reader)
     {
         if (!reader.IsAssembly)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2171,7 +2171,10 @@ public sealed class LibraryBodyIndex
         /// assembly into an unconstrained lookup: an <see cref="AssemblyResolutionScope.Any"/>
         /// reference can forward into a framework-signed assembly, and resolving that hop
         /// under <c>Any</c> would let a confusable local copy satisfy it. Scope only ever
-        /// tightens, never the reverse. Gated by <c>NextHopScope_*</c> tests.
+        /// tightens, never the reverse. The function is gated by the <c>NextHopScope_*</c>
+        /// tests; the call site below is gated by
+        /// <c>ForwarderIntoFrameworkSignedAssemblyIsResolvedUnderPlatformScope</c>, which is
+        /// the one test that fails if this call is dropped from the loop.
         /// </summary>
         internal static AssemblyResolutionScope NextHopScope(
             AssemblyResolutionScope current, AssemblyReferenceIdentity forwarded)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2129,18 +2129,52 @@ public sealed class LibraryBodyIndex
             string ns,
             string name)
         {
-            var metadata = ResolveReferencedAssembly(assemblyReference);
-            if (metadata is null)
-                return null;
+            var identity = AssemblyReferenceIdentity.From(_reader, assemblyReference);
+            var scope = ScopeForReference(assemblyReference);
+            string fullTypeName = ns.Length == 0 ? name : $"{ns}.{name}";
 
-            foreach (var candidateHandle in metadata.Reader.TypeDefinitions)
+            // A TypeRef names the assembly the compiler bound against, which is routinely
+            // a facade that type-forwards to the definer -- every framework reference in a
+            // reference-assembly or facade-only shared-framework layout resolves this way.
+            // Opening only the named assembly finds no TypeDef there and reports the type
+            // as unresolvable, so follow ExportedType forwarders to the defining assembly.
+            //
+            // Decoding a forwarder is TypeForwardResolver's mechanism and is reused here.
+            // The traversal itself runs in the builder because the defining MetadataReader
+            // must outlive this call under _referencedAssemblyCache's ownership, whereas
+            // TypeForwardResolver.LocateType disposes every assembly it opens.
+            HashSet<AssemblyReferenceIdentity>? visited = null;
+            for (int hop = 0; hop <= TypeForwardResolver.DefaultMaxHops; hop++)
             {
-                var candidate = metadata.Reader.GetTypeDefinition(candidateHandle);
+                var metadata = ResolveReferencedAssembly(identity, scope);
+                if (metadata is null)
+                    return null;
+
+                if (FindTopLevelTypeDefinition(metadata.Reader, ns, name) is { } definition)
+                    return (metadata.Reader, definition);
+
+                if (TypeForwardResolver.ForwardTargetAssemblyIdentity(metadata.Reader, fullTypeName) is not { } forwarded)
+                    return null;
+
+                visited ??= new HashSet<AssemblyReferenceIdentity> { identity };
+                if (!visited.Add(forwarded))
+                    return null;
+                identity = forwarded;
+            }
+
+            return null;
+        }
+
+        static TypeDefinitionHandle? FindTopLevelTypeDefinition(MetadataReader reader, string ns, string name)
+        {
+            foreach (var candidateHandle in reader.TypeDefinitions)
+            {
+                var candidate = reader.GetTypeDefinition(candidateHandle);
                 if (candidate.IsNested)
                     continue;
-                if (metadata.Reader.StringComparer.Equals(candidate.Namespace, ns)
-                    && metadata.Reader.StringComparer.Equals(candidate.Name, name))
-                    return (metadata.Reader, candidateHandle);
+                if (reader.StringComparer.Equals(candidate.Namespace, ns)
+                    && reader.StringComparer.Equals(candidate.Name, name))
+                    return candidateHandle;
             }
 
             return null;
@@ -2168,9 +2202,8 @@ public sealed class LibraryBodyIndex
             return null;
         }
 
-        ReferencedAssemblyMetadata? ResolveReferencedAssembly(AssemblyReferenceHandle handle)
+        ReferencedAssemblyMetadata? ResolveReferencedAssembly(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
         {
-            var identity = AssemblyReferenceIdentity.From(_reader, handle);
             // Guarded because parallel full builds resolve referenced assemblies concurrently
             // from many method-analysis threads. Resolution is per unique referenced assembly
             // (bounded and cached), so lock contention is negligible; the lock is reentrant on
@@ -2181,7 +2214,7 @@ public sealed class LibraryBodyIndex
                 if (_referencedAssemblyCache.TryGetValue(identity, out var cached))
                     return cached;
 
-                var resolved = OpenReferencedAssembly(identity, ScopeForReference(handle));
+                var resolved = OpenReferencedAssembly(identity, scope);
                 _referencedAssemblyCache[identity] = resolved;
                 return resolved;
             }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2160,10 +2160,25 @@ public sealed class LibraryBodyIndex
                 if (!visited.Add(forwarded))
                     return null;
                 identity = forwarded;
+                scope = NextHopScope(scope, forwarded);
             }
 
             return null;
         }
+
+        /// <summary>
+        /// Scope for the next forwarder hop. A forwarder must not launder a platform
+        /// assembly into an unconstrained lookup: an <see cref="AssemblyResolutionScope.Any"/>
+        /// reference can forward into a framework-signed assembly, and resolving that hop
+        /// under <c>Any</c> would let a confusable local copy satisfy it. Scope only ever
+        /// tightens, never the reverse. Gated by <c>NextHopScope_*</c> tests.
+        /// </summary>
+        internal static AssemblyResolutionScope NextHopScope(
+            AssemblyResolutionScope current, AssemblyReferenceIdentity forwarded)
+            => current == AssemblyResolutionScope.Any
+                && FrameworkAssemblyKeys.IsFrameworkToken(forwarded.PublicKeyToken)
+                    ? AssemblyResolutionScope.Platform
+                    : current;
 
         static TypeDefinitionHandle? FindTopLevelTypeDefinition(MetadataReader reader, string ns, string name)
         {

--- a/src/ILInspector.Metadata/TypeForwardResolver.cs
+++ b/src/ILInspector.Metadata/TypeForwardResolver.cs
@@ -66,6 +66,13 @@ public sealed record TypeLocation(
 public static class TypeForwardResolver
 {
     /// <summary>
+    /// Default bound on forwarder hops. Real chains are one or two hops
+    /// (facade to definer); the bound only stops pathological or hostile
+    /// metadata, and cycle detection stops the rest.
+    /// </summary>
+    public const int DefaultMaxHops = 8;
+
+    /// <summary>
     /// Resolves the assembly that defines <paramref name="fullTypeName"/>,
     /// starting at <paramref name="assemblyPath"/> and following type
     /// forwarders through assemblies supplied by <paramref name="resolver"/>.
@@ -74,7 +81,7 @@ public static class TypeForwardResolver
     /// </summary>
     public static TypeLocation? LocateType(
         string assemblyPath, string fullTypeName, IAssemblyReferenceResolver resolver,
-        int maxHops = 8, AssemblyResolutionScope scope = AssemblyResolutionScope.Any)
+        int maxHops = DefaultMaxHops, AssemblyResolutionScope scope = AssemblyResolutionScope.Any)
     {
         var start = new ResolvedAssemblyReference(
             new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(assemblyPath), Version: null, Culture: null, PublicKeyToken: null),
@@ -92,7 +99,7 @@ public static class TypeForwardResolver
     /// </summary>
     public static TypeLocation? LocateType(
         ResolvedAssemblyReference assembly, string fullTypeName, IAssemblyReferenceResolver resolver,
-        int maxHops = 8, AssemblyResolutionScope scope = AssemblyResolutionScope.Any)
+        int maxHops = DefaultMaxHops, AssemblyResolutionScope scope = AssemblyResolutionScope.Any)
     {
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var current = assembly;


### PR DESCRIPTION
## What

`LibraryBodyIndex.IndexBuilder` now follows type forwarders when resolving a cross-assembly `TypeRef`.

A `TypeRef` names the assembly the compiler **bound against**, which for framework references is routinely a facade that defines no types and forwards to the definer. `TryResolveTopLevelExternalType` opened only the named assembly, scanned its `TypeDefinitions`, and returned null when the type was not there. Against a reference-assembly or facade-only shared-framework layout, that is *every* framework `TypeRef`.

```
TypeRef System.Object, scope = System.Runtime
  -> open System.Runtime          (facade: zero TypeDefs)
  -> scan TypeDefinitions         (no match)
  -> return null                  <- never reads ExportedType
```

## Why it is a delegation fix, not a new capability

The general capability already exists and is correctly factored: `ILInspector.Metadata.TypeForwardResolver` is public, bounds hops, detects cycles, and splits mechanism from policy via the one-method `IAssemblyReferenceResolver` — its own doc cites `MetadataLoadContext` and ILSpy as precedent. It is already consumed by the decompiler (`MemberBodyProducer`, `CrossAssemblyTypeResolver`) and by `PlatformResolver`.

`ILInspector.Analysis` **already references `ILInspector.Metadata`** and `LibraryBodyIndex.Open` **already accepts an `IAssemblyReferenceResolver`**. It had the seam, the reference, and the interface — it just did a one-hop open. The call graph was the only major consumer not using the shared resolver.

Decoding a forwarder reuses `TypeForwardResolver.ForwardTargetAssemblyIdentity`. The traversal runs in the builder rather than calling `LocateType` because the defining `MetadataReader` must outlive the call under `_referencedAssemblyCache`'s ownership, while `LocateType` disposes every assembly it opens. `DefaultMaxHops` is now a named constant on the resolver so the two traversals cannot drift apart in value.

## Scope is carried, and never loosened

The resolution scope is computed once from the originating reference and reused for every hop, matching `LocateType`. A `Platform` reference stays `Platform`, so a forwarded framework type cannot be satisfied by a confusable local copy.

## Blast radius: none today — this is enabling work

**Corrected after review.** An earlier revision of this description claimed the change "can surface analysis that was silently empty before." That overstates it, and the correction is the most interesting thing about this PR.

`TryResolveExternalTypeDefinition` has **no product callers**. Only its own recursion through `TryResolveNestedExternalType` and four test call sites reach it.

The resolver itself is fully plumbed. `ApiAnalysisInspection.CreateReferenceResolver` builds a real `AssemblyDependencyResolver` and threads it through `MethodBodyInspectionSession.Open` into `LibraryBodyIndex.Open`, including on the `Callers` path. But nothing consumes it during indexing, and the suite already pins that: `Open_WithResolverDoesNotChangeIndexShape` asserts `Assert.Equal(0, resolver.ResolveCalls)` after a full build with a resolver supplied.

So cross-assembly type resolution is **built, plumbed, and unconsumed**. This PR makes it correct; #3419 is the change that makes something call it. That also explains the zero-regression result below rather than being contradicted by it.

This is the same pattern as #3426's root cause and as `ProgressiveMemberCallGraph` (which likewise has no callers outside its own tests): capability exists, is wired most of the way, and the consumer that needs it reaches past it.

## Evidence

`CrossAssemblyMetadataResolver_ResolvesFrameworkTypeDefinition` was a **deterministic pre-existing failure on `main`** (#3400). Causally confirmed both directions on this branch: with the product change stashed and the tests kept it fails with the original assertion; with the change applied it passes.

Two tests added, both against real framework artifacts:

- `..._FollowsForwardersToDefiningAssembly` **names the mechanism**. It uses a resolver that returns exactly the assembly a `TypeRef` names (no implementation-preference redirect), self-selects a `TypeRef` whose named assembly *forwards rather than defines* the type, and asserts the definition arrives from a **different** assembly that does define it. **Verified non-vacuous** — reverting the product change fails it with `System.Object is forwarded by System.Runtime and must resolve through that forwarder`.
- `..._ForwarderCycleTerminatesWithoutResolving` answers every identity with the same facade so the chain cycles, and asserts termination with an honest null. This one guards the new loop rather than gating the fix: it also passes on `main`, where resolution returns null one step earlier for a different reason.

| suite | result |
| --- | --- |
| Analysis | **576 / 0 failed** (was 574 with #3400 red; +2 new) |
| Services | 319 / 0 failed |
| Metadata | 1233 / 1 failed |
| CLI | 2323 / 2 failed / 10 skipped |
| Decompiler (`--gate fast`) | 4317 / 5 failed |

**Every remaining failure was verified pre-existing on `origin/main` (d7f38a1a)** by stashing the product change and re-running each one: 1 Metadata (`AuthoredSourceValidity`, source extraction), 2 CLI (`LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceLinkDoor`, `LibraryCommand_DetailedOutput_RendersSectionsAlphabetically`), 5 Decompiler (`ExpressionTreeLambda`, `StringSwitchRaising`, 3x `CorpusSensorComparison`). Zero regressions.

## Not in scope

- `ForwardTargetAssemblyIdentity` handles `Implementation.Kind == AssemblyReference`. Forwarders whose implementation is a nested `ExportedType` still resolve through `TryResolveNestedExternalType`, which now benefits from forwarding on the declaring type.
- #3419 (`MemberPattern.MatchesCrossAssembly` comparing decoded `TypeRef` identities rather than resolved definitions) is the same theme one layer up, and is the consumer that will exercise this path.

Fixes #3400.