### PR TITLE
Gate the two sweep properties that only hand-run probes covered

### DIFF
--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -390,8 +390,9 @@ catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or N
 // honored here so a caller can point this sweep at a cache of its own. Without them the
 // sweep reaches the developer's shared caches and the network unconditionally, which is
 // why its two central properties -- that the pin binds, and that the copies land where
-// told -- could only ever be evidenced by hand-run probes (#3560). This is not a test
-// backdoor: it is one program catching up to a convention the rest of the tool follows,
+// told -- could only ever be evidenced by hand-run probes (#3560). Those properties are
+// now gated by EvilPoolSweepGateTests, which runs this file offline against a scratch
+// cache. This is not a test backdoor: it is one program catching up to a convention the rest of the tool follows,
 // with the CLI's meanings unchanged. An isolated session skips the shared NuGet cache
 // and, absent an explicit directory, gets its own. Reading them costs nothing when they
 // are unset, which is the case for every real sweep.

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -1179,6 +1179,13 @@ static async Task<WriteOutcome> ReplaceOrReport(string path, Func<FileStream, Ta
     // directory can occupy first, and a write through a planted symlink lands wherever
     // that link points. CreateNew refuses to open anything that already exists, so the
     // sweep either makes this file itself or writes nothing.
+    //
+    // Reasoned, not gated, and marked as such. The destination half of this is gated --
+    // EvilPoolSweepGateTests plants a symlink at the destination and requires a real file
+    // afterwards -- but the temporary half is not, because the name is drawn inside this
+    // function and never leaves it, so nothing outside can occupy it except by racing a
+    // loop against the allocator. Treat the CreateNew above as load-bearing: it is the
+    // whole of the protection, and no test would notice it becoming Create.
     string temporary = path + $".{Path.GetRandomFileName()}.tmp";
     bool created = false;
     try

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -1200,7 +1200,11 @@ static async Task<WriteOutcome> ReplaceOrReport(string path, Func<FileStream, Ta
         // though -- something already sitting at that name is not this sweep's to
         // remove, and deleting whatever is found there would be a worse answer than
         // the failure being reported.
-        string fate = "none";
+        // Assumed left behind the moment it exists, and downgraded only by a delete that
+        // returned. Derived the other way round -- "none" until something says otherwise --
+        // a cleanup that stopped being called would report that no temporary was ever
+        // created, which is the one answer that makes the leak invisible.
+        string fate = created ? "left-behind" : "none";
         try
         {
             if (created)
@@ -1211,7 +1215,6 @@ static async Task<WriteOutcome> ReplaceOrReport(string path, Func<FileStream, Ta
         }
         catch (Exception cleanup) when (cleanup is IOException or UnauthorizedAccessException)
         {
-            fate = "left-behind";
         }
 
         return new WriteOutcome($"Could not write '{path}': {ex.Message}", fate);

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -759,31 +759,20 @@ if (unwritable is not null)
 // deep-inspect workflow writes its acquisition log into the output directory, beside
 // packages/ rather than inside it, and it is not this step's to remove.
 //
-// Every removal is recorded in the manifest, not merely printed. This step deletes
-// unrecorded files under packages/, and a write temporary this run leaked is an
-// unrecorded file under packages/ -- so a reconciliation that only cleaned up would
-// quietly erase the evidence of a leak, and the disk check in EvilPoolSweepGateTests
-// that used to catch one would pass over a swept pool. Measured: with the removals
-// unreported, a sweep that skipped its temporary cleanup while still reporting it as
-// "removed" left all seventeen cases green. Recording them keeps the fact the check was
-// looking for, and puts it where an operator reads it: a run that had to remove
-// anything is a run where something else went wrong.
+// How the walk itself is bounded, and why every removal is recorded, is on ReconcilePool.
 var removedFromPool = new List<string>();
+
+// Ordinal, because these are paths on a filesystem that distinguishes case, and
+// comparing them any other way would let an unrecorded file whose name differs from a
+// recorded one only in case pass for the recorded one and stay in the pool. That is
+// unverified: no case here plants such a file, because whether the assertion means
+// anything depends on the filesystem the suite happens to run on.
 var recordedAssemblies = new HashSet<string>(
     assemblies.Select(Path.GetFullPath), StringComparer.Ordinal);
 string? unreconciled = null;
 try
 {
-    foreach (string pooled in Directory.GetFiles(packageDirectory, "*", SearchOption.AllDirectories))
-    {
-        if (recordedAssemblies.Contains(Path.GetFullPath(pooled)))
-            continue;
-
-        File.Delete(pooled);
-        removedFromPool.Add(pooled);
-        Console.Error.WriteLine(
-            $"removed '{pooled}' from the pool: this sweep did not record it.");
-    }
+    ReconcilePool(packageDirectory, recordedAssemblies, removedFromPool);
 }
 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 {
@@ -793,6 +782,61 @@ catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
     unreconciled = $"Could not reconcile the pool under '{packageDirectory}': {ex.Message}";
     Console.Error.WriteLine(unreconciled);
     Environment.ExitCode = 1;
+}
+
+// Walks the pool without following links, and removes what the run did not record.
+//
+// The walk is written out rather than done with Directory.GetFiles(..., AllDirectories)
+// because that enumeration descends through a directory symlink and yields the paths it
+// finds on the far side. This step deletes what it is handed, so that enumeration aims a
+// deletion loop at whatever a link in the pool points at, and then reports success --
+// measured: a link planted beside packages/ had the file behind it deleted and the run
+// exited 0. A link is removed as a link instead, which is a deletion this step can bound
+// to the pool it owns: removing a symlink never touches its target.
+//
+// Every removal is recorded by the caller, not merely printed. This step deletes
+// unrecorded files under packages/, and a write temporary this run leaked is an
+// unrecorded file under packages/ -- so a reconciliation that only cleaned up would
+// quietly erase the evidence of a leak, and the disk check in EvilPoolSweepGateTests
+// that used to catch one would pass over a swept pool. Measured: with the removals
+// unreported, a sweep that skipped its temporary cleanup while still reporting it as
+// "removed" left all seventeen cases green. Recording them keeps the fact the check was
+// looking for, and puts it where an operator reads it: a run that had to remove
+// anything is a run where something else went wrong. The stderr line beside each
+// recorded removal is an operator convenience and is not itself gated.
+static void ReconcilePool(string directory, HashSet<string> recorded, List<string> removed)
+{
+    foreach (FileSystemInfo entry in new DirectoryInfo(directory).EnumerateFileSystemInfos())
+    {
+        // Non-null for a symlink alone, so a real directory is descended into and a hard
+        // link -- indistinguishable from the file it is, and whose removal frees only
+        // this name -- is treated as the file it appears to be.
+        if (entry.LinkTarget is not null)
+        {
+            entry.Delete();
+            Record(entry.FullName);
+            continue;
+        }
+
+        if (entry is DirectoryInfo child)
+        {
+            ReconcilePool(child.FullName, recorded, removed);
+            continue;
+        }
+
+        if (recorded.Contains(Path.GetFullPath(entry.FullName)))
+            continue;
+
+        entry.Delete();
+        Record(entry.FullName);
+    }
+
+    void Record(string path)
+    {
+        removed.Add(path);
+        Console.Error.WriteLine(
+            $"removed '{path}' from the pool: this sweep did not record it.");
+    }
 }
 
 removedFromPool.Sort(StringComparer.Ordinal);

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -386,8 +386,27 @@ catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or N
     return;
 }
 
-HttpClientFactory.Initialize();
-NuGetCache.Initialize("dotnet-inspect");
+// The same isolation knobs the CLI already reads (src/dotnet-inspect/Program.cs),
+// honored here so a caller can point this sweep at a cache of its own. Without them the
+// sweep reaches the developer's shared caches and the network unconditionally, which is
+// why its two central properties -- that the pin binds, and that the copies land where
+// told -- could only ever be evidenced by hand-run probes (#3560). This is not a test
+// backdoor: it is one program catching up to a convention the rest of the tool follows,
+// with the CLI's meanings unchanged. An isolated session skips the shared NuGet cache
+// and, absent an explicit directory, gets its own. Reading them costs nothing when they
+// are unset, which is the case for every real sweep.
+bool offline = string.Equals(
+    Environment.GetEnvironmentVariable("DOTNET_INSPECT_OFFLINE"), "1", StringComparison.Ordinal);
+string? sessionName = Environment.GetEnvironmentVariable("DOTNET_INSPECT_ISOLATED");
+if (string.IsNullOrWhiteSpace(sessionName))
+    sessionName = null;
+bool isolated = sessionName != null;
+string? cacheBasePath = Environment.GetEnvironmentVariable("DOTNET_INSPECT_CACHE_DIR");
+if (isolated && cacheBasePath == null)
+    cacheBasePath = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-{sessionName}");
+
+HttpClientFactory.Initialize(offline);
+NuGetCache.Initialize("dotnet-inspect", cacheBasePath, skipNuGetCache: isolated);
 
 // Counted where a package reaches the outcome its mode expects, not where it fails
 // to. An incident counter has to be remembered at every failure site and silently

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -587,7 +587,8 @@ foreach (var entry in selected)
         // reported success -- the arbitrary-file overwrite the metadata writes were
         // hardened against, still open on the ninety-one writes per sweep that carry the
         // pool itself.
-        string? uncopied = await CopyOntoOrReport(source, destination);
+        var copy = await CopyOntoOrReport(source, destination);
+        string? uncopied = copy.Error;
         if (uncopied is not null)
         {
             // Recorded as this package failing rather than thrown away. A copy that did
@@ -595,7 +596,7 @@ foreach (var entry in selected)
             // package must be short in the accounting too.
             results.Add(Failed(
                 entry, "copy-failed", uncopied, resolvedPackage, package.Version,
-                selection.Tfm, package.FromCache));
+                selection.Tfm, package.FromCache) with { WriteTemporary = copy.TemporaryFate });
             Console.Error.WriteLine($"rank {entry.Rank}: {entry.Package}: {uncopied}");
             continue;
         }
@@ -707,9 +708,9 @@ foreach (var entry in selected)
 
 assemblies.Sort(StringComparer.Ordinal);
 string assembliesPath = Path.Combine(outputDirectory, "assemblies.txt");
