### PR TITLE
Keep the token stream the slicer's scanner already computes

### DIFF
--- a/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
+++ b/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
@@ -1345,7 +1345,10 @@ public static class BodySlicer
 
                     if (run < frame.DollarRun)
                     {
-                        // Too short to delimit a hole.
+                        // Too short to delimit a hole. The depth passed here is inert: this
+                        // fragment always follows literal content, so coalescing fuses it into
+                        // the preceding StringLiteral, which keeps the first fragment's depth.
+                        // A wrong value here cannot reach an observer, so no test gates it.
                         Emit(depth, ScanTokenKind.StringLiteral, i, run);
                         i += run;
                         continue;
@@ -1409,7 +1412,8 @@ public static class BodySlicer
                         continue;
                     }
 
-                    // A shorter run inside a raw literal is content.
+                    // A shorter run inside a raw literal is content. As above, the depth is
+                    // inert: the fragment is always coalesced into a preceding StringLiteral.
                     Emit(depth, ScanTokenKind.StringLiteral, i, run);
                     i += run;
                     continue;

--- a/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
+++ b/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
@@ -1239,7 +1239,6 @@ public static class BodySlicer
         int i = start;
         bool opened = false;
         bool bracketOpened = false;
-        int entryCount = tokens?.Count ?? 0;
 
         void Emit(int atDepth, ScanTokenKind kind, int column, int length) =>
             EmitAt(atDepth, state.BracketDepth, kind, column, length);
@@ -1252,7 +1251,10 @@ public static class BodySlicer
             // Literal text arrives in fragments — an escape, a quote run, a stretch of plain
             // characters — because the scan decides what each one means separately. They are one
             // token to a caller, so adjacent fragments coalesce instead of surfacing that.
-            if (kind == ScanTokenKind.StringLiteral && tokens.Count > entryCount)
+            // Adjacency is same line and touching columns: a literal that spans lines emits one
+            // token per line, so an empty line inside a verbatim literal must not fuse the
+            // fragments on either side of it.
+            if (kind == ScanTokenKind.StringLiteral && tokens.Count > 0)
             {
                 var previous = tokens[^1];
 

--- a/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
+++ b/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
@@ -1586,6 +1586,15 @@ public static class BodySlicer
                         frame.HoleDepth = 0;
                         state.Replace(frame);
                         int closerAt = i;
+
+                        // Min because a longer run closes the hole with DollarRun braces and
+                        // leaves the rest as literal text. This cannot be gated through the token
+                        // stream: the leftover braces are re-consumed by the literal branch on the
+                        // next step and coalesce back into this token, so consuming one brace here
+                        // produces a byte-identical stream. Verified inert over every string up to
+                        // length 7 on the `$ " { } \ a` alphabet (335,922 inputs, 0 divergences).
+                        // It is kept because it is what the language says, and a consumer that
+                        // wants un-coalesced fragments would be able to tell.
                         i += frame.DollarRun > 1 ? Math.Min(run, frame.DollarRun) : 1;
                         EmitAt(depthBefore, bracketBefore, ScanTokenKind.StringLiteral, closerAt, i - closerAt);
                         continue;

--- a/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
+++ b/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
@@ -1345,10 +1345,7 @@ public static class BodySlicer
 
                     if (run < frame.DollarRun)
                     {
-                        // Too short to delimit a hole. The depth passed here is inert: this
-                        // fragment always follows literal content, so coalescing fuses it into
-                        // the preceding StringLiteral, which keeps the first fragment's depth.
-                        // A wrong value here cannot reach an observer, so no test gates it.
+                        // Too short to delimit a hole.
                         Emit(depth, ScanTokenKind.StringLiteral, i, run);
                         i += run;
                         continue;
@@ -1412,8 +1409,7 @@ public static class BodySlicer
                         continue;
                     }
 
-                    // A shorter run inside a raw literal is content. As above, the depth is
-                    // inert: the fragment is always coalesced into a preceding StringLiteral.
+                    // A shorter run inside a raw literal is content.
                     Emit(depth, ScanTokenKind.StringLiteral, i, run);
                     i += run;
                     continue;

--- a/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
+++ b/src/DotnetInspector.CSharpBodySlicer/BodySlicer.cs
@@ -1166,6 +1166,28 @@ public static class BodySlicer
     }
 
     /// <summary>
+    /// Scans <paramref name="lines"/> as one continuous stretch of C# and returns every token on
+    /// them, in order.
+    /// <para>
+    /// The scan is the same one the slicer's predicates run on; this entry point differs only in
+    /// keeping what that scan works out instead of discarding it at each line break. It exists so
+    /// the token stream can be pinned and checked directly, ahead of the predicates moving onto
+    /// it.
+    /// </para>
+    /// </summary>
+    internal static List<ScanToken> ScanTokens(IReadOnlyList<string> lines)
+    {
+        var state = new LexState();
+        var tokens = new List<ScanToken>();
+        int depth = 0;
+
+        for (int i = 0; i < lines.Count; i++)
+            Scan(lines[i], state, ref depth, start: 0, untilLiteralCloses: false, out _, tokens: tokens, lineIndex: i);
+
+        return tokens;
+    }
+
+    /// <summary>
     /// Scans <paramref name="line"/> from <paramref name="start"/>, returning the index it
     /// stopped at. With <paramref name="untilLiteralCloses"/> the scan stops as soon as the
     /// literal it opened is closed, which is how a caller consumes a single literal.
@@ -1178,12 +1200,94 @@ public static class BodySlicer
         bool untilLiteralCloses,
         out char significant,
         bool untilCodeResumes = false,
-        bool untilBracketsClose = false)
+        bool untilBracketsClose = false,
+        List<ScanToken>? tokens = null,
+        int lineIndex = 0)
+    {
+        bool untrackedOnEntry = state.Untracked;
+        int mark = tokens?.Count ?? 0;
+
+        int stopped = ScanCore(
+            line, state, ref depth, start, untilLiteralCloses, out significant,
+            untilCodeResumes, untilBracketsClose, tokens, lineIndex);
+
+        // Losing the place is discovered at the end of a line, after tokens on it were emitted.
+        // Those tokens recorded a depth that has since become meaningless, so correct them rather
+        // than leave a stale "known" that reads exactly like a real depth.
+        if (tokens is not null && state.Untracked && !untrackedOnEntry)
+        {
+            for (int t = mark; t < tokens.Count; t++)
+                tokens[t] = tokens[t] with { DepthKnown = false };
+        }
+
+        return stopped;
+    }
+
+    private static int ScanCore(
+        string line,
+        LexState state,
+        ref int depth,
+        int start,
+        bool untilLiteralCloses,
+        out char significant,
+        bool untilCodeResumes,
+        bool untilBracketsClose,
+        List<ScanToken>? tokens,
+        int lineIndex)
     {
         significant = '\0';
         int i = start;
         bool opened = false;
         bool bracketOpened = false;
+        int entryCount = tokens?.Count ?? 0;
+
+        void Emit(int atDepth, ScanTokenKind kind, int column, int length) =>
+            EmitAt(atDepth, state.BracketDepth, kind, column, length);
+
+        void EmitAt(int atDepth, int atBracketDepth, ScanTokenKind kind, int column, int length)
+        {
+            if (tokens is null || length <= 0)
+                return;
+
+            // Literal text arrives in fragments — an escape, a quote run, a stretch of plain
+            // characters — because the scan decides what each one means separately. They are one
+            // token to a caller, so adjacent fragments coalesce instead of surfacing that.
+            if (kind == ScanTokenKind.StringLiteral && tokens.Count > entryCount)
+            {
+                var previous = tokens[^1];
+
+                if (previous.Kind == ScanTokenKind.StringLiteral &&
+                    previous.Line == lineIndex &&
+                    previous.End == column)
+                {
+                    tokens[^1] = previous with { Length = previous.Length + length };
+                    return;
+                }
+            }
+
+            tokens.Add(new ScanToken(kind, lineIndex, column, length, atDepth, atBracketDepth, !state.Untracked));
+        }
+
+        // Advances past the rest of an open block comment, clearing the carried flag if the
+        // comment ends on this line. Shared by the branch that opens one and the branch that
+        // resumes one carried in from an earlier line.
+        int ConsumeBlockComment(int from)
+        {
+            int j = from;
+
+            while (j < line.Length)
+            {
+                if (line[j] == '*' && j + 1 < line.Length && line[j + 1] == '/')
+                {
+                    state.InBlockComment = false;
+                    return j + 2;
+                }
+
+                j++;
+            }
+
+            return j;
+        }
 
         if (!state.InBlockComment && !state.InLiteral && IsDirective(line, out bool conditional))
         {
@@ -1193,6 +1297,7 @@ public static class BodySlicer
             if (conditional)
                 state.Untracked = true;
 
+            Emit(depth, ScanTokenKind.Directive, i, line.Length - i);
             return line.Length;
         }
 
@@ -1211,16 +1316,9 @@ public static class BodySlicer
 
             if (state.InBlockComment)
             {
-                if (c == '*' && i + 1 < line.Length && line[i + 1] == '/')
-                {
-                    state.InBlockComment = false;
-                    i += 2;
-                }
-                else
-                {
-                    i++;
-                }
-
+                int commentStart = i;
+                i = ConsumeBlockComment(i);
+                Emit(depth, ScanTokenKind.Comment, commentStart, i - commentStart);
                 continue;
             }
 
@@ -1238,6 +1336,7 @@ public static class BodySlicer
                     {
                         // Not interpolated, or a closing run in literal text: content either
                         // way. A hole is closed from inside the hole, not from here.
+                        Emit(depth, ScanTokenKind.StringLiteral, i, run);
                         i += run;
                         continue;
                     }
@@ -1245,6 +1344,7 @@ public static class BodySlicer
                     if (run < frame.DollarRun)
                     {
                         // Too short to delimit a hole.
+                        Emit(depth, ScanTokenKind.StringLiteral, i, run);
                         i += run;
                         continue;
                     }
@@ -1254,6 +1354,7 @@ public static class BodySlicer
                         // One "$": braces pair off as escapes, and an odd one out opens a hole.
                         if (run % 2 == 0)
                         {
+                            Emit(depth, ScanTokenKind.StringLiteral, i, run);
                             i += run;
                             continue;
                         }
@@ -1264,12 +1365,14 @@ public static class BodySlicer
                     frame.InHole = true;
                     frame.HoleDepth = 1;
                     state.Replace(frame);
+                    Emit(depth, ScanTokenKind.StringLiteral, i, run);
                     i += run;
                     continue;
                 }
 
                 if (c == '\\' && !frame.Verbatim && !frame.Raw)
                 {
+                    Emit(depth, ScanTokenKind.StringLiteral, i, Math.Min(2, line.Length - i));
                     i += 2;
                     continue;
                 }
@@ -1283,12 +1386,14 @@ public static class BodySlicer
                         // "" is an escaped quote; a lone quote closes.
                         if (run >= 2)
                         {
+                            Emit(depth, ScanTokenKind.StringLiteral, i, 2);
                             i += 2;
                             continue;
                         }
 
                         state.Pop();
                         significant = '"';
+                        Emit(depth, ScanTokenKind.StringLiteral, i, 1);
                         i += 1;
                         continue;
                     }
@@ -1297,16 +1402,31 @@ public static class BodySlicer
                     {
                         state.Pop();
                         significant = '"';
+                        Emit(depth, ScanTokenKind.StringLiteral, i, run);
                         i += run;
                         continue;
                     }
 
                     // A shorter run inside a raw literal is content.
+                    Emit(depth, ScanTokenKind.StringLiteral, i, run);
                     i += run;
                     continue;
                 }
 
+                // Plain content. Consuming the whole run rather than one character at a time is
+                // the same scan — none of these characters carry meaning here — and it keeps the
+                // emitted token from being assembled a character at a time.
+                int contentStart = i;
                 i++;
+
+                while (i < line.Length &&
+                       line[i] is not ('{' or '}' or '"') &&
+                       !(line[i] == '\\' && !frame.Verbatim && !frame.Raw))
+                {
+                    i++;
+                }
+
+                Emit(depth, ScanTokenKind.StringLiteral, contentStart, i - contentStart);
                 continue;
             }
 
@@ -1319,24 +1439,29 @@ public static class BodySlicer
                 {
                     // A line comment runs to the end of the line. Inside a hole that means the
                     // literal cannot close here, which only a multi-line form survives.
+                    Emit(depth, ScanTokenKind.Comment, i, line.Length - i);
                     break;
                 }
 
                 if (line[i + 1] == '*')
                 {
                     state.InBlockComment = true;
-                    i += 2;
+                    int openerStart = i;
+                    i = ConsumeBlockComment(i + 2);
+                    Emit(depth, ScanTokenKind.Comment, openerStart, i - openerStart);
                     continue;
                 }
             }
 
             if (c == '\'')
             {
+                int literalStart = i;
                 i++;
                 while (i < line.Length && line[i] != '\'')
                     i += line[i] == '\\' ? 2 : 1;
                 i++;
                 significant = '\'';
+                Emit(depth, ScanTokenKind.CharLiteral, literalStart, Math.Min(i, line.Length) - literalStart);
                 continue;
             }
 
@@ -1360,9 +1485,11 @@ public static class BodySlicer
                 {
                     // "$" or "@" not opening a literal: an identifier like "@class", or an
                     // interpolation-free use. Consume what was examined and carry on.
+                    int examined = i;
                     i = open > i ? open : i + 1;
                     if (!char.IsWhiteSpace(c))
                         significant = c;
+                    Emit(depth, ScanTokenKind.Punctuator, examined, i - examined);
                     continue;
                 }
 
@@ -1375,6 +1502,7 @@ public static class BodySlicer
                 if (!raw && quotes == 2)
                 {
                     // The empty literal.
+                    Emit(depth, ScanTokenKind.StringLiteral, i, open + 2 - i);
                     i = open + 2;
                     significant = '"';
                     if (untilLiteralCloses)
@@ -1392,9 +1520,29 @@ public static class BodySlicer
 
                 opened = true;
                 significant = '"';
+                int openerAt = i;
                 i = open + (raw ? quotes : 1);
+                Emit(depth, ScanTokenKind.StringLiteral, openerAt, i - openerAt);
                 continue;
             }
+
+            // An identifier, keyword, or numeric literal. Taking the whole run at once is the
+            // same scan the character-at-a-time loop performed — none of these characters is a
+            // delimiter — and it is what lets a caller ask for a word rather than rebuild one.
+            if (c == '_' || char.IsLetterOrDigit(c))
+            {
+                int wordStart = i;
+
+                while (i < line.Length && (line[i] == '_' || char.IsLetterOrDigit(line[i])))
+                    i++;
+
+                significant = line[i - 1];
+                Emit(depth, ScanTokenKind.Word, wordStart, i - wordStart);
+                continue;
+            }
+
+            int depthBefore = depth;
+            int bracketBefore = state.BracketDepth;
 
             if (c == '{')
             {
@@ -1435,7 +1583,9 @@ public static class BodySlicer
                         frame.InHole = false;
                         frame.HoleDepth = 0;
                         state.Replace(frame);
+                        int closerAt = i;
                         i += frame.DollarRun > 1 ? Math.Min(run, frame.DollarRun) : 1;
+                        EmitAt(depthBefore, bracketBefore, ScanTokenKind.StringLiteral, closerAt, i - closerAt);
                         continue;
                     }
 
@@ -1449,7 +1599,10 @@ public static class BodySlicer
             }
 
             if (!char.IsWhiteSpace(c))
+            {
                 significant = c;
+                EmitAt(depthBefore, bracketBefore, ScanTokenKind.Punctuator, i, 1);
+            }
 
             i++;
         }

--- a/src/DotnetInspector.CSharpBodySlicer/ScanToken.cs
+++ b/src/DotnetInspector.CSharpBodySlicer/ScanToken.cs
@@ -19,8 +19,16 @@ internal enum ScanTokenKind
     Punctuator,
 
     /// <summary>
-    /// Literal text between a string's delimiters. An interpolated literal yields one of these
-    /// per run of literal text, with the holes emitted as ordinary code tokens in between.
+    /// Text between a string's delimiters, delimiters included.
+    /// <para>
+    /// One token may span more than one literal. Adjacent literal text coalesces, and a literal
+    /// that opens immediately inside another's interpolation hole is adjacent to it, so
+    /// <c>$"a{$"b{</c> arrives as a single token. The guarantee is the complement rather than the
+    /// extent: no character of code is ever inside one of these, because code is emitted as
+    /// <see cref="Word"/> or <see cref="Punctuator"/> and so breaks the adjacency. Callers use
+    /// this kind to ask "is this position code?", which it answers exactly; they must not use it
+    /// to count literals or to find one literal's bounds.
+    /// </para>
     /// </summary>
     StringLiteral,
 

--- a/src/DotnetInspector.CSharpBodySlicer/ScanToken.cs
+++ b/src/DotnetInspector.CSharpBodySlicer/ScanToken.cs
@@ -1,0 +1,86 @@
+namespace DotnetInspector.CSharpBodySlicer;
+
+/// <summary>
+/// The lexical category of a <see cref="ScanToken"/>.
+/// <para>
+/// The set is deliberately coarse. It names the distinctions the slicer's predicates actually
+/// ask about — is this text code, or is it commented out, quoted, or preprocessor — and stops
+/// there. It does not classify operators, separate keywords from identifiers, or decompose
+/// numeric literals, because nothing here needs those and inventing them would imply a fidelity
+/// this scanner does not have.
+/// </para>
+/// </summary>
+internal enum ScanTokenKind
+{
+    /// <summary>A run of identifier characters: a keyword, an identifier, or a numeric literal.</summary>
+    Word,
+
+    /// <summary>One significant character of code that is not part of a word.</summary>
+    Punctuator,
+
+    /// <summary>
+    /// Literal text between a string's delimiters. An interpolated literal yields one of these
+    /// per run of literal text, with the holes emitted as ordinary code tokens in between.
+    /// </summary>
+    StringLiteral,
+
+    /// <summary>A single-quoted character literal, delimiters included.</summary>
+    CharLiteral,
+
+    /// <summary>Comment text: a line comment to end of line, or one line's worth of a block comment.</summary>
+    Comment,
+
+    /// <summary>A preprocessor directive. The whole line is one token.</summary>
+    Directive,
+}
+
+/// <summary>
+/// One lexical unit found by <see cref="BodySlicer"/>'s scanner, with the position and the
+/// structural depth in effect where it sits.
+/// <para>
+/// A token never spans a line break. A construct that does — a block comment, a verbatim or raw
+/// string literal — yields one token per line it covers, so a caller can always ask what is on a
+/// given line without reconstructing the lexer's carried state. That carried state is what made
+/// the predicates fragile: each one re-derived "am I inside a comment or a literal?" from text it
+/// was handed, and a caller that forgot to thread the state got a plausible wrong answer.
+/// </para>
+/// </summary>
+/// <param name="Kind">The lexical category.</param>
+/// <param name="Line">Zero-based index of the line the token sits on.</param>
+/// <param name="Column">Zero-based index of the token's first character within that line.</param>
+/// <param name="Length">The token's length in characters. Always at least one.</param>
+/// <param name="Depth">
+/// The number of structural braces enclosing the token's first character. A <c>{</c> that opens a
+/// block carries the depth outside it, and the matching <c>}</c> carries the depth inside, so both
+/// delimiters report the depth of the text they bound rather than of each other.
+/// </param>
+/// <param name="BracketDepth">
+/// The number of enclosing square brackets, which is how an attribute list spanning lines is told
+/// from the code around it.
+/// </param>
+/// <param name="DepthKnown">
+/// False once the scanner has lost its place — an unterminated single-line literal, or a
+/// conditional directive whose braces may belong to a discarded branch. <see cref="Depth"/> is
+/// meaningless from that point on and callers must treat it as "do not know" rather than as zero.
+/// </param>
+internal readonly record struct ScanToken(
+    ScanTokenKind Kind,
+    int Line,
+    int Column,
+    int Length,
+    int Depth,
+    int BracketDepth,
+    bool DepthKnown)
+{
+    /// <summary>The index one past the token's last character, within its own line.</summary>
+    public int End => Column + Length;
+
+    /// <summary>
+    /// True when the token is C# the compiler acts on, rather than commented-out text, quoted
+    /// text, or a preprocessor line. Predicates that look for declarations want only these.
+    /// </summary>
+    public bool IsCode => Kind is ScanTokenKind.Word or ScanTokenKind.Punctuator;
+
+    /// <summary>The token's text, given the line it was found on.</summary>
+    public ReadOnlySpan<char> TextIn(string line) => line.AsSpan(Column, Length);
+}

--- a/src/DotnetInspector.CSharpBodySlicer/ScanToken.cs
+++ b/src/DotnetInspector.CSharpBodySlicer/ScanToken.cs
@@ -83,12 +83,6 @@ internal readonly record struct ScanToken(
     /// <summary>The index one past the token's last character, within its own line.</summary>
     public int End => Column + Length;
 
-    /// <summary>
-    /// True when the token is C# the compiler acts on, rather than commented-out text, quoted
-    /// text, or a preprocessor line. Predicates that look for declarations want only these.
-    /// </summary>
-    public bool IsCode => Kind is ScanTokenKind.Word or ScanTokenKind.Punctuator;
-
     /// <summary>The token's text, given the line it was found on.</summary>
     public ReadOnlySpan<char> TextIn(string line) => line.AsSpan(Column, Length);
 }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/AuthoredSourceValidityTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/AuthoredSourceValidityTests.cs
@@ -1944,4 +1944,56 @@ public class AuthoredSourceValidityTests
 
         Assert.Equal(member, slice);
     }
+
+    /// <summary>
+    /// A constructor recovered from below the type header must be recovered at the type's
+    /// member level, and an attribute list that never closes leaves the scanner unable to say
+    /// where member level is. The line below such a list reads exactly like a constructor
+    /// declaration -- and the scanner would accept it, presenting a fragment of an attribute
+    /// argument as authored source -- so the bracket depth is part of the member-level test,
+    /// not just the brace depth (adversarial review, Gemini).
+    /// </summary>
+    [Fact]
+    public void ConstructorUnderAnUnclosedAttributeList_IsNotRecovered()
+    {
+        var source = string.Join('\n', [
+            "namespace N;",                                 // 1
+            "readonly struct Result",                       // 2
+            "{",                                            // 3
+            "    [Attr(",                                   // 4  <- never closes
+            "    Result(string name)",                      // 5
+            "    {",                                        // 6  <- StartLine
+            "        Name = name;",                         // 7
+            "    }",                                        // 8  <- EndLine
+            "}",                                            // 9
+        ]);
+
+        Assert.Null(BodySlicer.ExtractMethodBody(source, startLine: 6, endLine: 8, methodName: ".ctor"));
+    }
+
+    /// <summary>
+    /// The close negative of the case above. The same attribute list, closed on its second
+    /// line, leaves the constructor at member level, so recovery must still find it. This is
+    /// what separates "the brackets are open" from "the line carries brackets at all".
+    /// </summary>
+    [Fact]
+    public void ConstructorUnderAClosedMultiLineAttributeList_IsStillRecovered()
+    {
+        var source = string.Join('\n', [
+            "namespace N;",                                 // 1
+            "readonly struct Result",                       // 2
+            "{",                                            // 3
+            "    [Attr(",                                   // 4
+            "        1)]",                                  // 5  <- closes here
+            "    Result(string name)",                      // 6
+            "    {",                                        // 7  <- StartLine
+            "        Name = name;",                         // 8
+            "    }",                                        // 9  <- EndLine
+            "}",                                            // 10
+        ]);
+
+        Assert.Equal(
+            "Result(string name)\n{\n    Name = name;\n}",
+            BodySlicer.ExtractMethodBody(source, startLine: 7, endLine: 9, methodName: ".ctor"));
+    }
 }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ExtractMethodBodyTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ExtractMethodBodyTests.cs
@@ -1202,4 +1202,27 @@ public class ExtractMethodBodyTests
         Assert.Null(thrown);
     }
 
+    /// <summary>
+    /// A body whose braces never close runs the forward brace-recovery scan to the end of the
+    /// file. The scan's limit is clamped to the file length rather than to the scan budget,
+    /// because a member that begins within the budget of the last line makes the unclamped
+    /// limit larger than the file. Without the clamp the loop reads past the last line and
+    /// throws, which no other test reaches: every unbalanced fixture elsewhere either closes
+    /// its braces or sits far enough from EOF (adversarial review, Gemini).
+    /// </summary>
+    [Fact]
+    public void UnbalancedBodyAtEndOfFile_StopsAtTheLastLineRatherThanReadingPastIt()
+    {
+        var source = string.Join('\n',
+            "class C",
+            "{",
+            "    void M()",
+            "    {",
+            "        if (x)",
+            "        {") + "\n";
+
+        var body = BodySlicer.ExtractMethodBody(source, 5, 6, "M");
+
+        Assert.Equal("void M()\n{\n    if (x)\n    {", body);
+    }
 }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ExtractMethodBodyTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ExtractMethodBodyTests.cs
@@ -1070,4 +1070,36 @@ public class ExtractMethodBodyTests
 
         Assert.Equal("public int Target() => 0;\n// trailing note", body);
     }
+
+    /// <summary>
+    /// Gates the scanner rule that the <c>}</c> closing an interpolation hole is part of the
+    /// enclosing literal and therefore must not become the line's last significant character.
+    /// <see cref="BodySlicer.ExtractMethodBody(string, int, int, string?)"/> asks
+    /// <c>EndsDeclaration</c> whether the range already terminates; a hole closer that counted
+    /// as a terminator would answer yes here and stop the slice on line 3, dropping the raw
+    /// literal's closing delimiter and the method's own <c>}</c>.
+    ///
+    /// The range must be a single line for this to be observable: over a multi-line range
+    /// <c>EndsDeclaration</c> and <c>IndexPastClosingBrace</c> compute brace depth over the
+    /// same span, so whenever the misclassification would flip the former to <c>true</c> the
+    /// latter would have declined to extend anyway. This is the gate for that rule — the
+    /// corpus contains no interpolation hole closing on the last significant column of a
+    /// single-line member, so removing this test leaves the rule unverified.
+    /// </summary>
+    [Fact]
+    public void HoleClosingBraceOnASingleLineRange_DoesNotTerminateTheDeclaration()
+    {
+        var source = Lines(
+            "class C",                                      // 1
+            "{",                                            // 2
+            "    void Target() { Log($\"\"\"x{y}",           // 3  <- StartLine, EndLine
+            "        \"\"\"); }",                            // 4
+            "",                                             // 5
+            "    void Other() { }",                          // 6
+            "}");                                           // 7
+
+        var body = BodySlicer.ExtractMethodBody(source, startLine: 3, endLine: 3, methodName: "Target");
+
+        Assert.Equal("void Target() { Log($\"\"\"x{y}\n    \"\"\"); }", body);
+    }
 }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ExtractMethodBodyTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ExtractMethodBodyTests.cs
