### PR TITLE
Preserve document line endings when reordering Markdown sections

### DIFF
--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1302,7 +1302,35 @@ public class OutputFormatterTests
         Assert.True(output.IndexOf("## Beta", StringComparison.Ordinal) < output.IndexOf("## Alpha", StringComparison.Ordinal));
         Assert.True(output.IndexOf("## Alpha", StringComparison.Ordinal) < output.IndexOf("## Zebra", StringComparison.Ordinal));
         Assert.Contains("## Not a section", output);
-        Assert.Contains("B\n\n## Alpha", output);
+        // This claim is about which lines end up adjacent, so it is asserted against
+        // normalized text. Line endings are the separate claim below; a raw string
+        // literal carries whatever ending this source file is checked out with, so
+        // spelling "\n" here would silently assert the platform rather than the shape.
+        Assert.Contains("B\n\n## Alpha", output.ReplaceLineEndings("\n"));
+    }
+
+    /// <summary>
+    /// This is the gate for line-ending preservation in <c>MarkdownSectionOrderer</c>.
+    /// Reordering selects the order sections appear in; it is not licensed to rewrite CRLF
+    /// to LF, for the same reason row limiting is not — the same document would otherwise
+    /// differ byte for byte depending on whether a section order was supplied. The orderer
+    /// used to rejoin on a hardcoded '\n', which on Windows silently converted the whole
+    /// document and broke every caller that split it on <see cref="Environment.NewLine"/>.
+    /// </summary>
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    public void MarkdownSectionOrderer_PreservesDocumentLineEndings(string newline)
+    {
+        string markdown = string.Join(newline, ["# Title", "", "intro", "", "## Zebra", "", "Z", "", "## Alpha", "", "A"]);
+
+        var output = MarkdownSectionOrderer.Apply(markdown, ["Alpha", "Zebra"]);
+
+        Assert.True(output.IndexOf("## Alpha", StringComparison.Ordinal) < output.IndexOf("## Zebra", StringComparison.Ordinal));
+        Assert.Equal(newline, MarkdownScan.DetectNewline(output));
+        Assert.Equal(
+            output.Split('\n').Length - 1,
+            output.Split(newline).Length - 1);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Output/MarkdownSectionOrderer.cs
+++ b/src/dotnet-inspect/Output/MarkdownSectionOrderer.cs
@@ -2,6 +2,9 @@ namespace DotnetInspector.Output;
 
 /// <summary>
 /// Reorders rendered Markdown H2 sections while preserving the document preamble.
+/// Reordering selects the order sections appear in; like row limiting, it is not
+/// licensed to rewrite the document's line endings, so it rejoins on the ending the
+/// text already used (see <see cref="MarkdownScan.DetectNewline"/>).
 /// </summary>
 internal static class MarkdownSectionOrderer
 {
@@ -10,7 +13,8 @@ internal static class MarkdownSectionOrderer
         if (string.IsNullOrEmpty(markdown) || sectionOrder.Count == 0)
             return markdown;
 
-        var lines = markdown.Replace("\r\n", "\n").Split('\n');
+        var newline = MarkdownScan.DetectNewline(markdown);
+        var lines = markdown.ReplaceLineEndings("\n").Split('\n');
         var sectionStarts = new List<int>();
         var inFence = false;
         for (var i = 0; i < lines.Length; i++)
@@ -53,6 +57,6 @@ internal static class MarkdownSectionOrderer
             output.AddRange(section.Lines);
         }
 
-        return string.Join('\n', output);
+        return string.Join(newline, output);
     }
 }


### PR DESCRIPTION
Fixes #3454.

## What was wrong

`MarkdownSectionOrderer.Apply` normalized the document to LF and rejoined on a hardcoded `'\n'`. Every sibling post-processing pass preserves the document's line ending via `MarkdownScan.DetectNewline` — `MarkdownTableRowLimiter.Apply` and `OutputFormatter.LimitRenderedTableRows` both do. The orderer was the only one that did not, and `DetectNewline` documents the convention it broke:

> a pass that splits on '\n' can rejoin without changing them ... it is **not licensed to rewrite CRLF to LF**, which would make the same output differ byte for byte depending on whether a row window was supplied.

That reasoning applies verbatim to a section order.

## Windows symptom

`library System.Text.Json -v:d` emitted **1 CRLF and 373 bare LFs**, so any consumer splitting on `Environment.NewLine` got a single line. `LibraryCommand_DetailedOutput_RendersSectionsAlphabetically` failed deterministically with `Assert.NotEmpty() Failure: Collection was empty` — the split yielded the whole document as one line, none of which starts with `## `, so it reported no sections for a document whose sections rendered correctly.

## The existing unit test was pinned to the bug

`MarkdownSectionOrderer_ReordersH2SectionsAndKeepsFenceHeadings` asserted `Assert.Contains(""B\n\n## Alpha"", output)`. Its input is a raw string literal, which carries whatever ending the source file is checked out with — CRLF here — so that assertion passed **because** the orderer rewrote CRLF to LF. It was guarding the defect, not the property.

That claim is about which lines end up adjacent, so it now asserts against normalized text. Spelling a bare LF against raw output silently asserts the platform rather than the shape.

## The gate

`MarkdownSectionOrderer_PreservesDocumentLineEndings` is the missing gate, a theory over both `\n` and `\r\n`. It asserts the ordering still happened, that `DetectNewline` reports the input's ending, and that the LF count equals the requested-ending count so no stray bare LF survives.

**Tamper-verified:** reverting the rejoin to a hardcoded `'\n'` fails the `\r\n` case.

## Validation

Windows, Release, full suite `dotnet run --project src/dotnet-inspect.Tests -c Release`:

- **2363 total, 0 failed, 10 skipped** (ildasm/ilasm absent)

`LibraryCommand_DetailedOutput_RendersSectionsAlphabetically` now passes. The suite also reproduces the order-dependent flake tracked in #3416 — a first run showed `PerformanceTriagePredicates_DoNotAlterDiscovery` and `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceLinkDoor` failing, both of which pass in isolation and were clean on the second full run. That is #3416's documented shape and is not touched here.