### PR TITLE
Trace which scanners and sections a library run actually executes

### DIFF
--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -189,6 +189,60 @@ When the pipeline computes multiple sections and the output format is the defaul
 
 This is tracked on options objects, which distinguish the default format from an explicit tabular flag.
 
+## Tracing
+
+`--trace` writes a diagnostic report to **stderr** describing the work a run actually did. stdout is
+untouched, so a caller parsing the document is unaffected (gated by a byte-identical stdout check).
+
+The report answers "did this run do the correct minimum work?", which nothing else can:
+
+```text
+trace: library ILInspector.Decompiler.dll [Minimal]
+  sections demanding a scanner
+    Library Info -> InfoCounts
+  scanners requested   InfoCounts
+  added by prerequisite ClassifiedMethods, CustomAttributes, ExtensionMethods, Resources, TypeForwarders
+  scanners executed
+    ExtensionMethods            9.3 ms
+    ClassifiedMethods           48.6 ms
+    ...
+    InfoCounts                  0.0 ms  (bundle, no work of its own)
+  resources acquired
+    metadata session            borrowed from the command's open image
+  total scanner time           74.4 ms
+```
+
+Five things are recorded, each at the only layer that knows it:
+
+| Fact | Recorded by |
+| --- | --- |
+| Which section demanded which scanner | `SectionPipeline.GetRequiredScanners` |
+| What prerequisite expansion added | `ScannerRegistry.ExpandRequired`, via `InspectAsync` |
+| Which scanners ran, in order, with timings | `ScannerRegistry.RunScanners` |
+| Whether a scanner is a bundle (no work of its own) | `ScannerRegistry.RunScanners` |
+| Which expensive resources were built | `ScannerContext.Session`/`BodyIndex`/`DrillMap` |
+
+Section-to-scanner attribution exists only on the demand side — downstream the registry sees a set of
+keys with no memory of who asked for them — which is why it is captured there rather than
+reconstructed later.
+
+Design points worth keeping:
+
+- **The typed record is the contract, not the text.** Tests assert on `InspectionTrace`, so the report
+  can be reformatted without rewriting gates.
+- **Resources are recorded at acquisition, not at request.** A resource that never appears was never
+  built. That absence is the observable: a regression that makes a metadata-only scan open the
+  whole-assembly IL index costs seconds and changes no output, so no other test would notice it.
+- **A failed acquisition is recorded too.** Scanners swallow a failed body index and render an empty
+  section; without a `FAILED` line, a run that tried and failed would look exactly like a run that
+  correctly never needed the index.
+- **Untraced runs pay nothing.** Tracing is threaded as a nullable object rather than a flag, so an
+  untraced run allocates nothing and takes no branch beyond a null check. A gate holds the shared
+  scan count equal with and without tracing, because a diagnostic that perturbs what it measures is
+  worse than none.
+- **The report is written in a `finally`.** A failed run still reports what it had done before
+  failing, which is when the question is most worth asking.
+
 ## Design Decisions
 
 **Static abstract interfaces over instances.** Descriptors are never instantiated. The pipeline extracts static members into delegate-based `SectionEntry<T>` records at registration time. This avoids allocations and keeps metadata in a format that NativeAOT can optimize.

