### PR TITLE
Make CI change detection fail safe instead of failing the run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,10 @@ jobs:
           # This step must never fail. Every downstream job is gated on its
           # outputs, so failing here does not just lose the filter -- it SKIPS
           # the entire build and test matrix, landing an unvalidated commit on
-          # main. So when the change set cannot be determined, fall back to
-          # "everything changed": CI over-runs instead of silently vanishing.
-          # Enforced by the fallback branch below, not by an automated gate.
+          # main. So when the change set cannot be determined, force every
+          # output true: CI over-runs instead of silently vanishing. Enforced
+          # by the fallback branch below, which runs no fallible command, not
+          # by an automated gate.
           FILES=""
           RESOLVED=false
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -75,8 +76,18 @@ jobs:
             fi
           fi
           if [ "$RESOLVED" != "true" ]; then
-            echo "::warning title=Change detection fell back::Could not determine the changed files for ${{ github.sha }}; treating every tracked file as changed so that no validation is skipped."
-            FILES=$(git ls-files)
+            # Force every gate on and stop here. Deliberately NOT "list every
+            # tracked file and classify it": that would put another fallible
+            # git call -- and a dependency on every case pattern below matching
+            # something -- on the one path whose entire job is to be
+            # infallible. `git ls-files` exits 128 on an unreadable index.
+            # Keep this list in sync with the `outputs:` block above.
+            echo "::warning title=Change detection fell back::Could not determine the changed files for ${{ github.sha }}; running every job so that no validation is skipped."
+            for name in code csharpdiff decompiler docs ildiff ilroundtrip packaging shipped; do
+              echo "$name=true" >> "$GITHUB_OUTPUT"
+            done
+            echo "Change detection fell back; every job filter forced true."
+            exit 0
           fi
           CODE=false
           CSHARPDIFF=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,19 +36,47 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          # Full history. Change detection diffs against github.event.before,
+          # which is not always the immediate parent: a push advances main by
+          # more than one commit whenever two PRs merge back to back or a
+          # batch is pushed. fetch-depth: 2 left that commit outside the
+          # shallow clone and the diff died with "Invalid symmetric difference
+          # expression", taking the whole run with it.
+          fetch-depth: 0
 
       - name: Detect changes
         id: filter
         run: |
+          # This step must never fail. Every downstream job is gated on its
+          # outputs, so failing here does not just lose the filter -- it SKIPS
+          # the entire build and test matrix, landing an unvalidated commit on
+          # main. So when the change set cannot be determined, fall back to
+          # "everything changed": CI over-runs instead of silently vanishing.
+          # Enforced by the fallback branch below, not by an automated gate.
+          FILES=""
+          RESOLVED=false
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
-          else
-            BEFORE=${{ github.event.before }}
-            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              BEFORE=HEAD~1
+            if FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only); then
+              RESOLVED=true
             fi
-            FILES=$(git diff --name-only "$BEFORE"..."${{ github.sha }}")
+          else
+            BEFORE="${{ github.event.before }}"
+            # The zero SHA means a new branch or a force push with no prior tip.
+            if [ "$BEFORE" != "0000000000000000000000000000000000000000" ] \
+               && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+              # Two dots, not three. A symmetric difference has to compute a
+              # merge base, which is a second way to fail and is not what
+              # change detection is asking. "What differs between the old tip
+              # and the new tip" is exactly the two-dot diff, and for the
+              # fast-forward pushes main receives the two agree anyway.
+              if FILES=$(git diff --name-only "$BEFORE" "${{ github.sha }}"); then
+                RESOLVED=true
+              fi
+            fi
+          fi
+          if [ "$RESOLVED" != "true" ]; then
+            echo "::warning title=Change detection fell back::Could not determine the changed files for ${{ github.sha }}; treating every tracked file as changed so that no validation is skipped."
+            FILES=$(git ls-files)
           fi
           CODE=false
           CSHARPDIFF=false


### PR DESCRIPTION
## What breaks

`github.event.before` is not always the immediate parent. A push advances `main` by more than one commit whenever two PRs merge back to back or a batch lands. `fetch-depth: 2` left that commit outside the shallow clone, so the change-detection diff aborted:

```
fatal: Invalid symmetric difference expression 93d4924f...5a337055
##[error]Process completed with exit code 128
```

That is `main` at `5a337055`, where #3470 and #3499 merged in the same second. #3525 hit it earlier from the same cause. **Four of the last twenty-five `main` runs failed this way.**

## Why it is worth fixing rather than tolerating

Every downstream job is gated on this job's outputs, so a failure here does not merely lose the filter — it **skips the jobs it gates**.

On a push to `main` the cost is small and I want to be precise about it: `test`, `build-net10`, `decompiler-gates`, both diff smokes and `pack` are all deliberately `github.event_name == 'pull_request'`-only, so they never run on `main` regardless. The push-event cost is `markdownlint` plus a spuriously red `main`.

The real exposure is on **pull requests**. There `FILES` comes from `gh pr diff`, and that call was equally unguarded — a transient API failure would fail the step, skip the **entire build and test matrix**, and leave nothing but a red change-detection job to notice. A re-run of just that job, or a glance at a mostly-green checks list, would hide it. That is the footgun this closes.

## The fix

Three parts, in increasing order of importance:

1. **`fetch-depth: 0`** — the before-commit is present however far back it is. Root cause. The repo is 44 MB / ~2.6k commits, so a full fetch for this tiny job is free.
2. **Two-dot diff instead of three-dot** — a symmetric difference has to compute a merge base, which is a second way to fail and is not the question change detection is asking. `main` only takes fast-forward pushes, where the two agree.
3. **A fallback** — when the change set cannot be determined, treat every tracked file as changed and emit a `::warning::` rather than exiting non-zero. **CI over-runs instead of silently vanishing.** This now also covers the `gh pr diff` path.

Per the repo rule on asserted properties: the "this step must never fail" claim is enforced by the fallback branch itself, and the comment says so rather than implying an automated gate that does not exist.

## Evidence

Local harness against real history, running the old and new logic verbatim against a `--depth 2` clone and a full clone:

| case | logic | clone | `before` | result |
|---|---|---|---|---|
| A | old | shallow | 2 commits back | **EXIT 128 — run fails**, reproduces the production error verbatim |
| B | old | shallow | 1 commit back | ok, 11 files |
| C | new | full | 2 commits back | ok, 32 files |
| D | new | full | 1 commit back | ok, 11 files |
| E | new | full | zero SHA | ok, **fell back**, 1714 files |
| F | new | full | absent SHA | ok, **fell back**, 1714 files |
| G | new | **shallow** | 2 commits back | ok, **fell back**, 1714 files |

Two of those rows carry the argument:

- **B and D are byte-identical** (`diff` reports no difference), so ordinary single-commit pushes are completely unaffected.
- **G isolates the fallback from the `fetch-depth` change.** With the shallow clone deliberately left in place, the step still cannot fail. So the two mechanisms are independently effective, and a future regression in `fetch-depth` cannot resurrect the outage.

Workflow structure re-validated after the edit: YAML parses, all 8 `changes` outputs still declared and still written, no three-dot diff remains.

## Behaviour change worth flagging

Zero-SHA pushes (newly created or force-pushed branch) now take the fallback rather than guessing `HEAD~1`. For a branch with no prior tip, "everything changed" is the honest answer. This cannot affect `main`, which is protected.

## Not included

I did not add `always()` guards to the downstream jobs. The single-point guarantee — change detection cannot fail — is simpler and cannot drift out of sync across eight job conditions.
