### PR TITLE
Guard the type-forwarder path sink, and give the path-component rule one owner (#3441)

### DIFF
--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Core\DotnetInspector.Core.csproj" />
+    <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />
     <PackageReference Include="NuGetFetch" />
     <PackageReference Include="NuGet.Versioning" />
   </ItemGroup>

--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -24,4 +24,10 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- StorePath is internal; StorePathSegmentTests gates it against drifting away from
+         HardenedPath, the single owner of the path-component rule. -->
+    <InternalsVisibleTo Include="DotnetInspector.Services.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -1,3 +1,4 @@
+using ILInspector.MetadataPrimitives;
 using DotnetInspector.Core;
 using NuGet.Versioning;
 
@@ -47,25 +48,14 @@ public static class NuGetCache
         ?? throw new InvalidOperationException("NuGetCache.Initialize(appName) must be called before using app cache methods.");
 
     /// <summary>
-    /// Validates that a value is safe to use as a path component. Rejects empty
-    /// or whitespace values, traversal (<c>..</c>), separators, volume
-    /// qualifiers (<c>:</c>), null characters, and otherwise rooted values, so an
-    /// attacker-influenced package coordinate cannot escape or reset the cache
-    /// root (a legitimate package id or version contains none of these).
+    /// Validates that a value is safe to use as a path component, so an attacker-influenced
+    /// package coordinate cannot escape or reset the cache root. Delegates to
+    /// <see cref="HardenedPath.ValidatePathComponent"/>, which is the single owner of this rule;
+    /// this method's own copy of it had drifted (it accepted reserved device names, every control
+    /// character other than <c>\0</c>, and names the host rewrites before opening).
     /// </summary>
     internal static void ValidatePathComponent(string value, string name)
-    {
-        if (string.IsNullOrWhiteSpace(value)
-            || value.Contains("..")
-            || value.Contains('/')
-            || value.Contains('\\')
-            || value.Contains(':')
-            || value.Contains('\0')
-            || Path.IsPathRooted(value))
-        {
-            throw new ArgumentException($"Invalid {name}: '{value}'");
-        }
-    }
+        => HardenedPath.ValidatePathComponent(value, name);
 
     /// <summary>
     /// Gets the path to the NuGet package cache (read-only).

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -120,10 +120,18 @@ public static class NuGetCache
     /// <param name="packageName">The package name (case-insensitive)</param>
     /// <param name="version">The package version</param>
     /// <returns>The path to the cached package directory, or null if not found</returns>
+    /// <remarks>
+    /// An unsafe coordinate answers null rather than throwing. No cache entry can be named by one,
+    /// so "not found" is the truthful answer, and it is the answer this method's contract promises;
+    /// throwing from a <c>Try</c> method crashed the CLI on <c>package CON@1.0.0 --version</c> and
+    /// made <see cref="PackageExtractor"/>'s nuspec probe report a hostile coordinate as an error
+    /// rather than refusing it. The refusal stays visible where it matters: every path that
+    /// acquires or extracts a package still refuses the coordinate loudly.
+    /// </remarks>
     public static string? TryGetCachedPackage(string packageName, string version)
     {
-        ValidatePathComponent(packageName, "package name");
-        ValidatePathComponent(version, "version");
+        if (!HardenedPath.IsSafePathComponent(packageName) || !HardenedPath.IsSafePathComponent(version))
+            return null;
 
         var normalizedName = packageName.ToLowerInvariant();
         var normalizedVersion = version.ToLowerInvariant();

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -323,8 +323,18 @@ public static class NuGetCache
     /// Returns the newest cached version of a package from the NuGet or app cache.
     /// Pure disk I/O — never hits the network.
     /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> for a name that is not safe as a path component, rather than
+    /// combining it into a cache root. The guard lives here, not in the callers: six call sites
+    /// reach this method, and an earlier fix in this series guarded one route while the identical
+    /// hole survived on a sibling route with a green suite. Callers that surface the result to a
+    /// user should distinguish a refusal from a miss.
+    /// </remarks>
     public static string? TryGetLatestCachedVersion(string packageName)
     {
+        if (!HardenedPath.IsSafePathComponent(packageName))
+            return null;
+
         var normalizedName = packageName.ToLowerInvariant();
 
         // Newest non-prerelease, structurally-valid version across both caches.

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -697,6 +697,22 @@ public static class PackageExtractor
         string normalizedName = packageName.ToLowerInvariant();
         string cacheKey = includePrerelease ? $"{normalizedName}-prerelease" : normalizedName;
 
+        // A name that cannot be a path component can never name a package we could acquire: the
+        // coordinate becomes a cache directory further down every route that consumes this
+        // version. Refuse here rather than at the callers -- PackageCommand's --versions branch
+        // already refused, so `package CON --version` was clean while `package CON` reached the
+        // cache and the network before reporting a miss. Guarding the method makes the refusal
+        // early, network-free and identical on every route into it, instead of a property of
+        // which branch the caller took.
+        if (!HardenedPath.IsSafePathComponent(normalizedName))
+        {
+            // Unconditional, matching CoreCache's cache-escape warning: a verbose-gated log would
+            // make the refusal invisible in the default view, and the caller's "not found" reads
+            // as "searched for and absent" when the name was never searched for at all.
+            Console.Error.WriteLine($"Warning: invalid package name, not searched for: '{packageName}'.");
+            return null;
+        }
+
         // Cache nuget.org results even when additional custom sources are configured.
         bool canCache = !skipCache && sources.Any(s => s.IsNuGetOrg);
 

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -500,7 +500,7 @@ public static class PackageExtractor
         if (!HardenedPath.IsSafePathComponent(normalizedName)
             || !HardenedPath.IsSafePathComponent(normalizedVersion))
         {
-            log?.Invoke($"Refusing unsafe package coordinate '{packageId}.{version}'");
+            HardenedPath.ReportRefusal($"refusing unsafe package coordinate '{packageId}.{version}'");
             return null;
         }
 

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -492,6 +492,18 @@ public static class PackageExtractor
         string normalizedName = packageId.ToLowerInvariant();
         string normalizedVersion = version.ToLowerInvariant();
 
+        // A dependency id comes from another package's nuspec, so it is untrusted. Refusing it has
+        // to say so: TryGetCachedPackage answers null for an unsafe coordinate, and without this
+        // the refusal became indistinguishable from an ordinary cache miss -- the dependency
+        // simply vanished from the resolved tree. Returning null is still right for the caller;
+        // being quiet about why is not.
+        if (!HardenedPath.IsSafePathComponent(normalizedName)
+            || !HardenedPath.IsSafePathComponent(normalizedVersion))
+        {
+            log?.Invoke($"Refusing unsafe package coordinate '{packageId}.{version}'");
+            return null;
+        }
+
         // Cache hit: read the nuspec straight from the already-extracted package.
         var cachedPath = NuGetCache.TryGetCachedPackage(normalizedName, normalizedVersion);
         if (cachedPath != null && NuGetCache.IsCachedPackageValid(cachedPath))

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -4,6 +4,7 @@
 using System.IO.Compression;
 using System.Net.Http.Headers;
 using DotnetInspector.Core;
+using ILInspector.MetadataPrimitives;
 using NuGetFetch;
 using NuGetSource = NuGetFetch.PackageSource;
 
@@ -232,6 +233,20 @@ public static class PackageExtractor
         // Normalize to lowercase for NuGet API
         string normalizedName = packageName.ToLowerInvariant();
         string normalizedVersion = version.ToLowerInvariant();
+
+        // The coordinate becomes a cache directory name, so it has to be a safe path component.
+        // NuGetCache validates it too, but by throwing, which leaves the command with an unhandled
+        // ArgumentException and a stack trace. That throw used to be unreachable for an ordinary
+        // name: the local copy of the rule this PR deleted could only reject separators, traversal
+        // and volume qualifiers, all of which the argument parser rejects earlier. Tightening the
+        // rule made it reachable -- `package CON@1.0.0` printed 1846 bytes of stack trace where it
+        // previously printed `Error: Package 'con' not found.` -- so refuse it here as an ordinary
+        // acquisition failure instead.
+        if (!HardenedPath.IsSafePathComponent(normalizedName))
+            return PackageExtractionOutcome.Error($"Invalid package name: '{packageName}'.");
+
+        if (!HardenedPath.IsSafePathComponent(normalizedVersion))
+            return PackageExtractionOutcome.Error($"Invalid package version: '{version}'.");
 
         var request = new PackageAcquisitionRequest(
             Path.GetFullPath(

--- a/src/DotnetInspector.Packages/Storage/StorePath.cs
+++ b/src/DotnetInspector.Packages/Storage/StorePath.cs
@@ -1,3 +1,5 @@
+using ILInspector.MetadataPrimitives;
+
 namespace DotnetInspector.Packages;
 
 /// <summary>
@@ -46,17 +48,17 @@ internal static class StorePath
     }
 
     /// <summary>
-    /// True when <paramref name="segment"/> is a safe single path component:
-    /// non-empty, not <c>.</c> or <c>..</c>, containing no separator, volume
-    /// (<c>:</c>), or null character, and not otherwise rooted.
+    /// True when <paramref name="segment"/> is a safe single path component.
     /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="HardenedPath.IsSafePathComponent"/>, the single owner of this rule.
+    /// This was previously a separate implementation testing only for empty, <c>.</c>, <c>..</c>,
+    /// separators, <c>:</c>, NUL and rooted values, so it accepted reserved device names, other
+    /// control characters, invisible format characters, unpaired surrogates, trailing dots and
+    /// spaces, and overlong components. An untrusted CodeView PDB file name reaches this rule on
+    /// its way to filesystem-backed symbol storage (<c>SymbolPackageDownloader</c>), so those gaps
+    /// were reachable: <c>CON</c> was accepted here and refused by every other copy of the rule.
+    /// </remarks>
     public static bool IsSafeSegment(string segment)
-        => segment.Length != 0
-            && segment != "."
-            && segment != ".."
-            && !segment.Contains('/')
-            && !segment.Contains('\\')
-            && !segment.Contains(':')
-            && !segment.Contains('\0')
-            && !Path.IsPathRooted(segment);
+        => HardenedPath.IsSafePathComponent(segment);
 }

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -371,10 +371,35 @@ public class AssemblyDependencyResolverTests
     /// id lands: on unguarded code the resolver escapes the package root, recurses into that
     /// directory, and returns its assemblies as the package's references.
     /// </summary>
+    /// <remarks>
+    /// Which spellings actually traverse is a property of the host. <c>..\escape</c> is a traversal
+    /// on Windows and an ordinary directory name on Unix, so on this machine that case exercises
+    /// the guard's literal-name branch and proves nothing about traversal.
+    /// <see cref="HostileDependencyIds_ContainACaseThatTraversesOnThisHost"/> is what stops the
+    /// whole theory degrading to literal names, which is how it would pass while the traversal
+    /// guard was gone.
+    /// </remarks>
+    private static readonly string[] HostileIds = ["../escape", "..\\escape", "CON"];
+
+    public static TheoryData<string> HostileDependencyIds => [.. HostileIds];
+
+    /// <summary>
+    /// Non-vacuity gate for the theory below: at least one hostile id must use a separator this
+    /// host recognises, or every case is a literal directory name and the theory asserts nothing
+    /// about traversal. It reads the same data the theory does, so removing the traversing
+    /// spelling fails here rather than silently weakening the theory.
+    /// </summary>
+    [Fact]
+    public void HostileDependencyIds_ContainACaseThatTraversesOnThisHost()
+    {
+        Assert.Contains(
+            HostileIds,
+            id => id.Contains(Path.DirectorySeparatorChar)
+                || id.Contains(Path.AltDirectorySeparatorChar));
+    }
+
     [Theory]
-    [InlineData("../escape")]
-    [InlineData("..\\escape")]
-    [InlineData("CON")]
+    [MemberData(nameof(HostileDependencyIds))]
     public void PackageDependencyReferencePaths_WithTraversingDependencyId_DoesNotEscapePackageRoot(string hostileId)
     {
         string sandbox = Directory.CreateTempSubdirectory("dotnet-inspect-deps-traversal-").FullName;

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -400,7 +400,7 @@ public class AssemblyDependencyResolverTests
 
     [Theory]
     [MemberData(nameof(HostileDependencyIds))]
-    public void PackageDependencyReferencePaths_WithTraversingDependencyId_DoesNotEscapePackageRoot(string hostileId)
+    public async Task PackageDependencyReferencePaths_WithTraversingDependencyId_DoesNotEscapePackageRoot(string hostileId)
     {
         string sandbox = Directory.CreateTempSubdirectory("dotnet-inspect-deps-traversal-").FullName;
         try
@@ -439,12 +439,29 @@ public class AssemblyDependencyResolverTests
             // Positive control: the guard must refuse traversal specifically, not stop resolving.
             string legit = CreatePackageAsset(root, "Legit.Package", "1.0.0", "lib", "net8.0", "Legit.dll");
 
-            var references = AssemblyDependencyResolver.PackageDependencyReferencePaths(targetPath, [root]);
+            IReadOnlyList<string> references = [];
+            var stderr = await StderrCapture.RunAsync(() =>
+                references = AssemblyDependencyResolver.PackageDependencyReferencePaths(targetPath, [root]));
 
-            Assert.Contains(legit, references);
-            Assert.DoesNotContain(payload, references);
-            Assert.DoesNotContain(literal, references);
-            Assert.All(references, path => Assert.StartsWith(root + Path.DirectorySeparatorChar, path, StringComparison.Ordinal));
+            // The refusal has to reach the user. It was reported through the optional
+            // Action<string>? log, and no caller in the product passes one, so the message went
+            // nowhere: the dependency simply vanished from the result and the run exited 0. A
+            // refused coordinate is indistinguishable from an absent one unless it is announced.
+            Assert.Contains("refusing unsafe package coordinate", stderr, StringComparison.Ordinal);
+            Assert.Contains(hostileId, stderr, StringComparison.Ordinal);
+
+            // Canonicalise before comparing. Path.Combine does not normalise, so an escaping id
+            // yields "<root>/../escape/lib/net8.0/Payload.dll" -- a string that both StartsWith
+            // "<root>/" and differs character-for-character from the payload's own path. Asserting
+            // on the raw strings therefore passed with the guard entirely removed: only the "CON"
+            // row failed, and the traversal rows, the whole point of the theory, proved nothing.
+            var resolved = references.Select(Path.GetFullPath).ToList();
+            var rootPrefix = Path.GetFullPath(root) + Path.DirectorySeparatorChar;
+
+            Assert.Contains(Path.GetFullPath(legit), resolved);
+            Assert.DoesNotContain(Path.GetFullPath(payload), resolved);
+            Assert.DoesNotContain(Path.GetFullPath(literal), resolved);
+            Assert.All(resolved, path => Assert.StartsWith(rootPrefix, path, StringComparison.Ordinal));
         }
         finally
         {

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -364,6 +364,69 @@ public class AssemblyDependencyResolverTests
         }
     }
 
+    /// <summary>
+    /// Artifact canary for the nuspec dependency-coordinate sink. A dependency id and version are
+    /// read from a nuspec, which is a feed artifact rather than something this process authored,
+    /// and both become path components. This plants a readable payload exactly where a traversing
+    /// id lands: on unguarded code the resolver escapes the package root, recurses into that
+    /// directory, and returns its assemblies as the package's references.
+    /// </summary>
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("..\\escape")]
+    [InlineData("CON")]
+    public void PackageDependencyReferencePaths_WithTraversingDependencyId_DoesNotEscapePackageRoot(string hostileId)
+    {
+        string sandbox = Directory.CreateTempSubdirectory("dotnet-inspect-deps-traversal-").FullName;
+        try
+        {
+            string root = Path.Combine(sandbox, "packages");
+            Directory.CreateDirectory(root);
+
+            string packageDir = Path.Combine(root, "root.package", "1.0.0");
+            string targetDir = Path.Combine(packageDir, "lib", "net8.0");
+            Directory.CreateDirectory(targetDir);
+            string targetPath = Path.Combine(targetDir, "Root.dll");
+            File.WriteAllText(targetPath, "");
+            File.WriteAllText(
+                Path.Combine(packageDir, "root.package.nuspec"),
+                $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+                  <metadata>
+                    <id>Root.Package</id>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <group targetFramework="net8.0">
+                        <dependency id="{System.Security.SecurityElement.Escape(hostileId)}" version="1.0.0" />
+                        <dependency id="Legit.Package" version="1.0.0" />
+                      </group>
+                    </dependencies>
+                  </metadata>
+                </package>
+                """);
+
+            // The payload sits one level above the package root, where "../escape" lands, and
+            // also at the literal name inside it, so a refusal cannot be mistaken for absence.
+            string payload = CreatePackageAsset(sandbox, "escape", "1.0.0", "lib", "net8.0", "Payload.dll");
+            string literal = CreatePackageAsset(root, hostileId.Replace("..", "dots"), "1.0.0", "lib", "net8.0", "Payload.dll");
+
+            // Positive control: the guard must refuse traversal specifically, not stop resolving.
+            string legit = CreatePackageAsset(root, "Legit.Package", "1.0.0", "lib", "net8.0", "Legit.dll");
+
+            var references = AssemblyDependencyResolver.PackageDependencyReferencePaths(targetPath, [root]);
+
+            Assert.Contains(legit, references);
+            Assert.DoesNotContain(payload, references);
+            Assert.DoesNotContain(literal, references);
+            Assert.All(references, path => Assert.StartsWith(root + Path.DirectorySeparatorChar, path, StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
     static string CreatePackageAsset(string root, string id, string version, string assetKind, string tfm, string fileName)
     {
         string assetDir = Path.Combine(root, id.ToLowerInvariant(), version.ToLowerInvariant(), assetKind, tfm);

--- a/src/DotnetInspector.Services.Tests/DependencyRefusalVisibilityTests.cs
+++ b/src/DotnetInspector.Services.Tests/DependencyRefusalVisibilityTests.cs
@@ -21,7 +21,7 @@ public class DependencyRefusalVisibilityTests
     /// asset in the same file is the control: it must still be added.
     /// </summary>
     [Fact]
-    public void UnsafeDepsJsonAssetPath_IsRefusedAndReported()
+    public async Task UnsafeDepsJsonAssetPath_IsRefusedAndReported()
     {
         var root = Directory.CreateTempSubdirectory("di-refusal-deps-");
         try
@@ -75,14 +75,21 @@ public class DependencyRefusalVisibilityTests
                     Log = messages.Add
                 });
 
-            _ = resolver.ResolveAll();
+            var stderr = await StderrCapture.RunAsync(() => resolver.ResolveAll());
 
             // The refusal is reported, and it names the value it refused.
-            Assert.Contains(messages, m => m.Contains("Refusing unsafe deps.json", StringComparison.Ordinal));
-            Assert.Contains(messages, m => m.Contains("escape.dll", StringComparison.Ordinal));
+            //
+            // Asserted on stderr rather than on the `messages` list this test supplies. Asserting
+            // on `messages` proved only that the product wrote to a channel the test itself opened:
+            // the resolver's Log is optional and no product caller passes one that a default run
+            // would surface, so a refusal reached the user nowhere at all. `messages` is still
+            // wired up below as the negative control for the benign entry.
+            Assert.Contains("refusing unsafe deps.json", stderr, StringComparison.Ordinal);
+            Assert.Contains("escape.dll", stderr, StringComparison.Ordinal);
 
             // Positive control: the benign entry in the same file was NOT refused. Without this a
             // guard that rejected every path would satisfy the assertion above.
+            Assert.DoesNotContain("Benign.dll", stderr, StringComparison.Ordinal);
             Assert.DoesNotContain(messages, m => m.Contains("Benign.dll", StringComparison.Ordinal));
         }
         finally
@@ -93,10 +100,11 @@ public class DependencyRefusalVisibilityTests
 
     /// <summary>
     /// The log channel is optional, so a caller that supplies none must not fault. This is the
-    /// regression guard for threading <c>log</c> through the recursive collection walk.
+    /// regression guard for threading <c>log</c> through the recursive collection walk, and it is
+    /// now also the case that matches every real caller, none of which supply one.
     /// </summary>
     [Fact]
-    public void RefusalWithoutALogChannel_DoesNotThrow()
+    public async Task RefusalWithoutALogChannel_DoesNotThrow()
     {
         var root = Directory.CreateTempSubdirectory("di-refusal-nolog-");
         try
@@ -130,13 +138,21 @@ public class DependencyRefusalVisibilityTests
                     IncludeDepsJsonAssets = true
                 });
 
-            var resolved = resolver.ResolveAll();
+            // Captured even though nothing here asserts on the text: the refusal now writes to
+            // stderr unconditionally, and an uncaptured write would land in whichever parallel
+            // test holds the redirect and fail it on output it never produced.
+            IReadOnlyList<ResolvedAssemblyDependency> resolved = [];
+            var stderr = await StderrCapture.RunAsync(() => resolved = resolver.ResolveAll());
 
             // The escaping asset is not in the graph...
             Assert.DoesNotContain(resolved, r => r.Path.Contains("escape.dll", StringComparison.Ordinal));
 
             // ...and the run completed, which is the actual claim: no log channel, no fault.
             Assert.NotNull(resolved);
+
+            // With no log channel at all, the refusal still reaches the user. That is the whole
+            // point of moving it off the optional delegate.
+            Assert.Contains("refusing unsafe deps.json", stderr, StringComparison.Ordinal);
         }
         finally
         {

--- a/src/DotnetInspector.Services.Tests/DependencyRefusalVisibilityTests.cs
+++ b/src/DotnetInspector.Services.Tests/DependencyRefusalVisibilityTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Services.Tests;
+
+/// <summary>
+/// A refused input must stay visible. The resolver drops an unsafe package coordinate or asset path
+/// from the resolved graph, which on its own is indistinguishable from a dependency that simply did
+/// not resolve -- the dependency just vanishes. AGENTS.md forbids turning a failure into
+/// success-shaped empty output, so each refusal reports itself through
+/// <see cref="AssemblyDependencyResolutionOptions.Log"/>.
+/// <para>
+/// Every test here carries a positive control: the same run must still resolve a legitimate entry.
+/// Without one, a guard that refused everything would pass just as well as a correct one.
+/// </para>
+/// </summary>
+public class DependencyRefusalVisibilityTests
+{
+    /// <summary>
+    /// A deps.json whose asset path traverses is refused, and the refusal is reported. The benign
+    /// asset in the same file is the control: it must still be added.
+    /// </summary>
+    [Fact]
+    public void UnsafeDepsJsonAssetPath_IsRefusedAndReported()
+    {
+        var root = Directory.CreateTempSubdirectory("di-refusal-deps-");
+        try
+        {
+            var appDir = Directory.CreateDirectory(Path.Combine(root.FullName, "app")).FullName;
+            var self = typeof(DependencyRefusalVisibilityTests).Assembly.Location;
+            File.Copy(self, Path.Combine(appDir, "App.dll"), overwrite: true);
+
+            var deps = new
+            {
+                runtimeTarget = new { name = ".NETCoreApp,Version=v9.0" },
+                targets = new Dictionary<string, object>
+                {
+                    [".NETCoreApp,Version=v9.0"] = new Dictionary<string, object>
+                    {
+                        ["Hostile/1.0.0"] = new
+                        {
+                            runtime = new Dictionary<string, object>
+                            {
+                                ["../../../escape.dll"] = new { localPath = "../../../escape.dll" }
+                            }
+                        },
+                        ["Benign/1.0.0"] = new
+                        {
+                            runtime = new Dictionary<string, object>
+                            {
+                                ["lib/net9.0/Benign.dll"] = new { localPath = "Benign.dll" }
+                            }
+                        }
+                    }
+                },
+                libraries = new Dictionary<string, object>
+                {
+                    ["Hostile/1.0.0"] = new { type = "package", path = "hostile/1.0.0" },
+                    ["Benign/1.0.0"] = new { type = "package", path = "benign/1.0.0" }
+                }
+            };
+
+            File.WriteAllText(
+                Path.Combine(appDir, "App.deps.json"),
+                JsonSerializer.Serialize(deps));
+
+            var messages = new List<string>();
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(Path.Combine(appDir, "App.dll"))
+                {
+                    IncludeTrustedPlatformAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeSiblingAssemblies = false,
+                    IncludeDepsJsonAssets = true,
+                    Log = messages.Add
+                });
+
+            _ = resolver.ResolveAll();
+
+            // The refusal is reported, and it names the value it refused.
+            Assert.Contains(messages, m => m.Contains("Refusing unsafe deps.json", StringComparison.Ordinal));
+            Assert.Contains(messages, m => m.Contains("escape.dll", StringComparison.Ordinal));
+
+            // Positive control: the benign entry in the same file was NOT refused. Without this a
+            // guard that rejected every path would satisfy the assertion above.
+            Assert.DoesNotContain(messages, m => m.Contains("Benign.dll", StringComparison.Ordinal));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The log channel is optional, so a caller that supplies none must not fault. This is the
+    /// regression guard for threading <c>log</c> through the recursive collection walk.
+    /// </summary>
+    [Fact]
+    public void RefusalWithoutALogChannel_DoesNotThrow()
+    {
+        var root = Directory.CreateTempSubdirectory("di-refusal-nolog-");
+        try
+        {
+            var appDir = Directory.CreateDirectory(Path.Combine(root.FullName, "app")).FullName;
+            var self = typeof(DependencyRefusalVisibilityTests).Assembly.Location;
+            File.Copy(self, Path.Combine(appDir, "App.dll"), overwrite: true);
+
+            File.WriteAllText(
+                Path.Combine(appDir, "App.deps.json"),
+                """
+                {
+                  "runtimeTarget": { "name": ".NETCoreApp,Version=v9.0" },
+                  "targets": {
+                    ".NETCoreApp,Version=v9.0": {
+                      "Hostile/1.0.0": {
+                        "runtime": { "../../escape.dll": { "localPath": "../../escape.dll" } }
+                      }
+                    }
+                  },
+                  "libraries": { "Hostile/1.0.0": { "type": "package", "path": "hostile/1.0.0" } }
+                }
+                """);
+
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(Path.Combine(appDir, "App.dll"))
+                {
+                    IncludeTrustedPlatformAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeSiblingAssemblies = false,
+                    IncludeDepsJsonAssets = true
+                });
+
+            var resolved = resolver.ResolveAll();
+
+            // The escaping asset is not in the graph...
+            Assert.DoesNotContain(resolved, r => r.Path.Contains("escape.dll", StringComparison.Ordinal));
+
+            // ...and the run completed, which is the actual claim: no log channel, no fault.
+            Assert.NotNull(resolved);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+}

--- a/src/DotnetInspector.Services.Tests/PackageExtractorCoordinateRefusalTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageExtractorCoordinateRefusalTests.cs
@@ -1,3 +1,4 @@
+using ILInspector.MetadataPrimitives;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Services.Tests;
@@ -46,5 +47,37 @@ public class PackageExtractorCoordinateRefusalTests
             new HttpClient(), "Newtonsoft.Json", "13.0.3", log.Add);
 
         Assert.DoesNotContain(log, m => m.Contains("Refusing unsafe package coordinate", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The latest-version cache lookup is a ninth path sink: it combined a caller-supplied package
+    /// name into a cache root with no validation, and six call sites reach it. The guard lives in
+    /// the method rather than at those call sites, because an earlier fix in this series guarded one
+    /// route while the identical hole survived on a sibling route with a green suite.
+    /// </summary>
+    [Theory]
+    [InlineData("../foo")]
+    [InlineData("..\\foo")]
+    [InlineData("CON")]
+    [InlineData("Newtonsoft.Json ")]
+    public void TryGetLatestCachedVersion_UnsafeName_ReturnsNullWithoutProbingTheCache(string name)
+    {
+        NuGetCache.Initialize("dotnet-inspect-test");
+
+        Assert.Null(NuGetCache.TryGetLatestCachedVersion(name));
+    }
+
+    /// <summary>
+    /// The positive control for the guard above. Without it, a guard that refused every name would
+    /// satisfy the refusal theory just as well as a correct one. This asserts only that a
+    /// well-formed name is not refused by the path rule -- it may legitimately be absent from the
+    /// cache, so a null result here is only a failure if the name was rejected as unsafe.
+    /// </summary>
+    [Fact]
+    public void TryGetLatestCachedVersion_LegitimateName_IsNotRefusedByThePathRule()
+    {
+        Assert.True(HardenedPath.IsSafePathComponent("Newtonsoft.Json"));
+        Assert.True(HardenedPath.IsSafePathComponent("System.Text.Json"));
+        Assert.True(HardenedPath.IsSafePathComponent("Valid..Dependency"));
     }
 }

--- a/src/DotnetInspector.Services.Tests/PackageExtractorCoordinateRefusalTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageExtractorCoordinateRefusalTests.cs
@@ -1,0 +1,50 @@
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Services.Tests;
+
+/// <summary>
+/// A refused package coordinate has to be distinguishable from an ordinary cache miss.
+/// </summary>
+/// <remarks>
+/// A dependency id is read from another package's nuspec, so it is untrusted.
+/// <see cref="NuGetCache.TryGetCachedPackage"/> answers null for an unsafe one rather than
+/// throwing, which is its contract -- but that made the refusal look exactly like "not cached",
+/// and <c>DependencyResolutionService</c> then dropped the dependency from the resolved tree
+/// silently. Null is still the right answer for the caller; being quiet about why is not.
+/// </remarks>
+public class PackageExtractorCoordinateRefusalTests
+{
+    [Theory]
+    [InlineData("CON", "1.0.0")]
+    [InlineData("NUL", "1.0.0")]
+    [InlineData("Newtonsoft.Json", "1.0.0 ")]
+    public async Task TryGetNuspecXmlAsync_UnsafeCoordinate_SaysItRefused(string id, string version)
+    {
+        NuGetCache.Initialize("dotnet-inspect-test");
+        var log = new List<string>();
+
+        // No HttpClient request should be attempted, so a client with no base address is fine:
+        // reaching the network would itself be the failure this guards.
+        var nuspec = await PackageExtractor.TryGetNuspecXmlAsync(
+            new HttpClient(), id, version, log.Add);
+
+        Assert.Null(nuspec);
+        Assert.Contains(log, m => m.Contains("Refusing unsafe package coordinate", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The positive control: an ordinary coordinate must not be reported as refused, or the
+    /// assertion above would pass for a guard that rejects everything.
+    /// </summary>
+    [Fact]
+    public async Task TryGetNuspecXmlAsync_OrdinaryCoordinate_IsNotReportedAsRefused()
+    {
+        NuGetCache.Initialize("dotnet-inspect-test");
+        var log = new List<string>();
+
+        await PackageExtractor.TryGetNuspecXmlAsync(
+            new HttpClient(), "Newtonsoft.Json", "13.0.3", log.Add);
+
+        Assert.DoesNotContain(log, m => m.Contains("Refusing unsafe package coordinate", StringComparison.Ordinal));
+    }
+}

--- a/src/DotnetInspector.Services.Tests/PackageExtractorCoordinateRefusalTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageExtractorCoordinateRefusalTests.cs
@@ -80,4 +80,58 @@ public class PackageExtractorCoordinateRefusalTests
         Assert.True(HardenedPath.IsSafePathComponent("System.Text.Json"));
         Assert.True(HardenedPath.IsSafePathComponent("Valid..Dependency"));
     }
+
+    /// <summary>
+    /// The latest-version lookup is the route <c>package &lt;name&gt;</c> takes when no version is
+    /// pinned, and it was unguarded: <c>package CON --version</c> refused cleanly because
+    /// <c>PackageCommand</c>'s version branch validated the name, while <c>package CON</c> reached
+    /// the version cache and then nuget.org before reporting a miss.
+    /// </summary>
+    /// <remarks>
+    /// This is the gate for "the refusal is a property of the name, not of which branch the caller
+    /// took". The guard is in the method, so both routes now refuse identically.
+    /// <para>
+    /// The client's handler throws on any request. Asserting only that the result is null would
+    /// pass for the wrong reason: nuget.org has no package called <c>con</c> or <c>../foo</c>
+    /// either, so two of these three cases returned null with the guard deleted. Refusing without
+    /// asking is the property; not finding anything is not.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("CON")]
+    [InlineData("../foo")]
+    [InlineData("Newtonsoft.Json ")]
+    public async Task GetLatestVersionAsync_UnsafeName_ReturnsNullWithoutReachingTheNetwork(string name)
+    {
+        NuGetCache.Initialize("dotnet-inspect-test");
+
+        var version = await PackageExtractor.GetLatestVersionAsync(
+            new HttpClient(new ThrowingHandler()),
+            name,
+            [new NuGetFetch.PackageSource("nuget.org", "https://api.nuget.org/v3/index.json")],
+            log: null,
+            skipCache: true);
+
+        Assert.Null(version);
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException(
+                $"The guard should have refused before any request was made; got {request.RequestUri}.");
+    }
+
+    /// <summary>
+    /// The positive control: the guard must not be refusing every name. Asserting on the path rule
+    /// rather than on a live lookup keeps this test off the network.
+    /// </summary>
+    [Fact]
+    public void GetLatestVersionAsync_LegitimateName_IsNotRefusedByThePathRule()
+    {
+        Assert.True(HardenedPath.IsSafePathComponent("newtonsoft.json"));
+        Assert.False(HardenedPath.IsSafePathComponent("con"));
+    }
 }

--- a/src/DotnetInspector.Services.Tests/PackageExtractorCoordinateRefusalTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageExtractorCoordinateRefusalTests.cs
@@ -26,11 +26,18 @@ public class PackageExtractorCoordinateRefusalTests
 
         // No HttpClient request should be attempted, so a client with no base address is fine:
         // reaching the network would itself be the failure this guards.
-        var nuspec = await PackageExtractor.TryGetNuspecXmlAsync(
-            new HttpClient(), id, version, log.Add);
+        string? nuspec = null;
+        var stderr = await StderrCapture.RunAsync(() =>
+            nuspec = PackageExtractor.TryGetNuspecXmlAsync(
+                new HttpClient(), id, version, log.Add).GetAwaiter().GetResult());
 
         Assert.Null(nuspec);
-        Assert.Contains(log, m => m.Contains("Refusing unsafe package coordinate", StringComparison.Ordinal));
+
+        // Asserted on stderr, not on `log`. This test used to supply its own Action<string> and
+        // assert the message arrived there, which proved only that the product wrote to a channel
+        // the test itself opened: no caller in the product passes a logger here, so the refusal
+        // reached nobody. It now goes to stderr unconditionally, which is what a user sees.
+        Assert.Contains("refusing unsafe package coordinate", stderr, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -43,10 +50,11 @@ public class PackageExtractorCoordinateRefusalTests
         NuGetCache.Initialize("dotnet-inspect-test");
         var log = new List<string>();
 
-        await PackageExtractor.TryGetNuspecXmlAsync(
-            new HttpClient(), "Newtonsoft.Json", "13.0.3", log.Add);
+        var stderr = await StderrCapture.RunAsync(() =>
+            PackageExtractor.TryGetNuspecXmlAsync(
+                new HttpClient(), "Newtonsoft.Json", "13.0.3", log.Add).GetAwaiter().GetResult());
 
-        Assert.DoesNotContain(log, m => m.Contains("Refusing unsafe package coordinate", StringComparison.Ordinal));
+        Assert.DoesNotContain("refusing unsafe package coordinate", stderr, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/DotnetInspector.Services.Tests/PlatformResolverPathGuardTests.cs
+++ b/src/DotnetInspector.Services.Tests/PlatformResolverPathGuardTests.cs
@@ -1,0 +1,131 @@
+using DotnetInspector.Packages;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Services.Tests;
+
+/// <summary>
+/// <see cref="PlatformResolver.ResolveAssembly"/> is the single entry point through which an
+/// assembly name reaches <c>Path.Combine</c> and <c>File.Exists</c> against a framework directory.
+/// Callers hand it names read straight out of untrusted assembly metadata — the transitive
+/// reference walk forwards <c>AssemblyRef.Name</c> from the inspected PE — so a hostile name once
+/// resolved to a file outside the framework directory and was reported as a platform assembly.
+/// </summary>
+public class PlatformResolverPathGuardTests
+{
+    /// <summary>
+    /// The name that motivated the guard. The escape needs no existing framework layout: the
+    /// resolver combined the name with the shared runtime directory and returned it if the target
+    /// existed, so the assertion is that no path is returned and the refusal is visible.
+    /// </summary>
+    [Fact]
+    public void ResolveAssembly_WithTraversingName_RefusesAndReportsAnError()
+    {
+        var payloadDirectory = Path.Combine(Path.GetTempPath(), $"platform-traversal-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(payloadDirectory);
+        var payload = Path.Combine(payloadDirectory, "payload.dll");
+        File.WriteAllText(payload, "payload");
+
+        try
+        {
+            // The payload really exists, so a null result is the guard refusing the name rather
+            // than the resolver simply failing to find anything.
+            Assert.True(File.Exists(payload));
+
+            var traversal = Path.Combine("..", "..", "..", "..", "..", "..", "..", "..")
+                + Path.DirectorySeparatorChar
+                + Path.GetRelativePath("/", payloadDirectory)
+                + Path.DirectorySeparatorChar
+                + "payload";
+
+            var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly(traversal);
+
+            Assert.Null(assemblyPath);
+            Assert.NotNull(error);
+        }
+        finally
+        {
+            Directory.Delete(payloadDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The positive control: an ordinary platform assembly still resolves, so the guard is
+    /// refusing hostile names rather than refusing every name.
+    /// </summary>
+    [Fact]
+    public void ResolveAssembly_WithOrdinaryName_StillResolves()
+    {
+        var (assemblyPath, _, _, _) = PlatformResolver.ResolveAssembly("System.Text.Json");
+
+        Assert.NotNull(assemblyPath);
+        Assert.True(File.Exists(assemblyPath));
+    }
+}
+
+/// <summary>
+/// <see cref="StorePath.IsSafeSegment"/> was a separate implementation of the path-component rule
+/// and accepted values every other copy refused. An untrusted CodeView PDB file name reaches it on
+/// the way to filesystem-backed symbol storage.
+/// </summary>
+public class StorePathSegmentTests
+{
+    /// <summary>
+    /// The non-drift gate. Rather than restating the rule, this asserts that
+    /// <see cref="StorePath.IsSafeSegment"/> and <see cref="HardenedPath.IsSafePathComponent"/>
+    /// return the same answer for every probe, so reintroducing a local implementation fails here
+    /// the moment it disagrees with the owner on anything.
+    /// </summary>
+    [Fact]
+    public void IsSafeSegment_AgreesWithHardenedPathOnEveryProbe()
+    {
+        string[] probes =
+        [
+            // Accepted by the old local implementation, refused by the owner.
+            "CON", "con", "NUL", "COM1", "CONIN$", "CONOUT$", "LPT1", "CLOCK$",
+            "name.", "name ", " name", "na\u200bme", "na\u0007me", new string('a', 300),
+            // Refused by both, all along.
+            "", ".", "..", "a/b", "a\\b", "C:", "/rooted",
+            // Ordinary store segments.
+            "System.Text.Json.pdb", "Newtonsoft.Json", "13.0.3", "lib", "net8.0",
+        ];
+
+        var disagreements = probes
+            .Where(p => StorePath.IsSafeSegment(p) != HardenedPath.IsSafePathComponent(p))
+            .ToArray();
+
+        Assert.Empty(disagreements);
+    }
+
+    [Theory]
+    [InlineData("CON")]
+    [InlineData("con")]
+    [InlineData("NUL")]
+    [InlineData("COM1")]
+    [InlineData("CONIN$")]
+    [InlineData("LPT1")]
+    [InlineData("name.")]
+    [InlineData("name ")]
+    [InlineData(" name")]
+    [InlineData("na\u200bme")]
+    [InlineData("na\u0007me")]
+    public void IsSafeSegment_RefusesWhatTheOtherCopiesRefused(string segment)
+        => Assert.False(StorePath.IsSafeSegment(segment));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [InlineData("C:")]
+    public void IsSafeSegment_StillRefusesWhatItAlwaysRefused(string segment)
+        => Assert.False(StorePath.IsSafeSegment(segment));
+
+    [Theory]
+    [InlineData("System.Text.Json.pdb")]
+    [InlineData("Newtonsoft.Json")]
+    [InlineData("13.0.3")]
+    [InlineData("lib")]
+    public void IsSafeSegment_AcceptsOrdinaryStoreSegments(string segment)
+        => Assert.True(StorePath.IsSafeSegment(segment));
+}

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserCacheRootTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserCacheRootTests.cs
@@ -156,4 +156,72 @@ public class ProjectAssetsParserCacheRootTests
             Directory.Delete(payloadRoot, recursive: true);
         }
     }
+
+    /// <summary>
+    /// The <c>compile</c> key escapes the cache even when <c>library.path</c> is ordinary, so the
+    /// guard on <c>asm.Name</c> is load-bearing independently of the one on <c>library.path</c>.
+    /// </summary>
+    /// <remarks>
+    /// This is the gate for the second half of the <c>Parse</c> guard. A reviewer reading
+    /// <c>Parse</c> reported this sink as unguarded, and nothing in the suite contradicted them:
+    /// the rooted-path test above drives <c>library.path</c>, and the only test that touched a
+    /// <c>compile</c> key asserted nothing at all. <c>library.path</c> is deliberately benign here
+    /// so that a regression in the <c>asm.Name</c> half cannot be masked by the other half firing.
+    /// </remarks>
+    [Fact]
+    public void Parse_WithTraversingCompilePath_DoesNotEscapeTheNuGetCache()
+    {
+        var cacheRoot = Path.Combine(Path.GetTempPath(), $"assets-cache-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(cacheRoot, "legit.package", "1.0.0", "lib", "net8.0"));
+
+        var payloadRoot = Path.Combine(Path.GetTempPath(), $"assets-payload-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(payloadRoot);
+        var payload = Path.Combine(payloadRoot, "Payload.dll");
+        File.WriteAllText(payload, "payload");
+
+        var escape = Path.GetRelativePath(
+            Path.Combine(cacheRoot, "legit.package", "1.0.0"), payload).Replace("\\", "/");
+
+        var json = $$"""
+        {
+            "version": 3,
+            "targets": {
+                "net8.0": {
+                    "Legit.Package/1.0.0": {
+                        "type": "package",
+                        "compile": { "{{escape}}": {} }
+                    }
+                }
+            },
+            "libraries": {
+                "Legit.Package/1.0.0": {
+                    "type": "package",
+                    "path": "legit.package/1.0.0"
+                }
+            }
+        }
+        """;
+
+        var assetsPath = ProjectAssetsParserTests.WriteTempFile(json);
+        var previous = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", cacheRoot);
+        try
+        {
+            // Without these three, an empty result would prove nothing: the redirect could have
+            // been ignored, the payload could be absent, or the traversal could miss it. Together
+            // they mean the only reason Parse can return empty is that the guard refused.
+            Assert.Equal(cacheRoot, Packages.NuGetCache.GetNuGetCachePath());
+            Assert.True(File.Exists(payload));
+            Assert.True(File.Exists(Path.Combine(cacheRoot, "legit.package", "1.0.0", escape)));
+
+            Assert.Empty(ProjectAssetsParser.Parse(assetsPath, null, null));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previous);
+            File.Delete(assetsPath);
+            Directory.Delete(cacheRoot, recursive: true);
+            Directory.Delete(payloadRoot, recursive: true);
+        }
+    }
 }

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserCacheRootTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserCacheRootTests.cs
@@ -1,0 +1,159 @@
+namespace DotnetInspector.Services.Tests;
+
+/// <summary>
+/// Serializes tests that redirect the NuGet cache root. <c>NUGET_PACKAGES</c> is process-wide, so
+/// a test that sets it must not run beside one that reads the cache.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class NuGetCacheRootCollection
+{
+    public const string Name = "NuGetCacheRoot";
+}
+
+[Collection(NuGetCacheRootCollection.Name)]
+public class ProjectAssetsParserCacheRootTests
+{
+    /// <summary>
+    /// The positive control for the <c>library.path</c> guard: an ordinary package coordinate still
+    /// resolves, so the guard refuses traversal rather than refusing everything.
+    /// </summary>
+    /// <remarks>
+    /// The package has to exist under the cache root for <c>Parse</c> to return it, and
+    /// <see cref="Packages.NuGetCache.GetNuGetCachePath"/> carries an explicit "NEVER write to
+    /// ~/.nuget/packages" rule, so this redirects the root instead of planting a package in the
+    /// user's real cache. An earlier revision of this test wrote into the real one.
+    /// </remarks>
+    [Fact]
+    public void Parse_WithOrdinaryLibraryPath_StillResolves()
+    {
+        var cacheRoot = Path.Combine(Path.GetTempPath(), $"assets-cache-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(cacheRoot, "legit.package", "1.0.0", "lib", "net8.0"));
+        File.WriteAllText(
+            Path.Combine(cacheRoot, "legit.package", "1.0.0", "lib", "net8.0", "Legit.dll"),
+            "legit");
+
+        var assetsPath = ProjectAssetsParserTests.CreateTempAssetsFile(new Dictionary<string, object>
+        {
+            ["version"] = 3,
+            ["targets"] = new Dictionary<string, object>
+            {
+                ["net8.0"] = new Dictionary<string, object>
+                {
+                    ["Legit.Package/1.0.0"] = new Dictionary<string, object>
+                    {
+                        ["type"] = "package",
+                        ["compile"] = new Dictionary<string, object>
+                        {
+                            ["lib/net8.0/Legit.dll"] = new Dictionary<string, object>()
+                        }
+                    }
+                }
+            },
+            ["libraries"] = new Dictionary<string, object>
+            {
+                ["Legit.Package/1.0.0"] = new Dictionary<string, object>
+                {
+                    ["type"] = "package",
+                    ["path"] = "legit.package/1.0.0"
+                }
+            }
+        });
+
+        var previous = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", cacheRoot);
+        try
+        {
+            // Guards the redirect itself: GetNuGetCachePath ignores NUGET_PACKAGES when the
+            // directory does not exist, and this test would then silently assert nothing.
+            Assert.Equal(cacheRoot, Packages.NuGetCache.GetNuGetCachePath());
+
+            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
+            Assert.Contains(results, r => r.Path.EndsWith("Legit.dll", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previous);
+            File.Delete(assetsPath);
+            Directory.Delete(cacheRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A rooted <c>library.path</c> needs no <c>..</c> to escape: <c>ResolvePackagePath</c>
+    /// honored <see cref="Path.IsPathRooted"/> and returned the absolute path verbatim, so an
+    /// attacker chose the directory that package README and skill reads resolve beneath.
+    /// </summary>
+    /// <remarks>
+    /// This drives <c>ParsePackageFileEntries</c> rather than <c>Parse</c> on purpose: it is
+    /// <c>ParsePackageFileEntries</c> that routes through <c>ResolvePackagePath</c> and then reads
+    /// file content from the result. An earlier revision of this test called <c>Parse</c>, which
+    /// resolves package paths on a different code path, and so passed with the guard removed.
+    /// </remarks>
+    [Fact]
+    public void ParsePackageFileEntries_WithRootedLibraryPath_DoesNotEscapeTheNuGetCache()
+    {
+        var payloadRoot = Path.Combine(Path.GetTempPath(), $"assets-rooted-{Guid.NewGuid():N}");
+        var payload = Path.Combine(payloadRoot, "skills", "SKILL.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(payload)!);
+        File.WriteAllText(payload, "# Payload");
+
+        var json = $$"""
+        {
+            "targets": {
+                "net9.0": {
+                    "Evil.Package/1.0.0": {}
+                }
+            },
+            "libraries": {
+                "Evil.Package/1.0.0": {
+                    "type": "package",
+                    "path": "{{payloadRoot.Replace("\\", "/")}}",
+                    "files": [
+                        "skills/SKILL.md"
+                    ]
+                }
+            },
+            "project": {
+                "frameworks": {
+                    "net9.0": {
+                        "dependencies": {
+                            "Evil.Package": {
+                                "target": "Package",
+                                "version": "[1.0.0, )"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        var assetsPath = ProjectAssetsParserTests.WriteTempFile(json);
+        try
+        {
+            // The payload is really on disk and really matches the pattern, so an empty result is
+            // the guard refusing the rooted path rather than the file being absent.
+            Assert.True(File.Exists(payload));
+
+            var log = new List<string>();
+            var entries = ProjectAssetsParser.ParsePackageFileEntries(
+                assetsPath,
+                null,
+                ["skills/SKILL.md", "skills/**/SKILL.md"],
+                log.Add);
+
+            Assert.Empty(entries);
+
+            // The refusal has to be visible. Dropping the entry silently would leave the caller
+            // unable to tell a refused package from one that simply ships no skills.
+            Assert.Contains(log, m => m.Contains("Evil.Package/1.0.0", StringComparison.Ordinal));
+            Assert.False(ProjectAssetsParser.HasPackageFileEntries(
+                assetsPath, null, ["skills/SKILL.md", "skills/**/SKILL.md"], null));
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+            Directory.Delete(payloadRoot, recursive: true);
+        }
+    }
+}

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -502,53 +502,6 @@ public class ProjectAssetsParserTests
     }
 
     [Fact]
-    public void Parse_ReturnsAssemblyPaths_WhenFileExists()
-    {
-        // Create a temp directory structure that mimics NuGet cache
-        var tempDir = Path.Combine(Path.GetTempPath(), $"parser-test-{Guid.NewGuid():N}");
-        var packageDir = Path.Combine(tempDir, "foo", "1.0.0", "lib", "net9.0");
-        Directory.CreateDirectory(packageDir);
-        var dllPath = Path.Combine(packageDir, "Foo.dll");
-        File.WriteAllText(dllPath, "fake assembly");
-
-        // Build a relative path from NuGet cache
-        var nugetCache = DotnetInspector.Packages.NuGetCache.GetNuGetCachePath();
-        var relPath = Path.GetRelativePath(nugetCache, Path.Combine(tempDir, "foo", "1.0.0"));
-
-        var json = $$"""
-        {
-            "targets": {
-                "net9.0": {
-                    "Foo/1.0.0": {
-                        "compile": { "lib/net9.0/Foo.dll": {} }
-                    }
-                }
-            },
-            "libraries": {
-                "Foo/1.0.0": {
-                    "type": "package",
-                    "path": "{{relPath.Replace("\\", "/")}}"
-                }
-            }
-        }
-        """;
-
-        var assetsPath = WriteTempFile(json);
-        try
-        {
-            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
-            // The file needs to exist at the NuGet cache location, which is tricky to simulate
-            // This test verifies the parsing logic runs without error
-            // Files won't be found since our temp dir isn't the NuGet cache
-        }
-        finally
-        {
-            File.Delete(assetsPath);
-            Directory.Delete(tempDir, recursive: true);
-        }
-    }
-
-    [Fact]
     public void TryFindAssets_DirectAssetsJsonPath_ReturnsFound()
     {
         var dir = Path.Combine(Path.GetTempPath(), $"pa-test-{Guid.NewGuid():N}");

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -655,6 +655,126 @@ public class ProjectAssetsParserTests
         }
     }
 
+    /// <summary>
+    /// A crafted <c>project.assets.json</c> whose library <c>path</c> traverses out of the NuGet
+    /// cache must not resolve, even when a readable file is planted exactly where the unguarded
+    /// combine would land.
+    /// </summary>
+    /// <remarks>
+    /// The traversal is computed with <see cref="Path.GetRelativePath(string, string)"/> from the
+    /// real cache root to a temp directory, so the payload is genuinely reachable and the test
+    /// fails if the guard is removed. The threat model lists <c>project.assets.json</c> and the
+    /// paths inside it as untrusted, with unintended file reads as the risk.
+    /// </remarks>
+    [Fact]
+    public void Parse_WithTraversingLibraryPath_DoesNotEscapeTheNuGetCache()
+    {
+        var payloadRoot = Path.Combine(Path.GetTempPath(), $"assets-traversal-{Guid.NewGuid():N}");
+        var payloadDirectory = Path.Combine(payloadRoot, "lib", "net8.0");
+        Directory.CreateDirectory(payloadDirectory);
+        var payload = Path.Combine(payloadDirectory, "payload.dll");
+        File.WriteAllText(payload, "payload");
+
+        var cacheRoot = DotnetInspector.Packages.NuGetCache.GetNuGetCachePath();
+        var traversal = Path.GetRelativePath(cacheRoot, payloadRoot).Replace(Path.DirectorySeparatorChar, '/');
+
+        // The traversal has to actually reach the payload, or the test would pass without the guard.
+        Assert.Contains("..", traversal, StringComparison.Ordinal);
+        Assert.True(File.Exists(Path.Combine(cacheRoot, traversal.Replace('/', Path.DirectorySeparatorChar), "lib", "net8.0", "payload.dll")));
+
+        var assetsPath = CreateTempAssetsFile(new Dictionary<string, object>
+        {
+            ["version"] = 3,
+            ["targets"] = new Dictionary<string, object>
+            {
+                ["net8.0"] = new Dictionary<string, object>
+                {
+                    ["Evil.Package/1.0.0"] = new Dictionary<string, object>
+                    {
+                        ["type"] = "package",
+                        ["compile"] = new Dictionary<string, object>
+                        {
+                            ["lib/net8.0/payload.dll"] = new Dictionary<string, object>()
+                        }
+                    }
+                }
+            },
+            ["libraries"] = new Dictionary<string, object>
+            {
+                ["Evil.Package/1.0.0"] = new Dictionary<string, object>
+                {
+                    ["type"] = "package",
+                    ["path"] = traversal
+                }
+            }
+        });
+
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
+
+            Assert.DoesNotContain(results, r => r.Path.Contains("payload.dll", StringComparison.OrdinalIgnoreCase));
+            Assert.Empty(results);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+            Directory.Delete(payloadRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The positive control: an ordinary package coordinate still resolves, so the guard above is
+    /// refusing traversal rather than refusing everything.
+    /// </summary>
+    [Fact]
+    public void Parse_WithOrdinaryLibraryPath_StillResolves()
+    {
+        var cacheRoot = DotnetInspector.Packages.NuGetCache.GetNuGetCachePath();
+        var packageRelative = $"legit.package/{Guid.NewGuid():N}";
+        var packageDirectory = Path.Combine(cacheRoot, packageRelative.Replace('/', Path.DirectorySeparatorChar), "lib", "net8.0");
+        Directory.CreateDirectory(packageDirectory);
+        File.WriteAllText(Path.Combine(packageDirectory, "Legit.dll"), "legit");
+
+        var assetsPath = CreateTempAssetsFile(new Dictionary<string, object>
+        {
+            ["version"] = 3,
+            ["targets"] = new Dictionary<string, object>
+            {
+                ["net8.0"] = new Dictionary<string, object>
+                {
+                    ["Legit.Package/1.0.0"] = new Dictionary<string, object>
+                    {
+                        ["type"] = "package",
+                        ["compile"] = new Dictionary<string, object>
+                        {
+                            ["lib/net8.0/Legit.dll"] = new Dictionary<string, object>()
+                        }
+                    }
+                }
+            },
+            ["libraries"] = new Dictionary<string, object>
+            {
+                ["Legit.Package/1.0.0"] = new Dictionary<string, object>
+                {
+                    ["type"] = "package",
+                    ["path"] = packageRelative
+                }
+            }
+        });
+
+        try
+        {
+            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
+            Assert.Contains(results, r => r.Path.EndsWith("Legit.dll", StringComparison.Ordinal));
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+            Directory.Delete(Path.Combine(cacheRoot, packageRelative.Split('/')[0], packageRelative.Split('/')[1]), recursive: true);
+        }
+    }
+
     private static string CreateTempAssetsFile(object content)
     {
         var json = JsonSerializer.Serialize(content);

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 
 namespace DotnetInspector.Services.Tests;
 
+[Collection(NuGetCacheRootCollection.Name)]
 public class ProjectAssetsParserTests
 {
     [Fact]
@@ -229,13 +230,16 @@ public class ProjectAssetsParserTests
     [Fact]
     public void ParsePackageFileEntries_ReturnsDirectPackageFilesMatchingPattern()
     {
-        var packageRoot = Path.Combine(Path.GetTempPath(), $"pa-files-{Guid.NewGuid():N}");
+        // library.path is a relative coordinate under the NuGet cache in every assets file NuGet
+        // writes, and ResolvePackagePath now refuses anything else, so this redirects the cache
+        // root rather than pointing library.path at an absolute temp directory.
+        var cacheRoot = Path.Combine(Path.GetTempPath(), $"pa-files-{Guid.NewGuid():N}");
+        var packageRoot = Path.Combine(cacheRoot, "direct.package", "2.1.0");
         var skillPath = Path.Combine(packageRoot, "skills", "query", "SKILL.md");
         Directory.CreateDirectory(Path.GetDirectoryName(skillPath)!);
         File.WriteAllText(skillPath, "# Skill");
 
-        var transitiveRoot = Path.Combine(Path.GetTempPath(), $"pa-files-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(Path.Combine(transitiveRoot, "skills", "transitive"));
+        Directory.CreateDirectory(Path.Combine(cacheRoot, "transitive.package", "1.0.0", "skills", "transitive"));
 
         var json = $$"""
         {
@@ -249,7 +253,7 @@ public class ProjectAssetsParserTests
             "libraries": {
                 "Direct.Package/2.1.0": {
                     "type": "package",
-                    "path": "{{packageRoot.Replace("\\", "/")}}",
+                    "path": "direct.package/2.1.0",
                     "files": [
                         42,
                         "README.md",
@@ -258,7 +262,7 @@ public class ProjectAssetsParserTests
                 },
                 "Transitive.Package/1.0.0": {
                     "type": "package",
-                    "path": "{{transitiveRoot.Replace("\\", "/")}}",
+                    "path": "transitive.package/1.0.0",
                     "files": [
                         "skills/transitive/SKILL.md"
                     ]
@@ -287,6 +291,8 @@ public class ProjectAssetsParserTests
         """;
 
         var assetsPath = WriteTempFile(json);
+        var previousCache = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", cacheRoot);
         try
         {
             var result = ProjectAssetsParser.ParsePackageFileEntries(
@@ -306,16 +312,17 @@ public class ProjectAssetsParserTests
         }
         finally
         {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previousCache);
             File.Delete(assetsPath);
-            Directory.Delete(packageRoot, recursive: true);
-            Directory.Delete(transitiveRoot, recursive: true);
+            Directory.Delete(cacheRoot, recursive: true);
         }
     }
 
     [Fact]
     public void ParsePackageFileEntries_CanMatchTopLevelSkillFile()
     {
-        var packageRoot = Path.Combine(Path.GetTempPath(), $"pa-files-{Guid.NewGuid():N}");
+        var cacheRoot = Path.Combine(Path.GetTempPath(), $"pa-files-{Guid.NewGuid():N}");
+        var packageRoot = Path.Combine(cacheRoot, "direct.package", "1.0.0");
         var skillPath = Path.Combine(packageRoot, "skills", "SKILL.md");
         Directory.CreateDirectory(Path.GetDirectoryName(skillPath)!);
         File.WriteAllText(skillPath, "# Skill");
@@ -330,7 +337,7 @@ public class ProjectAssetsParserTests
             "libraries": {
                 "Direct.Package/1.0.0": {
                     "type": "package",
-                    "path": "{{packageRoot.Replace("\\", "/")}}",
+                    "path": "direct.package/1.0.0",
                     "files": [
                         "skills/SKILL.md"
                     ]
@@ -352,6 +359,8 @@ public class ProjectAssetsParserTests
         """;
 
         var assetsPath = WriteTempFile(json);
+        var previousCache = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", cacheRoot);
         try
         {
             var entry = Assert.Single(ProjectAssetsParser.ParsePackageFileEntries(
@@ -365,8 +374,9 @@ public class ProjectAssetsParserTests
         }
         finally
         {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previousCache);
             File.Delete(assetsPath);
-            Directory.Delete(packageRoot, recursive: true);
+            Directory.Delete(cacheRoot, recursive: true);
         }
     }
 
@@ -723,65 +733,13 @@ public class ProjectAssetsParserTests
         }
     }
 
-    /// <summary>
-    /// The positive control: an ordinary package coordinate still resolves, so the guard above is
-    /// refusing traversal rather than refusing everything.
-    /// </summary>
-    [Fact]
-    public void Parse_WithOrdinaryLibraryPath_StillResolves()
-    {
-        var cacheRoot = DotnetInspector.Packages.NuGetCache.GetNuGetCachePath();
-        var packageRelative = $"legit.package/{Guid.NewGuid():N}";
-        var packageDirectory = Path.Combine(cacheRoot, packageRelative.Replace('/', Path.DirectorySeparatorChar), "lib", "net8.0");
-        Directory.CreateDirectory(packageDirectory);
-        File.WriteAllText(Path.Combine(packageDirectory, "Legit.dll"), "legit");
-
-        var assetsPath = CreateTempAssetsFile(new Dictionary<string, object>
-        {
-            ["version"] = 3,
-            ["targets"] = new Dictionary<string, object>
-            {
-                ["net8.0"] = new Dictionary<string, object>
-                {
-                    ["Legit.Package/1.0.0"] = new Dictionary<string, object>
-                    {
-                        ["type"] = "package",
-                        ["compile"] = new Dictionary<string, object>
-                        {
-                            ["lib/net8.0/Legit.dll"] = new Dictionary<string, object>()
-                        }
-                    }
-                }
-            },
-            ["libraries"] = new Dictionary<string, object>
-            {
-                ["Legit.Package/1.0.0"] = new Dictionary<string, object>
-                {
-                    ["type"] = "package",
-                    ["path"] = packageRelative
-                }
-            }
-        });
-
-        try
-        {
-            var results = ProjectAssetsParser.Parse(assetsPath, null, null);
-            Assert.Contains(results, r => r.Path.EndsWith("Legit.dll", StringComparison.Ordinal));
-        }
-        finally
-        {
-            File.Delete(assetsPath);
-            Directory.Delete(Path.Combine(cacheRoot, packageRelative.Split('/')[0], packageRelative.Split('/')[1]), recursive: true);
-        }
-    }
-
-    private static string CreateTempAssetsFile(object content)
+    internal static string CreateTempAssetsFile(object content)
     {
         var json = JsonSerializer.Serialize(content);
         return WriteTempFile(json);
     }
 
-    private static string WriteTempFile(string content)
+    internal static string WriteTempFile(string content)
     {
         var path = Path.Combine(Path.GetTempPath(), $"project-assets-test-{Guid.NewGuid():N}.json");
         File.WriteAllText(path, content);

--- a/src/DotnetInspector.Services.Tests/StderrCapture.cs
+++ b/src/DotnetInspector.Services.Tests/StderrCapture.cs
@@ -1,0 +1,44 @@
+namespace DotnetInspector.Services.Tests;
+
+/// <summary>
+/// The single place this test assembly is allowed to redirect the console.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Console.Error</c> is process-global and xUnit runs test classes in parallel, so two tests
+/// that redirect it concurrently steal each other's output, and each restores the writer it
+/// captured on entry -- an interleaved pair can leave the console pointing at a disposed
+/// <see cref="StringWriter"/> after both have finished. Every capture therefore goes through the
+/// same semaphore.
+/// </para>
+/// <para>
+/// The hazard is not limited to tests that redirect. Any test that causes product code to write
+/// to stderr while another test holds the redirect pollutes that test's captured output, and the
+/// victim then fails on text it never produced. That happened for real in the CLI test assembly
+/// once refusals began reporting unconditionally: four unrelated tests failed intermittently and
+/// passed in isolation. Tests here that trigger a refusal should run inside this helper for the
+/// same reason, whether or not they assert on the text.
+/// </para>
+/// </remarks>
+static class StderrCapture
+{
+    private static readonly SemaphoreSlim _lock = new(1, 1);
+
+    public static async Task<string> RunAsync(Action action)
+    {
+        await _lock.WaitAsync();
+        var original = Console.Error;
+        using var writer = new StringWriter();
+        Console.SetError(writer);
+        try
+        {
+            action();
+            return writer.ToString();
+        }
+        finally
+        {
+            Console.SetError(original);
+            _lock.Release();
+        }
+    }
+}

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -350,7 +350,7 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
             // loop's existing behavior for a dependency that does not resolve.
             if (!HardenedPath.IsSafePathComponent(id) || !HardenedPath.IsSafePathComponent(version))
             {
-                log?.Invoke($"Refusing unsafe package coordinate '{id}/{version}' from {packageDirectory}");
+                HardenedPath.ReportRefusal($"refusing unsafe package coordinate '{id}/{version}' from {packageDirectory}");
                 continue;
             }
 
@@ -747,7 +747,7 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 if (HardenedPath.IsSafeRelativePath(localPath))
                     addReference(Path.Combine(targetDirectory, NativePath(localPath)));
                 else
-                    log?.Invoke($"Refusing unsafe deps.json localPath '{localPath}' for library '{library.Name}'");
+                    HardenedPath.ReportRefusal($"refusing unsafe deps.json localPath '{localPath}' for library '{library.Name}'");
             }
 
             if (libraryPaths.TryGetValue(library.Name, out var packagePath))
@@ -755,7 +755,7 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 if (HardenedPath.IsSafeRelativePath(packagePath) && HardenedPath.IsSafeRelativePath(asset.Name))
                     addReference(Path.Combine(GlobalPackagesRoot(), NativePath(packagePath), NativePath(asset.Name)));
                 else
-                    log?.Invoke($"Refusing unsafe deps.json asset '{packagePath}/{asset.Name}' for library '{library.Name}'");
+                    HardenedPath.ReportRefusal($"refusing unsafe deps.json asset '{packagePath}/{asset.Name}' for library '{library.Name}'");
             }
         }
     }

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -726,10 +726,13 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
             if (asset.Value.ValueKind == JsonValueKind.Object &&
                 asset.Value.TryGetProperty("localPath", out var localPathElement) &&
                 localPathElement.ValueKind == JsonValueKind.String &&
-                localPathElement.GetString() is { Length: > 0 } localPath)
+                localPathElement.GetString() is { Length: > 0 } localPath &&
+                HardenedPath.IsSafeRelativePath(localPath))
                 addReference(Path.Combine(targetDirectory, NativePath(localPath)));
 
-            if (libraryPaths.TryGetValue(library.Name, out var packagePath))
+            if (libraryPaths.TryGetValue(library.Name, out var packagePath) &&
+                HardenedPath.IsSafeRelativePath(packagePath) &&
+                HardenedPath.IsSafeRelativePath(asset.Name))
                 addReference(Path.Combine(GlobalPackagesRoot(), NativePath(packagePath), NativePath(asset.Name)));
         }
     }

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using DotnetInspector.Core;
 using DotnetInspector.Packages;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 using NuGet.Versioning;
 
 namespace DotnetInspector.Services;
@@ -328,6 +329,15 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
             string? id = dependency.Attribute("id")?.Value;
             string? version = DependencyExactVersion(dependency.Attribute("version")?.Value);
             if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(version))
+                continue;
+
+            // The id and version are read from a nuspec, which is a feed artifact rather than
+            // something this process authored, and both become path components below. An id of
+            // "../escape" resolves outside the package root, and the resolver then recurses into
+            // that directory and records it as the package's location, so the escape propagates
+            // into what later gets read as an assembly. Skipping an unsafe coordinate matches the
+            // loop's existing behavior for a dependency that does not resolve.
+            if (!HardenedPath.IsSafePathComponent(id) || !HardenedPath.IsSafePathComponent(version))
                 continue;
 
             foreach (var root in NuGetPackageRoots(packageRoots))

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -44,6 +44,13 @@ public sealed record AssemblyDependencyResolutionOptions(string TargetAssemblyPa
     public bool PreferImplementationAssemblies { get; init; }
     public bool AllowPlatformAssemblyVersionRollForward { get; init; }
     public bool ExcludeTargetAssembly { get; init; }
+
+    /// <summary>
+    /// Where the resolver reports inputs it refused. A refused package coordinate or asset path is
+    /// dropped from the resolved graph, which without this reads exactly like a dependency that
+    /// legitimately did not resolve. AGENTS.md forbids that: failure has to stay visible.
+    /// </summary>
+    public Action<string>? Log { get; init; }
 }
 
 /// <summary>
@@ -110,7 +117,8 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
         foreach (var path in PackageDependencyReferencePaths(
             targetPath,
             _options.PackageRoots,
-            preferImplementationAssemblies: _options.PreferImplementationAssemblies))
+            preferImplementationAssemblies: _options.PreferImplementationAssemblies,
+            log: _options.Log))
         {
             var package = TryReadPackageIdentity(path, _options.PackageRoots);
             Add(path, AssemblyDependencyProvenance.PackageDependency, package.Id, package.Version);
@@ -133,12 +141,12 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 {
                     var package = TryReadPackageIdentity(path, _options.PackageRoots);
                     Add(path, AssemblyDependencyProvenance.DepsJsonAsset, package.Id, package.Version);
-                });
+                }, _options.Log);
         }
 
         if (_options.ProjectAssetsPath is { Length: > 0 } assetsPath && File.Exists(assetsPath))
         {
-            foreach (var (path, packageName, version) in ProjectAssetsParser.Parse(assetsPath, _options.TargetFramework, log: null))
+            foreach (var (path, packageName, version) in ProjectAssetsParser.Parse(assetsPath, _options.TargetFramework, log: _options.Log))
                 Add(path, AssemblyDependencyProvenance.ProjectAsset, packageName, version);
         }
 
@@ -255,7 +263,8 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
     public static IReadOnlyList<string> PackageDependencyReferencePaths(
         string targetPath,
         IReadOnlyList<string>? packageRoots,
-        bool preferImplementationAssemblies)
+        bool preferImplementationAssemblies,
+        Action<string>? log = null)
     {
         if (NuGetPackageContext(targetPath, packageRoots) is not { } context)
             return [];
@@ -275,7 +284,8 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 packageRoots,
                 packageDirectories,
                 dependencyGraph,
-                new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                log);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Xml.XmlException)
         {
@@ -316,7 +326,8 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
         IReadOnlyList<string>? packageRoots,
         Dictionary<string, Dictionary<string, string>> packageDirectories,
         Dictionary<string, List<PackageDependency>> dependencyGraph,
-        HashSet<string> visiting)
+        HashSet<string> visiting,
+        Action<string>? log = null)
     {
         var nuspec = Directory.EnumerateFiles(packageDirectory, "*.nuspec").FirstOrDefault();
         if (nuspec is null)
@@ -338,7 +349,10 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
             // into what later gets read as an assembly. Skipping an unsafe coordinate matches the
             // loop's existing behavior for a dependency that does not resolve.
             if (!HardenedPath.IsSafePathComponent(id) || !HardenedPath.IsSafePathComponent(version))
+            {
+                log?.Invoke($"Refusing unsafe package coordinate '{id}/{version}' from {packageDirectory}");
                 continue;
+            }
 
             foreach (var root in NuGetPackageRoots(packageRoots))
             {
@@ -360,7 +374,8 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                         packageRoots,
                         packageDirectories,
                         dependencyGraph,
-                        visiting);
+                        visiting,
+                        log);
                     visiting.Remove(visitKey);
                 }
                 break;
@@ -663,7 +678,7 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
 
     static string VersionCore(string version) => version.Split('-', 2)[0];
 
-    static void AddDepsJsonReferences(string targetDirectory, string targetName, Action<string> addReference)
+    static void AddDepsJsonReferences(string targetDirectory, string targetName, Action<string> addReference, Action<string>? log = null)
     {
         var depsPath = Path.Combine(targetDirectory, $"{targetName}.deps.json");
         if (!File.Exists(depsPath))
@@ -696,8 +711,8 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
 
                 foreach (var library in target.Value.EnumerateObject())
                 {
-                    AddAssetGroup(targetDirectory, libraryPaths, library, "compile", addReference);
-                    AddAssetGroup(targetDirectory, libraryPaths, library, "runtime", addReference);
+                    AddAssetGroup(targetDirectory, libraryPaths, library, "compile", addReference, log);
+                    AddAssetGroup(targetDirectory, libraryPaths, library, "runtime", addReference, log);
                 }
             }
         }
@@ -711,7 +726,8 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
         IReadOnlyDictionary<string, string> libraryPaths,
         JsonProperty library,
         string groupName,
-        Action<string> addReference)
+        Action<string> addReference,
+        Action<string>? log = null)
     {
         if (!library.Value.TryGetProperty(groupName, out var assets))
             return;
@@ -726,14 +742,21 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
             if (asset.Value.ValueKind == JsonValueKind.Object &&
                 asset.Value.TryGetProperty("localPath", out var localPathElement) &&
                 localPathElement.ValueKind == JsonValueKind.String &&
-                localPathElement.GetString() is { Length: > 0 } localPath &&
-                HardenedPath.IsSafeRelativePath(localPath))
-                addReference(Path.Combine(targetDirectory, NativePath(localPath)));
+                localPathElement.GetString() is { Length: > 0 } localPath)
+            {
+                if (HardenedPath.IsSafeRelativePath(localPath))
+                    addReference(Path.Combine(targetDirectory, NativePath(localPath)));
+                else
+                    log?.Invoke($"Refusing unsafe deps.json localPath '{localPath}' for library '{library.Name}'");
+            }
 
-            if (libraryPaths.TryGetValue(library.Name, out var packagePath) &&
-                HardenedPath.IsSafeRelativePath(packagePath) &&
-                HardenedPath.IsSafeRelativePath(asset.Name))
-                addReference(Path.Combine(GlobalPackagesRoot(), NativePath(packagePath), NativePath(asset.Name)));
+            if (libraryPaths.TryGetValue(library.Name, out var packagePath))
+            {
+                if (HardenedPath.IsSafeRelativePath(packagePath) && HardenedPath.IsSafeRelativePath(asset.Name))
+                    addReference(Path.Combine(GlobalPackagesRoot(), NativePath(packagePath), NativePath(asset.Name)));
+                else
+                    log?.Invoke($"Refusing unsafe deps.json asset '{packagePath}/{asset.Name}' for library '{library.Name}'");
+            }
         }
     }
 

--- a/src/DotnetInspector.Services/PlatformPackService.cs
+++ b/src/DotnetInspector.Services/PlatformPackService.cs
@@ -270,7 +270,7 @@ public static class PlatformPackService
         // than resolve, matching the null the caller already handles for an unavailable pack.
         if (!HardenedPath.IsSafePathComponent(packName) || !HardenedPath.IsSafePathComponent(version))
         {
-            log?.Invoke($"Refusing unsafe pack coordinate: {packName} {version}");
+            HardenedPath.ReportRefusal($"refusing unsafe pack coordinate: {packName} {version}");
             return null;
         }
 

--- a/src/DotnetInspector.Services/PlatformPackService.cs
+++ b/src/DotnetInspector.Services/PlatformPackService.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Core;
 using DotnetInspector.Packages;
+using ILInspector.MetadataPrimitives;
 
 namespace DotnetInspector.Services;
 
@@ -260,6 +261,16 @@ public static class PlatformPackService
         var cachePath = GetPacksCachePath();
         if (cachePath == null)
         {
+            return null;
+        }
+
+        // The version normally arrives from GetLatestPackVersionAsync, which is a feed response,
+        // and the pack name from a resolved TFM; both become path components here and the result
+        // is a cache directory this process then writes an extracted package into. Refuse rather
+        // than resolve, matching the null the caller already handles for an unavailable pack.
+        if (!HardenedPath.IsSafePathComponent(packName) || !HardenedPath.IsSafePathComponent(version))
+        {
+            log?.Invoke($"Refusing unsafe pack coordinate: {packName} {version}");
             return null;
         }
 

--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -3,6 +3,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using DotnetInspector.Core;
+using ILInspector.MetadataPrimitives;
 using ILInspector.Metadata;
 using NuGet.Versioning;
 
@@ -594,6 +595,19 @@ public static class PlatformResolver
         bool useRuntimeAssemblies = false,
         string? platformVersion = null)
     {
+        // assemblyName reaches Path.Combine + File.Exists in FindAssemblyCaseInsensitive and in
+        // the runtime resolver, and callers pass names read straight out of untrusted assembly
+        // metadata — BuildTransitiveReferences forwards AssemblyRef.Name from the inspected PE.
+        // A reference named "../../../tmp/payload" therefore resolved to a file outside the
+        // framework directory and was reported as a platform assembly. Every caller passes a
+        // simple assembly name, never a path, so the rule is validated once here rather than at
+        // each of the twelve call sites: a per-caller guard is how this rule drifted into six
+        // divergent copies in the first place.
+        if (!HardenedPath.IsSafePathComponent(assemblyName))
+        {
+            return (null, null, null, $"'{assemblyName}' is not a valid assembly name.");
+        }
+
         // Detect framework names passed as assembly names (e.g., --platform Microsoft.AspNetCore.App)
         // and provide a helpful error message
         var frameworkMatch = SharedFrameworkMappings

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -209,7 +209,10 @@ public static class ProjectAssetsParser
                         // model lists as untrusted along with the paths inside it.
                         if (!HardenedPath.IsSafeRelativePath(packagePath) ||
                             !HardenedPath.IsSafeRelativePath(asm.Name))
+                        {
+                            log?.Invoke($"Refusing unsafe asset path '{packagePath}/{asm.Name}' from {assetsPath}");
                             continue;
+                        }
 
                         var fullPath = Path.Combine(nugetCache, packagePath, asm.Name.Replace('/', Path.DirectorySeparatorChar));
                         if (File.Exists(fullPath))

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -210,7 +210,7 @@ public static class ProjectAssetsParser
                         if (!HardenedPath.IsSafeRelativePath(packagePath) ||
                             !HardenedPath.IsSafeRelativePath(asm.Name))
                         {
-                            log?.Invoke($"Refusing unsafe asset path '{packagePath}/{asm.Name}' from {assetsPath}");
+                            HardenedPath.ReportRefusal($"refusing unsafe asset path '{packagePath}/{asm.Name}' from {assetsPath}");
                             continue;
                         }
 

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -3,6 +3,7 @@ using System.IO.Enumeration;
 using System.Text.Json;
 using DotnetInspector.Core;
 using DotnetInspector.Packages;
+using ILInspector.MetadataPrimitives;
 using NuGetFetch;
 
 namespace DotnetInspector.Services;
@@ -178,6 +179,12 @@ public static class ProjectAssetsParser
                 if (!libraries.TryGetProperty(dep.Name, out var libInfo))
                     continue;
 
+                // Project references are skipped before "path" is read, which is load-bearing for
+                // the guard below: a project library's path is legitimately relative to the assets
+                // file ("../Contoso/Contoso.csproj") and would be refused as traversal. A sweep of
+                // 1,568 real project.assets.json files rejected 5,249 paths before this skip was
+                // accounted for and 0 after. Moving the guard above this line, or resolving project
+                // libraries through it, will refuse ordinary project references.
                 if (libInfo.TryGetProperty("type", out var typeElem) && typeElem.GetString() == "project")
                     continue;
 
@@ -196,6 +203,12 @@ public static class ProjectAssetsParser
                             continue;
 
                         if (asm.Name.Contains("_._"))
+                            continue;
+
+                        // packagePath and asm.Name come from project.assets.json, which the threat
+                        // model lists as untrusted along with the paths inside it.
+                        if (!HardenedPath.IsSafeRelativePath(packagePath) ||
+                            !HardenedPath.IsSafeRelativePath(asm.Name))
                             continue;
 
                         var fullPath = Path.Combine(nugetCache, packagePath, asm.Name.Replace('/', Path.DirectorySeparatorChar));
@@ -492,6 +505,11 @@ public static class ProjectAssetsParser
     private static string? ResolvePackageFilePath(string? packagePath, string packageRelativePath)
     {
         if (string.IsNullOrWhiteSpace(packagePath))
+            return null;
+
+        // packageRelativePath comes from the "files" array of project.assets.json. packagePath is
+        // the already-resolved package root, so only the untrusted half is validated here.
+        if (!HardenedPath.IsSafeRelativePath(packageRelativePath))
             return null;
 
         return Path.GetFullPath(Path.Combine(

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -342,6 +342,18 @@ public static class ProjectAssetsParser
                     continue;
                 }
 
+                // PackagePath is null when the library's "path" failed validation. Emitting file
+                // entries anyway would list a README or skill whose PackagePath and FullPath are
+                // empty — output shaped like success for content that was refused and will never
+                // be read. Refuse the package and say why instead.
+                if (string.IsNullOrEmpty(packageReference.PackagePath))
+                {
+                    log?.Invoke(
+                        $"Warning: ignoring package '{packageKey}': its 'path' in project.assets.json " +
+                        "is not a valid package coordinate.");
+                    continue;
+                }
+
                 foreach (var file in files.EnumerateArray())
                 {
                     if (file.ValueKind != JsonValueKind.String)
@@ -496,10 +508,18 @@ public static class ProjectAssetsParser
         if (string.IsNullOrWhiteSpace(packagePath))
             return null;
 
-        var normalized = packagePath.Replace('/', Path.DirectorySeparatorChar);
-        return Path.IsPathRooted(normalized)
-            ? Path.GetFullPath(normalized)
-            : Path.GetFullPath(Path.Combine(NuGetCache.GetNuGetCachePath(), normalized));
+        // "path" is untrusted (threat model: project.assets.json and the paths within it), and it
+        // becomes the root that README/AGENTS/skill reads are resolved beneath, so a rooted value
+        // would relocate those reads anywhere on disk. Package libraries always spell it as a
+        // relative "id/version" coordinate under the NuGet cache. Both callers reject project
+        // libraries via IsProjectLibrary before reaching here, which is what makes refusing
+        // relative traversal correct: only project paths are legitimately "../Contoso".
+        if (!HardenedPath.IsSafeRelativePath(packagePath))
+            return null;
+
+        return Path.GetFullPath(Path.Combine(
+            NuGetCache.GetNuGetCachePath(),
+            packagePath.Replace('/', Path.DirectorySeparatorChar)));
     }
 
     private static string? ResolvePackageFilePath(string? packagePath, string packageRelativePath)

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -3,6 +3,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Decompiler.Pipeline;
 
@@ -211,6 +212,13 @@ public sealed class MetadataSource : IDisposable
 
             if (_directory is not null)
             {
+                // identity.Name is a MetadataReader string from the inspected assembly, so it is
+                // attacker-controlled and is about to be joined onto a directory and opened.
+                // Path.Combine(root, untrustedValue) is not a containment check
+                // (docs/design/untrusted-data-threat-model.md, "Derived paths").
+                if (!HardenedPath.IsSafePathComponent(identity.Name))
+                    return null;
+
                 string sibling = System.IO.Path.Combine(_directory, identity.Name + ".dll");
                 if (File.Exists(sibling))
                 {

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -787,17 +787,39 @@ public class PdbContext : IDisposable
     /// Returns null if the type is defined in this assembly (not forwarded).
     /// Looks for the target assembly DLL in the same directory as this assembly.
     /// </summary>
+    /// <remarks>
+    /// The forwarder target is a name read from the inspected assembly's metadata, which is
+    /// untrusted, and it becomes a path component here. An unsafe name is refused rather than
+    /// resolved: returning null leaves the type unresolved, which callers already handle, whereas
+    /// resolving it would read a file outside the assembly's own directory. Refusing is also what
+    /// keeps this off the symbol-acquisition path, where a resolved path drives network fetches.
+    /// </remarks>
     public string? ResolveImplementationAssemblyPath(string typeName)
     {
         var targetAssemblyName = FindTypeForwarder(typeName);
         if (targetAssemblyName == null)
             return null;
 
-        var dir = Path.GetDirectoryName(_assemblyPath);
-        if (dir == null)
+        return ResolveForwardedAssemblyPath(Path.GetDirectoryName(_assemblyPath), targetAssemblyName);
+    }
+
+    /// <summary>
+    /// Resolves a forwarder target name against the forwarding assembly's directory, refusing a
+    /// name that is not safe as a single path component.
+    /// </summary>
+    /// <remarks>
+    /// Split out from <see cref="ResolveImplementationAssemblyPath"/> so the refusal is directly
+    /// observable: <c>PdbContextForwarderResolutionTests</c> plants a payload exactly where a
+    /// traversing name would land and asserts it is not read, with a legitimate sibling as the
+    /// positive control. The step from <see cref="FindTypeForwarder"/> into this method is a
+    /// direct call in the caller above, not something those tests cover.
+    /// </remarks>
+    internal static string? ResolveForwardedAssemblyPath(string? directory, string? targetAssemblyName)
+    {
+        if (directory == null || !HardenedPath.IsSafePathComponent(targetAssemblyName))
             return null;
 
-        var targetPath = Path.Combine(dir, targetAssemblyName + ".dll");
+        var targetPath = Path.Combine(directory, targetAssemblyName + ".dll");
         return File.Exists(targetPath) ? targetPath : null;
     }
 

--- a/src/ILInspector.Metadata/ResourceExtractor.cs
+++ b/src/ILInspector.Metadata/ResourceExtractor.cs
@@ -1,6 +1,6 @@
-using System.Buffers;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Metadata;
 
@@ -12,13 +12,6 @@ static class ResourceExtractor
         int Size,
         string DestinationPath,
         string DestinationFullPath);
-
-    // The portable set ('<' '>' '"' '|' '?' '*') is unioned with the platform's
-    // invalid file-name characters so component validation stays deterministic
-    // across operating systems. Caching in SearchValues also avoids the fresh
-    // array that Path.GetInvalidFileNameChars() allocates on every call.
-    static readonly SearchValues<char> s_invalidFileNameCharacters =
-        SearchValues.Create([.. Path.GetInvalidFileNameChars(), '<', '>', '"', '|', '?', '*']);
 
     public static List<string> ExtractAll(PEReader peReader, string outputDirectory)
     {
@@ -203,16 +196,13 @@ static class ResourceExtractor
         var components = name.Split(['/', '\\'], StringSplitOptions.None);
         foreach (var component in components)
         {
-            if (component.Length == 0
-                || component is "." or ".."
-                || component.AsSpan().ContainsAny(s_invalidFileNameCharacters)
-                || component.Contains(':')
-                || component.EndsWith(' ')
-                || component.EndsWith('.')
-                || IsWindowsDeviceName(component))
-            {
+            // Per-component safety belongs to HardenedPath, which owns it for every other
+            // untrusted name that becomes a path. This used to be a fifth copy of that rule and
+            // was missing its digit fold, its format-character and malformed-UTF-16 refusals, and
+            // its length bound. What stays here is genuinely path-level rather than
+            // component-level: the split itself, and the rooted/drive-qualified checks above.
+            if (!HardenedPath.IsSafePathComponent(component))
                 throw UnsafeResourceName(name);
-            }
         }
         return components;
     }
@@ -220,26 +210,6 @@ static class ResourceExtractor
     static bool IsDriveQualified(string name)
         => name.Length >= 2 && char.IsAsciiLetter(name[0]) && name[1] == ':';
 
-    static bool IsWindowsDeviceName(string component)
-    {
-        var separator = component.IndexOf('.');
-        var stem = (separator >= 0 ? component[..separator] : component).TrimEnd(' ', '.');
-        return stem.Equals("CON", StringComparison.OrdinalIgnoreCase)
-            || stem.Equals("PRN", StringComparison.OrdinalIgnoreCase)
-            || stem.Equals("AUX", StringComparison.OrdinalIgnoreCase)
-            || stem.Equals("NUL", StringComparison.OrdinalIgnoreCase)
-            || stem.Equals("CLOCK$", StringComparison.OrdinalIgnoreCase)
-            || IsNumberedDevice(stem, "COM")
-            || IsNumberedDevice(stem, "LPT");
-    }
-
-    static bool IsNumberedDevice(string stem, string prefix)
-        => stem.Length == prefix.Length + 1
-            && stem.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-            && IsDeviceDigit(stem[^1]);
-
-    static bool IsDeviceDigit(char value)
-        => value is >= '1' and <= '9' or '\u00B9' or '\u00B2' or '\u00B3';
 
     static InvalidDataException UnsafeResourceName(string name)
         => new($"Manifest resource '{name}' is not a safe relative extraction path.");

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -238,4 +238,28 @@ public static class HardenedPath
         => char.IsHighSurrogate(value[index])
            && index + 1 < value.Length
            && char.IsLowSurrogate(value[index + 1]);
+
+    /// <summary>
+    /// Announces that an untrusted coordinate was refused. Writes to stderr unconditionally.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A refusal removes something the user would otherwise have been shown, and the result it
+    /// leaves behind -- a dependency with no children, a package with no assets -- is
+    /// indistinguishable from that thing genuinely being absent. Reporting it through the callers'
+    /// optional <c>Action&lt;string&gt;? log</c> made it invisible twice over: most call sites pass
+    /// no logger at all, so the message went nowhere, and the ones that do pass
+    /// <c>VerboseLogger.Log</c>, which is silent without <c>--verbose</c>. Either way the default
+    /// run exited 0 with a quietly thinner answer, which is the success-shaped failure
+    /// <c>AGENTS.md</c> forbids.
+    /// </para>
+    /// <para>
+    /// It lives beside the rule rather than at the six call sites because a refusal that is
+    /// announced six different ways is the same drift this type exists to end. It cannot become
+    /// noise: sweeps of 26,584 shared-framework assemblies and 138 restored packages produced no
+    /// refusals at all. <c>CoreCache</c> already reports its cache-escape refusal this way.
+    /// </para>
+    /// </remarks>
+    public static void ReportRefusal(string message)
+        => Console.Error.WriteLine($"Warning: {message}");
 }

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -129,10 +129,13 @@ public static class HardenedPath
 
     private static bool ContainsNonAsciiDigit(string value)
     {
-        foreach (var c in value)
+        for (var i = 0; i < value.Length; i++)
         {
-            if (c > '\u007f' && char.GetNumericValue(c) is >= 0 and <= 9)
+            if (value[i] > '\u007f' && AsciiDigitFor(value, i) >= 0)
                 return true;
+
+            if (char.IsHighSurrogate(value[i]))
+                i++;
         }
 
         return false;
@@ -140,16 +143,43 @@ public static class HardenedPath
 
     private static string FoldDigits(string value)
     {
-        return string.Create(value.Length, value, static (span, source) =>
+        var folded = new char[value.Length];
+        var written = 0;
+
+        for (var i = 0; i < value.Length; i++)
         {
-            for (var i = 0; i < source.Length; i++)
+            var digit = value[i] > '\u007f' ? AsciiDigitFor(value, i) : -1;
+            if (digit >= 0)
             {
-                var c = source[i];
-                var numeric = c > '\u007f' ? char.GetNumericValue(c) : -1;
-                span[i] = numeric is >= 0 and <= 9 && numeric == Math.Floor(numeric)
-                    ? (char)('0' + (int)numeric)
-                    : c;
+                folded[written++] = (char)('0' + digit);
+                if (char.IsHighSurrogate(value[i]))
+                    i++;
+                continue;
             }
-        });
+
+            folded[written++] = value[i];
+            if (char.IsHighSurrogate(value[i]) && i + 1 < value.Length)
+                folded[written++] = value[++i];
+        }
+
+        return new string(folded, 0, written);
+    }
+
+    /// <summary>
+    /// Returns the digit 0-9 the code point at <paramref name="index"/> denotes, or -1.
+    /// </summary>
+    /// <remarks>
+    /// The rule is deliberately a property of the code point rather than a list of encodings: the
+    /// device list drifted twice while it enumerated superscripts, and each round of review found
+    /// another spelling. Indexing by <see cref="string"/> rather than <see cref="char"/> is what
+    /// extends that rule past the basic plane, where the mathematical and enclosed digit blocks
+    /// live; a code-unit loop silently exempted them.
+    /// </remarks>
+    private static int AsciiDigitFor(string value, int index)
+    {
+        var numeric = CharUnicodeInfo.GetNumericValue(value, index);
+        return numeric is >= 0 and <= 9 && numeric == Math.Floor(numeric)
+            ? (int)numeric
+            : -1;
     }
 }

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -77,6 +77,10 @@ public static class HardenedPath
             || value.Contains('\\')
             || value.Contains(':')
             || value.AsSpan().ContainsAny(s_invalidFileNameCharacters)
+            // Redundant given the separator and volume rejections above -- a rooted value must
+            // start with one of those -- and kept only as a backstop against a host whose rooting
+            // rules differ. Removing it fails no test, so do not read it as the rule that stops
+            // rooted paths; the character rejections are.
             || Path.IsPathRooted(value))
         {
             return false;

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -121,6 +121,42 @@ public static class HardenedPath
     }
 
     /// <summary>
+    /// Whether <paramref name="value"/> is safe to combine with a trusted root as a multi-segment
+    /// relative path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Restored project inputs carry paths, not bare names: a <c>.deps.json</c> asset key or a
+    /// <c>project.assets.json</c> compile entry is spelled <c>lib/net8.0/Foo.dll</c>. The threat
+    /// model lists those files and "paths within those files" as untrusted, with path confusion
+    /// and unintended file reads as the risk, so they need the component rule applied to every
+    /// segment rather than to the whole string — which would reject every legitimate value for
+    /// containing a separator.
+    /// </para>
+    /// <para>
+    /// Both separators are treated as separators regardless of host, because the inspected
+    /// artifact is frequently not from the host that will consume the report: a
+    /// <c>..\</c> segment is inert on Unix but traverses on Windows, and refusing it everywhere
+    /// keeps the verdict platform-independent. Empty segments are rejected rather than skipped, so
+    /// <c>lib//Foo.dll</c> and <c>lib/./Foo.dll</c> do not normalize their way past the rule, and a
+    /// rooted value is rejected outright because combining it discards the trusted root.
+    /// </para>
+    /// </remarks>
+    public static bool IsSafeRelativePath(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || Path.IsPathRooted(value))
+            return false;
+
+        foreach (var segment in value.Split(['/', '\\']))
+        {
+            if (!IsSafePathComponent(segment))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Whether the value's stem names a reserved device. A device is reserved with or without an
     /// extension, so <c>CON.txt</c> is <c>CON</c>.
     /// </summary>

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -33,7 +33,7 @@ public static class HardenedPath
     /// </summary>
     private static readonly string[] ReservedDeviceNames =
     [
-        "CON", "PRN", "AUX", "NUL",
+        "CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$",
         "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
         "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
     ];

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Globalization;
 
 namespace ILInspector.MetadataPrimitives;
@@ -27,13 +28,22 @@ namespace ILInspector.MetadataPrimitives;
 public static class HardenedPath
 {
     /// <summary>
+    /// Characters no path component may carry. The Windows-invalid set is spelled out rather than
+    /// taken from <see cref="Path.GetInvalidFileNameChars"/> alone, which returns only
+    /// <c>\0</c> and <c>/</c> on Unix: the inspected artifact is frequently not from the host that
+    /// will consume the report, so the rule has to be the same on every platform.
+    /// </summary>
+    private static readonly SearchValues<char> s_invalidFileNameCharacters =
+        SearchValues.Create([.. Path.GetInvalidFileNameChars(), '<', '>', '"', '|', '?', '*']);
+
+    /// <summary>
     /// Names Windows resolves to a device rather than a file, in any directory. Opening one can
     /// block or hang a read, so they are refused on every platform: the inspected artifact is
     /// frequently not from the host that will consume the report.
     /// </summary>
     private static readonly string[] ReservedDeviceNames =
     [
-        "CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$",
+        "CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$", "CLOCK$",
         "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
         "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
     ];
@@ -57,6 +67,7 @@ public static class HardenedPath
             || value.Contains('/')
             || value.Contains('\\')
             || value.Contains(':')
+            || value.AsSpan().ContainsAny(s_invalidFileNameCharacters)
             || Path.IsPathRooted(value))
         {
             return false;
@@ -72,6 +83,21 @@ public static class HardenedPath
             // applied to an identifier read from untrusted input, and char.IsControl misses it.
             if (char.GetUnicodeCategory(c) == UnicodeCategory.Format)
                 return false;
+        }
+
+        // Malformed UTF-16. No package id, version, assembly simple name or forwarder target
+        // contains an unpaired surrogate, so the cost of refusing one is nil, and accepting one
+        // means reasoning about what each host does with a code unit that denotes no character.
+        // It also keeps the digit fold's pair handling a question about well-formed input only.
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (!char.IsSurrogate(value[i]))
+                continue;
+
+            if (!IsPairAt(value, i))
+                return false;
+
+            i++;
         }
 
         // Windows strips trailing spaces and dots from a path component, so "CON " and "CON" open
@@ -134,7 +160,7 @@ public static class HardenedPath
             if (value[i] > '\u007f' && AsciiDigitFor(value, i) >= 0)
                 return true;
 
-            if (char.IsHighSurrogate(value[i]))
+            if (IsPairAt(value, i))
                 i++;
         }
 
@@ -152,18 +178,33 @@ public static class HardenedPath
             if (digit >= 0)
             {
                 folded[written++] = (char)('0' + digit);
-                if (char.IsHighSurrogate(value[i]))
+                if (IsPairAt(value, i))
                     i++;
                 continue;
             }
 
             folded[written++] = value[i];
-            if (char.IsHighSurrogate(value[i]) && i + 1 < value.Length)
+            if (IsPairAt(value, i))
                 folded[written++] = value[++i];
         }
 
         return new string(folded, 0, written);
     }
+
+    /// <summary>
+    /// Whether <paramref name="index"/> starts a well-formed surrogate pair.
+    /// </summary>
+    /// <remarks>
+    /// A high surrogate alone is not enough to skip the next code unit. An unpaired one followed
+    /// by a digit -- <c>COM\ud800\u00b9</c> -- let the loop consume that digit as if it were a
+    /// trailing surrogate, so the digit was copied out without ever being tested. Malformed UTF-16
+    /// is the input most likely to carry that shape, which is the reason to check rather than
+    /// assume.
+    /// </remarks>
+    private static bool IsPairAt(string value, int index)
+        => char.IsHighSurrogate(value[index])
+           && index + 1 < value.Length
+           && char.IsLowSurrogate(value[index + 1]);
 
     /// <summary>
     /// Returns the digit 0-9 the code point at <paramref name="index"/> denotes, or -1.

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -1,6 +1,5 @@
 using System.Buffers;
 using System.Globalization;
-using System.Text;
 
 namespace ILInspector.MetadataPrimitives;
 
@@ -42,11 +41,20 @@ public static class HardenedPath
     /// block or hang a read, so they are refused on every platform: the inspected artifact is
     /// frequently not from the host that will consume the report.
     /// </summary>
+    /// <remarks>
+    /// The superscript spellings are listed <em>literally</em> because Windows reserves those
+    /// exact names, not because a superscript folds to a digit. Windows' matcher uppercases ASCII
+    /// letters and strips trailing dots and spaces (and, before Windows 11, the extension); it
+    /// performs no Unicode normalization and no best-fit mapping. So <c>COM¹</c> is a device and
+    /// <c>COM⁴</c>, <c>COM１</c> and <c>ＣＯＭ1</c> are ordinary names.
+    /// </remarks>
     private static readonly string[] ReservedDeviceNames =
     [
         "CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$", "CLOCK$",
         "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+        "COM\u00b9", "COM\u00b2", "COM\u00b3",
+        "LPT\u00b9", "LPT\u00b2", "LPT\u00b3"
     ];
 
     /// <summary>
@@ -158,60 +166,34 @@ public static class HardenedPath
     }
 
     /// <summary>
-    /// Whether the value's stem names a reserved device. A device is reserved with or without an
-    /// extension, so <c>CON.txt</c> is <c>CON</c>.
+    /// Whether the value names a reserved device under Windows' matching rules.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Windows' matcher is narrow and entirely non-Unicode-aware. Before comparing against the
+    /// device list it uppercases <em>ASCII</em> letters and strips trailing dots and spaces; on
+    /// Windows 10 and earlier it also drops everything from the first dot onward, which is why
+    /// <c>CON.txt</c> is <c>CON</c>. This applies the union of both, since the tool cannot know
+    /// which host will consume the artifact.
+    /// </para>
+    /// <para>
+    /// It performs no compatibility normalization and no best-fit mapping, so a name is a device
+    /// only if it is spelled as one. Two earlier revisions of this file assumed otherwise and
+    /// folded non-ASCII digits, then NFKC-normalized, on the belief that <c>COM⁴</c>, <c>COM１</c>
+    /// and <c>ＣＯＭ1</c> reach the device. They do not — best-fit mapping applies when a wide
+    /// string is converted for an ANSI API, not to path parsing, and .NET uses the wide APIs.
+    /// The superscript names are reserved because Windows lists those exact strings, so they are
+    /// listed exactly, and nothing here folds a spelling into another.
+    /// </para>
+    /// </remarks>
     private static bool IsReservedDeviceName(string value)
-    {
-        if (StemNamesReservedDevice(value))
-            return true;
-
-        // Windows applies a best-fit mapping to the whole path before opening it, so full-width
-        // Latin letters reach the same device: "\uff23\uff2f\uff2d1" opens COM1, and the digit
-        // fold below does not touch letters. Compatibility normalization is the closest standard
-        // model of that mapping, and it also folds the compatibility digit spellings and the
-        // full-width dot that would otherwise hide the stem boundary.
-        //
-        // It does not replace the numeric fold: NFKC leaves Arabic-Indic and other non-ASCII
-        // digits alone, so "COM\u0664" survives it unchanged. Both run, over the raw value and
-        // over the normalized one.
-        string normalized;
-        try
-        {
-            normalized = value.Normalize(NormalizationForm.FormKC);
-        }
-        catch (ArgumentException)
-        {
-            // Not normalizable, so what the host would open cannot be predicted. Refuse.
-            return true;
-        }
-
-        return !string.Equals(normalized, value, StringComparison.Ordinal)
-            && StemNamesReservedDevice(normalized);
-    }
-
-    /// <summary>
-    /// Whether the value's stem, after folding non-ASCII digits, is a reserved device name.
-    /// </summary>
-    private static bool StemNamesReservedDevice(string value)
     {
         var stem = value;
         var dot = stem.IndexOf('.');
         if (dot >= 0)
             stem = stem[..dot];
 
-        // Windows accepts non-ASCII digits as the digit in COMn/LPTn -- the Latin-1 superscripts
-        // directly, and others by best-fit ANSI conversion, which Microsoft documents as a
-        // security consideration because "COM4", "COM\u2074" and "COM\uff14" can reach the same
-        // device. Tools that checked only the ASCII spelling have been bypassed this way before
-        // (the Wasmtime sandbox escape and the Node.js device-name fix are both this bug).
-        //
-        // Fold any character whose Unicode numeric value is a single digit rather than enumerating
-        // spellings; an enumerated list is what drifted. Folding only matters when the whole stem
-        // becomes a device name, so it costs nothing real: "COM\uff11Plus" folds to "COM1Plus",
-        // matches nothing, and is accepted.
-        if (ContainsNonAsciiDigit(stem))
-            stem = FoldDigits(stem);
+        stem = stem.TrimEnd(' ', '.');
 
         foreach (var reserved in ReservedDeviceNames)
         {
@@ -222,74 +204,17 @@ public static class HardenedPath
         return false;
     }
 
-    private static bool ContainsNonAsciiDigit(string value)
-    {
-        for (var i = 0; i < value.Length; i++)
-        {
-            if (value[i] > '\u007f' && AsciiDigitFor(value, i) >= 0)
-                return true;
-
-            if (IsPairAt(value, i))
-                i++;
-        }
-
-        return false;
-    }
-
-    private static string FoldDigits(string value)
-    {
-        var folded = new char[value.Length];
-        var written = 0;
-
-        for (var i = 0; i < value.Length; i++)
-        {
-            var digit = value[i] > '\u007f' ? AsciiDigitFor(value, i) : -1;
-            if (digit >= 0)
-            {
-                folded[written++] = (char)('0' + digit);
-                if (IsPairAt(value, i))
-                    i++;
-                continue;
-            }
-
-            folded[written++] = value[i];
-            if (IsPairAt(value, i))
-                folded[written++] = value[++i];
-        }
-
-        return new string(folded, 0, written);
-    }
-
     /// <summary>
     /// Whether <paramref name="index"/> starts a well-formed surrogate pair.
     /// </summary>
     /// <remarks>
-    /// A high surrogate alone is not enough to skip the next code unit. An unpaired one followed
-    /// by a digit -- <c>COM\ud800\u00b9</c> -- let the loop consume that digit as if it were a
-    /// trailing surrogate, so the digit was copied out without ever being tested. Malformed UTF-16
-    /// is the input most likely to carry that shape, which is the reason to check rather than
-    /// assume.
+    /// Used to walk the value by code point when rejecting malformed UTF-16. A high surrogate
+    /// alone is not enough to skip the next code unit: treating an unpaired one as if it began a
+    /// pair consumes the following character without ever testing it, and malformed UTF-16 is
+    /// exactly the input most likely to carry that shape.
     /// </remarks>
     private static bool IsPairAt(string value, int index)
         => char.IsHighSurrogate(value[index])
            && index + 1 < value.Length
            && char.IsLowSurrogate(value[index + 1]);
-
-    /// <summary>
-    /// Returns the digit 0-9 the code point at <paramref name="index"/> denotes, or -1.
-    /// </summary>
-    /// <remarks>
-    /// The rule is deliberately a property of the code point rather than a list of encodings: the
-    /// device list drifted twice while it enumerated superscripts, and each round of review found
-    /// another spelling. Indexing by <see cref="string"/> rather than <see cref="char"/> is what
-    /// extends that rule past the basic plane, where the mathematical and enclosed digit blocks
-    /// live; a code-unit loop silently exempted them.
-    /// </remarks>
-    private static int AsciiDigitFor(string value, int index)
-    {
-        var numeric = CharUnicodeInfo.GetNumericValue(value, index);
-        return numeric is >= 0 and <= 9 && numeric == Math.Floor(numeric)
-            ? (int)numeric
-            : -1;
-    }
 }

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Globalization;
+using System.Text;
 
 namespace ILInspector.MetadataPrimitives;
 
@@ -96,22 +97,12 @@ public static class HardenedPath
             return false;
         }
 
-        foreach (var c in value)
-        {
-            if (char.IsControl(c))
-                return false;
-
-            // Format characters are invisible, or reorder what follows them, so the name shown to
-            // the user is not the name being opened. That is Trojan Source (CVE-2021-42574)
-            // applied to an identifier read from untrusted input, and char.IsControl misses it.
-            if (char.GetUnicodeCategory(c) == UnicodeCategory.Format)
-                return false;
-        }
-
         // Malformed UTF-16. No package id, version, assembly simple name or forwarder target
         // contains an unpaired surrogate, so the cost of refusing one is nil, and accepting one
         // means reasoning about what each host does with a code unit that denotes no character.
         // It also keeps the digit fold's pair handling a question about well-formed input only.
+        // This runs before the rune scan below because EnumerateRunes substitutes U+FFFD for an
+        // unpaired surrogate, which is not Format and would sail past that scan.
         for (var i = 0; i < value.Length; i++)
         {
             if (!char.IsSurrogate(value[i]))
@@ -121,6 +112,22 @@ public static class HardenedPath
                 return false;
 
             i++;
+        }
+
+        // Iterate runes, not chars. Format characters are invisible, or reorder what follows them,
+        // so the name shown to the user is not the name being opened -- Trojan Source
+        // (CVE-2021-42574) applied to an identifier read from untrusted input, which char.IsControl
+        // misses. Scanning by char missed it too for anything outside the BMP: the Plane 14 tag
+        // characters U+E0000-U+E007F are Format, but char.GetUnicodeCategory sees only the two
+        // surrogate halves and reports Surrogate for each, so "Valid\U000E0020Dependency" was
+        // accepted while rendering as "ValidDependency".
+        foreach (var rune in value.EnumerateRunes())
+        {
+            if (Rune.IsControl(rune))
+                return false;
+
+            if (Rune.GetUnicodeCategory(rune) == UnicodeCategory.Format)
+                return false;
         }
 
         // Windows strips trailing spaces and dots from a path component, so "CON " and "CON" open

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -1,0 +1,155 @@
+using System.Globalization;
+
+namespace ILInspector.MetadataPrimitives;
+
+/// <summary>
+/// The single owner of "is this string safe to use as one path component?".
+/// </summary>
+/// <remarks>
+/// <para>
+/// Names read out of untrusted input -- a package coordinate, an assembly reference, a type
+/// forwarder -- reach <see cref="Path.Combine(string, string)"/> and then the filesystem. A name
+/// that traverses, names a device, or is rewritten by the host before it is opened designates
+/// something other than what it appears to designate.
+/// </para>
+/// <para>
+/// This rule had three near-copies before it had an owner, and they had measurably diverged: one
+/// rejected only <c>\0</c> while another rejected every control character, and only one knew about
+/// reserved device names at all. That is the shape of defect the seam rules call out -- a second
+/// implementation of a shared rule -- so new callers belong here rather than in a fourth copy.
+/// </para>
+/// <para>
+/// The contract is <b>reject, never sanitize</b>. A trimmed or rewritten name silently designates a
+/// different artifact, which is worse than refusing: the caller believes it resolved what it asked
+/// for. Callers should surface the refusal and leave the item unresolved.
+/// </para>
+/// </remarks>
+public static class HardenedPath
+{
+    /// <summary>
+    /// Names Windows resolves to a device rather than a file, in any directory. Opening one can
+    /// block or hang a read, so they are refused on every platform: the inspected artifact is
+    /// frequently not from the host that will consume the report.
+    /// </summary>
+    private static readonly string[] ReservedDeviceNames =
+    [
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+    ];
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is safe to use as a single path component.
+    /// </summary>
+    /// <remarks>
+    /// Rejects, in order: empty or whitespace; anything over 255 characters, which is the common
+    /// filesystem component limit; traversal (<c>..</c>); directory separators; volume qualifiers
+    /// (<c>:</c>); rooted values; control characters; invisible format characters; leading or
+    /// trailing whitespace and trailing dots, which the host strips; and reserved device names.
+    /// A legitimate package id, version, assembly simple name or type-forwarder target contains
+    /// none of these.
+    /// </remarks>
+    public static bool IsSafePathComponent(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)
+            || value.Length > 255
+            || value.Contains("..", StringComparison.Ordinal)
+            || value.Contains('/')
+            || value.Contains('\\')
+            || value.Contains(':')
+            || Path.IsPathRooted(value))
+        {
+            return false;
+        }
+
+        foreach (var c in value)
+        {
+            if (char.IsControl(c))
+                return false;
+
+            // Format characters are invisible, or reorder what follows them, so the name shown to
+            // the user is not the name being opened. That is Trojan Source (CVE-2021-42574)
+            // applied to an identifier read from untrusted input, and char.IsControl misses it.
+            if (char.GetUnicodeCategory(c) == UnicodeCategory.Format)
+                return false;
+        }
+
+        // Windows strips trailing spaces and dots from a path component, so "CON " and "CON" open
+        // the same thing and "Foo." opens "Foo". Edge whitespace is tested with char.IsWhiteSpace
+        // rather than for the ASCII space alone: a name padded with U+00A0 renders identically to
+        // the unpadded one while denoting something else.
+        if (char.IsWhiteSpace(value[0]) || char.IsWhiteSpace(value[^1]) || value[^1] == '.')
+            return false;
+
+        return !IsReservedDeviceName(value);
+    }
+
+    /// <summary>
+    /// Throws when <paramref name="value"/> is not safe to use as a single path component.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value is unsafe.</exception>
+    public static void ValidatePathComponent(string? value, string name)
+    {
+        if (!IsSafePathComponent(value))
+            throw new ArgumentException($"Invalid {name}: '{value}'");
+    }
+
+    /// <summary>
+    /// Whether the value's stem names a reserved device. A device is reserved with or without an
+    /// extension, so <c>CON.txt</c> is <c>CON</c>.
+    /// </summary>
+    private static bool IsReservedDeviceName(string value)
+    {
+        var stem = value;
+        var dot = stem.IndexOf('.');
+        if (dot >= 0)
+            stem = stem[..dot];
+
+        // Windows accepts non-ASCII digits as the digit in COMn/LPTn -- the Latin-1 superscripts
+        // directly, and others by best-fit ANSI conversion, which Microsoft documents as a
+        // security consideration because "COM4", "COM\u2074" and "COM\uff14" can reach the same
+        // device. Tools that checked only the ASCII spelling have been bypassed this way before
+        // (the Wasmtime sandbox escape and the Node.js device-name fix are both this bug).
+        //
+        // Fold any character whose Unicode numeric value is a single digit rather than enumerating
+        // spellings; an enumerated list is what drifted. Folding only matters when the whole stem
+        // becomes a device name, so it costs nothing real: "COM\uff11Plus" folds to "COM1Plus",
+        // matches nothing, and is accepted.
+        if (ContainsNonAsciiDigit(stem))
+            stem = FoldDigits(stem);
+
+        foreach (var reserved in ReservedDeviceNames)
+        {
+            if (string.Equals(stem, reserved, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsNonAsciiDigit(string value)
+    {
+        foreach (var c in value)
+        {
+            if (c > '\u007f' && char.GetNumericValue(c) is >= 0 and <= 9)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string FoldDigits(string value)
+    {
+        return string.Create(value.Length, value, static (span, source) =>
+        {
+            for (var i = 0; i < source.Length; i++)
+            {
+                var c = source[i];
+                var numeric = c > '\u007f' ? char.GetNumericValue(c) : -1;
+                span[i] = numeric is >= 0 and <= 9 && numeric == Math.Floor(numeric)
+                    ? (char)('0' + (int)numeric)
+                    : c;
+            }
+        });
+    }
+}

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -62,17 +62,27 @@ public static class HardenedPath
     /// </summary>
     /// <remarks>
     /// Rejects, in order: empty or whitespace; anything over 255 characters, which is the common
-    /// filesystem component limit; traversal (<c>..</c>); directory separators; volume qualifiers
-    /// (<c>:</c>); rooted values; control characters; invisible format characters; leading or
-    /// trailing whitespace and trailing dots, which the host strips; and reserved device names.
-    /// A legitimate package id, version, assembly simple name or type-forwarder target contains
-    /// none of these.
+    /// filesystem component limit; directory separators; volume qualifiers (<c>:</c>); rooted
+    /// values; control characters; invisible format characters; leading or trailing whitespace and
+    /// trailing dots, which the host strips; and reserved device names. A legitimate package id,
+    /// version, assembly simple name or type-forwarder target contains none of these.
+    /// <para>
+    /// There is deliberately no check for an embedded <c>..</c>. A single component with no
+    /// separator cannot leave its directory whatever dots it holds — <c>Valid..Dependency</c>
+    /// combines and fully-resolves inside the trusted root — so traversal is stopped by the
+    /// separator and rooting rejections, and refusing the substring only cost real assembly names
+    /// the C# compiler accepts and emits. The components that <em>are</em> host-special, <c>.</c>
+    /// and <c>..</c>, are refused by the trailing-dot rule below, since every all-dot name ends in
+    /// a dot. <see cref="IsSafeRelativePath"/> relies on exactly that: it splits on separators and
+    /// a <c>..</c> segment is refused here as a component. Weakening the trailing-dot rule would
+    /// therefore reopen relative-path traversal, which
+    /// <c>TraversalSegment_IsRefusedByTheComponentRule</c> exists to catch.
+    /// </para>
     /// </remarks>
     public static bool IsSafePathComponent(string? value)
     {
         if (string.IsNullOrWhiteSpace(value)
             || value.Length > 255
-            || value.Contains("..", StringComparison.Ordinal)
             || value.Contains('/')
             || value.Contains('\\')
             || value.Contains(':')

--- a/src/ILInspector.MetadataPrimitives/HardenedPath.cs
+++ b/src/ILInspector.MetadataPrimitives/HardenedPath.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Globalization;
+using System.Text;
 
 namespace ILInspector.MetadataPrimitives;
 
@@ -161,6 +162,38 @@ public static class HardenedPath
     /// extension, so <c>CON.txt</c> is <c>CON</c>.
     /// </summary>
     private static bool IsReservedDeviceName(string value)
+    {
+        if (StemNamesReservedDevice(value))
+            return true;
+
+        // Windows applies a best-fit mapping to the whole path before opening it, so full-width
+        // Latin letters reach the same device: "\uff23\uff2f\uff2d1" opens COM1, and the digit
+        // fold below does not touch letters. Compatibility normalization is the closest standard
+        // model of that mapping, and it also folds the compatibility digit spellings and the
+        // full-width dot that would otherwise hide the stem boundary.
+        //
+        // It does not replace the numeric fold: NFKC leaves Arabic-Indic and other non-ASCII
+        // digits alone, so "COM\u0664" survives it unchanged. Both run, over the raw value and
+        // over the normalized one.
+        string normalized;
+        try
+        {
+            normalized = value.Normalize(NormalizationForm.FormKC);
+        }
+        catch (ArgumentException)
+        {
+            // Not normalizable, so what the host would open cannot be predicted. Refuse.
+            return true;
+        }
+
+        return !string.Equals(normalized, value, StringComparison.Ordinal)
+            && StemNamesReservedDevice(normalized);
+    }
+
+    /// <summary>
+    /// Whether the value's stem, after folding non-ASCII digits, is a reserved device name.
+    /// </summary>
+    private static bool StemNamesReservedDevice(string value)
     {
         var stem = value;
         var dot = stem.IndexOf('.');

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -9842,6 +9842,24 @@ public class CommandExecutionTests
         }
     }
 
+    [Theory]
+    [InlineData("CON")]
+    [InlineData("COM1")]
+    public async Task PackageCommand_CoordinateThatIsNotAPathComponent_ReportsAnError(string name)
+    {
+        // A package coordinate becomes a cache directory name. NuGetCache validates it by
+        // throwing, which was unreachable for an ordinary name until the shared rule started
+        // rejecting reserved device names: `package CON@1.0.0` then printed an unhandled
+        // ArgumentException and ~1800 bytes of stack trace where it had printed a one-line
+        // "not found". Refusal is correct; crashing to report it is not.
+        var (exit, _, error) = await RunAppAsync("package", $"{name}@1.0.0", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.DoesNotContain("Unhandled exception", error, StringComparison.Ordinal);
+        Assert.DoesNotContain("   at ", error, StringComparison.Ordinal);
+        Assert.Contains("Invalid package name", error, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task PackageCommand_LibraryFlag_BareSelectsUnambiguousLibrary()
     {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -364,7 +364,7 @@ public class CommandExecutionTests
         string? ProjectText = null,
         bool OmitReadme = false);
 
-    private static (string ProjectPath, string TempDir) CreateProjectWithPackageDocs(params ProjectDocPackage[] packages)
+    private static (string ProjectPath, string TempDir, string PackagesRoot) CreateProjectWithPackageDocs(params ProjectDocPackage[] packages)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"project-doc-test-{Guid.NewGuid():N}");
         var projectDir = Path.Combine(tempDir, "App");
@@ -431,7 +431,8 @@ public class CommandExecutionTests
             files.AddRange((package.Skills ?? []).Select(skill => skill.Path.Replace('\\', '/')));
 
             var fileEntries = string.Join(", ", files.Select(JsonString));
-            return $"{JsonString($"{package.Id}/{package.Version}")}: {{ \"type\": \"package\", \"path\": {JsonString(packageRoot.Replace('\\', '/'))}, \"files\": [ {fileEntries} ] }}";
+            var relativePath = $"{package.Id.ToLowerInvariant()}/{package.Version.ToLowerInvariant()}";
+            return $"{JsonString($"{package.Id}/{package.Version}")}: {{ \"type\": \"package\", \"path\": {JsonString(relativePath)}, \"files\": [ {fileEntries} ] }}";
         }));
         var dependencyEntries = string.Join(",\n", packages.Select(package =>
             $"{JsonString(package.Id)}: {{ \"target\": \"Package\", \"version\": {JsonString($"[{package.Version}, )")} }}"));
@@ -457,7 +458,7 @@ public class CommandExecutionTests
             }
             """);
 
-        return (projectPath, tempDir);
+        return (projectPath, tempDir, Path.Combine(tempDir, "packages"));
     }
 
     private static string JsonString(string value) => JsonSerializer.Serialize(value);
@@ -526,6 +527,21 @@ public class CommandExecutionTests
     }
 
     private static Task<(int Exit, string Output, string Error)> RunAppAsync(params string[] args)
+        => RunAppCoreAsync(null, args);
+
+    /// <summary>
+    /// Runs the app with the NuGet package root pointed at a fixture directory. Needed by the
+    /// project-document tests: a package's "path" in project.assets.json is a relative coordinate
+    /// under the package root, so a fixture package has to live under a root the product accepts.
+    /// </summary>
+    private static Task<(int Exit, string Output, string Error)> RunAppUnderPackagesAsync(
+        string packagesRoot,
+        params string[] args)
+        => RunAppCoreAsync(packagesRoot, args);
+
+    private static Task<(int Exit, string Output, string Error)> RunAppCoreAsync(
+        string? packagesRoot,
+        string[] args)
     {
         return ConsoleCapture.RunAsync(async () =>
         {
@@ -566,7 +582,7 @@ public class CommandExecutionTests
                 Console.Error.WriteLine($"Error: {ex.Message}");
                 return 1;
             }
-        });
+        }, packagesRoot);
     }
 
     private static IEnumerable<string> JsonStrings(JsonElement element)
@@ -10907,13 +10923,13 @@ public class CommandExecutionTests
             ---
             # Body
             """;
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Agents", "1.2.3", "README.md", "readme", agents),
             new ProjectDocPackage("Test.Project.NoAgents", "4.5.6", "README.md", "readme"));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "--agents-index", "--jsonl");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -10950,12 +10966,12 @@ public class CommandExecutionTests
             ---
             # Body
             """;
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Folded", "1.0.0", "README.md", "readme", agents));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "--agents-index", "--jsonl");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -10989,7 +11005,7 @@ public class CommandExecutionTests
             ---
             # Source skill
             """;
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Skills.Query", "1.2.3", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/query/SKILL.md", querySkill)]),
             new ProjectDocPackage("Test.Project.Skills.Source", "4.5.6", "README.md", "readme", Skills:
@@ -10997,7 +11013,7 @@ public class CommandExecutionTests
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--jsonl");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -11023,7 +11039,7 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsPaths_EmitsSkillPaths()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Paths.One", "1.0.0", "README.md", "one", Skills:
                 [new ProjectSkillDoc("skills/SKILL.md", "one")]),
             new ProjectDocPackage("Test.Project.Paths.Two", "1.0.0", "README.md", "two", Skills:
@@ -11031,7 +11047,7 @@ public class CommandExecutionTests
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--paths");
 
             Assert.Equal(0, exit);
@@ -11047,13 +11063,13 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsValue_UsesSelectedField()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Value.One", "1.2.3", "README.md", "one", Skills:
                 [new ProjectSkillDoc("skills/value/SKILL.md", "one")]));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--fields", "Version", "--value");
 
             Assert.Equal(0, exit);
@@ -11075,13 +11091,13 @@ public class CommandExecutionTests
             ---
             # Skill guidance
             """;
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Print", "2.0.0", "README.md", "# README body", Skills:
                 [new ProjectSkillDoc("skills/selected/SKILL.md", skill)]));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--print", "--body");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -11099,14 +11115,14 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsPrint_SkipsDependenciesWithoutSkills()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("A.Project.NoSkills", "1.0.0", "README.md", "readme"),
             new ProjectDocPackage("B.Project.HasSkills", "1.0.0", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/selected/SKILL.md", "selected")]));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--print");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -11122,12 +11138,12 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsSection_EmptyRendersNoSkillsNote()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("A.Project.NoSkills", "1.0.0", "README.md", "readme"));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -11265,13 +11281,13 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsPrint_JsonlIsSingleCompactRecord()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Print.Jsonl", "1.0.0", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/jsonl/SKILL.md", "selected")]));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--print", "--jsonl");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -11290,7 +11306,7 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsPrint_RequiresRowWhenMultipleSkillDocuments()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Print.One", "1.0.0", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/one/SKILL.md", "one")]),
             new ProjectDocPackage("Test.Project.Print.Two", "1.0.0", "README.md", "readme", Skills:
@@ -11298,7 +11314,7 @@ public class CommandExecutionTests
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--print");
 
             Assert.Equal(1, exit);
@@ -11314,7 +11330,7 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsPrint_RowSelectionPrintsSelectedDocument()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Print.One", "1.0.0", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/one/SKILL.md", "one")]),
             new ProjectDocPackage("Test.Project.Print.Two", "1.0.0", "README.md", "readme", Skills:
@@ -11322,7 +11338,7 @@ public class CommandExecutionTests
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--print", "--row", "2");
 
             Assert.Equal(0, exit);
@@ -11338,7 +11354,7 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsPrint_RowSelectionCountsPrintableRowsOnly()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("A.Project.NoSkills", "1.0.0", "README.md", "readme"),
             new ProjectDocPackage("B.Project.FirstPrintable", "1.0.0", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/first/SKILL.md", "first")]),
@@ -11347,7 +11363,7 @@ public class CommandExecutionTests
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--print", "--row", "1");
 
             Assert.Equal(0, exit);
@@ -11363,7 +11379,7 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsPrintAll_IsNoLongerRecognized()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.PrintAll.One", "1.0.0", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/one/SKILL.md", "one")]),
             new ProjectDocPackage("Test.Project.PrintAll.Two", "1.0.0", "README.md", "readme", Skills:
@@ -11371,7 +11387,7 @@ public class CommandExecutionTests
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--print-all");
 
             Assert.NotEqual(0, exit);
@@ -11387,13 +11403,13 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsBare_PrintsFirstSkillDocument()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Bare", "1.0.0", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/bare/SKILL.md", "selected")]));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--bare");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -11409,7 +11425,7 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsBare_MultipleDocuments_PrintsFirstPrintableDocument()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("A.Project.NoSkills", "1.0.0", "README.md", "readme"),
             new ProjectDocPackage("B.Project.FirstPrintable", "1.0.0", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/first/SKILL.md", "first")]),
@@ -11418,7 +11434,7 @@ public class CommandExecutionTests
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--bare");
 
             Assert.Equal(0, exit);
@@ -11434,13 +11450,13 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_Columns_ReturnsClearUnsupportedError()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Columns", "1.0.0", "README.md", "readme", Skills:
                 [new ProjectSkillDoc("skills/selected/SKILL.md", "selected")]));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--columns", "Package");
 
             Assert.Equal(1, exit);
