### PR TITLE
Fail closed on unsupported --json projections (#3386)

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -237,6 +237,13 @@ enforced structurally rather than per command — the request is recorded from t
 parse result and the projection writers report which projection they honored, so
 a route that drops one fails loudly instead of shipping the wrong payload.
 
+The whole-surface type listing (`type` with no type name — the Classes, Structs,
+Interfaces, Enums, and Delegates sections) is a name table that exposes no
+printable payload, so `--print`/`--value`/`--urls`/`--paths` there is rejected up
+front rather than dumping the full surface and then tripping this audit. Inspect
+a single type (for example `type <Name>`) to project a member payload. `--count`
+is the one payload projection the surface does honor.
+
 Writers report *which* flag they honored rather than merely acknowledging one.
 A writer can be reached for more than one reason — the print writer also serves
 `--bare` — so an untyped signal would let it satisfy an unrelated request and let
@@ -251,7 +258,7 @@ resolved by discarding one.
 | Flag | Effect |
 | --- | --- |
 | `--markdown` | force the full Markdown Document format |
-| `--json` | render the selected shape as JSON: the whole Document when no narrower shape is selected, otherwise the projected payload (`--print`, `--value`, `--urls`, `--paths`) |
+| `--json` | render the selected shape as JSON: the whole Document when no narrower shape is selected, otherwise the projected payload (`--print`, `--value`, `--urls`, `--paths`). A column projection (`--fields`/`--columns`) does **not** compose with `--json`: JSON renders the whole document and has no column-slicing facility, so the combination is rejected rather than silently dropped — use `--tsv`/`--jsonl`/`--table` to project columns, or add `--value`/`--print` to project a payload (`--fields` then picks which column feeds it). |
 | `--tsv` / `--jsonl` | render the single selected section as TSV / JSON Lines (a Table or Vector) |
 | `--table` | render the single selected section as a space-padded pretty table |
 | `--no-header` (`--no-headers`) | drop the Table header row |

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3675,6 +3675,21 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task GlobListing_Discovery_IsHonoredNotRejected()
+    {
+        // #3386 regression guard: the glob (and prefix-browse) fallback routes ignored -D
+        // discovery and fell through to WriteFullApiOutput. Once that path rejects --fields+--json,
+        // a discovery request there would have been rejected with a misleading column message.
+        // Discovery must be dispatched before the projection guard, matching the main listing path.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.*", "--library", TestAssemblyPath, "-D", "Classes", "--fields", "Type", "--json");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("cannot be combined with --json", error);
+        Assert.Contains("\"kind\":\"column\"", output);
+    }
+
+    [Fact]
     public async Task Router_RewrittenCommand_IsAudited()
     {
         // The router captures projection flags as raw tokens, so the outer invocation records

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3559,15 +3559,18 @@ public class CommandExecutionTests
     [InlineData("--print")]
     public async Task WholeSurfaceListing_DroppedProjection_FailsLoudly(string projectionFlag)
     {
-        // The whole-surface type listing renders sections but has no projection dispatch, so
-        // before the audit it answered a projection request with the full unprojected listing
-        // and exit 0. The audit turns that silent drop into a reported failure. When this route
-        // gains real column projection, this expectation changes to a projected payload.
-        var (exit, _, error) = await RunAppAsync(
+        // The whole-surface type listing is a name table that exposes no printable payload, so a
+        // payload projection cannot be honored. It used to render the full unprojected listing and
+        // then trip the audit (#3390); it now (#3386) rejects the projection up front with a
+        // targeted message, before rendering, so the audit never has to fire a second line.
+        var (exit, output, error) = await RunAppAsync(
             "type", "--library", TestAssemblyPath, "-S", "Classes", projectionFlag);
 
         Assert.Equal(1, exit);
-        Assert.Contains($"'{projectionFlag}' was accepted but this command path produced unprojected output", error);
+        Assert.Empty(output);
+        Assert.Contains("not supported when listing types", error);
+        Assert.Contains(projectionFlag, error);
+        Assert.DoesNotContain("produced unprojected output", error);
     }
 
     [Fact]
@@ -3602,6 +3605,73 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.DoesNotContain("produced unprojected output", error);
         Assert.True(int.TryParse(output.Trim(), out _), $"expected a bare count, got: {output}");
+    }
+
+    [Fact]
+    public async Task TypeListing_ColumnProjectionWithJson_IsRejected()
+    {
+        // #3386: --columns/--fields select table columns; document --json has no column-slicing
+        // facility. The combination used to silently drop the column filter and emit the whole
+        // typed document; it now fails closed instead.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "--platform", "System.Runtime", "-S", "Interfaces", "--columns", "Type", "--json");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("cannot be combined with --json", error);
+        Assert.DoesNotContain("produced unprojected output", error);
+    }
+
+    [Fact]
+    public async Task TypeListing_PayloadProjection_IsRejected()
+    {
+        // #3386: the type-listing surface exposes no printable payload, so a payload projection
+        // used to dump the whole ~20 MB surface and then trip the projection audit. It now fails
+        // closed before rendering, and the audit must not add a second, misleading line.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "--platform", "System.Runtime", "-S", "Classes", "--value", "--json");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("not supported when listing types", error);
+        Assert.DoesNotContain("produced unprojected output", error);
+    }
+
+    [Fact]
+    public async Task SingleType_ColumnProjectionWithJson_IsRejected()
+    {
+        // #3386: the same rejection applies on the single-type path.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.String", "--platform", "System.Runtime", "-S", "Methods", "--fields", "Name", "--json");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("cannot be combined with --json", error);
+    }
+
+    [Fact]
+    public async Task Member_ColumnProjectionWithJson_IsRejected()
+    {
+        // #3386: the member path shares the single-type writer, so it inherits the rejection.
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String", "--platform", "System.Runtime", "-S", "Methods", "--fields", "Name", "--json");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("cannot be combined with --json", error);
+    }
+
+    [Fact]
+    public async Task ColumnProjectionWithValue_UnderJson_StillComposes()
+    {
+        // #3386 boundary: a scalar payload projection composes with --json (--fields picks which
+        // column feeds --value), so this must remain honored rather than swept into the rejection.
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Library Info", "--fields", "Assembly Version", "--value", "--json", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("\"value\"", output);
+        Assert.DoesNotContain("cannot be combined with --json", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -489,9 +489,18 @@ public class ApiCommand
 
     // ===== Full API Surface Rendering =====
 
-    internal static void WriteFullApiOutput(ApiSurface api, ApiOptions options, string? selectedTfm = null)
+    internal static int WriteFullApiOutput(ApiSurface api, ApiOptions options, string? selectedTfm = null)
     {
         ApplySurfaceFilters(api, options, (options as TypeOptions)?.TypeFilter);
+
+        // Fail closed: the type-listing surface has no dispatch for payload projections
+        // (--print/--value/--urls/--paths); its sections are type-name tables that expose no
+        // printable payload. Report that honestly before rendering, rather than emitting the
+        // whole document and then tripping the projection audit (#3390) with a "bug in
+        // dotnet-inspect" message. --count is a payload projection the surface does honor, so
+        // it is excluded from this guard.
+        if (IsProjectionRequested(options))
+            return RejectSurfacePayloadProjection(options);
 
         if (api.InspectionFailures.Count > 0
             && (options.Count
@@ -505,8 +514,12 @@ public class ApiCommand
 
         if (options.JsonOutput && !options.Count)
         {
+            // --fields/--columns select table columns; document JSON has no column-slicing
+            // facility, so the combination is rejected rather than silently dropped.
+            if (IsColumnProjectionRequested(options))
+                return RejectColumnProjectionUnderJson(suggestPayloadProjection: false);
             Console.WriteLine(JsonSerializer.Serialize(api, ApiJsonContext.Default.ApiSurface));
-            return;
+            return 0;
         }
 
         var (view, _) = ApiOutputFormatter.BuildFullApiView(api, options);
@@ -541,6 +554,8 @@ public class ApiCommand
                     MarkoutSerializer.Serialize(view, ApiViewContext.Default, writerOptions), options.Rows);
             }
         }
+
+        return 0;
     }
 
     // ===== Method Source Resolution =====
@@ -661,6 +676,37 @@ public class ApiCommand
     private static bool IsProjectionRequested(ApiOptions options)
         => options.Print || options.Value || options.Urls || options.Paths;
 
+    // --fields/--columns select table columns. They compose with the row-oriented formats
+    // (--table/--tsv/--jsonl) and, when paired with a scalar payload projection, pick which
+    // column feeds --value/--print. They do not compose with document --json, which renders the
+    // whole typed graph and has no column-slicing (jq-style) facility, so the combination is
+    // rejected rather than silently dropped. See dotnet-inspect#3386 and richlander/markout#173.
+    private static bool IsColumnProjectionRequested(ApiOptions options)
+        => options.Fields is { Length: > 0 } || options.Columns is { Length: > 0 };
+
+    private static int RejectColumnProjectionUnderJson(bool suggestPayloadProjection)
+    {
+        var hint = suggestPayloadProjection
+            ? " Use --tsv, --jsonl, or --table to project columns, or add --value/--print to project a payload."
+            : " Use --tsv, --jsonl, or --table to project columns.";
+        Console.Error.WriteLine(
+            "Error: --fields/--columns select table columns and cannot be combined with --json, "
+            + "which renders the whole document." + hint);
+        return 1;
+    }
+
+    private static int RejectSurfacePayloadProjection(ApiOptions options)
+    {
+        var flag = options.Print ? "--print"
+            : options.Value ? "--value"
+            : options.Urls ? "--urls"
+            : "--paths";
+        Console.Error.WriteLine(
+            $"Error: {flag} is not supported when listing types; the listing exposes no printable "
+            + "payload. Inspect a single type (for example `type <Name>`) to project a member payload.");
+        return 1;
+    }
+
     internal static async Task<int> WriteTypeOutputAsync(ApiType type, string? foundIn, string? packageName, string? packageVersion, string? apiSource, string? selectedTfm, ApiOptions options, TextWriter? output = null)
     {
         var sink = output ?? Console.Out;
@@ -673,6 +719,11 @@ public class ApiCommand
 
         if (options.JsonOutput && !options.Count && !IsProjectionRequested(options))
         {
+            // --fields/--columns select table columns; document JSON has no column-slicing
+            // facility, so the combination is rejected rather than silently dropped. A scalar
+            // payload projection (--value/--print) does compose, and is handled above.
+            if (IsColumnProjectionRequested(options))
+                return RejectColumnProjectionUnderJson(suggestPayloadProjection: true);
             WriteJsonTypeOutput(type, options);
             return 0;
         }

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -112,7 +112,9 @@ public static class TypeCommand
                         sectionCategories: typePipeline.GetCategoryMap());
                 }
 
-                ApiCommand.WriteFullApiOutput(api, options, selectedTfm);
+                var listExitCode = ApiCommand.WriteFullApiOutput(api, options, selectedTfm);
+                if (listExitCode != 0)
+                    return listExitCode;
                 inspectionIncomplete = api.InspectionFailures.Count > 0;
 
                 if (!options.FormatExplicitlySet && !options.IsRawOutput)
@@ -319,7 +321,7 @@ public static class TypeCommand
                         Hints.WriteTips(effectiveOptions.TipLevel, [.. tips]);
                     }
                 }
