### PR TITLE
Encourage stacked PRs for multi-slice issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,9 +460,11 @@ worse.
   now sits on a base that no longer exists and has to be restacked too. One
   gesture, several branches rewritten, most of which you were not looking at. That
   cascade is the stack's defining operational fact. The mechanism requires it:
-  once a parent lands by squash or rebase merge its commits get new identities, so
-  the child still carries the pre-merge originals and double-reports the parent's
-  work. Merging cannot repair that; rebasing onto the new base can.
+  once a parent lands by squash or rebase merge its commits get new identities,
+  so the child still carries the pre-merge originals. Its PR then re-reports the
+  parent's work — the parent's commits reappear in the child's commit list, and
+  the three-dot diff GitHub renders against the new base shows the parent's files
+  again. Merging cannot repair that; rebasing onto the new base can.
 
   So force-push is the norm inside a stack rather than the violation it would be
   on a standalone PR. The manual equivalent of the button, when you need it:
@@ -475,13 +477,22 @@ worse.
 
   Always `--force-with-lease`, never bare `--force`; it declines when the remote
   moved under you instead of destroying whatever arrived. Restack only your own
-  slices, and land a parent before disturbing what sits above it rather than
-  rewriting under a reviewer mid-read.
+  slices, never one another contributor has pushed to — coordinate first — and
+  land a parent before disturbing what sits above it rather than rewriting under
+  a reviewer mid-read.
 - **A restack must change the base and nothing else.** Prove that rather than
-  assuming it — `git range-diff <old-base>..<old-head> <new-base>..<new-head>`
-  reports exactly what the rebase altered, and an unchanged report is the claim.
-  A restack that also changes content is a rewrite wearing maintenance clothing;
-  say so in the PR instead of letting it pass as routine.
+  assuming it: record the pre-rebase head first, because afterwards the branch
+  name resolves to the *new* head, and a range built from it describes something
+  other than the slice you rebased.
+
+  ```bash
+  old=$(git rev-parse <slice-branch>)          # before rebasing
+  git range-diff <old-parent-tip>..$old origin/main..<slice-branch>
+  ```
+
+  Every commit reported `=` is the claim. A restack that also changes content is
+  a rewrite wearing maintenance clothing; say so in the PR instead of letting it
+  pass as routine.
 - **Review depth is per-slice, by that slice's own risk**, not the stack's total
   size. A long stack does not make a trivial slice risky, and a small slice in a
   risky area still earns the two-model tier.
@@ -493,6 +504,13 @@ worse.
   and it is paid per slice. A posted `range-diff` is what keeps each of those
   re-reviews a confirmation rather than a second full pass — without one, a
   reviewer cannot tell a restack from a rewrite.
+- **A restack does not retire a finding.** It can destroy the exact head a
+  reviewer was given, which makes "reproduce it on a clean exact-head review
+  worktree" temporarily unactionable — not moot. An open finding survives the
+  rewrite and is re-verified at the new head, and the burden sits with whoever
+  moved the head: say whether the finding still applies and at which commit, and
+  post the new head so review can resume. A finding that disappears because its
+  head did is an unresolved finding.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost
   is per PR; three coherent slices beat ten mechanical ones.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,10 @@ documentation.
 - Before requesting review, fetch `origin/main` and incorporate it into the
   feature branch. Rebase only before the branch's first push. Once a branch is
   public or under review, merge `origin/main`; never amend, rebase, or
-  force-push reviewed history.
+  force-push reviewed history. A slice in a stack is the standing exception:
+  restacking rebases and force-pushes a public branch by design — see
+  [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues) for
+  the discipline that replaces this rule there.
 - After updating from main or resolving conflicts, re-read `AGENTS.md` and
   task-relevant docs before continuing.
 - Do not mix unrelated changes into one commit or sweep another contributor's
@@ -448,19 +451,48 @@ worse.
 - **Target the parent branch** so the PR diff shows only its own slice:
   `gh pr create --base <parent-branch>`.
 - **Merge bottom-up, one at a time.** After each merge, confirm the next PR
