### PR TITLE
Fold reused-temp member-value spills after structuring (#3336)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4387,9 +4387,10 @@ public class CfgSampleClass
     public static string ReusedSlotNullableBool(JoinBase node)
         => node?.Label.Contains("x") == true ? "hit" : "miss";
 
-    // The object-initializer-like lowering reuses a stack slot first for the
-    // string Status value, then for the nullable list receiver, then for Count.
-    // Those disjoint live ranges need distinct synthetic carriers.
+    // A reused-temp member-value spill: `missing?.Count ?? 0` spills its receiver
+    // to a reused edge slot beneath the dup-chain object initializer. The #3336
+    // stage-2 post-structuring fold raises this to
+    // `new SlotReuseSection { Status = ..., Missing = ... }`.
     public static SlotReuseSection ReusedSlotStringListCount(System.Collections.Generic.List<string>? missing, bool complete)
     {
         var section = new SlotReuseSection();
@@ -5074,6 +5075,35 @@ public class CfgSampleClass
         public int X { get; set; }
         public int Y { get; set; }
         public InitFlag Flag { get; set; }
+    }
+
+    static string PickTag(int x) => x.ToString();
+
+    // #3336 stage 2: two branchy member values (`f ? PickTag(..) : null`) that
+    // Roslyn spills to reused temps beneath the dup chain. The early
+    // object-initializer pass (stage 18) sees cross-block ternary diamonds and
+    // declines; only the post-structuring late spill pass (stage 42), after the
+    // diamonds collapse to single Conditionals in one straight-line block, folds
+    // it to `new Branchy { A = ..., B = ... }`. Recompiles byte-exact.
+    public static Branchy MakeBranchyReusedTempSpill(int x, bool f)
+        => new Branchy { A = f ? PickTag(x) : null, B = f ? PickTag(-x) : null };
+
+    // #3336 stage 3: the outer initializer's Inner member is itself a branchy
+    // reused-temp spill initializer. The late pass folds inner-first, then the
+    // enclosing initializer, composing both levels in one straight-line block.
+    public static InitOuter MakeNestedReusedTempSpill(int x, bool f)
+        => new InitOuter { Inner = new Branchy { A = f ? PickTag(x) : null, B = f ? PickTag(-x) : null }, Tag = x };
+
+    public sealed class Branchy
+    {
+        public string? A { get; set; }
+        public string? B { get; set; }
+    }
+
+    public sealed class InitOuter
+    {
+        public Branchy? Inner { get; set; }
+        public int Tag { get; set; }
     }
 }
 

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2562,19 +2562,34 @@ public class RaisingPassTests
     }
 
     [Fact]
-    public void StackSlotLiveRange_ReusedStringListCount_SplitsTypedCarriers()
+    public void ReusedTempSpillFold_StringListCount_RaisesObjectInitializer()
     {
-        // One edge slot can carry unrelated straight-line values: a string
-        // property value, then a nullable list receiver, then the int Count. The
-        // final C# needs distinct synthetic carriers rather than assigning the
-        // list/int values through the earlier string slot (CS0029).
+        // This fixture used to reach StackSlotLiveRangePass with one edge slot
+        // carrying a string property value, then a nullable list receiver, then
+        // the int Count — disjoint live ranges that needed distinct typed
+        // carriers to avoid CS0029. After #3336 stage 2, the post-structuring
+        // reused-temp spill fold raises that dup-chain into an object initializer
+        // *before* StackSlotLiveRangePass runs, so the reused edge slot no longer
+        // reaches that pass. That reuse is intrinsic to the foldable dup-chain
+        // lowering (the member values sit on the stack beneath the dup'd receiver
+        // and merge into reused edge slots), so it cannot be reproduced in a
+        // non-folding fixture. The slot-splitting mechanism itself stays guarded
+        // by BooleanMaterialization_ReusedReceiverSlot_KeepsBoolLiveRangeDistinct
+        // (string -> bool) and the SlotMergedDateTimeFormat object-slot case.
+        //
+        // This test now pins the fold: the method raises to
+        // `new SlotReuseSection { Status = ..., Missing = ... }`, with the
+        // nullable-list Count spelled correctly and no mistyped carrier leaked.
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.ReusedSlotStringListCount), source);
 
