### PR TITLE
Remove the @Default section pole (#3547)

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files"
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
 ```
 
-For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders `@Default`, a curated high-density view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically. Workflow categories such as `@Source` and `@Audit` expand to scenario-focused section groups.
+For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders a curated high-density default view; type/member summaries use `Method Groups`, while `member Type -m Name` uses `Methods` overload rows. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Use `-S @All` to select all sections; it renders the default section first, then remaining sections alphabetically. Workflow categories such as `@Source` and `@Audit` expand to scenario-focused section groups.
 
 ## Common examples
 

--- a/docs/design/info-view.md
+++ b/docs/design/info-view.md
@@ -52,6 +52,6 @@ Some commands or contexts should not get a default preset until there is a clear
 
 When adding or changing a default preset, first write the bullseye question. Then select the smallest section set that answers it. If the question needs more than three sections, the preset is probably not focused enough.
 
-Avoid adding a section just because it is cheap. `@Default` is not "all safe sections"; it is the smallest high-value bundle.
+Avoid adding a section just because it is cheap. The default preset is not "all safe sections"; it is the smallest high-value bundle.
 
 For library defaults, large local metadata lists such as `Async Methods`, `Custom Attributes`, `Extension Methods`, `Resources`, and `Type Forwarders` are intentionally represented as counts in `Library Info`. Select those sections explicitly when the list itself is the answer.

--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -154,8 +154,9 @@ requires `-v:m`; every other bounded network-free section first renders at
 
 ### Bare `-S` — the network-free fixed overview
 
-Bare `-S` (the `-S` flag with no value, which parses to the lone `@Default`
-preset) is the ergonomic **network-free fixed overview**. Instead of the `-v:m`
+Bare `-S` (the `-S` flag with no value) is the ergonomic **network-free fixed
+overview**. It is a request for the command's default preset, carried as its own
+flag rather than as a selector value, so it has no spelling a caller can type. Instead of the `-v:m`
 target-only view, the library command renders only the sections whose declared
 growth class is `Fixed` and whose cost is `NetworkFree` — today the `Library
 Info`, `Signals`, and `Symbols` fact tables. Because membership is a function of
@@ -279,7 +280,7 @@ count > 0 and drops categories that become empty. `--schema` is the exhaustive
 escape hatch — the full section graph plus every topical door, still without
 annotations. `@All`/`@Hidden` are internal computed poles: `@All` is the flat
 standalone set, `@Hidden` is its complement, and neither is a user-facing door
-(`@Default`/`@All`/`@Hidden`/`@Switches` never appear in `-D`).
+(`@All`/`@Hidden`/`@Switches` never appear in `-D`).
 
 ### Invariants
 
@@ -356,12 +357,11 @@ $ dotnet run --project src/dotnet-inspect -- package System.CommandLine -D
 ```
 
 Curated catalogs lead with the topical doors, then list sections alphabetically.
-The `package` command goes further and drops the computed `@All` and `@Default`
-poles entirely (`WithoutComputedPoles`), so they are unresolvable rather than
-merely unlisted: its sections are reachable by name, by door, and by verbosity,
-and a pole that renders a superset nobody asked for is a surface no discovery
-output describes. `@Default` survives only as the internal encoding of bare
-`-S`, which is short-circuited before selector resolution. `SourceLink: Files` is absent from the
+The `package` command goes further and drops the computed `@All` pole entirely
+(`WithoutComputedPoles`), so it is unresolvable rather than merely unlisted: its
+sections are reachable by name, by door, and by verbosity, and a pole that
+renders a superset nobody asked for is a surface no discovery output describes.
+`SourceLink: Files` is absent from the
 section rows for the same reason a `Performance:` leaf is on the library
 command: the door above it is the entry point.
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -7736,28 +7736,24 @@ public partial class CommandExecutionTests
     }
 
     /// <summary>
-    /// Bare <c>-S</c> and the <c>@Default</c> pole are different requests, and on a pipeline that
-    /// still publishes the pole that difference is visible. Bare <c>-S</c> asks for the command's
-    /// default preset — the network-free fixed overview, which is broader than the Info sections
-    /// alone. <c>@Default</c> is a category, so it resolves to exactly its members. They used to
-    /// be indistinguishable because bare <c>-S</c> was encoded as the literal string
-    /// <c>"@Default"</c>, which is what let a hand-typed pole inherit preset-only behavior (#3547).
+    /// The default preset is reached only through bare <c>-S</c>. <c>@Default</c> was a computed
+    /// pole that restated what bare <c>-S</c> already meant, so it is gone — including on
+    /// pipelines that still publish <c>@All</c>. Bare <c>-S</c> keeps rendering the broader
+    /// network-free fixed overview, which the pole never matched anyway (#3547).
     /// </summary>
     [Fact]
