### PR TITLE
Hold the library section-to-scanner binding to a real gate

### DIFF
--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1120,17 +1120,19 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibraryScannerRegistry_HasAllDetailedScanners()
+    public void LibraryScannerRegistry_RegistrationMatchesDeclaration()
     {
+        // Set equality, not containment, so both failure directions are caught: a section
+        // declaring a key nobody registered (its data silently never collected) and a registered
+        // scanner no section asks for (dead code). Derived from the pipeline and the registry
+        // rather than restated as a literal list, so adding a section or a scanner cannot drift
+        // past this test.
         var registry = LibrarySections.CreateScannerRegistry();
         var pipeline = LibrarySections.CreatePipeline();
 
-        // All scanner keys from detailed sections should be registered
-        var detailedScanners = pipeline.GetRequiredScanners(Verbosity.Detailed);
-
-        // Registry should handle all of them without throwing
-        // (we can't easily inspect the registry, but we can verify it runs)
-        Assert.NotEmpty(detailedScanners);
+        Assert.Equal(
+            pipeline.DeclaredScannerKeys.OrderBy(k => k, StringComparer.Ordinal),
+            registry.RegisteredKeys.OrderBy(k => k, StringComparer.Ordinal));
     }
 
     // ===== Presence flag / CanRender discovery tests =====

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -10,8 +10,9 @@ namespace DotnetInspector.Sections;
 /// </summary>
 public static class LibrarySections
 {
-    // Scanner keys identify data collection steps in LibraryMetadataService
-    public const string ScannerTransitiveRefs = "TransitiveRefs";
+    // Scanner keys identify data collection steps in LibraryMetadataService.
+    // Every key here must be registered in CreateScannerRegistry and declared by at least one
+    // section. Gate: SectionPipelineTests.LibraryScannerRegistry_RegistrationMatchesDeclaration.
     public const string ScannerExtensionMethods = "ExtensionMethods";
     public const string ScannerClassifiedMethods = "ClassifiedMethods";
     public const string ScannerResources = "Resources";
@@ -19,7 +20,6 @@ public static class LibrarySections
     public const string ScannerUnionTypes = "UnionTypes";
     public const string ScannerTypeForwarders = "TypeForwarders";
     public const string ScannerInfoCounts = "InfoCounts";
-    public const string ScannerSymbols = "Symbols";
     public const string ScannerAuditSignals = "AuditSignals";
     public const string ScannerIntegrations = LibraryIntegrationCatalog.RollupName;
     public const string ScannerIntegrationOpportunities = "IntegrationOpportunities";
@@ -278,7 +278,7 @@ public static class LibrarySections
         public static string Name => SectionNames.Symbols;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Fixed;
-        public static string? ScannerKey => ScannerSymbols;
+        public static string? ScannerKey => null; // data comes from PdbContext (always collected)
         public static bool CanRender(LibraryInspection model) => true;
     }
 
@@ -516,7 +516,9 @@ public static class LibrarySections
         public static string Name => SectionNames.Dependencies;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerTransitiveRefs;
+        // Built inline by LibraryMetadataService under options.IncludeDependencies, before the
+        // scanner phase — not by a scanner.
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model)
             => model.UseDependenciesView
                && model.AssemblyInfo?.TransitiveReferences is { Count: > 0 };

--- a/src/dotnet-inspect/Sections/ScannerRegistry.cs
+++ b/src/dotnet-inspect/Sections/ScannerRegistry.cs
@@ -69,6 +69,16 @@ public sealed class ScannerRegistry
     private readonly Dictionary<string, Action<ScannerContext>> _scanners = [];
 
     /// <summary>
+    /// The keys of every registered scanner. This is the supply side of the section-to-scanner
+    /// binding; the demand side is <see cref="SectionPipeline{TModel}.DeclaredScannerKeys"/>.
+    /// Exposed so a test can hold the two sets equal: <see cref="RunScanners"/> skips a requested
+    /// key it has no registration for, so an unregistered key is otherwise silent. Gate for the
+    /// library pipeline:
+    /// <c>SectionPipelineTests.LibraryScannerRegistry_RegistrationMatchesDeclaration</c>.
+    /// </summary>
+    public IReadOnlyCollection<string> RegisteredKeys => _scanners.Keys;
+
+    /// <summary>
     /// Registers a scanner by key. The action populates the model with data.
     /// </summary>
     public ScannerRegistry Add(string key, Action<ScannerContext> scan)

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -154,6 +154,21 @@ public sealed class SectionPipeline<TModel>
         .ToList();
 
     /// <summary>