-        Assert.Contains(".Missing", output);
-        Assert.Contains(".Count", output);
-        Assert.DoesNotContain("string S_0 = missing", output);
-        Assert.DoesNotContain("string S_0 = S_", output);
+        Assert.Contains("new SlotReuseSection", output);
+        Assert.Contains("Status = complete ? \"Complete\" : \"Partial\"", output);
+        Assert.Contains("Missing = missing is not null ? missing.Count : 0", output);
+        // The verbose S_NNN version-copy chain is gone: no leaked receiver copy
+        // and no member store through a synthetic carrier.
+        Assert.DoesNotContain("section.Missing", output);
+        Assert.DoesNotContain("string S_0 = ", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -563,6 +563,55 @@ public class ObjectInitializerPassTests
             CSharpPrinter.Print(function).Output);
     }
 
+    // #3336 stage 2: a branchy member value (`f ? PickTag(..) : null`) that
+    // Roslyn spilled to a reused temp beneath the dup chain. The early pass
+    // declines it (the value is a cross-block ternary diamond at stage 18); the
+    // post-structuring late spill pass folds it once the diamond has collapsed
+    // to a single Conditional in one straight-line block.
+    [Fact]
+    public void ReusedTempSpill_BranchyMemberValues_FoldsWholeInitializer()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeBranchyReusedTempSpill));
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.False(initializer.IsCollection);
+        Assert.Equal(["A", "B"], initializer.Members);
+        // Both member values are the raised ternaries, not spilled version copies.
+        Assert.Equal(2, initializer.Entries.Count(entry => entry.Arguments.OfType<Conditional>().Any()));
+
+        // The whole dup chain, its version copies, and the reused spill temps are gone.
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+
+        Assert.Contains(
+            "new Branchy { A = f ? PickTag(x) : null, B = f ? PickTag(-x) : null }",
+            CSharpPrinter.Print(function).Output);
+    }
+
+    // #3336 stage 3: the outer initializer's Inner member is itself a branchy
+    // reused-temp spill initializer. The late pass folds inner-first (the inner
+    // initializer becomes the outer member's value), then the enclosing chain.
+    [Fact]
+    public void ReusedTempSpill_NestedInitializer_FoldsBothLevels()
+    {
+        var function = Raised(nameof(CfgSampleClass.MakeNestedReusedTempSpill));
+
+        var initializers = function.Descendants.OfType<ObjectInitializerExpression>().ToList();
+        Assert.Equal(2, initializers.Count);
+
+        var outer = Assert.Single(initializers, init => init.Members.SequenceEqual(["Inner", "Tag"]));
+        var inner = Assert.Single(initializers, init => init.Members.SequenceEqual(["A", "B"]));
+        // The inner initializer lands as the outer Inner member's value.
+        Assert.Contains(outer.Entries, entry => entry.Arguments.Contains(inner));
+
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+
+        Assert.Contains(
+            "new InitOuter { Inner = new Branchy { A = f ? PickTag(x) : null, B = f ? PickTag(-x) : null }, Tag = x }",
+            CSharpPrinter.Print(function).Output);
+    }
+
     static IrFunction FunctionWithSetter(bool generic, string propertyName = "set_Value")
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "Owner");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -176,6 +176,20 @@ public static class IrPasses
         // folding can recompose into one && return (issue #3051).
         new StructReceiverInliningPass(),
         new StructuringPass(),
