### PR TITLE
Make README.md and SKILL.md a release prerequisite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,12 @@ current product behavior and tests over design history. When current sources
 disagree, stop and resolve which owner is authoritative rather than silently
 choosing one.
 
-When adding a focused skill, register it in `SkillCommand.Skills`. Its YAML
-frontmatter `description:` is the single source of truth for the generated
-skill listing.
+When adding a focused skill, register it in `SkillCommand.Skills` **and** add an
+`EmbeddedResource` line for it in `src/dotnet-inspect/dotnet-inspect.csproj`;
+the embeds are enumerated per skill, and no test compares them against the
+`skills/` directory, so a skill missing from either list ships as nothing with a
+green suite. Its YAML frontmatter `description:` is the single source of truth
+for the generated skill listing.
 
 ## Repository-wide engineering constraints
 
@@ -203,9 +206,9 @@ public surface as an internal design constraint, not an external compatibility
 surface. `docs/release-workflow.md` owns the packaging mechanics.
 
 Changing `VersionPrefix` in `src/dotnet-inspect/dotnet-inspect.csproj` is a
-release, and `README.md` (packed as the package readme) and every
-`skills/**/SKILL.md` (embedded in the binary) ship with it. Consult both before
-the version moves and update whatever the release changed; the checklist is in
+release, and `README.md` (packed as the package readme) and the shipped
+`SKILL.md` files (embedded in the binary) ship with it. Consult both before the
+version moves and update whatever the release changed; the checklist is in
 `docs/release-workflow.md`.
 
 ### File-based apps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,12 @@ libraries carry no versioning story or API-stability commitment: treat their
 public surface as an internal design constraint, not an external compatibility
 surface. `docs/release-workflow.md` owns the packaging mechanics.
 
+Changing `VersionPrefix` in `src/dotnet-inspect/dotnet-inspect.csproj` is a
+release, and `README.md` (packed as the package readme) and every
+`skills/**/SKILL.md` (embedded in the binary) ship with it. Consult both before
+the version moves and update whatever the release changed; the checklist is in
+`docs/release-workflow.md`.
+
 ### File-based apps
 
 Do not use `dotnet-script`, `dotnet script`, `dotnet-fsi`, or `.csx` files.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -69,9 +69,11 @@ artifacts:
   `src/dotnet-inspect/dotnet-inspect.csproj`, packed via the `None Include`
   entry beside it), so it is the first thing a consumer of the published
   package reads.
-- Every `skills/**/SKILL.md` is embedded into the tool binary as a resource and
-  served by `dotnet-inspect skill`, so the published tool teaches agents
-  whatever those files said at build time.
+- Every shipped `SKILL.md` is embedded into the tool binary as an
+  `EmbeddedResource` and served by `dotnet-inspect skill`, so the published tool
+  teaches agents whatever those files said at build time. The embeds are
+  enumerated one line per skill in `src/dotnet-inspect/dotnet-inspect.csproj`,
+  not globbed.
 
 A change to `VersionPrefix` is therefore a documentation checkpoint. Consult
 both before dispatching, and expect to update them:
@@ -83,6 +85,14 @@ both before dispatching, and expect to update them:
   and is a new capability discoverable from the skill that owns it? A skill's
   YAML frontmatter `description:` is the single source of truth for the
   generated listing, so a stale description ships as a stale listing.
+- **Does every skill added since the last release appear in both places?** A
+  skill needs an `EmbeddedResource` line in
+  `src/dotnet-inspect/dotnet-inspect.csproj` *and* an entry in
+  `SkillCommand.Skills`. Nothing enforces this: every test in
+  `SkillCommandTests` iterates `SkillCommand.Skills`, so a skill directory that
+  was never registered is invisible to the suite and ships as nothing at all,
+  with a green build. Compare `skills/*/SKILL.md` on disk against both lists by
+  hand, and confirm with `dotnet-inspect skill list`.
 - Record the outcome either way. If neither needed a change, say so; silence
   reads the same as an unchecked box.
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -57,6 +57,34 @@ Before dispatching a release:
 2. Confirm that the commit contains the intended `VersionPrefix` and release
    notes.
 3. Confirm that the version has not already been published.
+4. Reconcile the shipped documentation with what the release actually does —
+   see [Shipped documentation](#shipped-documentation).
+
+## Shipped documentation
+
+`README.md` and the skills are not repository-side notes. They are release
+artifacts:
+
+- `README.md` is the package readme (`PackageReadmeFile` in
+  `src/dotnet-inspect/dotnet-inspect.csproj`, packed via the `None Include`
+  entry beside it), so it is the first thing a consumer of the published
+  package reads.
+- Every `skills/**/SKILL.md` is embedded into the tool binary as a resource and
+  served by `dotnet-inspect skill`, so the published tool teaches agents
+  whatever those files said at build time.
+
+A change to `VersionPrefix` is therefore a documentation checkpoint. Consult
+both before dispatching, and expect to update them:
+
+- Do the commands, flags, defaults, and example output in `README.md` still
+  match the tool? Re-run any example whose command surface changed rather than
+  eyeballing it.
+- Does each `SKILL.md` still describe capabilities the release actually has,
+  and is a new capability discoverable from the skill that owns it? A skill's
+  YAML frontmatter `description:` is the single source of truth for the
+  generated listing, so a stale description ships as a stale listing.
+- Record the outcome either way. If neither needed a change, say so; silence
+  reads the same as an unchecked box.
 
 ## Dispatching
 


### PR DESCRIPTION
Both files ship, so a release publishes whatever they currently say, and neither
had a release-time checkpoint. `README.md` is the package readme
(`PackageReadmeFile` in `src/dotnet-inspect/dotnet-inspect.csproj`, packed by
the `None Include` entry beside it). Every `skills/**/SKILL.md` is an
`EmbeddedResource` in the tool binary, served by `dotnet-inspect skill`. A
version bump could therefore publish a readme describing commands the tool no
longer has, or ship a skill teaching agents a capability that moved.

This makes a `VersionPrefix` change a documentation checkpoint.

- `docs/release-workflow.md` gains a fourth prerequisite and a **Shipped
  documentation** section: why the two are release artifacts rather than
  repository notes, what to check in each, and that a skill's frontmatter
  `description:` is the single source of truth for the generated listing — so a
  stale description ships as a stale listing.
- The outcome is recorded either way. "Neither needed a change" is a valid
  answer; silence reads the same as an unchecked box.
- `AGENTS.md` carries the four-line rule and points at the checklist, extending
  the packaging paragraph rather than opening a new section.

## Stack

Slice 2 of 2. Parent: #3524 (`docs/agents-md-shrink`), which is where the
packaging paragraph this extends now lives; this PR targets that branch, so the
diff is only its own slice. Nothing remains after this — the release checklist
is the last piece of guidance this pass touches.

## Compatibility and non-action

Guidance only; no product code, no behavior claim, and no change to what the
package actually contains. It does not attempt to *enforce* the checkpoint in
CI — the drift it addresses is a judgement call about whether prose still
matches behavior, which a gate cannot make. Related drift noticed and
deliberately left alone: `.claude-plugin/plugin.json` declares `0.7.2` against
the csproj's `0.16.0`.

## Validation

`npx markdownlint-cli AGENTS.md docs/release-workflow.md` — clean.
Docs-only with no measured behavior claim, so per `AGENTS.md` no product build
or test is required.