@@ -1102,4 +1102,33 @@ public class ExtractMethodBodyTests
 
         Assert.Equal("void Target() { Log($\"\"\"x{y}\n    \"\"\"); }", body);
     }
+
+    /// <summary>
+    /// A line that closes a literal carried in from above and then declares a sibling accessor
+    /// is a declaration from the point the literal ends. Asking only whether the line *began*
+    /// inside a literal suppressed the question on exactly the line that answers it, and the
+    /// getter's slice then swallowed the setter (adversarial review, GPT).
+    /// </summary>
+    [Fact]
+    public void AccessorClosingACarriedLiteral_DoesNotSwallowTheSiblingAccessor()
+    {
+        var source = string.Join('\n',
+            "class C",
+            "{",
+            "    public string P",
+            "    {",
+            "        get",
+            "        {",
+            "            return @\"a",
+            "\" set { _v = value; }",
+            "        }",
+            "    }",
+            "}") + "\n";
+
+        var body = BodySlicer.ExtractMethodBody(source, 5, 7, "get_P");
+
+        Assert.NotNull(body);
+        Assert.DoesNotContain("set {", body);
+    }
+
 }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ExtractMethodBodyTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ExtractMethodBodyTests.cs
@@ -1131,4 +1131,75 @@ public class ExtractMethodBodyTests
         Assert.DoesNotContain("set {", body);
     }
 
+
+    /// <summary>
+    /// The backward signature scan reads trivia off each line above the slice. A line that ends
+    /// in a lone "/" has no character after it to classify, and reading one throws rather than
+    /// deciding the line is not a comment (adversarial review, Gemini).
+    /// </summary>
+    [Fact]
+    public void SignatureScanOverALineEndingInASlash_DoesNotReadPastIt()
+    {
+        var source = string.Join('\n',
+            "class C",
+            "{",
+            "    public /",
+            "    {",
+            "        Body();",
+            "    }",
+            "}") + "\n";
+
+        var thrown = Record.Exception(() => BodySlicer.ExtractMethodBody(source, 5, 6, "M"));
+
+        Assert.Null(thrown);
+    }
+
+    /// <summary>
+    /// The same shape one character later: a declaration line ending in "=" is asked whether an
+    /// expression body ("=>") follows the member's name, and the ">" it would read is past the
+    /// end of the line (adversarial review, Gemini).
+    /// </summary>
+    [Fact]
+    public void SignatureScanOverALineEndingInAnEquals_DoesNotReadPastIt()
+    {
+        var source = string.Join('\n',
+            "class C",
+            "{",
+            "    int Target =",
+            "    {",
+            "        Body();",
+            "    }",
+            "}") + "\n";
+
+        // DeclaresMember only ever examines the slice's own first line, so the declaration
+        // under test has to be that line.
+        // The scan must reach a decision. Declining is a decision; throwing is not.
+        var thrown = Record.Exception(() => BodySlicer.ExtractMethodBody(source, 3, 6, "get_Target"));
+
+        Assert.Null(thrown);
+    }
+
+    /// <summary>
+    /// A destructor's declaring type is matched against the source a character at a time, and a
+    /// unicode escape is two characters. A name ending in a lone backslash has no second one
+    /// (adversarial review, Gemini).
+    /// </summary>
+    [Fact]
+    public void DestructorMatchOverANameEndingInABackslash_DoesNotReadPastIt()
+    {
+        var source = string.Join('\n',
+            "class C",
+            "{",
+            "    ~\\",
+            "    {",
+            "        Body();",
+            "    }",
+            "}") + "\n";
+
+        var thrown = Record.Exception(
+            () => BodySlicer.ExtractMethodBody(source, 5, 6, "Finalize", isDestructor: true, destructorTypeName: "C"));
+
+        Assert.Null(thrown);
+    }
+
 }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -930,22 +930,14 @@ public class ScanTokenTests
     {
         const string Alphabet = "#/*'\"@$\\{}a";
         int checked_ = 0;
-        HashSet<string>? seedFirstLines = null;
+        HashSet<(string First, string Second)>? seedPairs = null;
 
         void Check(string[] content)
         {
-            var bare = BodySlicer.ScanTokens(content);
+            if (seedPairs is not null && content.Length == 2)
+                seedPairs.Add((content[0], content[1]));
 
-            // Record only calls that actually did the seeded arm's work: two lines, whose
-            // second one opens with a fragment carried in from the first. Recording the first
-            // line alone would let a single-line call stand in for the two-line one.
-            if (seedFirstLines is not null
-                && content.Length > 1
-                && bare.FirstOrDefault(t => t.Line == 1) is
-                    { Kind: ScanTokenKind.StringLiteral or ScanTokenKind.Comment })
-            {
-                seedFirstLines.Add(content[0]);
-            }
+            var bare = BodySlicer.ScanTokens(content);
 
             string[] wrapped = ["{", "[", .. content];
             var enclosed = BodySlicer.ScanTokens(wrapped).Where(t => t.Line >= 2).ToList();
@@ -1018,7 +1010,7 @@ public class ScanTokenTests
         var tails = new List<string> { "" };
         Walk(new char[1], 0, 1, tails.Add);
 
-        seedFirstLines = [];
+        seedPairs = [];
 
         foreach (var opener in openers)
         {
@@ -1032,46 +1024,25 @@ public class ScanTokenTests
         // The sweep is only as good as its size; pin it so a shrunken alphabet is visible.
         Assert.Equal(16_104 + (132 * 132) + (9 * 12 * 132), checked_);
 
-        // Size and seed quality are still not the same as reach. A seed only does its work
-        // when it opens the *first* line, because scanner state runs forward: swapping the two
-        // lines preserves every pairing and every assertion above while removing the carried
-        // raw literal entirely (adversarial review, GPT). Pin that each seed was actually
-        // scanned in the position that carries.
+        // Size and seed quality are still not the same as reach: the arm only does its work if
+        // each seeded line is scanned in the position that carries, and against every second
+        // line, because scanner state runs forward. Neither is implied by the count. Swapping
+        // the two lines, or collapsing the inner loop onto one repeated second line, preserves
+        // the count and every assertion above while dropping the carried construct or the paths
+        // its continuation reaches -- the latter far enough to let a wrong depth on a carried
+        // interpolated fragment go unnoticed (adversarial review, GPT and Gemini).
         //
-        // Three narrowings make that pin bite, each closing a way the previous spelling passed
-        // without the arm doing its work (adversarial review, GPT and Gemini):
-        //
-        // The record is scoped to the seeded arm rather than collected across all three arms,
-        // because seven of the nine openers are spellable from the single-line alphabet and a
-        // shared set would already hold them.
-        //
-        // Only calls that carry a fragment onto a second line are recorded, so a single-line
-        // call cannot stand in for the two-line one.
-        //
-        // The key is the whole first line, opener *and* tail, not the opener alone. Under the
-        // swap the recorded lines are the `seconds`, which are every string of length two or
-        // less, so an opener of that length would be handed back to the record verbatim by a
-        // line that never opened it.
-        //
-        // A seeded line no longer than the pair arm's reach is exempt, because that arm already
-        // scanned it in first position; such a line is not something the seeds uniquely provide.
-        // Both lengths are read back off the collections that produced them rather than restated,
-        // so lengthening the tails, shortening the pair arm, or adding a short opener moves the
-        // exemption here instead of silently widening it. `"` is the only opener exempt for every
-        // tail it can take, and that is asserted as a set, so a second one cannot join it quietly.
-        int pairArmReach = seconds.Max(line => line.Length);
-        int longestTail = tails.Max(tail => tail.Length);
-
-        Assert.Equal(["\""], openers.Where(o => o.Length + longestTail <= pairArmReach));
-
+        // Recording the ordered pair rather than the first line alone pins both at once. The
+        // pair is ordered, so a swap no longer matches; it is the whole first line, so a second
+        // line short enough for the exhaustive pair arm to spell cannot vouch for a seed the
+        // arm cannot reach; and it names the second line, so the inner loop cannot collapse.
+        // Only two-line calls are recorded, so a single-line call cannot stand in either.
         foreach (var opener in openers)
         {
             foreach (var tail in tails)
             {
-                if ((opener + tail).Length <= pairArmReach)
-                    continue;
-
-                Assert.Contains(opener + tail, seedFirstLines);
+                foreach (var second in seconds)
+                    Assert.Contains((opener + tail, second), seedPairs);
             }
         }
     }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -888,4 +888,112 @@ public class ScanTokenTests
             RenderState("int x;", "var s = \"unterminated"));
     }
 
+
+    /// <summary>
+    /// Enclosing any content in a block and an attribute list shifts every token's structural
+    /// depth and bracket depth by exactly one, and changes nothing else about it.
+    /// <para>
+    /// This is the self-policing form of the two rounds of findings that preceded it. Gating
+    /// depth by naming the emission paths and writing a fixture for each failed twice: first
+    /// because the helper could not show the field, then because every fixture that showed it
+    /// sat at depth zero. Both times the fix covered the paths that had been named and left the
+    /// ones that had not (adversarial review, GPT). A path does not have to be known to this
+    /// test to be covered by it: any emission site reachable from the alphabet that hardcodes a
+    /// depth, or that reads the wrong one, breaks the shift.
+    /// </para>
+    /// <para>
+    /// The alphabet is chosen so the shift is exact rather than approximate. It spells a
+    /// directive, a comment in both forms, a character literal, every string-literal form and
+    /// its escape, an interpolation hole, and the brace that closes one. It excludes "]" alone:
+    /// bracket depth clamps at zero, so an unmatched "]" leaves the bare and enclosed runs at
+    /// depths that differ by less than one. That clamp is a rule in its own right, gated by
+    /// <see cref="ClosingBracketWithoutAnOpener_DoesNotDriveTheBracketDepthNegative"/>.
+    /// Structural depth has no such clamp -- it is allowed to go negative when a slice begins
+    /// below the brace that opened its block -- so "}" keeps the shift exact and is included.
+    /// </para>
+    /// <para>
+    /// Two literal-content emission sites survive this gate, and are inert rather than
+    /// unreachable: both always follow literal content, so coalescing fuses their fragment into
+    /// the preceding StringLiteral, which keeps the *first* fragment's depth. A wrong depth
+    /// there cannot reach an observer. Both carry a comment saying so. This is the same
+    /// inertness class as the hole-closer's Math.Min. The hole closer at the brace that *ends*
+    /// a hole is not in that class -- it begins a literal token, because the token before it is
+    /// code -- and is gated by
+    /// <see cref="BraceClosingAHole_ReportsTheDepthOutsideIt"/>.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EnclosingContent_ShiftsEveryTokensDepthByExactlyOne()
+    {
+        const string Alphabet = "#/*'\"@$\\{}a";
+        int checked_ = 0;
+
+        void Check(string[] content)
+        {
+            var bare = BodySlicer.ScanTokens(content);
+            string[] wrapped = ["{", "[", .. content];
+            var enclosed = BodySlicer.ScanTokens(wrapped).Where(t => t.Line >= 2).ToList();
+
+            Assert.Equal(bare.Count, enclosed.Count);
+
+            for (int i = 0; i < bare.Count; i++)
+            {
+                var b = bare[i];
+                var e = enclosed[i];
+                var where = $"[{string.Join("\\n", content)}] token {i}";
+
+                Assert.Equal((b.Kind, b.Line + 2, b.Column, b.Length, b.DepthKnown), (e.Kind, e.Line, e.Column, e.Length, e.DepthKnown));
+                Assert.True(b.Depth + 1 == e.Depth, $"{where}: depth {b.Depth} -> {e.Depth}");
+                Assert.True(b.BracketDepth + 1 == e.BracketDepth, $"{where}: bracket depth {b.BracketDepth} -> {e.BracketDepth}");
+            }
+
+            checked_++;
+        }
+
+        void Walk(char[] buffer, int depth, int limit, Action<string> body)
+        {
+            for (int i = 0; i < Alphabet.Length; i++)
+            {
+                buffer[depth] = Alphabet[i];
+                body(new string(buffer, 0, depth + 1));
+
+                if (depth + 1 < limit)
+                    Walk(buffer, depth + 1, limit, body);
+            }
+        }
+
+        // One line reaches every path that opens a construct.
+        Walk(new char[4], 0, 4, line => Check([line]));
+
+        // Two lines reach the paths that continue one carried in from the line above, which no
+        // single-line input can: a literal's later lines, and a block comment's.
+        var seconds = new List<string>();
+        Walk(new char[2], 0, 2, seconds.Add);
+
+        foreach (var first in seconds)
+        {
+            foreach (var second in seconds)
+                Check([first, second]);
+        }
+
+        // The sweep is only as good as its size; pin it so a shrunken alphabet is visible.
+        Assert.Equal(16_104 + (132 * 132), checked_);
+    }
+
+
+    /// <summary>
+    /// The brace that closes an interpolation hole reports the depth and bracket depth in effect
+    /// outside the hole, which is why it is emitted with the values captured before the hole was
+    /// left rather than with the current ones. It begins a literal token rather than joining one,
+    /// so unlike the fragment paths its own depth survives coalescing and is observable.
+    /// </summary>
+    [Fact]
+    public void BraceClosingAHole_ReportsTheDepthOutsideIt()
+    {
+        Assert.Equal(
+            "P:{:d0:b0 P:[:d1:b0 W:var:d1:b1 W:s:d1:b1 P:=:d1:b1 S:$\"{:d1:b1 W:a:d1:b1 " +
+            "S:}\":d1:b1 P:;:d1:b1",
+            RenderState("{", "[", "var s = $\"{a}\";"));
+    }
+
 }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1037,14 +1037,20 @@ public class ScanTokenTests
         // line short enough for the exhaustive pair arm to spell cannot vouch for a seed the
         // arm cannot reach; and it names the second line, so the inner loop cannot collapse.
         // Only two-line calls are recorded, so a single-line call cannot stand in either.
-        foreach (var opener in openers)
-        {
-            foreach (var tail in tails)
-            {
-                foreach (var second in seconds)
-                    Assert.Contains((opener + tail, second), seedPairs);
-            }
-        }
+        //
+        // The expected set is built from the same three collections the arm iterates, so on its
+        // own it would shrink in step with them: emptying `seconds` after the pair arm has used
+        // it, and padding the seeded arm with repeats to hold the count, would satisfy a smaller
+        // demand with less coverage (adversarial review, GPT). Its size is therefore pinned to
+        // literals, and the comparison is set equality rather than membership, so the demand
+        // cannot quietly shrink and the arm cannot quietly scan something else instead.
+        var expected = openers
+            .SelectMany(_ => tails, (opener, tail) => opener + tail)
+            .SelectMany(_ => seconds, (first, second) => (first, second))
+            .ToHashSet();
+
+        Assert.Equal(9 * 12 * 132, expected.Count);
+        Assert.Equal(expected, seedPairs);
     }
 
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -682,7 +682,7 @@ public class ScanTokenTests
         var rebuilt = new StringBuilder();
         int scans = 0;
         var scannedInputs = new HashSet<string>();
-        var tokenCounts = new SortedDictionary<ScanTokenKind, int>();
+        ulong fingerprint = 0;
 
         foreach (var input in swept)
         {
@@ -700,8 +700,10 @@ public class ScanTokenTests
 
             scannedInputs.Add(lines[0]);
 
-            foreach (var token in tokens)
-                tokenCounts[token.Kind] = tokenCounts.GetValueOrDefault(token.Kind) + 1;
+            unchecked
+            {
+                fingerprint += Fingerprint(tokens);
+            }
             rebuilt.Clear();
 
             foreach (var token in tokens)
@@ -748,19 +750,12 @@ public class ScanTokenTests
         // 8^L distinct strings of length L, so observing that many is observing all of them and
         // nothing about the input is left unpinned.
         AssertScannedAlphabet(" \"$@\\a{}", scannedInputs);
-        // Coverage and reconstruction both describe where the tokens START and END. Neither
-        // says how many there are: a change that merged two adjacent tokens, or split one, would
-        // cover the same characters and rebuild the same string. The token population is
-        // therefore pinned as well, per kind, so the sweep observes the stream's SHAPE and not
-        // only its extent.
-        Assert.Equal(
-            new[]
-            {
-                (ScanTokenKind.Word, 152_262),
-                (ScanTokenKind.Punctuator, 742_172),
-                (ScanTokenKind.StringLiteral, 165_535),
-            },
-            tokenCounts.Select(x => (x.Key, x.Value)));
+        // Coverage and reconstruction both describe where the tokens START and END, and neither
+        // says how many there are or where the boundaries between them fall: a change that merged
+        // two adjacent tokens, or split one, covers the same characters and rebuilds the same
+        // string. Population totals do not close that either, being marginals that can be traded
+        // against each other. See Fingerprint.
+        Assert.Equal(1_063_498_068_715_668_122ul, fingerprint);
         Assert.Equal(
             new[] { (1, 8), (2, 64), (3, 512), (4, 4_096), (5, 32_768), (6, 262_144) },
             scannedInputs.GroupBy(x => x.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));
@@ -789,6 +784,49 @@ public class ScanTokenTests
     /// </summary>
     private static void AssertScannedAlphabet(string alphabet, IEnumerable<string> scanned)
         => Assert.Equal(alphabet.Order(), scanned.SelectMany(x => x).ToHashSet().Order());
+
+    /// <summary>
+    /// An order-insensitive fingerprint of a scanned line's token stream, summed across a sweep.
+    /// <para>
+    /// Every summary a sweep can afford over hundreds of thousands of scans is a MARGINAL, and a
+    /// marginal can be traded against itself: splitting 9,855 two-character punctuators and
+    /// merging 9,855 pairs of one-character ones leaves both the token population and its
+    /// per-kind and per-length breakdowns exactly as they were, while every boundary involved
+    /// moves (adversarial review, GPT). Only a projection that is sensitive to WHERE each token
+    /// sits closes that, and materialising the streams is not affordable, so this folds each
+    /// token's full state into one value.
+    /// </para>
+    /// <para>
+    /// The per-scan hashes are SUMMED rather than chained because the sweeps iterate a
+    /// <see cref="HashSet{T}"/> of strings, whose enumeration order is not stable across
+    /// processes. Within a scan the fold is order-sensitive, so token order is pinned too.
+    /// </para>
+    /// <para>
+    /// This value is measured rather than derived, so it proves change detection, not
+    /// correctness. The shapes it would detect a change in are gated by the named tests above;
+    /// what it adds is that no change to them can pass unnoticed here.
+    /// </para>
+    /// </summary>
+    private static ulong Fingerprint(IEnumerable<ScanToken> tokens)
+    {
+        ulong hash = 0xCBF2_9CE4_8422_2325;
+
+        foreach (var token in tokens)
+        {
+            foreach (long field in (long[])
+                [(long)token.Kind, token.Line, token.Column, token.Length,
+                 token.Depth, token.BracketDepth, token.DepthKnown ? 1 : 0])
+            {
+                for (int i = 0; i < 8; i++)
+                {
+                    hash ^= (byte)(field >> (i * 8));
+                    hash *= 0x0000_0100_0000_01B3;
+                }
+            }
+        }
+
+        return hash;
+    }
 
     private static HashSet<string> AllStringsOver(string alphabet, int upTo)
     {
@@ -850,6 +888,7 @@ public class ScanTokenTests
         // and stopped the multi-dollar opener ever meeting the tail that reaches the short-brace
         // branch (adversarial review, GPT).
         var scannedPairs = new HashSet<(string Opener, string Tail)>();
+        ulong fingerprint = 0;
 
         foreach (string opener in openers)
         {
@@ -859,6 +898,11 @@ public class ScanTokenTests
                 var tokens = BodySlicer.ScanTokens(lines);
                 var opened = tokens.Single(t => t.Line == 2);
                 var first = tokens.First(t => t.Line == 3);
+
+                unchecked
+                {
+                    fingerprint += Fingerprint(tokens);
+                }
 
                 scannedPairs.Add((
                     opened.TextIn(lines[2]).ToString().TrimStart(),
@@ -900,6 +944,15 @@ public class ScanTokenTests
             new[] { "@\"", "$@\"", "\"\"\"", "$\"\"\"", "$$\"\"\"", "\"", "$\"" }.Order(),
             scannedPairs.Select(p => p.Opener).ToHashSet().Order());
         Assert.Equal(7 * 258, scannedPairs.Count);
+
+        // Reconstruction resolves token text against the caller's array, so it describes the
+        // tokens' EXTENT and not the text the scanner read: swapping the array's last line for
+        // the original after the scan, having scanned a copy with `\` replaced by an ordinary
+        // letter, rebuilt the original tail exactly and satisfied every count and the cross
+        // product, while the escape branch was never reached and 1377 survived (adversarial
+        // review, Gemini). The token POPULATION is what that substitution cannot preserve,
+        // because the character it removes is the one that makes the scanner cut a token.
+        Assert.Equal(8_186_124_917_422_309_577ul, fingerprint);
     }
 
     /// <summary>
@@ -929,6 +982,7 @@ public class ScanTokenTests
         Assert.Equal(9 + 81 + 729 + 6561, swept.Count);
 
         int known = 0, unknown = 0, inputsWithUnknown = 0, scans = 0;
+        ulong fingerprint = 0;
         var scanned = new HashSet<string>();
         var rebuilt = new StringBuilder();
 
@@ -953,6 +1007,11 @@ public class ScanTokenTests
             }
 
             scanned.Add(rebuilt.ToString());
+
+            unchecked
+            {
+                fingerprint += Fingerprint(tokens);
+            }
         }
 
         // Three integer totals are MARGINS. Nothing above stops the collection being exchanged
@@ -973,6 +1032,7 @@ public class ScanTokenTests
             new[] { (1, 9), (2, 81), (3, 729), (4, 6561) },
             scanned.GroupBy(x => x.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));
         Assert.Equal(9 + 81 + 729 + 6561, scans);
+        Assert.Equal(2_799_085_048_465_510_717ul, fingerprint);
 
         // Both readings are pinned, so the field cannot be moved in either direction: pinning
         // only the unknown tokens would let every token become knowable, and pinning only the

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -116,6 +116,90 @@ public class ScanTokenTests
     }
 
     [Fact]
