### PR TITLE
Make the fidelity dockets two-directional and retire 45 stale rows

### DIFF
--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -586,7 +586,11 @@ Report compile-back evidence in two layers:
    covers the changed shape. Name whether the sugared gate (`FidelityGateTests`),
    lowered gate (`LoweredFidelityGateTests`), or a pass-specific test is the
    relevant guard. If a fidelity-diff docket row is fixed, shrink `KnownDiffs` and
-   add the method to `PinnedExact` in the same PR.
+   add the method to `PinnedExact` in the same PR. `DocketRowsStayCheckedDiffs`
+   (both rails) enforces this: a `KnownDiffs` row that recompiles `Exact` fails the
+   gate and names the row to promote. Before #3584 the rule was documented but
+   unenforced, and 46 of 143 rows had silently gone stale — a stale row gates
+   nothing, because the diff it allows no longer happens.
 2. **Changed-method / corpus layer** — for risky or broad changes, identify the
    methods the PR actually changed and run `--fidelity-method-delta` over that
    population when available. Treat `Exact` as checked green and `OpcodeDiff` /

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -763,7 +763,10 @@ method (a previously-fixed one) regresses. Shrinking `KnownDiffs` and growing
 That ratchet is two-directional: `DocketRowsStayCheckedDiffs` fails when a
 `KnownDiffs` row stops being a diff, whether because it was fixed (promote it to
 `PinnedExact`) or because its C# stopped recompiling (a regression the
-diff-set-shaped assert would otherwise swallow).
+diff-set-shaped assert would otherwise swallow). The one tolerated non-diff state
+is an import below Full fidelity, which forms no opcode verdict at all; those rows
+must be named explicitly in `KnownNotFull`, so a row that *newly* drops to
+`NotFull` still fails as the validity regression it is.
 The **annotation gate** (`AnnotationGateTests`) holds annotation
 fidelity over the whole CoreLib corpus the same way — precision is absolute (a
 wrong fact always fails; it is never runtime drift), recall is held above a

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -760,6 +760,10 @@ contract V1 body — a regression beyond the documented `KnownDiffs` docket —
 when the product body comparison is unavailable, or when a `PinnedExact`
 method (a previously-fixed one) regresses. Shrinking `KnownDiffs` and growing
 `PinnedExact` is how fidelity progress ratchets forward and cannot slip back.
+That ratchet is two-directional: `DocketRowsStayCheckedDiffs` fails when a
+`KnownDiffs` row stops being a diff, whether because it was fixed (promote it to
+`PinnedExact`) or because its C# stopped recompiling (a regression the
+diff-set-shaped assert would otherwise swallow).
 The **annotation gate** (`AnnotationGateTests`) holds annotation
 fidelity over the whole CoreLib corpus the same way — precision is absolute (a
 wrong fact always fails; it is never runtime drift), recall is held above a

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -54,11 +54,6 @@ public class FidelityGateTests
         // now fully raised by ComparisonTreeBoolArmPass, but still recompiles to
         // different branch structure like the sparse-switch over-render docket.
         "ByteRangeSearchTree",
-        // CollectionListLiteral is the #1142 PDB-discriminated List<T>
-        // collection-expression raise. The original SDK csc lowering uses
-        // constant Span<T> indices, while the Roslyn compile-back package emits a
-        // hidden index temp for the same `return [a, b, 42];` source idiom.
-        "CollectionListLiteral",
         "GotoCommonExit",
         // This hand-written await-enumerator loop recompiles through the same
         // runtime-async shape but schedules the receiver load after the
@@ -70,7 +65,6 @@ public class FidelityGateTests
         // the element-ref helper. Exact recovery needs a higher-level inline-array
         // foreach/indexer raise.
         "RuntimeInlineArrayForeach",
-        "SelectBoolReturn",
         // SlotDiamondDispatch is a clustered-case switch with bool-computing arms
         // (#912): SlotDiamondPass folds each returned slot diamond so the dispatch
         // raises into nested if/else, the same honest comparison-tree over-render
@@ -86,16 +80,6 @@ public class FidelityGateTests
         "NullConditionalPropertyAssignment",
         "ObjectInitializerArgumentBeforeShortCircuit",
         "ReusedSlotStringListCount",
