### PR TITLE
Route all console redirection through ConsoleCapture's lock

### DIFF
--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -130,37 +130,21 @@ public class CommandLineTests
     }
 
     [Fact]
-    public void WriteTips_WithQuietLevel_WritesNothing()
+    public async Task WriteTips_WithQuietLevel_WritesNothing()
     {
-        var originalErr = Console.Error;
-        var errWriter = new System.IO.StringWriter();
-        Console.SetError(errWriter);
-        try
-        {
-            Hints.WriteTips(TipLevel.Quiet, new Tip("package", "Foo", "inspect"));
-            Assert.Empty(errWriter.ToString());
-        }
-        finally
-        {
-            Console.SetError(originalErr);
-        }
+        var (_, error) = await ConsoleCapture.RunAsync(
+            () => Hints.WriteTips(TipLevel.Quiet, new Tip("package", "Foo", "inspect")));
+
+        Assert.Empty(error);
     }
 
     [Fact]
-    public void WriteTips_WithMinimalLevel_WritesTips()
+    public async Task WriteTips_WithMinimalLevel_WritesTips()
     {
-        var originalErr = Console.Error;
-        var errWriter = new System.IO.StringWriter();
-        Console.SetError(errWriter);
-        try
-        {
-            Hints.WriteTips(TipLevel.Minimal, new Tip("package", "Foo", "inspect"));
-            Assert.Contains("Tips:", errWriter.ToString());
-        }
-        finally
-        {
-            Console.SetError(originalErr);
-        }
+        var (_, error) = await ConsoleCapture.RunAsync(
+            () => Hints.WriteTips(TipLevel.Minimal, new Tip("package", "Foo", "inspect")));
+
+        Assert.Contains("Tips:", error);
     }
 
     [Fact]
@@ -1292,40 +1276,44 @@ public class CommandLineTests
     [InlineData(false, true, null, true)]    // --layout --tools
     [InlineData(false, false, "net8.0", false)] // --tfm net8.0
     [InlineData(false, false, "net8.0", true)]  // --layout --tfm net8.0
-    public void WriteFileLayoutTips_NeverWritesTips(bool scopeLib, bool scopeTools, string? tfm, bool isLayout)
+    public async Task WriteFileLayoutTips_NeverWritesTips(bool scopeLib, bool scopeTools, string? tfm, bool isLayout)
     {
-        var originalErr = Console.Error;
-        var originalTips = Environment.GetEnvironmentVariable("DOTNET_INSPECT_TIPS");
-        var errWriter = new System.IO.StringWriter();
-        Console.SetError(errWriter);
-        Environment.SetEnvironmentVariable("DOTNET_INSPECT_TIPS", null);
-        try
+        // DOTNET_INSPECT_TIPS is read by OptionParsers, so clearing it is a second
+        // process-global mutation. It is set and restored inside the captured region so
+        // the console lock covers it too, and no command-running test can observe the
+        // cleared value.
+        var (_, error) = await ConsoleCapture.RunAsync(() =>
         {
-            var options = new InspectionOptions
-            {
-                ScopeLib = scopeLib,
-                ScopeTools = scopeTools,
-                Tfm = tfm,
-                TipLevel = TipLevel.Detailed,
-            };
-            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(Path.Combine(tempDir, "lib"));
-            Directory.CreateDirectory(Path.Combine(tempDir, "tools"));
+            var originalTips = Environment.GetEnvironmentVariable("DOTNET_INSPECT_TIPS");
+            Environment.SetEnvironmentVariable("DOTNET_INSPECT_TIPS", null);
             try
             {
-                PackageCommand.WriteFileLayoutTips(tempDir, options, "TestPackage", TipLevel.Detailed, isLayout);
-                Assert.DoesNotContain("Tips:", errWriter.ToString());
+                var options = new InspectionOptions
+                {
+                    ScopeLib = scopeLib,
+                    ScopeTools = scopeTools,
+                    Tfm = tfm,
+                    TipLevel = TipLevel.Detailed,
+                };
+                var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                Directory.CreateDirectory(Path.Combine(tempDir, "lib"));
+                Directory.CreateDirectory(Path.Combine(tempDir, "tools"));
+                try
+                {
+                    PackageCommand.WriteFileLayoutTips(tempDir, options, "TestPackage", TipLevel.Detailed, isLayout);
+                }
+                finally
+                {
+                    Directory.Delete(tempDir, recursive: true);
+                }
             }
             finally
             {
-                Directory.Delete(tempDir, recursive: true);
+                Environment.SetEnvironmentVariable("DOTNET_INSPECT_TIPS", originalTips);
             }
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("DOTNET_INSPECT_TIPS", originalTips);
-            Console.SetError(originalErr);
-        }
+        });
+
+        Assert.DoesNotContain("Tips:", error);
     }
 
     // ── router --version / --latest-version / --versions parsing ─────

