### PR TITLE
Return library scan results instead of mutating the aggregate

### DIFF
--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -28,10 +28,9 @@ public class LibraryFindingConsumerTests
     {
         var inspection = new LibraryInspection();
 
-        LibraryMetadataService.ScanClassifiedMethods(
+        inspection.Apply(LibraryMetadataService.ScanClassifiedMethods(
             typeof(SampleUnsafeClass).Assembly.Location,
-            inspection,
-            new VerboseLogger(enabled: false));
+            new VerboseLogger(enabled: false)));
 
         var finding = Assert.Single(
             inspection.ClassifiedMethodInspection.Findings(),
@@ -49,10 +48,9 @@ public class LibraryFindingConsumerTests
     {
         var inspection = new LibraryInspection();
 
-        LibraryMetadataService.ScanExtensionMembers(
+        inspection.Apply(LibraryMetadataService.ScanExtensionMembers(
             typeof(ExtensionsCommandTests).Assembly.Location,
-            inspection,
-            new VerboseLogger(enabled: false));
+            new VerboseLogger(enabled: false)));
 
         var finding = Assert.Single(
             inspection.ExtensionMemberInspection.Findings(),
@@ -170,10 +168,10 @@ public class LibraryFindingConsumerTests
             SwitchInspection = LibraryMetadataService.ScanSwitches(missingPath, logger),
         };
 
-        LibraryMetadataService.ScanClassifiedMethods(missingPath, inspection, logger);
-        LibraryMetadataService.ScanExtensionMembers(missingPath, inspection, logger);
-        LibraryMetadataService.ScanCustomAttributes(missingPath, inspection, logger);
-        LibraryMetadataService.ScanTypeForwarders(missingPath, inspection, logger);
+        inspection.Apply(LibraryMetadataService.ScanClassifiedMethods(missingPath, logger));
+        inspection.Apply(LibraryMetadataService.ScanExtensionMembers(missingPath, logger));
+        inspection.Apply(LibraryMetadataService.ScanCustomAttributes(missingPath, logger));
+        inspection.TypeForwarderInspection = LibraryMetadataService.ScanTypeForwarders(missingPath, logger);
         LibraryMetadataService.ScanIntegrations(missingPath, inspection, logger);
 
         AssertFailure(inspection.ClassifiedMethodInspection, MetadataFindings.ClassifiedMethodDescriptor);

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -42,7 +42,8 @@ internal static class AuditSignalBuilder
 
             // Reuse the same session for the classified-methods scan rather than re-opening the file.
             if (inspection.ClassifiedMethodInspection is null)
-                LibraryMetadataService.ScanClassifiedMethods(session, assemblyPath, inspection, logger);
+                inspection.Apply(
+                    LibraryMetadataService.ScanClassifiedMethods(session, assemblyPath, logger));
         }
         catch (Exception ex)
         {

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -163,12 +163,12 @@ internal static class LibraryMetadataService
                 try
                 {
                     using var session = AssemblyInspectionSession.Open(path);
-                    ScanExtensionMembers(session, path, inspection, logger);
-                    ScanClassifiedMethods(session, path, inspection, logger);
+                    inspection.Apply(ScanExtensionMembers(session, path, logger));
+                    inspection.Apply(ScanClassifiedMethods(session, path, logger));
                     inspection.ResourceInspection = ScanResources(session, path, logger);
-                    ScanCustomAttributes(session, path, inspection, logger);
+                    inspection.Apply(ScanCustomAttributes(session, path, logger));
                     inspection.UnionTypeInspection = ScanUnionTypes(session, path, logger);
-                    ScanTypeForwarders(session, path, inspection, logger);
+                    inspection.TypeForwarderInspection = ScanTypeForwarders(session, path, logger);
                 }
                 catch (Exception ex)
                 {
@@ -585,36 +585,34 @@ internal static class LibraryMetadataService
     /// <summary>
     /// Scans an assembly for extension members and retains Metadata's typed census.
     /// </summary>
-    internal static void ScanExtensionMembers(
+    internal static ExtensionMemberScan ScanExtensionMembers(
         string path,
-        LibraryInspection inspection,
         VerboseLogger logger)
     {
         try
         {
             using var session = AssemblyInspectionSession.Open(path);
-            ScanExtensionMembers(session, path, inspection, logger);
+            return ScanExtensionMembers(session, path, logger);
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning extensions in {path}: {ex.Message}");
-            inspection.SetExtensionMemberInspection(
+            return new ExtensionMemberScan(
                 FailedInspection<ExtensionMemberObservation>(
                     path, MetadataFindings.ExtensionMemberDescriptor, ex),
-                displayOrder: null);
+                DisplayOrder: null);
         }
     }
 
-    internal static void ScanExtensionMembers(
+    internal static ExtensionMemberScan ScanExtensionMembers(
         AssemblyInspectionSession session,
         string path,
-        LibraryInspection inspection,
         VerboseLogger logger)
     {
         try
         {
             var extensions = session.ExtensionMethods().ToArray();
-            inspection.SetExtensionMemberInspection(
+            return new ExtensionMemberScan(
                 MetadataFindings.InspectExtensionMembers(
                     extensions,
                     FindingSubjectFor(path)),
@@ -623,57 +621,56 @@ internal static class LibraryMetadataService
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning extensions in {path}: {ex.Message}");
-            inspection.SetExtensionMemberInspection(
+            return new ExtensionMemberScan(
                 FailedInspection<ExtensionMemberObservation>(
                     path, MetadataFindings.ExtensionMemberDescriptor, ex),
-                displayOrder: null);
+                DisplayOrder: null);
         }
     }
 
     /// <summary>
     /// Scans an assembly for unsafe and P/Invoke methods.
     /// </summary>
-    internal static void ScanClassifiedMethods(string path, LibraryInspection inspection, VerboseLogger logger)
+    internal static ClassifiedMethodScan ScanClassifiedMethods(string path, VerboseLogger logger)
     {
         try
         {
             using var session = AssemblyInspectionSession.Open(path);
-            ScanClassifiedMethods(session, path, inspection, logger);
+            return ScanClassifiedMethods(session, path, logger);
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning classified methods in {path}: {ex.Message}");
-            inspection.ClassifiedMethodInspection = FailedInspection<ClassifiedMethodObservation>(
-                path, MetadataFindings.ClassifiedMethodDescriptor, ex);
+            return ClassifiedMethodScan.FromInspectionOnly(
+                FailedInspection<ClassifiedMethodObservation>(
+                    path, MetadataFindings.ClassifiedMethodDescriptor, ex));
         }
     }
 
-    internal static void ScanClassifiedMethods(AssemblyInspectionSession session, string path, LibraryInspection inspection, VerboseLogger logger)
+    internal static ClassifiedMethodScan ScanClassifiedMethods(AssemblyInspectionSession session, string path, VerboseLogger logger)
     {
         try
         {
-            ApplyClassifiedMethods(
+            return ProjectClassifiedMethods(
                 session.ClassifiedMethods(),
-                inspection,
                 FindingSubjectFor(path));
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning classified methods in {path}: {ex.Message}");
-            inspection.ClassifiedMethodInspection = FailedInspection<ClassifiedMethodObservation>(
-                path, MetadataFindings.ClassifiedMethodDescriptor, ex);
+            return ClassifiedMethodScan.FromInspectionOnly(
+                FailedInspection<ClassifiedMethodObservation>(
+                    path, MetadataFindings.ClassifiedMethodDescriptor, ex));
         }
     }
 
-    static void ApplyClassifiedMethods(
+    static ClassifiedMethodScan ProjectClassifiedMethods(
         List<ClassifiedMethodInfo> classified,
-        LibraryInspection inspection,
         FindingSubject subject)
     {
-        inspection.ClassifiedMethodInspection =
-            MetadataFindings.InspectClassifiedMethods(classified, subject);
+        var inspection = MetadataFindings.InspectClassifiedMethods(classified, subject);
 
-        if (classified.Count == 0) return;
+        if (classified.Count == 0) return ClassifiedMethodScan.FromInspectionOnly(inspection);
 
         var unsafe_ = classified
             .Where(m => m.Classification == MethodClassification.Unsafe)
@@ -700,9 +697,6 @@ internal static class LibraryMetadataService
             .ThenBy(m => m.MethodName)
             .ToList();
 
-        inspection.UnsafeMethods = unsafe_.Count > 0 ? unsafe_ : null;
-        inspection.PInvokeMethods = pinvoke.Count > 0 ? pinvoke : null;
-
         var async = classified
             .Where(m => m.Classification is MethodClassification.RuntimeAsync
                                          or MethodClassification.StateMachineAsync)
@@ -721,7 +715,11 @@ internal static class LibraryMetadataService
             .ThenBy(m => m.MethodName)
             .ToList();
 
-        inspection.AsyncMethods = async.Count > 0 ? async : null;
+        return new ClassifiedMethodScan(
+            inspection,
+            unsafe_.Count > 0 ? unsafe_ : null,
+            pinvoke.Count > 0 ? pinvoke : null,
+            async.Count > 0 ? async : null);
     }
 
     internal static List<UnsafeMemberSummary>? ScanUnsafeMembers(Func<Analysis.LibraryBodyIndex> openIndex, string path, VerboseLogger logger)
@@ -943,25 +941,24 @@ internal static class LibraryMetadataService
         }
     }
 
-    internal static void ScanResourceTriage(
+    internal static ResourceTriageScan ScanResourceTriage(
         Func<Analysis.LibraryBodyIndex> openIndex,
         Func<IReadOnlyDictionary<int, (string? Stable, string Visibility, string Selector)>>
             getDrillMap,
         string path,
-        LibraryInspection inspection,
         VerboseLogger logger)
     {
         var result = Analysis.ResourceLifecycleAnalysis.InspectAssembly(
             openIndex,
             new FindingSubject(Path.GetFullPath(path), Path.GetFileName(path)));
-        inspection.ResourceLifecycleInspection = result;
-        inspection.ResourceTriage =
+        return new ResourceTriageScan(
+            result,
             result.Value
                 is FindingInspection<Analysis.ResourceLifecycleOccurrence>.Complete complete
                 ? ProjectResourceTriage(
                     complete,
                     getDrillMap())
-                : null;
+                : null);
     }
 
     static List<ResourceTriageSummary> ProjectResourceTriage(
@@ -1530,11 +1527,11 @@ internal static class LibraryMetadataService
         {
             using var session = AssemblyInspectionSession.Open(path);
             if (inspection.ExtensionMemberInspection is null)
-                ScanExtensionMembers(session, path, inspection, logger);
-            ScanClassifiedMethods(session, path, inspection, logger);
+                inspection.Apply(ScanExtensionMembers(session, path, logger));
+            inspection.Apply(ScanClassifiedMethods(session, path, logger));
             inspection.ResourceInspection ??= ScanResources(session, path, logger);
-            ScanCustomAttributes(session, path, inspection, logger);
-            ScanTypeForwarders(session, path, inspection, logger);
+            inspection.Apply(ScanCustomAttributes(session, path, logger));
+            inspection.TypeForwarderInspection = ScanTypeForwarders(session, path, logger);
         }
         catch (Exception ex)
         {
@@ -1653,29 +1650,29 @@ internal static class LibraryMetadataService
     /// <summary>
     /// Scans an assembly for custom attributes (assembly-level and module-level).
     /// </summary>
-    internal static void ScanCustomAttributes(string path, LibraryInspection inspection, VerboseLogger logger)
+    internal static AssemblyAttributeScan ScanCustomAttributes(string path, VerboseLogger logger)
     {
         try
         {
             using var session = AssemblyInspectionSession.Open(path);
-            ScanCustomAttributes(session, path, inspection, logger);
+            return ScanCustomAttributes(session, path, logger);
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning custom attributes in {path}: {ex.Message}");
-            inspection.SetAssemblyAttributeInspection(
+            return new AssemblyAttributeScan(
                 FailedInspection<AssemblyAttributeInfo>(
                     path, MetadataFindings.AssemblyAttributeDescriptor, ex),
-                jsonOrder: null);
+                JsonOrder: null);
         }
     }
 
-    internal static void ScanCustomAttributes(AssemblyInspectionSession session, string path, LibraryInspection inspection, VerboseLogger logger)
+    internal static AssemblyAttributeScan ScanCustomAttributes(AssemblyInspectionSession session, string path, VerboseLogger logger)
     {
         try
         {
             var attributes = session.CustomAttributes();
-            inspection.SetAssemblyAttributeInspection(
+            return new AssemblyAttributeScan(
                 MetadataFindings.InspectAssemblyAttributes(
                     attributes,
                     FindingSubjectFor(path)),
@@ -1684,10 +1681,10 @@ internal static class LibraryMetadataService
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning custom attributes in {path}: {ex.Message}");
-            inspection.SetAssemblyAttributeInspection(
+            return new AssemblyAttributeScan(
                 FailedInspection<AssemblyAttributeInfo>(
                     path, MetadataFindings.AssemblyAttributeDescriptor, ex),
-                jsonOrder: null);
+                JsonOrder: null);
         }
     }
 
@@ -1730,33 +1727,33 @@ internal static class LibraryMetadataService
     /// <summary>
     /// Scans an assembly for type forwarders.
     /// </summary>
-    internal static void ScanTypeForwarders(string path, LibraryInspection inspection, VerboseLogger logger)
+    internal static FindingInspection<TypeForwarderInfo> ScanTypeForwarders(string path, VerboseLogger logger)
     {
         try
         {
             using var session = AssemblyInspectionSession.Open(path);
-            ScanTypeForwarders(session, path, inspection, logger);
+            return ScanTypeForwarders(session, path, logger);
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning type forwarders in {path}: {ex.Message}");
-            inspection.TypeForwarderInspection = FailedInspection<TypeForwarderInfo>(
+            return FailedInspection<TypeForwarderInfo>(
                 path, MetadataFindings.TypeForwarderDescriptor, ex);
         }
     }
 
-    internal static void ScanTypeForwarders(AssemblyInspectionSession session, string path, LibraryInspection inspection, VerboseLogger logger)
+    internal static FindingInspection<TypeForwarderInfo> ScanTypeForwarders(AssemblyInspectionSession session, string path, VerboseLogger logger)
     {
         try
         {
-            inspection.TypeForwarderInspection = MetadataFindings.InspectTypeForwarders(
+            return MetadataFindings.InspectTypeForwarders(
                 session.TypeForwarders(),
                 FindingSubjectFor(path));
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning type forwarders in {path}: {ex.Message}");
-            inspection.TypeForwarderInspection = FailedInspection<TypeForwarderInfo>(
+            return FailedInspection<TypeForwarderInfo>(
                 path, MetadataFindings.TypeForwarderDescriptor, ex);
         }
     }

--- a/src/dotnet-inspect/Inspectors/LibraryScanResults.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryScanResults.cs
@@ -1,0 +1,91 @@
+using DotnetInspector.Models;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Inspectors;
+
+// Results returned by the library scanners that compute a self-contained answer.
+//
+// A scanner that produces a result returns it rather than writing into LibraryInspection, so the
+// computation can run for a caller that has no aggregate to write into. Where a scanner produces
+// several correlated values, they travel together in one record rather than as separate writes,
+// because they are only meaningful as a set — a census and the display order that census was
+// projected from, for instance, must not drift apart.
+//
+// These are the shapes a typed L1 inspection query would return; see
+// docs/design/inspection-layers.md. The assignment into the aggregate stays at the call site,
+// which is where it will be deleted once L1 owns the queries.
+
+/// <summary>
+/// Extension member census, plus the metadata order it was projected from. The order is retained
+/// separately because the census is a finding set (unordered by contract) while the rendered and
+/// serialized views need the assembly's own ordering.
+/// </summary>
+internal readonly record struct ExtensionMemberScan(
+    FindingInspection<ExtensionMemberObservation> Inspection,
+    IReadOnlyList<ExtensionMethodInfo>? DisplayOrder);
+
+/// <summary>
+/// Assembly attribute census, plus the order used for JSON serialization.
+/// </summary>
+internal readonly record struct AssemblyAttributeScan(
+    FindingInspection<AssemblyAttributeInfo> Inspection,
+    IReadOnlyList<AssemblyAttributeInfo>? JsonOrder);
+
+/// <summary>
+/// Method classification census, plus the three per-classification projections derived from it.
+/// All four come from one pass over the same classified-method list, so they are produced together;
+/// splitting them into separate scanners would re-walk the assembly three more times.
+/// </summary>
+internal readonly record struct ClassifiedMethodScan(
+    FindingInspection<ClassifiedMethodObservation> Inspection,
+    List<ClassifiedMethodSummary>? UnsafeMethods,
+    List<ClassifiedMethodSummary>? PInvokeMethods,
+    List<AsyncMethodSummary>? AsyncMethods)
+{
+    /// <summary>
+    /// The census alone, with no projections. Used on the failure path, where there is nothing to
+    /// project from.
+    /// </summary>
+    public static ClassifiedMethodScan FromInspectionOnly(
+        FindingInspection<ClassifiedMethodObservation> inspection)
+        => new(inspection, null, null, null);
+}
+
+/// <summary>
+/// Resource lifecycle findings, plus the actionable triage rows projected from them. The triage
+/// projection needs member drill coordinates, so it is computed here rather than by the view.
+/// </summary>
+internal readonly record struct ResourceTriageScan(
+    FindingInspection<Analysis.ResourceLifecycleOccurrence> Inspection,
+    List<ResourceTriageSummary>? Triage);
+
+/// <summary>
+/// Writes a scan result into the <see cref="LibraryInspection"/> aggregate. This is the CLI-side
+/// adapter between a scanner's result and the aggregate the views read from: it exists so the
+/// scanners themselves need not know the aggregate, and it is the code that goes away when L1 owns
+/// the queries and the aggregate is decomposed.
+/// </summary>
+internal static class LibraryScanApply
+{
+    public static void Apply(this LibraryInspection inspection, ExtensionMemberScan scan)
+        => inspection.SetExtensionMemberInspection(scan.Inspection, scan.DisplayOrder);
+
+    public static void Apply(this LibraryInspection inspection, AssemblyAttributeScan scan)
+        => inspection.SetAssemblyAttributeInspection(scan.Inspection, scan.JsonOrder);
+
+    public static void Apply(this LibraryInspection inspection, ClassifiedMethodScan scan)
+    {
+        inspection.ClassifiedMethodInspection = scan.Inspection;
+        inspection.UnsafeMethods = scan.UnsafeMethods;
+        inspection.PInvokeMethods = scan.PInvokeMethods;
+        inspection.AsyncMethods = scan.AsyncMethods;
+    }
+
+    public static void Apply(this LibraryInspection inspection, ResourceTriageScan scan)
+    {
+        inspection.ResourceLifecycleInspection = scan.Inspection;
+        inspection.ResourceTriage = scan.Triage;
+    }
+}

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -119,17 +119,17 @@ public static class LibrarySections
     {
         return new ScannerRegistry()
             .Add(ScannerExtensionMethods, ctx =>
-                LibraryMetadataService.ScanExtensionMembers(ctx.AssemblyPath, ctx.Model, ctx.Logger))
+                ctx.Model.Apply(LibraryMetadataService.ScanExtensionMembers(ctx.AssemblyPath, ctx.Logger)))
             .Add(ScannerClassifiedMethods, ctx =>
-                LibraryMetadataService.ScanClassifiedMethods(ctx.AssemblyPath, ctx.Model, ctx.Logger))
+                ctx.Model.Apply(LibraryMetadataService.ScanClassifiedMethods(ctx.AssemblyPath, ctx.Logger)))
             .Add(ScannerResources, ctx =>
                 ctx.Model.ResourceInspection = LibraryMetadataService.ScanResources(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerCustomAttributes, ctx =>
-                LibraryMetadataService.ScanCustomAttributes(ctx.AssemblyPath, ctx.Model, ctx.Logger))
+                ctx.Model.Apply(LibraryMetadataService.ScanCustomAttributes(ctx.AssemblyPath, ctx.Logger)))
             .Add(ScannerUnionTypes, ctx =>
                 ctx.Model.UnionTypeInspection = LibraryMetadataService.ScanUnionTypes(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerTypeForwarders, ctx =>
-                LibraryMetadataService.ScanTypeForwarders(ctx.AssemblyPath, ctx.Model, ctx.Logger))
+                ctx.Model.TypeForwarderInspection = LibraryMetadataService.ScanTypeForwarders(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerInfoCounts, ctx =>
                 LibraryMetadataService.ScanInfoCounts(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerAuditSignals, ctx =>
@@ -148,12 +148,11 @@ public static class LibrarySections
                 ctx.Model.OptimizationOpportunities = LibraryMetadataService.ScanOptimizationOpportunities(
                     ctx.BodyIndex, ctx.AssemblyPath, ctx.Logger, ctx.Model.PerformanceTriageOptions))
             .Add(ScannerResourceTriage, ctx =>
-                LibraryMetadataService.ScanResourceTriage(
+                ctx.Model.Apply(LibraryMetadataService.ScanResourceTriage(
                     ctx.BodyIndex,
                     ctx.DrillMap,
                     ctx.AssemblyPath,
-                    ctx.Model,
-                    ctx.Logger))
+                    ctx.Logger)))
             .Add(ScannerIntegrations, ctx =>
                 LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerIntegrationOpportunities, ctx =>


### PR DESCRIPTION
## What

Five library scanners wrote their answers into the shared `LibraryInspection`
aggregate by side effect. Each now **returns** its result; the call site does the
assignment.

| Scanner | Was | Now |
| --- | --- | --- |
| `ScanExtensionMembers` | `void` + 1 setter call | `ExtensionMemberScan` |
| `ScanClassifiedMethods` | `void` + 4 field writes | `ClassifiedMethodScan` |
| `ScanCustomAttributes` | `void` + 1 setter call | `AssemblyAttributeScan` |
| `ScanTypeForwarders` | `void` + 1 field write | `FindingInspection<TypeForwarderInfo>` |
| `ScanResourceTriage` | `void` + 2 field writes | `ResourceTriageScan` |

Six library scanners already returned their results; this brings five more to that
shape, leaving four.

## Why

This is the shape problem that made the libraries unreachable from a second
consumer. Computing an extension-member census required constructing an
85-setter aggregate purely to receive the answer. A returning scanner can run
for a caller that has no aggregate at all — which is the precondition for moving
these below the CLI as typed inspection queries
(`docs/design/inspection-layers.md`).

Where a scanner produces several correlated values they travel together in one
record rather than as separate writes, because they are only meaningful as a
set: a census and the metadata order that census was projected from must not
drift apart, and the three per-classification projections come from one pass
over the same classified-method list — splitting them into separate scanners
would re-walk the assembly three more times.

`LibraryScanApply` holds the assignment into the aggregate. It is deliberately a
separate, named seam rather than inline field writes at each call site: it is
exactly the adapter that gets deleted when the queries move below the CLI.

## Behavior

**No output change.** Byte-identical CLI output across a full sweep:

- `library <dll> -v:d --tips q` on `ILInspector.Metadata.dll`: **byte-identical**
  (52,397 bytes both sides, matching SHA-256).
- Every affected section, in both `--table` and `--json`, across **all 54 built
  assemblies**: **756 comparisons, 0 mismatches.** Sections compared:
  `Extension Methods`, `Custom Attributes`, `Type Forwarders`, `Signals`,
  `P/Invoke Methods`, `Async Methods`, `Array Pool Escapes`.
- Each of those sections produced non-empty data in at least some runs, so the
  comparison is not comparing empty output to empty output: Custom Attributes
  104, Array Pool Escapes 56, Signals 44, Extension Methods 33, Async Methods
  24, P/Invoke Methods 5, Type Forwarders 2.

Both binaries were pointed at the **same** input assemblies (the base worktree's
build output) so the only variable is the CLI under test.

## One deliberate semantic difference

The old `ApplyClassifiedMethods` returned early when the classified list was
empty, and the exception paths only assigned `ClassifiedMethodInspection`. In
both cases `UnsafeMethods`, `PInvokeMethods` and `AsyncMethods` were left
holding whatever they already had. `LibraryScanApply.Apply(ClassifiedMethodScan)`
now assigns all four unconditionally, so those three become `null`.

This scanner is the sole writer of all three fields (verified by grepping every
assignment repo-wide), so the only value it can overwrite is its own from an
earlier run. `AuditSignalBuilder` guards its call on
`ClassifiedMethodInspection is null`; `ScanInfoCounts` and the `Verbosity.Detailed`
fallback do **not** — they re-run the scanner unconditionally. So the overwrite
does happen, and it lands in one of two states:

- **The re-run computes the same answer** (same scanner, same assembly,
  deterministic). Nulls overwrite nulls. Unobservable — this is the ordinary case.
- **The re-run fails where the first succeeded** (file deleted or replaced
  mid-command). Here the old code was actually *wrong*: it assigned the failure
  to `ClassifiedMethodInspection` while leaving the three stale success
  projections in place, producing a model that reported a failed scan alongside
  populated rows derived from the scan that failed. The new code clears them, so
  the failure stays visible rather than being masked by stale data — which is
  what "do not turn analysis failures into success-shaped output" asks for.

Making the result total is the point rather than an accident: a returned result
that omits fields cannot express "leave the previous value alone" without
knowing there *is* a previous value — which is precisely the aggregate coupling
being removed. The `ClassifiedMethodScan.FromInspectionOnly` factory names the
failure case where there is genuinely nothing to project.

## Not converted here

- `ScanIntegrations` / `ScanIntegrationOpportunities` — the latter reads the
  former's output from the shared model and re-runs it when absent. That is a
  real inter-scanner dependency, currently papered over by dictionary insertion
  order. It needs an explicit expression (a result parameter), which is a design
  decision about how the query layer expresses dependencies, not a mechanical
  return-type change.
- `ScanInfoCounts` and `AuditSignalBuilder.PopulateLibraryAudit` — these write
  scattered presence flags rather than a single result. Different problem.

No package files touched: `PackageCommand.cs` calls
`LibrarySections.CreateScannerRegistry()`, so the two share a registry, but the
registry's own signature is unchanged.

## Validation

`dotnet build dotnet-inspect.slnx -c Release` — succeeded, 0 errors. The 5
warnings are pre-existing in unrelated test projects and are present at the base
commit.

`dotnet run --project src/dotnet-inspect.Tests -c Release`:

| | Total | Failed | Skipped |
| --- | --- | --- | --- |
| Base (`27cd64ee`) | 2361 | 2 | 10 |
| This branch | 2361 | 2 | 10 |

The two failures are identical on both sides and pre-existing, confirmed by
building and running the base commit in a separate worktree on this machine:

- `LibraryCommand_DetailedOutput_RendersSectionsAlphabetically` — Windows-only,
  tracked by #3445, root-caused by #3454 (`MarkdownSectionOrderer` rewrites CRLF
  to LF while the test splits on `Environment.NewLine`).
- `LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceLinkDoor` —
  order-dependent on shared symbol-cache state; passes in isolation on this
  branch.

The 10 skips are `ildasm`/`ilasm` absent.

