### PR TITLE
Move to Markout 0.33.0 ahead of the co-development phase

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
+    <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Markout" Version="0.29.0" />
+    <PackageVersion Include="Markout" Version="0.33.0" />
     <PackageVersion Include="Markout.Templates" Version="0.3.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />


### PR DESCRIPTION
Bumps `Markout` 0.29.0 → 0.33.0 and `MarkdownTable.Formatting` 0.3.3 → 0.3.4.

## Why now, and why alone

Upcoming work points this repository at Markout **source** through project references (see #3554). That resolves against Markout's current `main`, so it would absorb four minor versions of drift at the same moment as an unreleased Markout change. A failure then could mean either thing. Taking the drift here, on its own, makes any failure mean exactly one thing.

`MarkdownTable.Formatting` is not incidental tidying — Markout 0.33.0's nuspec declares `MarkdownTable.Formatting >= 0.3.4`, and NU1605 is warning-as-error here, so without it restore fails outright:

```text
error NU1605: Detected package downgrade: MarkdownTable.Formatting from 0.3.4 to 0.3.3
```

`Markout.Templates` is deliberately left at 0.3.0. It is a separate package on its own version line, nothing here needs it moved, and folding it in would widen the blast radius of a bump whose whole purpose is to be unambiguous.

## Evidence

Build of `dotnet-inspect.slnx -c Release`: **succeeds**. Suites run with `dotnet run` per AGENTS.md:

| Suite | Total | Failed |
| --- | ---: | ---: |
| `dotnet-inspect.Tests` | 2580 | 1 |
| `DotnetInspector.Services.Tests` | 357 | 0 |
| `ILInspector.Metadata.Tests` | 998 | 0 |
| `ILInspector.Analysis.Tests` | 584 | 0 |
| `ILInspector.Decompiler.Tests` | 4594 | 7 |

**No failure is attributable to this change.** Both sets reproduce on the unmodified base commit `02478b387`.

The `dotnet-inspect.Tests` failure is the known local-environment one (`Layout_Count_CountsFilesRatherThanRenderedTreeLines`; the local NuGet cache stores `newtonsoft.json.nuspec` lowercased). It passes in CI.

## The seven decompiler failures were baselined, not assumed

Markout renders markdown, TSV, and JSONL. It cannot reach IL fidelity or compile-back, so a Markout cause was implausible on its face — but implausible is not measured. I re-ran the same four test classes at `02478b387` with Markout still at **0.29.0**:

```text
ILInspector.Decompiler.Tests  Total: 30, Errors: 0, Failed: 7
```

The identical seven, by name. Their content independently agrees: assembly binding moving between `System.Runtime` and `System.Private.CoreLib`, Roslyn closure slots renumbering `<>9__103_0` → `<>9__128_0`, and `CS0246` on `int`. That is SDK drift against a pinned docket, and it is worth its own issue — but it is not this PR's, and this PR neither causes nor fixes it.

## Review depth

More than trivial (a dependency change with real reach across four minor versions), but not high risk: no product code changes, the full suite was run, and every failure is baselined to the unmodified base. That places it at the **single-review** tier — MAI-Code — per AGENTS.md.