-    public async Task LibraryCommand_BareSelect_IsNotTheSameRequestAsTheDefaultPole()
+    public async Task LibraryCommand_DefaultPole_IsNotResolvable()
     {
-        var (bareExit, bareOutput, _) = await RunAppAsync("library", "System.Text.Json", "-S");
-        var (poleExit, poleOutput, _) = await RunAppAsync("library", "System.Text.Json", "-S", "@Default");
+        var (bareExit, bareOutput, bareError) = await RunAppAsync("library", "System.Text.Json", "-S");
+        var (poleExit, poleOutput, poleError) = await RunAppAsync("library", "System.Text.Json", "-S", "@Default");
+
+        Assert.Equal(1, poleExit);
+        Assert.Contains("'@Default' not found", poleError, StringComparison.Ordinal);
+        Assert.DoesNotContain("## Library Info", poleOutput);
 
         Assert.Equal(0, bareExit);
-        Assert.Equal(0, poleExit);
-
-        // The pole resolves to its category members and stops there.
-        Assert.Contains("## Library Info", poleOutput);
-        Assert.DoesNotContain("## Signals", poleOutput);
-        Assert.DoesNotContain("## Symbols", poleOutput);
-
-        // The preset reaches further, so the two cannot be collapsed.
+        Assert.DoesNotContain("@Default", bareError, StringComparison.Ordinal);
+        Assert.Contains("## Library Info", bareOutput);
         Assert.Contains("## Signals", bareOutput);
         Assert.Contains("## Symbols", bareOutput);
     }
@@ -10923,7 +10919,7 @@ public partial class CommandExecutionTests
     }
 
     /// <summary>
-    /// The package command drops the computed <c>@All</c> and <c>@Default</c> poles
+    /// The package command drops the computed <c>@All</c> pole
     /// (<see cref="DotnetInspector.Sections.SectionPipeline{TModel}.WithoutComputedPoles"/>):
     /// its sections are reachable by name, by topical door, and by verbosity, so a pole that
     /// renders a superset nobody asked for is a surface no discovery output describes. This is
@@ -10939,10 +10935,8 @@ public partial class CommandExecutionTests
             Assert.Equal(1, allExit);
             Assert.Contains("'@All' not found", allError, StringComparison.Ordinal);
 
-            // @Default is dropped by the same call, so it must not resolve on its own either.
-            // It used to, because bare -S was encoded as the literal string "@Default" and the
-            // command short-circuited on that encoding — which made a hand-typed pole
-            // indistinguishable from the marker and so silently exempt from the drop (#3547).
+            // @Default is gone everywhere, not just here: it restated what bare -S already means
+            // and had no spelling worth keeping (#3547).
             var (defaultExit, defaultOutput, defaultError) = await RunAppAsync("package", packagePath, "-S", "@Default");
             Assert.Equal(1, defaultExit);
             Assert.Contains("'@Default' not found", defaultError, StringComparison.Ordinal);

--- a/src/dotnet-inspect.Tests/SelectResolverTests.cs
+++ b/src/dotnet-inspect.Tests/SelectResolverTests.cs
@@ -70,14 +70,28 @@ public class SelectResolverTests
         Assert.Equal(TestSections.OrderBy(s => s), result.Sections!.OrderBy(s => s));
     }
 
+    /// <summary>
+    /// The default preset is reached only through bare <c>-S</c>, which arrives as its own flag.
+    /// <c>@Default</c> is not a selector value, so spelling it is an ordinary miss (#3547).
+    /// </summary>
     [Fact]
-    public void ResolveSelect_DefaultSelector_ReturnsDefaultSections()
+    public void ResolveSelect_SelectDefaultFlag_ReturnsDefaultSections()
     {
-        var result = SelectResolver.ResolveSelectAsSections(["@Default"], TestSections, ["Package Info"]);
+        var result = SelectResolver.ResolveSelectAsSections(
+            null, TestSections, ["Package Info"], selectDefault: true);
 
         Assert.NotNull(result.Sections);
         Assert.Empty(result.Unresolved);
         Assert.Equal(["Package Info"], result.Sections!.ToArray());
+    }
+
+    [Fact]
+    public void ResolveSelect_DefaultPoleSpelledOut_DoesNotResolve()
+    {
+        var result = SelectResolver.ResolveSelectAsSections(["@Default"], TestSections, ["Package Info"]);
+
+        Assert.Null(result.Sections);
+        Assert.Equal("@Default", Assert.Single(result.Unresolved).Value);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -295,7 +295,7 @@ public class ApiCommand
     {
         if (options.IncludeSections is not { Count: > 0 })
             return;
-        if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.Select, options.IncludeSections)
+        if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
             || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
             return;
 
@@ -1008,7 +1008,7 @@ public class ApiCommand
                     var pipeline = ApiMemberSectionPipelines.Create(options);
                     markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.GetAllSelectorSections(type));
                 }