+        // Second, spill-anchored object-initializer run. The default run above
+        // (early, before diamond collapsing) cannot fold a member whose value
+        // Roslyn spilled to a reused temp because its branches could not sit on
+        // the stack beneath the dup-chain receiver (`cond ? f(x) : null`): at that
+        // point the value is still a ConditionalBranch diamond across basic
+        // blocks, so the spill and its member store are never adjacent. Only after
+        // structuring has collapsed the diamond into a single Conditional in one
+        // straight-line block does the `t = V; ref.M = t` pair become adjacent and
+        // foldable. This run (spillReusedTemps: true) recovers those, and — folding
+        // inner-first with the shared machinery — the enclosing initializers that
+        // held a lowered nested chain as well. It commits a fold only when the plan
+        // rests on such a spill, so every chain the early run already judged stays
+        // exactly as it left it (issue #3336).
+        new ObjectInitializerPass(spillReusedTemps: true),
         // Recover a destructor: a Finalize override's try/finally + base.Finalize()
         // scaffold, structured just above, collapses to the ~T() body.
         new DestructorRecoveryPass(),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -29,10 +29,40 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public sealed class ObjectInitializerPass : IIrPass
 {
-    public string Name => "object-initializer";
+    // When set, this is the second, post-structuring run (registered after
+    // StructuringPass). Its sole extra capability over the default run is folding
+    // reused-temp member-value spills (TryReusedTempSpill), which cannot fire at
+    // the default early position: Roslyn spills a branchy member value
+    // (`cond ? f(x) : null`) into a shared temp precisely because its branches
+    // cannot sit on the stack beneath the dup-chain receiver, so at the default
+    // position (before diamond collapsing and structuring) the value is still a
+    // ConditionalBranch diamond spread across basic blocks, never the adjacent
+    // `t = V; ref.M = t` this pass matches. Only after structuring has collapsed
+    // the diamond into a single Conditional in one straight-line block does the
+    // spill/store pair become adjacent. To stay narrow, the late run commits a
+    // fold only when the plan actually rests on such a spill (PlanRequiresSpill):
+    // any chain the early run could already have folded — one whose members are
+    // all plain stores — was deliberately left lowered there (e.g. an initializer
+    // argument sequenced before a short-circuit, or a trusted-platform factory
+    // lookalike), and re-folding it here would reorder or misclassify it. The
+    // spill anchor leaves those exactly as the early run decided.
+    readonly bool _spillReusedTemps;
+
+    public ObjectInitializerPass(bool spillReusedTemps = false) => _spillReusedTemps = spillReusedTemps;
+
+    public string Name => _spillReusedTemps ? "object-initializer-late-spill" : "object-initializer";
 
     public void Run(IrFunction function, PassContext context)
     {
+        // The late (spill) run folds inner-first, so an enclosing chain whose
+        // member value is a nested initializer this run already produced can still
+        // fold even though the enclosing chain has no spill of its own: the fold
+        // that composes a spill-recovered initializer is itself part of the
+        // #3336 residue. Track those produced nodes by identity so an outer plan
+        // that reaches one (through the version-copy chain, landed use-site as the
+        // member value) counts as resting on the spill.
+        var spillDerived = _spillReusedTemps ? new HashSet<IrNode>(ReferenceEqualityComparer.Instance) : null;
+
         // Process seeds inner-first. The compiler emits the outer `new T(...)`
         // before any nested `new U(...)` that feeds one of its members, so reverse
         // document order folds sub-initializers before their enclosing initializer
@@ -43,12 +73,24 @@ public sealed class ObjectInitializerPass : IIrPass
             if (seed.Parent is not Block || seed.Value is not NewObject creation)
                 continue;
 
-            if (TryBuild(function, seed, creation) is not { } plan)
+            if (TryBuild(function, seed, creation, _spillReusedTemps) is not { } plan)
+                continue;
+
+            // Late (spill) run: only commit folds that actually rest on a
+            // reused-temp spill — the capability the early run lacked — directly or
+            // by composing a nested initializer this run already recovered from a
+            // spill. A plan of all plain stores that reaches no such spill was
+            // already available to (and declined by) the early run; re-folding it
+            // here would reorder or misclassify it.
+            if (_spillReusedTemps
+                && !PlanRequiresSpill(plan)
+                && !PlanReferencesSpillDerived(plan, spillDerived!))
                 continue;
 
             context.Stepper.StepOver(
                 $"raise {creation.Constructor.DeclaringType.Name} {(plan.IsCollection ? "collection" : "object")} initializer", seed);
-            Apply(plan);
+            var produced = Apply(plan);
+            spillDerived?.Add(produced);
         }
 
         foreach (var seed in function.Descendants.OfType<StoreLocal>().Reverse().ToList())
@@ -61,9 +103,19 @@ public sealed class ObjectInitializerPass : IIrPass
             if (TryBuild(function, seed, creation) is not { } plan)
                 continue;
 
+            // The named-local TryBuild has no spill branch, so a named-local plan
+            // only reaches the late run by composing a nested spill-recovered
+            // initializer (PlanReferencesSpillDerived); a plain named-local chain
+            // stays exactly as the early run left it.
+            if (_spillReusedTemps
+                && !PlanRequiresSpill(plan)
+                && !PlanReferencesSpillDerived(plan, spillDerived!))
+                continue;
+
             context.Stepper.StepOver(
                 $"raise named-local {creation.Constructor.DeclaringType.Name} {(plan.IsCollection ? "collection" : "object")} initializer", seed);
-            Apply(plan);
+            var produced = Apply(plan);
+            spillDerived?.Add(produced);
         }
     }
 
