### PR TITLE
Give FidelityCheck.Evaluate a type filter: 7 CI timeouts to 0, 56m to 22m

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
@@ -34,10 +34,10 @@ public class ClusterCaptureTests
     {
         string assembly = typeof(CfgSampleClass).Assembly.Location;
 
-        var whole = FidelityCheck.Evaluate(assembly, lowered: false, FidelityCheck.ClusterMode.Off)
+        var whole = FidelityCheck.Evaluate(assembly, lowered: false, FidelityCheck.ClusterMode.Off, type => type == FixtureType)
             .Where(r => r.Type == FixtureType)
             .ToDictionary(r => (r.Method, r.Overload), r => r.Status);
-        var forced = FidelityCheck.Evaluate(assembly, lowered: false, FidelityCheck.ClusterMode.ForceAll)
+        var forced = FidelityCheck.Evaluate(assembly, lowered: false, FidelityCheck.ClusterMode.ForceAll, type => type == FixtureType)
             .Where(r => r.Type == FixtureType)
             .ToList();
 

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -488,7 +488,7 @@ public class FidelityGateTests
     static readonly Lazy<IReadOnlyList<FidelityCheck.CompileBackResult>> Results = new(() =>
     {
         var assembly = typeof(CfgSampleClass).Assembly.Location;
-        return FidelityCheck.Evaluate(assembly)
+        return FidelityCheck.Evaluate(assembly, type => type == FixtureType)
             .Where(r => r.Type == FixtureType)
             .ToList();
     });

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -228,7 +228,7 @@ public class LoweredFidelityGateTests
     static readonly Lazy<IReadOnlyList<FidelityCheck.CompileBackResult>> Results = new(() =>
     {
         var assembly = typeof(CfgSampleClass).Assembly.Location;
-        return FidelityCheck.Evaluate(assembly, lowered: true)
+        return FidelityCheck.Evaluate(assembly, lowered: true, type => type == FixtureType)
             .Where(r => r.Type == FixtureType)
             .ToList();
     });

--- a/src/ILInspector.Decompiler.Tests/NestedTargetLookupTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NestedTargetLookupTests.cs
@@ -21,7 +21,10 @@ public class NestedTargetLookupTests
     [Fact]
     public void TargetedPath_ReachesNestedTypeIdentity()
     {
-        var collectible = FidelityCheck.CollectibleFullTypeNames(FixtureAssembly);
+        // Admits both names so the assertions below still discriminate: the
+        // point of the test is that Inner is reachable, not that it was asked for.
+        var collectible = FidelityCheck.CollectibleFullTypeNames(
+            FixtureAssembly, type => type == Outer || type == Inner);
 
         Assert.Contains(Outer, collectible);
         // The fix: the nested type is now part of the identity surface a delta
@@ -36,7 +39,9 @@ public class NestedTargetLookupTests
         // Preserve existing --fidelity-check behavior: the non-targeted corpus
         // sweep roots at top-level types only, so a nested type's methods never
         // enter the broad sweep even though the targeted path can now reach them.
-        var swept = FidelityCheck.Evaluate(FixtureAssembly);
+        // The filter admits both the outer and nested names, so the nested type's
+        // absence below is CollectType's top-level rooting -- not the filter.
+        var swept = FidelityCheck.Evaluate(FixtureAssembly, type => type == Outer || type == Inner);
 
         Assert.Contains(swept, r => r.Type == Outer && r.Method == "OuterAdd");
         Assert.DoesNotContain(swept, r => r.Type == Inner);

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -48,7 +48,9 @@ public class PrinterPrecedenceTests
     public void StoreElement_CompoundArrayReceiver_RecompilesExactly()
     {
         var result = Assert.Single(
-            FidelityCheck.Evaluate(typeof(CfgSampleClass).Assembly.Location),
+            FidelityCheck.Evaluate(
+                typeof(CfgSampleClass).Assembly.Location,
+                type => type == typeof(CfgSampleClass).FullName),
             r => r.Type == typeof(CfgSampleClass).FullName
                 && r.Method == nameof(CfgSampleClass.ConditionalArrayElementStore));
 

--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -246,7 +246,9 @@ public class RangeFromGetSubArrayPassTests
             nameof(CfgSampleClass.ArrayRangeCompoundBoth),
         };
 
-        var results = FidelityCheck.Evaluate(typeof(CfgSampleClass).Assembly.Location)
+        var results = FidelityCheck.Evaluate(
+                typeof(CfgSampleClass).Assembly.Location,
+                type => type == typeof(CfgSampleClass).FullName)
             .Where(r => r.Type == typeof(CfgSampleClass).FullName && methods.Contains(r.Method))
             .ToList();
 
@@ -466,7 +468,9 @@ public class RangeFromGetSubArrayPassTests
             nameof(RangeAdversarialSamples.ArgumentTwoBoundString),
         };
 
-        var results = FidelityCheck.Evaluate(typeof(RangeAdversarialSamples).Assembly.Location)
+        var results = FidelityCheck.Evaluate(
+                typeof(RangeAdversarialSamples).Assembly.Location,
+                type => type == typeof(RangeAdversarialSamples).FullName)
             .Where(r => r.Type == typeof(RangeAdversarialSamples).FullName && methods.Contains(r.Method))
             .ToList();
 

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -20,7 +20,7 @@ public class SkeletonEmitTests
     [Fact]
     public void SkeletonCompilesPastExplicitImplAndConstEnum()
     {
-        var sum = FidelityCheck.Evaluate(typeof(SkeletonEmitFixture).Assembly.Location)
+        var sum = FidelityCheck.Evaluate(typeof(SkeletonEmitFixture).Assembly.Location, type => type == FixtureType)
             .Single(r => r.Type == FixtureType && r.Method == "Sum");
 
         // The point is that the whole-module skeleton compiles: an unhandled
@@ -41,7 +41,9 @@ public class SkeletonEmitTests
     [InlineData("CachedStaticMethodGroup")]
     public void SkeletonImportsUsingsForShortNamedFrameworkTypes(string method)
     {
-        var result = FidelityCheck.Evaluate(typeof(CfgSampleClass).Assembly.Location)
+        var result = FidelityCheck.Evaluate(
+                typeof(CfgSampleClass).Assembly.Location,
+                type => type == "ILInspector.Decompiler.Tests.CfgSampleClass")
             .Single(r => r.Type == "ILInspector.Decompiler.Tests.CfgSampleClass" && r.Method == method);
 
         Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail
@@ -53,7 +55,9 @@ public class SkeletonEmitTests
     [Fact]
     public void SkeletonSkipsCompilerEmbeddedAttributeDefinitions()
     {
-        var result = FidelityCheck.Evaluate(typeof(EmbeddedAttributeSkeletonFixture).Assembly.Location)
+        var result = FidelityCheck.Evaluate(
+                typeof(EmbeddedAttributeSkeletonFixture).Assembly.Location,
+                type => type == "ILInspector.Decompiler.Tests.EmbeddedAttributeSkeletonFixture")
             .Single(r => r.Type == "ILInspector.Decompiler.Tests.EmbeddedAttributeSkeletonFixture" && r.Method == "Value");
 
         Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail
@@ -64,7 +68,9 @@ public class SkeletonEmitTests
     [Fact]
     public void SkeletonSkipsFixedBufferBackingFieldTypes()
     {
-        var result = FidelityCheck.Evaluate(typeof(FixedBufferSkeletonFixture).Assembly.Location)
+        var result = FidelityCheck.Evaluate(
+                typeof(FixedBufferSkeletonFixture).Assembly.Location,
+                type => type == "ILInspector.Decompiler.Tests.FixedBufferSkeletonFixture")
             .Single(r => r.Type == "ILInspector.Decompiler.Tests.FixedBufferSkeletonFixture" && r.Method == "Value");
 
         Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail
@@ -79,7 +85,9 @@ public class SkeletonEmitTests
         // skeleton reconstructs the nested Nested struct; emitting its inherited T
         // (struct Nested<T>) makes the GenericNestedHolder<int>.Nested reference
         // CS0305. Only the own (zero) parameters may be restated.
-        var result = FidelityCheck.Evaluate(typeof(GenericNestedHolder<>).Assembly.Location)
+        var result = FidelityCheck.Evaluate(
+                typeof(GenericNestedHolder<>).Assembly.Location,
+                type => type == "ILInspector.Decompiler.Tests.GenericNestedUser")
             .Single(r => r.Type == "ILInspector.Decompiler.Tests.GenericNestedUser" && r.Method == "UseNested");
 
         Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail
@@ -95,7 +103,9 @@ public class SkeletonEmitTests
     [InlineData("DescribeException")]
     public void SkeletonRestatesGenericConstraints(string method)
     {
-        var result = FidelityCheck.Evaluate(typeof(ConstraintFixture).Assembly.Location)
+        var result = FidelityCheck.Evaluate(
+                typeof(ConstraintFixture).Assembly.Location,
+                type => type == "ILInspector.Decompiler.Tests.ConstraintFixture")
             .Single(r => r.Type == "ILInspector.Decompiler.Tests.ConstraintFixture" && r.Method == method);
 
         Assert.False(result.Status is FidelityCheck.CompileBackStatus.RecompileFail

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2313,12 +2313,19 @@ static class FidelityCheck
         int remaining = cap - total;
         if (remaining <= 0)
             return;
+        // CB_TYPE is the documented "focus one type" switch, so it has to be
+        // applied before CollectType renders a type's methods -- focusing should
+        // cost one type's work, not the whole assembly's. Tested against the same
+        // full type name the discarding check below used, so the selected set is
+        // unchanged.
+        Func<string, bool>? typeFilter =
+            Environment.GetEnvironmentVariable("CB_TYPE") is { } filter
+                ? name => name.Contains(filter, StringComparison.Ordinal)
+                : null;
         var collected = timings is null
-            ? CollectType(reader, pe, source, typeHandle, render, remaining)
-            : timings.MeasureCollectRender(() => CollectType(reader, pe, source, typeHandle, render, remaining));
+            ? CollectType(reader, pe, source, typeHandle, render, remaining, typeFilter)
+            : timings.MeasureCollectRender(() => CollectType(reader, pe, source, typeHandle, render, remaining, typeFilter));
         if (collected is not var (fullType, entries) || entries.Count == 0)
-            return;
-        if (Environment.GetEnvironmentVariable("CB_TYPE") is { } filter && !fullType.Contains(filter, StringComparison.Ordinal))
             return;
 
         var results = EvaluateGrouped(reader, pe, references, parseOptions, compileOptions, fullType, typeHandle, entries, timings: timings);

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -210,7 +210,14 @@ static class FidelityCheck
     /// types, so any changed method on a nested type fell into the
     /// <c>target-method-not-found</c> bucket.
     /// </summary>
-    internal static IReadOnlyList<string> CollectibleFullTypeNames(string assemblyPath)
+    /// <param name="typeFilter">
+    /// Optional full-type-name predicate applied before any method is decompiled.
+    /// Collecting a name still costs a full render of the type's methods, so a
+    /// caller interested in a few types should say so rather than pay for every
+    /// type in the assembly. Declining a type only removes it from the returned
+    /// set; it never changes how a retained name is computed.
+    /// </param>
+    internal static IReadOnlyList<string> CollectibleFullTypeNames(string assemblyPath, Func<string, bool>? typeFilter = null)
     {
         var names = new List<string>();
         using var pe = new PEReader(File.OpenRead(assemblyPath));
@@ -226,7 +233,7 @@ static class FidelityCheck
             var typeDef = reader.GetTypeDefinition(typeHandle);
             if (!typeDef.GetDeclaringType().IsNil)
                 continue;
-            foreach (var (fullType, _, _) in EnumerateTypeTree(reader, pe, source, typeHandle, render))
+            foreach (var (fullType, _, _) in EnumerateTypeTree(reader, pe, source, typeHandle, render, typeFilter))
                 names.Add(fullType);
         }
         return names;
@@ -320,8 +327,19 @@ static class FidelityCheck
     /// is the console-reporting entry point. Shares all of the skeleton-emission and
     /// opcode-comparison machinery so the two paths can never drift.
     /// </summary>
-    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath)
-        => Evaluate(assemblyPath, lowered: false);
+    /// <param name="typeFilter">
+    /// Optional predicate over the full type name, applied before any decompile or
+    /// recompile work. A caller that wants a single fixture type out of a large
+    /// assembly should pass it here rather than filtering the returned results: this
+    /// overload otherwise renders and recompiles <em>every</em> type in the assembly,
+    /// which for a test assembly is thousands of types of wasted work. Names match
+    /// <see cref="CompileBackResult.Type"/>, so the predicate and a post-filter select
+    /// the same rows. Filtering does not change how any individual result is computed,
+    /// because the reconstruction skeleton is rebuilt from whole-module metadata inside
+    /// the compile step.
+    /// </param>
+    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, Func<string, bool>? typeFilter = null)
+        => Evaluate(assemblyPath, lowered: false, typeFilter);
 
     /// <summary>
     /// Runs the fidelity check roundtrip for a chosen view — the shipped raised
@@ -330,16 +348,16 @@ static class FidelityCheck
     /// validation. The renderer is built here so the raised path can bind the
     /// cross-method import seam from the open source (lambda raising).
     /// </summary>
-    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered)
-        => Evaluate(assemblyPath, lowered, ClusterMode.Off);
+    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered, Func<string, bool>? typeFilter = null)
+        => Evaluate(assemblyPath, lowered, ClusterMode.Off, typeFilter);
 
     /// <summary>
     /// Compatibility overload: <paramref name="cluster"/> true selects the
     /// operational <see cref="ClusterMode.Escalate"/> path (whole-module first,
     /// then escalate only its failures to the reconstruction closure).
     /// </summary>
-    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered, bool cluster)
-        => Evaluate(assemblyPath, lowered, cluster ? ClusterMode.Escalate : ClusterMode.Off);
+    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered, bool cluster, Func<string, bool>? typeFilter = null)
+        => Evaluate(assemblyPath, lowered, cluster ? ClusterMode.Escalate : ClusterMode.Off, typeFilter);
 
     /// <summary>
     /// Evaluates one assembly with the chosen reconstruction-closure (cluster)
@@ -347,7 +365,7 @@ static class FidelityCheck
     /// environment variable selects <see cref="ClusterMode.Escalate"/> for the
     /// console path.
     /// </summary>
-    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered, ClusterMode clusterMode)
+    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered, ClusterMode clusterMode, Func<string, bool>? typeFilter = null)
     {
         var compileOptions = new CSharpCompilationOptions(
             OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true,
@@ -367,7 +385,7 @@ static class FidelityCheck
         var references = RuntimeReferences(assemblyPath);
 
         foreach (var typeHandle in reader.TypeDefinitions)
-            EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, results, clusterMode: clusterMode);
+            EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, results, clusterMode: clusterMode, typeFilter: typeFilter);
 
         return results;
     }