+    /// Every distinct non-null <see cref="SectionEntry{TModel}.ScannerKey"/> declared by a
+    /// registered section, independent of verbosity or selection. This is the demand side of the
+    /// section-to-scanner binding; the supply side is
+    /// <see cref="ScannerRegistry.RegisteredKeys"/>. The two must agree exactly — a key declared
+    /// here but not registered is a section whose data silently never gets collected, and a key
+    /// registered but not declared here is a scanner nothing can ask for. Gate for the library
+    /// pipeline: <c>SectionPipelineTests.LibraryScannerRegistry_RegistrationMatchesDeclaration</c>.
+    /// Other pipelines declare no scanner keys today, so nothing gates them.
+    /// </summary>
+    public IReadOnlySet<string> DeclaredScannerKeys => _entries
+        .Select(e => e.ScannerKey)
+        .Where(key => key != null)
+        .ToHashSet(StringComparer.Ordinal)!;
+
+    /// <summary>
     /// The authored topical category doors (e.g. <c>@Audit</c>, <c>@Source</c>). Excludes the
     /// computed/selector-only poles <c>@Default</c>, <c>@All</c>, and <c>@Hidden</c>. These are the
     /// only categories the curated <c>-D</c> catalog lists as doors.


### PR DESCRIPTION
## What this changes

Two of the seventeen library scanner keys were declared as consts, referenced by a section descriptor, and **never registered**:

| Key | Declared by | Registered in `CreateScannerRegistry` |
| --- | --- | --- |
| `TransitiveRefs` | `Dependencies` | no |
| `Symbols` | `Symbols` | no |

`ScannerRegistry.RunScanners` iterates its own registrations and runs the ones the caller asked for, so a requested key with no registration is skipped **in silence** — no throw, no log.

## Why nothing was visibly broken

Neither section ever depended on a scanner:

- **Dependencies** gets its tree from `LibraryMetadataService`, built inline under `options.IncludeDependencies` *before* the scanner phase.
- **Symbols** reads `PdbContext` fields set on the always-collected path — which is why its `CanRender` is an unconditional `true`.

Both keys were pure vestige. Confirmed by output rather than by reading:

```
library <asm> -S Symbols
library <asm> --dependencies -S Dependencies
```

Both are **byte-identical** before and after (`Compare-Object` → 0 differences).

## Why they survived

The test meant to catch this was `LibraryScannerRegistry_HasAllDetailedScanners`. It asserted only `Assert.NotEmpty(detailedScanners)`, and its own comment conceded the gap:

```csharp
// Registry should handle all of them without throwing
// (we can't easily inspect the registry, but we can verify it runs)
```

It read like a registration check in the test list and was one nowhere else. Both dead keys passed it. This is the `AGENTS.md` "asserted properties name their gate" failure mode in miniature — a green suite plus a confident name is indistinguishable from a verified property.

## The gate

Expose the two halves of the binding — `ScannerRegistry.RegisteredKeys` (supply) and `SectionPipeline.DeclaredScannerKeys` (demand) — and assert **set equality**.

Set equality rather than containment, so both directions fail: a section asking for a scanner nobody registered, *and* a scanner no section can ask for. Both sides are **derived** from the pipeline and the registry rather than restated as a literal list, so adding a section or a scanner cannot drift past the check.

**Confirmed non-vacuous by tampering.** Pointing the `Symbols` descriptor at an unregistered `"TamperKey"` fails with the offending key named:

```
Assert.Equal() Failure: Collections differ at index 11
Expected: "TamperKey"
Actual:   "TopLeverage"
```

`DeclaredScannerKeys` is defined on `SectionPipeline<TModel>` generally, but only the library pipeline declares scanner keys today — every descriptor in `ApiSectionDescriptors`, `PackageSectionDescriptors`, and `DiffSections` returns `null`, and none of those pipelines has a registry to pair with. The doc comment says so rather than implying wider coverage.

## Why this first

This is the opening slice of the library strand of the layering work ([`docs/design/inspection-layers.md`](docs/design/inspection-layers.md), #3439). L1 replaces the stringly-typed `ScannerKey` with a declared query type, at which point a dead binding becomes a compile error. Until then this test is the only thing standing between a section and data that silently never arrives — and the mechanical scanner-to-query conversion that follows needs a check that fails loudly when a binding is dropped mid-move.

No behavior change. No `package` files touched.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — 0 errors.
- `dotnet run --project src/dotnet-inspect.Tests -c Release` — 2361 total, 1 failed, 10 skipped.
- The one failure, `LibraryCommand_DetailedOutput_RendersSectionsAlphabetically`, is **pre-existing on `origin/main`**: verified by stashing this branch's changes, rebuilding at `adaf9414`, and reproducing the identical `Assert.NotEmpty() Failure: Collection was empty`. The underlying command succeeds when run directly, so it looks like a harness/environment issue rather than a product one. Untouched here; flagging separately.
- Skips are `ildasm`/`ilasm` absence, as expected.