-  retargeted to `main` and that its diff is still only its own slice.
-- **Propagate updates down the stack by merging**, parent branch into child.
-  Never rebase or force-push a pushed slice: the no-rewrite rule applies to
-  every branch in a stack, and rewriting a parent invalidates every review
-  beneath it.
+  retargeted to `main` and that its diff is still only its own slice. When the
+  diff shows work already in `main`, that is the signal to restack, not a defect.
+- **Restacking is normal, it is usually a button, and it force-pushes.** GitHub's
+  *Update with rebase* rebases the slice onto its base and force-pushes the head
+  branch; a stacking tool's restack does the same for every slice at once. Either
+  way the rewrite does not stop at the slice you pressed it on — every slice above
+  now sits on a base that no longer exists and has to be restacked too. One
+  gesture, several branches rewritten, most of which you were not looking at. That
+  cascade is the stack's defining operational fact. The mechanism requires it:
+  once a parent lands by squash or rebase merge its commits get new identities, so
+  the child still carries the pre-merge originals and double-reports the parent's
+  work. Merging cannot repair that; rebasing onto the new base can.
+
+  So force-push is the norm inside a stack rather than the violation it would be
+  on a standalone PR. The manual equivalent of the button, when you need it:
+
+  ```bash
+  git fetch origin main
+  git rebase --onto origin/main <old-parent-tip> <slice-branch>
+  git push --force-with-lease origin <slice-branch>
+  ```
+
+  Always `--force-with-lease`, never bare `--force`; it declines when the remote
+  moved under you instead of destroying whatever arrived. Restack only your own
+  slices, and land a parent before disturbing what sits above it rather than
+  rewriting under a reviewer mid-read.
+- **A restack must change the base and nothing else.** Prove that rather than
+  assuming it — `git range-diff <old-base>..<old-head> <new-base>..<new-head>`
+  reports exactly what the rebase altered, and an unchanged report is the claim.
+  A restack that also changes content is a rewrite wearing maintenance clothing;
+  say so in the PR instead of letting it pass as routine.
 - **Review depth is per-slice, by that slice's own risk**, not the stack's total
   size. A long stack does not make a trivial slice risky, and a small slice in a
   risky area still earns the two-model tier.
-- **A slice's head moves for reasons other than findings** — a parent merged
-  down into it, or a retarget after the parent lands. The fixed-head rule
-  applies to those the same way: a reviewed slice whose head has moved is not
-  ready until a review is clean at the *new* head. Sequence the stack so this is
-  rare, by landing a reviewed slice before disturbing the ones above it.
+- **A slice's head moves for reasons other than findings** — a restack, or a
+  retarget after the parent lands. The fixed-head rule applies to those the same
+  way: a reviewed slice whose head has moved is not ready until a review is clean
+  at the *new* head. Because one restack can move every head above it, a single
+  press can invalidate several reviews at once; that is the cost of the button,
+  and it is paid per slice. A posted `range-diff` is what keeps each of those
+  re-reviews a confirmation rather than a second full pass — without one, a
+  reviewer cannot tell a restack from a rewrite.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost
   is per PR; three coherent slices beat ten mechanical ones.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,9 +438,10 @@ worse.
   slice is only defensible once the next one lands, it is not a slice — fold it
   into the next.
 - **Name the stack in every PR.** State the slice's position, its parent PR, and
-  what remains. Say what it deliberately defers, so a reviewer reports a
-  declared residual as scope rather than as a defect. Each slice's residual is
-  the next slice's opening move; keep it enumerated.
+  what remains. A stack's deferrals *are* the compatibility or non-action
+  boundary the PR-summary rule already requires, so declare them: a reviewer
+  should read a declared residual as scope rather than as a defect. Each slice's
+  residual is the next slice's opening move; keep it enumerated.
 - **One branch and one worktree per slice**, as for any PR. Branch slice N+1
   from slice N's branch rather than `origin/main`:
   `git worktree add -b <branch> <path> <parent-branch>`.