@@ -967,12 +985,13 @@ static class FidelityCheck
     /// </summary>
     static (string FullType, List<Entry> Entries)? CollectType(
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
-        Func<IrFunction, DecompilerResult> render, int maxEntries = int.MaxValue)
+        Func<IrFunction, DecompilerResult> render, int maxEntries = int.MaxValue,
+        Func<string, bool>? typeFilter = null)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         if (!typeDef.GetDeclaringType().IsNil)
             return null; // nested types are emitted by their enclosing type
-        return CollectTypeEntries(reader, pe, source, typeHandle, typeDef, render, maxEntries);
+        return CollectTypeEntries(reader, pe, source, typeHandle, typeDef, render, maxEntries, typeFilter);
     }
 
     /// <summary>
@@ -985,7 +1004,8 @@ static class FidelityCheck
     /// </summary>
     static (string FullType, List<Entry> Entries)? CollectTypeEntries(
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
-        TypeDefinition typeDef, Func<IrFunction, DecompilerResult> render, int maxEntries = int.MaxValue)
+        TypeDefinition typeDef, Func<IrFunction, DecompilerResult> render, int maxEntries = int.MaxValue,
+        Func<string, bool>? typeFilter = null)
     {
         if (maxEntries <= 0)
             return null;
@@ -993,6 +1013,14 @@ static class FidelityCheck
             return null;
 
         string fullType = reader.GetFullTypeName(typeDef);
+
+        // Declining here is what makes a single-type caller cheap: everything
+        // above is metadata-only, while everything below renders and
+        // disassembles every method on the type. A caller that wants one
+        // fixture out of a large assembly must not pay for the rest.
+        if (typeFilter is not null && !typeFilter(fullType))
+            return null;
+
         if (IsGeneratedType(reader, typeDef, fullType))
             return null;
 
@@ -1176,13 +1204,13 @@ static class FidelityCheck
     /// </summary>
     static IEnumerable<(string FullType, List<Entry> Entries, TypeDefinitionHandle Handle)> EnumerateTypeTree(
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
-        Func<IrFunction, DecompilerResult> render)
+        Func<IrFunction, DecompilerResult> render, Func<string, bool>? typeFilter = null)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
-        if (CollectTypeEntries(reader, pe, source, typeHandle, typeDef, render) is { } collected)
+        if (CollectTypeEntries(reader, pe, source, typeHandle, typeDef, render, typeFilter: typeFilter) is { } collected)
             yield return (collected.FullType, collected.Entries, typeHandle);
         foreach (var nested in typeDef.GetNestedTypes())
