### PR TITLE
Add the --heap coordinate carrier and per-heap listing sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | Source mapping | `type`/`library`/`package -S "Source Files"`, `member -S "Source Locations"` / `"Original Source"` | SourceLink URLs, member file/line locations, source fetching, URL verification, token+IL-offset to source-line resolution. |
 | Performance analysis *(experimental)* | `library -S @Performance` (kind sections: `"Performance: Boxing"`, `"Performance: Arrays"`, …), `type`/`member -S "Performance Triage"`, `"Top Leverage"`, `"Resource Triage"`, `"Call Graph"` | Whole-assembly call-graph leverage ranking — direct callers, root reach, fanout, depth, loop calls — with opt-in per-node cost signals (alloc, copy, unsafe, reflection, throw/exception, catch/finally), actionable rewrite-shape detection, and exception-path resource-lifecycle candidates. |
 | Decompiler *(experimental)* | `member -S @Source` (`Decompiled Source`, `Annotated Source`, `Original Source`, `Source Diff`, `IL`); `member -S "Fidelity Causes"` | Raises method bodies to C#, interleaves IL and hidden-fact annotations, diffs SourceLink-backed source against decompiled source, and exposes typed `DEC####` fidelity causes rather than emitting plausible-but-wrong source. |
-| Raw metadata | `library -S @Metadata` (table sections: `"Metadata: TypeDef"`, `"Metadata: MethodDef"`, …, plus `"Metadata: Image"`) | The ECMA-335 metadata tables of an assembly, with handles resolved to the rows they point at and heap offsets to their values. Opt-in only: the tables are unbounded, so no verbosity renders them. |
+| Raw metadata | `library -S @Metadata` (table sections: `"Metadata: TypeDef"`, `"Metadata: MethodDef"`, …, plus `"Metadata: Image"`, the heap sections, and `--heap "#Strings:0x1a4"`) | The ECMA-335 metadata tables of an assembly, with handles resolved to the rows they point at and heap offsets to their values. Opt-in only: the tables are unbounded, so no verbosity renders them. |
 | Agent-friendly output | global flags | Markdown by default, compact `--table`, normalized `--tsv`, `--jsonl`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, table row limiting, built-in head/tail limiting. |
 
 ## Command inventory
@@ -377,6 +377,31 @@ dotnet-inspect library MyLib.dll -S "Metadata: TypeRef" --rows 20
 dotnet-inspect library MyLib.dll -S "Metadata: TypeRef" --columns Name --tsv
 dotnet-inspect library MyLib.dll -S "Metadata: MethodDef" --tsv --rows 100..199
 ```
+
+### Heaps
+
+The four ECMA-335 heaps get sections of their own (`Metadata: #Strings`,
+`Metadata: #Blob`, `Metadata: #GUID`, `Metadata: #US`), and a single address is
+addressable with the `--heap` coordinate carrier:
+
+```bash
+dotnet-inspect library MyLib.dll -S "Metadata: #Strings" --rows 20
+dotnet-inspect library MyLib.dll --heap "#Strings:0x1a4"
+```
+
+A heap name may be written with or without its `#`, and an address is decimal
+unless it carries an explicit `0x` — a bare `1a4` is rejected rather than
+guessed at.
+
+A heap is not a table, and the listings say so rather than implying a
+completeness they cannot deliver. `#Strings` and `#Blob` are length-prefixed
+byte soup with no index, so what a listing shows is the distinct values the
+projected table rows point at, address-ordered, with a `Refs` count. `#GUID` is
+listed completely, because its entries are fixed 16-byte records. `#US` lists
+nothing at all — no table column points into it, since its references are
+`ldstr` operands inside method bodies — but it keeps its section so its size
+stays visible and any address in it stays readable with `--heap`. Every listing
+renders its coverage as a caveat.
 
 ## Output and querying
 

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -217,8 +217,8 @@ session-lifetime rule in
 
 ## Surface — the `metadata` table lens
 
-**Status: implemented**, except the `--heap` coordinate carrier noted below. The
-commands and outputs below are the shipping surface.
+**Status: implemented.** The commands and outputs below are the shipping
+surface.
 
 Each metadata table is **one section**, and the tables together form a section
 category, `@Metadata`, registered the same way `@Performance` is:
@@ -306,17 +306,48 @@ coordinate-scoped section available and discoverable only when present (see the
 coordinate-carrier family in [output-shapes.md](output-shapes.md)):
 
 ```bash
-# bounded heap preview — just a section
+# what this heap holds — just a section
 dotnet-inspect library My.dll -S "Metadata: #Strings"
 
 # one address — a coordinate
 dotnet-inspect library My.dll --heap "#Strings:0x1a4"
 ```
 
