### PR TITLE
Gate the decompiler docket and byte-neutrality checks pre-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,14 +118,21 @@ jobs:
             # transitive closure, which an enumerated list cannot track without
             # rotting. Under-triggering silently disables the gate on exactly
             # the changes it exists to catch; over-triggering costs a parallel
-            # job that never blocks the hot lane. Prefer the cheap error.
+            # job that never blocks the hot lane. Prefer the cheap error. The
+            # documentation-extension arm covers only `*.md`, deliberately: a
+            # `.txt` or `.jsonl` under these trees can be a corpus or baseline
+            # fixture, and excluding it by extension would silently un-gate it.
+            # `global.json` and `nuget.config` select the SDK and package
+            # inputs, which select the compiler, which selects the IL compared.
             case "$file" in
               eng/check-decompiler-gate.cs) DECOMPILER=true ;;
               eng/decompiler-gate-known-red.txt) DECOMPILER=true ;;
-              *.md|*.txt) ;;
+              eng/decompiler-gate-expected-classes.txt) DECOMPILER=true ;;
+              *.md) ;;
               src/*) DECOMPILER=true ;;
               tests/*) DECOMPILER=true ;;
               tools/*) DECOMPILER=true ;;
+              global.json|nuget.config|NuGet.config|NuGet.Config) DECOMPILER=true ;;
               *.props|*.targets|*.slnx) DECOMPILER=true ;;
               .github/workflows/ci.yml) DECOMPILER=true ;;
             esac
@@ -456,7 +463,9 @@ jobs:
       - name: Compare against pinned known-red
         run: |
           dotnet run eng/check-decompiler-gate.cs -- \
-            "$RUNNER_TEMP/decompiler-gates.xml" eng/decompiler-gate-known-red.txt
+            "$RUNNER_TEMP/decompiler-gates.xml" \
+            eng/decompiler-gate-known-red.txt \
+            eng/decompiler-gate-expected-classes.txt
 
       - name: Upload gate report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       csharpdiff: ${{ steps.filter.outputs.csharpdiff }}
+      decompiler: ${{ steps.filter.outputs.decompiler }}
       docs: ${{ steps.filter.outputs.docs }}
       ildiff: ${{ steps.filter.outputs.ildiff }}
       ilroundtrip: ${{ steps.filter.outputs.ilroundtrip }}
@@ -51,6 +52,7 @@ jobs:
           fi
           CODE=false
           CSHARPDIFF=false
+          DECOMPILER=false
           DOCS=false
           ILDIFF=false
           ILROUNDTRIP=false
@@ -102,6 +104,28 @@ jobs:
             case "$file" in
               *.md|*.txt|docs/*|skills/*) DOCS=true ;;
             esac
+            # The decompiler docket/byte-neutrality gates cost ~15 minutes, so
+            # they run as their own job rather than in the hot `test` lane, and
+            # only when something that can move a fidelity result changes: the
+            # decompiler and its IL/CFG/C# substrate, the compile-back harness,
+            # the fixtures the gates decompile, the gate tests and their
+            # dockets, and the known-red pin itself. Docs, packaging, and
+            # unrelated tools must not trip this.
+            case "$file" in
+              src/ILInspector.Decompiler/*) DECOMPILER=true ;;
+              src/ILInspector.Decompiler.Tests/*) DECOMPILER=true ;;
+              src/ILInspector.Instructions/*) DECOMPILER=true ;;
+              src/ILInspector.ControlFlow/*) DECOMPILER=true ;;
+              src/ILInspector.CSharp/*) DECOMPILER=true ;;
+              src/ILInspector.Metadata/*) DECOMPILER=true ;;
+              tools/DecompilerHarness/*.md|tools/DecompilerHarness/*.txt) ;;
+              tools/DecompilerHarness/*) DECOMPILER=true ;;
+              eng/check-decompiler-gate.cs) DECOMPILER=true ;;
+              eng/decompiler-gate-known-red.txt) DECOMPILER=true ;;
+              Directory.Packages.props) DECOMPILER=true ;;
+              *.props|*.targets|*.slnx) DECOMPILER=true ;;
+              .github/workflows/ci.yml) DECOMPILER=true ;;
+            esac
             # The IL round-trip oracle has a fast PR subset plus a slow assembly
             # sweep. It depends on ILInspector.Metadata ->
             # { DotnetInspector.Core, ILInspector.MetadataPrimitives } plus the
@@ -150,6 +174,7 @@ jobs:
           done <<< "$FILES"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
           echo "csharpdiff=$CSHARPDIFF" >> "$GITHUB_OUTPUT"
+          echo "decompiler=$DECOMPILER" >> "$GITHUB_OUTPUT"
           echo "docs=$DOCS" >> "$GITHUB_OUTPUT"
           echo "ildiff=$ILDIFF" >> "$GITHUB_OUTPUT"
           echo "ilroundtrip=$ILROUNDTRIP" >> "$GITHUB_OUTPUT"
@@ -157,7 +182,7 @@ jobs:
           echo "shipped=$SHIPPED" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
           echo "$FILES"
-          echo "code=$CODE csharpdiff=$CSHARPDIFF docs=$DOCS ildiff=$ILDIFF ilroundtrip=$ILROUNDTRIP packaging=$PACKAGING shipped=$SHIPPED"
+          echo "code=$CODE csharpdiff=$CSHARPDIFF decompiler=$DECOMPILER docs=$DOCS ildiff=$ILDIFF ilroundtrip=$ILROUNDTRIP packaging=$PACKAGING shipped=$SHIPPED"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -350,6 +375,80 @@ jobs:
 
       - name: Build tool for net10.0 fallback
         run: dotnet build src/dotnet-inspect -c Release -p:DefaultTargetFramework=net10.0 -p:PublishAot=false
+
+  # Decompiler docket and byte-neutrality gates, pre-merge.
+  #
+  # These gates carry doc comments asserting they fail CI, but every pre-merge
+  # lane runs `-trait- "Speed=Slow"` and they are all Slow, so until now they
+  # ran only in release.yml and the weekly Deep Inspect lane — where they were
+  # exceeding the job timeout, and a *cancelled* job does not satisfy Deep
+  # Inspect's `if: ... && failure()` notifier. Detection latency was unbounded,
+  # not weekly (#3432). Five real regressions (#3489-#3493) accumulated unseen.
+  #
+  # This job runs the three gates whose failures are attributable to a specific
+  # fixture and docket entry, path-gated so it stays off most PRs, and as its
+  # own job so it never serializes with the hot `test` lane. Currently-open
+  # failures are pinned in eng/decompiler-gate-known-red.txt; the checker fails
+  # on any unpinned failure AND on any pin that starts passing, so the pin list
+  # is a ratchet in both directions rather than a permanent exemption.
+  #
+  # The remaining Fidelity-area classes are excluded on cost, not principle:
+  # ClusterCaptureTests and PrinterPrecedenceTests alone are ~21 minutes for two
+  # tests and want the #3495 type-filter treatment before they can be gated.
+  decompiler-gates:
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.decompiler == 'true'
+    runs-on: ubuntu-26.04
+    timeout-minutes: 45
+    env:
+      DOTNET_INSPECT_TIPS: q
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      # The gates decompile and recompile the fixture assemblies, so the whole
+      # solution must be built: building only the test project leaves the
+      # fixtures absent and the gates fail with a FileNotFoundException that
+      # reads exactly like a product regression.
+      - name: Build
+        run: dotnet build dotnet-inspect.slnx -c Release
+
+      # continue-on-error so the pinned known-red failures do not fail the job
+      # here; eng/check-decompiler-gate.cs decides pass/fail from the report.
+      # A crashed run produces no XML, which the checker treats as an error
+      # rather than an empty pass.
+      - name: Run decompiler gates
+        id: gates
+        continue-on-error: true
+        run: |
+          dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
+            --gate pre-merge -xml "$RUNNER_TEMP/decompiler-gates.xml"
+
+      - name: Compare against pinned known-red
+        run: |
+          dotnet run eng/check-decompiler-gate.cs -- \
+            "$RUNNER_TEMP/decompiler-gates.xml" eng/decompiler-gate-known-red.txt
+
+      - name: Upload gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: decompiler-gates-report
+          path: ${{ runner.temp }}/decompiler-gates.xml
+          if-no-files-found: warn
 
   # Cheap C# Diff harness coverage. Path-gated separately from the full test
   # lane so CSharpDiffHarness/card changes get focused snapshot/baseline JSONL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,15 +446,19 @@ jobs:
       - name: Build
         run: dotnet build dotnet-inspect.slnx -c Release
 
-      # The gate below trusts eng/decompiler-gate-expected-classes.txt to say
-      # what must have run. Validate that file here rather than relying on
-      # another job's path filter to have run the fast lane: the job that
-      # consumes the inventory is the job that should prove it still matches
-      # the preset. Cheap (sub-second) and not continue-on-error.
-      - name: Verify gate inventory matches the preset
+      # Enumerate what the preset selects, without running it. This is the
+      # reference the completeness check compares the results against; the
+      # report's own summary counters cannot serve, because an honestly
+      # truncated report declares its own smaller total and agrees with itself.
+      #
+      # Uses --gate pre-merge, the same preset as the run below, so the two
+      # cannot drift. Sub-second, and not continue-on-error: if discovery fails
+      # there is no reference and the gate must not proceed.
+      - name: Discover expected gate tests
         run: |
           dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
-            -class ILInspector.Decompiler.Tests.GateExpectedClassesTests
+            --gate pre-merge -noColor -list methods/json \
+            > "$RUNNER_TEMP/decompiler-gates-expected.json"
 
       # continue-on-error so the pinned known-red failures do not fail the job
       # here; eng/check-decompiler-gate.cs decides pass/fail from the report.
@@ -479,7 +483,8 @@ jobs:
           dotnet run eng/check-decompiler-gate.cs -- \
             "$RUNNER_TEMP/decompiler-gates.xml" \
             eng/decompiler-gate-known-red.txt \
-            eng/decompiler-gate-expected-classes.txt
+            eng/decompiler-gate-expected-classes.txt \
+            "$RUNNER_TEMP/decompiler-gates-expected.json"
 
       - name: Upload gate report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,25 +104,28 @@ jobs:
             case "$file" in
               *.md|*.txt|docs/*|skills/*) DOCS=true ;;
             esac
-            # The decompiler docket/byte-neutrality gates cost ~15 minutes, so
-            # they run as their own job rather than in the hot `test` lane, and
-            # only when something that can move a fidelity result changes: the
-            # decompiler and its IL/CFG/C# substrate, the compile-back harness,
-            # the fixtures the gates decompile, the gate tests and their
-            # dockets, and the known-red pin itself. Docs, packaging, and
-            # unrelated tools must not trip this.
+            # The decompiler docket/byte-neutrality gates cost ~8 minutes, so
+            # they run as their own job rather than in the hot `test` lane.
+            #
+            # This filter is deliberately broad. The first version enumerated
+            # the decompiler projects, and review found it already wrong: it
+            # missed ILInspector.Decompiler.Fixtures.* (the assemblies the
+            # gates decompile), tools/RoundTripCompilation (the compile-back
+            # harness), DiffFixtures.V*, and transitive substrate such as
+            # ILInspector.MetadataPrimitives, ILInspector.Findings, and
+            # ILInspector.Text. A fidelity result is a whole-pipeline
+            # observation, so its true input set is the test project's
+            # transitive closure, which an enumerated list cannot track without
+            # rotting. Under-triggering silently disables the gate on exactly
+            # the changes it exists to catch; over-triggering costs a parallel
+            # job that never blocks the hot lane. Prefer the cheap error.
             case "$file" in
-              src/ILInspector.Decompiler/*) DECOMPILER=true ;;
-              src/ILInspector.Decompiler.Tests/*) DECOMPILER=true ;;
-              src/ILInspector.Instructions/*) DECOMPILER=true ;;
-              src/ILInspector.ControlFlow/*) DECOMPILER=true ;;
-              src/ILInspector.CSharp/*) DECOMPILER=true ;;
-              src/ILInspector.Metadata/*) DECOMPILER=true ;;
-              tools/DecompilerHarness/*.md|tools/DecompilerHarness/*.txt) ;;
-              tools/DecompilerHarness/*) DECOMPILER=true ;;
               eng/check-decompiler-gate.cs) DECOMPILER=true ;;
               eng/decompiler-gate-known-red.txt) DECOMPILER=true ;;
-              Directory.Packages.props) DECOMPILER=true ;;
+              *.md|*.txt) ;;
+              src/*) DECOMPILER=true ;;
+              tests/*) DECOMPILER=true ;;
+              tools/*) DECOMPILER=true ;;
               *.props|*.targets|*.slnx) DECOMPILER=true ;;
               .github/workflows/ci.yml) DECOMPILER=true ;;
             esac
@@ -386,11 +389,17 @@ jobs:
   # not weekly (#3432). Five real regressions (#3489-#3493) accumulated unseen.
   #
   # This job runs the three gates whose failures are attributable to a specific
-  # fixture and docket entry, path-gated so it stays off most PRs, and as its
-  # own job so it never serializes with the hot `test` lane. Currently-open
-  # failures are pinned in eng/decompiler-gate-known-red.txt; the checker fails
-  # on any unpinned failure AND on any pin that starts passing, so the pin list
-  # is a ratchet in both directions rather than a permanent exemption.
+  # fixture and docket entry, as its own job so it never serializes with the
+  # hot `test` lane. Currently-open failures are pinned in
+  # eng/decompiler-gate-known-red.txt; the checker fails on any unpinned
+  # failure, on any pin that starts passing, and on any gate test that neither
+  # passes nor fails, so the pin list is a ratchet in both directions rather
+  # than a permanent exemption.
+  #
+  # NOTE: this job is not merge-blocking today, because the `main` ruleset
+  # declares no required status checks at all — no job in this workflow blocks
+  # a merge. That is a repository-wide gap tracked separately; this job is
+  # exactly as enforcing as the existing `test` job until it is closed.
   #
   # The remaining Fidelity-area classes are excluded on cost, not principle:
   # ClusterCaptureTests and PrinterPrecedenceTests alone are ~21 minutes for two
@@ -428,11 +437,18 @@ jobs:
 
       # continue-on-error so the pinned known-red failures do not fail the job
       # here; eng/check-decompiler-gate.cs decides pass/fail from the report.
-      # A crashed run produces no XML, which the checker treats as an error
-      # rather than an empty pass.
+      #
+      # The step timeout is the point, not a formality. This PR exists because
+      # a *job* timeout cancels the job, and a cancelled job runs no further
+      # steps and satisfies no `failure()` condition — it fails silently. A
+      # step timeout well under the job timeout converts a hang into a failed
+      # step that the job survives, so the checker still runs, finds a missing
+      # or truncated report, and fails the job loudly. Do not raise this to the
+      # job timeout.
       - name: Run decompiler gates
         id: gates
         continue-on-error: true
+        timeout-minutes: 25
         run: |
           dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
             --gate pre-merge -xml "$RUNNER_TEMP/decompiler-gates.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,15 @@ jobs:
           dotnet-version: '11.0.x'
           dotnet-quality: 'preview'
 
+      # Caches packages only. Do not add build outputs (artifacts/, bin/, obj/)
+      # here. The completeness check compares a discovery listing against a
+      # results file, and both steps below run with --no-build against whatever
+      # the Build step produced. That comparison is only meaningful because the
+      # two provably come from one build: the checkout is fresh, nothing
+      # restores binaries, and Build is fail-fast, so neither step can run
+      # against a stale or partial binary. Caching build outputs would break
+      # that silently -- the gate would still pass, while comparing a listing
+      # and a report from different builds.
       - name: Cache NuGet packages
         uses: actions/cache@v4
         with:
@@ -443,6 +452,9 @@ jobs:
       # solution must be built: building only the test project leaves the
       # fixtures absent and the gates fail with a FileNotFoundException that
       # reads exactly like a product regression.
+      #
+      # Deliberately not continue-on-error: the two --no-build steps below
+      # depend on this having succeeded.
       - name: Build
         run: dotnet build dotnet-inspect.slnx -c Release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,12 +482,18 @@ jobs:
       # step that the job survives, so the checker still runs, finds a missing
       # or truncated report, and fails the job loudly. Do not raise this to the
       # job timeout.
+      #
+      # --no-build is required, not an optimization. Without it `dotnet run`
+      # builds implicitly, which would (a) break the guarantee that this run and
+      # the discovery listing above describe the same binary, and (b) hide a
+      # build failure inside a continue-on-error step, where it would surface
+      # only as a missing report.
       - name: Run decompiler gates
         id: gates
         continue-on-error: true
         timeout-minutes: 25
         run: |
-          dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
+          dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
             --gate pre-merge -xml "$RUNNER_TEMP/decompiler-gates.xml"
 
       - name: Compare against pinned known-red

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
               eng/prepare-decompiler-opt-in-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
               eng/report-decompiler-opt-in-corpus-drift.sh) CODE=true ;;
+              # GateExpectedClassesTests lives in the fast lane and is the only
+              # thing keeping this file honest against the pre-merge preset, so
+              # editing the file must run the lane that validates it.
+              eng/decompiler-gate-expected-classes.txt) CODE=true ;;
               *.props|*.targets|*.sln|*.slnx) CODE=true ;;
               .github/workflows/*) CODE=true ;;
             esac
@@ -441,6 +445,16 @@ jobs:
       # reads exactly like a product regression.
       - name: Build
         run: dotnet build dotnet-inspect.slnx -c Release
+
+      # The gate below trusts eng/decompiler-gate-expected-classes.txt to say
+      # what must have run. Validate that file here rather than relying on
+      # another job's path filter to have run the fast lane: the job that
+      # consumes the inventory is the job that should prove it still matches
+      # the preset. Cheap (sub-second) and not continue-on-error.
+      - name: Verify gate inventory matches the preset
+        run: |
+          dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
+            -class ILInspector.Decompiler.Tests.GateExpectedClassesTests
 
       # continue-on-error so the pinned known-red failures do not fail the job
       # here; eng/check-decompiler-gate.cs decides pass/fail from the report.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,10 +330,12 @@ The PR `decompiler-gates` job runs `--gate pre-merge` (the docket and
 byte-neutrality gates) and compares the result against
 `eng/decompiler-gate-known-red.txt`. That list is a record of *open, filed*
 failures, not an escape hatch: do not add an entry to make your own change go
-green. A new failure means either a regression to fix or a diff to docket in the
-owning gate with a rationale. Adding a pin requires an issue and a date, and the
-checker fails the job when a pinned test starts passing, so retire pins as fixes
-land. See `docs/decompiler-correctness-pipeline.md`.
+green, and do not skip a gate test to green it — the checker treats a test that
+neither passed nor failed as a coverage hole and fails the job. A new failure
+means either a regression to fix or a diff to docket in the owning gate with a
+rationale. Adding a pin requires an issue and a date, and the checker fails the
+job when a pinned test starts passing, so retire pins as fixes land. See
+`docs/decompiler-correctness-pipeline.md`.
 
 Pack and publish flows remain separate and build `src/dotnet-inspect`
 directly. Packaging is off by default (`IsPackable=false` in the root

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,6 +326,15 @@ The executable also accepts a discoverable `--gate <preset>` flag that expands
 to these trait filters (e.g. `--gate fast`, `--gate no-corpus`); run
 `--gate list` for the table.
 
+The PR `decompiler-gates` job runs `--gate pre-merge` (the docket and
+byte-neutrality gates) and compares the result against
+`eng/decompiler-gate-known-red.txt`. That list is a record of *open, filed*
+failures, not an escape hatch: do not add an entry to make your own change go
+green. A new failure means either a regression to fix or a diff to docket in the
+owning gate with a rationale. Adding a pin requires an issue and a date, and the
+checker fails the job when a pinned test starts passing, so retire pins as fixes
+land. See `docs/decompiler-correctness-pipeline.md`.
+
 Pack and publish flows remain separate and build `src/dotnet-inspect`
 directly. Packaging is off by default (`IsPackable=false` in the root
 `Directory.Build.props`), so only `src/dotnet-inspect` and `src/runfaster` opt

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -299,7 +299,19 @@ same run, so a report containing four of fifteen tests and honestly declaring
 results against a **discovery listing** produced by `-list methods/json` over
 the same preset, which enumerates what should run without running it. Every
 discovered test must appear in the results, and every result must correspond to
-a discovered test.
+a discovered test. Identity comes from the report's `type` and `method`
+attributes rather than from parsing display names, which carry theory arguments
+and honor `-methodDisplayOptions`.
+
+That comparison is **method-granular**, and deliberately so: no `-list` mode
+enumerates theory cases. A theory with five cases is listed once, so a run that
+lost four of them would still satisfy the check. Method granularity is
+sufficient only while the gate classes declare no theories, and that is
+enforced rather than assumed —
+`GateExpectedClassesTests.PreMergeGateClasses_DeclareNoTheories` fails if a
+theory is added to a gate class, with a message pointing at this constraint.
+Resolving each preset class by name in the same test also catches an arm naming
+a renamed or deleted class, which would otherwise select zero tests and exit 0.
 
 The declared totals are still cross-checked, including `passed` and `failed`
 against the actual rows, but only as an internal-consistency check on a

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -299,17 +299,27 @@ same run, so a report containing four of fifteen tests and honestly declaring
 results against a **discovery listing** produced by `-list methods/json` over
 the same preset, which enumerates what should run without running it. Every
 discovered test must appear in the results, and every result must correspond to
-a discovered test. Identity comes from the report's `type` and `method`
-attributes rather than from parsing display names, which carry theory arguments
-and honor `-methodDisplayOptions`.
+a discovered test. Identity for every decision — pins, class coverage, and
+completeness alike — comes from the report's `type` and `method` attributes.
+The display name is a presentation string: it carries theory arguments, honors
+`-methodDisplayOptions`, and can disagree with the structured attributes
+outright, so a row whose name claims to be a pinned test cannot pass a new
+failure off as a known one.
 
 That comparison is **method-granular**, and deliberately so: no `-list` mode
-enumerates theory cases. A theory with five cases is listed once, so a run that
-lost four of them would still satisfy the check. Method granularity is
-sufficient only while the gate classes declare no theories, and that is
-enforced rather than assumed —
-`GateExpectedClassesTests.PreMergeGateClasses_DeclareNoTheories` fails if a
-theory is added to a gate class, with a message pointing at this constraint.
+enumerates individual cases. A method that expands to five cases is listed
+once, so a run that lost four of them would still satisfy the check. Method
+granularity is sufficient only while every gate test is exactly one case, and
+that is enforced rather than assumed —
+`GateExpectedClassesTests.PreMergeGateClasses_ContainOnlyPlainFacts` requires
+every test in a gate class to carry exactly `FactAttribute`.
+
+It is an **allow list**, not a deny list, because rejecting only `[Theory]`
+would miss `[CulturedFact]` — which derives from `FactAttribute`, not
+`TheoryAttribute`, and still yields one case per culture — and would miss any
+future multi-case attribute. It scans the same method surface xUnit discovers,
+including inherited and non-public methods and interface declarations, because
+a theory inherited from a base class runs exactly like a declared one.
 Resolving each preset class by name in the same test also catches an arm naming
 a renamed or deleted class, which would otherwise select zero tests and exit 0.
 

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -265,6 +265,7 @@ and treats drift in **both** directions as an error:
 | an expected class with nothing executed | the preset stopped selecting it |
 | a discovered test with no row in the report | the report is incomplete |
 | a row for a test discovery never listed | report and listing describe different runs |
+| one test with more than one result row | the method expanded into several cases |
 | a `<test>` with no usable name | the report is malformed |
 | the report contradicts its own declared totals | truncated or rewritten |
 | the report declares skipped, not-run, or errored tests | coverage did not run |
@@ -317,11 +318,30 @@ every test in a gate class to carry exactly `FactAttribute`.
 It is an **allow list**, not a deny list, because rejecting only `[Theory]`
 would miss `[CulturedFact]` — which derives from `FactAttribute`, not
 `TheoryAttribute`, and still yields one case per culture — and would miss any
-future multi-case attribute. It scans the same method surface xUnit discovers,
+future multi-case attribute. It is anchored on `IFactAttribute` rather than on
+`FactAttribute`, because that is the abstraction xUnit itself keys on
+(`ExtensibilityPointFactory.GetMethodFactAttributes` returns
+`IReadOnlyCollection<IFactAttribute>`): an attribute can implement that
+interface directly, skip `FactAttribute` entirely, and supply a discoverer that
+emits several cases. It scans the same method surface xUnit discovers,
 including inherited and non-public methods and interface declarations, because
-a theory inherited from a base class runs exactly like a declared one.
-Resolving each preset class by name in the same test also catches an arm naming
-a renamed or deleted class, which would otherwise select zero tests and exit 0.
+a theory inherited from a base class runs exactly like a declared one, and
+because a `[Fact]` on a *default interface method* runs on the implementing
+class. Multiplicity is counted per method signature, not judged per attribute:
+a plain `[Fact]` on an interface method declaration and a plain `[Fact]` on its
+implementation produce two cases from two perfectly ordinary `FactAttribute`s,
+so only their number is wrong. Resolving each preset class by name in the same
+test also catches an arm naming a renamed or deleted class, which would
+otherwise select zero tests and exit 0.
+
+That guard is prevention, and it has been wrong three times, so it is not the
+only line of defence. The checker independently fails any report in which one
+`(type, method)` produced more than one row. That check is purely
+observational: it needs to know nothing about xUnit's attribute model, and it
+catches every multi-case shape above — plus any future one — by counting what
+the run actually produced. The two are complementary. The guard fails fast, in
+the fast lane, before a multi-case test can ever reach the gate; the row check
+is the backstop for the case where the guard's reflection is wrong again.
 
 The declared totals are still cross-checked, including `passed` and `failed`
 against the actual rows, but only as an internal-consistency check on a

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -256,12 +256,39 @@ and treats drift in **both** directions as an error:
 | a failure that is not pinned | new breakage — the gate did its job |
 | a pinned test that passed | the fix landed; retire the pin |
 | a pinned test that never ran | dead pin — the test was renamed or deleted |
+| a gate test that neither passed nor failed | coverage silently disappeared |
 | no report, or a report with zero tests | a crashed or empty run is not a pass |
+
+Only `Pass` counts as passing. A skipped gate test is neither passing nor
+failing, and treating it as either is how a gate becomes vacuous: an unpinned
+skip would report an exact match, and a pinned skip would look like a landed
+fix, prompting removal of the pin that was the last thing naming the test.
+Skipping is not an approved way to green this job.
 
 The stale-pin check is what keeps the list a ratchet rather than a growing
 exemption set: a pin that outlives its failure silently un-gates the test it
 names. Pass `--partial` to suppress only the dead-pin check when deliberately
 running a subset locally.
+
+The path filter is deliberately broad — roughly `src/`, `tests/`, `tools/`, and
+build files, minus documentation. A fidelity result is a whole-pipeline
+observation, so its real input set is the test project's transitive closure,
+which an enumerated project list cannot track without rotting. Under-triggering
+silently disables the gate on exactly the changes it exists to catch;
+over-triggering costs a parallel job that never blocks the hot lane.
+
+A job-level timeout would cancel the job, and a cancelled job runs no further
+steps and satisfies no `failure()` condition — the same silent-cancellation
+failure mode this gate exists to fix. The gate step therefore carries its own
+`timeout-minutes` well under the job's, so a hang becomes a failed step that
+the job survives, letting the checker run and fail loudly on the missing or
+truncated report.
+
+> [!NOTE]
+> This job does not block merges today. The `main` ruleset declares no required
+> status checks at all, so no job in `ci.yml` blocks a merge; this one is
+> exactly as enforcing as the existing `test` job. Closing that gap is a
+> repository-wide change tracked separately.
 
 `pre-merge` deliberately selects three classes rather than the whole `Fidelity`
 area. The area is ~31 minutes; these three are ~8. The exclusions are cost, not

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -239,7 +239,9 @@ the hot `test` lane, and runs `--gate pre-merge`:
 dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
   --gate pre-merge -xml /tmp/gates.xml
 dotnet run eng/check-decompiler-gate.cs -- \
-  /tmp/gates.xml eng/decompiler-gate-known-red.txt
+  /tmp/gates.xml \
+  eng/decompiler-gate-known-red.txt \
+  eng/decompiler-gate-expected-classes.txt
 ```
 
 The gate runs **red**. Turning it on was not made conditional on the open
@@ -257,6 +259,8 @@ and treats drift in **both** directions as an error:
 | a pinned test that passed | the fix landed; retire the pin |
 | a pinned test that never ran | dead pin — the test was renamed or deleted |
 | a gate test that neither passed nor failed | coverage silently disappeared |
+| an expected class with nothing executed | the report is incomplete |
+| a `<test>` with no usable name | the report is malformed |
 | no report, or a report with zero tests | a crashed or empty run is not a pass |
 
 Only `Pass` counts as passing. A skipped gate test is neither passing nor
@@ -265,17 +269,33 @@ skip would report an exact match, and a pinned skip would look like a landed
 fix, prompting removal of the pin that was the last thing naming the test.
 Skipping is not an approved way to green this job.
 
-The stale-pin check is what keeps the list a ratchet rather than a growing
+`eng/decompiler-gate-expected-classes.txt` is what stops an *incomplete* report
+from passing. Judging only the tests a report happens to contain is not enough:
+a preset that stopped selecting a class, a renamed class, or a run killed after
+emitting some results would each yield a smaller report whose failing set still
+matched the pin list exactly. The checker therefore requires every listed class
+to have executed something.
+
+That inventory is only worth its accuracy, so it is not maintained by hand
+against the preset. `GateExpectedClassesTests` asserts set equality between the
+file and the `pre-merge` preset's `-class` arguments, in both directions, so a
+class added to the preset without being added to the file fails and so does a
+stale entry. That test is in the fast lane deliberately — it must run on PRs
+that never trigger the slow gates.
+
+The stale-pin check is what keeps the pin list a ratchet rather than a growing
 exemption set: a pin that outlives its failure silently un-gates the test it
-names. Pass `--partial` to suppress only the dead-pin check when deliberately
-running a subset locally.
+names. Pass `--partial` to suppress the dead-pin and expected-class checks when
+deliberately running a subset locally.
 
 The path filter is deliberately broad — roughly `src/`, `tests/`, `tools/`, and
-build files, minus documentation. A fidelity result is a whole-pipeline
-observation, so its real input set is the test project's transitive closure,
-which an enumerated project list cannot track without rotting. Under-triggering
-silently disables the gate on exactly the changes it exists to catch;
-over-triggering costs a parallel job that never blocks the hot lane.
+build files including `global.json` and `nuget.config`, minus `*.md`. A fidelity
+result is a whole-pipeline observation, so its real input set is the test
+project's transitive closure, which an enumerated project list cannot track
+without rotting. Under-triggering silently disables the gate on exactly the
+changes it exists to catch; over-triggering costs a parallel job that never
+blocks the hot lane. Only `*.md` is excluded by extension: a `.txt` or `.jsonl`
+under those trees can be a corpus or baseline fixture.
 
 A job-level timeout would cancel the job, and a cancelled job runs no further
 steps and satisfies no `failure()` condition — the same silent-cancellation

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -205,6 +205,7 @@ dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- --gate no-co
 | `fast` | `-trait- "Speed=Slow"` | the fast lane the PR CI test job runs |
 | `slow` | `-trait "Speed=Slow"` | only the slow gates |
 | `no-corpus` | `-trait- "Area=Corpus"` | everything except the multi-hour corpus sweep |
+| `pre-merge` | three `-class` filters | the docket + byte-neutrality gates the PR CI `decompiler-gates` job runs |
 | `corpus` | `-trait "Area=Corpus"` | only the corpus sweep |
 | `roundtrip` | `-trait "Area=RoundTrip"` | the compile-back / ReturnToSender seam |
 | `fidelity` | `-trait "Area=Fidelity"` | the changed-method fidelity gates |
@@ -215,6 +216,58 @@ presets compose with any additional xUnit arguments (e.g.
 `--gate fast -class …`), and omitting `--gate` leaves invocation behavior
 unchanged. The preset table lives in the test executable's entry point; keep it
 in sync with the areas above when an area is added or renamed.
+
+`pre-merge` is the one preset that names classes rather than a trait, because
+the set it selects is a *cost* decision rather than a functional slice — see
+below.
+
+### Pre-merge gate and the known-red pin
+
+The docket and byte-neutrality gates carry doc comments asserting they fail CI,
+but they are all `Speed=Slow` and every pre-merge lane ran `-trait-
+"Speed=Slow"`. They therefore ran only in `release.yml` and the weekly Deep
+Inspect lane — where they were exceeding the job timeout, and a *cancelled* job
+does not satisfy Deep Inspect's `if: ... && failure()` notifier, so no
+notification was ever sent. Detection latency was unbounded, not weekly
+(#3432), and five regressions (#3489–#3493) accumulated unseen.
+
+The `decompiler-gates` CI job closes that hole. It is path-gated on the
+decompiler and its substrate, runs as its own job so it never serializes with
+the hot `test` lane, and runs `--gate pre-merge`:
+
+```bash
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
+  --gate pre-merge -xml /tmp/gates.xml
+dotnet run eng/check-decompiler-gate.cs -- \
+  /tmp/gates.xml eng/decompiler-gate-known-red.txt
+```
+
+The gate runs **red**. Turning it on was not made conditional on the open
+failures being fixed first: a gate's job is to make *new* breakage attributable,
+and waiting for green is what let the current backlog accumulate. Open failures
+are pinned in `eng/decompiler-gate-known-red.txt`, one fully qualified test name
+per line, each preceded by its issue and the date it was pinned.
+
+`eng/check-decompiler-gate.cs` decides the job's pass/fail from the run report,
+and treats drift in **both** directions as an error:
+
+| Condition | Meaning |
+| --- | --- |
+| a failure that is not pinned | new breakage — the gate did its job |
+| a pinned test that passed | the fix landed; retire the pin |
+| a pinned test that never ran | dead pin — the test was renamed or deleted |
+| no report, or a report with zero tests | a crashed or empty run is not a pass |
+
+The stale-pin check is what keeps the list a ratchet rather than a growing
+exemption set: a pin that outlives its failure silently un-gates the test it
+names. Pass `--partial` to suppress only the dead-pin check when deliberately
+running a subset locally.
+
+`pre-merge` deliberately selects three classes rather than the whole `Fidelity`
+area. The area is ~31 minutes; these three are ~8. The exclusions are cost, not
+principle — `ClusterCaptureTests` and `PrinterPrecedenceTests` alone are ~21
+minutes for *two* tests and want the #3495 type-filter treatment before they can
+be gated. Widen the preset as classes get cheap enough.
 
 ## Vocabulary
 

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -237,11 +237,14 @@ the hot `test` lane, and runs `--gate pre-merge`:
 
 ```bash
 dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
+  --gate pre-merge -noColor -list methods/json > /tmp/expected.json
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
   --gate pre-merge -xml /tmp/gates.xml
 dotnet run eng/check-decompiler-gate.cs -- \
   /tmp/gates.xml \
   eng/decompiler-gate-known-red.txt \
-  eng/decompiler-gate-expected-classes.txt
+  eng/decompiler-gate-expected-classes.txt \
+  /tmp/expected.json
 ```
 
 The gate runs **red**. Turning it on was not made conditional on the open
@@ -259,11 +262,14 @@ and treats drift in **both** directions as an error:
 | a pinned test that passed | the fix landed; retire the pin |
 | a pinned test that never ran | dead pin — the test was renamed or deleted |
 | a gate test that neither passed nor failed | coverage silently disappeared |
-| an expected class with nothing executed | the report is incomplete |
+| an expected class with nothing executed | the preset stopped selecting it |
+| a discovered test with no row in the report | the report is incomplete |
+| a row for a test discovery never listed | report and listing describe different runs |
 | a `<test>` with no usable name | the report is malformed |
 | the report contradicts its own declared totals | truncated or rewritten |
 | the report declares skipped, not-run, or errored tests | coverage did not run |
 | no report, or a report with zero tests | a crashed or empty run is not a pass |
+| no discovery listing, or one listing zero tests | there is no reference to judge completeness against |
 
 Only `Pass` counts as passing. A skipped gate test is neither passing nor
 failing, and treating it as either is how a gate becomes vacuous: an unpinned
@@ -271,34 +277,40 @@ skip would report an exact match, and a pinned skip would look like a landed
 fix, prompting removal of the pin that was the last thing naming the test.
 Skipping is not an approved way to green this job.
 
-`eng/decompiler-gate-expected-classes.txt` is what stops an *incomplete* report
-from passing. Judging only the tests a report happens to contain is not enough:
-a preset that stopped selecting a class, a renamed class, or a run killed after
-emitting some results would each yield a smaller report whose failing set still
-matched the pin list exactly. The checker therefore requires every listed class
-to have executed something.
+`eng/decompiler-gate-expected-classes.txt` records the classes `--gate pre-merge`
+must select. It proves the *preset* has not quietly shrunk: a class renamed,
+deleted, or dropped from the preset yields a report whose failing set still
+matches the pin list exactly, and the inventory is what rejects it.
 
 That inventory is only worth its accuracy, so it is not maintained by hand
 against the preset. `GateExpectedClassesTests` asserts set equality between the
 file and the `pre-merge` preset's `-class` arguments, in both directions, so a
 class added to the preset without being added to the file fails and so does a
-stale entry. That test is in the fast lane deliberately — it must run on PRs
-that never trigger the slow gates — and editing the inventory sets `code=true`
-so the lane that validates it actually runs. The `decompiler-gates` job also
-runs that test directly before the gates, so the job that consumes the
-inventory proves it, rather than trusting another job's path filter.
+stale entry. That test is itself in the `pre-merge` preset, so it runs in the
+gate job and is covered by the same completeness check as the correctness
+gates. Running it as a *separate* CI step was worse than useless: a `-class`
+filter naming a renamed or deleted class discovers nothing and exits 0, so the
+step would have gone green while enforcing nothing.
 
-The class inventory proves the run selected every expected class; it does not
-prove no rows are missing *within* a class. For that the checker cross-checks
-the report against its own declared per-assembly totals, so a truncated or
-rewritten report fails even when every class is represented. Pinning expected
-test names would also catch it, but would rot on every added test; the declared
-totals do not.
+Completeness is a separate property, and it needs a reference the report cannot
+forge. The report's own summary counters are not one — they are written by the
+same run, so a report containing four of fifteen tests and honestly declaring
+`total="4"` is entirely self-consistent. The checker therefore compares the
+results against a **discovery listing** produced by `-list methods/json` over
+the same preset, which enumerates what should run without running it. Every
+discovered test must appear in the results, and every result must correspond to
+a discovered test.
+
+The declared totals are still cross-checked, including `passed` and `failed`
+against the actual rows, but only as an internal-consistency check on a
+possibly-corrupt report. They are not evidence of completeness and are not
+relied on as such.
 
 The stale-pin check is what keeps the pin list a ratchet rather than a growing
 exemption set: a pin that outlives its failure silently un-gates the test it
-names. Pass `--partial` to suppress the dead-pin and expected-class checks when
-deliberately running a subset locally.
+names. Pass `--partial` to suppress the dead-pin, expected-class, and
+completeness checks when deliberately running a subset locally. CI runs the full
+preset and never passes it.
 
 The path filter is deliberately broad — roughly `src/`, `tests/`, `tools/`, and
 build files including `global.json` and `nuget.config`, minus `*.md`. A fidelity

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -261,6 +261,8 @@ and treats drift in **both** directions as an error:
 | a gate test that neither passed nor failed | coverage silently disappeared |
 | an expected class with nothing executed | the report is incomplete |
 | a `<test>` with no usable name | the report is malformed |
+| the report contradicts its own declared totals | truncated or rewritten |
+| the report declares skipped, not-run, or errored tests | coverage did not run |
 | no report, or a report with zero tests | a crashed or empty run is not a pass |
 
 Only `Pass` counts as passing. A skipped gate test is neither passing nor
@@ -281,7 +283,17 @@ against the preset. `GateExpectedClassesTests` asserts set equality between the
 file and the `pre-merge` preset's `-class` arguments, in both directions, so a
 class added to the preset without being added to the file fails and so does a
 stale entry. That test is in the fast lane deliberately — it must run on PRs
-that never trigger the slow gates.
+that never trigger the slow gates — and editing the inventory sets `code=true`
+so the lane that validates it actually runs. The `decompiler-gates` job also
+runs that test directly before the gates, so the job that consumes the
+inventory proves it, rather than trusting another job's path filter.
+
+The class inventory proves the run selected every expected class; it does not
+prove no rows are missing *within* a class. For that the checker cross-checks
+the report against its own declared per-assembly totals, so a truncated or
+rewritten report fails even when every class is represented. Pinning expected
+test names would also catch it, but would rot on every added test; the declared
+totals do not.
 
 The stale-pin check is what keeps the pin list a ratchet rather than a growing
 exemption set: a pin that outlives its failure silently un-gates the test it

--- a/eng/check-decompiler-gate.cs
+++ b/eng/check-decompiler-gate.cs
@@ -172,6 +172,12 @@ static string? TestName(XElement test)
 var passed = new HashSet<string>(StringComparer.Ordinal);
 var failed = new HashSet<string>(StringComparer.Ordinal);
 var notExecuted = new SortedDictionary<string, string>(StringComparer.Ordinal);
+// Method identity taken from the report's own type/method attributes rather
+// than parsed out of the display name. Display names carry theory arguments,
+// honor -methodDisplayOptions, and can contain the very characters a parser
+// would split on; type/method are unambiguous.
+var executedMethods = new HashSet<string>(StringComparer.Ordinal);
+var executedClasses = new HashSet<string>(StringComparer.Ordinal);
 int unidentified = 0;
 
 foreach (var test in tests)
@@ -196,6 +202,28 @@ foreach (var test in tests)
         default:
             notExecuted[name] = result;
             break;
+    }
+
+    if (result is "Pass" or "Fail")
+    {
+        string? type = (string?)test.Attribute("type");
+        string? method = (string?)test.Attribute("method");
+        if (!string.IsNullOrWhiteSpace(type) && !string.IsNullOrWhiteSpace(method))
+        {
+            executedMethods.Add($"{type}.{method}");
+            executedClasses.Add(type);
+        }
+        else
+        {
+            // Fall back to the display name only when the structured identity is
+            // absent. Cutting at the first '(' strips theory arguments; the last
+            // '.' separates class from method.
+            int paren = name.IndexOf('(', StringComparison.Ordinal);
+            string bare = paren >= 0 ? name[..paren] : name;
+            executedMethods.Add(bare);
+            int dot = bare.LastIndexOf('.');
+            executedClasses.Add(dot > 0 ? bare[..dot] : bare);
+        }
     }
 }
 
@@ -226,15 +254,7 @@ executed.UnionWith(failed);
 // A class counts as covered only if it executed something. A class present in
 // the report solely as skips is a coverage hole, and is already reported as
 // one above.
-var coveredClasses = executed
-    .Select(name =>
-    {
-        int paren = name.IndexOf('(', StringComparison.Ordinal);
-        string bare = paren >= 0 ? name[..paren] : name;
-        int dot = bare.LastIndexOf('.');
-        return dot > 0 ? bare[..dot] : bare;
-    })
-    .ToHashSet(StringComparer.Ordinal);
+var coveredClasses = executedClasses;
 
 var missingClasses = partial
     ? []
@@ -244,6 +264,14 @@ var missingClasses = partial
 // enumerates what the preset selects without running anything, so a run that
 // was cut short, filtered down, or rewritten has a smaller result set than the
 // listing regardless of how self-consistent its own counters are.
+//
+// This is *method*-granular, because no `-list` mode enumerates theory cases:
+// a theory with five cases lists once, so a run that lost four of them would
+// still satisfy this check. Method granularity is only sufficient while the
+// gate classes declare no theories, which is not an assumption --
+// GateExpectedClassesTests.PreMergeGateClasses_DeclareNoTheories enforces it,
+// and adding a theory to a gate class fails that test rather than quietly
+// weakening this one.
 List<string> missingTests = [];
 List<string> unexpectedTests = [];
 
@@ -284,16 +312,9 @@ if (!partial)
         return 2;
     }
 
-    // Discovery lists methods; a theory contributes one row per case, so
-    // compare at method granularity in both directions.
-    var executedMethods = executed
-        .Select(name =>
-        {
-            int paren = name.IndexOf('(', StringComparison.Ordinal);
-            return paren >= 0 ? name[..paren] : name;
-        })
-        .ToHashSet(StringComparer.Ordinal);
-
+    // Discovery lists methods; identity comes from the report's type/method
+    // attributes, so theory arguments and display-name options cannot confuse
+    // the comparison.
     missingTests = discovered.Except(executedMethods, StringComparer.Ordinal)
         .Order(StringComparer.Ordinal).ToList();
     unexpectedTests = executedMethods.Except(discovered, StringComparer.Ordinal)

--- a/eng/check-decompiler-gate.cs
+++ b/eng/check-decompiler-gate.cs
@@ -6,13 +6,21 @@
 //   * a pinned test that passed     -> the fix landed, retire the pin
 //   * a pinned test that never ran  -> the pin is dead (renamed/deleted test)
 //   * a gate test that did not run  -> coverage silently disappeared
-//   * an expected class is absent   -> the report is incomplete
+//   * an expected class is absent   -> the preset stopped selecting it
+//   * a discovered test has no row  -> the report is incomplete
 //
-// The last case is what an inventory buys. Without it the checker could only
-// judge the tests a report happens to contain, so a preset that stopped
-// selecting a class, a renamed class, or a run killed partway would each
-// produce a smaller report whose failing set still matched the pin list
-// exactly, and pass.
+// The last two are different properties and both are needed.
+//
+// The class inventory proves the *preset* still selects the classes it is
+// supposed to. It cannot prove the report is whole, because it only asks
+// whether each class contributed at least one row.
+//
+// Completeness needs a reference the report cannot forge, and the report's own
+// summary counters are not one: they are written by the same run. A report
+// containing four of fourteen tests and honestly declaring total="4" is
+// internally consistent and tells the checker nothing. So the expected test set
+// comes from a separate `-list methods` discovery pass over the same preset,
+// and every discovered test must appear in the results.
 //
 // Only "Pass" counts as passing. A gate test that is skipped is neither
 // passing nor failing, and treating it as either is how a gate becomes
@@ -21,27 +29,36 @@
 // last thing naming the test.
 //
 // Usage:
-//   dotnet run eng/check-decompiler-gate.cs -- <results.xml> <known-red.txt> <expected-classes.txt> [--partial]
+//   dotnet run eng/check-decompiler-gate.cs -- <results.xml> <known-red.txt> \
+//       <expected-classes.txt> <discovered-tests.json> [--partial]
 //
-// --partial suppresses the dead-pin and expected-class checks, for developers
-// running a subset of the gate classes locally. CI always runs the full preset
-// and must not pass it.
+// Produce the discovery listing with the *same* preset as the run, so the two
+// cannot drift:
+//   dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
+//       --gate pre-merge -noColor -list methods/json > discovered-tests.json
+//
+// --partial suppresses the dead-pin, expected-class, and completeness checks,
+// for developers running a subset of the gate classes locally. CI always runs
+// the full preset and must not pass it.
 
+using System.Text.Json;
 using System.Xml.Linq;
 
 var positional = args.Where(a => !a.StartsWith("--", StringComparison.Ordinal)).ToArray();
 bool partial = args.Contains("--partial", StringComparer.Ordinal);
 
-if (positional.Length != 3)
+if (positional.Length != 4)
 {
     Console.Error.WriteLine(
-        "usage: check-decompiler-gate <results.xml> <known-red.txt> <expected-classes.txt> [--partial]");
+        "usage: check-decompiler-gate <results.xml> <known-red.txt> <expected-classes.txt> "
+            + "<discovered-tests.json> [--partial]");
     return 2;
 }
 
 string resultsPath = positional[0];
 string pinPath = positional[1];
 string expectedClassesPath = positional[2];
+string discoveredPath = positional[3];
 
 if (!File.Exists(resultsPath))
 {
@@ -61,6 +78,14 @@ if (!File.Exists(pinPath))
 if (!File.Exists(expectedClassesPath))
 {
     Console.Error.WriteLine($"error: expected-classes file not found: {expectedClassesPath}");
+    return 2;
+}
+
+if (!File.Exists(discoveredPath))
+{
+    Console.Error.WriteLine($"error: discovered-tests file not found: {discoveredPath}");
+    Console.Error.WriteLine("Without it there is no reference for what the run should have contained,");
+    Console.Error.WriteLine("and an incomplete report cannot be distinguished from a complete one.");
     return 2;
 }
 
@@ -86,15 +111,19 @@ if (tests.Count == 0)
     return 2;
 }
 
-// Cross-check the report against its own declared summary. The class inventory
-// proves the run selected every expected class; this proves the report is not
-// missing rows within them. xUnit writes per-assembly totals, so truncation is
-// detectable without pinning a test list that would rot on every added test.
+// Cross-check the report against its own declared summary. This is an
+// *internal consistency* check only: it catches a report that was truncated or
+// rewritten so that its rows no longer match its own counters. It deliberately
+// does not claim to prove completeness -- the counters come from the same run,
+// so an honestly-declared partial report satisfies them. The discovery
+// comparison below is what proves completeness.
 static int Sum(IEnumerable<XElement> assemblies, string attribute) =>
     assemblies.Sum(a => int.TryParse((string?)a.Attribute(attribute), out int n) ? n : 0);
 
 var assemblies = doc.Descendants("assembly").ToList();
 int declaredTotal = Sum(assemblies, "total");
+int declaredPassed = Sum(assemblies, "passed");
+int declaredFailed = Sum(assemblies, "failed");
 int declaredSkipped = Sum(assemblies, "skipped");
 int declaredNotRun = Sum(assemblies, "not-run");
 int declaredErrors = Sum(assemblies, "errors");
@@ -113,6 +142,18 @@ if (declaredSkipped != 0 || declaredNotRun != 0 || declaredErrors != 0)
         $"error: the report declares {declaredSkipped} skipped, {declaredNotRun} not-run, "
             + $"and {declaredErrors} errored tests.");
     Console.Error.WriteLine("Gate tests must run. Fix the environment or the test; do not skip it.");
+    return 2;
+}
+
+int actualPassed = tests.Count(t => (string?)t.Attribute("result") == "Pass");
+int actualFailed = tests.Count(t => (string?)t.Attribute("result") == "Fail");
+
+if (declaredPassed != actualPassed || declaredFailed != actualFailed)
+{
+    Console.Error.WriteLine(
+        $"error: the report declares {declaredPassed} passed and {declaredFailed} failed, "
+            + $"but contains {actualPassed} passing and {actualFailed} failing <test> elements.");
+    Console.Error.WriteLine("The report contradicts itself and cannot be trusted to describe the run.");
     return 2;
 }
 
@@ -199,6 +240,66 @@ var missingClasses = partial
     ? []
     : expectedClasses.Except(coveredClasses, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
 
+// Completeness, against a reference the results file cannot forge. Discovery
+// enumerates what the preset selects without running anything, so a run that
+// was cut short, filtered down, or rewritten has a smaller result set than the
+// listing regardless of how self-consistent its own counters are.
+List<string> missingTests = [];
+List<string> unexpectedTests = [];
+
+if (!partial)
+{
+    HashSet<string> discovered;
+    try
+    {
+        using var listing = JsonDocument.Parse(File.ReadAllText(discoveredPath));
+        if (listing.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            Console.Error.WriteLine($"error: {discoveredPath} is not a JSON array of test names.");
+            Console.Error.WriteLine("Produce it with '-noColor -list methods/json'.");
+            return 2;
+        }
+
+        discovered = listing.RootElement
+            .EnumerateArray()
+            .Where(e => e.ValueKind == JsonValueKind.String)
+            .Select(e => e.GetString()!)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToHashSet(StringComparer.Ordinal);
+    }
+    catch (JsonException ex)
+    {
+        Console.Error.WriteLine($"error: {discoveredPath} is not well-formed JSON: {ex.Message}");
+        Console.Error.WriteLine("A truncated listing would understate what the run owed, so this");
+        Console.Error.WriteLine("cannot be treated as an empty expectation.");
+        return 2;
+    }
+
+    if (discovered.Count == 0)
+    {
+        Console.Error.WriteLine($"error: {discoveredPath} lists no tests.");
+        Console.Error.WriteLine("Discovery matched nothing, so every report would satisfy it. A filter");
+        Console.Error.WriteLine("naming a renamed or deleted class discovers nothing and exits 0 --");
+        Console.Error.WriteLine("that is a broken preset, not an empty gate that passed.");
+        return 2;
+    }
+
+    // Discovery lists methods; a theory contributes one row per case, so
+    // compare at method granularity in both directions.
+    var executedMethods = executed
+        .Select(name =>
+        {
+            int paren = name.IndexOf('(', StringComparison.Ordinal);
+            return paren >= 0 ? name[..paren] : name;
+        })
+        .ToHashSet(StringComparer.Ordinal);
+
+    missingTests = discovered.Except(executedMethods, StringComparer.Ordinal)
+        .Order(StringComparer.Ordinal).ToList();
+    unexpectedTests = executedMethods.Except(discovered, StringComparer.Ordinal)
+        .Order(StringComparer.Ordinal).ToList();
+}
+
 var newFailures = failed.Except(pinned, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
 var nowPassing = pinned.Intersect(passed, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
 var deadPins = partial
@@ -233,6 +334,29 @@ if (missingClasses.Count > 0)
     Console.WriteLine("  pre-merge no longer selects this class (renamed? deleted? preset edited?).");
     Console.WriteLine($"  A shrinking gate passes trivially, which is why {expectedClassesPath}");
     Console.WriteLine("  exists. Pass --partial if you deliberately ran a subset.");
+    Console.WriteLine();
+}
+
+if (missingTests.Count > 0)
+{
+    Console.WriteLine($"INCOMPLETE REPORT ({missingTests.Count}) — discovered but absent from the results:");
+    foreach (var name in missingTests)
+        Console.WriteLine($"  {name}");
+    Console.WriteLine();
+    Console.WriteLine("  Discovery says the preset selects these; the report does not contain them.");
+    Console.WriteLine("  The run was cut short or the report was rewritten. A report that is missing");
+    Console.WriteLine("  tests cannot clear the gate no matter how consistent its own counters are.");
+    Console.WriteLine();
+}
+
+if (unexpectedTests.Count > 0)
+{
+    Console.WriteLine($"UNEXPECTED RESULTS ({unexpectedTests.Count}) — in the results but never discovered:");
+    foreach (var name in unexpectedTests)
+        Console.WriteLine($"  {name}");
+    Console.WriteLine();
+    Console.WriteLine("  The results and the discovery listing describe different runs. They must be");
+    Console.WriteLine("  produced from the same preset against the same build.");
     Console.WriteLine();
 }
 
@@ -288,6 +412,8 @@ if (newFailures.Count == 0
     && nowPassing.Count == 0
     && deadPins.Count == 0
     && missingClasses.Count == 0
+    && missingTests.Count == 0
+    && unexpectedTests.Count == 0
     && unidentified == 0)
 {
     Console.WriteLine("OK: the failing set matches the known-red list exactly.");

--- a/eng/check-decompiler-gate.cs
+++ b/eng/check-decompiler-gate.cs
@@ -157,26 +157,40 @@ if (declaredPassed != actualPassed || declaredFailed != actualFailed)
     return 2;
 }
 
+// Identity for *every* decision -- pins, coverage, and completeness alike --
+// comes from the structured type/method attributes, not the display name.
+// Splitting the two was a real bug: a row whose name said one thing and whose
+// method attribute said another could pass a new failure off as a pinned one.
+// The display name carries theory arguments and honors -methodDisplayOptions,
+// so it is a presentation string, not an identity.
 static string? TestName(XElement test)
 {
-    string? name = (string?)test.Attribute("name");
-    if (!string.IsNullOrWhiteSpace(name))
-        return name;
     string? type = (string?)test.Attribute("type");
     string? method = (string?)test.Attribute("method");
     if (!string.IsNullOrWhiteSpace(type) && !string.IsNullOrWhiteSpace(method))
         return $"{type}.{method}";
-    return null;
+    // Fall back to the display name only when the structured identity is
+    // absent entirely.
+    string? name = (string?)test.Attribute("name");
+    return string.IsNullOrWhiteSpace(name) ? null : name;
+}
+
+static string? TestClass(XElement test)
+{
+    string? type = (string?)test.Attribute("type");
+    if (!string.IsNullOrWhiteSpace(type))
+        return type;
+    if (TestName(test) is not string name)
+        return null;
+    int paren = name.IndexOf('(', StringComparison.Ordinal);
+    string bare = paren >= 0 ? name[..paren] : name;
+    int dot = bare.LastIndexOf('.');
+    return dot > 0 ? bare[..dot] : bare;
 }
 
 var passed = new HashSet<string>(StringComparer.Ordinal);
 var failed = new HashSet<string>(StringComparer.Ordinal);
 var notExecuted = new SortedDictionary<string, string>(StringComparer.Ordinal);
-// Method identity taken from the report's own type/method attributes rather
-// than parsed out of the display name. Display names carry theory arguments,
-// honor -methodDisplayOptions, and can contain the very characters a parser
-// would split on; type/method are unambiguous.
-var executedMethods = new HashSet<string>(StringComparer.Ordinal);
 var executedClasses = new HashSet<string>(StringComparer.Ordinal);
 int unidentified = 0;
 
@@ -204,27 +218,8 @@ foreach (var test in tests)
             break;
     }
 
-    if (result is "Pass" or "Fail")
-    {
-        string? type = (string?)test.Attribute("type");
-        string? method = (string?)test.Attribute("method");
-        if (!string.IsNullOrWhiteSpace(type) && !string.IsNullOrWhiteSpace(method))
-        {
-            executedMethods.Add($"{type}.{method}");
-            executedClasses.Add(type);
-        }
-        else
-        {
-            // Fall back to the display name only when the structured identity is
-            // absent. Cutting at the first '(' strips theory arguments; the last
-            // '.' separates class from method.
-            int paren = name.IndexOf('(', StringComparison.Ordinal);
-            string bare = paren >= 0 ? name[..paren] : name;
-            executedMethods.Add(bare);
-            int dot = bare.LastIndexOf('.');
-            executedClasses.Add(dot > 0 ? bare[..dot] : bare);
-        }
-    }
+    if (result is "Pass" or "Fail" && TestClass(test) is string cls)
+        executedClasses.Add(cls);
 }
 
 // A test that both passed and failed in one report (a retry) is treated as
@@ -312,12 +307,11 @@ if (!partial)
         return 2;
     }
 
-    // Discovery lists methods; identity comes from the report's type/method
-    // attributes, so theory arguments and display-name options cannot confuse
-    // the comparison.
-    missingTests = discovered.Except(executedMethods, StringComparer.Ordinal)
+    // `executed` is already keyed by method identity, so the comparison needs
+    // no name parsing.
+    missingTests = discovered.Except(executed, StringComparer.Ordinal)
         .Order(StringComparer.Ordinal).ToList();
-    unexpectedTests = executedMethods.Except(discovered, StringComparer.Ordinal)
+    unexpectedTests = executed.Except(discovered, StringComparer.Ordinal)
         .Order(StringComparer.Ordinal).ToList();
 }
 

--- a/eng/check-decompiler-gate.cs
+++ b/eng/check-decompiler-gate.cs
@@ -6,32 +6,42 @@
 //   * a pinned test that passed     -> the fix landed, retire the pin
 //   * a pinned test that never ran  -> the pin is dead (renamed/deleted test)
 //   * a gate test that did not run  -> coverage silently disappeared
+//   * an expected class is absent   -> the report is incomplete
 //
-// The last case is why only "Pass" counts as passing. A gate test that is
-// skipped is neither passing nor failing, and treating it as either is how a
-// gate becomes vacuous: an unpinned skip would report an exact match, and a
-// pinned skip would be reported as a landed fix, prompting removal of the pin
-// that was the last thing naming the test.
+// The last case is what an inventory buys. Without it the checker could only
+// judge the tests a report happens to contain, so a preset that stopped
+// selecting a class, a renamed class, or a run killed partway would each
+// produce a smaller report whose failing set still matched the pin list
+// exactly, and pass.
+//
+// Only "Pass" counts as passing. A gate test that is skipped is neither
+// passing nor failing, and treating it as either is how a gate becomes
+// vacuous: an unpinned skip would report an exact match, and a pinned skip
+// would be reported as a landed fix, prompting removal of the pin that was the
+// last thing naming the test.
 //
 // Usage:
-//   dotnet run eng/check-decompiler-gate.cs -- <results.xml> <known-red.txt> [--partial]
+//   dotnet run eng/check-decompiler-gate.cs -- <results.xml> <known-red.txt> <expected-classes.txt> [--partial]
 //
-// --partial suppresses the dead-pin check, for developers running a subset of
-// the gate classes locally. CI always runs the full preset and must not pass it.
+// --partial suppresses the dead-pin and expected-class checks, for developers
+// running a subset of the gate classes locally. CI always runs the full preset
+// and must not pass it.
 
 using System.Xml.Linq;
 
 var positional = args.Where(a => !a.StartsWith("--", StringComparison.Ordinal)).ToArray();
 bool partial = args.Contains("--partial", StringComparer.Ordinal);
 
-if (positional.Length != 2)
+if (positional.Length != 3)
 {
-    Console.Error.WriteLine("usage: check-decompiler-gate <results.xml> <known-red.txt> [--partial]");
+    Console.Error.WriteLine(
+        "usage: check-decompiler-gate <results.xml> <known-red.txt> <expected-classes.txt> [--partial]");
     return 2;
 }
 
 string resultsPath = positional[0];
 string pinPath = positional[1];
+string expectedClassesPath = positional[2];
 
 if (!File.Exists(resultsPath))
 {
@@ -45,6 +55,12 @@ if (!File.Exists(resultsPath))
 if (!File.Exists(pinPath))
 {
     Console.Error.WriteLine($"error: known-red file not found: {pinPath}");
+    return 2;
+}
+
+if (!File.Exists(expectedClassesPath))
+{
+    Console.Error.WriteLine($"error: expected-classes file not found: {expectedClassesPath}");
     return 2;
 }
 
@@ -70,21 +86,33 @@ if (tests.Count == 0)
     return 2;
 }
 
-static string TestName(XElement test)
+static string? TestName(XElement test)
 {
     string? name = (string?)test.Attribute("name");
-    if (!string.IsNullOrEmpty(name))
+    if (!string.IsNullOrWhiteSpace(name))
         return name;
-    return $"{(string?)test.Attribute("type")}.{(string?)test.Attribute("method")}";
+    string? type = (string?)test.Attribute("type");
+    string? method = (string?)test.Attribute("method");
+    if (!string.IsNullOrWhiteSpace(type) && !string.IsNullOrWhiteSpace(method))
+        return $"{type}.{method}";
+    return null;
 }
 
 var passed = new HashSet<string>(StringComparer.Ordinal);
 var failed = new HashSet<string>(StringComparer.Ordinal);
 var notExecuted = new SortedDictionary<string, string>(StringComparer.Ordinal);
+int unidentified = 0;
 
 foreach (var test in tests)
 {
-    string name = TestName(test);
+    string? name = TestName(test);
+    if (name is null)
+    {
+        // A result we cannot attribute to a test is not a result we can clear.
+        unidentified++;
+        continue;
+    }
+
     string result = (string?)test.Attribute("result") ?? "(no result attribute)";
     switch (result)
     {
@@ -109,8 +137,37 @@ var pinned = File.ReadAllLines(pinPath)
     .Where(line => line.Length > 0 && !line.StartsWith('#'))
     .ToHashSet(StringComparer.Ordinal);
 
+var expectedClasses = File.ReadAllLines(expectedClassesPath)
+    .Select(line => line.Trim())
+    .Where(line => line.Length > 0 && !line.StartsWith('#'))
+    .ToHashSet(StringComparer.Ordinal);
+
+if (expectedClasses.Count == 0)
+{
+    Console.Error.WriteLine($"error: no expected classes listed in {expectedClassesPath}.");
+    Console.Error.WriteLine("An empty inventory would clear any report, however incomplete.");
+    return 2;
+}
+
 var executed = new HashSet<string>(passed, StringComparer.Ordinal);
 executed.UnionWith(failed);
+
+// A class counts as covered only if it executed something. A class present in
+// the report solely as skips is a coverage hole, and is already reported as
+// one above.
+var coveredClasses = executed
+    .Select(name =>
+    {
+        int paren = name.IndexOf('(', StringComparison.Ordinal);
+        string bare = paren >= 0 ? name[..paren] : name;
+        int dot = bare.LastIndexOf('.');
+        return dot > 0 ? bare[..dot] : bare;
+    })
+    .ToHashSet(StringComparer.Ordinal);
+
+var missingClasses = partial
+    ? []
+    : expectedClasses.Except(coveredClasses, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
 
 var newFailures = failed.Except(pinned, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
 var nowPassing = pinned.Intersect(passed, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
@@ -123,8 +180,31 @@ var deadPins = partial
 
 Console.WriteLine(
     $"Decompiler gate: {tests.Count} tests, {passed.Count} passed, {failed.Count} failed, "
-        + $"{notExecuted.Count} not executed, {pinned.Count} pinned known-red.");
+        + $"{notExecuted.Count} not executed, {coveredClasses.Count}/{expectedClasses.Count} expected "
+        + $"classes covered, {pinned.Count} pinned known-red.");
 Console.WriteLine();
+
+if (unidentified > 0)
+{
+    Console.WriteLine($"UNIDENTIFIED RESULTS ({unidentified}) — <test> elements with no usable name:");
+    Console.WriteLine();
+    Console.WriteLine("  A result that cannot be attributed to a test is not a result that can");
+    Console.WriteLine("  clear one. The report is malformed.");
+    Console.WriteLine();
+}
+
+if (missingClasses.Count > 0)
+{
+    Console.WriteLine($"MISSING CLASSES ({missingClasses.Count}) — expected but nothing executed:");
+    foreach (var name in missingClasses)
+        Console.WriteLine($"  {name}");
+    Console.WriteLine();
+    Console.WriteLine($"  The report is incomplete. Either the run was cut short, or --gate");
+    Console.WriteLine("  pre-merge no longer selects this class (renamed? deleted? preset edited?).");
+    Console.WriteLine($"  A shrinking gate passes trivially, which is why {expectedClassesPath}");
+    Console.WriteLine("  exists. Pass --partial if you deliberately ran a subset.");
+    Console.WriteLine();
+}
 
 if (newFailures.Count > 0)
 {
@@ -173,7 +253,12 @@ if (deadPins.Count > 0)
     Console.WriteLine();
 }
 
-if (newFailures.Count == 0 && notExecuted.Count == 0 && nowPassing.Count == 0 && deadPins.Count == 0)
+if (newFailures.Count == 0
+    && notExecuted.Count == 0
+    && nowPassing.Count == 0
+    && deadPins.Count == 0
+    && missingClasses.Count == 0
+    && unidentified == 0)
 {
     Console.WriteLine("OK: the failing set matches the known-red list exactly.");
     if (pinned.Count > 0)

--- a/eng/check-decompiler-gate.cs
+++ b/eng/check-decompiler-gate.cs
@@ -86,6 +86,36 @@ if (tests.Count == 0)
     return 2;
 }
 
+// Cross-check the report against its own declared summary. The class inventory
+// proves the run selected every expected class; this proves the report is not
+// missing rows within them. xUnit writes per-assembly totals, so truncation is
+// detectable without pinning a test list that would rot on every added test.
+static int Sum(IEnumerable<XElement> assemblies, string attribute) =>
+    assemblies.Sum(a => int.TryParse((string?)a.Attribute(attribute), out int n) ? n : 0);
+
+var assemblies = doc.Descendants("assembly").ToList();
+int declaredTotal = Sum(assemblies, "total");
+int declaredSkipped = Sum(assemblies, "skipped");
+int declaredNotRun = Sum(assemblies, "not-run");
+int declaredErrors = Sum(assemblies, "errors");
+
+if (declaredTotal != tests.Count)
+{
+    Console.Error.WriteLine(
+        $"error: the report declares {declaredTotal} tests but contains {tests.Count} <test> elements.");
+    Console.Error.WriteLine("The report is truncated or was rewritten. It cannot clear the gate.");
+    return 2;
+}
+
+if (declaredSkipped != 0 || declaredNotRun != 0 || declaredErrors != 0)
+{
+    Console.Error.WriteLine(
+        $"error: the report declares {declaredSkipped} skipped, {declaredNotRun} not-run, "
+            + $"and {declaredErrors} errored tests.");
+    Console.Error.WriteLine("Gate tests must run. Fix the environment or the test; do not skip it.");
+    return 2;
+}
+
 static string? TestName(XElement test)
 {
     string? name = (string?)test.Attribute("name");

--- a/eng/check-decompiler-gate.cs
+++ b/eng/check-decompiler-gate.cs
@@ -167,8 +167,20 @@ static string? TestName(XElement test)
 {
     string? type = (string?)test.Attribute("type");
     string? method = (string?)test.Attribute("method");
-    if (!string.IsNullOrWhiteSpace(type) && !string.IsNullOrWhiteSpace(method))
+    bool hasType = !string.IsNullOrWhiteSpace(type);
+    bool hasMethod = !string.IsNullOrWhiteSpace(method);
+
+    if (hasType && hasMethod)
         return $"{type}.{method}";
+
+    // A row carrying only half of the structured identity is malformed, and
+    // must not quietly fall back: the display name would then assert an
+    // identity the row's own attributes do not corroborate, which is exactly
+    // the substitution the structured identity exists to prevent. Treat it as
+    // unidentified, which fails the run rather than clearing it.
+    if (hasType || hasMethod)
+        return null;
+
     // Fall back to the display name only when the structured identity is
     // absent entirely.
     string? name = (string?)test.Attribute("name");

--- a/eng/check-decompiler-gate.cs
+++ b/eng/check-decompiler-gate.cs
@@ -5,6 +5,13 @@
 //   * a failure that is not pinned  -> new breakage, the gate did its job
 //   * a pinned test that passed     -> the fix landed, retire the pin
 //   * a pinned test that never ran  -> the pin is dead (renamed/deleted test)
+//   * a gate test that did not run  -> coverage silently disappeared
+//
+// The last case is why only "Pass" counts as passing. A gate test that is
+// skipped is neither passing nor failing, and treating it as either is how a
+// gate becomes vacuous: an unpinned skip would report an exact match, and a
+// pinned skip would be reported as a landed fix, prompting removal of the pin
+// that was the last thing naming the test.
 //
 // Usage:
 //   dotnet run eng/check-decompiler-gate.cs -- <results.xml> <known-red.txt> [--partial]
@@ -30,7 +37,8 @@ if (!File.Exists(resultsPath))
 {
     Console.Error.WriteLine($"error: results file not found: {resultsPath}");
     Console.Error.WriteLine("The gate run must produce XML via '-xml <path>'. A missing file means");
-    Console.Error.WriteLine("the run crashed before reporting, which is a failure, not an empty pass.");
+    Console.Error.WriteLine("the run crashed, hung, or was killed before reporting, which is a");
+    Console.Error.WriteLine("failure, not an empty pass.");
     return 2;
 }
 
@@ -40,7 +48,19 @@ if (!File.Exists(pinPath))
     return 2;
 }
 
-var doc = XDocument.Load(resultsPath);
+XDocument doc;
+try
+{
+    doc = XDocument.Load(resultsPath);
+}
+catch (System.Xml.XmlException ex)
+{
+    Console.Error.WriteLine($"error: results file is not well-formed XML: {resultsPath}");
+    Console.Error.WriteLine($"  {ex.Message}");
+    Console.Error.WriteLine("A truncated report usually means the run was killed mid-write.");
+    return 2;
+}
+
 var tests = doc.Descendants("test").ToList();
 
 if (tests.Count == 0)
@@ -58,27 +78,52 @@ static string TestName(XElement test)
     return $"{(string?)test.Attribute("type")}.{(string?)test.Attribute("method")}";
 }
 
-var ran = tests.Select(TestName).ToHashSet(StringComparer.Ordinal);
-var failed = tests
-    .Where(t => string.Equals((string?)t.Attribute("result"), "Fail", StringComparison.Ordinal))
-    .Select(TestName)
-    .ToHashSet(StringComparer.Ordinal);
+var passed = new HashSet<string>(StringComparer.Ordinal);
+var failed = new HashSet<string>(StringComparer.Ordinal);
+var notExecuted = new SortedDictionary<string, string>(StringComparer.Ordinal);
+
+foreach (var test in tests)
+{
+    string name = TestName(test);
+    string result = (string?)test.Attribute("result") ?? "(no result attribute)";
+    switch (result)
+    {
+        case "Fail":
+            failed.Add(name);
+            break;
+        case "Pass":
+            passed.Add(name);
+            break;
+        default:
+            notExecuted[name] = result;
+            break;
+    }
+}
+
+// A test that both passed and failed in one report (a retry) is treated as
+// failing: the gate reports the worst observed outcome, never the best.
+passed.ExceptWith(failed);
 
 var pinned = File.ReadAllLines(pinPath)
     .Select(line => line.Trim())
     .Where(line => line.Length > 0 && !line.StartsWith('#'))
     .ToHashSet(StringComparer.Ordinal);
 
+var executed = new HashSet<string>(passed, StringComparer.Ordinal);
+executed.UnionWith(failed);
+
 var newFailures = failed.Except(pinned, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
-var nowPassing = pinned.Intersect(ran, StringComparer.Ordinal)
-    .Except(failed, StringComparer.Ordinal)
-    .Order(StringComparer.Ordinal)
-    .ToList();
+var nowPassing = pinned.Intersect(passed, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
 var deadPins = partial
     ? []
-    : pinned.Except(ran, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
+    : pinned.Except(executed, StringComparer.Ordinal)
+        .Except(notExecuted.Keys, StringComparer.Ordinal)
+        .Order(StringComparer.Ordinal)
+        .ToList();
 
-Console.WriteLine($"Decompiler gate: {tests.Count} tests, {failed.Count} failed, {pinned.Count} pinned known-red.");
+Console.WriteLine(
+    $"Decompiler gate: {tests.Count} tests, {passed.Count} passed, {failed.Count} failed, "
+        + $"{notExecuted.Count} not executed, {pinned.Count} pinned known-red.");
 Console.WriteLine();
 
 if (newFailures.Count > 0)
@@ -90,6 +135,19 @@ if (newFailures.Count > 0)
     Console.WriteLine("  This is the gate working. Fix the regression, or — only if the diff is");
     Console.WriteLine("  understood and intentional — docket it in the owning gate and, if it must");
     Console.WriteLine("  stay red, add it to the known-red list with an issue and a date.");
+    Console.WriteLine();
+}
+
+if (notExecuted.Count > 0)
+{
+    Console.WriteLine($"NOT EXECUTED ({notExecuted.Count}) — selected but neither passed nor failed:");
+    foreach (var (name, result) in notExecuted)
+        Console.WriteLine($"  {name} (result=\"{result}\")");
+    Console.WriteLine();
+    Console.WriteLine("  A gate test that does not run is a coverage hole, not a pass. Either the");
+    Console.WriteLine("  environment is missing something the gate needs, or the test was disabled.");
+    Console.WriteLine("  Skipping is not an approved way to green this job; fix the environment or");
+    Console.WriteLine("  the test.");
     Console.WriteLine();
 }
 
@@ -115,7 +173,7 @@ if (deadPins.Count > 0)
     Console.WriteLine();
 }
 
-if (newFailures.Count == 0 && nowPassing.Count == 0 && deadPins.Count == 0)
+if (newFailures.Count == 0 && notExecuted.Count == 0 && nowPassing.Count == 0 && deadPins.Count == 0)
 {
     Console.WriteLine("OK: the failing set matches the known-red list exactly.");
     if (pinned.Count > 0)

--- a/eng/check-decompiler-gate.cs
+++ b/eng/check-decompiler-gate.cs
@@ -192,6 +192,7 @@ var passed = new HashSet<string>(StringComparer.Ordinal);
 var failed = new HashSet<string>(StringComparer.Ordinal);
 var notExecuted = new SortedDictionary<string, string>(StringComparer.Ordinal);
 var executedClasses = new HashSet<string>(StringComparer.Ordinal);
+var occurrences = new Dictionary<string, int>(StringComparer.Ordinal);
 int unidentified = 0;
 
 foreach (var test in tests)
@@ -203,6 +204,8 @@ foreach (var test in tests)
         unidentified++;
         continue;
     }
+
+    occurrences[name] = occurrences.GetValueOrDefault(name) + 1;
 
     string result = (string?)test.Attribute("result") ?? "(no result attribute)";
     switch (result)
@@ -267,6 +270,29 @@ var missingClasses = partial
 // GateExpectedClassesTests.PreMergeGateClasses_DeclareNoTheories enforces it,
 // and adding a theory to a gate class fails that test rather than quietly
 // weakening this one.
+// Method-granular completeness is only sufficient while one method means one
+// case. Rather than trust that, measure it: if any (type, method) produced
+// more than one row, that method expanded, and a lost case would be invisible
+// to the comparison below.
+//
+// This is deliberately observational. The fast-lane guard
+// (GateExpectedClassesTests.PreMergeGateClasses_ContainOnlyPlainFacts) tries to
+// prevent multi-case tests by inspecting attributes, but that reflection has
+// been wrong repeatedly -- it missed [CulturedFact], then attributes that
+// implement IFactAttribute without deriving from FactAttribute, then a plain
+// [Fact] declared on *both* an interface method and its implementation, which
+// yields two cases from two ordinary FactAttributes. This check needs to know
+// none of that: it counts what the run actually produced.
+//
+// A duplicate here means one of two things, and both must fail: the method
+// expanded into several cases, or the same case was reported twice (a retry).
+// Neither is compatible with method-granular completeness.
+var multiCase = occurrences
+    .Where(kv => kv.Value > 1)
+    .Select(kv => $"{kv.Key} ({kv.Value} rows)")
+    .Order(StringComparer.Ordinal)
+    .ToList();
+
 List<string> missingTests = [];
 List<string> unexpectedTests = [];
 
@@ -364,6 +390,20 @@ if (missingTests.Count > 0)
     Console.WriteLine();
 }
 
+if (multiCase.Count > 0)
+{
+    Console.WriteLine($"MULTI-CASE TESTS ({multiCase.Count}) — one method, several result rows:");
+    foreach (var name in multiCase)
+        Console.WriteLine($"  {name}");
+    Console.WriteLine();
+    Console.WriteLine("  Completeness here is method-granular, because no '-list' mode enumerates");
+    Console.WriteLine("  individual cases. A method that expands to several cases breaks that: it is");
+    Console.WriteLine("  discovered once, so losing all but one of its cases would look complete.");
+    Console.WriteLine("  Make these plain single-case [Fact] tests, or teach this checker a");
+    Console.WriteLine("  case-level expectation before adding them to a gate class.");
+    Console.WriteLine();
+}
+
 if (unexpectedTests.Count > 0)
 {
     Console.WriteLine($"UNEXPECTED RESULTS ({unexpectedTests.Count}) — in the results but never discovered:");
@@ -429,6 +469,7 @@ if (newFailures.Count == 0
     && missingClasses.Count == 0
     && missingTests.Count == 0
     && unexpectedTests.Count == 0
+    && multiCase.Count == 0
     && unidentified == 0)
 {
     Console.WriteLine("OK: the failing set matches the known-red list exactly.");

--- a/eng/check-decompiler-gate.cs
+++ b/eng/check-decompiler-gate.cs
@@ -1,0 +1,129 @@
+// Compares the failing tests of a decompiler gate run against the pinned
+// known-red list, so the gate can run pre-merge while known failures are
+// still open. Drift in either direction is an error:
+//
+//   * a failure that is not pinned  -> new breakage, the gate did its job
+//   * a pinned test that passed     -> the fix landed, retire the pin
+//   * a pinned test that never ran  -> the pin is dead (renamed/deleted test)
+//
+// Usage:
+//   dotnet run eng/check-decompiler-gate.cs -- <results.xml> <known-red.txt> [--partial]
+//
+// --partial suppresses the dead-pin check, for developers running a subset of
+// the gate classes locally. CI always runs the full preset and must not pass it.
+
+using System.Xml.Linq;
+
+var positional = args.Where(a => !a.StartsWith("--", StringComparison.Ordinal)).ToArray();
+bool partial = args.Contains("--partial", StringComparer.Ordinal);
+
+if (positional.Length != 2)
+{
+    Console.Error.WriteLine("usage: check-decompiler-gate <results.xml> <known-red.txt> [--partial]");
+    return 2;
+}
+
+string resultsPath = positional[0];
+string pinPath = positional[1];
+
+if (!File.Exists(resultsPath))
+{
+    Console.Error.WriteLine($"error: results file not found: {resultsPath}");
+    Console.Error.WriteLine("The gate run must produce XML via '-xml <path>'. A missing file means");
+    Console.Error.WriteLine("the run crashed before reporting, which is a failure, not an empty pass.");
+    return 2;
+}
+
+if (!File.Exists(pinPath))
+{
+    Console.Error.WriteLine($"error: known-red file not found: {pinPath}");
+    return 2;
+}
+
+var doc = XDocument.Load(resultsPath);
+var tests = doc.Descendants("test").ToList();
+
+if (tests.Count == 0)
+{
+    Console.Error.WriteLine("error: the results file contains no tests.");
+    Console.Error.WriteLine("A gate that selected nothing is not a gate that passed.");
+    return 2;
+}
+
+static string TestName(XElement test)
+{
+    string? name = (string?)test.Attribute("name");
+    if (!string.IsNullOrEmpty(name))
+        return name;
+    return $"{(string?)test.Attribute("type")}.{(string?)test.Attribute("method")}";
+}
+
+var ran = tests.Select(TestName).ToHashSet(StringComparer.Ordinal);
+var failed = tests
+    .Where(t => string.Equals((string?)t.Attribute("result"), "Fail", StringComparison.Ordinal))
+    .Select(TestName)
+    .ToHashSet(StringComparer.Ordinal);
+
+var pinned = File.ReadAllLines(pinPath)
+    .Select(line => line.Trim())
+    .Where(line => line.Length > 0 && !line.StartsWith('#'))
+    .ToHashSet(StringComparer.Ordinal);
+
+var newFailures = failed.Except(pinned, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
+var nowPassing = pinned.Intersect(ran, StringComparer.Ordinal)
+    .Except(failed, StringComparer.Ordinal)
+    .Order(StringComparer.Ordinal)
+    .ToList();
+var deadPins = partial
+    ? []
+    : pinned.Except(ran, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
+
+Console.WriteLine($"Decompiler gate: {tests.Count} tests, {failed.Count} failed, {pinned.Count} pinned known-red.");
+Console.WriteLine();
+
+if (newFailures.Count > 0)
+{
+    Console.WriteLine($"NEW FAILURES ({newFailures.Count}) — not in {pinPath}:");
+    foreach (var name in newFailures)
+        Console.WriteLine($"  {name}");
+    Console.WriteLine();
+    Console.WriteLine("  This is the gate working. Fix the regression, or — only if the diff is");
+    Console.WriteLine("  understood and intentional — docket it in the owning gate and, if it must");
+    Console.WriteLine("  stay red, add it to the known-red list with an issue and a date.");
+    Console.WriteLine();
+}
+
+if (nowPassing.Count > 0)
+{
+    Console.WriteLine($"STALE PINS ({nowPassing.Count}) — pinned known-red but passing:");
+    foreach (var name in nowPassing)
+        Console.WriteLine($"  {name}");
+    Console.WriteLine();
+    Console.WriteLine($"  Remove these from {pinPath}. A pin that outlives its failure silently");
+    Console.WriteLine("  un-gates the test it names.");
+    Console.WriteLine();
+}
+
+if (deadPins.Count > 0)
+{
+    Console.WriteLine($"DEAD PINS ({deadPins.Count}) — pinned but not present in the run:");
+    foreach (var name in deadPins)
+        Console.WriteLine($"  {name}");
+    Console.WriteLine();
+    Console.WriteLine("  The test was renamed or deleted. Update the pin, or pass --partial if you");
+    Console.WriteLine("  deliberately ran a subset.");
+    Console.WriteLine();
+}
+
+if (newFailures.Count == 0 && nowPassing.Count == 0 && deadPins.Count == 0)
+{
+    Console.WriteLine("OK: the failing set matches the known-red list exactly.");
+    if (pinned.Count > 0)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Reminder: {pinned.Count} gate test(s) are still red. They are pinned, not fixed.");
+    }
+    return 0;
+}
+
+return 1;

--- a/eng/decompiler-gate-expected-classes.txt
+++ b/eng/decompiler-gate-expected-classes.txt
@@ -1,14 +1,12 @@
 # Decompiler gate: expected classes
 #
 # The classes `--gate pre-merge` must actually execute. eng/check-decompiler-gate.cs
-# requires at least one executed test from every class listed here, so that a
-# report which is well-formed but incomplete fails instead of passing.
+# requires at least one executed test from every class listed here.
 #
-# Without this, the checker could only judge the tests a report happens to
-# contain. A preset that stopped selecting a class, a renamed class, or a run
-# killed after emitting only some results would all produce a smaller report
-# whose failing set still matched the pin list exactly -- a silent loss of
-# coverage, which is the whole failure mode this gate exists to prevent.
+# Scope, precisely: this file proves the *preset still selects these classes*. It
+# does not prove the report is complete -- a report can honestly contain fewer
+# tests than the preset would select. Completeness is a separate check, against
+# the runner's own discovery listing; see check-decompiler-gate.cs.
 #
 # This file is not maintained by hand against the preset: GateExpectedClassesTests
 # asserts it matches the `pre-merge` preset's -class arguments exactly, so a class
@@ -16,3 +14,4 @@
 ILInspector.Decompiler.Tests.FidelityGateTests
 ILInspector.Decompiler.Tests.LoweredFidelityGateTests
 ILInspector.Decompiler.Tests.ByteNeutralityGateTests
+ILInspector.Decompiler.Tests.GateExpectedClassesTests

--- a/eng/decompiler-gate-expected-classes.txt
+++ b/eng/decompiler-gate-expected-classes.txt
@@ -1,0 +1,18 @@
+# Decompiler gate: expected classes
+#
+# The classes `--gate pre-merge` must actually execute. eng/check-decompiler-gate.cs
+# requires at least one executed test from every class listed here, so that a
+# report which is well-formed but incomplete fails instead of passing.
+#
+# Without this, the checker could only judge the tests a report happens to
+# contain. A preset that stopped selecting a class, a renamed class, or a run
+# killed after emitting only some results would all produce a smaller report
+# whose failing set still matched the pin list exactly -- a silent loss of
+# coverage, which is the whole failure mode this gate exists to prevent.
+#
+# This file is not maintained by hand against the preset: GateExpectedClassesTests
+# asserts it matches the `pre-merge` preset's -class arguments exactly, so a class
+# added to the preset without being added here fails, and so does the reverse.
+ILInspector.Decompiler.Tests.FidelityGateTests
+ILInspector.Decompiler.Tests.LoweredFidelityGateTests
+ILInspector.Decompiler.Tests.ByteNeutralityGateTests

--- a/eng/decompiler-gate-known-red.txt
+++ b/eng/decompiler-gate-known-red.txt
@@ -1,0 +1,32 @@
+# Decompiler gate: pinned known-red tests
+#
+# Tests listed here are known to fail and are allowed to fail in the pre-merge
+# `decompiler-gates` CI job. Everything else in `--gate pre-merge` must pass.
+#
+# This list is a ratchet in both directions. `eng/check-decompiler-gate.cs`
+# fails the job when a test fails that is NOT listed here (new breakage) and
+# also when a test listed here PASSES (the fix landed; retire the pin). A pin is
+# a dated debt with an owner, not a permanent exemption.
+#
+# Format: one fully qualified `Namespace.Class.Method` per line. Precede each
+# entry with the issue that tracks it and the date it was pinned.
+#
+# ---------------------------------------------------------------------------
+# #3489 — pinned 2026-07-29. The declaration formatter @-escapes unnamed
+# keyword-typed tuple elements, so `(int, int)` renders as `(@int, @int)` and
+# CfgSampleClass.TupleRest no longer recompiles (CS0246). Root-caused; the fix
+# is in the declaration formatter, not the decompiler.
+ILInspector.Decompiler.Tests.FidelityGateTests.PinnedFixesStayExact
+#
+# #3490 — pinned 2026-07-29. MakeConsumerWithTwoLeadingArgs shows a spurious
+# stloc/ldloc pair on the raised path. Real, and already docketed in the lowered
+# gate (LoweredFidelityGateTests.cs) against #3272; the raised docket needs the
+# same entry, or ExpressionInliningPass needs to remove both spill temps.
+ILInspector.Decompiler.Tests.FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket
+#
+# #3491 — pinned 2026-07-29. Five of the six diffs are Roslyn local-function
+# name-mangling ordinals (`g__Name|N_K`), which encode source member position
+# and cannot match after reconstruction — no decompiler can pass that
+# comparison. The sixth (ManualConstantOnlyComparisonFactory) is a real
+# stack-slot/temporary reshape whose five siblings are already docketed.
+ILInspector.Decompiler.Tests.LoweredFidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket

--- a/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
@@ -1,0 +1,55 @@
+using ILInspector.Decompiler.Tests.Gating;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins <c>eng/decompiler-gate-expected-classes.txt</c> to the <c>pre-merge</c> preset.
+///
+/// <para>The CI checker requires every class in that file to have executed something,
+/// which is what stops an incomplete report from passing trivially. That guarantee is
+/// only worth as much as the file's accuracy, so the file is not maintained by hand
+/// against the preset: this test asserts set equality in both directions, so a class
+/// added to the preset without being added to the file fails, and so does a stale
+/// entry left behind after a class is renamed or removed.</para>
+///
+/// <para>This is the gate that enforces the inventory. It is deliberately in the fast
+/// lane: it must run on every PR, including PRs that never trigger the slow gates.</para>
+/// </summary>
+public class GateExpectedClassesTests
+{
+    [Fact]
+    public void ExpectedClassesFile_MatchesThePreMergePresetExactly()
+    {
+        GatePreset preset = Assert.Single(Program.Presets, p => p.Name == "pre-merge");
+
+        var fromPreset = preset.Args
+            .Select((arg, i) => (arg, i))
+            .Where(x => x.arg == "-class")
+            .Select(x => preset.Args[x.i + 1])
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.NotEmpty(fromPreset);
+
+        string path = Path.Combine(RepoRoot(), "eng", "decompiler-gate-expected-classes.txt");
+        var fromFile = File.ReadAllLines(path)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0 && !line.StartsWith('#'))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(fromPreset, fromFile);
+    }
+
+    // Fails rather than skips when the source tree is absent. A skip here would
+    // silently retire the inventory's only enforcement, which is exactly the
+    // failure mode the inventory exists to prevent.
+    private static string RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+            if (File.Exists(Path.Combine(dir.FullName, "eng", "decompiler-gate-expected-classes.txt")))
+                return dir.FullName;
+
+        throw new InvalidOperationException(
+            "Could not locate the repository root from "
+                + $"'{AppContext.BaseDirectory}'. This test must run from a source checkout.");
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using ILInspector.Decompiler.Tests.Gating;
+using Xunit.v3;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -56,9 +57,24 @@ public class GateExpectedClassesTests
     /// future multi-case attribute. Requiring the attribute to be exactly
     /// <see cref="FactAttribute"/> fails closed on all of them.</para>
     ///
+    /// <para>The scan is anchored on <see cref="IFactAttribute"/> rather than on
+    /// <see cref="FactAttribute"/> because that is the abstraction xUnit itself keys on:
+    /// <c>ExtensibilityPointFactory.GetMethodFactAttributes</c> returns
+    /// <c>IReadOnlyCollection&lt;IFactAttribute&gt;</c>. An attribute may implement that
+    /// interface directly, without deriving from <see cref="FactAttribute"/>, and supply a
+    /// discoverer that emits several cases. Anchoring on the class would discover such an
+    /// attribute in xUnit and miss it here, which is the same mistake as a deny list in a
+    /// different disguise.</para>
+    ///
     /// <para>The method surface scanned here mirrors what xUnit itself discovers —
     /// inherited and non-public methods, plus interface declarations — because a theory
-    /// inherited from a base class is discovered and run exactly like a declared one.</para>
+    /// inherited from a base class is discovered and run exactly like a declared one.
+    /// The interface arm is load-bearing and measured, not defensive: a <c>[Fact]</c> on a
+    /// default interface method runs on the implementing class, and a <c>[Fact]</c> on an
+    /// interface method *declaration* runs in addition to the one on the implementation,
+    /// producing two cases from two perfectly ordinary <see cref="FactAttribute"/>s.
+    /// That last shape is why multiplicity is counted per signature rather than judged
+    /// per attribute: both attributes are plain, and only their number is wrong.</para>
     ///
     /// <para>Resolving each class by name also catches a preset arm naming a renamed or
     /// deleted class. That matters because a <c>-class</c> filter matching nothing runs
@@ -93,15 +109,37 @@ public class GateExpectedClassesTests
             IEnumerable<MethodInfo> methods = type.GetMethods(Surface)
                 .Concat(type.GetInterfaces().SelectMany(i => i.GetMethods(Surface)));
 
+            // Keyed by signature, not by MethodInfo: a [Fact] on an interface
+            // method declaration and a [Fact] on its implementation are two
+            // distinct MethodInfos, and xUnit runs the method twice. Counting
+            // per signature is what makes that visible.
+            var factsBySignature = new Dictionary<string, List<IFactAttribute>>(StringComparer.Ordinal);
+
             foreach (MethodInfo method in methods)
             {
-                FactAttribute? fact = method
+                foreach (IFactAttribute fact in method
                     .GetCustomAttributes(inherit: true)
-                    .OfType<FactAttribute>()
-                    .FirstOrDefault();
+                    .OfType<IFactAttribute>())
+                {
+                    string signature = method.Name
+                        + "(" + string.Join(",", method.GetParameters().Select(p => p.ParameterType.FullName)) + ")";
 
-                if (fact is not null && fact.GetType() != typeof(FactAttribute))
-                    offenders.Add($"{className}.{method.Name} [{fact.GetType().Name}]");
+                    if (!factsBySignature.TryGetValue(signature, out List<IFactAttribute>? facts))
+                        factsBySignature[signature] = facts = [];
+
+                    facts.Add(fact);
+                }
+            }
+
+            foreach ((string signature, List<IFactAttribute> facts) in factsBySignature)
+            {
+                string name = signature[..signature.IndexOf('(', StringComparison.Ordinal)];
+
+                foreach (IFactAttribute fact in facts.Where(f => f.GetType() != typeof(FactAttribute)))
+                    offenders.Add($"{className}.{name} [{fact.GetType().Name}]");
+
+                if (facts.Count > 1)
+                    offenders.Add($"{className}.{name} [{facts.Count} fact attributes on one method]");
             }
         }
 

--- a/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
@@ -41,22 +41,31 @@ public class GateExpectedClassesTests
     }
 
     /// <summary>
-    /// Forbids <c>[Theory]</c> in the <c>pre-merge</c> gate classes, and proves the preset
-    /// names classes that exist.
+    /// Requires every test in the <c>pre-merge</c> gate classes to be a plain <c>[Fact]</c>,
+    /// and proves the preset names classes that exist.
     ///
     /// <para>The CI completeness check compares the run against a <c>-list methods</c>
-    /// discovery listing, and no <c>-list</c> mode enumerates theory cases: a theory with
-    /// five cases is listed once, so a run that lost four of them would still satisfy the
-    /// check. Method granularity is sufficient only while the gate classes are fact-only.
-    /// This test is what makes that true instead of assumed — adding a theory to a gate
-    /// class fails here rather than silently weakening the gate.</para>
+    /// discovery listing, and no <c>-list</c> mode enumerates individual cases: a method
+    /// that expands to five cases is listed once, so a run that lost four of them would
+    /// still satisfy the check. Method granularity is sufficient only while every gate
+    /// test is exactly one case. This test is what makes that true instead of assumed.</para>
+    ///
+    /// <para>It is an allow list, not a deny list. Rejecting only <c>[Theory]</c> would miss
+    /// <c>[CulturedFact]</c>, which derives from <see cref="FactAttribute"/> rather than
+    /// <c>TheoryAttribute</c> and still yields one case per culture, and would miss any
+    /// future multi-case attribute. Requiring the attribute to be exactly
+    /// <see cref="FactAttribute"/> fails closed on all of them.</para>
+    ///
+    /// <para>The method surface scanned here mirrors what xUnit itself discovers —
+    /// inherited and non-public methods, plus interface declarations — because a theory
+    /// inherited from a base class is discovered and run exactly like a declared one.</para>
     ///
     /// <para>Resolving each class by name also catches a preset arm naming a renamed or
     /// deleted class. That matters because a <c>-class</c> filter matching nothing runs
     /// zero tests and exits 0, so the mistake is otherwise invisible.</para>
     /// </summary>
     [Fact]
-    public void PreMergeGateClasses_DeclareNoTheories()
+    public void PreMergeGateClasses_ContainOnlyPlainFacts()
     {
         GatePreset preset = Assert.Single(Program.Presets, p => p.Name == "pre-merge");
 
@@ -68,7 +77,11 @@ public class GateExpectedClassesTests
 
         Assert.NotEmpty(classNames);
 
-        var theories = new List<string>();
+        const BindingFlags Surface =
+            BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public
+            | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
+
+        var offenders = new SortedSet<string>(StringComparer.Ordinal);
         foreach (string className in classNames)
         {
             Type type = typeof(Program).Assembly.GetType(className)
@@ -77,20 +90,30 @@ public class GateExpectedClassesTests
                         + "assembly. A -class filter matching nothing runs zero tests and exits 0, "
                         + "so this would silently un-gate that class.");
 
-            theories.AddRange(
-                type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
-                    .Where(m => m.GetCustomAttribute<TheoryAttribute>() is not null)
-                    .Select(m => $"{className}.{m.Name}"));
+            IEnumerable<MethodInfo> methods = type.GetMethods(Surface)
+                .Concat(type.GetInterfaces().SelectMany(i => i.GetMethods(Surface)));
+
+            foreach (MethodInfo method in methods)
+            {
+                FactAttribute? fact = method
+                    .GetCustomAttributes(inherit: true)
+                    .OfType<FactAttribute>()
+                    .FirstOrDefault();
+
+                if (fact is not null && fact.GetType() != typeof(FactAttribute))
+                    offenders.Add($"{className}.{method.Name} [{fact.GetType().Name}]");
+            }
         }
 
         Assert.True(
-            theories.Count == 0,
+            offenders.Count == 0,
             "The pre-merge gate completeness check is method-granular because xUnit's discovery "
-                + "listing does not enumerate theory cases, so a theory that silently lost cases "
-                + "would still satisfy it. Either make these facts, or teach "
+                + "listing does not enumerate individual cases, so a test that expands to several "
+                + "cases and silently loses some would still satisfy it. Gate classes must contain "
+                + "only plain [Fact] tests. Either make these facts, or teach "
                 + "eng/check-decompiler-gate.cs a case-level expectation before adding them:"
                 + Environment.NewLine
-                + string.Join(Environment.NewLine, theories.Order(StringComparer.Ordinal).Select(t => "  " + t)));
+                + string.Join(Environment.NewLine, offenders.Select(o => "  " + o)));
     }
 
     // Fails rather than skips when the source tree is absent. A skip here would

--- a/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using ILInspector.Decompiler.Tests.Gating;
 
 namespace ILInspector.Decompiler.Tests;
@@ -37,6 +38,59 @@ public class GateExpectedClassesTests
             .ToHashSet(StringComparer.Ordinal);
 
         Assert.Equal(fromPreset, fromFile);
+    }
+
+    /// <summary>
+    /// Forbids <c>[Theory]</c> in the <c>pre-merge</c> gate classes, and proves the preset
+    /// names classes that exist.
+    ///
+    /// <para>The CI completeness check compares the run against a <c>-list methods</c>
+    /// discovery listing, and no <c>-list</c> mode enumerates theory cases: a theory with
+    /// five cases is listed once, so a run that lost four of them would still satisfy the
+    /// check. Method granularity is sufficient only while the gate classes are fact-only.
+    /// This test is what makes that true instead of assumed — adding a theory to a gate
+    /// class fails here rather than silently weakening the gate.</para>
+    ///
+    /// <para>Resolving each class by name also catches a preset arm naming a renamed or
+    /// deleted class. That matters because a <c>-class</c> filter matching nothing runs
+    /// zero tests and exits 0, so the mistake is otherwise invisible.</para>
+    /// </summary>
+    [Fact]
+    public void PreMergeGateClasses_DeclareNoTheories()
+    {
+        GatePreset preset = Assert.Single(Program.Presets, p => p.Name == "pre-merge");
+
+        var classNames = preset.Args
+            .Select((arg, i) => (arg, i))
+            .Where(x => x.arg == "-class")
+            .Select(x => preset.Args[x.i + 1])
+            .ToList();
+
+        Assert.NotEmpty(classNames);
+
+        var theories = new List<string>();
+        foreach (string className in classNames)
+        {
+            Type type = typeof(Program).Assembly.GetType(className)
+                ?? throw new InvalidOperationException(
+                    $"The pre-merge preset names '{className}', which does not exist in the test "
+                        + "assembly. A -class filter matching nothing runs zero tests and exits 0, "
+                        + "so this would silently un-gate that class.");
+
+            theories.AddRange(
+                type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                    .Where(m => m.GetCustomAttribute<TheoryAttribute>() is not null)
+                    .Select(m => $"{className}.{m.Name}"));
+        }
+
+        Assert.True(
+            theories.Count == 0,
+            "The pre-merge gate completeness check is method-granular because xUnit's discovery "
+                + "listing does not enumerate theory cases, so a theory that silently lost cases "
+                + "would still satisfy it. Either make these facts, or teach "
+                + "eng/check-decompiler-gate.cs a case-level expectation before adding them:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, theories.Order(StringComparer.Ordinal).Select(t => "  " + t)));
     }
 
     // Fails rather than skips when the source tree is absent. A skip here would

--- a/src/ILInspector.Decompiler.Tests/Program.cs
+++ b/src/ILInspector.Decompiler.Tests/Program.cs
@@ -25,7 +25,9 @@ namespace ILInspector.Decompiler.Tests;
 internal static class Program
 {
     // Presets over the Speed/Area traits. Order matches --gate list output.
-    private static readonly IReadOnlyList<GatePreset> Presets =
+    // internal so GateExpectedClassesTests can assert the pre-merge preset and
+    // eng/decompiler-gate-expected-classes.txt name the same classes.
+    internal static readonly IReadOnlyList<GatePreset> Presets =
     [
         new("all", "Every test, including all slow gates (default with no --gate)."),
         new("fast", "Skip every slow gate (fast unit lane; matches the PR CI test job).", "-trait-", "Speed=Slow"),

--- a/src/ILInspector.Decompiler.Tests/Program.cs
+++ b/src/ILInspector.Decompiler.Tests/Program.cs
@@ -38,7 +38,13 @@ internal static class Program
             "The docket and byte-neutrality gates only (matches the PR CI decompiler-gates job).",
             "-class", "ILInspector.Decompiler.Tests.FidelityGateTests",
             "-class", "ILInspector.Decompiler.Tests.LoweredFidelityGateTests",
-            "-class", "ILInspector.Decompiler.Tests.ByteNeutralityGateTests"),
+            "-class", "ILInspector.Decompiler.Tests.ByteNeutralityGateTests",
+            // The gate's own plumbing guard rides along in the preset it guards.
+            // Running it as a separate CI step was vacuous: a filter naming a
+            // renamed or deleted class discovers nothing and exits 0. Inside the
+            // preset it is covered by the same discovery/coverage checks as the
+            // correctness gates, so it cannot silently stop running.
+            "-class", "ILInspector.Decompiler.Tests.GateExpectedClassesTests"),
         new("corpus", "Only the Corpus area (the multi-hour sweep).", "-trait", "Area=Corpus"),
         new("roundtrip", "Only the RoundTrip area (compile-back / ReturnToSender).", "-trait", "Area=RoundTrip"),
         new("fidelity", "Only the Fidelity area.", "-trait", "Area=Fidelity"),

--- a/src/ILInspector.Decompiler.Tests/Program.cs
+++ b/src/ILInspector.Decompiler.Tests/Program.cs
@@ -31,6 +31,12 @@ internal static class Program
         new("fast", "Skip every slow gate (fast unit lane; matches the PR CI test job).", "-trait-", "Speed=Slow"),
         new("slow", "Only the slow gates.", "-trait", "Speed=Slow"),
         new("no-corpus", "Everything except the multi-hour Corpus sweep.", "-trait-", "Area=Corpus"),
+        new(
+            "pre-merge",
+            "The docket and byte-neutrality gates only (matches the PR CI decompiler-gates job).",
+            "-class", "ILInspector.Decompiler.Tests.FidelityGateTests",
+            "-class", "ILInspector.Decompiler.Tests.LoweredFidelityGateTests",
+            "-class", "ILInspector.Decompiler.Tests.ByteNeutralityGateTests"),
         new("corpus", "Only the Corpus area (the multi-hour sweep).", "-trait", "Area=Corpus"),
         new("roundtrip", "Only the RoundTrip area (compile-back / ReturnToSender).", "-trait", "Area=RoundTrip"),
         new("fidelity", "Only the Fidelity area.", "-trait", "Area=Fidelity"),


### PR DESCRIPTION
Closes #3432.

## What this does

Runs the three decompiler docket / byte-neutrality gates on PRs, in a path-gated job, and decides the job's result by comparing the run against a pinned list of known-red tests.

**The gate goes on red, deliberately.** The three currently-open failures are pinned, not fixed. Waiting for green is what let the backlog accumulate in the first place; a gate's job is to make the *next* breakage attributable to the PR that caused it.

## Why the existing gates never fired

The gates carry doc comments asserting they fail CI. They do not, and have not.

- They are all `Speed=Slow`, and the PR `test` job runs `-trait- "Speed=Slow"` (`ci.yml:326`). No pre-merge lane ran them.
- That left `release.yml` and the weekly Deep Inspect lane. In Deep Inspect they were **exceeding the job timeout**, and a *cancelled* job does not satisfy that workflow's `if: ... && failure()` notifier — so no notification was ever sent.

Detection latency was therefore unbounded, not weekly (#3432). Five real regressions accumulated unseen: #3489, #3490, #3491, #3492, #3493.

## Design

| Piece | Role |
| --- | --- |
| `--gate pre-merge` | new preset; the three gate classes |
| `decompiler-gates` job | path-gated, own job, never serializes with the hot `test` lane |
| `eng/decompiler-gate-known-red.txt` | pinned failures, each with issue + pin date + root cause |
| `eng/check-decompiler-gate.cs` | reads the xUnit report, decides pass/fail |

The gate step is `continue-on-error`; the checker owns the verdict. It fails on:

| Condition | Why |
| --- | --- |
| a failure that is not pinned | new breakage — the point of the job |
| a pinned test that **passed** | the fix landed; retire the pin |
| a pinned test that never ran | dead pin — renamed or deleted test |
| missing report, or zero tests | a crashed run is not an empty pass |

The stale-pin check is the part that matters. A pin that outlives its failure silently un-gates the test it names, and that is how a known-red list decays into wallpaper. This one is a ratchet in both directions.

## Scope is a cost decision, not a principle

`pre-merge` names three classes rather than taking the whole `Fidelity` area, because the area is too expensive for the PR lane:

| Selection | Wall | Tests |
| --- | --- | --- |
| `--gate fidelity` | 31m12s | 66 |
| `--gate pre-merge` | **7m46s** | 14 |

`ClusterCaptureTests` and `PrinterPrecedenceTests` are ~21 minutes of CPU **for two tests** between them. They want the #3495 type-filter treatment before they can be gated; that is the blocker to widening this preset, and it is called out in the job comment and the docs.

(Timings are from a shared local machine and are indicative, not benchmarks. The job's `timeout-minutes: 45` is deliberately loose against a 7m46s local run since runner cost is unmeasured.)

## Evidence

- **End to end**, the exact CI invocation: 14 tests, 3 failures, checker exit 0.
- **Checker is non-vacuous.** Verified against the real 66-test run artifact (exit 0), then five negative controls, each of which failed it as intended: unpinned failure; pinned-but-passing; dead pin; missing report; zero-test report.
- `GateArgumentExpanderTests` 11/0; `--gate list` renders the new preset; solution builds clean.

## Note for reviewers: two of the three pinned issues have wrong diagnoses

I root-caused #3489 and #3491 while pinning them, and **both filed diagnoses were wrong**. Their titles and bodies have been corrected in place with superseded-diagnosis banners.

- **#3491** is not a decompiler defect. Five of its six diffs are Roslyn local-function name-mangling ordinals (`g__Name|N_K`), which encode the enclosing method's *source position*. Reconstruction re-nests the 18 hoisted methods, so the ordinal shifts, and **no correct decompiler can match it**. ([analysis](https://github.com/richlander/dotnet-inspect/issues/3491#issuecomment-5123310485))
- **#3489** is not a decompiler defect either. It is a **shipping-product bug in the declaration formatter**: any unnamed tuple element whose type spells as a keyword is `@`-escaped, so `(int, int)` renders as `(@int, @int)` and `dotnet-inspect member -s Methods` prints non-compiling C#. Arity and `TRest` are irrelevant; `--json` is clean. ([analysis](https://github.com/richlander/dotnet-inspect/issues/3489#issuecomment-5123965893))

Both landed **outside** the decompiler. #3492 and #3493 remain untraced, and given two-for-two, their filed diagnoses should be treated as unverified too.

## Non-goals

Fixing any of the pinned failures. Widening the gate beyond the three classes. Changing the Deep Inspect notifier (the timeout/`failure()` interaction is real and still open).