### PR TITLE
Add a fixed Type Info section to the type view

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2980,10 +2980,110 @@ public partial class CommandExecutionTests
         Assert.DoesNotContain("├─", output);
     }
 
+    /// <summary>
+    /// <c>Type Info</c> is the type view's identity fact table, and the only section on the type
+    /// pipeline that does not grow with the type under inspection.
+    /// </summary>
     [Fact]
-    public async Task Type_SingleType_SelectWithColumns_ProjectsColumns()
+    public async Task Type_TypeInfoSection_RendersIdentityFactsRatherThanMembers()
     {
         var options = new TypeOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializer",
+            Select = [SectionNames.TypeInfo]
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => TypeCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Type Info", output);
+        Assert.Contains("| Type | System.Text.Json.JsonSerializer |", output);
+        Assert.Contains("| Kind | class |", output);
+        Assert.Contains("| Library | System.Text.Json |", output);
+        // Identity, not inventory: the member sections stay out.
+        Assert.DoesNotContain("## Methods", output);
+        Assert.DoesNotContain("## Method Groups", output);
+    }
+
+    /// <summary>
+    /// The section is <c>ExplicitOnly</c>, so it must not join the default markdown view, where
+    /// the same facts already render as the inline identity line. This is the gate for the
+    /// "new sections do not enter the default -v:m view" rule for this section.
+    /// </summary>
+    [Fact]
+    public async Task Type_TypeInfoSection_DoesNotEnterTheDefaultMarkdownView()
+    {
+        var options = new TypeOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializer",
+            MarkdownExplicitlySet = true
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => TypeCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("## Type Info", output);
+        // The identity facts are present, just inline rather than as a section.
+        Assert.Contains("Kind: class", output);
+    }
+
+    /// <summary>
+    /// The boundedness claim: the row set is a function of which facts apply to the type, never of
+    /// how many members it has. A 200+ member type must not produce a materially larger section
+    /// than an 8-member enum, and every label it emits must come from the same fixed vocabulary.
+    /// </summary>
+    [Fact]
+    public async Task Type_TypeInfoSection_DoesNotGrowWithTheType()
+    {
+        var large = await RenderTypeInfoLabelsAsync("System.Private.CoreLib", "String");
+        var small = await RenderTypeInfoLabelsAsync("System.Private.CoreLib", "DayOfWeek");
+
+        Assert.NotEmpty(large);
+        Assert.NotEmpty(small);
+
+        // Both draw from one declared vocabulary; neither invents rows for members.
+        string[] vocabulary =
+        [
+            "Type", "Kind", "Modifiers", "Base", "Type Parameters", "Interfaces", "Library",
+            "Package", "Version", "TFM", "Source", "Members", "Constructors", "Finalizer",
+            "Fields", "Properties", "Methods", "Operators", "Events",
+            "Explicit Interface Implementations", "Extension Methods"
+        ];
+
+        Assert.All(large, label => Assert.Contains(label, vocabulary));
+        Assert.All(small, label => Assert.Contains(label, vocabulary));
+        Assert.True(
+            large.Count <= vocabulary.Length,
+            $"Type Info grew past its declared vocabulary: {string.Join(", ", large)}");
+    }
+
+    private static async Task<List<string>> RenderTypeInfoLabelsAsync(string assembly, string typeName)
+    {
+        var options = new TypeOptions
+        {
+            PlatformAssembly = assembly,
+            TypeName = typeName,
+            Select = [SectionNames.TypeInfo]
+        };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => TypeCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+
+        return output.Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.StartsWith('|') && !line.StartsWith("| ---") && line != "| Field | Value |")
+            .Select(line => line.Split('|', StringSplitOptions.RemoveEmptyEntries)[0].Trim())
+            .ToList();
+    }
+
+    [Fact]
+    public async Task Type_SingleType_SelectWithColumns_ProjectsColumns()    {        var options = new TypeOptions
         {
             PlatformAssembly = "System.Text.Json",
             TypeName = "JsonSerializer",

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3057,7 +3057,7 @@ public partial class CommandExecutionTests
         // property silently - including an unbounded one. Pinning the count makes any addition fail
         // here, so whoever adds a property has to state that it is a fixed fact about the type and
         // not a per-member row. Bump this only alongside that judgement.
-        Assert.Equal(21, vocabulary.Count);
+        Assert.Equal(11, vocabulary.Count);
 
         Assert.All(large, label => Assert.Contains(label, vocabulary));
         Assert.All(small, label => Assert.Contains(label, vocabulary));
@@ -3125,12 +3125,26 @@ public partial class CommandExecutionTests
     // An enum is the case that catches a census computed off a different member list than the one
     // discovery sees: DayOfWeek's only field is the compiler-generated `value__`.
     [InlineData("System.DayOfWeek")]
-    public async Task Type_TypeInfoSection_EffectiveDiscovery_ListsTheFieldsItRenders(string typeName)
+    // A readonly ref struct: BuildFilteredTypeForSections did not copy IsReadOnly/IsByRefLike, so
+    // discovery hid the Modifiers row that -S renders.
+    [InlineData("System.Span`1")]
+    [InlineData("System.DateTime")]
+    // Filters narrow the type discovery builds its manifest from. Type Info reports identity, not
+    // the filtered slice, so its field set must not move when a filter is active.
+    [InlineData("System.String", "-m", "Contains")]
+    [InlineData("System.String", "--all")]
+    [InlineData("System.String", "-m", "5")]
+    [InlineData("System.String", "-k", "property")]
+    [InlineData("System.Span`1", "--unsafe")]
+    public async Task Type_TypeInfoSection_EffectiveDiscovery_ListsTheFieldsItRenders(
+        string typeName,
+        params string[] extraArgs)
     {
-        var (discoverExit, discoverOutput, _) = await RunAppAsync(
-            "type", typeName, "-D", SectionNames.TypeInfo);
-        var (renderExit, renderOutput, _) = await RunAppAsync(
-            "type", typeName, "-S", SectionNames.TypeInfo);
+        string[] discoverArgs = ["type", typeName, .. extraArgs, "-D", SectionNames.TypeInfo];
+        string[] renderArgs = ["type", typeName, .. extraArgs, "-S", SectionNames.TypeInfo];
+
+        var (discoverExit, discoverOutput, _) = await RunAppAsync(discoverArgs);
+        var (renderExit, renderOutput, _) = await RunAppAsync(renderArgs);
 
         Assert.Equal(0, discoverExit);
         Assert.Equal(0, renderExit);

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3082,9 +3082,73 @@ public partial class CommandExecutionTests
             .ToList();
     }
 
+    /// <summary>
+    /// Effective <c>-D</c> must list the fields <c>Type Info</c> actually renders. Two things can
+    /// break this and both did: the section is a <c>Field</c>/<c>Value</c> fact table, so matching
+    /// the schema against rendered *table columns* intersects nothing and reports the section as
+    /// having no queryable fields at all; and the discovery render manifest is built without
+    /// acquisition context, so the provenance rows are invisible to it unless that context is
+    /// threaded in. Either failure is silent — exit 0 with fields missing.
+    /// </summary>
     [Fact]
-    public async Task Type_SingleType_SelectWithColumns_ProjectsColumns()    {        var options = new TypeOptions
-        {
+    public async Task Type_TypeInfoSection_EffectiveDiscovery_ListsTheFieldsItRenders()
+    {
+        var (discoverExit, discoverOutput, _) = await RunAppAsync(
+            "type", "System.String", "-D", SectionNames.TypeInfo);
+        var (renderExit, renderOutput, _) = await RunAppAsync(
+            "type", "System.String", "-S", SectionNames.TypeInfo);
+
+        Assert.Equal(0, discoverExit);
+        Assert.Equal(0, renderExit);
+
+        var advertised = ParseFirstColumn(discoverOutput, "Name");
+        var rendered = ParseFirstColumn(renderOutput, "Field");
+
+        Assert.NotEmpty(advertised);
+        Assert.NotEmpty(rendered);
+
+        // Structural facts the manifest can see from the type itself.
+        Assert.Contains("Kind", advertised);
+        Assert.Contains("Methods", advertised);
+        // Provenance facts that only exist if acquisition context reached the manifest.
+        Assert.Contains("Library", advertised);
+        Assert.Contains("Source", advertised);
+
+        var missing = rendered.Except(advertised).ToList();
+        Assert.True(
+            missing.Count == 0,
+            $"-D under-reports fields that -S renders: {string.Join(", ", missing)}");
+    }
+
+    /// <summary>
+    /// Type parameters are an identity fact, so an open generic must report them. The summary used
+    /// to be computed only at quiet verbosity for the inline header, which left the section's
+    /// declared field permanently empty and made <c>--fields "Type Parameters"</c> report no data.
+    /// </summary>
+    [Fact]
+    public async Task Type_TypeInfoSection_ReportsTypeParametersForOpenGenerics()
+    {
+        var (exit, output, _) = await RunAppAsync(
+            "type", "System.Collections.Generic.List`1", "-S", SectionNames.TypeInfo);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("| Type Parameters | T |", output);
+    }
+
+    private static List<string> ParseFirstColumn(string output, string headerLabel)
+    {
+        return output.Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.StartsWith('|'))
+            .Select(line => line.Split('|', StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } cells
+                ? cells[0].Trim()
+                : string.Empty)
+            .Where(cell => cell.Length > 0 && cell != headerLabel && !cell.StartsWith('-'))
+            .ToList();
+    }
+
+    [Fact]
+    public async Task Type_SingleType_SelectWithColumns_ProjectsColumns()    {        var options = new TypeOptions        {
             PlatformAssembly = "System.Text.Json",
             TypeName = "JsonSerializer",
             Select = ["Properties"],

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -7,6 +7,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using DotnetInspector.Fixtures;
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
@@ -17,8 +18,10 @@ using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
+using DotnetInspector.Views;
 using ILInspector.Metadata;
 using ILInspector.Research;
+using Markout;
 
 namespace DotnetInspector.Tests;
 
@@ -3045,20 +3048,46 @@ public partial class CommandExecutionTests
         Assert.NotEmpty(large);
         Assert.NotEmpty(small);
 
-        // Both draw from one declared vocabulary; neither invents rows for members.
-        string[] vocabulary =
-        [
-            "Type", "Kind", "Modifiers", "Base", "Type Parameters", "Interfaces", "Library",
-            "Package", "Version", "TFM", "Source", "Members", "Constructors", "Finalizer",
-            "Fields", "Properties", "Methods", "Operators", "Events",
-            "Explicit Interface Implementations", "Extension Methods"
-        ];
+        // The vocabulary is derived from TypeInfoSection's declaration rather than copied here, so
+        // the declaration drives the gate: a row whose label is not a declared property fails, and
+        // the bound tracks the property count instead of a hand-maintained literal that goes stale.
+        var vocabulary = DeclaredTypeInfoLabels();
+
+        // Deriving the vocabulary keeps it from going stale, but on its own it would absorb a new
+        // property silently - including an unbounded one. Pinning the count makes any addition fail
+        // here, so whoever adds a property has to state that it is a fixed fact about the type and
+        // not a per-member row. Bump this only alongside that judgement.
+        Assert.Equal(21, vocabulary.Count);
 
         Assert.All(large, label => Assert.Contains(label, vocabulary));
         Assert.All(small, label => Assert.Contains(label, vocabulary));
+
+        // The bound that makes the section Fixed: one row per declared property, never one per
+        // member. String has 250+ members and DayOfWeek has 7; both stay inside a constant.
         Assert.True(
-            large.Count <= vocabulary.Length,
+            large.Count <= vocabulary.Count,
             $"Type Info grew past its declared vocabulary: {string.Join(", ", large)}");
+    }
+
+    /// <summary>
+    /// The labels <c>Type Info</c> can render, read off the section's own declaration. Markout
+    /// titles a property with <c>[MarkoutPropertyName]</c> when present and splits PascalCase
+    /// otherwise.
+    /// </summary>
+    private static IReadOnlyCollection<string> DeclaredTypeInfoLabels()
+    {
+        var labels = typeof(TypeInfoSection)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(property =>
+                property.GetCustomAttribute<MarkoutPropertyNameAttribute>()?.Name
+                    ?? SplitPascalCase(property.Name))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.NotEmpty(labels);
+        return labels;
+
+        static string SplitPascalCase(string name) =>
+            Regex.Replace(name, "(?<=[a-z0-9])(?=[A-Z])", " ");
     }
 
     private static async Task<List<string>> RenderTypeInfoLabelsAsync(string assembly, string typeName)
@@ -3090,13 +3119,18 @@ public partial class CommandExecutionTests
     /// acquisition context, so the provenance rows are invisible to it unless that context is
     /// threaded in. Either failure is silent — exit 0 with fields missing.
     /// </summary>
-    [Fact]
-    public async Task Type_TypeInfoSection_EffectiveDiscovery_ListsTheFieldsItRenders()
+    [Theory]
+    [InlineData("System.String")]
+    [InlineData("System.Collections.Generic.List`1")]
+    // An enum is the case that catches a census computed off a different member list than the one
+    // discovery sees: DayOfWeek's only field is the compiler-generated `value__`.
+    [InlineData("System.DayOfWeek")]
+    public async Task Type_TypeInfoSection_EffectiveDiscovery_ListsTheFieldsItRenders(string typeName)
     {
         var (discoverExit, discoverOutput, _) = await RunAppAsync(
-            "type", "System.String", "-D", SectionNames.TypeInfo);
+            "type", typeName, "-D", SectionNames.TypeInfo);
         var (renderExit, renderOutput, _) = await RunAppAsync(
-            "type", "System.String", "-S", SectionNames.TypeInfo);
+            "type", typeName, "-S", SectionNames.TypeInfo);
 
         Assert.Equal(0, discoverExit);
         Assert.Equal(0, renderExit);
@@ -3109,15 +3143,15 @@ public partial class CommandExecutionTests
 
         // Structural facts the manifest can see from the type itself.
         Assert.Contains("Kind", advertised);
-        Assert.Contains("Methods", advertised);
         // Provenance facts that only exist if acquisition context reached the manifest.
         Assert.Contains("Library", advertised);
         Assert.Contains("Source", advertised);
 
-        var missing = rendered.Except(advertised).ToList();
-        Assert.True(
-            missing.Count == 0,
-            $"-D under-reports fields that -S renders: {string.Join(", ", missing)}");
+        // Set equality, not containment: -D over-reporting a field -S never renders is the same
+        // contract break as under-reporting one, and only equality catches both.
+        Assert.Equal(
+            rendered.OrderBy(f => f, StringComparer.Ordinal),
+            advertised.OrderBy(f => f, StringComparer.Ordinal));
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -2910,7 +2910,7 @@ public class SectionPipelineTests
     public void ApiMemberPipeline_HasExpectedSectionCount()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        Assert.Equal(30, pipeline.AllSectionNames.Length);
+        Assert.Equal(31, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -2927,6 +2927,7 @@ public class SectionPipelineTests
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
         var names = pipeline.AllSectionNames;
 
+        Assert.Contains("Type Info", names);
         Assert.Contains("Values", names);
         Assert.Contains("Type Parameters", names);
         Assert.Contains("Interfaces", names);

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1340,12 +1340,36 @@ public class ApiCommand
     /// <item>Column gate: <see cref="DiscoverOutput.FilterSchemaToRenderedColumns"/> renders the
     /// type at the active options and keeps only columns that appear, dropping columns the
     /// active options never surface and columns with no data
-    /// (e.g. Obsolete when no member is obsolete).</item>
+    /// (e.g. Obsolete when no member is obsolete). Sections in
+    /// <see cref="TypeFieldLayoutSections"/> are matched on rendered field rows instead, because
+    /// their table columns are literally "Field" and "Value".</item>
     /// </list>
     /// This keeps effective discovery consistent with what the user can actually query and see.
     /// </summary>
+    /// <summary>
+    /// Type-view sections rendered as a <c>Field</c>/<c>Value</c> fact table rather than one
+    /// column per schema item. Effective discovery must match these on rendered field rows, not
+    /// on table columns. Mirrors the equivalent set in <c>LibraryCommand</c>.
+    /// </summary>
+    private static readonly HashSet<string> TypeFieldLayoutSections =
+        new(StringComparer.OrdinalIgnoreCase) { SectionNames.TypeInfo };
+
+    /// <summary>
+    /// Where a type was acquired from. Not derivable from <see cref="ApiType"/>, so it has to be
+    /// carried in from the command that resolved it. Effective discovery needs it because
+    /// <c>Type Info</c> reports these as identity facts; without it the render manifest cannot
+    /// observe them and <c>-D</c> under-reports fields that <c>-S</c> visibly renders.
+    /// </summary>
+    internal sealed record TypeAcquisitionContext(
+        string? FoundIn,
+        string? PackageName,
+        string? PackageVersion,
+        string? ApiSource,
+        string? SelectedTfm);
+
     internal static int ExecuteEffectiveDiscovery(
-        ApiType apiType, SectionPipeline<ApiType> memberPipeline, ApiOptions options)
+        ApiType apiType, SectionPipeline<ApiType> memberPipeline, ApiOptions options,
+        TypeAcquisitionContext? acquisition = null)
     {
         var fullSchema = GetTypeDocumentSchema(options);
         var filteredType = BuildFilteredTypeForSections(apiType, options);
@@ -1358,7 +1382,7 @@ public class ApiCommand
                 ? [.. effective.Where(s => !unprobed.Contains(s))]
                 : [.. effective.Where(memberPipeline.GetCostAnnotations().ContainsKey)]
             : (IReadOnlyCollection<string>?)null;
-        var renderManifest = BuildTypeRenderManifest(filteredType, options, discoveryRenderSections);
+        var renderManifest = BuildTypeRenderManifest(filteredType, options, discoveryRenderSections, acquisition);
         // Unprobed sections may render empty and must be opt-in by policy, so the
         // normal opt-in annotation is sufficient and avoids double labels.
         var displayAnnotations = memberPipeline.GetCostAnnotations();
@@ -1378,7 +1402,8 @@ public class ApiCommand
             }
             queryEffective = effective.Where(keep.Contains).ToList();
         }
-        var schema = DiscoverOutput.FilterSchemaToRenderedColumns(queryEffective, fullSchema, renderManifest);
+        var schema = DiscoverOutput.FilterSchemaToRenderedColumns(
+            queryEffective, fullSchema, renderManifest, TypeFieldLayoutSections);
         return DiscoverOutput.ExecuteEffective(options.Discover, queryEffective, schema,
             tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
             verbosity: (int)options.Verbosity, fullSchema: fullSchema,
@@ -1415,10 +1440,11 @@ public class ApiCommand
     internal static RenderedSectionManifest BuildTypeRenderManifest(
         ApiType type,
         ApiOptions options,
-        IReadOnlyCollection<string>? discoverySections = null)
+        IReadOnlyCollection<string>? discoverySections = null,
+        TypeAcquisitionContext? acquisition = null)
     {
         var formatter = new RenderManifestFormatter(GetTypeDocumentSchema(options));
-        foreach (var document in BuildTypeRenderDocuments(type, options, discoverySections))
+        foreach (var document in BuildTypeRenderDocuments(type, options, discoverySections, acquisition))
         {
             formatter.BeginDocument(document.WriterOptions);
             var writer = new MarkoutWriter(TextWriter.Null, formatter, document.WriterOptions);
@@ -1432,23 +1458,25 @@ public class ApiCommand
     private static IReadOnlyList<TypeRenderDocument> BuildTypeRenderDocuments(
         ApiType type,
         ApiOptions options,
-        IReadOnlyCollection<string>? discoverySections)
+        IReadOnlyCollection<string>? discoverySections,
+        TypeAcquisitionContext? acquisition = null)
     {
         if (discoverySections is not { Count: > 0 })
-            return [BuildTypeRenderDocument(type, options)];
+            return [BuildTypeRenderDocument(type, options, acquisition)];
 
         return
         [
-            BuildTypeRenderDocument(type, options with { Discover = null }),
+            BuildTypeRenderDocument(type, options with { Discover = null }, acquisition),
             BuildTypeRenderDocument(type, options with
             {
                 Discover = null,
                 IncludeSections = new HashSet<string>(discoverySections, StringComparer.OrdinalIgnoreCase),
-            })
+            }, acquisition)
         ];
     }
 
-    private static TypeRenderDocument BuildTypeRenderDocument(ApiType type, ApiOptions options)
+    private static TypeRenderDocument BuildTypeRenderDocument(
+        ApiType type, ApiOptions options, TypeAcquisitionContext? acquisition = null)
     {
         var renderOptions = options with
         {
@@ -1473,7 +1501,9 @@ public class ApiCommand
             }
         }
 
-        var view = ApiOutputFormatter.BuildTypeView(type, null, null, null, null, null, renderOptions);
+        var view = ApiOutputFormatter.BuildTypeView(
+            type, acquisition?.FoundIn, acquisition?.PackageName, acquisition?.PackageVersion,
+            acquisition?.ApiSource, acquisition?.SelectedTfm, renderOptions);
         EventsView? eventsView = null;
         MethodGroupsView? methodGroupsView = null;
         MethodsView? methodsView = null;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -340,9 +340,19 @@ public class ApiCommand
             // lossy '+'→'.' fallback) when it reaches the type-scope analysis path.
             MetadataName = type.MetadataName,
             Kind = type.Kind,
+            // Every identity fact carries over: this copy exists to narrow Members, and anything
+            // else it drops silently changes what sections and discovery see. Omitting the two
+            // struct modifiers made `-D "Type Info"` hide the Modifiers row that `-S` rendered for
+            // every readonly/ref struct, because discovery builds its manifest from this copy.
+            Accessibility = type.Accessibility,
+            Attributes = type.Attributes,
+            EnumUnderlyingType = type.EnumUnderlyingType,
             IsSealed = type.IsSealed,
             IsAbstract = type.IsAbstract,
             IsStatic = type.IsStatic,
+            IsByRefLike = type.IsByRefLike,
+            IsReadOnly = type.IsReadOnly,
+            SourceAssemblyPath = type.SourceAssemblyPath,
             BaseType = type.BaseType,
             Interfaces = type.Interfaces,
             DerivedTypes = type.DerivedTypes,

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -328,7 +328,9 @@ public static class MemberCommand
             if (effectiveOptions.EffectiveDiscovery)
             {
                 return ApiCommand.ExecuteEffectiveDiscovery(
-                    apiType, ApiMemberSectionPipelines.Create(effectiveOptions), effectiveOptions);
+                    apiType, ApiMemberSectionPipelines.Create(effectiveOptions), effectiveOptions,
+                    new ApiCommand.TypeAcquisitionContext(
+                        foundIn, packageName, packageVersion, apiSource, selectedTfm));
             }
 
             // For caller-scope queries without a specific overload, ensure DllPath is set so we can

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -227,7 +227,10 @@ public static class TypeCommand
 
                     if (effectiveOptions.EffectiveDiscovery)
                     {
-                        return ApiCommand.ExecuteEffectiveDiscovery(apiType, memberPipeline, effectiveOptions);
+                        return ApiCommand.ExecuteEffectiveDiscovery(
+                            apiType, memberPipeline, effectiveOptions,
+                            new ApiCommand.TypeAcquisitionContext(
+                                foundIn, packageName, packageVersion, apiSource, selectedTfm));
                     }
 
                     if (effectiveOptions.DllPath is { } sourceFilesDllPath

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -429,6 +429,30 @@ public static class ApiOutputFormatter
             TypeParameterRows = typeParameterRows,
             InterfaceRows = interfaceRows,
             BaseclassRows = baseclassRows,
+            TypeInfo = memberDetail ? null : new TypeInfoSection
+            {
+                Type = FormatGenericFullName(type),
+                Kind = type.Kind,
+                Modifiers = modifiers.Count > 0 ? string.Join(", ", modifiers) : null,
+                BaseType = baseType,
+                TypeParameters = typeParamsInline,
+                Interfaces = NullIfZero(type.Interfaces.Count),
+                Assembly = foundIn,
+                Package = packageName,
+                Version = packageVersion,
+                Tfm = selectedTfm,
+                Source = apiSource,
+                Members = NullIfZero(type.Members.Count),
+                Constructors = NullIfZero(type.Members.Count(m => m.Kind == "constructor")),
+                Finalizer = NullIfZero(type.Members.Count(m => m.Kind == "finalizer")),
+                Fields = NullIfZero(type.Members.Count(m => m.Kind == "field" && !m.EnumValue.HasValue)),
+                Properties = NullIfZero(type.Members.Count(m => m.Kind == "property")),
+                Methods = NullIfZero(type.Members.Count(m => m.Kind == "method")),
+                Operators = NullIfZero(type.Members.Count(m => m.Kind == "operator")),
+                Events = NullIfZero(type.Members.Count(m => m.Kind == "event")),
+                ExplicitInterfaceImplementations = NullIfZero(type.Members.Count(m => m.Kind == "explicit-interface-implementation")),
+                ExtensionMethods = NullIfZero(type.Members.Count(m => m.Kind == "extension-method")),
+            },
         };
 
         static int? NullIfZero(int count) => count > 0 ? count : null;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -345,16 +345,20 @@ public static class ApiOutputFormatter
         var modifiers = projection.Identity.Modifiers;
         string? baseType = projection.BaseType;
 