-**Status: the heap carrier above is designed, not yet implemented.** The table
-lens, the `Metadata: Image` section, and the shape ladder ship;
-`--heap` and the `Metadata: #Strings` preview sections do not, and are tracked
-separately. Everything else in this section runs today.
+**Status: implemented**
+([#3467](https://github.com/richlander/dotnet-inspect/issues/3467)). Both
+spellings of a heap name are accepted (`#Strings` and `String`), and an address
+is decimal unless it carries an explicit `0x`. Hex is never *inferred*: a bare
+`1a4` is rejected rather than read as `0x1a4`, because guessing would silently
+address a different entry than the one a dump printed.
+
+### Heaps are not tables
+
+A heap listing cannot be what a table listing is, and the difference is a
+property of ECMA-335 rather than of this projection. A table has a row count and
+fixed-width rows, so "row 40 000" is arithmetic. `#Strings` and `#Blob` are
+length-prefixed byte soup with no index, and `System.Reflection.Metadata`
+exposes no walker for them — only random access from an address a table cell
+already holds. So each heap section is listed by the strongest honest means
+available, and `MetadataHeapCoverage` makes *which one* part of the answer
+rather than a footnote:
+
+| Heap | Coverage | What is listed |
+| --- | --- | --- |
+| `#GUID` | `Complete` | Every entry. Records are a fixed 16 bytes, so the count is `size / 16` and each is read by index. |
+| `#Strings`, `#Blob` | `ReferencedOnly` | The distinct values projected table rows point at, address-ordered. An entry no row references is invisible. |
+| `#US` | `NotEnumerable` | Nothing. No table column points into `#US` — its references are `ldstr` operands in method bodies — so there is no reference set to list. |
+
+Every listing renders its coverage as a caveat, so a referenced-values listing
+never reads as a walk of the heap and `#US`'s empty table never reads as an
+empty heap. `#US` keeps its section rather than being hidden: the section is how
+a caller learns the heap exists, how large it is, and that `--heap "#US:<addr>"`
+still reads any address in it.
+
+Reference scanning deliberately ignores a `--tables` filter. An entry is
+referenced by the *image*, not by whichever subset of tables the caller happens
+to be looking at, so honoring the filter would drop entries and undercount
+references while looking complete. A row window is different — it is a stated
+bound — so a short window is honored and reported as `RowsTruncated`.
 
 Deep paging into the middle of a table needs no metadata-specific gesture. It is
 a general row-selection concern, and `--rows` now carries it
@@ -685,8 +716,11 @@ tables never reference the `#US` heap, this is also the only way to browse the
 user strings that IL points at.
 
 What is deliberately *not* here: heap **enumeration**. SRM exposes no public way
-to walk every entry of a heap, so the surface is overview plus random access,
-and says so rather than faking a walk by scanning bytes.
+to walk every entry of a heap, so `mdi`'s surface is overview plus random access,
+and says so rather than faking a walk by scanning bytes. The `library` heap
+sections go one step further without crossing that line — they list what the
+projection can *prove* is in a heap, and name their coverage (see
+[Heaps are not tables](#heaps-are-not-tables)).
 
 Both facets hang off `AssemblyInspectionSession` (`MetadataImage()`,
 `MetadataHeapValue(...)`), render through `MetadataProjectionRenderer`, and are
@@ -917,8 +951,13 @@ Resolved:
   dedicated command. Metadata tables introduce no new currency, so section
   selection already addresses them. This also avoids a collision: `--table` is
   already taken as a presentation modifier ("render as a pretty table").
-- **Heap surfacing flags.** Bounded per-heap previews are ordinary sections
+- **Heap surfacing flags.** Per-heap listings are ordinary sections
   (`Metadata: #Strings`). Reading a specific address is a coordinate, so it gets
   a carrier: `--heap "#Strings:0x1a4"`.
+- **What a heap listing contains.** Not a byte scan, and not nothing. Each heap
+  is listed by the strongest honest means it admits — complete for `#GUID`,
+  referenced-values-only for `#Strings` and `#Blob`, nothing at all for `#US` —
+  and the listing states which, so a partial view is never mistaken for a whole
+  one. See [Heaps are not tables](#heaps-are-not-tables).
 - **Table selection grammar.** Both, since output already prints hex tokens and
   users will paste them: `TypeDef` and `0x02` address the same table.

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -56,10 +56,9 @@ of the ladder families contributes in one of three ways:
 
 A fourth kind of flag does not walk the ladder at all: it *supplies an input the
 command has no other way to express*, and in doing so changes which sections
-exist to be selected. The IL coordinate is the family's one implemented
-currency; `--heap` (see
-[metadata-table-projection.md](metadata-table-projection.md)) is designed to be
-the second.
+exist to be selected. The family has two currencies: the IL coordinate, and the
+heap coordinate `--heap` carries (see
+[metadata-table-projection.md](metadata-table-projection.md)).
 
 The family is counted in currencies, not flags, because one currency can have
 more than one spelling. The IL coordinate has two: `--il-offset` takes a single
@@ -572,10 +571,10 @@ The stable vocabulary is:
   GitHub links, not the shape of the payload itself.
 - `--plaintext` remains distinct from `--bare`; if it stays in the product, it is
   a whole-document plain-text rendering mode rather than a bare-payload mode.
-- `--il-offset` / `--il-offsets` are coordinate carriers: they supply an input
-  that has no other expression and gate the sections it makes meaningful. They
-  do not narrow a shape, and a flag qualifies for this family only if its input
-  is a new currency. Both spell the same currency, so they are one member;
-  `--heap` is the designed second.
+- `--il-offset` / `--il-offsets` / `--heap` are coordinate carriers: they supply
+  an input that has no other expression and gate the sections it makes
+  meaningful. They do not narrow a shape, and a flag qualifies for this family
+  only if its input is a new currency. The first two spell the same currency, so
+  they are one member; `--heap` is the second.
 
 New flags should fit one of those buckets rather than blending concepts.

--- a/src/DotnetInspector.MetadataRendering/MetadataHeapCoordinate.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataHeapCoordinate.cs
@@ -1,0 +1,133 @@
+using System.Globalization;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.MetadataRendering;
+
+/// <summary>
+/// The <c>Heap:Address</c> coordinate that names one value in one metadata heap — the parsed
+/// form of <c>--heap "#Strings:0x1a4"</c>.
+///
+/// This lives beside the projection renderer, and with it in the layer both metadata tools share,
+/// because a coordinate is only useful if reading it and writing it agree. The renderer prints a
+/// heap and address; this reads them back. Keeping the two together is what lets a coordinate
+/// copied out of one tool's output be pasted into the other's input.
+///
+/// The grammar accepts two spellings of every heap because two already exist in the wild and
+/// neither is wrong: the ECMA-335 stream names a metadata dump prints (<c>#Strings</c>, <c>#US</c>,
+/// <c>#Blob</c>, <c>#GUID</c>, with the <c>#</c> optional) and the <see cref="HeapKind"/> member
+/// names this codebase's models carry (<c>String</c>, <c>UserString</c>, <c>Blob</c>, <c>Guid</c>).
+/// Addresses accept decimal or <c>0x</c> hex for the same reason — dumps print hex, models print
+/// decimal.
+/// </summary>
+public static class MetadataHeapCoordinate
+{
+    /// <summary>
+    /// The ECMA-335 stream name of <paramref name="heap"/> (§II.24.2.2). This is the canonical
+    /// spelling: it is what diagnostics suggest, what section names use, and what a metadata dump
+    /// from any other tool shows.
+    /// </summary>
+    public static string StreamName(HeapKind heap) => heap switch
+    {
+        HeapKind.String => "#Strings",
+        HeapKind.Blob => "#Blob",
+        HeapKind.Guid => "#GUID",
+        HeapKind.UserString => "#US",
+        _ => throw new ArgumentOutOfRangeException(nameof(heap), heap, "Unknown heap."),
+    };
+
+    /// <summary>Every heap, in the order the stream names are conventionally listed.</summary>
+    public static IReadOnlyList<HeapKind> Heaps { get; } =
+        [HeapKind.String, HeapKind.UserString, HeapKind.Blob, HeapKind.Guid];
+
+    static readonly Dictionary<string, HeapKind> Names = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["#Strings"] = HeapKind.String,
+        ["Strings"] = HeapKind.String,
+        ["String"] = HeapKind.String,
+        ["#US"] = HeapKind.UserString,
+        ["US"] = HeapKind.UserString,
+        ["UserString"] = HeapKind.UserString,
+        ["#Blob"] = HeapKind.Blob,
+        ["Blob"] = HeapKind.Blob,
+        ["#GUID"] = HeapKind.Guid,
+        ["GUID"] = HeapKind.Guid,
+    };
+
+    /// <summary>The accepted heap spellings, for diagnostics.</summary>
+    public static string AcceptedHeaps { get; } =
+        string.Join(", ", Heaps.Select(StreamName)) + " (or String, UserString, Blob, Guid)";
+
+    /// <summary>
+    /// Parses a heap name on its own. Exposed separately from
+    /// <see cref="TryParse(string, out HeapKind, out int, out string?)"/> so a caller that already
+    /// has the two halves apart — a section name, say — resolves them the same way.
+    /// </summary>
+    public static bool TryParseHeap(string name, out HeapKind heap)
+        => Names.TryGetValue(name.Trim(), out heap);
+
+    /// <summary>
+    /// Parses a heap address: a non-negative decimal, or hex with a <c>0x</c> prefix.
+    ///
+    /// The prefix is required for hex rather than inferred, because a bare <c>10</c> would
+    /// otherwise be ambiguous and silently address the wrong entry. Both radixes reject a sign and
+    /// any thousands separator, so no locale changes what a coordinate means.
+    /// </summary>
+    public static bool TryParseAddress(string text, out int address)
+    {
+        text = text.Trim();
+        address = 0;
+
+        if (text.Length == 0)
+            return false;
+
+        bool hex = text.StartsWith("0x", StringComparison.OrdinalIgnoreCase);
+        string digits = hex ? text[2..] : text;
+
+        if (digits.Length == 0)
+            return false;
+
+        return hex
+            ? int.TryParse(digits, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out address)
+            : int.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out address);
+    }
+
+    /// <summary>
+    /// Parses a <c>Heap:Address</c> coordinate (for example <c>#Strings:0x1a4</c>).
+    ///
+    /// The two halves are validated separately so the diagnostic names the half that is wrong: a
+    /// message that only says the whole coordinate is bad leaves a caller guessing which end to
+    /// fix. The split is on the *last* colon, so a heap spelling is never confused with an address.
+    /// </summary>
+    public static bool TryParse(string spec, out HeapKind heap, out int address, out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+
+        heap = default;
+        address = 0;
+
+        int separator = spec.LastIndexOf(':');
+        if (separator < 0)
+        {
+            error = $"'{spec}' is not a heap reference. Use Heap:Address, for example #Strings:0x1a4.";
+            return false;
+        }
+
+        string heapName = spec[..separator].Trim();
+        string addressText = spec[(separator + 1)..].Trim();
+
+        if (!TryParseHeap(heapName, out heap))
+        {
+            error = $"unknown heap '{heapName}'. Use {AcceptedHeaps}.";
+            return false;
+        }
+
+        if (!TryParseAddress(addressText, out address))
+        {
+            error = $"'{addressText}' is not a heap address. Addresses are non-negative integers, in decimal or 0x hex.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+}

--- a/src/DotnetInspector.MetadataRendering/MetadataHeapCoordinate.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataHeapCoordinate.cs
@@ -71,6 +71,12 @@ public static class MetadataHeapCoordinate
     /// The prefix is required for hex rather than inferred, because a bare <c>10</c> would
     /// otherwise be ambiguous and silently address the wrong entry. Both radixes reject a sign and
     /// any thousands separator, so no locale changes what a coordinate means.
+    ///
+    /// Hex is parsed through <see cref="uint"/> and then range-checked, because
+    /// <see cref="NumberStyles.AllowHexSpecifier"/> on a signed <see cref="int"/> *wraps* rather
+    /// than overflows: <c>0x80000000</c> would parse successfully as <c>-2147483648</c> and address
+    /// a heap position that does not exist. Rejecting it here keeps a bad coordinate a parse error
+    /// instead of a malformed read that still exits 0.
     /// </summary>
     public static bool TryParseAddress(string text, out int address)
     {
@@ -86,9 +92,17 @@ public static class MetadataHeapCoordinate
         if (digits.Length == 0)
             return false;
 
-        return hex
-            ? int.TryParse(digits, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out address)
-            : int.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out address);
+        if (!hex)
+            return int.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out address);
+
+        if (!uint.TryParse(digits, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out uint parsed)
+            || parsed > int.MaxValue)
+        {
+            return false;
+        }
+
+        address = (int)parsed;
+        return true;
     }
 
     /// <summary>

--- a/src/DotnetInspector.MetadataRendering/MetadataHeapCoordinate.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataHeapCoordinate.cs
@@ -110,7 +110,10 @@ public static class MetadataHeapCoordinate
     ///
     /// The two halves are validated separately so the diagnostic names the half that is wrong: a
     /// message that only says the whole coordinate is bad leaves a caller guessing which end to
-    /// fix. The split is on the *last* colon, so a heap spelling is never confused with an address.
+    /// fix. The split is on the *first* colon, because no accepted heap spelling contains one. A
+    /// last-colon split would hand a stray colon in the address to the heap half instead, so
+    /// <c>#Strings:0x1a4:0x1b4</c> would report <c>unknown heap '#Strings:0x1a4'</c> — blaming the
+    /// one half the caller got right.
     /// </summary>
     public static bool TryParse(string spec, out HeapKind heap, out int address, out string? error)
     {
@@ -119,7 +122,7 @@ public static class MetadataHeapCoordinate
         heap = default;
         address = 0;
 
-        int separator = spec.LastIndexOf(':');
+        int separator = spec.IndexOf(':');
         if (separator < 0)
         {
             error = $"'{spec}' is not a heap reference. Use Heap:Address, for example #Strings:0x1a4.";

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -546,34 +546,181 @@ public static class MetadataProjectionRenderer
         ArgumentNullException.ThrowIfNull(value);
         ArgumentNullException.ThrowIfNull(output);
 
+        if (format == MetadataTableFormat.Markdown)
+        {
+            var markdown = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
+            markdown.WriteHeading(2, $"{MetadataHeapCoordinate.StreamName(heap)} heap at {address}");
+            markdown.WriteTable(HeapValueHeaders, HeapValueHeaderNames, [HeapValueRow(value, heap, address)]);
+            markdown.Flush();
+            return;
+        }
+
+        RenderHeapValue(value, heap, address, output, columns: null, format);
+    }
+
+    static readonly string[] HeapValueHeaders = ["Heap", "Address", "Length", "Truncated", "Value"];
+    static readonly string[] HeapValueHeaderNames = ["heap", "address", "length", "truncated", "value"];
+
+    /// <summary>
+    /// The column names <see cref="RenderHeapValue"/> emits. Exposed so a caller that must declare
+    /// this shape — the CLI registers its sections' columns for discovery and <c>--columns</c>
+    /// validation — reads them from the renderer instead of restating them and drifting.
+    /// </summary>
+    public static IReadOnlyList<string> HeapValueColumns => HeapValueHeaders;
+
+    static string[] HeapValueRow(MetadataValue value, HeapKind heap, int address)
+    {
         var heapReference = value as MetadataValue.HeapReference;
-        string[] row =
+        return
         [
-            heap.ToString(),
+            MetadataHeapCoordinate.StreamName(heap),
             address.ToString(),
             heapReference is null ? string.Empty : heapReference.Length.ToString(),
             heapReference is { Truncated: true } ? "yes" : "no",
             FormatCell(value),
         ];
+    }
 
-        string[] headers = ["Heap", "Address", "Length", "Truncated", "Value"];
-        string[] headerNames = ["heap", "address", "length", "truncated", "value"];
+    /// <summary>
+    /// Renders a single heap value as a heading-free one-row table.
+    ///
+    /// This is the shape the CLI's coordinate-scoped heap section needs: that section owns its
+    /// heading, because the section orderer, the section filter, and <c>--count</c> all key off
+    /// the heading text, whereas
+    /// <see cref="Render(MetadataValue, HeapKind, int, TextWriter, MetadataTableFormat)"/> writes
+    /// its own heading for a standalone report. Both build the same row from the same cell
+    /// renderer, so the two cannot disagree about a value.
+    ///
+    /// <paramref name="columns"/> narrows the rendered columns; null, empty, or a selection that
+    /// names none of them leaves the table whole rather than rendering a blank row.
+    /// </summary>
+    public static void RenderHeapValue(
+        MetadataValue value,
+        HeapKind heap,
+        int address,
+        TextWriter output,
+        IReadOnlyCollection<string>? columns = null,
+        MetadataTableFormat format = MetadataTableFormat.Markdown)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(output);
 
-        if (format == MetadataTableFormat.Markdown)
+        WriteNarrowedTable(
+            output, format, HeapValueHeaders, HeapValueHeaderNames, [HeapValueRow(value, heap, address)], columns);
+    }
+
+    static readonly string[] HeapEntryHeaders = ["Address", "Length", "Refs", "Truncated", "Value"];
+    static readonly string[] HeapEntryHeaderNames = ["address", "length", "refs", "truncated", "value"];
+
+    /// <summary>The column names <see cref="RenderHeapEntries"/> emits.</summary>
+    public static IReadOnlyList<string> HeapEntryColumns => HeapEntryHeaders;
+
+    /// <summary>
+    /// Renders a heap's listable entries as a heading-free table, one row per entry, in address
+    /// order.
+    ///
+    /// The table is only half the answer — what the listing *covers* is the other half, and it is
+    /// not rendered here. A caller must also render <see cref="Caveats(MetadataHeapEntrySet)"/>,
+    /// exactly as the table sections do, or a referenced-values listing reads as a complete heap.
+    /// </summary>
+    public static void RenderHeapEntries(
+        MetadataHeapEntrySet entries,
+        TextWriter output,
+        IReadOnlyCollection<string>? columns = null,
+        MetadataTableFormat format = MetadataTableFormat.Markdown)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(output);
+
+        var rows = new List<string[]>(entries.Entries.Length);
+        foreach (var entry in entries.Entries)
         {
-            var markdown = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
-            markdown.WriteHeading(2, $"{heap} heap at {address}");
-            markdown.WriteTable(headers, headerNames, [row]);
-            markdown.Flush();
-            return;
+            var heapReference = entry.Value as MetadataValue.HeapReference;
+            rows.Add([
+                entry.Offset.ToString(),
+                heapReference is null ? string.Empty : heapReference.Length.ToString(),
+                entry.ReferenceCount.ToString(),
+                heapReference is { Truncated: true } ? "yes" : "no",
+                FormatCell(entry.Value),
+            ]);
         }
 
-        var options = new MarkoutWriterOptions
+        WriteNarrowedTable(output, format, HeapEntryHeaders, HeapEntryHeaderNames, rows, columns);
+    }
+
+    /// <summary>
+    /// What <paramref name="entries"/> does not show. Every bound the set carries becomes a
+    /// sentence, so a listing is never presented as more than it is.
+    /// </summary>
+    public static IEnumerable<string> Caveats(MetadataHeapEntrySet entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        string name = MetadataHeapCoordinate.StreamName(entries.Heap);
+
+        switch (entries.Coverage)
         {
-            TableMode = format == MetadataTableFormat.Tsv ? MarkoutTableMode.Tsv : MarkoutTableMode.Jsonl,
-        };
-        var writer = new MarkoutWriter(output, new TableFormatter(showHeader: true), options);
-        writer.WriteTable(headers, headerNames, [row]);
+            case MetadataHeapCoverage.Complete:
+                yield return $"The {name} heap holds fixed-size records, so every entry in its {entries.SizeInBytes} bytes is listed. Refs counts the projected table cells pointing at each one; zero means the entry is stored but unreferenced.";
+                break;
+
+            case MetadataHeapCoverage.ReferencedOnly:
+                yield return $"Listed entries are the distinct {name} values that projected table rows point at, not a walk of the heap: ECMA-335 stores it as length-prefixed items with no index and System.Reflection.Metadata exposes no walker, so entries no row references are not listed. The heap is {entries.SizeInBytes} bytes; any address in it stays readable with --heap \"{name}:<address>\".";
+                break;
+
+            case MetadataHeapCoverage.NotEnumerable:
+                yield return $"No entry of the {name} heap can be listed: no metadata table column points into it — its references are ldstr operands inside method bodies, which this projection does not read — and it cannot be walked. Its {entries.SizeInBytes} bytes are not empty; read a known address with --heap \"{name}:<address>\".";
+                break;
+        }
+
+        if (entries.EntriesTruncated)
+            yield return $"The entry budget stopped this listing short, so it is a prefix of the {name} entries rather than all of them.";
+
+        if (entries.RowsTruncated)
+            yield return "At least one table projected fewer than all of its rows, so a reference from an unscanned row was not counted and an entry only such rows point at is missing.";
+    }
+
+    /// <summary>
+    /// Writes one table, optionally narrowed to <paramref name="columns"/>, in the requested
+    /// format.
+    ///
+    /// A selection naming none of the table's columns leaves the table whole. That is deliberate
+    /// and matches <see cref="RenderImageFacts"/>: with several sections selected, a
+    /// <c>--columns</c> name usually belongs to a sibling section, and narrowing to nothing would
+    /// misreport a populated section as a set of blank rows.
+    /// </summary>
+    static void WriteNarrowedTable(
+        TextWriter output,
+        MetadataTableFormat format,
+        string[] headers,
+        string[] headerNames,
+        IReadOnlyList<string[]> rows,
+        IReadOnlyCollection<string>? columns)
+    {
+        if (columns is { Count: > 0 })
+        {
+            var wanted = new HashSet<string>(columns, StringComparer.OrdinalIgnoreCase);
+            var keep = Enumerable.Range(0, headers.Length).Where(i => wanted.Contains(headers[i])).ToArray();
+
+            if (keep.Length > 0)
+            {
+                headers = [.. keep.Select(i => headers[i])];
+                headerNames = [.. keep.Select(i => headerNames[i])];
+                rows = [.. rows.Select(row => keep.Select(i => row[i]).ToArray())];
+            }
+        }
+
+        var writer = format == MetadataTableFormat.Markdown
+            ? new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions())
+            : new MarkoutWriter(
+                output,
+                new TableFormatter(showHeader: true),
+                new MarkoutWriterOptions
+                {
+                    TableMode = format == MetadataTableFormat.Tsv ? MarkoutTableMode.Tsv : MarkoutTableMode.Jsonl,
+                });
+
+        writer.WriteTable(headers, headerNames, [.. rows]);
         writer.Flush();
     }
 

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -169,5 +169,17 @@ public sealed class AssemblyInspectionSession : IDisposable
         MetadataProjectionOptions? options = null)
         => MetadataTableProjector.ReadHeapValue(_image.PEReader, heap, address, options);
 
