### PR TITLE
Let a raised array literal keep the offset of the newarr it replaced

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
@@ -187,6 +187,16 @@ public static class AllocSampleClass
     // cross-assembly resolution can.
     public static System.DateTime MakeDateTime(int year, int month, int day) => new(year, month, day);
 
+    // Two heap allocations, the second a newarr/dup/stelem run that the raise
+    // folds into an array literal. The fold subsumes the newarr, so unless the
+    // literal inherits its offset the alloc.array fact has no node carrying it
+    // and anchors onto the preceding statement instead of the return.
+    public static object[] AllocatesTwice()
+    {
+        object first = new object();
+        return new object[] { first };
+    }
+
     public static System.Func<int, int> Capture(int k) => x => x + k;
 
     public static System.Func<int, int> Cached() => x => x + 1;

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -33,6 +33,24 @@ public class AnnotationAnchorTests
     }
 
     [Fact]
+    public void RaisedArrayLiteral_AnchorsToItsOwnStatement_NotThePrecedingOne()
+    {
+        // object first = new object(); return new object[] { first };
+        // Both allocations are real and distinct. The array's newarr is subsumed
+        // by the array-literal fold, so this only holds because the fold hands
+        // the literal the offset it consumed — otherwise nothing in the tree
+        // covers that offset and the fact falls back onto the preceding store.
+        var (_, map) = AnchorFor(nameof(AllocSampleClass.AllocatesTwice));
+
+        var arrayOwner = Assert.Single(map, e => e.Value.Any(a => a.Descriptor.Id == "alloc.array")).Key;
+        var newOwner = Assert.Single(map, e => e.Value.Any(a => a.Descriptor.Id == "alloc.new")).Key;
+
+        Assert.IsType<Return>(arrayOwner);
+        Assert.IsType<StoreLocal>(newOwner);
+        Assert.NotSame(arrayOwner, newOwner);
+    }
+
+    [Fact]
     public void EveryAnnotation_IsAnchoredSomewhere()
     {
         // Positive-only: a fact is never silently dropped.

--- a/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
@@ -312,4 +312,27 @@ public class ArrayLiteralFromStoresPassTests
         Assert.Equal(0, ArrayLiteralCount(function));
         function.CheckInvariant();
     }
+
+    // The fold consumes the newarr, and offset-keyed facts (alloc.array) are
+    // anchored by the offsets surviving in the tree. If the literal did not
+    // adopt the allocation's offset, that offset would exist nowhere and the
+    // fact would anchor to whatever statement precedes it.
+    [Fact]
+    public void FoldedLiteral_AdoptsTheAllocationsSourceOffset()
+    {
+        var allocation = new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")));
+        allocation.SetSourceOffset(7);
+        var store = new StoreLocal(0, ObjectArray, allocation);
+        store.SetSourceOffset(11);
+        var function = Build(
+            store,
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Constant("A", StringType)),
+            new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)])));
+
+        RunPass(function);
+
+        var literal = Assert.Single(function.Descendants.OfType<ArrayLiteral>());
+        Assert.Equal(7, literal.SourceOffset);
+        function.CheckInvariant();
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -21,6 +21,30 @@ public class RvaSpanPassTests
         function.CheckInvariant();
     }
 