@@ -85,18 +137,26 @@ public sealed class ObjectInitializerPass : IIrPass
     /// carries a <see cref="BlockPlan"/> and no direct arguments. Block construction
     /// is deferred to <see cref="Apply"/> so its leaf arguments are detached from
     /// their lowered statements before being reparented into the new IR.
+    /// <para>
+    /// <see cref="FromReusedSpill"/> marks an entry recovered by
+    /// <see cref="TryReusedTempSpill"/>. The late (post-structuring) run folds a
+    /// plan only when it — directly or through a nested block — contains such an
+    /// entry (see <see cref="PlanRequiresSpill"/>), because that spill is the one
+    /// capability the early run lacked.
+    /// </para>
     /// </summary>
     sealed record EntryPlan(
         string? Member,
         IReadOnlyList<IrExpression> Arguments,
         BlockPlan? Block,
         MethodRef? ConsumedMethod = null,
-        FieldRef? ConsumedField = null);
+        FieldRef? ConsumedField = null,
+        bool FromReusedSpill = false);
 
     /// <summary>A nested initializer body: an object/collection brace group with no creation.</summary>
     sealed record BlockPlan(bool IsCollection, IReadOnlyList<EntryPlan> Entries);
 
-    static Plan? TryBuild(IrFunction function, StoreStackSlot seed, NewObject creation)
+    static Plan? TryBuild(IrFunction function, StoreStackSlot seed, NewObject creation, bool spillReusedTemps)
     {
         var statements = seed.Parent!.Children;
         var aliasSlots = new HashSet<int> { seed.Slot };
@@ -187,17 +247,30 @@ public sealed class ObjectInitializerPass : IIrPass
                 continue;
             }
 
-            // A single-use member-value spill feeding the immediately-following
-            // member store: `default(T) V = default; ref.M = V`, where the compiler
-            // spills a `default(T)` (a struct-typed `initobj` into its own local)
-            // and reads it straight back as the member value. Fold both into
-            // `M = default` inlined at the member's position. Sound because the
-            // member value stays in member order at the fold site — unlike a
-            // pre-entry skip, it is never reordered across the `newobj` or other
-            // members; and `default(T)` is a pure zero-init with no side effect.
+            // A member-value spill feeding the immediately-following member store,
+            // in either of two shapes:
+            //   * `default(T) V = default; ref.M = V` — the compiler spills a
+            //     struct `default(T)` (an `initobj` into its own local) and reads it
+            //     straight back (TryDefaultValueSpill).
+            //   * `t = V; ref.M = t` — a (possibly reused) stack-slot temp holds a
+            //     computed member value, e.g. `t = cond ? Write(x) : null; ref.M = t`
+            //     that Roslyn spills because the value's branches cannot sit on the
+            //     stack beneath the dup-chain receiver (TryReusedTempSpill).
+            // Either way, fold both statements into `M = <value>` inlined at the
+            // member's position. Sound because the member value stays in member order
+            // at the fold site — unlike a pre-entry skip, it is never reordered across
+            // the `newobj` or other members: the spill statement and its consuming
+            // member store are adjacent in the same straight-line block, so the spilled
+            // value already evaluated immediately before the member store and keeps
+            // that spot in the initializer. TryReusedTempSpill additionally proves the
+            // temp is a linear spill slot (each definition consumed by exactly its next
+            // statement), so dropping this store/load pair strands no other reader.
             if (i + 1 < statements.Count
                 && !TouchesAnySlot(statement, aliasSlots)
-                && TryDefaultValueSpill(function, statement, statements[i + 1], aliasSlots) is { } spilled)
+                && (TryDefaultValueSpill(function, statement, statements[i + 1], aliasSlots)
+                    ?? (spillReusedTemps
+                        ? TryReusedTempSpill(function, statement, statements[i + 1], aliasSlots)
+                        : null)) is { } spilled)
             {
                 if (isCollection == true)
                     break;
@@ -599,6 +672,147 @@ public sealed class ObjectInitializerPass : IIrPass
         return new EntryPlan(member, [new DefaultValue(init.Type)], null, ConsumedMethod: method, ConsumedField: fieldRef);
     }
 