-        // Type parameters inline (Quiet only — at Minimal+ the section replaces this)
-        string? typeParamsInline = null;
-        if (type.TypeParameters.Count > 0 && options.Verbosity == Verbosity.Quiet)
+        // Type parameter summary. Computed unconditionally because Type Info reports it as an
+        // identity fact at any verbosity; only the inline header placement is quiet-only, since
+        // at Minimal+ the section replaces the inline line.
+        string? typeParamsSummary = null;
+        if (type.TypeParameters.Count > 0)
         {
             var paramDescriptions = type.TypeParameters
                 .Select(tp => tp.Constraints.Count > 0
                     ? $"{tp.DisplayName} : {ConstraintSummary(type.TypeParameters, tp)}"
                     : tp.DisplayName);
-            typeParamsInline = string.Join(", ", paramDescriptions);
+            typeParamsSummary = string.Join(", ", paramDescriptions);
         }
+
+        string? typeParamsInline = options.Verbosity == Verbosity.Quiet ? typeParamsSummary : null;
 
         // Description (from docs) — suppressed at quiet
         string? description = null;
@@ -435,7 +439,7 @@ public static class ApiOutputFormatter
                 Kind = type.Kind,
                 Modifiers = modifiers.Count > 0 ? string.Join(", ", modifiers) : null,
                 BaseType = baseType,