-        // OrBoolIntMix / OrBoolUintMix are the #1452 bool-operand materialization:
-        // a bitwise `bool | int` is CS0019, so BitwiseBoolOperandPass rewrites the
-        // bool operand to `(cond ? 1 : 0)`. In the slot-form shapes that ternary
-        // recompiles to a branch-select that differs from the original branchless
-        // 0/1 — valid C# (no CS0019), not opcode-exact. OrBoolUintMix additionally
-        // takes the `(uint)` mixed-sign reinterpret. The siblings AndBoolIntMix,
-        // AndNestedConditionalBool, and AndNestedBoolIntMix stay opcode-exact, so
-        // they are not docketed.
-        "OrBoolIntMix",
-        "OrBoolUintMix",
         // SwitchStoreThenUse is the #1710 ConditionalStoreChainPass fold: a
         // compare-chain switch assigning a local folds to a nested conditional
         // store, which csc re-lowers differently than the original per-arm stores
@@ -128,20 +112,12 @@ public class FidelityGateTests
         // `ref`. With the type compiling, they are finally compile-checked and show
         // honest pre-existing body over-renders (ref/in/out call sites, positional
         // patterns, slot/ternary merges, null-coalescing assignment).
-        "CallOutTarget",
         "FloatPositionalPattern",
-        "GenericRefKindCallSites",
         // Expression-tree factory fixtures are valid and Full, but SDK preview6
         // compile-back reshapes the manually emitted Expression.* calls around
         // stack-slot/local temporaries. This is toolchain drift in an existing
         // over-render frontier, not a new daily product regression.
         "ManualSimpleExpressionTreeFactory",
-        "SimpleExpressionTreeLambda",
-        // The parameter-dependent manual factory graph recovers to a lambda, so it
-        // recompiles to the compiler's expression-tree lowering rather than the
-        // hand-written factory calls — the same recovery-induced diff as
-        // SimpleExpressionTreeLambda.
-        "ManualParameterPlusConstantFactory",
         // The manual factory fixtures below DECLINE and decompile to honest
         // Expression.* factory-call C# with clean locals: the malformed/shared-graph
         // near misses (reused parameter identity, duplicate names, unspellable name),
@@ -177,43 +153,25 @@ public class FidelityGateTests
         "MergedReferenceSlot",
         "MergedTernaryDeclaration",
         "NullCoalescingAssignStaticProperty",
-        "RefKindCallSites",
         "set_SlotMergedDateTimeFormat",
         // Compile-back fidelity contract V1 reclassifies these previously
         // opcode-exact rows because a value, symbolic target, or branch target
         // differs after recompilation.
         "BreakWithSideEffect",
-        "CachedDelegateArgument",
-        "CachedDelegateChain",
         "CapturingLambda",
         "CapturingLocalBodyLambda",
         // #2945: outer-body reads of a hoisted capture field are substituted back
         // to the captured source and the display class elides, so this fully
-        // raises; recompiling regenerates a fresh display class whose synthesized
-        // ordinals differ under contract V1.
+        // raises. #3505 canonicalized the synthesized ordinals that used to make
+        // this an OperandDiff, and what remains underneath is an import below Full
+        // fidelity, so the harness now reports NotFull and forms no opcode verdict.
+        // Listed in <see cref="KnownNotFull"/> so that state is explicit rather
+        // than an unexamined docket row.
         "CapturedParamReadInOuterBody",
         "ClosureCapture",
-        "CountPositive",
         "DayNumber",
-        "DoubleViaLocalFunction",
-        // #2983: the enum-argument-in-nested-local-function fixture. Its raised
-        // body prints through a freshly reconstructed nested scope and now spells
-        // the enum constant by member (the fix under test); the call opcodes stay
-        // identical (`ldarg call ret`), but recompiling reassigns the local
-        // function's synthesized ordinal (g__Classify|N_0), which contract V1
-        // observes — the same benign reconstruction-ordinal diff as its sibling
-        // StaticLocalFunctionWithLocal below.
-        "EnumArgInLocalFunctionWithLocal",
-        // #2983 (inline path): the enum-argument-in-inline-local-function fixture.
-        // Its raised body has no locals or stack slots, so it prints inline through
-        // the enclosing scope and now spells the enum constant by member (the fix
-        // under test); the call opcodes stay identical (`ldarg call ret`), but
-        // recompiling reassigns the local function's synthesized ordinal, the same
-        // benign reconstruction-ordinal diff as its sibling below.
-        "EnumArgInInlineLocalFunction",
         "InvokeLocalCapture",
         "JustBreak",
-        "LocalBodyLambda",
         // MakeConsumerWithTwoLeadingArgs (#3272): ExpressionInliningPass removes only
         // one of the two single-use spill temps around the trailing object
         // initializer, leaving an extra stloc/ldloc pair on compile-back. #3290 added
@@ -225,26 +183,6 @@ public class FidelityGateTests
         // itself stays Valid + Correct and is pinned by
         // ObjectInitializerPassTests. Tracked as #3490.
         "MakeConsumerWithTwoLeadingArgs",