+    /// <summary>
+    /// Matches a stack-slot member-value spill and its consuming member store:
+    /// <c>t = V</c> (a <see cref="StoreStackSlot"/> writing a computed value into a
+    /// non-threaded temp slot <c>t</c>) immediately followed by
+    /// <c>ref.M = LoadStackSlot t</c> on a threaded slot, where the load is the whole
+    /// right-hand side. Returns the member entry with <paramref name="V"/> inlined in
+    /// place of the temp so both statements fold into <c>M = V</c>.
+    /// <para>
+    /// The temp may be reused across several members (Roslyn spills each branchy
+    /// member value — e.g. <c>cond ? Write(x) : null</c> — into one shared slot
+    /// because the branches cannot straddle the dup-chain receiver on the stack), so
+    /// the single-use ownership guard of <see cref="TryDefaultValueSpill"/> does not
+    /// apply. Instead <see cref="IsLinearSpillSlot"/> proves the slot is used
+    /// strictly linearly — every definition is consumed by exactly the immediately
+    /// following statement — so removing this (store, load) pair strands no other
+    /// reader and reorders nothing: spill and store are adjacent in one straight-line
+    /// block, so <c>V</c> already evaluated in this exact position, after the
+    /// <c>newobj</c> and in member order.
+    /// </para>
+    /// </summary>
+    static EntryPlan? TryReusedTempSpill(IrFunction function, IrNode spill, IrNode memberStatement, HashSet<int> aliasSlots)
+    {
+        // The spill: `t = V`, where `t` is a temp slot distinct from the threaded
+        // reference chain (a store into an alias slot is a version copy, not a spill).
+        if (spill is not StoreStackSlot { Slot: var tempSlot, Value: var spilledValue }
+            || aliasSlots.Contains(tempSlot))
+            return null;
+
+        // The consuming member store: `ref.M = LoadStackSlot t` on a threaded slot,
+        // with no index arguments (the temp is the whole right-hand side).
+        var (member, method, fieldRef) = memberStatement switch
+        {
+            StoreProperty { HasInstance: true, Instance: LoadStackSlot slot, Value: LoadStackSlot use } property
+                when aliasSlots.Contains(slot.Slot) && use.Slot == tempSlot
+                    && property.IndexArguments.Count == 0 && IsInitializerSpellable(property)
+                => (property.PropertyName, (MethodRef?)property.Accessor, (FieldRef?)null),
+            StoreField { HasInstance: true, Instance: LoadStackSlot slot, Value: LoadStackSlot use } field
+                when aliasSlots.Contains(slot.Slot) && use.Slot == tempSlot
+                => (field.Field.Name, null, field.Field),
+            _ => ((string?)null, null, null),
+        };
+        if (member is null)
+            return null;
+
+        // The spilled value must not read the temp itself — that would observe the
+        // slot's prior definition, which this fold drops.
+        if (SubtreeLoadsStackSlot(spilledValue, tempSlot))
+            return null;
+
+        // Fold only when the temp is a linear spill slot: each definition reaches
+        // exactly its adjacent consuming use, so dropping this pair is sound.
+        if (!IsLinearSpillSlot(function, tempSlot))
+            return null;
+
+        return new EntryPlan(member, [spilledValue], null, ConsumedMethod: method, ConsumedField: fieldRef, FromReusedSpill: true);
+    }
+
+    /// <summary>
+    /// Whether a plan rests on a reused-temp spill — an entry recovered by
+    /// <see cref="TryReusedTempSpill"/>, directly or inside a nested block. The
+    /// late (post-structuring) run folds only such plans, leaving every
+    /// all-plain-store chain exactly as the early run decided.
+    /// </summary>
+    static bool PlanRequiresSpill(Plan plan) => EntriesRequireSpill(plan.Entries);
+
+    static bool EntriesRequireSpill(IEnumerable<EntryPlan> entries)
+        => entries.Any(entry => entry.FromReusedSpill
+            || (entry.Block is { } block && EntriesRequireSpill(block.Entries)));
+
+    /// <summary>
+    /// Whether a plan composes a nested initializer this run already recovered from
+    /// a spill: any leaf member value (recursively) is or contains one of the
+    /// tracked <paramref name="spillDerived"/> nodes. Inner-first folding lands such
+    /// a nested initializer use-site as the enclosing member's value, so the
+    /// enclosing fold is part of the same #3336 residue even without a spill of its
+    /// own. All of the pass's ordering guards still apply; this only relaxes the
+    /// spill-narrowing, never a soundness check.
+    /// </summary>
+    static bool PlanReferencesSpillDerived(Plan plan, HashSet<IrNode> spillDerived)
+        => spillDerived.Count != 0 && EntriesReferenceSpillDerived(plan.Entries, spillDerived);
+
+    static bool EntriesReferenceSpillDerived(IEnumerable<EntryPlan> entries, HashSet<IrNode> spillDerived)
+        => entries.Any(entry =>
+            entry.Arguments.Any(argument => argument.Descendants.Prepend(argument).Any(spillDerived.Contains))
+            || (entry.Block is { } block && EntriesReferenceSpillDerived(block.Entries, spillDerived)));
+
+    /// <summary>
+    /// Whether stack slot <paramref name="slot"/> is used strictly linearly: every
+    /// <see cref="StoreStackSlot"/> of it is a block statement whose value does not
+    /// re-read the slot and whose immediately following sibling statement consumes it
+    /// with exactly one <see cref="LoadStackSlot"/> and no re-store, and the total
+    /// load count equals the store count. Together these make each definition reach
+    /// exactly its adjacent use (adjacency in a straight-line block means no branch
+    /// intervenes), so folding any (store, load) pair strands no other reader.
+    /// </summary>
+    static bool IsLinearSpillSlot(IrFunction function, int slot)
+    {
+        int stores = 0;
+        int loads = 0;
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case StoreStackSlot store when store.Slot == slot:
+                {
+                    stores++;
+                    if (store.Parent is not { } parent)
+                        return false;
+                    int next = store.ChildIndex + 1;
+                    if (next >= parent.Children.Count)
+                        return false;  // a definition with no following consumer
+                    if (SubtreeLoadsStackSlot(store.Value, slot))
+                        return false;  // the definition reads the slot it defines
+                    var consumer = parent.Children[next];
+                    if (CountStackSlotLoads(consumer, slot) != 1 || SubtreeStoresStackSlot(consumer, slot))
+                        return false;  // the next statement is not a lone consuming use
+                    break;
+                }
+
+                case LoadStackSlot load when load.Slot == slot:
+                    loads++;
+                    break;
+            }
+        }
+
+        // Each store contributes one consuming load in a distinct next-sibling
+        // statement (two stores cannot share a consumer, and adjacent stores are
+        // rejected by the re-store check above). Equal totals therefore mean every
+        // load is one of those consuming loads — no stray reader of any definition.
+        return stores > 0 && stores == loads;
+    }
+
+    static bool SubtreeLoadsStackSlot(IrNode root, int slot)
+        => root.Descendants.Prepend(root).Any(node => node is LoadStackSlot load && load.Slot == slot);
+
+    static bool SubtreeStoresStackSlot(IrNode root, int slot)
+        => root.Descendants.Prepend(root).Any(node => node is StoreStackSlot store && store.Slot == slot);
+
+    static int CountStackSlotLoads(IrNode root, int slot)
+        => root.Descendants.Prepend(root).Count(node => node is LoadStackSlot load && load.Slot == slot);
+
     static EntryPlan? TryMemberStore(IrNode statement, int localIndex) => statement switch
     {
         StoreProperty { HasInstance: true, Instance: LoadLocal local } property
@@ -764,7 +978,7 @@ public sealed class ObjectInitializerPass : IIrPass
         return false;
     }
 