--- a/src/dotnet-inspect.Tests/ConsoleCapture.cs
+++ b/src/dotnet-inspect.Tests/ConsoleCapture.cs
@@ -1,5 +1,23 @@
 namespace DotnetInspector.Tests;
 
+/// <summary>
+/// The single place this test assembly is allowed to redirect the console.
+/// <para>
+/// <c>Console.Out</c> and <c>Console.Error</c> are process-global, so two tests that
+/// redirect them concurrently steal each other's output: one sees an empty writer and
+/// fails its assertion, the other sees text it never produced. Worse, each restores the
+/// writer it captured on entry, so an interleaved pair can leave the console pointing at
+/// a disposed <see cref="StringWriter"/> after both have finished. That was the
+/// order-dependent flake in #3416, where the failing member of the pair varied per run.
+/// </para>
+/// <para>
+/// Every capture therefore goes through the same semaphore. Redirecting the console
+/// anywhere else in this assembly re-opens the race even if this type is used correctly
+/// everywhere else, so
+/// <c>ConsoleCaptureTests.TestAssemblyRedirectsConsoleOnlyThroughConsoleCapture</c>
+/// fails if another file does it.
+/// </para>
+/// </summary>
 static class ConsoleCapture
 {
     // Serialize access to Console.Out/Error to prevent parallel test interference
@@ -25,5 +43,27 @@ static class ConsoleCapture
             Console.SetError(origErr);
             _lock.Release();
         }
+    }
+
+    /// <summary>
+    /// Captures a synchronous action under the same lock as <see cref="RunAsync(Func{Task{int}})"/>.
+    /// Kept asynchronous deliberately: a blocking overload would park a thread-pool thread
+    /// while waiting on the semaphore, and xUnit runs tests on the pool, so a handful of
+    /// contending callers can starve it and time out unrelated async tests.
+    /// <para>
+    /// Anything the action mutates that is also process-global — an environment variable
+    /// the product reads, for example — should be set and restored inside
+    /// <paramref name="action"/> so it is covered by the same exclusion.
+    /// </para>
+    /// </summary>
+    public static async Task<(string Output, string Error)> RunAsync(Action action)
+    {
+        var (_, output, error) = await RunAsync(() =>
+        {
+            action();
+            return Task.FromResult(0);
+        });
+
+        return (output, error);
     }
 }