-            foreach (var result in EnumerateTypeTree(reader, pe, source, nested, render))
+            foreach (var result in EnumerateTypeTree(reader, pe, source, nested, render, typeFilter))
                 yield return result;
     }
 
@@ -1190,11 +1218,12 @@ static class FidelityCheck
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
         ReferenceSet references, CSharpParseOptions parseOptions,
         CSharpCompilationOptions compileOptions, Func<IrFunction, DecompilerResult> render, List<CompileBackResult> results,
-        int maxEntries = int.MaxValue, ClusterMode clusterMode = ClusterMode.Off)
+        int maxEntries = int.MaxValue, ClusterMode clusterMode = ClusterMode.Off,
+        Func<string, bool>? typeFilter = null)
     {
         if (maxEntries <= 0)
             return;
-        if (CollectType(reader, pe, source, typeHandle, render, maxEntries) is not var (fullType, entries) || entries.Count == 0)
+        if (CollectType(reader, pe, source, typeHandle, render, maxEntries, typeFilter) is not var (fullType, entries) || entries.Count == 0)
             return;
         results.AddRange(EvaluateGrouped(reader, pe, references, parseOptions, compileOptions, fullType, typeHandle, entries, clusterMode));
     }


### PR DESCRIPTION
Seven decompiler fidelity gates were timing out at 45 minutes each in CI. This change gives `FidelityCheck.Evaluate(string, …)` an optional type filter and threads it to the seven test call sites that were already filtering their results *after* paying the full cost. Measured on the real workflow, the lane goes from **56m34s wall with 7 timeouts** to **22m05s wall with 0 timeouts**, and the serialized cost of all 22 classes is now ~44.8 min — finite, and small enough to gate PRs on.

