### PR TITLE
Normalize synthesized-member ordinals in the compile-back fidelity oracle

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -797,14 +797,21 @@ public class CorpusSensorComparisonTests
         Assert.Same(fidelityDiff, aligned.FidelityDiff);
     }
 
+    /// <summary>
+    /// Contract V1 must compose every declared <see cref="IlBodyDiffNormalization"/>
+    /// option. The enforcement set is derived from the enum rather than restated,
+    /// so a newly declared option fails here until someone decides explicitly
+    /// whether the compile-back oracle should apply it — a stale entry and a
+    /// missing entry both fail, instead of the pin silently drifting.
+    /// </summary>
     [Fact]
     public void FidelityContractV1_ComposesAllIlBodyNormalizations()
     {
-        Assert.Equal(
-            IlBodyDiffNormalization.NormalizeVariableLayout
-            | IlBodyDiffNormalization.NormalizeCurrentAssemblyScope
-            | IlBodyDiffNormalization.NormalizePlatformAssemblyScope,
-            FidelityCheck.ContractV1BodyDiffNormalization);
+        IlBodyDiffNormalization allDeclared = Enum.GetValues<IlBodyDiffNormalization>()
+            .Where(option => option != IlBodyDiffNormalization.None)
+            .Aggregate(IlBodyDiffNormalization.None, (all, option) => all | option);
+
+        Assert.Equal(FidelityCheck.ContractV1BodyDiffNormalization, allDeclared);
     }
 
     [Fact]

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -13,11 +13,23 @@ public class IlBodyDiffNormalizationTests
         Enum.GetValues<IlBodyDiffNormalization>()
             .Aggregate(IlBodyDiffNormalization.None, (all, option) => all | option);
 
+    /// <summary>
+    /// Every declared option must be accepted by <see cref="IlBodyDiff.Compare"/>,
+    /// which rejects any flag outside its internal <c>SupportedNormalizations</c>
+    /// mask. This is the wiring gate: declaring an enum member without adding it
+    /// to that mask makes every caller that requests it throw, and this fails
+    /// rather than letting the gap surface at a call site.
+    /// </summary>
     [Fact]
-    public void AllNormalizations_CoversEveryDeclaredOption()
+    public void EveryDeclaredNormalization_IsAcceptedByCompare()
     {
+        var body = Decode([0x2a]); // ret
+
         foreach (var option in Enum.GetValues<IlBodyDiffNormalization>())
-            Assert.Equal(option, AllNormalizations & option);
+        {
+            var result = Record.Exception(() => IlBodyDiff.Compare(body, body, option));
+            Assert.True(result is null, $"{option} was rejected by Compare: {result?.Message}");
+            }
     }
 
     [Fact]
@@ -214,6 +226,9 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<>9__103_0", "<>9__128_0")]                          // lambda cache field
     [InlineData("<Run>b__103_0", "<Run>b__128_0")]                    // lambda method
     [InlineData("<Run>g__Local|103_0", "<Run>g__Local|128_0")]        // local function
+    [InlineData("<.ctor>b__103_0", "<.ctor>b__128_0")]                // lambda in a constructor
+    [InlineData("<Run>g__A__B|103_0", "<Run>g__A__B|128_0")]          // local name containing `__`
+    [InlineData("<<Run>b__103_0>b__104_1", "<<Run>b__128_0>b__129_1")] // lambda nested in a lambda
     public void NormalizeSynthesizedMemberOrdinals_ToleratesContainingMethodRenumbering(
         string oldName,
         string newName)
@@ -238,6 +253,10 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<Run>g__Local|103_0", "<Run>g__Other|103_0")]  // different local function
     [InlineData("<Run>d__103", "<Run>d__128")]                  // state machine: not normalized
     [InlineData("Grab__103_0", "Grab__128_0")]                  // authored name, not synthesized
+    [InlineData("<b__1_0>b__103_0", "<b__2_0>b__128_0")]        // authored enclosing name that looks synthesized
+    [InlineData("<Run>c__DisplayClass103_0", "<Run>c__DisplayClass128_0")] // display class: not normalized
+    [InlineData("<Run>b__103_0_extra", "<Run>b__128_0_extra")]  // trailing text: not a closure name
+    [InlineData("<Run>g__Local|103_0x", "<Run>g__Local|128_0x")] // trailing text after a local function
     public void NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent(
         string oldName,
         string newName)

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -7,10 +7,18 @@ namespace ILInspector.Instructions.Tests;
 
 public class IlBodyDiffNormalizationTests
 {
-    const IlBodyDiffNormalization AllNormalizations =
-        IlBodyDiffNormalization.NormalizeVariableLayout
-        | IlBodyDiffNormalization.NormalizeCurrentAssemblyScope
-        | IlBodyDiffNormalization.NormalizePlatformAssemblyScope;
+    // Derived from the enum rather than restated, so a normalization added
+    // without coverage here still flows into every AllNormalizations test.
+    static readonly IlBodyDiffNormalization AllNormalizations =
+        Enum.GetValues<IlBodyDiffNormalization>()
+            .Aggregate(IlBodyDiffNormalization.None, (all, option) => all | option);
+
+    [Fact]
+    public void AllNormalizations_CoversEveryDeclaredOption()
+    {
+        foreach (var option in Enum.GetValues<IlBodyDiffNormalization>())
+            Assert.Equal(option, AllNormalizations & option);
+    }
 
     [Fact]
     public void NormalizeVariableLayout_ToleratesLocalMacroAndSlotLayout()
@@ -195,6 +203,62 @@ public class IlBodyDiffNormalizationTests
             AllNormalizations).IsExact);
     }
 
+    /// <summary>
+    /// The gate for #3503. ``StatementBodyLambdaInsideIf`` failed
+    /// <c>FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket</c> with
+    /// identical opcodes and only <c>&lt;&gt;9__103_0</c> vs
+    /// <c>&lt;&gt;9__128_0</c> differing, because recompiling a reconstructed
+    /// unit renumbers the containing method.
+    /// </summary>
+    [Theory]
+    [InlineData("<>9__103_0", "<>9__128_0")]                          // lambda cache field
+    [InlineData("<Run>b__103_0", "<Run>b__128_0")]                    // lambda method
+    [InlineData("<Run>g__Local|103_0", "<Run>g__Local|128_0")]        // local function
+    public void NormalizeSynthesizedMemberOrdinals_ToleratesContainingMethodRenumbering(
+        string oldName,
+        string newName)
+    {
+        Assert.False(CompareMemberNames(oldName, newName).IsExact);
+        Assert.True(CompareMemberNames(
+            oldName,
+            newName,
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    /// <summary>
+    /// The negative half of #3503: only the containing-method ordinal is
+    /// non-evidence. Every other component of a closure name still identifies
+    /// which lambda a body binds to, so a real mis-binding must keep diffing.
+    /// State-machine names are a documented non-goal — their ordinal is their
+    /// only distinguishing component.
+    /// </summary>
+    [Theory]
+    [InlineData("<Run>b__103_0", "<Run>b__103_1")]              // different lambda in the same method
+    [InlineData("<Run>b__103_0", "<Walk>b__103_0")]             // different containing method
+    [InlineData("<Run>g__Local|103_0", "<Run>g__Other|103_0")]  // different local function
+    [InlineData("<Run>d__103", "<Run>d__128")]                  // state machine: not normalized
+    [InlineData("Grab__103_0", "Grab__128_0")]                  // authored name, not synthesized
+    public void NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent(
+        string oldName,
+        string newName)
+    {
+        Assert.False(CompareMemberNames(
+            oldName,
+            newName,
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_PreservesSynthesizedLikeStringLiterals()
+    {
+        var diff = CompareImages(
+            BuildStringImage("Old", "<>9__103_0"),
+            BuildStringImage("New", "<>9__128_0"),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals);
+
+        Assert.False(diff.IsExact);
+    }
+
     [Fact]
     public void Compare_RejectsUndefinedOptions()
     {
@@ -203,6 +267,15 @@ public class IlBodyDiffNormalizationTests
         Assert.Throws<ArgumentOutOfRangeException>(
             () => IlBodyDiff.Compare(body, body, (IlBodyDiffNormalization)(1 << 10)));
     }
+
+    static IlBodyDiffResult CompareMemberNames(
+        string oldMemberName,
+        string newMemberName,
+        IlBodyDiffNormalization normalization = IlBodyDiffNormalization.None)
+        => CompareImages(
+            BuildCallImage("Same", "Library.Probe", oldMemberName),
+            BuildCallImage("Same", "Library.Probe", newMemberName),
+            normalization);
 
     static MethodInstructions Decode(byte[] il)
         => MethodInstructions.Decode(il, il.Length, exceptionRegions: []);
@@ -237,7 +310,10 @@ public class IlBodyDiffNormalizationTests
             normalization: normalization).Diff;
     }
 
-    static byte[] BuildCallImage(string assemblyName, string? referenceAssemblyName = null)
+    static byte[] BuildCallImage(
+        string assemblyName,
+        string? referenceAssemblyName = null,
+        string? memberName = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -274,7 +350,7 @@ public class IlBodyDiffNormalizationTests
                 metadata.GetOrAddString(selfReference ? "C" : "Probe"));
             target = metadata.AddMemberReference(
                 type,
-                metadata.GetOrAddString(selfReference ? "Caller" : "Target"),
+                metadata.GetOrAddString(memberName ?? (selfReference ? "Caller" : "Target")),
                 metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }));
         }
 

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -229,7 +229,7 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<.ctor>b__103_0", "<.ctor>b__128_0")]                // lambda in a constructor
     [InlineData("<Run>g__A__B|103_0", "<Run>g__A__B|128_0")]          // local name containing `__`
     [InlineData("<<Run>b__103_0>b__104_1", "<<Run>b__128_0>b__129_1")] // lambda nested in a lambda
-    [InlineData("<<Run>b__103_0>d__1", "<<Run>b__128_0>d__1")]        // async lambda: outer state machine is declined, inner still normalizes
+    [InlineData("<<Run>b__103_0>d__1", "<<Run>b__128_0>d__1")]        // enclosing name declined, inner still normalizes
     public void NormalizeSynthesizedMemberOrdinals_ToleratesContainingMethodRenumbering(
         string oldName,
         string newName)
@@ -264,7 +264,13 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<Run>b__103_0_extra", "<Run>b__128_0_extra")]  // trailing text: not a closure name
     [InlineData("<Run>g__Local|103_0x", "<Run>g__Local|128_0x")] // trailing text after a local function
     [InlineData("<Run>b__103_0$x", "<Run>b__128_0$x")]          // trailing `$`, which some producers emit
-    [InlineData("<Run>b__103_0\u00e9", "<Run>b__128_0\u00e9")]  // trailing non-ASCII identifier character
+    [InlineData("<Run>b__103_0\u00e9", "<Run>b__128_0\u00e9")]  // trailing letter (Lu/Ll)
+    [InlineData("<Run>b__103_0\u16ee", "<Run>b__128_0\u16ee")]  // trailing letter number (Nl)
+    [InlineData("<Run>b__103_0\u0301", "<Run>b__128_0\u0301")]  // trailing combining mark (Mn)
+    [InlineData("<Run>b__103_0\u0903", "<Run>b__128_0\u0903")]  // trailing combining mark (Mc)
+    [InlineData("<Run>b__103_0\u203f", "<Run>b__128_0\u203f")]  // trailing connector punctuation (Pc)
+    [InlineData("<Run>b__103_0\u200c", "<Run>b__128_0\u200c")]  // trailing format character (Cf)
+    [InlineData("<Run>b__103_0\U00010400", "<Run>b__128_0\U00010400")] // trailing supplementary-plane letter
     public void NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent(
         string oldName,
         string newName)
@@ -328,6 +334,62 @@ public class IlBodyDiffNormalizationTests
         Assert.False(diff.IsExact);
     }
 