+    public void NestedInterpolation_KeepsTheInnerHoleAsCode()
+    {
+        // Two literals, and the inner one opens immediately inside the outer one's hole, so the
+        // two openers coalesce into a single token. That is the documented meaning of the kind:
+        // it marks text that is not code, not the bounds of one literal. What matters is that the
+        // hole contents still arrive as code, and they do.
+        Assert.Equal(
+            "W:var W:s P:= S:$\"outer {$\"inner { W:x S:}\"} end\" P:;",
+            Render("var s = $\"outer {$\"inner {x}\"} end\";"));
+    }
+
+    [Fact]
+    public void ConditionalInsideAHole_YieldsItsOwnLiteralsAsSeparateTokens()
+    {
+        // Here the hole does contain code between the literals, so nothing coalesces across it.
+        Assert.Equal(
+            "W:var W:s P:= S:$\"{ P:( W:cond P:? S:\"a\" P:: S:\"b\" P:) S:}\" P:;",
+            Render("var s = $\"{(cond ? \"a\" : \"b\")}\";"));
+    }
+
+    [Fact]
+    public void TripleBraceRunInDoubleDollarLiteral_OpensAHoleWithTheLastTwo()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:$$\"\"\"a{{{ W:b S:}}}c\"\"\" P:;",
+            Render("var s = $$\"\"\"a{{{b}}}c\"\"\";"));
+    }
+
+    [Theory]
+    [InlineData("$@")]
+    [InlineData("@$")]
+    public void VerbatimAndInterpolatedInEitherOrder_StillInterpolates(string prefix)
+    {
+        Assert.Equal(
+            $"W:var W:s P:= S:{prefix}\"a{{ W:b S:}}c\" P:;",
+            Render($"var s = {prefix}\"a{{b}}c\";"));
+    }
+
+    [Fact]
+    public void QuoteRunShorterThanTheDelimiter_IsRawLiteralContent()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:\"\"\"\"a \"\"\" b\"\"\"\" P:;",
+            Render("var s = \"\"\"\"a \"\"\" b\"\"\"\";"));
+    }
+
+    [Fact]
+    public void VerbatimLiteral_EndingALineOnAnEscapedQuote_StaysOpen()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:@\"ends with quote\"\" S:still literal\" P:;",
+            Render("var s = @\"ends with quote\"\"", "still literal\";"));
+    }
+
+    [Theory]
+    [InlineData("var s = \"http://not/a/comment\";", "W:var W:s P:= S:\"http://not/a/comment\" P:;")]
+    [InlineData("var s = \"/* not a comment */\";", "W:var W:s P:= S:\"/* not a comment */\" P:;")]
+    public void CommentOpenerInsideALiteral_IsLiteralText(string line, string expected)
+    {
+        Assert.Equal(expected, Render(line));
+    }
+
+    [Theory]
+    [InlineData("// a \" quote in a comment", "C:// a \" quote in a comment")]
+    [InlineData("/* a \" quote */ int x;", "C:/* a \" quote */ W:int W:x P:;")]
+    public void QuoteInsideAComment_DoesNotOpenALiteral(string line, string expected)
+    {
+        Assert.Equal(expected, Render(line));
+    }
+
+    [Fact]
+    public void IndexerBrackets_RaiseBracketDepthJustAsAnAttributeListDoes()
+    {
+        // Bracket depth says "inside square brackets", not "inside an attribute list". A predicate
+        // moving onto these tokens must not read a non-zero bracket depth as an attribute.
+        var lines = new[] { "var x = a[i] + b[j];" };
+        var tokens = BodySlicer.ScanTokens(lines);
+
+        Assert.Equal(1, Single(tokens, lines, "i", line: 0).BracketDepth);
+        Assert.Equal(1, Single(tokens, lines, "j", line: 0).BracketDepth);
+        Assert.Equal(0, Single(tokens, lines, "+", line: 0).BracketDepth);
+    }
+
+    [Fact]
     public void CharLiteral_SurvivesAnEscapedQuote()
     {
         Assert.Equal("W:char W:c P:= H:'\\'' P:;", Render("char c = '\\'';"));

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -934,9 +934,19 @@ public class ScanTokenTests
 
         void Check(string[] content)
         {
-            seedFirstLines?.Add(content[0]);
-
             var bare = BodySlicer.ScanTokens(content);
+
+            // Record only calls that actually did the seeded arm's work: two lines, whose
+            // second one opens with a fragment carried in from the first. Recording the first
+            // line alone would let a single-line call stand in for the two-line one.
+            if (seedFirstLines is not null
+                && content.Length > 1
+                && bare.FirstOrDefault(t => t.Line == 1) is
+                    { Kind: ScanTokenKind.StringLiteral or ScanTokenKind.Comment })
+            {
+                seedFirstLines.Add(content[0]);
+            }
+
             string[] wrapped = ["{", "[", .. content];
             var enclosed = BodySlicer.ScanTokens(wrapped).Where(t => t.Line >= 2).ToList();
 
@@ -1030,7 +1040,9 @@ public class ScanTokenTests
         //
         // The record is scoped to the seeded arm rather than collected across all three. Seven
         // of the nine openers are spellable from the single-line alphabet, so a set shared with
-        // the earlier arms would already contain them and pin nothing.
+        // the earlier arms would already contain them and pin nothing. It is further restricted
+        // to calls that carry a fragment onto a second line, so a single-line call cannot stand
+        // in for the two-line one (adversarial review, GPT).
         Assert.All(openers, opener => Assert.Contains(opener, seedFirstLines));
     }
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text;
 using ILInspector.Metadata;
 
 namespace DotnetInspector.CSharpBodySlicer.Tests;
@@ -671,16 +672,38 @@ public class ScanTokenTests
         var swept = AllStringsOver(Alphabet, 6);
         Assert.Equal(299_592, swept.Count);
 
+        // Reading the loop variable back would pin the intended input rather than the scanned
+        // one, so each scan is reconstructed from its own output: tokens are laid down at their
+        // columns and the gaps between them filled with spaces, which is exact because a space is
+        // the only character in this alphabet that no token covers. Collapsing the loop to one
+        // string leaves the alphabet and the count intact and was otherwise silent (adversarial
+        // review, GPT).
+        var scanned = new HashSet<string>();
+        var rebuilt = new StringBuilder();
+
         foreach (var input in swept)
         {
-            // No local holds the scanned line: an in-loop substitution would have to be spelled
-            // at the scan call itself, which is the visible, out-of-scope class rather than a
-            // silent weakening of a value the test supplies (adversarial review, GPT).
-            string? gap = FindCoverageGap([input], BodySlicer.ScanTokens([input]));
+            var tokens = BodySlicer.ScanTokens([input]);
+            string? gap = FindCoverageGap([input], tokens);
 
             if (gap is not null)
                 Assert.Fail($"input \"{input}\": {gap}");
+
+            rebuilt.Clear();
+
+            foreach (var token in tokens)
+            {
+                rebuilt.Append(' ', token.Column - rebuilt.Length);
+                rebuilt.Append(token.TextIn(input));
+            }
+
+            scanned.Add(rebuilt.ToString().TrimEnd());
         }
+
+        // Trailing spaces are the one ambiguity: an unterminated literal's token runs to the end
+        // of the line and swallows them, while outside one they belong to no token at all. Both
+        // sides are trimmed so the comparison is exact; nothing else about the input is discarded.
+        Assert.Equal(swept.Select(x => x.TrimEnd()).ToHashSet().Order(), scanned.Order());
     }
 
     /// <summary>
@@ -737,18 +760,38 @@ public class ScanTokenTests
         var tails = AllStringsOver(Alphabet, 3);
         Assert.Equal(6 + 36 + 216, tails.Count);
 
+        // What the scanner actually saw, read back out of its own output rather than from the
+        // loop variable. Pinning the opener list by value does not pin that the loop uses it:
+        // collapsing the body to `openers[0]` left the list intact, scanned one opener seven
+        // times, and let a wrong depth through at the multi-dollar raw branch (adversarial
+        // review, GPT). Recording the loop variable instead would restore that hole, since it
+        // would again describe the intended input rather than the scanned one.
+        // The tail is read back the same way. Its alphabet holds no whitespace, so the line's
+        // tokens cover it exactly and concatenating them reconstructs what the scanner consumed.
+        var openersScanned = new HashSet<string>();
+        var tailsScanned = new HashSet<string>();
+
         foreach (string opener in openers)
         {
             foreach (string tail in tails)
             {
                 var lines = new[] { "{", "    x = [", "        " + opener, tail };
-                var first = BodySlicer.ScanTokens(lines).First(t => t.Line == 3);
+                var tokens = BodySlicer.ScanTokens(lines);
+                var opened = tokens.Single(t => t.Line == 2);
+                var first = tokens.First(t => t.Line == 3);
+
+                openersScanned.Add(opened.TextIn(lines[2]).ToString().TrimStart());
+                tailsScanned.Add(string.Concat(
+                    tokens.Where(t => t.Line == 3).Select(t => t.TextIn(lines[3]).ToString())));
 
                 Assert.Equal(
                     (ScanTokenKind.StringLiteral, 1, 1),
                     (first.Kind, first.Depth, first.BracketDepth));
             }
         }
+
+        Assert.Equal(openers.Order(), openersScanned.Order());
+        Assert.Equal(tails.Order(), tailsScanned.Order());
     }
 
     /// <summary>

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -930,11 +930,11 @@ public class ScanTokenTests
     {
         const string Alphabet = "#/*'\"@$\\{}a";
         int checked_ = 0;
-        var opened = new HashSet<string>();
+        HashSet<string>? seedFirstLines = null;
 
         void Check(string[] content)
         {
-            opened.Add(content[0]);
+            seedFirstLines?.Add(content[0]);
 
             var bare = BodySlicer.ScanTokens(content);
             string[] wrapped = ["{", "[", .. content];
@@ -1008,6 +1008,8 @@ public class ScanTokenTests
         var tails = new List<string> { "" };
         Walk(new char[1], 0, 1, tails.Add);
 
+        seedFirstLines = [];
+
         foreach (var opener in openers)
         {
             foreach (var tail in tails)
@@ -1025,7 +1027,11 @@ public class ScanTokenTests
         // lines preserves every pairing and every assertion above while removing the carried
         // raw literal entirely (adversarial review, GPT). Pin that each opener was actually
         // scanned in the position that carries.
-        Assert.All(openers, opener => Assert.Contains(opener, opened));
+        //
+        // The record is scoped to the seeded arm rather than collected across all three. Seven
+        // of the nine openers are spellable from the single-line alphabet, so a set shared with
+        // the earlier arms would already contain them and pin nothing.
+        Assert.All(openers, opener => Assert.Contains(opener, seedFirstLines));
     }
 
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -912,13 +912,16 @@ public class ScanTokenTests
     /// below the brace that opened its block -- so "}" keeps the shift exact and is included.
     /// </para>
     /// <para>
-    /// Two literal-content emission sites survive this gate, and are inert rather than
-    /// unreachable: both always follow literal content, so coalescing fuses their fragment into
-    /// the preceding StringLiteral, which keeps the *first* fragment's depth. A wrong depth
-    /// there cannot reach an observer. Both carry a comment saying so. This is the same
-    /// inertness class as the hole-closer's Math.Min. The hole closer at the brace that *ends*
-    /// a hole is not in that class -- it begins a literal token, because the token before it is
-    /// code -- and is gated by
+    /// The exhaustive arms are bounded by length, so on their own they cannot spell an opener
+    /// longer than the bound: a raw literal needs three characters and a multi-dollar raw
+    /// opener five. That gap is not cosmetic. It decides whether the first token on a carried
+    /// line can be a raw-literal fragment, and two emission paths are reachable only that way.
+    /// Measuring inertness over the bounded arms alone concluded, wrongly, that those two
+    /// paths could not be observed (adversarial review, GPT). A third arm therefore seeds each
+    /// literal and comment opener explicitly rather than waiting for the sweep to spell one.
+    /// </para>
+    /// <para>
+    /// The one site this gate does not reach is the hole closer, which is gated by
     /// <see cref="BraceClosingAHole_ReportsTheDepthOutsideIt"/>.
     /// </para>
     /// </summary>
@@ -976,8 +979,28 @@ public class ScanTokenTests
                 Check([first, second]);
         }
 
+        // A construct carried across a line break can be opened by a delimiter longer than the
+        // exhaustive arms reach. Seed each one, so that the first token on the second line is a
+        // fragment of every literal and comment form rather than only the short ones.
+        string[] openers =
+        [
+            "\"", "@\"", "$\"", "$@\"", "\"\"\"", "$\"\"\"", "$$\"\"\"", "$$$\"\"\"\"", "/*",
+        ];
+
+        var tails = new List<string> { "" };
+        Walk(new char[1], 0, 1, tails.Add);
+
+        foreach (var opener in openers)
+        {
+            foreach (var tail in tails)
+            {
+                foreach (var second in seconds)
+                    Check([opener + tail, second]);
+            }
+        }
+
         // The sweep is only as good as its size; pin it so a shrunken alphabet is visible.
-        Assert.Equal(16_104 + (132 * 132), checked_);
+        Assert.Equal(16_104 + (132 * 132) + (9 * 12 * 132), checked_);
     }
 
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -845,4 +845,47 @@ public class ScanTokenTests
             Render("var s = $\"{new { X = 1 }}\"; int y;"));
     }
 
+
+    /// <summary>
+    /// Every token records the structural depth in effect where it sits, but only words and
+    /// structural punctuators were ever asserted at a depth other than zero, so five emission
+    /// paths could report zero from inside a block and no test could tell (adversarial review,
+    /// GPT). This covers each of them at depth one: a directive, a line comment, a single-line
+    /// block comment, a character literal, the "@" of a verbatim identifier, and a literal.
+    /// </summary>
+    [Fact]
+    public void EveryKindOfTokenInsideABlock_ReportsTheEnclosingDepth()
+    {
+        Assert.Equal(
+            "P:{:d0:b0 D:#region X:d1:b0 C:// c:d1:b0 C:/* b */:d1:b0 H:'x':d1:b0 " +
+            "P:@:d1:b0 W:class:d1:b0 S:\"s\":d1:b0 P:;:d1:b0 P:}:d1:b0",
+            RenderState("{", "#region X", "// c", "/* b */", "'x'", "@class", "\"s\";", "}"));
+    }
+
+    /// <summary>
+    /// A block comment carried in from an earlier line is emitted by a different path than the
+    /// one that opens it, and it too must report the depth it sits at.
+    /// </summary>
+    [Fact]
+    public void BlockCommentCarriedIntoALine_ReportsTheEnclosingDepth()
+    {
+        Assert.Equal(
+            "P:{:d0:b0 C:/* a:d1:b0 C:b */:d1:b0 P:}:d1:b0",
+            RenderState("{", "/* a", "b */", "}"));
+    }
+
+    /// <summary>
+    /// Losing the place is discovered at the end of the line that loses it, so the correction
+    /// must reach back only as far as that line's own tokens. Reaching further would retract a
+    /// depth that was known when it was recorded, and the lines above stay answerable.
+    /// </summary>
+    [Fact]
+    public void LosingThePlaceOnALine_DoesNotUnknowTheLinesAboveIt()
+    {
+        Assert.Equal(
+            "W:int:d0:b0 W:x:d0:b0 P:;:d0:b0 " +
+            "W:var:d0:b0? W:s:d0:b0? P:=:d0:b0? S:\"unterminated:d0:b0?",
+            RenderState("int x;", "var s = \"unterminated"));
+    }
+
 }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -930,9 +930,12 @@ public class ScanTokenTests
     {
         const string Alphabet = "#/*'\"@$\\{}a";
         int checked_ = 0;
+        var opened = new HashSet<string>();
 
         void Check(string[] content)
         {
+            opened.Add(content[0]);
+
             var bare = BodySlicer.ScanTokens(content);
             string[] wrapped = ["{", "[", .. content];
             var enclosed = BodySlicer.ScanTokens(wrapped).Where(t => t.Line >= 2).ToList();
@@ -1016,6 +1019,13 @@ public class ScanTokenTests
 
         // The sweep is only as good as its size; pin it so a shrunken alphabet is visible.
         Assert.Equal(16_104 + (132 * 132) + (9 * 12 * 132), checked_);
+
+        // Size and seed quality are still not the same as reach. A seed only does its work
+        // when it opens the *first* line, because scanner state runs forward: swapping the two
+        // lines preserves every pairing and every assertion above while removing the carried
+        // raw literal entirely (adversarial review, GPT). Pin that each opener was actually
+        // scanned in the position that carries.
+        Assert.All(openers, opener => Assert.Contains(opener, opened));
     }
 
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1079,6 +1079,22 @@ public class ScanTokenTests
         Assert.Equal(Enum.GetValues<ScanTokenKind>().ToHashSet(), kindsReached);
         Assert.True(deepest > 0, "no input opened a block, so no token was ever scanned inside one");
         Assert.True(shallowest < 0, "no input closed an unopened block, so depth never went below its start");
+
+        // Those three say what the alphabet must accomplish without saying which characters
+        // spell it, and that is both their strength and their blind spot: a character whose
+        // whole job is invisible to a summary of kinds and depths can be dropped without any of
+        // them noticing. `\` opens no construct, closes none, and produces no kind of its own;
+        // it only changes what the next character means. Removing it leaves every count and
+        // every reach intact while deleting the escape path from the sweep, after which a wrong
+        // depth on an escaped fragment survives (adversarial review, GPT). Pin the alphabet
+        // itself as well.
+        //
+        // The pin does not make the reach assertions redundant, and the division is measured
+        // rather than assumed. Replacing a character *and* updating this pin in step -- the
+        // shape a well-meaning edit takes -- is still caught for `{`, `}`, `#`, and `'` by the
+        // three assertions above, which is what keeps editing the alphabet honest. `\` is the
+        // one such edit they do not catch, and this is the assertion that does.
+        Assert.Equal("#/*'\"@$\\{}a", Alphabet);
     }
 
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -702,7 +702,7 @@ public class ScanTokenTests
 
             unchecked
             {
-                fingerprint += Fingerprint(tokens);
+                fingerprint += Fingerprint(lines, tokens);
             }
             rebuilt.Clear();
 
@@ -755,7 +755,7 @@ public class ScanTokenTests
         // two adjacent tokens, or split one, covers the same characters and rebuilds the same
         // string. Population totals do not close that either, being marginals that can be traded
         // against each other. See Fingerprint.
-        Assert.Equal(1_063_498_068_715_668_122ul, fingerprint);
+        Assert.Equal(11_951_850_630_526_800_311ul, fingerprint);
         Assert.Equal(
             new[] { (1, 8), (2, 64), (3, 512), (4, 4_096), (5, 32_768), (6, 262_144) },
             scannedInputs.GroupBy(x => x.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));
@@ -797,6 +797,15 @@ public class ScanTokenTests
     /// token's full state into one value.
     /// </para>
     /// <para>
+    /// The LINES ARE FOLDED IN TOO, so the value binds an input to the stream it produced.
+    /// Without that the sum is blind to which input produced which stream, and the sweeps are
+    /// exhaustive: rewriting `$` to `@` and back permutes the swept set onto itself, so every
+    /// per-scan hash reappears against a different input and the total is unchanged
+    /// (adversarial review, GPT). Folding the lines also ties the stream to the text the
+    /// reconstruction reads, closing the swap-after-the-scan seam directly rather than by
+    /// consequence.
+    /// </para>
+    /// <para>
     /// The per-scan hashes are SUMMED rather than chained because the sweeps iterate a
     /// <see cref="HashSet{T}"/> of strings, whose enumeration order is not stable across
     /// processes. Within a scan the fold is order-sensitive, so token order is pinned too.
@@ -807,25 +816,39 @@ public class ScanTokenTests
     /// what it adds is that no change to them can pass unnoticed here.
     /// </para>
     /// </summary>
-    private static ulong Fingerprint(IEnumerable<ScanToken> tokens)
+    private static ulong Fingerprint(IReadOnlyList<string> lines, IEnumerable<ScanToken> tokens)
     {
         ulong hash = 0xCBF2_9CE4_8422_2325;
 
+        foreach (var line in lines)
+        {
+            foreach (char c in line)
+                Fold(c);
+
+            Fold('\n');
+        }
+
         foreach (var token in tokens)
         {
-            foreach (long field in (long[])
-                [(long)token.Kind, token.Line, token.Column, token.Length,
-                 token.Depth, token.BracketDepth, token.DepthKnown ? 1 : 0])
-            {
-                for (int i = 0; i < 8; i++)
-                {
-                    hash ^= (byte)(field >> (i * 8));
-                    hash *= 0x0000_0100_0000_01B3;
-                }
-            }
+            Fold((long)token.Kind);
+            Fold(token.Line);
+            Fold(token.Column);
+            Fold(token.Length);
+            Fold(token.Depth);
+            Fold(token.BracketDepth);
+            Fold(token.DepthKnown ? 1 : 0);
         }
 
         return hash;
+
+        void Fold(long field)
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                hash ^= (byte)(field >> (i * 8));
+                hash *= 0x0000_0100_0000_01B3;
+            }
+        }
     }
 
     private static HashSet<string> AllStringsOver(string alphabet, int upTo)
@@ -901,7 +924,7 @@ public class ScanTokenTests
 
                 unchecked
                 {
-                    fingerprint += Fingerprint(tokens);
+                    fingerprint += Fingerprint(lines, tokens);
                 }
 
                 scannedPairs.Add((
@@ -952,7 +975,7 @@ public class ScanTokenTests
         // product, while the escape branch was never reached and 1377 survived (adversarial
         // review, Gemini). The token POPULATION is what that substitution cannot preserve,
         // because the character it removes is the one that makes the scanner cut a token.
-        Assert.Equal(8_186_124_917_422_309_577ul, fingerprint);
+        Assert.Equal(7_678_094_121_913_078_782ul, fingerprint);
     }
 
     /// <summary>
@@ -988,7 +1011,8 @@ public class ScanTokenTests
 
         foreach (var input in swept)
         {
-            var tokens = BodySlicer.ScanTokens([input]);
+            var lines = new[] { input };
+            var tokens = BodySlicer.ScanTokens(lines);
             int lost = tokens.Count(t => !t.DepthKnown);
 
             unknown += lost;
@@ -1003,14 +1027,14 @@ public class ScanTokenTests
             foreach (var token in tokens)
             {
                 rebuilt.Append(' ', token.Column - rebuilt.Length);
-                rebuilt.Append(token.TextIn(input));
+                rebuilt.Append(token.TextIn(lines[0]));
             }
 
             scanned.Add(rebuilt.ToString());
 
             unchecked
             {
-                fingerprint += Fingerprint(tokens);
+                fingerprint += Fingerprint(lines, tokens);
             }
         }
 
@@ -1032,7 +1056,7 @@ public class ScanTokenTests
             new[] { (1, 9), (2, 81), (3, 729), (4, 6561) },
             scanned.GroupBy(x => x.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));
         Assert.Equal(9 + 81 + 729 + 6561, scans);
-        Assert.Equal(2_799_085_048_465_510_717ul, fingerprint);
+        Assert.Equal(14_232_786_410_893_318_623ul, fingerprint);
 
         // Both readings are pinned, so the field cannot be moved in either direction: pinning
         // only the unknown tokens would let every token become knowable, and pinning only the

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -101,6 +101,56 @@ public class ScanTokenTests
             Render("var s = \"\"\"", "  raw { text }", "  \"\"\";"));
     }
 
+    /// <summary>
+    /// Pins the depth and bracket depth a carried raw-literal fragment reports, absolutely.
+    /// <para>
+    /// <see cref="RawLiteral_SpansLines_AndItsBracesAreLiteralText"/> renders kind and text only,
+    /// and the differential sweep compares the bare scan against the enclosed one, so a value
+    /// that is consistently wrong on both sides satisfies both. Measured, emitting
+    /// <c>depth + 1</c> — or <c>BracketDepth + 1</c> — for these fragments left the whole suite
+    /// green, at ten emission sites (adversarial review, GPT).
+    /// </para>
+    /// <para>
+    /// The carried line opens with <c>}</c> and contains <c>{</c> so that reading it as code
+    /// rather than as literal text would move the depth, and the literal is carried inside both
+    /// a block and a collection expression so that neither field is zero where a defect could
+    /// hide in it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void CarriedRawLiteralFragments_ReportTheDepthAndBracketDepthEnclosingThem()
+    {
+        var lines = new[] { "{", "    x = [", "        \"\"\"", "} raw { text", "        \"\"\"", "    ];", "}" };
+
+        var literals = BodySlicer.ScanTokens(lines)
+            .Where(t => t.Kind == ScanTokenKind.StringLiteral)
+            .ToList();
+
+        Assert.Equal(
+            [(2, 1, 1), (3, 1, 1), (4, 1, 1)],
+            literals.Select(t => (t.Line, t.Depth, t.BracketDepth)));
+    }
+
+    /// <summary>
+    /// The same absolute pin for the fragment an interpolated literal emits up to its hole
+    /// opener, which is a different emission site and was the one site
+    /// <see cref="CarriedRawLiteralFragments_ReportTheDepthAndBracketDepthEnclosingThem"/> does
+    /// not reach: emitting <c>depth + 1</c> there left the whole suite green.
+    /// </summary>
+    [Fact]
+    public void InterpolatedLiteralFragments_ReportTheDepthAndBracketDepthEnclosingThem()
+    {
+        var lines = new[] { "{", "    x = [", "        $\"a{b}c\"", "    ];", "}" };
+
+        var literals = BodySlicer.ScanTokens(lines)
+            .Where(t => t.Kind == ScanTokenKind.StringLiteral)
+            .ToList();
+
+        Assert.Equal(
+            [(2, 1, 1), (2, 1, 1)],
+            literals.Select(t => (t.Line, t.Depth, t.BracketDepth)));
+    }
+
     [Fact]
     public void InterpolatedLiteral_ScansItsHoleAsCode()
     {
@@ -127,10 +177,25 @@ public class ScanTokenTests
             RenderState("var s = $$\"\"\"x{y}z\"\"\";"));
     }
 
+    /// <summary>
+    /// The empty literal is one token, and it reports the depth and bracket depth around it.
+    /// Rendering text alone left its own emission site free to report either field wrongly with
+    /// the whole suite green, because the differential sweep reads both only relatively
+    /// (adversarial review, GPT); it is the one site the other absolute fixtures do not reach,
+    /// since every literal they carry has content.
+    /// </summary>
     [Fact]
     public void EmptyLiteral_IsOneToken()
     {
-        Assert.Equal("W:var W:e P:= S:\"\" P:;", Render("var e = \"\";"));
+        Assert.Equal("W:var:d0:b0 W:e:d0:b0 P:=:d0:b0 S:\"\":d0:b0 P:;:d0:b0", RenderState("var e = \"\";"));
+
+        var lines = new[] { "{", "    x = [", "        \"\"", "    ];", "}" };
+
+        Assert.Equal(
+            [(2, 1, 1)],
+            BodySlicer.ScanTokens(lines)
+                .Where(t => t.Kind == ScanTokenKind.StringLiteral)
+                .Select(t => (t.Line, t.Depth, t.BracketDepth)));
     }
 
     [Fact]
@@ -559,57 +624,29 @@ public class ScanTokenTests
     [Fact]
     public void EveryStringOverTheDelimiterAlphabet_IsFullyCovered()
     {
-        char[] alphabet = ['$', '@', '"', '{', '}', '\\', ' ', 'a'];
-        var buffer = new char[6];
-        var sweptChars = new HashSet<char>();
-        var sweptInputs = new HashSet<string>();
-        int checkedCount = 0;
+        // The alphabet is pinned by value, and the sweep scans exactly the set generated from
+        // it. Every count above survives exchanging `\` for an ordinary letter, which keeps all
+        // 299,592 cases and drops every terminal-escape path; and a set recorded alongside the
+        // scan is not the set scanned, because the recording can be pointed at the value the
+        // input was generated from while the scanner is handed another (adversarial review,
+        // GPT, twice). There is no recording here: `swept` is both the pinned collection and
+        // the collection iterated, so the two cannot be separated without rewriting the loop.
+        const string Alphabet = " \"$@\\a{}";
+        Assert.Equal(" \"$@\\a{}", Alphabet);
 
-        void Walk(int at, int length)
+        var swept = AllStringsOver(Alphabet, 6);
+        Assert.Equal(299_592, swept.Count);
+
+        foreach (var input in swept)
         {
-            if (at == length)
-            {
-                var lines = new[] { new string(buffer, 0, length) };
-                string? gap = FindCoverageGap(lines, BodySlicer.ScanTokens(lines));
-                checkedCount++;
+            // No local holds the scanned line: an in-loop substitution would have to be spelled
+            // at the scan call itself, which is the visible, out-of-scope class rather than a
+            // silent weakening of a value the test supplies (adversarial review, GPT).
+            string? gap = FindCoverageGap([input], BodySlicer.ScanTokens([input]));
 
-                foreach (char swept in lines[0])
-                    sweptChars.Add(swept);
-
-                sweptInputs.Add(lines[0]);
-
-                if (gap is not null)
-                    Assert.Fail($"input \"{lines[0]}\": {gap}");
-
-                return;
-            }
-
-            foreach (char c in alphabet)
-            {
-                buffer[at] = c;
-                Walk(at + 1, length);
-            }
+            if (gap is not null)
+                Assert.Fail($"input \"{input}\": {gap}");
         }
-
-        for (int length = 1; length <= buffer.Length; length++)
-            Walk(0, length);
-
-        // Pins the size of the space so a later edit cannot quietly shrink it to nothing.
-        Assert.Equal(299_592, checkedCount);
-
-        // Size is not content. Every count above survives exchanging `\` for an ordinary letter,
-        // which keeps all 299,592 cases and drops every terminal-escape path: measured, that
-        // weakening leaves the suite green while a defect that reads past the end of a literal
-        // ending in a backslash survives (adversarial review, GPT). Pin the alphabet by value,
-        // and by the value the scanner actually received rather than the one declared above, so
-        // that a substitution between the declaration and the sweep is visible too.
-        Assert.Equal(" \"$@\\a{}", string.Concat(sweptChars.Order()));
-
-        // Nor is the character set the input set. Substituting one swept string for another of
-        // the same length over the same characters leaves every count and the set above intact
-        // while dropping that string's state, so pin the strings themselves, derived from the
-        // pinned alphabet rather than read back from the walk that produced them.
-        Assert.Equal(AllStringsOver(" \"$@\\a{}", 6), sweptInputs);
     }
 
     /// <summary>