--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -235,8 +235,10 @@ Design points worth keeping:
   command asked for it directly (today only discovery mode's metadata row counts), or a declared
   prerequisite pulled it in. Collapsing the second into the third would render a prerequisite edge
   that does not exist, and send anyone chasing an unexpected scan to the wrong declaration.
-  `Trace_AttributesEveryAddedScannerToARealPrerequisiteEdge` walks the registry's declared edges and
-  fails if anything shown as expansion is not actually reachable from a requested key.
+  `Trace_ExplainsEveryScannerThatRan` seeds reachability from what the trace *claims* — the recorded
+  section and command demands — and walks the registry's declared edges to reach the closure the run
+  actually produced. That asymmetry is what makes it a gate: seeding from the requested set instead
+  would re-derive `ExpandRequired`'s own input and assert a set is a subset of itself.
 - **Resources are recorded at acquisition, not at request.** A resource that never appears was never
   built. That absence is the observable: a regression that makes a metadata-only scan open the
   whole-assembly IL index costs seconds and changes no output, so no other test would notice it.

--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -217,6 +217,7 @@ Five things are recorded, each at the only layer that knows it:
 | Fact | Recorded by |
 | --- | --- |
 | Which section demanded which scanner | `SectionPipeline.GetRequiredScanners` |
+| Which scanners the command asked for directly | `LibraryCommand` (discovery mode) |
 | What prerequisite expansion added | `ScannerRegistry.ExpandRequired`, via `InspectAsync` |
 | Which scanners ran, in order, with timings | `ScannerRegistry.RunScanners` |
 | Whether a scanner is a bundle (no work of its own) | `ScannerRegistry.RunScanners` |
@@ -230,6 +231,12 @@ Design points worth keeping:
 
 - **The typed record is the contract, not the text.** Tests assert on `InspectionTrace`, so the report
   can be reformatted without rewriting gates.
+- **Each of the three ways a scanner can be pulled in has its own bucket.** A section demanded it, the
+  command asked for it directly (today only discovery mode's metadata row counts), or a declared
+  prerequisite pulled it in. Collapsing the second into the third would render a prerequisite edge
+  that does not exist, and send anyone chasing an unexpected scan to the wrong declaration.
+  `Trace_AttributesEveryAddedScannerToARealPrerequisiteEdge` walks the registry's declared edges and
+  fails if anything shown as expansion is not actually reachable from a requested key.
 - **Resources are recorded at acquisition, not at request.** A resource that never appears was never
   built. That absence is the observable: a regression that makes a metadata-only scan open the
   whole-assembly IL index costs seconds and changes no output, so no other test would notice it.

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1650,17 +1650,19 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void Trace_AttributesEveryAddedScannerToARealPrerequisiteEdge()
+    public void Trace_ExplainsEveryScannerThatRan()
     {
-        // "added by prerequisite" is a claim about *why* a scanner ran, and the report's whole value
-        // is that a reader can trust it. Anything added to the requested set after selection lands
-        // in the closure too, and rendering that as a prerequisite asserts an edge that does not
-        // exist -- sending whoever chases an unexpected scan to the wrong declaration. Discovery
-        // mode's Metadata scan is exactly that case, which is why it goes through the pipeline's
-        // commandDemand parameter rather than being bolted onto the returned set.
+        // The report attributes each scanner to one of three mechanisms: a section named it, the
+        // command named it, or a declared prerequisite pulled it in. That attribution is the report's
+        // entire value, and it is the part with no other check on it -- a wrong bucket still renders
+        // a plausible-looking report and sends whoever chases an unexpected scan to a declaration
+        // that does not exist. Discovery mode's Metadata scan was exactly that bug.
         //
-        // Check against the registry's declared edges rather than a hand-written expectation, so
-        // the gate cannot drift as the scanner graph changes.
+        // The asymmetry is what makes this a gate rather than a restatement: the closure comes from
+        // what the run actually *did* (ExpandRequired over the returned set), while reachability is
+        // seeded from what the trace *claims* (recorded section and command demands). Seeding from
+        // trace.Requested instead would re-derive ExpandRequired's own input and assert X is a subset
+        // of X -- which an earlier version of this test did, and which stayed green under tampering.
         var registry = LibrarySections.CreateScannerRegistry();
         (string, string)[] discoveryDemand = [("discovery catalog", LibrarySections.ScannerMetadata)];
 
@@ -1673,8 +1675,12 @@ public class SectionPipelineTests
 
             trace.RecordClosure(registry.ExpandRequired(requested));
 
-            var reachable = new HashSet<string>(trace.Requested, StringComparer.Ordinal);
-            var queue = new Queue<string>(trace.Requested);
+            var claimed = trace.Demand.Select(d => d.Scanner)
+                .Concat(trace.CommandDemand.Select(c => c.Scanner))
+                .ToHashSet(StringComparer.Ordinal);
+
+            var reachable = new HashSet<string>(claimed, StringComparer.Ordinal);
+            var queue = new Queue<string>(claimed);
             while (queue.Count > 0)
             {
                 foreach (var requirement in registry.RequirementsOf(queue.Dequeue()))
@@ -1687,8 +1693,8 @@ public class SectionPipelineTests
             Assert.Empty(trace.Closure.Except(reachable, StringComparer.Ordinal));
         }
 
-        // Non-vacuity: the discovery case has to actually add a scanner the sections never named,
-        // or the loop above proves nothing beyond the plain case.
+        // Non-vacuity: the discovery case has to actually pull in a scanner no section named, or the
+        // second iteration proves nothing the first did not.
         var plain = LibrarySections.CreatePipeline().GetRequiredScanners(Verbosity.Detailed);
         var withDiscovery = LibrarySections.CreatePipeline()
             .GetRequiredScanners(Verbosity.Detailed, commandDemand: discoveryDemand);

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1650,6 +1650,52 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void Trace_AttributesEveryAddedScannerToARealPrerequisiteEdge()
+    {
+        // "added by prerequisite" is a claim about *why* a scanner ran, and the report's whole value
+        // is that a reader can trust it. Anything added to the requested set after selection lands
+        // in the closure too, and rendering that as a prerequisite asserts an edge that does not
+        // exist -- sending whoever chases an unexpected scan to the wrong declaration. Discovery
+        // mode's Metadata scan is exactly that case, which is why it goes through the pipeline's
+        // commandDemand parameter rather than being bolted onto the returned set.
+        //
+        // Check against the registry's declared edges rather than a hand-written expectation, so
+        // the gate cannot drift as the scanner graph changes.
+        var registry = LibrarySections.CreateScannerRegistry();
+        (string, string)[] discoveryDemand = [("discovery catalog", LibrarySections.ScannerMetadata)];
+
+        foreach (var commandDemand in new[] { null, discoveryDemand })
+        {
+            var pipeline = LibrarySections.CreatePipeline();
+            var trace = new InspectionTrace();
+            var requested = pipeline.GetRequiredScanners(
+                Verbosity.Detailed, trace: trace, commandDemand: commandDemand);
+
+            trace.RecordClosure(registry.ExpandRequired(requested));
+
+            var reachable = new HashSet<string>(trace.Requested, StringComparer.Ordinal);
+            var queue = new Queue<string>(trace.Requested);
+            while (queue.Count > 0)
+            {
+                foreach (var requirement in registry.RequirementsOf(queue.Dequeue()))
+                {
+                    if (reachable.Add(requirement))
+                        queue.Enqueue(requirement);
+                }
+            }
+
+            Assert.Empty(trace.Closure.Except(reachable, StringComparer.Ordinal));
+        }
+
+        // Non-vacuity: the discovery case has to actually add a scanner the sections never named,
+        // or the loop above proves nothing beyond the plain case.
+        var plain = LibrarySections.CreatePipeline().GetRequiredScanners(Verbosity.Detailed);
+        var withDiscovery = LibrarySections.CreatePipeline()
+            .GetRequiredScanners(Verbosity.Detailed, commandDemand: discoveryDemand);
+        Assert.Equal([LibrarySections.ScannerMetadata], withDiscovery.Except(plain, StringComparer.Ordinal));
+    }
+
+    [Fact]
     public void Trace_RecordsNoBodyIndexForAScanThatDoesNotNeedOne()
     {
         // The negative half of the minimum-work claim, and the one worth gating. A regression that

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1600,6 +1600,155 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void Trace_RecordsWhatRan_AndMarksBundlesAsDoingNoWorkOfTheirOwn()
+    {
+        // InfoCounts is a bundle: it does no work itself and exists only to pull in five scanners.
+        // A trace that reported it as an ordinary scanner would attribute the bundle's dispatch
+        // cost to a step that has none, and hide that the real work belongs to its prerequisites.
+        var registry = LibrarySections.CreateScannerRegistry();
+        var trace = new InspectionTrace();
+        using var context = new ScannerContext
+        {
+            AssemblyPath = typeof(SectionPipelineTests).Assembly.Location,
+            Model = new LibraryInspection(),
+            Logger = new Output.VerboseLogger(false),
+            Trace = trace,
+        };
+
+        var closure = registry.ExpandRequired([LibrarySections.ScannerInfoCounts]);
+        registry.RunScanners(closure, context);
+
+        Assert.Equal(
+            closure.OrderBy(k => k, StringComparer.Ordinal),
+            trace.Executions.Select(e => e.Key).OrderBy(k => k, StringComparer.Ordinal));
+
+        var bundles = trace.Executions.Where(e => e.IsBundle).Select(e => e.Key).ToArray();
+        Assert.Equal([LibrarySections.ScannerInfoCounts], bundles);
+    }
+
+    [Fact]
+    public void Trace_SeparatesDirectDemandFromPrerequisiteExpansion()
+    {
+        // The distinction is the point of the report: a key in the closure but not in the request
+        // is work no section asked for by name, which is where an unintended cost creeps in.
+        var pipeline = LibrarySections.CreatePipeline();
+        var registry = LibrarySections.CreateScannerRegistry();
+        var trace = new InspectionTrace();
+
+        var requested = pipeline.GetRequiredScanners(Verbosity.Minimal, trace: trace);
+        trace.RecordClosure(registry.ExpandRequired(requested));
+
+        // Minimal selects the target section only, and it demands exactly the bundle.
+        Assert.Equal([LibrarySections.ScannerInfoCounts], trace.Requested);
+        Assert.All(trace.Demand, d => Assert.Equal(LibrarySections.ScannerInfoCounts, d.Scanner));
+
+        // Everything the bundle names is expansion, not demand.
+        var added = trace.Closure.Except(trace.Requested, StringComparer.Ordinal).ToHashSet(StringComparer.Ordinal);
+        Assert.Equal(
+            registry.RequirementsOf(LibrarySections.ScannerInfoCounts).ToHashSet(StringComparer.Ordinal),
+            added);
+    }
+
+    [Fact]
+    public void Trace_RecordsNoBodyIndexForAScanThatDoesNotNeedOne()
+    {
+        // The negative half of the minimum-work claim, and the one worth gating. A regression that
+        // makes a metadata-only scan open the whole-assembly IL index costs seconds and changes no
+        // output at all, so no other test in the suite would notice. Its absence from the resource
+        // list is the observable.
+        var registry = LibrarySections.CreateScannerRegistry();
+        var trace = new InspectionTrace();
+        using var metadataContext = PdbContext.Open(typeof(SectionPipelineTests).Assembly.Location);
+        using var context = new ScannerContext
+        {
+            AssemblyPath = typeof(SectionPipelineTests).Assembly.Location,
+            Model = new LibraryInspection(),
+            Logger = new Output.VerboseLogger(false),
+            MetadataContext = metadataContext,
+            Trace = trace,
+        };
+
+        registry.RunScanners(registry.ExpandRequired([LibrarySections.ScannerInfoCounts]), context);
+
+        Assert.Contains(trace.Resources, r => r.Resource == "metadata session");
+        Assert.DoesNotContain(trace.Resources, r => r.Resource == "body index");
+        Assert.DoesNotContain(trace.Resources, r => r.Resource == "drill map");
+    }
+
+    [Fact]
+    public void Trace_RecordsTheBodyIndexWhenAScannerActuallyBuildsIt()
+    {
+        // Paired positive. Without it the negative above is satisfied by a trace that never
+        // records a body index under any circumstances, which would pass while observing nothing.
+        // The index needs the prefetched image the command opens for exactly this reason; a plain
+        // PdbContext.Open cannot back it, and the scanner would swallow the failure and render an
+        // empty section. Opening it the way InspectAsync does is what makes this a real positive.
+        var registry = LibrarySections.CreateScannerRegistry();
+        var trace = new InspectionTrace();
+        using var service = SourceLinkService.OpenPrefetched(
+            typeof(SectionPipelineTests).Assembly.Location,
+            _ => { });
+        using var context = new ScannerContext
+        {
+            AssemblyPath = typeof(SectionPipelineTests).Assembly.Location,
+            Model = new LibraryInspection(),
+            Logger = new Output.VerboseLogger(false),
+            MetadataContext = service.Context,
+            Trace = trace,
+        };
+
+        registry.RunScanners(registry.ExpandRequired([LibrarySections.ScannerUnsafeMembers]), context);
+
+        var bodyIndex = Assert.Single(trace.Resources, r => r.Resource == "body index");
+        Assert.StartsWith("built in", bodyIndex.Detail);
+    }
+
+    [Fact]
+    public void Trace_RecordsAScannerThatThrew()
+    {
+        // The report is written in a finally, so a run that failed still says what it had done by
+        // the time it failed. If the throwing scanner were dropped from the record, the trace would
+        // implicate whichever scanner ran last before it.
+        var registry = new ScannerRegistry()
+            .Add("Boom", _ => throw new InvalidOperationException("boom"));
+        var trace = new InspectionTrace();
+        using var context = new ScannerContext
+        {
+            AssemblyPath = typeof(SectionPipelineTests).Assembly.Location,
+            Model = new LibraryInspection(),
+            Logger = new Output.VerboseLogger(false),
+            Trace = trace,
+        };
+
+        Assert.Throws<InvalidOperationException>(() => registry.RunScanners(["Boom"], context));
+
+        Assert.Equal(["Boom"], trace.Executions.Select(e => e.Key));
+    }
+
+    [Fact]
+    public void Tracing_DoesNotChangeTheWorkTheRunDoes()
+    {
+        // A diagnostic that perturbs what it measures is worse than none. Held against the shared
+        // scan count, which is the observable the atomicity gates already rely on.
+        static int RunAndCountSharedScans(InspectionTrace? trace)
+        {
+            var registry = LibrarySections.CreateScannerRegistry();
+            using var context = new ScannerContext
+            {
+                AssemblyPath = typeof(SectionPipelineTests).Assembly.Location,
+                Model = new LibraryInspection(),
+                Logger = new Output.VerboseLogger(false),
+                Trace = trace,
+            };
+
+            registry.RunScanners(registry.ExpandRequired(SharedSessionScannerKeys), context);
+            return context.SharedScanCount;
+        }
+
+        Assert.Equal(RunAndCountSharedScans(trace: null), RunAndCountSharedScans(new InspectionTrace()));
+    }
+
+    [Fact]
     public void SharedSessionScanners_MapTheirOwnFailuresRatherThanThrowing()
     {
         // Routing a scanner through the shared session means it runs its SESSION overload where it

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -322,6 +322,10 @@ public static class InspectionCommandDefinitions
         assemblyCommand.Options.Add(opts.RawUrls);
         assemblyCommand.Options.Add(opts.BrowsableUrls);
         assemblyCommand.Options.Add(extractResourcesOption);
+        // Registered per-command rather than in AddOutputOptionsTo: only the commands that build a
+        // trace should advertise the flag. A flag every command accepts and only one honours is
+        // worse than an unrecognized argument, which at least fails loudly.
+        assemblyCommand.Options.Add(opts.Trace);
         opts.AddAllOptionsTo(assemblyCommand);
         opts.AddCountOptionTo(assemblyCommand);
         opts.AddPrintOptionTo(assemblyCommand);
@@ -443,6 +447,7 @@ public static class InspectionCommandDefinitions
                 FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
                 Format = opts.ResolveFormat(parseResult),
                 Verbose = parseResult.GetValue(opts.Verbose),
+                Trace = parseResult.GetValue(opts.Trace),
                 Verbosity = opts.ParseVerbosity(parseResult),
                 Discover = opts.ParseDiscover(parseResult),
                 Tree = parseResult.GetValue(opts.Tree),

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -28,6 +28,19 @@ namespace DotnetInspector.Commands;
 /// </summary>
 public class LibraryCommand
 {
+    /// <summary>
+    /// Discovery must know which metadata tables carry rows, or the whole <c>@Metadata</c> category
+    /// filters out of the catalog: its sections are explicit-only, so no verbosity requests them,
+    /// and their applicability is the scanned row count. The scan is deliberately the cheap half of
+    /// the lens — table row counts, never rows — so listing the category accurately costs a header
+    /// read rather than a projection.
+    ///
+    /// Passed into <see cref="SectionPipeline.GetRequiredScanners"/> rather than added to its result,
+    /// so the one method that computes the requested set is also the one that records it.
+    /// </summary>
+    private static readonly (string Reason, string Scanner)[] DiscoveryScanners =
+        [("discovery catalog", LibrarySections.ScannerMetadata)];
+
     public static async Task<int> ExecuteAsync(LibraryOptions options)
     {
         if (!options.Trace)
@@ -305,15 +318,8 @@ public class LibraryCommand
         if (trace is not null)
             trace.Verbosity = options.Verbosity.ToString();
         var scanners = pipeline.GetRequiredScanners(
-            options.Verbosity, options.IncludeSections, options.FixedOverview, trace);
-
-        // Discovery must know which metadata tables carry rows, or the whole @Metadata category
-        // filters out of the catalog: its sections are explicit-only, so no verbosity requests
-        // them, and their applicability is the scanned row count. The scan is deliberately the
-        // cheap half of the lens -- table row counts, never rows -- so listing the category
-        // accurately costs a header read rather than a projection.
-        if (effectiveDiscovery)
-            scanners.Add(LibrarySections.ScannerMetadata);
+            options.Verbosity, options.IncludeSections, options.FixedOverview, trace,
+            effectiveDiscovery ? DiscoveryScanners : null);
 
         // Check for valid input source
         if (string.IsNullOrEmpty(assemblyPath) &&

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -30,6 +30,33 @@ public class LibraryCommand
 {
     public static async Task<int> ExecuteAsync(LibraryOptions options)
     {
+        if (!options.Trace)
+            return await ExecuteCoreAsync(options, trace: null);
+
+        // Rendered in a finally so a failed run still reports the work it did before failing —
+        // which is exactly when "what did this actually scan?" is worth knowing.
+        var trace = new InspectionTrace
+        {
+            Command = "library",
+            Target = Path.GetFileName(
+                options.AssemblyName
+                    ?? options.PackagePath
+                    ?? options.PlatformAssembly
+                    ?? string.Empty),
+        };
+
+        try
+        {
+            return await ExecuteCoreAsync(options, trace);
+        }
+        finally
+        {
+            Console.Error.Write(trace.Render());
+        }
+    }
+
+    private static async Task<int> ExecuteCoreAsync(LibraryOptions options, InspectionTrace? trace)
+    {
         var assemblyPath = options.AssemblyName;
         var pipeline = LibrarySections.CreatePipeline();
         var scannerRegistry = LibrarySections.CreateScannerRegistry();
@@ -275,8 +302,10 @@ public class LibraryCommand
             OutputFormatResolver.WarnIfTabularDetailMismatch(options.Tabular, options.Verbosity, options.IncludeSections);
 
         // Compute which scanners are needed for the requested sections
+        if (trace is not null)
+            trace.Verbosity = options.Verbosity.ToString();
         var scanners = pipeline.GetRequiredScanners(
-            options.Verbosity, options.IncludeSections, options.FixedOverview);
+            options.Verbosity, options.IncludeSections, options.FixedOverview, trace);
 
         // Discovery must know which metadata tables carry rows, or the whole @Metadata category
         // filters out of the catalog: its sections are explicit-only, so no verbosity requests
@@ -353,7 +382,7 @@ public class LibraryCommand
                     }
                 }
 
-                var inspection = await LibraryMetadataService.InspectAsync(resolvedPath!, options, logger, null, null, context.HttpClient, isPlatformAssembly: true, scanners: scanners, scannerRegistry: scannerRegistry, discoveryOnly: effectiveDiscovery);
+                var inspection = await LibraryMetadataService.InspectAsync(resolvedPath!, options, logger, null, null, context.HttpClient, isPlatformAssembly: true, scanners: scanners, scannerRegistry: scannerRegistry, discoveryOnly: effectiveDiscovery, trace: trace);
                 if (inspection == null)
                 {
                     Console.Error.WriteLine($"Error: Could not read library: {resolvedPath}");
@@ -435,7 +464,7 @@ public class LibraryCommand
                 // Inspect all assemblies
                 var inspections = await CollectPackageInspectionsAsync(
                     assemblyPaths, options, logger, packageName, packageVersion,
-                    extractPath, context.HttpClient, signatureResult, scanners, scannerRegistry, effectiveDiscovery);
+                    extractPath, context.HttpClient, signatureResult, scanners, scannerRegistry, effectiveDiscovery, trace);
 
                 if (inspections.Count == 0)
                 {
@@ -507,7 +536,7 @@ public class LibraryCommand
                     }
                 }
 
-                var inspection = await LibraryMetadataService.InspectAsync(assemblyPath!, options, logger, null, null, context.HttpClient, scanners: scanners, scannerRegistry: scannerRegistry, discoveryOnly: effectiveDiscovery);
+                var inspection = await LibraryMetadataService.InspectAsync(assemblyPath!, options, logger, null, null, context.HttpClient, scanners: scanners, scannerRegistry: scannerRegistry, discoveryOnly: effectiveDiscovery, trace: trace);
                 if (inspection == null)
                 {
                     Console.Error.WriteLine($"Error: Could not read library: {assemblyPath}");
@@ -1933,7 +1962,7 @@ public class LibraryCommand
         string? packageName, string? packageVersion, string extractPath,
         HttpClient httpClient, SignatureVerificationResult? signatureResult,
         HashSet<string>? scanners = null, ScannerRegistry? scannerRegistry = null,
-        bool discoveryOnly = false)
+        bool discoveryOnly = false, InspectionTrace? trace = null)
     {
         List<LibraryInspection> inspections = [];
 
@@ -1941,7 +1970,7 @@ public class LibraryCommand
         {
             var version = packageVersion ?? (packageName != null ? PackageExtractor.ExtractVersionFromPath(targetPath, packageName) : null);
 
-            var inspection = await LibraryMetadataService.InspectAsync(targetPath, options, logger, packageName, version, httpClient, scanners: scanners, scannerRegistry: scannerRegistry, discoveryOnly: discoveryOnly);
+            var inspection = await LibraryMetadataService.InspectAsync(targetPath, options, logger, packageName, version, httpClient, scanners: scanners, scannerRegistry: scannerRegistry, discoveryOnly: discoveryOnly, trace: trace);
             if (inspection == null)
             {
                 logger.Log($"Warning: Could not read library: {Path.GetFileName(targetPath)}");

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -36,7 +36,8 @@ internal static class LibraryMetadataService
         bool isPlatformAssembly = false,
         HashSet<string>? scanners = null,
         ScannerRegistry? scannerRegistry = null,
-        bool discoveryOnly = false)
+        bool discoveryOnly = false,
+        Sections.InspectionTrace? trace = null)
     {
         logger.Log($"Inspecting: {Path.GetFileName(path)}");
 
@@ -47,6 +48,8 @@ internal static class LibraryMetadataService
             var requiredScanners = scannerRegistry is not null && scanners is not null
                 ? scannerRegistry.ExpandRequired(scanners)
                 : scanners;
+            if (requiredScanners is not null)
+                trace?.RecordClosure(requiredScanners);
             var bodyAnalysisFeatures = requiredScanners is null
                 ? Analysis.LibraryBodyAnalysisFeatures.None
                 : SelectBodyAnalysisFeatures(requiredScanners);
@@ -160,6 +163,7 @@ internal static class LibraryMetadataService
                     Logger = logger,
                     MetadataContext = pdbContext,
                     BodyAnalysisFeatures = bodyAnalysisFeatures,
+                    Trace = trace,
                 };
                 scannerRegistry.RunScanners(requiredScanners, scannerContext);
             }

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -143,6 +143,13 @@ public record LibraryOptions : IProjectionOptions
     public bool Verbose { get; init; }
 
     /// <summary>
+    /// Report the work the run actually did — selected sections, the scanners they demanded, what
+    /// prerequisite expansion added, execution times, and expensive resource acquisition — on
+    /// stderr. Diagnostic only: stdout is unchanged, so a caller parsing the document is unaffected.
+    /// </summary>
+    public bool Trace { get; init; }
+
+    /// <summary>
     /// Output verbosity level.
     /// </summary>
     public Verbosity Verbosity { get; init; } = Verbosity.Normal;

--- a/src/dotnet-inspect/Sections/InspectionTrace.cs
+++ b/src/dotnet-inspect/Sections/InspectionTrace.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace DotnetInspector.Sections;
+
+/// <summary>
+/// One scanner that <see cref="ScannerRegistry.RunScanners"/> actually invoked.
+/// </summary>
+/// <param name="Key">The scanner key.</param>
+/// <param name="IsBundle">
+/// True when the key does no work of its own and exists only to pull in prerequisites
+/// (<see cref="ScannerRegistry.AddBundle"/>). A bundle's elapsed time is its own dispatch only —
+/// the work is attributed to the prerequisites it named.
+/// </param>
+/// <param name="Elapsed">Wall time spent inside the scanner body.</param>
+public readonly record struct ScannerExecution(string Key, bool IsBundle, TimeSpan Elapsed);
+
+/// <summary>
+/// A record of what a single inspection actually did: which sections were selected, which scanner
+/// keys those sections demanded, what the prerequisite closure added, which scanners ran and for
+/// how long, and which expensive resources were acquired.
+///
+/// This exists to make "the system did the correct minimum work" checkable rather than asserted.
+/// The section/scanner pipeline is demand-driven — a scanner runs only when a selected section
+/// declares its key — but nothing about a correct run looks different from a run that scanned the
+/// whole assembly and threw the result away. Both print the same sections. A trace is the only
+/// place the difference is visible, so it is also what a test asserts on: the typed record, not
+/// rendered text.
+///
+/// Tracing is off unless a trace object is threaded through, so an untraced run allocates nothing
+/// and takes no branch beyond a null check.
+/// </summary>
+public sealed class InspectionTrace
+{
+    private readonly List<(string Section, string Scanner)> _demand = [];
+    private readonly List<string> _requested = [];
+    private readonly List<string> _closure = [];
+    private readonly List<ScannerExecution> _executions = [];
+    private readonly List<(string Resource, string Detail)> _resources = [];
+
+    /// <summary>The command that produced this trace (for the report header).</summary>
+    public string? Command { get; set; }
+
+    /// <summary>The inspection target (for the report header).</summary>
+    public string? Target { get; set; }
+
+    /// <summary>The effective verbosity the selection ran at (for the report header).</summary>
+    public string? Verbosity { get; set; }
+
+    /// <summary>Sections that were selected and the scanner key each one demanded.</summary>
+    public IReadOnlyList<(string Section, string Scanner)> Demand => _demand;
+
+    /// <summary>Scanner keys demanded directly by a selected section.</summary>
+    public IReadOnlyList<string> Requested => _requested;
+
+    /// <summary>
+    /// Scanner keys after prerequisite expansion. Anything here but not in
+    /// <see cref="Requested"/> was pulled in by a declared prerequisite.
+    /// </summary>
+    public IReadOnlyList<string> Closure => _closure;
+
+    /// <summary>Scanners that ran, in execution order.</summary>
+    public IReadOnlyList<ScannerExecution> Executions => _executions;
+
+    /// <summary>
+    /// Expensive resources the run acquired, in acquisition order — the shared metadata session,
+    /// the whole-assembly body index, the drill map. A resource that never appears was never built,
+    /// which is the property most worth checking: a section that should not have cost anything
+    /// leaves no resource line.
+    /// </summary>
+    public IReadOnlyList<(string Resource, string Detail)> Resources => _resources;
+
+    /// <summary>Total time attributed to scanner bodies.</summary>
+    public TimeSpan TotalScannerTime
+    {
+        get
+        {
+            var total = TimeSpan.Zero;
+            foreach (var execution in _executions)
+                total += execution.Elapsed;
+            return total;
+        }
+    }
+
+    /// <summary>Records that <paramref name="section"/> demanded <paramref name="scanner"/>.</summary>
+    public void RecordDemand(string section, string scanner) => _demand.Add((section, scanner));
+
+    /// <summary>Records the scanner keys demanded directly by the selected sections.</summary>
+    public void RecordRequested(IEnumerable<string> keys)
+    {
+        _requested.Clear();
+        _requested.AddRange(keys);
+        _requested.Sort(StringComparer.Ordinal);
+    }
+
+    /// <summary>Records the scanner keys after prerequisite expansion.</summary>
+    public void RecordClosure(IEnumerable<string> keys)
+    {
+        _closure.Clear();
+        _closure.AddRange(keys);
+        _closure.Sort(StringComparer.Ordinal);
+    }
+
+    /// <summary>Records one scanner invocation.</summary>
+    public void RecordExecution(string key, bool isBundle, TimeSpan elapsed)
+        => _executions.Add(new ScannerExecution(key, isBundle, elapsed));
+
+    /// <summary>
+    /// Records an expensive resource acquisition. Called at the point of acquisition rather than
+    /// at the point of request, so the trace shows what was built, not what might have been.
+    /// </summary>
+    public void RecordResource(string resource, string detail)
+        => _resources.Add((resource, detail));
+
+    /// <summary>
+    /// Runs <paramref name="body"/> and records it as a scanner execution. Timing uses
+    /// <see cref="Stopwatch.GetTimestamp"/> deltas rather than a Stopwatch instance so a traced run
+    /// allocates nothing per scanner.
+    /// </summary>
+    public void Time(string key, bool isBundle, Action body)
+    {
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            body();
+        }
+        finally
+        {
+            RecordExecution(key, isBundle, Stopwatch.GetElapsedTime(start));
+        }
+    }
+
+    /// <summary>
+    /// Renders the plain-text diagnostic report written to stderr under <c>--trace</c>. This is a
+    /// diagnostic surface, deliberately not a Markout section: it must not alter the stdout
+    /// document a caller is parsing.
+    /// </summary>
+    public string Render()
+    {
+        var text = new StringBuilder();
+        text.Append("trace: ").Append(Command ?? "inspect");
+        if (Target is { Length: > 0 })
+            text.Append(' ').Append(Target);
+        if (Verbosity is { Length: > 0 })
+            text.Append(" [").Append(Verbosity).Append(']');
+        text.AppendLine();
+
+        text.AppendLine("  sections demanding a scanner");
+        if (_demand.Count == 0)
+        {
+            text.AppendLine("    (none)");
+        }
+        else
+        {
+            foreach (var (section, scanner) in _demand)
+                text.Append("    ").Append(section).Append(" -> ").AppendLine(scanner);
+        }
+
+        text.Append("  scanners requested   ").AppendLine(Join(_requested));
+
+        var added = _closure.Where(k => !_requested.Contains(k, StringComparer.Ordinal)).ToList();
+        text.Append("  added by prerequisite").Append(' ').AppendLine(Join(added));
+
+        text.AppendLine("  scanners executed");
+        if (_executions.Count == 0)
+        {
+            text.AppendLine("    (none)");
+        }
+        else
+        {
+            foreach (var execution in _executions)
+            {
+                text.Append("    ")
+                    .Append(execution.Key.PadRight(28))
+                    .Append(Format(execution.Elapsed));
+                if (execution.IsBundle)
+                    text.Append("  (bundle, no work of its own)");
+                text.AppendLine();
+            }
+        }
+
+        text.AppendLine("  resources acquired");
+        if (_resources.Count == 0)
+        {
+            text.AppendLine("    (none)");
+        }
+        else
+        {
+            foreach (var (resource, detail) in _resources)
+                text.Append("    ").Append(resource.PadRight(28)).AppendLine(detail);
+        }
+
+        text.Append("  total scanner time   ").AppendLine(Format(TotalScannerTime));
+        return text.ToString();
+    }
+
+    private static string Join(IReadOnlyList<string> values)
+        => values.Count == 0 ? "(none)" : string.Join(", ", values);
+
+    private static string Format(TimeSpan elapsed)
+        => elapsed.TotalMilliseconds.ToString("F1", CultureInfo.InvariantCulture) + " ms";
+}

--- a/src/dotnet-inspect/Sections/InspectionTrace.cs
+++ b/src/dotnet-inspect/Sections/InspectionTrace.cs
@@ -34,6 +34,7 @@ public readonly record struct ScannerExecution(string Key, bool IsBundle, TimeSp
 public sealed class InspectionTrace
 {
     private readonly List<(string Section, string Scanner)> _demand = [];
+    private readonly List<(string Reason, string Scanner)> _commandDemand = [];
     private readonly List<string> _requested = [];
     private readonly List<string> _closure = [];
     private readonly List<ScannerExecution> _executions = [];
@@ -50,6 +51,13 @@ public sealed class InspectionTrace
 
     /// <summary>Sections that were selected and the scanner key each one demanded.</summary>
     public IReadOnlyList<(string Section, string Scanner)> Demand => _demand;
+
+    /// <summary>
+    /// Scanners the command asked for directly, with the reason. Kept separate from
+    /// <see cref="Demand"/> because no selected section named them, and separate from the
+    /// prerequisite closure because no prerequisite edge pulled them in.
+    /// </summary>
+    public IReadOnlyList<(string Reason, string Scanner)> CommandDemand => _commandDemand;
 
     /// <summary>Scanner keys demanded directly by a selected section.</summary>
     public IReadOnlyList<string> Requested => _requested;
@@ -85,6 +93,26 @@ public sealed class InspectionTrace
 
     /// <summary>Records that <paramref name="section"/> demanded <paramref name="scanner"/>.</summary>
     public void RecordDemand(string section, string scanner) => _demand.Add((section, scanner));
+
+    /// <summary>
+    /// Records a scanner the command itself asked for after section selection had finished — today
+    /// only discovery mode, which needs metadata table row counts to decide whether the
+    /// <c>@Metadata</c> category has anything worth listing.
+    ///
+    /// This has its own recorder rather than folding into the closure because the report's entire
+    /// value is that a reader can trust which mechanism pulled a scanner in. A command-level demand
+    /// rendered as "added by prerequisite" asserts a prerequisite edge that does not exist, and
+    /// sends anyone chasing an unexpected scan to the wrong declaration.
+    /// </summary>
+    public void RecordCommandDemand(string reason, string scanner)
+    {
+        _commandDemand.Add((reason, scanner));
+        if (!_requested.Contains(scanner, StringComparer.Ordinal))
+        {
+            _requested.Add(scanner);
+            _requested.Sort(StringComparer.Ordinal);
+        }
+    }
 
     /// <summary>Records the scanner keys demanded directly by the selected sections.</summary>
     public void RecordRequested(IEnumerable<string> keys)
@@ -155,6 +183,13 @@ public sealed class InspectionTrace
         {
             foreach (var (section, scanner) in _demand)
                 text.Append("    ").Append(section).Append(" -> ").AppendLine(scanner);
+        }
+
+        if (_commandDemand.Count > 0)
+        {
+            text.AppendLine("  demanded by the command");
+            foreach (var (reason, scanner) in _commandDemand)
+                text.Append("    ").Append(reason).Append(" -> ").AppendLine(scanner);
         }
 
         text.Append("  scanners requested   ").AppendLine(Join(_requested));

--- a/src/dotnet-inspect/Sections/ScannerRegistry.cs
+++ b/src/dotnet-inspect/Sections/ScannerRegistry.cs
@@ -17,6 +17,12 @@ public sealed class ScannerContext : IDisposable
     public PdbContext? MetadataContext { get; init; }
 
     /// <summary>
+    /// When supplied, records scanner execution and expensive resource acquisition. Null for an
+    /// untraced run, which is every run that did not pass <c>--trace</c>.
+    /// </summary>
+    public InspectionTrace? Trace { get; init; }
+
+    /// <summary>
     /// Analysis features required by the complete scanner set. The shared body session computes
     /// their union once, so Array Pool Escapes can share acquisition with leverage/performance scans
     /// without making a resource-only request pay for unrelated body evidence.
@@ -69,14 +75,22 @@ public sealed class ScannerContext : IDisposable
         _sessionOpenAttempted = true;
         try
         {
-            _session = MetadataContext is { HasMetadata: true } context
-                ? AssemblyInspectionSession.Borrow(context)
-                : AssemblyInspectionSession.Open(AssemblyPath);
+            if (MetadataContext is { HasMetadata: true } context)
+            {
+                _session = AssemblyInspectionSession.Borrow(context);
+                Trace?.RecordResource("metadata session", "borrowed from the command's open image");
+            }
+            else
+            {
+                _session = AssemblyInspectionSession.Open(AssemblyPath);
+                Trace?.RecordResource("metadata session", "opened (no shared image available)");
+            }
         }
         catch (Exception)
         {
             // Left to the fallback path overload, which logs and produces the failed inspection.
             _session = null;
+            Trace?.RecordResource("metadata session", "failed to open; scanners reopen individually");
         }
 
         return _session;
@@ -130,11 +144,37 @@ public sealed class ScannerContext : IDisposable
     /// narrowed to the phases the requested scanners consume (see
     /// <see cref="BodyAnalysisFeatures"/>).
     /// </summary>
-    public Analysis.LibraryBodyIndex BodyIndex() =>
-        (_bodySession ??= MethodBodyInspectionSession.OpenWithPrefetchedImage(
-            AssemblyPath,
-            GetMetadataContext(),
-            BodyAnalysisFeatures)).BodyIndex;
+    public Analysis.LibraryBodyIndex BodyIndex()
+    {
+        if (_bodySession is not null)
+            return _bodySession.BodyIndex;
+
+        var start = System.Diagnostics.Stopwatch.GetTimestamp();
+        try
+        {
+            _bodySession = MethodBodyInspectionSession.OpenWithPrefetchedImage(
+                AssemblyPath,
+                GetMetadataContext(),
+                BodyAnalysisFeatures);
+        }
+        catch (Exception ex)
+        {
+            // Scanners swallow a failed index and render an empty section, so without this the
+            // trace would show no body index for a run that tried to build one and failed —
+            // indistinguishable from a run that correctly never needed it.
+            Trace?.RecordResource("body index", $"FAILED after {Elapsed(start)}: {ex.GetType().Name}");
+            throw;
+        }
+
+        var index = _bodySession.BodyIndex;
+        Trace?.RecordResource(
+            "body index",
+            $"built in {Elapsed(start)} (features: {BodyAnalysisFeatures})");
+        return index;
+    }
+
+    private static string Elapsed(long start)
+        => $"{System.Diagnostics.Stopwatch.GetElapsedTime(start).TotalMilliseconds:F1} ms";
 
     /// <summary>
     /// Stable member drill coordinates, derived once from the command's shared
@@ -142,10 +182,15 @@ public sealed class ScannerContext : IDisposable
     /// </summary>
     public IReadOnlyDictionary<int, (string? Stable, string Visibility, string Selector)>
         DrillMap()
-        => _drillMap ??=
-            LibraryMetadataService.BuildLibraryDrillMap(
-                GetMetadataContext(),
-                Logger);
+    {
+        if (_drillMap is not null)
+            return _drillMap;
+
+        var start = System.Diagnostics.Stopwatch.GetTimestamp();
+        _drillMap = LibraryMetadataService.BuildLibraryDrillMap(GetMetadataContext(), Logger);
+        Trace?.RecordResource("drill map", $"built in {Elapsed(start)} ({_drillMap.Count} members)");
+        return _drillMap;
+    }
 
     PdbContext GetMetadataContext()
         => MetadataContext
@@ -305,6 +350,10 @@ public sealed class ScannerRegistry
 
         running.Remove(key);
         ran.Add(key);
-        scan?.Invoke(context);
+
+        if (context.Trace is { } trace)
+            trace.Time(key, isBundle: scan is null, () => scan?.Invoke(context));
+        else
+            scan?.Invoke(context);
     }
 }

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -578,9 +578,16 @@ public sealed class SectionPipeline<TModel>
     /// pipeline and the only place the section-to-scanner attribution exists — downstream, the
     /// registry sees a set of keys with no memory of who asked for them.
     /// </param>
+    /// <param name="commandDemand">
+    /// Scanners the caller needs for reasons no section expresses, each paired with the reason.
+    /// They belong here rather than being added to the returned set afterwards: this method is the
+    /// one place that knows the full requested set, so anything added later is a scanner the trace
+    /// cannot attribute and will misreport as prerequisite expansion.
+    /// </param>
     public HashSet<string> GetRequiredScanners(Verbosity verbosity,
         HashSet<string>? include = null, bool fixedOverview = false,
-        InspectionTrace? trace = null)
+        InspectionTrace? trace = null,
+        IReadOnlyList<(string Reason, string Scanner)>? commandDemand = null)
     {
         HashSet<string> scanners = [];
         for (int i = 0; i < _entries.Count; i++)
@@ -592,6 +599,15 @@ public sealed class SectionPipeline<TModel>
             {
                 scanners.Add(entry.ScannerKey);
                 trace?.RecordDemand(entry.Name, entry.ScannerKey);
+            }
+        }
+
+        if (commandDemand is not null)
+        {
+            foreach (var (reason, scanner) in commandDemand)
+            {
+                scanners.Add(scanner);
+                trace?.RecordCommandDemand(reason, scanner);
             }
         }
 

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -573,8 +573,14 @@ public sealed class SectionPipeline<TModel>
     /// Returns the set of scanner keys needed to satisfy all requested sections.
     /// Sections with a null scanner key are always collected and not included.
     /// </summary>
+    /// <param name="trace">
+    /// When supplied, records which section demanded which scanner. This is the demand side of the
+    /// pipeline and the only place the section-to-scanner attribution exists — downstream, the
+    /// registry sees a set of keys with no memory of who asked for them.
+    /// </param>
     public HashSet<string> GetRequiredScanners(Verbosity verbosity,
-        HashSet<string>? include = null, bool fixedOverview = false)
+        HashSet<string>? include = null, bool fixedOverview = false,
+        InspectionTrace? trace = null)
     {
         HashSet<string> scanners = [];
         for (int i = 0; i < _entries.Count; i++)
@@ -583,8 +589,13 @@ public sealed class SectionPipeline<TModel>
             if (entry.ScannerKey == null)
                 continue;
             if (IsRequested(entry, i, verbosity, include, fixedOverview))
+            {
                 scanners.Add(entry.ScannerKey);
+                trace?.RecordDemand(entry.Name, entry.ScannerKey);
+            }
         }
+
+        trace?.RecordRequested(scanners);
         return scanners;
     }
 

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -31,6 +31,7 @@ public class SharedOptions
 
     // Verbosity options
     public Option<bool> Verbose { get; } = new("--verbose") { Description = "Show progress messages on stderr" };