-                else if (!TryWritePrefixBrowse(
+                else if (TryWritePrefixBrowse(
                     api,
                     apiDllPath,
                     originalTypeQuery,
@@ -328,7 +330,12 @@ public static class TypeCommand
                     apiSource,
                     apiVersion,
                     selectedTfm,
-                    options))
+                    options) is { } prefixBrowseExitCode)
+                {
+                    if (prefixBrowseExitCode != 0)
+                        return prefixBrowseExitCode;
+                }
+                else
                 {
                     var widePrefixExitCode = await TryExecuteWidePlatformPrefixFallbackAsync(options, originalTypeQuery, typePipeline);
                     if (widePrefixExitCode.HasValue)
@@ -348,7 +355,9 @@ public static class TypeCommand
                                 Verbosity = options.Verbosity < Verbosity.Minimal ? Verbosity.Minimal : options.Verbosity
                             };
 
-                            ApiCommand.WriteFullApiOutput(api, options, selectedTfm);
+                            var globExitCode = ApiCommand.WriteFullApiOutput(api, options, selectedTfm);
+                            if (globExitCode != 0)
+                                return globExitCode;
                         }
                         else
                         {
@@ -490,8 +499,7 @@ public static class TypeCommand
                 sectionCategories: typePipeline.GetCategoryMap());
         }
 