@@ -651,52 +688,29 @@ public class ScanTokenTests
     [Fact]
     public void UnknowableDepth_IsCarriedByExactlyTheTokensTheScannerCouldNotPlace()
     {
-        char[] alphabet = ['$', '@', '"', '{', '}', '\\', '/', '*', 'a'];
-        var buffer = new char[4];
-        var sweptChars = new HashSet<char>();
-        var sweptInputs = new HashSet<string>();
-        int known = 0, unknown = 0, inputsWithUnknown = 0, inputs = 0;
+        const string Alphabet = "\"$*/@\\a{}";
+        Assert.Equal("\"$*/@\\a{}", Alphabet);
 
-        void Walk(int at, int length)
+        var swept = AllStringsOver(Alphabet, 4);
+        Assert.Equal(9 + 81 + 729 + 6561, swept.Count);
+
+        int known = 0, unknown = 0, inputsWithUnknown = 0;
+
+        foreach (var input in swept)
         {
-            if (at == length)
-            {
-                var lines = new[] { new string(buffer, 0, length) };
-                var tokens = BodySlicer.ScanTokens(lines);
-                inputs++;
+            var tokens = BodySlicer.ScanTokens([input]);
+            int lost = tokens.Count(t => !t.DepthKnown);
 
-                foreach (char swept in lines[0])
-                    sweptChars.Add(swept);
+            unknown += lost;
+            known += tokens.Count - lost;
 
-                sweptInputs.Add(lines[0]);
-
-                int lost = tokens.Count(t => !t.DepthKnown);
-                unknown += lost;
-                known += tokens.Count - lost;
-
-                if (lost > 0)
-                    inputsWithUnknown++;
-
-                return;
-            }
-
-            foreach (char c in alphabet)
-            {
-                buffer[at] = c;
-                Walk(at + 1, length);
-            }
+            if (lost > 0)
+                inputsWithUnknown++;
         }
-
-        for (int length = 1; length <= buffer.Length; length++)
-            Walk(0, length);
 
         // Both readings are pinned, so the field cannot be moved in either direction: pinning
         // only the unknown tokens would let every token become knowable, and pinning only the
         // known ones would let every token lose its place.
-        Assert.Equal(4, buffer.Length);
-        Assert.Equal(9 + 81 + 729 + 6561, inputs);
-        Assert.Equal("\"$*/@\\a{}", string.Concat(sweptChars.Order()));
-        Assert.Equal(AllStringsOver("\"$*/@\\a{}", 4), sweptInputs);
         Assert.Equal(17_602, known);
         Assert.Equal(4_452, unknown);
         Assert.Equal(1_996, inputsWithUnknown);

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -987,6 +987,21 @@ public class ScanTokenTests
             "\"", "@\"", "$\"", "$@\"", "\"\"\"", "$\"\"\"", "$$\"\"\"", "$$$\"\"\"\"", "/*",
         ];
 
+        // The seeds are hand-written, which is the failure mode this test exists to avoid, so
+        // they police themselves twice. They must be distinct, or the pinned count can be met
+        // by repeating one. And each must actually open something that carries: if a seed
+        // stops carrying, the "a" below it is code rather than literal or comment text, and
+        // the seed is no longer reaching the paths it was added for (adversarial review, GPT).
+        Assert.Equal(openers.Length, openers.Distinct().Count());
+
+        foreach (var opener in openers)
+        {
+            var carried = BodySlicer.ScanTokens([opener, "a"]).Last();
+            Assert.True(
+                carried.Kind is ScanTokenKind.StringLiteral or ScanTokenKind.Comment,
+                $"opener [{opener}] no longer carries: 'a' below it scanned as {carried.Kind}");
+        }
+
         var tails = new List<string> { "" };
         Walk(new char[1], 0, 1, tails.Add);
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1069,6 +1069,33 @@ public class ScanTokenTests
         // the fifth was unpinned.
         Assert.Equal(5, openers.Count(o => o.Length > 2));
 
+        // Length is not reach either. `$@"` can be exchanged for `"bbb` -- nine distinct seeds,
+        // eight strings, one comment, four raw, five longer than two characters, value pin
+        // updated in step -- and the only seed that opens a literal which is *both* verbatim
+        // and interpolated is gone. Measured, a wrong depth on that frame's fragment
+        // (BodySlicer.cs:1431, guarded on `frame.Verbatim && frame.DollarRun > 0`) then
+        // survives (adversarial review, GPT). Pin that family the same behavioural way: on the
+        // next line a backslash does not escape in a verbatim literal, so the quote after it
+        // closes and what follows is code; and a brace opens a hole only in an interpolated
+        // one. A seed that does both is verbatim *and* interpolated, whatever it is spelled.
+        bool CodeOnSecondLine(string opener, string second) =>
+            BodySlicer.ScanTokens([opener, second]).Any(t => t.Line == 1 && t.Kind is ScanTokenKind.Word);
+
+        Assert.Equal(1, openers.Count(o => CodeOnSecondLine(o, "\\\"a") && CodeOnSecondLine(o, "{a}")));
+
+        // Four raw seeds can be four *non-interpolated* raw seeds, which would erase the
+        // dollar-run ladder: the scanner tracks how many braces open a hole (`frame.DollarRun`),
+        // and only `$"""`, `$$"""` and `$$$""""` exercise runs of one, two and three. Pin the
+        // ladder by the run each seed actually needs, so the three cannot collapse onto one run
+        // or drop out of the seeds entirely.
+        int MinBraceRun(string opener) =>
+            CodeOnSecondLine(opener, "{a}") ? 1
+            : CodeOnSecondLine(opener, "{{a}}") ? 2
+            : CodeOnSecondLine(opener, "{{{a}}}") ? 3
+            : 0;
+
+        Assert.Equal([0, 0, 0, 0, 1, 1, 1, 2, 3], openers.Select(MinBraceRun).Order());
+
         // Those properties still describe the seeds rather than name them, and a seed can be
         // exchanged for another of the same kind and length -- `$@"` for `@$"` -- without
         // disturbing any of them, which drops one interpolation-order path and keeps the suite

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -704,6 +704,7 @@ public class ScanTokenTests
         // of the line and swallows them, while outside one they belong to no token at all. Both
         // sides are trimmed so the comparison is exact; nothing else about the input is discarded.
         Assert.Equal(swept.Select(x => x.TrimEnd()).ToHashSet().Order(), scanned.Order());
+        AssertScannedAlphabet(" \"$@\\a{}", scanned);
     }
 
     /// <summary>
@@ -714,6 +715,22 @@ public class ScanTokenTests
     /// is the same length and draws on the same characters, leaving every count identical while
     /// the state that input existed for is never reached (adversarial review, GPT).
     /// </summary>
+    /// <summary>
+    /// Asserts that the strings a sweep actually scanned draw on exactly <paramref
+    /// name="alphabet"/>, character for character.
+    /// <para>
+    /// Pinning the alphabet constant by value does not pin the alphabet swept, because the
+    /// constant is not what <see cref="AllStringsOver"/> is handed: passing a same-length
+    /// literal in its place leaves the constant's pin untouched, leaves every count identical
+    /// because the generator reads only the alphabet's length, and erases a character's paths
+    /// from the sweep entirely. Nor can the expected side be derived from the generated set,
+    /// since that moves with it. So this reads the characters back out of what the scanner
+    /// consumed and compares them against a literal (adversarial review, Gemini).
+    /// </para>
+    /// </summary>
+    private static void AssertScannedAlphabet(string alphabet, IEnumerable<string> scanned)
+        => Assert.Equal(alphabet.Order(), scanned.SelectMany(x => x).ToHashSet().Order());
+
     private static HashSet<string> AllStringsOver(string alphabet, int upTo)
     {
         var singles = alphabet.Select(c => c.ToString()).ToArray();
@@ -788,15 +805,21 @@ public class ScanTokenTests
                     opened.TextIn(lines[2]).ToString().TrimStart(),
                     string.Concat(tokens.Where(t => t.Line == 3).Select(t => t.TextIn(lines[3]).ToString()))));
 
+                // The line and column are asserted with the depths so that the assertion says
+                // WHICH token it read. Naming only kind and the two depths let the opener token
+                // stand in for it: that token is also a literal at the same depths, so reading it
+                // instead satisfied every pin while no fragment was examined at all (adversarial
+                // review, GPT).
                 Assert.Equal(
-                    (ScanTokenKind.StringLiteral, 1, 1),
-                    (first.Kind, first.Depth, first.BracketDepth));
+                    (ScanTokenKind.StringLiteral, 3, 0, 1, 1),
+                    (first.Kind, first.Line, first.Column, first.Depth, first.BracketDepth));
             }
         }
 
         Assert.Equal(
             (from opener in openers from tail in tails select (opener, tail)).Order(),
             scannedPairs.Order());
+        AssertScannedAlphabet("\"$\\{}a", scannedPairs.Select(p => p.Tail));
     }
 
     /// <summary>

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -682,6 +682,7 @@ public class ScanTokenTests
         var rebuilt = new StringBuilder();
         int scans = 0;
         var scannedInputs = new HashSet<string>();
+        var tokenCounts = new SortedDictionary<ScanTokenKind, int>();
 
         foreach (var input in swept)
         {
@@ -698,6 +699,9 @@ public class ScanTokenTests
                 Assert.Fail($"input \"{lines[0]}\": {gap}");
 
             scannedInputs.Add(lines[0]);
+
+            foreach (var token in tokens)
+                tokenCounts[token.Kind] = tokenCounts.GetValueOrDefault(token.Kind) + 1;
             rebuilt.Clear();
 
             foreach (var token in tokens)
@@ -744,6 +748,19 @@ public class ScanTokenTests
         // 8^L distinct strings of length L, so observing that many is observing all of them and
         // nothing about the input is left unpinned.
         AssertScannedAlphabet(" \"$@\\a{}", scannedInputs);
+        // Coverage and reconstruction both describe where the tokens START and END. Neither
+        // says how many there are: a change that merged two adjacent tokens, or split one, would
+        // cover the same characters and rebuild the same string. The token population is
+        // therefore pinned as well, per kind, so the sweep observes the stream's SHAPE and not
+        // only its extent.
+        Assert.Equal(
+            new[]
+            {
+                (ScanTokenKind.Word, 152_262),
+                (ScanTokenKind.Punctuator, 742_172),
+                (ScanTokenKind.StringLiteral, 165_535),
+            },
+            tokenCounts.Select(x => (x.Key, x.Value)));
         Assert.Equal(
             new[] { (1, 8), (2, 64), (3, 512), (4, 4_096), (5, 32_768), (6, 262_144) },
             scannedInputs.GroupBy(x => x.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1035,15 +1035,45 @@ public class ScanTokenTests
         // Size and seed quality are still not the same as reach. A seed only does its work
         // when it opens the *first* line, because scanner state runs forward: swapping the two
         // lines preserves every pairing and every assertion above while removing the carried
-        // raw literal entirely (adversarial review, GPT). Pin that each opener was actually
+        // raw literal entirely (adversarial review, GPT). Pin that each seed was actually
         // scanned in the position that carries.
         //
-        // The record is scoped to the seeded arm rather than collected across all three. Seven
-        // of the nine openers are spellable from the single-line alphabet, so a set shared with
-        // the earlier arms would already contain them and pin nothing. It is further restricted
-        // to calls that carry a fragment onto a second line, so a single-line call cannot stand
-        // in for the two-line one (adversarial review, GPT).
-        Assert.All(openers, opener => Assert.Contains(opener, seedFirstLines));
+        // Three narrowings make that pin bite, each closing a way the previous spelling passed
+        // without the arm doing its work (adversarial review, GPT and Gemini):
+        //
+        // The record is scoped to the seeded arm rather than collected across all three arms,
+        // because seven of the nine openers are spellable from the single-line alphabet and a
+        // shared set would already hold them.
+        //
+        // Only calls that carry a fragment onto a second line are recorded, so a single-line
+        // call cannot stand in for the two-line one.
+        //
+        // The key is the whole first line, opener *and* tail, not the opener alone. Under the
+        // swap the recorded lines are the `seconds`, which are every string of length two or
+        // less, so an opener of that length would be handed back to the record verbatim by a
+        // line that never opened it.
+        //
+        // A seeded line no longer than the pair arm's reach is exempt, because that arm already
+        // scanned it in first position; such a line is not something the seeds uniquely provide.
+        // Both lengths are read back off the collections that produced them rather than restated,
+        // so lengthening the tails, shortening the pair arm, or adding a short opener moves the
+        // exemption here instead of silently widening it. `"` is the only opener exempt for every
+        // tail it can take, and that is asserted as a set, so a second one cannot join it quietly.
+        int pairArmReach = seconds.Max(line => line.Length);
+        int longestTail = tails.Max(tail => tail.Length);
+
+        Assert.Equal(["\""], openers.Where(o => o.Length + longestTail <= pairArmReach));
+
+        foreach (var opener in openers)
+        {
+            foreach (var tail in tails)
+            {
+                if ((opener + tail).Length <= pairArmReach)
+                    continue;
+
+                Assert.Contains(opener + tail, seedFirstLines);
+            }
+        }
     }
 
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -122,17 +122,17 @@ public class ScanTokenTests
     {
         var lines = new[] { "{", "    x = [", "        \"\"\"", "} raw { text", "        \"\"\"", "    ];", "}" };
 
-        var literals = BodySlicer.ScanTokens(lines)
-            .Where(t => t.Kind == ScanTokenKind.StringLiteral)
-            .ToList();
-
-        // The token text is asserted alongside the depths so that the assertion reads the very
-        // characters the fixture relies on. Replacing the carried line's leading `}` with plain
-        // text stops it reaching the brace emission site, and pinning position alone left that
-        // substitution silent (adversarial review, GPT).
+        // The text is asserted with the depths so the assertion reads the very characters the
+        // fixture relies on: replacing the carried line's leading `}` with plain text stops it
+        // reaching the brace emission site, and pinning position alone left that silent
+        // (adversarial review, GPT).
         Assert.Equal(
-            [(2, 1, 1, "\"\"\""), (3, 1, 1, "} raw { text"), (4, 1, 1, "        \"\"\"")],
-            literals.Select(t => (t.Line, t.Depth, t.BracketDepth, Text(lines, t))));
+            [
+                (0, 0, 0, "P:{"), (1, 1, 0, "W:x"), (1, 1, 0, "P:="), (1, 1, 0, "P:["),
+                (2, 1, 1, "S:\"\"\""), (3, 1, 1, "S:} raw { text"), (4, 1, 1, "S:        \"\"\""),
+                (5, 1, 1, "P:]"), (5, 1, 0, "P:;"), (6, 1, 0, "P:}"),
+            ],
+            Placed(lines));
     }
 
     /// <summary>
@@ -146,13 +146,13 @@ public class ScanTokenTests
     {
         var lines = new[] { "{", "    x = [", "        $\"a{b}c\"", "    ];", "}" };
 
-        var literals = BodySlicer.ScanTokens(lines)
-            .Where(t => t.Kind == ScanTokenKind.StringLiteral)
-            .ToList();
-
         Assert.Equal(
-            [(2, 1, 1, "$\"a{"), (2, 1, 1, "}c\"")],
-            literals.Select(t => (t.Line, t.Depth, t.BracketDepth, Text(lines, t))));
+            [
+                (0, 0, 0, "P:{"), (1, 1, 0, "W:x"), (1, 1, 0, "P:="), (1, 1, 0, "P:["),
+                (2, 1, 1, "S:$\"a{"), (2, 1, 1, "W:b"), (2, 1, 1, "S:}c\""),
+                (3, 1, 1, "P:]"), (3, 1, 0, "P:;"), (4, 1, 0, "P:}"),
+            ],
+            Placed(lines));
     }
 
     [Fact]
@@ -196,10 +196,8 @@ public class ScanTokenTests
         var lines = new[] { "{", "    x = [", "        \"\"", "    ];", "}" };
 
         Assert.Equal(
-            [(2, 1, 1, "\"\"")],
-            BodySlicer.ScanTokens(lines)
-                .Where(t => t.Kind == ScanTokenKind.StringLiteral)
-                .Select(t => (t.Line, t.Depth, t.BracketDepth, Text(lines, t))));
+            [(0, 0, 0, "P:{"), (1, 1, 0, "W:x"), (1, 1, 0, "P:="), (1, 1, 0, "P:["), (2, 1, 1, "S:\"\""), (3, 1, 1, "P:]"), (3, 1, 0, "P:;"), (4, 1, 0, "P:}"),],
+            Placed(lines));
     }
 
     [Fact]
@@ -309,11 +307,19 @@ public class ScanTokenTests
         // Bracket depth says "inside square brackets", not "inside an attribute list". A predicate
         // moving onto these tokens must not read a non-zero bracket depth as an attribute.
         var lines = new[] { "var x = a[i] + b[j];" };
-        var tokens = BodySlicer.ScanTokens(lines);
 
-        Assert.Equal(1, Single(tokens, lines, "i", line: 0).BracketDepth);
-        Assert.Equal(1, Single(tokens, lines, "j", line: 0).BracketDepth);
-        Assert.Equal(0, Single(tokens, lines, "+", line: 0).BracketDepth);
+        // The whole stream is asserted, not three looked-up tokens: picking tokens out by text
+        // leaves the rest of the input free, so it can be replaced by one that still contains
+        // them and no longer exercises the shape the test is named for (adversarial review,
+        // Gemini).
+        Assert.Equal(
+            [
+                (0, 0, 0, "W:var"), (0, 0, 0, "W:x"), (0, 0, 0, "P:="), (0, 0, 0, "W:a"),
+                (0, 0, 0, "P:["), (0, 0, 1, "W:i"), (0, 0, 1, "P:]"), (0, 0, 0, "P:+"),
+                (0, 0, 0, "W:b"), (0, 0, 0, "P:["), (0, 0, 1, "W:j"), (0, 0, 1, "P:]"),
+                (0, 0, 0, "P:;"),
+            ],
+            Placed(lines));
     }
 
     [Fact]
@@ -361,10 +367,16 @@ public class ScanTokenTests
         // An attribute argument that reads like a declaration — "set" here — is what truncated an
         // accessor before brackets were carried across lines.
         var lines = new[] { "[Obsolete(", "    set)]", "public int P { get; set; }" };
-        var tokens = BodySlicer.ScanTokens(lines);
 
-        Assert.Equal(1, Single(tokens, lines, "set", line: 1).BracketDepth);
-        Assert.Equal(0, Single(tokens, lines, "get", line: 2).BracketDepth);
+        Assert.Equal(
+            [
+                (0, 0, 0, "P:["), (0, 0, 1, "W:Obsolete"), (0, 0, 1, "P:("),
+                (1, 0, 1, "W:set"), (1, 0, 1, "P:)"), (1, 0, 1, "P:]"),
+                (2, 0, 0, "W:public"), (2, 0, 0, "W:int"), (2, 0, 0, "W:P"), (2, 0, 0, "P:{"),
+                (2, 1, 0, "W:get"), (2, 1, 0, "P:;"), (2, 1, 0, "W:set"), (2, 1, 0, "P:;"),
+                (2, 1, 0, "P:}"),
+            ],
+            Placed(lines));
     }
 
     [Fact]
@@ -421,9 +433,19 @@ public class ScanTokenTests
     /// state a predicate reading raw text used to be in.
     /// </para>
     /// </summary>
-    /// <summary>The source text a token covers, so an assertion can read its input back.</summary>
-    private static string Text(IReadOnlyList<string> lines, ScanToken token) =>
-        lines[token.Line].Substring(token.Column, token.Length);
+    /// <summary>
+    /// Projects the whole token stream as line, both depths, and "kind:text", for the fixtures
+    /// whose claim is about where a token sits rather than about the stream's shape.
+    /// <para>
+    /// These assert every token rather than filtering to the kind under test. Filtering discards
+    /// exactly the evidence that the fixture reached the branch it was written for: a supplied
+    /// input can be steered off that branch while every surviving row keeps its position and its
+    /// text, leaving the suite green with a real defect live (adversarial review, GPT).
+    /// </para>
+    /// </summary>
+    private static (int Line, int Depth, int BracketDepth, string Text)[] Placed(params string[] lines) =>
+        [.. BodySlicer.ScanTokens(lines)
+            .Select(t => (t.Line, t.Depth, t.BracketDepth, $"{Code(t.Kind)}:{t.TextIn(lines[t.Line])}"))];
 
     private static string? FindCoverageGap(IReadOnlyList<string> lines, IReadOnlyList<ScanToken> tokens)
     {
@@ -586,12 +608,16 @@ public class ScanTokenTests
     {
         var lines = new[] { "var s = $\"{  \"x\"}\";" };
 
-        var literals = BodySlicer.ScanTokens(lines)
-            .Where(t => t.Kind == ScanTokenKind.StringLiteral)
-            .Select(t => (t.Column, t.Length))
-            .ToList();
-
-        Assert.Equal([(8, 3), (13, 5)], literals);
+        // Asserted over the whole stream for the same reason as the cross-line sibling: the two
+        // literal columns alone are satisfied by an input with no interpolation hole in it at all
+        // (adversarial review, Gemini).
+        Assert.Equal(
+            [
+                (0, 0, 3, "W:var"), (0, 4, 1, "W:s"), (0, 6, 1, "P:="),
+                (0, 8, 3, "S:$\"{"), (0, 13, 5, "S:\"x\"}\""), (0, 18, 1, "P:;"),
+            ],
+            BodySlicer.ScanTokens(lines)
+                .Select(t => (t.Line, t.Column, t.Length, $"{Code(t.Kind)}:{t.TextIn(lines[t.Line])}")));
     }
 
     /// <summary>
@@ -677,6 +703,55 @@ public class ScanTokenTests
     }
 
     /// <summary>
+    /// Every fragment of a literal carried in from an earlier line reports the depth and bracket
+    /// depth in effect where that literal opened.
+    /// <para>
+    /// This is the absolute counterpart the fragment-emitting branches had been missing. Those
+    /// branches pass a depth to <c>Emit</c>, but on the line that opens the literal their token
+    /// coalesces into the fragment before it, and coalescing keeps the earlier token's depth and
+    /// discards the argument entirely — so <c>Emit(depth + 1, ...)</c> at eight of them changed
+    /// no output at all. Coalescing requires <c>previous.Line == lineIndex</c>, so the first
+    /// token of a carried line is the one shape in which the argument survives to be read
+    /// (adversarial review, Gemini).
+    /// </para>
+    /// <para>
+    /// The tail is swept rather than hand-picked because which branch consumes it is exactly what
+    /// a defect would change: a fixed tail pins one branch and lets a wrong depth at any other
+    /// through. Only the line's first token is asserted, since a tail may close its literal and
+    /// continue as code at a legitimately different depth.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryFragmentOfACarriedLiteral_ReportsTheDepthWhereItsLiteralOpened()
+    {
+        const string Alphabet = "\"$\\{}a";
+        Assert.Equal("\"$\\{}a", Alphabet);
+
+        // The two unterminated openers are here because a plain literal carries too: the scanner
+        // loses its place rather than closing the frame, so the next line still arrives as literal
+        // content. They are the only shape that reaches the backslash-escape branch as a line's
+        // first token, that branch requiring a frame that is neither verbatim nor raw.
+        string[] openers = ["@\"", "$@\"", "\"\"\"", "$\"\"\"", "$$\"\"\"", "\"", "$\""];
+        Assert.Equal(["@\"", "$@\"", "\"\"\"", "$\"\"\"", "$$\"\"\"", "\"", "$\""], openers);
+
+        var tails = AllStringsOver(Alphabet, 3);
+        Assert.Equal(6 + 36 + 216, tails.Count);
+
+        foreach (string opener in openers)
+        {
+            foreach (string tail in tails)
+            {
+                var lines = new[] { "{", "    x = [", "        " + opener, tail };
+                var first = BodySlicer.ScanTokens(lines).First(t => t.Line == 3);
+
+                Assert.Equal(
+                    (ScanTokenKind.StringLiteral, 1, 1),
+                    (first.Kind, first.Depth, first.BracketDepth));
+            }
+        }
+    }
+
+    /// <summary>
     /// Pins how often the scanner reports the depth as unknowable, and how often it does not.
     /// <para>
     /// Every other assertion on this field is either a rule about one shape — a conditional
@@ -745,13 +820,14 @@ public class ScanTokenTests
         var lines = new[] { "\"xyzzyxyzzy\"", "            \"ab\"" };
         //                    column 12 ────┘  (== the first literal's end column)
 