-        "NonCapturingLambda",
-        "RecursiveLocalFunction",
-        "StatementBodyLambda",
-        // StatementBodyLambdaInsideIf is the same benign reconstruction-ordinal
-        // class as TwoLocalFunctionQuadrants and the iterator entries below: the
-        // opcode stream is identical, but recompiling the reconstructed fixture type
-        // assigns the cached lambda a different synthesized ordinal
-        // (<>9__103_0 -> <>9__128_0, with the matching <>c method and cache field),
-        // which contract V1 observes as changed symbolic targets. Nothing about the
-        // raise changed — the fixture's position in CfgSampleClass did, as fixtures
-        // were added after #2987 introduced it. Tracked as #3503, which proposes
-        // canonicalizing synthesized ordinals in the oracle so this whole class of
-        // row stops needing docket entries.
-        "StatementBodyLambdaInsideIf",
-        "StaticLocalFunctionCalledTwice",
-        "StaticLocalFunctionWithLocal",
-        // Tuple-switch fixture additions changed the reconstructed source ordinal
-        // of both local functions from |5_* to |31_*. The call opcodes remain
-        // identical, but contract V1 observes the changed symbolic targets.
-        "TwoLocalFunctionQuadrants",
         // The iterator raises added by #2884 recover the source bodies and retain
         // the same outer factory opcodes, but recompiling the reconstructed large
         // fixture type assigns different synthesized state-machine ordinals
@@ -265,6 +203,20 @@ public class FidelityGateTests
         "YieldStrings",
         "YieldThree",
         "YieldTwo",
+    };
+
+    /// <summary>
+    /// Docket rows the harness reports as <see cref="FidelityCheck.CompileBackStatus.NotFull"/>:
+    /// the body imports below Full fidelity, so no opcode verdict is formed and an
+    /// opcode diff is expected rather than a defect. These are a distinct, named
+    /// state — not an unexamined <see cref="KnownDiffs"/> row — so that
+    /// <see cref="DocketRowsStayCheckedDiffs"/> can require every *other* docket row to
+    /// remain an actual diff. A row that newly drops to NotFull is a validity
+    /// regression and must fail rather than land here silently.
+    /// </summary>
+    static readonly HashSet<string> KnownNotFull = new(StringComparer.Ordinal)
+    {
+        "CapturedParamReadInOuterBody",
     };
 
     /// <summary>
@@ -515,6 +467,39 @@ public class FidelityGateTests
         "ULongSumIndexAsSigned",
         "ULongSumIndexBare",
         "Finalize",
+        // Promoted from KnownDiffs by #3584 after they were measured Exact on the
+        // current main. Most are the benign reconstruction-ordinal class that #3505
+        // retired by canonicalizing synthesized-member ordinals in the oracle — the
+        // outcome the StatementBodyLambdaInsideIf row predicted when it was filed as
+        // #3503 ("so this whole class of row stops needing docket entries"). The
+        // remainder (CollectionListLiteral, OrBool*Mix, RefKindCallSites,
+        // GenericRefKindCallSites, CallOutTarget, SelectBoolReturn, CountPositive, and
+        // the two expression-tree rows) became exact through unrelated raising work.
+        // They are pinned rather than merely deleted so each fix is now guarded:
+        // a docket row that stops diffing gates nothing, a PinnedExact row does.
+        "CachedDelegateArgument",
+        "CachedDelegateChain",
+        "CallOutTarget",
+        "CollectionListLiteral",
+        "CountPositive",
+        "DoubleViaLocalFunction",
+        "EnumArgInInlineLocalFunction",
+        "EnumArgInLocalFunctionWithLocal",
+        "GenericRefKindCallSites",
+        "LocalBodyLambda",
+        "ManualParameterPlusConstantFactory",
+        "NonCapturingLambda",
+        "OrBoolIntMix",
+        "OrBoolUintMix",
+        "RecursiveLocalFunction",
+        "RefKindCallSites",
+        "SelectBoolReturn",
+        "SimpleExpressionTreeLambda",
+        "StatementBodyLambda",
+        "StatementBodyLambdaInsideIf",
+        "StaticLocalFunctionCalledTwice",
+        "StaticLocalFunctionWithLocal",
+        "TwoLocalFunctionQuadrants",
     };
 
     static readonly Lazy<IReadOnlyList<FidelityCheck.CompileBackResult>> Results = new(() =>
@@ -553,6 +538,72 @@ public class FidelityGateTests
             "New fidelity check contract V1 diffs (decompiled C# recompiles to different IL):\n"
             + string.Join("\n\n", details)
             + $"\n\nFull current diff set: {string.Join(", ", diffResults.Select(result => result.Method))}");