-        ApiCommand.WriteFullApiOutput(api, browseOptions);
-        return 0;
+        return ApiCommand.WriteFullApiOutput(api, browseOptions);
     }
 
     private static string ToFindPrefixPattern(string query)
@@ -595,7 +603,7 @@ public static class TypeCommand
         return merged;
     }
 
-    private static bool TryWritePrefixBrowse(
+    private static int? TryWritePrefixBrowse(
         ApiSurface api,
         string? apiDllPath,
         string? originalTypeQuery,
@@ -607,13 +615,13 @@ public static class TypeCommand
         TypeOptions options)
     {
         if (string.IsNullOrWhiteSpace(originalTypeQuery))
-            return false;
+            return null;
         if (originalTypeQuery.Contains('*') || originalTypeQuery.Contains('?'))
-            return false;
+            return null;
 
         var matches = FindPrefixMatches(api.Types, originalTypeQuery);
         if (matches.Count == 0)
-            return false;
+            return null;
 
         api.Types = matches;
         RecomputeSurfaceCounts(api);
@@ -628,8 +636,7 @@ public static class TypeCommand
         };
 
         Console.Error.WriteLine($"Note: Type '{resolvedTypeName}' not found. Showing best-effort prefix matches for '{originalTypeQuery}'.");
-        ApiCommand.WriteFullApiOutput(api, browseOptions, selectedTfm);
-        return true;
+        return ApiCommand.WriteFullApiOutput(api, browseOptions, selectedTfm);
     }
 
     private static List<ApiType> FindPrefixMatches(IEnumerable<ApiType> types, string query)

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -321,6 +321,22 @@ public static class TypeCommand
                         Hints.WriteTips(effectiveOptions.TipLevel, [.. tips]);
                     }
                 }