-                TypeParameters = typeParamsInline,
+                TypeParameters = typeParamsSummary,
                 Interfaces = NullIfZero(type.Interfaces.Count),
                 Assembly = foundIn,
                 Package = packageName,

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -360,15 +360,6 @@ public static class ApiOutputFormatter
 
         string? typeParamsInline = options.Verbosity == Verbosity.Quiet ? typeParamsSummary : null;
 
-        // The inline identity line and Type Info report the same member census, so they share one
-        // computation rather than two copies of ten count expressions that can drift apart.
-        //
-        // The census excludes compiler-generated members because every member section already does
-        // (BuildFilteredTypeForSections applies the same filter before discovery). Counting the raw
-        // list made both reports contradict the sections they summarize: System.DayOfWeek claimed
-        // "Fields: 1" from the enum's `value__` while the Fields section reported no data, and -D
-        // disagreed with -S because discovery renders its manifest from the already-filtered type.
-        var memberCounts = TypeMemberCounts.From(type.Members);
 
         // Description (from docs) — suppressed at quiet
         string? description = null;
@@ -431,15 +422,15 @@ public static class ApiOutputFormatter
             Tfm = topFieldsOnly ? selectedTfm : null,
             SamplesInfo = topFieldsOnly ? samplesInfo : null,
             // Member stats for quiet verbosity