-    static void Apply(Plan plan)
+    static ObjectInitializerExpression Apply(Plan plan)
     {
         // Drop the lowered run from the block, then lift the creation and leaf
         // arguments out of those now-detached statements before reparenting them
@@ -789,7 +1003,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 var initializer = new ObjectInitializerExpression(plan.Creation, plan.IsCollection, entries);
                 initializer.InheritSourceOffset(plan.Creation);
                 stackSlot.Use.ReplaceWith(initializer);
-                break;
+                return initializer;
             }
 
             case StackSlotSeedTarget stackSlotSeed:
@@ -800,7 +1014,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 plan.Creation.ReplaceWith(initializer);
                 if (stackSlotSeed.Use.Slot != stackSlotSeed.Seed.Slot)
                     stackSlotSeed.Use.ReplaceWith(new LoadStackSlot(stackSlotSeed.Seed.Slot, stackSlotSeed.Use.Type));
-                break;
+                return initializer;
             }
 
             case LocalSeedTarget:
@@ -809,8 +1023,11 @@ public sealed class ObjectInitializerPass : IIrPass
                 var initializer = new ObjectInitializerExpression(creation, plan.IsCollection, entries);
                 initializer.InheritSourceOffset(plan.Creation);
                 plan.Creation.ReplaceWith(initializer);
