### PR TITLE
Fail closed on find --fields/--columns under --json (#3386 follow-up)

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4380,6 +4380,71 @@ public class CommandExecutionTests
         Assert.True(int.TryParse(output.Trim(), out _), $"expected a bare count, got: {output}");
     }
 
+    [Theory]
+    [InlineData("--fields")]
+    [InlineData("--columns")]
+    public async Task Find_ColumnProjectionWithJson_IsRejected(string projectionFlag)
+    {
+        // Same category error as #3386: --fields/--columns select table columns, but find's
+        // --json emits the full per-result objects and has no column-slicing facility, so the
+        // combination used to silently drop the column filter. It now fails closed.
+        var (exit, output, error) = await RunAppAsync(
+            "find", "Cache", "--library", TestAssemblyPath, projectionFlag, "Type", "--json");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("cannot be combined with --json", error);
+    }
+
+    [Fact]
+    public async Task Find_MemberSearch_ColumnProjectionWithJson_IsRejected()
+    {
+        // The member-search path shares ExecuteAsync's guard, so it rejects too.
+        var (exit, output, error) = await RunAppAsync(
+            "find", "Cache", "--members", "--library", TestAssemblyPath, "--fields", "Member", "--json");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("cannot be combined with --json", error);
+    }
+
+    [Fact]
+    public async Task Find_ColumnProjectionWithJsonl_IsHonored()
+    {
+        // Boundary: the row-oriented formats keep honoring column projection. Only document
+        // --json is rejected.
+        var (exit, _, error) = await RunAppAsync(
+            "find", "Cache", "--library", TestAssemblyPath, "--columns", "Type", "--jsonl");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("cannot be combined with --json", error);
+    }
+
+    [Fact]
+    public async Task Find_ColumnProjectionWithCountAndJson_IsHonored()
+    {
+        // --count reduces to a scalar and is excluded from the rejection.
+        var (exit, output, error) = await RunAppAsync(
+            "find", "Cache", "--library", TestAssemblyPath, "--fields", "Type", "--count", "--json");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("cannot be combined with --json", error);
+        Assert.True(int.TryParse(output.Trim(), out _), $"expected a bare count, got: {output}");
+    }
+
+    [Fact]
+    public async Task Find_Discovery_ColumnProjectionWithJson_IsHonored()
+    {
+        // The -D discovery branch honors projection itself and returns before the guard, so a
+        // discovery request carrying --fields/--json must not be rejected.
+        var (exit, output, error) = await RunAppAsync(
+            "find", "Cache", "--library", TestAssemblyPath, "-D", "Results", "--fields", "Type", "--json");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("cannot be combined with --json", error);
+        Assert.Contains("\"kind\":\"column\"", output);
+    }
+
     [Fact]
     public async Task Implements_Count_ComposesWithJson()
     {

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -41,6 +41,15 @@ public class FindCommand
                 return 1;
             }
 
+            // Fail closed, like the type/member paths (#3386): --fields/--columns select table
+            // columns, but find's --json emits the full per-result objects and has no column-
+            // slicing facility, so the combination silently dropped the column filter. Reject it
+            // rather than emitting an unfiltered document. --count reduces to a scalar and is
+            // handled below, so it is excluded. Placed after the -D discovery branch, which honors
+            // projection itself. The row-oriented formats (--tsv/--jsonl/--table) project columns.
+            if (options.JsonOutput && !options.Count && IsColumnProjectionRequested(options))
+                return RejectColumnProjectionUnderJson();
+
             if (!options.HasAnyScope)
             {
                 logger.Log("No scope specified, defaulting to all platform frameworks");
@@ -121,6 +130,17 @@ public class FindCommand
         }
 
         return 0;
+    }
+
+    private static bool IsColumnProjectionRequested(FindOptions options)
+        => options.Fields is { Length: > 0 } || options.Columns is { Length: > 0 };
+
+    private static int RejectColumnProjectionUnderJson()
+    {
+        Console.Error.WriteLine(
+            "Error: --fields/--columns select table columns and cannot be combined with --json, "
+            + "which emits the full result objects. Use --tsv, --jsonl, or --table to project columns.");
+        return 1;
     }
 
     private static void WriteOutput(List<TypeFindResult> rawData, string title, FindOptions options)


### PR DESCRIPTION
## Summary

`find --fields`/`--columns` combined with `--json` **silently dropped** the column filter, emitting the full per-result JSON object with exit 0. This is the `find` analog of the two silent-projection-drop bugs fixed for the `type`/`api` surface in #3386 (merged as #3462). This PR applies the same **fail-closed** resolution to `find`: the unsupported combination is now rejected cleanly with exit 1 and a clear message.

## Why fail closed

`--fields`/`--columns` select **table columns**. `find --json` is an object/document format whose keys (`type`, `library`, `source_version`) differ from the table column vocabulary (`Type`, `Library`, `Sim`, `Match`, `Pattern`), and it has no jq-style column-slicing facility. The combination is a category error, so silently ignoring the filter hides user intent. Rejecting is consistent with the command-agnostic rule already documented in `docs/design/output-shapes.md` (no doc change needed).

## What still works (unchanged)

- Row-oriented formats still honor projection: `--jsonl`, `--tsv`, `--table`.
- `--count` reduces to a scalar and composes with `--json` → excluded from the guard.
- `-D`/discovery is dispatched **before** the guard, so discovery requests carrying `--fields`/`--json` are honored, not rejected.
- Both type-search and member-search (`--members`) paths flow through the single guard.

## Validation

- Full CLI suite green: 2405 tests, 0 failed (14 ilasm-dependent tests skip when ildasm/ilasm absent).
- 6 new tests in `CommandExecutionTests.cs` covering: `--fields`/`--columns` rejection (Theory), member-search rejection, `--jsonl` honored, `--count`+`--json` honored, discovery honored.
- Real-run probes confirm: rejected combos exit 1 with empty stdout + clear error; plain `--json`, `--jsonl`/`--tsv`/`--table` projection, `--count`+`--json`, and discovery all exit 0 with expected output.

## Adversarial review

Localized output-path rejection mirroring the already-reviewed #3386 pattern → one review (MAI-Code) per policy. Review was clean with real-run verification of the rejection, honored formats, discovery, and member-search paths.

Refs #3386.