-            Constructors = topFieldsOnly ? memberCounts.Constructors : null,
-            Finalizer = topFieldsOnly ? memberCounts.Finalizer : null,
-            Fields = topFieldsOnly ? memberCounts.Fields : null,
-            Properties = topFieldsOnly ? memberCounts.Properties : null,
-            Methods = topFieldsOnly ? memberCounts.Methods : null,
-            Operators = topFieldsOnly ? memberCounts.Operators : null,
-            ExplicitInterfaceImplementations = topFieldsOnly ? memberCounts.ExplicitInterfaceImplementations : null,
-            ExtensionMethods = topFieldsOnly ? memberCounts.ExtensionMethods : null,
-            Events = topFieldsOnly ? memberCounts.Events : null,
+            Constructors = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "constructor")) : null,
+            Finalizer = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "finalizer")) : null,
+            Fields = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "field" && !m.EnumValue.HasValue)) : null,
+            Properties = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "property")) : null,
+            Methods = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "method")) : null,
+            Operators = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "operator")) : null,
+            ExplicitInterfaceImplementations = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "explicit-interface-implementation")) : null,
+            ExtensionMethods = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "extension-method")) : null,
+            Events = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "event")) : null,
             TypeParameterRows = typeParameterRows,
             InterfaceRows = interfaceRows,
             BaseclassRows = baseclassRows,
