### PR TITLE
Correct the Format row's owner and value list

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -94,7 +94,7 @@ interchangeably.
 | **Query** | a typed inspection request producing a typed result | — | L1 |
 | **Section** | the named, selectable unit | table \| fields \| list \| blob \| tree | L2 |
 | **Shape** | the narrowing rung | Document \| Table \| Vector \| Scalar | L2 (Markout-defined) |
-| **Format** | presentation of a selected payload | markdown \| json \| tsv \| jsonl \| plaintext | L3 |
+| **Format** | presentation of a selected payload | markdown \| plaintext \| table \| tsv \| jsonl \| json \| mermaid | L3 (selection) |
 
 A **query** may run one or more **scanners**. A **section** presents the result
 of a query at some **shape**, rendered in some **format**.
@@ -124,6 +124,17 @@ graph, and all of them are still "one section". Trees and tables are siblings
 **JSON is a format, not a shape and not a section.** `--json`, `--tsv`, and
 `--jsonl` are presentation modifiers: they change how a selected payload is
 rendered without changing the shape.
+
+**Format is owned as *selection*, not as rendering.** The L3 description above
+is deliberate: L3 owns output format *selection*. Deciding which format a
+request produces is a CLI concern; turning a payload into bytes largely is not.
+Markout renders markdown, tsv, and jsonl, so most of the format axis is
+implemented below L3 even though L3 names the value. Read the owner column as
+"who chooses", not "who writes the characters" — the same distinction the Shape
+row makes by crediting Markout with defining the ladder that L2 selects a rung
+from. A renderer that lives in `src/dotnet-inspect/Output/` is not evidence that
+rendering is an L3 responsibility; it is either genuinely
+dotnet-inspect-specific or a candidate to move.
 
 **Query** has a typed precedent and two senses to keep clear of. The typed
 precedent is small but exact:


### PR DESCRIPTION
The Vocabulary table in `docs/design/inspection-layers.md` had two independent errors in its **Format** row.

## The owner error is the one that misleads

The row read `L3`, flat, while the **Shape** row directly above it reads `L2 (Markout-defined)`. Read literally, that says the CLI owns the format axis outright — which invites the conclusion that anything rendering a format belongs in `dotnet-inspect`.

The document contradicts itself here. The L3 section says L3 owns output "**format** selection" — *selection*. And Markout renders markdown, tsv, and jsonl (`MarkoutTableMode.Tsv`, `MarkoutTableMode.Jsonl`), so most of the axis is implemented below L3 even though L3 names the value.

The row now reads `L3 (selection)`, and a new paragraph in *Why these words* states the rule the owner column actually follows: **it names who chooses, not who writes the characters.** That is the same distinction the Shape row already makes by crediting Markout with defining the ladder L2 selects a rung from, so the two rows now read consistently.

I hit this while assessing whether `src/dotnet-inspect/Output/` is correctly placed. I reached the wrong answer from the table and had to correct it from the L3 prose — so the ambiguity has demonstrably misled at least one reader.

## The value list was also stale

It named five formats; `OutputFormat` has seven. Both omissions are user-facing flags, not internal states:

| Missing | Flag | Description in `SharedOptions.cs` |
| --- | --- | --- |
| `Table` | `--table` | "Output as a pretty table (space-padded columns)" |
| `Mermaid` | `--mermaid` | "Output as mermaid diagram (standalone or with --markdown for embedded)" |

The list is now in a deliberate order — human-readable, then machine-readable, then diagram — rather than the previous arbitrary one.

## Validation

`npx markdownlint-cli docs/design/inspection-layers.md` — clean.

Documentation-only, no product code, no behavior claim; per AGENTS.md that calls for Markdown validation rather than builds or tests. Every factual claim is checked against source in-tree (`OutputFormat.cs`, `SharedOptions.cs:23,27`, `MarkoutTableMode` usages).

## Review depth

Trivial: a docs-only correction where each assertion is verifiable against a named file in this repository, and the change removes a contradiction rather than introducing a position. No review requested.