-                break;
+                return initializer;
             }
+
+            default:
+                throw new InvalidOperationException($"Unhandled initializer target {plan.Target.GetType().Name}.");
         }
     }
 


### PR DESCRIPTION
- Advances #3336 (stage 2/3: reused-temp member-value spill + nested composition)
- Changes: object initializers whose branchy member values Roslyn spilled to a reused temp beneath the dup-chain receiver now fold, including the enclosing nested initializers that held them
- Card revision: `ee0f238b`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a second, spill-anchored object-initializer run after structuring folds reused-temp member-value spills the early run structurally cannot reach; it is byte-neutral (13/13 Exact on the standalone witness) and commits a fold only when the plan rests on such a spill, so every chain the early run judged stays exactly as it left it.

### Benchmark target

Benchmark target: `OpenAI@2.12.0`

dotnet-inspect command:

```bash
dotnet-inspect member OpenAI.FineTuning.FineTuningTrainingMethod CreateSupervised --library <cache>/openai/2.12.0/lib/net10.0/OpenAI.dll -S "Decompiled Source"
```

### Original source

SourceLink cannot supply C# for this OpenAI member (no source server), so the authoritative anchor is the raw IL — the canonical dup-chain object-initializer lowering the fold recovers:

```il
IL_0000: newobj       FineTuningTrainingMethod::.ctor()
IL_0005: dup
IL_0006: call         InternalFineTuneMethodType::get_Supervised()
IL_000B: callvirt     FineTuningTrainingMethod::set_Kind(...)
IL_0010: dup
IL_0011: newobj       InternalFineTuningJobRequestMethodSupervised::.ctor()
IL_0016: dup
IL_0017: newobj       HyperparametersForSupervised::.ctor()
IL_001C: dup
IL_001D: ldarg.0
IL_001E: brtrue.s     IL_0023
IL_0020: ldnull
IL_0021: br.s         IL_0033
IL_0023: ldarg.0
IL_0024: call         ModelReaderWriterOptions::get_Json()
IL_0029: call         OpenAIContext::get_Default()
IL_002E: call         ModelReaderWriter::Write<HyperparameterBatchSize>(...)
IL_0033: callvirt     HyperparametersForSupervised::set__BatchSize(BinaryData)
// ... set__NEpochs, set__LearningRateMultiplier (same ternary shape) ...
IL_0070: callvirt     InternalFineTuningJobRequestMethodSupervised::set_Hyperparameters(...)
IL_0075: callvirt     FineTuningTrainingMethod::set_Supervised(...)
IL_007A: ret
```

### Before

```csharp
public static FineTuningTrainingMethod CreateSupervised(HyperparameterBatchSize batchSize = null, HyperparameterEpochCount epochCount = null, HyperparameterLearningRate learningRate = null)
{
    BinaryData S_6;

    FineTuningTrainingMethod S_256 = new();
    S_256.Kind = InternalFineTuneMethodType.Supervised;
    FineTuningTrainingMethod S_257 = S_256;
    InternalFineTuningJobRequestMethodSupervised S_258 = new();
    HyperparametersForSupervised S_259 = new();
    InternalFineTuningJobRequestMethodSupervised S_2 = S_258;
    S_6 = batchSize is not null ? ModelReaderWriter.Write<HyperparameterBatchSize>(batchSize, ModelReaderWriterOptions.get_Json(), OpenAIContext.Default) : null;
    S_259._BatchSize = S_6;
    HyperparametersForSupervised S_260 = S_259;
    S_6 = epochCount is not null ? ModelReaderWriter.Write<HyperparameterEpochCount>(epochCount, ModelReaderWriterOptions.get_Json(), OpenAIContext.Default) : null;
    S_260._NEpochs = S_6;
    HyperparametersForSupervised S_261 = S_260;
    HyperparametersForSupervised S_4 = S_261;
    S_6 = learningRate is not null ? ModelReaderWriter.Write<HyperparameterLearningRate>(learningRate, ModelReaderWriterOptions.get_Json(), OpenAIContext.Default) : null;
    S_261._LearningRateMultiplier = S_6;
    S_258.Hyperparameters = S_4;
    S_257.Supervised = S_2;
    return S_257;
}
```