+    /// <summary>
+    /// The listable entries of one heap, with the limits of that listing attached — complete for
+    /// the GUID heap, the values projected rows reference for the string and blob heaps, and
+    /// nothing at all for the user-string heap, which no table column points into. The result
+    /// carries its own <see cref="MetadataHeapEntrySet.Coverage"/> so a bounded or partial listing
+    /// is never read as a whole heap. Null when the image carries no metadata.
+    /// </summary>
+    public MetadataHeapEntrySet? MetadataHeapEntries(
+        HeapKind heap,
+        MetadataProjectionOptions? options = null)
+        => MetadataTableProjector.ReadHeapEntries(_image.PEReader, heap, options);
+
     public void Dispose() => _image.Dispose();
 }

--- a/src/ILInspector.Metadata/MetadataHeapEntries.cs
+++ b/src/ILInspector.Metadata/MetadataHeapEntries.cs
@@ -1,0 +1,112 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// How completely a <see cref="MetadataHeapEntrySet"/> covers its heap.
+///
+/// ECMA-335 heaps are not tables: only the GUID heap is a sequence of fixed-size records, so only
+/// it can be enumerated. The string, blob, and user-string heaps are sequences of length-prefixed
+/// items with no index, and <c>System.Reflection.Metadata</c> exposes no public walker for them.
+/// The coverage of a set is therefore part of the answer, not a detail — a caller that cannot tell
+/// "every entry" from "the entries something pointed at" would read a partial list as a whole heap.
+/// </summary>
+public enum MetadataHeapCoverage
+{
+    /// <summary>
+    /// Every entry in the heap is listed. Reached only for the GUID heap, whose entries are
+    /// 16-byte records at consecutive 1-based indices, so the entry count follows from the heap
+    /// size by arithmetic rather than by scanning bytes.
+    /// </summary>
+    Complete,
+
+    /// <summary>
+    /// Only entries referenced by a projected table row are listed. The heap may hold entries no
+    /// row points at, and those are invisible here; they remain readable by address.
+    /// </summary>
+    ReferencedOnly,
+
+    /// <summary>
+    /// No entry can be listed at all. This is the user-string heap: no ECMA-335 table column
+    /// points into it — its references are <c>ldstr</c> operands inside method bodies — and it
+    /// cannot be walked, so neither enumeration nor a referenced-value scan yields anything.
+    /// An empty entry list under this coverage is a blind spot, not an empty heap.
+    /// </summary>
+    NotEnumerable,
+}
+
+/// <summary>
+/// One heap entry: its address, its value, and how many projected table cells referenced it.
+/// </summary>
+/// <param name="Offset">
+/// The entry's heap address — a byte offset, or a 1-based index for the GUID heap. This is the
+/// same address a projected cell's <see cref="MetadataValue.HeapReference.Offset"/> carries, so a
+/// listed entry round-trips through a by-address read.
+/// </param>
+/// <param name="Value">
+/// The entry's value. Normally a <see cref="MetadataValue.HeapReference"/> carrying the decoded
+/// length, bounded preview, and truncation flag — the same shape a projected cell carries, so a
+/// listed entry and a cell pointing at it render identically. Typed as the open
+/// <see cref="MetadataValue"/> so a value the reader rejected stays a
+/// <see cref="MetadataValue.Malformed"/> rather than being dropped from the listing.
+/// </param>
+/// <param name="ReferenceCount">
+/// How many projected table cells referenced this entry. Zero is meaningful: under
+/// <see cref="MetadataHeapCoverage.Complete"/> it marks an entry that exists but that no projected
+/// row points at.
+/// </param>
+public sealed record MetadataHeapEntry(int Offset, MetadataValue Value, int ReferenceCount);
+
+/// <summary>
+/// The listable entries of one metadata heap, with the limits of that listing attached.
+///
+/// Every field that bounds the answer travels with it: <see cref="Coverage"/> says what kind of
+/// listing this is, <see cref="EntriesTruncated"/> says the entry budget cut it short, and
+/// <see cref="RowsTruncated"/> says the reference scan did not see every row of every table. A
+/// consumer that ignores them reports a bounded sample as a complete heap.
+/// </summary>
+public sealed record MetadataHeapEntrySet
+{
+    public MetadataHeapEntrySet(
+        HeapKind Heap,
+        int SizeInBytes,
+        MetadataHeapCoverage Coverage,
+        ImmutableArray<MetadataHeapEntry> Entries,
+        bool EntriesTruncated = false,
+        bool RowsTruncated = false)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(SizeInBytes);
+        if (Entries.IsDefault)
+            throw new ArgumentException("Entries must be initialized.", nameof(Entries));
+
+        this.Heap = Heap;
+        this.SizeInBytes = SizeInBytes;
+        this.Coverage = Coverage;
+        this.Entries = Entries;
+        this.EntriesTruncated = EntriesTruncated;
+        this.RowsTruncated = RowsTruncated;
+    }
+
+    /// <summary>The heap these entries come from.</summary>
+    public HeapKind Heap { get; }
+
+    /// <summary>The heap's physical size, independent of how many entries were listed.</summary>
+    public int SizeInBytes { get; }
+
+    /// <summary>What the entry list covers.</summary>
+    public MetadataHeapCoverage Coverage { get; }
+
+    /// <summary>The listed entries, ordered by heap address.</summary>
+    public ImmutableArray<MetadataHeapEntry> Entries { get; }
+
+    /// <summary>
+    /// True when the entry budget stopped the listing before every listable entry was added.
+    /// </summary>
+    public bool EntriesTruncated { get; }
+
+    /// <summary>
+    /// True when at least one table's row window covered fewer than all its rows, so a reference
+    /// from an unscanned row was not counted and an entry only such rows point at is missing.
+    /// </summary>
+    public bool RowsTruncated { get; }
+}

--- a/src/ILInspector.Metadata/MetadataTableProjection.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjection.cs
@@ -306,6 +306,9 @@ public sealed record MetadataProjectionOptions
     /// <summary>The default bounded blob preview length, in bytes.</summary>
     public const int DefaultMaxPreviewBytes = 32;
 
+    /// <summary>The default ceiling on listed heap entries.</summary>
+    public const int DefaultMaxHeapEntries = 4096;
+
     /// <summary>The default bounded string/name preview length, in characters.</summary>
     public const int DefaultMaxStringChars = 1024;
 
@@ -329,6 +332,14 @@ public sealed record MetadataProjectionOptions
 
     /// <summary>The maximum number of blob bytes captured in a bounded preview.</summary>
     public int MaxPreviewBytes { get; init; } = DefaultMaxPreviewBytes;
+
+    /// <summary>
+    /// The maximum number of entries a heap listing returns before
+    /// <see cref="MetadataHeapEntrySet.EntriesTruncated"/> marks it short. Bounds the largest
+    /// amplification surface in the projection: a heap listing is one row per distinct value, and
+    /// a string heap can hold tens of thousands.
+    /// </summary>
+    public int MaxHeapEntries { get; init; } = DefaultMaxHeapEntries;
 
     /// <summary>
     /// The maximum number of characters retained from a decoded string/name

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -504,12 +504,162 @@ public static class MetadataTableProjector
     }
 
     /// <summary>