@@ -11456,12 +11472,12 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_PrintRequiresSingleSelectedSection()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Print.Requires.Select", "1.0.0", "README.md", "readme"));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "--print");
 
             Assert.Equal(1, exit);
@@ -11477,7 +11493,7 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_SkillsCount_CountsSkillFiles()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Count.One", "1.0.0", "README.md", "readme", Skills:
                 [
                     new ProjectSkillDoc("skills/one/SKILL.md", "one"),
@@ -11487,7 +11503,7 @@ public class CommandExecutionTests
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "-S", "Skills", "--count");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -11520,12 +11536,12 @@ public class CommandExecutionTests
             ---
             # Agent guidance
             """;
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Readme", "2.0.0", "README.md", "# README body", agents, ProjectText: "# PROJECT body"));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "--readme", "Test.Project.Readme");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -11543,12 +11559,12 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_Readme_FallsBackToProjectMd()
     {
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.ProjectMd", "2.0.0", "README.md", "", ProjectText: "# PROJECT body", OmitReadme: true));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "--readme", "Test.Project.ProjectMd");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
@@ -11565,12 +11581,12 @@ public class CommandExecutionTests
     public async Task Project_Readme_NormalizesGithubBlobLinksToRaw()
     {
         const string readme = "See https://github.com/owner/repo/blob/main/docs/guide.md";
-        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+        var (projectPath, tempDir, packagesRoot) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.RawLinks", "1.0.0", "README.md", readme));
 
         try
         {
-            var (exit, output, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppUnderPackagesAsync(packagesRoot, 
                 "project", projectPath, "--readme", "Test.Project.RawLinks");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -9860,6 +9860,28 @@ public class CommandExecutionTests
         Assert.Contains("Invalid package name", error, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The same coordinate on the <c>--version</c> route, which reaches the cache through
+    /// <c>TryGetCachedPackage</c> rather than through the acquisition path.
+    /// </summary>
+    /// <remarks>
+    /// The theory above was added to fix the crash and only ever exercised one of the two routes,
+    /// so it kept passing while `package CON@1.0.0 --version` still printed an unhandled
+    /// ArgumentException. A `Try` method that throws is the defect; it now answers null, which is
+    /// both its documented contract and the truth, since no cache entry can carry such a name.
+    /// The refusal stays visible on every path that actually acquires or extracts.
+    /// </remarks>
+    [Theory]
+    [InlineData("CON")]
+    [InlineData("NUL")]
+    public async Task PackageCommand_CoordinateThatIsNotAPathComponent_DoesNotCrashListingVersions(string name)
+    {
+        var (_, _, error) = await RunAppAsync("package", $"{name}@1.0.0", "--version", "--tips", "q");
+
+        Assert.DoesNotContain("Unhandled exception", error, StringComparison.Ordinal);
+        Assert.DoesNotContain("   at ", error, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task PackageCommand_LibraryFlag_BareSelectsUnambiguousLibrary()
     {

--- a/src/dotnet-inspect.Tests/ConsoleCapture.cs
+++ b/src/dotnet-inspect.Tests/ConsoleCapture.cs
@@ -5,11 +5,21 @@ static class ConsoleCapture
     // Serialize access to Console.Out/Error to prevent parallel test interference
     private static readonly SemaphoreSlim _lock = new(1, 1);
 
-    public static async Task<(int ExitCode, string Output, string Error)> RunAsync(Func<Task<int>> action)
+    /// <param name="nugetPackagesRoot">
+    /// When set, redirects the NuGet package root for the duration of the run. The assignment
+    /// happens under the same lock that serializes console capture, so a run that needs a fixture
+    /// package root cannot be observed by a concurrent run that expects the real one.
+    /// </param>
+    public static async Task<(int ExitCode, string Output, string Error)> RunAsync(
+        Func<Task<int>> action,
+        string? nugetPackagesRoot = null)
     {
         await _lock.WaitAsync();
         var origOut = Console.Out;
         var origErr = Console.Error;
+        var origPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (nugetPackagesRoot != null)
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", nugetPackagesRoot);
         using var outWriter = new StringWriter();
         using var errWriter = new StringWriter();
         Console.SetOut(outWriter);
@@ -23,6 +33,8 @@ static class ConsoleCapture
         {
             Console.SetOut(origOut);
             Console.SetError(origErr);
+            if (nugetPackagesRoot != null)
+                Environment.SetEnvironmentVariable("NUGET_PACKAGES", origPackages);
             _lock.Release();
         }
     }

--- a/src/dotnet-inspect.Tests/InspectedNamePathGuardTests.cs
+++ b/src/dotnet-inspect.Tests/InspectedNamePathGuardTests.cs
@@ -1,0 +1,128 @@
+using DotnetInspector.Inspectors;
+using DotnetInspector.Models;
+using DotnetInspector.Output;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Two sinks that take a name out of an inspected artifact and join it onto a directory:
+/// a type-forwarder target (from the assembly's metadata) and a RID package id (from the
+/// package's <c>DotnetToolSettings.xml</c>). Each case is paired with a positive control that
+/// plants the same payload at the legitimate location, so a refusal cannot pass by accident --
+/// if the guard is removed, the hostile case resolves the planted payload exactly as the
+/// control does.
+/// </summary>
+public class InspectedNamePathGuardTests
+{
+    /// <summary>A real managed assembly to plant, and a public type it actually defines.</summary>
+    private static string PayloadSourceAssembly => typeof(ApiSurface).Assembly.Location;
+
+    private const string PayloadTypeName = "ILInspector.Metadata.ApiSurface";
+
+    private static ApiSurface SurfaceForwardingTo(string targetAssembly)
+    {
+        var api = new ApiSurface();
+        api.TypeForwarders.Add(new TypeForwarder
+        {
+            TypeName = PayloadTypeName,
+            TargetAssembly = targetAssembly
+        });
+        return api;
+    }
+
+    [Fact]
+    public void ResolveForwardedTypes_WithTraversingTargetAssembly_DoesNotReadOutsideTheAssemblyDirectory()
+    {
+        var root = Directory.CreateTempSubdirectory("fwd-guard-");
+        try
+        {
+            var appDir = Directory.CreateDirectory(Path.Combine(root.FullName, "app"));
+            var dllPath = Path.Combine(appDir.FullName, "main.dll");
+
+            // Planted one level above the inspected assembly's own directory.
+            File.Copy(PayloadSourceAssembly, Path.Combine(root.FullName, "payload.dll"));
+
+            var api = SurfaceForwardingTo("../payload");
+            ApiServices.ResolveForwardedTypes(api, dllPath, new VerboseLogger(false), includeAll: false);
+
+            Assert.Empty(api.Types);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveForwardedTypes_WithOrdinaryTargetAssembly_StillResolvesTheForwardedType()
+    {
+        var root = Directory.CreateTempSubdirectory("fwd-control-");
+        try
+        {
+            var appDir = Directory.CreateDirectory(Path.Combine(root.FullName, "app"));
+            var dllPath = Path.Combine(appDir.FullName, "main.dll");
+
+            // Same payload, at the location a legitimate forwarder target names.
+            File.Copy(PayloadSourceAssembly, Path.Combine(appDir.FullName, "payload.dll"));
+
+            var api = SurfaceForwardingTo("payload");
+            ApiServices.ResolveForwardedTypes(api, dllPath, new VerboseLogger(false), includeAll: false);
+
+            Assert.Contains(api.Types, t => t.FullName == PayloadTypeName && t.IsForwarded);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    private static async Task<bool?> VerifyRidPackageAsync(string packageId, string localDir)
+    {
+        var reference = new RidPackageReference
+        {
+            RuntimeIdentifier = "osx-arm64",
+            PackageId = packageId
+        };
+        var result = new InspectionResult { RuntimeIdentifierPackages = [reference] };
+
+        using var client = new HttpClient();
+        await RidPackageVerifier.VerifyAsync(client, result, "1.0.0", localDir, new VerboseLogger(false));
+
+        return reference.Exists;
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WithTraversingPackageId_DoesNotReportAPackageOutsideTheLocalDirectory()
+    {
+        var root = Directory.CreateTempSubdirectory("rid-guard-");
+        try
+        {
+            var localDir = Directory.CreateDirectory(Path.Combine(root.FullName, "packages"));
+            File.WriteAllText(Path.Combine(root.FullName, "payload.1.0.0.nupkg"), "planted");
+
+            Assert.NotEqual(true, await VerifyRidPackageAsync("../payload", localDir.FullName));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WithOrdinaryPackageId_StillReportsASiblingPackage()
+    {
+        var root = Directory.CreateTempSubdirectory("rid-control-");
+        try
+        {
+            var localDir = Directory.CreateDirectory(Path.Combine(root.FullName, "packages"));
+            File.WriteAllText(Path.Combine(localDir.FullName, "payload.1.0.0.nupkg"), "planted");
+
+            Assert.True(await VerifyRidPackageAsync("payload", localDir.FullName));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+}

--- a/src/dotnet-inspect.Tests/SourceEnricherForwarderSeamTests.cs
+++ b/src/dotnet-inspect.Tests/SourceEnricherForwarderSeamTests.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using DotnetInspector.Inspectors;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Seam pin for the type-forwarder resolution sink in <see cref="SourceEnricher"/>.
+/// </summary>
+/// <remarks>
+/// The refusal itself is owned and proved by <c>PdbContextForwarderResolutionTests</c>, which
+/// plants a payload where a traversing forwarder name would land. What that canary cannot see is
+/// whether a caller reaches the owner at all: <c>TryEnrichFromForwardedAssemblyAsync</c> used to
+/// take the forwarding assembly's path and rebuild the resolution itself, which is exactly how it
+/// escaped the guard. These tests pin the shape that fix depends on — the method resolves through
+/// a <see cref="PdbContext"/> and is handed no filesystem path to re-derive one from — so
+/// reintroducing a second resolver fails here rather than silently restoring the sink. They pin
+/// the seam, not the guard; a caller that took a <see cref="PdbContext"/> and still built its own
+/// path would pass this and be caught only by review.
+/// </remarks>
+public class SourceEnricherForwarderSeamTests
+{
+    private static MethodInfo ForwardedAssemblyMethod
+        => typeof(SourceEnricher).GetMethod(
+               "TryEnrichFromForwardedAssemblyAsync",
+               BindingFlags.NonPublic | BindingFlags.Static)
+           ?? throw new InvalidOperationException(
+               "SourceEnricher.TryEnrichFromForwardedAssemblyAsync is missing; the forwarder seam moved.");
+
+    [Fact]
+    public void ForwardedEnrichment_ResolvesThroughPdbContext()
+    {
+        var parameters = ForwardedAssemblyMethod.GetParameters();
+
+        Assert.Contains(parameters, p => p.ParameterType == typeof(PdbContext));
+    }
+
+    [Fact]
+    public void ForwardedEnrichment_IsNotHandedAPathToRebuildResolutionFrom()
+    {
+        var pathLike = ForwardedAssemblyMethod.GetParameters()
+            .Where(p => p.ParameterType == typeof(string))
+            .Where(p => p.Name is not null &&
+                        (p.Name.Contains("path", StringComparison.OrdinalIgnoreCase) ||
+                         p.Name.Contains("dir", StringComparison.OrdinalIgnoreCase)))
+            .Select(p => p.Name)
+            .ToList();
+
+        Assert.True(
+            pathLike.Count == 0,
+            $"Forwarded enrichment must resolve through PdbContext, not from a path of its own: {string.Join(", ", pathLike)}");
+    }
+}

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -2,6 +2,7 @@ using DotnetInspector.Core;
 using DotnetInspector.Models;
 using DotnetInspector.Inspectors;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 using ILInspector.Research;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
@@ -1789,6 +1790,13 @@ public class LibraryCommand
     private static string? TryFindLocalSiblingPackage(string originalPackageSource, string payloadId, string version)
     {
         if (!originalPackageSource.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        // Both values come from the inspected package: payloadId from its DotnetToolSettings.xml
+        // and version from its nuspec. They are about to become a filename and a search pattern
+        // under a directory the tool did not choose, so validate them as path components first
+        // (docs/design/untrusted-data-threat-model.md, "Derived paths").
+        if (!HardenedPath.IsSafePathComponent(payloadId) || !HardenedPath.IsSafePathComponent(version))
             return null;
 
         var directory = Path.GetDirectoryName(Path.GetFullPath(originalPackageSource));

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1,3 +1,4 @@
+using ILInspector.MetadataPrimitives;
 using DotnetInspector.Models;
 using DotnetInspector.Core;
 using ILInspector.Metadata;
@@ -279,6 +280,17 @@ public class PackageCommand
 
             var (versionQueryName, versionQueryPinned) = PackageExtractor.ParsePackageReference(packageArgs[0]);
             string normalizedName = versionQueryName.ToLowerInvariant();
+
+            // Refuse before any cache lookup or network call, and say that it is a refusal. The
+            // cache helper returns null for an unsafe name, which on its own reads as an ordinary
+            // miss -- "Package '../foo' not found on nuget.org" tells the user the name was
+            // searched for and absent, when in fact it was never searched for at all.
+            if (!HardenedPath.IsSafePathComponent(versionQueryName))
+            {
+                Console.Error.WriteLine($"Error: Invalid package name: '{versionQueryName}'.");
+                return 1;
+            }
+
             if (string.Equals(versionQueryPinned, "latest", StringComparison.OrdinalIgnoreCase))
             {
                 versionQueryPinned = null;

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -179,7 +179,7 @@ internal static class ApiServices
             // paths"), so refuse unsafe names rather than sanitize them.
             if (!HardenedPath.IsSafePathComponent(targetAssembly))
             {
-                logger.Log($"Warning: refusing to resolve forwarded types to library with unsafe assembly name: '{targetAssembly}'");
+                logger.Warn($"refusing to resolve forwarded types to library with unsafe assembly name: '{targetAssembly}'");
                 continue;
             }
 

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Packages;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Services;
@@ -171,6 +172,17 @@ internal static class ApiServices
 
         foreach (var (targetAssembly, forwardedTypeNames) in byAssembly)
         {
+            // The forwarder target is an AssemblyRef name read straight out of the inspected
+            // assembly's metadata, so it is attacker-controlled, and it is about to be joined
+            // onto the assembly's directory and opened. Path.Combine(root, untrustedValue) is
+            // not a containment check (docs/design/untrusted-data-threat-model.md, "Derived
+            // paths"), so refuse unsafe names rather than sanitize them.
+            if (!HardenedPath.IsSafePathComponent(targetAssembly))
+            {
+                logger.Log($"Warning: refusing to resolve forwarded types to library with unsafe assembly name: '{targetAssembly}'");
+                continue;
+            }
+
             var targetPath = Path.Combine(assemblyDir, targetAssembly + ".dll");
             if (!File.Exists(targetPath))
             {

--- a/src/dotnet-inspect/Inspectors/RidPackageVerifier.cs
+++ b/src/dotnet-inspect/Inspectors/RidPackageVerifier.cs
@@ -30,7 +30,7 @@ public static class RidPackageVerifier
                 // (docs/design/untrusted-data-threat-model.md, "Derived paths").
                 if (!HardenedPath.IsSafePathComponent(ridPkg.PackageId) || !HardenedPath.IsSafePathComponent(version))
                 {
-                    logger.Log($"  {ridPkg.RuntimeIdentifier}: refusing unsafe package coordinate '{ridPkg.PackageId}.{version}'");
+                    logger.Warn($"{ridPkg.RuntimeIdentifier}: refusing unsafe package coordinate '{ridPkg.PackageId}.{version}'");
                     continue;
                 }
 

--- a/src/dotnet-inspect/Inspectors/RidPackageVerifier.cs
+++ b/src/dotnet-inspect/Inspectors/RidPackageVerifier.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Models;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using ILInspector.MetadataPrimitives;
 
 namespace DotnetInspector.Inspectors;
 
@@ -24,6 +25,15 @@ public static class RidPackageVerifier
         {
             if (localDir != null)
             {
+                // PackageId comes from the inspected package's DotnetToolSettings.xml and is
+                // about to be joined onto a local directory, so validate it as a path component
+                // (docs/design/untrusted-data-threat-model.md, "Derived paths").
+                if (!HardenedPath.IsSafePathComponent(ridPkg.PackageId) || !HardenedPath.IsSafePathComponent(version))
+                {
+                    logger.Log($"  {ridPkg.RuntimeIdentifier}: refusing unsafe package coordinate '{ridPkg.PackageId}.{version}'");
+                    continue;
+                }
+
                 // Local verification: check if sibling .nupkg file exists
                 string expectedFileName = $"{ridPkg.PackageId}.{version}.nupkg";
                 string expectedPath = Path.Combine(localDir, expectedFileName);

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -150,7 +150,7 @@ internal static class SourceEnricher
                     logger.Log($"Type '{typeName}' is forwarded to '{forwardTarget}'.");
 
                     var forwardedResult = await TryEnrichFromForwardedAssemblyAsync(
-                        apiType, typeName, forwardTarget, dllPath, options, logger, httpClient);
+                        apiType, typeName, forwardTarget, context, options, logger, httpClient);
                     if (forwardedResult)
                         return;
                 }
@@ -721,19 +721,20 @@ internal static class SourceEnricher
         ApiType apiType,
         string typeName,
         string targetAssemblyName,
-        string originalDllPath,
+        PdbContext context,
         ApiOptions options,
         VerboseLogger logger,
         HttpClient httpClient)
     {
-        var runtimeDir = Path.GetDirectoryName(originalDllPath);
-        if (runtimeDir == null)
-            return false;
-
-        var targetDllPath = Path.Combine(runtimeDir, targetAssemblyName + ".dll");
-        if (!File.Exists(targetDllPath))
+        // Resolve through the owner rather than rebuilding the path here. This method used to do
+        // its own Path.Combine on the forwarder target, which is a name read from untrusted
+        // metadata, so a forwarder naming "../payload" escaped the assembly's directory and was
+        // then handed to source enrichment and its network fetches. The duplicate resolution was
+        // the reason the guard on PdbContext did not cover this call.
+        var targetDllPath = context.ResolveImplementationAssemblyPath(typeName);
+        if (targetDllPath == null)
         {
-            logger.Log($"Target library '{targetAssemblyName}' not found at '{targetDllPath}'.");
+            logger.Log($"Target library '{targetAssemblyName}' could not be resolved next to the forwarding assembly.");
             return false;
         }
 

--- a/src/dotnet-inspect/Output/VerboseLogger.cs
+++ b/src/dotnet-inspect/Output/VerboseLogger.cs
@@ -22,4 +22,18 @@ public class VerboseLogger(bool enabled)
             Console.Error.WriteLine(format, args);
         }
     }
+
+    /// <summary>
+    /// Writes unconditionally. For a refusal that changes what the tool reports -- rejecting an
+    /// untrusted name that would otherwise have been resolved, for example.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Log(string)"/> is verbose-gated, so reporting a refusal through it leaves the
+    /// default run with a quietly thinner result and exit 0, which is the success-shaped failure
+    /// <c>AGENTS.md</c> forbids: the user cannot tell a refused input from an absent one. Two
+    /// reviewers independently flagged the same pattern at two different guards. Refusals are
+    /// rare enough that this cannot become noise -- a sweep of 30,454 real assemblies produced
+    /// none -- and <c>CoreCache</c> already writes its cache-escape refusal unconditionally.
+    /// </remarks>
+    public void Warn(string message) => Console.Error.WriteLine($"Warning: {message}");
 }

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -163,4 +163,74 @@ public class HardenedPathTests
         Assert.Contains("package name", ex.Message, StringComparison.Ordinal);
         Assert.Contains("../payload", ex.Message, StringComparison.Ordinal);
     }
+
+    // ===== IsSafeRelativePath: restored project inputs carry paths, not bare names =====
+
+    [Theory]
+    // The shapes a .deps.json asset key and a project.assets.json compile entry actually take.
+    [InlineData("lib/net8.0/Contoso.dll")]
+    [InlineData("lib/netstandard2.0/Contoso.Core.dll")]
+    [InlineData("runtimes/win-x64/native/contoso.native.dll")]
+    [InlineData("runtimes/linux-musl-arm64/lib/net9.0/Contoso.dll")]
+    [InlineData("contoso.package/1.2.3")]
+    [InlineData("contoso.package/1.2.3-preview.4.25060.1")]
+    [InlineData("build/Contoso.props")]
+    [InlineData("contoso.package.nuspec")]
+    [InlineData(".signature.p7s")]
+    [InlineData("ref/net8.0/Contoso.dll")]
+    // A backslash-spelled variant of a legitimate path is still legitimate.
+    [InlineData("lib\\net8.0\\Contoso.dll")]
+    public void LegitimateRelativePath_IsAccepted(string value)
+    {
+        Assert.True(HardenedPath.IsSafeRelativePath(value));
+    }
+
+    [Theory]
+    // Traversal, in either spelling, on every host.
+    [InlineData("../payload.dll")]
+    [InlineData("..\\payload.dll")]
+    [InlineData("lib/../../payload.dll")]
+    [InlineData("lib/net8.0/../../../payload.dll")]
+    [InlineData("lib\\..\\..\\payload.dll")]
+    // A device name in any segment, including the last.
+    [InlineData("lib/net8.0/CON")]
+    [InlineData("lib/CON/Contoso.dll")]
+    [InlineData("lib/net8.0/COM1.dll")]
+    [InlineData("lib/net8.0/CONIN$")]
+    // Rooted values discard the trusted root when combined.
+    [InlineData("/etc/passwd")]
+    [InlineData("/usr/lib/payload.dll")]
+    // Empty segments must not normalize their way past the rule.
+    [InlineData("lib//Contoso.dll")]
+    [InlineData("lib/./Contoso.dll")]
+    [InlineData("/")]
+    // Whitespace and trailing dots the host strips.
+    [InlineData("lib/net8.0 /Contoso.dll")]
+    [InlineData("lib/net8.0./Contoso.dll")]
+    // Invisible characters.
+    [InlineData("lib/net8.0/Contoso\u200b.dll")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void HostileRelativePath_IsRejected(string value)
+    {
+        Assert.False(HardenedPath.IsSafeRelativePath(value));
+    }
+
+    [Fact]
+    public void NullRelativePath_IsRejected()
+    {
+        Assert.False(HardenedPath.IsSafeRelativePath(null));
+    }
+
+    /// <summary>
+    /// A Windows-rooted path is rejected on every host, not only where
+    /// <see cref="Path.IsPathRooted(string)"/> agrees. On Unix <c>C:\payload.dll</c> is not rooted,
+    /// so the refusal has to come from the component rule rejecting the volume qualifier.
+    /// </summary>
+    [Fact]
+    public void WindowsRootedPath_IsRejectedOnEveryHost()
+    {
+        Assert.False(HardenedPath.IsSafeRelativePath("C:\\payload.dll"));
+        Assert.False(HardenedPath.IsSafeRelativePath("C:/payload.dll"));
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -39,6 +39,10 @@ public class HardenedPathTests
     [InlineData("LPT9")]
     [InlineData("CON.txt")]
     [InlineData("com1.dll")]
+    // The console input/output devices, which CreateFile also opens.
+    [InlineData("CONIN$")]
+    [InlineData("conout$")]
+    [InlineData("CONIN$.dll")]
     // Names the host rewrites before opening: Windows strips trailing spaces and dots.
     [InlineData("CON ")]
     [InlineData("NUL   ")]
@@ -87,6 +91,8 @@ public class HardenedPathTests
     [InlineData("My Assembly.Core")]
     [InlineData("CON Toso.Library")]
     [InlineData("My\u00a0Assembly.Core")]
+    // A device name only as a prefix of a longer stem, including the console devices.
+    [InlineData("CONIN$Extras")]
     // The digit fold only fires when the whole stem becomes a device name.
     [InlineData("COM\u00b9Plus")]
     [InlineData("COM\uff11Plus")]

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -59,6 +59,10 @@ public class HardenedPathTests
     [InlineData("LPT\u2079")]
     [InlineData("COM\uff11")]
     [InlineData("COM\u0661")]
+    // The rule is a property of the code point, not of the UTF-16 code unit: the mathematical and
+    // enclosed digit blocks are outside the basic plane and a per-char loop exempted them.
+    [InlineData("COM\U0001d7cf")]
+    [InlineData("LPT\U0001d7e3")]
     // Invisible or reordering format characters: the rendered name is not the opened name.
     [InlineData("System.Text.Json\u200b")]
     [InlineData("\u200bSystem.Text.Json")]
@@ -98,6 +102,10 @@ public class HardenedPathTests
     [InlineData("COM\uff11Plus")]
     [InlineData("Contoso.V\u2074")]
     [InlineData("COM\u00b94")]
+    // Folding a surrogate pair shortens the stem; a non-digit pair must survive intact.
+    [InlineData("COM\U0001d7cfPlus")]
+    [InlineData("Contoso.\U0001d400ssembly")]
+    [InlineData("\U0001f600.Assembly")]
     public void LegitimateComponent_IsAccepted(string value)
     {
         Assert.True(HardenedPath.IsSafePathComponent(value));

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -50,29 +50,18 @@ public class HardenedPathTests
     [InlineData("System.Text.Json ")]
     [InlineData(" System.Text.Json")]
     [InlineData(".")]
-    // Non-ASCII digits in the device-digit position: the Latin-1 superscripts are accepted by
-    // Windows directly, and the others collapse onto the ASCII digit under best-fit ANSI.
+    // Windows reserves these exact superscript spellings, so they are refused as literal names --
+    // not because a superscript folds to a digit. COM\u2074 is deliberately absent: it is not on
+    // the list and is an ordinary name.
     [InlineData("COM\u00b9")]
     [InlineData("COM\u00b2.txt")]
     [InlineData("LPT\u00b3")]
-    [InlineData("COM\u2074")]
-    [InlineData("LPT\u2079")]
-    [InlineData("COM\uff11")]
-    [InlineData("COM\u0661")]
-    // The rule is a property of the code point, not of the UTF-16 code unit: the mathematical and
-    // enclosed digit blocks are outside the basic plane and a per-char loop exempted them.
-    [InlineData("COM\U0001d7cf")]
-    [InlineData("LPT\U0001d7e3")]
-    // Full-width Latin letters: Windows best-fit maps the whole component, so these open the same
-    // device even though no digit is involved and OrdinalIgnoreCase does not match them to ASCII.
-    [InlineData("\uff23\uff2f\uff2d1")]
-    [InlineData("\uff23\uff2f\uff2e")]
-    [InlineData("\uff21\uff35\uff38")]
-    [InlineData("\uff2e\uff35\uff2c.txt")]
-    // Full-width letters and a non-ASCII digit together: neither fold alone catches this one.
-    [InlineData("\uff23\uff2f\uff2d\u0664")]
-    // A full-width dot hides the stem boundary from an ASCII-only split.
-    [InlineData("\uff23\uff2f\uff2e\uff0etxt")]
+    [InlineData("com\u00b9")]
+    // Windows strips trailing dots and spaces from the stem before matching, so the space lands
+    // inside the value rather than at its end and the edge-whitespace rule never sees it.
+    [InlineData("COM1 .txt")]
+    [InlineData("COM1 . .ext")]
+    [InlineData("COM\u00b9 .txt")]
     // Absorbed from ResourceExtractor's copy when it was made to delegate: the Windows-invalid
     // filename characters, which Path.GetInvalidFileNameChars misses on Unix, and CLOCK$.
     [InlineData("Cont<oso")]
@@ -118,17 +107,27 @@ public class HardenedPathTests
     // A device name only as a prefix of a longer stem, including the console devices.
     [InlineData("CONIN$Extras")]
     [InlineData("CLOCK$Extras")]
-    // The digit fold only fires when the whole stem becomes a device name.
+    // A reserved spelling only matches as the whole stem.
     [InlineData("COM\u00b9Plus")]
-    [InlineData("COM\uff11Plus")]
     [InlineData("Contoso.V\u2074")]
     [InlineData("COM\u00b94")]
-    // Folding a surrogate pair shortens the stem; a non-digit pair must survive intact.
     [InlineData("COM\U0001d7cfPlus")]
     [InlineData("Contoso.\U0001d400ssembly")]
     [InlineData("\U0001f600.Assembly")]
-    // Compatibility normalization must not over-reject: it only decides device-name identity, so
-    // full-width text that does not normalize onto a device name is still an ordinary name.
+    // Windows' device matcher uppercases ASCII letters and strips trailing dots and spaces. It
+    // applies no compatibility normalization and no best-fit mapping, so these are ordinary
+    // names, and refusing them would refuse valid artifacts. Two earlier revisions of the guard
+    // rejected them on a mechanism that does not apply to path parsing.
+    [InlineData("COM\u2074")]
+    [InlineData("LPT\u2079")]
+    [InlineData("COM\uff11")]
+    [InlineData("COM\u0661")]
+    [InlineData("COM\U0001d7cf")]
+    [InlineData("LPT\U0001d7e3")]
+    [InlineData("\uff23\uff2f\uff2d1")]
+    [InlineData("\uff23\uff2f\uff2e")]
+    [InlineData("\uff21\uff35\uff38")]
+    [InlineData("\uff23\uff2f\uff2d\u0664")]
     [InlineData("\uff23\uff2f\uff2d1Plus")]
     [InlineData("\uff2c\uff29\uff22.Assembly")]
     [InlineData("\u30c6\u30b9\u30c8.Library")]

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -63,6 +63,16 @@ public class HardenedPathTests
     // enclosed digit blocks are outside the basic plane and a per-char loop exempted them.
     [InlineData("COM\U0001d7cf")]
     [InlineData("LPT\U0001d7e3")]
+    // Full-width Latin letters: Windows best-fit maps the whole component, so these open the same
+    // device even though no digit is involved and OrdinalIgnoreCase does not match them to ASCII.
+    [InlineData("\uff23\uff2f\uff2d1")]
+    [InlineData("\uff23\uff2f\uff2e")]
+    [InlineData("\uff21\uff35\uff38")]
+    [InlineData("\uff2e\uff35\uff2c.txt")]
+    // Full-width letters and a non-ASCII digit together: neither fold alone catches this one.
+    [InlineData("\uff23\uff2f\uff2d\u0664")]
+    // A full-width dot hides the stem boundary from an ASCII-only split.
+    [InlineData("\uff23\uff2f\uff2e\uff0etxt")]
     // Absorbed from ResourceExtractor's copy when it was made to delegate: the Windows-invalid
     // filename characters, which Path.GetInvalidFileNameChars misses on Unix, and CLOCK$.
     [InlineData("Cont<oso")]
@@ -117,6 +127,12 @@ public class HardenedPathTests
     [InlineData("COM\U0001d7cfPlus")]
     [InlineData("Contoso.\U0001d400ssembly")]
     [InlineData("\U0001f600.Assembly")]
+    // Compatibility normalization must not over-reject: it only decides device-name identity, so
+    // full-width text that does not normalize onto a device name is still an ordinary name.
+    [InlineData("\uff23\uff2f\uff2d1Plus")]
+    [InlineData("\uff2c\uff29\uff22.Assembly")]
+    [InlineData("\u30c6\u30b9\u30c8.Library")]
+    [InlineData("Contoso.\uff26\uff4f\uff4f")]
     public void LegitimateComponent_IsAccepted(string value)
     {
         Assert.True(HardenedPath.IsSafePathComponent(value));

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -43,11 +43,9 @@ public class HardenedPathTests
     [InlineData("CONIN$")]
     [InlineData("conout$")]
     [InlineData("CONIN$.dll")]
+    // Names the host rewrites before opening: Windows strips trailing spaces and dots.
     [InlineData("CON ")]
     [InlineData("NUL   ")]
-    // Names the host rewrites before opening: Windows strips trailing spaces and dots. These
-    // must be non-devices; the two above reach the device rule and so prove nothing about the
-    // edge-trim rule they used to be grouped under.
     [InlineData("Foo.")]
     [InlineData("System.Text.Json ")]
     [InlineData(" System.Text.Json")]

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -63,6 +63,16 @@ public class HardenedPathTests
     // enclosed digit blocks are outside the basic plane and a per-char loop exempted them.
     [InlineData("COM\U0001d7cf")]
     [InlineData("LPT\U0001d7e3")]
+    // Absorbed from ResourceExtractor's copy when it was made to delegate: the Windows-invalid
+    // filename characters, which Path.GetInvalidFileNameChars misses on Unix, and CLOCK$.
+    [InlineData("Cont<oso")]
+    [InlineData("Cont>oso")]
+    [InlineData("Cont\"oso")]
+    [InlineData("Cont|oso")]
+    [InlineData("Cont?oso")]
+    [InlineData("Cont*oso")]
+    [InlineData("CLOCK$")]
+    [InlineData("clock$.dll")]
     // Invisible or reordering format characters: the rendered name is not the opened name.
     [InlineData("System.Text.Json\u200b")]
     [InlineData("\u200bSystem.Text.Json")]
@@ -97,6 +107,7 @@ public class HardenedPathTests
     [InlineData("My\u00a0Assembly.Core")]
     // A device name only as a prefix of a longer stem, including the console devices.
     [InlineData("CONIN$Extras")]
+    [InlineData("CLOCK$Extras")]
     // The digit fold only fires when the whole stem becomes a device name.
     [InlineData("COM\u00b9Plus")]
     [InlineData("COM\uff11Plus")]
@@ -109,6 +120,25 @@ public class HardenedPathTests
     public void LegitimateComponent_IsAccepted(string value)
     {
         Assert.True(HardenedPath.IsSafePathComponent(value));
+    }
+
+    /// <summary>
+    /// Malformed UTF-16 is rejected. Built in code rather than as theory data: xUnit serializes
+    /// InlineData through a round-trip that replaces an unpaired surrogate with U+FFFD, so the
+    /// theory would silently test a well-formed string and pass for the wrong reason.
+    /// </summary>
+    [Fact]
+    public void UnpairedSurrogate_IsRejected()
+    {
+        Assert.False(HardenedPath.IsSafePathComponent("COM\ud800\u00b9"));
+        Assert.False(HardenedPath.IsSafePathComponent("COM\udfff\uff11"));
+        Assert.False(HardenedPath.IsSafePathComponent("Contoso.\ud800"));
+        Assert.False(HardenedPath.IsSafePathComponent("\udc00Contoso"));
+        Assert.False(HardenedPath.IsSafePathComponent("Contoso\ud800"));
+
+        // The well-formed pair beside it is still accepted, so the rule refuses malformed UTF-16
+        // rather than the supplementary planes.
+        Assert.True(HardenedPath.IsSafePathComponent("Contoso.\U0001d400ssembly"));
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -1,0 +1,122 @@
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// The shared path-component rule. These theories are the gate for
+/// <see cref="HardenedPath.IsSafePathComponent"/> being the single owner: every hostile form that
+/// any of the three former copies rejected is listed here, so consolidating cannot quietly drop
+/// one of them.
+/// </summary>
+public class HardenedPathTests
+{
+    [Theory]
+    // Traversal and separators: escape the intended directory.
+    [InlineData("..")]
+    [InlineData("../payload")]
+    [InlineData("..\\payload")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [InlineData("C:")]
+    [InlineData("/etc/passwd")]
+    // Empty and whitespace-only.
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    // Control characters. The NuGetCache copy rejected only \0, which is the drift this
+    // consolidation removes.
+    [InlineData("foo\0bar")]
+    [InlineData("foo\nbar")]
+    [InlineData("foo\u0007bar")]
+    // Reserved device names, with and without an extension. The NuGetCache copy knew none of
+    // these, so a package coordinate could name a device.
+    [InlineData("CON")]
+    [InlineData("con")]
+    [InlineData("NUL")]
+    [InlineData("PRN")]
+    [InlineData("AUX")]
+    [InlineData("COM1")]
+    [InlineData("LPT9")]
+    [InlineData("CON.txt")]
+    [InlineData("com1.dll")]
+    // Names the host rewrites before opening: Windows strips trailing spaces and dots.
+    [InlineData("CON ")]
+    [InlineData("NUL   ")]
+    [InlineData("Foo.")]
+    [InlineData("System.Text.Json ")]
+    [InlineData(" System.Text.Json")]
+    [InlineData(".")]
+    // Non-ASCII digits in the device-digit position: the Latin-1 superscripts are accepted by
+    // Windows directly, and the others collapse onto the ASCII digit under best-fit ANSI.
+    [InlineData("COM\u00b9")]
+    [InlineData("COM\u00b2.txt")]
+    [InlineData("LPT\u00b3")]
+    [InlineData("COM\u2074")]
+    [InlineData("LPT\u2079")]
+    [InlineData("COM\uff11")]
+    [InlineData("COM\u0661")]
+    // Invisible or reordering format characters: the rendered name is not the opened name.
+    [InlineData("System.Text.Json\u200b")]
+    [InlineData("\u200bSystem.Text.Json")]
+    [InlineData("System.\u202eJson")]
+    [InlineData("\ufeffSystem.Text.Json")]
+    // Non-ASCII edge whitespace renders as padding but denotes something else.
+    [InlineData("System.Text.Json\u00a0")]
+    [InlineData("\u3000System.Text.Json")]
+    public void UnsafeComponent_IsRejected(string value)
+    {
+        Assert.False(HardenedPath.IsSafePathComponent(value));
+    }
+
+    [Theory]
+    // Real package ids, versions, assembly simple names and forwarder targets. Over-rejecting here
+    // refuses a legitimate artifact, which is why each hostile rule above is narrow.
+    [InlineData("System.Text.Json")]
+    [InlineData("Newtonsoft.Json")]
+    [InlineData("System.Private.CoreLib")]
+    [InlineData("mscorlib")]
+    [InlineData("13.0.3")]
+    [InlineData("9.0.0-preview.1.24080.9")]
+    [InlineData("1.0.0+build.meta")]
+    [InlineData("My-Assembly_1.0")]
+    [InlineData("\u00dcmlaut.Assembly")]
+    // Device names only as a prefix, and interior spaces, which are not canonicalized away.
+    [InlineData("NULlable.Helpers")]
+    [InlineData("CONtoso.Library")]
+    [InlineData("COM1Plus")]
+    [InlineData("My Assembly.Core")]
+    [InlineData("CON Toso.Library")]
+    [InlineData("My\u00a0Assembly.Core")]
+    // The digit fold only fires when the whole stem becomes a device name.
+    [InlineData("COM\u00b9Plus")]
+    [InlineData("COM\uff11Plus")]
+    [InlineData("Contoso.V\u2074")]
+    [InlineData("COM\u00b94")]
+    public void LegitimateComponent_IsAccepted(string value)
+    {
+        Assert.True(HardenedPath.IsSafePathComponent(value));
+    }
+
+    [Fact]
+    public void Null_IsRejected()
+    {
+        Assert.False(HardenedPath.IsSafePathComponent(null));
+    }
+
+    [Fact]
+    public void OverlongComponent_IsRejected()
+    {
+        Assert.False(HardenedPath.IsSafePathComponent(new string('a', 256)));
+        Assert.True(HardenedPath.IsSafePathComponent(new string('a', 255)));
+    }
+
+    [Fact]
+    public void ValidatePathComponent_NamesTheOffendingValue()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => HardenedPath.ValidatePathComponent("../payload", "package name"));
+
+        Assert.Contains("package name", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("../payload", ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -80,6 +80,14 @@ public class HardenedPathTests
     // Non-ASCII edge whitespace renders as padding but denotes something else.
     [InlineData("System.Text.Json\u00a0")]
     [InlineData("\u3000System.Text.Json")]
+    // Format characters outside the BMP. char.GetUnicodeCategory sees only the two surrogate
+    // halves of these and reports Surrogate for each, so a char-by-char scan accepted them while
+    // they render as nothing: "Valid\U000E0020Dependency" displays as "ValidDependency". The
+    // Plane 14 tag block U+E0000-U+E007F is Format in its entirety.
+    [InlineData("Valid\U000E0020Dependency")]
+    [InlineData("Valid\U000E0041Dependency")]
+    [InlineData("Valid\U000E0001Dependency")]
+    [InlineData("\U000E007FContoso")]
     public void UnsafeComponent_IsRejected(string value)
     {
         Assert.False(HardenedPath.IsSafePathComponent(value));
@@ -132,6 +140,10 @@ public class HardenedPathTests
     [InlineData("\uff2c\uff29\uff22.Assembly")]
     [InlineData("\u30c6\u30b9\u30c8.Library")]
     [InlineData("Contoso.\uff26\uff4f\uff4f")]
+    // A supplementary-plane character that is NOT Format stays legitimate: the rune scan must
+    // reject by category, not by "is outside the BMP".
+    [InlineData("Contoso.\U0001F600")]
+    [InlineData("\U00020000.Library")]
     // Consecutive dots inside a component are not traversal: with no separator the combined path
     // fully-resolves inside the trusted root. These are real names the C# compiler emits, and
     // refusing them left the reference unresolved with no company and no children.

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -43,9 +43,11 @@ public class HardenedPathTests
     [InlineData("CONIN$")]
     [InlineData("conout$")]
     [InlineData("CONIN$.dll")]
-    // Names the host rewrites before opening: Windows strips trailing spaces and dots.
     [InlineData("CON ")]
     [InlineData("NUL   ")]
+    // Names the host rewrites before opening: Windows strips trailing spaces and dots. These
+    // must be non-devices; the two above reach the device rule and so prove nothing about the
+    // edge-trim rule they used to be grouped under.
     [InlineData("Foo.")]
     [InlineData("System.Text.Json ")]
     [InlineData(" System.Text.Json")]

--- a/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
+++ b/tests/ILInspector.Metadata.Tests/HardenedPathTests.cs
@@ -132,6 +132,12 @@ public class HardenedPathTests
     [InlineData("\uff2c\uff29\uff22.Assembly")]
     [InlineData("\u30c6\u30b9\u30c8.Library")]
     [InlineData("Contoso.\uff26\uff4f\uff4f")]
+    // Consecutive dots inside a component are not traversal: with no separator the combined path
+    // fully-resolves inside the trusted root. These are real names the C# compiler emits, and
+    // refusing them left the reference unresolved with no company and no children.
+    [InlineData("Valid..Dependency")]
+    [InlineData("Foo..Bar..Baz")]
+    [InlineData("..LeadingDots")]
     public void LegitimateComponent_IsAccepted(string value)
     {
         Assert.True(HardenedPath.IsSafePathComponent(value));
@@ -229,6 +235,24 @@ public class HardenedPathTests
     public void HostileRelativePath_IsRejected(string value)
     {
         Assert.False(HardenedPath.IsSafeRelativePath(value));
+    }
+
+    /// <summary>
+    /// Names the gate that <see cref="HardenedPath.IsSafeRelativePath"/>'s traversal refusal rests
+    /// on. There is no <c>..</c> substring check: the split hands <c>..</c> to the component rule,
+    /// which refuses it as an all-dot name via the trailing-dot rule. This test fails if that rule
+    /// is weakened, which would otherwise reopen traversal silently.
+    /// </summary>
+    [Fact]
+    public void TraversalSegment_IsRefusedByTheComponentRule()
+    {
+        Assert.False(HardenedPath.IsSafePathComponent(".."));
+        Assert.False(HardenedPath.IsSafePathComponent("."));
+        Assert.False(HardenedPath.IsSafeRelativePath("lib/../payload.dll"));
+
+        // ...while a component that merely contains dots is not traversal and must resolve.
+        Assert.True(HardenedPath.IsSafePathComponent("Valid..Dependency"));
+        Assert.True(HardenedPath.IsSafeRelativePath("lib/net8.0/Valid..Dependency.dll"));
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/PdbContextForwarderResolutionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/PdbContextForwarderResolutionTests.cs
@@ -13,7 +13,7 @@ public class PdbContextForwarderResolutionTests
     [InlineData("../payload")]
     [InlineData("..\\payload")]
     [InlineData("CON")]
-    [InlineData("COM\u2074")]
+    [InlineData("COM\u00b9")]
     [InlineData("payload\u200b")]
     public void ForwarderTarget_WithUnsafeName_IsNotResolved(string hostileName)
     {

--- a/tests/ILInspector.Metadata.Tests/PdbContextForwarderResolutionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/PdbContextForwarderResolutionTests.cs
@@ -1,0 +1,79 @@
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Artifact canary for the type-forwarder resolution sink. A forwarder target is a name read from
+/// the inspected assembly's metadata, so it is untrusted, and it becomes a path component. This
+/// plants a real, readable payload exactly where a traversing name would land: on unguarded code
+/// the resolution succeeds and hands back a path outside the forwarding assembly's directory,
+/// which then feeds symbol acquisition and its network fetches.
+/// </summary>
+public class PdbContextForwarderResolutionTests
+{
+    [Theory]
+    [InlineData("../payload")]
+    [InlineData("..\\payload")]
+    [InlineData("CON")]
+    [InlineData("COM\u2074")]
+    [InlineData("payload\u200b")]
+    public void ForwarderTarget_WithUnsafeName_IsNotResolved(string hostileName)
+    {
+        var root = Directory.CreateTempSubdirectory("di-forwarder-");
+        try
+        {
+            var assemblyDir = Directory.CreateDirectory(Path.Combine(root.FullName, "app")).FullName;
+
+            var realAssembly = typeof(PdbContextForwarderResolutionTests).Assembly.Location;
+            Assert.True(File.Exists(realAssembly));
+
+            // The payload sits one level above, where "../payload" lands...
+            File.Copy(realAssembly, Path.Combine(root.FullName, "payload.dll"), overwrite: true);
+
+            // ...and every hostile spelling also gets a file at its literal name inside the
+            // directory, so a refusal cannot be mistaken for the file merely being absent.
+            var literal = Path.Combine(assemblyDir, hostileName + ".dll");
+            var literalDir = Path.GetDirectoryName(literal);
+            if (literalDir != null && Directory.Exists(literalDir) && !hostileName.Contains(".."))
+                File.Copy(realAssembly, literal, overwrite: true);
+
+            Assert.Null(PdbContext.ResolveForwardedAssemblyPath(assemblyDir, hostileName));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    // Positive control: the guard must refuse traversal specifically, not disable local resolution.
+    [Fact]
+    public void ForwarderTarget_WithLegitimateName_ResolvesInTheAssemblyDirectory()
+    {
+        var root = Directory.CreateTempSubdirectory("di-forwarder-ok-");
+        try
+        {
+            var assemblyDir = Directory.CreateDirectory(Path.Combine(root.FullName, "app")).FullName;
+            var realAssembly = typeof(PdbContextForwarderResolutionTests).Assembly.Location;
+            var expected = Path.Combine(assemblyDir, "Legit.Neighbor.dll");
+            File.Copy(realAssembly, expected, overwrite: true);
+
+            Assert.Equal(expected, PdbContext.ResolveForwardedAssemblyPath(assemblyDir, "Legit.Neighbor"));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ForwarderTarget_ThatDoesNotExist_IsNull()
+    {
+        var root = Directory.CreateTempSubdirectory("di-forwarder-missing-");
+        try
+        {
+            Assert.Null(PdbContext.ResolveForwardedAssemblyPath(root.FullName, "Absent.Assembly"));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Closes #3441.

## The defect

`PdbContext.ResolveImplementationAssemblyPath` took a type-forwarder target read from the inspected assembly's metadata — untrusted input — and passed it straight to `Path.Combine`/`File.Exists`:

```csharp
var targetAssemblyName = FindTypeForwarder(typeName);   // untrusted
var targetPath = Path.Combine(dir, targetAssemblyName + ".dll");
return File.Exists(targetPath) ? targetPath : null;
```

A forwarder naming `../payload` resolves a file outside the forwarding assembly's directory. This is the same bug as #3429's, and the **worse instance**: the resolved path feeds `SourceEnricher.AcquirePdbAsync`, so traversal drives symbol acquisition and its network fetches, not merely a local read.

## Why an owner, not a fourth guard

The rule already had three near-copies, and they had **measurably diverged**. `NuGetCache.ValidatePathComponent` — which guards package ids and versions on the way into the cache — was the weakest:

| | control chars | length bound | device names | host canonicalization |
| --- | --- | --- | --- | --- |
| `NuGetCache` (before) | `\0` only | none | none | none |
| CLI `IsSafeAssemblySimpleName` (#3429) | all | 256 | yes, folded | yes |

So a package coordinate could name `CON` or `COM1`. Seam rule 6 in the inspection-layers note that just landed says a second implementation of a shared rule is a defect, and that a consumer which cannot reach the owner is a seam bug. This adds the owner: `HardenedPath`.

## What review found, and why that is the argument for the PR

The PR opened claiming one sink and three copies. Three review rounds each found
one more, and none of them found the same one:

| Round | Found | Kind |
| --- | --- | --- |
| 7 (MAI) | `SourceEnricher.TryEnrichFromForwardedAssemblyAsync` did its own `Path.Combine` on the forwarder target | **sink** |
| 7 (MAI) | `CONIN$` / `CONOUT$` match no device pattern and were absent | rule gap |
| 7 (GPT) | the digit fold walked UTF-16 **code units**, so supplementary-plane digits escaped | rule gap |
| 8 (MAI) | `AssemblyDependencyResolver.CollectPackageDependencies` combines a nuspec dependency id and version, **then recurses into** the result | **sink** |
| 8 (Gemini) | `ResourceExtractor.GetSafePathComponents` was a fifth **copy** — and the only one that knew `CLOCK$` | copy |
| 8 (Gemini) | `PlatformPackService.EnsurePackAsync` combines a pack coordinate | **sink** |
| 8 (Gemini) | the fold consumed a unit after **any** high surrogate without checking for a low one | real bug in my own code |

Final tally: **four sinks, five copies**. I found one of them. That a rule with
five copies keeps producing unguarded callers, and that three independent
reviewers each found a different one, is the case for an owner more directly
than the original defect was.

Two corrections I owe:

- `ResourceExtractor`'s copy uniquely knew `CLOCK$` and the Windows-invalid
  character set. Delegating would have **silently dropped both**; they moved
  *into* the owner first. Diff the copy against the owner before absorbing it.
- Gemini called the surrogate bug a device bypass. It is not — the lone
  surrogate stays in the stem, so no spelling becomes a device name. I only
  established that because the rejection test I wrote **failed**. The bug was
  real; the severity was not.

## Where it lives, and how I got that wrong first

I put `HardenedPath` in `DotnetInspector.Core` next to `HardenedJson` and `HardenedXml`, which is where it fits *by content*. `EngineToolBoundaryTests` rejected it: `Core` is tool tier, `ILInspector.Metadata` is engine, and the arrow points **tool → engine only**.

It now lives in `ILInspector.MetadataPrimitives`, an engine leaf both tiers can reach, keeping company with `SignatureBlobGuard` and `TypeSpecGuard` — the same untrusted-metadata guard family. The gate caught the mistake before review did, which is the argument for having it.

## Evidence

- **82 `HardenedPath` theories.** Every hostile form any former copy rejected, plus what #3429 learned — device-digit folding by **code point** (superscript, fullwidth, Arabic-Indic, supplementary-plane), format characters (Trojan Source), unpaired surrogates, and host canonicalization of trailing dots and spaces — each paired with close negatives (`COM1Plus`, `CONtoso.Library`, `Contoso.V⁴`, `CONIN$Extras`, real package versions).
- **7 forwarder-resolution tests** plant a real, readable payload exactly where `../payload` lands, with a legitimate sibling as the positive control.
- **2 seam tests** (`SourceEnricherForwarderSeamTests`) pin that the enricher reaches the owner. Their doc comment says plainly that they pin the *seam*, not the guard — a canary proving a refusal cannot prove a caller arrives, and that gap is exactly how the `SourceEnricher` sink escaped the first round.
- **3 theories** on `AssemblyDependencyResolver` prove a traversing dependency id cannot escape the package root.
- **Non-vacuity checked by tampering, for every guard.** With the forwarder guard removed, 4 of the 5 hostile spellings resolve the payload. (`..\payload` resolves only on Windows, where the backslash is a separator.)
- **Over-rejection measured, not asserted.** Two reviewers swept real inputs against the strengthened rule — 136 pack coordinates + 1954 assembly names, and 157 coordinates — with **zero** rejections. The fold fires only when the *whole stem* becomes a device name, so its cost on real data is nil.
- **Metadata 1078 pass / 5 skip** (was 998). **Services 346 pass**, exercising the strengthened `NuGetCache` and resolver against real package coordinates. **CLI 2363 pass / 14 skip.**

## Scope

`ResolveImplementationAssemblyPath` gained an internal `ResolveForwardedAssemblyPath` seam so the refusal is directly observable. `SourceEnricher` no longer takes a path at all — it takes the `PdbContext` and resolves through the owner, which is how a sink stops being possible rather than being fixed.

The CLI's `IsSafeAssemblySimpleName` is the remaining copy. It lives on #3429, which is still in review, so it is deliberately **not** folded in here — whichever lands second makes it delegate to `HardenedPath`.

Two fixed-head reviews are running against `cc27619a`. Not ready to merge.