+    public Option<bool> Trace { get; } = new("--trace") { Description = "Report which sections were selected, which scanners ran and for how long, and which expensive resources were built, on stderr" };
     public Option<string?> Verbosity { get; } = new("-v") { Description = "Verbosity: q(uiet), m(inimal), n(ormal), d(etailed)", Arity = ArgumentArity.ZeroOrOne, DefaultValueFactory = _ => null };
 
     // Output control options


### PR DESCRIPTION
## What

Adds `--trace` to the `library` command. It writes a plain diagnostic report to **stderr**; stdout markout is untouched and byte-identical.

## Why

The section pipeline is demand-driven — a section declares a scanner key, the registry expands prerequisites, only the closure runs. That is the design, but nothing observed it. "The system does the correct minimum work" was a claim resting on reading the code.

The next change in this area (moving cost declaration from sections onto scanners) needs to prove a before/after difference in **what runs**, not just in what renders. This is the instrument for that.

## The report

Default `-v:m` against `ILInspector.Decompiler.dll`:

```
trace: library ILInspector.Decompiler.dll [Minimal]
  sections demanding a scanner
    Library Info -> InfoCounts
  scanners requested   InfoCounts
  added by prerequisite ClassifiedMethods, CustomAttributes, ExtensionMethods, Resources, TypeForwarders
  scanners executed
    ExtensionMethods            11.4 ms
    ClassifiedMethods           53.1 ms
    Resources                    2.1 ms
    CustomAttributes             9.1 ms
    TypeForwarders               2.0 ms
    InfoCounts                   0.0 ms  (bundle, no work of its own)
  resources acquired
    metadata session            borrowed from the command's open image
  total scanner time   77.8 ms
```

