### PR TITLE
Give the printed body map a producer (#3328)

### DIFF
--- a/src/ILInspector.Research.Tests/PrintedBodyMapProjectionTests.cs
+++ b/src/ILInspector.Research.Tests/PrintedBodyMapProjectionTests.cs
@@ -1,0 +1,213 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Annotations;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Research.Tests;
+
+/// <summary>
+/// The projection that hands a member's positions to a consumer outside this
+/// process. <see cref="ResearchViews.MemberProjectionResult.AnnotatedSource"/>
+/// answers "what does this member look like annotated?" by baking one gesture
+/// into a string; the body map answers "where is everything?" and leaves the
+/// gesture to whoever renders. A browser needs the second, because the choice of
+/// side comment, caret, or category focus belongs to the reader.
+/// </summary>
+public class PrintedBodyMapProjectionTests
+{
+    static PrintedBodyMap Map(string method)
+    {
+        using var source = MetadataSource.Open(typeof(BodyMapFixture).Assembly.Location);
+        var projection = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+            source,
+            typeof(BodyMapFixture).FullName!,
+            method,
+            BodyMap: true));
+        return Assert.IsType<PrintedBodyMap>(projection.BodyMap);
+    }
+
+    [Fact]
+    public void TheProjectionIsOffUnlessAsked()
+    {
+        using var source = MetadataSource.Open(typeof(BodyMapFixture).Assembly.Location);
+        var projection = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+            source,
+            typeof(BodyMapFixture).FullName!,
+            nameof(BodyMapFixture.AllocatesTwice)));
+
+        Assert.Null(projection.BodyMap);
+    }
+
+    // The claim the payload exists to make: a position addresses characters that
+    // are really there. An off-by-one in the line split, or a column measured
+    // against a different string than the one shipped, would leave a consumer
+    // underlining past the end of a line.
+    [Fact]
+    public void EveryPlacedSpanAddressesCharactersThatExistOnTheLineItNames()
+    {
+        var map = Map(nameof(BodyMapFixture.AllocatesTwice));
+
+        Assert.NotEmpty(map.Annotations);
+        Assert.NotEmpty(map.Nodes);
+
+        foreach (var node in map.Nodes)
+        {
+            Assert.InRange(node.Line, 0, map.Lines.Count - 1);
+            Assert.InRange(node.Column, 0, map.Lines[node.Line].Length);
+            Assert.True(
+                node.Column + node.Length <= map.Lines[node.Line].Length,
+                $"{node.Kind} claims [{node.Column}..{node.Column + node.Length}) on a line of {map.Lines[node.Line].Length} characters.");
+        }
+
+        foreach (var fact in map.Annotations)
+        {
+            Assert.InRange(fact.Line, 0, map.Lines.Count - 1);
+            if (fact.Length < 0)
+                continue;
+            Assert.True(
+                fact.Column + fact.Length <= map.Lines[fact.Line].Length,
+                $"{fact.Descriptor} claims [{fact.Column}..{fact.Column + fact.Length}) on a line of {map.Lines[fact.Line].Length} characters.");
+        }
+    }
+
+    // A cached delegate allocates once for the life of the process; an uncached
+    // one allocates per call. The difference is carried only by Conditionality --
+    // AnnotationText renders it as "cached-once" -- so a consumer holding the
+    // payload alone would otherwise promote a cached allocation to an
+    // unconditional one. CachedOnce is the only non-default value the pipeline
+    // actually produces today: AllocationFrequency.PerIteration is declared but
+    // never assigned, so pinning it here would gate nothing.
+    [Fact]
+    public void ConditionalitySurvivesTheProjection()
+    {
+        var map = Map(nameof(BodyMapFixture.CachesADelegate));
+
+        Assert.Contains(
+            map.Annotations,
+            fact => fact.Conditionality == AnnotationConditionality.CachedOnce);
+    }
+
+    // The hazard this projection introduced: a byte-divergent style lens rewrites
+    // the IR in place, so a body map printed from the function the other
+    // projections read would leave its rewrites on their graph. It takes its own
+    // import, and is produced before them, so asking for it must change nothing
+    // they report.
+    //
+    // The semantics overlay is what this checks, not the annotated render: that
+    // render already takes its own import for the same reason, so it would
+    // survive the bug and gate nothing. The overlay prints `imported` directly,
+    // so a graph rewritten under it renders the lens's spelling instead of the
+    // shipped one.
+    [Fact]
+    public void AskingForTheMapLeavesEveryOtherProjectionIdentical()
+    {
+        static string Overlay(bool alsoBodyMap)
+        {
+            using var source = MetadataSource.Open(typeof(BodyMapFixture).Assembly.Location);
+            var projection = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+                source,
+                typeof(BodyMapFixture).FullName!,
+                nameof(BodyMapFixture.GuardBothArmsVariable),
+                SemanticsOverlay: true,
+                BodyMap: alsoBodyMap,
+                PrinterOptions: new PrinterOptions { PreferConditionalExpressionReturn = true }));
+            return Assert.IsType<string>(Assert.IsType<DecompilerResult>(projection.SemanticsOverlay).Output);
+        }
+
+        string without = Overlay(alsoBodyMap: false);
+
+        // The overlay is not asked for the lens, so it must show the flat guard.
+        // If this stops holding the test is measuring nothing, so it is asserted
+        // rather than assumed.
+        Assert.Contains("if (flag)", without);
+
+        Assert.Equal(without, Overlay(alsoBodyMap: true));
+    }
+
+    // The map has to describe the text the same request would render. A consumer
+    // showing a style lens while holding positions measured against the shipped
+    // spelling would underline the wrong characters.
+    [Fact]
+    public void PrinterOptionsReachTheMap()
+    {
+        static PrintedBodyMap Lensed(PrinterOptions? options)
+        {
+            using var source = MetadataSource.Open(typeof(BodyMapFixture).Assembly.Location);
+            var projection = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+                source,
+                typeof(BodyMapFixture).FullName!,
+                nameof(BodyMapFixture.GuardBothArmsVariable),
+                BodyMap: true,
+                PrinterOptions: options));
+            return Assert.IsType<PrintedBodyMap>(projection.BodyMap);
+        }
+
+        var shipped = Lensed(null);
+        var lensed = Lensed(new PrinterOptions { PreferConditionalExpressionReturn = true });
+
+        Assert.DoesNotContain(shipped.Lines, line => line.Contains('?') && line.Contains(':'));
+        Assert.Contains(lensed.Lines, line => line.Contains('?') && line.Contains(':'));
+    }
+
+    // The payload's reason for existing is that it can leave the process, and the
+    // process it is going to (a wasm browser engine) has no reflection-based
+    // serializer. Passing the source-generated JsonTypeInfo explicitly is what
+    // makes this a test of that path rather than of the reflection fallback the
+    // test host happens to allow.
+    [Fact]
+    public void TheMapSerializesThroughASourceGeneratedContext()
+    {
+        var map = Map(nameof(BodyMapFixture.AllocatesInALoop));
+
+        string json = JsonSerializer.Serialize(map, BodyMapJsonContext.Default.PrintedBodyMap);
+        var replayed = JsonSerializer.Deserialize(json, BodyMapJsonContext.Default.PrintedBodyMap);
+
+        Assert.NotNull(replayed);
+        Assert.Equal(map.Lines, replayed.Lines);
+        Assert.Equal(map.Nodes, replayed.Nodes);
+        Assert.Equal(map.Annotations, replayed.Annotations);
+    }
+}
+
+[JsonSerializable(typeof(PrintedBodyMap))]
+internal sealed partial class BodyMapJsonContext : JsonSerializerContext;
+
+public sealed class BodyMapFixture
+{
+    public static object[] AllocatesTwice()
+    {
+        var first = new object();
+        var second = new object[] { first };
+        return second;
+    }
+
+    public static List<object> AllocatesInALoop(int count)
+    {
+        var sink = new List<object>();
+        for (int i = 0; i < count; i++)
+        {
+            sink.Add(new object());
+        }
+
+        return sink;
+    }
+
+    // Non-capturing, so Roslyn caches the delegate instance in a static field and
+    // the allocation happens once rather than per call.
+    public static IEnumerable<string> CachesADelegate(IEnumerable<string> items)
+        => items.Where(item => item.Length > 0);
+
+    // Both arms variable and returned directly, which is the shape the
+    // byte-divergent conditional-return lens rewrites.
+    public static bool GuardBothArmsVariable(bool flag, bool first, bool second)
+    {
+        if (flag)
+        {
+            return first;
+        }
+
+        return second;
+    }
+}

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -32,6 +32,7 @@ public static partial class ResearchViews
         bool CostOverlay = false,
         bool SemanticsOverlay = false,
         bool FactRows = false,
