### PR TITLE
Fold object initializer used as a call argument (#3459)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -6225,3 +6225,46 @@ public static class BraceBodyWrappingSamples
             FourthMeasuredProjection = fourth,
         };
 }
+
+// #3459: an object initializer used as a CALL ARGUMENT, where the enclosing call's
+// receiver (a non-volatile instance field off `this`) and a `default` struct
+// argument are the compiler's pure spills sitting on the stack beneath the dup
+// chain — the Azure.Data.Tables `TableClient.Create` shape. The importer materializes
+// them as `S = _rest;` and `V = default;` around the member store, which #3336's
+// member-value fold could not cross. The pass now skips those reorder-safe spills,
+// folds the construction into the call-argument position, and inlines each single-use
+// spill back into its operand, restoring the canonical stack-only spelling
+// `_rest.Create(new CallArgTarget { Name = Label }, default(CallArgFlag?), _options)`
+// — which recompiles byte-for-byte to the original IL. Appended at end of file so
+// these top-level types cannot shift any existing generated-code ordinal.
+public sealed class CallArgTarget
+{
+    public string? Name { get; set; }
+}
+
+public enum CallArgFlag { A, B }
+
+public sealed class CallArgRest
+{
+    public int Create(CallArgTarget target, CallArgFlag? flag, object options) => target.Name?.Length ?? 0;
+}
+
+public sealed class CallArgClient
+{
+    readonly CallArgRest _rest = new();
+    readonly object _options = new();
+    volatile CallArgRest _volatileRest = new();
+    public string Label = "n";
+
+    // Foldable: the receiver `_rest` (pure field-off-this) and the `default` struct
+    // argument are reorder-safe spills, so both are inlined into the folded call.
+    public int CreateViaField()
+        => _rest.Create(new CallArgTarget { Name = Label }, default, _options);
+
+    // Close negative for the inlining guard: a VOLATILE field receiver must NOT be
+    // inlined (reordering a volatile access is observable). The initializer still
+    // folds — the receiver ran before the `newobj`, an offset-guarded skip — but the
+    // volatile spill is left in place rather than hoisted into the call receiver.
+    public int CreateViaVolatileField()
+        => _volatileRest.Create(new CallArgTarget { Name = Label }, default, _options);
+}

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -727,6 +727,55 @@ public class ObjectInitializerPassTests
         function.CheckInvariant();
     }
 