The same assembly at `-v:d`: **6,880 ms**, of which `OptimizationOpportunities` is **4,728 ms**, `ResourceTriage` 1,273 ms, `Switches` 753 ms; resources show `body index built in 2,153.4 ms` and `drill map built in 1,263.5 ms (7,463 members)`.

Those sections — the eight `Performance: *` plus `Array Pool Escapes` — declare `Cost = NetworkFree`. That is the defect the next PR fixes, and this is the measurement it will be judged against.

## Design decisions worth reviewing

**The trace is a nullable object, not a flag.** An untraced run allocates nothing and pays one null check per site. There is no second code path. `Tracing_DoesNotChangeTheWorkTheRunDoes` holds `SharedScanCount` equal with and without a trace, so the observer cannot start perturbing what it observes.

**Resources are recorded at acquisition, not at request.** Absence is the observable fact: a metadata-only scan that quietly starts building the IL body index costs seconds and changes no output, so no other gate in the suite would notice. `Trace_RecordsNoBodyIndexForAScanThatDoesNotNeedOne` is the minimum-work gate; `Trace_RecordsTheBodyIndexWhenAScannerActuallyBuildsIt` is its paired positive — without it, a recorder that never records anything passes.

**Failed acquisition is recorded** (`FAILED after X ms: <Type>`). Scanners swallow a failed body index and render an empty section, so without this line "tried and failed" is indistinguishable from "correctly never needed it".

