### PR TITLE
Window the package tabular render with --rows (#3457)

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4132,6 +4132,47 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PackageSection_Rows_WindowsTheTabularRenderAndAgreesWithCount()
+    {
+        // Regression (#3457): --count windowed the section through the markdown limiter, but the
+        // tabular render never received options.Rows, so `--rows 1..1 --count` reported one row
+        // while `--rows 1..1 --jsonl` emitted the whole section. A count that does not describe
+        // the payload it is counting is worse than no count at all.
+        const string Package = "Newtonsoft.Json@13.0.4";
+
+        // Negative case: with no window, the count and the render already agreed, and must still.
+        var (bareCountExit, bareCountOutput, _) = await RunAppAsync(
+            "package", Package, "-S", "Package Info", "--count", "--tips", "q");
+        var (bareRowsExit, bareRowsOutput, _) = await RunAppAsync(
+            "package", Package, "-S", "Package Info", "--jsonl", "--tips", "q");
+        Assert.Equal(0, bareCountExit);
+        Assert.Equal(0, bareRowsExit);
+        var bareRows = bareRowsOutput.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries).Length;
+        Assert.True(bareRows > 2, "The section must have more rows than the window keeps for this test to prove anything.");
+        Assert.Equal(bareRows, int.Parse(bareCountOutput.Trim(), CultureInfo.InvariantCulture));
+
+        var (countExit, countOutput, _) = await RunAppAsync(
+            "package", Package, "-S", "Package Info", "--rows", "2..3", "--count", "--tips", "q");
+        Assert.Equal(0, countExit);
+        Assert.Equal(2, int.Parse(countOutput.Trim(), CultureInfo.InvariantCulture));
+
+        var (jsonlExit, jsonlOutput, _) = await RunAppAsync(
+            "package", Package, "-S", "Package Info", "--rows", "2..3", "--jsonl", "--tips", "q");
+        Assert.Equal(0, jsonlExit);
+        Assert.Equal(2, jsonlOutput.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
+
+        // The window is absolute, so it names rows 2 and 3 of the section rather than the first
+        // two, and the header survives it.
+        var (tsvExit, tsvOutput, _) = await RunAppAsync(
+            "package", Package, "-S", "Package Info", "--rows", "2..3", "--tsv", "--tips", "q");
+        Assert.Equal(0, tsvExit);
+        var tsvLines = tsvOutput.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(3, tsvLines.Length);
+        Assert.StartsWith("Built\t", tsvLines[1], StringComparison.Ordinal);
+        Assert.StartsWith("Content\t", tsvLines[2], StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Content_Count_CountsMatchedFilesBecauseThePayloadIsAVector()
     {
         // --content renders text, but it yields one structured row per matched file rather than a

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4162,14 +4162,19 @@ public partial class CommandExecutionTests
         Assert.Equal(2, jsonlOutput.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
 
         // The window is absolute, so it names rows 2 and 3 of the section rather than the first
-        // two, and the header survives it.
+        // two, and the header survives it. Derive that expectation from the unwindowed render so
+        // the assertion pins the windowing semantics rather than this package's field list.
+        var (fullTsvExit, fullTsvOutput, _) = await RunAppAsync(
+            "package", Package, "-S", "Package Info", "--tsv", "--tips", "q");
+        Assert.Equal(0, fullTsvExit);
+        var fullTsvLines = fullTsvOutput.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.True(fullTsvLines.Length > 3, "The section must have at least three data rows for the window to exclude one.");
+
         var (tsvExit, tsvOutput, _) = await RunAppAsync(
             "package", Package, "-S", "Package Info", "--rows", "2..3", "--tsv", "--tips", "q");
         Assert.Equal(0, tsvExit);
         var tsvLines = tsvOutput.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.Equal(3, tsvLines.Length);
-        Assert.StartsWith("Built\t", tsvLines[1], StringComparison.Ordinal);
-        Assert.StartsWith("Content\t", tsvLines[2], StringComparison.Ordinal);
+        Assert.Equal<string>([fullTsvLines[0], fullTsvLines[2], fullTsvLines[3]], tsvLines);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -205,6 +205,13 @@ public static class OutputFormatter
         return CountOutput.CountMarkdownTableRows(markdown).ToString(CultureInfo.InvariantCulture);
     }
 
+    /// <summary>
+    /// Renders one package section as tabular output (TSV/JSONL/pretty table). The caller has
+    /// already narrowed <paramref name="options"/> to a single section, so the rendered text is a
+    /// single table and <c>--rows</c> windows it exactly as it windows every other tabular section.
+    /// Forwarding <c>options.Rows</c> is what keeps this path agreeing with <c>--count</c>, which
+    /// windows the same section through <see cref="FormatResult"/> (#3457).
+    /// </summary>
     public static void WritePackageTable(InspectionResult result, InspectionOptions options,
         SectionPipeline<InspectionResult> pipeline, bool showHeader)
     {
@@ -212,7 +219,8 @@ public static class OutputFormatter
         ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
         var view = new InspectionResultView(result);
         WriteTable(Console.Out, showHeader,
-            (writer, formatter) => MarkoutSerializer.Serialize(view, writer, formatter, InspectionContext.Default, writerOpts));
+            (writer, formatter) => MarkoutSerializer.Serialize(view, writer, formatter, InspectionContext.Default, writerOpts),
+            options.Rows);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #3457.

`package -S <section> --rows <window> --count` reported the windowed count while the rendered table ignored the window entirely, so the count and the payload disagreed. `--count` routes through `FormatResult`, which applies the markdown row limiter; the render routed through `OutputFormatter.WritePackageTable`, which never passed `options.Rows` down to `WriteTable`. `WriteLibraryResult` does pass it, which is why `library -S <section> --rows N` already windowed correctly and `package` did not.

## Change

One call site: forward `options.Rows` from `WritePackageTable` into `WriteTable`. The caller has already narrowed to a single section for tabular output (`CheckMultiSection` collapses a multi-section selection to `Package Info`), so the rendered text is a single table and the existing text-level limiter applies unchanged — no new windowing semantics.

A null or unlimited window still takes `WriteTable`s unbuffered fast path, so output with no `--rows` is byte-identical.

## Evidence

Before:

```console
$ dotnet-inspect package Newtonsoft.Json@13.0.4 -S "Package Info" --rows 1..1 --count
1
$ dotnet-inspect package Newtonsoft.Json@13.0.4 -S "Package Info" --rows 1..1 --jsonl | wc -l
15
```

After: both report 1.

`CommandExecutionTests.PackageSection_Rows_WindowsTheTabularRenderAndAgreesWithCount` pins count/render agreement **with and without** a window (the no-window case is the negative that catches accidental windowing), and pins that an absolute `--rows 2..3` names rows 2 and 3 rather than the first two.

Non-vacuity: with the product change reverted, the test fails `Assert.Equal() Failure: Expected: 2, Actual: 15`.

Suite: `dotnet run --project src/dotnet-inspect.Tests -c Release` — 2503 total, 1 failed, 14 skipped. The single failure is `Layout_Count_CountsFilesRatherThanRenderedTreeLines`, which fails identically on unmodified `origin/main` in this environment (`Assert.Contains` for `Newtonsoft.Json.nuspec`, a stale local package extract). Skips are the `ildasm`/`ilasm` and Windows-only cases.

## Residual (deliberately not in this PR)

Two sibling paths in `package` bypass `WritePackageTable` and still ignore `--rows`. Both were found while fixing this one and are filed rather than folded in, to keep this change to a single call site:

- #3548 — `package -S Files --jsonl` short-circuits into `WritePackageFilesJsonl`, which emits every row.
- #3549 — the `--fields`/`--columns` projection branch renders via `RenderTable` and writes unwindowed.

No behavior outside `package`s non-projection tabular render is touched. `library`, markdown, and JSON output paths are unchanged.