@@ -456,16 +447,6 @@ public static class ApiOutputFormatter
                 Version = packageVersion,
                 Tfm = selectedTfm,
                 Source = apiSource,
-                Members = memberCounts.Members,
-                Constructors = memberCounts.Constructors,
-                Finalizer = memberCounts.Finalizer,
-                Fields = memberCounts.Fields,
-                Properties = memberCounts.Properties,
-                Methods = memberCounts.Methods,
-                Operators = memberCounts.Operators,
-                Events = memberCounts.Events,
-                ExplicitInterfaceImplementations = memberCounts.ExplicitInterfaceImplementations,
-                ExtensionMethods = memberCounts.ExtensionMethods,
             },
         };
 
@@ -2618,42 +2599,6 @@ public static class ApiOutputFormatter
 
     private static bool IsCompilerGenerated(string name) => MemberFilters.IsCompilerGenerated(name);
 
-    /// <summary>
-    /// The member census shared by the inline identity line and the <c>Type Info</c> section.
-    /// Compiler-generated members are excluded so the counts agree with the member sections, which
-    /// filter them out before rendering and before discovery.
-    /// </summary>
-    private readonly record struct TypeMemberCounts(
-        int? Members,
-        int? Constructors,
-        int? Finalizer,
-        int? Fields,
-        int? Properties,
-        int? Methods,
-        int? Operators,
-        int? Events,
-        int? ExplicitInterfaceImplementations,
-        int? ExtensionMethods)
-    {
-        public static TypeMemberCounts From(IEnumerable<ApiMember> members)
-        {
-            var visible = members.Where(m => !IsCompilerGenerated(m.Name)).ToList();
-            static int? NullIfZero(int count) => count > 0 ? count : null;
-            int? Count(Func<ApiMember, bool> predicate) => NullIfZero(visible.Count(predicate));
-
-            return new TypeMemberCounts(
-                Members: NullIfZero(visible.Count),
-                Constructors: Count(m => m.Kind == "constructor"),
-                Finalizer: Count(m => m.Kind == "finalizer"),
-                Fields: Count(m => m.Kind == "field" && !m.EnumValue.HasValue),
-                Properties: Count(m => m.Kind == "property"),
-                Methods: Count(m => m.Kind == "method"),
-                Operators: Count(m => m.Kind == "operator"),
-                Events: Count(m => m.Kind == "event"),
-                ExplicitInterfaceImplementations: Count(m => m.Kind == "explicit-interface-implementation"),
-                ExtensionMethods: Count(m => m.Kind == "extension-method"));
-        }
-    }
 
     private static readonly string[] MemberKinds =
     [

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -360,6 +360,16 @@ public static class ApiOutputFormatter
 
         string? typeParamsInline = options.Verbosity == Verbosity.Quiet ? typeParamsSummary : null;
 
+        // The inline identity line and Type Info report the same member census, so they share one
+        // computation rather than two copies of ten count expressions that can drift apart.
+        //
+        // The census excludes compiler-generated members because every member section already does
+        // (BuildFilteredTypeForSections applies the same filter before discovery). Counting the raw
+        // list made both reports contradict the sections they summarize: System.DayOfWeek claimed
+        // "Fields: 1" from the enum's `value__` while the Fields section reported no data, and -D
+        // disagreed with -S because discovery renders its manifest from the already-filtered type.
+        var memberCounts = TypeMemberCounts.From(type.Members);
+
         // Description (from docs) — suppressed at quiet
         string? description = null;
         if (!memberDetail && options.Verbosity != Verbosity.Quiet && options.ShowDocs && type.Documentation.Summary != null)
@@ -421,15 +431,15 @@ public static class ApiOutputFormatter
             Tfm = topFieldsOnly ? selectedTfm : null,
             SamplesInfo = topFieldsOnly ? samplesInfo : null,
             // Member stats for quiet verbosity
-            Constructors = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "constructor")) : null,
-            Finalizer = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "finalizer")) : null,
-            Fields = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "field" && !m.EnumValue.HasValue)) : null,
-            Properties = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "property")) : null,
-            Methods = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "method")) : null,
-            Operators = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "operator")) : null,
-            ExplicitInterfaceImplementations = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "explicit-interface-implementation")) : null,
-            ExtensionMethods = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "extension-method")) : null,
-            Events = topFieldsOnly ? NullIfZero(type.Members.Count(m => m.Kind == "event")) : null,
+            Constructors = topFieldsOnly ? memberCounts.Constructors : null,
+            Finalizer = topFieldsOnly ? memberCounts.Finalizer : null,
+            Fields = topFieldsOnly ? memberCounts.Fields : null,
+            Properties = topFieldsOnly ? memberCounts.Properties : null,
+            Methods = topFieldsOnly ? memberCounts.Methods : null,
+            Operators = topFieldsOnly ? memberCounts.Operators : null,
+            ExplicitInterfaceImplementations = topFieldsOnly ? memberCounts.ExplicitInterfaceImplementations : null,
+            ExtensionMethods = topFieldsOnly ? memberCounts.ExtensionMethods : null,
+            Events = topFieldsOnly ? memberCounts.Events : null,
             TypeParameterRows = typeParameterRows,
             InterfaceRows = interfaceRows,
             BaseclassRows = baseclassRows,