+    }
+
+    /// <summary>
+    /// The reverse direction of <see cref="NoNewFidelityDiffsBeyondKnownDocket"/>, which is a
+    /// one-directional allow list: it fails when an undocketed method diffs, but never
+    /// when a docketed method stops diffing. Both ways a row can leave the diff set are
+    /// silent un-gates today, and both are already known to matter here:
+    /// <list type="bullet">
+    /// <item>It became <c>Exact</c> — the residual was fixed. The row now allows a
+    /// future regression it was never meant to cover, and no run reports it. #3505
+    /// canonicalized synthesized-member ordinals and retired a whole class of row this
+    /// way; nothing said so, and the stale rows sat in the docket across releases.</item>
+    /// <item>It became <c>RecompileFail</c>/<c>ContextFail</c> — the decompiled C# stopped
+    /// compiling. That drops it out of the diff set too, so the allow list swallows a
+    /// real regression. <see cref="SwitchStoreFold_StaysCompileBackCheckable"/> and
+    /// <see cref="PointerStoreUsesOriginalAddress_StaysCompileBackCheckable"/> were written
+    /// to cover exactly this for two fixtures; this generalizes them to the whole docket.</item>
+    /// </list>
+    /// Keeping the docket two-directional matches the decompiler lane pin file
+    /// (<c>eng/decompiler-gate-known-red.txt</c>), which fails both when an unpinned test
+    /// fails and when a pinned test passes.
+    /// </summary>
+    [Fact]
+    public void DocketRowsStayCheckedDiffs()
+    {
+        var results = EvaluateFixtures();
+        var failures = new List<string>();
+
+        foreach (string method in KnownDiffs.OrderBy(m => m, StringComparer.Ordinal))
+        {
+            var matches = results.Where(r => r.Method == method).ToList();
+            if (matches.Count == 0)
+            {
+                failures.Add($"{method}: docketed, but the fidelity check no longer renders it. "
+                    + "Remove the row if the fixture is gone, or restore the fixture.");
+                continue;
+            }
+
+            foreach (var result in matches)
+            {
+                if (result.Status is FidelityCheck.CompileBackStatus.OpcodeDiff
+                    or FidelityCheck.CompileBackStatus.OperandDiff)
+                    continue;
+
+                if (result.Status == FidelityCheck.CompileBackStatus.NotFull
+                    && KnownNotFull.Contains(method))
+                    continue;
+
+                failures.Add(result.Status switch
+                {
+                    FidelityCheck.CompileBackStatus.Exact =>
+                        $"{method}: now recompiles Exact, so its docket row is stale and silently allows a "
+                        + "future regression. Move it to PinnedExact so the fix is guarded.",
+                    FidelityCheck.CompileBackStatus.NotFull =>
+                        $"{method}: dropped to NotFull — it now imports below Full fidelity, so no opcode "
+                        + "verdict is formed. That is a validity regression, not a docketed diff.",
+                    _ =>
+                        $"{method}: regressed to {result.Status} — its decompiled C# no longer recompiles, so "
+                        + $"it silently left the diff set the docket gates.\n  detail: {result.Detail}",
+                });
+            }
+        }
+
+        Assert.True(failures.Count == 0,
+            "Stale or regressed rows in FidelityGateTests.KnownDiffs (#3584):\n"
+            + string.Join("\n", failures));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -594,6 +594,9 @@ public class FidelityGateTests
                     FidelityCheck.CompileBackStatus.NotFull =>
                         $"{method}: dropped to NotFull — it now imports below Full fidelity, so no opcode "
                         + "verdict is formed. That is a validity regression, not a docketed diff.",
+                    FidelityCheck.CompileBackStatus.FidelityUnavailable =>
+                        $"{method}: the body comparison produced no verdict, so the row gates nothing. "
+                        + $"BodyComparisonRemainsAvailable reports the cause.\n  detail: {result.Detail}",
                     _ =>
                         $"{method}: regressed to {result.Status} — its decompiled C# no longer recompiles, so "
                         + $"it silently left the diff set the docket gates.\n  detail: {result.Detail}",

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -46,19 +46,12 @@ public class LoweredFidelityGateTests
         // now fully raised by ComparisonTreeBoolArmPass, but still recompiles to
         // different branch structure like the sparse-switch over-render docket.
         "ByteRangeSearchTree",
-        // CollectionListLiteral is raised by InlineArrayCollectionPass, which the
-        // lowered view keeps for collection-expression validity. Compile-back
-        // Roslyn emits a hidden index temp instead of the SDK csc's constant
-        // Span<T> indices for the same source idiom.
-        "CollectionListLiteral",
         "GotoCommonExit",
         "ManualAwaitEnumeratorLoop",
-        "ReverseCopy",
         // RuntimeInlineArrayForeach is the runtime-style inline-array enumerator
         // frontier from #1045: the lowered view is representable, but recompiles
         // through an extra span conversion before the element-ref helper.
         "RuntimeInlineArrayForeach",
-        "SelectBoolReturn",
         // Clustered-case switch with bool arms raised to nested if/else via
         // SlotDiamondPass (#912) — honest comparison-tree over-render, not exact.
         "SlotDiamondDispatch",
@@ -71,14 +64,6 @@ public class LoweredFidelityGateTests
         "NullConditionalPropertyAssignment",
         "ObjectInitializerArgumentBeforeShortCircuit",
         "ReusedSlotStringListCount",
-        // OrBoolIntMix / OrBoolUintMix are the #1452 bool-operand materialization:
-        // a bitwise `bool | int` is CS0019, so BitwiseBoolOperandPass rewrites the
-        // bool operand to `(cond ? 1 : 0)`; in the slot-form shapes that ternary
-        // recompiles to a branch-select differing from the original branchless 0/1
-        // — valid C#, not opcode-exact. OrBoolUintMix additionally takes the
-        // `(uint)` mixed-sign reinterpret. The And* siblings stay opcode-exact.
-        "OrBoolIntMix",
-        "OrBoolUintMix",
         // SwitchStoreThenUse (#1743) is a known opcode-diff in the sibling sugared
         // FidelityGateTests docket — the ConditionalStoreChainPass ternary
         // (sel == 0 ? 11 : ...) re-lowers differently than the per-arm stores. It
@@ -89,19 +74,13 @@ public class LoweredFidelityGateTests
         // Lowered output omits ForLoopPass, so protected increment targets retain
         // #2857's valid while-loop fallback. The explicit default declaration
         // before initialization adds an opcode pair on compile-back.
-        "Issue2830_ForLoopEhCleanupContinue",
-        "Issue2830_ForLoopLeave",
-        "Issue2830_ForLoopNestedContinue",
-        "Issue2861_ForLoopTryAndCatchContinues",
         "Issue2861_NestedProtectedLeaveToOuterIncrement",
-        // CharConditionalElementStore (#1784) and WhileNestedContinueKeepsArmExclusive:
-        // pre-existing slow-docket gaps from recent main merges (a char ternary
-        // element store that spills to temps; a nested-continue loop structuring),
-        // both honest valid re-lowerings. Surfaced by running the Speed=Slow gate
-        // locally; verified independent of MixedShortCircuitChainPass (it folds
-        // neither). See the sibling FidelityGateTests docket.
+        // CharConditionalElementStore (#1784): a pre-existing slow-docket gap from
+        // recent main merges (a char ternary element store that spills to temps),
+        // an honest valid re-lowering. Surfaced by running the Speed=Slow gate
+        // locally; verified independent of MixedShortCircuitChainPass (it does not
+        // fold it). See the sibling FidelityGateTests docket.
         "CharConditionalElementStore",
-        "WhileNestedContinueKeepsArmExclusive",
         // PointerStoreUsesOriginalAddress (#2644): same intentional residual as
         // the sugared view. The lowered body keeps the original pointer address
         // in the store target, but compile-back introduces locals around the
@@ -113,20 +92,15 @@ public class LoweredFidelityGateTests
         // (the reconstructed CfgSampleClass failed to compile on InOperatorVec's
         // in-parameter operators rendered as illegal `ref`). Now compile-checked,
         // showing honest pre-existing over-renders. Same set as the sugared docket.
-        "CallOutTarget",
         "FloatPositionalPattern",
-        "GenericRefKindCallSites",
         // Expression-tree factory fixtures are valid and Full, but SDK preview6
         // compile-back reshapes the manually emitted Expression.* calls around
         // stack-slot/local temporaries. Same preview drift as the sugared gate.
         "ManualSimpleExpressionTreeFactory",
-        "SimpleExpressionTreeLambda",
-        // Same expression-tree docket as the sugared gate: the parameter-dependent
-        // graph recovers to a lambda, while the manual factory fixtures below decline
-        // to honest Expression.* factory-call C# whose emitted calls recompile through
-        // the same preview compile-back temporary reshaping. Verified by running the
-        // Speed=Slow lowered fidelity gate locally.
-        "ManualParameterPlusConstantFactory",
+        // Same expression-tree docket as the sugared gate: the manual factory
+        // fixtures below decline to honest Expression.* factory-call C# whose
+        // emitted calls recompile through the same preview compile-back temporary
+        // reshaping. Verified by running the Speed=Slow lowered fidelity gate locally.
         "ManualCanonicalReturnedAsExpression",
         "ManualCanonicalReturnedAsLambdaExpression",
         "ManualCanonicalReturnedAsObject",
@@ -146,30 +120,10 @@ public class LoweredFidelityGateTests
         "MergedReferenceSlot",
         "MergedTernaryDeclaration",
         "NullCoalescingAssignStaticProperty",
-        "RefKindCallSites",
         "set_SlotMergedDateTimeFormat",
         // Contract V1 rebaseline: opcode names still match, but canonical
         // operands, symbolic targets, or branch targets differ.
         "DayNumber",
-        "DoubleViaLocalFunction",
-        "StaticLocalFunctionCalledTwice",
-        // Synthesized local-function ordinals. Recompiling the reconstructed fixture
-        // type renumbers each local function's `g__Name|N_M` symbol (and the display
-        // class backing a captured one), which contract V1 observes as changed
-        // symbolic targets even though the opcode stream is unchanged. De-sugaring
-        // does not touch those ordinals, so this class of row affects the lowered
-        // rail exactly as it affects the sugared one — and the sugared gate already
-        // dockets all five with per-fixture rationale (see
-        // FidelityGateTests.KnownDiffs; #2983 covers the two EnumArg* entries,
-        // TwoLocalFunctionQuadrants records the |5_* -> |31_* shift). The lowered
-        // docket simply fell behind the sugared one while this Speed=Slow gate was
-        // being cancelled rather than reported. Tracked as #3491, and #3503 proposes
-        // canonicalizing synthesized ordinals so neither docket needs these rows.
-        "EnumArgInInlineLocalFunction",
-        "EnumArgInLocalFunctionWithLocal",
-        "RecursiveLocalFunction",
-        "StaticLocalFunctionWithLocal",
-        "TwoLocalFunctionQuadrants",
         // MakeConsumerWithTwoLeadingArgs (#3272): the trailing object initializer
         // with TWO preceding constructor arguments folds correctly (Valid + Correct)
         // to `new InitConsumer3(Identity(tag), Identity(a), new InitTarget { ... })`,
@@ -182,9 +136,19 @@ public class LoweredFidelityGateTests
     };
 
     /// <summary>