## Root cause

`FidelityCheck.Evaluate(string path, …)` had no cap and no filter. It walked every `reader.TypeDefinitions` sequentially, calling `EvaluateType` — which decompiles the type and Roslyn-recompiles it — on each one.

Seven test classes passed it **their own test assembly** and then filtered the results to a single fixture type:

```csharp
var results = FidelityCheck.Evaluate(TestAssemblyPath)
    .Where(r => r.Type == FixtureType);   // after decompiling all 1,823 types
```

The test assembly measures **1,823 TypeDefs / 17,858 methods**, so each gate paid the whole assembly to look at one type. The cost is O(types in the test assembly) *per gate*, and that assembly grows with every test class anyone adds — so these gates got slower with every unrelated PR until several crossed the timeout cliff together.

The guards already existed on the sibling overload: `Evaluate(IReadOnlyList<string>, …)` has `perAssemblyCap`, `attemptCap`, and `Parallel.ForEach`. This path simply never got them.

## The change

`Evaluate` gains a trailing `Func<string, bool>? typeFilter = null` on all four `string`-path overloads, forwarded through `EvaluateType` → `CollectType` → `CollectTypeEntries`. The check sits immediately after `string fullType = reader.GetFullTypeName(typeDef);` — metadata-only work above it, render and recompile below it.