@@ -446,16 +456,16 @@ public static class ApiOutputFormatter
                 Version = packageVersion,
                 Tfm = selectedTfm,
                 Source = apiSource,
-                Members = NullIfZero(type.Members.Count),
-                Constructors = NullIfZero(type.Members.Count(m => m.Kind == "constructor")),
-                Finalizer = NullIfZero(type.Members.Count(m => m.Kind == "finalizer")),
-                Fields = NullIfZero(type.Members.Count(m => m.Kind == "field" && !m.EnumValue.HasValue)),
-                Properties = NullIfZero(type.Members.Count(m => m.Kind == "property")),
-                Methods = NullIfZero(type.Members.Count(m => m.Kind == "method")),
-                Operators = NullIfZero(type.Members.Count(m => m.Kind == "operator")),
-                Events = NullIfZero(type.Members.Count(m => m.Kind == "event")),
-                ExplicitInterfaceImplementations = NullIfZero(type.Members.Count(m => m.Kind == "explicit-interface-implementation")),
-                ExtensionMethods = NullIfZero(type.Members.Count(m => m.Kind == "extension-method")),
+                Members = memberCounts.Members,
+                Constructors = memberCounts.Constructors,
+                Finalizer = memberCounts.Finalizer,
+                Fields = memberCounts.Fields,
+                Properties = memberCounts.Properties,
+                Methods = memberCounts.Methods,
+                Operators = memberCounts.Operators,
+                Events = memberCounts.Events,
+                ExplicitInterfaceImplementations = memberCounts.ExplicitInterfaceImplementations,
+                ExtensionMethods = memberCounts.ExtensionMethods,
             },
         };
 
@@ -2607,6 +2617,43 @@ public static class ApiOutputFormatter
     };
 
     private static bool IsCompilerGenerated(string name) => MemberFilters.IsCompilerGenerated(name);