-    /// Methods the lowered view keeps exact under contract V1. This is the sugared pinned set minus the
-    /// two methods the lowered view legitimately reshapes: ReverseCopy (now an expected diff,
-    /// see <see cref="KnownDiffs"/>) and ClassicLock (lowering skips LockSugarPass, emitting an
+    /// Docket rows the harness reports as <see cref="FidelityCheck.CompileBackStatus.NotFull"/>:
+    /// the body imports below Full fidelity, so no opcode verdict is formed and an
+    /// opcode diff is expected rather than a defect. Empty on this rail today; it
+    /// exists so <see cref="DocketRowsStayCheckedDiffs"/> can require every other docket
+    /// row to remain an actual diff, and so a row that newly drops to NotFull fails as
+    /// the validity regression it is instead of landing here silently.
+    /// </summary>
+    static readonly HashSet<string> KnownNotFull = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Methods the lowered view keeps exact under contract V1. This is the sugared pinned set minus
+    /// ClassicLock, which the lowered view legitimately reshapes (lowering skips LockSugarPass,
+    /// emitting an
     /// explicit Monitor.Enter/Exit form the fidelity check shell cannot bind — it lands in the
     /// recompile-fail bucket the gate excludes by design, same as the sugared rail's
     /// shell-attribution failures). DayNumber moved to the V1 difference docket