+        bool BodyMap = false,
         AnnotationStage AnnotatedStage = AnnotationStage.Raised,
         ResearchFactRegistry? Registry = null,
         int? MethodToken = null,
@@ -52,7 +53,22 @@ public static partial class ResearchViews
         /// renders — so without this a mistyped focus is indistinguishable from
         /// a correct one.
         /// </summary>
-        IReadOnlyList<string>? UnmatchedFocusAlternatives = null);
+        IReadOnlyList<string>? UnmatchedFocusAlternatives = null,
+
+        /// <summary>
+        /// The printed body and the positions of everything known about it, in
+        /// text coordinates only. Set when <see cref="MemberProjectionRequest.BodyMap"/>
+        /// was asked for.
+        /// </summary>
+        /// <remarks>
+        /// This is the same information the annotated render draws, before it is
+        /// drawn: <see cref="AnnotatedSource"/> has already chosen a gesture and
+        /// baked the result into text, so a consumer receiving it can only display
+        /// that one choice. The map carries the positions instead, so the choice
+        /// of side comment, caret, or category focus belongs to whoever renders —
+        /// which is what lets a client outside this process make it.
+        /// </remarks>
+        PrintedBodyMap? BodyMap = null);
 
     public static MemberProjectionResult ProjectMember(MemberProjectionRequest request)
     {
@@ -81,6 +97,19 @@ public static partial class ResearchViews
             var headerFacts = request.CostOverlay || request.FactRows
                 ? effectiveRegistry.CollectHeaderFacts(context)
                 : [];
+
+            // Produced before the projections that read `imported`, not after.
+            // Printing raises and rewrites in place, so this takes its own import
+            // -- and doing it first is what makes that isolation load-bearing
+            // rather than incidental: were it to share the graph, every
+            // projection below would read the rewritten one.
+            PrintedBodyMap? bodyMap = null;
+            if (request.BodyMap)
+            {
+                var bodyMapFunction = ImportFunction()
+                    ?? throw new InvalidOperationException($"{request.Type}::{request.Method} has no IL body");
+                bodyMap = BuildBodyMap(bodyMapFunction, facts, request.Source, request.PrinterOptions);
+            }
 
             DecompilerResult? annotatedSource = null;
             if (request.AnnotatedSource)
@@ -147,7 +176,8 @@ public static partial class ResearchViews
                 semanticsOverlay,
                 factRows,
                 annotatedSource?.Trace ?? costOverlay?.Body.Trace ?? semanticsOverlay?.Trace,
-                UnmatchedFocusAlternatives(request.CaretFocus, gestures, facts));
+                UnmatchedFocusAlternatives(request.CaretFocus, gestures, facts),
+                bodyMap);
         }
         catch (Exception ex)
         {
@@ -443,6 +473,31 @@ public static partial class ResearchViews
             ? output
             : AddTrailingComments(imported, output, printedRanges, annotations, gestures ?? AnnotationGestureSelector.SideOnly);
         return result with { Output = projected };
+    }
+
+    // The same print the overlay does, stopping one step earlier. RenderRaisedOverlay
+    // goes on to bake a chosen gesture into the text; this keeps the printer's ranges
+    // and the fact/node binding as data, which is the only form a consumer outside
+    // this process can re-render from.
+    //
+    // Printer options are honoured because the positions have to describe the text
+    // the same request would render -- a map of the shipped spelling handed to a
+    // client showing a style lens would underline the wrong characters. That is also
+    // why this needs its own import: a byte-divergent lens rewrites the graph in
+    // place.
+    static PrintedBodyMap BuildBodyMap(
+        IrFunction fn,
+        IReadOnlyList<IAnnotation> facts,
+        MetadataSource source,
+        PrinterOptions? options)
+    {
+        var result = CSharpPrinter.PrintRaised(fn, out var printedRanges, importMethodBody: null, options: options, typesProvablyDisjoint: source.AreProvablyDisjoint);
+        if (result.Output is not { Length: > 0 })
+            return PrintedBodyMap.Empty;
+
+        // Anchor after printing, not before: PrintRaised raises `fn` in place, and
+        // the statements the printer recorded ranges for are the raised ones.
+        return PrintedBodyMap.Create(printedRanges, AnnotationAnchor.Anchor(fn, facts));
     }
 
     static IReadOnlyList<FactRow> BuildFactRows(


### PR DESCRIPTION
**Slice 1 of 2.** Slice 2 (#3558) wires this into the wasm browser engine.

`PrintedBodyMap` shipped in #3461 with **no production caller**. It was exercised only by tests, so the claim it was built for — that positions can leave the process and be re-rendered elsewhere — was untested in the role that motivated it. This adds the projection that produces one.

## What this adds

`ResearchViews.MemberProjectionRequest` gains an opt-in `BodyMap` flag, and the result gains a `PrintedBodyMap?`.

The projection prints the same raised body the overlay prints and stops one step earlier. `RenderRaisedOverlay` goes on to bake a chosen gesture into text, so a consumer receiving it can display only that choice; the map keeps the printer's ranges and the fact/node binding as data. That is what lets the *reader* choose a side comment, a caret, or a category focus.

Printer options are honoured, because positions measured against the shipped spelling would underline the wrong characters for a reader shown a style lens.

## The isolation, and how it was nearly fake

The projection takes its own IR import and is produced **before** the others. A byte-divergent lens rewrites the IR in place, so a map printed from the shared function would leave its rewrites on the graph the overlay and fact-row projections read.

That ordering is load-bearing, and I only know so because the test caught me:

- Written the obvious way, the map was produced **last**. The isolation test **passed under the shared-import mutation** — nothing read the graph afterwards, so corrupting it broke nothing.
- Moving the projection first was not enough either. Without a style lens there is nothing for the isolation to protect, so the mutation still passed.
- Routing `PrinterOptions` through — which the feature wanted anyway — made the hazard real, and the gate now bites.

## Evidence

| gate | mutation that breaks it |
|---|---|
| `AskingForTheMapLeavesEveryOtherProjectionIdentical` | share `imported` instead of taking an import |
| `PrinterOptionsReachTheMap` | pass `null` options to the map |
| `EveryPlacedSpanAddressesCharactersThatExistOnTheLineItNames` | shift every column by one |
| `ConditionalitySurvivesTheProjection` | drop conditionality from the payload |
| `TheProjectionIsOffUnlessAsked` | produce the map unasked |

Each mutation fails exactly one test and nothing else.

Suites: `ILInspector.Research.Tests` 138/138, `ILInspector.Decompiler.Tests` fast lane 4,348/4,348, `dotnet-inspect.Tests` 1,743/1,743.

## Honest negatives

- **`AllocationFrequency.PerIteration` is declared but never assigned anywhere in the pipeline.** My conditionality test targeted it first and failed. It pins `CachedOnce` instead — the only non-default value a producer actually emits. Pinning `PerIteration` would have gated nothing.
- **Facts still anchor to statements**, so spans are statement-wide (`col 0`, length = the statement). The narrow expression ranges from #3461 exist and place correctly; re-anchoring facts to them is separate work.
- **No consumer on `main`.** Slice 2 supplies one, in the browser engine.