+    /// The listable entries of one heap, with the limits of that listing attached. Null when the
+    /// image carries no metadata.
+    ///
+    /// A heap is not a table, and this method does not pretend otherwise. ECMA-335 stores the
+    /// string, blob, and user-string heaps as sequences of length-prefixed items with no index,
+    /// and <c>System.Reflection.Metadata</c> exposes no walker over them; the only way to produce
+    /// a full listing would be to re-parse the heap bytes ourselves, which would fork a second
+    /// metadata decoder and hand back items SRM never validated. So each heap is listed by the
+    /// strongest honest means available, and the result says which was used:
+    ///
+    /// <list type="bullet">
+    /// <item><b>GUID</b> — <see cref="MetadataHeapCoverage.Complete"/>. Its entries are 16-byte
+    /// records at consecutive 1-based indices, so the entry count follows from the heap size by
+    /// arithmetic and every entry is read through SRM by index.</item>
+    /// <item><b>String, Blob</b> — <see cref="MetadataHeapCoverage.ReferencedOnly"/>. The distinct
+    /// values the projected table rows point at, in address order. Entries no row references are
+    /// absent and stay readable only by address.</item>
+    /// <item><b>UserString</b> — <see cref="MetadataHeapCoverage.NotEnumerable"/>, with no
+    /// entries. No table column points into it: its references are <c>ldstr</c> operands in method
+    /// bodies, which this projection does not read. An empty list here is a blind spot the
+    /// coverage names, not an empty heap — <see cref="MetadataHeapEntrySet.SizeInBytes"/> still
+    /// reports the real size.</item>
+    /// </list>
+    ///
+    /// The reference scan covers every projected table, not the caller's
+    /// <see cref="MetadataProjectionOptions.Tables"/> selection: an entry is referenced by the
+    /// image, not by a subset of it, so honoring a table filter here would silently drop entries
+    /// and undercount references. The row window is honored, and a table whose window fell short
+    /// sets <see cref="MetadataHeapEntrySet.RowsTruncated"/>.
+    /// </summary>
+    public static MetadataHeapEntrySet? ReadHeapEntries(
+        PEReader peReader,
+        HeapKind heap,
+        MetadataProjectionOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(peReader);
+        options ??= new MetadataProjectionOptions();
+
+        if (!peReader.HasMetadata)
+            return null;
+
+        var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+        int size = reader.GetHeapSize(MetadataImageInspector.ToHeapIndex(heap));
+        int budget = Math.Max(1, options.MaxHeapEntries);
+
+        if (heap == HeapKind.UserString)
+            return new MetadataHeapEntrySet(heap, size, MetadataHeapCoverage.NotEnumerable, []);
+
+        var references = ScanHeapReferences(peReader, heap, options, out bool rowsTruncated);
+
+        return heap == HeapKind.Guid
+            ? EnumerateGuidHeap(reader, size, references, budget, rowsTruncated)
+            : ReferencedHeapEntries(heap, size, references, budget, rowsTruncated);
+    }
+
+    /// <summary>
+    /// Every projected cell that points into <paramref name="heap"/>, keyed by heap address: the
+    /// first value seen at that address plus how many cells referenced it. Values are compared by
+    /// address rather than by content, so two cells naming the same address are one entry and two
+    /// equal strings stored twice remain two entries — which is what the heap actually holds.
+    /// </summary>
+    static Dictionary<int, (MetadataValue Value, int Count)> ScanHeapReferences(
+        PEReader peReader,
+        HeapKind heap,
+        MetadataProjectionOptions options,
+        out bool rowsTruncated)
+    {
+        var found = new Dictionary<int, (MetadataValue Value, int Count)>();
+        rowsTruncated = false;
+
+        var projection = Project(peReader, options with { Tables = default });
+        foreach (var table in projection.Tables)
+        {
+            if (table.Truncation is not null)
+                rowsTruncated = true;
+
+            foreach (var row in table.Rows)
+            {
+                foreach (var cell in row.Cells)
+                {
+                    if (cell is not MetadataValue.HeapReference reference || reference.Heap != heap)
+                        continue;
+
+                    found[reference.Offset] = found.TryGetValue(reference.Offset, out var existing)
+                        ? (existing.Value, existing.Count + 1)
+                        : (reference, 1);
+                }
+            }
+        }
+
+        return found;
+    }
+
+    static MetadataHeapEntrySet EnumerateGuidHeap(
+        MetadataReader reader,
+        int size,
+        Dictionary<int, (MetadataValue Value, int Count)> references,
+        int budget,
+        bool rowsTruncated)
+    {
+        int count = size / MetadataHeapAddressingSizes.GuidSize;
+        var entries = ImmutableArray.CreateBuilder<MetadataHeapEntry>(Math.Min(count, budget));
+
+        // 1-based: index 0 is the nil GUID in every image, not a stored record.
+        for (int index = 1; index <= count && entries.Count < budget; index++)
+        {
+            MetadataValue value;
+            try
+            {
+                value = GuidCell(reader, MetadataTokens.GuidHandle(index));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+            {
+                value = new MetadataValue.Malformed($"Guid heap read failed at index {index}: {ex.Message}");
+            }
+
+            entries.Add(new MetadataHeapEntry(
+                index, value, references.TryGetValue(index, out var hit) ? hit.Count : 0));
+        }
+
+        return new MetadataHeapEntrySet(
+            HeapKind.Guid,
+            size,
+            MetadataHeapCoverage.Complete,
+            entries.ToImmutable(),
+            EntriesTruncated: entries.Count < count,
+            RowsTruncated: rowsTruncated);
+    }
+
+    static MetadataHeapEntrySet ReferencedHeapEntries(
+        HeapKind heap,
+        int size,
+        Dictionary<int, (MetadataValue Value, int Count)> references,
+        int budget,
+        bool rowsTruncated)
+    {
+        var ordered = references
+            .OrderBy(static entry => entry.Key)
+            .Take(budget)
+            .Select(static entry => new MetadataHeapEntry(entry.Key, entry.Value.Value, entry.Value.Count));
+
+        return new MetadataHeapEntrySet(
+            heap,
+            size,
+            MetadataHeapCoverage.ReferencedOnly,
+            [.. ordered],
+            EntriesTruncated: references.Count > budget,
+            RowsTruncated: rowsTruncated);
+    }
+
+    /// <summary>
     /// Whether <paramref name="value"/> is an edge onto the target row. A handle
     /// names one row; a list column covers the half-open run
     /// <c>[StartRowId, EndRowId)</c>, so membership — not equality — decides.
     /// </summary>
-    static bool PointsAt(MetadataValue value, TableIndex table, int rowId, out MetadataRowReferenceKind kind)
-    {
+    static bool PointsAt(MetadataValue value, TableIndex table, int rowId, out MetadataRowReferenceKind kind)    {
         switch (value)
         {
             case MetadataValue.Handle handle

--- a/src/dotnet-inspect.Tests/MetadataLensTests.cs
+++ b/src/dotnet-inspect.Tests/MetadataLensTests.cs
@@ -610,6 +610,11 @@ public partial class CommandExecutionTests
     [InlineData("#Strings", "not a heap reference")]
     [InlineData("#Nope:1", "unknown heap")]
     [InlineData("#Strings:zz", "not a heap address")]
+    // Reported by adversarial review of #3497: NumberStyles.AllowHexSpecifier on a signed int
+    // wraps, so this parsed as -2147483648, reached the heap read, and rendered a malformed cell
+    // while still exiting 0. Asserted through the command surface because the exit code was the
+    // part that was wrong.
+    [InlineData("#Strings:0x80000000", "not a heap address")]
     public async Task MetadataLens_MalformedHeapCoordinate_NamesTheHalfThatIsWrong(
         string coordinate, string expected)
     {
@@ -697,6 +702,35 @@ public partial class CommandExecutionTests
             foreach (var heap in MetadataHeapCoordinate.Heaps)
                 Assert.DoesNotContain("## " + MetadataSectionNames.ForHeap(heap), output, StringComparison.Ordinal);
         }
+    }
+
+    /// <summary>
+    /// A well-formed coordinate that does not resolve is an error, not a successful render
+    /// containing a malformed cell. Reported by adversarial review of #3497, which observed exit 0
+    /// with a <c>!malformed</c> row — and, worse, <c>-D</c> still advertising the section.
+    ///
+    /// The distinction the product draws: a bad heap reference inside a projected table row is a
+    /// fact about the image and renders as <c>!malformed</c>; a coordinate is the caller's own
+    /// input naming one thing that does not exist. <c>--il-offset</c> already exits 1 here.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_UnresolvableHeapCoordinate_IsAnErrorNotAMalformedRow()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "--heap", "#Strings:999999999", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("#Strings", error, StringComparison.Ordinal);
+        Assert.Contains("999999999", error, StringComparison.Ordinal);
+        Assert.DoesNotContain("## " + MetadataSectionNames.Heap, output, StringComparison.Ordinal);
+
+        // Discovery must not advertise a section the coordinate cannot produce.
+        var (discoverExit, discoverOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", SectionCategoryNames.Metadata,
+            "--heap", "#Strings:999999999", "--tsv", "--tips", "q");
+
+        Assert.Equal(1, discoverExit);
+        Assert.DoesNotContain(MetadataSectionNames.Heap, DiscoveryNames(discoverOutput));
     }
 
     /// <summary>Section names from a <c>-D --tsv</c> listing, header row dropped.</summary>

--- a/src/dotnet-inspect.Tests/MetadataLensTests.cs
+++ b/src/dotnet-inspect.Tests/MetadataLensTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using DotnetInspector.MetadataRendering;
 using DotnetInspector.Models;
 using DotnetInspector.Sections;
 using ILInspector.Metadata;
@@ -21,15 +22,19 @@ public partial class CommandExecutionTests
     private const string MetadataHeadingPrefix = "## " + MetadataSectionNames.Prefix;
 
     /// <summary>
-    /// The registered section set is derived from <see cref="MetadataTableProjector.ProjectedTables"/>,
-    /// not restated. This asserts <em>set equality</em> so both failure directions are caught: a
-    /// table added to the projector without a section, and a section left behind by a table the
-    /// projector dropped. Without the equality a stale entry would pass unnoticed.
+    /// The registered section set is derived from
+    /// <see cref="MetadataTableProjector.ProjectedTables"/> and
+    /// <see cref="MetadataHeapCoordinate.Heaps"/>, not restated. This asserts <em>set equality</em>
+    /// so both failure directions are caught: a table or heap gaining no section, and a section
+    /// left behind by one that was dropped. Without the equality a stale entry would pass
+    /// unnoticed.
     /// </summary>
     [Fact]
     public void MetadataLens_RegisteredSections_EqualProjectedTables()
     {
-        var expected = new[] { MetadataSectionNames.Image }
+        var expected = new[] { MetadataSectionNames.Image, MetadataSectionNames.Heap }
+            .Concat(MetadataHeapCoordinate.Heaps.Select(
+                h => MetadataSectionNames.Prefix + MetadataHeapCoordinate.StreamName(h)))
             .Concat(MetadataTableProjector.ProjectedTables.Select(t => MetadataSectionNames.Prefix + t))
             .ToHashSet(StringComparer.Ordinal);
 
@@ -500,6 +505,198 @@ public partial class CommandExecutionTests
         static string Normalize(string output) => string.Join(
             '\n',
             output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(l => l.TrimEnd('\r')));
+    }
+
+    // ---- --heap coordinate carrier and heap listings (#3467) ------------------------------
+
+    /// <summary>
+    /// The coordinate carrier resolves one heap value and renders it under the section name.
+    ///
+    /// Also the honesty check for the two discoverability gates below: the section really does
+    /// produce output when a coordinate is given, so their absence assertions measure gating
+    /// rather than a section that never renders.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_HeapCoordinate_RendersTheValueAtThatAddress()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "--heap", "#Strings:1", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## " + MetadataSectionNames.Heap, output, StringComparison.Ordinal);
+        Assert.Contains("| #Strings | 1 |", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A coordinate is a coordinate however it is spelled: the ECMA-335 stream name and the
+    /// HeapKind member name, hex and decimal, all address the same entry. Asserted by rendering
+    /// the same value four ways rather than by unit-testing the parser, so the equivalence holds
+    /// through the command surface and not just inside it.
+    /// </summary>
+    [Theory]
+    [InlineData("#Strings:1")]
+    [InlineData("String:1")]
+    [InlineData("Strings:0x1")]
+    [InlineData("#Strings:0x01")]
+    public async Task MetadataLens_HeapCoordinate_AcceptsEverySpelling(string coordinate)
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "--heap", coordinate, "--tsv", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("#Strings\t1\t", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The acceptance property of #3467: the coordinate-scoped section is discoverable exactly
+    /// when its coordinate exists. Both directions are asserted in one test because either alone
+    /// passes trivially — a section that is never listed satisfies the first, and one that is
+    /// always listed satisfies the second.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_HeapSection_IsDiscoverableOnlyWithItsCoordinate()
+    {
+        var (withoutExit, withoutOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", SectionCategoryNames.Metadata, "--tsv", "--tips", "q");
+
+        Assert.Equal(0, withoutExit);
+        Assert.DoesNotContain(MetadataSectionNames.Heap, DiscoveryNames(withoutOutput));
+
+        var (withExit, withOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", SectionCategoryNames.Metadata,
+            "--heap", "#Strings:1", "--tsv", "--tips", "q");
+
+        Assert.Equal(0, withExit);
+        Assert.Contains(MetadataSectionNames.Heap, DiscoveryNames(withOutput));
+    }
+
+    /// <summary>
+    /// Naming the coordinate section without a coordinate is an error, not an empty section: the
+    /// caller asked for something specific that cannot exist, and silently rendering nothing would
+    /// read as "this assembly has no heaps".
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_HeapSection_WithoutCoordinate_IsRejected()
+    {
+        var (exit, _, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", MetadataSectionNames.Heap, "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--heap", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Reaching the coordinate section through the <c>@Metadata</c> door without a coordinate is
+    /// not an error — a category selection asks for whatever applies — so the rest of the family
+    /// still renders. This is the negative case that keeps the rejection above from being a blanket
+    /// refusal.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_CategoryDoor_WithoutHeapCoordinate_StillRenders()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", SectionCategoryNames.Metadata, "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Metadata: Image", output, StringComparison.Ordinal);
+        Assert.DoesNotContain(MetadataSectionNames.Heap, output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A malformed coordinate is rejected before any assembly is read, and the diagnostic names
+    /// the half that is wrong rather than the whole coordinate.
+    /// </summary>
+    [Theory]
+    [InlineData("#Strings", "not a heap reference")]
+    [InlineData("#Nope:1", "unknown heap")]
+    [InlineData("#Strings:zz", "not a heap address")]
+    public async Task MetadataLens_MalformedHeapCoordinate_NamesTheHalfThatIsWrong(
+        string coordinate, string expected)
+    {
+        var (exit, _, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "--heap", coordinate, "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains(expected, error, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A string-heap listing renders the values rows point at, and says so. The caveat is asserted
+    /// because it is the load-bearing half: without it a referenced-values listing reads as a walk
+    /// of the heap, which SRM cannot do and this does not claim to.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_StringHeapListing_MarksItselfReferencedOnly()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", MetadataSectionNames.ForHeap(HeapKind.String),
+            "--rows", "5", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Metadata: #Strings", output, StringComparison.Ordinal);
+        Assert.Contains("not a walk of the heap", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The GUID heap is the one heap that can be listed completely, because its entries are
+    /// fixed-size records. The entry count is asserted against the heap size the image scan
+    /// reports, so a listing that silently stopped short would fail.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_GuidHeapListing_ListsEveryEntry()
+    {
+        using var session = AssemblyInspectionSession.Open(TestAssemblyPath);
+        var overview = session.MetadataImage();
+        Assert.NotNull(overview);
+        int expected = overview!.Heaps.Single(h => h.Heap == HeapKind.Guid).MaxAddress;
+        Assert.True(expected > 0, "The test assembly must store at least one GUID for this gate to mean anything.");
+
+        var (exit, output, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", MetadataSectionNames.ForHeap(HeapKind.Guid),
+            "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(expected.ToString(), output.Trim());
+    }
+
+    /// <summary>
+    /// The user-string heap lists nothing and says why. This is the case a listing must not
+    /// fake: no table column points into #US, so an empty table here is a blind spot, and rendering
+    /// it without the explanation would report a populated heap as empty.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_UserStringHeapListing_ExplainsWhyItIsEmpty()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", MetadataSectionNames.ForHeap(HeapKind.UserString), "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Metadata: #US", output, StringComparison.Ordinal);
+        Assert.Contains("ldstr", output, StringComparison.Ordinal);
+        Assert.Contains("cannot be walked", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The heap listings join the disclosure gate: they are the largest amplification surface in
+    /// the projection, so no verbosity and no <c>-S @All</c> may render one.
+    /// </summary>
+    [Theory]
+    [InlineData("-v:q")]
+    [InlineData("-v:d")]
+    public async Task MetadataLens_NoVerbosity_RendersAnyHeapListing(string verbosity)
+    {
+        foreach (var args in new[]
+                 {
+                     new[] { "library", TestAssemblyPath, verbosity, "--tips", "q" },
+                     new[] { "library", TestAssemblyPath, verbosity, "-S", "@All", "--tips", "q" },
+                 })
+        {
+            var (exit, output, _) = await RunAppAsync(args);
+
+            Assert.Equal(0, exit);
+            foreach (var heap in MetadataHeapCoordinate.Heaps)
+                Assert.DoesNotContain("## " + MetadataSectionNames.ForHeap(heap), output, StringComparison.Ordinal);
+        }
     }
 
     /// <summary>Section names from a <c>-D --tsv</c> listing, header row dropped.</summary>

--- a/src/dotnet-inspect.Tests/MetadataLensTests.cs
+++ b/src/dotnet-inspect.Tests/MetadataLensTests.cs
@@ -733,6 +733,30 @@ public partial class CommandExecutionTests
         Assert.DoesNotContain(MetadataSectionNames.Heap, DiscoveryNames(discoverOutput));
     }
 
+    /// <summary>
+    /// A cached <c>-D</c> catalog must not short-circuit coordinate resolution. Reported by
+    /// adversarial review of #3497: the cache <em>write</em> sites were guarded by
+    /// <c>HasHeapCoordinate</c> but the <em>read</em> sites were not, so a warm cache returned a
+    /// stale catalog and exit 0 — silently skipping the resolution that would have rejected the
+    /// coordinate. Priming twice is what makes this a cache-hit test rather than a cold-path one.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_CachedDiscovery_DoesNotBypassHeapCoordinateResolution()
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            var (primeExit, _, _) = await RunAppAsync(
+                "library", TestAssemblyPath, "-D", "--tsv", "--tips", "q");
+            Assert.Equal(0, primeExit);
+        }
+
+        var (exit, _, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", "--heap", "#Strings:999999999", "--tsv", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("999999999", error, StringComparison.Ordinal);
+    }
+
     /// <summary>Section names from a <c>-D --tsv</c> listing, header row dropped.</summary>
     private static string[] DiscoveryNames(string output) => output
         .Split('\n', StringSplitOptions.RemoveEmptyEntries)

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -408,10 +408,14 @@ public class SectionPipelineTests
         var expected = command == "library"
             ? registered
                 .Except(["Context: Source Location", "Inspection Failures", "Context: Member", "Context: Instruction", "Context: Exception", "Context: Callsite", "Context: Return Address", "Context: Allocation", "Context: Safety", "Context: Cost"], StringComparer.OrdinalIgnoreCase)
-                // @Metadata table sections are data-gated: a table with no rows in this image is
-                // legitimately not discoverable, and listing it would advertise an empty section.
-                // Derived from the fixture image rather than hard-coded, so a table that gains or
-                // loses rows moves the exclusion with it and every non-empty table stays required.
+                // Coordinate-gated like the Context: sections above: without --heap there is no
+                // value to show, so the section is legitimately not discoverable.
+                .Except([MetadataSectionNames.Heap], StringComparer.OrdinalIgnoreCase)
+                // @Metadata table and heap sections are data-gated: a table with no rows or a heap
+                // with no bytes in this image is legitimately not discoverable, and listing it
+                // would advertise an empty section. Derived from the fixture image rather than
+                // hard-coded, so one that gains or loses content moves the exclusion with it and
+                // every non-empty one stays required.
                 .Except(EmptyMetadataSectionsInFixtureImage(), StringComparer.OrdinalIgnoreCase)
             : registered;
         var missing = expected
@@ -423,9 +427,10 @@ public class SectionPipelineTests
     }
 
     /// <summary>
-    /// The <c>@Metadata</c> sections whose table has no rows in the image
-    /// <see cref="DiscoverablePipelineCases"/> seeds the library fixture from. These are the only
-    /// metadata sections allowed to be absent from discovery.
+    /// The <c>@Metadata</c> sections with no content in the image
+    /// <see cref="DiscoverablePipelineCases"/> seeds the library fixture from: tables with no rows
+    /// and heaps with no bytes. These are the only data-gated metadata sections allowed to be
+    /// absent from discovery.
     /// </summary>
     private static string[] EmptyMetadataSectionsInFixtureImage()
     {
@@ -434,9 +439,15 @@ public class SectionPipelineTests
         if (overview is null)
             return [];
 
-        return [.. overview.Tables
-            .Where(table => table.RowCount == 0)
-            .Select(table => MetadataSectionNames.ForTable(table.Index))];
+        return
+        [
+            .. overview.Tables
+                .Where(table => table.RowCount == 0)
+                .Select(table => MetadataSectionNames.ForTable(table.Index)),
+            .. overview.Heaps
+                .Where(heap => heap.SizeInBytes == 0)
+                .Select(heap => MetadataSectionNames.ForHeap(heap.Heap)),
+        ];
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -301,6 +301,7 @@ public static class InspectionCommandDefinitions
         typeFilterOption.Aliases.Add("--type");
         var ilOffsetOption = new Option<string?>("--il-offset") { Description = "MethodDef token + IL offset for coordinate-scoped sections (e.g., 0x06000001+0x5)" };
         var ilOffsetsOption = new Option<string?>("--il-offsets") { Description = "Text file of sparse MethodDef token + IL offset coordinates to explain" };
+        var heapOption = new Option<string?>("--heap") { Description = "Metadata heap coordinate for the coordinate-scoped heap section (e.g., #Strings:0x1a4)" };
         var extractResourcesOption = new Option<string?>("--extract-resources")
         {
             Description = "Extract embedded resources beneath a directory without overwriting files"
@@ -317,6 +318,7 @@ public static class InspectionCommandDefinitions
         assemblyCommand.Options.Add(typeFilterOption);
         assemblyCommand.Options.Add(ilOffsetOption);
         assemblyCommand.Options.Add(ilOffsetsOption);
+        assemblyCommand.Options.Add(heapOption);
         assemblyCommand.Options.Add(opts.RawUrls);
         assemblyCommand.Options.Add(opts.BrowsableUrls);
         assemblyCommand.Options.Add(extractResourcesOption);
@@ -428,6 +430,7 @@ public static class InspectionCommandDefinitions
                 TypeFilter = typeFilter,
                 ILOffsetParameter = parseResult.GetValue(ilOffsetOption),
                 ILOffsetsPath = parseResult.GetValue(ilOffsetsOption),
+                HeapParameter = parseResult.GetValue(heapOption),
                 BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls)
                     && !parseResult.GetValue(opts.RawUrls),
                 JsonOutput = opts.ResolveFormat(parseResult) == OutputFormat.Json,

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -227,7 +227,7 @@ public static class ArgumentPreprocessor
         "--platform", CommandLineHelpers.PlatformLibraryOptionName, "--framework", "--tfm",
         "-t", "--type", "-m", "--member", "-k", "--kind", "--index",
         "--caller-package", "--caller-project", "--match", "--path",
-        "--il-offset", "--il-offsets", "--extract-resources", "--version", "--versions",
+        "--il-offset", "--il-offsets", "--heap", "--extract-resources", "--version", "--versions",
         "--out", "--take", "--row", "--where", "--order-by",
         "--min-confidence", "--triage-shape", "--top", "--session",
         "--package-prefix", "--depth", "-n", "--rows", "--source",

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -355,7 +355,9 @@ public class LibraryCommand
                     inspection, resolvedPath!, null, null, isPlatformAssembly: true, options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
-                PopulateMetadataHeapIfRequested(inspection, options, logger);
+                int heapExitCode = PopulateMetadataHeapIfRequested(inspection, options, logger);
+                if (heapExitCode != 0)
+                    return heapExitCode;
                 if (effectiveDiscovery)
                     return WriteEffectiveSections(resolvedPath!, inspection, options, pipeline, userVerbosity, sourceLinkAvailable, cache: !HasILOffsetCoordinate(options) && !HasHeapCoordinate(options), inspectedContentHash: inspectedContentHash);
                 if (TryWriteLibrarySingletonCount(inspection, options))
@@ -436,7 +438,9 @@ public class LibraryCommand
                     options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
-                PopulateMetadataHeapIfRequested(inspections[0], options, logger);
+                int heapExitCode = PopulateMetadataHeapIfRequested(inspections[0], options, logger);
+                if (heapExitCode != 0)
+                    return heapExitCode;
                 if (effectiveDiscovery)
                     return WriteEffectiveSections(assemblyPaths[0], inspections[0], options, pipeline, userVerbosity, sourceLinkAvailable, cache: !HasILOffsetCoordinate(options) && !HasHeapCoordinate(options), inspectedContentHash: inspectedContentHash);
                 if (TryWriteLibrarySingletonCount(inspections[0], options))
@@ -504,7 +508,9 @@ public class LibraryCommand
                     options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
-                PopulateMetadataHeapIfRequested(inspection, options, logger);
+                int heapExitCode = PopulateMetadataHeapIfRequested(inspection, options, logger);
+                if (heapExitCode != 0)
+                    return heapExitCode;
                 if (effectiveDiscovery)
                     return WriteEffectiveSections(assemblyPath!, inspection, options, pipeline, userVerbosity, sourceLinkAvailable, cache: !HasILOffsetCoordinate(options) && !HasHeapCoordinate(options), inspectedContentHash: inspectedContentHash);
                 if (TryWriteLibrarySingletonCount(inspection, options))
@@ -931,36 +937,58 @@ public class LibraryCommand
 
     /// <summary>
     /// Reads the heap value <c>--heap</c> named onto the model, which is what makes the
-    /// coordinate-scoped section applicable.
+    /// coordinate-scoped section applicable. Returns a process exit code, having written its own
+    /// diagnostic, exactly as the <c>--il-offset</c> resolution above it does.
     ///
-    /// A read failure becomes a malformed value on the model rather than a null: the section was
-    /// asked for by an explicit coordinate, so it must render and say what went wrong instead of
-    /// vanishing as though no coordinate had been given.
+    /// A coordinate that does not resolve is an <em>error</em>, not a malformed cell in an
+    /// otherwise successful render. The two cases look alike but are not: a bad heap reference
+    /// found inside a projected table row is a fact about the image, so it renders as
+    /// <c>!malformed</c> and the command succeeds; a coordinate is the caller's own input, and the
+    /// caller asked for exactly one thing that does not exist. Rendering that as a successful row
+    /// would exit 0 while answering nothing, and — worse — <c>-D</c> would go on advertising
+    /// <c>Metadata: Heap</c> as an available section. <c>--il-offset</c> already draws the line
+    /// here (<c>IL offset 0x… is not an instruction boundary</c>, exit 1) and this matches it.
     /// </summary>
-    private static void PopulateMetadataHeapIfRequested(
+    private static int PopulateMetadataHeapIfRequested(
         LibraryInspection inspection, LibraryOptions options, VerboseLogger logger)
     {
         if (string.IsNullOrWhiteSpace(options.HeapParameter)
             || (options.Discover == null && options.IncludeSections?.Contains(MetadataSectionNames.Heap) != true))
-            return;
+            return 0;
 
         if (inspection.MetadataAssemblyPath is not { } path)
-            return;
+            return 0;
 
         if (!MetadataHeapCoordinate.TryParse(options.HeapParameter, out var heap, out int address, out _))
             throw new UnreachableException("NormalizeHeapSelection rejects a malformed --heap coordinate before this point.");
 
+        string name = MetadataHeapCoordinate.StreamName(heap);
+        MetadataValue? value;
         try
         {
             using var session = AssemblyInspectionSession.Open(path);
-            if (session.MetadataHeapValue(heap, address) is { } value)
-                inspection.MetadataHeap = new MetadataHeapLookup(heap, address, value);
+            value = session.MetadataHeapValue(heap, address);
         }
         catch (Exception ex)
         {
-            logger.Log($"Warning: Error reading {MetadataHeapCoordinate.StreamName(heap)} heap at {address} in {path}: {ex.Message}");
-            inspection.MetadataHeap = new MetadataHeapLookup(
-                heap, address, new MetadataValue.Malformed($"{MetadataHeapCoordinate.StreamName(heap)} heap read failed: {ex.Message}"));
+            logger.Log($"Warning: Error reading {name} heap at {address} in {path}: {ex.Message}");
+            Console.Error.WriteLine($"Error: could not read {name} heap at {address}: {ex.Message}");
+            return 1;
+        }
+
+        switch (value)
+        {
+            case null:
+                Console.Error.WriteLine($"Error: could not read {name} heap at {address}: {path} carries no metadata.");
+                return 1;
+
+            case MetadataValue.Malformed malformed:
+                Console.Error.WriteLine($"Error: could not read {name} heap at {address}: {malformed.Detail}");
+                return 1;
+
+            default:
+                inspection.MetadataHeap = new MetadataHeapLookup(heap, address, value);
+                return 0;
         }
     }
 

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -330,7 +330,7 @@ public class LibraryCommand
                 string? inspectedContentHash = effectiveDiscovery ? TryGetContentHash(resolvedPath!) : null;
 
                 // Check effective sections cache before running full inspection
-                if (effectiveDiscovery && inspectedContentHash != null && options.Discover is { Length: 0 } && !HasILOffsetCoordinate(options))
+                if (effectiveDiscovery && inspectedContentHash != null && options.Discover is { Length: 0 } && !HasILOffsetCoordinate(options) && !HasHeapCoordinate(options))
                 {
                     var cached = TryGetCachedEffective(resolvedPath!, inspectedContentHash, sourceLinkAvailable);
                     if (cached != null)
@@ -401,7 +401,7 @@ public class LibraryCommand
                     : null;
 
                 // Check effective sections cache before running full inspection
-                if (effectiveDiscovery && inspectedContentHash != null && options.Discover is { Length: 0 } && assemblyPaths.Count > 0 && !HasILOffsetCoordinate(options))
+                if (effectiveDiscovery && inspectedContentHash != null && options.Discover is { Length: 0 } && assemblyPaths.Count > 0 && !HasILOffsetCoordinate(options) && !HasHeapCoordinate(options))
                 {
                     var cached = TryGetCachedEffective(assemblyPaths[0], inspectedContentHash, sourceLinkAvailable);
                     if (cached != null)
@@ -484,7 +484,7 @@ public class LibraryCommand
                 string? inspectedContentHash = effectiveDiscovery ? TryGetContentHash(assemblyPath!) : null;
 
                 // Check effective sections cache before running full inspection
-                if (effectiveDiscovery && inspectedContentHash != null && options.Discover is { Length: 0 } && !HasILOffsetCoordinate(options))
+                if (effectiveDiscovery && inspectedContentHash != null && options.Discover is { Length: 0 } && !HasILOffsetCoordinate(options) && !HasHeapCoordinate(options))
                 {
                     var cached = TryGetCachedEffective(assemblyPath!, inspectedContentHash, sourceLinkAvailable);
                     if (cached != null)
@@ -1719,6 +1719,12 @@ public class LibraryCommand
             sections = sections.Where(s => options.IncludeSections.Contains(s)).ToList();
         if (!HasILOffsetCoordinate(options))
             sections = sections.Where(s => !ILCoordinateSections.Contains(s, StringComparer.OrdinalIgnoreCase)).ToList();
+        // Belt and braces, matching the IL-coordinate line above: the cache is never written while
+        // a heap coordinate is present, so a cached listing should not carry this section — but a
+        // catalog that advertises a section the coordinate cannot produce is exactly the failure
+        // this family exists to avoid, so it is filtered rather than assumed absent.
+        if (!HasHeapCoordinate(options))
+            sections = sections.Where(s => !s.Equals(MetadataSectionNames.Heap, StringComparison.OrdinalIgnoreCase)).ToList();
         return sections;
     }
 

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Core;
+using DotnetInspector.MetadataRendering;
 using DotnetInspector.Models;
 using DotnetInspector.Inspectors;
 using ILInspector.Metadata;
@@ -13,6 +14,7 @@ using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using Markout;
+using System.Diagnostics;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -93,6 +95,14 @@ public class LibraryCommand
         }
         options = normalized.Options;
 
+        var heapNormalized = NormalizeHeapSelection(options);
+        if (heapNormalized.Error is not null)
+        {
+            Console.Error.WriteLine(heapNormalized.Error);
+            return 1;
+        }
+        options = heapNormalized.Options;
+
         // @Hidden is a discovery-only pole: it lists via -D @Hidden / --schema and its members
         // render by exact name, but it is not a render selector. This keeps -S from fanning out to
         // unbounded @Hidden members as a group.
@@ -119,7 +129,33 @@ public class LibraryCommand
                 }
             }
 
+            if (selectResult.Sections.Contains(MetadataSectionNames.Heap)
+                && string.IsNullOrWhiteSpace(options.HeapParameter))
+            {
+                // Same discipline as the IL coordinate sections above: reached through the
+                // @Metadata door the section is simply dropped, because a category selection is a
+                // request for whatever applies; named exactly it is an error, because the caller
+                // asked for a specific section that cannot exist without its coordinate.
+                if (!HasExactSelection(options.Select, MetadataSectionNames.Heap))
+                {
+                    selectResult.Sections.Remove(MetadataSectionNames.Heap);
+                }
+                else if (options.Discover == null)
+                {
+                    Console.Error.WriteLine($"Error: \"{MetadataSectionNames.Heap}\" requires --heap <heap>:<address>, for example --heap \"#Strings:0x1a4\".");
+                    return 1;
+                }
+            }
+
             options = options with { IncludeSections = selectResult.Sections };
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.HeapParameter)
+            && options.IncludeSections is { Count: > 0 }
+            && !options.IncludeSections.Contains(MetadataSectionNames.Heap))
+        {
+            Console.Error.WriteLine($"Error: --heap requires the heap coordinate section. Omit -S or include -S \"{MetadataSectionNames.Heap}\".");
+            return 1;
         }
 
         if (!string.IsNullOrWhiteSpace(options.ILOffsetParameter)
@@ -319,8 +355,9 @@ public class LibraryCommand
                     inspection, resolvedPath!, null, null, isPlatformAssembly: true, options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
+                PopulateMetadataHeapIfRequested(inspection, options, logger);
                 if (effectiveDiscovery)
-                    return WriteEffectiveSections(resolvedPath!, inspection, options, pipeline, userVerbosity, sourceLinkAvailable, cache: !HasILOffsetCoordinate(options), inspectedContentHash: inspectedContentHash);
+                    return WriteEffectiveSections(resolvedPath!, inspection, options, pipeline, userVerbosity, sourceLinkAvailable, cache: !HasILOffsetCoordinate(options) && !HasHeapCoordinate(options), inspectedContentHash: inspectedContentHash);
                 if (TryWriteLibrarySingletonCount(inspection, options))
                     return 0;
                 if (options.Print)
@@ -399,8 +436,9 @@ public class LibraryCommand
                     options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
+                PopulateMetadataHeapIfRequested(inspections[0], options, logger);
                 if (effectiveDiscovery)
-                    return WriteEffectiveSections(assemblyPaths[0], inspections[0], options, pipeline, userVerbosity, sourceLinkAvailable, cache: !HasILOffsetCoordinate(options), inspectedContentHash: inspectedContentHash);
+                    return WriteEffectiveSections(assemblyPaths[0], inspections[0], options, pipeline, userVerbosity, sourceLinkAvailable, cache: !HasILOffsetCoordinate(options) && !HasHeapCoordinate(options), inspectedContentHash: inspectedContentHash);
                 if (TryWriteLibrarySingletonCount(inspections[0], options))
                     return 0;
                 if (options.Print)
@@ -466,8 +504,9 @@ public class LibraryCommand
                     options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
+                PopulateMetadataHeapIfRequested(inspection, options, logger);
                 if (effectiveDiscovery)
-                    return WriteEffectiveSections(assemblyPath!, inspection, options, pipeline, userVerbosity, sourceLinkAvailable, cache: !HasILOffsetCoordinate(options), inspectedContentHash: inspectedContentHash);
+                    return WriteEffectiveSections(assemblyPath!, inspection, options, pipeline, userVerbosity, sourceLinkAvailable, cache: !HasILOffsetCoordinate(options) && !HasHeapCoordinate(options), inspectedContentHash: inspectedContentHash);
                 if (TryWriteLibrarySingletonCount(inspection, options))
                     return 0;
                 if (options.Print)
@@ -839,6 +878,91 @@ public class LibraryCommand
 
     private static bool HasILOffsetCoordinate(LibraryOptions options)
         => !string.IsNullOrWhiteSpace(options.ILOffsetParameter);
+
+    /// <summary>
+    /// True when a heap coordinate was supplied. Like an IL coordinate, it changes which sections
+    /// exist, so a discovery catalog computed with one must not be served to a run without one.
+    /// </summary>
+    private static bool HasHeapCoordinate(LibraryOptions options)
+        => !string.IsNullOrWhiteSpace(options.HeapParameter);
+
+    /// <summary>
+    /// True when <paramref name="select"/> names <paramref name="section"/> exactly, as opposed to
+    /// reaching it through an <c>@Category</c>. The distinction decides whether a coordinate
+    /// section with no coordinate is an error or is simply dropped.
+    /// </summary>
+    private static bool HasExactSelection(string[]? select, string section)
+    {
+        if (select is not { Length: > 0 })
+            return false;
+
+        foreach (var value in select)
+        {
+            if (value.StartsWith('@'))
+                continue;
+            if (value.Trim().Equals(section, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Validates the <c>--heap</c> coordinate and, when no selection was given, selects the
+    /// section it feeds.
+    ///
+    /// The coordinate is parsed here — before any assembly is opened — so a malformed one fails
+    /// immediately with a diagnostic naming the wrong half, rather than after the cost of an
+    /// inspection.
+    /// </summary>
+    private static (LibraryOptions Options, string? Error) NormalizeHeapSelection(LibraryOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.HeapParameter))
+            return (options, null);
+
+        if (!MetadataHeapCoordinate.TryParse(options.HeapParameter, out _, out _, out string? error))
+            return (options, $"Error: invalid --heap value '{options.HeapParameter}': {error}");
+
+        if (options.Discover != null || options.Select is { Length: > 0 })
+            return (options, null);
+
+        return (options with { Select = [MetadataSectionNames.Heap] }, null);
+    }
+
+    /// <summary>
+    /// Reads the heap value <c>--heap</c> named onto the model, which is what makes the
+    /// coordinate-scoped section applicable.
+    ///
+    /// A read failure becomes a malformed value on the model rather than a null: the section was
+    /// asked for by an explicit coordinate, so it must render and say what went wrong instead of
+    /// vanishing as though no coordinate had been given.
+    /// </summary>
+    private static void PopulateMetadataHeapIfRequested(
+        LibraryInspection inspection, LibraryOptions options, VerboseLogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(options.HeapParameter)
+            || (options.Discover == null && options.IncludeSections?.Contains(MetadataSectionNames.Heap) != true))
+            return;
+
+        if (inspection.MetadataAssemblyPath is not { } path)
+            return;
+
+        if (!MetadataHeapCoordinate.TryParse(options.HeapParameter, out var heap, out int address, out _))
+            throw new UnreachableException("NormalizeHeapSelection rejects a malformed --heap coordinate before this point.");
+
+        try
+        {
+            using var session = AssemblyInspectionSession.Open(path);
+            if (session.MetadataHeapValue(heap, address) is { } value)
+                inspection.MetadataHeap = new MetadataHeapLookup(heap, address, value);
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error reading {MetadataHeapCoordinate.StreamName(heap)} heap at {address} in {path}: {ex.Message}");
+            inspection.MetadataHeap = new MetadataHeapLookup(
+                heap, address, new MetadataValue.Malformed($"{MetadataHeapCoordinate.StreamName(heap)} heap read failed: {ex.Message}"));
+        }
+    }
 
     private static bool HasExactILCoordinateSelection(string[]? select)
     {

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -497,6 +497,16 @@ public class LibraryInspection
     [JsonIgnore]
     public string? MetadataAssemblyPath { get; set; }
 
+    /// <summary>
+    /// The heap value <c>--heap</c> named, or null when no heap coordinate was given.
+    ///
+    /// This is the carrier that makes the coordinate-scoped heap section exist: like
+    /// <see cref="ILOffset"/>, the section is applicable exactly when this is non-null, so a
+    /// section that has nothing to show is never listed or rendered.
+    /// </summary>
+    [JsonIgnore]
+    public MetadataHeapLookup? MetadataHeap { get; set; }
+
     [JsonIgnore]
     public FindingInspection<AssemblyAttributeInfo>? AssemblyAttributeInspection =>
         _assemblyAttributeInspection;
@@ -1219,3 +1229,20 @@ public record class AsyncMethodSummary
     /// <summary>"Runtime" for runtime async, "State machine" for classic compiler async.</summary>
     public string Kind { get; init; } = "";
 }
+
+/// <summary>
+/// One heap value read by coordinate: what was asked for, and what was found there.
+///
+/// The coordinate travels with the value because a heap value carries no identity of its own — a
+/// string is just a string — so rendering it without the heap and address it came from would give
+/// a reader nothing to check or follow up on.
+/// </summary>
+/// <param name="Heap">The heap the coordinate named.</param>
+/// <param name="Address">
+/// The address the coordinate named: a byte offset, or a 1-based index for the GUID heap.
+/// </param>
+/// <param name="Value">
+/// What was read there. A <see cref="MetadataValue.Malformed"/> when the address is out of range
+/// or the value did not decode; never silently replaced by an empty value.
+/// </param>
+public sealed record MetadataHeapLookup(HeapKind Heap, int Address, MetadataValue Value);

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -73,6 +73,11 @@ public record LibraryOptions : IProjectionOptions
     public string? ILOffsetParameter { get; init; }
 
     /// <summary>
+    /// Heap coordinate (<c>Heap:Address</c>) for the coordinate-scoped metadata heap section.
+    /// </summary>
+    public string? HeapParameter { get; init; }
+
+    /// <summary>
     /// Path to a text file containing sparse MethodDef token + IL offset coordinates.
     /// </summary>
     public string? ILOffsetsPath { get; init; }

--- a/src/dotnet-inspect/Output/MetadataLensRenderer.cs
+++ b/src/dotnet-inspect/Output/MetadataLensRenderer.cs
@@ -33,6 +33,13 @@ internal static class MetadataLensRenderer
     internal const int MaxRowsPerTable = 1_000_000;
 
     /// <summary>
+    /// The per-heap entry ceiling the lens lists with. Raised far above
+    /// <see cref="MetadataProjectionOptions.DefaultMaxHeapEntries"/> for the same reason
+    /// <see cref="MaxRowsPerTable"/> is, and finite for the same reason.
+    /// </summary>
+    internal const int MaxHeapEntries = 1_000_000;
+
+    /// <summary>
     /// Maps the command's tabular flags onto the projection renderer's format. JSONL wins over TSV
     /// because it is the more specific request; with neither set the caller is on the pretty-table
     /// path, whose rows the Markdown pipe form already carries.
@@ -85,6 +92,31 @@ internal static class MetadataLensRenderer
             MetadataProjectionRenderer.RenderImageFacts(overview, output, columns);
             WriteCaveats(output, MetadataProjectionRenderer.Caveats(overview));
             first = false;
+        }
+
+        if (selected.Contains(MetadataSectionNames.Heap, StringComparer.OrdinalIgnoreCase)
+            && inspection.MetadataHeap is { } lookup)
+        {
+            if (!first)
+                output.WriteLine();
+            first = false;
+
+            output.WriteLine($"## {MetadataSectionNames.Heap}");
+            output.WriteLine();
+            MetadataProjectionRenderer.RenderHeapValue(
+                lookup.Value, lookup.Heap, lookup.Address, output, columns);
+        }
+
+        foreach (var entries in ListSelectedHeaps(inspection, selected, caveats))
+        {
+            if (!first)
+                output.WriteLine();
+            first = false;
+
+            output.WriteLine($"## {MetadataSectionNames.ForHeap(entries.Heap)}");
+            output.WriteLine();
+            MetadataProjectionRenderer.RenderHeapEntries(entries, output, columns);
+            WriteCaveats(output, MetadataProjectionRenderer.Caveats(entries));
         }
 
         foreach (var table in ProjectSelected(inspection, selected, caveats, columns))
@@ -158,6 +190,20 @@ internal static class MetadataLensRenderer
                 caveats.WriteLine(caveat);
         }
 
+        if (selected.Contains(MetadataSectionNames.Heap, StringComparer.OrdinalIgnoreCase)
+            && inspection.MetadataHeap is { } lookup)
+        {
+            MetadataProjectionRenderer.RenderHeapValue(
+                lookup.Value, lookup.Heap, lookup.Address, output, columns, format);
+        }
+
+        foreach (var entries in ListSelectedHeaps(inspection, selected, caveats))
+        {
+            MetadataProjectionRenderer.RenderHeapEntries(entries, output, columns, format);
+            foreach (string caveat in MetadataProjectionRenderer.Caveats(entries))
+                caveats.WriteLine(caveat);
+        }
+
         var views = ProjectSelected(inspection, selected, caveats, columns);
         if (views.Length > 0)
         {
@@ -169,6 +215,64 @@ internal static class MetadataLensRenderer
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Lists exactly the heaps the selection names — never the rest.
+    ///
+    /// Each listing costs a projection of every table (an entry is referenced by the image, not by
+    /// a subset of it), so this is the lens's other expensive half and is restricted to the
+    /// selection for the same reason <see cref="ProjectSelected"/> is.
+    ///
+    /// The entry ceiling is raised far above the projection default for the same reason
+    /// <see cref="MaxRowsPerTable"/> is: entry *selection* is <c>--rows</c>'s job and it windows
+    /// the rendered table, so a low ceiling would put entries beyond it out of reach of any
+    /// <c>--rows</c> range. It stays finite so a hostile image cannot drive unbounded allocation,
+    /// and crossing it surfaces as a caveat rather than as a silently short list.
+    /// </summary>
+    static ImmutableArray<MetadataHeapEntrySet> ListSelectedHeaps(
+        LibraryInspection inspection,
+        IReadOnlyCollection<string> sections,
+        TextWriter caveats)
+    {
+        var heaps = MetadataSectionNames.HeapsFor(sections);
+        if (heaps.IsEmpty)
+            return [];
+
+        if (inspection.MetadataAssemblyPath is not { } path)
+        {
+            caveats.WriteLine(
+                "Metadata heaps were selected but the assembly path is unavailable, so no heap could be listed.");
+            return [];
+        }
+
+        try
+        {
+            using var session = AssemblyInspectionSession.Open(path);
+            var options = new MetadataProjectionOptions
+            {
+                MaxRowsPerTable = MaxRowsPerTable,
+                MaxHeapEntries = MaxHeapEntries,
+            };
+
+            var builder = ImmutableArray.CreateBuilder<MetadataHeapEntrySet>(heaps.Length);
+            foreach (var heap in heaps)
+            {
+                if (session.MetadataHeapEntries(heap, options) is { } entries)
+                    builder.Add(entries);
+                else
+                    caveats.WriteLine($"{path} carries no metadata, so its {MetadataHeapCoordinate.StreamName(heap)} heap could not be listed.");
+            }
+
+            return builder.ToImmutable();
+        }
+        catch (Exception ex)
+        {
+            // Surfaced rather than swallowed: an unreadable image must not render as a set of
+            // legitimately empty heaps.
+            caveats.WriteLine($"Metadata heaps could not be listed from {path}: {ex.Message}");
+            return [];
+        }
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Sections/MetadataSectionNames.cs
+++ b/src/dotnet-inspect/Sections/MetadataSectionNames.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata.Ecma335;
+using DotnetInspector.MetadataRendering;
 using ILInspector.Metadata;
 using Markout;
 
@@ -31,6 +32,55 @@ public static class MetadataSectionNames
     public const string Image = Prefix + "Image";
 
     /// <summary>
+    /// The coordinate-scoped section: the single heap value <c>--heap</c> names.
+    ///
+    /// Like the IL-offset sections, this one exists only when its coordinate does. Without
+    /// <c>--heap</c> there is no value to show, so the section is inapplicable and <c>-D</c> does
+    /// not list it; a section listed with nothing to render would advertise a view the command
+    /// cannot produce.
+    /// </summary>
+    public const string Heap = Prefix + "Heap";
+
+    /// <summary>
+    /// One section name per heap, spelled with the ECMA-335 stream name
+    /// (<c>Metadata: #Strings</c>), so the section a user selects and the coordinate they pass to
+    /// <c>--heap</c> name the heap the same way.
+    /// </summary>
+    public static ImmutableArray<string> Heaps { get; } =
+        [.. MetadataHeapCoordinate.Heaps.Select(static heap => Prefix + MetadataHeapCoordinate.StreamName(heap))];
+
+    static readonly ImmutableDictionary<string, HeapKind> HeapsByName =
+        MetadataHeapCoordinate.Heaps.ToImmutableDictionary(
+            static heap => Prefix + MetadataHeapCoordinate.StreamName(heap),
+            static heap => heap,
+            StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The section name that lists <paramref name="heap"/>'s entries.</summary>
+    public static string ForHeap(HeapKind heap) => Prefix + MetadataHeapCoordinate.StreamName(heap);
+
+    /// <summary>
+    /// Resolves a section name to the heap it lists. Returns <see langword="false"/> for
+    /// <see cref="Heap"/> — the coordinate section is one value, not a heap listing — and for
+    /// every non-heap section.
+    /// </summary>
+    public static bool TryGetHeap(string section, out HeapKind heap)
+        => HeapsByName.TryGetValue(section, out heap);
+
+    /// <summary>
+    /// The heaps selected by <paramref name="sections"/>, in stream-name order. Sections that are
+    /// not heap listings are skipped.
+    /// </summary>
+    public static ImmutableArray<HeapKind> HeapsFor(IEnumerable<string> sections)
+    {
+        var selected = sections
+            .Where(static s => HeapsByName.ContainsKey(s))
+            .Select(static s => HeapsByName[s])
+            .ToHashSet();
+
+        return [.. MetadataHeapCoordinate.Heaps.Where(selected.Contains)];
+    }
+
+    /// <summary>
     /// One section name per projected table, in ECMA-335 table order — the same order
     /// <see cref="MetadataTableProjector.ProjectedTables"/> declares, so rendered sections follow
     /// table order rather than an independent list that could drift out of it.
@@ -39,11 +89,12 @@ public static class MetadataSectionNames
         [.. MetadataTableProjector.ProjectedTables.Select(static index => Prefix + index)];
 
     /// <summary>
-    /// Every section in the <c>@Metadata</c> category: the image overview first, then the tables.
+    /// Every section in the <c>@Metadata</c> category: the image overview first, then the heap
+    /// coordinate section, the per-heap listings, and the tables.
     /// This is the category membership list and the registration list, so a table can never be
     /// registered without being reachable through the category door.
     /// </summary>
-    public static ImmutableArray<string> All { get; } = [Image, .. Tables];
+    public static ImmutableArray<string> All { get; } = [Image, Heap, .. Heaps, .. Tables];
 
     static readonly ImmutableDictionary<string, TableIndex> ByName =
         MetadataTableProjector.ProjectedTables.ToImmutableDictionary(
@@ -68,6 +119,8 @@ public static class MetadataSectionNames
     /// </summary>
     public static bool IsMetadataSection(string section)
         => string.Equals(section, Image, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(section, Heap, StringComparison.OrdinalIgnoreCase)
+            || HeapsByName.ContainsKey(section)
             || ByName.ContainsKey(section);
 
     /// <summary>
@@ -93,7 +146,11 @@ public static class MetadataSectionNames
     public static ImmutableArray<string> ColumnsFor(string section)
         => TryGetTable(section, out var table)
             ? [RowIdColumn, .. MetadataTableProjector.ColumnsFor(table).Select(static c => c.Name)]
-            : [];
+            : string.Equals(section, Heap, StringComparison.OrdinalIgnoreCase)
+                ? [.. MetadataProjectionRenderer.HeapValueColumns]
+                : TryGetHeap(section, out _)
+                    ? [.. MetadataProjectionRenderer.HeapEntryColumns]
+                    : [];
 
     /// <summary>
     /// The name of the leading row-id column every table section carries. It is not an ECMA-335
@@ -115,6 +172,13 @@ public static class MetadataSectionNames
         ArgumentNullException.ThrowIfNull(schema);
 
         schema.Add(Image, "column", "Property", "Value");
+        schema.Add(Heap, "column", [.. ColumnsFor(Heap)]);
+        foreach (var heap in MetadataHeapCoordinate.Heaps)
+        {
+            var heapSection = ForHeap(heap);
+            schema.Add(heapSection, "column", [.. ColumnsFor(heapSection)]);
+        }
+
         foreach (var table in MetadataTableProjector.ProjectedTables)
         {
             var name = ForTable(table);

--- a/src/dotnet-inspect/Sections/MetadataSections.cs
+++ b/src/dotnet-inspect/Sections/MetadataSections.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.MetadataRendering;
 using DotnetInspector.Models;
 
 namespace DotnetInspector.Sections;
@@ -58,8 +59,53 @@ public static class MetadataSections
             CanRender = HasMetadata,
         });
 
-        foreach (var table in ILInspector.Metadata.MetadataTableProjector.ProjectedTables)
+        // The coordinate-scoped section. Applicable exactly when --heap supplied a coordinate, so
+        // it is listed by -D only then — the same discipline the IL-offset coordinate sections
+        // follow, and for the same reason: a section with no coordinate has nothing to render, and
+        // listing it would advertise a view the command cannot produce.
+        pipeline.Add(new SectionEntry<LibraryInspection>
         {
+            Name = MetadataSectionNames.Heap,
+            IsExpensive = false,
+            ExplicitOnly = true,
+            ListedInCatalog = false,
+            // One value at one address: a fixed shape, and cheap — the read is by address and
+            // touches no table.
+            SizeClass = SectionSizeClass.Fixed,
+            Cost = SectionCost.NetworkFree,
+            ScannerKey = LibrarySections.ScannerMetadata,
+            HasExplicitApplicability = true,
+            IsApplicable = static model => model.MetadataHeap is not null,
+            CanRender = static model => model.MetadataHeap is not null,
+        });
+
+        foreach (var heap in MetadataHeapCoordinate.Heaps)
+        {
+            var kind = heap;
+
+            pipeline.Add(new SectionEntry<LibraryInspection>
+            {
+                Name = MetadataSectionNames.ForHeap(kind),
+                IsExpensive = false,
+                ExplicitOnly = true,
+                ListedInCatalog = false,
+                SizeClass = SectionSizeClass.Verbose,
+                // Listing a heap costs a projection of every table — an entry is referenced by the
+                // image, not by a subset of it — and a string heap can hold tens of thousands of
+                // entries. Unbounded is the honest classification.
+                Cost = SectionCost.Unbounded,
+                ScannerKey = LibrarySections.ScannerMetadata,
+                // Effectiveness follows the heap's size from the cheap image scan. Probing by
+                // rendering would project every table during discovery, paying the section's whole
+                // cost just to decide whether to list it.
+                ProbeEffectiveness = false,
+                HasExplicitApplicability = true,
+                IsApplicable = model => HasHeapBytes(model, kind),
+                CanRender = model => HasHeapBytes(model, kind),
+            });
+        }
+
+        foreach (var table in ILInspector.Metadata.MetadataTableProjector.ProjectedTables)        {
             // Captured per iteration so each entry's predicate closes over its own table rather
             // than the loop's final value.
             var index = table;
@@ -90,6 +136,28 @@ public static class MetadataSections
     }
 
     static bool HasMetadata(LibraryInspection model) => model.MetadataOverview is not null;
+
+    /// <summary>
+    /// True when <paramref name="heap"/> holds any bytes in this image. Heap sizes come from the
+    /// cheap image scan, so this never lists entries.
+    ///
+    /// Size, not listability, is the applicability test — including for <c>#US</c>, which cannot
+    /// be enumerated at all. An image that stores user strings has a <c>#US</c> heap worth naming,
+    /// and its section says why its entries cannot be listed and how to read one by address. An
+    /// image with no user strings has a zero-byte heap and no section, which is the honest answer
+    /// in both directions.
+    /// </summary>
+    static bool HasHeapBytes(LibraryInspection model, ILInspector.Metadata.HeapKind heap)
+    {
+        if (model.MetadataOverview is not { } overview)
+            return false;
+
+        foreach (var summary in overview.Heaps)
+            if (summary.Heap == heap)
+                return summary.SizeInBytes > 0;
+
+        return false;
+    }
 
     /// <summary>
     /// True when <paramref name="table"/> has at least one row in this image. Row counts come from

--- a/src/mdi/MdiCommand.cs
+++ b/src/mdi/MdiCommand.cs
@@ -73,7 +73,7 @@ public static class MdiCommand
 
         var heapOption = new Option<string?>("--heap")
         {
-            Description = "Instead of dumping tables, read one heap value, given as Heap:Address (for example String:1234 or Guid:1). Addresses match a cell's offset: a byte offset, except the Guid heap's 1-based index.",
+            Description = "Instead of dumping tables, read one heap value, given as Heap:Address (for example #Strings:0x1a4 or #GUID:1). Addresses match a cell's offset: a byte offset, except the #GUID heap's 1-based index.",
         };
 
         var maxBytesOption = new Option<int>("--max-bytes")
@@ -162,7 +162,7 @@ public static class MdiCommand
 
             if (heapSpec is not null)
             {
-                if (!TryParseHeapLocation(heapSpec, out var heap, out int address, out string? heapError))
+                if (!MetadataHeapCoordinate.TryParse(heapSpec, out var heap, out int address, out string? heapError))
                 {
                     Console.Error.WriteLine($"Error: {heapError}");
                     return 1;
@@ -533,42 +533,6 @@ public static class MdiCommand
         if (!int.TryParse(rowText, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out rowId) || rowId < 1)
         {
             error = $"'{rowText}' is not a row id. Row ids are 1-based positive integers.";
-            return false;
-        }
-
-        error = null;
-        return true;
-    }
-
-    /// <summary>
-    /// Parses a <c>Heap:Address</c> heap reference (for example
-    /// <c>String:1234</c>). The two halves are validated separately so the
-    /// diagnostic names the half that is wrong.
-    /// </summary>
-    internal static bool TryParseHeapLocation(string spec, out HeapKind heap, out int address, out string? error)
-    {
-        heap = default;
-        address = 0;
-
-        int separator = spec.LastIndexOf(':');
-        if (separator < 0)
-        {
-            error = $"'{spec}' is not a heap reference. Use Heap:Address, for example String:1234.";
-            return false;
-        }
-
-        string heapName = spec[..separator].Trim();
-        string addressText = spec[(separator + 1)..].Trim();
-
-        if (!Enum.TryParse(heapName, ignoreCase: true, out heap) || !Enum.IsDefined(heap))
-        {
-            error = $"unknown heap '{heapName}'. Use String, Blob, Guid, or UserString.";
-            return false;
-        }
-
-        if (!int.TryParse(addressText, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out address))
-        {
-            error = $"'{addressText}' is not a heap address. Addresses are non-negative integers.";
             return false;
         }
 

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
@@ -428,6 +428,10 @@ public class MetadataImageOverviewRendererTests
     [InlineData("String:0xFFFFFFFF", "not a heap address")]
     [InlineData("String:0x100000000", "not a heap address")]
     [InlineData("String:2147483648", "not a heap address")]
+    // Reported by adversarial review of #3497: a last-colon split handed the stray colon to the
+    // heap half and reported `unknown heap '#Strings:0x1a4'` -- blaming the half the caller got
+    // right. No accepted heap spelling contains a colon, so the first one is the separator.
+    [InlineData("#Strings:0x1a4:0x1b4", "not a heap address")]
     public void TryParseHeapLocation_NamesTheHalfThatIsWrong(string spec, string expected)
     {
         Assert.False(MetadataHeapCoordinate.TryParse(spec, out _, out _, out string? error));

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
@@ -421,11 +421,32 @@ public class MetadataImageOverviewRendererTests
     // Hex is opt-in, never inferred: a bare "1a4" would otherwise silently address a different
     // entry than the "0x1a4" a metadata dump printed.
     [InlineData("String:1a4", "not a heap address")]
+    // NumberStyles.AllowHexSpecifier on a signed int *wraps* rather than overflows, so these
+    // parsed successfully as -2147483648 and -1 and produced a malformed heap read that still
+    // exited 0. An address that cannot exist is a parse error.
+    [InlineData("String:0x80000000", "not a heap address")]
+    [InlineData("String:0xFFFFFFFF", "not a heap address")]
+    [InlineData("String:0x100000000", "not a heap address")]
+    [InlineData("String:2147483648", "not a heap address")]
     public void TryParseHeapLocation_NamesTheHalfThatIsWrong(string spec, string expected)
     {
         Assert.False(MetadataHeapCoordinate.TryParse(spec, out _, out _, out string? error));
         Assert.NotNull(error);
         Assert.Contains(expected, error);
+    }
+
+    /// <summary>
+    /// The boundary the overflow rejection must not overshoot: <c>int.MaxValue</c> is still a
+    /// representable address and stays accepted in both radixes.
+    /// </summary>
+    [Theory]
+    [InlineData("String:0x7FFFFFFF")]
+    [InlineData("String:2147483647")]
+    public void TryParseHeapLocation_AcceptsTheLargestRepresentableAddress(string spec)
+    {
+        Assert.True(MetadataHeapCoordinate.TryParse(spec, out _, out int address, out string? error));
+        Assert.Equal(int.MaxValue, address);
+        Assert.Null(error);
     }
 
     [Fact]

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
@@ -237,8 +237,8 @@ public class MetadataImageOverviewRendererTests
 
         string markdown = RenderHeap(value, HeapKind.String, 42, MetadataTableFormat.Markdown);
 
-        Assert.Contains("## String heap at 42", markdown);
-        Assert.Contains("| String | 42 | 5 | no | hello |", markdown);
+        Assert.Contains("## #Strings heap at 42", markdown);
+        Assert.Contains("| #Strings | 42 | 5 | no | hello |", markdown);
     }
 
     [Fact]
@@ -248,7 +248,7 @@ public class MetadataImageOverviewRendererTests
 
         string markdown = RenderHeap(value, HeapKind.Blob, 7, MetadataTableFormat.Markdown);
 
-        Assert.Contains("| Blob | 7 | 64 | yes |", markdown);
+        Assert.Contains("| #Blob | 7 | 64 | yes |", markdown);
         Assert.Contains("0011\u2026", markdown);
     }
 
@@ -268,7 +268,7 @@ public class MetadataImageOverviewRendererTests
         string tsv = RenderHeap(new MetadataValue.Nil(), HeapKind.String, 0, MetadataTableFormat.Tsv);
 
         Assert.Contains("nil", tsv);
-        Assert.Contains("String\t0\t\tno\tnil", tsv);
+        Assert.Contains("#Strings\t0\t\tno\tnil", tsv);
     }
 
     [Fact]
@@ -278,7 +278,7 @@ public class MetadataImageOverviewRendererTests
 
         string jsonl = RenderHeap(value, HeapKind.UserString, 1, MetadataTableFormat.Jsonl);
 
-        Assert.Contains("\"heap\":\"UserString\"", jsonl);
+        Assert.Contains("\"heap\":\"#US\"", jsonl);
         Assert.Contains("\"address\":\"1\"", jsonl);
         Assert.Contains("\"value\":\"abc\"", jsonl);
     }
@@ -357,7 +357,7 @@ public class MetadataImageOverviewRendererTests
             SelfPath, HeapKind.Guid, 1, new MetadataProjectionOptions(), MetadataTableFormat.Markdown, output, error);
 
         Assert.Equal(0, code);
-        Assert.Contains("## Guid heap at 1", output.ToString());
+        Assert.Contains("## #GUID heap at 1", output.ToString());
         Assert.DoesNotContain("malformed", output.ToString());
     }
 
@@ -394,9 +394,17 @@ public class MetadataImageOverviewRendererTests
     [InlineData("guid:1", HeapKind.Guid, 1)]
     [InlineData(" UserString : 0 ", HeapKind.UserString, 0)]
     [InlineData("Blob:0", HeapKind.Blob, 0)]
+    [InlineData("#Strings:1234", HeapKind.String, 1234)]
+    [InlineData("#GUID:1", HeapKind.Guid, 1)]
+    [InlineData("#US:0", HeapKind.UserString, 0)]
+    [InlineData("#Blob:0", HeapKind.Blob, 0)]
+    [InlineData("#Strings:0x1a4", HeapKind.String, 0x1a4)]
+    [InlineData("#Strings:0X1A4", HeapKind.String, 0x1a4)]
+    [InlineData("Strings:10", HeapKind.String, 10)]
+    [InlineData("us:5", HeapKind.UserString, 5)]
     public void TryParseHeapLocation_AcceptsAHeapAndAddress(string spec, HeapKind heap, int address)
     {
-        Assert.True(MdiCommand.TryParseHeapLocation(spec, out var parsedHeap, out int parsedAddress, out string? error));
+        Assert.True(MetadataHeapCoordinate.TryParse(spec, out var parsedHeap, out int parsedAddress, out string? error));
         Assert.Equal(heap, parsedHeap);
         Assert.Equal(address, parsedAddress);
         Assert.Null(error);
@@ -405,11 +413,17 @@ public class MetadataImageOverviewRendererTests
     [Theory]
     [InlineData("String", "not a heap reference")]
     [InlineData("Nope:1", "unknown heap")]
+    [InlineData("#Str:1", "unknown heap")]
     [InlineData("String:abc", "not a heap address")]
     [InlineData("String:-1", "not a heap address")]
+    [InlineData("String:0x", "not a heap address")]
+    [InlineData("String:", "not a heap address")]
+    // Hex is opt-in, never inferred: a bare "1a4" would otherwise silently address a different
+    // entry than the "0x1a4" a metadata dump printed.
+    [InlineData("String:1a4", "not a heap address")]
     public void TryParseHeapLocation_NamesTheHalfThatIsWrong(string spec, string expected)
     {
-        Assert.False(MdiCommand.TryParseHeapLocation(spec, out _, out _, out string? error));
+        Assert.False(MetadataHeapCoordinate.TryParse(spec, out _, out _, out string? error));
         Assert.NotNull(error);
         Assert.Contains(expected, error);
     }


### PR DESCRIPTION
Closes #3467. Carries the one #3401 acceptance bullet that #3465 did not meet, so **#3401 can close once #3468 lands**.

A heap coordinate such as `#Strings:0x1a4` is not a section name, so it needs a carrier. `--heap` is that carrier and behaves like `--il-offset`: it makes `Metadata: Heap` exist and be discoverable exactly when a coordinate is present. Four per-heap listing sections join it.

```console
$ dotnet-inspect library My.dll --heap "#Strings:0x1a4"
## Metadata: Heap

| Heap | Address | Length | Truncated | Value |
| ---- | ------- | ------ | --------- | ----- |
| #Strings | 420 | 8 | no | ToString |

$ dotnet-inspect library My.dll -D @Metadata --tsv | grep Heap    # nothing
$ dotnet-inspect library My.dll -D @Metadata --heap "#Strings:1" --tsv | grep Heap
Metadata: Heap
```

## Heaps are not tables, and the listings say so

A table has a row count and fixed-width rows. `#Strings` and `#Blob` are length-prefixed items with no index, and `System.Reflection.Metadata` exposes no walker — only random access from an address a table cell already holds. I checked this directly rather than assuming it: there is no `StringHandles`/`UserStringHandles` collection, only `GetUserString(UserStringHandle)`.

So "bounded heap preview" cannot mean what the issue's wording suggests without faking a walk by scanning bytes, which [metadata-table-projection.md](https://github.com/richlander/dotnet-inspect/blob/main/docs/design/metadata-table-projection.md) explicitly forbids. Instead each heap is listed by the strongest honest means it admits, and `MetadataHeapCoverage` makes **which one** part of the answer:

| Heap | Coverage | What is listed |
| --- | --- | --- |
| `#GUID` | `Complete` | Every entry. Records are a fixed 16 bytes, so the count is `size / 16` and each is read by index. |
| `#Strings`, `#Blob` | `ReferencedOnly` | The distinct values projected table rows point at, address-ordered, with a `Refs` count. |
| `#US` | `NotEnumerable` | Nothing. |

Every listing renders its coverage as a caveat, so a referenced-values listing never reads as a walk of the heap:

```console
$ dotnet-inspect library My.dll -S "Metadata: #US"
## Metadata: #US

| Address | Length | Truncated | Refs | Value |
| ------- | ------ | --------- | ---- | ----- |

No entry of the #US heap can be listed: no metadata table column points into it — its
references are ldstr operands inside method bodies, which this projection does not read —
and it cannot be walked. Its 65812 bytes are not empty; read a known address with
--heap "#US:<address>".
```

`#US` deliberately **keeps** its section rather than being hidden. The section is how a caller learns the heap exists, how large it is, and that `--heap "#US:<addr>"` still reads any address in it. Hiding it would be undiscoverable; rendering the empty table without the caveat would report a 65 KB heap as empty.

## Notes for review

- **Reference scanning ignores the caller's table filter** (`options with { Tables = default }`). An entry is referenced by the *image*, not by whichever subset of tables the caller is looking at, so honoring the filter would drop entries and undercount references while looking complete. A row window is a stated bound, so it *is* honored and reported as `RowsTruncated`.
- **Hex is opt-in, never inferred.** A bare `1a4` is rejected rather than read as `0x1a4`, because guessing would silently address a different entry than the one a dump printed. The coordinate splits on the **last** colon and validates each half separately, so the diagnostic names the half that is wrong.
- **The discovery cache is disabled when `--heap` is present**, exactly as it is for `--il-offset`: the coordinate changes which sections exist, so a catalog cached without it would omit `Metadata: Heap`, and one cached with it would offer a section that no longer resolves. All three `WriteEffectiveSections` call sites.
- **Selection semantics mirror `--il-offset`.** Reached through `@Metadata`, `Metadata: Heap` is silently dropped when there is no coordinate — a category selection asks for whatever applies. Named *exactly*, it is an error naming the missing carrier.
- **`mdi` behavior change:** the ~40-line coordinate parser is promoted into `DotnetInspector.MetadataRendering` so both tools share one grammar, and heap names now render as ECMA-335 stream names (`#Strings`, not `String`). That makes a rendered cell paste back as a `--heap` coordinate. Four rendering-test expectations updated.

## Evidence

New gates in `MetadataLensTests.cs`: coordinate rendering, spelling/radix equivalence through the command surface, the discoverability property, the without-carrier rejection *and* its category-door negative case, three malformed-coordinate diagnostics, the three coverage behaviors, and heap listings joining the `-v:d` / `-S @All` disclosure gate.

`MetadataLens_HeapSection_IsDiscoverableOnlyWithItsCoordinate` asserts both directions in one test because either alone passes trivially. Measured non-vacuous by mutation, rebuilding the test project each time:

| Mutation | Result |
| --- | --- |
| `IsApplicable = static model => true` | FAIL — `Assert.DoesNotContain() Failure: Item found in collection` |
| `IsApplicable = static model => false` | FAIL — `Assert.Contains() Failure: Item not found in collection` |
| restored | PASS |

Suites, Release, rebased onto `e1b3cac9`:

| Suite | Result |
| --- | --- |
| `src/dotnet-inspect.Tests` | 2476 total, 2 failed |
| `tests/ILInspector.Metadata.Tests` | 998, 0 failed |
| `tests/DotnetInspector.MetadataRendering.Tests` | 111, 0 failed |

The two failures are `Package_DeclaredNonMarkdownReadme_IsStillNotMarkdown(readmePath: "images/logo.png.")` and `Layout_Count_CountsFilesRatherThanRenderedTreeLines`. Both are **pre-existing**: confirmed reproducing in a clean detached worktree at unmodified `origin/main` (`3d0f7efd`), deterministically and in isolation. Windows-only; they pass in ubuntu CI.

## Docs

`docs/design/metadata-table-projection.md` moves the heap carrier from "designed, not yet implemented" to implemented and gains a **Heaps are not tables** section recording the coverage decision. `docs/design/output-shapes.md` promotes `--heap` from "the designed second" carrier currency to the second. `README.md` gains a **Heaps** subsection.