**Bundles are marked.** `InfoCounts` does no work of its own; attributing its prerequisites' time to it would be a lie in the one place the report is meant to be trusted.

**Written in a `finally`**, so a failing run still says what it did before failing.

**Section→scanner attribution exists only on the demand side.** Downstream the registry sees a bare set of keys, and the report does not pretend otherwise.

**Scoped to the command that implements it.** `--trace` is registered on the `library` command directly, not in the shared `AddOutputOptionsTo` helper. A flag every command accepts and only one honours is worse than an unrecognized argument, which at least fails loudly. `dotnet-inspect package <id> --trace` now reports `Unrecognized option '--trace'`.

**Tests assert on the `InspectionTrace` object, not on rendered text**, so the report can be reformatted without rewriting the gates.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release` — clean, 0 errors, 6 pre-existing warnings.
- `dotnet run --project src/dotnet-inspect.Tests -c Release` — **2587 total / 2 failed / 10 skipped**. Both failures (`Layout_Count_CountsFilesRatherThanRenderedTreeLines`, `Package_DeclaredNonMarkdownReadme_IsStillNotMarkdown(readmePath: "images/logo.png.")`) reproduce at clean `origin/main`.
- stdout **SHA-256 identical** with and without `--trace` at `-v:n` (103,620 bytes).
- `--trace` rejected as unrecognized on `package`; accepted and honoured on `library`.

## Boundary

`PackageCommand` also calls `GetRequiredScanners` and is deliberately **not** wired for tracing here — it shares the registry, so extending it is additive and belongs in its own change.