-                else if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.Select, options.IncludeSections))
+                else if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections))
                 {
                     var pipeline = ApiMemberSectionPipelines.Create(options);
                     markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.InfoSectionNames);

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -493,7 +493,6 @@ public static class MemberCommand
             return false;
         // Bare -S carries no selector value, so it cannot be recognized by inspecting Select.
         if ((options.SelectDefault && options.Select is null)
-            || IsPureSelector(options.Select, SelectResolver.InfoSelector)
             || IsPureSelector(options.Select, SelectResolver.AllSelector))
             return false;
 

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -229,8 +229,7 @@ public class ProjectCommand
     private static IReadOnlyDictionary<string, string[]> ProjectCategoryMap()
         => new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
         {
-            [SelectResolver.AllSelector] = ProjectSectionNames,
-            [SelectResolver.InfoSelector] = []
+            [SelectResolver.AllSelector] = ProjectSectionNames
         };
 
     private static int WriteAgentsIndex(IReadOnlyList<ProjectPackageReference> dependencies, ProjectOptions options)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -182,7 +182,7 @@ public static class ApiOutputFormatter
         options is MemberOptions { OverloadIndex: not null }
         && options.IncludeSections is { Count: > 0 }
         && !SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections)
-        && !SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.Select, options.IncludeSections)
+        && !SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
         && !options.Count
         && !options.JsonOutput
         && !options.Tabular;
@@ -205,7 +205,7 @@ public static class ApiOutputFormatter
         options.Verbosity != Verbosity.Minimal
         || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options)
         || SectionRequested(options.IncludeSections, SectionNames.Methods)
-        || (!SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.Select, options.IncludeSections)
+        || (!SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
             && (SectionRequested(options.IncludeSections, SectionNames.Operators)
                 || SectionRequested(options.IncludeSections, SectionNames.ExplicitInterfaceImplementations)
                 || SectionRequested(options.IncludeSections, SectionNames.ExtensionMethods)))
@@ -225,7 +225,7 @@ public static class ApiOutputFormatter
         options.Verbosity == Verbosity.Minimal
         && !ShouldRenderMemberRows(options)
         && (options.IncludeSections is null
-            || SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.Select, options.IncludeSections));
+            || SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections));
 
     internal static bool ShouldRenderSectionedTabularView(ApiType type, ApiOptions options)
     {

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -224,7 +224,7 @@ public static class OutputFormatter
         }
 
         bool selectAll = SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
-        bool selectInfo = SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.Select, options.IncludeSections);
+        bool selectInfo = SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections);
         bool includeContext = ShouldRenderPackageContext(options);
         var view = new InspectionResultView(result, includeTitleVersion: false);
         var writerOptions = BuildWriterOptions(result, options, pipeline, includeContext);
@@ -284,7 +284,7 @@ public static class OutputFormatter
         SectionPipeline<InspectionResult> pipeline, bool includeContext = false)
     {
         var selectAll = SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
-        var selectInfo = SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.Select, options.IncludeSections);
+        var selectInfo = SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections);
         var includeSections = pipeline.ComputeIncludeSections(
             result, options.Verbosity, options.IncludeSections, selectAll, options.FixedOverview);
         if (includeContext && includeSections is { Count: > 0 })
@@ -526,7 +526,7 @@ public static class OutputFormatter
         options.Verbosity == Verbosity.Quiet
         || (options.IncludeSections is { Count: > 0 }
             && !SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections)
-            && !SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.Select, options.IncludeSections)
+            && !SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
             && !options.Count
             && !options.JsonOutput
             && !options.Tabular);
@@ -534,7 +534,7 @@ public static class OutputFormatter
     internal static bool ShouldRenderPackageContext(InspectionOptions options) =>
         options.IncludeSections is { Count: > 0 }
         && !SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections)
-        && !SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.Select, options.IncludeSections)
+        && !SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
         && !options.Count
         && !options.JsonOutput
         && !options.Tabular;