@@ -455,6 +456,11 @@ worse.
 - **Review depth is per-slice, by that slice's own risk**, not the stack's total
   size. A long stack does not make a trivial slice risky, and a small slice in a
   risky area still earns the two-model tier.
+- **A slice's head moves for reasons other than findings** — a parent merged
+  down into it, or a retarget after the parent lands. The fixed-head rule
+  applies to those the same way: a reviewed slice whose head has moved is not
+  ready until a review is clean at the *new* head. Sequence the stack so this is
+  rare, by landing a reviewed slice before disturbing the ones above it.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost
   is per PR; three coherent slices beat ten mechanical ones.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,9 @@ documentation.
 - Before starting a change, run `git fetch origin main` from the primary
   checkout, then create a descriptive branch and linked worktree with
   `git worktree add -b <branch> <path> origin/main`. Make all edits, builds,
-  tests, and commits in the worktree, not the primary checkout.
+  tests, and commits in the worktree, not the primary checkout. A slice in a
+  stack branches from its parent slice's branch instead — see
+  [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues).
 - Use one development worktree per PR, plus temporary worktrees for independent
   reviews. Do not reuse a worktree across unrelated changes.
 - Never amend commits; create follow-up commits.
@@ -411,7 +413,9 @@ until every required fixed-head review is clean.
 ## PR and CI discipline
 
 - Prefer fewer coherent PRs over many small PRs that each pay fixed CI cost and
-  increase merge contention.
+  increase merge contention. That is an argument against splitting one coherent
+  change, not against sequencing a genuinely multi-slice one — see
+  [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues).
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
 - Treat CI as confirmation, not discovery: run relevant local checks first.
 - Do not broaden CI without a measured need. The PR `test` job validates the
@@ -420,6 +424,39 @@ until every required fixed-head review is clean.
 - Keep PR summaries conclusion-first. Include the behavioral claim, evidence,
   compatibility or non-action boundary, and exact validation appropriate to
   the change.
+
+### Stacked PRs for multi-slice issues
+
+When an issue is too large for one coherent PR, prefer a **stack** — a sequence
+of PRs, each targeting its predecessor's branch — over a single PR that grows
+until it is unreviewable, and over parallel PRs that race in the same files. The
+alternative to a stack is not a smaller change; it is the same change reviewed
+worse.
+
+- **Every slice lands on its own.** A slice carries one behavioral claim, its
+  own evidence, and no dependency on a later slice to be correct or safe. If a
+  slice is only defensible once the next one lands, it is not a slice — fold it
+  into the next.
+- **Name the stack in every PR.** State the slice's position, its parent PR, and
+  what remains. Say what it deliberately defers, so a reviewer reports a
+  declared residual as scope rather than as a defect. Each slice's residual is
+  the next slice's opening move; keep it enumerated.
+- **One branch and one worktree per slice**, as for any PR. Branch slice N+1
+  from slice N's branch rather than `origin/main`:
+  `git worktree add -b <branch> <path> <parent-branch>`.
+- **Target the parent branch** so the PR diff shows only its own slice:
+  `gh pr create --base <parent-branch>`.
+- **Merge bottom-up, one at a time.** After each merge, confirm the next PR
+  retargeted to `main` and that its diff is still only its own slice.
+- **Propagate updates down the stack by merging**, parent branch into child.
+  Never rebase or force-push a pushed slice: the no-rewrite rule applies to
+  every branch in a stack, and rewriting a parent invalidates every review
+  beneath it.
+- **Review depth is per-slice, by that slice's own risk**, not the stack's total
+  size. A long stack does not make a trivial slice risky, and a small slice in a
+  risky area still earns the two-model tier.
+- **Stop stacking when a slice would exist only to continue the stack.** CI cost
+  is per PR; three coherent slices beat ten mechanical ones.
 
 ## Markdown
 