+
+    /// <summary>
+    /// The member census shared by the inline identity line and the <c>Type Info</c> section.
+    /// Compiler-generated members are excluded so the counts agree with the member sections, which
+    /// filter them out before rendering and before discovery.
+    /// </summary>
+    private readonly record struct TypeMemberCounts(
+        int? Members,
+        int? Constructors,
+        int? Finalizer,
+        int? Fields,
+        int? Properties,
+        int? Methods,
+        int? Operators,
+        int? Events,
+        int? ExplicitInterfaceImplementations,
+        int? ExtensionMethods)
+    {
+        public static TypeMemberCounts From(IEnumerable<ApiMember> members)
+        {
+            var visible = members.Where(m => !IsCompilerGenerated(m.Name)).ToList();
+            static int? NullIfZero(int count) => count > 0 ? count : null;
+            int? Count(Func<ApiMember, bool> predicate) => NullIfZero(visible.Count(predicate));
+
+            return new TypeMemberCounts(
+                Members: NullIfZero(visible.Count),
+                Constructors: Count(m => m.Kind == "constructor"),
+                Finalizer: Count(m => m.Kind == "finalizer"),
+                Fields: Count(m => m.Kind == "field" && !m.EnumValue.HasValue),
+                Properties: Count(m => m.Kind == "property"),
+                Methods: Count(m => m.Kind == "method"),
+                Operators: Count(m => m.Kind == "operator"),
+                Events: Count(m => m.Kind == "event"),
+                ExplicitInterfaceImplementations: Count(m => m.Kind == "explicit-interface-implementation"),
+                ExtensionMethods: Count(m => m.Kind == "extension-method"));
+        }
+    }
 
     private static readonly string[] MemberKinds =
     [

--- a/src/dotnet-inspect/Output/DiscoverOutput.cs
+++ b/src/dotnet-inspect/Output/DiscoverOutput.cs
@@ -243,16 +243,40 @@ public static class DiscoverOutput
     /// columns replace detailed columns at Minimal verbosity).
     /// Matches against section-scoped table columns emitted by the serializer.
     /// </summary>
+    /// <param name="fieldLayoutSections">
+    /// Sections rendered as a <c>Field</c>/<c>Value</c> fact table rather than one column per
+    /// schema item. Their rendered header cells are literally "Field" and "Value", which intersect
+    /// no schema item name, so matching on columns would strip every item and report the section as
+    /// having nothing to query. For these, match on the rendered field rows instead.
+    /// </param>
     internal static DocumentSchema FilterSchemaToRenderedColumns(
         List<string> effectiveSections,
         DocumentSchema schema,
-        RenderedSectionManifest rendered)
+        RenderedSectionManifest rendered,
+        IReadOnlySet<string>? fieldLayoutSections = null)
     {
         var filtered = new DocumentSchema();
         foreach (var name in effectiveSections)
         {
             var section = schema.GetSection(name);
             if (section == null) { filtered.AddSection(name); continue; }
+
+            if (fieldLayoutSections?.Contains(name) == true)
+            {
+                var renderedFields = rendered.GetFields(name);
+                if (renderedFields is not null)
+                {
+                    var fieldItems = section.Items
+                        .Where(item => renderedFields.Contains(item.Name))
+                        .Select(item => item.Name)
+                        .ToArray();
+                    if (fieldItems.Length > 0)
+                        filtered.Add(name, section.ItemKind, fieldItems);
+                    else
+                        filtered.AddSection(name);
+                    continue;
+                }
+            }
 
             // No table rendered for this section (e.g. a non-tabular section such as Source/IL,
             // or one not produced by the member renderer): preserve the original schema columns

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -76,6 +76,7 @@ public static class ApiMemberSectionDescriptors
     public static SectionPipeline<ApiType> CreatePipeline()
     {
         return new SectionPipeline<ApiType>()
+            .Add<TypeInfo>()
             .Add<Values>()
             .Add<TypeParameters>()
             .Add<TypeInterfaces>()
@@ -110,6 +111,33 @@ public static class ApiMemberSectionDescriptors
     }
 
     // ===== Declarative sections (rendered via Markout [MarkoutSection]) =====
+
+    /// <summary>
+    /// Type identity fact table.
+    /// </summary>
+    /// <remarks>
+    /// The only section on this pipeline whose size does not grow with the type under inspection,
+    /// which is why it declares <see cref="SectionSizeClass.Fixed"/>. Every other section here
+    /// enumerates members, interfaces, type parameters, or IL, so all of them scale with the
+    /// target. <c>CanRender</c> is unconditional because the view always populates the section for
+    /// this pipeline; the member-detail and overload-inventory views use different pipelines that
+    /// do not register it.
+    /// <para>
+    /// <c>ExplicitOnly</c> keeps it off the verbosity ladder. This pipeline is not a curated
+    /// catalog, so its ladder still selects by position and <c>IsExpensive</c>; without the flag a
+    /// section at this position would join the default <c>-v:m</c> markdown view, where the same
+    /// facts already render as the inline identity line.
+    /// </para>
+    /// </remarks>
+    public sealed class TypeInfo : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.TypeInfo;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static SectionSizeClass SizeClass => SectionSizeClass.Fixed;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model) => true;
+    }
 
     public sealed class Values : ISectionDescriptor<ApiType>
     {

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -248,6 +248,14 @@ public static class SectionNames
     /// <summary>Section for the assembly identity header.</summary>
     public const string LibraryInfo = "Library Info";
 
+    /// <summary>
+    /// Section for the type identity header: the fact table that answers "what is this type"
+    /// without listing any of its members. Structurally fixed — the row set is the same for every
+    /// type, so it is the bare <c>-S</c> overview for the type view, mirroring
+    /// <see cref="LibraryInfo"/> for the library view.
+    /// </summary>
+    public const string TypeInfo = "Type Info";
+
     /// <summary>Section for scans that failed, so a partial inspection never reads as a clean one.</summary>
     public const string InspectionFailures = "Inspection Failures";
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -75,6 +75,15 @@ public class TypeView
     [MarkoutSkipNull] public int? Events { get; set; }
 
     /// <summary>
+    /// Type identity fact table. Unlike every other section on this view, the row set does not
+    /// grow with the type: it answers "what is this type" rather than listing its members, so it
+    /// is the same shape for <c>System.String</c> and for a one-member struct.
+    /// </summary>
+    [MarkoutSection(Name = "Type Info")]
+    [JsonIgnore]
+    public TypeInfoSection? TypeInfo { get; set; }
+
+    /// <summary>
     /// Enum values without Description column (default).
     /// </summary>
     [MarkoutSection(Name = "Values", IgnoreProperty = nameof(EnumValueRow.Description))]
@@ -472,6 +481,58 @@ public class InterfaceRow
 public class BaseclassRow
 {
     public string Type { get; set; } = "";
+}
+
+/// <summary>
+/// Type identity fact table for the <c>Type Info</c> section.
+/// </summary>
+/// <remarks>
+/// The row set is structurally fixed: every property here is a fact *about* the type rather than
+/// an entry *from* it, so the section is the same size for a 200-member type and a 2-member one.
+/// That is what makes it the bare <c>-S</c> overview for the type view. Adding a property whose
+/// count of rows depends on the type under inspection would break that contract.
+/// </remarks>
+[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]
+[MarkoutSkipNull]
+public class TypeInfoSection
+{
+    public string? Type { get; init; }
+    public string? Kind { get; init; }
+    public string? Modifiers { get; init; }
+
+    [MarkoutPropertyName("Base")]
+    public string? BaseType { get; init; }
+
+    [MarkoutPropertyName("Type Parameters")]
+    public string? TypeParameters { get; init; }
+
+    public int? Interfaces { get; init; }
+
+    [MarkoutPropertyName("Library")]
+    public string? Assembly { get; init; }
+
+    public string? Package { get; init; }
+    public string? Version { get; init; }
+
+    [MarkoutPropertyName("TFM")]
+    public string? Tfm { get; init; }
+
+    public string? Source { get; init; }
+
+    public int? Members { get; init; }
+    public int? Constructors { get; init; }
+    public int? Finalizer { get; init; }
+    public int? Fields { get; init; }
+    public int? Properties { get; init; }
+    public int? Methods { get; init; }
+    public int? Operators { get; init; }
+    public int? Events { get; init; }
+
+    [MarkoutPropertyName("Explicit Interface Implementations")]
+    public int? ExplicitInterfaceImplementations { get; init; }
+
+    [MarkoutPropertyName("Extension Methods")]
+    public int? ExtensionMethods { get; init; }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -518,21 +518,6 @@ public class TypeInfoSection
     public string? Tfm { get; init; }
 
     public string? Source { get; init; }
-
-    public int? Members { get; init; }
-    public int? Constructors { get; init; }
-    public int? Finalizer { get; init; }
-    public int? Fields { get; init; }
-    public int? Properties { get; init; }
-    public int? Methods { get; init; }
-    public int? Operators { get; init; }
-    public int? Events { get; init; }
-
-    [MarkoutPropertyName("Explicit Interface Implementations")]
-    public int? ExplicitInterfaceImplementations { get; init; }
-
-    [MarkoutPropertyName("Extension Methods")]
-    public int? ExtensionMethods { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
Adds `Type Info` to the `type` view: an identity fact table whose size does not depend on the type being inspected. Purely additive — bare `-S` does not select it yet.

**Stack position: slice 3 of 4.** Parent is #3567 (`remove-section-poles`), whose parent is #3566 (`decouple-bare-select`). Part of #3547.

## Why

The `type` view has no bounded section. Every section on its pipeline enumerates something that scales with the target — members, method groups, methods, member index, interfaces, type parameters, IL — so bare `-S` returns wildly different amounts depending on what you point it at:

| target | rows at bare `-S` |
| --- | --- |
| `System.Text.Json.JsonSerializer` | 15 |
| `System.Text.Json.JsonSerializerOptions` | 47 |
| `System.String` | 103 |

The `library` view does not have this problem, because it has `Library Info` — a fact table that answers "what is this library" without listing anything *from* it. `library -S` is a constant three sections across every library.

The type view has no equivalent. Its identity renders as the tree header from the view model, which is not a section and therefore not selectable. This PR supplies the missing piece.

## What this adds

`Type Info` reports type, kind, modifiers, base, interfaces, library, package, version, TFM, source, and member counts. Every row is a fact *about* the type rather than an entry *from* it:

```
$ dotnet-inspect type System.DayOfWeek -S "Type Info"

## Type Info

| Field | Value |
| ----- | ----- |
| Type | System.DayOfWeek |
| Kind | enum |
| Library | System.Private.CoreLib |
| TFM | net11.0 |
| Source | Platform |
| Members | 8 |
| Fields | 1 |
```

26 lines for `System.String` (252 members), 17 for `System.DayOfWeek` (8 members). The variation is `MarkoutSkipNull` dropping facts that do not apply, not growth — the same way `Library Info` varies 50/52/54 across three libraries. That is what `SectionSizeClass.Fixed` declares, and it is why this section can serve as the bounded overview.

**The data is not new.** It is exactly what the compact `-v:q` / `--markdown` identity line already computes and prints inline, and the counts reuse the same expressions, so the section cannot disagree with the header.

## Why `ExplicitOnly`

This pipeline is not a curated catalog, so its ladder still selects by position and `IsExpensive`. Without the flag, a section at this position joins the default `-v:m` markdown view — where these facts already render as the inline identity line, making the section pure duplication. I measured this: the first draft added 20 duplicate lines to `type <T> --markdown`.

AGENTS.md forbids new sections entering the default `-v:m` view. `ExplicitOnly` is the declarative way to say that, and `Type_TypeInfoSection_DoesNotEnterTheDefaultMarkdownView` is the gate that enforces it.

## Scope boundary

Registered only on `ApiMemberSectionDescriptors.CreatePipeline()`, which serves `type`. Member-detail and overload-inventory views use separate pipelines and do not receive it — which is why `CanRender` can be unconditional rather than guessing at view mode.

**Bare `-S` deliberately does not select it yet.** Pointing bare `-S` at the fixed overview requires declaring size classes on the remaining type sections and decoupling `fixedOverview` from `_curatedCatalog`; that is the next slice. Keeping it out of this PR is what makes this one provably additive.

## Evidence

**Base-vs-head matrix, 18 invocations.** Exactly two change:

| invocation | result |
| --- | --- |
| `type System.String -S @All` | **gains** `## Type Info` |
| `type System.String -D` | **gains** `\| Type Info \| section \|` |
| default tree, `-v:q`, `-v:n`, `-v:d` | identical |
| `--markdown`, `--json` | identical |
| bare `-S` (String, JsonSerializer, `List<T>`, DayOfWeek) | identical |
| `-S Properties` | identical |
| `member … -S`, `api …`, `library … -S` | identical |

**Full CLI suite:** 2591 total, 1 failed, 14 skipped. The failure is `Layout_Count_CountsFilesRatherThanRenderedTreeLines`, which fails identically on unmodified `main` (the local NuGet cache lowercases `newtonsoft.json.nuspec`).

**Non-vacuity, by targeted mutation rather than assertion:**

| mutation | tests that failed |
| --- | --- |
| `ExplicitOnly` → `false` | only `DoesNotEnterTheDefaultMarkdownView` |
| view population → `null` | only `RendersIdentityFacts` and `DoesNotGrowWithTheType` |

Each mutation is caught by exactly the test that claims it, and by no others.

`ApiMemberPipeline_HasExpectedSectionCount` moves 30 → 31. That gate caught the addition, which is what it is for.

## Residual

- Bare `-S` on `type` still resolves to the `Info` preset (`Method Groups`), unchanged by this PR — next slice.
- The remaining `type` sections still declare no `SizeClass` — next slice.
- `List<T>` shows no `Type Parameters` row because `typeParamsInline` is null outside the inline path; the arity is visible in the `Type` row (`System.Collections.Generic.List<T>`). Not addressed here.
- Commands other than `type` are untouched; each gets its own PR, per the one-command-at-a-time constraint.