-        var literals = BodySlicer.ScanTokens(lines)
-            .Where(t => t.Kind == ScanTokenKind.StringLiteral)
-            .ToList();
-
+        // Every token is asserted, not only the literals. Inserting a punctuator before the
+        // second line's literal keeps both literals at their asserted positions but stops the
+        // stream ever reaching the coalescing guard, and the filtered assertion could not see
+        // that the guard had gone unexercised (adversarial review, GPT).
         Assert.Equal(
-            [(0, 0, 12), (1, 12, 4)],
-            literals.Select(t => (t.Line, t.Column, t.Length)));
+            [(0, 0, 12, "S:\"xyzzyxyzzy\""), (1, 12, 4, "S:\"ab\"")],
+            BodySlicer.ScanTokens(lines)
+                .Select(t => (t.Line, t.Column, t.Length, $"{Code(t.Kind)}:{t.TextIn(lines[t.Line])}")));
     }
 
     [Theory]

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -404,6 +404,53 @@ public class ScanTokenTests
     }
 
     /// <summary>
+    /// Gates both conjuncts of the guard that decides whether a line is a preprocessor directive.
+    /// A line beginning with <c>#</c> is only a directive when the scan is not already inside a
+    /// literal or a block comment; either conjunct can be dropped on its own, so each needs a
+    /// case. Without these, a <c>#define</c> carried inside a raw literal or a block comment is
+    /// emitted as a <see cref="ScanTokenKind.Directive"/> and the line's real content is lost.
+    /// </summary>
+    [Fact]
+    public void HashLine_CarriedInsideALiteralOrAComment_IsNotADirective()
+    {
+        Assert.Equal(
+            """"W:var W:s P:= S:""" S:#define FOO S:""" P:;"""",
+            Render("var s = \"\"\"", "#define FOO", "\"\"\";"));
+
+        Assert.Equal(
+            "C:/* C:#define FOO C:*/",
+            Render("/*", "#define FOO", "*/"));
+    }
+
+    /// <summary>
+    /// Gates the bounds half of the guard that looks for a comment opener. A <c>/</c> is only the
+    /// start of <c>//</c> or <c>/*</c> when another character follows it, and a line may legally
+    /// end with one — a division split across lines does exactly that. Dropping the length check
+    /// reads one past the end of the line, so this is the test standing between that guard and an
+    /// <see cref="IndexOutOfRangeException"/>.
+    /// </summary>
+    [Fact]
+    public void SlashAtEndOfLine_IsAPunctuator_NotACommentOpener()
+    {
+        Assert.Equal(
+            "W:int W:x P:= W:a P:/ W:b P:;",
+            Render("int x = a /", "    b;"));
+    }
+
+    /// <summary>
+    /// Gates the underscore half of the character test that starts an identifier run. An
+    /// identifier may begin with <c>_</c>, and dropping that conjunct splits <c>_value</c> into a
+    /// punctuator and a word — two tokens whose spans still cover the line completely, which is
+    /// why the coverage gate cannot see it.
+    /// </summary>
+    [Fact]
+    public void IdentifierStartingWithAnUnderscore_IsASingleWord()
+    {
+        Assert.Equal("W:_value P:= W:1 P:;", Render("_value = 1;"));
+        Assert.Equal("W:var W:_ P:= W:M P:( P:) P:;", Render("var _ = M();"));
+    }
+
+    /// <summary>
     /// Gates the column half of the adjacency rule. Two literal fragments can sit on one line
     /// with a gap between them when a hole's code is separated from its braces by whitespace:
     /// <c>$"{  "x"}"</c> emits <c>$"{</c>, then two skipped spaces, then <c>"x"}"</c>. Fusing

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1,0 +1,414 @@
+using ILInspector.Metadata;
+
+namespace DotnetInspector.CSharpBodySlicer.Tests;
+
+/// <summary>
+/// Pins the token stream the slicer's scanner produces.
+/// <para>
+/// The scanner is not new work: the slicer has always lexed each line to place braces, and it has
+/// always thrown that away at the line break, leaving every predicate to re-derive "am I inside a
+/// comment, a literal, or an attribute list?" from a string it was handed. These tests fix the
+/// stream that scan already computes, so the predicates can be moved onto it without the move
+/// itself being the first thing that ever inspected it.
+/// </para>
+/// </summary>
+public class ScanTokenTests
+{
+    /// <summary>
+    /// Renders the token stream for a single line as "kind:text" pairs, so an assertion reads as
+    /// the sequence a person would expect rather than as a list of offsets.
+    /// </summary>
+    private static string Render(params string[] lines)
+    {
+        var tokens = BodySlicer.ScanTokens(lines);
+        return string.Join(' ', tokens.Select(t => $"{Code(t.Kind)}:{t.TextIn(lines[t.Line])}"));
+    }
+
+    private static char Code(ScanTokenKind kind) => kind switch
+    {
+        ScanTokenKind.Word => 'W',
+        ScanTokenKind.Punctuator => 'P',
+        ScanTokenKind.StringLiteral => 'S',
+        ScanTokenKind.CharLiteral => 'H',
+        ScanTokenKind.Comment => 'C',
+        ScanTokenKind.Directive => 'D',
+        _ => throw new InvalidOperationException($"Unhandled kind {kind}."),
+    };
+
+    [Fact]
+    public void Declaration_SeparatesWordsFromPunctuation()
+    {
+        Assert.Equal(
+            "W:public W:int W:Add P:( W:int W:a P:, W:int W:b P:)",
+            Render("    public int Add(int a, int b)"));
+    }
+
+    [Fact]
+    public void LineComment_RunsToEndOfLine_AndItsBracesAreNotCode()
+    {
+        Assert.Equal(
+            "W:int W:x P:; C:// trailing { comment",
+            Render("int x; // trailing { comment"));
+    }
+
+    [Fact]
+    public void BlockComment_YieldsOneTokenPerLineItCovers()
+    {
+        // The brace on the middle line is comment text. A predicate handed that line in isolation
+        // would read it as structure; a predicate handed these tokens cannot.
+        Assert.Equal(
+            "C:/* start C: middle { C: end */ W:int W:x P:;",
+            Render("/* start", " middle {", " end */ int x;"));
+    }
+
+    [Fact]
+    public void BlockComment_OpeningAndClosingOnOneLine_IsASingleToken()
+    {
+        Assert.Equal("W:int C:/**/ W:x P:;", Render("int /**/ x;"));
+    }
+
+    [Fact]
+    public void VerbatimLiteral_KeepsItsBracesAsLiteralText()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:@\"a{b\" P:; W:var W:t P:= W:1 P:;",
+            Render("var s = @\"a{b\";", "var t = 1;"));
+    }
+
+    [Fact]
+    public void RawLiteral_SpansLines_AndItsBracesAreLiteralText()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:\"\"\" S:  raw { text } S:  \"\"\" P:;",
+            Render("var s = \"\"\"", "  raw { text }", "  \"\"\";"));
+    }
+
+    [Fact]
+    public void InterpolatedLiteral_ScansItsHoleAsCode()
+    {
+        // The hole's contents are ordinary C# and come back as code tokens; the delimiters stay
+        // with the literal.
+        Assert.Equal(
+            "W:var W:s P:= S:$\"a{ W:b P:+ W:1 S:}c\" P:;",
+            Render("var s = $\"a{b + 1}c\";"));
+    }
+
+    [Fact]
+    public void DoubleDollarRawLiteral_TakesTwoBracesToOpenAHole()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:$$\"\"\"x{{ W:y S:}}z\"\"\" P:;",
+            Render("var s = $$\"\"\"x{{y}}z\"\"\";"));
+    }
+
+    [Fact]
+    public void SingleBraceInDoubleDollarLiteral_IsContent()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:$$\"\"\"x{y}z\"\"\" P:;",
+            Render("var s = $$\"\"\"x{y}z\"\"\";"));
+    }
+
+    [Fact]
+    public void EmptyLiteral_IsOneToken()
+    {
+        Assert.Equal("W:var W:e P:= S:\"\" P:;", Render("var e = \"\";"));
+    }
+
+    [Fact]
+    public void CharLiteral_SurvivesAnEscapedQuote()
+    {
+        Assert.Equal("W:char W:c P:= H:'\\'' P:;", Render("char c = '\\'';"));
+    }
+
+    [Fact]
+    public void VerbatimIdentifier_IsNotALiteral()
+    {
+        Assert.Equal("W:var W:v P:= P:@ W:class P:;", Render("var v = @class;"));
+    }
+
+    [Fact]
+    public void BraceDepth_PlacesEachDelimiterWithTheTextItBounds()
+    {
+        var lines = new[] { "class C {", "  void M() { }", "}" };
+        var tokens = BodySlicer.ScanTokens(lines);
+
+        // An opener carries the depth outside it and a closer the depth inside, so both report
+        // the block they delimit rather than each other.
+        Assert.Equal(0, Single(tokens, lines, "{", line: 0).Depth);
+        Assert.Equal(1, Single(tokens, lines, "void", line: 1).Depth);
+        Assert.Equal(1, Single(tokens, lines, "{", line: 1).Depth);
+        Assert.Equal(2, Single(tokens, lines, "}", line: 1).Depth);
+        Assert.Equal(1, Single(tokens, lines, "}", line: 2).Depth);
+    }
+
+    [Fact]
+    public void AttributeList_RaisesBracketDepthForItsContents()
+    {
+        var lines = new[] { "[Obsolete(\"x\")]", "public void M() { }" };
+        var tokens = BodySlicer.ScanTokens(lines);
+
+        Assert.Equal(0, Single(tokens, lines, "[", line: 0).BracketDepth);
+        Assert.Equal(1, Single(tokens, lines, "Obsolete", line: 0).BracketDepth);
+        Assert.Equal(1, Single(tokens, lines, "]", line: 0).BracketDepth);
+        Assert.Equal(0, Single(tokens, lines, "public", line: 1).BracketDepth);
+    }
+
+    [Fact]
+    public void AttributeListSpanningLines_KeepsItsContentsBracketed()
+    {
+        // An attribute argument that reads like a declaration — "set" here — is what truncated an
+        // accessor before brackets were carried across lines.
+        var lines = new[] { "[Obsolete(", "    set)]", "public int P { get; set; }" };
+        var tokens = BodySlicer.ScanTokens(lines);
+
+        Assert.Equal(1, Single(tokens, lines, "set", line: 1).BracketDepth);
+        Assert.Equal(0, Single(tokens, lines, "get", line: 2).BracketDepth);
+    }
+
+    [Fact]
+    public void ConditionalDirective_MarksTheDepthUnknowable()
+    {
+        var lines = new[] { "#if DEBUG", "int x;", "#endif" };
+        var tokens = BodySlicer.ScanTokens(lines);
+
+        // The braces around a conditional branch may belong to text the compiler discards, so the
+        // depth stops meaning anything — and the tokens say so rather than reporting a plausible
+        // number.
+        Assert.All(tokens, t => Assert.False(t.DepthKnown));
+        Assert.Equal(ScanTokenKind.Directive, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void NonConditionalDirective_LeavesTheDepthKnown()
+    {
+        var lines = new[] { "#region Things", "int x;" };
+        var tokens = BodySlicer.ScanTokens(lines);
+
+        Assert.All(tokens, t => Assert.True(t.DepthKnown));
+        Assert.Equal(ScanTokenKind.Directive, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void UnterminatedSingleLineLiteral_MarksEveryTokenOnThatLineUnknown()
+    {
+        var lines = new[] { "var s = \"unterminated;", "int y;" };
+        var tokens = BodySlicer.ScanTokens(lines);
+
+        // The scan loses its place at the end of the line, which is after the earlier tokens on
+        // it were emitted. They are corrected rather than left reporting a depth that has since
+        // become meaningless.
+        Assert.All(tokens, t => Assert.False(t.DepthKnown));
+        Assert.Equal("var", tokens[0].TextIn(lines[0]).ToString());
+    }
+
+    private static ScanToken Single(IReadOnlyList<ScanToken> tokens, string[] lines, string text, int line)
+    {
+        var matches = tokens.Where(t => t.Line == line && t.TextIn(lines[line]).SequenceEqual(text)).ToList();
+        return Assert.Single(matches);
+    }
+
+    // ---- Coverage invariant -------------------------------------------------------------
+
+    /// <summary>
+    /// Describes the first place the token stream fails to account for <paramref name="lines"/>,
+    /// or null when it accounts for all of them.
+    /// <para>
+    /// Three things are checked together because they fail together: tokens must stay in bounds,
+    /// must not overlap or run backwards, and must cover every character that is not whitespace.
+    /// A gap means the scan advanced over text without deciding what it was, which is exactly the
+    /// state a predicate reading raw text used to be in.
+    /// </para>
+    /// </summary>
+    private static string? FindCoverageGap(IReadOnlyList<string> lines, IReadOnlyList<ScanToken> tokens)
+    {
+        int index = 0;
+
+        for (int line = 0; line < lines.Count; line++)
+        {
+            string text = lines[line];
+            int covered = 0;
+
+            while (index < tokens.Count && tokens[index].Line == line)
+            {
+                var token = tokens[index];
+
+                if (token.Length <= 0 || token.Column < 0 || token.End > text.Length)
+                    return $"line {line}: token {token.Kind} at {token.Column}+{token.Length} is out of bounds for a {text.Length}-character line";
+
+                if (token.Column < covered)
+                    return $"line {line}: token {token.Kind} at {token.Column} overlaps or precedes the previous token, which ended at {covered}";
+
+                for (int c = covered; c < token.Column; c++)
+                {
+                    if (!char.IsWhiteSpace(text[c]))
+                        return $"line {line}: '{text[c]}' at column {c} is not covered by any token";
+                }
+
+                covered = token.End;
+                index++;
+            }
+
+            for (int c = covered; c < text.Length; c++)
+            {
+                if (!char.IsWhiteSpace(text[c]))
+                    return $"line {line}: '{text[c]}' at column {c} is past the last token and not covered";
+            }
+        }
+
+        return index == tokens.Count ? null : $"{tokens.Count - index} tokens refer to lines that do not exist";
+    }
+
+    /// <summary>
+    /// The gate for <see cref="FindCoverageGap"/> itself. Without this, a checker that returned
+    /// null unconditionally would leave every coverage test below passing and say nothing, and the
+    /// only way to tell that apart from a real result would be to break the scanner on purpose.
+    /// </summary>
+    [Fact]
+    public void CoverageCheck_ReportsATokenThatWasRemoved()
+    {
+        var lines = new[] { "int x = 1;" };
+        var tokens = BodySlicer.ScanTokens(lines);
+
+        Assert.Null(FindCoverageGap(lines, tokens));
+
+        for (int drop = 0; drop < tokens.Count; drop++)
+        {
+            var damaged = tokens.Where((_, i) => i != drop).ToList();
+            Assert.NotNull(FindCoverageGap(lines, damaged));
+        }
+    }
+
+    [Fact]
+    public void CoverageCheck_ReportsATokenThatWasShortened()
+    {
+        var lines = new[] { "int identifier = 1;" };
+        var tokens = BodySlicer.ScanTokens(lines);
+        var damaged = tokens.ToList();
+
+        int word = damaged.FindIndex(t => t.Kind == ScanTokenKind.Word && t.Length > 1);
+        damaged[word] = damaged[word] with { Length = damaged[word].Length - 1 };
+
+        Assert.NotNull(FindCoverageGap(lines, damaged));
+    }
+
+    [Theory]
+    [InlineData("int x; // c")]
+    [InlineData("var s = $\"a{b}c\";")]
+    [InlineData("var s = $$\"\"\"a{{b}}c\"\"\";")]
+    [InlineData("var s = @\"a\"\"b\";")]
+    [InlineData("char c = '\\\\';")]
+    [InlineData("#if DEBUG")]
+    [InlineData("[A] void M() { }")]
+    [InlineData("x = y is not null ? 1 : 2;")]
+    [InlineData("var s = \"unterminated")]
+    [InlineData("var v = @;")]
+    [InlineData("int /**/ x;")]
+    [InlineData("f(a => a.B<C>(1_000, 0xFF, 1.5e3));")]
+    public void EveryCharacterOfALine_IsAccountedFor(string line)
+    {
+        var lines = new[] { line };
+        Assert.Null(FindCoverageGap(lines, BodySlicer.ScanTokens(lines)));
+    }
+
+    /// <summary>
+    /// The same invariant over real source: every C# file the corpus assemblies' PDBs point at.
+    /// Hand-written cases cover the constructs someone thought of, and this covers the ones they
+    /// did not.
+    /// </summary>
+    [Fact]
+    public void EveryCharacterOfTheCorpus_IsAccountedFor()
+    {
+        var files = CorpusSourceFiles();
+
+        // The corpus is whatever the test project's references drag into the output directory, so
+        // it can shrink without anything turning red. Assert its size rather than trust it.
+        Assert.True(files.Count >= 100, $"Corpus fell to {files.Count} source files; the invariant below would prove little.");
+
+        int lineCount = 0;
+        int tokenCount = 0;
+        var kinds = new HashSet<ScanTokenKind>();
+
+        foreach (var file in files)
+        {
+            string[] lines;
+            try
+            {
+                lines = File.ReadAllLines(file);
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+
+            var tokens = BodySlicer.ScanTokens(lines);
+            lineCount += lines.Length;
+            tokenCount += tokens.Count;
+
+            foreach (var token in tokens)
+                kinds.Add(token.Kind);
+
+            string? gap = FindCoverageGap(lines, tokens);
+            Assert.True(gap is null, $"{file}: {gap}");
+        }
+
+        Assert.True(lineCount >= 25_000, $"Corpus fell to {lineCount} lines; the invariant above would prove little.");
+
+        // Coverage on its own would also be satisfied by a scanner that called each whole line one
+        // token, which would say nothing about whether the text was understood. Require the stream
+        // to be decomposed, and to have exercised every kind the corpus can produce.
+        Assert.True(tokenCount > lineCount * 3, $"{tokenCount} tokens over {lineCount} lines is too coarse to be a real decomposition.");
+
+        var expected = Enum.GetValues<ScanTokenKind>().Except(KindsTheCorpusCannotReach).ToHashSet();
+        Assert.Equal(expected, kinds);
+    }
+
+    /// <summary>
+    /// Kinds no corpus file happens to contain, so the corpus cannot be what proves the scanner
+    /// emits them.
+    /// <para>
+    /// This is compared for set equality rather than merely subtracted, so the entry cannot go
+    /// stale: if a corpus assembly later gains a preprocessor directive, this test fails and the
+    /// entry should be deleted. Directives are exercised instead by
+    /// <see cref="ConditionalDirective_MarksTheDepthUnknowable"/> and
+    /// <see cref="NonConditionalDirective_LeavesTheDepthKnown"/>.
+    /// </para>
+    /// </summary>
+    private static readonly ScanTokenKind[] KindsTheCorpusCannotReach = [ScanTokenKind.Directive];
+
+    private static List<string> CorpusSourceFiles()
+    {
+        var paths = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var assemblyPath in Directory.GetFiles(AppContext.BaseDirectory, "*.dll").OrderBy(p => p, StringComparer.Ordinal))
+        {
+            PdbContext context;
+            try
+            {
+                context = PdbContext.Open(assemblyPath);
+            }
+            catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            using (context)
+            {
+                try
+                {
+                    foreach (var member in context.EnumerateMemberSources())
+                    {
+                        if (File.Exists(member.FilePath))
+                            paths.Add(member.FilePath);
+                    }
+                }
+                catch (BadImageFormatException)
+                {
+                    continue;
+                }
+            }
+        }
+
+        return [.. paths.OrderBy(p => p, StringComparer.Ordinal)];
+    }
+}

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -126,9 +126,13 @@ public class ScanTokenTests
             .Where(t => t.Kind == ScanTokenKind.StringLiteral)
             .ToList();
 
+        // The token text is asserted alongside the depths so that the assertion reads the very
+        // characters the fixture relies on. Replacing the carried line's leading `}` with plain
+        // text stops it reaching the brace emission site, and pinning position alone left that
+        // substitution silent (adversarial review, GPT).
         Assert.Equal(
-            [(2, 1, 1), (3, 1, 1), (4, 1, 1)],
-            literals.Select(t => (t.Line, t.Depth, t.BracketDepth)));
+            [(2, 1, 1, "\"\"\""), (3, 1, 1, "} raw { text"), (4, 1, 1, "        \"\"\"")],
+            literals.Select(t => (t.Line, t.Depth, t.BracketDepth, Text(lines, t))));
     }
 
     /// <summary>
@@ -147,8 +151,8 @@ public class ScanTokenTests
             .ToList();
 
         Assert.Equal(
-            [(2, 1, 1), (2, 1, 1)],
-            literals.Select(t => (t.Line, t.Depth, t.BracketDepth)));
+            [(2, 1, 1, "$\"a{"), (2, 1, 1, "}c\"")],
+            literals.Select(t => (t.Line, t.Depth, t.BracketDepth, Text(lines, t))));
     }
 
     [Fact]
@@ -192,10 +196,10 @@ public class ScanTokenTests
         var lines = new[] { "{", "    x = [", "        \"\"", "    ];", "}" };
 
         Assert.Equal(
-            [(2, 1, 1)],
+            [(2, 1, 1, "\"\"")],
             BodySlicer.ScanTokens(lines)
                 .Where(t => t.Kind == ScanTokenKind.StringLiteral)
-                .Select(t => (t.Line, t.Depth, t.BracketDepth)));
+                .Select(t => (t.Line, t.Depth, t.BracketDepth, Text(lines, t))));
     }
 
     [Fact]
@@ -417,6 +421,10 @@ public class ScanTokenTests
     /// state a predicate reading raw text used to be in.
     /// </para>
     /// </summary>
+    /// <summary>The source text a token covers, so an assertion can read its input back.</summary>
+    private static string Text(IReadOnlyList<string> lines, ScanToken token) =>
+        lines[token.Line].Substring(token.Column, token.Length);
+
     private static string? FindCoverageGap(IReadOnlyList<string> lines, IReadOnlyList<ScanToken> tokens)
     {
         int index = 0;

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1096,6 +1096,24 @@ public class ScanTokenTests
 
         Assert.Equal([0, 0, 0, 0, 1, 1, 1, 2, 3], openers.Select(MinBraceRun).Order());
 
+        // The same argument applies to the quote run a raw literal needs in order to close
+        // (`frame.QuoteRun`): four raw seeds can all be spelled with runs of five, seven, nine
+        // and eleven, satisfying every pin above while leaving no carried frame with a run of
+        // three (adversarial review, GPT). Pin the closing run each seed actually needs, for the
+        // same reason and in the same way as the brace run.
+        int MinCloseRun(string opener)
+        {
+            for (int run = 1; run <= 5; run++)
+            {
+                if (CodeOnSecondLine(opener, new string('"', run) + "a"))
+                    return run;
+            }
+
+            return 0;
+        }
+
+        Assert.Equal([0, 1, 1, 1, 1, 3, 3, 3, 4], openers.Select(MinCloseRun).Order());
+
         // Those properties still describe the seeds rather than name them, and a seed can be
         // exchanged for another of the same kind and length -- `$@"` for `@$"` -- without
         // disturbing any of them, which drops one interpolation-order path and keeps the suite

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1011,13 +1011,37 @@ public class ScanTokenTests
         // the seed is no longer reaching the paths it was added for (adversarial review, GPT).
         Assert.Equal(openers.Length, openers.Distinct().Count());
 
+        var carriedKinds = new List<ScanTokenKind>();
+
         foreach (var opener in openers)
         {
             var carried = BodySlicer.ScanTokens([opener, "a"]).Last();
             Assert.True(
                 carried.Kind is ScanTokenKind.StringLiteral or ScanTokenKind.Comment,
                 $"opener [{opener}] no longer carries: 'a' below it scanned as {carried.Kind}");
+            carriedKinds.Add(carried.Kind);
         }
+
+        // "Carries" is not the property the arm needs, only the nearest visible one. Nine
+        // distinct unterminated comments all carry, satisfy the count, the distinctness, and
+        // the concatenation check, and leave the suite green -- while deleting every carried
+        // *string* fragment the arm exists to reach. Measured, that swap lets a wrong depth
+        // survive at two emit sites that nothing else in the suite catches. So pin the kinds
+        // the seeds carry as, which is exactly what the swap destroys, and pin that some seed
+        // is longer than the exhaustive arms can spell, which is why the arm exists at all.
+        Assert.Equal(8, carriedKinds.Count(k => k is ScanTokenKind.StringLiteral));
+        Assert.Equal(1, carriedKinds.Count(k => k is ScanTokenKind.Comment));
+        Assert.Equal(5, openers.Count(o => o.Length > 2));
+
+        // Those properties still describe the seeds rather than name them, and a seed can be
+        // exchanged for another of the same kind and length -- `$@"` for `@$"` -- without
+        // disturbing any of them, which drops one interpolation-order path and keeps the suite
+        // green (adversarial review, Gemini). The seeds are a hand-written list, so pin the
+        // list, for the same reason the alphabet is pinned by value: the properties above are
+        // why these forms, and this is which.
+        Assert.Equal(
+            ["\"", "@\"", "$\"", "$@\"", "\"\"\"", "$\"\"\"", "$$\"\"\"", "$$$\"\"\"\"", "/*"],
+            openers);
 
         var tails = new List<string> { "" };
         Walk(new char[1], 0, 1, tails.Add);
@@ -1068,8 +1092,20 @@ public class ScanTokenTests
         // against 1 second are the same number and not the same test (adversarial review, GPT).
         // Pin each dimension, so one cannot be spent to buy another.
         Assert.Equal(9, openers.Length);
-        Assert.Equal(12, tails.Count);
-        Assert.Equal(132, seconds.Count);
+
+        // Counting the swept lines says nothing about what they spell: 132 arbitrary unique
+        // strings satisfy a count as well as the 132 exhaustive ones, and carry none of the
+        // alphabet's meaning with them (adversarial review, GPT). Derive both sets here from the
+        // pinned alphabet, independently of the `Walk` that produced them, and compare in order.
+        // A second derivation is worth its duplication precisely because it is not the first:
+        // it pins the contents, the ordering, and `Walk`'s limits at once, and it is anchored,
+        // because the alphabet it reads is itself pinned just above.
+        var expectedTails = new[] { "" }.Concat(Alphabet.Select(c => c.ToString()));
+        var expectedSeconds = Alphabet.SelectMany(first =>
+            new[] { first.ToString() }.Concat(Alphabet.Select(second => $"{first}{second}")));
+
+        Assert.Equal(expectedTails, tails);
+        Assert.Equal(expectedSeconds, seconds);
 
         // Every count above can be met by an alphabet that spells nothing: replacing `{` with a
         // letter keeps all three dimensions and the pinned total while deleting the only input

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -171,6 +171,24 @@ public class ScanTokenTests
             Render($"var s = {prefix}\"a{{b}}c\";"));
     }
 