+    /// <summary>
+    /// The option is scoped to a member's simple name, so a type operand keeps
+    /// its ordinal even when the type name is spelled like a closure. Applying
+    /// the rewrite to the formatted operand string instead would let it reach
+    /// declaring types, parameter types, and generic arguments, collapsing
+    /// references to genuinely distinct types.
+    /// </summary>
+    [Theory]
+    [InlineData("<Run>b__103_0", "<Run>b__128_0")]
+    [InlineData("<>9__103_0", "<>9__128_0")]
+    [InlineData("<>c__DisplayClass103_0", "<>c__DisplayClass128_0")]
+    public void NormalizeSynthesizedMemberOrdinals_LeavesTypeOperandsAlone(
+        string oldTypeName,
+        string newTypeName)
+    {
+        Assert.False(CompareDeclaringTypeNames(
+            oldTypeName,
+            newTypeName,
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    /// <summary>
+    /// Each candidate <c>&lt;</c> starts its own forward scan for the <c>&gt;</c>
+    /// that closes it, so a name built from unbalanced <c>&lt;</c> characters
+    /// costs O(n²) without a budget. Member names come from untrusted metadata
+    /// and the threat model requires CPU amplification to be bounded
+    /// (docs/design/untrusted-data-threat-model.md). This pins the budget's
+    /// observable behavior instead of its timing: a closure name buried behind
+    /// a few unbalanced <c>&lt;</c> characters still normalizes, and one buried
+    /// behind enough of them to exhaust the budget is declined rather than
+    /// scanned. Declining can only cost a false positive, never a masked
+    /// difference.
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_BoundsScanWorkOnUnbalancedNames()
+    {
+        Assert.True(CompareMemberNames(
+            Buried(unbalanced: 4, ordinal: 103),
+            Buried(unbalanced: 4, ordinal: 128),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "Within the scan budget a buried closure name must still normalize.");
+
+        Assert.False(CompareMemberNames(
+            Buried(unbalanced: 200, ordinal: 103),
+            Buried(unbalanced: 200, ordinal: 128),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "Past the scan budget the name must be declined rather than scanned quadratically.");
+    }
+
+    /// <summary>
+    /// A closure name preceded by <paramref name="unbalanced"/> <c>&lt;</c>
+    /// characters that never close, each of which starts its own failing scan.
+    /// </summary>
+    static string Buried(int unbalanced, int ordinal)
+        => new string('<', unbalanced) + $"<Run>b__{ordinal}_0";
+
     [Fact]
     public void Compare_RejectsUndefinedOptions()
     {
@@ -344,6 +406,15 @@ public class IlBodyDiffNormalizationTests
         => CompareImages(
             BuildCallImage("Same", "Library.Probe", oldMemberName),
             BuildCallImage("Same", "Library.Probe", newMemberName),
+            normalization);
+
+    static IlBodyDiffResult CompareDeclaringTypeNames(
+        string oldTypeName,
+        string newTypeName,
+        IlBodyDiffNormalization normalization = IlBodyDiffNormalization.None)
+        => CompareImages(
+            BuildCallImage("Same", "Library.Probe", "Target", oldTypeName),
+            BuildCallImage("Same", "Library.Probe", "Target", newTypeName),
             normalization);
 
     static MethodInstructions Decode(byte[] il)
@@ -382,7 +453,8 @@ public class IlBodyDiffNormalizationTests
     static byte[] BuildCallImage(
         string assemblyName,
         string? referenceAssemblyName = null,
-        string? memberName = null)
+        string? memberName = null,
+        string? typeName = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -416,7 +488,7 @@ public class IlBodyDiffNormalizationTests
             var type = metadata.AddTypeReference(
                 reference,
                 selfReference ? default : metadata.GetOrAddString("System"),
-                metadata.GetOrAddString(selfReference ? "C" : "Probe"));
+                metadata.GetOrAddString(typeName ?? (selfReference ? "C" : "Probe")));
             target = metadata.AddMemberReference(
                 type,
                 metadata.GetOrAddString(memberName ?? (selfReference ? "Caller" : "Target")),

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -288,6 +288,30 @@ public class IlBodyDiffNormalizationTests
     }
 
     /// <summary>
+    /// The cache form carries no containing-method name — Roslyn spells it
+    /// <c>&lt;&gt;9__N_M</c>, with nothing between the angle brackets. A field
+    /// whose name puts a containing method in front of the <c>9</c> is not a
+    /// form any compiler emits, so it must keep comparing literally.
+    /// <para>
+    /// This is the field half of the containing-name correspondence. The
+    /// method half — a <c>b</c> or <c>g</c> form with an empty containing
+    /// name, such as <c>&lt;&gt;b__103_0</c> — is gated by
+    /// <c>NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent</c>.
+    /// The two halves need separate gates because the single predicate that
+    /// enforces both can be broken one direction at a time: removing only the
+    /// field half leaves every other test green.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_RejectsACacheFormWithAContainingName()
+    {
+        Assert.False(CompareFieldNames(
+            "<Run>9__103_0",
+            "<Run>9__128_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    /// <summary>
     /// The cache form's ordinals must be canonical too. Checked separately
     /// from the method forms because <c>&lt;&gt;9__N_M</c> only ever reaches
     /// the field paths.

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -229,6 +229,7 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<.ctor>b__103_0", "<.ctor>b__128_0")]                // lambda in a constructor
     [InlineData("<Run>g__A__B|103_0", "<Run>g__A__B|128_0")]          // local name containing `__`
     [InlineData("<<Run>b__103_0>b__104_1", "<<Run>b__128_0>b__129_1")] // lambda nested in a lambda
+    [InlineData("<<Run>b__103_0>d__1", "<<Run>b__128_0>d__1")]        // async lambda: outer state machine is declined, inner still normalizes
     public void NormalizeSynthesizedMemberOrdinals_ToleratesContainingMethodRenumbering(
         string oldName,
         string newName)
@@ -244,8 +245,13 @@ public class IlBodyDiffNormalizationTests
     /// The negative half of #3503: only the containing-method ordinal is
     /// non-evidence. Every other component of a closure name still identifies
     /// which lambda a body binds to, so a real mis-binding must keep diffing.
-    /// State-machine names are a documented non-goal — their ordinal is their
-    /// only distinguishing component.
+    /// Two forms are documented limitations rather than desired outcomes:
+    /// state-machine names (<c>&lt;Name&gt;d__N</c>), whose ordinal is their
+    /// only distinguishing component, and display classes
+    /// (<c>&lt;&gt;c__DisplayClassN_M</c>), which do carry the same
+    /// compilation-unit ordinal and so can still produce a false positive for
+    /// a capturing lambda. Widening to display classes is deliberately out of
+    /// scope here; the corpus has no remaining row that needs it.
     /// </summary>
     [Theory]
     [InlineData("<Run>b__103_0", "<Run>b__103_1")]              // different lambda in the same method
@@ -254,7 +260,7 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<Run>d__103", "<Run>d__128")]                  // state machine: not normalized
     [InlineData("Grab__103_0", "Grab__128_0")]                  // authored name, not synthesized
     [InlineData("<b__1_0>b__103_0", "<b__2_0>b__128_0")]        // authored enclosing name that looks synthesized
-    [InlineData("<Run>c__DisplayClass103_0", "<Run>c__DisplayClass128_0")] // display class: not normalized
+    [InlineData("<>c__DisplayClass103_0", "<>c__DisplayClass128_0")] // display class: known limitation, see remarks
     [InlineData("<Run>b__103_0_extra", "<Run>b__128_0_extra")]  // trailing text: not a closure name
     [InlineData("<Run>g__Local|103_0x", "<Run>g__Local|128_0x")] // trailing text after a local function
     public void NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent(

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -263,6 +263,8 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<>c__DisplayClass103_0", "<>c__DisplayClass128_0")] // display class: known limitation, see remarks
     [InlineData("<Run>b__103_0_extra", "<Run>b__128_0_extra")]  // trailing text: not a closure name
     [InlineData("<Run>g__Local|103_0x", "<Run>g__Local|128_0x")] // trailing text after a local function
+    [InlineData("<Run>b__103_0$x", "<Run>b__128_0$x")]          // trailing `$`, which some producers emit
+    [InlineData("<Run>b__103_0\u00e9", "<Run>b__128_0\u00e9")]  // trailing non-ASCII identifier character
     public void NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent(
         string oldName,
         string newName)

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -490,6 +490,102 @@ public class IlBodyDiffNormalizationTests
             BuildCallImage("Same", "Library.Probe", newMemberName),
             normalization);
 
+    /// <summary>
+    /// The kind check must hold on <em>every</em> member-reference path, not
+    /// only the direct ones. A <c>MethodSpecification</c> can name a
+    /// <c>MemberReference</c> that is actually a field — malformed, but a
+    /// shape untrusted metadata can carry — and the generic-instantiation
+    /// formatter reaches the name through its own code path. Without a kind
+    /// check there, a method-form name on a field normalizes and two
+    /// unrelated members collapse.
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_RejectsAMethodFormBehindAMethodSpecificationOnAField()
+    {
+        Assert.False(CompareImages(
+            BuildMethodSpecificationOverFieldReferenceImage("Same", "<Run>b__103_0"),
+            BuildMethodSpecificationOverFieldReferenceImage("Same", "<Run>b__128_0"),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    /// <summary>
+    /// Builds a body whose call target is a <c>MethodSpecification</c> naming
+    /// a <c>MemberReference</c> that carries a <em>field</em> signature.
+    /// </summary>
+    static byte[] BuildMethodSpecificationOverFieldReferenceImage(string assemblyName, string memberName)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString($"{assemblyName}.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(assemblyName),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        var reference = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Library.Probe"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        var type = metadata.AddTypeReference(
+            reference,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Probe"));
+        var fieldReference = metadata.AddMemberReference(
+            type,
+            metadata.GetOrAddString(memberName),
+            metadata.GetOrAddBlob(new byte[] { 0x06, 0x08 }));
+        var spec = metadata.AddMethodSpecification(
+            fieldReference,
+            metadata.GetOrAddBlob(new byte[] { 0x0a, 0x01, 0x08 }));
+
+        metadata.AddTypeDefinition(
+            TypeAttributes.NotPublic,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed,
+            default,
+            metadata.GetOrAddString("C"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var il = new BlobBuilder();
+        var encoder = new InstructionEncoder(il, new ControlFlowBuilder());
+        encoder.Call(spec);
+        encoder.OpCode(ILOpCode.Ret);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = new MethodBodyStreamEncoder(methodBodies).AddMethodBody(encoder);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Caller"),
+            metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }),
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
     static IlBodyDiffResult CompareFieldNames(
         string oldMemberName,
         string newMemberName,

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -299,6 +299,11 @@ public class IlBodyDiffNormalizationTests
             "<>9__0103_0",
             "<>9__0128_0",
             IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+
+        Assert.False(CompareFieldNames(
+            "<>9__2147483648_0",
+            "<>9__2147483649_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
     }
 
     /// <summary>
@@ -341,7 +346,9 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<Run>b__103_00", "<Run>b__128_00")]              // leading zero in the per-method index
     [InlineData(
         "<Run>b__000000000000000000000000000103_0",
-        "<Run>b__000000000000000000000000000128_0")]              // ordinal wider than `int`
+        "<Run>b__000000000000000000000000000128_0")]              // padded ordinal
+    [InlineData("<Run>b__2147483648_0", "<Run>b__2147483649_0")]  // ordinal past int.MaxValue, no leading zero
+    [InlineData("<Run>b__103_2147483648", "<Run>b__128_2147483648")] // per-method index past int.MaxValue
     public void NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent(
         string oldName,
         string newName)

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -223,7 +223,6 @@ public class IlBodyDiffNormalizationTests
     /// unit renumbers the containing method.
     /// </summary>
     [Theory]
-    [InlineData("<>9__103_0", "<>9__128_0")]                          // lambda cache field
     [InlineData("<Run>b__103_0", "<Run>b__128_0")]                    // lambda method
     [InlineData("<Run>g__Local|103_0", "<Run>g__Local|128_0")]        // local function
     [InlineData("<.ctor>b__103_0", "<.ctor>b__128_0")]                // lambda in a constructor
@@ -237,6 +236,68 @@ public class IlBodyDiffNormalizationTests
         Assert.True(CompareMemberNames(
             oldName,
             newName,
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    /// <summary>
+    /// The cache-field half of #3503. <c>&lt;&gt;9__N_M</c> is a field, so it
+    /// reaches the formatter through the field paths rather than the call
+    /// paths and needs its own gate — the ``StatementBodyLambdaInsideIf`` row
+    /// diffed on exactly this name.
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_ToleratesRenumberingOfALambdaCacheField()
+    {
+        Assert.False(CompareFieldNames("<>9__103_0", "<>9__128_0").IsExact);
+        Assert.True(CompareFieldNames(
+            "<>9__103_0",
+            "<>9__128_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    /// <summary>
+    /// Roslyn emits the cache form only as a field and the lambda and
+    /// local-function forms only as methods. A name that carries one form on
+    /// the other metadata table did not come from C#, so relating its ordinals
+    /// would equate two members that nothing else relates.
+    /// </summary>
+    [Theory]
+    [InlineData("<>9__103_0", "<>9__128_0")]                    // cache form on a method
+    public void NormalizeSynthesizedMemberOrdinals_RejectsAFieldFormOnAMethod(
+        string oldName,
+        string newName)
+    {
+        Assert.False(CompareMemberNames(
+            oldName,
+            newName,
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    /// <inheritdoc cref="NormalizeSynthesizedMemberOrdinals_RejectsAFieldFormOnAMethod"/>
+    [Theory]
+    [InlineData("<Run>b__103_0", "<Run>b__128_0")]              // lambda form on a field
+    [InlineData("<Run>g__Local|103_0", "<Run>g__Local|128_0")]  // local-function form on a field
+    public void NormalizeSynthesizedMemberOrdinals_RejectsAMethodFormOnAField(
+        string oldName,
+        string newName)
+    {
+        Assert.False(CompareFieldNames(
+            oldName,
+            newName,
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    /// <summary>
+    /// The cache form's ordinals must be canonical too. Checked separately
+    /// from the method forms because <c>&lt;&gt;9__N_M</c> only ever reaches
+    /// the field paths.
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_RejectsANonCanonicalCacheFieldOrdinal()
+    {
+        Assert.False(CompareFieldNames(
+            "<>9__0103_0",
+            "<>9__0128_0",
             IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
     }
 
@@ -276,6 +337,11 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<>b__103_0", "<>b__128_0")]                      // empty containing method with a lambda marker
     [InlineData("<Run>g__|103_0", "<Run>g__|128_0")]              // empty local function name
     [InlineData("<<Run>b__103_0>d__1", "<<Run>b__128_0>d__1")]    // state machine of an async lambda: a type name
+    [InlineData("<Run>b__0103_0", "<Run>b__0128_0")]              // leading zero: not how Roslyn spells an ordinal
+    [InlineData("<Run>b__103_00", "<Run>b__128_00")]              // leading zero in the per-method index
+    [InlineData(
+        "<Run>b__000000000000000000000000000103_0",
+        "<Run>b__000000000000000000000000000128_0")]              // ordinal wider than `int`
     public void NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent(
         string oldName,
         string newName)
@@ -424,6 +490,15 @@ public class IlBodyDiffNormalizationTests
             BuildCallImage("Same", "Library.Probe", newMemberName),
             normalization);
 
+    static IlBodyDiffResult CompareFieldNames(
+        string oldMemberName,
+        string newMemberName,
+        IlBodyDiffNormalization normalization = IlBodyDiffNormalization.None)
+        => CompareImages(
+            BuildFieldImage("Same", "Library.Probe", oldMemberName),
+            BuildFieldImage("Same", "Library.Probe", newMemberName),
+            normalization);
+
     static IlBodyDiffResult CompareDeclaringTypeNames(
         string oldTypeName,
         string newTypeName,
@@ -471,6 +546,26 @@ public class IlBodyDiffNormalizationTests
         string? referenceAssemblyName = null,
         string? memberName = null,
         string? typeName = null)
+        => BuildMemberImage(assemblyName, referenceAssemblyName, memberName, typeName, asField: false);
+
+    /// <summary>
+    /// The field counterpart of <see cref="BuildCallImage"/>: the body loads a
+    /// static field through a <c>MemberReference</c> rather than calling a
+    /// method, so a name reaches the formatter as a <em>field</em> name.
+    /// </summary>
+    static byte[] BuildFieldImage(
+        string assemblyName,
+        string? referenceAssemblyName = null,
+        string? memberName = null,
+        string? typeName = null)
+        => BuildMemberImage(assemblyName, referenceAssemblyName, memberName, typeName, asField: true);
+
+    static byte[] BuildMemberImage(
+        string assemblyName,
+        string? referenceAssemblyName,
+        string? memberName,
+        string? typeName,
+        bool asField)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -489,7 +584,9 @@ public class IlBodyDiffNormalizationTests
         EntityHandle target;
         if (referenceAssemblyName is null)
         {
-            target = MetadataTokens.MethodDefinitionHandle(1);
+            target = asField
+                ? MetadataTokens.FieldDefinitionHandle(1)
+                : MetadataTokens.MethodDefinitionHandle(1);
         }
         else
         {
@@ -508,7 +605,9 @@ public class IlBodyDiffNormalizationTests
             target = metadata.AddMemberReference(
                 type,
                 metadata.GetOrAddString(memberName ?? (selfReference ? "Caller" : "Target")),
-                metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }));
+                metadata.GetOrAddBlob(asField
+                    ? new byte[] { 0x06, 0x08 }
+                    : new byte[] { 0x00, 0x00, 0x01 }));
         }
 
         metadata.AddTypeDefinition(
@@ -528,7 +627,17 @@ public class IlBodyDiffNormalizationTests
 
         var il = new BlobBuilder();
         var encoder = new InstructionEncoder(il, new ControlFlowBuilder());
-        encoder.Call(target);
+        if (asField)
+        {
+            encoder.OpCode(ILOpCode.Ldsfld);
+            encoder.Token(target);
+            encoder.OpCode(ILOpCode.Pop);
+        }
+        else
+        {
+            encoder.Call(target);
+        }
+
         encoder.OpCode(ILOpCode.Ret);
         var methodBodies = new BlobBuilder();
         int bodyOffset = new MethodBodyStreamEncoder(methodBodies).AddMethodBody(encoder);

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -267,6 +267,48 @@ public class IlBodyDiffNormalizationTests
             IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
     }
 
+    /// <summary>
+    /// Member names come from untrusted metadata, and the threat model
+    /// requires recursion over hostile input to be bounded
+    /// (docs/design/untrusted-data-threat-model.md), so the enclosing-name
+    /// recursion stops at <c>MaxNestingDepth</c> (16). This pins the
+    /// boundary's observable behavior: an ordinal nested within the cap is
+    /// still normalized, and one nested past it stays literal. Degrading to
+    /// literal can only cost a false positive, never a masked difference.
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_StopsNormalizingPastTheNestingCap()
+    {
+        Assert.True(CompareMemberNames(
+            Nest(depth: 20, differingLevel: 0),
+            Nest(depth: 20, differingLevel: 0, shift: 500),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "The outermost ordinal is within the cap and must still normalize.");
+
+        Assert.False(CompareMemberNames(
+            Nest(depth: 20, differingLevel: 19),
+            Nest(depth: 20, differingLevel: 19, shift: 500),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "An ordinal nested past the cap must stay literal rather than silently comparing equal.");
+    }
+
+    /// <summary>
+    /// Builds a name nested <paramref name="depth"/> levels deep where only
+    /// the ordinal at <paramref name="differingLevel"/> (counted from the
+    /// outermost) is moved by <paramref name="shift"/>.
+    /// </summary>
+    static string Nest(int depth, int differingLevel, int shift = 0)
+    {
+        string name = "Run";
+        for (int level = depth - 1; level >= 0; level--)
+        {
+            int ordinal = 100 + (level == differingLevel ? shift : 0);
+            name = $"<{name}>b__{ordinal}_0";
+        }
+
+        return name;
+    }
+
     [Fact]
     public void NormalizeSynthesizedMemberOrdinals_PreservesSynthesizedLikeStringLiterals()
     {

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -381,12 +381,6 @@ public class IlBodyDiffNormalizationTests
             "<<Inner>b__#_0>b__103_0",
             IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
             "A placeholder the recursion introduces must not collapse onto a literal one at the same position.");
-
-        Assert.False(CompareMemberNames(
-            "<<In#er>b__5_0>b__103_0",
-            "<<In#er>b__#_0>b__103_0",
-            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
-            "A literal placeholder in a nested containing name must not let the recursion's placeholder collide either.");
     }
 
     /// <summary>

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -309,6 +309,55 @@ public class IlBodyDiffNormalizationTests
             "<Run>9__103_0",
             "<Run>9__128_0",
             IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+
+        // The one-character containing name is the boundary of `close > 1`.
+        // Widening that to `close > 2` reads `<A>9__103_0` as having no
+        // containing name at all, and the multi-character case above stays
+        // green, so only this case pins it.
+        Assert.False(CompareFieldNames(
+            "<A>9__103_0",
+            "<A>9__128_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact);
+    }
+
+    /// <summary>
+    /// Normalization introduces <c>#</c> as the ordinal placeholder, and
+    /// member names come from untrusted metadata that may already contain
+    /// one. Without escaping, <c>&lt;Run&gt;b__103_0</c> normalizes to
+    /// <c>&lt;Run&gt;b__#_0</c> — a legal metadata name that matches no
+    /// recognized form and so passes through unchanged — and the two compare
+    /// equal despite naming different members. That is a masked difference,
+    /// the one outcome this option must never produce.
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_DoesNotCollideWithALiteralPlaceholder()
+    {
+        Assert.False(CompareMemberNames(
+            "<Run>b__103_0",
+            "<Run>b__#_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "A real closure name must not collapse onto a literal name spelled with the placeholder.");
+
+        Assert.False(CompareFieldNames(
+            "<>9__103_0",
+            "<>9__#_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "The cache field form must not collapse onto a literal placeholder name either.");
+
+        // Escaping must stay injective: two literal names that differ only in
+        // how many placeholders they carry must keep differing.
+        Assert.False(CompareMemberNames(
+            "<Run>b__#_0",
+            "<Run>b__##_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "Escaping must not relate two literal names that differ only in placeholder count.");
+
+        // And it must not disturb the collapse the option exists to make.
+        Assert.True(CompareMemberNames(
+            "<Run>b__103_0",
+            "<Run>b__128_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "Escaping must leave the intended renumbering collapse intact.");
     }
 
     /// <summary>
@@ -365,6 +414,11 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<<Run>b__103_0", "<<Run>b__128_0")]              // buried behind an unbalanced `<`
     [InlineData("<>b__103_0", "<>b__128_0")]                      // empty containing method with a lambda marker
     [InlineData("<>g__Local|103_0", "<>g__Local|128_0")]          // empty containing method with a local-function marker
+    [InlineData("<>h__103_0", "<>h__128_0")]                      // marker adjacent to the accepted set
+    [InlineData("<A__B>b-_103_0", "<A__B>b-_128_0")]              // first marker separator is not '_'
+    [InlineData("<A__B>b_-103_0", "<A__B>b_-128_0")]              // second marker separator is not '_'
+    [InlineData("<Run]b__103_0", "<Run]b__128_0")]                // containing name closed by ']' rather than '>'
+    [InlineData("<Run>g__Local!103_0", "<Run>g__Local!128_0")]    // local-function ordinal separator is not '|'
     [InlineData("<Run>g__|103_0", "<Run>g__|128_0")]              // empty local function name
     [InlineData("<<Run>b__103_0>d__1", "<<Run>b__128_0>d__1")]    // state machine of an async lambda: a type name
     [InlineData("<Run>b__0103_0", "<Run>b__0128_0")]              // leading zero: not how Roslyn spells an ordinal

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -384,9 +384,9 @@ public class IlBodyDiffNormalizationTests
 
         Assert.False(CompareMemberNames(
             "<<In#er>b__5_0>b__103_0",
-            "<<In##er>b__5_0>b__103_0",
+            "<<In#er>b__#_0>b__103_0",
             IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
-            "A literal placeholder in a nested containing name must survive the recursion as evidence.");
+            "A literal placeholder in a nested containing name must not let the recursion's placeholder collide either.");
     }
 
     /// <summary>

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -390,6 +390,53 @@ public class IlBodyDiffNormalizationTests
     static string Buried(int unbalanced, int ordinal)
         => new string('<', unbalanced) + $"<Run>b__{ordinal}_0";
 
+    /// <summary>
+    /// The local function form searches forward for the <c>|</c> that
+    /// terminates the local's own name, and that search runs to the end of the
+    /// string when there is none. Charging it to the same budget as the angle
+    /// scan is what stops a name built from <c>&lt;&gt;g__.</c> repeats from
+    /// costing O(n²): those repeats close their angles immediately, so the
+    /// angle scan alone never notices them.
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_ChargesTheLocalFunctionSeparatorScan()
+    {
+        Assert.False(CompareMemberNames(
+            LocalFunctionFiller(repeats: 200, ordinal: 103),
+            LocalFunctionFiller(repeats: 200, ordinal: 128),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "A separator search that runs to the end of the string must consume the scan budget.");
+    }
+
+    /// <summary>
+    /// Budget exhaustion has to decline the whole name however it is reached.
+    /// When it happens on the last candidate in the string the scan loop just
+    /// ends, so the in-loop check never runs again; without a check after the
+    /// loop the leading closure name would stay rewritten and two names that
+    /// differ only past the exhaustion point would compare equal. These
+    /// constants were found by searching for an input the two behaviors
+    /// disagree on.
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_DeclinesWhenTheBudgetRunsOutOnTheLastCandidate()
+    {
+        Assert.False(CompareMemberNames(
+            LocalFunctionFiller(repeats: 22, ordinal: 103, trailing: 353),
+            LocalFunctionFiller(repeats: 22, ordinal: 128, trailing: 353),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "A budget exhausted on the last candidate must decline the whole name, not leave it half-rewritten.");
+    }
+
+    /// <summary>
+    /// A closure name followed by <paramref name="repeats"/> local-function
+    /// prefixes that never supply a <c>|</c>, then <paramref name="trailing"/>
+    /// characters containing no <c>&lt;</c>.
+    /// </summary>
+    static string LocalFunctionFiller(int repeats, int ordinal, int trailing = 0)
+        => $"<Run>b__{ordinal}_0"
+            + string.Concat(Enumerable.Repeat("<>g__.", repeats))
+            + new string('A', trailing);
+
     [Fact]
     public void Compare_RejectsUndefinedOptions()
     {

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -229,7 +229,6 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<.ctor>b__103_0", "<.ctor>b__128_0")]                // lambda in a constructor
     [InlineData("<Run>g__A__B|103_0", "<Run>g__A__B|128_0")]          // local name containing `__`
     [InlineData("<<Run>b__103_0>b__104_1", "<<Run>b__128_0>b__129_1")] // lambda nested in a lambda
-    [InlineData("<<Run>b__103_0>d__1", "<<Run>b__128_0>d__1")]        // enclosing name declined, inner still normalizes
     public void NormalizeSynthesizedMemberOrdinals_ToleratesContainingMethodRenumbering(
         string oldName,
         string newName)
@@ -271,6 +270,12 @@ public class IlBodyDiffNormalizationTests
     [InlineData("<Run>b__103_0\u203f", "<Run>b__128_0\u203f")]  // trailing connector punctuation (Pc)
     [InlineData("<Run>b__103_0\u200c", "<Run>b__128_0\u200c")]  // trailing format character (Cf)
     [InlineData("<Run>b__103_0\U00010400", "<Run>b__128_0\U00010400")] // trailing supplementary-plane letter
+    [InlineData("<Run>b__103_0!suffix", "<Run>b__128_0!suffix")]  // trailing text after a non-identifier char
+    [InlineData("x!<Run>b__103_0", "x!<Run>b__128_0")]            // synthesized form buried after leading text
+    [InlineData("<<Run>b__103_0", "<<Run>b__128_0")]              // buried behind an unbalanced `<`
+    [InlineData("<>b__103_0", "<>b__128_0")]                      // empty containing method with a lambda marker
+    [InlineData("<Run>g__|103_0", "<Run>g__|128_0")]              // empty local function name
+    [InlineData("<<Run>b__103_0>d__1", "<<Run>b__128_0>d__1")]    // state machine of an async lambda: a type name
     public void NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent(
         string oldName,
         string newName)
@@ -356,86 +361,50 @@ public class IlBodyDiffNormalizationTests
     }
 
     /// <summary>
-    /// Each candidate <c>&lt;</c> starts its own forward scan for the <c>&gt;</c>
-    /// that closes it, so a name built from unbalanced <c>&lt;</c> characters
-    /// costs O(n²) without a budget. Member names come from untrusted metadata
-    /// and the threat model requires CPU amplification to be bounded
-    /// (docs/design/untrusted-data-threat-model.md). This pins the budget's
-    /// observable behavior instead of its timing: a closure name buried behind
-    /// a few unbalanced <c>&lt;</c> characters still normalizes, and one buried
-    /// behind enough of them to exhaust the budget is declined rather than
-    /// scanned. Declining can only cost a false positive, never a masked
-    /// difference.
+    /// Member names come from untrusted metadata and the threat model requires
+    /// CPU amplification to be bounded
+    /// (docs/design/untrusted-data-threat-model.md). Anchoring the grammar to
+    /// the whole name is what supplies that bound: there is exactly one
+    /// candidate start, so each nesting level performs one angle scan plus at
+    /// most one separator scan over a disjoint part of the same string, and
+    /// <c>MaxNestingDepth</c> bounds the levels. Work is therefore linear in
+    /// the name's length.
     /// </summary>
+    /// <remarks>
+    /// The property is only observable as timing, because an anchored scan
+    /// declines hostile input at every size rather than changing behavior at a
+    /// threshold. The bound is deliberately loose: the shapes below are
+    /// microseconds when the scan is anchored, and were measured at 5.7 s
+    /// (unbalanced angles) and 1.4 s (local-function separators) at a quarter
+    /// of this size back when each candidate rescanned. Anything that
+    /// reintroduces a per-candidate rescan misses this bound by orders of
+    /// magnitude.
+    /// </remarks>
     [Fact]
-    public void NormalizeSynthesizedMemberOrdinals_BoundsScanWorkOnUnbalancedNames()
+    public void NormalizeSynthesizedMemberOrdinals_BoundsScanWorkOnHostileNames()
     {
-        Assert.True(CompareMemberNames(
-            Buried(unbalanced: 4, ordinal: 103),
-            Buried(unbalanced: 4, ordinal: 128),
-            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
-            "Within the scan budget a buried closure name must still normalize.");
+        string unbalanced = new string('<', 400_000) + "<Run>b__103_0";
+        string separators = "<Run>b__103_0" + string.Concat(Enumerable.Repeat("<>g__.", 64_000));
+
+        var elapsed = System.Diagnostics.Stopwatch.StartNew();
 
         Assert.False(CompareMemberNames(
-            Buried(unbalanced: 200, ordinal: 103),
-            Buried(unbalanced: 200, ordinal: 128),
+            unbalanced,
+            unbalanced.Replace("103", "128", StringComparison.Ordinal),
             IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
-            "Past the scan budget the name must be declined rather than scanned quadratically.");
-    }
+            "A name that is not entirely one of these forms must compare literally.");
 
-    /// <summary>
-    /// A closure name preceded by <paramref name="unbalanced"/> <c>&lt;</c>
-    /// characters that never close, each of which starts its own failing scan.
-    /// </summary>
-    static string Buried(int unbalanced, int ordinal)
-        => new string('<', unbalanced) + $"<Run>b__{ordinal}_0";
-
-    /// <summary>
-    /// The local function form searches forward for the <c>|</c> that
-    /// terminates the local's own name, and that search runs to the end of the
-    /// string when there is none. Charging it to the same budget as the angle
-    /// scan is what stops a name built from <c>&lt;&gt;g__.</c> repeats from
-    /// costing O(n²): those repeats close their angles immediately, so the
-    /// angle scan alone never notices them.
-    /// </summary>
-    [Fact]
-    public void NormalizeSynthesizedMemberOrdinals_ChargesTheLocalFunctionSeparatorScan()
-    {
         Assert.False(CompareMemberNames(
-            LocalFunctionFiller(repeats: 200, ordinal: 103),
-            LocalFunctionFiller(repeats: 200, ordinal: 128),
+            separators,
+            separators.Replace("103", "128", StringComparison.Ordinal),
             IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
-            "A separator search that runs to the end of the string must consume the scan budget.");
-    }
+            "A name that is not entirely one of these forms must compare literally.");
 
-    /// <summary>
-    /// Budget exhaustion has to decline the whole name however it is reached.
-    /// When it happens on the last candidate in the string the scan loop just
-    /// ends, so the in-loop check never runs again; without a check after the
-    /// loop the leading closure name would stay rewritten and two names that
-    /// differ only past the exhaustion point would compare equal. These
-    /// constants were found by searching for an input the two behaviors
-    /// disagree on.
-    /// </summary>
-    [Fact]
-    public void NormalizeSynthesizedMemberOrdinals_DeclinesWhenTheBudgetRunsOutOnTheLastCandidate()
-    {
-        Assert.False(CompareMemberNames(
-            LocalFunctionFiller(repeats: 22, ordinal: 103, trailing: 353),
-            LocalFunctionFiller(repeats: 22, ordinal: 128, trailing: 353),
-            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
-            "A budget exhausted on the last candidate must decline the whole name, not leave it half-rewritten.");
-    }
+        elapsed.Stop();
 
-    /// <summary>
-    /// A closure name followed by <paramref name="repeats"/> local-function
-    /// prefixes that never supply a <c>|</c>, then <paramref name="trailing"/>
-    /// characters containing no <c>&lt;</c>.
-    /// </summary>
-    static string LocalFunctionFiller(int repeats, int ordinal, int trailing = 0)
-        => $"<Run>b__{ordinal}_0"
-            + string.Concat(Enumerable.Repeat("<>g__.", repeats))
-            + new string('A', trailing);
+        Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(5),
+            $"Scanning hostile names must stay linear; took {elapsed.Elapsed.TotalSeconds:F1}s.");
+    }
 
     [Fact]
     public void Compare_RejectsUndefinedOptions()

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -361,6 +361,35 @@ public class IlBodyDiffNormalizationTests
     }
 
     /// <summary>
+    /// The escape runs once on the whole name, not once per level: the
+    /// recursion calls the private overload deliberately. That is what makes
+    /// the separation total rather than merely top-level — a literal
+    /// <c>#</c> anywhere, including inside a containing name several levels
+    /// down, is doubled before any level is parsed, while every placeholder a
+    /// level introduces is a lone <c>#</c> bounded by <c>_</c>. Gated apart
+    /// from
+    /// <see cref="NormalizeSynthesizedMemberOrdinals_DoesNotCollideWithALiteralPlaceholder"/>
+    /// so that neither can stand in for the other: that test's first assertion
+    /// fails on a missing escape at depth 0 and would otherwise hide whether
+    /// the nested case is checked at all.
+    /// </summary>
+    [Fact]
+    public void NormalizeSynthesizedMemberOrdinals_DoesNotCollideWithALiteralPlaceholderWhileNested()
+    {
+        Assert.False(CompareMemberNames(
+            "<<Inner>b__5_0>b__103_0",
+            "<<Inner>b__#_0>b__103_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "A placeholder the recursion introduces must not collapse onto a literal one at the same position.");
+
+        Assert.False(CompareMemberNames(
+            "<<In#er>b__5_0>b__103_0",
+            "<<In##er>b__5_0>b__103_0",
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "A literal placeholder in a nested containing name must survive the recursion as evidence.");
+    }
+
+    /// <summary>
     /// The cache form's ordinals must be canonical too. Checked separately
     /// from the method forms because <c>&lt;&gt;9__N_M</c> only ever reaches
     /// the field paths.

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -364,6 +364,7 @@ public class IlBodyDiffNormalizationTests
     [InlineData("x!<Run>b__103_0", "x!<Run>b__128_0")]            // synthesized form buried after leading text
     [InlineData("<<Run>b__103_0", "<<Run>b__128_0")]              // buried behind an unbalanced `<`
     [InlineData("<>b__103_0", "<>b__128_0")]                      // empty containing method with a lambda marker
+    [InlineData("<>g__Local|103_0", "<>g__Local|128_0")]          // empty containing method with a local-function marker
     [InlineData("<Run>g__|103_0", "<Run>g__|128_0")]              // empty local function name
     [InlineData("<<Run>b__103_0>d__1", "<<Run>b__128_0>d__1")]    // state machine of an async lambda: a type name
     [InlineData("<Run>b__0103_0", "<Run>b__0128_0")]              // leading zero: not how Roslyn spells an ordinal
@@ -394,9 +395,16 @@ public class IlBodyDiffNormalizationTests
     /// requires recursion over hostile input to be bounded
     /// (docs/design/untrusted-data-threat-model.md), so the enclosing-name
     /// recursion stops at <c>MaxNestingDepth</c> (16). This pins the
-    /// boundary's observable behavior: an ordinal nested within the cap is
-    /// still normalized, and one nested past it stays literal. Degrading to
-    /// literal can only cost a false positive, never a masked difference.
+    /// boundary's observable behavior exactly: the last level within the cap
+    /// still normalizes, and the first level past it stays literal.
+    /// Degrading to literal can only cost a false positive, never a masked
+    /// difference.
+    /// <para>
+    /// Asserting only a far-outside level (19) would not pin the boundary —
+    /// widening the cap by one still leaves such a test green. The level-16
+    /// and level-17 assertions are what make an off-by-one in the comparison
+    /// observable.
+    /// </para>
     /// </summary>
     [Fact]
     public void NormalizeSynthesizedMemberOrdinals_StopsNormalizingPastTheNestingCap()
@@ -406,6 +414,18 @@ public class IlBodyDiffNormalizationTests
             Nest(depth: 20, differingLevel: 0, shift: 500),
             IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
             "The outermost ordinal is within the cap and must still normalize.");
+
+        Assert.True(CompareMemberNames(
+            Nest(depth: 20, differingLevel: 16),
+            Nest(depth: 20, differingLevel: 16, shift: 500),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "Level 16 is the last level within the cap and must still normalize.");
+
+        Assert.False(CompareMemberNames(
+            Nest(depth: 20, differingLevel: 17),
+            Nest(depth: 20, differingLevel: 17, shift: 500),
+            IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).IsExact,
+            "Level 17 is the first level past the cap and must stay literal.");
 
         Assert.False(CompareMemberNames(
             Nest(depth: 20, differingLevel: 19),

--- a/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlBodyDiffNormalizationTests.cs
@@ -349,6 +349,12 @@ public class IlBodyDiffNormalizationTests
         "<Run>b__000000000000000000000000000128_0")]              // padded ordinal
     [InlineData("<Run>b__2147483648_0", "<Run>b__2147483649_0")]  // ordinal past int.MaxValue, no leading zero
     [InlineData("<Run>b__103_2147483648", "<Run>b__128_2147483648")] // per-method index past int.MaxValue
+    [InlineData("<>x__103_0", "<>x__128_0")]                      // marker outside the `9`/`b`/`g` set
+    [InlineData("<A__B>bX_103_0", "<A__B>bX_128_0")]              // marker not followed by `__`
+    [InlineData("<A__B>b_X103_0", "<A__B>b_X128_0")]              // marker followed by only one `_`
+    [InlineData("<Run>b___0", "<Run>b__128_0")]                   // no ordinal digits at all
+    [InlineData("<Run>b__103_", "<Run>b__128_")]                  // no per-method index digits
+    [InlineData("<Run>b__103X0", "<Run>b__128X0")]                // ordinals not separated by `_`
     public void NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent(
         string oldName,
         string newName)

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -120,21 +120,24 @@ public enum IlBodyDiffNormalization
     /// <c>StopsNormalizingPastTheNestingCap</c> for the depth bound.
     /// </para>
     /// <para>
-    /// Four checks are deliberately <em>not</em> gated, and fall into two
-    /// kinds. The length floor and the marker bounds check in
-    /// <c>TryNormalizeName</c> are <em>bounds guards</em>: neutering either
-    /// makes the scan index past the end, so their failure mode is an
-    /// exception, not a collapse. They cannot mask a difference, and a test
-    /// that pinned them would be pinning an <c>IndexOutOfRangeException</c>.
-    /// The <c>__</c> pre-check in <c>Normalize</c> and the closing-angle check
-    /// in <c>TryNormalizeName</c> are <em>redundant fast paths</em>: each is
-    /// subsumed by a later check — the grammar re-derives <c>__</c> at the
-    /// marker, and a name with no closing angle leaves the marker on the
-    /// leading <c>&lt;</c>, which no marker accepts — so neutering either
-    /// changes no observable behavior and no test can distinguish it. The
-    /// empty-span check in <c>IsCanonicalOrdinal</c> is redundant in the same
-    /// way, subsumed by the parse. These are listed so that a future reader
-    /// does not mistake their absence from the gate list for an oversight.
+    /// Six checks are deliberately <em>not</em> gated, and fall into two
+    /// kinds. Three are <em>bounds guards</em>: the length floor in
+    /// <c>Normalize</c>, and the marker bounds check
+    /// (<c>marker + 2 &gt;= value.Length</c>) and the ordinal bounds check
+    /// (<c>digitsEnd &gt;= value.Length</c>) in <c>TryNormalizeName</c>.
+    /// Neutering any of them makes the scan index past the end, so their
+    /// failure mode is an exception, not a collapse. They cannot mask a
+    /// difference, and a test that pinned them would be pinning an
+    /// <c>IndexOutOfRangeException</c>. Three are <em>redundant fast
+    /// paths</em>: the <c>__</c> pre-check in <c>Normalize</c>, the
+    /// closing-angle check in <c>TryNormalizeName</c>, and the empty-span
+    /// check in <c>IsCanonicalOrdinal</c>. Each is subsumed by a later check
+    /// — the grammar re-derives <c>__</c> at the marker, a name with no
+    /// closing angle leaves the marker on the leading <c>&lt;</c> which no
+    /// marker accepts, and the parse rejects an empty span — so neutering
+    /// any of them changes no observable behavior and no test can
+    /// distinguish it. These are listed so that a future reader does not
+    /// mistake their absence from the gate list for an oversight.
     /// </para>
     /// </remarks>
     NormalizeSynthesizedMemberOrdinals = 1 << 3,
@@ -1244,10 +1247,11 @@ public static class IlBodyDiff
             // compiler emits, such as `<>b__1_0`, comparing literally.
             //
             // One predicate, two independently breakable directions, so each
-            // has its own gate: `<>b__103_0` in
-            // `PreservesEveryOtherNameComponent` covers a method form with no
-            // containing name, and `RejectsACacheFormWithAContainingName`
-            // covers a cache field that has one.
+            // has its own gate: `<>b__103_0` and `<>g__Local|103_0` in
+            // `PreservesEveryOtherNameComponent` cover the two method forms
+            // with no containing name, and
+            // `RejectsACacheFormWithAContainingName` covers a cache field
+            // that has one.
             bool namesContainingMethod = close > 1;
             if (namesContainingMethod != (value[marker] is 'b' or 'g'))
                 return false;
@@ -1273,6 +1277,9 @@ public static class IlBodyDiff
             // is what separates a closure name from an identifier that merely
             // ends in digits, and it stays significant so a lambda bound to the
             // wrong slot still differs.
+            // `digitsEnd >= value.Length` is a bounds guard for the read that
+            // follows it, not a rejection rule; neutering it indexes past the
+            // end on a name like `<Run>b__103` that stops after the ordinal.
             if (!IsCanonicalOrdinal(value, digitsStart, digitsEnd)
                 || digitsEnd >= value.Length
                 || value[digitsEnd] != '_')

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -74,7 +75,12 @@ public enum IlBodyDiffNormalization
     /// must be one of the three forms. A synthesized-looking <em>substring</em>
     /// is never rewritten, so names that arrive from a producer other than C#
     /// (<c>x!&lt;Run&gt;b__1_0</c>, <c>&lt;Run&gt;b__1_0!suffix</c>) keep
-    /// comparing literally.
+    /// comparing literally. The form must also match the member's metadata
+    /// table — the cache form is accepted only on a field and the lambda and
+    /// local-function forms only on a method — and both indices must be
+    /// spelled the way Roslyn spells them, as canonical non-negative
+    /// <see cref="int"/> values, so <c>&lt;Run&gt;b__0103_0</c> and a
+    /// 30-digit ordinal are not recognized either.
     /// </para>
     /// <para>
     /// Known limitation, deliberately not addressed: overloads share a
@@ -765,7 +771,7 @@ public static class IlBodyDiff
                 ? decoded
                 : GuardedProviderDecode.FallbackSignature(
                     GuardedProviderDecode.RejectedIdentity(reader, method.Signature));
-            return FormatCall(signature, FormatType(method.GetDeclaringType()), NormalizeMemberName(reader.GetString(method.Name)), genericArgs: null);
+            return FormatCall(signature, FormatType(method.GetDeclaringType()), NormalizeMemberName(reader.GetString(method.Name), SynthesizedMemberKind.Method), genericArgs: null);
         }
 
         string FormatMemberReference(MemberReferenceHandle handle)
@@ -783,7 +789,7 @@ public static class IlBodyDiff
                 ? decoded
                 : GuardedProviderDecode.FallbackSignature(
                     GuardedProviderDecode.RejectedIdentity(reader, member.Signature));
-            return FormatCall(signature, FormatMemberParent(member.Parent), NormalizeMemberName(reader.GetString(member.Name)), genericArgs: null);
+            return FormatCall(signature, FormatMemberParent(member.Parent), NormalizeMemberName(reader.GetString(member.Name), SynthesizedMemberKind.Method), genericArgs: null);
         }
 
         string FormatMethodSpecification(MethodSpecificationHandle handle)
@@ -819,7 +825,7 @@ public static class IlBodyDiff
                 ? decoded
                 : GuardedProviderDecode.FallbackSignature(
                     GuardedProviderDecode.RejectedIdentity(reader, method.Signature));
-            return FormatCall(signature, FormatType(method.GetDeclaringType()), NormalizeMemberName(reader.GetString(method.Name)), genericArgs);
+            return FormatCall(signature, FormatType(method.GetDeclaringType()), NormalizeMemberName(reader.GetString(method.Name), SynthesizedMemberKind.Method), genericArgs);
         }
 
         string FormatMethodSpecificationReference(MemberReferenceHandle handle, string genericArgs)
@@ -834,7 +840,7 @@ public static class IlBodyDiff
                 ? decoded
                 : GuardedProviderDecode.FallbackSignature(
                     GuardedProviderDecode.RejectedIdentity(reader, member.Signature));
-            return FormatCall(signature, FormatMemberParent(member.Parent), NormalizeMemberName(reader.GetString(member.Name)), genericArgs);
+            return FormatCall(signature, FormatMemberParent(member.Parent), NormalizeMemberName(reader.GetString(member.Name), SynthesizedMemberKind.Method), genericArgs);
         }
 
         string FormatFieldDefinition(FieldDefinitionHandle handle)
@@ -848,7 +854,7 @@ public static class IlBodyDiff
                 out var decoded)
                 ? decoded
                 : GuardedProviderDecode.RejectedIdentity(reader, field.Signature);
-            return $"{fieldType} {FormatType(field.GetDeclaringType())}::{NormalizeMemberName(reader.GetString(field.Name))}";
+            return $"{fieldType} {FormatType(field.GetDeclaringType())}::{NormalizeMemberName(reader.GetString(field.Name), SynthesizedMemberKind.Field)}";
         }
 
         string FormatFieldMemberReference(MemberReferenceHandle handle)
@@ -865,7 +871,7 @@ public static class IlBodyDiff
                 out var decoded)
                 ? decoded
                 : GuardedProviderDecode.RejectedIdentity(reader, member.Signature);
-            return $"{fieldType} {FormatMemberParent(member.Parent)}::{NormalizeMemberName(reader.GetString(member.Name))}";
+            return $"{fieldType} {FormatMemberParent(member.Parent)}::{NormalizeMemberName(reader.GetString(member.Name), SynthesizedMemberKind.Field)}";
         }
 
         string FormatCall(MethodSignature<string> signature, string parent, string name, string? genericArgs)
@@ -1031,10 +1037,22 @@ public static class IlBodyDiff
         /// <see cref="SignatureIdentityProvider"/>.
         /// </para>
         /// </remarks>
-        string NormalizeMemberName(string name)
+        string NormalizeMemberName(string name, SynthesizedMemberKind kind)
             => (normalization & IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals) != 0
-                ? SynthesizedOrdinals.Normalize(name)
+                ? SynthesizedOrdinals.Normalize(name, kind)
                 : name;
+    }
+
+    /// <summary>
+    /// Which metadata table a member name came from. Roslyn emits the lambda
+    /// cache form <c>&lt;&gt;9__N_M</c> only as a field and the lambda and
+    /// local-function forms only as methods, so the normalizer needs the kind
+    /// to hold names to that correspondence.
+    /// </summary>
+    internal enum SynthesizedMemberKind
+    {
+        Field,
+        Method,
     }
 
     /// <summary>
@@ -1080,10 +1098,10 @@ public static class IlBodyDiff
         /// <c>&lt;Run&gt;b__103_0</c>), rewriting only the containing-method
         /// ordinal. Any other name is returned unchanged.
         /// </summary>
-        public static string Normalize(string value)
-            => Normalize(value, depth: 0);
+        public static string Normalize(string value, SynthesizedMemberKind kind)
+            => Normalize(value, kind, depth: 0);
 
-        static string Normalize(string value, int depth)
+        static string Normalize(string value, SynthesizedMemberKind kind, int depth)
         {
             // Every recognized form opens with '<', which C# cannot spell, and
             // carries the '__' separator. Both checks are cheap rejects.
@@ -1094,7 +1112,7 @@ public static class IlBodyDiff
                 return value;
             }
 
-            return TryNormalizeName(value, depth, out string replacement) ? replacement : value;
+            return TryNormalizeName(value, kind, depth, out string replacement) ? replacement : value;
         }
 
         /// <summary>
@@ -1123,7 +1141,7 @@ public static class IlBodyDiff
         /// (see docs/design/untrusted-data-threat-model.md).
         /// </para>
         /// </remarks>
-        static bool TryNormalizeName(string value, int depth, out string replacement)
+        static bool TryNormalizeName(string value, SynthesizedMemberKind kind, int depth, out string replacement)
         {
             replacement = "";
 
@@ -1142,6 +1160,14 @@ public static class IlBodyDiff
             {
                 return false;
             }
+
+            // Roslyn emits the cache form `<>9__N_M` only as a field and the
+            // lambda and local-function forms only as methods. Holding names to
+            // that correspondence keeps a *method* named `<>9__1_0` — which no
+            // C# compiler emits — comparing literally.
+            var markerKind = value[marker] == '9' ? SynthesizedMemberKind.Field : SynthesizedMemberKind.Method;
+            if (kind != markerKind)
+                return false;
 
             // Roslyn omits the containing-method name only for the lambda
             // cache field `<>9__N_M`; the lambda and local-function forms
@@ -1172,7 +1198,7 @@ public static class IlBodyDiff
             // is what separates a closure name from an identifier that merely
             // ends in digits, and it stays significant so a lambda bound to the
             // wrong slot still differs.
-            if (digitsEnd == digitsStart
+            if (!IsCanonicalOrdinal(value, digitsStart, digitsEnd)
                 || digitsEnd >= value.Length
                 || value[digitsEnd] != '_')
             {
@@ -1187,20 +1213,51 @@ public static class IlBodyDiff
             while (lambdaEnd < value.Length && char.IsAsciiDigit(value[lambdaEnd]))
                 lambdaEnd++;
 
-            if (lambdaEnd == lambdaStart || lambdaEnd != value.Length)
+            if (lambdaEnd != value.Length || !IsCanonicalOrdinal(value, lambdaStart, lambdaEnd))
                 return false;
 
             // The enclosing name carries its own ordinal when it is itself a
             // closure, so normalize it under the same grammar. Recursing rather
             // than rescanning is what keeps an authored enclosing method named
-            // `b__1_0` distinct from one named `b__2_0`.
+            // `b__1_0` distinct from one named `b__2_0`. A containing name is
+            // always a method, whatever kind the outer member is.
             string inner = value[1..close];
             string normalizedInner = depth < MaxNestingDepth
-                ? Normalize(inner, depth + 1)
+                ? Normalize(inner, SynthesizedMemberKind.Method, depth + 1)
                 : inner;
 
             replacement = $"<{normalizedInner}{value[close..digitsStart]}{Placeholder}{value[digitsEnd..]}";
             return true;
+        }
+
+        /// <summary>
+        /// Reports whether <c>value[start..end]</c> is an ordinal exactly as
+        /// Roslyn spells one.
+        /// </summary>
+        /// <remarks>
+        /// Roslyn formats these indices with an invariant <see cref="int"/>
+        /// conversion, so <c>0103</c> and a 30-digit run are not forms it can
+        /// emit. Accepting them would let <c>&lt;Run&gt;b__0103_0</c> and
+        /// <c>&lt;Run&gt;b__0128_0</c> collapse — a masked difference between
+        /// two names that no compiler produced and that nothing else relates.
+        /// Requiring the canonical encoding costs at most a false positive on
+        /// such a name, which is the safe direction.
+        /// </remarks>
+        static bool IsCanonicalOrdinal(string value, int start, int end)
+        {
+            int length = end - start;
+            if (length == 0)
+                return false;
+
+            // "0" is canonical; "0" followed by anything is not.
+            if (length > 1 && value[start] == '0')
+                return false;
+
+            return int.TryParse(
+                value.AsSpan(start, length),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out _);
         }
 
         /// <summary>

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -109,6 +109,9 @@ public enum IlBodyDiffNormalization
     /// grammar, and both canonical-ordinal rules;
     /// <c>RejectsAFieldFormOnAMethod</c> and
     /// <c>RejectsAMethodFormOnAField</c> for the kind correspondence;
+    /// <c>RejectsACacheFormWithAContainingName</c> for the field half of the
+    /// containing-name correspondence, whose method half
+    /// <c>PreservesEveryOtherNameComponent</c> covers;
     /// <c>RejectsAMethodFormBehindAMethodSpecificationOnAField</c> for the
     /// generic-instantiation path;
     /// <c>RejectsANonCanonicalCacheFieldOrdinal</c> for the cache field's
@@ -1239,6 +1242,12 @@ public static class IlBodyDiff
             // cache field `<>9__N_M`; the lambda and local-function forms
             // always carry one. Pinning that correspondence keeps names no C#
             // compiler emits, such as `<>b__1_0`, comparing literally.
+            //
+            // One predicate, two independently breakable directions, so each
+            // has its own gate: `<>b__103_0` in
+            // `PreservesEveryOtherNameComponent` covers a method form with no
+            // containing name, and `RejectsACacheFormWithAContainingName`
+            // covers a cache field that has one.
             bool namesContainingMethod = close > 1;
             if (namesContainingMethod != (value[marker] is 'b' or 'g'))
                 return false;

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -43,6 +43,37 @@ public enum IlBodyDiffNormalization
     /// Replace known platform assembly reference scopes with a shared scope.
     /// </summary>
     NormalizePlatformAssemblyScope = 1 << 2,
+
+    /// <summary>
+    /// Replace the containing-method ordinal inside Roslyn-synthesized closure
+    /// member names with <c>#</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Roslyn names a lambda's cache field <c>&lt;&gt;9__N_M</c>, its method
+    /// <c>&lt;Name&gt;b__N_M</c>, and a local function
+    /// <c>&lt;Name&gt;g__Local|N_M</c>, where <c>N</c> is the containing
+    /// method's declaration ordinal in the <em>compilation unit</em> and
+    /// <c>M</c> indexes the lambda within that method. <c>N</c> therefore
+    /// describes the unit, not the member: recompiling the same source in a
+    /// unit whose member ordering or member count differs renumbers it while
+    /// the emitted IL stays behaviorally identical.
+    /// </para>
+    /// <para>
+    /// Only <c>N</c> is replaced. The containing-method name, the local
+    /// function name, and the per-method index <c>M</c> all stay significant,
+    /// so a body that binds to the wrong lambda, or to a lambda of a
+    /// differently named method, still diffs.
+    /// </para>
+    /// <para>
+    /// Known limitation, deliberately not addressed: overloads share a
+    /// containing-method name and are told apart only by <c>N</c>, so this
+    /// option conflates the closures of two overloads with the same lambda
+    /// index. State-machine names (<c>&lt;Name&gt;d__N</c>) are left alone for
+    /// the same reason — <c>N</c> is their only distinguishing component.
+    /// </para>
+    /// </remarks>
+    NormalizeSynthesizedMemberOrdinals = 1 << 3,
 }
 
 public enum IlBodyDiffOutcome
@@ -127,7 +158,8 @@ public static class IlBodyDiff
     const IlBodyDiffNormalization SupportedNormalizations =
         IlBodyDiffNormalization.NormalizeVariableLayout
         | IlBodyDiffNormalization.NormalizeCurrentAssemblyScope
-        | IlBodyDiffNormalization.NormalizePlatformAssemblyScope;
+        | IlBodyDiffNormalization.NormalizePlatformAssemblyScope
+        | IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals;
 
     public static IlBodyDiffResult Compare(MethodInstructions oldBody, MethodInstructions newBody)
         => Compare(oldBody, newBody, oldResolver: null, newResolver: null, IlBodyDiffNormalization.None);
@@ -634,6 +666,8 @@ public static class IlBodyDiff
                     string assembly = reader.GetString(reader.GetAssemblyDefinition().Name);
                     value = NormalizeAssemblyScopes(value, assembly);
                 }
+                if (instruction.Operand != OperandKind.InlineString)
+                    value = NormalizeSynthesizedOrdinals(value);
                 operand = new IlOperandIdentity(IlOperandIdentityKind.Token, value);
                 failure = null;
                 return true;
@@ -959,6 +993,117 @@ public static class IlBodyDiff
                 || name.Equals("Microsoft.CSharp", StringComparison.Ordinal)
                 || name.StartsWith("Microsoft.VisualBasic", StringComparison.Ordinal);
 
+        string NormalizeSynthesizedOrdinals(string value)
+        {
+            if ((normalization & IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals) == 0)
+                return value;
+
+            return SynthesizedOrdinals.Normalize(value);
+        }
+    }
+
+    /// <summary>
+    /// Rewrites the containing-method ordinal out of Roslyn closure member
+    /// names. See
+    /// <see cref="IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals"/>
+    /// for what the ordinal means and why it is not evidence.
+    /// </summary>
+    internal static class SynthesizedOrdinals
+    {
+        internal const char Placeholder = '#';
+
+        public static string Normalize(string value)
+        {
+            // Cheap reject: every recognized form contains this separator.
+            if (!value.Contains("__", StringComparison.Ordinal))
+                return value;
+
+            StringBuilder? builder = null;
+            int copied = 0;
+
+            for (int i = 0; i + 2 < value.Length; i++)
+            {
+                if (value[i] != '_' || value[i + 1] != '_')
+                    continue;
+
+                // `<>9__N_M` (cache field) and `<Name>b__N_M` (lambda method)
+                // put the ordinal straight after the separator. `g__` is a
+                // local function: `<Name>g__Local|N_M`, so the ordinal sits
+                // after the `|` that follows the local's own name.
+                char marker = i > 0 ? value[i - 1] : '\0';
+                int digitsStart;
+                if (marker is '9' or 'b')
+                {
+                    digitsStart = i + 2;
+                }
+                else if (marker == 'g')
+                {
+                    int bar = value.IndexOf('|', i + 2);
+                    if (bar < 0)
+                        continue;
+                    // The local's name must not itself contain a separator we
+                    // would rather have matched; bail if one intervenes.
+                    if (value.AsSpan(i + 2, bar - (i + 2)).Contains("__", StringComparison.Ordinal))
+                        continue;
+                    digitsStart = bar + 1;
+                }
+                else
+                {
+                    continue;
+                }
+
+                // Every Roslyn closure name begins with '<' — `<>9__…` or
+                // `<Method>b__…`. C# cannot spell that, so requiring it keeps
+                // an authored identifier that merely ends in `b`/`g` before a
+                // digit run (`Grab__1_0`) out of the rewrite.
+                if (!StartsSynthesizedName(value, i))
+                    continue;
+
+                int digitsEnd = digitsStart;
+                while (digitsEnd < value.Length && char.IsAsciiDigit(value[digitsEnd]))
+                    digitsEnd++;
+
+                // Require at least one digit, and require the ordinal to be
+                // followed by `_M` — that trailing index is what distinguishes
+                // a closure name from an ordinary identifier ending in digits.
+                if (digitsEnd == digitsStart
+                    || digitsEnd >= value.Length
+                    || value[digitsEnd] != '_'
+                    || digitsEnd + 1 >= value.Length
+                    || !char.IsAsciiDigit(value[digitsEnd + 1]))
+                {
+                    continue;
+                }
+
+                builder ??= new StringBuilder(value.Length);
+                builder.Append(value, copied, digitsStart - copied);
+                builder.Append(Placeholder);
+                copied = digitsEnd;
+                i = digitsEnd - 1;
+            }
+
+            if (builder is null)
+                return value;
+
+            builder.Append(value, copied, value.Length - copied);
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// True when the identifier containing <paramref name="index"/> opens
+        /// with <c>&lt;</c>, the marker Roslyn puts on every synthesized name.
+        /// </summary>
+        static bool StartsSynthesizedName(string value, int index)
+        {
+            int start = index;
+            while (start > 0 && IsNameChar(value[start - 1]))
+                start--;
+
+            return value[start] == '<';
+        }
+
+        static bool IsNameChar(char c)
+            => char.IsAsciiLetterOrDigit(c) || c is '_' or '<' or '>' or '|' or '`';
     }
 
     sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -94,6 +94,21 @@ public enum IlBodyDiffNormalization
     /// are types rather than members. Each of these costs a false positive,
     /// never a masked difference.
     /// </para>
+    /// <para>
+    /// Every property claimed above is enforced by a gate in
+    /// <c>IlBodyDiffNormalizationTests</c>, each of which asserts the two
+    /// names differ <em>without</em> the option as well as agreeing (or still
+    /// differing) with it, so none can pass vacuously:
+    /// <c>ToleratesContainingMethodRenumbering</c> and
+    /// <c>ToleratesRenumberingOfALambdaCacheField</c> for what is related,
+    /// <c>PreservesEveryOtherNameComponent</c> for the components that stay
+    /// significant and the anchoring, <c>RejectsAFieldFormOnAMethod</c> and
+    /// <c>RejectsAMethodFormOnAField</c> for the kind correspondence,
+    /// <c>RejectsANonCanonicalCacheFieldOrdinal</c> for the cache field's
+    /// ordinal spelling, <c>LeavesTypeOperandsAlone</c> and
+    /// <c>PreservesSynthesizedLikeStringLiterals</c> for the scope, and
+    /// <c>StopsNormalizingPastTheNestingCap</c> for the depth bound.
+    /// </para>
     /// </remarks>
     NormalizeSynthesizedMemberOrdinals = 1 << 3,
 }
@@ -831,6 +846,15 @@ public static class IlBodyDiff
         string FormatMethodSpecificationReference(MemberReferenceHandle handle, string genericArgs)
         {
             var member = reader.GetMemberReference(handle);
+
+            // Same check as the direct member-reference path. A method
+            // specification can name a member reference that is actually a
+            // field, and without this the generic-instantiation path would
+            // normalize a method-form name on a field. Gated by
+            // IlBodyDiffNormalizationTests.NormalizeSynthesizedMemberOrdinals_RejectsAMethodFormBehindAMethodSpecificationOnAField.
+            if (member.GetKind() != MemberReferenceKind.Method)
+                throw new BadImageFormatException("Expected method member reference.");
+
             var signature = GuardedProviderDecode.TryMemberRefMethod(
                 reader,
                 member,
@@ -1164,7 +1188,9 @@ public static class IlBodyDiff
             // Roslyn emits the cache form `<>9__N_M` only as a field and the
             // lambda and local-function forms only as methods. Holding names to
             // that correspondence keeps a *method* named `<>9__1_0` — which no
-            // C# compiler emits — comparing literally.
+            // C# compiler emits — comparing literally. Gated by
+            // IlBodyDiffNormalizationTests.NormalizeSynthesizedMemberOrdinals_RejectsAFieldFormOnAMethod
+            // and ..._RejectsAMethodFormOnAField.
             var markerKind = value[marker] == '9' ? SynthesizedMemberKind.Field : SynthesizedMemberKind.Method;
             if (kind != markerKind)
                 return false;
@@ -1242,6 +1268,13 @@ public static class IlBodyDiff
         /// two names that no compiler produced and that nothing else relates.
         /// Requiring the canonical encoding costs at most a false positive on
         /// such a name, which is the safe direction.
+        /// <para>
+        /// Gated by
+        /// <c>IlBodyDiffNormalizationTests.NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent</c>
+        /// (leading zeros in either index, and an ordinal wider than
+        /// <see cref="int"/>) and
+        /// <c>..._RejectsANonCanonicalCacheFieldOrdinal</c> for the field form.
+        /// </para>
         /// </remarks>
         static bool IsCanonicalOrdinal(string value, int start, int end)
         {

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -96,14 +96,19 @@ public enum IlBodyDiffNormalization
     /// </para>
     /// <para>
     /// Every property claimed above is enforced by a gate in
-    /// <c>IlBodyDiffNormalizationTests</c>, each of which asserts the two
-    /// names differ <em>without</em> the option as well as agreeing (or still
-    /// differing) with it, so none can pass vacuously:
+    /// <c>IlBodyDiffNormalizationTests</c>:
     /// <c>ToleratesContainingMethodRenumbering</c> and
-    /// <c>ToleratesRenumberingOfALambdaCacheField</c> for what is related,
-    /// <c>PreservesEveryOtherNameComponent</c> for the components that stay
-    /// significant and the anchoring, <c>RejectsAFieldFormOnAMethod</c> and
+    /// <c>ToleratesRenumberingOfALambdaCacheField</c> for what is related —
+    /// each asserts the two names differ <em>without</em> the option as well
+    /// as agreeing with it, so neither can pass vacuously in either
+    /// direction. The remaining gates assert only that the names still differ
+    /// <em>with</em> the option, which is the whole claim for a name this
+    /// option must not relate: <c>PreservesEveryOtherNameComponent</c> for the
+    /// components that stay significant, the anchoring, and non-canonical
+    /// ordinals, <c>RejectsAFieldFormOnAMethod</c> and
     /// <c>RejectsAMethodFormOnAField</c> for the kind correspondence,
+    /// <c>RejectsAMethodFormBehindAMethodSpecificationOnAField</c> for the
+    /// generic-instantiation path,
     /// <c>RejectsANonCanonicalCacheFieldOrdinal</c> for the cache field's
     /// ordinal spelling, <c>LeavesTypeOperandsAlone</c> and
     /// <c>PreservesSynthesizedLikeStringLiterals</c> for the scope, and
@@ -1262,18 +1267,22 @@ public static class IlBodyDiff
         /// </summary>
         /// <remarks>
         /// Roslyn formats these indices with an invariant <see cref="int"/>
-        /// conversion, so <c>0103</c> and a 30-digit run are not forms it can
-        /// emit. Accepting them would let <c>&lt;Run&gt;b__0103_0</c> and
-        /// <c>&lt;Run&gt;b__0128_0</c> collapse — a masked difference between
-        /// two names that no compiler produced and that nothing else relates.
-        /// Requiring the canonical encoding costs at most a false positive on
-        /// such a name, which is the safe direction.
+        /// conversion, so <c>0103</c> and a value past <see cref="int.MaxValue"/>
+        /// are not forms it can emit. Accepting them would let
+        /// <c>&lt;Run&gt;b__0103_0</c> and <c>&lt;Run&gt;b__0128_0</c>
+        /// collapse — a masked difference between two names that no compiler
+        /// produced and that nothing else relates. Requiring the canonical
+        /// encoding costs at most a false positive on such a name, which is
+        /// the safe direction.
         /// <para>
-        /// Gated by
+        /// The two rules are gated separately, because a padded ordinal is
+        /// rejected by the leading-zero rule before the parse is reached and
+        /// would leave the range rule untested.
         /// <c>IlBodyDiffNormalizationTests.NormalizeSynthesizedMemberOrdinals_PreservesEveryOtherNameComponent</c>
-        /// (leading zeros in either index, and an ordinal wider than
-        /// <see cref="int"/>) and
-        /// <c>..._RejectsANonCanonicalCacheFieldOrdinal</c> for the field form.
+        /// covers both rules against both indices — a leading zero and a
+        /// value past <see cref="int.MaxValue"/> with no leading zero — and
+        /// <c>..._RejectsANonCanonicalCacheFieldOrdinal</c> covers both
+        /// against the field form.
         /// </para>
         /// </remarks>
         static bool IsCanonicalOrdinal(string value, int start, int end)

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -66,11 +67,22 @@ public enum IlBodyDiffNormalization
     /// differently named method, still diffs.
     /// </para>
     /// <para>
+    /// Applies to a member's simple name only, never to the rest of a
+    /// formatted operand. Declaring types, return types, parameter types,
+    /// generic arguments, standalone signatures, and string literals are left
+    /// alone, so the rewrite cannot reach text that is not a member name.
+    /// </para>
+    /// <para>
     /// Known limitation, deliberately not addressed: overloads share a
     /// containing-method name and are told apart only by <c>N</c>, so this
     /// option conflates the closures of two overloads with the same lambda
     /// index. State-machine names (<c>&lt;Name&gt;d__N</c>) are left alone for
     /// the same reason — <c>N</c> is their only distinguishing component.
+    /// Synthesized <em>types</em> that do carry the ordinal — display classes
+    /// (<c>&lt;&gt;c__DisplayClassN_M</c>) and the state machine of an async
+    /// lambda (<c>&lt;&lt;Run&gt;b__N_M&gt;d__1</c>) — keep it, because they
+    /// are types rather than members. Each of these costs a false positive,
+    /// never a masked difference.
     /// </para>
     /// </remarks>
     NormalizeSynthesizedMemberOrdinals = 1 << 3,
@@ -666,8 +678,6 @@ public static class IlBodyDiff
                     string assembly = reader.GetString(reader.GetAssemblyDefinition().Name);
                     value = NormalizeAssemblyScopes(value, assembly);
                 }
-                if (instruction.Operand != OperandKind.InlineString)
-                    value = NormalizeSynthesizedOrdinals(value);
                 operand = new IlOperandIdentity(IlOperandIdentityKind.Token, value);
                 failure = null;
                 return true;
@@ -751,7 +761,7 @@ public static class IlBodyDiff
                 ? decoded
                 : GuardedProviderDecode.FallbackSignature(
                     GuardedProviderDecode.RejectedIdentity(reader, method.Signature));
-            return FormatCall(signature, FormatType(method.GetDeclaringType()), reader.GetString(method.Name), genericArgs: null);
+            return FormatCall(signature, FormatType(method.GetDeclaringType()), NormalizeMemberName(reader.GetString(method.Name)), genericArgs: null);
         }
 
         string FormatMemberReference(MemberReferenceHandle handle)
@@ -769,7 +779,7 @@ public static class IlBodyDiff
                 ? decoded
                 : GuardedProviderDecode.FallbackSignature(
                     GuardedProviderDecode.RejectedIdentity(reader, member.Signature));
-            return FormatCall(signature, FormatMemberParent(member.Parent), reader.GetString(member.Name), genericArgs: null);
+            return FormatCall(signature, FormatMemberParent(member.Parent), NormalizeMemberName(reader.GetString(member.Name)), genericArgs: null);
         }
 
         string FormatMethodSpecification(MethodSpecificationHandle handle)
@@ -805,7 +815,7 @@ public static class IlBodyDiff
                 ? decoded
                 : GuardedProviderDecode.FallbackSignature(
                     GuardedProviderDecode.RejectedIdentity(reader, method.Signature));
-            return FormatCall(signature, FormatType(method.GetDeclaringType()), reader.GetString(method.Name), genericArgs);
+            return FormatCall(signature, FormatType(method.GetDeclaringType()), NormalizeMemberName(reader.GetString(method.Name)), genericArgs);
         }
 
         string FormatMethodSpecificationReference(MemberReferenceHandle handle, string genericArgs)
@@ -820,7 +830,7 @@ public static class IlBodyDiff
                 ? decoded
                 : GuardedProviderDecode.FallbackSignature(
                     GuardedProviderDecode.RejectedIdentity(reader, member.Signature));
-            return FormatCall(signature, FormatMemberParent(member.Parent), reader.GetString(member.Name), genericArgs);
+            return FormatCall(signature, FormatMemberParent(member.Parent), NormalizeMemberName(reader.GetString(member.Name)), genericArgs);
         }
 
         string FormatFieldDefinition(FieldDefinitionHandle handle)
@@ -834,7 +844,7 @@ public static class IlBodyDiff
                 out var decoded)
                 ? decoded
                 : GuardedProviderDecode.RejectedIdentity(reader, field.Signature);
-            return $"{fieldType} {FormatType(field.GetDeclaringType())}::{reader.GetString(field.Name)}";
+            return $"{fieldType} {FormatType(field.GetDeclaringType())}::{NormalizeMemberName(reader.GetString(field.Name))}";
         }
 
         string FormatFieldMemberReference(MemberReferenceHandle handle)
@@ -851,7 +861,7 @@ public static class IlBodyDiff
                 out var decoded)
                 ? decoded
                 : GuardedProviderDecode.RejectedIdentity(reader, member.Signature);
-            return $"{fieldType} {FormatMemberParent(member.Parent)}::{reader.GetString(member.Name)}";
+            return $"{fieldType} {FormatMemberParent(member.Parent)}::{NormalizeMemberName(reader.GetString(member.Name))}";
         }
 
         string FormatCall(MethodSignature<string> signature, string parent, string name, string? genericArgs)
@@ -993,13 +1003,34 @@ public static class IlBodyDiff
                 || name.Equals("Microsoft.CSharp", StringComparison.Ordinal)
                 || name.StartsWith("Microsoft.VisualBasic", StringComparison.Ordinal);
 
-        string NormalizeSynthesizedOrdinals(string value)
-        {
-            if ((normalization & IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals) == 0)
-                return value;
-
-            return SynthesizedOrdinals.Normalize(value);
-        }
+        /// <summary>
+        /// Applies <see cref="IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals"/>
+        /// to a member's simple name, taken straight from the metadata string
+        /// heap.
+        /// </summary>
+        /// <remarks>
+        /// The normalization is applied here, to the typed identity, rather
+        /// than to the formatted operand string. A formatted operand also
+        /// carries declaring types, return types, parameter types, and generic
+        /// arguments, and scanning that flattened text would let the rewrite
+        /// reach names that are not members at all. Scoping it to the member
+        /// name is what makes the flag mean what it says.
+        /// <para>
+        /// The corollary is that synthesized <em>type</em> names keep their
+        /// ordinals: display classes (<c>&lt;&gt;c__DisplayClassN_M</c>) and
+        /// the state machine of an async lambda
+        /// (<c>&lt;&lt;Run&gt;b__N_M&gt;d__1</c>) are types, so a body that
+        /// references one can still diff on a renumbered ordinal. That costs a
+        /// false positive, never a masked difference, and no corpus row needs
+        /// it today. Covering it means normalizing type leaf names too, which
+        /// requires threading this option through
+        /// <see cref="SignatureIdentityProvider"/>.
+        /// </para>
+        /// </remarks>
+        string NormalizeMemberName(string name)
+            => (normalization & IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals) != 0
+                ? SynthesizedOrdinals.Normalize(name)
+                : name;
     }
 
     /// <summary>
@@ -1035,14 +1066,31 @@ public static class IlBodyDiff
         const int MaxNestingDepth = 16;
 
         /// <summary>
-        /// Normalizes every synthesized name inside a resolved operand string
-        /// (for example <c>[Asm]Ns.Type::&lt;Run&gt;b__103_0</c>), rewriting
-        /// only the containing-method ordinal in each.
+        /// Bounds the total characters <see cref="FindClosingAngle"/> may
+        /// visit across one top-level call, expressed as a multiple of the
+        /// input length. Each candidate <c>&lt;</c> starts its own forward
+        /// scan, so a name made of unbalanced <c>&lt;</c> characters would
+        /// otherwise cost O(n²)
+        /// (see docs/design/untrusted-data-threat-model.md, which requires CPU
+        /// amplification over hostile input to be bounded). Every recognized
+        /// form pairs its angles off in one scan per nesting level, so real
+        /// input stays far inside the budget; exhausting it means the name is
+        /// not one of these forms.
+        /// </summary>
+        const int ScanBudgetFactor = MaxNestingDepth + 1;
+
+        /// <summary>
+        /// Normalizes every synthesized name inside a member's simple name
+        /// (for example <c>&lt;Run&gt;b__103_0</c>), rewriting only the
+        /// containing-method ordinal in each.
         /// </summary>
         public static string Normalize(string value)
-            => Normalize(value, depth: 0);
+        {
+            int budget = ScanBudgetFactor * (value.Length + 16);
+            return Normalize(value, depth: 0, ref budget);
+        }
 
-        static string Normalize(string value, int depth)
+        static string Normalize(string value, int depth, ref int budget)
         {
             // Every recognized form opens with '<', which C# cannot spell, and
             // carries the separator. Both checks are cheap rejects.
@@ -1067,7 +1115,13 @@ public static class IlBodyDiff
                 if (i > 0 && IsInteriorChar(value[i - 1]))
                     continue;
 
-                if (!TryNormalizeName(value, i, depth, out string replacement, out int end))
+                // Out of scan budget: abandon the whole string rather than
+                // return it half-rewritten. Declining can only cost a false
+                // positive, never a masked difference.
+                if (budget <= 0)
+                    return value;
+
+                if (!TryNormalizeName(value, i, depth, ref budget, out string replacement, out int end))
                     continue;
 
                 builder ??= new StringBuilder(value.Length);
@@ -1090,14 +1144,14 @@ public static class IlBodyDiff
         /// and rewrites only <c>N</c>. Any other identifier, including the
         /// state-machine form <c>&lt;Name&gt;d__N</c>, is declined.
         /// </summary>
-        static bool TryNormalizeName(string value, int start, int depth, out string replacement, out int end)
+        static bool TryNormalizeName(string value, int start, int depth, ref int budget, out string replacement, out int end)
         {
             replacement = "";
             end = start;
 
             // The enclosing name may itself be synthesized (a nested lambda),
             // so match the '>' that closes this name rather than the first one.
-            int close = FindClosingAngle(value, start);
+            int close = FindClosingAngle(value, start, ref budget);
             if (close < 0)
                 return false;
 
@@ -1157,7 +1211,7 @@ public static class IlBodyDiff
             // `b__1_0` distinct from one named `b__2_0`.
             string inner = value[(start + 1)..close];
             string normalizedInner = depth < MaxNestingDepth
-                ? Normalize(inner, depth + 1)
+                ? Normalize(inner, depth + 1, ref budget)
                 : inner;
 
             replacement = string.Concat(
@@ -1171,13 +1225,17 @@ public static class IlBodyDiff
 
         /// <summary>
         /// Returns the index of the <c>&gt;</c> closing the <c>&lt;</c> at
-        /// <paramref name="start"/>, honoring nesting, or -1 when unbalanced.
+        /// <paramref name="start"/>, honoring nesting, or -1 when unbalanced
+        /// or when <paramref name="budget"/> runs out.
         /// </summary>
-        static int FindClosingAngle(string value, int start)
+        static int FindClosingAngle(string value, int start, ref int budget)
         {
             int depth = 0;
             for (int i = start; i < value.Length; i++)
             {
+                if (--budget < 0)
+                    return -1;
+
                 if (value[i] == '<')
                 {
                     depth++;
@@ -1192,12 +1250,28 @@ public static class IlBodyDiff
         }
 
         /// <summary>
-        /// True for characters that can occur inside an identifier. Metadata
-        /// names come from any .NET producer, not just C#, so this is Unicode
-        /// aware and includes <c>$</c>, which several compilers emit.
+        /// True for characters that can continue an identifier. Metadata names
+        /// come from any .NET producer, not just C#, so this covers every
+        /// Unicode category the language admits as an identifier-part
+        /// character, plus <c>$</c>, which several compilers emit. A surrogate
+        /// counts as interior so a name continuing into a supplementary-plane
+        /// character is still recognized as continuing.
         /// </summary>
+        /// <remarks>
+        /// Used only to decide whether a name <em>ends</em> where a recognized
+        /// form does. Erring toward "interior" therefore declines to
+        /// normalize, which is the safe direction.
+        /// </remarks>
         static bool IsInteriorChar(char c)
-            => char.IsLetterOrDigit(c) || c is '_' or '$';
+            => char.IsLetterOrDigit(c)
+                || c is '_' or '$'
+                || char.IsSurrogate(c)
+                || CharUnicodeInfo.GetUnicodeCategory(c) is
+                    UnicodeCategory.LetterNumber
+                    or UnicodeCategory.NonSpacingMark
+                    or UnicodeCategory.SpacingCombiningMark
+                    or UnicodeCategory.ConnectorPunctuation
+                    or UnicodeCategory.Format;
     }
 
     sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -83,6 +83,16 @@ public enum IlBodyDiffNormalization
     /// 30-digit ordinal are not recognized either.
     /// </para>
     /// <para>
+    /// One rewrite does reach a name that matches no form: a literal
+    /// <c>#</c> is doubled, because <c>#</c> is the placeholder this option
+    /// substitutes for <c>N</c>. Metadata names may contain any character, so
+    /// without that escape <c>&lt;Run&gt;b__103_0</c> would normalize onto the
+    /// legal, unrecognized name <c>&lt;Run&gt;b__#_0</c> and mask a real
+    /// difference. Escaping is injective and runs before the grammar, so it
+    /// relates no names that were not already equal and changes which names
+    /// normalize not at all — no form Roslyn emits contains <c>#</c>.
+    /// </para>
+    /// <para>
     /// Known limitation, deliberately not addressed: overloads share a
     /// containing-method name and are told apart only by <c>N</c>, so this
     /// option conflates the closures of two overloads with the same lambda
@@ -112,6 +122,8 @@ public enum IlBodyDiffNormalization
     /// <c>RejectsACacheFormWithAContainingName</c> for the field half of the
     /// containing-name correspondence, whose method half
     /// <c>PreservesEveryOtherNameComponent</c> covers;
+    /// <c>DoesNotCollideWithALiteralPlaceholder</c> for the escape that keeps
+    /// a normalized name distinct from every literal one;
     /// <c>RejectsAMethodFormBehindAMethodSpecificationOnAField</c> for the
     /// generic-instantiation path;
     /// <c>RejectsANonCanonicalCacheFieldOrdinal</c> for the cache field's
@@ -120,7 +132,7 @@ public enum IlBodyDiffNormalization
     /// <c>StopsNormalizingPastTheNestingCap</c> for the depth bound.
     /// </para>
     /// <para>
-    /// Six checks are deliberately <em>not</em> gated, and fall into two
+    /// Seven checks are deliberately <em>not</em> gated, and fall into two
     /// kinds. Three are <em>bounds guards</em>: the length floor in
     /// <c>Normalize</c>, and the marker bounds check
     /// (<c>marker + 2 &gt;= value.Length</c>) and the ordinal bounds check
@@ -128,14 +140,16 @@ public enum IlBodyDiffNormalization
     /// Neutering any of them makes the scan index past the end, so their
     /// failure mode is an exception, not a collapse. They cannot mask a
     /// difference, and a test that pinned them would be pinning an
-    /// <c>IndexOutOfRangeException</c>. Three are <em>redundant fast
+    /// <c>IndexOutOfRangeException</c>. Four are <em>redundant fast
     /// paths</em>: the <c>__</c> pre-check in <c>Normalize</c>, the
-    /// closing-angle check in <c>TryNormalizeName</c>, and the empty-span
-    /// check in <c>IsCanonicalOrdinal</c>. Each is subsumed by a later check
-    /// — the grammar re-derives <c>__</c> at the marker, a name with no
-    /// closing angle leaves the marker on the leading <c>&lt;</c> which no
-    /// marker accepts, and the parse rejects an empty span — so neutering
-    /// any of them changes no observable behavior and no test can
+    /// closing-angle check in <c>TryNormalizeName</c>, the empty-span
+    /// check in <c>IsCanonicalOrdinal</c>, and the <c>Contains</c> test in
+    /// <c>EscapePlaceholders</c>. Each is subsumed by a later check — the
+    /// grammar re-derives <c>__</c> at the marker, a name with no closing
+    /// angle leaves the marker on the leading <c>&lt;</c> which no marker
+    /// accepts, the parse rejects an empty span, and the replacement it
+    /// guards is already the identity on a name with no placeholder — so
+    /// neutering any of them changes no observable behavior and no test can
     /// distinguish it. These are listed so that a future reader does not
     /// mistake their absence from the gate list for an oversight.
     /// </para>
@@ -1150,10 +1164,46 @@ public static class IlBodyDiff
         /// Normalizes a member's simple name when the <em>whole</em> name is
         /// one of the recognized synthesized forms (for example
         /// <c>&lt;Run&gt;b__103_0</c>), rewriting only the containing-method
-        /// ordinal. Any other name is returned unchanged.
+        /// ordinal. Any other name is returned unchanged, except that a
+        /// literal <see cref="Placeholder"/> is escaped — see
+        /// <see cref="EscapePlaceholders"/>.
         /// </summary>
         public static string Normalize(string value, SynthesizedMemberKind kind)
-            => Normalize(value, kind, depth: 0);
+            => Normalize(EscapePlaceholders(value), kind, depth: 0);
+
+        /// <summary>
+        /// Doubles every literal <see cref="Placeholder"/> in a name before
+        /// normalization introduces one of its own.
+        /// </summary>
+        /// <remarks>
+        /// Without this, normalization masks a real difference. Member names
+        /// come from untrusted metadata and may contain any character,
+        /// including <c>#</c>. <c>&lt;Run&gt;b__103_0</c> normalizes to
+        /// <c>&lt;Run&gt;b__#_0</c>, which is itself a legal metadata name —
+        /// one that matches no recognized form and so passes through
+        /// unchanged. The two would then compare equal even though they name
+        /// different members, which is exactly the failure this option must
+        /// never produce.
+        /// <para>
+        /// Doubling separates the two. Escaping is injective, so it relates no
+        /// names that were not already equal, and it runs before the grammar,
+        /// so it cannot change which names normalize: no form Roslyn emits
+        /// contains <c>#</c>, making this the identity on every real name.
+        /// After escaping, every literal run of <c>#</c> has even length while
+        /// the ordinal placeholder is a lone <c>#</c> bounded by <c>_</c>, so
+        /// a normalized form can never equal a literal one.
+        /// </para>
+        /// <para>
+        /// Gated by
+        /// <c>IlBodyDiffNormalizationTests.NormalizeSynthesizedMemberOrdinals_DoesNotCollideWithALiteralPlaceholder</c>,
+        /// which pins the collision itself, the escape's injectivity on two
+        /// literal names, and that a real form still normalizes.
+        /// </para>
+        /// </remarks>
+        static string EscapePlaceholders(string value)
+            => value.Contains(Placeholder)
+                ? value.Replace("#", "##", StringComparison.Ordinal)
+                : value;
 
         static string Normalize(string value, SynthesizedMemberKind kind, int depth)
         {

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -117,14 +117,21 @@ public enum IlBodyDiffNormalization
     /// <c>StopsNormalizingPastTheNestingCap</c> for the depth bound.
     /// </para>
     /// <para>
-    /// Four checks are deliberately <em>not</em> gated, because they are
-    /// redundant fast paths rather than rules: the length floor, the leading
-    /// <c>&lt;</c> pre-check, and the <c>__</c> pre-check in
-    /// <c>Normalize</c>, and the empty-span check in
-    /// <c>IsCanonicalOrdinal</c>. Each is subsumed by a check that follows it,
-    /// so neutering one changes no observable behavior and no test can
-    /// distinguish it. They are listed here so that a future reader does not
-    /// mistake their absence from the gate list for an ungated property.
+    /// Four checks are deliberately <em>not</em> gated, and fall into two
+    /// kinds. The length floor and the marker bounds check in
+    /// <c>TryNormalizeName</c> are <em>bounds guards</em>: neutering either
+    /// makes the scan index past the end, so their failure mode is an
+    /// exception, not a collapse. They cannot mask a difference, and a test
+    /// that pinned them would be pinning an <c>IndexOutOfRangeException</c>.
+    /// The <c>__</c> pre-check in <c>Normalize</c> and the closing-angle check
+    /// in <c>TryNormalizeName</c> are <em>redundant fast paths</em>: each is
+    /// subsumed by a later check — the grammar re-derives <c>__</c> at the
+    /// marker, and a name with no closing angle leaves the marker on the
+    /// leading <c>&lt;</c>, which no marker accepts — so neutering either
+    /// changes no observable behavior and no test can distinguish it. The
+    /// empty-span check in <c>IsCanonicalOrdinal</c> is redundant in the same
+    /// way, subsumed by the parse. These are listed so that a future reader
+    /// does not mistake their absence from the gate list for an oversight.
     /// </para>
     /// </remarks>
     NormalizeSynthesizedMemberOrdinals = 1 << 3,
@@ -1144,15 +1151,19 @@ public static class IlBodyDiff
 
         static string Normalize(string value, SynthesizedMemberKind kind, int depth)
         {
-            // Cheap rejects, subsumed by the grammar below rather than adding
-            // to it. The shortest recognized form is `<>9__0_0`, every form
-            // opens with '<', which C# cannot spell, and every form carries
-            // '__'. `TryNormalizeName` declines each of these on its own, so
-            // no test distinguishes their presence — they exist to skip the
-            // scan on the overwhelming majority of names, not to reject
-            // anything the grammar would otherwise accept. Widening one is
-            // therefore safe; narrowing one is not, since a form the grammar
-            // accepts must be able to reach it.
+            // Two cheap rejects plus a bounds guard. The length floor keeps
+            // the indexing below in bounds — the shortest recognized form,
+            // `<>9__0_0`, is exactly its 8 characters — so neutering it
+            // throws rather than admitting anything. The `__` pre-check is
+            // subsumed by the grammar, which re-derives it at the marker, so
+            // no test distinguishes its presence; it exists to skip the scan
+            // on the overwhelming majority of names.
+            //
+            // The leading `<` check is NOT redundant. It anchors the form to
+            // the start of the name, which is what keeps `x!<Run>b__103_0`
+            // and `x!<Run>b__128_0` — two names that differ before the
+            // synthesized part — from collapsing. It is gated by that case in
+            // `PreservesEveryOtherNameComponent`.
             if (value.Length < MinNameLength
                 || value[0] != '<'
                 || !value.Contains("__", StringComparison.Ordinal))
@@ -1196,10 +1207,15 @@ public static class IlBodyDiff
             // The enclosing name may itself be synthesized (a lambda inside a
             // lambda, or one inside top-level statements' `<Main>$`), so match
             // the '>' that closes this name rather than the first one.
+            // Subsumed by the marker check below: with no closing angle,
+            // `marker` lands on the leading '<', which no marker accepts. Kept
+            // as an explicit statement of the form's shape.
             int close = FindClosingAngle(value);
             if (close < 0)
                 return false;
 
+            // `marker + 2` is a bounds guard for the three reads that follow,
+            // not a rejection rule; neutering it indexes past the end.
             int marker = close + 1;
             if (marker + 2 >= value.Length
                 || value[marker] is not ('9' or 'b' or 'g')

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1139,17 +1139,17 @@ public static class IlBodyDiff
             }
 
             // The trailing index must end the name. Roslyn emits nothing after
-            // it, so a name that continues (`<Run>b__103_0_extra`) is not one
-            // of these forms and must keep comparing literally.
+            // it, so a name that continues (`<Run>b__103_0_extra`,
+            // `<Run>b__103_0$x`) is not one of these forms and must keep
+            // comparing literally. The test is the inverse of a delimiter
+            // allow list on purpose: metadata names are untrusted, and a
+            // producer other than C# can use any identifier character here.
             int lambdaEnd = digitsEnd + 1;
             while (lambdaEnd < value.Length && char.IsAsciiDigit(value[lambdaEnd]))
                 lambdaEnd++;
 
-            if (lambdaEnd < value.Length
-                && (char.IsAsciiLetter(value[lambdaEnd]) || value[lambdaEnd] == '_'))
-            {
+            if (lambdaEnd < value.Length && IsInteriorChar(value[lambdaEnd]))
                 return false;
-            }
 
             // The enclosing name carries its own ordinal when it is itself a
             // closure, so normalize it under the same grammar. Recursing rather
@@ -1191,8 +1191,13 @@ public static class IlBodyDiff
             return -1;
         }
 
+        /// <summary>
+        /// True for characters that can occur inside an identifier. Metadata
+        /// names come from any .NET producer, not just C#, so this is Unicode
+        /// aware and includes <c>$</c>, which several compilers emit.
+        /// </summary>
         static bool IsInteriorChar(char c)
-            => char.IsAsciiLetterOrDigit(c) || c == '_';
+            => char.IsLetterOrDigit(c) || c is '_' or '$';
     }
 
     sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1008,78 +1008,54 @@ public static class IlBodyDiff
     /// <see cref="IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals"/>
     /// for what the ordinal means and why it is not evidence.
     /// </summary>
+    /// <remarks>
+    /// The grammar is matched from the start of the identifier rather than by
+    /// scanning for <c>__</c>. Anchoring matters: a scan reaches separators
+    /// inside the enclosing method's own name, so an authored method named
+    /// <c>b__1_0</c> would have its digits rewritten and would then compare
+    /// equal to an authored <c>b__2_0</c>. Anchoring also removes the need to
+    /// guess where an identifier begins, which is what previously left
+    /// <c>&lt;.ctor&gt;b__1_0</c> unnormalized.
+    /// </remarks>
     internal static class SynthesizedOrdinals
     {
         internal const char Placeholder = '#';
 
+        /// <summary>
+        /// Normalizes every synthesized name inside a resolved operand string
+        /// (for example <c>[Asm]Ns.Type::&lt;Run&gt;b__103_0</c>), rewriting
+        /// only the containing-method ordinal in each.
+        /// </summary>
         public static string Normalize(string value)
         {
-            // Cheap reject: every recognized form contains this separator.
+            // Every recognized form opens with '<', which C# cannot spell, and
+            // carries the separator. Both checks are cheap rejects.
             if (!value.Contains("__", StringComparison.Ordinal))
                 return value;
 
             StringBuilder? builder = null;
             int copied = 0;
 
-            for (int i = 0; i + 2 < value.Length; i++)
+            for (int i = 0; i < value.Length; i++)
             {
-                if (value[i] != '_' || value[i + 1] != '_')
+                if (value[i] != '<')
                     continue;
 
-                // `<>9__N_M` (cache field) and `<Name>b__N_M` (lambda method)
-                // put the ordinal straight after the separator. `g__` is a
-                // local function: `<Name>g__Local|N_M`, so the ordinal sits
-                // after the `|` that follows the local's own name.
-                char marker = i > 0 ? value[i - 1] : '\0';
-                int digitsStart;
-                if (marker is '9' or 'b')
-                {
-                    digitsStart = i + 2;
-                }
-                else if (marker == 'g')
-                {
-                    int bar = value.IndexOf('|', i + 2);
-                    if (bar < 0)
-                        continue;
-                    // The local's name must not itself contain a separator we
-                    // would rather have matched; bail if one intervenes.
-                    if (value.AsSpan(i + 2, bar - (i + 2)).Contains("__", StringComparison.Ordinal))
-                        continue;
-                    digitsStart = bar + 1;
-                }
-                else
-                {
-                    continue;
-                }
-
-                // Every Roslyn closure name begins with '<' — `<>9__…` or
-                // `<Method>b__…`. C# cannot spell that, so requiring it keeps
-                // an authored identifier that merely ends in `b`/`g` before a
-                // digit run (`Grab__1_0`) out of the rewrite.
-                if (!StartsSynthesizedName(value, i))
+                // Only start at a '<' that opens a name. One preceded by an
+                // identifier character is interior text, and one preceded by
+                // '<' or '>' belongs to a nested name that the recursive call
+                // below already covers.
+                if (i > 0 && IsInteriorChar(value[i - 1]))
                     continue;
 
-                int digitsEnd = digitsStart;
-                while (digitsEnd < value.Length && char.IsAsciiDigit(value[digitsEnd]))
-                    digitsEnd++;
-
-                // Require at least one digit, and require the ordinal to be
-                // followed by `_M` — that trailing index is what distinguishes
-                // a closure name from an ordinary identifier ending in digits.
-                if (digitsEnd == digitsStart
-                    || digitsEnd >= value.Length
-                    || value[digitsEnd] != '_'
-                    || digitsEnd + 1 >= value.Length
-                    || !char.IsAsciiDigit(value[digitsEnd + 1]))
-                {
+                if (!TryNormalizeName(value, i, out string replacement, out int end))
                     continue;
-                }
 
                 builder ??= new StringBuilder(value.Length);
-                builder.Append(value, copied, digitsStart - copied);
-                builder.Append(Placeholder);
-                copied = digitsEnd;
-                i = digitsEnd - 1;
+                builder.Append(value, copied, i - copied);
+                builder.Append(replacement);
+                copied = end;
+                i = end - 1;
             }
 
             if (builder is null)
@@ -1090,20 +1066,112 @@ public static class IlBodyDiff
         }
 
         /// <summary>
-        /// True when the identifier containing <paramref name="index"/> opens
-        /// with <c>&lt;</c>, the marker Roslyn puts on every synthesized name.
+        /// Matches <c>&lt;&gt;9__N_M</c>, <c>&lt;Name&gt;b__N_M</c>, or
+        /// <c>&lt;Name&gt;g__Local|N_M</c> starting at <paramref name="start"/>
+        /// and rewrites only <c>N</c>. Any other identifier, including the
+        /// state-machine form <c>&lt;Name&gt;d__N</c>, is declined.
         /// </summary>
-        static bool StartsSynthesizedName(string value, int index)
+        static bool TryNormalizeName(string value, int start, out string replacement, out int end)
         {
-            int start = index;
-            while (start > 0 && IsNameChar(value[start - 1]))
-                start--;
+            replacement = "";
+            end = start;
 
-            return value[start] == '<';
+            // The enclosing name may itself be synthesized (a nested lambda),
+            // so match the '>' that closes this name rather than the first one.
+            int close = FindClosingAngle(value, start);
+            if (close < 0)
+                return false;
+
+            int marker = close + 1;
+            if (marker + 2 >= value.Length
+                || value[marker] is not ('9' or 'b' or 'g')
+                || value[marker + 1] != '_'
+                || value[marker + 2] != '_')
+            {
+                return false;
+            }
+
+            int digitsStart = marker + 3;
+            if (value[marker] == 'g')
+            {
+                // Local function: the ordinal follows the '|' that terminates
+                // the local's own name, which cannot contain '|'.
+                int bar = value.IndexOf('|', digitsStart);
+                if (bar < 0)
+                    return false;
+                digitsStart = bar + 1;
+            }
+
+            int digitsEnd = digitsStart;
+            while (digitsEnd < value.Length && char.IsAsciiDigit(value[digitsEnd]))
+                digitsEnd++;
+
+            // Require at least one digit followed by `_M`. That trailing index
+            // is what separates a closure name from an identifier that merely
+            // ends in digits, and it stays significant so a lambda bound to the
+            // wrong slot still differs.
+            if (digitsEnd == digitsStart
+                || digitsEnd >= value.Length
+                || value[digitsEnd] != '_'
+                || digitsEnd + 1 >= value.Length
+                || !char.IsAsciiDigit(value[digitsEnd + 1]))
+            {
+                return false;
+            }
+
+            // The trailing index must end the name. Roslyn emits nothing after
+            // it, so a name that continues (`<Run>b__103_0_extra`) is not one
+            // of these forms and must keep comparing literally.
+            int lambdaEnd = digitsEnd + 1;
+            while (lambdaEnd < value.Length && char.IsAsciiDigit(value[lambdaEnd]))
+                lambdaEnd++;
+
+            if (lambdaEnd < value.Length
+                && (char.IsAsciiLetter(value[lambdaEnd]) || value[lambdaEnd] == '_'))
+            {
+                return false;
+            }
+
+            // The enclosing name carries its own ordinal when it is itself a
+            // closure, so normalize it under the same grammar. Recursing rather
+            // than rescanning is what keeps an authored enclosing method named
+            // `b__1_0` distinct from one named `b__2_0`.
+            string inner = value[(start + 1)..close];
+            string normalizedInner = Normalize(inner);
+
+            replacement = string.Concat(
+                "<",
+                normalizedInner,
+                value.AsSpan(close, digitsStart - close),
+                Placeholder.ToString());
+            end = digitsEnd;
+            return true;
         }
 
-        static bool IsNameChar(char c)
-            => char.IsAsciiLetterOrDigit(c) || c is '_' or '<' or '>' or '|' or '`';
+        /// <summary>
+        /// Returns the index of the <c>&gt;</c> closing the <c>&lt;</c> at
+        /// <paramref name="start"/>, honoring nesting, or -1 when unbalanced.
+        /// </summary>
+        static int FindClosingAngle(string value, int start)
+        {
+            int depth = 0;
+            for (int i = start; i < value.Length; i++)
+            {
+                if (value[i] == '<')
+                {
+                    depth++;
+                }
+                else if (value[i] == '>' && --depth == 0)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        static bool IsInteriorChar(char c)
+            => char.IsAsciiLetterOrDigit(c) || c is '_' or '<' or '>';
     }
 
     sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -71,6 +70,11 @@ public enum IlBodyDiffNormalization
     /// formatted operand. Declaring types, return types, parameter types,
     /// generic arguments, standalone signatures, and string literals are left
     /// alone, so the rewrite cannot reach text that is not a member name.
+    /// Within that name the match is anchored at both ends: the whole name
+    /// must be one of the three forms. A synthesized-looking <em>substring</em>
+    /// is never rewritten, so names that arrive from a producer other than C#
+    /// (<c>x!&lt;Run&gt;b__1_0</c>, <c>&lt;Run&gt;b__1_0!suffix</c>) keep
+    /// comparing literally.
     /// </para>
     /// <para>
     /// Known limitation, deliberately not addressed: overloads share a
@@ -1066,96 +1070,67 @@ public static class IlBodyDiff
         const int MaxNestingDepth = 16;
 
         /// <summary>
-        /// Bounds the total characters <see cref="FindClosingAngle"/> may
-        /// visit across one top-level call, expressed as a multiple of the
-        /// input length. Each candidate <c>&lt;</c> starts its own forward
-        /// scan, so a name made of unbalanced <c>&lt;</c> characters would
-        /// otherwise cost O(n²)
-        /// (see docs/design/untrusted-data-threat-model.md, which requires CPU
-        /// amplification over hostile input to be bounded). Every recognized
-        /// form pairs its angles off in one scan per nesting level, so real
-        /// input stays far inside the budget; exhausting it means the name is
-        /// not one of these forms.
+        /// Shortest recognized form, <c>&lt;&gt;9__0_0</c>.
         /// </summary>
-        const int ScanBudgetFactor = MaxNestingDepth + 1;
+        const int MinNameLength = 8;
 
         /// <summary>
-        /// Normalizes every synthesized name inside a member's simple name
-        /// (for example <c>&lt;Run&gt;b__103_0</c>), rewriting only the
-        /// containing-method ordinal in each.
+        /// Normalizes a member's simple name when the <em>whole</em> name is
+        /// one of the recognized synthesized forms (for example
+        /// <c>&lt;Run&gt;b__103_0</c>), rewriting only the containing-method
+        /// ordinal. Any other name is returned unchanged.
         /// </summary>
         public static string Normalize(string value)
-        {
-            int budget = ScanBudgetFactor * (value.Length + 16);
-            return Normalize(value, depth: 0, ref budget);
-        }
+            => Normalize(value, depth: 0);
 
-        static string Normalize(string value, int depth, ref int budget)
+        static string Normalize(string value, int depth)
         {
             // Every recognized form opens with '<', which C# cannot spell, and
-            // carries the separator. Both checks are cheap rejects.
-            if (!value.Contains("__", StringComparison.Ordinal))
-                return value;
-
-            StringBuilder? builder = null;
-            int copied = 0;
-
-            for (int i = 0; i < value.Length; i++)
+            // carries the '__' separator. Both checks are cheap rejects.
+            if (value.Length < MinNameLength
+                || value[0] != '<'
+                || !value.Contains("__", StringComparison.Ordinal))
             {
-                if (value[i] != '<')
-                    continue;
-
-                // Only start at a '<' that opens a name. One preceded by an
-                // identifier character is interior text. A '<' preceded by
-                // '<' or '>' is reachable and must be scanned: a successful
-                // match jumps past the whole name it consumed, so the only way
-                // to arrive at a nested '<' is for the enclosing name to have
-                // been declined (`<<Run>b__103_0>d__1`, the state machine of an
-                // async lambda), and the name inside it still needs normalizing.
-                if (i > 0 && IsInteriorChar(value[i - 1]))
-                    continue;
-
-                // Out of scan budget: abandon the whole string rather than
-                // return it half-rewritten. Declining can only cost a false
-                // positive, never a masked difference.
-                if (budget < 0)
-                    return value;
-
-                if (!TryNormalizeName(value, i, depth, ref budget, out string replacement, out int end))
-                    continue;
-
-                builder ??= new StringBuilder(value.Length);
-                builder.Append(value, copied, i - copied);
-                builder.Append(replacement);
-                copied = end;
-                i = end - 1;
+                return value;
             }
 
-            // The budget can also run out on the last candidate in the string,
-            // after which the loop simply ends and the check above is never
-            // reached again. Re-check here so an exhausted scan always declines
-            // the whole string, whatever position exhausted it.
-            if (builder is null || budget < 0)
-                return value;
-
-            builder.Append(value, copied, value.Length - copied);
-            return builder.ToString();
+            return TryNormalizeName(value, depth, out string replacement) ? replacement : value;
         }
 
         /// <summary>
-        /// Matches <c>&lt;&gt;9__N_M</c>, <c>&lt;Name&gt;b__N_M</c>, or
-        /// <c>&lt;Name&gt;g__Local|N_M</c> starting at <paramref name="start"/>
-        /// and rewrites only <c>N</c>. Any other identifier, including the
-        /// state-machine form <c>&lt;Name&gt;d__N</c>, is declined.
+        /// Matches <paramref name="value"/> in its entirety against
+        /// <c>&lt;&gt;9__N_M</c>, <c>&lt;Name&gt;b__N_M</c>, or
+        /// <c>&lt;Name&gt;g__Local|N_M</c> and rewrites only <c>N</c>. Any
+        /// other name, including the state-machine form
+        /// <c>&lt;Name&gt;d__N</c>, is declined.
         /// </summary>
-        static bool TryNormalizeName(string value, int start, int depth, ref int budget, out string replacement, out int end)
+        /// <remarks>
+        /// <para>
+        /// The match is anchored at both ends on purpose. These names arrive
+        /// from arbitrary metadata, not only from Roslyn, so recognizing a
+        /// synthesized-looking <em>substring</em> would let unrelated names
+        /// collapse: <c>x!&lt;Run&gt;b__103_0</c> and
+        /// <c>&lt;Run&gt;b__103_0!suffix</c> are legal metadata names that no
+        /// C# compiler emits, and normalizing an ordinal buried inside them
+        /// would equate members that genuinely differ.
+        /// </para>
+        /// <para>
+        /// Anchoring also bounds the work. There is exactly one candidate
+        /// start, so each nesting level performs one angle scan plus at most
+        /// one separator scan over a disjoint part of the same string, and the
+        /// depth cap bounds the levels — linear overall, with no per-candidate
+        /// rescan for a hostile name to amplify
+        /// (see docs/design/untrusted-data-threat-model.md).
+        /// </para>
+        /// </remarks>
+        static bool TryNormalizeName(string value, int depth, out string replacement)
         {
             replacement = "";
-            end = start;
 
-            // The enclosing name may itself be synthesized (a nested lambda),
-            // so match the '>' that closes this name rather than the first one.
-            int close = FindClosingAngle(value, start, ref budget);
+            // The enclosing name may itself be synthesized (a lambda inside a
+            // lambda, or one inside top-level statements' `<Main>$`), so match
+            // the '>' that closes this name rather than the first one.
+            int close = FindClosingAngle(value);
             if (close < 0)
                 return false;
 
@@ -1168,17 +1143,23 @@ public static class IlBodyDiff
                 return false;
             }
 
+            // Roslyn omits the containing-method name only for the lambda
+            // cache field `<>9__N_M`; the lambda and local-function forms
+            // always carry one. Pinning that correspondence keeps names no C#
+            // compiler emits, such as `<>b__1_0`, comparing literally.
+            bool namesContainingMethod = close > 1;
+            if (namesContainingMethod != (value[marker] is 'b' or 'g'))
+                return false;
+
             int digitsStart = marker + 3;
             if (value[marker] == 'g')
             {
                 // Local function: the ordinal follows the '|' that terminates
-                // the local's own name, which cannot contain '|'. This search
-                // runs to the end of the string when there is no '|', so it is
-                // charged to the same budget as the angle scan; leaving it
-                // uncharged keeps the quadratic behavior the budget exists to
-                // bound.
-                int bar = FindLocalFunctionSeparator(value, digitsStart, ref budget);
-                if (bar < 0)
+                // the local's own name, which cannot contain '|'. The name
+                // must be non-empty, so the separator cannot sit immediately
+                // after `g__`.
+                int bar = value.IndexOf('|', digitsStart);
+                if (bar <= digitsStart)
                     return false;
                 digitsStart = bar + 1;
             }
@@ -1193,76 +1174,44 @@ public static class IlBodyDiff
             // wrong slot still differs.
             if (digitsEnd == digitsStart
                 || digitsEnd >= value.Length
-                || value[digitsEnd] != '_'
-                || digitsEnd + 1 >= value.Length
-                || !char.IsAsciiDigit(value[digitsEnd + 1]))
+                || value[digitsEnd] != '_')
             {
                 return false;
             }
 
-            // The trailing index must end the name. Roslyn emits nothing after
-            // it, so a name that continues (`<Run>b__103_0_extra`,
-            // `<Run>b__103_0$x`) is not one of these forms and must keep
-            // comparing literally. The test is the inverse of a delimiter
-            // allow list on purpose: metadata names are untrusted, and a
-            // producer other than C# can use any identifier character here.
-            int lambdaEnd = digitsEnd + 1;
+            // `M` must be digits that run to the end of the name. Roslyn emits
+            // nothing after the per-method index, so a name that continues is
+            // not one of these forms and must keep comparing literally.
+            int lambdaStart = digitsEnd + 1;
+            int lambdaEnd = lambdaStart;
             while (lambdaEnd < value.Length && char.IsAsciiDigit(value[lambdaEnd]))
                 lambdaEnd++;
 
-            if (lambdaEnd < value.Length && IsInteriorChar(value[lambdaEnd]))
+            if (lambdaEnd == lambdaStart || lambdaEnd != value.Length)
                 return false;
 
             // The enclosing name carries its own ordinal when it is itself a
             // closure, so normalize it under the same grammar. Recursing rather
             // than rescanning is what keeps an authored enclosing method named
             // `b__1_0` distinct from one named `b__2_0`.
-            string inner = value[(start + 1)..close];
+            string inner = value[1..close];
             string normalizedInner = depth < MaxNestingDepth
-                ? Normalize(inner, depth + 1, ref budget)
+                ? Normalize(inner, depth + 1)
                 : inner;
 
-            replacement = string.Concat(
-                "<",
-                normalizedInner,
-                value.AsSpan(close, digitsStart - close),
-                Placeholder.ToString());
-            end = digitsEnd;
+            replacement = $"<{normalizedInner}{value[close..digitsStart]}{Placeholder}{value[digitsEnd..]}";
             return true;
         }
 
         /// <summary>
-        /// Returns the index of the <c>|</c> at or after <paramref name="start"/>
-        /// that terminates a local function's own name, or -1 when there is
-        /// none or when <paramref name="budget"/> runs out.
-        /// </summary>
-        static int FindLocalFunctionSeparator(string value, int start, ref int budget)
-        {
-            for (int i = start; i < value.Length; i++)
-            {
-                if (--budget < 0)
-                    return -1;
-
-                if (value[i] == '|')
-                    return i;
-            }
-
-            return -1;
-        }
-
-        /// <summary>
         /// Returns the index of the <c>&gt;</c> closing the <c>&lt;</c> at
-        /// <paramref name="start"/>, honoring nesting, or -1 when unbalanced
-        /// or when <paramref name="budget"/> runs out.
+        /// index 0, honoring nesting, or -1 when unbalanced.
         /// </summary>
-        static int FindClosingAngle(string value, int start, ref int budget)
+        static int FindClosingAngle(string value)
         {
             int depth = 0;
-            for (int i = start; i < value.Length; i++)
+            for (int i = 0; i < value.Length; i++)
             {
-                if (--budget < 0)
-                    return -1;
-
                 if (value[i] == '<')
                 {
                     depth++;
@@ -1275,30 +1224,6 @@ public static class IlBodyDiff
 
             return -1;
         }
-
-        /// <summary>
-        /// True for characters that can continue an identifier. Metadata names
-        /// come from any .NET producer, not just C#, so this covers every
-        /// Unicode category the language admits as an identifier-part
-        /// character, plus <c>$</c>, which several compilers emit. A surrogate
-        /// counts as interior so a name continuing into a supplementary-plane
-        /// character is still recognized as continuing.
-        /// </summary>
-        /// <remarks>
-        /// Used only to decide whether a name <em>ends</em> where a recognized
-        /// form does. Erring toward "interior" therefore declines to
-        /// normalize, which is the safe direction.
-        /// </remarks>
-        static bool IsInteriorChar(char c)
-            => char.IsLetterOrDigit(c)
-                || c is '_' or '$'
-                || char.IsSurrogate(c)
-                || CharUnicodeInfo.GetUnicodeCategory(c) is
-                    UnicodeCategory.LetterNumber
-                    or UnicodeCategory.NonSpacingMark
-                    or UnicodeCategory.SpacingCombiningMark
-                    or UnicodeCategory.ConnectorPunctuation
-                    or UnicodeCategory.Format;
     }
 
     sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -95,24 +95,36 @@ public enum IlBodyDiffNormalization
     /// never a masked difference.
     /// </para>
     /// <para>
-    /// Every property claimed above is enforced by a gate in
-    /// <c>IlBodyDiffNormalizationTests</c>:
-    /// <c>ToleratesContainingMethodRenumbering</c> and
-    /// <c>ToleratesRenumberingOfALambdaCacheField</c> for what is related —
+    /// Every rule that can change what this option relates is enforced by a
+    /// gate in <c>IlBodyDiffNormalizationTests</c>, and each was confirmed
+    /// load-bearing by neutering it individually and observing that gate — and
+    /// only that gate — fail. <c>ToleratesContainingMethodRenumbering</c> and
+    /// <c>ToleratesRenumberingOfALambdaCacheField</c> cover what is related;
     /// each asserts the two names differ <em>without</em> the option as well
     /// as agreeing with it, so neither can pass vacuously in either
     /// direction. The remaining gates assert only that the names still differ
     /// <em>with</em> the option, which is the whole claim for a name this
     /// option must not relate: <c>PreservesEveryOtherNameComponent</c> for the
-    /// components that stay significant, the anchoring, and non-canonical
-    /// ordinals, <c>RejectsAFieldFormOnAMethod</c> and
-    /// <c>RejectsAMethodFormOnAField</c> for the kind correspondence,
+    /// components that stay significant, the anchoring, every component of the
+    /// grammar, and both canonical-ordinal rules;
+    /// <c>RejectsAFieldFormOnAMethod</c> and
+    /// <c>RejectsAMethodFormOnAField</c> for the kind correspondence;
     /// <c>RejectsAMethodFormBehindAMethodSpecificationOnAField</c> for the
-    /// generic-instantiation path,
+    /// generic-instantiation path;
     /// <c>RejectsANonCanonicalCacheFieldOrdinal</c> for the cache field's
-    /// ordinal spelling, <c>LeavesTypeOperandsAlone</c> and
-    /// <c>PreservesSynthesizedLikeStringLiterals</c> for the scope, and
+    /// ordinal spelling; <c>LeavesTypeOperandsAlone</c> and
+    /// <c>PreservesSynthesizedLikeStringLiterals</c> for the scope; and
     /// <c>StopsNormalizingPastTheNestingCap</c> for the depth bound.
+    /// </para>
+    /// <para>
+    /// Four checks are deliberately <em>not</em> gated, because they are
+    /// redundant fast paths rather than rules: the length floor, the leading
+    /// <c>&lt;</c> pre-check, and the <c>__</c> pre-check in
+    /// <c>Normalize</c>, and the empty-span check in
+    /// <c>IsCanonicalOrdinal</c>. Each is subsumed by a check that follows it,
+    /// so neutering one changes no observable behavior and no test can
+    /// distinguish it. They are listed here so that a future reader does not
+    /// mistake their absence from the gate list for an ungated property.
     /// </para>
     /// </remarks>
     NormalizeSynthesizedMemberOrdinals = 1 << 3,
@@ -1132,8 +1144,15 @@ public static class IlBodyDiff
 
         static string Normalize(string value, SynthesizedMemberKind kind, int depth)
         {
-            // Every recognized form opens with '<', which C# cannot spell, and
-            // carries the '__' separator. Both checks are cheap rejects.
+            // Cheap rejects, subsumed by the grammar below rather than adding
+            // to it. The shortest recognized form is `<>9__0_0`, every form
+            // opens with '<', which C# cannot spell, and every form carries
+            // '__'. `TryNormalizeName` declines each of these on its own, so
+            // no test distinguishes their presence — they exist to skip the
+            // scan on the overwhelming majority of names, not to reject
+            // anything the grammar would otherwise accept. Widening one is
+            // therefore safe; narrowing one is not, since a form the grammar
+            // accepts must be able to reach it.
             if (value.Length < MinNameLength
                 || value[0] != '<'
                 || !value.Contains("__", StringComparison.Ordinal))
@@ -1288,6 +1307,9 @@ public static class IlBodyDiff
         static bool IsCanonicalOrdinal(string value, int start, int end)
         {
             int length = end - start;
+
+            // Redundant with the parse below, which also rejects an empty
+            // span; kept because it states the intent at the top.
             if (length == 0)
                 return false;
 

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1058,9 +1058,12 @@ public static class IlBodyDiff
                     continue;
 
                 // Only start at a '<' that opens a name. One preceded by an
-                // identifier character is interior text, and one preceded by
-                // '<' or '>' belongs to a nested name that the recursive call
-                // below already covers.
+                // identifier character is interior text. A '<' preceded by
+                // '<' or '>' is reachable and must be scanned: a successful
+                // match jumps past the whole name it consumed, so the only way
+                // to arrive at a nested '<' is for the enclosing name to have
+                // been declined (`<<Run>b__103_0>d__1`, the state machine of an
+                // async lambda), and the name inside it still needs normalizing.
                 if (i > 0 && IsInteriorChar(value[i - 1]))
                     continue;
 
@@ -1189,7 +1192,7 @@ public static class IlBodyDiff
         }
 
         static bool IsInteriorChar(char c)
-            => char.IsAsciiLetterOrDigit(c) || c is '_' or '<' or '>';
+            => char.IsAsciiLetterOrDigit(c) || c == '_';
     }
 
     sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1022,11 +1022,27 @@ public static class IlBodyDiff
         internal const char Placeholder = '#';
 
         /// <summary>
+        /// Caps how deep the enclosing-name recursion goes. Roslyn nests
+        /// closure names only as deep as the source nests lambdas, so a
+        /// handful of levels covers real input. The cap exists because member
+        /// names come from untrusted metadata, where an adversarially nested
+        /// name would otherwise recurse once per level and overflow the stack
+        /// (see docs/design/untrusted-data-threat-model.md, which requires
+        /// recursion over hostile input to be bounded). Past the cap the
+        /// enclosing name is left literal, which can only cost a false
+        /// positive, never a masked difference.
+        /// </summary>
+        const int MaxNestingDepth = 16;
+
+        /// <summary>
         /// Normalizes every synthesized name inside a resolved operand string
         /// (for example <c>[Asm]Ns.Type::&lt;Run&gt;b__103_0</c>), rewriting
         /// only the containing-method ordinal in each.
         /// </summary>
         public static string Normalize(string value)
+            => Normalize(value, depth: 0);
+
+        static string Normalize(string value, int depth)
         {
             // Every recognized form opens with '<', which C# cannot spell, and
             // carries the separator. Both checks are cheap rejects.
@@ -1048,7 +1064,7 @@ public static class IlBodyDiff
                 if (i > 0 && IsInteriorChar(value[i - 1]))
                     continue;
 
-                if (!TryNormalizeName(value, i, out string replacement, out int end))
+                if (!TryNormalizeName(value, i, depth, out string replacement, out int end))
                     continue;
 
                 builder ??= new StringBuilder(value.Length);
@@ -1071,7 +1087,7 @@ public static class IlBodyDiff
         /// and rewrites only <c>N</c>. Any other identifier, including the
         /// state-machine form <c>&lt;Name&gt;d__N</c>, is declined.
         /// </summary>
-        static bool TryNormalizeName(string value, int start, out string replacement, out int end)
+        static bool TryNormalizeName(string value, int start, int depth, out string replacement, out int end)
         {
             replacement = "";
             end = start;
@@ -1137,7 +1153,9 @@ public static class IlBodyDiff
             // than rescanning is what keeps an authored enclosing method named
             // `b__1_0` distinct from one named `b__2_0`.
             string inner = value[(start + 1)..close];
-            string normalizedInner = Normalize(inner);
+            string normalizedInner = depth < MaxNestingDepth
+                ? Normalize(inner, depth + 1)
+                : inner;
 
             replacement = string.Concat(
                 "<",

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1118,7 +1118,7 @@ public static class IlBodyDiff
                 // Out of scan budget: abandon the whole string rather than
                 // return it half-rewritten. Declining can only cost a false
                 // positive, never a masked difference.
-                if (budget <= 0)
+                if (budget < 0)
                     return value;
 
                 if (!TryNormalizeName(value, i, depth, ref budget, out string replacement, out int end))
@@ -1131,7 +1131,11 @@ public static class IlBodyDiff
                 i = end - 1;
             }
 
-            if (builder is null)
+            // The budget can also run out on the last candidate in the string,
+            // after which the loop simply ends and the check above is never
+            // reached again. Re-check here so an exhausted scan always declines
+            // the whole string, whatever position exhausted it.
+            if (builder is null || budget < 0)
                 return value;
 
             builder.Append(value, copied, value.Length - copied);
@@ -1168,8 +1172,12 @@ public static class IlBodyDiff
             if (value[marker] == 'g')
             {
                 // Local function: the ordinal follows the '|' that terminates
-                // the local's own name, which cannot contain '|'.
-                int bar = value.IndexOf('|', digitsStart);
+                // the local's own name, which cannot contain '|'. This search
+                // runs to the end of the string when there is no '|', so it is
+                // charged to the same budget as the angle scan; leaving it
+                // uncharged keeps the quadratic behavior the budget exists to
+                // bound.
+                int bar = FindLocalFunctionSeparator(value, digitsStart, ref budget);
                 if (bar < 0)
                     return false;
                 digitsStart = bar + 1;
@@ -1221,6 +1229,25 @@ public static class IlBodyDiff
                 Placeholder.ToString());
             end = digitsEnd;
             return true;
+        }
+
+        /// <summary>
+        /// Returns the index of the <c>|</c> at or after <paramref name="start"/>
+        /// that terminates a local function's own name, or -1 when there is
+        /// none or when <paramref name="budget"/> runs out.
+        /// </summary>
+        static int FindLocalFunctionSeparator(string value, int start, ref int budget)
+        {
+            for (int i = start; i < value.Length; i++)
+            {
+                if (--budget < 0)
+                    return -1;
+
+                if (value[i] == '|')
+                    return i;
+            }
+
+            return -1;
         }
 
         /// <summary>

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -44,7 +44,12 @@ static class FidelityCheck
     internal const IlBodyDiffNormalization ContractV1BodyDiffNormalization =
         IlBodyDiffNormalization.NormalizeVariableLayout
         | IlBodyDiffNormalization.NormalizeCurrentAssemblyScope
-        | IlBodyDiffNormalization.NormalizePlatformAssemblyScope;
+        | IlBodyDiffNormalization.NormalizePlatformAssemblyScope
+        // Compile-back recompiles a reconstructed unit, whose member ordering
+        // is the harness's rather than the original source file's, so Roslyn
+        // renumbers the containing-method ordinal in every closure name it
+        // synthesizes. That renumbering is not decompiler evidence (#3503).
+        | IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals;
 
     const int MaxTransientEmptyEmitAttempts = 3;
 


### PR DESCRIPTION
- Fixes #3503
- Fixes #3491 (five of its six rows; the sixth, `ManualConstantOnlyComparisonFactory`, is #3502 and is unaffected)
- Advances #3326
- Changes the compile-back fidelity **oracle**, not decompiler output: Contract V1 no longer treats Roslyn's renumbering of synthesized-member ordinals as a diff.

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the harness was comparing a property of member ordering in the recompiled compilation unit, which is not evidence about the method body. The normalization removes exactly those six false positives while leaving every genuine diff in place.

This is not a raise, structuring, or printer change, so the template's Original source / Before / After render blocks do not apply: **no decompiled output changes**. The Before/After that matters is the oracle's verdict, recorded in the Evidence table.

### Root cause

Roslyn embeds the containing method's declaration ordinal in the names it synthesizes for closures, lambda caches, and local functions:

```text
<>9__N_M            lambda cache field
<Name>b__N_M        lambda method
<Name>g__Local|N_M  local function
```

`N` is the containing method's ordinal **in the compilation unit**. It is a fact about member ordering, not about the body.

The compile-back harness recompiles a reconstructed skeleton whose member ordering is the harness's, not the original source file's, so Roslyn assigns a different `N` to the same method. `CfgSampleClass.StatementBodyLambdaInsideIf` is the clearest witness: the shipped assembly contains `b__103_0`, the recompiled skeleton contains `b__128_0`, and Contract V1 compared the two literally and reported an OperandDiff.

`ContractV1BodyDiffNormalization` already normalizes variable layout and assembly scopes for the same reason — both are recompilation artifacts rather than body evidence. This adds the third member of that family.

### Why this is not harness compensation for a product gap

`AGENTS.md` prohibits harness-side normalization that covers for missing or incorrect product behavior. This is the opposite case: the product's decompiled C# is **correct**, and the divergence is introduced by Roslyn on the recompile leg. The harness owns the oracle, and an oracle that reports a difference the product did not cause is an oracle defect. That is why the fix sits in the shared diff substrate plus Contract V1, and not in a shape-recognizer that special-cases the failing rows.

### How the normalization is bounded

Masking is the only dangerous failure here. Normalization is many-to-one, so an over-broad rewrite can hide a real IL difference, while an under-broad or declined rewrite only costs a false positive. Every design choice below leans toward declining.

**Scope: the member's simple name, never the operand string.** Normalization is applied through a `NormalizeMemberName` helper at six formatting sites in `MetadataOperandResolver` — `FormatMethodDefinition`, `FormatMemberReference`, `FormatMethodSpecificationDefinition`, `FormatMethodSpecificationReference`, `FormatFieldDefinition`, `FormatFieldMemberReference`. It is **not** applied to the flattened operand string, which also carries declaring types, return types, parameter types, generic arguments, and standalone signatures.

This matters: an earlier revision of this PR normalized the operand string, which could collapse two distinct *types* that happened to be spelled like closures. The rescope is a strict narrowing, and the corpus separation is **byte-identical** before and after it — proving the type-name coverage was never doing any work. It also follows the `AGENTS.md` rule against inferring identity from display text when a typed identity exists.

| Kept significant | Why |
| --- | --- |
| Containing-method name (`<Name>`) | A lambda bound to the wrong method still diffs |
| Per-method index `M` | A lambda bound to the wrong slot within a method still diffs |
| State machines `<Name>d__N` | `N` is their only distinguishing component, so it is never rewritten |
| **All synthesized *type* names** | `<>c__DisplayClassN_M`, `<<Run>b__N_M>d__1` — structurally out of scope after the rescope |
| `OperandKind.InlineString` | A synthesized-looking *string literal* is still compared byte for byte, mirroring `PreservesPlatformLikeStringLiterals` |

The rewrite additionally requires the enclosing identifier to begin with `<`, which C# cannot spell, so an authored member named `Grab__103_0` is left alone.

**Form: exactly what Roslyn emits, on the table Roslyn emits it.** Two further constraints hold names to the shapes a C# compiler actually produces:

- **Member kind must match the form.** Roslyn emits the cache form `<>9__N_M` only as a *field* and the lambda and local-function forms only as *methods*. The member kind threads from each call site into the normalizer, so a method named `<>9__1_0` or a field named `<Run>b__1_0` — neither of which any compiler emits — compares literally. An SRM scan of the Release outputs shows real output has perfect correspondence: `fieldCache=31765, methodCache=0, fieldClosure=0, methodClosure=52236`.
- **Both ordinals must be spelled canonically.** Roslyn formats `N` and `M` with an invariant `int` conversion, so leading zeros and values wider than `int` are not forms it emits. Without this, `<Run>b__0103_0` collapsed with `<Run>b__0128_0`, and 30-digit ordinals collapsed too. An SRM scan of 19,982 unique real synthesized names found zero non-canonical encodings.

Both are strict narrowings, and the corpus separation is byte-identical across them — the same evidence as for the rescope: the accepted-but-unreal forms were never doing any work.

**Deliberately not constrained: the containing name's character set.** It would be easy to also require `<Name>` to look like an identifier, and no real name violates that. But the containing name is an arbitrary metadata *method* name whose legal forms already carry non-identifier characters — `.ctor` has a dot, and an explicit interface implementation is spelled `IFoo.Bar` — so there is no principled line to draw, and an allow list tuned to one corpus risks rejecting a real form later. Names that share a containing name and differ only in `N` are exactly what this option exists to relate.

**Declared limitations** (each costs a false positive, never a masked difference): two overloads of the same name share a normalized form; state machines are not normalized; synthesized type names are not normalized.

### Untrusted input

Member names come from arbitrary assembly metadata, not only from Roslyn, so per `docs/design/untrusted-data-threat-model.md` the parser is strict and bounded:

- **Anchored at both ends** — the *whole* member simple name must be one of the three forms. A synthesized-looking substring is never rewritten, so names no C# compiler emits (`x!<Run>b__1_0`, `<Run>b__1_0!suffix`, `<>b__1_0`, `<Run>g__|1_0`) keep comparing literally. This is what stops unrelated members from collapsing onto each other.
- **Linear by construction** — with exactly one candidate start, each nesting level performs one angle scan plus at most one separator scan over *disjoint* parts of the same string, and the depth cap bounds the levels. There is no per-candidate rescan for a hostile name to amplify, so no scan budget is needed.
- **Depth-capped** — `MaxNestingDepth = 16` caps the enclosing-name recursion, and the inner substring strictly shrinks each level.

Anchoring also removed the need for a character-classification heuristic: "does the name end here" is answered exactly by end-of-string.

## Evidence

Release, full-solution build (`dotnet build dotnet-inspect.slnx -c Release`), Windows.

| Check | Baseline (`origin/main`) | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| `FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket` | **Fail** — 3 unexpected rows | **Fail** — 2 unexpected rows |
| `LoweredFidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket` | **Fail** — 6 unexpected rows | **Fail** — 1 unexpected row |
| `FidelityGateTests.PinnedFixesStayExact` | **Fail** — `TupleRest` RecompileFail | **Fail** — `TupleRest` RecompileFail (unchanged) |
| `ILInspector.Instructions.Tests` | 147, 0 failed | **189, 0 failed** |
| `ILInspector.Analysis.Tests` | 584, 0 failed | 584, 0 failed |

The baseline failures are pre-existing and tracked; this PR does not claim to make these gate classes green.

**Raised gate, rows removed and rows kept.** This separation is the substance of the evidence:

| Row | Baseline | Head | Tracked as |
| --- | --- | --- | --- |
| `StatementBodyLambdaInsideIf` | unexpected OperandDiff | **gone** | #3503 (this PR) |
| `MakeConsumerWithTwoLeadingArgs` | unexpected OpcodeDiff | **still fails** | #3490 |
| `ManualConstantOnlyComparisonFactory` | unexpected OpcodeDiff | **still fails** | #3502 |

Both surviving rows are genuine spurious `stloc`/`ldloc` pairs — real opcode differences that this change cannot and does not hide.

**Lowered gate.** All five local-function rows enumerated in #3491 drop out; the one non-local-function row remains:

| Row | Head |
| --- | --- |
| `EnumArgInInlineLocalFunction` | gone |
| `EnumArgInLocalFunctionWithLocal` | gone |
| `RecursiveLocalFunction` | gone |
| `StaticLocalFunctionWithLocal` | gone |
| `TwoLocalFunctionQuadrants` | gone |
| `ManualConstantOnlyComparisonFactory` | still fails (#3502) |

This confirms #3491's own hypothesis, but inverts its conclusion: the five shared a single root cause, and that cause was in the oracle rather than in local-function lowering. No decompiler change is needed for them.

**`TupleRest` is untouched.** It is #3489, a `RecompileFail` — the recompilation does not compile at all (CS0246). A comparison-side normalization runs only after a successful recompile, so it cannot cause or cure that status. It fails identically on both sides.

### Gate integrity

Per `AGENTS.md`, every asserted property names the gate that enforces it:

| Asserted property | Gate |
| --- | --- |
| Renumbering is tolerated | `..._ToleratesContainingMethodRenumbering` (6 cases; asserts the images differ **without** the flag and match **with** it, so it cannot pass vacuously in either direction) |
| Nothing else in the name is rewritten | `..._PreservesEveryOtherNameComponent` (26 cases, including the four non-Roslyn collapses round 5 found and the non-canonical ordinals round 6 found) |
| The cache field form is normalized on a real field | `..._ToleratesRenumberingOfALambdaCacheField` (built with `BuildFieldImage`, an `ldsfld` through a field-signature `MemberReference`, so it exercises the field paths rather than the call paths) |
| A form on the wrong metadata table is not normalized | `..._RejectsAFieldFormOnAMethod`, `..._RejectsAMethodFormOnAField` |
| The cache field ordinal must be canonical too | `..._RejectsANonCanonicalCacheFieldOrdinal` |
| Type operands are out of scope | `..._LeavesTypeOperandsAlone` |
| String literals are compared byte for byte | `..._PreservesSynthesizedLikeStringLiterals` |
| Recursion is depth-capped | `..._StopsNormalizingPastTheNestingCap` |
| Work stays linear on hostile names | `..._BoundsScanWorkOnHostileNames` |
| Contract V1 composes every declared option | `CorpusSensorComparisonTests.FidelityContractV1_ComposesAllIlBodyNormalizations` |

`AllNormalizations` is not a hand-maintained constant — it is derived from `Enum.GetValues` and asserted for set equality, so a future option that no test exercises fails rather than passing silently. This follows the `AGENTS.md` preference for a declaration that *drives* its enforcement set.

**Tamper-verified.** Each gate was confirmed non-vacuous by reverting exactly the fix it covers and checking that it — and only it — fails. Details in the round-by-round reconciliation comments below.

### Review

High-risk tier. Six rounds, two different non-Claude model families per round (GPT-5.6 Sol, Gemini 3.1 Pro, MAI-Code), each in an isolated detached review worktree at a fixed head. Reviews found eleven real defects — including the operand-string over-scope that motivated the rescope, two independent quadratic scan paths, the substring matching that motivated the anchoring, and the two form constraints above. One finding was raised, investigated against a real compiled artifact, rebutted, and retracted by its author. Each round is reconciled publicly in the comments with attribution.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Instructions.Tests -c Release
dotnet run --project src/ILInspector.Analysis.Tests -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class ILInspector.Decompiler.Tests.FidelityGateTests \
  -class ILInspector.Decompiler.Tests.LoweredFidelityGateTests
```