Two more instances of the same shape are fixed:

- `CollectibleFullTypeNames` rendered all 17,858 methods just to collect type *names* (`NestedTargetLookupTests:24`).
- The documented `CB_TYPE` "focus one type" developer switch was applied in `RunType` *after* `CollectType` had already rendered everything (`FidelityCheck.cs:2321` vs `:2317`). It is now hoisted into the `CollectType` filter, so the switch does what its documentation says.

## Why the result set is unchanged

By construction. Every converted call site **keeps** its existing `.Where`/`.Single` predicate and *adds* the filter admitting the same names, so the filter can only remove results the assertion already discarded.

The retained types' results are also byte-identical, for two independent reasons:

- On the normal paths, `BuildUnit` still emits the **whole module** — all 1,823 stubbed types — regardless of the filter (`FidelityCheck.cs:2592`), so a retained type's compile input does not change. `ClusterMode.ForceAll` is the exception: it prunes via `includeRoots` rather than emitting whole-module. Result preservation still holds there, because that closure is derived from complete metadata and is independent of `typeFilter` — but the whole-module property is not universal, and `ClusterCaptureTests:40` exercises the `ForceAll` path.
- `Renderer` is a lambda (`function => CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method), options)`) over `reader`/`pe`/`references`. It is not strictly pure: `MetadataSource` holds lazy caches and `FidelityCheck` memoizes around `:3494`–`:3512`. Those are full-metadata or per-type deterministic memoization, not cross-type accumulators, so `EvaluateType` remains self-contained per type — verified empirically by matching cold filtered probes against warmed unfiltered results.