+    /// <summary>
+    /// An even brace run in a single-dollar literal is escaped text, not a hole. Nothing
+    /// pinned the kind that path emits: mutating it from a string fragment to a word left the
+    /// whole suite green (adversarial review, Gemini). The differential invariant cannot see
+    /// it, because it compares a bare scan against a wrapped one and both sides change
+    /// together; only a rendering assertion can.
+    /// </summary>
+    [Theory]
+    [InlineData("$")]
+    [InlineData("$@")]
+    [InlineData("@$")]
+    public void EscapedBraceRunInAnInterpolatedLiteral_StaysStringContent(string prefix)
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:" + prefix + "\"a{{b}}c\" P:;",
+            Render("var s = " + prefix + "\"a{{b}}c\";"));
+    }
+
     [Fact]
     public void QuoteRunShorterThanTheDelimiter_IsRawLiteralContent()
     {
@@ -940,21 +958,22 @@ public class ScanTokenTests
 
         void Check(string[] content)
         {
-            // Build the wrapped input before either scan, so it holds a snapshot of the lines
-            // taken up front, and compare the two back once both scans have run. The invariant
-            // is only differential if both sides consumed the same content, and nothing else
-            // says so: substituting the content between the two scans -- exchanging a verbatim
-            // interpolated opener for a raw one of the same length, so kind, column, length and
-            // the expected shift all still match -- leaves every assertion passing while the two
-            // sides exercise different frame states, and measured, a depth defect on the frame
-            // only one side now carries survives (adversarial review, GPT).
+            // Build the wrapped input first and derive the bare input from it, so both scans
+            // provably consume the same lines: there is exactly one array in the flow, and the
+            // comparison below ties it to the content the recording observes.
             //
-            // A single substitution anywhere is caught: before this line, both scans see it and
-            // the recorded sequences fail their derivation pins; after it, `wrapped` still holds
-            // the original element references, so the comparison below fails.
+            // The invariant is only differential if both sides scan the same content, and
+            // nothing said so. Substituting the content between the two scans -- exchanging a
+            // verbatim interpolated opener for a raw one of the same length, so kind, column,
+            // length and the expected shift all still match -- left every assertion passing
+            // while the two sides exercised different frame states, and measured, a depth
+            // defect on the frame only one side carried then survived (adversarial review,
+            // GPT). A single substitution of either value is now caught: before this line both
+            // scans see it and the recorded sequences fail their derivation pins; after it,
+            // `wrapped` still holds the original element references.
             string[] wrapped = ["{", "[", .. content];
 
-            var bare = BodySlicer.ScanTokens(content);
+            var bare = BodySlicer.ScanTokens(wrapped[2..]);
             var enclosed = BodySlicer.ScanTokens(wrapped).Where(t => t.Line >= 2).ToList();
 
             Assert.Equal(wrapped[2..], content);

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -930,6 +930,8 @@ public class ScanTokenTests
     {
         const string Alphabet = "#/*'\"@$\\{}a";
         int checked_ = 0;
+        HashSet<string>? singleSeen = null;
+        HashSet<(string First, string Second)>? pairSeen = null;
         HashSet<(string First, string Second)>? seedPairs = null;
 
         var kindsReached = new HashSet<ScanTokenKind>();
@@ -938,6 +940,12 @@ public class ScanTokenTests
 
         void Check(string[] content)
         {
+            if (singleSeen is not null && content.Length == 1)
+                singleSeen.Add(content[0]);
+
+            if (pairSeen is not null && content.Length == 2)
+                pairSeen.Add((content[0], content[1]));
+
             if (seedPairs is not null && content.Length == 2)
                 seedPairs.Add((content[0], content[1]));
 
@@ -983,18 +991,26 @@ public class ScanTokenTests
         }
 
         // One line reaches every path that opens a construct.
+        singleSeen = [];
         Walk(new char[4], 0, 4, line => Check([line]));
+        int checkedSingle = checked_;
 
         // Two lines reach the paths that continue one carried in from the line above, which no
         // single-line input can: a literal's later lines, and a block comment's.
         var seconds = new List<string>();
         Walk(new char[2], 0, 2, seconds.Add);
 
+        pairSeen = [];
+
         foreach (var first in seconds)
         {
             foreach (var second in seconds)
                 Check([first, second]);
         }
+
+        int checkedPairs = checked_ - checkedSingle;
+        var sweptPairs = pairSeen!;
+        pairSeen = null;
 
         // A construct carried across a line break can be opened by a delimiter longer than the
         // exhaustive arms reach. Seed each one, so that the first token on the second line is a
@@ -1026,12 +1042,22 @@ public class ScanTokenTests
         // distinct unterminated comments all carry, satisfy the count, the distinctness, and
         // the concatenation check, and leave the suite green -- while deleting every carried
         // *string* fragment the arm exists to reach. Measured, that swap lets a wrong depth
-        // survive at two emit sites that nothing else in the suite catches. So pin the kinds
-        // the seeds carry as, which is exactly what the swap destroys, and pin that some seed
-        // is longer than the exhaustive arms can spell, which is why the arm exists at all.
-        Assert.Equal(8, carriedKinds.Count(k => k is ScanTokenKind.StringLiteral));
+        // survive at two emit sites that nothing else in the suite catches. One seed must
+        // therefore still open a comment, and the rest must open strings; with nine seeds and
+        // the string-or-comment check above, pinning the comment pins both halves.
         Assert.Equal(1, carriedKinds.Count(k => k is ScanTokenKind.Comment));
-        Assert.Equal(5, openers.Count(o => o.Length > 2));
+
+        // Kind and length are still not the whole of why these forms: an opener list of nine
+        // distinct seeds, eight of them strings, five longer than two characters, can be spelled
+        // entirely without raw literals (`$$"`, `$$$"`, `$$$$"` for `"""`, `$"""`, `$$"""`), and
+        // measured, that erases the carried raw-literal path at BodySlicer.cs:1413 while every
+        // pin above and the suite stay green (adversarial review, GPT). Pin the raw family by
+        // the behaviour that makes it a separate path rather than by its spelling: a lone quote
+        // on the next line closes a quoted or verbatim literal, and does not close a raw one.
+        var rawSeeds = openers.Count(o =>
+            BodySlicer.ScanTokens([o, "\"a"]).Last().Kind is ScanTokenKind.StringLiteral);
+
+        Assert.Equal(4, rawSeeds);
 
         // Those properties still describe the seeds rather than name them, and a seed can be
         // exchanged for another of the same kind and length -- `$@"` for `@$"` -- without
@@ -1057,8 +1083,30 @@ public class ScanTokenTests
             }
         }
 
-        // The sweep is only as good as its size; pin it so a shrunken alphabet is visible.
+        // The sweep is only as good as its size; pin it so a shrunken alphabet is visible. One
+        // total across three arms is not that pin: a drop in one arm can be paid for with
+        // padding in another, or with padding inside the same arm, and both trades were
+        // measured to survive -- lowering the single-line limit to 3 and replacing the 14,641
+        // lost calls with repeats of `Check(["a"])`, and dropping the `/*` seed and padding the
+        // single-line arm by 1,584 (adversarial review, Gemini). Pin each arm's own count, and
+        // pin what each arm actually swept, so padding cannot stand in for reach.
+        int checkedSeeded = checked_ - checkedSingle - checkedPairs;
+
+        Assert.Equal(16_104, checkedSingle);
+        Assert.Equal(132 * 132, checkedPairs);
+        Assert.Equal(9 * 12 * 132, checkedSeeded);
         Assert.Equal(16_104 + (132 * 132) + (9 * 12 * 132), checked_);
+
+        // The single-line arm's own inputs, derived from the pinned alphabet rather than read
+        // back from the `Walk` that produced them, which pins its limit of 4 as well.
+        var alpha = Alphabet.Select(c => c.ToString()).ToArray();
+        var byLength = new List<string[]> { alpha };
+
+        for (int n = 1; n < 4; n++)
+            byLength.Add([.. byLength[n - 1].SelectMany(_ => alpha, (prefix, next) => prefix + next)]);
+
+        Assert.Equal(byLength.SelectMany(x => x).ToHashSet(), singleSeen);
+        Assert.Equal(seconds.SelectMany(_ => seconds, (first, second) => (first, second)).ToHashSet(), sweptPairs);
 
         // Size and seed quality are still not the same as reach: the arm only does its work if
         // each seeded line is scanned in the position that carries, and against every second

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -443,11 +443,23 @@ public class ScanTokenTests
     /// and it is an oracle rather than a re-implementation.
     ///
     /// What it deliberately does not reach, so that no one mistakes it for a general gate:
-    /// it is single-line, so the line half of the coalescing rule and all carried state are out
-    /// of scope; six characters cannot open a <c>$$</c> raw interpolation hole, which needs
-    /// seven, nor produce the eight-character shape that makes the backslash rules observable;
-    /// and coverage cannot see a wrong token *kind* as long as the spans stay complete. Each of
-    /// those is gated by a named test above instead.
+    ///
+    /// It is single-line, so the line half of the coalescing rule and all carried state are out
+    /// of scope.
+    ///
+    /// Six characters cannot open a <c>$$</c> raw interpolation hole, which needs seven, and
+    /// cannot close a raw literal at all: an opener and a closer would have to be adjacent, and
+    /// adjacent quotes merge into one run, so <c>""""""</c> is a six-quote opener rather than two
+    /// three-quote delimiters. Raw closure therefore also needs seven, and the raw backslash shape
+    /// needs eight.
+    ///
+    /// The oracle is blind to token *kind* while the spans stay complete, which is a separate
+    /// limit from length and the more important one. The verbatim backslash shape is reachable
+    /// here at six characters — <c>@"{\"a</c> — and the gate still does not catch the mutation
+    /// that drops <c>!frame.Verbatim</c>, because that only turns the trailing <c>a</c> from a
+    /// word into literal content and every character remains covered exactly once.
+    ///
+    /// Each of those is gated by a named test above instead.
     /// </summary>
     [Fact]
     public void EveryStringOverTheDelimiterAlphabet_IsFullyCovered()

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1059,6 +1059,16 @@ public class ScanTokenTests
 
         Assert.Equal(4, rawSeeds);
 
+        // The arm's whole reason for existing is seeds the exhaustive arms cannot spell, so pin
+        // how many exceed their reach. Without this, `$@"` can be exchanged for `"b` -- still
+        // nine distinct seeds, eight strings, one comment, four raw -- which drops the verbatim
+        // interpolated path and replaces it with a two-character opener the pair arm already
+        // sweeps, adding nothing (adversarial review, GPT). I had removed this pin as redundant
+        // on the grounds that the raw pin already forces four seeds of three characters or
+        // more; that was wrong, and this mutation is the counterexample: it forces four, and
+        // the fifth was unpinned.
+        Assert.Equal(5, openers.Count(o => o.Length > 2));
+
         // Those properties still describe the seeds rather than name them, and a seed can be
         // exchanged for another of the same kind and length -- `$@"` for `@$"` -- without
         // disturbing any of them, which drops one interpolation-order path and keeps the suite

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -940,7 +940,24 @@ public class ScanTokenTests
 
         void Check(string[] content)
         {
+            // Build the wrapped input before either scan, so it holds a snapshot of the lines
+            // taken up front, and compare the two back once both scans have run. The invariant
+            // is only differential if both sides consumed the same content, and nothing else
+            // says so: substituting the content between the two scans -- exchanging a verbatim
+            // interpolated opener for a raw one of the same length, so kind, column, length and
+            // the expected shift all still match -- leaves every assertion passing while the two
+            // sides exercise different frame states, and measured, a depth defect on the frame
+            // only one side now carries survives (adversarial review, GPT).
+            //
+            // A single substitution anywhere is caught: before this line, both scans see it and
+            // the recorded sequences fail their derivation pins; after it, `wrapped` still holds
+            // the original element references, so the comparison below fails.
+            string[] wrapped = ["{", "[", .. content];
+
             var bare = BodySlicer.ScanTokens(content);
+            var enclosed = BodySlicer.ScanTokens(wrapped).Where(t => t.Line >= 2).ToList();
+
+            Assert.Equal(wrapped[2..], content);
 
             // Record after the scan, not before. The derivation pins below are only worth
             // anything if they observe what the invariant actually ran on: recording first
@@ -964,10 +981,6 @@ public class ScanTokenTests
                 deepest = Math.Max(deepest, token.Depth);
                 shallowest = Math.Min(shallowest, token.Depth);
             }
-
-
-            string[] wrapped = ["{", "[", .. content];
-            var enclosed = BodySlicer.ScanTokens(wrapped).Where(t => t.Line >= 2).ToList();
 
             Assert.Equal(bare.Count, enclosed.Count);
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -377,27 +377,30 @@ public class ScanTokenTests
     }
 
     /// <summary>
-    /// Gates the rule that a raw literal has no escape sequences — a backslash in one is ordinary
-    /// content, and in particular cannot consume the quote that closes the literal.
+    /// Gates the rule that raw and verbatim literals have no escape sequences — a backslash in
+    /// one is ordinary content, and in particular cannot consume the quote that closes it.
     ///
     /// The backslash has to sit at the start of a scan step for the escape branch to be consulted
     /// at all: the plain-content run stops only at <c>{</c>, <c>}</c>, <c>"</c>, and (outside a
     /// raw or verbatim literal) a backslash, so a backslash following ordinary text is swallowed
     /// by the run before the branch is reached. Putting it directly after a brace is what makes
-    /// the rule observable. Without that placement the mutation that drops <c>!frame.Raw</c>
-    /// changes nothing, which is why the corpus and every other test miss it; with it, the
-    /// literal swallows its own closing delimiter and the entire rest of the line.
+    /// the rule observable — <c>@"a\"</c> is not affected by the mutation, only <c>@"{\"</c> is.
+    /// Without that placement, dropping either <c>!frame.Raw</c> or <c>!frame.Verbatim</c> changes
+    /// nothing, which is why the corpus and every other test miss both; with it, the literal
+    /// swallows its own closing delimiter and the entire rest of the line.
+    ///
+    /// The two guards live in one condition but are independent: each mode needs its own case.
     /// </summary>