--- a/src/dotnet-inspect/Output/SelectResolver.cs
+++ b/src/dotnet-inspect/Output/SelectResolver.cs
@@ -29,7 +29,6 @@ public record SelectResult(HashSet<string>? Sections, IReadOnlyList<SelectMiss> 
 public static class SelectResolver
 {
     public const string AllSelector = SectionPipeline<object>.AllCategory;
-    public const string InfoSelector = SectionPipeline<object>.DefaultCategory;
 
     /// <summary>
     /// Legacy section names that keep resolving after a rename, so existing selectors and
@@ -97,17 +96,12 @@ public static class SelectResolver
     public static bool IsActiveAllSelector(string[]? select, HashSet<string>? includeSections)
         => IsAllSelector(select) && includeSections is { Count: > 1 };
 
-    public static bool IsInfoSelector(string[]? select)
-        => select?.Any(value => value.Equals(InfoSelector, StringComparison.OrdinalIgnoreCase)) == true;
-
     /// <summary>
-    /// Whether the default preset is in effect and actually resolved to something, either because
-    /// the caller passed bare <c>-S</c> (<paramref name="selectDefault"/>) or because they spelled
-    /// the <c>@Default</c> pole. The two are separate inputs because only the pole is a selector
-    /// value; the pole disjunct goes away with the pole itself.
+    /// Whether the default preset is in effect and actually resolved to something. The preset is
+    /// reached only through bare <c>-S</c>; it has no selector spelling.
     /// </summary>
-    public static bool IsActiveInfoSelector(bool selectDefault, string[]? select, HashSet<string>? includeSections)
-        => (selectDefault || IsInfoSelector(select)) && includeSections is { Count: > 0 };
+    public static bool IsActiveInfoSelector(bool selectDefault, HashSet<string>? includeSections)
+        => selectDefault && includeSections is { Count: > 0 };
 
     /// <summary>
     /// Resolves a single name against known sections: exact (case-insensitive), then glob.
@@ -182,7 +176,7 @@ public static class SelectResolver
         if (!selectDefault && select is not { Length: > 0 })
             return new(null, []);
 
-        categories ??= BuildFallbackCategories(knownSections, infoSections);
+        categories ??= BuildFallbackCategories(knownSections);
         var matched = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var unresolved = new List<SelectMiss>();
 
@@ -229,11 +223,10 @@ public static class SelectResolver
         return new(matched.Count > 0 ? matched : null, unresolved);
     }
 
-    private static IReadOnlyDictionary<string, string[]> BuildFallbackCategories(string[] knownSections, string[]? infoSections)
+    private static IReadOnlyDictionary<string, string[]> BuildFallbackCategories(string[] knownSections)
     {
         Dictionary<string, string[]> categories = new(StringComparer.OrdinalIgnoreCase)
         {
-            [InfoSelector] = infoSections ?? [],
             [AllSelector] = knownSections
         };
         return categories;

--- a/src/dotnet-inspect/Sections/ISectionDescriptor.cs
+++ b/src/dotnet-inspect/Sections/ISectionDescriptor.cs
@@ -28,8 +28,9 @@ public interface ISectionDescriptor<TModel>
     static virtual bool ExplicitOnly => false;
 
     /// <summary>
-    /// When true, this section is part of the command/context's curated @Default preset
-    /// selected by bare <c>-S</c>.
+    /// When true, this section is part of the command/context's curated default preset
+    /// selected by bare <c>-S</c>. The preset has no user-spellable name; it is reachable only
+    /// through bare <c>-S</c>.
     /// </summary>
     static virtual bool Info => false;
 

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -48,7 +48,6 @@ public sealed class SectionPipeline<TModel>
     private bool _curatedCatalog;
     private bool _computedPoles = true;
 
-    public const string DefaultCategory = "@Default";
     public const string AllCategory = "@All";
     public const string HiddenCategory = "@Hidden";
 
@@ -67,12 +66,11 @@ public sealed class SectionPipeline<TModel>
     }
 
     /// <summary>
-    /// Drops the computed <c>@All</c> and <c>@Default</c> poles from this pipeline's category map,
-    /// making them unresolvable as selectors rather than merely undiscoverable. They are artifacts
-    /// of the legacy catalog: <c>@All</c> renders a superset nobody asked for, and <c>@Default</c>
-    /// restates what bare <c>-S</c> already means. A command whose sections are reachable through
-    /// topical doors and verbosity does not need either, and keeping them resolvable-but-unlisted
-    /// leaves a surface no discovery output describes.
+    /// Drops the computed <c>@All</c> pole from this pipeline's category map, making it
+    /// unresolvable as a selector rather than merely undiscoverable. It is an artifact of the
+    /// legacy catalog: it renders a superset nobody asked for. A command whose sections are
+    /// reachable through topical doors and verbosity does not need it, and keeping it
+    /// resolvable-but-unlisted leaves a surface no discovery output describes.
     /// </summary>
     public SectionPipeline<TModel> WithoutComputedPoles()
     {
@@ -237,7 +235,6 @@ public sealed class SectionPipeline<TModel>
         Dictionary<string, string[]> categories = new(StringComparer.OrdinalIgnoreCase);
         if (_computedPoles)
         {
-            categories[DefaultCategory] = InfoSectionNames;
             categories[AllCategory] = _curatedCatalog
                 ? _entries.Where(e => IsSelectable(e) && IsAllMember(e)).Select(e => e.Name).ToArray()
                 : SelectableSectionNames;

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -227,7 +227,7 @@ public sealed class SectionPipeline<TModel>
         .Select(e => e.Name)
         .ToArray();
 
-    /// <summary>Sections in the curated @Default preset, in registration order.</summary>
+    /// <summary>Sections in the curated default preset, in registration order.</summary>
     public string[] InfoSectionNames => _entries.Where(e => e.Info && IsSelectable(e)).Select(e => e.Name).ToArray();
 
     public IReadOnlyDictionary<string, string[]> GetCategoryMap()
@@ -284,7 +284,7 @@ public sealed class SectionPipeline<TModel>
     /// Maps each section name to a short annotation for discovery output:
     /// <c>"opt-in"</c> for <see cref="SectionEntry{TModel}.ExplicitOnly"/> sections (never shown
     /// in a default flow), and <c>"verbose"</c> for explicitly applicable alternate
-    /// sections that render only outside the compact <c>@Default</c> preset.
+    /// sections that render only outside the compact default preset.
     /// Default sections are omitted (no annotation).
     /// </summary>
     public Dictionary<string, string> GetCostAnnotations()


### PR DESCRIPTION
`@Default` is gone. It was a computed pole that restated what bare `-S` already means.

**Stack**: slice 2 of 3 for #3547. Parent: #3566 (`decouple-bare-select`). Next slice removes `@All` and fixes the `--select` help text.

> Review this against its parent. The diff shown here is this slice only; #3566 must land first.

## What changed

Slice 1 gave bare `-S` its own marker, which left `@Default` with no job. This drops it from every pipeline's category map and deletes the constants, predicates, and fallback entries that published it:

- `SectionPipeline.DefaultCategory` and `SelectResolver.InfoSelector` / `IsInfoSelector`
- the `@Default` entry in `GetCategoryMap` and in `BuildFallbackCategories` (whose now-unused `infoSections` parameter goes with it)
- `SelectResolver.IsActiveInfoSelector` loses its selector-array parameter — the preset is reachable only through bare `-S`, so there is no selector list to inspect
- `MemberCommand`'s pure-selector check and `ProjectCommand`'s category map lose their `@Default` entries

`WithoutComputedPoles` now drops only `@All`; its doc comment says so.

## Behavioral claim

`-S @Default` reports `Select value '@Default' not found.` on every command, exactly as `package` already did for `@All`.

**Bare `-S` is unchanged everywhere.** Verified per command against the pre-change build:

| Command | bare `-S` renders |
| --- | --- |
| `package Markout` | Manifest, Package Info, Package nuspec file, Package README file, Signature |
| `library System.Text.Json` | Library Info, Signals, Symbols |
| `type …JsonSerializer` | Properties, Method Groups |
| `project …csproj` | unchanged mode error |

`library -S @All` still resolves — that is slice 3's job.

## Evidence

Full CLI suite: `2584 total, 0 failed, 14 skipped`.

Gates:

- `LibraryCommand_DefaultPole_IsNotResolvable` replaces the slice 1 test that pinned the pole's divergence from bare `-S`; it now asserts the pole errors while bare `-S` still renders the full fixed overview
- `ResolveSelect_DefaultPoleSpelledOut_DoesNotResolve` pairs with `ResolveSelect_SelectDefaultFlag_ReturnsDefaultSections`, so the flag path and the retired spelling are both covered
- `Package_ComputedPoles_AreNotResolvable` keeps its slice 1 coverage of `-S @Default` alone

Docs: `docs/design/section-model.md` and `docs/design/info-view.md` updated; no `@Default` references remain under `docs/`. `markdownlint` clean on both.

## Residual

`@All` is still resolvable on every pipeline that has not called `WithoutComputedPoles`, and `--select`'s help text still advertises it on `package`, which rejects it (gap 1). Slice 3 takes both. It is a larger change because `@All` has real consumers beyond resolution — `GetAllSelectorSections` and the `MarkdownSectionOrderer` path — which is why it is not folded in here.

Gaps 4, 5, and 6 of #3547 remain untouched.