-string? unwritable = await ReplaceTextOrReport(
+string? unwritable = (await ReplaceTextOrReport(
     assembliesPath,
-    string.Concat(assemblies.Select(assembly => assembly + Environment.NewLine)));
+    string.Concat(assemblies.Select(assembly => assembly + Environment.NewLine)))).Error;
 if (unwritable is not null)
 {
     Console.Error.WriteLine(unwritable);
@@ -726,9 +727,9 @@ var manifest = new PackageSweepManifest(
     SelectedPackageCount: assemblies.Count,
     Packages: results);
 string manifestPath = Path.Combine(outputDirectory, "manifest.json");
-unwritable = await ReplaceTextOrReport(
+unwritable = (await ReplaceTextOrReport(
     manifestPath,
-    JsonSerializer.Serialize(manifest, jsonContext.PackageSweepManifest) + Environment.NewLine);
+    JsonSerializer.Serialize(manifest, jsonContext.PackageSweepManifest) + Environment.NewLine)).Error;
 if (unwritable is not null)
 {
     Console.Error.WriteLine(unwritable);
@@ -780,7 +781,7 @@ if (refreshPin)
     // Rank lives in nuget-top-packages.json and is deliberately not repeated here.
     // Two files stating the same rank is two things to keep in step, and the one that
     // drifts is the one nothing reads.
-    unwritable = await ReplaceTextOrReport(
+    unwritable = (await ReplaceTextOrReport(
         pinPath,
         JsonSerializer.Serialize(
             // No timestamp: the file is a pure function of the pins, so re-recording an
@@ -789,7 +790,7 @@ if (refreshPin)
             // #3349 found that hashing a file with a timestamp in it yields an identity
             // that never repeats.
             new PackagePinFile(SchemaVersion: 1, Packages: recorded),
-            jsonContext.PackagePinFile) + Environment.NewLine);
+            jsonContext.PackagePinFile) + Environment.NewLine)).Error;
     if (unwritable is not null)
     {
         // A refresh that cannot write the pin has not refreshed anything, and the file
@@ -1150,7 +1151,7 @@ static bool IsBarePackageId(string? id) =>
 /// appears, which is the hang the read path already had to grow a deadline for. A move
 /// onto the name replaces whatever is there instead of writing through it.</para>
 /// </summary>
-static async Task<string?> ReplaceTextOrReport(string path, string content) =>
+static async Task<WriteOutcome> ReplaceTextOrReport(string path, string content) =>
     await ReplaceOrReport(
         path, stream => stream.WriteAsync(Encoding.UTF8.GetBytes(content)).AsTask());
 
@@ -1158,7 +1159,7 @@ static async Task<string?> ReplaceTextOrReport(string path, string content) =>
 /// Copies <paramref name="source"/> onto <paramref name="destination"/> without opening
 /// the destination, or says why it could not.
 /// </summary>
-static async Task<string?> CopyOntoOrReport(string source, string destination) =>
+static async Task<WriteOutcome> CopyOntoOrReport(string source, string destination) =>
     await ReplaceOrReport(destination, async stream =>
     {
         await using var input = new FileStream(
@@ -1171,7 +1172,7 @@ static async Task<string?> CopyOntoOrReport(string source, string destination) =
 /// hold, then moved onto the name. Every write goes through here, because the property
 /// is not one a second implementation keeps -- File.Copy kept none of it.
 /// </summary>
-static async Task<string?> ReplaceOrReport(string path, Func<FileStream, Task> write)
+static async Task<WriteOutcome> ReplaceOrReport(string path, Func<FileStream, Task> write)
 {
     // Random and created exclusively, not a name another process can predict. A
     // temporary named after the pid is a name anything with write access to the
@@ -1190,7 +1191,7 @@ static async Task<string?> ReplaceOrReport(string path, Func<FileStream, Task> w
         }
 
         File.Move(temporary, path, overwrite: true);
-        return null;
+        return new WriteOutcome(null, "moved");
     }
     catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
     {
@@ -1199,16 +1200,21 @@ static async Task<string?> ReplaceOrReport(string path, Func<FileStream, Task> w
         // though -- something already sitting at that name is not this sweep's to
         // remove, and deleting whatever is found there would be a worse answer than
         // the failure being reported.
+        string fate = "none";
         try
         {
             if (created)
+            {
                 File.Delete(temporary);
+                fate = "removed";
+            }
         }
         catch (Exception cleanup) when (cleanup is IOException or UnauthorizedAccessException)
         {
+            fate = "left-behind";
         }
 
-        return $"Could not write '{path}': {ex.Message}";
+        return new WriteOutcome($"Could not write '{path}': {ex.Message}", fate);
     }
 }
 
@@ -1287,7 +1293,26 @@ sealed record SweepPackageResult(
     bool? FromCache,
     string? CleanupStatus = null,
     string? CleanupDetail = null,
-    string? Sha256 = null);
+    string? Sha256 = null,
+    string? WriteTemporary = null);
+
+/// <summary>
+/// What a write did, and what became of the temporary it writes through.
+///
+/// <para><c>Error</c> is the message, or null when the write landed.
+/// <c>TemporaryFate</c> is <c>moved</c> when it became the file, <c>removed</c> when the
+/// write failed after it existed and it was cleaned up, <c>left-behind</c> when that
+/// cleanup itself failed, and <c>none</c> when the failure happened before it existed.
+/// </para>
+///
+/// <para>Reported rather than inferred because the difference is not visible from
+/// outside. A failure before the temporary exists and a failure after it is cleaned up
+/// leave the same directory behind and the same message, so nothing downstream can tell
+/// a cleanup that ran from one that was never needed -- including the operator reading
+/// the manifest to find out whether a failed sweep left anything in the pool, which is
+/// the question <c>left-behind</c> exists to answer out loud.</para>
+/// </summary>
+readonly record struct WriteOutcome(string? Error, string TemporaryFate);
 
 [JsonSerializable(typeof(List<PackageListEntry>))]
 [JsonSerializable(typeof(PackagePinFile))]

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -444,6 +444,13 @@ foreach (var entry in selected)
             // A backstop behind the version-shape check above: the extractor validates
             // its own path components and throws, and a throw here exits 134 --
             // indistinguishable from a crash, over an input the pin file supplied.
+            //
+            // Ungated, deliberately: IsBareVersion and IsBarePackageId already refuse
+            // every spelling that reaches this, so no input the sweep will accept can
+            // make the extractor throw, and no black-box case can arrange one. It stays
+            // because the two shape checks and this catch guard the same 134 from
+            // opposite sides, and the cheap side to be wrong on is this one. Measured:
+            // disabling this catch leaves every case in EvilPoolSweepGateTests green.
             results.Add(Failed(entry, "acquisition-failed", ex.Message));
             Console.Error.WriteLine(
                 $"rank {entry.Rank}: {entry.Package}: acquisition failed: {ex.Message}");
@@ -465,6 +472,13 @@ foreach (var entry in selected)
         // that matters is made against what came back: a pool entry acquired under a
         // different identity than the one selected is not the package the list ranked,
         // whatever spelling got it there.
+        //
+        // Ungated, and not gateable by EvilPoolSweepGateTests: those cases run offline
+        // against a seeded cache, and the cache-hit path echoes the requested name back
+        // as PackageName (PackageExtractor.AcquireResolvedPackageAsync), so the two sides
+        // of this comparison are the same string by construction. It has teeth only on
+        // the download path, where the name comes from what was served. Measured:
+        // deleting this check outright leaves every case in that class green.
         if (!string.Equals(resolvedPackage, entry.Package, StringComparison.OrdinalIgnoreCase))
         {
             results.Add(Failed(
@@ -722,6 +736,50 @@ if (unwritable is not null)
     Console.Error.WriteLine(unwritable);
     Environment.ExitCode = 2;
     return;
+}
+
+// The pool is made to hold what this run recorded, rather than merely being described
+// by it. Writing assemblies.txt from the in-memory list keeps a stray file out of the
+// record; nothing kept one out of the pool, and the pool is reused by design -- the
+// corpus script passes the same output directory every time so that the paths in an
+// earlier assemblies.txt stay valid. So a package that was pooled once and is refused,
+// re-versioned, or dropped from the list later left its assembly behind, unrecorded and
+// indistinguishable from a current one, for as long as the directory survived. Measured
+// before this existed: a second run whose subject could not be acquired recorded the
+// lead alone and left the first run's assembly sitting in packages/.
+//
+// Held against the record rather than by clearing the directory first. Clearing is the
+// obvious spelling and the wrong one: it also removes whatever a caller had put at a
+// destination, which is the seam two of this sweep's gates use to make a copy fail, and
+// a fix that silently disarms the tests for the code it touches is worse than the leak.
+// Reconciling afterwards touches only what the run did not record.
+//
+// Scoped to packages/, which is the sweep's own: it names every child and records what
+// it put there. Files elsewhere under the output directory belong to the caller.
+// Deletions are announced -- a leftover the sweep removes is still a fault somewhere,
+// and a silent cleanup is how one goes unnoticed for a release.
+var recordedAssemblies = new HashSet<string>(
+    assemblies.Select(Path.GetFullPath), StringComparer.Ordinal);
+try
+{
+    foreach (string pooled in Directory.GetFiles(packageDirectory, "*", SearchOption.AllDirectories))
+    {
+        if (recordedAssemblies.Contains(Path.GetFullPath(pooled)))
+            continue;
+
+        File.Delete(pooled);
+        Console.Error.WriteLine(
+            $"removed '{pooled}' from the pool: this sweep did not record it.");
+    }
+}
+catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+{
+    // Reported, and the run fails: the pool now holds something the record does not
+    // name, which is the state this whole step exists to prevent. Exiting 0 here would
+    // hand a consumer a pool the manifest misdescribes.
+    Console.Error.WriteLine(
+        $"Could not reconcile the pool under '{packageDirectory}' with the record: {ex.Message}");
+    Environment.ExitCode = 1;
 }
 
 var manifest = new PackageSweepManifest(

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -609,6 +609,12 @@ foreach (var entry in selected)
         // and then copying it leaves an interval a cache writer can land in, and the
         // file in the pool is the one that gets measured -- so that is the one whose
         // bytes must match.
+        //
+        // That last step is reasoning, not a gated property, and is marked so rather
+        // than left to read as covered: every case in EvilPoolSweepGateTests tampers
+        // with the cache entry, so source and destination carry the same bytes and no
+        // black-box case can tell which was measured. Hashing the source here leaves
+        // the whole class green. What is gated is that the hash is compared at all.
         string assemblySha = Convert.ToHexStringLower(
             SHA256.HashData(File.ReadAllBytes(destination)));
         if (honorPin && pin is not null

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -755,11 +755,23 @@ if (unwritable is not null)
 // Reconciling afterwards touches only what the run did not record.
 //
 // Scoped to packages/, which is the sweep's own: it names every child and records what
-// it put there. Files elsewhere under the output directory belong to the caller.
-// Deletions are announced -- a leftover the sweep removes is still a fault somewhere,
-// and a silent cleanup is how one goes unnoticed for a release.
+// it put there. Files elsewhere under the output directory belong to the caller -- the
+// deep-inspect workflow writes its acquisition log into the output directory, beside
+// packages/ rather than inside it, and it is not this step's to remove.
+//
+// Every removal is recorded in the manifest, not merely printed. This step deletes
+// unrecorded files under packages/, and a write temporary this run leaked is an
+// unrecorded file under packages/ -- so a reconciliation that only cleaned up would
+// quietly erase the evidence of a leak, and the disk check in EvilPoolSweepGateTests
+// that used to catch one would pass over a swept pool. Measured: with the removals
+// unreported, a sweep that skipped its temporary cleanup while still reporting it as
+// "removed" left all seventeen cases green. Recording them keeps the fact the check was
+// looking for, and puts it where an operator reads it: a run that had to remove
+// anything is a run where something else went wrong.
+var removedFromPool = new List<string>();
 var recordedAssemblies = new HashSet<string>(
     assemblies.Select(Path.GetFullPath), StringComparer.Ordinal);
+string? unreconciled = null;
 try
 {
     foreach (string pooled in Directory.GetFiles(packageDirectory, "*", SearchOption.AllDirectories))
@@ -768,6 +780,7 @@ try
             continue;
 
         File.Delete(pooled);
+        removedFromPool.Add(pooled);
         Console.Error.WriteLine(
             $"removed '{pooled}' from the pool: this sweep did not record it.");
     }
@@ -777,10 +790,12 @@ catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
     // Reported, and the run fails: the pool now holds something the record does not
     // name, which is the state this whole step exists to prevent. Exiting 0 here would
     // hand a consumer a pool the manifest misdescribes.
-    Console.Error.WriteLine(
-        $"Could not reconcile the pool under '{packageDirectory}' with the record: {ex.Message}");
+    unreconciled = $"Could not reconcile the pool under '{packageDirectory}': {ex.Message}";
+    Console.Error.WriteLine(unreconciled);
     Environment.ExitCode = 1;
 }
+
+removedFromPool.Sort(StringComparer.Ordinal);
 
 var manifest = new PackageSweepManifest(
     SchemaVersion: 1,
@@ -789,7 +804,9 @@ var manifest = new PackageSweepManifest(
     StartRank: startRank,
     RequestedPackageCount: packageCount,
     SelectedPackageCount: assemblies.Count,
-    Packages: results);
+    Packages: results,
+    RemovedFromPool: removedFromPool,
+    Unreconciled: unreconciled);
 string manifestPath = Path.Combine(outputDirectory, "manifest.json");
 unwritable = (await ReplaceTextOrReport(
     manifestPath,
@@ -1352,7 +1369,22 @@ sealed record PackageSweepManifest(
     int StartRank,
     int RequestedPackageCount,
     int SelectedPackageCount,
-    IReadOnlyList<SweepPackageResult> Packages);
+    IReadOnlyList<SweepPackageResult> Packages,
+
+    /// <summary>
+    /// Files this run deleted from <c>packages/</c> because it did not record them.
+    /// Empty for a run that found the pool already agreeing with its record, which is
+    /// every ordinary run: a non-empty list means either a previous sweep's leftovers
+    /// were still there or this one leaked something, and both are worth seeing.
+    /// </summary>
+    IReadOnlyList<string> RemovedFromPool,
+
+    /// <summary>
+    /// Why the pool could not be reconciled with the record, or null when it was. Set
+    /// only alongside a non-zero exit code: the pool holds a file the record does not
+    /// name, so the manifest describes it rather than pretending otherwise.
+    /// </summary>
+    string? Unreconciled);
 
 sealed record SweepPackageResult(
     int Rank,

--- a/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
@@ -19,9 +19,10 @@ namespace ILInspector.Decompiler.Tests;
 /// <see cref="TheSweepRefusesEveryPinFileShapeThisSuiteRefuses"/>, which runs the sweep's
 /// own validator over tampered pin files so that the rules about a pin's shape live in
 /// one place instead of two that drift. That the sweep <em>honors</em> the pin -- acquires
-/// the pinned bytes and refuses anything else -- is still a property of
-/// <c>eng/prepare-decompiler-package-sweep.cs</c> evidenced by real runs recorded on the
-/// PR, because gating it would mean acquiring packages from this suite.</para>
+/// the pinned bytes and refuses anything else -- is a different question, and one this
+/// class cannot answer, because answering it means running a sweep that acquires a
+/// package. <see cref="EvilPoolSweepGateTests"/> answers it: it runs real sweeps offline
+/// against a scratch cache holding one synthetic package (#3560).</para>
 /// </summary>
 [Trait("Area", "Corpus")]
 public class EvilPoolPinTests
@@ -644,8 +645,9 @@ public class EvilPoolPinTests
     /// change. <c>no-library</c> entries have no assembly, so they must carry no hash --
     /// a hash there would describe a file that does not exist.</para>
     ///
-    /// <para>This test gates the file. That the sweep <em>verifies</em> the hash is
-    /// evidenced by real runs on the PR, for the reason given in the class summary.</para>
+    /// <para>This test gates the file. That the sweep <em>verifies</em> the hash against
+    /// the assembly it pooled is gated by
+    /// <see cref="EvilPoolSweepGateTests.ASweepRefusesBytesThePinDoesNotName"/>.</para>
     /// </summary>
     [Fact]
     public void EveryPinnedPackageNamesTheBytesOfItsAssembly()

--- a/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
@@ -645,9 +645,14 @@ public class EvilPoolPinTests
     /// change. <c>no-library</c> entries have no assembly, so they must carry no hash --
     /// a hash there would describe a file that does not exist.</para>
     ///
-    /// <para>This test gates the file. That the sweep <em>verifies</em> the hash against
-    /// the assembly it pooled is gated by
-    /// <see cref="EvilPoolSweepGateTests.ASweepRefusesBytesThePinDoesNotName"/>.</para>
+    /// <para>This test gates the file. That the sweep <em>verifies</em> the hash at all is
+    /// gated by <see cref="EvilPoolSweepGateTests.ASweepRefusesBytesThePinDoesNotName"/>.
+    /// That it verifies it against the <em>pooled copy</em> rather than the cache entry it
+    /// copied from is not gated by anything: that case tampers with the cache, so both
+    /// files carry the same bytes and no black-box case can tell which was measured --
+    /// measured, hashing the source instead leaves all nine green. The sweep's reason for
+    /// hashing the destination is a TOCTOU window a cache writer can land in, which is
+    /// sound and unverified here.</para>
     /// </summary>
     [Fact]
     public void EveryPinnedPackageNamesTheBytesOfItsAssembly()

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -284,22 +284,23 @@ public class EvilPoolSweepGateTests
     /// reached the copy is what makes the absence afterwards mean the cleanup happened.
     /// </para>
     ///
-    /// <para>The creation itself is watched, rather than inferred. Reaching the copy is
-    /// not the same as having created the temporary: a failure raised inside
-    /// <c>ReplaceOrReport</c> before the file exists reports the same
-    /// <c>copy-failed</c>, and a case stopping at the status would pass with the cleanup
-    /// deleted. An earlier revision of this comment claimed that gap could not be closed
-    /// from outside, because the temporary's name is randomized and lives for one write.
-    /// That was wrong, and a reviewer disproved it by doing it: a watcher needs no name.
-    /// </para>
+    /// <para>And the creation itself is asserted, because reaching the copy is not the
+    /// same as having created the temporary: a failure raised inside <c>ReplaceOrReport</c>
+    /// before the file exists reports the same <c>copy-failed</c>, and a case stopping at
+    /// the status passed with the cleanup deleted. Two reviewers closed that gap the same
+    /// way, with a <c>FileSystemWatcher</c>, disproving a claim made here that the
+    /// randomized name put it out of reach. They were right that it was reachable and the
+    /// watcher was the wrong instrument: on a machine whose inotify watch limit is
+    /// exhausted -- which a developer box with enough worktrees and editors on it reaches
+    /// -- arming fails through the <c>Error</c> event and the case reports a sweep that
+    /// did create its temporary as one that never did. Measured here, reproducibly.</para>
     ///
-    /// <para>Watched only where the mechanism is dependable, which is the same bargain
-    /// <see cref="PlantSymbolicLink"/> makes. On Linux this is inotify and the event is
-    /// reliable for a file created in a watched directory; the other backends are laxer,
-    /// and a missed event here would fail a run that did nothing wrong. So elsewhere the
-    /// observation is skipped and the case keeps its weaker form, which is stated rather
-    /// than quietly assumed. CI runs Linux, so the strong form is the one that gates.
-    /// </para>
+    /// <para>So the sweep says what became of it instead, in the manifest, beside the
+    /// staging-directory cleanup it already reported: <c>removed</c> against <c>none</c>
+    /// separates a cleanup that ran from one that was never needed, and <c>left-behind</c>
+    /// is the answer an operator actually wants when a failed sweep may have dropped a
+    /// partial assembly in the pool. Deterministic, on every platform, and observable for
+    /// the same reason the rest of this file reads statuses rather than prose.</para>
     /// </summary>
     [Fact]
     public void ASweepLeavesNoTemporaryWhenAWriteFailsAfterCreatingOne()
@@ -310,14 +311,6 @@ public class EvilPoolSweepGateTests
             world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly);
         Directory.CreateDirectory(destination);
 
-        // Armed before the sweep runs, on the directory the temporary is a sibling in.
-        // The pool's other writes go to a different directory, so this sees the assembly
-        // write and nothing else.
-        using var created = new ManualResetEventSlim(false);
-        using var watcher = new FileSystemWatcher(Path.GetDirectoryName(destination)!, "*.tmp");
-        watcher.Created += (_, _) => created.Set();
-        watcher.EnableRaisingEvents = true;
-
         var sweep = world.Run();
 
         Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a directory standing at the destination"));
@@ -325,16 +318,8 @@ public class EvilPoolSweepGateTests
         // Reached the copy and failed there, rather than exiting earlier.
         Assert.Equal("copy-failed", world.ReportedStatus(sweep));
 
-        if (OperatingSystem.IsLinux())
-        {
-            // Events are delivered on the watcher's own thread, so the sweep exiting does
-            // not mean the notification has arrived. The wait is for that hand-off only --
-            // the creation is already over by now, so a full wait here means it never
-            // happened rather than that it was slow.
-            Assert.True(
-                created.Wait(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken),
-                world.Explain(sweep, "a run that never created the temporary this case is about"));
-        }
+        // Created, then removed -- not "none", which is the failure this case is not about.
+        Assert.Equal("removed", world.ReportedWriteTemporary(sweep));
 
         world.AssertNoTemporaryLeftBehind();
     }
@@ -697,6 +682,19 @@ public class EvilPoolSweepGateTests
                 Explain(sweep, $"a manifest reporting on '{recorded}' when '{_requestedPackage}' was asked for"));
 
             return packages[0]!["Status"]!.GetValue<string>();
+        }
+
+        /// <summary>
+        /// What the sweep recorded became of the temporary the failing write went through:
+        /// <c>moved</c>, <c>removed</c>, <c>left-behind</c>, or <c>none</c>.
+        /// </summary>
+        public string? ReportedWriteTemporary((int ExitCode, string Output, string Errors) sweep)
+        {
+            Assert.True(File.Exists(ManifestPath), Explain(sweep, "a run that wrote no manifest"));
+            var manifested = JsonNode.Parse(File.ReadAllText(ManifestPath))!;
+            var packages = manifested["Packages"]!.AsArray();
+            Assert.True(packages.Count == 1, Explain(sweep, $"a manifest holding {packages.Count} packages"));
+            return packages[0]!["WriteTemporary"]?.GetValue<string>();
         }
 
         /// <summary>

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -365,6 +365,8 @@ public class EvilPoolSweepGateTests
     /// </summary>
     sealed class SweepWorld : IDisposable
     {
+        string? _cachedAssemblyPath;
+
         SweepWorld(string scratch, string cacheDirectory, byte[] fixtureBytes)
         {
             Scratch = scratch;
@@ -393,15 +395,13 @@ public class EvilPoolSweepGateTests
         /// <summary>
         /// The fixture assembly as the cache holds it. Overwriting this is how a case
         /// makes the cache answer with bytes the pin does not name.
+        ///
+        /// <para>Recorded by <see cref="SeedCache"/> from the path the product itself
+        /// names, not composed here: the directory a committed package lands in is the
+        /// product's to decide, down to the casing it applies to the name and version.</para>
         /// </summary>
-        public string CachedAssemblyPath => Path.Combine(
-            CacheDirectory,
-            "package-content-v2",
-            FixturePackage,
-            FixtureVersion,
-            "lib",
-            FixtureTfm,
-            FixtureAssembly);
+        public string CachedAssemblyPath => _cachedAssemblyPath
+            ?? throw new InvalidOperationException("The cache has not been seeded yet.");
 
         /// <summary>
         /// Builds the world. <paramref name="version"/> and <paramref name="tfm"/> are what
@@ -449,8 +449,27 @@ public class EvilPoolSweepGateTests
             // Points this process's cache at the scratch directory only so that the commit
             // below lands there. The sweep is told the same directory by environment, and
             // resolves it with this same code, so the two cannot disagree about where it is.
+            //
+            // This is process-global state with no reset, and it is left pointing at a
+            // directory Dispose removes. That is deliberate: no other type in this test
+            // assembly references CoreCache or NuGetCache, and if one ever does, resolving
+            // against a removed directory fails loudly, where leaving a usable scratch
+            // cache behind would quietly serve it this fixture instead.
             NuGetCache.Initialize("dotnet-inspect", CacheDirectory, skipNuGetCache: true);
             NuGetCache.CommitPackage(staged, null, FixturePackage, FixtureVersion);
+
+            // Where the product put it, plus the layout of the package this test authored.
+            // A product that moved its cache layout fails here, naming the path it did not
+            // write, rather than downstream as a sweep that mysteriously ignored a tamper.
+            _cachedAssemblyPath = Path.Combine(
+                NuGetCache.GetPackageCachePath(FixturePackage, FixtureVersion),
+                "lib",
+                FixtureTfm,
+                FixtureAssembly);
+
+            Assert.True(
+                File.Exists(_cachedAssemblyPath),
+                $"The committed package does not hold the fixture assembly at {_cachedAssemblyPath}.");
         }
 
         void WriteInputs(string pinnedVersion, string pinnedTfm)

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -805,17 +805,40 @@ public class EvilPoolSweepGateTests
             + $"stdout:\n{sweep.Output}\nstderr:\n{sweep.Errors}";
 
         /// <summary>
-        /// No half-written assembly is left in the output directory. A write goes to a
-        /// fresh sibling and is renamed onto the destination, so a leftover sibling is a
-        /// partial file that a later sweep would find, hash, and disagree with the pin
-        /// about -- reported as the pin failing rather than as the run that made it.
+        /// The pool holds exactly what the sweep recorded pooling, and nothing else.
+        ///
+        /// <para>Which is the sweep's own claim, made at the point it deletes an assembly
+        /// that failed its pin: <em>"assemblies.txt is written from the in-memory list so
+        /// a stray file cannot enter the pool"</em>. A leftover write temporary is one way
+        /// to break it and a rejected assembly left in place is another, and both matter
+        /// for the same reason -- a file in <c>packages/</c> that nothing recorded is one a
+        /// later sweep finds, hashes, and disagrees with the pin about, reported as the pin
+        /// failing rather than as the run that made it.</para>
+        ///
+        /// <para>Asked as a set difference rather than by name. This used to glob
+        /// <c>*.tmp</c>, which is the product's naming convention restated in the harness:
+        /// a reviewer changed the sweep's temporary suffix to <c>.temp</c>, disabled the
+        /// cleanup, and watched the case stay green over a temporary genuinely left behind.
+        /// Nothing here now knows what a temporary is called, so nothing here goes stale
+        /// when that changes -- what it knows is that the pool and the record must agree,
+        /// and the record is the product's.</para>
         /// </summary>
         public void AssertNoTemporaryLeftBehind()
         {
             if (!Directory.Exists(OutputDirectory))
                 return;
 
-            Assert.Empty(Directory.GetFiles(OutputDirectory, "*.tmp", SearchOption.AllDirectories));
+            string pool = Path.Combine(OutputDirectory, "packages");
+            string[] present = Directory.Exists(pool)
+                ? [.. Directory.GetFiles(pool, "*", SearchOption.AllDirectories).Order(StringComparer.Ordinal)]
+                : [];
+            string[] recorded = File.Exists(PooledListPath)
+                ? [.. File.ReadAllLines(PooledListPath)
+                    .Where(line => line.Length > 0)
+                    .Order(StringComparer.Ordinal)]
+                : [];
+
+            Assert.Equal(recorded, present);
         }
 
         public void Dispose()

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -103,7 +103,10 @@ public class EvilPoolSweepGateTests
 
         // And that it came from the cache rather than the network, which is the manifest's
         // own record of the isolation every other case rests on -- measured: hardcoding it
-        // false left every case green.
+        // false left every case green. One direction only, and worth saying: a constant
+        // true passes this too, because no case here can produce a row that legitimately
+        // reports false. The gate on the isolation itself is
+        // ASweepCannotReachAPackageTheSeededCacheDoesNotHold.
         Assert.True(entry["FromCache"]!.GetValue<bool>(), world.Explain(sweep, "a pool the cache did not serve"));
 
         // Where it landed, too. The manifest is how an operator finds the pooled file
@@ -194,6 +197,42 @@ public class EvilPoolSweepGateTests
         Assert.Equal("pin-mismatch", world.ReportedStatus(sweep));
 
         world.AssertOnlyTheLeadWasPooled(sweep);
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// The pin binds the bytes at the first rank as well as the second, and one package's
+    /// refusal is not the run's.
+    ///
+    /// <para>The companion to <see cref="ASweepRefusesBytesThePinDoesNotName"/>, which
+    /// tampers with the subject at rank 2. Moving the subject off the front is what made
+    /// the first iteration observable at all, and it left the first iteration itself
+    /// unwatched: gating the hash comparison on <c>entry.Rank &gt; 1</c> left all ten cases
+    /// green while a poisoned rank-1 package entered the pool -- measured. So this case
+    /// tampers with the lead instead, and the two together hold both ends of the window
+    /// the sweep is run over.</para>
+    ///
+    /// <para>It asserts the other half too, which nothing else could: the subject behind it
+    /// is still pooled. A refusal has to stop the package it is about, and a sweep that
+    /// abandoned the rest of the list on the first bad hash would pass every other case
+    /// here, because in all of them the refused package is the last one.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepRefusesBytesThePinDoesNotNameAtTheFirstRankToo()
+    {
+        using var world = SweepWorld.Create();
+        File.WriteAllBytes(world.LeadCachedAssemblyPath, [.. world.LeadBytes, 0]);
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a cache answering rank 1 with other bytes"));
+        Assert.Equal("pin-mismatch", world.ReportedStatus(sweep, LeadPackage));
+
+        // The run carried on to rank 2 and pooled it, and the pool is that alone.
+        Assert.Equal("selected", world.ReportedStatus(sweep));
+        Assert.Equal([world.SubjectDestination], PooledAssemblies(world.OutputDirectory));
+        Assert.Equal(world.FixtureSha256, Sha256Of(world.SubjectDestination));
+
         world.AssertNoTemporaryLeftBehind();
     }
 
@@ -609,20 +648,36 @@ public class EvilPoolSweepGateTests
     /// A repository root, a package list, a pin, a cache holding two packages, and an output
     /// directory -- everything one sweep reads and writes, all of it scratch.
     ///
-    /// <para>Two packages, and the one each case is about is always the second. A real sweep
-    /// runs this loop ninety-odd times; a world holding a single package can only ever
+    /// <para>Two packages, and the one each case is about is normally the second. A real
+    /// sweep runs this loop ninety-odd times; a world holding a single package can only ever
     /// exercise the first iteration, and every guarantee here would then hold for the first
     /// package alone. Measured, on a one-package world: restricting the hash comparison, the
     /// replace-don't-write-through copy, the failure accounting, and the manifest's package
-    /// identity to <c>accountedFor == 0</c> each left all nine cases green, while a real
+    /// identity to <c>accountedFor == 0</c> each left all cases green, while a real
     /// hundred-package sweep would pool poisoned bytes, write through a planted symlink,
-    /// exit 0 over a failed copy, and refresh the wrong pin key. With the subject at rank 2
-    /// each of those is a mutation that turns the subject's own iteration off.</para>
+    /// exit 0 over a failed copy, and refresh the wrong pin key.</para>
     ///
-    /// <para>The lead is pooled successfully by every case, including the ones whose subject
-    /// is refused, which is the other half of what it buys: a refusal must stop the package
-    /// it is about and nothing else, and a sweep that abandoned the run would take the lead
-    /// with it.</para>
+    /// <para>What that buys, exactly: the sweep is run over a window of two, and both ends
+    /// of that window are subjects. <see cref="ASweepRefusesBytesThePinDoesNotName"/>
+    /// tampers with rank 2 and
+    /// <see cref="ASweepRefusesBytesThePinDoesNotNameAtTheFirstRankToo"/> with rank 1, so a
+    /// mutation that spares either end is caught -- and a two-package window has no interior
+    /// to hide in.</para>
+    ///
+    /// <para>It does <em>not</em> make the guarantee loop-wide, and this file should not be
+    /// read as though it does. A mutation keyed on the index -- <c>accountedFor &lt;= 1</c>,
+    /// say -- enforces the property for exactly the ranks this fixture occupies and drops it
+    /// for every rank beyond, with all cases green; measured, on the byte pin, the safe copy,
+    /// and the failure accounting alike. No finite fixture closes that, because the threshold
+    /// simply moves. What is gated is the loop <em>body</em>, at both ends of the window it
+    /// is run over; that the body is reached identically on the eighty-eight iterations no
+    /// fixture here reaches is unverified, and is named here rather than left to read as
+    /// covered.</para>
+    ///
+    /// <para>The lead is pooled successfully by every case that does not tamper with it,
+    /// including the ones whose subject is refused, which is the other half of what it buys:
+    /// a refusal must stop the package it is about and nothing else, and a sweep that
+    /// abandoned the run would take the lead with it.</para>
     ///
     /// <para>The cache is seeded through <see cref="NuGetCache.CommitPackage"/> rather than
     /// by writing the directories directly. The layout of a committed package, including
@@ -633,6 +688,7 @@ public class EvilPoolSweepGateTests
     sealed class SweepWorld : IDisposable
     {
         string? _cachedAssemblyPath;
+        string? _leadCachedAssemblyPath;
         string _requestedPackage = FixturePackage;
 
         SweepWorld(string scratch, string cacheDirectory, byte[] fixtureBytes)
@@ -692,6 +748,10 @@ public class EvilPoolSweepGateTests
         public string CachedAssemblyPath => _cachedAssemblyPath
             ?? throw new InvalidOperationException("The cache has not been seeded yet.");
 
+        /// <summary>The same, for the lead -- how a case makes rank 1 the one being refused.</summary>
+        public string LeadCachedAssemblyPath => _leadCachedAssemblyPath
+            ?? throw new InvalidOperationException("The cache has not been seeded yet.");
+
         /// <summary>
         /// Builds the world. <paramref name="version"/> and <paramref name="tfm"/> are what
         /// the <em>pin</em> claims; the package in the cache is always the real one, so a
@@ -732,7 +792,7 @@ public class EvilPoolSweepGateTests
             // cache behind would quietly serve it this fixture instead.
             NuGetCache.Initialize("dotnet-inspect", CacheDirectory, skipNuGetCache: true);
 
-            Commit(LeadPackage, LeadAssembly, LeadBytes);
+            _leadCachedAssemblyPath = Commit(LeadPackage, LeadAssembly, LeadBytes);
             _cachedAssemblyPath = Commit(FixturePackage, FixtureAssembly, FixtureBytes);
         }
 
@@ -863,8 +923,9 @@ public class EvilPoolSweepGateTests
         /// Asking the row who it is about is what makes the status an answer to the
         /// question the case put.</para>
         /// </summary>
-        public string ReportedStatus((int ExitCode, string Output, string Errors) sweep) =>
-            ReportedEntry(sweep)["Status"]!.GetValue<string>();
+        public string ReportedStatus(
+            (int ExitCode, string Output, string Errors) sweep, string? package = null) =>
+            ReportedEntry(sweep, package)["Status"]!.GetValue<string>();
 
         /// <summary>
         /// The manifest row about the package this world asked for, having established that it
@@ -880,19 +941,21 @@ public class EvilPoolSweepGateTests
         /// is the parse this is built on and reaches no row; a reader wanting one comes
         /// here.</para>
         /// </summary>
-        public JsonNode ReportedEntry((int ExitCode, string Output, string Errors) sweep)
+        public JsonNode ReportedEntry(
+            (int ExitCode, string Output, string Errors) sweep, string? package = null)
         {
+            string subject = package ?? _requestedPackage;
             var packages = ReportedManifest(sweep)["Packages"]!.AsArray();
             Assert.True(packages.Count == 2, Explain(sweep, $"a manifest holding {packages.Count} packages"));
 
             var matching = packages
-                .Where(row => row!["RequestedPackage"]?.GetValue<string>() == _requestedPackage)
+                .Where(row => row!["RequestedPackage"]?.GetValue<string>() == subject)
                 .ToArray();
             Assert.True(
                 matching.Length == 1,
                 Explain(
                     sweep,
-                    $"a manifest with {matching.Length} rows about '{_requestedPackage}', reporting on "
+                    $"a manifest with {matching.Length} rows about '{subject}', reporting on "
                     + string.Join(
                         ", ",
                         packages.Select(row => $"'{row!["RequestedPackage"]?.GetValue<string>()}'"))));

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -279,9 +279,21 @@ public class EvilPoolSweepGateTests
     /// <para>Which is why the reported outcome is asserted and not just the exit code.
     /// Absence is satisfied by a sweep that never got far enough to create anything, so a
     /// case asserting only "no temporary" passes on any early exit at all -- measured: a
-    /// sweep failing before the copy stage, with the cleanup deleted, left this case
-    /// green. Requiring the run to have reached the copy is what makes the absence
-    /// afterwards mean the cleanup happened.</para>
+    /// sweep that exits before acquisition, with the cleanup deleted, left this case
+    /// green, and now fails on the manifest it never wrote. Requiring the run to have
+    /// reached the copy is what makes the absence afterwards mean the cleanup happened.
+    /// </para>
+    ///
+    /// <para><em>Not</em> gated, and deliberately not: that the temporary was created at
+    /// all. Reaching the copy and failing there is as close as a black-box case gets --
+    /// a failure raised inside <c>ReplaceOrReport</c> before the file is created reports
+    /// the same <c>copy-failed</c>, and this case would pass with the cleanup deleted.
+    /// Closing that needs the temporary to be observable, and it is deliberately not: the
+    /// name is randomized precisely so nothing can predict or occupy it, and it exists for
+    /// the length of one write. The property this case does carry is that the current
+    /// implementation's post-creation failure leaves nothing behind; a refactor moving the
+    /// failure earlier would weaken it silently, and that is the known limit rather than a
+    /// claim being made.</para>
     /// </summary>
     [Fact]
     public void ASweepLeavesNoTemporaryWhenAWriteFailsAfterCreatingOne()

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -769,6 +769,16 @@ public class EvilPoolSweepGateTests
             startInfo.Environment["DOTNET_INSPECT_ISOLATED"] = "evil-sweep-gate";
             startInfo.Environment["DOTNET_INSPECT_CACHE_DIR"] = CacheDirectory;
 
+            // NUGET_PACKAGES is deliberately left alone, and cannot be used for isolation.
+            // The sweep is a file-based app, so this subprocess restores itself before it
+            // runs anything, and it restores from wherever that variable points. Aiming it
+            // somewhere without this repository's own package graph fails the restore
+            // (NU1102) and the sweep never starts -- every case here goes red naming a
+            // package it has nothing to do with. That is a broken environment reporting
+            // itself, not a false green, and Explain prints the restore error that says so.
+            // Isolation from the shared NuGet cache is DOTNET_INSPECT_ISOLATED's job, which
+            // the sweep applies to its own lookups and not to its restore.
+
             using var process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException("could not start the sweep");
 

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -101,6 +101,11 @@ public class EvilPoolSweepGateTests
         Assert.Equal("selected", entry["Status"]!.GetValue<string>());
         Assert.Equal(world.FixtureSha256, entry["Sha256"]!.GetValue<string>());
 
+        // And that it came from the cache rather than the network, which is the manifest's
+        // own record of the isolation every other case rests on -- measured: hardcoding it
+        // false left every case green.
+        Assert.True(entry["FromCache"]!.GetValue<bool>(), world.Explain(sweep, "a pool the cache did not serve"));
+
         // Where it landed, too. The manifest is how an operator finds the pooled file
         // without walking the tree, and the path is the one recorded field nothing else
         // here reads -- measured: replacing it with a literal left all nine cases green.
@@ -143,6 +148,49 @@ public class EvilPoolSweepGateTests
         // package this case plants is pinned out of the pool permanently and the evidence
         // of the tamper goes with it -- measured: relabelling both pin-mismatch sites left
         // all nine cases green, because exit code, prose and an empty pool are unchanged.
+        Assert.Equal("pin-mismatch", world.ReportedStatus(sweep));
+
+        world.AssertOnlyTheLeadWasPooled(sweep);
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// A package pinned as shipping no library, which now ships one, is refused.
+    ///
+    /// <para>The other direction of the pin, and the one that is easy to miss. Nine of the
+    /// top hundred packages genuinely carry no primary library -- meta-packages, and
+    /// packages whose primary is ambiguous -- so the pin records <c>no-library</c> for them
+    /// and the sweep neither acquires nor fails over them. That is an assertion about the
+    /// package, not a way of ignoring it: a version that starts shipping an assembly starts
+    /// contributing to the pool, and a pool that absorbed it quietly would have grown
+    /// without anyone approving the bytes.</para>
+    ///
+    /// <para>Gated because nothing reached this behavior at all before: no case pinned a
+    /// package as <c>no-library</c>, so the whole arm was unexercised.</para>
+    ///
+    /// <para>What the case proves is the refusal, not the arm. Replacing the arm's
+    /// condition with <c>false</c> leaves this green, and that is correct rather than a
+    /// gap: a <c>no-library</c> pin carries no hash -- there is no assembly for one to
+    /// describe, which is the invariant <c>EvilPoolPinTests</c> holds the committed file to
+    /// -- so the assembly that arrived is compared against no hash and refused a few lines
+    /// later anyway. The arm is a better-diagnosed refusal in front of a backstop that
+    /// would catch it regardless, which is worth having and is not what keeps the pool
+    /// pinned. A reviewer read the green as the pool silently drifting; measured, it does
+    /// not -- the pool still holds the lead alone, which is what this case asserts. Gating
+    /// the arm itself would need a pin that is <c>no-library</c> and carries a matching
+    /// hash, a combination the real file cannot hold, so it is left ungated and said so.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ASweepRefusesAPackagePinnedAsShippingNoLibraryThatShipsOne()
+    {
+        using var world = SweepWorld.Create(status: "no-library");
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a no-library pin over a package with one"));
+
+        // The same word as any other pin failure: what arrived is not what was named.
         Assert.Equal("pin-mismatch", world.ReportedStatus(sweep));
 
         world.AssertOnlyTheLeadWasPooled(sweep);
@@ -649,7 +697,7 @@ public class EvilPoolSweepGateTests
         /// the <em>pin</em> claims; the package in the cache is always the real one, so a
         /// case that changes them is changing the pin alone.
         /// </summary>
-        public static SweepWorld Create(string? version = null, string? tfm = null)
+        public static SweepWorld Create(string? version = null, string? tfm = null, string? status = null)
         {
             string scratch = Directory.CreateTempSubdirectory("evil-sweep-gate").FullName;
             try
@@ -661,7 +709,7 @@ public class EvilPoolSweepGateTests
                 var world = new SweepWorld(scratch, cacheDirectory, bytes);
 
                 world.SeedCache();
-                world.WriteInputs(version ?? FixtureVersion, tfm ?? FixtureTfm);
+                world.WriteInputs(version ?? FixtureVersion, tfm ?? FixtureTfm, status ?? "pinned");
                 return world;
             }
             catch
@@ -729,7 +777,7 @@ public class EvilPoolSweepGateTests
             return committed;
         }
 
-        void WriteInputs(string pinnedVersion, string pinnedTfm)
+        void WriteInputs(string pinnedVersion, string pinnedTfm, string pinnedStatus)
         {
             string data = Path.Combine(FakeRoot, "docs", "data");
             Directory.CreateDirectory(data);
@@ -738,14 +786,24 @@ public class EvilPoolSweepGateTests
             // the two files beside it instead of the committed ones.
             File.WriteAllText(Path.Combine(FakeRoot, "dotnet-inspect.slnx"), "");
 
-            WriteListAndPin(data, FixturePackage, pinnedVersion, pinnedTfm, FixtureSha256);
+            WriteListAndPin(data, FixturePackage, pinnedVersion, pinnedTfm, FixtureSha256, pinnedStatus);
         }
 
         /// <summary>
         /// Writes the list and the pin the sweep reads: the lead at rank 1, always correct,
         /// and the subject at rank 2 with whatever this case is asking for.
+        ///
+        /// <para>A <c>no-library</c> pin carries no hash, because there is no assembly for
+        /// one to describe -- which is what <c>EvilPoolPinTests</c> holds the committed pin
+        /// file to, so writing one here would be a fixture the real file could not be.</para>
         /// </summary>
-        void WriteListAndPin(string data, string package, string version, string? tfm, string sha256)
+        void WriteListAndPin(
+            string data,
+            string package,
+            string version,
+            string? tfm,
+            string sha256,
+            string status = "pinned")
         {
             var list = new JsonArray(
                 new JsonObject
@@ -778,9 +836,9 @@ public class EvilPoolSweepGateTests
                         ["package"] = package,
                         ["version"] = version,
                         ["tfm"] = tfm,
-                        ["status"] = "pinned",
-                        ["detail"] = null,
-                        ["sha256"] = sha256,
+                        ["status"] = status,
+                        ["detail"] = status == "no-library" ? "ships no primary library" : null,
+                        ["sha256"] = status == "no-library" ? null : sha256,
                     }),
             };
 

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -1,0 +1,520 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DotnetInspector.Packages;
+using Xunit;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The two properties the EVIL pool's version pin exists to provide, run rather than read.
+///
+/// <para><see cref="EvilPoolPinTests"/> gates the pin as a <em>file</em> -- its shape, its
+/// encoding, the bounds on reading it, the words the sweep refuses it in. None of that
+/// runs a sweep, so neither of the properties the pinning work was done for was watched by
+/// anything (#3560):</para>
+///
+/// <list type="bullet">
+/// <item>the sweep pools the exact bytes <c>nuget-top-packages.lock.json</c> names, and
+/// fails rather than pool anything else;</item>
+/// <item>the assembly copies put those bytes at the right path inside the output
+/// directory, without writing through whatever is already there, and every package whose
+/// copy fails is counted as failed rather than dropping out of the pool and out of the
+/// total owed together.</item>
+/// </list>
+///
+/// <para>Both were evidenced only by probes run by hand and recorded on #3434, which no
+/// future change re-runs. That mattered: the two most serious defects sixteen rounds of
+/// review found were both here. A pin that described the <em>request</em> rather than the
+/// bytes let a poisoned cache entry satisfy it, and <c>File.Copy</c> wrote an assembly
+/// through a symlink planted at the destination while the sweep exited 0. Every case below
+/// is one of those probes, kept.</para>
+///
+/// <para>These run a real sweep and are still hermetic. The sweep resolves its inputs from
+/// the repository root above its working directory, so a directory holding a
+/// <c>dotnet-inspect.slnx</c> and a <c>docs/data</c> feeds a real run a one-package list
+/// and pin of this suite's choosing -- no product path override is involved. It is pointed
+/// at a scratch cache holding one synthetic package and told to stay offline, so it reads
+/// no shared cache and opens no socket. Offline is what keeps that honest: a case that
+/// stopped being served from the seeded cache would reach for the network and fail here
+/// rather than quietly passing on whatever the machine happened to have.</para>
+/// </summary>
+[Trait("Area", "Corpus")]
+public class EvilPoolSweepGateTests
+{
+    const string FixturePackage = "sweep.fixture";
+    const string FixtureVersion = "1.0.0";
+    const string FixtureTfm = "net8.0";
+    const string FixtureAssembly = "Sweep.Fixture.dll";
+
+    /// <summary>
+    /// A sweep whose pin matches the cache pools those bytes, at the path the manifest
+    /// says, and leaves nothing behind.
+    ///
+    /// <para>This is the case every other one below is a deviation from. It is also what
+    /// stops those cases passing for the wrong reason: a harness that could not produce a
+    /// successful sweep at all would report every refusal as correct.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepPoolsTheBytesThePinNames()
+    {
+        using var world = SweepWorld.Create();
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 0, world.Explain(sweep, "a pin naming the cached bytes"));
+
+        string pooled = Path.Combine(
+            world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly);
+        Assert.True(File.Exists(pooled), $"the sweep exited 0 without pooling '{pooled}'");
+        Assert.Equal(world.FixtureSha256, Sha256Of(pooled));
+
+        // The pool is only reproducible if what the sweep reports is what it wrote.
+        Assert.Equal(pooled, File.ReadAllText(world.PooledListPath).Trim());
+        var manifested = JsonNode.Parse(File.ReadAllText(world.ManifestPath))!;
+        var entry = manifested["Packages"]!.AsArray()[0]!;
+        Assert.Equal("selected", entry["Status"]!.GetValue<string>());
+        Assert.Equal(world.FixtureSha256, entry["Sha256"]!.GetValue<string>());
+
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// Bytes the pin does not name are refused, and are not left in the pool.
+    ///
+    /// <para>The defect this replays: the pin recorded a version and a TFM, which describe
+    /// what the sweep <em>asks</em> the cache for, and the cache is a directory anything
+    /// can write to. Answering with a different assembly satisfied both. Swapping the
+    /// cached file for other bytes here is exactly that -- the request is untouched and
+    /// only the answer changes -- so only a check over the bytes themselves can refuse
+    /// it.</para>
+    ///
+    /// <para>Refusing is half of it. A rejected assembly left in the output directory
+    /// would be pooled by everything downstream, which reads the directory.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepRefusesBytesThePinDoesNotName()
+    {
+        using var world = SweepWorld.Create();
+        byte[] impostor = [.. world.FixtureBytes, 0];
+        File.WriteAllBytes(world.CachedAssemblyPath, impostor);
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a cache answering with other bytes"));
+        Assert.Contains(world.FixtureSha256, sweep.Output + sweep.Errors, StringComparison.Ordinal);
+        Assert.Contains(Sha256Of(impostor), sweep.Output + sweep.Errors, StringComparison.Ordinal);
+
+        Assert.Empty(PooledAssemblies(world.OutputDirectory));
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// A pin naming a TFM the package does not carry is refused.
+    ///
+    /// <para>Gated because this check was silently off for a year of the pin's life: the
+    /// comparison was guarded by <c>pin.Tfm is not null</c>, so a null TFM matched
+    /// anything. A pin that binds the version but not the framework pools a different
+    /// assembly out of the same package.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepRefusesATfmThePinDoesNotName()
+    {
+        using var world = SweepWorld.Create(tfm: "net10.0");
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a pin naming a TFM the package lacks"));
+        Assert.Contains("net10.0", sweep.Output + sweep.Errors, StringComparison.Ordinal);
+        Assert.Empty(PooledAssemblies(world.OutputDirectory));
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// A pin naming a version that is not there is refused rather than served by whatever
+    /// is.
+    ///
+    /// <para>The version in the pin is the coordinate the sweep acquires at, so this is
+    /// the property that a pinned pool is a pinned pool: asked for a version the cache
+    /// does not hold, a sweep must come up short rather than fall back to the version it
+    /// does hold. Falling back is how the pool drifted before it was pinned.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepRefusesAVersionThePinDoesNotName()
+    {
+        using var world = SweepWorld.Create(version: "9.9.9");
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a pin naming an absent version"));
+        Assert.Empty(PooledAssemblies(world.OutputDirectory));
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// Something planted at a destination is replaced, not written through.
+    ///
+    /// <para>This is the round-sixteen defect, kept. The three metadata writes had been
+    /// hardened and the ninety-one assembly copies had not, so a bare
+    /// <c>File.Copy(overwrite: true)</c> opened the destination, followed a symlink at it,
+    /// and turned a file outside the output directory into a copy of a .NET assembly at
+    /// exit 0. Nothing downstream could notice: the hash is taken over the destination,
+    /// and reading back through the same link returns the bytes that were written.</para>
+    ///
+    /// <para>So the assertion is not about the sweep's exit code -- the sweep is entitled
+    /// to succeed here, and does. It is that the file outside the output directory still
+    /// holds its own bytes, and that what the sweep pooled is a real file rather than a
+    /// link to somewhere else.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepReplacesWhatIsPlantedAtItsDestinationRatherThanWritingThroughIt()
+    {
+        using var world = SweepWorld.Create();
+
+        string outsider = Path.Combine(world.Scratch, "outside.txt");
+        const string Sentinel = "bytes that belong to someone else";
+        File.WriteAllText(outsider, Sentinel);
+
+        string destination = Path.Combine(
+            world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly);
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        if (!TryPlantSymbolicLink(destination, outsider))
+            return;
+
+        var sweep = world.Run();
+
+        Assert.Equal(Sentinel, File.ReadAllText(outsider));
+        Assert.True(sweep.ExitCode == 0, world.Explain(sweep, "a symlink planted at the destination"));
+
+        // Replaced, so the pooled path is the assembly itself rather than a way back out
+        // to the file above -- which would read as correct while pooling nothing.
+        Assert.Null(new FileInfo(destination).LinkTarget);
+        Assert.Equal(world.FixtureSha256, Sha256Of(destination));
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// A package whose copy fails is counted as failed.
+    ///
+    /// <para>The family that produced findings in four consecutive review rounds was a
+    /// package dropping out of the pool and out of the total owed at the same time, so the
+    /// two cancelled and a short pool exited 0. A copy that cannot be written is the last
+    /// place that can happen, and the one furthest from the pin, which is why an
+    /// unwritable destination is the case here.</para>
+    ///
+    /// <para>The temporary matters as much as the exit code. Writes go to a fresh sibling
+    /// and are renamed onto the destination, so a failure that leaves the sibling behind
+    /// leaves a partial assembly in the output directory for a later run to hash.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepCountsAPackageWhoseCopyFailedAsFailed()
+    {
+        using var world = SweepWorld.Create();
+
+        string destinationDirectory = Path.Combine(
+            world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion);
+        Directory.CreateDirectory(destinationDirectory);
+        if (!TryMakeUnwritable(destinationDirectory))
+            return;
+
+        try
+        {
+            var sweep = world.Run();
+
+            Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a destination that cannot be written"));
+            Assert.Empty(PooledAssemblies(world.OutputDirectory));
+
+            // Reported as this package failing, not as a pool that was simply smaller.
+            var manifested = JsonNode.Parse(File.ReadAllText(world.ManifestPath))!;
+            Assert.Equal(0, manifested["SelectedPackageCount"]!.GetValue<int>());
+            Assert.NotEqual("selected", manifested["Packages"]!.AsArray()[0]!["Status"]!.GetValue<string>());
+        }
+        finally
+        {
+            RestoreWritable(destinationDirectory);
+        }
+
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    static IReadOnlyList<string> PooledAssemblies(string outputDirectory) =>
+        Directory.Exists(Path.Combine(outputDirectory, "packages"))
+            ? Directory.GetFiles(Path.Combine(outputDirectory, "packages"), "*.dll", SearchOption.AllDirectories)
+            : [];
+
+    static string Sha256Of(string path) => Sha256Of(File.ReadAllBytes(path));
+
+    static string Sha256Of(byte[] bytes) => Convert.ToHexStringLower(SHA256.HashData(bytes));
+
+    /// <summary>
+    /// Plants a symlink, or returns false where the platform will not make one. Returning
+    /// false drops the case rather than weakening it: on Windows an unprivileged process
+    /// cannot create a symlink, and a case that quietly asserted something else would be
+    /// worse than a case that did not run.
+    /// </summary>
+    static bool TryPlantSymbolicLink(string path, string target)
+    {
+        try
+        {
+            File.CreateSymbolicLink(path, target);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Makes a directory refuse new files, or returns false where that cannot be arranged.
+    /// Unix mode bits are the only mechanism here; on Windows this case does not run.
+    /// </summary>
+    static bool TryMakeUnwritable(string directory)
+    {
+        if (OperatingSystem.IsWindows())
+            return false;
+
+        File.SetUnixFileMode(directory, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        return true;
+    }
+
+    /// <summary>
+    /// Undoes <see cref="TryMakeUnwritable"/>, so the scratch directory can be deleted.
+    /// </summary>
+    static void RestoreWritable(string directory)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        File.SetUnixFileMode(
+            directory,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    /// <summary>
+    /// A repository root, a package list, a pin, a cache holding one package, and an output
+    /// directory -- everything one sweep reads and writes, all of it scratch.
+    ///
+    /// <para>The cache is seeded through <see cref="NuGetCache.CommitPackage"/> rather than
+    /// by writing the directories directly. The layout of a committed package, including
+    /// the marker that makes it count as committed, belongs to the product; a harness that
+    /// laid it out itself would be a second implementation of it, and would keep passing
+    /// after the product's own layout moved.</para>
+    /// </summary>
+    sealed class SweepWorld : IDisposable
+    {
+        SweepWorld(string scratch, string cacheDirectory, byte[] fixtureBytes)
+        {
+            Scratch = scratch;
+            CacheDirectory = cacheDirectory;
+            FixtureBytes = fixtureBytes;
+            FixtureSha256 = Sha256Of(fixtureBytes);
+        }
+
+        public string Scratch { get; }
+
+        public string CacheDirectory { get; }
+
+        public byte[] FixtureBytes { get; }
+
+        /// <summary>The hash of the assembly the pin names, and the only correct pool.</summary>
+        public string FixtureSha256 { get; }
+
+        public string FakeRoot => Path.Combine(Scratch, "root");
+
+        public string OutputDirectory => Path.Combine(Scratch, "pool");
+
+        public string ManifestPath => Path.Combine(OutputDirectory, "manifest.json");
+
+        public string PooledListPath => Path.Combine(OutputDirectory, "assemblies.txt");
+
+        /// <summary>
+        /// The fixture assembly as the cache holds it. Overwriting this is how a case
+        /// makes the cache answer with bytes the pin does not name.
+        /// </summary>
+        public string CachedAssemblyPath => Path.Combine(
+            CacheDirectory,
+            "package-content-v2",
+            FixturePackage,
+            FixtureVersion,
+            "lib",
+            FixtureTfm,
+            FixtureAssembly);
+
+        /// <summary>
+        /// Builds the world. <paramref name="version"/> and <paramref name="tfm"/> are what
+        /// the <em>pin</em> claims; the package in the cache is always the real one, so a
+        /// case that changes them is changing the pin alone.
+        /// </summary>
+        public static SweepWorld Create(string? version = null, string? tfm = null)
+        {
+            string scratch = Directory.CreateTempSubdirectory("evil-sweep-gate").FullName;
+            try
+            {
+                // An assembly the build already produced, so the fixture is a real PE file
+                // rather than something shaped like one.
+                byte[] bytes = File.ReadAllBytes(typeof(EvilPoolSweepGateTests).Assembly.Location);
+                string cacheDirectory = Path.Combine(scratch, "cache");
+                var world = new SweepWorld(scratch, cacheDirectory, bytes);
+
+                world.SeedCache();
+                world.WriteInputs(version ?? FixtureVersion, tfm ?? FixtureTfm);
+                return world;
+            }
+            catch
+            {
+                Directory.Delete(scratch, recursive: true);
+                throw;
+            }
+        }
+
+        void SeedCache()
+        {
+            string staged = Path.Combine(Scratch, "staged");
+            Directory.CreateDirectory(Path.Combine(staged, "lib", FixtureTfm));
+            File.WriteAllBytes(Path.Combine(staged, "lib", FixtureTfm, FixtureAssembly), FixtureBytes);
+            File.WriteAllText(
+                Path.Combine(staged, $"{FixturePackage}.nuspec"),
+                $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package><metadata>
+                  <id>{FixturePackage}</id><version>{FixtureVersion}</version>
+                  <authors>{nameof(EvilPoolSweepGateTests)}</authors>
+                  <description>A synthetic package that exists only to be pooled.</description>
+                </metadata></package>
+                """);
+
+            // Points this process's cache at the scratch directory only so that the commit
+            // below lands there. The sweep is told the same directory by environment, and
+            // resolves it with this same code, so the two cannot disagree about where it is.
+            NuGetCache.Initialize("dotnet-inspect", CacheDirectory, skipNuGetCache: true);
+            NuGetCache.CommitPackage(staged, null, FixturePackage, FixtureVersion);
+        }
+
+        void WriteInputs(string pinnedVersion, string pinnedTfm)
+        {
+            string data = Path.Combine(FakeRoot, "docs", "data");
+            Directory.CreateDirectory(data);
+
+            // What makes this directory a repository root, and so what makes the sweep read
+            // the two files beside it instead of the committed ones.
+            File.WriteAllText(Path.Combine(FakeRoot, "dotnet-inspect.slnx"), "");
+
+            var list = new JsonArray(
+                new JsonObject
+                {
+                    ["rank"] = 1,
+                    ["package"] = FixturePackage,
+                    ["downloads"] = 1,
+                });
+            var pin = new JsonObject
+            {
+                ["schemaVersion"] = 1,
+                ["packages"] = new JsonArray(
+                    new JsonObject
+                    {
+                        ["package"] = FixturePackage,
+                        ["version"] = pinnedVersion,
+                        ["tfm"] = pinnedTfm,
+                        ["status"] = "pinned",
+                        ["detail"] = null,
+                        ["sha256"] = Sha256Of(FixtureBytes),
+                    }),
+            };
+
+            var indented = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(Path.Combine(data, "nuget-top-packages.json"), list.ToJsonString(indented));
+            File.WriteAllText(Path.Combine(data, "nuget-top-packages.lock.json"), pin.ToJsonString(indented));
+        }
+
+        /// <summary>
+        /// Runs the sweep over this world's inputs, offline and against this world's cache.
+        ///
+        /// <para>Offline is not decoration. It is what makes a green result mean the seeded
+        /// cache answered: without it, a case that stopped reaching the fixture would go to
+        /// nuget.org and could pass on a real package, and the suite would be gating the
+        /// network instead of the pin.</para>
+        /// </summary>
+        public (int ExitCode, string Output, string Errors) Run()
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") is { Length: > 0 } host
+                    ? host
+                    : "dotnet",
+                WorkingDirectory = FakeRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            startInfo.ArgumentList.Add("run");
+            startInfo.ArgumentList.Add(Path.Combine(
+                AuthoredCorpusRatchetTests.FindRepositoryRoot(),
+                "eng",
+                "prepare-decompiler-package-sweep.cs"));
+            startInfo.ArgumentList.Add("--");
+            startInfo.ArgumentList.Add(OutputDirectory);
+            startInfo.ArgumentList.Add("1");
+            startInfo.ArgumentList.Add("1");
+
+            startInfo.Environment["DOTNET_INSPECT_OFFLINE"] = "1";
+            startInfo.Environment["DOTNET_INSPECT_ISOLATED"] = "evil-sweep-gate";
+            startInfo.Environment["DOTNET_INSPECT_CACHE_DIR"] = CacheDirectory;
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("could not start the sweep");
+
+            var output = process.StandardOutput.ReadToEndAsync();
+            var failures = process.StandardError.ReadToEndAsync();
+
+            // Bounded, because a hang here would otherwise be reported by CI killing the
+            // job, which says nothing about which case hung. Minutes rather than seconds
+            // because a cold `dotnet run` of a file-based app builds it first.
+            if (!process.WaitForExit((int)TimeSpan.FromMinutes(5).TotalMilliseconds))
+            {
+                process.Kill(entireProcessTree: true);
+                Assert.Fail("the sweep did not exit within five minutes");
+            }
+
+            return (process.ExitCode, output.GetAwaiter().GetResult(), failures.GetAwaiter().GetResult());
+        }
+
+        /// <summary>
+        /// Reports a sweep in full when its exit code was not the expected one. A bare
+        /// "expected 1, got 0" over a subprocess sends the reader back to reproduce it by
+        /// hand, which is what these cases exist to stop.
+        /// </summary>
+        public string Explain((int ExitCode, string Output, string Errors) sweep, string what) =>
+            $"the sweep exited {sweep.ExitCode} over {what}.\n"
+            + $"stdout:\n{sweep.Output}\nstderr:\n{sweep.Errors}";
+
+        /// <summary>
+        /// No half-written assembly is left in the output directory. A write goes to a
+        /// fresh sibling and is renamed onto the destination, so a leftover sibling is a
+        /// partial file that a later sweep would find, hash, and disagree with the pin
+        /// about -- reported as the pin failing rather than as the run that made it.
+        /// </summary>
+        public void AssertNoTemporaryLeftBehind()
+        {
+            if (!Directory.Exists(OutputDirectory))
+                return;
+
+            Assert.Empty(Directory.GetFiles(OutputDirectory, "*.tmp", SearchOption.AllDirectories));
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Scratch, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A scratch directory that outlives the run is not a result.
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -34,8 +34,8 @@ namespace ILInspector.Decompiler.Tests;
 /// <para>These run a real sweep, and what they isolate is the sweep's own acquisition.
 /// It resolves its inputs from the repository root above its working directory, so a
 /// directory holding a <c>dotnet-inspect.slnx</c> and a <c>docs/data</c> feeds a real run
-/// a one-package list and pin of this suite's choosing -- no product path override is
-/// involved. It is pointed at a scratch cache holding one synthetic package and told to
+/// a package list and pin of this suite's choosing -- no product path override is
+/// involved. It is pointed at a scratch cache holding two synthetic packages and told to
 /// stay offline, so <em>it</em> acquires over no network and reads no shared cache, and
 /// nothing it pools or acquires comes from outside the scratch directory. Offline is what
 /// keeps that honest: a case that stopped being served from the seeded cache would reach
@@ -60,6 +60,12 @@ public class EvilPoolSweepGateTests
     const string FixtureTfm = "net8.0";
     const string FixtureAssembly = "Sweep.Fixture.dll";
 
+    // A second package, ranked ahead of the one each case is about, which every sweep here
+    // pools successfully before reaching the subject. See SweepWorld for why the subject is
+    // never first.
+    const string LeadPackage = "sweep.lead";
+    const string LeadAssembly = "Sweep.Lead.dll";
+
     /// <summary>
     /// A sweep whose pin matches the cache pools those bytes, at the path the manifest
     /// says, and leaves nothing behind.
@@ -77,13 +83,20 @@ public class EvilPoolSweepGateTests
 
         Assert.True(sweep.ExitCode == 0, world.Explain(sweep, "a pin naming the cached bytes"));
 
-        string pooled = Path.Combine(
-            world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly);
+        string pooled = world.SubjectDestination;
         Assert.True(File.Exists(pooled), $"the sweep exited 0 without pooling '{pooled}'");
         Assert.Equal(world.FixtureSha256, Sha256Of(pooled));
 
-        // The pool is only reproducible if what the sweep reports is what it wrote.
-        Assert.Equal(pooled, File.ReadAllText(world.PooledListPath).Trim());
+        // The pool is only reproducible if what the sweep reports is what it wrote -- both
+        // packages, in rank order, and no third thing.
+        Assert.Equal(
+            [world.LeadDestination, pooled],
+            File.ReadAllLines(world.PooledListPath).Where(line => line.Length > 0));
+
+        // And the count agrees with the record. Nothing read this aggregate before, so a
+        // successful two-package pool could report zero selected -- measured.
+        Assert.Equal(2, world.ReportedManifest(sweep)["SelectedPackageCount"]!.GetValue<int>());
+
         var entry = world.ReportedEntry(sweep);
         Assert.Equal("selected", entry["Status"]!.GetValue<string>());
         Assert.Equal(world.FixtureSha256, entry["Sha256"]!.GetValue<string>());
@@ -92,7 +105,7 @@ public class EvilPoolSweepGateTests
         // without walking the tree, and the path is the one recorded field nothing else
         // here reads -- measured: replacing it with a literal left all nine cases green.
         Assert.Equal(
-            Path.Combine("packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly),
+            Path.Combine("packages", $"002-{FixturePackage}", FixtureVersion, FixtureAssembly),
             entry["AssemblyPath"]!.GetValue<string>());
 
         world.AssertNoTemporaryLeftBehind();
@@ -132,7 +145,7 @@ public class EvilPoolSweepGateTests
         // all nine cases green, because exit code, prose and an empty pool are unchanged.
         Assert.Equal("pin-mismatch", world.ReportedStatus(sweep));
 
-        Assert.Empty(PooledAssemblies(world.OutputDirectory));
+        world.AssertOnlyTheLeadWasPooled(sweep);
         world.AssertNoTemporaryLeftBehind();
     }
 
@@ -159,7 +172,7 @@ public class EvilPoolSweepGateTests
         // what a wrong label costs.
         Assert.Equal("pin-mismatch", world.ReportedStatus(sweep));
 
-        Assert.Empty(PooledAssemblies(world.OutputDirectory));
+        world.AssertOnlyTheLeadWasPooled(sweep);
         world.AssertNoTemporaryLeftBehind();
     }
 
@@ -193,7 +206,7 @@ public class EvilPoolSweepGateTests
         // request. A fallback to the version the cache does hold would read as selected.
         Assert.Equal("acquisition-failed", world.ReportedStatus(sweep));
 
-        Assert.Empty(PooledAssemblies(world.OutputDirectory));
+        world.AssertOnlyTheLeadWasPooled(sweep);
         world.AssertNoTemporaryLeftBehind();
     }
 
@@ -221,8 +234,7 @@ public class EvilPoolSweepGateTests
         const string Sentinel = "bytes that belong to someone else";
         File.WriteAllText(outsider, Sentinel);
 
-        string destination = Path.Combine(
-            world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly);
+        string destination = world.SubjectDestination;
         Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
         PlantSymbolicLink(destination, outsider);
 
@@ -256,8 +268,7 @@ public class EvilPoolSweepGateTests
     {
         using var world = SweepWorld.Create();
 
-        string destinationDirectory = Path.Combine(
-            world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion);
+        string destinationDirectory = Path.GetDirectoryName(world.SubjectDestination)!;
         Directory.CreateDirectory(destinationDirectory);
         MakeUnwritable(destinationDirectory);
 
@@ -266,11 +277,13 @@ public class EvilPoolSweepGateTests
             var sweep = world.Run();
 
             Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a destination that cannot be written"));
-            Assert.Empty(PooledAssemblies(world.OutputDirectory));
+            world.AssertOnlyTheLeadWasPooled(sweep);
 
-            // Reported as this package failing, not as a pool that was simply smaller.
-            Assert.Equal(0, world.ReportedManifest(sweep)["SelectedPackageCount"]!.GetValue<int>());
-            Assert.NotEqual("selected", world.ReportedStatus(sweep));
+            // Reported as this package failing, not as a pool that was simply smaller, and
+            // as the failure it was: labelling an unwritable destination acquisition-failed
+            // sends an operator to the network for a fault on their own disk -- measured,
+            // green until this asserted the label rather than merely "not selected".
+            Assert.Equal("copy-failed", world.ReportedStatus(sweep));
 
             // The other half of the delta's own claim: this failure happens before the
             // temporary exists, so the sweep must say so rather than report a cleanup it
@@ -355,8 +368,7 @@ public class EvilPoolSweepGateTests
     {
         using var world = SweepWorld.Create();
 
-        string destination = Path.Combine(
-            world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly);
+        string destination = world.SubjectDestination;
         Directory.CreateDirectory(destination);
 
         var sweep = world.Run();
@@ -418,7 +430,7 @@ public class EvilPoolSweepGateTests
         // pin-mismatch instead, because the package was found and then failed the pin.
         Assert.Equal("acquisition-failed", world.ReportedStatus(sweep));
 
-        Assert.Empty(PooledAssemblies(world.OutputDirectory));
+        world.AssertOnlyTheLeadWasPooled(sweep);
     }
 
     /// <summary>
@@ -546,8 +558,23 @@ public class EvilPoolSweepGateTests
     }
 
     /// <summary>
-    /// A repository root, a package list, a pin, a cache holding one package, and an output
+    /// A repository root, a package list, a pin, a cache holding two packages, and an output
     /// directory -- everything one sweep reads and writes, all of it scratch.
+    ///
+    /// <para>Two packages, and the one each case is about is always the second. A real sweep
+    /// runs this loop ninety-odd times; a world holding a single package can only ever
+    /// exercise the first iteration, and every guarantee here would then hold for the first
+    /// package alone. Measured, on a one-package world: restricting the hash comparison, the
+    /// replace-don't-write-through copy, the failure accounting, and the manifest's package
+    /// identity to <c>accountedFor == 0</c> each left all nine cases green, while a real
+    /// hundred-package sweep would pool poisoned bytes, write through a planted symlink,
+    /// exit 0 over a failed copy, and refresh the wrong pin key. With the subject at rank 2
+    /// each of those is a mutation that turns the subject's own iteration off.</para>
+    ///
+    /// <para>The lead is pooled successfully by every case, including the ones whose subject
+    /// is refused, which is the other half of what it buys: a refusal must stop the package
+    /// it is about and nothing else, and a sweep that abandoned the run would take the lead
+    /// with it.</para>
     ///
     /// <para>The cache is seeded through <see cref="NuGetCache.CommitPackage"/> rather than
     /// by writing the directories directly. The layout of a committed package, including
@@ -566,6 +593,11 @@ public class EvilPoolSweepGateTests
             CacheDirectory = cacheDirectory;
             FixtureBytes = fixtureBytes;
             FixtureSha256 = Sha256Of(fixtureBytes);
+
+            // Distinct bytes, so a sweep that pooled one package's assembly for the other
+            // fails the hash rather than passing on a coincidence.
+            LeadBytes = [.. fixtureBytes, (byte)'l', (byte)'e', (byte)'a', (byte)'d'];
+            LeadSha256 = Sha256Of(LeadBytes);
         }
 
         public string Scratch { get; }
@@ -574,8 +606,24 @@ public class EvilPoolSweepGateTests
 
         public byte[] FixtureBytes { get; }
 
+        /// <summary>The lead package's assembly, pooled ahead of the subject in every case.</summary>
+        public byte[] LeadBytes { get; }
+
+        public string LeadSha256 { get; }
+
         /// <summary>The hash of the assembly the pin names, and the only correct pool.</summary>
         public string FixtureSha256 { get; }
+
+        /// <summary>
+        /// Where the subject's assembly belongs, at rank 2. Composed here rather than in
+        /// each case so the rank the subject sits at is stated once.
+        /// </summary>
+        public string SubjectDestination => Path.Combine(
+            OutputDirectory, "packages", $"002-{FixturePackage}", FixtureVersion, FixtureAssembly);
+
+        /// <summary>Where the lead's assembly belongs, at rank 1.</summary>
+        public string LeadDestination => Path.Combine(
+            OutputDirectory, "packages", $"001-{LeadPackage}", FixtureVersion, LeadAssembly);
 
         public string FakeRoot => Path.Combine(Scratch, "root");
 
@@ -625,22 +673,8 @@ public class EvilPoolSweepGateTests
 
         void SeedCache()
         {
-            string staged = Path.Combine(Scratch, "staged");
-            Directory.CreateDirectory(Path.Combine(staged, "lib", FixtureTfm));
-            File.WriteAllBytes(Path.Combine(staged, "lib", FixtureTfm, FixtureAssembly), FixtureBytes);
-            File.WriteAllText(
-                Path.Combine(staged, $"{FixturePackage}.nuspec"),
-                $"""
-                <?xml version="1.0" encoding="utf-8"?>
-                <package><metadata>
-                  <id>{FixturePackage}</id><version>{FixtureVersion}</version>
-                  <authors>{nameof(EvilPoolSweepGateTests)}</authors>
-                  <description>A synthetic package that exists only to be pooled.</description>
-                </metadata></package>
-                """);
-
-            // Points this process's cache at the scratch directory only so that the commit
-            // below lands there. The sweep is told the same directory by environment, and
+            // Points this process's cache at the scratch directory only so that the commits
+            // below land there. The sweep is told the same directory by environment, and
             // resolves it with this same code, so the two cannot disagree about where it is.
             //
             // This is process-global state with no reset, and it is left pointing at a
@@ -649,20 +683,50 @@ public class EvilPoolSweepGateTests
             // against a removed directory fails loudly, where leaving a usable scratch
             // cache behind would quietly serve it this fixture instead.
             NuGetCache.Initialize("dotnet-inspect", CacheDirectory, skipNuGetCache: true);
-            NuGetCache.CommitPackage(staged, null, FixturePackage, FixtureVersion);
 
-            // Where the product put it, plus the layout of the package this test authored.
-            // A product that moved its cache layout fails here, naming the path it did not
-            // write, rather than downstream as a sweep that mysteriously ignored a tamper.
-            _cachedAssemblyPath = Path.Combine(
-                NuGetCache.GetPackageCachePath(FixturePackage, FixtureVersion),
+            Commit(LeadPackage, LeadAssembly, LeadBytes);
+            _cachedAssemblyPath = Commit(FixturePackage, FixtureAssembly, FixtureBytes);
+        }
+
+        /// <summary>
+        /// Stages one synthetic package and commits it, answering with the path the product
+        /// put its assembly at.
+        ///
+        /// <para>The path is the product's, not one composed here: the directory a committed
+        /// package lands in is the product's to decide, down to the casing it applies to the
+        /// name and version. A product that moved its cache layout fails here, naming the
+        /// path it did not write, rather than downstream as a sweep that mysteriously
+        /// ignored a tamper.</para>
+        /// </summary>
+        string Commit(string package, string assembly, byte[] bytes)
+        {
+            string staged = Path.Combine(Scratch, "staged", package);
+            Directory.CreateDirectory(Path.Combine(staged, "lib", FixtureTfm));
+            File.WriteAllBytes(Path.Combine(staged, "lib", FixtureTfm, assembly), bytes);
+            File.WriteAllText(
+                Path.Combine(staged, $"{package}.nuspec"),
+                $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package><metadata>
+                  <id>{package}</id><version>{FixtureVersion}</version>
+                  <authors>{nameof(EvilPoolSweepGateTests)}</authors>
+                  <description>A synthetic package that exists only to be pooled.</description>
+                </metadata></package>
+                """);
+
+            NuGetCache.CommitPackage(staged, null, package, FixtureVersion);
+
+            string committed = Path.Combine(
+                NuGetCache.GetPackageCachePath(package, FixtureVersion),
                 "lib",
                 FixtureTfm,
-                FixtureAssembly);
+                assembly);
 
             Assert.True(
-                File.Exists(_cachedAssemblyPath),
-                $"The committed package does not hold the fixture assembly at {_cachedAssemblyPath}.");
+                File.Exists(committed),
+                $"The committed package '{package}' does not hold its assembly at {committed}.");
+
+            return committed;
         }
 
         void WriteInputs(string pinnedVersion, string pinnedTfm)
@@ -674,11 +738,26 @@ public class EvilPoolSweepGateTests
             // the two files beside it instead of the committed ones.
             File.WriteAllText(Path.Combine(FakeRoot, "dotnet-inspect.slnx"), "");
 
+            WriteListAndPin(data, FixturePackage, pinnedVersion, pinnedTfm, FixtureSha256);
+        }
+
+        /// <summary>
+        /// Writes the list and the pin the sweep reads: the lead at rank 1, always correct,
+        /// and the subject at rank 2 with whatever this case is asking for.
+        /// </summary>
+        void WriteListAndPin(string data, string package, string version, string? tfm, string sha256)
+        {
             var list = new JsonArray(
                 new JsonObject
                 {
                     ["rank"] = 1,
-                    ["package"] = FixturePackage,
+                    ["package"] = LeadPackage,
+                    ["downloads"] = 2,
+                },
+                new JsonObject
+                {
+                    ["rank"] = 2,
+                    ["package"] = package,
                     ["downloads"] = 1,
                 });
             var pin = new JsonObject
@@ -687,12 +766,21 @@ public class EvilPoolSweepGateTests
                 ["packages"] = new JsonArray(
                     new JsonObject
                     {
-                        ["package"] = FixturePackage,
-                        ["version"] = pinnedVersion,
-                        ["tfm"] = pinnedTfm,
+                        ["package"] = LeadPackage,
+                        ["version"] = FixtureVersion,
+                        ["tfm"] = FixtureTfm,
                         ["status"] = "pinned",
                         ["detail"] = null,
-                        ["sha256"] = Sha256Of(FixtureBytes),
+                        ["sha256"] = LeadSha256,
+                    },
+                    new JsonObject
+                    {
+                        ["package"] = package,
+                        ["version"] = version,
+                        ["tfm"] = tfm,
+                        ["status"] = "pinned",
+                        ["detail"] = null,
+                        ["sha256"] = sha256,
                     }),
             };
 
@@ -721,8 +809,8 @@ public class EvilPoolSweepGateTests
             ReportedEntry(sweep)["Status"]!.GetValue<string>();
 
         /// <summary>
-        /// The manifest's one row, having established that it is about the package this
-        /// world asked for.
+        /// The manifest row about the package this world asked for, having established that it
+        /// is about that package and not the lead beside it.
         ///
         /// <para>Every read of a package row goes through here, which is the point. A status
         /// is a value, not a subject, so a row reporting the right outcome for some other
@@ -737,14 +825,37 @@ public class EvilPoolSweepGateTests
         public JsonNode ReportedEntry((int ExitCode, string Output, string Errors) sweep)
         {
             var packages = ReportedManifest(sweep)["Packages"]!.AsArray();
-            Assert.True(packages.Count == 1, Explain(sweep, $"a manifest holding {packages.Count} packages"));
+            Assert.True(packages.Count == 2, Explain(sweep, $"a manifest holding {packages.Count} packages"));
 
-            var recorded = packages[0]!["RequestedPackage"]?.GetValue<string>();
+            var matching = packages
+                .Where(row => row!["RequestedPackage"]?.GetValue<string>() == _requestedPackage)
+                .ToArray();
             Assert.True(
-                recorded == _requestedPackage,
-                Explain(sweep, $"a manifest reporting on '{recorded}' when '{_requestedPackage}' was asked for"));
+                matching.Length == 1,
+                Explain(
+                    sweep,
+                    $"a manifest with {matching.Length} rows about '{_requestedPackage}', reporting on "
+                    + string.Join(
+                        ", ",
+                        packages.Select(row => $"'{row!["RequestedPackage"]?.GetValue<string>()}'"))));
 
-            return packages[0]!;
+            return matching[0]!;
+        }
+
+        /// <summary>
+        /// The pool holds the lead's assembly and nothing else -- what a case asserts when
+        /// its subject was refused.
+        ///
+        /// <para>Stronger than an empty pool, and the reason the lead is there: a refusal
+        /// has to stop the package it is about and leave the rest of the run alone. A sweep
+        /// that abandoned everything on the first refusal, or one that pooled the subject
+        /// anyway under the lead's name, both satisfy "the subject's assembly is absent".</para>
+        /// </summary>
+        public void AssertOnlyTheLeadWasPooled((int ExitCode, string Output, string Errors) sweep)
+        {
+            Assert.Equal([LeadDestination], PooledAssemblies(OutputDirectory));
+            Assert.Equal(LeadSha256, Sha256Of(LeadDestination));
+            Assert.Equal(1, ReportedManifest(sweep)["SelectedPackageCount"]!.GetValue<int>());
         }
 
         /// <summary>
@@ -775,32 +886,8 @@ public class EvilPoolSweepGateTests
         public void PinInstead(string package, string version, string tfm)
         {
             _requestedPackage = package;
-            string data = Path.Combine(FakeRoot, "docs", "data");
-            var list = new JsonArray(
-                new JsonObject
-                {
-                    ["rank"] = 1,
-                    ["package"] = package,
-                    ["downloads"] = 1,
-                });
-            var pin = new JsonObject
-            {
-                ["schemaVersion"] = 1,
-                ["packages"] = new JsonArray(
-                    new JsonObject
-                    {
-                        ["package"] = package,
-                        ["version"] = version,
-                        ["tfm"] = tfm,
-                        ["status"] = "pinned",
-                        ["detail"] = null,
-                        ["sha256"] = Sha256Of(FixtureBytes),
-                    }),
-            };
-
-            var indented = new JsonSerializerOptions { WriteIndented = true };
-            File.WriteAllText(Path.Combine(data, "nuget-top-packages.json"), list.ToJsonString(indented));
-            File.WriteAllText(Path.Combine(data, "nuget-top-packages.lock.json"), pin.ToJsonString(indented));
+            WriteListAndPin(
+                Path.Combine(FakeRoot, "docs", "data"), package, version, tfm, FixtureSha256);
         }
 
         /// <summary>
@@ -831,8 +918,13 @@ public class EvilPoolSweepGateTests
                 "prepare-decompiler-package-sweep.cs"));
             startInfo.ArgumentList.Add("--");
             startInfo.ArgumentList.Add(OutputDirectory);
+
+            // Ranks 1 through 2: the lead and then the subject. The window has to cover
+            // both, and the sweep refuses a window its list does not rank, so a world that
+            // stopped writing the lead fails here rather than quietly narrowing back to one
+            // package and taking the coverage of every later iteration with it.
             startInfo.ArgumentList.Add("1");
-            startInfo.ArgumentList.Add("1");
+            startInfo.ArgumentList.Add("2");
 
             startInfo.Environment["DOTNET_INSPECT_OFFLINE"] = "1";
             startInfo.Environment["DOTNET_INSPECT_ISOLATED"] = "evil-sweep-gate";

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -537,6 +537,12 @@ public class EvilPoolSweepGateTests
     /// <para>The second run refuses on a version the scratch cache cannot serve, which is
     /// the cheapest way to make a package that <em>was</em> pooled stop being pooled. Any
     /// refusal would do -- the point is the leftover, not the reason for it.</para>
+    ///
+    /// <para>Three leftovers rather than one, in two directories and not all of them
+    /// assemblies, because one leftover cannot tell a reconciliation that removes
+    /// everything from one that removes something. Measured: with a single leftover, a
+    /// walk that stopped after its first removal and a walk that considered only
+    /// <c>*.dll</c> were both green.</para>
     /// </summary>
     [Fact]
     public void ASweepIntoAReusedDirectoryPoolsOnlyWhatItRecorded()
@@ -551,16 +557,73 @@ public class EvilPoolSweepGateTests
         // one, so anything of its still in packages/ afterwards is the previous run's.
         world.PinInstead(FixturePackage, "9.9.9", FixtureTfm);
 
+        // Two more leftovers of the shape a partial or abandoned run leaves: one beside the
+        // subject's, one under the lead's own directory, and one that is not an assembly.
+        string sibling = Path.Combine(
+            Path.GetDirectoryName(world.SubjectDestination)!, "Sweep.Fixture.tmp");
+        string underLead = Path.Combine(
+            Path.GetDirectoryName(world.LeadDestination)!, "Sweep.Lead.Stale.dll");
+        File.WriteAllBytes(sibling, world.FixtureBytes);
+        File.WriteAllBytes(underLead, world.FixtureBytes);
+
         var second = world.Run();
         Assert.True(second.ExitCode == 1, world.Explain(second, "a rerun whose subject cannot be acquired"));
         Assert.Equal("acquisition-failed", world.ReportedStatus(second));
 
         world.AssertOnlyTheLeadWasPooled(second);
 
-        // Named, not merely gone. The sweep says which file it removed, so a run that had
+        // Named, not merely gone. The sweep says which files it removed, so a run that had
         // to remove one is visible to whoever reads the manifest -- and so a leak this
         // step would otherwise quietly tidy away cannot pass for a clean pool.
-        world.AssertPoolMatchesRecord([world.SubjectDestination]);
+        world.AssertPoolMatchesRecord([world.SubjectDestination, sibling, underLead]);
+    }
+
+    /// <summary>
+    /// A sweep removes a link planted in the pool as a link, rather than deleting what is
+    /// on the far side of it.
+    ///
+    /// <para>The reconciliation deletes what the run did not record, so what it is willing
+    /// to walk into decides what it is willing to delete. Enumerating the pool with
+    /// <c>SearchOption.AllDirectories</c> -- the obvious spelling, and the one this started
+    /// as -- descends through a directory symlink and yields the paths behind it, so a link
+    /// under <c>packages/</c> aims the deletion at a directory the sweep does not own.
+    /// Measured against that spelling: the file outside the pool was deleted and the run
+    /// exited 0.</para>
+    ///
+    /// <para>Removing the link itself keeps the property the reconciliation is for -- the
+    /// pool holds only what the record names -- with a deletion that cannot reach past the
+    /// pool, because removing a symlink never touches its target.</para>
+    ///
+    /// <para>This is not a claim that something plants links in the pool. It is that a
+    /// step which deletes recursively should be unable to delete outside the directory it
+    /// owns, whatever is in it.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepRemovesALinkPlantedInThePoolWithoutDeletingWhatItPointsAt()
+    {
+        using var world = SweepWorld.Create();
+
+        // Somewhere the sweep has no business touching, holding a file worth keeping.
+        string outsider = Path.Combine(world.Scratch, "outside-the-pool");
+        Directory.CreateDirectory(outsider);
+        string bystander = Path.Combine(outsider, "keep.dll");
+        File.WriteAllBytes(bystander, world.FixtureBytes);
+
+        string link = Path.Combine(world.OutputDirectory, "packages", "linked");
+        Directory.CreateDirectory(Path.GetDirectoryName(link)!);
+        Directory.CreateSymbolicLink(link, outsider);
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 0, world.Explain(sweep, "a link planted in the pool"));
+
+        // The whole point: the deletion stopped at the pool boundary.
+        Assert.True(File.Exists(bystander), "the sweep deleted a file outside the pool.");
+        Assert.True(Directory.Exists(outsider), "the sweep removed a directory outside the pool.");
+
+        // And the pool still ends up holding only what the record names.
+        Assert.False(Path.Exists(link), "the link is still in the pool.");
+        world.AssertPoolMatchesRecord([link]);
     }
 
     /// <summary>
@@ -1463,7 +1526,8 @@ public class EvilPoolSweepGateTests
             string[] recordedRemovals =
                 [.. (manifest["RemovedFromPool"]?.AsArray() ?? [])
                     .Select(removed => removed!.GetValue<string>())];
-            Assert.Equal<IEnumerable<string>>(removals, recordedRemovals);
+            Assert.Equal<IEnumerable<string>>(
+                [.. removals.Order(StringComparer.Ordinal)], recordedRemovals);
         }
 
         public void Dispose()

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -66,6 +66,13 @@ public class EvilPoolSweepGateTests
     const string LeadPackage = "sweep.lead";
     const string LeadAssembly = "Sweep.Lead.dll";
 
+    // A third package, committed by every world and pooled by none of them, which ships a
+    // nuspec and no library at all. It is what the !IsSelected arm needs: the two packages
+    // above both ship an assembly, so that whole arm -- library-unavailable, and the
+    // no-library pin it confirms -- was unreachable, and deleting the arm outright left all
+    // eleven cases green.
+    const string EmptyPackage = "sweep.empty";
+
     /// <summary>
     /// A sweep whose pin matches the cache pools those bytes, at the path the manifest
     /// says, and leaves nothing behind.
@@ -298,6 +305,22 @@ public class EvilPoolSweepGateTests
     }
 
     /// <summary>
+    /// What a case plants at the destination before the sweep runs: the three shapes a
+    /// path can take that are not an ordinary file the sweep may simply overwrite.
+    /// </summary>
+    public enum Plant
+    {
+        /// <summary>A symlink to an existing file outside the output directory.</summary>
+        SymbolicLink,
+
+        /// <summary>A symlink whose target does not exist.</summary>
+        DanglingSymbolicLink,
+
+        /// <summary>A second name for an existing file outside the output directory.</summary>
+        HardLink,
+    }
+
+    /// <summary>
     /// Something planted at a destination is replaced, not written through.
     ///
     /// <para>This is the round-sixteen defect, kept. The three metadata writes had been
@@ -308,30 +331,55 @@ public class EvilPoolSweepGateTests
     /// and reading back through the same link returns the bytes that were written.</para>
     ///
     /// <para>So the assertion is not about the sweep's exit code -- the sweep is entitled
-    /// to succeed here, and does. It is that the file outside the output directory still
-    /// holds its own bytes, and that what the sweep pooled is a real file rather than a
-    /// link to somewhere else.</para>
+    /// to succeed here, and does. It is that the path outside the output directory is
+    /// exactly as it was, and that what the sweep pooled is a real file rather than a link
+    /// to somewhere else.</para>
+    ///
+    /// <para>All three shapes, because one of them was the whole coverage and the other two
+    /// are the ways around it. Gated on a live symlink alone, a sweep that protected links
+    /// whose target exists and wrote through the rest kept every case green while creating
+    /// an arbitrary external file through a dangling one; and a sweep that asked only
+    /// whether <c>LinkTarget</c> was set -- which a hard link leaves null -- wrote straight
+    /// through a hard-linked destination onto the file it shares an inode with. Both were
+    /// measured green against the single-shape case. The property was never about symlinks;
+    /// it is that the sweep replaces what it finds instead of opening it.</para>
     /// </summary>
-    [Fact]
-    public void ASweepReplacesWhatIsPlantedAtItsDestinationRatherThanWritingThroughIt()
+    [Theory]
+    [InlineData(Plant.SymbolicLink)]
+    [InlineData(Plant.DanglingSymbolicLink)]
+    [InlineData(Plant.HardLink)]
+    public void ASweepReplacesWhatIsPlantedAtItsDestinationRatherThanWritingThroughIt(Plant plant)
     {
         using var world = SweepWorld.Create();
 
         string outsider = Path.Combine(world.Scratch, "outside.txt");
         const string Sentinel = "bytes that belong to someone else";
-        File.WriteAllText(outsider, Sentinel);
+        if (plant != Plant.DanglingSymbolicLink)
+            File.WriteAllText(outsider, Sentinel);
 
         string destination = world.SubjectDestination;
         Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
-        PlantSymbolicLink(destination, outsider);
+        PlantAt(destination, outsider, plant);
 
         var sweep = world.Run();
 
-        Assert.Equal(Sentinel, File.ReadAllText(outsider));
-        Assert.True(sweep.ExitCode == 0, world.Explain(sweep, "a symlink planted at the destination"));
+        // The outside path first, before anything about the sweep: whatever it exited, this
+        // is the fact the case is about.
+        if (plant == Plant.DanglingSymbolicLink)
+        {
+            Assert.False(
+                File.Exists(outsider),
+                $"the sweep created '{outsider}' by writing through a dangling link at its destination.");
+        }
+        else
+        {
+            Assert.Equal(Sentinel, File.ReadAllText(outsider));
+        }
+
+        Assert.True(sweep.ExitCode == 0, world.Explain(sweep, $"a {plant} planted at the destination"));
 
         // Replaced, so the pooled path is the assembly itself rather than a way back out
-        // to the file above -- which would read as correct while pooling nothing.
+        // to the path above -- which would read as correct while pooling nothing.
         Assert.Null(new FileInfo(destination).LinkTarget);
         Assert.Equal(world.FixtureSha256, Sha256Of(destination));
         world.AssertNoTemporaryLeftBehind();
@@ -472,6 +520,132 @@ public class EvilPoolSweepGateTests
     }
 
     /// <summary>
+    /// A second sweep into the same output directory pools what that sweep recorded, and
+    /// not what the one before it left there.
+    ///
+    /// <para>Reuse is the normal way this sweep is run, not an edge: the corpus script
+    /// passes the same <c>&lt;outdir&gt;/sweep</c> every time, deliberately, so that the
+    /// paths in an earlier <c>assemblies.txt</c> stay valid. So the pool accumulates
+    /// across runs while each run's record describes only itself, and the two disagree
+    /// the first time a package stops being pooled -- which is exactly the state
+    /// <see cref="SweepWorld.AssertNoTemporaryLeftBehind"/> already says is the dangerous
+    /// one: <em>a file in <c>packages/</c> that nothing recorded is one a later sweep
+    /// finds, hashes, and disagrees with the pin about, reported as the pin failing
+    /// rather than as the run that made it.</em> That was prose about a single run; this
+    /// is the case that makes it true across runs.</para>
+    ///
+    /// <para>The second run refuses on a version the scratch cache cannot serve, which is
+    /// the cheapest way to make a package that <em>was</em> pooled stop being pooled. Any
+    /// refusal would do -- the point is the leftover, not the reason for it.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepIntoAReusedDirectoryPoolsOnlyWhatItRecorded()
+    {
+        using var world = SweepWorld.Create();
+
+        var first = world.Run();
+        Assert.True(first.ExitCode == 0, world.Explain(first, "a first sweep with a matching pin"));
+        Assert.Equal("selected", world.ReportedStatus(first));
+
+        // Same package, a version nothing seeded: pooled by the run above, refused by this
+        // one, so anything of its still in packages/ afterwards is the previous run's.
+        world.PinInstead(FixturePackage, "9.9.9", FixtureTfm);
+
+        var second = world.Run();
+        Assert.True(second.ExitCode == 1, world.Explain(second, "a rerun whose subject cannot be acquired"));
+        Assert.Equal("acquisition-failed", world.ReportedStatus(second));
+
+        world.AssertOnlyTheLeadWasPooled(second);
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// A package that ships no primary library is refused as <c>library-unavailable</c>,
+    /// rather than pooled or crashed over.
+    ///
+    /// <para>Nothing reached this arm before: the two packages every other case uses both
+    /// ship an assembly, so <c>!selection.IsSelected</c> was never true and the whole arm
+    /// below it -- this refusal, and the <c>no-library</c> pin it confirms -- could be
+    /// deleted outright with every case still green. It is not a quiet corner. A run that
+    /// records <c>library-unavailable</c> is what <c>--refresh-pin</c> turns into a
+    /// permanent <c>no-library</c> pin, so this is the status that decides whether a
+    /// package is in the pool at all from then on.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepRefusesAPackageThatShipsNoLibrary()
+    {
+        using var world = SweepWorld.Create();
+        world.PinEmptyInstead();
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a package that ships no library"));
+        Assert.Equal("library-unavailable", world.ReportedStatus(sweep));
+
+        // The description the pin is later confirmed against, so the two cases below are
+        // about the same fact this one records.
+        Assert.Equal("NoAssemblies", world.ReportedDetail(sweep));
+
+        world.AssertOnlyTheLeadWasPooled(sweep);
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// A package pinned as shipping no library, that ships none, is confirmed -- accounted
+    /// for rather than counted as a failure.
+    ///
+    /// <para>The other half of
+    /// <see cref="ASweepRefusesAPackagePinnedAsShippingNoLibraryThatShipsOne"/>, and the
+    /// half that makes <c>no-library</c> a claim about a package rather than a way to
+    /// delete one from the pool: nine of the real top hundred are meta-packages, and this
+    /// is the arm that lets the sweep account for them without pretending they contributed
+    /// an assembly.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepConfirmsAPackagePinnedAsShippingNoLibraryThatShipsNone()
+    {
+        using var world = SweepWorld.Create();
+        world.PinEmptyInstead("no-library", "NoAssemblies");
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 0, world.Explain(sweep, "a confirmed no-library pin"));
+        Assert.Equal("no-library-confirmed", world.ReportedStatus(sweep));
+
+        world.AssertOnlyTheLeadWasPooled(sweep);
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// A <c>no-library</c> pin is confirmed against the detail it was recorded over, so a
+    /// package that has since lost its candidates no longer confirms.
+    ///
+    /// <para>This is the check the sweep describes as its defence against a wiped or
+    /// truncated cache entry: an emptied extraction reports exactly what a genuine
+    /// meta-package reports, so without comparing the recorded detail the sweep would
+    /// confirm a package it no longer has. Dropping the detail comparison leaves the case
+    /// above green, because there the two agree; only a disagreement can tell whether it
+    /// was consulted.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepDoesNotConfirmANoLibraryPinRecordedOverSomethingElse()
+    {
+        using var world = SweepWorld.Create();
+        world.PinEmptyInstead("no-library", "NoAssemblies: Some.Candidate.dll");
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a no-library pin whose detail no longer holds"));
+
+        // Refused, not confirmed: the pin describes a package that had candidates, and this
+        // one has none.
+        Assert.Equal("library-unavailable", world.ReportedStatus(sweep));
+
+        world.AssertOnlyTheLeadWasPooled(sweep);
+        world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
     /// A package the seeded cache does not hold is unreachable, rather than fetched.
     ///
     /// <para>This is the case that gates the other seven. They all pool a synthetic package
@@ -589,12 +763,34 @@ public class EvilPoolSweepGateTests
     /// because on those platforms this always works, and the reason it stopped working is
     /// something the run should say out loud rather than swallow.</para>
     /// </summary>
-    static void PlantSymbolicLink(string path, string target)
+    /// <summary>
+    /// Plants one of the three shapes at <paramref name="path"/>, skipping visibly where
+    /// the platform will not allow it.
+    /// </summary>
+    static void PlantAt(string path, string target, Plant plant)
     {
         if (OperatingSystem.IsWindows())
-            Assert.Skip("planting a symlink needs privileges an unelevated Windows process lacks.");
+            Assert.Skip("planting a link needs privileges an unelevated Windows process lacks.");
 
-        File.CreateSymbolicLink(path, target);
+        if (plant != Plant.HardLink)
+        {
+            File.CreateSymbolicLink(path, target);
+            return;
+        }
+
+        // No BCL API makes a hard link, so this is the platform's. Reported rather than
+        // skipped when it fails: the file it names was just written, so there is no
+        // ordinary reason for `ln` not to succeed, and a case that skipped here would
+        // quietly stop covering the shape it exists for.
+        using var link = Process.Start(new ProcessStartInfo("ln")
+        {
+            ArgumentList = { target, path },
+            RedirectStandardError = true,
+        }) ?? throw new InvalidOperationException("could not start ln");
+
+        string errors = link.StandardError.ReadToEnd();
+        link.WaitForExit();
+        Assert.True(link.ExitCode == 0, $"could not hard-link '{path}' to '{target}': {errors}");
     }
 
     /// <summary>
@@ -794,7 +990,37 @@ public class EvilPoolSweepGateTests
 
             _leadCachedAssemblyPath = Commit(LeadPackage, LeadAssembly, LeadBytes);
             _cachedAssemblyPath = Commit(FixturePackage, FixtureAssembly, FixtureBytes);
+            CommitWithoutLibrary(EmptyPackage);
         }
+
+        /// <summary>
+        /// Stages the part of a synthetic package that is not its library -- the directory
+        /// and the nuspec -- and answers with the staged path for a caller to fill in.
+        /// </summary>
+        string Stage(string package)
+        {
+            string staged = Path.Combine(Scratch, "staged", package);
+            Directory.CreateDirectory(staged);
+            File.WriteAllText(
+                Path.Combine(staged, $"{package}.nuspec"),
+                $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package><metadata>
+                  <id>{package}</id><version>{FixtureVersion}</version>
+                  <authors>{nameof(EvilPoolSweepGateTests)}</authors>
+                  <description>A synthetic package that exists only to be pooled.</description>
+                </metadata></package>
+                """);
+
+            return staged;
+        }
+
+        /// <summary>
+        /// Commits a package that ships a nuspec and no library, so that the sweep's
+        /// <c>!IsSelected</c> arm has something to be about.
+        /// </summary>
+        void CommitWithoutLibrary(string package) =>
+            NuGetCache.CommitPackage(Stage(package), null, package, FixtureVersion);
 
         /// <summary>
         /// Stages one synthetic package and commits it, answering with the path the product
@@ -808,19 +1034,9 @@ public class EvilPoolSweepGateTests
         /// </summary>
         string Commit(string package, string assembly, byte[] bytes)
         {
-            string staged = Path.Combine(Scratch, "staged", package);
+            string staged = Stage(package);
             Directory.CreateDirectory(Path.Combine(staged, "lib", FixtureTfm));
             File.WriteAllBytes(Path.Combine(staged, "lib", FixtureTfm, assembly), bytes);
-            File.WriteAllText(
-                Path.Combine(staged, $"{package}.nuspec"),
-                $"""
-                <?xml version="1.0" encoding="utf-8"?>
-                <package><metadata>
-                  <id>{package}</id><version>{FixtureVersion}</version>
-                  <authors>{nameof(EvilPoolSweepGateTests)}</authors>
-                  <description>A synthetic package that exists only to be pooled.</description>
-                </metadata></package>
-                """);
 
             NuGetCache.CommitPackage(staged, null, package, FixtureVersion);
 
@@ -863,7 +1079,8 @@ public class EvilPoolSweepGateTests
             string version,
             string? tfm,
             string sha256,
-            string status = "pinned")
+            string status = "pinned",
+            string? detail = null)
         {
             var list = new JsonArray(
                 new JsonObject
@@ -897,7 +1114,7 @@ public class EvilPoolSweepGateTests
                         ["version"] = version,
                         ["tfm"] = tfm,
                         ["status"] = status,
-                        ["detail"] = status == "no-library" ? "ships no primary library" : null,
+                        ["detail"] = detail ?? (status == "no-library" ? "ships no primary library" : null),
                         ["sha256"] = status == "no-library" ? null : sha256,
                     }),
             };
@@ -1001,6 +1218,14 @@ public class EvilPoolSweepGateTests
             ReportedEntry(sweep)["WriteTemporary"]?.GetValue<string>();
 
         /// <summary>
+        /// The detail the sweep recorded beside the status -- for the <c>!IsSelected</c>
+        /// arm, its description of what it found instead of a library, which a
+        /// <c>no-library</c> pin is confirmed against.
+        /// </summary>
+        public string? ReportedDetail((int ExitCode, string Output, string Errors) sweep) =>
+            ReportedEntry(sweep)["Detail"]?.GetValue<string>();
+
+        /// <summary>
         /// Replaces the inputs so the sweep is asked for some other package, pinned to
         /// bytes nothing has. Used to ask for something the scratch cache cannot answer.
         /// </summary>
@@ -1009,6 +1234,18 @@ public class EvilPoolSweepGateTests
             _requestedPackage = package;
             WriteListAndPin(
                 Path.Combine(FakeRoot, "docs", "data"), package, version, tfm, FixtureSha256);
+        }
+
+        /// <summary>
+        /// Replaces the inputs so the sweep is asked for the package that ships no library,
+        /// pinned however this case needs.
+        /// </summary>
+        public void PinEmptyInstead(string status = "pinned", string? detail = null)
+        {
+            _requestedPackage = EmptyPackage;
+            WriteListAndPin(
+                Path.Combine(FakeRoot, "docs", "data"), EmptyPackage, FixtureVersion, FixtureTfm,
+                FixtureSha256, status, detail);
         }
 
         /// <summary>

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -238,6 +238,37 @@ public class EvilPoolSweepGateTests
         world.AssertNoTemporaryLeftBehind();
     }
 
+    /// <summary>
+    /// A write that fails after its temporary exists leaves no temporary.
+    ///
+    /// <para>The other failing case here cannot prove this. An unwritable directory fails
+    /// at the moment the temporary is created, so there is nothing to clean up and the
+    /// cleanup is never reached -- a case that asserted the absence of a temporary there
+    /// would be asserting that a file which was never created does not exist. A directory
+    /// standing at the destination is the failure that happens <em>after</em>: the
+    /// temporary is created beside it and written, and only the rename onto the name
+    /// fails.</para>
+    ///
+    /// <para>What is left behind matters because the temporary is a sibling of the
+    /// destination, inside the pool. A partial assembly left in <c>packages/</c> is a file
+    /// a later run finds and hashes, and the pin disagreeing with it would be reported as
+    /// the pin failing rather than as the run that abandoned it.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepLeavesNoTemporaryWhenAWriteFailsAfterCreatingOne()
+    {
+        using var world = SweepWorld.Create();
+
+        string destination = Path.Combine(
+            world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly);
+        Directory.CreateDirectory(destination);
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a directory standing at the destination"));
+        world.AssertNoTemporaryLeftBehind();
+    }
+
     static IReadOnlyList<string> PooledAssemblies(string outputDirectory) =>
         Directory.Exists(Path.Combine(outputDirectory, "packages"))
             ? Directory.GetFiles(Path.Combine(outputDirectory, "packages"), "*.dll", SearchOption.AllDirectories)

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -284,16 +284,22 @@ public class EvilPoolSweepGateTests
     /// reached the copy is what makes the absence afterwards mean the cleanup happened.
     /// </para>
     ///
-    /// <para><em>Not</em> gated, and deliberately not: that the temporary was created at
-    /// all. Reaching the copy and failing there is as close as a black-box case gets --
-    /// a failure raised inside <c>ReplaceOrReport</c> before the file is created reports
-    /// the same <c>copy-failed</c>, and this case would pass with the cleanup deleted.
-    /// Closing that needs the temporary to be observable, and it is deliberately not: the
-    /// name is randomized precisely so nothing can predict or occupy it, and it exists for
-    /// the length of one write. The property this case does carry is that the current
-    /// implementation's post-creation failure leaves nothing behind; a refactor moving the
-    /// failure earlier would weaken it silently, and that is the known limit rather than a
-    /// claim being made.</para>
+    /// <para>The creation itself is watched, rather than inferred. Reaching the copy is
+    /// not the same as having created the temporary: a failure raised inside
+    /// <c>ReplaceOrReport</c> before the file exists reports the same
+    /// <c>copy-failed</c>, and a case stopping at the status would pass with the cleanup
+    /// deleted. An earlier revision of this comment claimed that gap could not be closed
+    /// from outside, because the temporary's name is randomized and lives for one write.
+    /// That was wrong, and a reviewer disproved it by doing it: a watcher needs no name.
+    /// </para>
+    ///
+    /// <para>Watched only where the mechanism is dependable, which is the same bargain
+    /// <see cref="PlantSymbolicLink"/> makes. On Linux this is inotify and the event is
+    /// reliable for a file created in a watched directory; the other backends are laxer,
+    /// and a missed event here would fail a run that did nothing wrong. So elsewhere the
+    /// observation is skipped and the case keeps its weaker form, which is stated rather
+    /// than quietly assumed. CI runs Linux, so the strong form is the one that gates.
+    /// </para>
     /// </summary>
     [Fact]
     public void ASweepLeavesNoTemporaryWhenAWriteFailsAfterCreatingOne()
@@ -304,13 +310,31 @@ public class EvilPoolSweepGateTests
             world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly);
         Directory.CreateDirectory(destination);
 
+        // Armed before the sweep runs, on the directory the temporary is a sibling in.
+        // The pool's other writes go to a different directory, so this sees the assembly
+        // write and nothing else.
+        using var created = new ManualResetEventSlim(false);
+        using var watcher = new FileSystemWatcher(Path.GetDirectoryName(destination)!, "*.tmp");
+        watcher.Created += (_, _) => created.Set();
+        watcher.EnableRaisingEvents = true;
+
         var sweep = world.Run();
 
         Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a directory standing at the destination"));
 
-        // Reached the copy and failed there, so a temporary really was created and the
-        // absence below is the cleanup rather than an earlier exit.
+        // Reached the copy and failed there, rather than exiting earlier.
         Assert.Equal("copy-failed", world.ReportedStatus(sweep));
+
+        if (OperatingSystem.IsLinux())
+        {
+            // Events are delivered on the watcher's own thread, so the sweep exiting does
+            // not mean the notification has arrived. The wait is for that hand-off only --
+            // the creation is already over by now, so a full wait here means it never
+            // happened rather than that it was slow.
+            Assert.True(
+                created.Wait(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken),
+                world.Explain(sweep, "a run that never created the temporary this case is about"));
+        }
 
         world.AssertNoTemporaryLeftBehind();
     }
@@ -334,33 +358,24 @@ public class EvilPoolSweepGateTests
     /// <c>pin-mismatch</c> are the sweep's own recorded statuses, and they separate the two
     /// without depending on how any layer words its message.</para>
     ///
-    /// <para>Half of its power is ambient, so the case checks for it rather than assuming
-    /// it. The network half holds anywhere. The shared-NuGet-cache half only bites where
-    /// that cache actually holds this package: somewhere it does not, a sweep with
-    /// <c>skipNuGetCache</c> regressed misses the cache, falls through to a severed
-    /// network, and fails exactly as it should have -- a green result that gated nothing.
-    /// The precondition is a visible skip instead, because the alternative is a case that
-    /// looks like it is covering the regression and is not.</para>
+    /// <para>Half of its power is ambient, and the case runs anyway rather than skipping.
+    /// The network half holds anywhere: a sweep that regressed <c>Initialize(false)</c>
+    /// downloads this package from nuget.org and reaches <c>pin-mismatch</c> on any
+    /// machine. The shared-NuGet-cache half only bites where that cache actually holds the
+    /// package; somewhere it does not, a sweep with <c>skipNuGetCache</c> regressed misses
+    /// the cache, falls through to a severed network, and fails exactly as it should have.
+    /// Skipping the whole case over that used to throw away the network half with it --
+    /// measured: on a machine whose cache lacks the package, bypassing the old skip left
+    /// the case discriminating correctly (<c>acquisition-failed</c> against the regressed
+    /// sweep's <c>pin-mismatch</c>). So the assertion is unconditional, and the ambient
+    /// half it may be missing is reported by
+    /// <see cref="TheSharedNuGetCacheHoldsWhatTheIsolationCaseNeeds"/> instead.</para>
     /// </summary>
     [Fact]
     public void ASweepCannotReachAPackageTheSeededCacheDoesNotHold()
     {
-        // Present in the shared NuGet cache of any machine that has built this repository,
-        // and on nuget.org. Reachable by either knob's absence, and by neither's presence.
-        const string Package = "newtonsoft.json";
-        const string Version = "13.0.4";
-
-        // Read through the product, and only read: this directory is shared, and the one
-        // thing a test may never do to it is write.
-        if (!Directory.Exists(Path.Combine(NuGetCache.GetNuGetCachePath(), Package, Version)))
-        {
-            Assert.Skip(
-                $"{Package} {Version} is not in the shared NuGet cache, so this case cannot " +
-                "tell an isolated sweep from one that merely found nothing.");
-        }
-
         using var world = SweepWorld.Create();
-        world.PinInstead(Package, Version, "net6.0");
+        world.PinInstead(IsolationProbePackage, IsolationProbeVersion, "net6.0");
 
         var sweep = world.Run();
 
@@ -371,6 +386,55 @@ public class EvilPoolSweepGateTests
         Assert.Equal("acquisition-failed", world.ReportedStatus(sweep));
 
         Assert.Empty(PooledAssemblies(world.OutputDirectory));
+    }
+
+    /// <summary>
+    /// Present in the shared NuGet cache of any machine that has built this repository,
+    /// and on nuget.org: reachable by either isolation knob's absence, and by neither's
+    /// presence. Which is what makes it the probe
+    /// <see cref="ASweepCannotReachAPackageTheSeededCacheDoesNotHold"/> uses.
+    /// </summary>
+    const string IsolationProbePackage = "newtonsoft.json";
+
+    const string IsolationProbeVersion = "13.0.4";
+
+    /// <summary>
+    /// The shared NuGet cache holds the package the isolation case probes with.
+    ///
+    /// <para>Not a property of the product: a precondition of one case's coverage, asserted
+    /// separately so that losing it is a visible skip rather than a silent narrowing.
+    /// <see cref="ASweepCannotReachAPackageTheSeededCacheDoesNotHold"/> keeps gating the
+    /// network knob without this; what it loses is the cache knob, because a sweep that
+    /// regressed <c>skipNuGetCache</c> can only be caught reaching a cache that has
+    /// something to give it.</para>
+    ///
+    /// <para>Asked of the product, and asked as the product asks it. Whether a directory
+    /// exists is not whether the package is there to be served: an empty
+    /// <c>newtonsoft.json/13.0.4/</c> satisfies <c>Directory.Exists</c> and is rejected by
+    /// the cache lookup, so a precondition spelled that way declares power the case does
+    /// not have -- measured, and it left the isolation case green over a regression it
+    /// could no longer see. These are the same two calls
+    /// <see cref="NuGetCache.TryGetCachedPackage"/> makes on its NuGet-cache branch, so
+    /// this and the sweep cannot disagree about what is cached.</para>
+    ///
+    /// <para>Read-only, deliberately. The directory is shared with every other agent and
+    /// with the developer, and the one thing a test may never do to it is write -- seeding
+    /// it to make this precondition true would be a test repairing its own coverage by
+    /// damaging the machine.</para>
+    /// </summary>
+    [Fact]
+    public void TheSharedNuGetCacheHoldsWhatTheIsolationCaseNeeds()
+    {
+        string cached = Path.Combine(
+            NuGetCache.GetNuGetCachePath(), IsolationProbePackage, IsolationProbeVersion);
+
+        if (!Directory.Exists(cached) || !NuGetCache.IsCachedPackageValid(cached, IsolationProbePackage))
+        {
+            Assert.Skip(
+                $"The shared NuGet cache cannot serve {IsolationProbePackage} {IsolationProbeVersion}, so " +
+                $"{nameof(ASweepCannotReachAPackageTheSeededCacheDoesNotHold)} gates the network knob but " +
+                "not the cache knob on this machine.");
+        }
     }
 
     static IReadOnlyList<string> PooledAssemblies(string outputDirectory) =>
@@ -461,6 +525,7 @@ public class EvilPoolSweepGateTests
     sealed class SweepWorld : IDisposable
     {
         string? _cachedAssemblyPath;
+        string _requestedPackage = FixturePackage;
 
         SweepWorld(string scratch, string cacheDirectory, byte[] fixtureBytes)
         {
@@ -611,6 +676,13 @@ public class EvilPoolSweepGateTests
         /// prose any layer happens to render. A case asserting on message text fails when
         /// wording changes and behavior does not, which trains the next reader to edit the
         /// assertion rather than read it.</para>
+        ///
+        /// <para>The entry has to be about the package that was asked for. A status is a
+        /// value, not a subject, so a manifest whose one row reports the right outcome for
+        /// some other package satisfies every caller of this that reads only the status --
+        /// measured: rewriting every recorded package name left all eight cases green.
+        /// Asking the row who it is about is what makes the status an answer to the
+        /// question the case put.</para>
         /// </summary>
         public string ReportedStatus((int ExitCode, string Output, string Errors) sweep)
         {
@@ -618,6 +690,12 @@ public class EvilPoolSweepGateTests
             var manifested = JsonNode.Parse(File.ReadAllText(ManifestPath))!;
             var packages = manifested["Packages"]!.AsArray();
             Assert.True(packages.Count == 1, Explain(sweep, $"a manifest holding {packages.Count} packages"));
+
+            var recorded = packages[0]!["RequestedPackage"]?.GetValue<string>();
+            Assert.True(
+                recorded == _requestedPackage,
+                Explain(sweep, $"a manifest reporting on '{recorded}' when '{_requestedPackage}' was asked for"));
+
             return packages[0]!["Status"]!.GetValue<string>();
         }
 
@@ -627,6 +705,7 @@ public class EvilPoolSweepGateTests
         /// </summary>
         public void PinInstead(string package, string version, string tfm)
         {
+            _requestedPackage = package;
             string data = Path.Combine(FakeRoot, "docs", "data");
             var list = new JsonArray(
                 new JsonObject

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -556,7 +556,11 @@ public class EvilPoolSweepGateTests
         Assert.Equal("acquisition-failed", world.ReportedStatus(second));
 
         world.AssertOnlyTheLeadWasPooled(second);
-        world.AssertNoTemporaryLeftBehind();
+
+        // Named, not merely gone. The sweep says which file it removed, so a run that had
+        // to remove one is visible to whoever reads the manifest -- and so a leak this
+        // step would otherwise quietly tidy away cannot pass for a clean pool.
+        world.AssertPoolMatchesRecord([world.SubjectDestination]);
     }
 
     /// <summary>
@@ -643,6 +647,64 @@ public class EvilPoolSweepGateTests
 
         world.AssertOnlyTheLeadWasPooled(sweep);
         world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// A sweep that cannot reconcile the pool with its record says so, and fails.
+    ///
+    /// <para>The other side of <see cref="ASweepIntoAReusedDirectoryPoolsOnlyWhatItRecorded"/>:
+    /// there the leftover is removed, here it cannot be. Exiting 0 would hand a consumer a
+    /// pool holding an assembly the manifest does not name, which is the state the
+    /// reconciliation exists to prevent -- so the failure to prevent it has to be as loud
+    /// as the thing it was preventing.</para>
+    ///
+    /// <para>The stray sits in a directory of its own, and every package the sweep is
+    /// about is acquired, copied, and recorded normally. That is deliberate and is what
+    /// makes the case about the reconciliation: an earlier shape here made the
+    /// <em>subject's own</em> directory unwritable, which fails the copy, and a copy
+    /// failure exits 1 too -- so the case passed while the exit code under test was
+    /// mutated to 0. Nothing else in this run can fail, so the exit code can only have
+    /// come from the reconciliation. Measured after the rework: setting that exit code to
+    /// 0 turns this case, and only this case, red.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepThatCannotReconcileThePoolSaysSoAndFails()
+    {
+        using var world = SweepWorld.Create();
+
+        // A file the sweep will not record, in a directory that will not let it go. Given
+        // a rank no window here reaches, so it is a leftover rather than a destination.
+        string stallDirectory = Path.Combine(
+            world.OutputDirectory, "packages", "999-sweep.stale", "1.0.0");
+        Directory.CreateDirectory(stallDirectory);
+        string stale = Path.Combine(stallDirectory, "Sweep.Stale.dll");
+        File.WriteAllBytes(stale, world.FixtureBytes);
+        MakeUnwritable(stallDirectory);
+
+        try
+        {
+            var sweep = world.Run();
+
+            Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a pool that cannot be reconciled"));
+
+            // Still there -- which is the point, and why the run had to fail.
+            Assert.True(File.Exists(stale), "the leftover was removed after all.");
+
+            // The reason, in the manifest rather than only on stderr: a consumer reading
+            // the pool reads this file, and a pool that could not be reconciled is one its
+            // record misdescribes.
+            Assert.NotNull(world.ReportedManifest(sweep)["Unreconciled"]?.GetValue<string>());
+
+            // Both packages were pooled and recorded: the run did its work, and the
+            // failure is about the pool it could not clean rather than about them.
+            Assert.Equal("selected", world.ReportedStatus(sweep));
+            Assert.True(File.Exists(world.LeadDestination), "the lead was not pooled.");
+            Assert.True(File.Exists(world.SubjectDestination), "the subject was not pooled.");
+        }
+        finally
+        {
+            RestoreWritable(stallDirectory);
+        }
     }
 
     /// <summary>
@@ -1357,7 +1419,24 @@ public class EvilPoolSweepGateTests
         /// those is a sweep that did not finish -- measured: suppressing the write whenever
         /// the pool came out empty left every case green.</para>
         /// </summary>
-        public void AssertNoTemporaryLeftBehind()
+        public void AssertNoTemporaryLeftBehind() => AssertPoolMatchesRecord(removals: []);
+
+        /// <summary>
+        /// The pool holds exactly what the sweep recorded, and the sweep says which files
+        /// it had to remove to make that true.
+        ///
+        /// <para>The removals are the half a set difference over the disk cannot see. The
+        /// sweep deletes unrecorded files under <c>packages/</c>, and a write temporary it
+        /// leaked is an unrecorded file under <c>packages/</c> -- so once it started
+        /// reconciling, a sweep that skipped its cleanup and still reported the temporary
+        /// as <c>removed</c> had the evidence swept up behind it, and the disk check that
+        /// used to catch exactly that passed. Measured: with the removals unreported, that
+        /// mutation left all seventeen cases green, and reverting the reconciliation turned
+        /// it red again. Asking what the sweep removed puts the fact back, and takes it
+        /// from the sweep's own record rather than from a name this harness would have to
+        /// know.</para>
+        /// </summary>
+        public void AssertPoolMatchesRecord(string[] removals)
         {
             if (!Directory.Exists(OutputDirectory))
                 return;
@@ -1378,6 +1457,13 @@ public class EvilPoolSweepGateTests
                     .Order(StringComparer.Ordinal)];
 
             Assert.Equal(expected, present);
+
+            var manifest = JsonNode.Parse(File.ReadAllText(ManifestPath))!;
+            Assert.Null(manifest["Unreconciled"]?.GetValue<string>());
+            string[] recordedRemovals =
+                [.. (manifest["RemovedFromPool"]?.AsArray() ?? [])
+                    .Select(removed => removed!.GetValue<string>())];
+            Assert.Equal<IEnumerable<string>>(removals, recordedRemovals);
         }
 
         public void Dispose()

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -37,14 +37,15 @@ namespace ILInspector.Decompiler.Tests;
 /// a one-package list and pin of this suite's choosing -- no product path override is
 /// involved. It is pointed at a scratch cache holding one synthetic package and told to
 /// stay offline, so <em>it</em> acquires over no network and reads no shared cache, and
-/// nothing it writes lands outside the scratch directory. Offline is what keeps that
-/// honest: a case that stopped being served from the seeded cache would reach for the
-/// network and fail here rather than quietly passing on whatever the machine happened to
-/// have.</para>
+/// nothing it pools or acquires comes from outside the scratch directory. Offline is what
+/// keeps that honest: a case that stopped being served from the seeded cache would reach
+/// for the network and fail here rather than quietly passing on whatever the machine
+/// happened to have.</para>
 ///
 /// <para>The claim stops there, deliberately. Each case launches the sweep with
 /// <c>dotnet run</c>, and a file-based app is restored and built before it runs, which
-/// reads the ordinary NuGet package cache and may go to the network to fill it. That is
+/// reads the ordinary NuGet package cache, writes to it and to the SDK's runfile
+/// directories, and may go to the network to fill them. That is
 /// true of every build in this repository and of the sweep runs in
 /// <see cref="EvilPoolPinTests"/>; it is not something these cases control, so they do
 /// not claim a process that opens no socket. What is gated is narrower and is the part
@@ -87,6 +88,13 @@ public class EvilPoolSweepGateTests
         Assert.Equal("selected", entry["Status"]!.GetValue<string>());
         Assert.Equal(world.FixtureSha256, entry["Sha256"]!.GetValue<string>());
 
+        // Where it landed, too. The manifest is how an operator finds the pooled file
+        // without walking the tree, and the path is the one recorded field nothing else
+        // here reads -- measured: replacing it with a literal left all nine cases green.
+        Assert.Equal(
+            Path.Combine("packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly),
+            entry["AssemblyPath"]!.GetValue<string>());
+
         world.AssertNoTemporaryLeftBehind();
     }
 
@@ -116,6 +124,14 @@ public class EvilPoolSweepGateTests
         Assert.Contains(world.FixtureSha256, sweep.Output + sweep.Errors, StringComparison.Ordinal);
         Assert.Contains(Sha256Of(impostor), sweep.Output + sweep.Errors, StringComparison.Ordinal);
 
+        // Which refusal, not merely that it refused. The label is what --refresh-pin acts
+        // on: pin-mismatch records nothing and leaves the existing pin standing, while
+        // library-unavailable rewrites the pin to no-library. Mislabelled, the tampered
+        // package this case plants is pinned out of the pool permanently and the evidence
+        // of the tamper goes with it -- measured: relabelling both pin-mismatch sites left
+        // all nine cases green, because exit code, prose and an empty pool are unchanged.
+        Assert.Equal("pin-mismatch", world.ReportedStatus(sweep));
+
         Assert.Empty(PooledAssemblies(world.OutputDirectory));
         world.AssertNoTemporaryLeftBehind();
     }
@@ -137,6 +153,12 @@ public class EvilPoolSweepGateTests
 
         Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a pin naming a TFM the package lacks"));
         Assert.Contains("net10.0", sweep.Output + sweep.Errors, StringComparison.Ordinal);
+
+        // The sweep's own word for a package that arrived and was refused, and the other
+        // of the two sites that produce it. See ASweepRefusesBytesThePinDoesNotName for
+        // what a wrong label costs.
+        Assert.Equal("pin-mismatch", world.ReportedStatus(sweep));
+
         Assert.Empty(PooledAssemblies(world.OutputDirectory));
         world.AssertNoTemporaryLeftBehind();
     }
@@ -702,19 +724,19 @@ public class EvilPoolSweepGateTests
         /// The manifest's one row, having established that it is about the package this
         /// world asked for.
         ///
-        /// <para>Every read of the manifest goes through here, which is the point. A status
+        /// <para>Every read of a package row goes through here, which is the point. A status
         /// is a value, not a subject, so a row reporting the right outcome for some other
         /// package satisfies any reader that takes the value and never asks whose it is --
         /// measured: rewriting every recorded package name left all nine cases green, and
         /// after the check was added to the status reader alone it still left two of them
         /// green, because those two indexed the array themselves. One door, so a case
-        /// cannot get the value without the question having been put.</para>
+        /// cannot get the value without the question having been put. <see cref="ReportedManifest"/>
+        /// is the parse this is built on and reaches no row; a reader wanting one comes
+        /// here.</para>
         /// </summary>
         public JsonNode ReportedEntry((int ExitCode, string Output, string Errors) sweep)
         {
-            Assert.True(File.Exists(ManifestPath), Explain(sweep, "a run that wrote no manifest"));
-            var manifested = JsonNode.Parse(File.ReadAllText(ManifestPath))!;
-            var packages = manifested["Packages"]!.AsArray();
+            var packages = ReportedManifest(sweep)["Packages"]!.AsArray();
             Assert.True(packages.Count == 1, Explain(sweep, $"a manifest holding {packages.Count} packages"));
 
             var recorded = packages[0]!["RequestedPackage"]?.GetValue<string>();
@@ -725,7 +747,11 @@ public class EvilPoolSweepGateTests
             return packages[0]!;
         }
 
-        /// <summary>The manifest as a whole, for the fields that are not the one row.</summary>
+        /// <summary>
+        /// The manifest as a whole, for the fields that are not a package row -- the
+        /// aggregates, which have no subject to ask about. Read a row through
+        /// <see cref="ReportedEntry"/> instead.
+        /// </summary>
         public JsonNode ReportedManifest((int ExitCode, string Output, string Errors) sweep)
         {
             Assert.True(File.Exists(ManifestPath), Explain(sweep, "a run that wrote no manifest"));

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -867,23 +867,41 @@ public class EvilPoolSweepGateTests
         /// Nothing here now knows what a temporary is called, so nothing here goes stale
         /// when that changes -- what it knows is that the pool and the record must agree,
         /// and the record is the product's.</para>
+        ///
+        /// <para>Over the whole output directory, not <c>packages/</c>. Narrowed to the
+        /// subtree the pool lives in, a cleanup that moved its temporary one level up
+        /// instead of deleting it left the file sitting beside <c>packages/</c> with all
+        /// nine cases green -- measured. The sweep's output directory has exactly three
+        /// kinds of occupant, and naming all three is what makes anything else a failure:
+        /// the manifest, the record, and the assemblies the record lists.</para>
+        ///
+        /// <para>The record has to exist, rather than being read as empty when it is
+        /// absent. Mapping a missing file to no entries makes "the sweep wrote no record"
+        /// indistinguishable from "the sweep recorded pooling nothing", and the first of
+        /// those is a sweep that did not finish -- measured: suppressing the write whenever
+        /// the pool came out empty left every case green.</para>
         /// </summary>
         public void AssertNoTemporaryLeftBehind()
         {
             if (!Directory.Exists(OutputDirectory))
                 return;
 
-            string pool = Path.Combine(OutputDirectory, "packages");
-            string[] present = Directory.Exists(pool)
-                ? [.. Directory.GetFiles(pool, "*", SearchOption.AllDirectories).Order(StringComparer.Ordinal)]
-                : [];
-            string[] recorded = File.Exists(PooledListPath)
-                ? [.. File.ReadAllLines(PooledListPath)
-                    .Where(line => line.Length > 0)
-                    .Order(StringComparer.Ordinal)]
-                : [];
+            Assert.True(
+                File.Exists(PooledListPath),
+                $"the sweep left an output directory behind without writing '{PooledListPath}', "
+                + "so there is no record to hold the pool against.");
 
-            Assert.Equal(recorded, present);
+            string[] present =
+                [.. Directory.GetFiles(OutputDirectory, "*", SearchOption.AllDirectories)
+                    .Order(StringComparer.Ordinal)];
+            string[] expected =
+                [.. File.ReadAllLines(PooledListPath)
+                    .Where(line => line.Length > 0)
+                    .Append(PooledListPath)
+                    .Append(ManifestPath)
+                    .Order(StringComparer.Ordinal)];
+
+            Assert.Equal(expected, present);
         }
 
         public void Dispose()

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -150,6 +150,14 @@ public class EvilPoolSweepGateTests
     /// the property that a pinned pool is a pinned pool: asked for a version the cache
     /// does not hold, a sweep must come up short rather than fall back to the version it
     /// does hold. Falling back is how the pool drifted before it was pinned.</para>
+    ///
+    /// <para>Enforced at the <em>request</em>, which is what the status below pins down.
+    /// The sweep also compares the returned version against the pin afterwards, and this
+    /// case does not reach that comparison -- measured: disabling it alone leaves this
+    /// case green, because acquisition has already refused. That comparison is a backstop
+    /// against an extractor that answers with something other than what it was asked for,
+    /// and nothing here can arrange for it to; it is deliberately left ungated rather than
+    /// left looking gated.</para>
     /// </summary>
     [Fact]
     public void ASweepRefusesAVersionThePinDoesNotName()
@@ -159,6 +167,11 @@ public class EvilPoolSweepGateTests
         var sweep = world.Run();
 
         Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a pin naming an absent version"));
+
+        // Never acquired, rather than acquired and then caught: the version bound the
+        // request. A fallback to the version the cache does hold would read as selected.
+        Assert.Equal("acquisition-failed", world.ReportedStatus(sweep));
+
         Assert.Empty(PooledAssemblies(world.OutputDirectory));
         world.AssertNoTemporaryLeftBehind();
     }
@@ -262,6 +275,13 @@ public class EvilPoolSweepGateTests
     /// destination, inside the pool. A partial assembly left in <c>packages/</c> is a file
     /// a later run finds and hashes, and the pin disagreeing with it would be reported as
     /// the pin failing rather than as the run that abandoned it.</para>
+    ///
+    /// <para>Which is why the reported outcome is asserted and not just the exit code.
+    /// Absence is satisfied by a sweep that never got far enough to create anything, so a
+    /// case asserting only "no temporary" passes on any early exit at all -- measured: a
+    /// sweep failing before the copy stage, with the cleanup deleted, left this case
+    /// green. Requiring the run to have reached the copy is what makes the absence
+    /// afterwards mean the cleanup happened.</para>
     /// </summary>
     [Fact]
     public void ASweepLeavesNoTemporaryWhenAWriteFailsAfterCreatingOne()
@@ -275,6 +295,11 @@ public class EvilPoolSweepGateTests
         var sweep = world.Run();
 
         Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a directory standing at the destination"));
+
+        // Reached the copy and failed there, so a temporary really was created and the
+        // absence below is the cleanup rather than an earlier exit.
+        Assert.Equal("copy-failed", world.ReportedStatus(sweep));
+
         world.AssertNoTemporaryLeftBehind();
     }
 
@@ -290,24 +315,49 @@ public class EvilPoolSweepGateTests
     /// on claiming otherwise. Naming a real package is what makes that regression visible:
     /// it is reachable both ways, so only genuine isolation can fail to reach it.</para>
     ///
-    /// <para>The assertion is on the <em>reason</em>, not just the exit code. A sweep that
-    /// found this package would still exit 1 -- on a pin mismatch, since the pin below
-    /// names bytes no real package has -- so an exit-code-only case would pass equally well
-    /// with the isolation removed, which is the failure it exists to catch.</para>
+    /// <para>The outcome is asserted, not just the exit code. A sweep that found this
+    /// package would still exit 1 -- on the pin, which names bytes no real package has --
+    /// so an exit-code-only case would pass equally well with the isolation removed, which
+    /// is the failure it exists to catch. <c>acquisition-failed</c> and
+    /// <c>pin-mismatch</c> are the sweep's own recorded statuses, and they separate the two
+    /// without depending on how any layer words its message.</para>
+    ///
+    /// <para>Half of its power is ambient, so the case checks for it rather than assuming
+    /// it. The network half holds anywhere. The shared-NuGet-cache half only bites where
+    /// that cache actually holds this package: somewhere it does not, a sweep with
+    /// <c>skipNuGetCache</c> regressed misses the cache, falls through to a severed
+    /// network, and fails exactly as it should have -- a green result that gated nothing.
+    /// The precondition is a visible skip instead, because the alternative is a case that
+    /// looks like it is covering the regression and is not.</para>
     /// </summary>
     [Fact]
     public void ASweepCannotReachAPackageTheSeededCacheDoesNotHold()
     {
-        using var world = SweepWorld.Create();
-
         // Present in the shared NuGet cache of any machine that has built this repository,
         // and on nuget.org. Reachable by either knob's absence, and by neither's presence.
-        world.PinInstead("newtonsoft.json", "13.0.4", "net6.0");
+        const string Package = "newtonsoft.json";
+        const string Version = "13.0.4";
+
+        // Read through the product, and only read: this directory is shared, and the one
+        // thing a test may never do to it is write.
+        if (!Directory.Exists(Path.Combine(NuGetCache.GetNuGetCachePath(), Package, Version)))
+        {
+            Assert.Skip(
+                $"{Package} {Version} is not in the shared NuGet cache, so this case cannot " +
+                "tell an isolated sweep from one that merely found nothing.");
+        }
+
+        using var world = SweepWorld.Create();
+        world.PinInstead(Package, Version, "net6.0");
 
         var sweep = world.Run();
 
         Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a package the scratch cache does not hold"));
-        Assert.Contains("not available offline", sweep.Errors, StringComparison.Ordinal);
+
+        // Never reached, rather than reached and rejected. Isolation regressed, this reads
+        // pin-mismatch instead, because the package was found and then failed the pin.
+        Assert.Equal("acquisition-failed", world.ReportedStatus(sweep));
+
         Assert.Empty(PooledAssemblies(world.OutputDirectory));
     }
 
@@ -539,6 +589,24 @@ public class EvilPoolSweepGateTests
             var indented = new JsonSerializerOptions { WriteIndented = true };
             File.WriteAllText(Path.Combine(data, "nuget-top-packages.json"), list.ToJsonString(indented));
             File.WriteAllText(Path.Combine(data, "nuget-top-packages.lock.json"), pin.ToJsonString(indented));
+        }
+
+        /// <summary>
+        /// The status the sweep recorded for the one package it was given.
+        ///
+        /// <para>The sweep's own vocabulary -- <c>acquisition-failed</c>,
+        /// <c>pin-mismatch</c>, <c>copy-failed</c>, <c>selected</c> -- rather than the
+        /// prose any layer happens to render. A case asserting on message text fails when
+        /// wording changes and behavior does not, which trains the next reader to edit the
+        /// assertion rather than read it.</para>
+        /// </summary>
+        public string ReportedStatus((int ExitCode, string Output, string Errors) sweep)
+        {
+            Assert.True(File.Exists(ManifestPath), Explain(sweep, "a run that wrote no manifest"));
+            var manifested = JsonNode.Parse(File.ReadAllText(ManifestPath))!;
+            var packages = manifested["Packages"]!.AsArray();
+            Assert.True(packages.Count == 1, Explain(sweep, $"a manifest holding {packages.Count} packages"));
+            return packages[0]!["Status"]!.GetValue<string>();
         }
 
         /// <summary>

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -278,6 +278,39 @@ public class EvilPoolSweepGateTests
         world.AssertNoTemporaryLeftBehind();
     }
 
+    /// <summary>
+    /// A package the seeded cache does not hold is unreachable, rather than fetched.
+    ///
+    /// <para>This is the case that gates the other seven. They all pool a synthetic package
+    /// that only the scratch cache holds, so they stay green whatever the isolation does:
+    /// deleting both knobs from the sweep -- <c>HttpClientFactory.Initialize(false)</c> and
+    /// <c>skipNuGetCache: false</c> -- leaves all seven passing, because the fixture is
+    /// still found where it was seeded. The suite would quietly become able to reach the
+    /// developer's NuGet cache and the network, and <see cref="SweepWorld.Run"/> would go
+    /// on claiming otherwise. Naming a real package is what makes that regression visible:
+    /// it is reachable both ways, so only genuine isolation can fail to reach it.</para>
+    ///
+    /// <para>The assertion is on the <em>reason</em>, not just the exit code. A sweep that
+    /// found this package would still exit 1 -- on a pin mismatch, since the pin below
+    /// names bytes no real package has -- so an exit-code-only case would pass equally well
+    /// with the isolation removed, which is the failure it exists to catch.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepCannotReachAPackageTheSeededCacheDoesNotHold()
+    {
+        using var world = SweepWorld.Create();
+
+        // Present in the shared NuGet cache of any machine that has built this repository,
+        // and on nuget.org. Reachable by either knob's absence, and by neither's presence.
+        world.PinInstead("newtonsoft.json", "13.0.4", "net6.0");
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a package the scratch cache does not hold"));
+        Assert.Contains("not available offline", sweep.Errors, StringComparison.Ordinal);
+        Assert.Empty(PooledAssemblies(world.OutputDirectory));
+    }
+
     static IReadOnlyList<string> PooledAssemblies(string outputDirectory) =>
         Directory.Exists(Path.Combine(outputDirectory, "packages"))
             ? Directory.GetFiles(Path.Combine(outputDirectory, "packages"), "*.dll", SearchOption.AllDirectories)
@@ -509,12 +542,48 @@ public class EvilPoolSweepGateTests
         }
 
         /// <summary>
+        /// Replaces the inputs so the sweep is asked for some other package, pinned to
+        /// bytes nothing has. Used to ask for something the scratch cache cannot answer.
+        /// </summary>
+        public void PinInstead(string package, string version, string tfm)
+        {
+            string data = Path.Combine(FakeRoot, "docs", "data");
+            var list = new JsonArray(
+                new JsonObject
+                {
+                    ["rank"] = 1,
+                    ["package"] = package,
+                    ["downloads"] = 1,
+                });
+            var pin = new JsonObject
+            {
+                ["schemaVersion"] = 1,
+                ["packages"] = new JsonArray(
+                    new JsonObject
+                    {
+                        ["package"] = package,
+                        ["version"] = version,
+                        ["tfm"] = tfm,
+                        ["status"] = "pinned",
+                        ["detail"] = null,
+                        ["sha256"] = Sha256Of(FixtureBytes),
+                    }),
+            };
+
+            var indented = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(Path.Combine(data, "nuget-top-packages.json"), list.ToJsonString(indented));
+            File.WriteAllText(Path.Combine(data, "nuget-top-packages.lock.json"), pin.ToJsonString(indented));
+        }
+
+        /// <summary>
         /// Runs the sweep over this world's inputs, offline and against this world's cache.
         ///
         /// <para>Offline is not decoration. It is what makes a green result mean the seeded
         /// cache answered: without it, a case that stopped reaching the fixture would go to
         /// nuget.org and could pass on a real package, and the suite would be gating the
-        /// network instead of the pin.</para>
+        /// network instead of the pin. That claim is itself gated, by
+        /// <see cref="ASweepCannotReachAPackageTheSeededCacheDoesNotHold"/> -- without it,
+        /// both knobs could be deleted from the sweep with all other cases still green.</para>
         /// </summary>
         public (int ExitCode, string Output, string Errors) Run()
         {

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -31,14 +31,25 @@ namespace ILInspector.Decompiler.Tests;
 /// through a symlink planted at the destination while the sweep exited 0. Every case below
 /// is one of those probes, kept.</para>
 ///
-/// <para>These run a real sweep and are still hermetic. The sweep resolves its inputs from
-/// the repository root above its working directory, so a directory holding a
-/// <c>dotnet-inspect.slnx</c> and a <c>docs/data</c> feeds a real run a one-package list
-/// and pin of this suite's choosing -- no product path override is involved. It is pointed
-/// at a scratch cache holding one synthetic package and told to stay offline, so it reads
-/// no shared cache and opens no socket. Offline is what keeps that honest: a case that
-/// stopped being served from the seeded cache would reach for the network and fail here
-/// rather than quietly passing on whatever the machine happened to have.</para>
+/// <para>These run a real sweep, and what they isolate is the sweep's own acquisition.
+/// It resolves its inputs from the repository root above its working directory, so a
+/// directory holding a <c>dotnet-inspect.slnx</c> and a <c>docs/data</c> feeds a real run
+/// a one-package list and pin of this suite's choosing -- no product path override is
+/// involved. It is pointed at a scratch cache holding one synthetic package and told to
+/// stay offline, so <em>it</em> acquires over no network and reads no shared cache, and
+/// nothing it writes lands outside the scratch directory. Offline is what keeps that
+/// honest: a case that stopped being served from the seeded cache would reach for the
+/// network and fail here rather than quietly passing on whatever the machine happened to
+/// have.</para>
+///
+/// <para>The claim stops there, deliberately. Each case launches the sweep with
+/// <c>dotnet run</c>, and a file-based app is restored and built before it runs, which
+/// reads the ordinary NuGet package cache and may go to the network to fill it. That is
+/// true of every build in this repository and of the sweep runs in
+/// <see cref="EvilPoolPinTests"/>; it is not something these cases control, so they do
+/// not claim a process that opens no socket. What is gated is narrower and is the part
+/// that matters: no package <em>the sweep pools</em> can come from anywhere but the
+/// fixture seeded below.</para>
 /// </summary>
 [Trait("Area", "Corpus")]
 public class EvilPoolSweepGateTests
@@ -179,8 +190,7 @@ public class EvilPoolSweepGateTests
         string destination = Path.Combine(
             world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion, FixtureAssembly);
         Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
-        if (!TryPlantSymbolicLink(destination, outsider))
-            return;
+        PlantSymbolicLink(destination, outsider);
 
         var sweep = world.Run();
 
@@ -215,8 +225,7 @@ public class EvilPoolSweepGateTests
         string destinationDirectory = Path.Combine(
             world.OutputDirectory, "packages", $"001-{FixturePackage}", FixtureVersion);
         Directory.CreateDirectory(destinationDirectory);
-        if (!TryMakeUnwritable(destinationDirectory))
-            return;
+        MakeUnwritable(destinationDirectory);
 
         try
         {
@@ -279,35 +288,56 @@ public class EvilPoolSweepGateTests
     static string Sha256Of(byte[] bytes) => Convert.ToHexStringLower(SHA256.HashData(bytes));
 
     /// <summary>
-    /// Plants a symlink, or returns false where the platform will not make one. Returning
-    /// false drops the case rather than weakening it: on Windows an unprivileged process
-    /// cannot create a symlink, and a case that quietly asserted something else would be
-    /// worse than a case that did not run.
+    /// Plants a symlink at <paramref name="path"/>.
+    ///
+    /// <para>Only Windows is allowed to duck this, and it does so as a <em>skip</em>. An
+    /// unprivileged Windows process cannot create a symlink, but a case that returned
+    /// early and let the test pass would report the sweep's most serious historical defect
+    /// as gated on a platform where nothing had run -- a green result covering an empty
+    /// one. Everywhere else a failure to plant the link is a real failure and is thrown,
+    /// because on those platforms this always works, and the reason it stopped working is
+    /// something the run should say out loud rather than swallow.</para>
     /// </summary>
-    static bool TryPlantSymbolicLink(string path, string target)
+    static void PlantSymbolicLink(string path, string target)
     {
-        try
-        {
-            File.CreateSymbolicLink(path, target);
-            return true;
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
-        {
-            return false;
-        }
+        if (OperatingSystem.IsWindows())
+            Assert.Skip("planting a symlink needs privileges an unelevated Windows process lacks.");
+
+        File.CreateSymbolicLink(path, target);
     }
 
     /// <summary>
-    /// Makes a directory refuse new files, or returns false where that cannot be arranged.
-    /// Unix mode bits are the only mechanism here; on Windows this case does not run.
+    /// Makes <paramref name="directory"/> refuse new files, skipping visibly where that
+    /// cannot be arranged.
+    ///
+    /// <para>Unix mode bits are the mechanism, so Windows skips. So does running as root,
+    /// which ignores them: the check is not that the bits were set but that they now
+    /// <em>bite</em>, because a case that believed the chmod and ran anyway would watch
+    /// the copy succeed and report a failing copy as being accounted for.</para>
     /// </summary>
-    static bool TryMakeUnwritable(string directory)
+    static void MakeUnwritable(string directory)
     {
         if (OperatingSystem.IsWindows())
-            return false;
+        {
+            Assert.Skip("making a directory refuse writes here needs Unix mode bits.");
+            return;
+        }
 
         File.SetUnixFileMode(directory, UnixFileMode.UserRead | UnixFileMode.UserExecute);
-        return true;
+
+        string probe = Path.Combine(directory, "probe");
+        try
+        {
+            File.WriteAllText(probe, "");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return;
+        }
+
+        File.Delete(probe);
+        RestoreWritable(directory);
+        Assert.Skip("this process can write to a directory it just made read-only (running as root?).");
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -83,8 +83,7 @@ public class EvilPoolSweepGateTests
 
         // The pool is only reproducible if what the sweep reports is what it wrote.
         Assert.Equal(pooled, File.ReadAllText(world.PooledListPath).Trim());
-        var manifested = JsonNode.Parse(File.ReadAllText(world.ManifestPath))!;
-        var entry = manifested["Packages"]!.AsArray()[0]!;
+        var entry = world.ReportedEntry(sweep);
         Assert.Equal("selected", entry["Status"]!.GetValue<string>());
         Assert.Equal(world.FixtureSha256, entry["Sha256"]!.GetValue<string>());
 
@@ -248,9 +247,16 @@ public class EvilPoolSweepGateTests
             Assert.Empty(PooledAssemblies(world.OutputDirectory));
 
             // Reported as this package failing, not as a pool that was simply smaller.
-            var manifested = JsonNode.Parse(File.ReadAllText(world.ManifestPath))!;
-            Assert.Equal(0, manifested["SelectedPackageCount"]!.GetValue<int>());
-            Assert.NotEqual("selected", manifested["Packages"]!.AsArray()[0]!["Status"]!.GetValue<string>());
+            Assert.Equal(0, world.ReportedManifest(sweep)["SelectedPackageCount"]!.GetValue<int>());
+            Assert.NotEqual("selected", world.ReportedStatus(sweep));
+
+            // The other half of the delta's own claim: this failure happens before the
+            // temporary exists, so the sweep must say so rather than report a cleanup it
+            // never performed. Without this, a sweep whose "did I create one" flag was
+            // stuck true reported "removed" here -- File.Delete swallows a missing file
+            // even in a directory it could not have written -- and nothing in the class
+            // read the value that would have said otherwise.
+            Assert.Equal("none", world.ReportedWriteTemporary(sweep));
         }
         finally
         {
@@ -296,11 +302,31 @@ public class EvilPoolSweepGateTests
     /// did create its temporary as one that never did. Measured here, reproducibly.</para>
     ///
     /// <para>So the sweep says what became of it instead, in the manifest, beside the
-    /// staging-directory cleanup it already reported: <c>removed</c> against <c>none</c>
-    /// separates a cleanup that ran from one that was never needed, and <c>left-behind</c>
-    /// is the answer an operator actually wants when a failed sweep may have dropped a
-    /// partial assembly in the pool. Deterministic, on every platform, and observable for
-    /// the same reason the rest of this file reads statuses rather than prose.</para>
+    /// staging-directory cleanup it already reported. <c>removed</c> against <c>none</c>
+    /// separates a cleanup that ran from one that was never needed, and both halves are
+    /// gated: this case requires <c>removed</c>, and
+    /// <see cref="ASweepCountsAPackageWhoseCopyFailedAsFailed"/> -- whose write fails
+    /// before the temporary exists -- requires <c>none</c>. Deterministic, on every
+    /// platform, and read for the same reason the rest of this file reads statuses rather
+    /// than prose.</para>
+    ///
+    /// <para><c>left-behind</c> is the third value and is <em>not</em> gated, deliberately
+    /// and not silently. It needs <c>File.Delete</c> to throw on a file <c>CreateNew</c>
+    /// had just made, and on Linux the two need the same directory permission, so no
+    /// black-box case can arrange it. It is worth reporting anyway -- it is the answer an
+    /// operator wants when a failed sweep may have dropped a partial assembly in the pool
+    /// -- but nothing here proves the sweep would say it, and that is stated rather than
+    /// left to read as covered. The set difference in
+    /// <see cref="SweepWorld.AssertNoTemporaryLeftBehind"/> is what actually catches the
+    /// leak; <c>left-behind</c> is how it would be explained.</para>
+    ///
+    /// <para>The value is derived from creation downward -- <c>created ? "left-behind" :
+    /// "none"</c> -- so a cleanup that stopped being called reports a leak rather than
+    /// reporting that no temporary was ever made. That direction is a defensive choice for
+    /// the operator reading the manifest, not a property this gate enforces: reverting it
+    /// leaves every case green, because the two derivations differ only on the
+    /// <c>left-behind</c> path that nothing can reach. Measured, and recorded here so the
+    /// next reader does not mistake the argument for a covered claim.</para>
     /// </summary>
     [Fact]
     public void ASweepLeavesNoTemporaryWhenAWriteFailsAfterCreatingOne()
@@ -669,7 +695,22 @@ public class EvilPoolSweepGateTests
         /// Asking the row who it is about is what makes the status an answer to the
         /// question the case put.</para>
         /// </summary>
-        public string ReportedStatus((int ExitCode, string Output, string Errors) sweep)
+        public string ReportedStatus((int ExitCode, string Output, string Errors) sweep) =>
+            ReportedEntry(sweep)["Status"]!.GetValue<string>();
+
+        /// <summary>
+        /// The manifest's one row, having established that it is about the package this
+        /// world asked for.
+        ///
+        /// <para>Every read of the manifest goes through here, which is the point. A status
+        /// is a value, not a subject, so a row reporting the right outcome for some other
+        /// package satisfies any reader that takes the value and never asks whose it is --
+        /// measured: rewriting every recorded package name left all nine cases green, and
+        /// after the check was added to the status reader alone it still left two of them
+        /// green, because those two indexed the array themselves. One door, so a case
+        /// cannot get the value without the question having been put.</para>
+        /// </summary>
+        public JsonNode ReportedEntry((int ExitCode, string Output, string Errors) sweep)
         {
             Assert.True(File.Exists(ManifestPath), Explain(sweep, "a run that wrote no manifest"));
             var manifested = JsonNode.Parse(File.ReadAllText(ManifestPath))!;
@@ -681,21 +722,25 @@ public class EvilPoolSweepGateTests
                 recorded == _requestedPackage,
                 Explain(sweep, $"a manifest reporting on '{recorded}' when '{_requestedPackage}' was asked for"));
 
-            return packages[0]!["Status"]!.GetValue<string>();
+            return packages[0]!;
+        }
+
+        /// <summary>The manifest as a whole, for the fields that are not the one row.</summary>
+        public JsonNode ReportedManifest((int ExitCode, string Output, string Errors) sweep)
+        {
+            Assert.True(File.Exists(ManifestPath), Explain(sweep, "a run that wrote no manifest"));
+            return JsonNode.Parse(File.ReadAllText(ManifestPath))!;
         }
 
         /// <summary>
-        /// What the sweep recorded became of the temporary the failing write went through:
-        /// <c>moved</c>, <c>removed</c>, <c>left-behind</c>, or <c>none</c>.
+        /// What the sweep recorded became of the temporary a failing write went through:
+        /// <c>removed</c>, <c>left-behind</c>, or <c>none</c> -- and <c>null</c> on any row
+        /// that is not a <c>copy-failed</c>, which is the only status the sweep records it
+        /// on. <c>moved</c> is a value the write returns and the manifest never carries,
+        /// because a write that landed has no temporary to account for.
         /// </summary>
-        public string? ReportedWriteTemporary((int ExitCode, string Output, string Errors) sweep)
-        {
-            Assert.True(File.Exists(ManifestPath), Explain(sweep, "a run that wrote no manifest"));
-            var manifested = JsonNode.Parse(File.ReadAllText(ManifestPath))!;
-            var packages = manifested["Packages"]!.AsArray();
-            Assert.True(packages.Count == 1, Explain(sweep, $"a manifest holding {packages.Count} packages"));
-            return packages[0]!["WriteTemporary"]?.GetValue<string>();
-        }
+        public string? ReportedWriteTemporary((int ExitCode, string Output, string Errors) sweep) =>
+            ReportedEntry(sweep)["WriteTemporary"]?.GetValue<string>();
 
         /// <summary>
         /// Replaces the inputs so the sweep is asked for some other package, pinned to


### PR DESCRIPTION
The EVIL pool's version pin was gated as a *file* and never as a *run*. `EvilPoolPinTests` checks its shape, encoding, read bounds and refusal wording — none of which starts a sweep. So the two properties the pinning work exists to provide were the two nothing in CI watched:

- a sweep pools the exact bytes `nuget-top-packages.lock.json` names, and fails rather than pool anything else;
- the assembly copies put those bytes at the right path inside the output directory, without writing through whatever is already there, and every package whose copy fails is counted as failed.

Both were evidenced only by probes run by hand and recorded on #3434. That mattered: the two most serious defects sixteen review rounds found were both on this path — a pin that described the *request* rather than the bytes, so a poisoned cache entry satisfied it; and `File.Copy` writing an assembly through a symlink planted at the destination while the sweep exited 0.

`EvilPoolSweepGateTests` runs real sweeps in ~20 seconds. Seven cases, one per probe, plus an eighth that gates the isolation the other seven rest on.

## The issue's premise was wrong, and the change is smaller for it

#3560 said the sweep "hardcodes its inputs" and would need `--package-list`/`--pin-file` or `--data-directory`, flagging that as a call to make deliberately. It needs none of them: the sweep already resolves its inputs from the repository root **above its working directory**, so a scratch directory holding a `dotnet-inspect.slnx` and a `docs/data` feeds a real run a list and pin of the suite's choosing. `EvilPoolPinTests.RunSweep` has done exactly this since #3434; nobody had noticed it reaches acquisition. **No new argument surface.**

What was genuinely missing was isolation. The sweep called `HttpClientFactory.Initialize()` and `NuGetCache.Initialize("dotnet-inspect")` with no arguments, so it always used the shared caches and the real network. It now honors the three knobs the CLI has always read — `DOTNET_INSPECT_OFFLINE`, `DOTNET_INSPECT_ISOLATED`, `DOTNET_INSPECT_CACHE_DIR` — with the CLI's meanings unchanged. That is one program catching up to a convention the rest of the tool follows, not a test backdoor, and it is inert when the variables are unset, which is every real sweep.

Offline is what keeps the gate honest rather than merely fast: a case that stopped being served from the seeded cache would reach for the network and **fail**, instead of quietly passing on whatever the machine happened to have. Verified — pointed at an empty cache, the sweep reports `not available offline` and exits 1.

The precise claim is that no package the sweep pools can come from anywhere but the seeded fixture. It is not that the test opens no socket: each case launches the sweep with `dotnet run`, which restores and builds a file-based app first, and that reads the ordinary NuGet cache and may go to the network to fill it. That is true of every build in this repository and of the sweep runs in `EvilPoolPinTests`; it is the acquisition under test that is sealed.

The seven cases cannot check that isolation themselves: they all pool a synthetic package only the scratch cache holds, so they pass whatever the isolation does. Measured — deleting both knobs from the sweep (`HttpClientFactory.Initialize(false)`, `skipNuGetCache: false`) leaves **all seven green**, and the suite silently regains the shared NuGet cache and the network. The eighth case names a real package instead, `newtonsoft.json@13.0.4`, reachable by either knob's absence and by neither's presence, and asserts the sweep cannot reach it — asserting the *reason* (`not available offline`), because a sweep that found it would still exit 1 on the pin. Each knob dropped alone turns exactly that case red.

The fixture package is committed through `NuGetCache.CommitPackage`. The layout of a committed package, including the marker that makes it count as committed, is the product's; a harness that laid it out itself would be a second implementation and would keep passing after the product's moved.

## Non-vacuity

Every case was proved to bite, and to bite alone. Each tamper is one edit to the sweep; the column is which tests went red.

| Tamper on the sweep | Red |
| --- | --- |
| `File.Copy(overwrite: true)` restored (the round-sixteen defect) | destination case only |
| sha256 comparison disabled | poisoned-bytes case only |
| TFM comparison re-guarded by `pin.Tfm is not null` | TFM case only |
| failed copy counted as accounted-for | accounting case only |
| temporary cleanup disabled | cleanup case only |
| acquisition falls back to a cached version + version check off | version case only |
| acquisition ignores the pin entirely | the clean run, plus 3 others |

The last row is the positive control: a harness that could not produce a *successful* sweep would report every refusal as correct.

**A gap this found in itself.** The leftover-temporary assertion was vacuous as first written. It rode on the unwritable-directory case, which fails at the moment the temporary is created — `created` stays false, the cleanup branch is never reached, and the assertion was that a file which was never made does not exist. A directory standing at the destination is the failure that happens *after*; that case is `ASweepLeavesNoTemporaryWhenAWriteFailsAfterCreatingOne`, and disabling the cleanup turns it red.

## Evidence

- Full solution build **0 errors**.
- `Area=Corpus` **355/0**; `--gate fast` **4402/0**; new class **7/0 in 11s** (`Area=Corpus`, not `Speed=Slow`, so PR CI runs it).
- **Real sweep unchanged**: ranks 1–3 against the committed list and pin, exit 0, same three assemblies. The env change is inert when unset.
- **Shared caches untouched**: `newtonsoft.json` 13.0.4 still `a28c251d…` in both `~/.nuget/packages` and `~/.cache/dotnet-inspect`, and no `sweep.fixture` anywhere in either.

## Boundary

Not covered, deliberately: the `no-library` claim still needs the network, because it asks a real package whether it ships a library — that doc comment is left as it was rather than made to point at this gate. Symlinks planted at *parent* directories remain out of scope per the call on #3434.

Closes #3560

