### PR TITLE
Pin the PDB declaration-placement frontier with a fixture (#3591)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -6424,3 +6424,72 @@ public sealed class CallArgClient
     public int CreateViaVolatileField()
         => _volatileRest.Create(new CallArgTarget { Name = Label }, default, _options);
 }
+
+// Declaration placement (#3591). A local the source declared inside a nested block
+// is emitted as a bare declaration hoisted to the top of the method, because
+// MetadataSource.LocalNames reads the portable PDB's LocalScope table for names only
+// and drops each scope's StartOffset/EndOffset. These two shapes are the discriminator
+// the PDB records and the printer currently ignores: in CreateNarrow the local's scope
+// is the try block, in CreateHoisted it is the whole method, and both print the same
+// way. Modeled on Azure.Data.Tables `TableClient.Create`. Appended at end of file so
+// these top-level types cannot shift any existing generated-code ordinal.
+public sealed class DeclScopeGuard : IDisposable
+{
+    public void Failed(Exception e) { }
+
+    public void Dispose() { }
+}
+
+public sealed class DeclScopeResult
+{
+    public string Value = "v";
+    public int Raw;
+}
+
+public sealed class DeclScopeOps
+{
+    public DeclScopeResult Create(string name, int timeout) => new DeclScopeResult { Value = name, Raw = timeout };
+}
+
+public sealed class DeclScopeClient
+{
+    readonly DeclScopeOps _ops = new();
+
+    // The local is read twice (so it survives as a slot rather than inlining) and is
+    // never referenced outside the try, so the PDB scopes it to the try block alone.
+    public string CreateNarrow(string name, int timeout)
+    {
+        using (DeclScopeGuard scope = new DeclScopeGuard())
+        {
+            try
+            {
+                DeclScopeResult response = _ops.Create(name, timeout);
+                return response.Value + response.Raw;
+            }
+            catch (Exception ex)
+            {
+                new DeclScopeGuard().Failed(ex);
+                throw;
+            }
+        }
+    }
+
+    // Control for the same shape: the catch arm reads the local, so the source
+    // genuinely must declare it above the try and the PDB scopes it to the whole
+    // method. Today's hoisting emitter is accidentally right here, which is why
+    // placement alone cannot be read off the current output.
+    public string CreateHoisted(string name, int timeout)
+    {
+        DeclScopeResult? response = null;
+        try
+        {
+            response = _ops.Create(name, timeout);
+            return response.Value + response.Raw;
+        }
+        catch (Exception ex)
+        {
+            new DeclScopeGuard().Failed(ex);
+            return response is null ? "none" : response.Value;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/DeclarationPlacementFrontierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeclarationPlacementFrontierTests.cs
@@ -1,0 +1,204 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text.RegularExpressions;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Declaration placement for a local the source declared inside a nested block
+/// (#3591). The portable PDB's <c>LocalScope</c> table records each local's true
+/// extent, but <c>MetadataSource.LocalNames</c> keeps only the variable names and
+/// drops <c>StartOffset</c>/<c>EndOffset</c>, so the printer hoists a narrowly
+/// scoped local to the top of the method. These tests pin that frontier and, just
+/// as importantly, pin the evidence that would close it: the PDB already
+/// distinguishes the two shapes that today print identically.
+/// </summary>
+/// <remarks>
+/// Closing #3591 must flip <see cref="NarrowLocal_IsHoistedAboveTheUsing_WithPdb"/>
+/// and <see cref="NarrowLocal_PlacementIsIdenticalWithAndWithoutPdb"/>: with a PDB
+/// the declaration should merge into its store inside the try, which is exactly the
+/// masked equality this class currently asserts. The remaining tests are invariants
+/// and should keep passing.
+/// </remarks>
+public class DeclarationPlacementFrontierTests
+{
+    static readonly IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.TrustedPlatformAssemblies();
+
+    /// <summary>
+    /// The PDB names a local declared in the try block. The scope range that comes
+    /// with the name is what the printer never reads.
+    /// </summary>
+    [Fact]
+    public void NarrowLocal_IsHoistedAboveTheUsing_WithPdb()
+    {
+        var output = Print(nameof(DeclScopeClient.CreateNarrow));
+
+        Assert.Contains("DeclScopeResult response;", output);
+        Assert.Contains("response = _ops.Create(name, timeout);", output);
+        AssertDeclarationPrecedesUsing(output, "DeclScopeResult response;");
+    }
+
+    /// <summary>
+    /// Same method with symbols withheld. The local loses its source name, and
+    /// nothing else moves.
+    /// </summary>
+    [Fact]
+    public void NarrowLocal_IsHoistedAboveTheUsing_WithoutPdb()
+    {
+        var output = PrintWithoutSymbols(nameof(DeclScopeClient.CreateNarrow));
+
+        var declaration = Assert.Single(Regex.Matches(output, @"DeclScopeResult V_\d+;")).Value;
+        Assert.DoesNotContain("response", output);
+        AssertDeclarationPrecedesUsing(output, declaration);
+    }
+
+    /// <summary>
+    /// The headline claim of #3591: a present PDB changes the local's *name* and
+    /// nothing about where it is declared. Masking every local identifier makes the
+    /// two renderings byte-identical, which is only possible because the scope
+    /// ranges are discarded.
+    /// </summary>
+    [Fact]
+    public void NarrowLocal_PlacementIsIdenticalWithAndWithoutPdb()
+    {
+        var withPdb = Print(nameof(DeclScopeClient.CreateNarrow));
+        var withoutPdb = PrintWithoutSymbols(nameof(DeclScopeClient.CreateNarrow));
+
+        Assert.NotEqual(withPdb, withoutPdb);
+        Assert.Equal(MaskLocalNames(withPdb), MaskLocalNames(withoutPdb));
+    }
+
+    /// <summary>
+    /// Control: when the source really did declare above the try (the catch arm
+    /// reads the local), today's emitter is correct. The gap is one-directional,
+    /// so correct output on this method is not evidence that placement is derived.
+    /// </summary>
+    [Fact]
+    public void HoistedLocal_RoundTripsAtMethodTop()
+    {
+        var output = Print(nameof(DeclScopeClient.CreateHoisted));
+
+        Assert.Contains("DeclScopeResult response = null;", output);
+        Assert.Contains("response = _ops.Create(name, timeout);", output);
+        Assert.True(
+            output.IndexOf("DeclScopeResult response = null;", StringComparison.Ordinal)
+                < output.IndexOf("try", StringComparison.Ordinal),
+            $"Expected the declaration above the try.{Environment.NewLine}{output}");
+    }
+
+    /// <summary>
+    /// Non-vacuity gate for the frontier above. If this fails, the two fixture
+    /// shapes stopped being distinguishable in the PDB and the other tests here
+    /// would be pinning a limitation that no longer has a knowable answer.
+    /// </summary>
+    [Fact]
+    public void PdbScopes_DistinguishTheNarrowAndHoistedShapes()
+    {
+        var narrow = PdbScope(nameof(DeclScopeClient.CreateNarrow), "response");
+        var hoisted = PdbScope(nameof(DeclScopeClient.CreateHoisted), "response");
+
+        Assert.True(
+            narrow.Start > 0 && narrow.End < narrow.IlLength,
+            $"Expected a scope narrower than the method body, got IL_{narrow.Start:X4}..IL_{narrow.End:X4} of 0x{narrow.IlLength:X4}.");
+        Assert.Equal(0, hoisted.Start);
+        Assert.True(
+            hoisted.End >= hoisted.IlLength,
+            $"Expected a whole-method scope, got IL_{hoisted.Start:X4}..IL_{hoisted.End:X4} of 0x{hoisted.IlLength:X4}.");
+    }
+
+    /// <summary>
+    /// A compiler temp carries no <c>LocalScope</c> entry at all, which is the same
+    /// evidence in its degenerate form: absence of a scope marks a slot the source
+    /// never declared.
+    /// </summary>
+    [Fact]
+    public void PdbScopes_OmitCompilerTemps()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeResolver);
+        var function = IrImporter.Import(source, typeof(DeclScopeClient).FullName!, nameof(DeclScopeClient.CreateNarrow));
+        Assert.NotNull(function);
+
+        Assert.Contains("response", function!.LocalNames);
+        Assert.Contains(function.LocalNames, name => name is null);
+    }
+
+    static void AssertDeclarationPrecedesUsing(string output, string declaration)
+    {
+        int declarationIndex = output.IndexOf(declaration, StringComparison.Ordinal);
+        int usingIndex = output.IndexOf("using (", StringComparison.Ordinal);
+
+        Assert.True(declarationIndex >= 0, $"Missing declaration `{declaration}`.{Environment.NewLine}{output}");
+        Assert.True(usingIndex >= 0, $"Missing using statement.{Environment.NewLine}{output}");
+        Assert.True(
+            declarationIndex < usingIndex,
+            $"Expected `{declaration}` hoisted above the using.{Environment.NewLine}{output}");
+    }
+
+    // Every local identifier the two renderings can disagree on: the PDB source
+    // names and the V_index fallbacks. Masking them isolates placement from naming.
+    static string MaskLocalNames(string output)
+        => Regex.Replace(output, @"\b(?:V_\d+|response|scope|ex)\b", "N");
+
+    static string Print(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeResolver);
+        return Raise(source, methodName);
+    }
+
+    static string PrintWithoutSymbols(string methodName)
+    {
+        using var source = MetadataSource.OpenWithoutSymbols(typeof(CfgSampleClass).Assembly.Location, RuntimeResolver);
+        return Raise(source, methodName);
+    }
+
+    static string Raise(MetadataSource source, string methodName)
+    {
+        var function = IrImporter.Import(source, typeof(DeclScopeClient).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    static (int Start, int End, int IlLength) PdbScope(string methodName, string localName)
+    {
+        foreach (var (scope, ilLength, pdb) in Scopes(methodName))
+        {
+            foreach (var variableHandle in scope.GetLocalVariables())
+            {
+                if (pdb.GetString(pdb.GetLocalVariable(variableHandle).Name) == localName)
+                    return (scope.StartOffset, scope.EndOffset, ilLength);
+            }
+        }
+
+        throw new InvalidOperationException($"No PDB local scope for {methodName}/{localName}.");
+    }
+
+    static IEnumerable<(LocalScope Scope, int IlLength, MetadataReader Pdb)> Scopes(string methodName)
+    {
+        string assemblyPath = typeof(CfgSampleClass).Assembly.Location;
+        string pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
+        Assert.True(File.Exists(pdbPath), $"The test assembly must ship a portable PDB: {pdbPath}");
+
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var metadata = pe.GetMetadataReader();
+        using var pdbStream = File.OpenRead(pdbPath);
+        using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var pdb = provider.GetMetadataReader();
+
+        foreach (var handle in metadata.MethodDefinitions)
+        {
+            var method = metadata.GetMethodDefinition(handle);
+            if (metadata.GetString(method.Name) != methodName)
+                continue;
+            if (metadata.GetString(metadata.GetTypeDefinition(method.GetDeclaringType()).Name) != nameof(DeclScopeClient))
+                continue;
+
+            int ilLength = pe.GetMethodBody(method.RelativeVirtualAddress).GetILReader().Length;
+            foreach (var scopeHandle in pdb.GetLocalScopes(handle))
+                yield return (pdb.GetLocalScope(scopeHandle), ilLength, pdb);
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/DeclarationPlacementFrontierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeclarationPlacementFrontierTests.cs
@@ -111,17 +111,22 @@ public class DeclarationPlacementFrontierTests
     /// <summary>
     /// A compiler temp carries no <c>LocalScope</c> entry at all, which is the same
     /// evidence in its degenerate form: absence of a scope marks a slot the source
-    /// never declared.
+    /// never declared. Read from the PDB directly, then cross-checked against the
+    /// importer's view so the two cannot drift apart.
     /// </summary>
     [Fact]
     public void PdbScopes_OmitCompilerTemps()
     {
+        var scoped = PdbScopedSlots(nameof(DeclScopeClient.CreateNarrow));
+        Assert.Contains(scoped, slot => slot.Name == "response");
+
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeResolver);
         var function = IrImporter.Import(source, typeof(DeclScopeClient).FullName!, nameof(DeclScopeClient.CreateNarrow));
         Assert.NotNull(function);
 
-        Assert.Contains("response", function!.LocalNames);
-        Assert.Contains(function.LocalNames, name => name is null);
+        int[] unscoped = [.. Enumerable.Range(0, function!.Locals.Length).Where(index => !scoped.Any(slot => slot.Index == index))];
+        Assert.NotEmpty(unscoped);
+        Assert.All(unscoped, index => Assert.Null(function.LocalNames[index]));
     }
 
     static void AssertDeclarationPrecedesUsing(string output, string declaration)
@@ -174,6 +179,21 @@ public class DeclarationPlacementFrontierTests
         }
 
         throw new InvalidOperationException($"No PDB local scope for {methodName}/{localName}.");
+    }
+
+    static (int Index, string Name)[] PdbScopedSlots(string methodName)
+    {
+        var slots = new List<(int, string)>();
+        foreach (var (scope, _, pdb) in Scopes(methodName))
+        {
+            foreach (var variableHandle in scope.GetLocalVariables())
+            {
+                var variable = pdb.GetLocalVariable(variableHandle);
+                slots.Add((variable.Index, pdb.GetString(variable.Name)));
+            }
+        }
+
+        return [.. slots];
     }
 
     static IEnumerable<(LocalScope Scope, int IlLength, MetadataReader Pdb)> Scopes(string methodName)


### PR DESCRIPTION
Fixes the evidence gap in #3591 by pinning it. **Tests and fixtures only — no
product behavior changes.**

## Claim

A present PDB changes a local's **name** and nothing about **where it is
declared**. That is only possible because `MetadataSource.LocalNames` reads the
portable PDB's `LocalScope` table for names and drops each scope's
`StartOffset`/`EndOffset`.

Because the correct answer is PDB-knowable, this is a raising gap and must not
be modeled as a `StyleOptionCatalog` taste option.

## Benchmark target

`Azure.Data.Tables@12.11.0` — `Azure.Data.Tables.TableClient.Create`. The
package ships a PDB and dotnet-inspect already acquires it to
`~/.cache/dotnet-inspect/packages/symbols/servers/Azure.Data.Tables.pdb/`, which
is where the `response`, `scope`, and `ex` names in its output come from.

```bash
dotnet-inspect member 'Azure.Data.Tables.TableClient' -m Create \
  --package Azure.Data.Tables@12.11.0 -S "Decompiled Source"
```

Original source declares at the assignment site, inside the `try`; the output
hoists it to the method top. The two fixtures added here reproduce that shape
in-repo so it can be pinned without a network dependency.

## Fixtures

Appended to the end of `CfgSampleClass.cs`, per that file's convention, so no
generated-code ordinal shifts.

`DeclScopeClient.CreateNarrow` — the local is read twice (so it survives as a
slot rather than inlining) and never referenced outside the try:

```csharp
using (DeclScopeGuard scope = new DeclScopeGuard())
{
    try
    {
        DeclScopeResult response = _ops.Create(name, timeout);
        return response.Value + response.Raw;
    }
    catch (Exception ex) { new DeclScopeGuard().Failed(ex); throw; }
}
```

`DeclScopeClient.CreateHoisted` — the control. The catch arm reads the local, so
the source genuinely must declare it above the try.

### PDB ground truth

```
DeclScopeClient.CreateNarrow    slot 1  response   IL_0006..IL_002D   <- the try, NOT the method
DeclScopeClient.CreateHoisted   slot 0  response   IL_0000..IL_004A   <- whole method
```

The PDB separates the two cases exactly.

## Current output

`CreateNarrow` with the PDB present:

```csharp
public string CreateNarrow(string name, int timeout)
{
    DeclScopeResult response;

    using (DeclScopeGuard scope = new DeclScopeGuard())
    {
        try
        {
            response = _ops.Create(name, timeout);
            return string.Concat(response.Value, response.Raw.ToString());
        }
        catch (Exception ex)
        {
            new DeclScopeGuard().Failed(ex);
            throw;
        }
    }
}
```

With symbols withheld (`MetadataSource.OpenWithoutSymbols`) the same method
renders with `V_index` names and **identical placement**.

`CreateHoisted` round-trips correctly (`DeclScopeResult response = null;` above
the try), so the gap is one-directional: the emitter is accidentally right
whenever the source really did hoist, which is why correct output on a hoisted
method is not evidence that placement is derived.

## Tests

`DeclarationPlacementFrontierTests`, modeled on `CollectionExpressionFrontierTests`
(which already carries the `Raised` / `RaisedWithoutSymbols` pair).

| Test | Pins |
| --- | --- |
| `NarrowLocal_IsHoistedAboveTheUsing_WithPdb` | the gap, with symbols |
| `NarrowLocal_IsHoistedAboveTheUsing_WithoutPdb` | the gap, without symbols |
| `NarrowLocal_PlacementIsIdenticalWithAndWithoutPdb` | **the headline claim** |
| `HoistedLocal_RoundTripsAtMethodTop` | control — the gap is one-directional |
| `PdbScopes_DistinguishTheNarrowAndHoistedShapes` | non-vacuity: the evidence exists |
| `PdbScopes_OmitCompilerTemps` | a temp has no scope entry at all |

The headline test masks every local identifier (`V_\d+`, `response`, `scope`,
`ex`) and asserts the two renderings are then byte-identical, while also
asserting they are *not* equal unmasked. Naming is the only difference.

`PdbScopes_DistinguishTheNarrowAndHoistedShapes` is the non-vacuity gate named
per AGENTS.md: if it fails, the two fixture shapes stopped being distinguishable
in the PDB and the frontier tests would be pinning a limitation that no longer
has a knowable answer. It reads the `LocalScope` table directly rather than
through a product API, because exposing those ranges is exactly what #3591 asks
for and does not exist yet.

The class `<remarks>` states that closing #3591 must flip the two `NarrowLocal`
placement tests, so a future implementer is not left guessing whether a failure
is a regression.

## Oracle consultation

Required by AGENTS.md for anything touching style-oriented output. Recorded
here because this PR asserts the difference is **not** a style question.

**Declared facet** — `dotnet/runtime` `.editorconfig`: no key governs general
declaration placement; the nearest, `csharp_style_inlined_variable_declaration =
true:suggestion` (line 124), covers `out` parameters only. On placement the
declared oracle is **silent**. Separately `csharp_style_var_* = false` (lines
52-54), so the correct *spelling* here is the explicit type, not the original's
`var` — an already-modeled, byte-neutral axis (`var-spelling-style`), out of
scope for this PR.

**Revealed facet** — runtime declares at first use when use is confined to the
block (`HttpContent c = response.Content;`
`src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs:199`;
`StringBuilder sb = new StringBuilder();`
`src/libraries/System.Private.CoreLib/src/System/IO/File.cs:1132`) and hoists
only when a `catch`/`finally` or later code needs the local
(`HttpResponseMessage? response = null;` `HttpClient.cs:189`; `char[]? buffer =
null;` `File.cs:1126`). The rule is *narrowest scope covering all uses*, which is
precisely what the PDB encodes.

## Non-action boundary

This PR does not plumb `LocalScope` extents through `MetadataSource`, does not
touch `CSharpPrinter.CollectDeclaringStores`, and does not change any rendered
output. It only makes the gap and its available evidence testable. The fix
direction is described in #3591.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- --gate fast
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build
```

- `ILInspector.Decompiler.Tests --gate fast`: **4382 passed, 0 failed**.
- `dotnet-inspect.Tests`: 2581 run, 14 skipped, **1 failure** —
  `CommandExecutionTests.Layout_Count_CountsFilesRatherThanRenderedTreeLines`,
  reproduced identically on a clean detached `origin/main` worktree. Pre-existing
  and unrelated: it counts files inside a downloaded `Newtonsoft.Json@13.0.4`
  package and fails on `Assert.Contains("Newtonsoft.Json.nuspec", ...)`, a cached
  package artifact.

## Review

Test-only, no product code, no output change — the *more than trivial, but not
high risk* tier. One review.
