### PR TITLE
Address a metadata table by its ECMA-335 index (#3468)

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,8 +390,9 @@ The two spellings are one section, not two: the hex form is an input alias, so
 the heading, section order, `--count`, and `-D` all answer in the canonical
 name. Hex must carry its `0x` — a bare `02` is a table *name* position — and
 only projected tables resolve, so an index outside the projection is an error
-naming what is available rather than an empty section. A full metadata token
-such as `0x02000015` addresses a row, not a table, and is rejected as one.
+naming what is available rather than an empty section. A table index is one
+byte, so it is one or two hex digits; a full metadata token such as
+`0x02000015` or `0x00000001` addresses a row, not a table, and is rejected.
 
 ### Heaps
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,21 @@ dotnet-inspect library MyLib.dll -S "Metadata: TypeRef" --columns Name --tsv
 dotnet-inspect library MyLib.dll -S "Metadata: MethodDef" --tsv --rows 100..199
 ```
 
+A table can also be named by its ECMA-335 index, since this tool's own output
+prints hex tokens and a reader following a `0x02000015` reference already has
+the index in hand:
+
+```bash
+dotnet-inspect library MyLib.dll -S "Metadata: 0x02"   # same as "Metadata: TypeDef"
+```
+
+The two spellings are one section, not two: the hex form is an input alias, so
+the heading, section order, `--count`, and `-D` all answer in the canonical
+name. Hex must carry its `0x` — a bare `02` is a table *name* position — and
+only projected tables resolve, so an index outside the projection is an error
+naming what is available rather than an empty section. A full metadata token
+such as `0x02000015` addresses a row, not a table, and is rejected as one.
+
 ### Heaps
 
 The four ECMA-335 heaps get sections of their own (`Metadata: #Strings`,

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -1006,4 +1006,4 @@ Resolved:
   one. See [Heaps are not tables](#heaps-are-not-tables).
 - **Table selection grammar.** Both, since output already prints hex tokens and
   users will paste them: `TypeDef` and `0x02` address the same table. See
-  [Hex table selection](#hex-table-selection).
+  [Hex table selection](#implemented-hex-table-selection).

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -907,6 +907,49 @@ caching state and lifetime questions to the projector. If `mdi`'s default path
 becomes a memory complaint, this table says to start with `Scalar`/`Flags`
 interning and the `Nil` singleton, and the probe says how to prove it moved.
 
+## Implemented: hex table selection
+
+`-S "Metadata: 0x02"` and `-S "Metadata: TypeDef"` are the same selector. The
+motivation is mechanical: this tool's own output prints hex tokens, so a reader
+following a `0x02000015` reference already has the table index in hand and
+should not have to translate `0x02` to `TypeDef` before asking for the table.
+
+The alias rewrites the **input selector**; it does not register a second
+section. That is the whole design, and it is what makes the two spellings *one*
+section rather than two that happen to render alike. A hex alias registered in
+the catalog would print its own heading, sort independently in the section
+order, count separately under `--count`, and appear as a second entry under
+`-D`. Rewriting at the boundary means everything downstream — the orderer, the
+heading, `--count`, the document schema, the effective-section cache key — only
+ever sees the canonical name, so those failure modes are not merely untested but
+unreachable.
+
+`MetadataSectionNames.TryGetTable` therefore stays canonical-only. Teaching it
+hex as well would put alias resolution in two places, and would make
+`IsMetadataSection` claim a name that selection resolution — which matches
+against the canonical catalog — would still reject.
+
+Three rules follow from treating the hex form as an address rather than a name:
+
+- **Hex carries its `0x`.** A bare `02` is a table *name* position, and
+  inferring a radix would let one spelling mean two things. This matches the
+  `--heap` address rule.
+- **Only projected tables resolve.** The alias table is derived from
+  `MetadataTableProjector.ProjectedTables`, the same array the canonical names
+  come from, so a table the projection does not cover cannot become selectable
+  by its index. The rejection names the projected tables in both spellings,
+  because a caller who pasted an index is thinking in hex.
+- **A metadata token is not a table.** `0x02000015` addresses a *row*; its high
+  byte is the table. The byte-width parse rejects it rather than silently
+  reading the high byte and returning `TypeDef`.
+
+A bad index fails the run even beside a selector that does match — a deliberate
+divergence from the unknown-*name* rule, which tolerates a miss when something
+else matched. That tolerance exists for names that may exist in one inspected
+assembly and not another; a hex index outside the projection is not that, since
+no image can ever supply it. Tolerating it would silently drop a selector the
+caller definitely got wrong.
+
 ## Layer placement
 
 The projection lives in the **Metadata layer** (`ILInspector.Metadata`), beside
@@ -960,4 +1003,5 @@ Resolved:
   and the listing states which, so a partial view is never mistaken for a whole
   one. See [Heaps are not tables](#heaps-are-not-tables).
 - **Table selection grammar.** Both, since output already prints hex tokens and
-  users will paste them: `TypeDef` and `0x02` address the same table.
+  users will paste them: `TypeDef` and `0x02` address the same table. See
+  [Hex table selection](#hex-table-selection).

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -940,8 +940,10 @@ Three rules follow from treating the hex form as an address rather than a name:
   by its index. The rejection names the projected tables in both spellings,
   because a caller who pasted an index is thinking in hex.
 - **A metadata token is not a table.** `0x02000015` addresses a *row*; its high
-  byte is the table. The byte-width parse rejects it rather than silently
-  reading the high byte and returning `TypeDef`.
+  byte is the table. Width is checked **textually** — a table index is one byte,
+  hence one or two hex digits — because a numeric range check alone accepts an
+  eight-digit token whose value happens to fit, so `0x00000001` (a Module row
+  token) would resolve as table `0x01`, TypeRef.
 
 A bad index fails the run even beside a selector that does match — a deliberate
 divergence from the unknown-*name* rule, which tolerates a miss when something

--- a/src/dotnet-inspect.Tests/MetadataLensTests.cs
+++ b/src/dotnet-inspect.Tests/MetadataLensTests.cs
@@ -886,12 +886,23 @@ public partial class CommandExecutionTests
     ///
     /// <c>0x02000015</c> is the close negative: it is a well-formed metadata <em>token</em>, whose
     /// high byte is the table this test's sibling accepts. A token addresses a row, not a table,
-    /// so it must not resolve — the byte-width parse is what rejects it.
+    /// so it must not resolve.
+    ///
+    /// The cases whose value <em>fits</em> in a byte are the ones that matter. Adversarial review
+    /// of #3510 found that a numeric-range check alone accepted <c>0x00000001</c> — a Module row
+    /// token — as table <c>0x01</c>, TypeRef, because 1 fits in a byte. <c>0x02000015</c> was
+    /// being rejected for overflowing, not for being a token, so it never covered the rule it was
+    /// written for. Width is now checked textually: a table index is one byte, hence one or two
+    /// hex digits, so <c>0x0002</c> is not a table index either.
     /// </summary>
     [Theory]
     [InlineData("Metadata: 0x99")]
     [InlineData("Metadata: 0x03")]
     [InlineData("Metadata: 0x02000015")]
+    [InlineData("Metadata: 0x00000001")]
+    [InlineData("Metadata: 0x02000002")]
+    [InlineData("Metadata: 0x80000002")]
+    [InlineData("Metadata: 0x0002")]
     [InlineData("Metadata: 0x")]
     [InlineData("Metadata: 0xzz")]
     public async Task MetadataLens_UnprojectedHexTable_IsRejected(string selector)
@@ -917,6 +928,45 @@ public partial class CommandExecutionTests
             "library", TestAssemblyPath, "-S", "Metadata: 02", "--tips", "q");
 
         Assert.NotEqual(0, exit);
+    }
+
+    /// <summary>
+    /// The alias must be resolved before <em>every</em> reader of a selector, including the static
+    /// <c>-D --schema</c> path that returns early without loading the assembly at all.
+    ///
+    /// Reported by adversarial review of #3510: the normalizer originally sat below that early
+    /// return, so <c>-D "Metadata: 0x02" --schema</c> answered "not found" while the
+    /// effective-discovery path — which runs later — resolved the same selector. The gate above
+    /// missed it precisely because it supplied an input source and so took the later path.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_StaticSchemaDiscovery_ResolvesHexTables()
+    {
+        var (hexExit, hexOutput, hexError) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", "Metadata: 0x02", "--schema", "--tsv", "--tips", "q");
+        var (nameExit, nameOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", "Metadata: TypeDef", "--schema", "--tsv", "--tips", "q");
+
+        Assert.True(hexExit == 0, $"expected success, got {hexExit}: {hexError}");
+        Assert.Equal(nameExit, hexExit);
+        Assert.Equal(nameOutput, hexOutput);
+    }
+
+    /// <summary>
+    /// The same early return is also taken when no input source is given at all, so the alias has
+    /// to hold on a selector that is never matched against a real image.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_DiscoveryWithoutAnAssembly_ResolvesHexTables()
+    {
+        var (hexExit, hexOutput, hexError) = await RunAppAsync(
+            "library", "-D", "Metadata: 0x02", "--tsv", "--tips", "q");
+        var (nameExit, nameOutput, _) = await RunAppAsync(
+            "library", "-D", "Metadata: TypeDef", "--tsv", "--tips", "q");
+
+        Assert.True(hexExit == 0, $"expected success, got {hexExit}: {hexError}");
+        Assert.Equal(nameExit, hexExit);
+        Assert.Equal(nameOutput, hexOutput);
     }
 
     /// <summary>Section names from a <c>-D --tsv</c> listing, header row dropped.</summary>

--- a/src/dotnet-inspect.Tests/MetadataLensTests.cs
+++ b/src/dotnet-inspect.Tests/MetadataLensTests.cs
@@ -782,11 +782,18 @@ public partial class CommandExecutionTests
     /// Hex and name are the same selector, not merely two selectors that both work: identical
     /// output, and identical <c>--count</c>. Comparing whole documents is what would catch an
     /// alias that reached the right rows through a different section identity.
+    ///
+    /// The lowercase and uppercase prefixes are here because section matching is case-insensitive
+    /// everywhere else in this CLI, so the alias must be too — a case-sensitive prefix check would
+    /// make <c>metadata: 0x02</c> the one spelling that silently stopped working. Adversarial
+    /// review of #3510 found that gap by mutation.
     /// </summary>
     [Theory]
     [InlineData("Metadata: 0x02")]
     [InlineData("Metadata: 0x2")]
     [InlineData("Metadata: 0X02")]
+    [InlineData("metadata: 0x02")]
+    [InlineData("METADATA: 0x2")]
     public async Task MetadataLens_HexTableSpellings_AreTheNameSelector(string hex)
     {
         var (hexExit, hexOutput, _) = await RunAppAsync(
@@ -903,8 +910,10 @@ public partial class CommandExecutionTests
     [InlineData("Metadata: 0x02000002")]
     [InlineData("Metadata: 0x80000002")]
     [InlineData("Metadata: 0x0002")]
+    [InlineData("Metadata: 0x002")]
     [InlineData("Metadata: 0x")]
     [InlineData("Metadata: 0xzz")]
+    [InlineData("metadata: 0x99")]
     public async Task MetadataLens_UnprojectedHexTable_IsRejected(string selector)
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/MetadataLensTests.cs
+++ b/src/dotnet-inspect.Tests/MetadataLensTests.cs
@@ -757,6 +757,168 @@ public partial class CommandExecutionTests
         Assert.Contains("999999999", error, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The point of #3468: a hex table index addresses the same section as its name. A reader who
+    /// has a raw index in hand — from a spec table, a token dump, or another tool — should not
+    /// have to translate it before selecting.
+    ///
+    /// The rendered heading must be the <em>canonical</em> one. The alias rewrites the input, so
+    /// there is exactly one section and one spelling of it in the output; a hex alias registered
+    /// as its own section would have produced a second heading that sorted and counted
+    /// independently.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_HexTableSelection_RendersTheCanonicalSection()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "Metadata: 0x02", "--rows", "3", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## " + MetadataSectionNames.ForTable(System.Reflection.Metadata.Ecma335.TableIndex.TypeDef), output, StringComparison.Ordinal);
+        Assert.DoesNotContain("0x02", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Hex and name are the same selector, not merely two selectors that both work: identical
+    /// output, and identical <c>--count</c>. Comparing whole documents is what would catch an
+    /// alias that reached the right rows through a different section identity.
+    /// </summary>
+    [Theory]
+    [InlineData("Metadata: 0x02")]
+    [InlineData("Metadata: 0x2")]
+    [InlineData("Metadata: 0X02")]
+    public async Task MetadataLens_HexTableSpellings_AreTheNameSelector(string hex)
+    {
+        var (hexExit, hexOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", hex, "--rows", "5", "--tips", "q");
+        var (nameExit, nameOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "Metadata: TypeDef", "--rows", "5", "--tips", "q");
+
+        Assert.Equal(0, hexExit);
+        Assert.Equal(nameExit, hexExit);
+        Assert.Equal(nameOutput, hexOutput);
+
+        var (hexCount, hexCountOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", hex, "--count", "--tips", "q");
+        var (nameCount, nameCountOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "Metadata: TypeDef", "--count", "--tips", "q");
+
+        Assert.Equal(0, hexCount);
+        Assert.Equal(nameCount, hexCount);
+        Assert.Equal(nameCountOutput, hexCountOutput);
+    }
+
+    /// <summary>
+    /// Selecting both spellings at once selects one section, not two. This is the property that a
+    /// second registered section would break while every single-spelling test above still passed.
+    ///
+    /// The hex-alone precondition is what keeps this non-vacuous: without it, an implementation
+    /// that simply ignored the hex selector would also produce one heading and pass. Mutation
+    /// testing found exactly that hole.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_BothTableSpellings_SelectOneSection()
+    {
+        var (aloneExit, aloneOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "Metadata: 0x02", "--rows", "3", "--tips", "q");
+        Assert.Equal(0, aloneExit);
+
+        var (exit, output, _) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Metadata: 0x02", "-S", "Metadata: TypeDef", "--rows", "3", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(1, output.Split('\n').Count(l => l.StartsWith("## ", StringComparison.Ordinal)));
+        Assert.Equal(aloneOutput, output);
+    }
+
+    /// <summary>
+    /// A bad hex index fails the whole run even alongside a selector that does match — a
+    /// deliberate divergence from the unknown-<em>name</em> rule, which tolerates a miss when
+    /// something else matched.
+    ///
+    /// The tolerance rule exists for names that may exist in one inspected assembly and not
+    /// another. A hex index outside the projection is not that: no image can ever supply it, so
+    /// tolerating it would silently drop a selector the caller definitely got wrong. This matches
+    /// the <c>--heap</c> coordinate rule, where input that names nothing is exit 1.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_BadHexTable_FailsEvenBesideAMatchingSelector()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Metadata: 0x99", "-S", "Metadata: TypeDef", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Metadata: 0x99", error, StringComparison.Ordinal);
+        Assert.DoesNotContain("## ", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Discovery answers in canonical names only. The hex form is an input alias, so advertising
+    /// it would double the catalog and imply two sections exist. <c>-D</c> on a hex selector still
+    /// works — it is the same selector — and returns exactly the name form's answer.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_Discovery_AnswersInCanonicalNamesOnly()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", SectionCategoryNames.Metadata, "--tsv", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain(DiscoveryNames(output), n => n.Contains("0x", StringComparison.OrdinalIgnoreCase));
+
+        var (hexExit, hexOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", "Metadata: 0x02", "--tsv", "--tips", "q");
+        var (nameExit, nameOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", "Metadata: TypeDef", "--tsv", "--tips", "q");
+
+        Assert.Equal(0, hexExit);
+        Assert.Equal(nameExit, hexExit);
+        Assert.Equal(nameOutput, hexOutput);
+    }
+
+    /// <summary>
+    /// A hex index the projection does not cover is rejected with a diagnostic that names what is
+    /// available, and exits 1 — the same treatment a coordinate that names nothing gets. Silently
+    /// rendering nothing would read as "this table is empty in this image", which is a different
+    /// and wrong claim.
+    ///
+    /// <c>0x02000015</c> is the close negative: it is a well-formed metadata <em>token</em>, whose
+    /// high byte is the table this test's sibling accepts. A token addresses a row, not a table,
+    /// so it must not resolve — the byte-width parse is what rejects it.
+    /// </summary>
+    [Theory]
+    [InlineData("Metadata: 0x99")]
+    [InlineData("Metadata: 0x03")]
+    [InlineData("Metadata: 0x02000015")]
+    [InlineData("Metadata: 0x")]
+    [InlineData("Metadata: 0xzz")]
+    public async Task MetadataLens_UnprojectedHexTable_IsRejected(string selector)
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", selector, "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains(selector, error, StringComparison.Ordinal);
+        Assert.Contains("0x02 TypeDef", error, StringComparison.Ordinal);
+        Assert.DoesNotContain("## ", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Hex must carry its <c>0x</c>. A bare <c>02</c> is a table <em>name</em> position, and
+    /// inferring a radix would let one spelling mean two things; the rule matches
+    /// <c>--heap</c>'s address rule. It fails as an unknown section name, not as a bad index.
+    /// </summary>
+    [Fact]
+    public async Task MetadataLens_BareDigits_AreNotATableIndex()
+    {
+        var (exit, _, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "Metadata: 02", "--tips", "q");
+
+        Assert.NotEqual(0, exit);
+    }
+
     /// <summary>Section names from a <c>-D --tsv</c> listing, header row dropped.</summary>
     private static string[] DiscoveryNames(string output) => output
         .Split('\n', StringSplitOptions.RemoveEmptyEntries)

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -40,6 +40,19 @@ public class LibraryCommand
             || !string.IsNullOrEmpty(options.PackagePath)
             || !string.IsNullOrEmpty(options.PlatformAssembly);
 
+        // Hex table aliases are resolved before anything reads a selector — including the static
+        // discovery return below — so every consumer of Select/Discover sees canonical names. That
+        // placement is the invariant the alias rests on, not an optimization: adversarial review of
+        // #3510 found the normalizer sitting below this branch, where `-D "Metadata: 0x02"
+        // --schema` returned "not found" while the effective-discovery path resolved it.
+        var aliasNormalized = NormalizeMetadataTableAliases(options);
+        if (aliasNormalized.Error is not null)
+        {
+            Console.Error.WriteLine(aliasNormalized.Error);
+            return 1;
+        }
+        options = aliasNormalized.Options;
+
         // Static discovery mode: -D --schema lists schema without resolving/loading the library.
         if (options.Discover != null)
         {
@@ -102,14 +115,6 @@ public class LibraryCommand
             return 1;
         }
         options = heapNormalized.Options;
-
-        var aliasNormalized = NormalizeMetadataTableAliases(options);
-        if (aliasNormalized.Error is not null)
-        {
-            Console.Error.WriteLine(aliasNormalized.Error);
-            return 1;
-        }
-        options = aliasNormalized.Options;
 
         // @Hidden is a discovery-only pole: it lists via -D @Hidden / --schema and its members
         // render by exact name, but it is not a render selector. This keeps -S from fanning out to

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -103,6 +103,14 @@ public class LibraryCommand
         }
         options = heapNormalized.Options;
 
+        var aliasNormalized = NormalizeMetadataTableAliases(options);
+        if (aliasNormalized.Error is not null)
+        {
+            Console.Error.WriteLine(aliasNormalized.Error);
+            return 1;
+        }
+        options = aliasNormalized.Options;
+
         // @Hidden is a discovery-only pole: it lists via -D @Hidden / --schema and its members
         // render by exact name, but it is not a render selector. This keeps -S from fanning out to
         // unbounded @Hidden members as a group.
@@ -911,6 +919,59 @@ public class LibraryCommand
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Rewrites hex table spellings in <c>-S</c> and <c>-D</c> to canonical section names, so
+    /// <c>-S "Metadata: 0x02"</c> and <c>-S "Metadata: TypeDef"</c> reach the same section.
+    ///
+    /// This runs before selection resolution, so everything downstream — the section orderer, the
+    /// rendered heading, <c>--count</c>, the schema, the effective-section cache key — sees only
+    /// canonical names and cannot treat the two spellings as two sections.
+    /// </summary>
+    private static (LibraryOptions Options, string? Error) NormalizeMetadataTableAliases(LibraryOptions options)
+    {
+        var (select, selectError) = ResolveTableAliases(options.Select);
+        if (selectError is not null)
+            return (options, $"Error: {selectError}");
+
+        var (discover, discoverError) = ResolveTableAliases(options.Discover);
+        if (discoverError is not null)
+            return (options, $"Error: {discoverError}");
+
+        if (select is null && discover is null)
+            return (options, null);
+
+        return (options with
+        {
+            Select = select ?? options.Select,
+            Discover = discover ?? options.Discover,
+        }, null);
+    }
+
+    /// <summary>
+    /// Resolves every hex table spelling in <paramref name="values"/>. Returns a null array when
+    /// nothing needed rewriting, so an untouched selection keeps its original instance.
+    /// </summary>
+    private static (string[]? Values, string? Error) ResolveTableAliases(string[]? values)
+    {
+        if (values is not { Length: > 0 })
+            return (null, null);
+
+        string[]? rewritten = null;
+        for (int i = 0; i < values.Length; i++)
+        {
+            if (!MetadataSectionNames.TryResolveTableAlias(values[i], out string canonical, out string? error))
+                return (null, error);
+
+            if (!ReferenceEquals(canonical, values[i]))
+            {
+                rewritten ??= [.. values];
+                rewritten[i] = canonical;
+            }
+        }
+
+        return (rewritten, null);
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Sections/MetadataSectionNames.cs
+++ b/src/dotnet-inspect/Sections/MetadataSectionNames.cs
@@ -148,7 +148,14 @@ public static class MetadataSectionNames
             return true;
 
         string digits = suffix[2..];
-        if (digits.Length != 0
+
+        // Width is checked textually, not just numerically. A table index is one byte, so it is at
+        // most two hex digits; `byte.TryParse` alone enforces the numeric range but not the width,
+        // which accepts an eight-digit metadata token whose value happens to fit — `0x00000001` is
+        // a Module *row* token and would otherwise resolve as table 0x01, TypeRef. Adversarial
+        // review of #3510 found this: the original close-negative case, 0x02000015, was rejected
+        // only because it overflowed, not because it was recognized as a token.
+        if (digits.Length is 1 or 2
             && byte.TryParse(digits, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out byte index)
             && HexAliases.TryGetValue((TableIndex)index, out string? resolved))
         {

--- a/src/dotnet-inspect/Sections/MetadataSectionNames.cs
+++ b/src/dotnet-inspect/Sections/MetadataSectionNames.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Reflection.Metadata.Ecma335;
 using DotnetInspector.MetadataRendering;
 using ILInspector.Metadata;
@@ -106,9 +107,78 @@ public static class MetadataSectionNames
     public static string ForTable(TableIndex table) => Prefix + table;
 
     /// <summary>
+    /// The hex spelling of every projected table, derived from the same
+    /// <see cref="MetadataTableProjector.ProjectedTables"/> array the canonical names come from.
+    /// Deriving rather than restating is what keeps an <em>unprojected</em> index from becoming
+    /// selectable by its hex spelling: a table absent from that array has no entry here either.
+    /// </summary>
+    static readonly ImmutableDictionary<TableIndex, string> HexAliases =
+        MetadataTableProjector.ProjectedTables.ToImmutableDictionary(
+            static index => index,
+            static index => ForTable(index));
+
+    /// <summary>
+    /// Rewrites a hex table spelling to its canonical section name: <c>Metadata: 0x02</c> becomes
+    /// <c>Metadata: TypeDef</c>. Anything that is not a hex spelling passes through unchanged, so
+    /// this is safe to run over every selector.
+    ///
+    /// Rewriting the *input* — rather than registering a second section — is what keeps the two
+    /// spellings one section. A hex alias registered as its own section would render its own
+    /// heading, order independently, and count separately, which is exactly the "two
+    /// different-looking sections" outcome this alias exists to avoid. For the same reason
+    /// <see cref="Tables"/> and the catalog are untouched: the hex form is an input alias, not a
+    /// second catalog entry.
+    ///
+    /// Hex is required to carry its <c>0x</c>, matching the <c>--heap</c> address rule: a bare
+    /// <c>02</c> is not a table index here, because a suffix without the prefix is a table
+    /// <em>name</em> and inferring a radix would let one spelling mean two things.
+    /// </summary>
+    public static bool TryResolveTableAlias(string section, out string canonical, out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(section);
+
+        canonical = section;
+        error = null;
+
+        if (!section.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        string suffix = section[Prefix.Length..].Trim();
+        if (!suffix.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        string digits = suffix[2..];
+        if (digits.Length != 0
+            && byte.TryParse(digits, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out byte index)
+            && HexAliases.TryGetValue((TableIndex)index, out string? resolved))
+        {
+            canonical = resolved;
+            return true;
+        }
+
+        error = $"\"{section}\" is not a projected metadata table. Projected tables: {ProjectedTableList}.";
+        return false;
+    }
+
+    /// <summary>
+    /// Every projected table as <c>0xNN Name</c>, for the rejection diagnostic. A caller who
+    /// pasted a hex index is thinking in hex, so the remedy answers in both spellings at once.
+    /// </summary>
+    static string ProjectedTableList { get; } = string.Join(
+        ", ",
+        MetadataTableProjector.ProjectedTables.Select(
+            static index => $"0x{(int)index:X2} {index}"));
+
+    /// <summary>
     /// Resolves a section name to the table it renders. Returns <see langword="false"/> for
     /// <see cref="Image"/> and for any non-metadata section, so a caller cannot mistake the
     /// image overview for a table.
+    ///
+    /// This deliberately does <em>not</em> accept the hex spelling. Hex is resolved once, at the
+    /// input boundary, by <see cref="TryResolveTableAlias"/>; by the time any lookup here runs the
+    /// name is already canonical. Teaching this method hex as well would put alias resolution in
+    /// two places and would make <see cref="IsMetadataSection"/> claim a name that selection
+    /// resolution — which matches against the canonical catalog — would still reject.
     /// </summary>
     public static bool TryGetTable(string section, out TableIndex table)
         => ByName.TryGetValue(section, out table);


### PR DESCRIPTION
Closes #3468.

`-S "Metadata: 0x02"` and `-S "Metadata: TypeDef"` are now the same selector. This tool's own output prints hex tokens, so a reader following a `0x02000015` reference already has the table index in hand and should not have to translate it before asking for the table.

## The design decision

**The alias rewrites the input selector; it does not register a second section.** That is what makes the two spellings *one* section rather than two that happen to render alike. A hex alias in the catalog would print its own heading, sort independently in the section order, count separately under `--count`, and appear as a second `-D` entry. Rewriting at the boundary (`NormalizeMetadataTableAliases`, alongside the existing `--il-offset` and `--heap` normalizers and before `SelectResolver`) means the orderer, the heading, `--count`, the document schema, and the effective-section cache key only ever see the canonical name -- so those failure modes are unreachable, not merely untested.

**Divergence from the issue's note.** #3468 suggested `MetadataSectionNames.TryGetTable` "is the single lookup point today and is where the alias belongs". It is not, and it stays canonical-only: by the time any lookup runs the name is already canonical. Teaching `TryGetTable` hex would put alias resolution in two places and would make `IsMetadataSection` claim a name that selection resolution -- which matches against the canonical catalog -- would still reject.

Three rules follow from treating hex as an address rather than a name:

- **Hex carries its `0x`.** A bare `02` is a table *name* position; inferring a radix would let one spelling mean two things. Matches the `--heap` address rule.
- **Only projected tables resolve.** The alias map is derived from `MetadataTableProjector.ProjectedTables`, the same array the canonical names come from, so a table the projection does not cover cannot become selectable by index. The rejection names the projected tables in *both* spellings, since a caller who pasted an index is thinking in hex.
- **A metadata token is not a table.** `0x02000015` addresses a row; its high byte is the table. The byte-width parse rejects it rather than silently returning `TypeDef`.

## One deliberate behavior divergence

A bad index fails the run **even beside a selector that does match**, where an unknown *name* is tolerated (`-S "Metadata: NoSuchTable" -S "Metadata: TypeDef"` exits 0 today).

The tolerance rule exists for names that may exist in one inspected assembly and not another. A hex index outside the projection is not that -- no image can ever supply it -- so tolerating it would silently drop a selector the caller definitely got wrong. This matches the `--heap` coordinate rule, where input naming nothing is exit 1. Confirmed with the repo owner before landing, and pinned by `MetadataLens_BadHexTable_FailsEvenBesideAMatchingSelector`.

## Evidence

8 gates in `MetadataLensTests`, **mutation-proven in both directions**:

| Mutation | Killed | Survived (correctly) |
| --- | --- | --- |
| `canonical = resolved` -> `canonical = section` (rewrite suppressed) | all 6 rewrite gates | both rejection gates |
| rejection `return false` -> `return true` (bad hex passed through) | both rejection gates | rewrite gates |

The one-section gate was **vacuous on the first pass** -- it also passed when hex was merely ignored, since one heading is one heading either way. It now asserts the hex-alone precondition first, and dies under the rewrite mutation.

Suites, all on Windows:

- CLI: `Total: 2492, Failed: 2` -- both pre-existing and Windows-only (`Package_DeclaredNonMarkdownReadme_IsStillNotMarkdown(readmePath: "images/logo.png.")`, `Layout_Count_CountsFilesRatherThanRenderedTreeLines`), confirmed reproducing in a clean worktree at unmodified `origin/main` during #3497 and green in ubuntu CI.
- `ILInspector.Metadata.Tests`: 998/0.
- `DotnetInspector.MetadataRendering.Tests`: 118/0.

## Compatibility

Purely additive at the input boundary. Every existing selector string resolves exactly as before -- the alias passes through anything that does not start with `Metadata: 0x`. No section, schema, or output shape changes.

## Docs

`docs/design/metadata-table-projection.md` gains a **Hex table selection** section (linked from the decisions list, which already anticipated this) and `README.md` gains the hex example plus the one-section rule.