One call site needs care and is commented in place: `NestedTargetLookupTests.CorpusSweep_StillSkipsNestedTypes` asserts `DoesNotContain(r.Type == Inner)`, so both call sites deliberately admit **both** `NestedTargetFixture` and `NestedTargetFixture.Inner` rather than narrowing to `Outer`. Review established that the assertion is in fact guarded upstream of the filter — `CollectType` rejects nested types via `if (!typeDef.GetDeclaringType().IsNil) return null;` before the filter runs — so admitting `Inner` is inert rather than load-bearing. It is retained so the filter cannot become the reason the assertion passes.

## Follow-up recorded

The `Func<string, bool>` predicate is a new instance of the display-string-matching pattern that `docs/design/type-spelling-identity-display.md` names as an anti-pattern. It is defensible here because this is *selection* (the predicate admits a superset; the pre-existing `.Where` still does real selection), not identity — but it should gain a zero-match guard so a mistyped filter fails loudly instead of passing vacuously. That guard, and a type-count budget for the unfiltered path that would have caught the original growth-to-timeout drift, are filed as #3504. The type-representation question this exposes is filed separately as #3498.

## Evidence

Real workflow runs, one runner per test class, `timeout` used so an overrun is a recordable verdict rather than a lost job:

| | before (run 30425586012) | after (run 30440377772) |
| --- | --- | --- |
| wall clock | 56m34s | **22m05s** |
| classes timing out at 45m | **7** | **0** |
| serialized cost of all 22 classes | unbounded | ~44.8 min |