@@ -243,6 +207,38 @@ public class LoweredFidelityGateTests
         "ClassifyMode",
         "ClassifyWide",
         "AnonShorthand",
+        // Promoted from KnownDiffs by #3584 after they were measured Exact on the
+        // current main. The local-function/lambda rows are the benign
+        // reconstruction-ordinal class that #3505 retired by canonicalizing
+        // synthesized-member ordinals in the oracle — the outcome this rail's
+        // ordinal comment anticipated when it pointed at #3503. The Issue2830_* /
+        // Issue2861_ForLoopTryAndCatchContinues rows became exact through the
+        // try/catch return-sinking work (#3553), and the rest through unrelated
+        // raising. They are pinned rather than merely deleted so each fix is now
+        // guarded: a docket row that stops diffing gates nothing, a PinnedExact
+        // row does.
+        "CallOutTarget",
+        "CollectionListLiteral",
+        "DoubleViaLocalFunction",
+        "EnumArgInInlineLocalFunction",
+        "EnumArgInLocalFunctionWithLocal",
+        "GenericRefKindCallSites",
+        "Issue2830_ForLoopEhCleanupContinue",
+        "Issue2830_ForLoopLeave",
+        "Issue2830_ForLoopNestedContinue",
+        "Issue2861_ForLoopTryAndCatchContinues",
+        "ManualParameterPlusConstantFactory",
+        "OrBoolIntMix",
+        "OrBoolUintMix",
+        "RecursiveLocalFunction",
+        "RefKindCallSites",
+        "ReverseCopy",
+        "SelectBoolReturn",
+        "SimpleExpressionTreeLambda",
+        "StaticLocalFunctionCalledTwice",
+        "StaticLocalFunctionWithLocal",
+        "TwoLocalFunctionQuadrants",
+        "WhileNestedContinueKeepsArmExclusive",
     };
 
     static readonly Lazy<IReadOnlyList<FidelityCheck.CompileBackResult>> Results = new(() =>
@@ -281,6 +277,61 @@ public class LoweredFidelityGateTests
             "New lowered fidelity check contract V1 diffs (lowered C# recompiles to different IL):\n"
             + string.Join("\n\n", details)
             + $"\n\nFull current diff set: {string.Join(", ", diffResults.Select(r => r.Method))}");