--- a/src/dotnet-inspect.Tests/ConsoleCaptureTests.cs
+++ b/src/dotnet-inspect.Tests/ConsoleCaptureTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Concurrent;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Gates for the console-redirection invariant behind #3416. The flake there was not a
+/// wrong assertion in any one test; it was two tests redirecting the process-global
+/// console at once. Both halves of the invariant are gated: that the shared lock actually
+/// excludes concurrent captures, and that no other file in this assembly redirects the
+/// console outside that lock.
+/// </summary>
+public class ConsoleCaptureTests
+{
+    /// <summary>
+    /// The behavioral half. Each capture must observe exactly the text its own action
+    /// wrote — no other worker's token, and never an empty writer. Without the shared
+    /// semaphore, concurrent workers overwrite <c>Console.Out</c> and this fails.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentCapturesDoNotObserveEachOthersOutput()
+    {
+        var failures = new ConcurrentBag<string>();
+
+        await Task.WhenAll(Enumerable.Range(0, 16).Select(async i =>
+        {
+            string token = $"token-{i}";
+            var (output, error) = await ConsoleCapture.RunAsync(() =>
+            {
+                Console.Write(token);
+                Console.Error.Write(token);
+            });
+
+            if (output != token)
+                failures.Add($"worker {i} stdout: expected '{token}', got '{output}'");
+            if (error != token)
+                failures.Add($"worker {i} stderr: expected '{token}', got '{error}'");
+        }));
+
+        Assert.Empty(failures);
+    }
+
+    /// <summary>
+    /// The two capture overloads share one lock, so a mixed workload must be serialized
+    /// too. This is the shape the #3416 flake actually took: the tests that bypassed the
+    /// lock were synchronous, and the tests whose output they corrupted were not.
+    /// </summary>
+    [Fact]
+    public async Task SyncAndAsyncCapturesExcludeEachOther()
+    {
+        var failures = new ConcurrentBag<string>();
+
+        await Task.WhenAll(Enumerable.Range(0, 16).Select(async i =>
+        {
+            string token = $"mixed-{i}";
+            string observed = i % 2 == 0
+                ? (await ConsoleCapture.RunAsync(() => Console.Write(token))).Output
+                : (await ConsoleCapture.RunAsync(() =>
+                {
+                    Console.Write(token);
+                    return Task.FromResult(0);
+                })).Output;
+
+            if (observed != token)
+                failures.Add($"worker {i}: expected '{token}', got '{observed}'");
+        }));
+
+        Assert.Empty(failures);
+    }
+
+    /// <summary>
+    /// The structural half, and the one that keeps the fix from decaying. The behavioral
+    /// gates above pass even if a brand-new test redirects the console on its own, because
+    /// they only exercise <see cref="ConsoleCapture"/> itself. This derives its subject
+    /// from the test sources on disk rather than from a hardcoded list, so a new offending
+    /// file fails it without anyone remembering to update anything.
+    /// </summary>
+    [Fact]
+    public void TestAssemblyRedirectsConsoleOnlyThroughConsoleCapture()
+    {
+        string testSourceRoot = Path.Combine(FindRepositoryRoot(), "src", "dotnet-inspect.Tests");
+        List<string> offenders = [];
+
+        foreach (string path in Directory.EnumerateFiles(testSourceRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            // Build output under bin/obj contains generated and copied sources.
+            string relative = Path.GetRelativePath(testSourceRoot, path);
+            string[] segments = relative.Split(Path.DirectorySeparatorChar);
+            if (segments.Contains("bin") || segments.Contains("obj"))
+                continue;
+
+            if (string.Equals(segments[^1], "ConsoleCapture.cs", StringComparison.Ordinal))
+                continue;
+
+            string text = File.ReadAllText(path);
+            if (text.Contains(SetOutCall, StringComparison.Ordinal)
+                || text.Contains(SetErrorCall, StringComparison.Ordinal))
+            {
+                offenders.Add(relative.Replace(Path.DirectorySeparatorChar, '/'));
+            }
+        }
+
+        offenders.Sort(StringComparer.Ordinal);
+
+        Assert.True(
+            offenders.Count == 0,
+            "Console.Out/Error are process-global; redirecting them outside ConsoleCapture "
+                + "reintroduces the #3416 order-dependent flake. Use ConsoleCapture.Capture or "
+                + "ConsoleCapture.RunAsync instead. Offending files: "
+                + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// Non-vacuity for the scan above: it must actually be reading sources that contain
+    /// the pattern, or it would pass simply by finding nothing. ConsoleCapture.cs is the
+    /// one file expected to match, so it is the natural canary.
+    /// </summary>
+    [Fact]
+    public void ConsoleRedirectionScanReadsRealSources()
+    {
+        string consoleCapture = Path.Combine(
+            FindRepositoryRoot(), "src", "dotnet-inspect.Tests", "ConsoleCapture.cs");
+
+        Assert.True(File.Exists(consoleCapture), $"Expected to find {consoleCapture}.");
+        Assert.Contains(SetOutCall, File.ReadAllText(consoleCapture), StringComparison.Ordinal);
+    }
+
+    // Composed rather than written literally so this file is not itself an offender.
+    static readonly string SetOutCall = $"Console.{nameof(Console.SetOut)}(";
+    static readonly string SetErrorCall = $"Console.{nameof(Console.SetError)}(";
+
+    static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+                return directory.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not find repository root containing dotnet-inspect.slnx.");
+    }
+}

--- a/src/dotnet-inspect.Tests/ConsoleCaptureTests.cs
+++ b/src/dotnet-inspect.Tests/ConsoleCaptureTests.cs
@@ -13,19 +13,35 @@ public class ConsoleCaptureTests
 {
     /// <summary>
     /// The behavioral half. Each capture must observe exactly the text its own action
-    /// wrote — no other worker's token, and never an empty writer. Without the shared
-    /// semaphore, concurrent workers overwrite <c>Console.Out</c> and this fails.
+    /// wrote — no other worker's token, and never an empty writer.
     /// </summary>
+    /// <remarks>
+    /// Forcing real overlap takes deliberate work, and an earlier version of this test got
+    /// it wrong: <see cref="ConsoleCapture.RunAsync(Action)"/> completes synchronously on an
+    /// uncontended semaphore, so plain <c>async</c> lambdas ran start-to-finish one after
+    /// another and the gate passed with the lock deleted. Two things fix that. Workers are
+    /// started with <c>Task.Run</c> and released together, so they genuinely contend; and
+    /// each sleeps <em>before</em> writing, because the damaging window is between
+    /// <c>ConsoleCapture</c> redirecting the console and the action using it. A peer that
+    /// redirects during that window steals this worker's writes.
+    /// </remarks>
     [Fact]
     public async Task ConcurrentCapturesDoNotObserveEachOthersOutput()
     {
+        const int workers = 8;
         var failures = new ConcurrentBag<string>();
+        using var ready = new CountdownEvent(workers);
+        var go = new TaskCompletionSource();
 
-        await Task.WhenAll(Enumerable.Range(0, 16).Select(async i =>
+        var tasks = Enumerable.Range(0, workers).Select(i => Task.Run(async () =>
         {
+            ready.Signal();
+            await go.Task;
+
             string token = $"token-{i}";
             var (output, error) = await ConsoleCapture.RunAsync(() =>
             {
+                Thread.Sleep(25);
                 Console.Write(token);
                 Console.Error.Write(token);
             });
@@ -34,7 +50,11 @@ public class ConsoleCaptureTests
                 failures.Add($"worker {i} stdout: expected '{token}', got '{output}'");
             if (error != token)
                 failures.Add($"worker {i} stderr: expected '{token}', got '{error}'");
-        }));
+        })).ToArray();
+
+        ready.Wait(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        go.SetResult();
+        await Task.WhenAll(tasks);
 
         Assert.Empty(failures);
     }
@@ -47,22 +67,37 @@ public class ConsoleCaptureTests
     [Fact]
     public async Task SyncAndAsyncCapturesExcludeEachOther()
     {
+        const int workers = 8;
         var failures = new ConcurrentBag<string>();
+        using var ready = new CountdownEvent(workers);
+        var go = new TaskCompletionSource();
 
-        await Task.WhenAll(Enumerable.Range(0, 16).Select(async i =>
+        var tasks = Enumerable.Range(0, workers).Select(i => Task.Run(async () =>
         {
+            ready.Signal();
+            await go.Task;
+
             string token = $"mixed-{i}";
             string observed = i % 2 == 0
-                ? (await ConsoleCapture.RunAsync(() => Console.Write(token))).Output
-                : (await ConsoleCapture.RunAsync(() =>
+                ? (await ConsoleCapture.RunAsync(() =>
                 {
+                    Thread.Sleep(25);
                     Console.Write(token);
-                    return Task.FromResult(0);
+                })).Output
+                : (await ConsoleCapture.RunAsync(async () =>
+                {
+                    await Task.Delay(25);
+                    Console.Write(token);
+                    return 0;
                 })).Output;
 
             if (observed != token)
                 failures.Add($"worker {i}: expected '{token}', got '{observed}'");
-        }));
+        })).ToArray();
+
+        ready.Wait(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        go.SetResult();
+        await Task.WhenAll(tasks);
 
         Assert.Empty(failures);
     }


### PR DESCRIPTION
Fixes #3416.

## What was wrong

`ConsoleCapture` serializes `Console.Out`/`Console.Error` behind a semaphore, and 136 call sites across 28 files use it correctly. Three tests in `CommandLineTests` redirected `Console.Error` **directly**, without taking that lock.

`Console.Out`/`Error` are process-global, so those three raced every test using `ConsoleCapture`. Two things go wrong when they interleave:

- One side's writer is swapped out mid-test — it asserts on an empty writer, or on text another test wrote.
- Each side restores the writer *it* captured on entry, so an interleaved pair can leave the console pointing at a **disposed** `StringWriter` after both finish.

That is exactly the reported signature: a varying member of a pair fails, and everything passes in isolation.

The theory `WriteFileLayoutTips_NeverWritesTips` had a second process-global mutation — it cleared `DOTNET_INSPECT_TIPS`, which `OptionParsers.cs:45` reads — visible to any concurrently running command test.

## The fix

A `ConsoleCapture.RunAsync(Action)` overload for synchronous bodies, and the three tests moved onto it. The env-var mutation now happens inside the captured region, so the same lock covers it.

The overload is **async rather than blocking on purpose**, and I have measurements for that. I first wrote it as a blocking `_lock.Wait()`. xUnit runs tests on the thread pool, so blocking parks pool threads; with 24 `Task.Run` workers contending it starved the pool and **failed 29 unrelated tests**. Reusing the existing async path adds no new blocking and no new lock.

## Gates

Both halves of the invariant, because they fail independently:

| Gate | Covers |
| --- | --- |
| `ConcurrentCapturesDoNotObserveEachOthersOutput` | the lock actually excludes |
| `SyncAndAsyncCapturesExcludeEachOther` | the sync and async paths share one lock — the shape this bug took |
| `TestAssemblyRedirectsConsoleOnlyThroughConsoleCapture` | nothing bypasses the lock |
| `ConsoleRedirectionScanReadsRealSources` | the scan above is non-vacuous |

The structural gate derives its subject from the test sources on disk rather than a hardcoded list, so a newly added raw redirection fails it without anyone remembering to update anything. Its needles are composed via `nameof` so the scanner is not its own offender.

## Tamper evidence

Removing the lock reproduces **both** #3416 failure shapes exactly:

```text
worker 0 stdout: expected 'token-0', got ''
worker 1 stdout: expected 'token-1', got 'token-0t'...
```

The first is the `WriteTips_WithMinimalLevel_WritesTips` mode (empty writer); the second is the `DiffCommandTests` mode (stolen output). Adding a raw `Console.SetError` to `SkillCommandTests` fails the structural gate naming that file.

## Validation, and what is *not* fixed

Three full-suite runs, Release, Windows, after `dotnet build dotnet-inspect.slnx -c Release`: **2365 tests, 2 failures each run**. The `WriteTips`/`DiffCommandTests` pair named in the issue **never recurred**.

The two remaining failures are not this bug, and I am not claiming them:

1. `LibraryCommand_DetailedOutput_RendersSectionsAlphabetically` fails **all three** runs deterministically. That is #3454, fixed separately by #3455.
2. A **second, distinct** varying pair remains — `PerformanceTriagePredicates_DoNotAlterDiscovery(library)` in runs 1 and 3, `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceLinkDoor` in run 2. Same varying-pair signature, different shared state; both are `LibraryCommand` discovery tests, so the console lock does not address them.

So this closes the console-redirection race that #3416 documents, and leaves a separate discovery-side flake that deserves its own investigation rather than being folded in here.