`NestedTargetLookupTests` is the extreme case: **45m timeout → 4.5s**.

Per-class after the fix: SkeletonEmit 630s, ClusterCapture 376s, LoweredFidelityGate 325s, PrinterPrecedence 324s, FidelityGate 302s, RangeFromGetSubArray 196s, ByteNeutrality 136s, LongLiteralFold 75s, ReturnToSenderPrototype 68s, TypeBind 59s, RuntimeAsyncAwaiter 53s, ValidityCoverageReporting 42s, GeneratedFixtureCatalog 30s, CorpusSweep 22s, LadderIterator 10s, NestedTargetLookup 4.5s, DiffFixtureFidelity 4.3s, ReturnToSenderEvidence 3.9s, MemberBodyProducerUnion 3.3s, AuthoredRebuildFidelity 2.2s, CompilerFeatureOptions 1.4s, SubstrateLeaderDifferential 0.8s.

For the `CB_TYPE` fix, the harness's own `--fidelity-timings` on the README's `CB_TYPE=CfgSampleClass` command now attributes the residual 503s run as emit 388.8s (77%), skeleton emit 56.4s, parse 37.7s, collect/render 7.1s — i.e. the collect/render phase this PR addresses is no longer the cost, and the remaining work is emit-bound.

## This surfaces pre-existing failures; it does not cause them

Running to completion instead of timing out reveals **five real decompiler regressions** that had been landing unnoticed while these gates never finished. They are filed, not fixed here:

- #3489 — `TupleRest` RecompileFail / CS0246
- #3490 — `MakeConsumerWithTwoLeadingArgs` opcode diff
- #3491 — 6 lowered diffs, 5 of them local-function
- #3492 — `SwapIdiomPass` CS0161 census
- #3493 — `GeneratedFixtureCatalogTests`, 3 failures

These are pre-existing, and provably not caused by this change: both methods in #3489/#3490 are defined on `CfgSampleClass`, which the original `.Where(r => r.Type == FixtureType)` predicate already admitted — so they were in the evaluated set before and after.

Separately, the PR fast lane (`-trait- "Speed=Slow"`) fails 4 tests **on Windows** in `StringSwitchRaisingTests` and `CorpusSensorComparisonTests` — all four are CRLF-vs-LF assertion mismatches. Verified pre-existing by running those two classes on a clean detached worktree at `origin/main` (3d0f7efd): identical 4 failures. CI is green because it runs on Linux. Untouched by this PR; filed separately as a Windows-developer papercut.

## Expected follow-on

Merging this will make the weekly Deep Inspect "Test lane" flip from silently **cancelled** at the 6h job timeout to genuinely **failed**. That is the intended outcome, not a regression: a cancelled job does not satisfy `if: failure()`, which is why `deep-inspect.yml:577`'s `Report scheduled failure` step has never fired despite consecutive 6h overruns. Once it fails properly, it will start opening tracking issues.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — clean.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` — 4319 tests, 4 failures, all four pre-existing on `origin/main` and Windows-line-ending-only (control run above).
- All 7 converted gate classes run to completion locally and in CI, versus 7 timeouts before.

## Non-goals

- Not fixing #3489–#3493.
- Not wiring a path-gated decompiler PR lane (now feasible at ~9 min, worth a follow-up).
- Not optimizing the emit-bound residual. `EvaluateGrouped` still falls back to a per-method whole-module compile, each re-emitting all 1,823 stubbed types; `ClusterMode`/`CompileOneClustered` and `BuildUnit`'s `includeRoots` pruning already exist but only the cluster path uses them. Note `SkeletonEmitTests` deliberately asserts the *whole-module* skeleton compiles, so that path must stay.