- Valid: True
- Correct: True
- IL fidelity: True (verbose but byte-faithful — the version-copy chain is the literal dup-chain lowering)
- Taste applied: None
- Commit: `adaf9414`

The reused temp `S_6` carries each branchy member value (`cond ? Write(...) : null`); Roslyn spills it because the ternary branches cannot straddle the dup-chain receiver on the stack. The early object-initializer pass sees cross-block diamonds and declines, leaving the whole nested chain lowered.

### After

```csharp
public static FineTuningTrainingMethod CreateSupervised(HyperparameterBatchSize batchSize = null, HyperparameterEpochCount epochCount = null, HyperparameterLearningRate learningRate = null) => new FineTuningTrainingMethod
{
    Kind = InternalFineTuneMethodType.Supervised,
    Supervised = new InternalFineTuningJobRequestMethodSupervised { Hyperparameters = new HyperparametersForSupervised { _BatchSize = batchSize is not null ? ModelReaderWriter.Write<HyperparameterBatchSize>(batchSize, ModelReaderWriterOptions.get_Json(), OpenAIContext.Default) : null, _NEpochs = epochCount is not null ? ModelReaderWriter.Write<HyperparameterEpochCount>(epochCount, ModelReaderWriterOptions.get_Json(), OpenAIContext.Default) : null, _LearningRateMultiplier = learningRate is not null ? ModelReaderWriter.Write<HyperparameterLearningRate>(learningRate, ModelReaderWriterOptions.get_Json(), OpenAIContext.Default) : null } }
};
```

- Valid: True
- Correct: True
- IL fidelity: True (standalone witness `--fidelity-check`: 13/13 Exact; the recovered spelling recompiles to the original opcode stream above)
- Taste applied: None (`-S "Applied Taste"`: "No recorded style choices were applied") — the fold is byte-neutral raising, not a style lens
- Commit: `ee0f238b`

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Result |
| --- | --- |
| ObjectInitializerPassTests | 38/38 (2 new: branchy reused-temp fold + nested both-levels fold) |
| RaisingPassTests | 109/109 (split test converted to assert the #3336 fold; split mechanism still guarded by `ReusedSlotNullableBool` string→bool + `set_SlotMergedDateTimeFormat` object siblings) |
| Full fast suite (`--gate fast`) | 4319/0 |
| Byte-neutrality (standalone witness `--fidelity-check`) | 13/13 Exact — the fold recompiles to the original opcode stream |
| Corpus | OpenAI `CreateSupervised` (above) + `CreateDirectPreferenceOptimization` now fully fold |
| Oracle | dotnet/runtime `.editorconfig`: `dotnet_style_object_initializer = true`; object initializers are pervasive in dotnet/runtime source — default-on folding matches taste |

Notes:

- The late run is spill-anchored: it commits a fold only when the plan rests on a reused-temp spill (`PlanRequiresSpill`) or composes a nested initializer this run already recovered (`PlanReferencesSpillDerived`). Every all-plain-store chain the early run deliberately left lowered (initializer-arg-before-short-circuit, trusted-platform-factory lookalikes) stays exactly as it decided — covered by the existing `*_StaysLowered` close-negatives.
- `IsLinearSpillSlot` proves the reused temp is used strictly linearly (each definition consumed by exactly its adjacent next statement; load count == store count), so dropping the (store, load) pair strands no other reader and reorders no side effect.
- Whole-assembly `FidelityGateTests`/`LoweredFidelityGateTests` are Speed=Slow and excluded from the merge-blocking `test` job; byte-neutrality is proven here via the standalone witness `--fidelity-check`.