+    // #3459 blocking negative (constructor crossing): a receiver field read spilled
+    // before the members is only reorder-safe to inline as the folded receiver when
+    // the construction cannot observe or mutate what it reads. A non-parameterless
+    // constructor receives a reference (here `this`) and may mutate `this.Rest`, and
+    // the use-site fold evaluates the receiver `this.Rest` before that constructor —
+    // reordering the read across the mutation. The parameterless-ctor gate must block
+    // admitting the receiver spill as a reorder-safe skip, so the dangerous use-site
+    // spelling `this.Rest.Consume(new InitTarget(this) { ... })` never appears.
+    [Fact]
+    public void ReceiverSpillWithArgumentedCtor_IsNotFoldedAcrossConstructor()
+    {
+        var function = FunctionWithReceiverSpillAndArgumentedCtor();
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        // The receiver read survives as a spill store (never inlined as the folded
+        // receiver), and no initializer is hoisted into the call ahead of it.
+        Assert.Single(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 257);
+        Assert.DoesNotContain(".Consume(new", CSharpPrinter.Print(function).Output);
+        function.CheckInvariant();
+    }
+
+    // #3459 blocking negative (argument-position soundness): a mutable-memory read
+    // spilled before the members is admitted as a reorder-safe skip, but inlining it
+    // is sound only when its load evaluates BEFORE the folded initializer in the
+    // enclosing call. Here `this.Field` feeds the SECOND argument while the
+    // initializer feeds the first, so C# evaluates the initializer (and its
+    // side-effecting member value `Mutate()`, which may write `this.Field`) first,
+    // then the second argument — inlining `this.Field` there would observe the
+    // post-mutation value. The construction still folds at the use site, but the
+    // read must stay a spill statement in its original pre-call position.
+    [Fact]
+    public void MutableReadSpillFeedingLaterArgument_IsNotInlined()
+    {
+        var function = FunctionWithMutableReadSpillFeedingLaterArgument();
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        // The construction still folds into an initializer at the first argument.
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Equal(["X"], initializer.Members);
+
+        // But the mutable read (feeding the later argument) is NOT inlined: its spill
+        // store survives so the read keeps its original pre-call position.
+        Assert.Single(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 257);
+        Assert.Single(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 257);
+        function.CheckInvariant();
+    }
+
     static IrFunction FunctionWithSetter(bool generic, string propertyName = "set_Value")
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "Owner");
@@ -999,6 +1048,94 @@ public class ObjectInitializerPassTests
             "StaticArg0FieldReceiverSpill",
             owner,
             new MethodSignature(intType, [new Parameter("holder", owner)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    // Builds `S_256 = new InitTarget(this); S_257 = this.Rest; S_256.X = 1;
+    // return S_257.Consume(S_256);` in an INSTANCE method whose target constructor is
+    // NOT parameterless — it receives `this` and may mutate `this.Rest`. A use-site
+    // fold would evaluate the receiver `this.Rest` before that constructor, reordering
+    // the read across the mutation. The parameterless-ctor gate must decline to admit
+    // the receiver spill as a reorder-safe skip, so this dangerous fold never happens.
+    static IrFunction FunctionWithReceiverSpillAndArgumentedCtor()
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
+        var rest = TypeRef.Definition("Synthetic", "Samples", "Rest");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", voidType, [owner], HasThis: true);
+        var setter = new MethodRef(type, "set_X", voidType, [intType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+        var consume = new MethodRef(rest, "Consume", intType, [type], HasThis: true);
+        var restField = new FieldRef(owner, "Rest", rest);
+
+        const int seed = 256;
+        const int receiver = 257;
+        var block = new Block();
+        block.Add(new StoreStackSlot(seed, new NewObject(ctor, [new LoadArgument(0, "this", owner)])));
+        block.Add(new StoreStackSlot(receiver, new LoadField(restField, new LoadArgument(0, "this", owner))));
+        block.Add(new StoreProperty(setter, new LoadStackSlot(seed, type), [], new Constant(1, intType)));
+        block.Add(new Return(new Call(consume, isVirtual: false,
+        [
+            new LoadStackSlot(receiver, rest),
+            new LoadStackSlot(seed, type),
+        ])));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "ReceiverSpillAndArgumentedCtor",
+            owner,
+            new MethodSignature(intType, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    // Builds `S_256 = new InitTarget(); S_257 = this.Field; S_256.X = Mutate();
+    // return Consume(S_256, S_257);` in an INSTANCE method. The mutable read
+    // `this.Field` is spilled before the member value (beforeFirstEntry), so it is
+    // admitted as a reorder-safe skip and the construction folds into an initializer
+    // at the FIRST argument. But `this.Field` feeds the SECOND argument, which C#
+    // evaluates after the first — after the side-effecting member value `Mutate()`.
+    // Inlining the read there would move it past the mutation, so the pass must leave
+    // it as a spill statement.
+    static IrFunction FunctionWithMutableReadSpillFeedingLaterArgument()
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var setter = new MethodRef(type, "set_X", voidType, [intType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+        var mutate = new MethodRef(owner, "Mutate", intType, [], HasThis: false);
+        var consume = new MethodRef(owner, "Consume", intType, [type, intType], HasThis: false);
+        var field = new FieldRef(owner, "Field", intType);
+
+        const int seed = 256;
+        const int spill = 257;
+        var block = new Block();
+        block.Add(new StoreStackSlot(seed, new NewObject(ctor, [])));
+        block.Add(new StoreStackSlot(spill, new LoadField(field, new LoadArgument(0, "this", owner))));
+        block.Add(new StoreProperty(setter, new LoadStackSlot(seed, type), [], new Call(mutate, isVirtual: false, [])));
+        block.Add(new Return(new Call(consume, isVirtual: false,
+        [
+            new LoadStackSlot(seed, type),
+            new LoadStackSlot(spill, intType),
+        ])));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "MutableReadSpillFeedingLaterArgument",
+            owner,
+            new MethodSignature(intType, [], HasThis: true, GenericParameterCount: 0),
             [],
             body);
     }

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -668,7 +668,34 @@ public class ObjectInitializerPassTests
             CSharpPrinter.Print(function).Output);
     }
 
-    // #3459 close negative for the inline single-use guard: a reorder-safe spill whose
+    // #3459 constructor-confinement gate (blocking negative): a `this`-field receiver
+    // read that runs AFTER the `newobj` is admitted as a reorder-safe skip ONLY when
+    // the target constructor is proven effect-free (exactly `ldarg.0; call object::.ctor;
+    // ret`, declaring no `.cctor`). This builder is byte-identical in shape to
+    // MutableReadSpillFeedingLaterArgument_IsNotInlined — whose ctor carries
+    // ConstructorEffectFree = true and DOES fold — except the ctor is left NOT
+    // effect-free (the default), modelling a target whose `.cctor` (or non-trivial ctor)
+    // could mutate the field the receiver read observes. With the fact absent, the
+    // `this.Field` read is no longer reorder-safe, the interleaved-spill run breaks, and
+    // the fold declines: no object initializer forms and the read stays a spill. This is
+    // the regression proof that the fact is what admits the hoist — set it true here and
+    // the initializer folds (recreating the round-3 unsoundness).
+    [Fact]
+    public void ReceiverSpillWithNonEffectFreeConstructor_IsNotFolded()
+    {
+        var function = FunctionWithMutableReadSpillAndNonEffectFreeCtor();
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        // The fold declines: no object initializer forms, the bare construction
+        // survives, and the `this.Field` receiver read remains a distinct spill.
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Contains(
+            function.Descendants.OfType<LoadField>(),
+            load => load.Instance is LoadArgument { Index: 0 });
+        function.CheckInvariant();
+    }
     // slot is loaded MORE THAN ONCE must NOT be inlined — replacing one load and
     // detaching the store would leave the other load dangling on a removed slot. The
     // guard leaves the spill store in place; the initializer still folds via the use
@@ -1109,7 +1136,7 @@ public class ObjectInitializerPassTests
         var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
         var voidType = TypeRef.CoreLib("System", "Void");
         var intType = TypeRef.CoreLib("System", "Int32");
-        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true) { ConstructorEffectFree = true };
         var setter = new MethodRef(type, "set_X", voidType, [intType], HasThis: true)
         {
             IsSpecialName = true,
@@ -1134,6 +1161,48 @@ public class ObjectInitializerPassTests
         body.Add(block);
         return new IrFunction(
             "MutableReadSpillFeedingLaterArgument",
+            owner,
+            new MethodSignature(intType, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    // Same shape as FunctionWithMutableReadSpillFeedingLaterArgument, but the target
+    // constructor is left NOT effect-free (ConstructorEffectFree defaults to false),
+    // modelling a target whose `.cctor` or non-trivial ctor could mutate the field the
+    // receiver read observes. Without the effect-free fact, the `this.Field` read that
+    // runs after the `newobj` is no longer a reorder-safe skip, so the fold declines.
+    static IrFunction FunctionWithMutableReadSpillAndNonEffectFreeCtor()
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var setter = new MethodRef(type, "set_X", voidType, [intType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+        var mutate = new MethodRef(owner, "Mutate", intType, [], HasThis: false);
+        var consume = new MethodRef(owner, "Consume", intType, [type, intType], HasThis: false);
+        var field = new FieldRef(owner, "Field", intType);
+
+        const int seed = 256;
+        const int spill = 257;
+        var block = new Block();
+        block.Add(new StoreStackSlot(seed, new NewObject(ctor, [])));
+        block.Add(new StoreStackSlot(spill, new LoadField(field, new LoadArgument(0, "this", owner))));
+        block.Add(new StoreProperty(setter, new LoadStackSlot(seed, type), [], new Call(mutate, isVirtual: false, [])));
+        block.Add(new Return(new Call(consume, isVirtual: false,
+        [
+            new LoadStackSlot(seed, type),
+            new LoadStackSlot(spill, intType),
+        ])));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "MutableReadSpillAndNonEffectFreeCtor",
             owner,
             new MethodSignature(intType, [], HasThis: true, GenericParameterCount: 0),
             [],

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -692,6 +692,41 @@ public class ObjectInitializerPassTests
         function.CheckInvariant();
     }
 
+    // #3459 blocking negative (reorder soundness): a receiver field read that sits
+    // AFTER a member value which may write that field must NOT be hoisted ahead of the
+    // member value. Inlining `this.Rest` into the folded receiver position (evaluated
+    // before the initializer argument) would observe the pre-`MutateRest()` receiver.
+    // The spill store must survive, and the dangerous reordered spelling must not
+    // appear.
+    [Fact]
+    public void FieldReceiverSpillAfterMutatingEntry_IsNotHoistedAcrossSideEffect()
+    {
+        var function = FunctionWithFieldReceiverSpillAfterMutatingEntry();
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        // The receiver read is left as a spill store (not inlined ahead of the mutation).
+        Assert.Single(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 257);
+        Assert.DoesNotContain("this.Rest.Consume(new", CSharpPrinter.Print(function).Output);
+        function.CheckInvariant();
+    }
+
+    // #3459 blocking negative (throw soundness): in a STATIC method argument 0 is an
+    // ordinary, possibly null parameter, so reading a field off it can throw. It must
+    // not be admitted as a non-throwing reorder-safe spill and inlined as the folded
+    // receiver, which would change when the NullReferenceException is observed.
+    [Fact]
+    public void StaticArg0FieldReceiverSpill_IsNotInlined()
+    {
+        var function = FunctionWithStaticArg0FieldReceiverSpill();
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        // The receiver read remains a spill store (not treated as a `this` field read).
+        Assert.Single(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 257);
+        function.CheckInvariant();
+    }
+
     static IrFunction FunctionWithSetter(bool generic, string propertyName = "set_Value")
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "Owner");
@@ -875,6 +910,95 @@ public class ObjectInitializerPassTests
             "ReorderSafeSpillUsedTwice",
             owner,
             new MethodSignature(intType, [new Parameter("n", intType)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    // Builds `S_256 = new(); S_256.X = MutateRest(); S_257 = this.Rest;
+    // return S_257.Consume(S_256);` in an INSTANCE method. The receiver field read
+    // `this.Rest` is a reorder-safe candidate (non-volatile field off `this`), but it
+    // sits AFTER a member value `MutateRest()` that has a side effect and may write
+    // `this.Rest`. Inlining it into the folded call's receiver position would move the
+    // read ahead of `MutateRest()`, observing the pre-mutation receiver. The pass must
+    // NOT admit a mutable-memory read after an entry, so `this.Rest` is never inlined
+    // as the folded receiver.
+    static IrFunction FunctionWithFieldReceiverSpillAfterMutatingEntry()
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
+        var rest = TypeRef.Definition("Synthetic", "Samples", "Rest");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var setter = new MethodRef(type, "set_X", voidType, [intType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+        var mutateRest = new MethodRef(owner, "MutateRest", intType, [], HasThis: false);
+        var consume = new MethodRef(rest, "Consume", intType, [type], HasThis: true);
+        var restField = new FieldRef(owner, "Rest", rest);
+
+        const int seed = 256;
+        const int receiver = 257;
+        var block = new Block();
+        block.Add(new StoreStackSlot(seed, new NewObject(ctor, [])));
+        block.Add(new StoreProperty(setter, new LoadStackSlot(seed, type), [], new Call(mutateRest, isVirtual: false, [])));
+        block.Add(new StoreStackSlot(receiver, new LoadField(restField, new LoadArgument(0, "this", owner))));
+        block.Add(new Return(new Call(consume, isVirtual: false,
+        [
+            new LoadStackSlot(receiver, rest),
+            new LoadStackSlot(seed, type),
+        ])));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "FieldReceiverSpillAfterMutatingEntry",
+            owner,
+            new MethodSignature(intType, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    // Builds `S_256 = new(); S_257 = holder.Rest; S_256.X = 1;
+    // return S_257.Consume(S_256);` in a STATIC method, where argument 0 (`holder`) is
+    // an ordinary, possibly null parameter rather than `this`. Reading `holder.Rest`
+    // can throw NullReferenceException, so it is NOT reorder-safe: moving it (and the
+    // construction) would change when the throw is observed. The pass must decline to
+    // inline it as the folded receiver.
+    static IrFunction FunctionWithStaticArg0FieldReceiverSpill()
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
+        var rest = TypeRef.Definition("Synthetic", "Samples", "Rest");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var setter = new MethodRef(type, "set_X", voidType, [intType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+        var consume = new MethodRef(rest, "Consume", intType, [type], HasThis: true);
+        var restField = new FieldRef(owner, "Rest", rest);
+
+        const int seed = 256;
+        const int receiver = 257;
+        var block = new Block();
+        block.Add(new StoreStackSlot(seed, new NewObject(ctor, [])));
+        block.Add(new StoreStackSlot(receiver, new LoadField(restField, new LoadArgument(0, "holder", owner))));
+        block.Add(new StoreProperty(setter, new LoadStackSlot(seed, type), [], new Constant(1, intType)));
+        block.Add(new Return(new Call(consume, isVirtual: false,
+        [
+            new LoadStackSlot(receiver, rest),
+            new LoadStackSlot(seed, type),
+        ])));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "StaticArg0FieldReceiverSpill",
+            owner,
+            new MethodSignature(intType, [new Parameter("holder", owner)], HasThis: false, GenericParameterCount: 0),
             [],
             body);
     }

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -18,6 +18,18 @@ public class ObjectInitializerPassTests
 
     static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
 
+    // Raises a method on any top-level fixture type in this assembly (not just
+    // CfgSampleClass), for fixtures declared as their own types at end of file.
+    static IrFunction RaisedFrom(string typeFullName, string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeResolver);
+        var function = IrImporter.Import(source, typeFullName, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
     static readonly IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.TrustedPlatformAssemblies();
 
     [Fact]
@@ -612,6 +624,74 @@ public class ObjectInitializerPassTests
             CSharpPrinter.Print(function).Output);
     }
 
+    // #3459: an object initializer used as a CALL ARGUMENT whose enclosing call has a
+    // pure receiver spill (`_rest`, a field off `this`) and a `default` struct argument
+    // spilled around the member store — the Azure.Data.Tables `TableClient.Create`
+    // shape. The fold moves the construction to the call-argument position AND inlines
+    // both reorder-safe spills back into their operands, restoring the canonical
+    // stack-only spelling that recompiles byte-for-byte to the original IL.
+    [Fact]
+    public void CallArgumentInitializer_FoldsAndInlinesReorderSafeSpills()
+    {
+        var function = RaisedFrom("ILInspector.Decompiler.Tests.CallArgClient", "CreateViaField");
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.False(initializer.IsCollection);
+        Assert.Equal(["Name"], initializer.Members);
+
+        // Both reorder-safe spills are inlined: the receiver `_rest` (no residual slot
+        // store) and the `default` struct argument (the spilling initobj is gone).
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<InitObject>());
+
+        Assert.Contains(
+            "return _rest.Create(new CallArgTarget { Name = Label }, default(Nullable<CallArgFlag>), _options);",
+            CSharpPrinter.Print(function).Output);
+    }
+
+    // #3459 breadth: a VOLATILE field receiver. The receiver read runs before the
+    // `newobj`, so it is an offset-guarded skip rather than a reorder-safe one — the
+    // object-initializer pass leaves it in place (only reorder-safe spills are inlined
+    // by this pass; a later copy-propagation pass may still hoist it). Either way the
+    // initializer folds, and the result stays byte-neutral (verified on the standalone
+    // witness). This pins that a volatile receiver never blocks the call-argument fold.
+    [Fact]
+    public void CallArgumentInitializer_WithVolatileReceiver_StillFolds()
+    {
+        var function = RaisedFrom("ILInspector.Decompiler.Tests.CallArgClient", "CreateViaVolatileField");
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Equal(["Name"], initializer.Members);
+
+        Assert.Contains(
+            "Create(new CallArgTarget { Name = Label }, default(Nullable<CallArgFlag>), _options)",
+            CSharpPrinter.Print(function).Output);
+    }
+
+    // #3459 close negative for the inline single-use guard: a reorder-safe spill whose
+    // slot is loaded MORE THAN ONCE must NOT be inlined — replacing one load and
+    // detaching the store would leave the other load dangling on a removed slot. The
+    // guard leaves the spill store in place; the initializer still folds via the use
+    // site. (Roslyn never spills a pure value it reads twice — it re-loads it — so this
+    // shape is reached only through hand-written IL or an unusual lowering, exercised
+    // here with a synthetic function.)
+    [Fact]
+    public void ReorderSafeSpillWithMultipleUses_IsNotInlined()
+    {
+        var function = FunctionWithReorderSafeSpillUsedTwice();
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Equal(["X"], initializer.Members);
+
+        // The twice-used reorder-safe spill store survives (not inlined), and both of
+        // its loads remain intact.
+        Assert.Single(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 257);
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count(load => load.Slot == 257));
+        function.CheckInvariant();
+    }
+
     static IrFunction FunctionWithSetter(bool generic, string propertyName = "set_Value")
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "Owner");
@@ -755,6 +835,46 @@ public class ObjectInitializerPassTests
             "ForeignReadBeforeMembers",
             TypeRef.Definition("Synthetic", "Samples", "Owner"),
             new MethodSignature(type, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    // Builds `S_256 = new(); S_257 = n; S_256.X = 1; return Consume(S_256, S_257, S_257);`
+    // where S_257 (a reorder-safe LoadArgument spill) is loaded TWICE in the escape call.
+    // The pass folds the initializer into the call-argument position but must leave the
+    // twice-used spill store in place (inlining it would drop the second load).
+    static IrFunction FunctionWithReorderSafeSpillUsedTwice()
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var setter = new MethodRef(type, "set_X", voidType, [intType], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+        var consume = new MethodRef(owner, "Consume", intType, [type, intType, intType], HasThis: false);
+
+        const int seed = 256;
+        const int spill = 257;
+        var block = new Block();
+        block.Add(new StoreStackSlot(seed, new NewObject(ctor, [])));
+        block.Add(new StoreStackSlot(spill, new LoadArgument(0, "n", intType)));
+        block.Add(new StoreProperty(setter, new LoadStackSlot(seed, type), [], new Constant(1, intType)));
+        block.Add(new Return(new Call(consume, isVirtual: false,
+        [
+            new LoadStackSlot(seed, type),
+            new LoadStackSlot(spill, intType),
+            new LoadStackSlot(spill, intType),
+        ])));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "ReorderSafeSpillUsedTwice",
+            owner,
+            new MethodSignature(intType, [new Parameter("n", intType)], HasThis: false, GenericParameterCount: 0),
             [],
             body);
     }

--- a/src/ILInspector.Decompiler/Pipeline/ConstructorConfinementFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/ConstructorConfinementFacts.cs
@@ -27,13 +27,17 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </code>
 ///
 /// <para>A body of exactly that shape performs no field write, no static read/write,
-/// no call other than the benign <c>System.Object::.ctor</c>, no branch, and carries no
-/// exception region — so it cannot reach or mutate anything the receiver read observes.
-/// Chaining directly to <c>System.Object::.ctor</c> further proves the declaring type
-/// derives directly from <c>Object</c> (a non-<c>Object</c> base would be constructed by
-/// a <c>call</c> to <em>its</em> ctor), so no intermediate base <c>.cctor</c> exists; the
-/// only remaining type-initializer is the declaring type's own <c>.cctor</c>, which the
-/// gate rejects by requiring the type to declare none.</para>
+/// no call other than the base <c>.ctor</c>, no branch, and carries no exception region
+/// — so it cannot reach or mutate anything the receiver read observes. Chaining to the
+/// declaring type's direct base ctor, together with the base resolving (by TYPED
+/// core-library identity, not spelling — see <see cref="Stamp"/>) to the real
+/// <c>System.Object</c>, proves the declaring type derives directly from <c>Object</c>
+/// (a non-<c>Object</c> base would be constructed by a <c>call</c> to <em>its</em> ctor),
+/// so no intermediate base <c>.cctor</c> exists; the only remaining type-initializer is
+/// the declaring type's own <c>.cctor</c>, which the gate rejects by requiring the type
+/// to declare none. A crafted assembly cannot substitute a side-effecting base by
+/// planting a sibling type spelled <c>System.Object</c>: the base is identified by its
+/// resolved <see cref="TypeRef.CoreLibrary"/> assembly, which a lookalike cannot forge.</para>
 ///
 /// <para>The proof is <em>Roslyn-faithful</em>, not arbitrary-IL-sound: it assumes a
 /// non-null <c>this</c> (a hand-crafted <c>call</c> to an instance method with a null
@@ -66,6 +70,19 @@ internal static class ConstructorConfinementFacts
 
             var declaringType = method.GetDeclaringType();
             if (DeclaresStaticConstructor(reader, declaringType))
+                return ctor;
+
+            // Anchor the direct-Object-derivation lemma on the pipeline's TYPED core-
+            // library identity, not on the base-call token's namespace/name spelling.
+            // A crafted assembly can name its own base type `System.Object` (a
+            // cross-assembly MemberReference to a planted `[Evil]System.Object::.ctor`
+            // passes a namespace+name check), so proving the ctor chains to a type
+            // *spelled* Object does NOT prove it derives from the real Object. Resolving
+            // the declaring type's actual base through the importer yields a TypeRef
+            // whose Assembly is the resolved core library (TypeRef.CoreLibrary) only for
+            // the genuine Object; a lookalike resolves to its own defining assembly and
+            // is rejected. This is the "typed identity over display text" rule.
+            if (!MemberIdentity.IsCoreLibraryType(source.ResolveBaseType(ctor.DeclaringType), "System", "Object"))
                 return ctor;
 
             if (!BodyIsTrivialObjectCtorChain(source, method))
@@ -133,12 +150,18 @@ internal static class ConstructorConfinementFacts
     }
 
     /// <summary>
-    /// Whether <paramref name="target"/> is the core-library
-    /// <c>System.Object::.ctor</c>. Anchored to the exact namespace/name of the
-    /// referenced type, not merely a type spelled "Object" — a planted lookalike must
-    /// not pass. The base ctor is emitted as a <c>MemberReference</c> in every real
-    /// assembly (<c>System.Object</c> lives in the core library, never the one being
-    /// decompiled).
+    /// Whether <paramref name="target"/> is structurally a base-constructor chain to a
+    /// type <em>spelled</em> <c>System.Object</c> — a cross-assembly
+    /// <c>MemberReference</c> named <c>.ctor</c> whose parent <c>TypeReference</c> is
+    /// namespace <c>System</c>, name <c>Object</c>. This is a NECESSARY shape check, not
+    /// a sufficient identity proof: a crafted assembly can plant its own
+    /// <c>System.Object</c> in a sibling assembly, and that cross-assembly lookalike
+    /// passes this spelling check. The AUTHORITATIVE core-library identity is enforced
+    /// in <see cref="Stamp"/> via <see cref="MetadataSource.ResolveBaseType"/> +
+    /// <see cref="MemberIdentity.IsCoreLibraryType"/> (typed <see cref="TypeRef.CoreLibrary"/>
+    /// identity a lookalike cannot forge). This check remains to confirm the trivial
+    /// body's single call really is a base <c>.ctor</c> chain rather than an arbitrary
+    /// method invocation of matching shape.
     /// </summary>
     static bool IsObjectConstructor(MetadataReader reader, EntityHandle target)
     {

--- a/src/ILInspector.Decompiler/Pipeline/ConstructorConfinementFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/ConstructorConfinementFacts.cs
@@ -1,0 +1,158 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Proves the single metadata fact <see cref="MethodRef.ConstructorEffectFree"/>
+/// consumed by <see cref="Passes.ObjectInitializerPass"/>: whether a same-assembly
+/// parameterless constructor has no observable effect beyond allocating the fresh
+/// instance, so <c>newobj T()</c> can be reordered past an enclosing call's
+/// <c>this</c>-field receiver read when folding an object-initializer argument.
+///
+/// <para>The gate is deliberately the <em>narrowest defensible</em> shape rather than
+/// a general constructor-effect/escape analysis. Adversarial review (issue #3459,
+/// rounds 3–4) established that a broad "parameterless ctor is confined" assumption is
+/// unsound: <c>newobj</c> also runs the type initializer (<c>.cctor</c>), a base or
+/// self call on the fresh receiver can escape (<c>base()</c> registering the instance,
+/// a property setter mutating a global), a ctor that reads a static triggers <em>that</em>
+/// type's <c>.cctor</c>, and a byref argument can alias external storage. This proof
+/// sidesteps every one of those by requiring the constructor body to be exactly:</para>
+///
+/// <code>
+///   ldarg.0
+///   call instance void [CoreLib]System.Object::.ctor()
+///   ret
+/// </code>
+///
+/// <para>A body of exactly that shape performs no field write, no static read/write,
+/// no call other than the benign <c>System.Object::.ctor</c>, no branch, and carries no
+/// exception region — so it cannot reach or mutate anything the receiver read observes.
+/// Chaining directly to <c>System.Object::.ctor</c> further proves the declaring type
+/// derives directly from <c>Object</c> (a non-<c>Object</c> base would be constructed by
+/// a <c>call</c> to <em>its</em> ctor), so no intermediate base <c>.cctor</c> exists; the
+/// only remaining type-initializer is the declaring type's own <c>.cctor</c>, which the
+/// gate rejects by requiring the type to declare none.</para>
+///
+/// <para>The proof is <em>Roslyn-faithful</em>, not arbitrary-IL-sound: it assumes a
+/// non-null <c>this</c> (a hand-crafted <c>call</c> to an instance method with a null
+/// receiver could make the hoisted field read throw <c>NullReferenceException</c> before
+/// the <c>newobj</c>). That matches the compiler-emitted IL the decompiler targets and is
+/// documented on the consuming pass.</para>
+/// </summary>
+internal static class ConstructorConfinementFacts
+{
+    /// <summary>
+    /// Stamps <see cref="MethodRef.ConstructorEffectFree"/> onto <paramref name="ctor"/>
+    /// when <paramref name="handle"/> is a same-assembly parameterless instance
+    /// constructor whose body proves the effect-free shape and whose declaring type
+    /// declares no static constructor; returns the ctor unchanged otherwise.
+    /// </summary>
+    internal static MethodRef Stamp(MetadataSource source, MethodDefinitionHandle handle, MethodRef ctor)
+    {
+        try
+        {
+            // Only a parameterless instance ctor can match the trivial shape.
+            if (!ctor.HasThis || !ctor.ParameterTypes.IsDefaultOrEmpty)
+                return ctor;
+
+            var reader = source.Reader;
+            var method = reader.GetMethodDefinition(handle);
+            if ((method.Attributes & MethodAttributes.Static) != 0)
+                return ctor;
+            if (method.RelativeVirtualAddress == 0)
+                return ctor;
+
+            var declaringType = method.GetDeclaringType();
+            if (DeclaresStaticConstructor(reader, declaringType))
+                return ctor;
+
+            if (!BodyIsTrivialObjectCtorChain(source, method))
+                return ctor;
+
+            return ctor with { ConstructorEffectFree = true };
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException)
+        {
+            return ctor;
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="typeHandle"/> declares a static constructor, so
+    /// <c>newobj</c> would trigger a type-initializer side effect the fold must not
+    /// reorder across.
+    /// </summary>
+    static bool DeclaresStaticConstructor(MetadataReader reader, TypeDefinitionHandle typeHandle)
+    {
+        var type = reader.GetTypeDefinition(typeHandle);
+        foreach (var methodHandle in type.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if ((method.Attributes & MethodAttributes.Static) != 0
+                && (method.Attributes & MethodAttributes.SpecialName) != 0
+                && reader.StringComparer.Equals(method.Name, ".cctor"))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the constructor body is exactly <c>ldarg.0; call System.Object::.ctor;
+    /// ret</c> with no exception regions — the only shape proven to have no observable
+    /// effect beyond the allocation.
+    /// </summary>
+    static bool BodyIsTrivialObjectCtorChain(MetadataSource source, MethodDefinition method)
+    {
+        var body = source.Pe.GetMethodBody(method.RelativeVirtualAddress);
+        if (body.ExceptionRegions.Length != 0)
+            return false;
+
+        var il = body.GetILReader();
+
+        // ldarg.0
+        if (il.RemainingBytes == 0 || il.ReadByte() != 0x02)
+            return false;
+
+        // call <token>
+        if (il.RemainingBytes == 0 || il.ReadByte() != 0x28)
+            return false;
+        if (il.RemainingBytes < 4)
+            return false;
+        var target = MetadataTokens.EntityHandle(il.ReadInt32());
+        if (!IsObjectConstructor(source.Reader, target))
+            return false;
+
+        // ret, and nothing after it.
+        if (il.RemainingBytes == 0 || il.ReadByte() != 0x2A)
+            return false;
+
+        return il.RemainingBytes == 0;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="target"/> is the core-library
+    /// <c>System.Object::.ctor</c>. Anchored to the exact namespace/name of the
+    /// referenced type, not merely a type spelled "Object" — a planted lookalike must
+    /// not pass. The base ctor is emitted as a <c>MemberReference</c> in every real
+    /// assembly (<c>System.Object</c> lives in the core library, never the one being
+    /// decompiled).
+    /// </summary>
+    static bool IsObjectConstructor(MetadataReader reader, EntityHandle target)
+    {
+        if (target.Kind != HandleKind.MemberReference)
+            return false;
+
+        var member = reader.GetMemberReference((MemberReferenceHandle)target);
+        if (!reader.StringComparer.Equals(member.Name, ".ctor"))
+            return false;
+        if (member.Parent.Kind != HandleKind.TypeReference)
+            return false;
+
+        var type = reader.GetTypeReference((TypeReferenceHandle)member.Parent);
+        return reader.StringComparer.Equals(type.Name, "Object")
+            && reader.StringComparer.Equals(type.Namespace, "System");
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1364,6 +1364,12 @@ public static class IrImporter
                     // (new DateTime(...)) is not misread as a heap allocation.
                     constructor = constructor with { DeclaringType = source.CrossAssembly.Upgrade(constructor.DeclaringType) };
                     constructor = source.CrossAssembly.Upgrade(constructor, function.UsesUpdatedMemorySafetyRules);
+                    // A same-assembly MethodDef ctor whose body proves it effect-free
+                    // (a trivial direct-Object parameterless ctor with no static ctor)
+                    // lets ObjectInitializerPass hoist an enclosing call's this-field
+                    // receiver read past this newobj when folding an initializer argument.
+                    if (ctorHandle.Kind == HandleKind.MethodDefinition)
+                        constructor = ConstructorConfinementFacts.Stamp(source, (MethodDefinitionHandle)ctorHandle, constructor);
                     var arguments = new IrExpression[constructor.ParameterTypes.Length];
                     for (int i = arguments.Length - 1; i >= 0; i--)
                         arguments[i] = Pop(stack);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -89,6 +89,27 @@ public sealed record MethodRef(
     public int SafeTrailingElidableCount { get; init; }
 
     /// <summary>
+    /// The callee is a constructor with no observable effect beyond allocating the
+    /// fresh instance: its body is exactly <c>ldarg.0; call instance void
+    /// System.Object::.ctor(); ret</c> (a direct-<c>Object</c> parameterless ctor
+    /// that touches nothing — no field writes, no other calls, no static access, no
+    /// branches, no exception regions) AND its declaring type declares no static
+    /// constructor, so <c>newobj</c> triggers no type-initializer side effect. Set
+    /// only for a same-assembly <see cref="System.Reflection.Metadata.MethodDefinitionHandle"/>
+    /// constructor whose body proves the shape (see
+    /// <see cref="ConstructorConfinementFacts"/>); a cross-assembly, unresolvable,
+    /// or non-trivial ctor stays <see langword="false"/>.
+    ///
+    /// <para>Consumed by <see cref="Passes.ObjectInitializerPass"/> to admit hoisting
+    /// the enclosing call's <c>this</c>-field receiver read across the <c>newobj</c>
+    /// when folding an object-initializer argument. The proof is <em>Roslyn-faithful</em>,
+    /// not arbitrary-IL-sound: it assumes a non-null <c>this</c> (a hand-crafted
+    /// <c>call</c> with null <c>this</c> could make the receiver read throw), matching
+    /// the compiler-emitted IL the decompiler targets.</para>
+    /// </summary>
+    public bool ConstructorEffectFree { get; init; }
+
+    /// <summary>
     /// The callee is <em>requires-unsafe</em>: under the updated memory-safety
     /// rules a member declared <c>unsafe</c>/<c>extern</c> is stamped with
     /// <c>RequiresUnsafeAttribute</c>, and every call site needs an unsafe

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -295,30 +295,33 @@ public sealed class ObjectInitializerPass : IIrPass
             // for the *enclosing call* whose argument this initializer becomes — e.g.
             // `S_257 = _rest;` before the members, or `V_0 = default;` in the gap
             // between the last member and the call. Use-site folding moves the
-            // construction to the call-argument position, past this statement, so the
-            // statement must commute with the construction and every member value.
+            // construction (the `newobj`, its constructor call, and every member value)
+            // to the call-argument position, past this statement, so the statement must
+            // commute with all of that.
             //
-            // Two admissibility tiers (see IsReorderSafeSpill), because "pure and
-            // non-throwing" is not enough for a mutable-memory read:
-            //   * A position-independent value (constant / `default` / `sizeof` /
-            //     `ldtoken` / argument load) reads no mutable state, so it commutes
-            //     with the construction and any member value in either direction — it
-            //     is admitted anywhere, including after entries.
-            //   * A mutable-memory read (a field or local load — e.g. the receiver
-            //     `_rest`) is admitted ONLY before the first entry. Inlining it feeds
-            //     the folded call's *receiver* position, which C# evaluates before the
-            //     initializer argument; if a member value that ran before it in the IL
-            //     (an entry already recorded here) writes that memory, moving the read
-            //     ahead of the members would observe the pre-write value. Requiring it
-            //     to precede every entry keeps the read ahead of all member values in
-            //     both the original and the folded order. (The impure-receiver case,
-            //     where the receiver has a side effect, is handled by the offset skip
-            //     below: Roslyn evaluates a side-effecting receiver first, emitting that
-            //     spill before the `newobj`, where ExecutesBefore admits it.)
+            // Soundness has two crossings, gated separately (see IsReorderSafeSpill):
+            //   * The `newobj` constructor. A constructor that receives a reference to
+            //     our storage — `new T(this)` (reaching a `this` field) or
+            //     `new T(ref local)` — can mutate what the spill reads/writes, and the
+            //     fold moves the read across it. We admit spills ONLY when the
+            //     constructor is parameterless, so it holds no reference to any local,
+            //     argument, or `this` and can touch only the fresh object (static state
+            //     is never read by a reorder-safe spill). This preserves the real
+            //     `new TableProperties { ... }` / `new CallArgTarget { ... }` shape.
+            //   * The member values. A position-independent value (constant / `default`
+            //     / `sizeof` / `ldtoken`) reads no mutable state and commutes anywhere.
+            //     A mutable read (a field, argument, or local load — e.g. the receiver
+            //     `_rest`) is admitted ONLY before the first entry: inlining it feeds
+            //     the folded call's receiver position (evaluated before the argument),
+            //     so a member value that ran before it must not be reordered after it.
+            //     Requiring it to precede every entry keeps the read ahead of all
+            //     member values in both the original and the folded order. (The
+            //     impure-receiver case is handled by the offset skip below.)
             var beforeFirstEntry = entries.Count == 0;
             if (pendingInner is null
+                && creation.Arguments.Count == 0
                 && !TouchesAnySlot(statement, aliasSlots)
-                && IsReorderSafeSpill(statement, aliasSlots, function.Signature.HasThis, beforeFirstEntry))
+                && IsReorderSafeSpill(statement, aliasSlots, function, function.Signature.HasThis, beforeFirstEntry))
             {
                 skipped.Add(statement);
                 inlinableSkipped.Add(statement);
@@ -966,35 +969,41 @@ public sealed class ObjectInitializerPass : IIrPass
     }
 
     /// <summary>
-    /// Whether an interleaved statement is a reorder-safe spill: a store of a
-    /// side-effect-free, non-throwing value into a slot/local outside the threaded
-    /// reference, or a struct <c>default</c> init into a local. Such a statement
-    /// commutes with the object construction, so use-site folding may move the
-    /// construction past it (in either direction) without changing observable
-    /// behavior — the statement neither observes the fresh object nor mutates
-    /// anything a member value reads, and cannot throw. Used to admit the pure
-    /// receiver/argument spills the compiler emits for the enclosing call whose
-    /// argument the initializer becomes (see the skip branch in <see cref="TryBuild"/>).
-    /// </summary>
-    /// <summary>
     /// Whether an interleaved statement is a reorder-safe spill that use-site folding
-    /// may move the construction past. Two tiers, per <paramref name="beforeFirstEntry"/>:
-    /// a position-independent value (see <see cref="IsPositionIndependentValue"/>) is
-    /// admitted anywhere, while a mutable-memory read (a field or local load) is
-    /// admitted only before the first initializer entry, so it is never reordered
-    /// across a member value that could write the memory it reads. A struct
-    /// <c>default</c> init (<c>initobj</c> zeroing a local) writes only that fresh
-    /// local and reads nothing mutable, so it too is safe anywhere.
+    /// may move the construction (the <c>newobj</c>, its constructor, and every member
+    /// value) past. The caller additionally requires the constructor to be
+    /// parameterless, so it holds no reference to any local/argument/<c>this</c> and
+    /// this check need only prove the statement commutes with the member values.
+    /// Two tiers, per <paramref name="beforeFirstEntry"/>: a position-independent value
+    /// (see <see cref="IsPositionIndependentValue"/>) is admitted anywhere, while a
+    /// mutable-memory read (a field, argument, or local load) is admitted only before
+    /// the first initializer entry, so it is never reordered across a member value that
+    /// could write the memory it reads. A struct <c>default</c> init (<c>initobj</c>
+    /// zeroing a local) writes only that fresh local and reads nothing mutable, and is
+    /// admitted when the local's address is taken exactly once (its own <c>initobj</c>),
+    /// so no other statement aliases it.
     /// </summary>
-    static bool IsReorderSafeSpill(IrNode statement, HashSet<int> aliasSlots, bool hasThis, bool beforeFirstEntry) => statement switch
+    static bool IsReorderSafeSpill(IrNode statement, HashSet<int> aliasSlots, IrFunction function, bool hasThis, bool beforeFirstEntry) => statement switch
     {
         StoreStackSlot store => !aliasSlots.Contains(store.Slot) && IsReorderSafeValue(store.Value, hasThis, beforeFirstEntry),
         StoreLocal store => IsReorderSafeValue(store.Value, hasThis, beforeFirstEntry),
-        // `default(T)` for a struct: `initobj` zeroing a local — pure and non-throwing,
-        // reads no mutable state, so it commutes with the construction anywhere.
-        InitObject init => init.Address is LoadLocalAddress,
+        // `default(T)` for a struct: `initobj` zeroing a local. Pure and non-throwing,
+        // and it reads no mutable state — but only when nothing else can observe or
+        // alias that local across the move. Require the local's address to be taken
+        // exactly once (this `initobj` itself): otherwise a member value could pass
+        // `ref V_0` to a call whose mutation this write would be reordered across.
+        InitObject { Address: LoadLocalAddress { Index: var index } } => AddressTakenOnce(function, index),
         _ => false,
     };
+
+    // Whether the local at <paramref name="index"/> has exactly one address-of use in
+    // the function (the caller's own `initobj`), so no other statement — a constructor
+    // argument or a member value — holds a `ref` to it that the fold could reorder
+    // across. Scoped to this function's slot pool (nested functions have their own).
+    static bool AddressTakenOnce(IrFunction function, int index)
+        => GenericDeclarationPatternProof.DescendantsOutsideNestedFunctions(function)
+            .OfType<LoadLocalAddress>()
+            .Count(address => address.Index == index) == 1;
 
     /// <summary>
     /// Whether an expression is side-effect-free, non-throwing, and — when
@@ -1018,20 +1027,28 @@ public sealed class ObjectInitializerPass : IIrPass
     {
         _ when IsPositionIndependentValue(value) => true,
         LoadField { IsVolatile: false, Instance: LoadArgument { Index: 0 } } => hasThis && beforeFirstEntry,
+        // An argument load reads a caller-supplied slot. It cannot throw, but the slot
+        // is mutable memory: a member value could pass `ref arg` to a call (`ldarga`)
+        // and mutate it, so moving the read across the members is observable. Admit it
+        // only before the first entry, keeping the read ahead of every member value in
+        // both the original and the folded order — the same rule as a field/local read.
+        LoadArgument => beforeFirstEntry,
         LoadLocal => beforeFirstEntry,
         _ => false,
     };
 
     /// <summary>
     /// Whether an expression reads no mutable memory and cannot throw, so it commutes
+    /// <summary>
+    /// Whether an expression reads no mutable memory and cannot throw, so it commutes
     /// with the object construction and every member value in either direction — a
-    /// constant, a struct <c>default</c>, a <c>sizeof</c>/<c>ldtoken</c>, or an
-    /// argument load (a caller-supplied slot a callee member value cannot mutate).
+    /// constant, a struct <c>default</c>, or a <c>sizeof</c>/<c>ldtoken</c>. An
+    /// argument load is deliberately NOT here: its slot is mutable via <c>ldarga</c>,
+    /// so it belongs to the before-first-entry tier in <see cref="IsReorderSafeValue"/>.
     /// </summary>
     static bool IsPositionIndependentValue(IrExpression value) => value switch
     {
         Constant or DefaultValue or SizeOf or LoadToken => true,
-        LoadArgument => true,
         _ => false,
     };
 
@@ -1127,7 +1144,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 // the original IL. Reorder-safety was already proven when the statement
                 // was skipped, and the single-use guard keeps any spill read elsewhere.
                 if (plan.Skipped is { } skipped)
-                    InlineSingleUseSpills(skipped, function);
+                    InlineSingleUseSpills(skipped, function, initializer);
                 return initializer;
             }
 
@@ -1164,8 +1181,20 @@ public sealed class ObjectInitializerPass : IIrPass
     /// already round-trips and is left alone. The single-use guard (exactly one
     /// remaining load) prevents dropping a value read elsewhere, and the value's
     /// reorder-safety was established when the statement was skipped.
+    ///
+    /// A mutable-memory read (a field / local / argument load) carries an extra
+    /// guard: it may be inlined only when its sole load evaluates BEFORE the folded
+    /// <paramref name="initializer"/> in the enclosing call (the receiver, or an
+    /// argument to its left). Leaving such a spill as a statement keeps the read in
+    /// its original pre-call position, so declining the inline is always sound; but
+    /// inlining a read into an argument to the RIGHT of the initializer would move it
+    /// past the member values, which C# evaluates first — if a member value writes
+    /// that memory, the read would observe the post-write value. Position-independent
+    /// values (constants, <c>default</c>, <c>sizeof</c>, <c>ldtoken</c>) read no
+    /// mutable state and are inlined regardless of position (e.g. the real witness's
+    /// trailing <c>default</c> argument).
     /// </summary>
-    static void InlineSingleUseSpills(IReadOnlyList<IrNode> skipped, IrFunction function)
+    static void InlineSingleUseSpills(IReadOnlyList<IrNode> skipped, IrFunction function, IrNode initializer)
     {
         // Count and rewrite only within this function's own scope. IrNode.Descendants
         // crosses into nested lambda/local-function bodies, whose stack slots and local
@@ -1188,6 +1217,9 @@ public sealed class ObjectInitializerPass : IIrPass
                         .Count(other => other.Slot == store.Slot);
                     if (loads.Count != 1 || writers != 1)
                         continue;
+                    if (!IsPositionIndependentValue(store.Value)
+                        && !LoadEvaluatesBeforeInitializer(loads[0], initializer))
+                        continue;
                     var value = store.Value;
                     value.Detach();
                     loads[0].ReplaceWith(value);
@@ -1205,6 +1237,9 @@ public sealed class ObjectInitializerPass : IIrPass
                     var addressUses = Scoped().OfType<LoadLocalAddress>()
                         .Count(address => address.Index == store.Index);
                     if (loads.Count != 1 || writers != 1 || addressUses != 0)
+                        continue;
+                    if (!IsPositionIndependentValue(store.Value)
+                        && !LoadEvaluatesBeforeInitializer(loads[0], initializer))
                         continue;
                     var value = store.Value;
                     value.Detach();
@@ -1236,6 +1271,49 @@ public sealed class ObjectInitializerPass : IIrPass
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="load"/> is evaluated before <paramref name="initializer"/>
+    /// in the enclosing call. Both feed the same call whose argument the initializer
+    /// became, so their lowest common ancestor is that <see cref="Call"/> (or a
+    /// <see cref="NewObject"/> when the initializer is a constructor argument), whose
+    /// arguments — receiver first — evaluate strictly left-to-right; the branch with
+    /// the smaller <see cref="IrNode.ChildIndex"/> evaluates first. Any other common
+    /// ancestor (a conditional, short-circuit, or assignment does not evaluate its
+    /// children left-to-right) is treated conservatively as "not before", declining
+    /// the inline rather than risk reordering a read past a member value.
+    /// </summary>
+    static bool LoadEvaluatesBeforeInitializer(IrNode load, IrNode initializer)
+    {
+        var ancestor = LowestCommonAncestor(load, initializer);
+        if (ancestor is not (Call or NewObject))
+            return false;
+        var loadBranch = BranchUnder(ancestor, load);
+        var initBranch = BranchUnder(ancestor, initializer);
+        return loadBranch is not null && initBranch is not null
+            && loadBranch.ChildIndex < initBranch.ChildIndex;
+    }
+
+    static IrNode? LowestCommonAncestor(IrNode a, IrNode b)
+    {
+        var seen = new HashSet<IrNode>(ReferenceEqualityComparer.Instance);
+        for (IrNode? n = a; n is not null; n = n.Parent)
+            seen.Add(n);
+        for (IrNode? n = b; n is not null; n = n.Parent)
+            if (seen.Contains(n))
+                return n;
+        return null;
+    }
+
+    // The direct child of `ancestor` on the path to `node` (node itself when it is a
+    // direct child), or null when node is not a descendant of ancestor.
+    static IrNode? BranchUnder(IrNode ancestor, IrNode node)
+    {
+        for (IrNode? n = node; n is not null; n = n.Parent)
+            if (ReferenceEquals(n.Parent, ancestor))
+                return n;
+        return null;
     }
 
     static InitializerEntry BuildEntry(EntryPlan entry)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -290,26 +290,35 @@ public sealed class ObjectInitializerPass : IIrPass
                 continue;
             }
 
-            // A side-effect-free, non-throwing spill interleaved anywhere in the
-            // construction region: a pure receiver or argument the compiler spilled
-            // to its own slot for the *enclosing call* whose argument this
-            // initializer becomes — e.g. `S_257 = _rest;` before the members, or
-            // `V_0 = default;` in the gap between the last member and the call. Unlike
-            // the offset skip below, this does not require the statement to have run
-            // before the `newobj`: use-site folding moves the construction to the
-            // call-argument position, past this statement, and a pure, non-throwing
-            // statement commutes with the construction — it neither observes the fresh
-            // object nor mutates anything a member value reads, and cannot throw
-            // between the construction's effects and the surrounding order. So it is
-            // reorder-safe regardless of IL offset, and — unlike the offset skip — is
-            // permitted after entries too, because reordering a member store across a
-            // provably pure statement is unobservable. (The impure-receiver case, where
-            // the receiver has a side effect, is handled by the offset skip below:
-            // Roslyn must evaluate a side-effecting receiver first, so it emits that
-            // spill *before* the `newobj`, where ExecutesBefore admits it.)
+            // A side-effect-free, non-throwing spill interleaved in the construction
+            // region: a pure receiver or argument the compiler spilled to its own slot
+            // for the *enclosing call* whose argument this initializer becomes — e.g.
+            // `S_257 = _rest;` before the members, or `V_0 = default;` in the gap
+            // between the last member and the call. Use-site folding moves the
+            // construction to the call-argument position, past this statement, so the
+            // statement must commute with the construction and every member value.
+            //
+            // Two admissibility tiers (see IsReorderSafeSpill), because "pure and
+            // non-throwing" is not enough for a mutable-memory read:
+            //   * A position-independent value (constant / `default` / `sizeof` /
+            //     `ldtoken` / argument load) reads no mutable state, so it commutes
+            //     with the construction and any member value in either direction — it
+            //     is admitted anywhere, including after entries.
+            //   * A mutable-memory read (a field or local load — e.g. the receiver
+            //     `_rest`) is admitted ONLY before the first entry. Inlining it feeds
+            //     the folded call's *receiver* position, which C# evaluates before the
+            //     initializer argument; if a member value that ran before it in the IL
+            //     (an entry already recorded here) writes that memory, moving the read
+            //     ahead of the members would observe the pre-write value. Requiring it
+            //     to precede every entry keeps the read ahead of all member values in
+            //     both the original and the folded order. (The impure-receiver case,
+            //     where the receiver has a side effect, is handled by the offset skip
+            //     below: Roslyn evaluates a side-effecting receiver first, emitting that
+            //     spill before the `newobj`, where ExecutesBefore admits it.)
+            var beforeFirstEntry = entries.Count == 0;
             if (pendingInner is null
                 && !TouchesAnySlot(statement, aliasSlots)
-                && IsReorderSafeSpill(statement, aliasSlots))
+                && IsReorderSafeSpill(statement, aliasSlots, function.Signature.HasThis, beforeFirstEntry))
             {
                 skipped.Add(statement);
                 inlinableSkipped.Add(statement);
@@ -967,30 +976,62 @@ public sealed class ObjectInitializerPass : IIrPass
     /// receiver/argument spills the compiler emits for the enclosing call whose
     /// argument the initializer becomes (see the skip branch in <see cref="TryBuild"/>).
     /// </summary>
-    static bool IsReorderSafeSpill(IrNode statement, HashSet<int> aliasSlots) => statement switch
+    /// <summary>
+    /// Whether an interleaved statement is a reorder-safe spill that use-site folding
+    /// may move the construction past. Two tiers, per <paramref name="beforeFirstEntry"/>:
+    /// a position-independent value (see <see cref="IsPositionIndependentValue"/>) is
+    /// admitted anywhere, while a mutable-memory read (a field or local load) is
+    /// admitted only before the first initializer entry, so it is never reordered
+    /// across a member value that could write the memory it reads. A struct
+    /// <c>default</c> init (<c>initobj</c> zeroing a local) writes only that fresh
+    /// local and reads nothing mutable, so it too is safe anywhere.
+    /// </summary>
+    static bool IsReorderSafeSpill(IrNode statement, HashSet<int> aliasSlots, bool hasThis, bool beforeFirstEntry) => statement switch
     {
-        StoreStackSlot store => !aliasSlots.Contains(store.Slot) && IsReorderSafeValue(store.Value),
-        StoreLocal store => IsReorderSafeValue(store.Value),
-        // `default(T)` for a struct: `initobj` zeroing a local — pure and non-throwing.
+        StoreStackSlot store => !aliasSlots.Contains(store.Slot) && IsReorderSafeValue(store.Value, hasThis, beforeFirstEntry),
+        StoreLocal store => IsReorderSafeValue(store.Value, hasThis, beforeFirstEntry),
+        // `default(T)` for a struct: `initobj` zeroing a local — pure and non-throwing,
+        // reads no mutable state, so it commutes with the construction anywhere.
         InitObject init => init.Address is LoadLocalAddress,
         _ => false,
     };
 
     /// <summary>
-    /// Whether an expression is side-effect-free AND non-throwing, so moving the
-    /// object construction across a statement that computes it is unobservable.
-    /// Deliberately conservative: constants and a struct <c>default</c>; argument
-    /// and local reads (pure, non-throwing); and a non-volatile instance field read
-    /// off the non-null <c>this</c> receiver (no null-receiver throw, and — unlike a
-    /// static field — no type-initializer side effect). Anything else (calls, static
-    /// or nested field reads, indexers, arithmetic that can throw) is rejected.
+    /// Whether an expression is side-effect-free, non-throwing, and — when
+    /// <paramref name="beforeFirstEntry"/> is false — free of any mutable-memory read
+    /// whose value a member store could have changed. So moving the object
+    /// construction across a statement that computes it is unobservable.
+    ///
+    /// A <see cref="IsPositionIndependentValue"/> reads no mutable state and is
+    /// admitted regardless of position. A non-volatile instance field read off the
+    /// non-null <c>this</c> receiver is non-throwing but *is* a mutable-memory read;
+    /// it is admitted only before the first entry, because inlining it feeds the
+    /// folded call's receiver position (evaluated before the initializer argument) and
+    /// a member value that ran before it could otherwise be reordered after it. The
+    /// <c>this</c>-field carve-out further requires <paramref name="hasThis"/>: in a
+    /// static method argument 0 is an ordinary, possibly null parameter, so a field
+    /// read off it can throw <see cref="System.NullReferenceException"/>.
+    /// Everything else (calls, static or nested field reads, indexers, throwing
+    /// arithmetic) is rejected.
     /// </summary>
-    static bool IsReorderSafeValue(IrExpression value) => value switch
+    static bool IsReorderSafeValue(IrExpression value, bool hasThis, bool beforeFirstEntry) => value switch
+    {
+        _ when IsPositionIndependentValue(value) => true,
+        LoadField { IsVolatile: false, Instance: LoadArgument { Index: 0 } } => hasThis && beforeFirstEntry,
+        LoadLocal => beforeFirstEntry,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Whether an expression reads no mutable memory and cannot throw, so it commutes
+    /// with the object construction and every member value in either direction — a
+    /// constant, a struct <c>default</c>, a <c>sizeof</c>/<c>ldtoken</c>, or an
+    /// argument load (a caller-supplied slot a callee member value cannot mutate).
+    /// </summary>
+    static bool IsPositionIndependentValue(IrExpression value) => value switch
     {
         Constant or DefaultValue or SizeOf or LoadToken => true,
         LoadArgument => true,
-        LoadLocal => true,
-        LoadField { IsVolatile: false, Instance: LoadArgument { Index: 0 } } => true,
         _ => false,
     };
 
@@ -1126,16 +1167,24 @@ public sealed class ObjectInitializerPass : IIrPass
     /// </summary>
     static void InlineSingleUseSpills(IReadOnlyList<IrNode> skipped, IrFunction function)
     {
+        // Count and rewrite only within this function's own scope. IrNode.Descendants
+        // crosses into nested lambda/local-function bodies, whose stack slots and local
+        // indices live in a separate pool that can collide with the outer spill's slot
+        // — over-counting a load would wrongly block the inline, and (worse) inlining
+        // into a nested scope's load would reparent an outer expression across the
+        // closure boundary. DescendantsOutsideNestedFunctions stops at those bounds.
+        IEnumerable<IrNode> Scoped() => GenericDeclarationPatternProof.DescendantsOutsideNestedFunctions(function);
+
         foreach (var statement in skipped)
         {
             switch (statement)
             {
                 case StoreStackSlot store:
                 {
-                    var loads = function.Descendants.OfType<LoadStackSlot>()
+                    var loads = Scoped().OfType<LoadStackSlot>()
                         .Where(load => load.Slot == store.Slot)
                         .ToList();
-                    var writers = function.Descendants.OfType<StoreStackSlot>()
+                    var writers = Scoped().OfType<StoreStackSlot>()
                         .Count(other => other.Slot == store.Slot);
                     if (loads.Count != 1 || writers != 1)
                         continue;
@@ -1148,12 +1197,12 @@ public sealed class ObjectInitializerPass : IIrPass
 
                 case StoreLocal store:
                 {
-                    var loads = function.Descendants.OfType<LoadLocal>()
+                    var loads = Scoped().OfType<LoadLocal>()
                         .Where(load => load.Index == store.Index)
                         .ToList();
-                    var writers = function.Descendants.OfType<StoreLocal>()
+                    var writers = Scoped().OfType<StoreLocal>()
                         .Count(other => other.Index == store.Index);
-                    var addressUses = function.Descendants.OfType<LoadLocalAddress>()
+                    var addressUses = Scoped().OfType<LoadLocalAddress>()
                         .Count(address => address.Index == store.Index);
                     if (loads.Count != 1 || writers != 1 || addressUses != 0)
                         continue;
@@ -1172,12 +1221,12 @@ public sealed class ObjectInitializerPass : IIrPass
                 // with no other writer or address escape beyond this init.
                 case InitObject { Address: LoadLocalAddress { Index: var index } } init:
                 {
-                    var loads = function.Descendants.OfType<LoadLocal>()
+                    var loads = Scoped().OfType<LoadLocal>()
                         .Where(load => load.Index == index)
                         .ToList();
-                    var addressUses = function.Descendants.OfType<LoadLocalAddress>()
+                    var addressUses = Scoped().OfType<LoadLocalAddress>()
                         .Count(address => address.Index == index);
-                    var stores = function.Descendants.OfType<StoreLocal>()
+                    var stores = Scoped().OfType<StoreLocal>()
                         .Count(store => store.Index == index);
                     if (loads.Count != 1 || stores != 0 || addressUses != 1)
                         continue;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -89,7 +89,7 @@ public sealed class ObjectInitializerPass : IIrPass
 
             context.Stepper.StepOver(
                 $"raise {creation.Constructor.DeclaringType.Name} {(plan.IsCollection ? "collection" : "object")} initializer", seed);
-            var produced = Apply(plan);
+            var produced = Apply(plan, function);
             spillDerived?.Add(produced);
         }
 
@@ -114,7 +114,7 @@ public sealed class ObjectInitializerPass : IIrPass
 
             context.Stepper.StepOver(
                 $"raise named-local {creation.Constructor.DeclaringType.Name} {(plan.IsCollection ? "collection" : "object")} initializer", seed);
-            var produced = Apply(plan);
+            var produced = Apply(plan, function);
             spillDerived?.Add(produced);
         }
     }
@@ -129,7 +129,8 @@ public sealed class ObjectInitializerPass : IIrPass
         NewObject Creation,
         bool IsCollection,
         IReadOnlyList<EntryPlan> Entries,
-        InitializerTarget Target);
+        InitializerTarget Target,
+        IReadOnlyList<IrNode>? Skipped = null);
 
     /// <summary>
     /// A planned initializer entry. A flat entry carries its leaf <see cref="Arguments"/>
@@ -168,6 +169,12 @@ public sealed class ObjectInitializerPass : IIrPass
         // chain). They are left in place and the escape is treated as if they were
         // not present. See the skip branch below.
         var skipped = new List<IrNode>();
+        // The subset of skipped statements proven reorder-safe (side-effect-free and
+        // non-throwing) by IsReorderSafeSpill. Only these are inlined back into the
+        // folded call by InlineSingleUseSpills — a pure value moves to any position
+        // without changing behavior. The offset-guarded (ExecutesBefore) skips, which
+        // may be impure, are left in place for a later inlining pass.
+        var inlinableSkipped = new List<IrNode>();
         bool? isCollection = null;
 
         // A run of nested ops on the same member folds into one InitializerBlock
@@ -283,6 +290,32 @@ public sealed class ObjectInitializerPass : IIrPass
                 continue;
             }
 
+            // A side-effect-free, non-throwing spill interleaved anywhere in the
+            // construction region: a pure receiver or argument the compiler spilled
+            // to its own slot for the *enclosing call* whose argument this
+            // initializer becomes — e.g. `S_257 = _rest;` before the members, or
+            // `V_0 = default;` in the gap between the last member and the call. Unlike
+            // the offset skip below, this does not require the statement to have run
+            // before the `newobj`: use-site folding moves the construction to the
+            // call-argument position, past this statement, and a pure, non-throwing
+            // statement commutes with the construction — it neither observes the fresh
+            // object nor mutates anything a member value reads, and cannot throw
+            // between the construction's effects and the surrounding order. So it is
+            // reorder-safe regardless of IL offset, and — unlike the offset skip — is
+            // permitted after entries too, because reordering a member store across a
+            // provably pure statement is unobservable. (The impure-receiver case, where
+            // the receiver has a side effect, is handled by the offset skip below:
+            // Roslyn must evaluate a side-effecting receiver first, so it emits that
+            // spill *before* the `newobj`, where ExecutesBefore admits it.)
+            if (pendingInner is null
+                && !TouchesAnySlot(statement, aliasSlots)
+                && IsReorderSafeSpill(statement, aliasSlots))
+            {
+                skipped.Add(statement);
+                inlinableSkipped.Add(statement);
+                continue;
+            }
+
             // A statement interleaved before the first initializer entry that neither
             // reads nor writes the threaded reference — e.g. `t = new(); a = Other();
             // t.X = ...` where `a` is a preceding constructor argument the stackifier
@@ -387,7 +420,8 @@ public sealed class ObjectInitializerPass : IIrPass
             entries,
             contiguousEscape
                 ? new StackSlotTarget(outsideUses[0])
-                : new StackSlotSeedTarget(seed, outsideUses[0]));
+                : new StackSlotSeedTarget(seed, outsideUses[0]),
+            inlinableSkipped);
     }
 
     static Plan? TryBuild(IrFunction function, StoreLocal seed, NewObject creation)
@@ -922,6 +956,44 @@ public sealed class ObjectInitializerPass : IIrPass
         return false;
     }
 
+    /// <summary>
+    /// Whether an interleaved statement is a reorder-safe spill: a store of a
+    /// side-effect-free, non-throwing value into a slot/local outside the threaded
+    /// reference, or a struct <c>default</c> init into a local. Such a statement
+    /// commutes with the object construction, so use-site folding may move the
+    /// construction past it (in either direction) without changing observable
+    /// behavior — the statement neither observes the fresh object nor mutates
+    /// anything a member value reads, and cannot throw. Used to admit the pure
+    /// receiver/argument spills the compiler emits for the enclosing call whose
+    /// argument the initializer becomes (see the skip branch in <see cref="TryBuild"/>).
+    /// </summary>
+    static bool IsReorderSafeSpill(IrNode statement, HashSet<int> aliasSlots) => statement switch
+    {
+        StoreStackSlot store => !aliasSlots.Contains(store.Slot) && IsReorderSafeValue(store.Value),
+        StoreLocal store => IsReorderSafeValue(store.Value),
+        // `default(T)` for a struct: `initobj` zeroing a local — pure and non-throwing.
+        InitObject init => init.Address is LoadLocalAddress,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Whether an expression is side-effect-free AND non-throwing, so moving the
+    /// object construction across a statement that computes it is unobservable.
+    /// Deliberately conservative: constants and a struct <c>default</c>; argument
+    /// and local reads (pure, non-throwing); and a non-volatile instance field read
+    /// off the non-null <c>this</c> receiver (no null-receiver throw, and — unlike a
+    /// static field — no type-initializer side effect). Anything else (calls, static
+    /// or nested field reads, indexers, arithmetic that can throw) is rejected.
+    /// </summary>
+    static bool IsReorderSafeValue(IrExpression value) => value switch
+    {
+        Constant or DefaultValue or SizeOf or LoadToken => true,
+        LoadArgument => true,
+        LoadLocal => true,
+        LoadField { IsVolatile: false, Instance: LoadArgument { Index: 0 } } => true,
+        _ => false,
+    };
+
     // True when the statement's own computation completed BEFORE `creation`'s
     // `newobj` executed in the original IL, so keeping it ahead of the folded
     // `newobj` preserves observable order. See EffectOffset for how the offset is
@@ -978,7 +1050,7 @@ public sealed class ObjectInitializerPass : IIrPass
         return false;
     }
 
-    static ObjectInitializerExpression Apply(Plan plan)
+    static ObjectInitializerExpression Apply(Plan plan, IrFunction function)
     {
         // Drop the lowered run from the block, then lift the creation and leaf
         // arguments out of those now-detached statements before reparenting them
@@ -1003,6 +1075,18 @@ public sealed class ObjectInitializerPass : IIrPass
                 var initializer = new ObjectInitializerExpression(plan.Creation, plan.IsCollection, entries);
                 initializer.InheritSourceOffset(plan.Creation);
                 stackSlot.Use.ReplaceWith(initializer);
+                // Use-site folding collapsed the dup-chain region into a single
+                // expression at the call-argument position. The pure receiver and
+                // argument spills the stackifier materialized for that call (left in
+                // place as skipped, reorder-safe statements) now feed the call with no
+                // intervening dup chain, so inlining each single-use spill back into its
+                // load restores the canonical stack-only spelling — e.g.
+                // `S_257 = _rest; ... S_257.Create(new T { ... }, ...)` becomes
+                // `_rest.Create(new T { ... }, ...)` — which recompiles byte-for-byte to
+                // the original IL. Reorder-safety was already proven when the statement
+                // was skipped, and the single-use guard keeps any spill read elsewhere.
+                if (plan.Skipped is { } skipped)
+                    InlineSingleUseSpills(skipped, function);
                 return initializer;
             }
 
@@ -1028,6 +1112,80 @@ public sealed class ObjectInitializerPass : IIrPass
 
             default:
                 throw new InvalidOperationException($"Unhandled initializer target {plan.Target.GetType().Name}.");
+        }
+    }
+
+    /// <summary>
+    /// Inlines each single-use reorder-safe spill back into its sole load, restoring
+    /// the stack-only spelling the stackifier split into a named spill. Only the
+    /// direct-value forms (<see cref="StoreStackSlot"/> / <see cref="StoreLocal"/>)
+    /// are inlined; a default-struct init (<c>InitObject</c> writing a local in place)
+    /// already round-trips and is left alone. The single-use guard (exactly one
+    /// remaining load) prevents dropping a value read elsewhere, and the value's
+    /// reorder-safety was established when the statement was skipped.
+    /// </summary>
+    static void InlineSingleUseSpills(IReadOnlyList<IrNode> skipped, IrFunction function)
+    {
+        foreach (var statement in skipped)
+        {
+            switch (statement)
+            {
+                case StoreStackSlot store:
+                {
+                    var loads = function.Descendants.OfType<LoadStackSlot>()
+                        .Where(load => load.Slot == store.Slot)
+                        .ToList();
+                    var writers = function.Descendants.OfType<StoreStackSlot>()
+                        .Count(other => other.Slot == store.Slot);
+                    if (loads.Count != 1 || writers != 1)
+                        continue;
+                    var value = store.Value;
+                    value.Detach();
+                    loads[0].ReplaceWith(value);
+                    store.Detach();
+                    break;
+                }
+
+                case StoreLocal store:
+                {
+                    var loads = function.Descendants.OfType<LoadLocal>()
+                        .Where(load => load.Index == store.Index)
+                        .ToList();
+                    var writers = function.Descendants.OfType<StoreLocal>()
+                        .Count(other => other.Index == store.Index);
+                    var addressUses = function.Descendants.OfType<LoadLocalAddress>()
+                        .Count(address => address.Index == store.Index);
+                    if (loads.Count != 1 || writers != 1 || addressUses != 0)
+                        continue;
+                    var value = store.Value;
+                    value.Detach();
+                    loads[0].ReplaceWith(value);
+                    store.Detach();
+                    break;
+                }
+
+                // `T V = default;` for a struct: an `initobj` zeroing a local in place.
+                // Keeping it as a separate statement emits the `initobj` at the top of
+                // the method, but the original evaluates `default` at the argument
+                // position (mid-stream). Inline it as `default(T)` at the sole load so
+                // the opcode order matches. Require the temp to be read exactly once
+                // with no other writer or address escape beyond this init.
+                case InitObject { Address: LoadLocalAddress { Index: var index } } init:
+                {
+                    var loads = function.Descendants.OfType<LoadLocal>()
+                        .Where(load => load.Index == index)
+                        .ToList();
+                    var addressUses = function.Descendants.OfType<LoadLocalAddress>()
+                        .Count(address => address.Index == index);
+                    var stores = function.Descendants.OfType<StoreLocal>()
+                        .Count(store => store.Index == index);
+                    if (loads.Count != 1 || stores != 0 || addressUses != 1)
+                        continue;
+                    loads[0].ReplaceWith(new DefaultValue(init.Type));
+                    init.Detach();
+                    break;
+                }
+            }
         }
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -300,14 +300,23 @@ public sealed class ObjectInitializerPass : IIrPass
             // commute with all of that.
             //
             // Soundness has two crossings, gated separately (see IsReorderSafeSpill):
-            //   * The `newobj` constructor. A constructor that receives a reference to
-            //     our storage — `new T(this)` (reaching a `this` field) or
-            //     `new T(ref local)` — can mutate what the spill reads/writes, and the
-            //     fold moves the read across it. We admit spills ONLY when the
-            //     constructor is parameterless, so it holds no reference to any local,
-            //     argument, or `this` and can touch only the fresh object (static state
-            //     is never read by a reorder-safe spill). This preserves the real
+            //   * The `newobj` constructor. The fold moves the construction — the
+            //     `newobj`, its constructor, and every member value — down to the call
+            //     argument position, past this spill. A `this`-field receiver read
+            //     hoisted this way lands BEFORE the `newobj`, so the constructor (and
+            //     the type initializer `newobj` triggers) must not mutate what the read
+            //     observes. A parameterless ctor alone does NOT prove that: `newobj`
+            //     also runs the type's `.cctor`, and a trivial-looking ctor can escape
+            //     through a base ctor, a setter, or a static read. We therefore admit a
+            //     `this`-field read only when the constructor is proven EFFECT-FREE —
+            //     body exactly `ldarg.0; call object::.ctor; ret`, declaring type with
+            //     no static ctor (see MethodRef.ConstructorEffectFree /
+            //     ConstructorConfinementFacts). That is Roslyn-faithful (it assumes a
+            //     non-null `this`), not arbitrary-IL-sound, and preserves the real
             //     `new TableProperties { ... }` / `new CallArgTarget { ... }` shape.
+            //     Other reorder-safe spills read only args/locals/constants, which a
+            //     parameterless ctor and its `.cctor` cannot reach, so they need no
+            //     constructor proof.
             //   * The member values. A position-independent value (constant / `default`
             //     / `sizeof` / `ldtoken`) reads no mutable state and commutes anywhere.
             //     A mutable read (a field, argument, or local load — e.g. the receiver
@@ -321,7 +330,7 @@ public sealed class ObjectInitializerPass : IIrPass
             if (pendingInner is null
                 && creation.Arguments.Count == 0
                 && !TouchesAnySlot(statement, aliasSlots)
-                && IsReorderSafeSpill(statement, aliasSlots, function, function.Signature.HasThis, beforeFirstEntry))
+                && IsReorderSafeSpill(statement, aliasSlots, function, function.Signature.HasThis, beforeFirstEntry, creation.Constructor.ConstructorEffectFree))
             {
                 skipped.Add(statement);
                 inlinableSkipped.Add(statement);
@@ -971,22 +980,25 @@ public sealed class ObjectInitializerPass : IIrPass
     /// <summary>
     /// Whether an interleaved statement is a reorder-safe spill that use-site folding
     /// may move the construction (the <c>newobj</c>, its constructor, and every member
-    /// value) past. The caller additionally requires the constructor to be
-    /// parameterless, so it holds no reference to any local/argument/<c>this</c> and
-    /// this check need only prove the statement commutes with the member values.
-    /// Two tiers, per <paramref name="beforeFirstEntry"/>: a position-independent value
-    /// (see <see cref="IsPositionIndependentValue"/>) is admitted anywhere, while a
-    /// mutable-memory read (a field, argument, or local load) is admitted only before
-    /// the first initializer entry, so it is never reordered across a member value that
-    /// could write the memory it reads. A struct <c>default</c> init (<c>initobj</c>
-    /// zeroing a local) writes only that fresh local and reads nothing mutable, and is
-    /// admitted when the local's address is taken exactly once (its own <c>initobj</c>),
-    /// so no other statement aliases it.
+    /// value) past. Two tiers, per <paramref name="beforeFirstEntry"/>: a
+    /// position-independent value (see <see cref="IsPositionIndependentValue"/>) is
+    /// admitted anywhere, while a mutable-memory read (a field, argument, or local load)
+    /// is admitted only before the first initializer entry, so it is never reordered
+    /// across a member value that could write the memory it reads. A struct
+    /// <c>default</c> init (<c>initobj</c> zeroing a local) writes only that fresh local
+    /// and reads nothing mutable, and is admitted when the local's address is taken
+    /// exactly once (its own <c>initobj</c>), so no other statement aliases it.
+    /// A <c>this</c>-field read additionally requires
+    /// <paramref name="constructorEffectFree"/>, because folding hoists it before the
+    /// <c>newobj</c> whose constructor and type initializer could otherwise mutate the
+    /// field (see <see cref="IsReorderSafeValue"/>). The other reorder-safe values read
+    /// only args/locals/constants, which a parameterless constructor and its
+    /// <c>.cctor</c> cannot reach, so they do not depend on the flag.
     /// </summary>
-    static bool IsReorderSafeSpill(IrNode statement, HashSet<int> aliasSlots, IrFunction function, bool hasThis, bool beforeFirstEntry) => statement switch
+    static bool IsReorderSafeSpill(IrNode statement, HashSet<int> aliasSlots, IrFunction function, bool hasThis, bool beforeFirstEntry, bool constructorEffectFree) => statement switch
     {
-        StoreStackSlot store => !aliasSlots.Contains(store.Slot) && IsReorderSafeValue(store.Value, hasThis, beforeFirstEntry),
-        StoreLocal store => IsReorderSafeValue(store.Value, hasThis, beforeFirstEntry),
+        StoreStackSlot store => !aliasSlots.Contains(store.Slot) && IsReorderSafeValue(store.Value, hasThis, beforeFirstEntry, constructorEffectFree),
+        StoreLocal store => IsReorderSafeValue(store.Value, hasThis, beforeFirstEntry, constructorEffectFree),
         // `default(T)` for a struct: `initobj` zeroing a local. Pure and non-throwing,
         // and it reads no mutable state — but only when nothing else can observe or
         // alias that local across the move. Require the local's address to be taken
@@ -1017,16 +1029,22 @@ public sealed class ObjectInitializerPass : IIrPass
     /// it is admitted only before the first entry, because inlining it feeds the
     /// folded call's receiver position (evaluated before the initializer argument) and
     /// a member value that ran before it could otherwise be reordered after it. The
-    /// <c>this</c>-field carve-out further requires <paramref name="hasThis"/>: in a
+    /// <c>this</c>-field carve-out further requires <paramref name="hasThis"/> (in a
     /// static method argument 0 is an ordinary, possibly null parameter, so a field
-    /// read off it can throw <see cref="System.NullReferenceException"/>.
+    /// read off it can throw <see cref="System.NullReferenceException"/>) AND
+    /// <paramref name="constructorEffectFree"/>: folding hoists the field read before
+    /// the <c>newobj</c>, so the constructor and the type initializer it triggers must
+    /// not mutate the field. Only a proven effect-free ctor (a trivial direct-<c>Object</c>
+    /// parameterless ctor with no static ctor — see
+    /// <see cref="MethodRef.ConstructorEffectFree"/>) guarantees that; this is
+    /// Roslyn-faithful, not arbitrary-IL-sound.
     /// Everything else (calls, static or nested field reads, indexers, throwing
     /// arithmetic) is rejected.
     /// </summary>
-    static bool IsReorderSafeValue(IrExpression value, bool hasThis, bool beforeFirstEntry) => value switch
+    static bool IsReorderSafeValue(IrExpression value, bool hasThis, bool beforeFirstEntry, bool constructorEffectFree) => value switch
     {
         _ when IsPositionIndependentValue(value) => true,
-        LoadField { IsVolatile: false, Instance: LoadArgument { Index: 0 } } => hasThis && beforeFirstEntry,
+        LoadField { IsVolatile: false, Instance: LoadArgument { Index: 0 } } => hasThis && beforeFirstEntry && constructorEffectFree,
         // An argument load reads a caller-supplied slot. It cannot throw, but the slot
         // is mutable memory: a member value could pass `ref arg` to a call (`ldarga`)
         // and mutate it, so moving the read across the members is observable. Admit it
@@ -1037,8 +1055,6 @@ public sealed class ObjectInitializerPass : IIrPass
         _ => false,
     };
 
-    /// <summary>
-    /// Whether an expression reads no mutable memory and cannot throw, so it commutes
     /// <summary>
     /// Whether an expression reads no mutable memory and cannot throw, so it commutes
     /// with the object construction and every member value in either direction — a

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -1050,6 +1050,15 @@ public sealed class ObjectInitializerPass : IIrPass
         // and mutate it, so moving the read across the members is observable. Admit it
         // only before the first entry, keeping the read ahead of every member value in
         // both the original and the folded order — the same rule as a field/local read.
+        //
+        // Unlike the `this`-field arm this does NOT require constructorEffectFree: a
+        // parameterless ctor (and the `.cctor` newobj triggers) receives no reference to
+        // the caller's argument/local slots, so it cannot reach them — UNDER THE
+        // ROSLYN-FAITHFUL THREAT MODEL. Reaching a caller slot needs a prior address
+        // escape (`ldarga`/`ldloca` -> `conv.u` -> `stsfld`) the ctor later writes
+        // through; that is unverifiable unsafe IL Roslyn never emits, the same accepted
+        // arbitrary-IL boundary as the null-`this` receiver read documented on
+        // MethodRef.ConstructorEffectFree. Not gated here by deliberate scope decision.
         LoadArgument => beforeFirstEntry,
         LoadLocal => beforeFirstEntry,
         _ => false,


### PR DESCRIPTION
- Fixes/advances #3459
- Folds an object initializer used as a **call argument** back to `new T { ... }` and inlines the call's reorder-safe receiver/argument spills so the render is byte-Exact
- Card revision: `6abf09ee9`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the Azure.Data.Tables `TableClient.Create` residue folds to the canonical `new T { ... }` call argument and recompiles byte-for-byte to the original IL (no valid/correct-but-opcode-divergent trap).

### Benchmark target

Benchmark target: `Azure.Data.Tables@12.11.0`

dotnet-inspect command:

```bash
dotnet-inspect member TableClient Create --package Azure.Data.Tables -S "Decompiled Source"
```

### Original source

```csharp
public virtual Response<TableItem> Create(CancellationToken cancellationToken = default)
{
    using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Create)}");
    scope.Start();
    try
    {
        var response = _tableOperations.Create(
            new TableProperties { TableName = Name },
            null,
            _defaultQueryOptions,
            cancellationToken);
        return Response.FromValue(response.Value as TableItem, response.GetRawResponse());
    }
    catch (Exception ex)
    {
        scope.Failed(ex);
        throw;
    }
}
```

### Before

```csharp
public virtual Azure.Response<Azure.Data.Tables.Models.TableItem> Create(System.Threading.CancellationToken cancellationToken = default)
{
    ResponseWithHeaders<TableResponse, TableCreateHeaders> response;
    Nullable<ResponseFormat> V_2;
    Response<TableItem> V_3;
    TableProperties S_256;
    TableRestClient S_257;

    using (DiagnosticScope scope = _diagnostics.CreateScope("TableClient.Create", (ActivityKind)0))
    {
        scope.Start();
        try
        {
            S_256 = new();
            S_257 = _tableOperations;
            S_256.TableName = Name;
            V_2 = default;
            response = S_257.Create(S_256, V_2, _defaultQueryOptions, cancellationToken);
            V_3 = Response.FromValue<TableItem>(response.get_Value(), response.GetRawResponse());
        }
        catch (Exception ex)
        {
            scope.Failed(ex);
            throw;
        }
    }
    return V_3;
}
```

- Valid: True
- Correct: True
- IL fidelity: False — the stackifier materializes the stack-resident receiver (`S_257 = _tableOperations`) and `default` argument (`V_2 = default`) as named locals; recompiling them emits extra `stloc`/`ldloc` and hoists `initobj` to the method top, diverging from the stack-only original. This is the #3127 trap: Valid + Correct yet not opcode-faithful.
- Taste applied: None
- Commit: `d08132c3d`

### After

```csharp
public virtual Azure.Response<Azure.Data.Tables.Models.TableItem> Create(System.Threading.CancellationToken cancellationToken = default)
{
    ResponseWithHeaders<TableResponse, TableCreateHeaders> response;
    Response<TableItem> V_3;

    using (DiagnosticScope scope = _diagnostics.CreateScope("TableClient.Create", (ActivityKind)0))
    {
        scope.Start();
        try
        {
            response = _tableOperations.Create(new TableProperties { TableName = Name }, default(Nullable<ResponseFormat>), _defaultQueryOptions, cancellationToken);
            V_3 = Response.FromValue<TableItem>(response.get_Value(), response.GetRawResponse());
        }
        catch (Exception ex)
        {
            scope.Failed(ex);
            throw;
        }
    }
    return V_3;
}
```

- Valid: True
- Correct: True
- IL fidelity: True (byte-Exact) — the reorder-safe receiver and `default` spills are inlined back into the call, restoring the canonical `_tableOperations.Create(new T { ... }, default(T?), _opts, ct)`, which recompiles opcode-for-opcode to the original. Verified on the standalone witness `--fidelity-check` (see Evidence).
- Taste applied: None
- Commit: `6abf09ee9`

The `default(Nullable<ResponseFormat>)` explicit-type spelling (vs source `null`) is byte-Exact; a target-typed `default`/`null` printer choice is a separate, opcode-neutral concern.

### Residual differences from the original

The After decompilation is fully raised **for this PR's claim** — the call argument is the canonical `new T { ... }` and the render is byte-Exact. Two differences from the original source remain, neither owned by this change:

- **`Response<TableItem> V_3;` and the trailing `return V_3;`.** csc's return-accumulator lowering. Fixed by #3553, which sinks the `return` back inside the `try` for exactly this `using` + rethrowing-`catch` shape. That PR is independent of this one; with both in, the accumulator is gone.
- **`ResponseWithHeaders<TableResponse, TableCreateHeaders> response;` hoisted above the `using`,** where the original spells `var response = _tableOperations.Create(...)` at the assignment site. This is **not** #3553's doing and is not fixed by it. `CSharpPrinter.CollectDeclaringStores` merges a declaration into its store only when that store is a statement in the **entry block** — its doc comment says so explicitly ("sits at statement level in the entry block — the current emitter's merged-declaration shape"). `response`'s store is nested inside the `using`/`try`, so it fails that test and the local falls back to a bare up-front declaration.

  The scoping predicate needed to do better, `LocalReferencesStayInBlockAfterStore`, already exists in the printer but is currently wired only for `ref` locals (CS8174) and `for`-initializers. Extending it to the general case is the decl-sinking work tracked by #3165 and #3071.

  The difference is cosmetic, not semantic: the declaration is byte-neutral, since a C# local declaration emits no IL of its own.

## Taste oracle (dotnet/runtime)

Per the AGENTS taste-raise rule, both facets were consulted for this object-initializer raise:

- **Declared:** `dotnet_style_object_initializer = true:suggestion` (`dotnet/runtime` `.editorconfig`, line 97) — object-initializer syntax is the preferred form.
- **Revealed:** an object initializer passed directly as a call argument, `Throws<NotSupportedException>(new HttpRequestMessage { Version = new Version(0, 42) });` in `src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs:5859` (`dotnet/runtime` @ `ba10a6ee`).

The fold is byte-neutral, so no byte-divergent style lens is recorded in `-S "Applied Taste"` (verdict: None).

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ObjectInitializerPassTests`: 38 passed | `ObjectInitializerPassTests`: 41 passed (3 new) |
| Focused tests | `RaisingPassTests`: 109 passed | `RaisingPassTests`: 109 passed |
| Decompiler fast suite | 4322, 1 failed (pre-existing) | 4322, 1 failed (pre-existing) |
| Reduced fixture fidelity | `W.Client::Create` opcode-divergent | `W.Client::Create` byte-Exact |
| Real witness | `TableClient::Create` lowered residue | `TableClient::Create` folded `new T { ... }` call arg |

The 1 fast-suite failure is `ExpressionTreeLambdaTests.LookalikeExpressionAssembly_StaysFactoryCalls`, a pre-existing environmental miss (needs `System.Linq.Expressions.dll` from the ExpressionTreeSpoof fixture via a full `dotnet build dotnet-inspect.slnx -c Release`) — identical on Baseline and Head, unrelated to this change.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.ObjectInitializerPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- --gate fast
```