+    static IrFunction BuildCreateSpanReal()
+    {
+        var createSpan = new MethodRef(
+            TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers"),
+            "CreateSpan",
+            s_readOnlySpanInt,
+            [s_runtimeFieldHandle],
+            HasThis: false)
+        {
+            TypeArguments = [s_int],
+        };
+        var token = new LoadToken(RuntimeTokenKind.Field, null, "<PrivateImplementationDetails>.Blob")
+        {
+            FieldRvaData = [1, 0, 0, 0, 2, 0, 0, 0],
+        };
+
+        var block = new Block();
+        block.Add(new Return(new Call(createSpan, isVirtual: false, [token])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(s_readOnlySpanInt, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
+    }
+
     static IrFunction BuildCreateSpanLookalike()
     {
         var createSpan = new MethodRef(
@@ -179,6 +203,70 @@ public class RvaSpanPassTests
 
         Assert.Single(function.Descendants.OfType<ArrayLiteral>());
         Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InitializeArray");
+        function.CheckInvariant();
+    }
+
+    // The caller detaches the InitializeArray statement after folding. If the
+    // creation is that statement's own argument, folding would delete the array
+    // along with the call, so the shape is declined and the IL stands unraised.
+    [Fact]
+    public void InitializeArray_InlineCreation_StaysUnraisedRatherThanVanishing()
+    {
+        var intArray = TypeRef.SzArray(s_int);
+        var token = new LoadToken(RuntimeTokenKind.Field, null, "<PrivateImplementationDetails>.Blob")
+        {
+            FieldRvaData = [1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0],
+        };
+        var block = new Block();
+        block.Add(new ExpressionStatement(new Call(
+            RealInitializeArray(),
+            isVirtual: false,
+            [new NewArray(s_int, new Constant(3, s_int)), token])));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ArrayLiteral>());
+        Assert.Single(function.Descendants.OfType<NewArray>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InitializeArray");
+        function.CheckInvariant();
+    }
+
+    // Every raise in this pass replaces one offset-bearing instruction with a
+    // synthesized literal, and the replacement is the only place that offset can
+    // survive. Facts and the mixed IL view both locate a statement by the offsets
+    // beneath it, so a dropped offset strands them on a neighbouring statement.
+    [Fact]
+    public void CreateSpan_RaisedLiteral_AdoptsTheCallsSourceOffset()
+    {
+        var function = BuildCreateSpanReal();
+        Assert.Single(function.Descendants.OfType<Call>()).SetSourceOffset(21);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        var literal = Assert.Single(function.Descendants.OfType<SpanLiteral>());
+        Assert.Equal(21, literal.SourceOffset);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ReadOnlySpanRvaConstructor_RaisedLiteral_AdoptsTheConstructionsSourceOffset()
+    {
+        var function = BuildReadOnlySpanByteCtor([10, 20, 30, 0], spanLength: 3);
+        Assert.Single(function.Descendants.OfType<NewObject>()).SetSourceOffset(33);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        var literal = Assert.Single(function.Descendants.OfType<SpanLiteral>());
+        Assert.Equal(33, literal.SourceOffset);
         function.CheckInvariant();
     }
 

--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -182,6 +182,22 @@ public class RvaSpanPassTests
         function.CheckInvariant();
     }
 
+    // The literal stands in for the newarr it replaces. Offset-keyed facts are
+    // anchored by the offsets left in the tree, so dropping the allocation's
+    // offset here would strand alloc.array on a neighbouring statement.
+    [Fact]
+    public void InitializeArray_RaisedLiteral_AdoptsTheAllocationsSourceOffset()
+    {
+        var function = BuildInitializeArrayRaising(RealInitializeArray());
+        Assert.Single(function.Descendants.OfType<NewArray>()).SetSourceOffset(9);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        var literal = Assert.Single(function.Descendants.OfType<ArrayLiteral>());
+        Assert.Equal(9, literal.SourceOffset);
+        function.CheckInvariant();
+    }
+
     [Fact]
     public void InitializeArray_WrongFirstParameter_IsNotRaised()
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
@@ -153,6 +153,10 @@ public sealed class ArrayLiteralFromStoresPass : IIrPass
             detachedElements[k] = (IrExpression)storeElement.DetachChildren()[2];
         }
         var literal = new ArrayLiteral(elementType, arrayType, detachedElements);
+        // The raise subsumes the newarr, so the literal inherits its offset. Without
+        // this the instruction's offset survives nowhere in the tree, and any fact
+        // keyed to it (alloc.array) has no node to anchor to.
+        literal.SetSourceOffset(newArray.SourceOffset);
         IrNode combined = place.IsSlot ? new StoreStackSlot(place.Index, literal) : new StoreLocal(place.Index, ArrayLocalType(block, seedIndex), literal);
 
         // Replace the first fill statement with the combined declaration, drop

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -102,6 +102,9 @@ public sealed class RvaSpanPass : IIrPass
                 continue;
 
             var arrayLiteral = new ArrayLiteral(creation.ElementType, TypeRef.SzArray(creation.ElementType), arrayElements);
+            // The literal stands in for the newarr it replaces, so it inherits the
+            // offset; otherwise alloc.array has no node left to anchor to.
+            arrayLiteral.SetSourceOffset(creation.SourceOffset);
             context.Stepper.StepOver("raise InitializeArray RVA blob to array literal", creation);
             creation.ReplaceWith(arrayLiteral);
             statement.Detach();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -44,6 +44,11 @@ public sealed class RvaSpanPass : IIrPass
                 continue;
 
             var literal = new SpanLiteral(element, spanType, elements);
+            // Each raise here replaces one offset-bearing instruction with a
+            // synthesized literal. The replacement inherits that offset: it is the
+            // only place the instruction survives, and offset-keyed facts and the
+            // mixed IL view both locate a statement by the offsets under it.
+            literal.SetSourceOffset(call.SourceOffset);
             context.Stepper.StepOver("raise CreateSpan RVA blob to span literal", call);
             call.ReplaceWith(literal);
         }
@@ -72,6 +77,7 @@ public sealed class RvaSpanPass : IIrPass
                 continue;
 
             var spanLiteral = new SpanLiteral(spanElement, spanInstance, spanElements);
+            spanLiteral.SetSourceOffset(construction.SourceOffset);
             context.Stepper.StepOver("raise ReadOnlySpan RVA field to span literal", construction);
             construction.ReplaceWith(spanLiteral);
         }
@@ -102,8 +108,6 @@ public sealed class RvaSpanPass : IIrPass
                 continue;
 
             var arrayLiteral = new ArrayLiteral(creation.ElementType, TypeRef.SzArray(creation.ElementType), arrayElements);
-            // The literal stands in for the newarr it replaces, so it inherits the
-            // offset; otherwise alloc.array has no node left to anchor to.
             arrayLiteral.SetSourceOffset(creation.SourceOffset);
             context.Stepper.StepOver("raise InitializeArray RVA blob to array literal", creation);
             creation.ReplaceWith(arrayLiteral);
@@ -119,8 +123,14 @@ public sealed class RvaSpanPass : IIrPass
     /// </summary>
     static NewArray? ResolveArrayCreation(IrExpression arrayArg, ExpressionStatement statement)
     {
-        if (arrayArg is NewArray inline)
-            return inline;
+        // An inline creation is the argument of the very statement the caller
+        // detaches, so folding it would take the literal down with the call and
+        // erase the allocation from the output entirely. csc never emits this
+        // shape — it dups the array so the initialized value survives the call —
+        // and it is absent from the runtime (0 of 283 InitializeArray calls
+        // across 181 assemblies), so declining loses nothing real.
+        if (arrayArg is NewArray)
+            return null;
 
         if (statement.Parent is not Block block)
             return null;


### PR DESCRIPTION
Slice 1 of the stack for #3570. Lands on its own.

## The defect

An offset-keyed fact is placed by finding the statement whose subtree covers its IL offset (`AnnotationAnchor.ComputeSpans` takes the min/max `SourceOffset` over each statement's subtree). Both array-literal raises — `ArrayLiteralFromStoresPass` and `RvaSpanPass` — construct the replacement `ArrayLiteral` without an offset, so the `newarr`'s offset survives nowhere in the tree. No statement covers it, and `Best`'s nearest-preceding fallback files the fact on whatever statement came before.

Reproducible from the shipped CLI on a two-line method:

```csharp
public static object[] AllocatesTwice()
{
    object first = new object();
    return new object[] { first };
}
```

```
dotnet-inspect member --library Fx.dll Fx -m AllocatesTwice --all \
  -S "Annotated Source" --focus alloc.array
```

### Before

```csharp
public static object[] AllocatesTwice()
{
    object first = new object();  // alloc.new(object; alloc=System.Object; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes; escape-kind=escapes-collection; multiplicity=once)
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ alloc.array(object[]; alloc=System.Object[]; path=straight-line;
//                               path-confidence=dominates-return;
//                               post-dominance=return-post-dominates; multiplicity=once)
        // IL_0000: newobj       object::.ctor()  // alloc.new(object; alloc=System.Object; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes; escape-kind=escapes-collection; multiplicity=once); stack: [object]
        // IL_0005: stloc.0                       // local: first; stack: []
        // IL_0006: ldc.i4.1                      // stack: [int]
        // IL_0007: newarr       object  // alloc.array(object[]; alloc=System.Object[]; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; multiplicity=once); stack: [object[]]
        // IL_000C: dup                           // stack: [object[], object[]]
        // IL_000D: ldc.i4.0                      // stack: [object[], object[], int]
    return new object[] { first };
        // IL_000E: ldloc.0                       // local: first; stack: [object[], object[], int, object]
        // IL_000F: stelem.ref                    // stack: [object[]]
        // IL_0010: ret                           // stack: []
}
```

The caret names the array allocation and underlines the line that has none. Because the same ranges bucket IL instructions into the mixed view, `IL_0007 newarr` is filed under the preceding statement too — it appears above the `return` that actually contains it.

### After

```csharp
public static object[] AllocatesTwice()
{
    object first = new object();  // alloc.new(object; alloc=System.Object; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes; escape-kind=escapes-collection; multiplicity=once)
        // IL_0000: newobj       object::.ctor()  // alloc.new(object; alloc=System.Object; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes; escape-kind=escapes-collection; multiplicity=once); stack: [object]
        // IL_0005: stloc.0                       // local: first; stack: []
        // IL_0006: ldc.i4.1                      // stack: [int]
    return new object[] { first };
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ alloc.array(object[]; alloc=System.Object[]; path=straight-line;
//                                 path-confidence=dominates-return;
//                                 post-dominance=return-post-dominates; multiplicity=once)
        // IL_0007: newarr       object  // alloc.array(object[]; alloc=System.Object[]; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; multiplicity=once); stack: [object[]]
        // IL_000C: dup                           // stack: [object[], object[]]
        // IL_000D: ldc.i4.0                      // stack: [object[], object[], int]
        // IL_000E: ldloc.0                       // local: first; stack: [object[], object[], int, object]
        // IL_000F: stelem.ref                    // stack: [object[]]
        // IL_0010: ret                           // stack: []
}
```

The caret moves onto the `return`, and `IL_0007 newarr` moves with it into that statement's block. `alloc.new` stays where it was.

**The caret is still statement-wide, and that is not fixed here.** It underlines all of `return new object[] { first };` when the allocation is only `new object[] { first }`. That is a second defect — right line, wrong extent — and it comes from anchoring being statement-granular, not from the offsets this PR restores.

It is worth being precise that this PR is what makes the narrow caret *reachable* for this case: the printed range for the literal is already recorded (characters 36..58, i.e. line 1 column 7, exactly `new object[] { first }`), and after this change the `ArrayLiteral` owning that range carries source offset 7 — the fact's own offset. Before, it carried none, so there was nothing to join on.

Measured ceiling for the narrowing slice across `System.Private.CoreLib` (37,800 facts — the 61 facts in methods that print no output are excluded, since no caret is possible there):

| | | |
| --- | --- | --- |
| a printed node owns *exactly* the fact's offset — tight caret available | 34,008 | 89.97% |
| only an enclosing printed subtree covers it — caret can narrow to that node, not to the expression | 3,363 | 8.90% |
| no printed node covers it — no C# extent; the IL line remains exact | 429 | 1.13% |

## The change

Every raise in `RvaSpanPass` and `ArrayLiteralFromStoresPass` that replaces an offset-bearing instruction with a synthesized literal now hands that offset to the replacement. There are four such sites: two `ArrayLiteral` and two `SpanLiteral`.

One further fix, from review: `ResolveArrayCreation` accepted an *inline* creation — `InitializeArray(new int[3], token)` — where the creation belongs to the very statement the caller then detaches. Folding it placed the literal inside the doomed statement, deleting the allocation from the output. That shape is now declined. It is not reachable from real compiler output (csc dups the array so the initialized value outlives the call); a sweep found **0 of 283** `InitializeArray` calls using it across 181 assemblies and 135,228 methods. It is fixed here only because it sits two lines from code this PR already changes, and silently deleting an allocation is a bad failure mode to leave armed.

## What this is and is not

It is a **placement** fix, not a volume one — it changes where facts land, not how many exist.

**Correction.** An earlier revision of this description claimed the change "moves 0 of 35,812 facts between statements." That was wrong, and it was wrong for an instructive reason: the measurement compared the *aggregate counts* of contained-vs-fallback facts before and after. Those counts are identical, because the change does not move facts between those two buckets — but it does move facts between *statements* within the contained bucket. The metric asked "is this fact contained by some statement?" and not "which statement?". That is the same bounds-versus-placement mistake this PR exists to fix, made in the measurement of the fix. Both reviewers caught it independently.

**Second correction — every corpus number below was re-derived.** A later revision still carried numbers from a broken probe. The sweep called `ResearchViews.CollectFacts(source, string type, string method, int overloadIndex = 0)`, whose `overloadIndex` defaults to `0`. Iterating `IrImporter.ImportAssembly` yields *every* overload, so that call re-imported **overload 0 every time**: it counted overload 0's facts once per same-named overload, never collected overloads 1..N-1, and anchored the facts it did collect against a *different* method body than the one they came from. The correct seam for a sweep is the 2-arg `CollectFacts(src, importedFunction)`. Two reviewers independently reported a fact population of ~37,866 against the published 35,807; that discrepancy was the visible symptom.

Re-measured with the correct seam, comparing this branch against `origin/main` directly (`System.Private.CoreLib`, **37,861 facts**):

- **121 facts change the printed line they anchor to** — 117 `alloc.array`, 4 `safety.callee`. (Counting by owner *statement* identity rather than printed line gives 122; two statements can share a line.)

Direction was then checked semantically rather than structurally, by asking whether an `alloc.array` fact lands on a statement whose subtree actually creates an array:

| | before | after |
| --- | ---: | ---: |
| `alloc.array` on a statement that really creates an array | 722 (88.05%) | **816 (99.51%)** |
| `alloc.array` misplaced | 98 | **4** |
| any fact whose owner contains its offset | 37,418 (98.83%) | **37,522 (99.10%)** |

No fact moves to a worse statement. The remaining 4 misplaced `alloc.array` facts come from offsets dropped by raises this PR does not touch.

The broader defect is untouched here and is what the anchoring slice addresses: **339 of 37,861 facts (0.90%)** still reach a statement that does not cover their offset, dominated by `safety.callee`, `cost.callee`, `alloc.new` and `alloc.box`.

## Gates

Six tests, each verified to fail with its production line reverted:

- `ArrayLiteralFromStoresPassTests.FoldedLiteral_AdoptsTheAllocationsSourceOffset`
- `RvaSpanPassTests.InitializeArray_RaisedLiteral_AdoptsTheAllocationsSourceOffset`
- `RvaSpanPassTests.CreateSpan_RaisedLiteral_AdoptsTheCallsSourceOffset`
- `RvaSpanPassTests.ReadOnlySpanRvaConstructor_RaisedLiteral_AdoptsTheConstructionsSourceOffset`
- `RvaSpanPassTests.InitializeArray_InlineCreation_StaysUnraisedRatherThanVanishing`
- `AnnotationAnchorTests.RaisedArrayLiteral_AnchorsToItsOwnStatement_NotThePrecedingOne` — asserts `alloc.array` and `alloc.new` land on *different* statements, which is the property that was broken. The pre-existing `EveryAnnotation_IsAnchoredSomewhere` passes with the bug present, confirmed by both reviewers; it is vacuous for placement.

Suites: decompiler 4382, CLI 1818, research 132 — all green.

## Review

Two independent adversarial reviews (Opus 4.8, GPT-5.6-sol) in separate worktrees. Both found the `SpanLiteral` incompleteness independently, and both falsified the "0 facts moved" claim independently. One additionally demonstrated the inline-creation array loss. Both verified no offset-aliasing hazard: the node whose offset is inherited is always removed from the tree in the same operation, and label emission is gated on the *statement's* offset, which a raised literal never is. Both confirmed the new fixture method is safe — all seven `AllocSampleClass` references are by-name.

All findings from both reviews are addressed in this PR.

## Stack

1. **this PR** — offset preservation in the two array-literal raises
2. `AnnotatedSourceLine` → `BoundSourceLine`, alone (the 3-arg ctor would compile against either type with no diagnostic)
3. printed regions + roles, laminarity asserted at construction
4. portable line stream; stop baking facts into IL text
5. CLI consumer

Refs #3570