### PR DESCRIPTION
**Conclusion:** documentation only — adds guidance for what to do when an issue is too large for one coherent PR, including the fact that stacks are maintained by rebase and force-push rather than by merging.

## What changed

`AGENTS.md` said to prefer fewer coherent PRs but was silent on genuinely multi-slice work. That silence pushed such work toward the two shapes the repo least wants: one PR that grows until it is unreviewable, or parallel PRs racing in the same central files.

- New `### Stacked PRs for multi-slice issues` under **PR and CI discipline**.
- The existing "prefer fewer coherent PRs" bullet now says what it argues against — splitting one *coherent* change — and links the new subsection.
- The worktree-creation bullet under **Before changing files** notes that a stacked slice branches from its parent's branch.
- The **"never amend, rebase, or force-push reviewed history"** bullet now names the stack as its standing exception, because restacking rebases and force-pushes a public branch by design.

## The central fact: restacking force-pushes, and it is a button

A stack is not maintained by merging. Once a parent lands by squash or rebase merge its commits get new identities; the child still carries the pre-merge originals, so its PR re-reports the parent's work. Merging cannot repair that — rebasing onto the new base can.

That gesture is usually a button: GitHub's *Update with rebase* rebases the slice and force-pushes its head branch, and a stacking tool's restack does every slice at once. The rewrite does not stop where it was pressed — every slice above sits on a base that no longer exists and must be restacked too. **Force-push is the norm inside a stack**, and one press can invalidate several reviews at once.

The section therefore pairs the mechanism with the discipline that makes it safe: `--force-with-lease` over bare `--force`, restack only your own slices, don't rewrite under a reviewer mid-read, prove with `git range-diff` that the base moved and nothing else, and treat every moved head as owing a clean review.

## Why these rules

Most are consequences of constraints already in this file. The ones that are new are marked as such rather than dressed up as derivations:

| Rule | Basis |
| --- | --- |
| Every slice lands on its own | Derived — "Keep PR summaries conclusion-first… behavioral claim, evidence" |
| One branch and one worktree per slice, branched from the parent | Derived — "Use one development worktree per PR… do not reuse a worktree across unrelated changes" |
| Review depth is per-slice by its own risk | Derived — "How much review a PR needs is a function of its triviality and risk alone" |
| Declare what a slice defers, so a residual reads as scope not defect | Derived — the PR-summary bullet's "compatibility or non-action boundary" |
| Stop stacking when a slice exists only to continue the stack | Derived — "many small PRs… each pay fixed CI cost and increase merge contention" |
| **Restacking is expected; force-push with `--force-with-lease`** | **New**, and it *reverses* the general no-force-push rule for stacked slices — the mechanism requires it |
| **A moved head needs a clean review at the new head** | **New.** The fixed-head rule is phrased "After addressing findings…", which does not reach a head moved by a restack or retarget |
| **A restack does not retire an open finding** | **New.** A restack can destroy the exact head a reviewer was given; the finding survives and is re-verified at the new head |
| **State the slice's position and parent PR** | **New.** A stack whose slices do not name their parent is not navigable |

## Compatibility

No product behavior claim; no code, test, or CI change. The single-PR workflow is untouched — every stack-specific rule, including the force-push exception, is scoped to slices in a stack.

## Validation

Documentation-only with no measured behavior claim, so per `AGENTS.md` this needs Markdown validation rather than product builds or tests:

```bash
npx markdownlint-cli AGENTS.md   # no output, exit 0
```

The factual claims are not assumed. GitHub's force-push behavior for *Update with rebase* was checked against GitHub's own documentation, and the `git rebase --onto` and `git range-diff` recipes were executed in scratch repositories — by the author and again independently by the reviewer — including a negative case confirming `range-diff` detects content that changed during a rebase. That testing corrected one of my own claims: "double-reports the parent's work" is false for a two-dot `git diff main..slice` and true for the PR's three-dot diff and commit list, and the text now says which.

Adversarial review (MAI-Code): four rounds, three blocking findings, all resolved; clean at fixed head `dc09c192a`. Reconciled in PR comments.