+    }
+
+    /// <summary>
+    /// The reverse direction of <see cref="NoNewFidelityDiffsBeyondKnownDocket"/>, which is a
+    /// one-directional allow list: it fails when an undocketed method diffs, but never when a
+    /// docketed method stops diffing. A row that became <c>Exact</c> silently allows a future
+    /// regression it was never meant to cover, and a row that became
+    /// <c>RecompileFail</c>/<c>ContextFail</c> silently drops a real regression out of the
+    /// gated set. See the sugared rail's <c>DocketRowsStayCheckedDiffs</c> for the full
+    /// rationale and the #3505 precedent (#3584).
+    /// </summary>
+    [Fact]
+    public void DocketRowsStayCheckedDiffs()
+    {
+        var results = EvaluateFixtures();
+        var failures = new List<string>();
+
+        foreach (string method in KnownDiffs.OrderBy(m => m, StringComparer.Ordinal))
+        {
+            var matches = results.Where(r => r.Method == method).ToList();
+            if (matches.Count == 0)
+            {
+                failures.Add($"{method}: docketed, but the lowered fidelity check no longer renders it. "
+                    + "Remove the row if the fixture is gone, or restore the fixture.");
+                continue;
+            }
+
+            foreach (var result in matches)
+            {
+                if (result.Status is FidelityCheck.CompileBackStatus.OpcodeDiff
+                    or FidelityCheck.CompileBackStatus.OperandDiff)
+                    continue;
+
+                if (result.Status == FidelityCheck.CompileBackStatus.NotFull
+                    && KnownNotFull.Contains(method))
+                    continue;
+
+                failures.Add(result.Status switch
+                {
+                    FidelityCheck.CompileBackStatus.Exact =>
+                        $"{method}: now recompiles Exact in the lowered view, so its docket row is stale and "
+                        + "silently allows a future regression. Move it to PinnedExact so the fix is guarded.",
+                    FidelityCheck.CompileBackStatus.NotFull =>
+                        $"{method}: dropped to NotFull — it now imports below Full fidelity, so no opcode "
+                        + "verdict is formed. That is a validity regression, not a docketed diff.",
+                    _ =>
+                        $"{method}: regressed to {result.Status} — its lowered C# no longer recompiles, so it "
+                        + $"silently left the diff set the docket gates.\n  detail: {result.Detail}",
+                });
+            }
+        }
+
+        Assert.True(failures.Count == 0,
+            "Stale or regressed rows in LoweredFidelityGateTests.KnownDiffs (#3584):\n"
+            + string.Join("\n", failures));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -21,12 +21,12 @@ public class LoweredFidelityGateTests
 
     /// <summary>
     /// Methods whose lowered C# still differs under compile-back fidelity contract V1 — the open
-    /// lowered docket. The gate tolerates these but fails if a NEW method joins the set.
-    /// Beyond the shared sugared docket (BothPositive, GotoCommonExit,
-    /// SelectBoolReturn), the lowered view adds ReverseCopy:
-    /// lowering deliberately skips
-    /// IncrementDecrementPass, so the dup-based ++/-- idiom round-trips as an explicit temp
-    /// rather than the folded operator — a benign by-design divergence for this view.
+    /// lowered docket. The gate tolerates these but fails if a NEW method joins the set, and
+    /// <see cref="DocketRowsStayCheckedDiffs"/> fails if a listed method stops differing.
+    /// The lowered view's by-design divergences (for example lowering skipping
+    /// IncrementDecrementPass, so a dup-based ++/-- idiom round-trips as an explicit temp rather
+    /// than the folded operator) land here alongside the shared sugared docket. Rows are annotated
+    /// individually below; #3584 retired the entries that had silently stopped differing.
     /// </summary>
     static readonly HashSet<string> KnownDiffs = new(StringComparer.Ordinal)
     {
@@ -322,6 +322,9 @@ public class LoweredFidelityGateTests
                     FidelityCheck.CompileBackStatus.NotFull =>
                         $"{method}: dropped to NotFull — it now imports below Full fidelity, so no opcode "
                         + "verdict is formed. That is a validity regression, not a docketed diff.",
+                    FidelityCheck.CompileBackStatus.FidelityUnavailable =>
+                        $"{method}: the body comparison produced no verdict, so the row gates nothing. "
+                        + $"BodyComparisonRemainsAvailable reports the cause.\n  detail: {result.Detail}",
                     _ =>
                         $"{method}: regressed to {result.Status} — its lowered C# no longer recompiles, so it "
                         + $"silently left the diff set the docket gates.\n  detail: {result.Detail}",


### PR DESCRIPTION
## What

`NoNewFidelityDiffsBeyondKnownDocket` is a **one-directional allow list**. It fails when an
undocketed method diffs, but never when a docketed method *stops* diffing. Both ways a row can
leave the diff set are silent un-gates:

| Row becomes | Meaning | Today |
| --- | --- | --- |
| `Exact` | the residual was fixed | row now allows a regression it was never meant to cover; nothing reports it |
| `RecompileFail`/`ContextFail` | decompiled C# stopped compiling | drops out of the diff set, so the allow list **swallows a real regression** |

The repo already knew about the second mode and patched it **one fixture at a time**.
`FidelityGateTests.cs` remarks, on `SwitchStoreThenUse`:

> its danger mode is a *silent* regression that produces uncompilable output: that would drop it
> out of the opcode-diff set, so `NoNewFidelityDiffsBeyondKnownDocket` would not catch it.

That is why `SwitchStoreFold_StaysCompileBackCheckable` and
`PointerStoreUsesOriginalAddress_StaysCompileBackCheckable` exist. This PR generalizes them to all
143 docket rows.

## The measurement

Measured on this PR's merge-base:

| Rail | rendered | docket | actual diffs | MISSING | STALE |
| --- | --- | --- | --- | --- | --- |
| Raised | 668 | 83 | 59 | **0** | **24** |
| Lowered | 668 | 60 | 38 | **0** | **22** |

`missing = 0` on both rails, so retiring the rows cannot mask a current diff.

This was 10 raised / 15 lowered when #3584 was filed. #3505 landed after #3528, canonicalized
synthesized-member ordinals, and took the raised rail from 10 to 24 — exactly the outcome the
`StatementBodyLambdaInsideIf` row predicted when it was filed as #3503:

> Tracked as #3503, which proposes canonicalizing synthesized ordinals in the oracle so this whole
> class of row stops needing docket entries.

The class stopped needing entries. Nothing removed them, and nothing said so. `StatementBodyLambdaInsideIf`
was added by #3528, one commit before #3505 made it stale.

## The change

1. **`DocketRowsStayCheckedDiffs`** on both rails: every `KnownDiffs` row must still be `OpcodeDiff`
   or `OperandDiff`. This matches `eng/decompiler-gate-known-red.txt`, which already fails both when
   an unpinned test fails and when a pinned test passes.
2. **45 now-`Exact` rows promoted to `PinnedExact`**, not deleted. A docket row that stops diffing
   gates nothing; a `PinnedExact` row does. Promoting converts each silent allow into a real guarantee.
3. **`KnownNotFull`** — one row (`CapturedParamReadInOuterBody`) imports below Full, so the harness
   reports `NotFull` and forms no opcode verdict. It gets a named set rather than blanket tolerance,
   so a row that *newly* drops to `NotFull` still fails as the validity regression it is.

## Evidence

- `FidelityGateTests` + `LoweredFidelityGateTests`: **11/11 green**, Release.
- **Non-vacuity**: adding `CheckedAdd` (a `PinnedExact` method) to `KnownDiffs` fails with
  `CheckedAdd: now recompiles Exact, so its docket row is stale and silently allows a future
  regression.` Reverting it passes. The gate is not vacuous.

## Validation note

These gates are `Speed=Slow`, so **PR CI does not run them** — they run in Deep Inspect / publish.
The measurement above was taken on Windows, and some docket prose attributes rows to *SDK toolchain
drift* (the expression-tree group), so the stale set could in principle be toolchain-sensitive. I am
dispatching `deep-inspect.yml` on this branch to confirm the set on Linux before this merges. If the
Linux set differs, that is itself a finding and I will adjust the rows.

Closes #3584