-    [Fact]
-    public void RawLiteral_TreatsABackslashAsContent_NotAnEscape()
+    [Theory]
+    // Raw.
+    [InlineData(""""var s = """{\"""; int after = 1;"""", """"W:var W:s P:= S:"""{\""" P:; W:int W:after P:= W:1 P:;"""")]
+    // Raw interpolated, where the brace ending the run is a hole's closer.
+    [InlineData(""""var s = $"""{b}\""";"""", """"W:var W:s P:= S:$"""{ W:b S:}\""" P:;"""")]
+    // Verbatim.
+    [InlineData("""var s = @"{\"; int after = 1;""", """W:var W:s P:= S:@"{\" P:; W:int W:after P:= W:1 P:;""")]
+    public void LiteralsWithoutEscapes_TreatABackslashAsContent(string line, string expected)
     {
-        Assert.Equal(
-            """"W:var W:s P:= S:"""{\""" P:; W:int W:after P:= W:1 P:;"""",
-            Render(""""var s = """{\"""; int after = 1;""""));
-
-        Assert.Equal(
-            """"W:var W:s P:= S:$"""{ W:b S:}\""" P:;"""",
-            Render(""""var s = $"""{b}\""";""""));
+        Assert.Equal(expected, Render(line));
     }
 
     /// <summary>
@@ -425,7 +428,7 @@ public class ScanTokenTests
 
     /// <summary>
     /// Runs the coverage invariant over every string up to six characters long drawn from the
-    /// alphabet that actually drives the literal state machine — <c>$ " { } \</c>, a space, and
+    /// alphabet that actually drives the literal state machine — <c>$ @ " { } \</c>, a space, and
     /// one ordinary character. The authored corpus is large but it is well-formed C#; it contains
     /// almost none of the delimiter soup that distinguishes the raw, verbatim, and interpolated
     /// rules from one another. This covers that space exhaustively rather than by example.
@@ -438,11 +441,18 @@ public class ScanTokenTests
     /// strings mean, every non-whitespace character is inside exactly one token and no token runs
     /// off its line. That is weaker than pinning output, but it holds for inputs no one wrote down,
     /// and it is an oracle rather than a re-implementation.
+    ///
+    /// What it deliberately does not reach, so that no one mistakes it for a general gate:
+    /// it is single-line, so the line half of the coalescing rule and all carried state are out
+    /// of scope; six characters cannot open a <c>$$</c> raw interpolation hole, which needs
+    /// seven, nor produce the eight-character shape that makes the backslash rules observable;
+    /// and coverage cannot see a wrong token *kind* as long as the spans stay complete. Each of
+    /// those is gated by a named test above instead.
     /// </summary>
     [Fact]
     public void EveryStringOverTheDelimiterAlphabet_IsFullyCovered()
     {
-        char[] alphabet = ['$', '"', '{', '}', '\\', ' ', 'a'];
+        char[] alphabet = ['$', '@', '"', '{', '}', '\\', ' ', 'a'];
         var buffer = new char[6];
         int checkedCount = 0;
 
@@ -471,7 +481,7 @@ public class ScanTokenTests
             Walk(0, length);
 
         // Pins the size of the space so a later edit cannot quietly shrink it to nothing.
-        Assert.Equal(137_256, checkedCount);
+        Assert.Equal(299_592, checkedCount);
     }
 
     /// <summary>

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -161,14 +161,22 @@ public class ScanTokenTests
             Render("var s = $$\"\"\"a{{{b}}}c\"\"\";"));
     }
 
+    /// <summary>
+    /// Both spellings of a verbatim interpolated literal open a hole.
+    /// </summary>
+    /// <remarks>
+    /// The input and the expected rendering are spelled out per row rather than derived from a
+    /// shared parameter. A theory that builds both sides from one value validates whatever it
+    /// is given: substituting the row silently moves the case to a different state and the
+    /// expectation follows it, leaving the suite green at the same test count while the state
+    /// the row existed for goes unscanned (adversarial review, GPT).
+    /// </remarks>
     [Theory]
-    [InlineData("$@")]
-    [InlineData("@$")]
-    public void VerbatimAndInterpolatedInEitherOrder_StillInterpolates(string prefix)
+    [InlineData("var s = $@\"a{b}c\";", "W:var W:s P:= S:$@\"a{ W:b S:}c\" P:;")]
+    [InlineData("var s = @$\"a{b}c\";", "W:var W:s P:= S:@$\"a{ W:b S:}c\" P:;")]
+    public void VerbatimAndInterpolatedInEitherOrder_StillInterpolates(string line, string expected)
     {
-        Assert.Equal(
-            $"W:var W:s P:= S:{prefix}\"a{{ W:b S:}}c\" P:;",
-            Render($"var s = {prefix}\"a{{b}}c\";"));
+        Assert.Equal(expected, Render(line));
     }
 
     /// <summary>
@@ -178,15 +186,19 @@ public class ScanTokenTests
     /// it, because it compares a bare scan against a wrapped one and both sides change
     /// together; only a rendering assertion can.
     /// </summary>
+    /// <remarks>
+    /// Each row spells out its own input and expectation, for the reason given on
+    /// <see cref="VerbatimAndInterpolatedInEitherOrder_StillInterpolates"/>. The first row is
+    /// the only non-verbatim case, and when both sides were derived from one prefix it could be
+    /// exchanged for a second verbatim spelling with the expectation following it.
+    /// </remarks>
     [Theory]
-    [InlineData("$")]
-    [InlineData("$@")]
-    [InlineData("@$")]
-    public void EscapedBraceRunInAnInterpolatedLiteral_StaysStringContent(string prefix)
+    [InlineData("var s = $\"a{{b}}c\";", "W:var W:s P:= S:$\"a{{b}}c\" P:;")]
+    [InlineData("var s = $@\"a{{b}}c\";", "W:var W:s P:= S:$@\"a{{b}}c\" P:;")]
+    [InlineData("var s = @$\"a{{b}}c\";", "W:var W:s P:= S:@$\"a{{b}}c\" P:;")]
+    public void EscapedBraceRunInAnInterpolatedLiteral_StaysStringContent(string line, string expected)
     {
-        Assert.Equal(
-            "W:var W:s P:= S:" + prefix + "\"a{{b}}c\" P:;",
-            Render("var s = " + prefix + "\"a{{b}}c\";"));
+        Assert.Equal(expected, Render(line));
     }
 
     [Fact]

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -768,8 +768,12 @@ public class ScanTokenTests
         // would again describe the intended input rather than the scanned one.
         // The tail is read back the same way. Its alphabet holds no whitespace, so the line's
         // tokens cover it exactly and concatenating them reconstructs what the scanner consumed.
-        var openersScanned = new HashSet<string>();
-        var tailsScanned = new HashSet<string>();
+        //
+        // The two are recorded as a PAIR rather than as two sets, because separate sets pin only
+        // the margins: substituting a fixed tail for one opener alone kept both margins complete
+        // and stopped the multi-dollar opener ever meeting the tail that reaches the short-brace
+        // branch (adversarial review, GPT).
+        var scannedPairs = new HashSet<(string Opener, string Tail)>();
 
         foreach (string opener in openers)
         {
@@ -780,9 +784,9 @@ public class ScanTokenTests
                 var opened = tokens.Single(t => t.Line == 2);
                 var first = tokens.First(t => t.Line == 3);
 
-                openersScanned.Add(opened.TextIn(lines[2]).ToString().TrimStart());
-                tailsScanned.Add(string.Concat(
-                    tokens.Where(t => t.Line == 3).Select(t => t.TextIn(lines[3]).ToString())));
+                scannedPairs.Add((
+                    opened.TextIn(lines[2]).ToString().TrimStart(),
+                    string.Concat(tokens.Where(t => t.Line == 3).Select(t => t.TextIn(lines[3]).ToString()))));
 
                 Assert.Equal(
                     (ScanTokenKind.StringLiteral, 1, 1),
@@ -790,8 +794,9 @@ public class ScanTokenTests
             }
         }
 
-        Assert.Equal(openers.Order(), openersScanned.Order());
-        Assert.Equal(tails.Order(), tailsScanned.Order());
+        Assert.Equal(
+            (from opener in openers from tail in tails select (opener, tail)).Order(),
+            scannedPairs.Order());
     }
 
     /// <summary>

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -214,8 +214,8 @@ public class ScanTokenTests
     public void VerbatimLiteral_EndingALineOnAnEscapedQuote_StaysOpen()
     {
         Assert.Equal(
-            "W:var W:s P:= S:@\"ends with quote\"\" S:still literal\" P:;",
-            Render("var s = @\"ends with quote\"\"", "still literal\";"));
+            "W:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:@\"ends with quote\"\":d0:b0 S:still literal\":d0:b0 P:;:d0:b0",
+            RenderState("var s = @\"ends with quote\"\"", "still literal\";"));
     }
 
     [Theory]
@@ -562,6 +562,7 @@ public class ScanTokenTests
         char[] alphabet = ['$', '@', '"', '{', '}', '\\', ' ', 'a'];
         var buffer = new char[6];
         var sweptChars = new HashSet<char>();
+        var sweptInputs = new HashSet<string>();
         int checkedCount = 0;
 
         void Walk(int at, int length)
@@ -574,6 +575,8 @@ public class ScanTokenTests
 
                 foreach (char swept in lines[0])
                     sweptChars.Add(swept);
+
+                sweptInputs.Add(lines[0]);
 
                 if (gap is not null)
                     Assert.Fail($"input \"{lines[0]}\": {gap}");
@@ -601,6 +604,31 @@ public class ScanTokenTests
         // and by the value the scanner actually received rather than the one declared above, so
         // that a substitution between the declaration and the sweep is visible too.
         Assert.Equal(" \"$@\\a{}", string.Concat(sweptChars.Order()));
+
+        // Nor is the character set the input set. Substituting one swept string for another of
+        // the same length over the same characters leaves every count and the set above intact
+        // while dropping that string's state, so pin the strings themselves, derived from the
+        // pinned alphabet rather than read back from the walk that produced them.
+        Assert.Equal(AllStringsOver(" \"$@\\a{}", 6), sweptInputs);
+    }
+
+    /// <summary>
+    /// Every string of length 1..<paramref name="upTo"/> over <paramref name="alphabet"/>, built
+    /// from the pinned literal its caller passes rather than read back from the generator that
+    /// produced the sweep. A sweep that pins only its size, its character set and its result
+    /// totals does not pin the strings it scanned: one input can be exchanged for another that
+    /// is the same length and draws on the same characters, leaving every count identical while
+    /// the state that input existed for is never reached (adversarial review, GPT).
+    /// </summary>
+    private static HashSet<string> AllStringsOver(string alphabet, int upTo)
+    {
+        var singles = alphabet.Select(c => c.ToString()).ToArray();
+        var byLength = new List<string[]> { singles };
+
+        for (int n = 1; n < upTo; n++)
+            byLength.Add([.. byLength[n - 1].SelectMany(_ => singles, (prefix, next) => prefix + next)]);
+
+        return byLength.SelectMany(x => x).ToHashSet();
     }
 
     /// <summary>
@@ -626,6 +654,7 @@ public class ScanTokenTests
         char[] alphabet = ['$', '@', '"', '{', '}', '\\', '/', '*', 'a'];
         var buffer = new char[4];
         var sweptChars = new HashSet<char>();
+        var sweptInputs = new HashSet<string>();
         int known = 0, unknown = 0, inputsWithUnknown = 0, inputs = 0;
 
         void Walk(int at, int length)
@@ -638,6 +667,8 @@ public class ScanTokenTests
 
                 foreach (char swept in lines[0])
                     sweptChars.Add(swept);
+
+                sweptInputs.Add(lines[0]);
 
                 int lost = tokens.Count(t => !t.DepthKnown);
                 unknown += lost;
@@ -662,8 +693,10 @@ public class ScanTokenTests
         // Both readings are pinned, so the field cannot be moved in either direction: pinning
         // only the unknown tokens would let every token become knowable, and pinning only the
         // known ones would let every token lose its place.
+        Assert.Equal(4, buffer.Length);
         Assert.Equal(9 + 81 + 729 + 6561, inputs);
         Assert.Equal("\"$*/@\\a{}", string.Concat(sweptChars.Order()));
+        Assert.Equal(AllStringsOver("\"$*/@\\a{}", 4), sweptInputs);
         Assert.Equal(17_602, known);
         Assert.Equal(4_452, unknown);
         Assert.Equal(1_996, inputsWithUnknown);
@@ -719,8 +752,7 @@ public class ScanTokenTests
     }
 
     /// <summary>
-    /// Gates every <c>[Theory]</c> in this file against having a row exchanged for a copy of one
-    /// of its siblings.
+    /// Pins the rows of every <c>[Theory]</c> in this file by value.
     /// <para>
     /// xUnit counts rows, not distinct rows, so replacing one <c>[InlineData]</c> with a
     /// duplicate of another leaves the reported test count unchanged and every assertion
@@ -732,16 +764,26 @@ public class ScanTokenTests
     /// (adversarial review, Gemini).
     /// </para>
     /// <para>
-    /// This is checked here rather than by splitting that one theory into facts, because the
-    /// weakness belongs to the shape and not to the theory that happened to expose it: any
-    /// theory in this file, including ones not yet written, is open to the same substitution.
-    /// The totals are pinned so the gate cannot go quiet by finding nothing to check.
+    /// Requiring the rows merely to be <em>distinct</em> does not close that: the same two rows
+    /// can be replaced by two different variations of the verbatim row, which are distinct
+    /// strings and drop exactly as much (adversarial review, Gemini, again). Distinctness is a
+    /// property of the spelling and the coverage that matters is a property of the state each
+    /// row reaches, and no mechanical check of the rows can bridge that. So the rows are pinned
+    /// the way this file pins every other hand-written list it depends on — the delimiter
+    /// alphabet, the carried-construct openers — by value.
+    /// </para>
+    /// <para>
+    /// This is checked here rather than by splitting the theory that exposed it into facts,
+    /// because the weakness belongs to the shape and not to that theory: every theory in this
+    /// file, including ones not yet written, is open to the same substitution. The totals are
+    /// pinned as well, so the gate cannot go quiet by finding nothing to check.
     /// </para>
     /// </summary>
     [Fact]
     public void EveryTheoryRow_DiffersFromItsSiblings()
     {
         int theories = 0, rows = 0;
+        var pinned = new List<string>();
 
         foreach (var method in typeof(ScanTokenTests).GetMethods().OrderBy(m => m.Name))
         {
@@ -758,13 +800,40 @@ public class ScanTokenTests
             theories++;
             rows += data.Count;
 
-            Assert.Equal(
-                (method.Name, data.Count),
-                (method.Name, data.Distinct().Count()));
+            foreach (var row in data)
+                pinned.Add($"{method.Name}\u001f{row}");
         }
 
         Assert.Equal(6, theories);
         Assert.Equal(24, rows);
+        Assert.Equal(
+            [
+                "CommentOpenerInsideALiteral_IsLiteralText\u001fvar s = \"/* not a comment */\";\u001fW:var W:s P:= S:\"/* not a comment */\" P:;",
+                "CommentOpenerInsideALiteral_IsLiteralText\u001fvar s = \"http://not/a/comment\";\u001fW:var W:s P:= S:\"http://not/a/comment\" P:;",
+                "EscapedBraceRunInAnInterpolatedLiteral_StaysStringContent\u001fvar s = @$\"a{{b}}c\";\u001fW:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:@$\"a{{b}}c\":d0:b0 P:;:d0:b0",
+                "EscapedBraceRunInAnInterpolatedLiteral_StaysStringContent\u001fvar s = $\"a{{b}}c\";\u001fW:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:$\"a{{b}}c\":d0:b0 P:;:d0:b0",
+                "EscapedBraceRunInAnInterpolatedLiteral_StaysStringContent\u001fvar s = $@\"a{{b}}c\";\u001fW:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:$@\"a{{b}}c\":d0:b0 P:;:d0:b0",
+                "EveryCharacterOfALine_IsAccountedFor\u001f[A] void M() { }",
+                "EveryCharacterOfALine_IsAccountedFor\u001f#if DEBUG",
+                "EveryCharacterOfALine_IsAccountedFor\u001fchar c = '\\\\';",
+                "EveryCharacterOfALine_IsAccountedFor\u001ff(a => a.B<C>(1_000, 0xFF, 1.5e3));",
+                "EveryCharacterOfALine_IsAccountedFor\u001fint /**/ x;",
+                "EveryCharacterOfALine_IsAccountedFor\u001fint x; // c",
+                "EveryCharacterOfALine_IsAccountedFor\u001fvar s = \"unterminated",
+                "EveryCharacterOfALine_IsAccountedFor\u001fvar s = @\"a\"\"b\";",
+                "EveryCharacterOfALine_IsAccountedFor\u001fvar s = $\"a{b}c\";",
+                "EveryCharacterOfALine_IsAccountedFor\u001fvar s = $$\"\"\"a{{b}}c\"\"\";",
+                "EveryCharacterOfALine_IsAccountedFor\u001fvar v = @;",
+                "EveryCharacterOfALine_IsAccountedFor\u001fx = y is not null ? 1 : 2;",
+                "LiteralsWithoutEscapes_TreatABackslashAsContent\u001fvar s = \"\"\"{\\\"\"\"; int after = 1;\u001fW:var W:s P:= S:\"\"\"{\\\"\"\" P:; W:int W:after P:= W:1 P:;",
+                "LiteralsWithoutEscapes_TreatABackslashAsContent\u001fvar s = @\"{\\\"; int after = 1;\u001fW:var W:s P:= S:@\"{\\\" P:; W:int W:after P:= W:1 P:;",
+                "LiteralsWithoutEscapes_TreatABackslashAsContent\u001fvar s = $\"\"\"{b}\\\"\"\";\u001fW:var W:s P:= S:$\"\"\"{ W:b S:}\\\"\"\" P:;",
+                "QuoteInsideAComment_DoesNotOpenALiteral\u001f/* a \" quote */ int x;\u001fC:/* a \" quote */ W:int W:x P:;",
+                "QuoteInsideAComment_DoesNotOpenALiteral\u001f// a \" quote in a comment\u001fC:// a \" quote in a comment",
+                "VerbatimAndInterpolatedInEitherOrder_StillInterpolates\u001fvar s = @$\"a{b}c\";\u001fW:var W:s P:= S:@$\"a{ W:b S:}c\" P:;",
+                "VerbatimAndInterpolatedInEitherOrder_StillInterpolates\u001fvar s = $@\"a{b}c\";\u001fW:var W:s P:= S:$@\"a{ W:b S:}c\" P:;",
+            ],
+            pinned.Order());
 
         static IEnumerable<string> Flatten(CustomAttributeTypedArgument argument) =>
             argument.Value is IReadOnlyCollection<CustomAttributeTypedArgument> nested
@@ -945,8 +1014,8 @@ public class ScanTokenTests
     public void EscapedQuoteInsideALiteral_DoesNotCloseIt()
     {
         Assert.Equal(
-            "W:var W:s P:= S:\"a\\\"b\" P:; W:int W:y P:;",
-            Render("var s = \"a\\\"b\"; int y;"));
+            "W:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:\"a\\\"b\":d0:b0 P:;:d0:b0 W:int:d0:b0 W:y:d0:b0 P:;:d0:b0",
+            RenderState("var s = \"a\\\"b\"; int y;"));
     }
 
     /// <summary>

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -940,6 +940,15 @@ public class ScanTokenTests
 
         void Check(string[] content)
         {
+            var bare = BodySlicer.ScanTokens(content);
+
+            // Record after the scan, not before. The derivation pins below are only worth
+            // anything if they observe what the invariant actually ran on: recording first
+            // lets the scanned content be substituted afterwards while every pin still sees
+            // the canonical inputs, and measured, a carried-verbatim depth defect then
+            // survives (adversarial review, GPT). Recording here means a substitution before
+            // the scan is recorded too and fails the sequence pins, and one after the scan
+            // fails them without weakening the scan.
             if (singleSeen is not null && content.Length == 1)
                 singleSeen.Add(content[0]);
 
@@ -948,8 +957,6 @@ public class ScanTokenTests
 
             if (seedPairs is not null && content.Length == 2)
                 seedPairs.Add((content[0], content[1]));
-
-            var bare = BodySlicer.ScanTokens(content);
 
             foreach (var token in bare)
             {

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -680,9 +680,12 @@ public class ScanTokenTests
         // review, GPT).
         var scanned = new HashSet<string>();
         var rebuilt = new StringBuilder();
+        int scans = 0;
 
         foreach (var input in swept)
         {
+            scans++;
+
             var tokens = BodySlicer.ScanTokens([input]);
             string? gap = FindCoverageGap([input], tokens);
 
@@ -705,6 +708,24 @@ public class ScanTokenTests
         // sides are trimmed so the comparison is exact; nothing else about the input is discarded.
         Assert.Equal(swept.Select(x => x.TrimEnd()).ToHashSet().Order(), scanned.Order());
         AssertScannedAlphabet(" \"$@\\a{}", scanned);
+
+        // Both sides of that comparison derive from `swept`, so narrowing the collection after
+        // its count was asserted moves them together and leaves the alphabet intact. The number
+        // of scans actually performed is therefore pinned against a literal, which no narrowing
+        // of the collection can satisfy (adversarial review, GPT, generalising the same attack
+        // on the carried-literal sweep).
+        Assert.Equal(299_592, scans);
+
+        // A count is still only a margin: the collection could be exchanged for another of the
+        // same size that keeps one backslash to satisfy the alphabet and drops the rest. So the
+        // scanned set is characterised exactly, from literals. Trailing spaces are the one
+        // ambiguity, so the characterisation is of the TRIMMED images: a trimmed string of
+        // length L in 1..6 is any string of that length not ending in a space, of which there
+        // are exactly 7 x 8^(L-1), and the all-space inputs collapse to the single empty string.
+        // Observing that many DISTINCT images at each length is observing all of them.
+        Assert.Equal(
+            new[] { (0, 1), (1, 7), (2, 56), (3, 448), (4, 3_584), (5, 28_672), (6, 229_376) },
+            scanned.GroupBy(x => x.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));
     }
 
     /// <summary>
@@ -819,7 +840,28 @@ public class ScanTokenTests
         Assert.Equal(
             (from opener in openers from tail in tails select (opener, tail)).Order(),
             scannedPairs.Order());
-        AssertScannedAlphabet("\"$\\{}a", scannedPairs.Select(p => p.Tail));
+
+        // That comparison alone is not enough, because its expected side derives from `tails`
+        // and therefore moves with any narrowing applied to it: filtering the tails beginning
+        // with a single `{` out of the collection after its count was asserted left the count,
+        // the alphabet and the cross product all satisfied, while the short-brace branch was
+        // never reached and 1349 survived (adversarial review, GPT). So the scanned set is
+        // characterised below from LITERALS only.
+        //
+        // The characterisation is exact rather than marginal. Over an alphabet of exactly six
+        // characters there are only 6, 36 and 216 distinct strings of length 1, 2 and 3, so
+        // observing that many DISTINCT tails at each length is observing all of them, and no
+        // other length occurs. With seven openers observed and 7 x 258 distinct pairs, there is
+        // no room for a pair to be missing.
+        var scannedTails = scannedPairs.Select(p => p.Tail).ToHashSet();
+        AssertScannedAlphabet("\"$\\{}a", scannedTails);
+        Assert.Equal(
+            new[] { (1, 6), (2, 36), (3, 216) },
+            scannedTails.GroupBy(t => t.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));
+        Assert.Equal(
+            new[] { "@\"", "$@\"", "\"\"\"", "$\"\"\"", "$$\"\"\"", "\"", "$\"" }.Order(),
+            scannedPairs.Select(p => p.Opener).ToHashSet().Order());
+        Assert.Equal(7 * 258, scannedPairs.Count);
     }
 
     /// <summary>
@@ -848,7 +890,9 @@ public class ScanTokenTests
         var swept = AllStringsOver(Alphabet, 4);
         Assert.Equal(9 + 81 + 729 + 6561, swept.Count);
 
-        int known = 0, unknown = 0, inputsWithUnknown = 0;
+        int known = 0, unknown = 0, inputsWithUnknown = 0, scans = 0;
+        var scanned = new HashSet<string>();
+        var rebuilt = new StringBuilder();
 
         foreach (var input in swept)
         {
@@ -857,10 +901,40 @@ public class ScanTokenTests
 
             unknown += lost;
             known += tokens.Count - lost;
+            scans++;
 
             if (lost > 0)
                 inputsWithUnknown++;
+
+            rebuilt.Clear();
+
+            foreach (var token in tokens)
+            {
+                rebuilt.Append(' ', token.Column - rebuilt.Length);
+                rebuilt.Append(token.TextIn(input));
+            }
+
+            scanned.Add(rebuilt.ToString());
         }
+
+        // Three integer totals are MARGINS. Nothing above stops the collection being exchanged
+        // for a different one of the same size whose totals happen to balance — a set that omits
+        // `\` entirely, say, padded back to the same totals by strings that lose track the same
+        // way, which would erase the escape paths from the sweep while every number held
+        // (adversarial review, Gemini). So the input is characterised here from LITERALS, read
+        // back out of the scanner's own output rather than from the collection.
+        //
+        // The characterisation is exact rather than marginal, by the same counting argument the
+        // carried-literal sweep uses: over an alphabet of exactly nine characters there are only
+        // 9, 81, 729 and 6561 distinct strings of length 1 to 4, so observing that many DISTINCT
+        // inputs at each length is observing all of them, and no other length occurs. This
+        // alphabet contains no whitespace, so laying each token down at its column reconstructs
+        // the input exactly and no trimming is needed on either side.
+        AssertScannedAlphabet("\"$*/@\\a{}", scanned);
+        Assert.Equal(
+            new[] { (1, 9), (2, 81), (3, 729), (4, 6561) },
+            scanned.GroupBy(x => x.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));
+        Assert.Equal(9 + 81 + 729 + 6561, scans);
 
         // Both readings are pinned, so the field cannot be moved in either direction: pinning
         // only the unknown tokens would let every token become knowable, and pinning only the

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -681,23 +681,29 @@ public class ScanTokenTests
         var scanned = new HashSet<string>();
         var rebuilt = new StringBuilder();
         int scans = 0;
+        var scannedInputs = new HashSet<string>();
 
         foreach (var input in swept)
         {
             scans++;
 
-            var tokens = BodySlicer.ScanTokens([input]);
-            string? gap = FindCoverageGap([input], tokens);
+            // One array, built here and handed to the scanner, read back for the length below
+            // and used for the coverage check. There is no second copy for a recording to be
+            // pointed at while the scanner is given something else.
+            var lines = new[] { input };
+            var tokens = BodySlicer.ScanTokens(lines);
+            string? gap = FindCoverageGap(lines, tokens);
 
             if (gap is not null)
-                Assert.Fail($"input \"{input}\": {gap}");
+                Assert.Fail($"input \"{lines[0]}\": {gap}");
 
+            scannedInputs.Add(lines[0]);
             rebuilt.Clear();
 
             foreach (var token in tokens)
             {
                 rebuilt.Append(' ', token.Column - rebuilt.Length);
-                rebuilt.Append(token.TextIn(input));
+                rebuilt.Append(token.TextIn(lines[0]));
             }
 
             scanned.Add(rebuilt.ToString().TrimEnd());
@@ -726,6 +732,21 @@ public class ScanTokenTests
         Assert.Equal(
             new[] { (0, 1), (1, 7), (2, 56), (3, 448), (4, 3_584), (5, 28_672), (6, 229_376) },
             scanned.GroupBy(x => x.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));
+
+        // That vector characterises the TRIMMED images, which is not the same as characterising
+        // what the scanner consumed: appending spaces to every input ending in `\` leaves every
+        // image, every count and the alphabet untouched, while removing long lines that end in a
+        // backslash from the sweep entirely and letting an unclamped escape length through at
+        // 1377 (adversarial review, GPT). The lengths actually handed to the scanner are
+        // therefore characterised too, from the same array the scan consumed. Counting DISTINCT
+        // inputs rather than scans matters: a multiplicity vector is satisfied by scanning one
+        // string eight times. With the alphabet pinned to exactly eight characters there are only
+        // 8^L distinct strings of length L, so observing that many is observing all of them and
+        // nothing about the input is left unpinned.
+        AssertScannedAlphabet(" \"$@\\a{}", scannedInputs);
+        Assert.Equal(
+            new[] { (1, 8), (2, 64), (3, 512), (4, 4_096), (5, 32_768), (6, 262_144) },
+            scannedInputs.GroupBy(x => x.Length).OrderBy(g => g.Key).Select(g => (g.Key, g.Count())));
     }
 
     /// <summary>

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1085,22 +1085,23 @@ public class ScanTokenTests
 
         // Four raw seeds can be four *non-interpolated* raw seeds, which would erase the
         // dollar-run ladder: the scanner tracks how many braces open a hole (`frame.DollarRun`),
-        // and only `$"""`, `$$"""` and `$$$""""` exercise runs of one, two and three. Pin the
-        // ladder by the run each seed actually needs, so the three cannot collapse onto one run
-        // or drop out of the seeds entirely.
+        // and only `$"""`, `$$"""` and `$$$""""` exercise runs of one, two and three. The same
+        // argument applies to the quote run a raw literal needs in order to close
+        // (`frame.QuoteRun`): the four raw seeds can all be spelled with runs of five, seven,
+        // nine and eleven, leaving no carried frame with a run of three.
+        //
+        // Pin the two together rather than one at a time. Separate distributions pin only the
+        // marginals, and the pairing is free between them: exchanging `$$"""` for `$$""""` and
+        // `$$$""""` for `$$$"""b` holds both marginals while the carried combination of dollar
+        // run three with quote run four disappears, after which a wrong depth on exactly that
+        // frame survives (adversarial review, GPT). The joint multiset implies both marginals,
+        // so it replaces them rather than joining them.
         int MinBraceRun(string opener) =>
             CodeOnSecondLine(opener, "{a}") ? 1
             : CodeOnSecondLine(opener, "{{a}}") ? 2
             : CodeOnSecondLine(opener, "{{{a}}}") ? 3
             : 0;
 
-        Assert.Equal([0, 0, 0, 0, 1, 1, 1, 2, 3], openers.Select(MinBraceRun).Order());
-
-        // The same argument applies to the quote run a raw literal needs in order to close
-        // (`frame.QuoteRun`): four raw seeds can all be spelled with runs of five, seven, nine
-        // and eleven, satisfying every pin above while leaving no carried frame with a run of
-        // three (adversarial review, GPT). Pin the closing run each seed actually needs, for the
-        // same reason and in the same way as the brace run.
         int MinCloseRun(string opener)
         {
             for (int run = 1; run <= 5; run++)
@@ -1112,7 +1113,9 @@ public class ScanTokenTests
             return 0;
         }
 
-        Assert.Equal([0, 1, 1, 1, 1, 3, 3, 3, 4], openers.Select(MinCloseRun).Order());
+        Assert.Equal(
+            [(0, 0), (0, 1), (0, 1), (0, 3), (1, 1), (1, 1), (1, 3), (2, 3), (3, 4)],
+            openers.Select(o => (Brace: MinBraceRun(o), Close: MinCloseRun(o))).Order());
 
         // Those properties still describe the seeds rather than name them, and a seed can be
         // exchanged for another of the same kind and length -- `$@"` for `@$"` -- without

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -24,6 +24,23 @@ public class ScanTokenTests
         return string.Join(' ', tokens.Select(t => $"{Code(t.Kind)}:{t.TextIn(lines[t.Line])}"));
     }
 
+    /// <summary>
+    /// Renders the token stream as <see cref="Render"/> does, with the three state fields each
+    /// token carries appended: structural depth, bracket depth, and a trailing "?" when the
+    /// scanner has lost its place and the depth is meaningless.
+    /// <para>
+    /// <see cref="Render"/> shows only kind and text, which is why every rule that governs these
+    /// three fields alone went ungated: a mutation could corrupt the depth of every token on a
+    /// line and no assertion in this file could see it (adversarial review, GPT).
+    /// </para>
+    /// </summary>
+    private static string RenderState(params string[] lines)
+    {
+        var tokens = BodySlicer.ScanTokens(lines);
+        return string.Join(' ', tokens.Select(t =>
+            $"{Code(t.Kind)}:{t.TextIn(lines[t.Line])}:d{t.Depth}:b{t.BracketDepth}{(t.DepthKnown ? "" : "?")}"));
+    }
+
     private static char Code(ScanTokenKind kind) => kind switch
     {
         ScanTokenKind.Word => 'W',
@@ -692,4 +709,140 @@ public class ScanTokenTests
 
         return [.. paths.OrderBy(p => p, StringComparer.Ordinal)];
     }
+
+    /// <summary>
+    /// A block comment closes on "*/" and on nothing else. Each of the three parts of that test
+    /// -- the "*", the bounds check, and the "/" -- was separately droppable with a green suite
+    /// (adversarial review, GPT), so each gets an input that only it rejects.
+    /// </summary>
+    [Fact]
+    public void BlockComment_DoesNotCloseOnASlashThatNoAsteriskPrecedes()
+    {
+        Assert.Equal(
+            "W:int W:x P:; C:/* a/b */ W:int W:y P:;",
+            Render("int x; /* a/b */ int y;"));
+    }
+
+    [Fact]
+    public void BlockComment_DoesNotCloseOnAnAsteriskThatNoSlashFollows()
+    {
+        Assert.Equal(
+            "W:int W:x P:; C:/* a*x */ W:int W:y P:;",
+            Render("int x; /* a*x */ int y;"));
+    }
+
+    /// <summary>
+    /// The bounds half of the same test. A line inside a block comment that ends in "*" has no
+    /// character after it to read, and reading one throws rather than misclassifying.
+    /// </summary>
+    [Fact]
+    public void BlockCommentLineEndingInAnAsterisk_DoesNotReadPastTheLine()
+    {
+        Assert.Equal(
+            "C:/* a C:b* C:c */ W:int W:y P:;",
+            Render("/* a", "b*", "c */ int y;"));
+    }
+
+    /// <summary>
+    /// "#if" makes the structural depth unknowable, because the braces below it may belong to a
+    /// branch the compiler discards. "#ifdef" is not a C# directive and names no branch, so
+    /// matching it as a conditional would discard the depth for every token that follows.
+    /// </summary>
+    [Fact]
+    public void DirectiveWhoseNameOnlyStartsWithAConditional_KeepsTheDepthKnown()
+    {
+        Assert.Equal(
+            "D:#ifdef X:d0:b0 W:int:d0:b0 W:x:d0:b0 P:;:d0:b0",
+            RenderState("#ifdef X", "int x;"));
+
+        // The close negative: the real directive must still give the depth up.
+        Assert.Equal(
+            "D:#if X:d0:b0? W:int:d0:b0? W:x:d0:b0? P:;:d0:b0?",
+            RenderState("#if X", "int x;"));
+    }
+
+    /// <summary>
+    /// A hole opens on "{". A "}" in literal text closes nothing -- the hole is closed from
+    /// inside it -- so it is content, and the text after it is still the literal's.
+    /// </summary>
+    [Fact]
+    public void ClosingBraceInAnInterpolatedLiteral_IsContentNotAHoleOpener()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:$\"}x\" P:;",
+            Render("var s = $\"}x\";"));
+    }
+
+    /// <summary>
+    /// The escaped quote is the reason the plain-content run stops at a backslash at all. Losing
+    /// that stop closes the literal early and reports its remaining text as code.
+    /// </summary>
+    [Fact]
+    public void EscapedQuoteInsideALiteral_DoesNotCloseIt()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:\"a\\\"b\" P:; W:int W:y P:;",
+            Render("var s = \"a\\\"b\"; int y;"));
+    }
+
+    /// <summary>
+    /// An unterminated character literal runs to the end of the line and stops there. Scanning
+    /// for its closing quote without a bounds check reads past the line instead of ending.
+    /// </summary>
+    [Fact]
+    public void UnterminatedCharLiteral_DoesNotReadPastTheLine()
+    {
+        Assert.Equal("W:char W:c P:= H:'x", Render("char c = 'x"));
+    }
+
+    /// <summary>
+    /// Bracket depth is how an attribute list spanning lines is told from the code around it, so
+    /// a bracket that belongs to an expression inside an interpolation hole must not move it.
+    /// </summary>
+    [Fact]
+    public void BracketInsideAnInterpolationHole_DoesNotMoveTheOuterBracketDepth()
+    {
+        Assert.Equal(
+            "P:[:d0:b0 W:A:d0:b1 P:(:d0:b1 S:$\"{:d0:b1 W:xs:d0:b1 P:[:d0:b1 W:i:d0:b1 " +
+            "P:]:d0:b1 S:}\":d0:b1 P:):d0:b1 P:]:d0:b1 W:int:d0:b0 W:f:d0:b0 P:;:d0:b0",
+            RenderState("[A($\"{xs[i]}\")] int f;"));
+    }
+
+    /// <summary>
+    /// A slice can begin below the "[" that opened a list. The unmatched "]" that follows must
+    /// leave the depth at zero rather than drive it negative, which would read as "inside a
+    /// list" to every predicate that asks.
+    /// </summary>
+    [Fact]
+    public void ClosingBracketWithoutAnOpener_DoesNotDriveTheBracketDepthNegative()
+    {
+        Assert.Equal("P:]:d0:b0 W:x:d0:b0", RenderState("] x"));
+    }
+
+    /// <summary>
+    /// A verbatim literal spans lines by design, so carrying one is not losing the place. Only a
+    /// literal that cannot span a line -- an unterminated single-quoted one -- is.
+    /// </summary>
+    [Fact]
+    public void MultilineVerbatimLiteral_KeepsTheDepthKnown()
+    {
+        Assert.Equal(
+            "W:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:@\"a:d0:b0 S:b\":d0:b0 P:;:d0:b0 " +
+            "W:int:d0:b0 W:y:d0:b0 P:;:d0:b0",
+            RenderState("var s = @\"a", "b\"; int y;"));
+    }
+
+    /// <summary>
+    /// A hole closes on the brace that matches its opener, not on the first "}" inside it. An
+    /// object initializer in a hole spells braces of its own, and closing on those turns the
+    /// rest of the expression into literal text.
+    /// </summary>
+    [Fact]
+    public void BracesInsideAHole_DoNotCloseTheInterpolation()
+    {
+        Assert.Equal(
+            "W:var W:s P:= S:$\"{ W:new P:{ W:X P:= W:1 P:} S:}\" P:; W:int W:y P:;",
+            Render("var s = $\"{new { X = 1 }}\"; int y;"));
+    }
+
 }

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -377,6 +377,104 @@ public class ScanTokenTests
     }
 
     /// <summary>