+                else if (options.EffectiveDiscovery)
+                {
+                    // Discovery is a schema query about the surface's sections; it is independent
+                    // of which (unmatched) type was requested. The main listing and platform-prefix
+                    // routes already dispatch it before rendering, so the glob and prefix-browse
+                    // fallbacks must too — otherwise `-D` falls through to WriteFullApiOutput, which
+                    // ignores it and (with --fields/--json) now rejects the request outright.
+                    ApiCommand.ApplySurfaceFilters(api, options, options.TypeFilter);
+                    var schema = ApiViewContext.Default.GetSchemaInfo<CliApiSurface>()!.ToDocumentSchema();
+                    var effective = typePipeline.GetDiscoverableSections(api, options.IncludeSections);
+                    return DiscoverOutput.ExecuteEffective(options.Discover, effective, schema,
+                        tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
+                        verbosity: (int)options.Verbosity,
+                        sectionCostAnnotations: typePipeline.GetCostAnnotations(),
+                        sectionCategories: typePipeline.GetCategoryMap());
+                }
                 else if (TryWritePrefixBrowse(
                     api,
                     apiDllPath,


### PR DESCRIPTION
Fixes #3386.

## Problem

Two output paths in the `type` command silently dropped a projection request instead of honoring or rejecting it:

1. **`--fields`/`--columns` + document `--json` (no payload projection)** silently discarded the column filter and emitted the whole typed document with exit 0. Column projection has no meaning against the typed JSON document schema — table columns such as `Type` are *synthesized* from namespace+name, not document properties — and `--json` has no jq-style column-slicing facility.
2. **A payload projection (`--print`/`--value`/`--urls`/`--paths`) against the whole-surface type listing** (`type` with no type name) had no dispatch, so it dumped the full ~20 MB `ApiSurface` to stdout and *then* tripped the #3390 projection audit with a misleading "bug in dotnet-inspect; please report it" message.

## Fix (fail closed)

- `WriteFullApiOutput` now returns `int`. It rejects payload projections against the type-listing surface up front (the listing is a name table with no printable payload), and rejects `--fields`/`--columns` under `--json` when no payload projection is present. The four `TypeCommand` call sites propagate the exit code so the #3390 audit does not re-fire the double error.
- The single-type and member paths reject `--fields`/`--columns` + `--json` (no payload) as well.
- `--fields X --value --json` still composes (the column feeds `--value`); `--count`, `--tsv`/`--jsonl`/`--table`, plain `--json`, and default output are unchanged.
- Adversarial review (GPT-5.6) found that the glob and prefix-browse fallback routes never dispatched `-D` discovery — they fell through to `WriteFullApiOutput` — so a discovery request carrying `--fields --json` was rejected with a misleading message. Discovery is now dispatched on those routes before the projection guard, matching the main and platform-prefix routes.

## Why not build the projection instead

A column projection's natural JSON home is the row shape (`--jsonl`), which already exists; slicing a hierarchical document like `jq` is a capability Markout (the output library) does not have. Filed as a companion design issue: richlander/markout#173.

## Validation

- Full CLI suite green (2367 tests; 14 ilasm skips). `Package_LibrarySourceFilesSection_PreservesTypeFilterAndBlobUrls` is a pre-existing network-flaky test that passes in isolation and is unrelated to these paths.
- New tests cover single-type/member/surface rejection, the still-composing `--fields --value --json` case, the discovery-on-glob regression, and unchanged `--count`/row-format behavior; the stale #3390-era `WholeSurfaceListing_DroppedProjection_FailsLoudly` now asserts the up-front rejection.
- `docs/design/output-shapes.md` updated (markdownlint clean).