+    /// Gates the rule that a raw literal has no escape sequences — a backslash in one is ordinary
+    /// content, and in particular cannot consume the quote that closes the literal.
+    ///
+    /// The backslash has to sit at the start of a scan step for the escape branch to be consulted
+    /// at all: the plain-content run stops only at <c>{</c>, <c>}</c>, <c>"</c>, and (outside a
+    /// raw or verbatim literal) a backslash, so a backslash following ordinary text is swallowed
+    /// by the run before the branch is reached. Putting it directly after a brace is what makes
+    /// the rule observable. Without that placement the mutation that drops <c>!frame.Raw</c>
+    /// changes nothing, which is why the corpus and every other test miss it; with it, the
+    /// literal swallows its own closing delimiter and the entire rest of the line.
+    /// </summary>
+    [Fact]
+    public void RawLiteral_TreatsABackslashAsContent_NotAnEscape()
+    {
+        Assert.Equal(
+            """"W:var W:s P:= S:"""{\""" P:; W:int W:after P:= W:1 P:;"""",
+            Render(""""var s = """{\"""; int after = 1;""""));
+
+        Assert.Equal(
+            """"W:var W:s P:= S:$"""{ W:b S:}\""" P:;"""",
+            Render(""""var s = $"""{b}\""";""""));
+    }
+
+    /// <summary>
+    /// Gates the column half of the adjacency rule. Two literal fragments can sit on one line
+    /// with a gap between them when a hole's code is separated from its braces by whitespace:
+    /// <c>$"{  "x"}"</c> emits <c>$"{</c>, then two skipped spaces, then <c>"x"}"</c>. Fusing
+    /// those would produce a token whose length spans the gap but stops short of where the
+    /// second fragment actually ends, leaving that fragment's last characters covered by nothing.
+    ///
+    /// This is the shape the sibling cross-line test cannot reach, because there the two
+    /// fragments are on different lines. Both guards need their own gate.
+    /// </summary>
+    [Fact]
+    public void LiteralFragments_DoNotCoalesceAcrossAGapOnTheSameLine()
+    {
+        var lines = new[] { "var s = $\"{  \"x\"}\";" };
+
+        var literals = BodySlicer.ScanTokens(lines)
+            .Where(t => t.Kind == ScanTokenKind.StringLiteral)
+            .Select(t => (t.Column, t.Length))
+            .ToList();
+
+        Assert.Equal([(8, 3), (13, 5)], literals);
+    }
+
+    /// <summary>
+    /// Runs the coverage invariant over every string up to six characters long drawn from the
+    /// alphabet that actually drives the literal state machine — <c>$ " { } \</c>, a space, and
+    /// one ordinary character. The authored corpus is large but it is well-formed C#; it contains
+    /// almost none of the delimiter soup that distinguishes the raw, verbatim, and interpolated
+    /// rules from one another. This covers that space exhaustively rather than by example.
+    ///
+    /// The space is load-bearing, not filler: it is what lets two tokens on one line be separated
+    /// by a gap, which is the only situation in which the column half of the coalescing rule
+    /// decides anything.
+    ///
+    /// The claim is the coverage invariant, not a token shape: whatever the scan decides these
+    /// strings mean, every non-whitespace character is inside exactly one token and no token runs
+    /// off its line. That is weaker than pinning output, but it holds for inputs no one wrote down,
+    /// and it is an oracle rather than a re-implementation.
+    /// </summary>
+    [Fact]
+    public void EveryStringOverTheDelimiterAlphabet_IsFullyCovered()
+    {
+        char[] alphabet = ['$', '"', '{', '}', '\\', ' ', 'a'];
+        var buffer = new char[6];
+        int checkedCount = 0;
+
+        void Walk(int at, int length)
+        {
+            if (at == length)
+            {
+                var lines = new[] { new string(buffer, 0, length) };
+                string? gap = FindCoverageGap(lines, BodySlicer.ScanTokens(lines));
+                checkedCount++;
+
+                if (gap is not null)
+                    Assert.Fail($"input \"{lines[0]}\": {gap}");
+
+                return;
+            }
+
+            foreach (char c in alphabet)
+            {
+                buffer[at] = c;
+                Walk(at + 1, length);
+            }
+        }
+
+        for (int length = 1; length <= buffer.Length; length++)
+            Walk(0, length);
+
+        // Pins the size of the space so a later edit cannot quietly shrink it to nothing.
+        Assert.Equal(137_256, checkedCount);
+    }
+
+    /// <summary>
     /// Gates both guards on the rule that coalesces literal fragments. Fragments fuse when they
     /// touch, and "touch" has to mean same line and touching columns: a literal token carries a
     /// single <see cref="ScanToken.Line"/>, so fusing across a line break would produce one token

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -932,12 +932,24 @@ public class ScanTokenTests
         int checked_ = 0;
         HashSet<(string First, string Second)>? seedPairs = null;
 
+        var kindsReached = new HashSet<ScanTokenKind>();
+        int deepest = 0;
+        int shallowest = 0;
+
         void Check(string[] content)
         {
             if (seedPairs is not null && content.Length == 2)
                 seedPairs.Add((content[0], content[1]));
 
             var bare = BodySlicer.ScanTokens(content);
+
+            foreach (var token in bare)
+            {
+                kindsReached.Add(token.Kind);
+                deepest = Math.Max(deepest, token.Depth);
+                shallowest = Math.Min(shallowest, token.Depth);
+            }
+
 
             string[] wrapped = ["{", "[", .. content];
             var enclosed = BodySlicer.ScanTokens(wrapped).Where(t => t.Line >= 2).ToList();
@@ -1051,6 +1063,22 @@ public class ScanTokenTests
 
         Assert.Equal(9 * 12 * 132, expected.Count);
         Assert.Equal(expected, seedPairs);
+
+        // A single product pins only the product: 12 tails against 132 seconds and 1,584 tails
+        // against 1 second are the same number and not the same test (adversarial review, GPT).
+        // Pin each dimension, so one cannot be spent to buy another.
+        Assert.Equal(9, openers.Length);
+        Assert.Equal(12, tails.Count);
+        Assert.Equal(132, seconds.Count);
+
+        // Every count above can be met by an alphabet that spells nothing: replacing `{` with a
+        // letter keeps all three dimensions and the pinned total while deleting the only input
+        // that opens a block, and with it the depth movement this whole test is about
+        // (adversarial review, GPT). Pin what the alphabet must reach rather than which
+        // characters spell it, so the demand is on the coverage and not on the notation.
+        Assert.Equal(Enum.GetValues<ScanTokenKind>().ToHashSet(), kindsReached);
+        Assert.True(deepest > 0, "no input opened a block, so no token was ever scanned inside one");
+        Assert.True(shallowest < 0, "no input closed an unopened block, so depth never went below its start");
     }
 
 

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -376,6 +376,36 @@ public class ScanTokenTests
         Assert.NotNull(FindCoverageGap(lines, damaged));
     }
 
+    /// <summary>
+    /// Gates both guards on the rule that coalesces literal fragments. Fragments fuse when they
+    /// touch, and "touch" has to mean same line and touching columns: a literal token carries a
+    /// single <see cref="ScanToken.Line"/>, so fusing across a line break would produce one token
+    /// claiming a span that runs off the end of the earlier line.
+    ///
+    /// The columns here are aligned deliberately — the second line's literal opens at exactly the
+    /// column where the first line's literal ended. That is the only shape in which the column
+    /// test alone would say yes, so it is the only shape that can tell whether the line test is
+    /// doing anything. The first line opens with the literal so that the stream's very first
+    /// token is one, which is the only shape that reaches the emptiness guard before it. The
+    /// corpus contains neither; without this test both guards are unverified, and removing either
+    /// one leaves every other test passing.
+    /// </summary>
+    [Fact]
+    public void LiteralFragments_DoNotCoalesceAcrossALineBreak()
+    {
+        //                  columns 0..11 ─┐
+        var lines = new[] { "\"xyzzyxyzzy\"", "            \"ab\"" };
+        //                    column 12 ────┘  (== the first literal's end column)
+
+        var literals = BodySlicer.ScanTokens(lines)
+            .Where(t => t.Kind == ScanTokenKind.StringLiteral)
+            .ToList();
+
+        Assert.Equal(
+            [(0, 0, 12), (1, 12, 4)],
+            literals.Select(t => (t.Line, t.Column, t.Length)));
+    }
+
     [Theory]
     [InlineData("int x; // c")]
     [InlineData("var s = $\"a{b}c\";")]

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1081,7 +1081,7 @@ public class ScanTokenTests
         bool CodeOnSecondLine(string opener, string second) =>
             BodySlicer.ScanTokens([opener, second]).Any(t => t.Line == 1 && t.Kind is ScanTokenKind.Word);
 
-        Assert.Equal(1, openers.Count(o => CodeOnSecondLine(o, "\\\"a") && CodeOnSecondLine(o, "{a}")));
+        bool Verbatim(string opener) => CodeOnSecondLine(opener, "\\\"a");
 
         // Four raw seeds can be four *non-interpolated* raw seeds, which would erase the
         // dollar-run ladder: the scanner tracks how many braces open a hole (`frame.DollarRun`),
@@ -1096,6 +1096,13 @@ public class ScanTokenTests
         // run three with quote run four disappears, after which a wrong depth on exactly that
         // frame survives (adversarial review, GPT). The joint multiset implies both marginals,
         // so it replaces them rather than joining them.
+        //
+        // Verbatim belongs in the same tuple for the same reason. Pinning only how many seeds
+        // are verbatim *and* interpolated leaves the non-interpolated verbatim frame free: `@"`
+        // can be exchanged for an ordinary carrier while `$@"` keeps that count at one, and
+        // measured, a wrong depth guarded on `frame.Verbatim && frame.DollarRun == 0` at
+        // BodySlicer.cs:1431 then survives (adversarial review, GPT). Pinning the three
+        // together is what stops the state from being traded away one projection at a time.
         int MinBraceRun(string opener) =>
             CodeOnSecondLine(opener, "{a}") ? 1
             : CodeOnSecondLine(opener, "{{a}}") ? 2
@@ -1114,8 +1121,9 @@ public class ScanTokenTests
         }
 
         Assert.Equal(
-            [(0, 0), (0, 1), (0, 1), (0, 3), (1, 1), (1, 1), (1, 3), (2, 3), (3, 4)],
-            openers.Select(o => (Brace: MinBraceRun(o), Close: MinCloseRun(o))).Order());
+            [(false, 0, 0), (false, 0, 1), (false, 0, 3), (false, 1, 1), (false, 1, 3),
+             (false, 2, 3), (false, 3, 4), (true, 0, 1), (true, 1, 1)],
+            openers.Select(o => (Verbatim(o), MinBraceRun(o), MinCloseRun(o))).Order());
 
         // Those properties still describe the seeds rather than name them, and a seed can be
         // exchanged for another of the same kind and length -- `$@"` for `@$"` -- without

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/ScanTokenTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using ILInspector.Metadata;
 
 namespace DotnetInspector.CSharpBodySlicer.Tests;
@@ -122,8 +123,8 @@ public class ScanTokenTests
     public void SingleBraceInDoubleDollarLiteral_IsContent()
     {
         Assert.Equal(
-            "W:var W:s P:= S:$$\"\"\"x{y}z\"\"\" P:;",
-            Render("var s = $$\"\"\"x{y}z\"\"\";"));
+            "W:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:$$\"\"\"x{y}z\"\"\":d0:b0 P:;:d0:b0",
+            RenderState("var s = $$\"\"\"x{y}z\"\"\";"));
     }
 
     [Fact]
@@ -193,20 +194,20 @@ public class ScanTokenTests
     /// exchanged for a second verbatim spelling with the expectation following it.
     /// </remarks>
     [Theory]
-    [InlineData("var s = $\"a{{b}}c\";", "W:var W:s P:= S:$\"a{{b}}c\" P:;")]
-    [InlineData("var s = $@\"a{{b}}c\";", "W:var W:s P:= S:$@\"a{{b}}c\" P:;")]
-    [InlineData("var s = @$\"a{{b}}c\";", "W:var W:s P:= S:@$\"a{{b}}c\" P:;")]
+    [InlineData("var s = $\"a{{b}}c\";", "W:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:$\"a{{b}}c\":d0:b0 P:;:d0:b0")]
+    [InlineData("var s = $@\"a{{b}}c\";", "W:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:$@\"a{{b}}c\":d0:b0 P:;:d0:b0")]
+    [InlineData("var s = @$\"a{{b}}c\";", "W:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:@$\"a{{b}}c\":d0:b0 P:;:d0:b0")]
     public void EscapedBraceRunInAnInterpolatedLiteral_StaysStringContent(string line, string expected)
     {
-        Assert.Equal(expected, Render(line));
+        Assert.Equal(expected, RenderState(line));
     }
 
     [Fact]
     public void QuoteRunShorterThanTheDelimiter_IsRawLiteralContent()
     {
         Assert.Equal(
-            "W:var W:s P:= S:\"\"\"\"a \"\"\" b\"\"\"\" P:;",
-            Render("var s = \"\"\"\"a \"\"\" b\"\"\"\";"));
+            "W:var:d0:b0 W:s:d0:b0 P:=:d0:b0 S:\"\"\"\"a \"\"\" b\"\"\"\":d0:b0 P:;:d0:b0",
+            RenderState("var s = \"\"\"\"a \"\"\" b\"\"\"\";"));
     }
 
     [Fact]
@@ -560,6 +561,7 @@ public class ScanTokenTests
     {
         char[] alphabet = ['$', '@', '"', '{', '}', '\\', ' ', 'a'];
         var buffer = new char[6];
+        var sweptChars = new HashSet<char>();
         int checkedCount = 0;
 
         void Walk(int at, int length)
@@ -569,6 +571,9 @@ public class ScanTokenTests
                 var lines = new[] { new string(buffer, 0, length) };
                 string? gap = FindCoverageGap(lines, BodySlicer.ScanTokens(lines));
                 checkedCount++;
+
+                foreach (char swept in lines[0])
+                    sweptChars.Add(swept);
 
                 if (gap is not null)
                     Assert.Fail($"input \"{lines[0]}\": {gap}");
@@ -588,6 +593,80 @@ public class ScanTokenTests
 
         // Pins the size of the space so a later edit cannot quietly shrink it to nothing.
         Assert.Equal(299_592, checkedCount);
+
+        // Size is not content. Every count above survives exchanging `\` for an ordinary letter,
+        // which keeps all 299,592 cases and drops every terminal-escape path: measured, that
+        // weakening leaves the suite green while a defect that reads past the end of a literal
+        // ending in a backslash survives (adversarial review, GPT). Pin the alphabet by value,
+        // and by the value the scanner actually received rather than the one declared above, so
+        // that a substitution between the declaration and the sweep is visible too.
+        Assert.Equal(" \"$@\\a{}", string.Concat(sweptChars.Order()));
+    }
+
+    /// <summary>
+    /// Pins how often the scanner reports the depth as unknowable, and how often it does not.
+    /// <para>
+    /// Every other assertion on this field is either a rule about one shape — a conditional
+    /// directive, an unterminated literal — or the differential invariant, which compares the
+    /// bare scan against the enclosed one and therefore reads this field only *relatively*. A
+    /// defect that flips <see cref="ScanToken.DepthKnown"/> on both sides at once satisfies it
+    /// by construction: <c>!true == !true</c>. Measured, that left the field unpinned at seven
+    /// emission sites, where a token could claim its depth was meaningless — or claim a
+    /// meaningless depth was real — with the whole suite green (adversarial review, Gemini).
+    /// </para>
+    /// <para>
+    /// A count is not a shape, and this is not trying to be one; the shapes are gated by the
+    /// named rules above. What no rule above supplies is an *absolute* reading of the field over
+    /// a space large enough to reach every site that emits it, which is what this pins.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void UnknowableDepth_IsCarriedByExactlyTheTokensTheScannerCouldNotPlace()
+    {
+        char[] alphabet = ['$', '@', '"', '{', '}', '\\', '/', '*', 'a'];
+        var buffer = new char[4];
+        var sweptChars = new HashSet<char>();
+        int known = 0, unknown = 0, inputsWithUnknown = 0, inputs = 0;
+
+        void Walk(int at, int length)
+        {
+            if (at == length)
+            {
+                var lines = new[] { new string(buffer, 0, length) };
+                var tokens = BodySlicer.ScanTokens(lines);
+                inputs++;
+
+                foreach (char swept in lines[0])
+                    sweptChars.Add(swept);
+
+                int lost = tokens.Count(t => !t.DepthKnown);
+                unknown += lost;
+                known += tokens.Count - lost;
+
+                if (lost > 0)
+                    inputsWithUnknown++;
+
+                return;
+            }
+
+            foreach (char c in alphabet)
+            {
+                buffer[at] = c;
+                Walk(at + 1, length);
+            }
+        }
+
+        for (int length = 1; length <= buffer.Length; length++)
+            Walk(0, length);
+
+        // Both readings are pinned, so the field cannot be moved in either direction: pinning
+        // only the unknown tokens would let every token become knowable, and pinning only the
+        // known ones would let every token lose its place.
+        Assert.Equal(9 + 81 + 729 + 6561, inputs);
+        Assert.Equal("\"$*/@\\a{}", string.Concat(sweptChars.Order()));
+        Assert.Equal(17_602, known);
+        Assert.Equal(4_452, unknown);
+        Assert.Equal(1_996, inputsWithUnknown);
     }
 
     /// <summary>
@@ -640,12 +719,67 @@ public class ScanTokenTests
     }
 
     /// <summary>
+    /// Gates every <c>[Theory]</c> in this file against having a row exchanged for a copy of one
+    /// of its siblings.
+    /// <para>
+    /// xUnit counts rows, not distinct rows, so replacing one <c>[InlineData]</c> with a
+    /// duplicate of another leaves the reported test count unchanged and every assertion
+    /// passing while the case that row existed for is no longer scanned. Measured, substituting
+    /// the two raw-literal rows of
+    /// <see cref="LiteralsWithoutEscapes_TreatABackslashAsContent"/> with copies of its verbatim
+    /// row kept the suite green at the same count while a defect that treats a backslash as an
+    /// escape inside a raw literal — swallowing the quote that would close it — survived
+    /// (adversarial review, Gemini).
+    /// </para>
+    /// <para>
+    /// This is checked here rather than by splitting that one theory into facts, because the
+    /// weakness belongs to the shape and not to the theory that happened to expose it: any
+    /// theory in this file, including ones not yet written, is open to the same substitution.
+    /// The totals are pinned so the gate cannot go quiet by finding nothing to check.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryTheoryRow_DiffersFromItsSiblings()
+    {
+        int theories = 0, rows = 0;
+
+        foreach (var method in typeof(ScanTokenTests).GetMethods().OrderBy(m => m.Name))
+        {
+            var data = CustomAttributeData.GetCustomAttributes(method)
+                .Where(a => a.AttributeType.Name == "InlineDataAttribute")
+                .Select(a => string.Join(
+                    '\u001f',
+                    a.ConstructorArguments.SelectMany(Flatten)))
+                .ToList();
+
+            if (data.Count == 0)
+                continue;
+
+            theories++;
+            rows += data.Count;
+
+            Assert.Equal(
+                (method.Name, data.Count),
+                (method.Name, data.Distinct().Count()));
+        }
+
+        Assert.Equal(6, theories);
+        Assert.Equal(24, rows);
+
+        static IEnumerable<string> Flatten(CustomAttributeTypedArgument argument) =>
+            argument.Value is IReadOnlyCollection<CustomAttributeTypedArgument> nested
+                ? nested.SelectMany(Flatten)
+                : [argument.Value?.ToString() ?? "\u0000"];
+    }
+
+    /// <summary>
     /// The same invariant over real source: every C# file the corpus assemblies' PDBs point at.
     /// Hand-written cases cover the constructs someone thought of, and this covers the ones they
     /// did not.
     /// </summary>
     [Fact]
     public void EveryCharacterOfTheCorpus_IsAccountedFor()
+
     {
         var files = CorpusSourceFiles();
 
@@ -1190,15 +1324,29 @@ public class ScanTokenTests
         Walk(new char[1], 0, 1, tails.Add);
 
         seedPairs = [];
+        var seededOpeners = new List<string>();
 
         foreach (var opener in openers)
         {
+            seededOpeners.Add(opener);
+
             foreach (var tail in tails)
             {
                 foreach (var second in seconds)
                     Check([opener + tail, second]);
             }
         }
+
+        // The list is pinned by value from what the loop above actually seeded, not from the
+        // array as it stood when the properties were computed. Every assertion on `openers` runs
+        // before this loop, so assigning `openers[3] = "\"bbb"` in between satisfies all of them
+        // and still drops the carried verbatim-interpolated seed, leaving the suite green while
+        // a depth defect on that path survives (adversarial review, GPT). This is the same shape
+        // as `Check` recording its input before scanning it: a pin that observes the intended
+        // value rather than the consumed one pins nothing about what ran.
+        Assert.Equal(
+            ["\"", "@\"", "$\"", "$@\"", "\"\"\"", "$\"\"\"", "$$\"\"\"", "$$$\"\"\"\"", "/*"],
+            seededOpeners);
 
         // The sweep is only as good as its size; pin it so a shrunken alphabet is visible. One
         // total across three arms is not that pin: a drop in one arm can be paid for with


### PR DESCRIPTION
## What this changes

The slicer has always lexed each line to place braces, and has always thrown that work away at the line break. Every predicate then re-derived "am I inside a comment, a literal, or an attribute list?" from a string it was handed — and a caller that forgot to thread the carried lexical state got a *plausible wrong answer* rather than an error. That shape is the root of two of the defect families found across the ten review rounds in this series.

This keeps what the scan already works out.

**No predicate moves onto the token stream here, and no behavior changes.** The existing suites are the evidence for that. Migrating the ~16 predicates is the next PR; doing it in the same change would mean the migration was the first thing that ever looked at the stream.

## Why a sink, not a second lexer

The literal, interpolation, and raw-string rules in `Scan` took ten review rounds to settle — `$$` hole runs, verbatim vs raw quote counting, `@` before a triple quote, holes spanning lines since C# 11. Rewriting them independently would have risked regressing hard-won fixes to gain a differential oracle I do not actually need. So the token stream is emitted **from the existing loop**: same code, same rules, output retained instead of discarded.

Two branches now consume a run where they previously stepped one character at a time (plain literal content, and identifier runs). Both are behavior-identical — none of the characters consumed is a delimiter, and the loop's early-exit flags cannot change mid-run — and the reasoning is in the diff comments.

## The model

`ScanToken` carries kind, position, block depth, and bracket depth. Two decisions worth review:

- **A delimiter is placed with the text it bounds.** An opener reports the depth *outside* it, a closer the depth *inside*, so `{` and `}` describe their block rather than each other.
- **`DepthKnown` is corrected retroactively.** The scan discovers it lost its place at *end* of line — after tokens on that line were already emitted. Those tokens are rewritten rather than left reporting a depth that has since become meaningless, because a stale depth reads exactly like a real one.

## Gates

| Gate | What it holds |
| --- | --- |
| `EveryCharacterOfTheCorpus_IsAccountedFor` | Every non-whitespace character of every C# file the corpus PDBs point at falls inside exactly one token — **36,651 lines**, zero gaps |
| same test, second half | Coverage alone is also satisfied by a scanner that calls each line one token, so the stream must additionally be decomposed (>3 tokens/line) and exercise every kind the corpus can reach |
| `CoverageCheck_ReportsATokenThatWasRemoved` / `_ThatWasShortened` | Non-vacuity gate for the checker itself |
| 20 pinning tests | raw/verbatim/interpolated/`$$` literals, block and line comments, char literals, attribute lists across lines, conditional vs non-conditional directives, verbatim identifiers |

`Directive` is the one kind no corpus file contains. It is named in `KindsTheCorpusCannotReach` and compared for **set equality**, so if a corpus assembly ever gains a directive the test fails and the entry gets deleted — the entry cannot go stale silently.

**Verified by tampering, not by assertion:** suppressing the token for three-character words fails the corpus gate at `DiffAsmFixtures.Target/Api.cs` line 8 column 24.

## Validation

Release, at `c098f913` (rebased onto `adaf9414`):

| Suite | Result |
| --- | --- |
| `DotnetInspector.CSharpBodySlicer.Tests` | 277, 0 failed (244 + 33 new) |
| `ILInspector.Metadata.Tests` | 998, 0 failed |
| `DotnetInspector.Services.Tests` | 343, 0 failed |
| `dotnet-inspect.Tests` | 2361, 0 failed |

The commit message quotes the counts measured before the rebase onto `adaf9414`; the table above is the current head. The commit was not amended.

## Naming

`ScanToken`/`ScanTokens` sit in `DotnetInspector.CSharpBodySlicer` and are `internal`. They deliberately avoid `Lexer`/`Tokenizer`: this is not a general C# lexer — keywords are matched by text, numeric literals are not decomposed, and `@class` comes back as `@` plus a word — and a lexer name would invite a fidelity it does not have. #3439's reserved noun **Scanner** (a sequential pass over metadata in `ILInspector.Metadata`) is not used; no `*Scanner` type is declared here.
