### PR TITLE
Expose a product-owned registry of style-option tiers (#3486)

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -751,6 +751,21 @@ delegates that read and drive that value's backing state without reflection. The
 descriptor reads and single-selects the whole axis through
 `GetValue`/`WithValue`.
 
+The tier itself is described by the catalog too, one level above the knobs:
+`StyleOptionCatalog.Tiers` lists a `StyleOptionTierDescriptor` per
+`StyleOptionTier`, carrying the tier as its stable `Id`, a display `Title` and
+`Summary` (the fidelity contract its knobs honor), an explicit `Order`
+(ascending, most conservative contract first), and the tier-level
+`ByteDivergent` flag — with `GetTier` resolving one by id. A host renders a
+grouped picker by walking `Tiers` and filtering `Options` on `Tier`, holding no
+label, blurb, or ordering of its own, so a knob in a newly added tier surfaces
+without a consumer edit
+([#3486](https://github.com/richlander/dotnet-inspect/issues/3486)). The
+registry is exhaustive against the enum and agrees with its knobs' own
+`ByteDivergent` by gate (`StyleOptionCatalogTests`), so neither a missing tier
+nor a misfiled knob is silent. `Order` is deliberately not the enum ordinal, so
+presentation order and declaration order can move independently.
+
 `OracleEndorsed` records **declared**-oracle endorsement specifically — the value
 has a `.editorconfig` rule behind it. `CorpusEndorsed` records **revealed**
 endorsement — the runtime's own source corpus reveals a dominant practice for the

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -445,4 +445,84 @@ public class StyleOptionCatalogTests
         var full = StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default);
         Assert.Equal("explicit", varStyle.GetValue(full));
     }
+
+    [Fact]
+    public void Tiers_CoverEveryTierExactlyOnce()
+    {
+        // The registry drives the grouping a host lays the catalog out with, so it
+        // has to be total: a StyleOptionTier value with no descriptor would drop
+        // its knobs out of a grouped picker silently. Set equality fails both a
+        // missing entry and a stale one.
+        var declared = Enum.GetValues<StyleOptionTier>().ToHashSet();
+        var registered = StyleOptionCatalog.Tiers.Select(t => t.Id).ToArray();
+
+        Assert.Equal(declared, registered.ToHashSet());
+        Assert.Equal(registered.Length, registered.Distinct().Count());
+    }
+
+    [Fact]
+    public void Tiers_AreListedInAscendingDisplayOrder_WithUniquePositions()
+    {
+        // Order is the product's presentation fact, so the list is already sorted
+        // by it — a host renders Tiers as-is and never sorts. Positions are unique
+        // so the layout cannot depend on an unstable tie-break.
+        var orders = StyleOptionCatalog.Tiers.Select(t => t.Order).ToArray();
+
+        Assert.Equal(orders.OrderBy(o => o).ToArray(), orders);
+        Assert.Equal(orders.Length, orders.Distinct().Count());
+    }
+
+    [Fact]
+    public void Tiers_HaveNonEmptyTitlesAndSummaries()
+    {
+        Assert.All(StyleOptionCatalog.Tiers, tier =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(tier.Title));
+            Assert.False(string.IsNullOrWhiteSpace(tier.Summary));
+        });
+    }
+
+    [Fact]
+    public void ByteDivergence_IsATierProperty()
+    {
+        // The tier states the contract its knobs honor, so a host can warn about a
+        // whole group. Per-knob agreement makes that statement enforced rather than
+        // documented: a byte-divergent knob filed under a byte-neutral tier fails
+        // here, as does the reverse.
+        Assert.All(Options, option =>
+            Assert.Equal(StyleOptionCatalog.GetTier(option.Tier).ByteDivergent, option.ByteDivergent));
+
+        // Non-vacuity in the other direction: a tier cannot claim byte-divergence
+        // with no knob to witness it, so the registry's flag stays a statement
+        // about real knobs. ByteDivergent_IsExactlyTheLensTier pins which tier
+        // that is; this pins that the registry agrees with the knobs.
+        Assert.Equal(
+            StyleOptionCatalog.Tiers.Where(t => t.ByteDivergent).Select(t => t.Id).ToHashSet(),
+            Options.Where(o => o.ByteDivergent).Select(o => o.Tier).ToHashSet());
+    }
+
+    [Fact]
+    public void GetTier_ResolvesEveryTier_AndRejectsAnUnregisteredOne()
+    {
+        foreach (var tier in Enum.GetValues<StyleOptionTier>())
+            Assert.Equal(tier, StyleOptionCatalog.GetTier(tier).Id);
+
+        // A miss is a catalog defect, so it throws instead of yielding an unlabeled
+        // group that renders as if it were fine.
+        Assert.Throws<ArgumentOutOfRangeException>(() => StyleOptionCatalog.GetTier((StyleOptionTier)(-1)));
+    }
+
+    [Fact]
+    public void EveryOption_GroupsUnderARegisteredTier()
+    {
+        // The grouped-picker walk a host performs: every knob lands in exactly one
+        // rendered group, so none is invisible to a consumer that trusts Tiers.
+        var grouped = StyleOptionCatalog.Tiers
+            .SelectMany(tier => Options.Where(o => o.Tier == tier.Id))
+            .Select(o => o.Id)
+            .ToArray();
+
+        Assert.Equal(Options.Select(o => o.Id).ToHashSet(StringComparer.Ordinal), grouped.ToHashSet(StringComparer.Ordinal));
+        Assert.Equal(Options.Count, grouped.Length);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -38,6 +38,59 @@ public enum StyleOptionTier
 }
 
 /// <summary>
+/// The product-owned presentation of one <see cref="StyleOptionTier"/>: the
+/// category level of the catalog, sitting one level above
+/// <see cref="StyleOptionDescriptor"/>. A host grouping the catalog by tier reads
+/// its label, blurb, and display position from here instead of restating a
+/// taxonomy the product already owns, so a knob in a newly added tier surfaces
+/// without a consumer edit.
+///
+/// <para>The <see cref="Id"/> is the stable grouping key; <see cref="Title"/> and
+/// <see cref="Summary"/> are presentation and may be reworded. Every tier has
+/// exactly one descriptor, which
+/// <c>StyleOptionCatalogTests.Tiers_CoverEveryTierExactlyOnce</c> enforces by set
+/// equality against <see cref="StyleOptionTier"/> — a new enum value with no
+/// descriptor fails there rather than silently vanishing from a picker.</para>
+/// </summary>
+public sealed record StyleOptionTierDescriptor
+{
+    /// <summary>
+    /// The tier this describes. The enum token is the stable, never-localized
+    /// grouping key a host keys presentation and persisted selections off.
+    /// </summary>
+    public required StyleOptionTier Id { get; init; }
+
+    /// <summary>Short human-facing label for a group heading in a picker.</summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// One-sentence statement of the fidelity contract every knob in this tier
+    /// honors, so a host can explain a group and not merely name it.
+    /// </summary>
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Explicit display position, ascending, most conservative contract first.
+    /// First-class rather than an <see cref="StyleOptionTier"/> ordinal so the
+    /// enum's declaration order and the presentation order can move
+    /// independently.
+    /// </summary>
+    public required int Order { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when every knob in this tier is byte-divergent —
+    /// the tier-level statement of the contract
+    /// <see cref="StyleOptionDescriptor.ByteDivergent"/> carries per knob. A host
+    /// can warn about a whole group without inspecting its members.
+    /// <c>StyleOptionCatalogTests.ByteDivergence_IsATierProperty</c> enforces the
+    /// agreement in both directions, so
+    /// <see cref="StyleOptionTier.Lens"/> being the only byte-divergent tier is a
+    /// gated claim rather than a comment.
+    /// </summary>
+    public required bool ByteDivergent { get; init; }
+}
+
+/// <summary>
 /// One selectable value on a <see cref="StyleOptionDescriptor"/>'s axis: its
 /// stable token, optional human label, oracle endorsement, and the
 /// <c>.dotnet-inspectconfig</c> key (if any) that selects it. A boolean knob has
@@ -257,6 +310,66 @@ public static class StyleOptionCatalog
     private const string VarStyleBuiltInTypes = "var-for-built-in-types";
     private const string VarStyleWhenApparent = "var-when-type-apparent";
     private const string VarStyleElsewhere = "var-elsewhere";
+
+    /// <summary>
+    /// Every <see cref="StyleOptionTier"/> as a presentation descriptor, in
+    /// display order (most conservative contract first). This is the category
+    /// level of the catalog: a host renders a grouped picker by walking these and
+    /// filtering <see cref="Options"/> on <see cref="StyleOptionDescriptor.Tier"/>,
+    /// with no locally-held label, blurb, or ordering. The list is exhaustive and
+    /// duplicate-free by gate (<c>StyleOptionCatalogTests</c>), so a tier added to
+    /// the enum cannot silently drop out of a consumer's layout.
+    /// </summary>
+    public static IReadOnlyList<StyleOptionTierDescriptor> Tiers { get; } =
+    [
+        new StyleOptionTierDescriptor
+        {
+            Id = StyleOptionTier.Formatting,
+            Title = "Formatting",
+            Summary = "Layout only — whitespace and line breaks. Token- and byte-identical to the shipped default.",
+            Order = 1,
+            ByteDivergent = false,
+        },
+        new StyleOptionTierDescriptor
+        {
+            Id = StyleOptionTier.Spelling,
+            Title = "Spelling",
+            Summary = "An equally faithful token choice, such as this. qualification or var. Byte-preserving (IL-identical).",
+            Order = 2,
+            ByteDivergent = false,
+        },
+        new StyleOptionTierDescriptor
+        {
+            Id = StyleOptionTier.Synthesis,
+            Title = "Name synthesis",
+            Summary = "Readable synthesized names. The emitted IL is unchanged, but Annotated-IL name alignment is traded.",
+            Order = 3,
+            ByteDivergent = false,
+        },
+        new StyleOptionTierDescriptor
+        {
+            Id = StyleOptionTier.Lens,
+            Title = "Style lenses",
+            Summary = "Behavior-faithful but not opcode-faithful: output recompiles to different bytes than the shipped default, so it never feeds the compile-back fidelity gates.",
+            Order = 4,
+            ByteDivergent = true,
+        },
+    ];
+
+    /// <summary>
+    /// The presentation descriptor for <paramref name="tier"/>. Throws rather than
+    /// returning null for an unregistered tier: the registry is exhaustive by
+    /// gate, so a miss is a catalog defect and stays visible instead of degrading
+    /// into an unlabeled group.
+    /// </summary>
+    public static StyleOptionTierDescriptor GetTier(StyleOptionTier tier)
+    {
+        foreach (var descriptor in Tiers)
+            if (descriptor.Id == tier)
+                return descriptor;
+
+        throw new ArgumentOutOfRangeException(nameof(tier), tier, "No style-option tier descriptor is registered for this tier.");
+    }
 
     /// <summary>
     /// Every opt-in knob, in a stable presentation order (formatting and spelling

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -66,6 +66,12 @@ public sealed record StyleOptionTierDescriptor
     /// <summary>
     /// One-sentence statement of the fidelity contract every knob in this tier
     /// honors, so a host can explain a group and not merely name it.
+    ///
+    /// <para>This is user-facing copy, not internal prose: a picker renders it
+    /// verbatim as escaped plain text, so it must read as a complete sentence
+    /// without code formatting, and must avoid vocabulary that only means
+    /// something inside this repository (name what a choice costs the reader,
+    /// rather than naming the gate that measures it).</para>
     /// </summary>
     public required string Summary { get; init; }
 
@@ -326,7 +332,7 @@ public static class StyleOptionCatalog
         {
             Id = StyleOptionTier.Formatting,
             Title = "Formatting",
-            Summary = "Layout only — whitespace and line breaks. Token- and byte-identical to the shipped default.",
+            Summary = "Layout only — whitespace and line breaks. The code itself is unchanged, and compiles to identical IL.",
             Order = 1,
             ByteDivergent = false,
         },
@@ -334,7 +340,7 @@ public static class StyleOptionCatalog
         {
             Id = StyleOptionTier.Spelling,
             Title = "Spelling",
-            Summary = "An equally faithful token choice, such as this. qualification or var. Byte-preserving (IL-identical).",
+            Summary = "An equally faithful way to spell the same code, such as qualifying a member with this or writing var. Compiles to identical IL.",
             Order = 2,
             ByteDivergent = false,
         },
@@ -342,7 +348,7 @@ public static class StyleOptionCatalog
         {
             Id = StyleOptionTier.Synthesis,
             Title = "Name synthesis",
-            Summary = "Readable synthesized names. The emitted IL is unchanged, but Annotated-IL name alignment is traded.",
+            Summary = "Readable invented names for locals that have none of their own. Compiles to identical IL, but these names no longer match the ones the IL uses.",
             Order = 3,
             ByteDivergent = false,
         },
@@ -350,7 +356,7 @@ public static class StyleOptionCatalog
         {
             Id = StyleOptionTier.Lens,
             Title = "Style lenses",
-            Summary = "Behavior-faithful but not opcode-faithful: output recompiles to different bytes than the shipped default, so it never feeds the compile-back fidelity gates.",
+            Summary = "Keeps what the code does, but not the exact bytes: this rendering recompiles to different IL than the shipped output, so it is excluded from byte-level fidelity checking.",
             Order = 4,
             ByteDivergent = true,
         },


### PR DESCRIPTION
Closes #3486 (product half).

## What changes

`StyleOptionCatalog` is data-driven at the **option** level but not at the
**category** level: `StyleOptionTier` is a bare enum, so every consumer that
groups the catalog by tier has to restate the taxonomy with its own labels and
ordering. This adds the missing level.

- **`StyleOptionTierDescriptor`** — the enum token as a stable `Id`, a display
  `Title`, a `Summary` stating the fidelity contract the tier's knobs honor, an
  explicit `Order` (ascending, most conservative contract first), and the
  tier-level `ByteDivergent` flag.
- **`StyleOptionCatalog.Tiers`** — every tier in display order, plus `GetTier`
  to resolve one by id.

A host now renders a grouped picker by walking `Tiers` and filtering `Options`
on `Tier`, holding no label, blurb, or ordering of its own.

`Order` is deliberately **not** the enum ordinal, which is the point of the ask:
presentation order and declaration order can move independently.

## Behavioral claim

**Additive only.** No existing type, member, output, config key, or default
changes. `PrinterOptions`, the `Options` list, the endorsement subsets, and
`ApplyFullTaste` are untouched; the new surface is two additions to a public
static class plus one new record.

## Evidence

Gates follow the declaration-drives-enforcement convention — the registry
*drives* the checks rather than being restated by them, so a stale entry and a
missing entry both fail:

- `Tiers_CoverEveryTierExactlyOnce` — set equality against
  `Enum.GetValues<StyleOptionTier>()`, plus no duplicates.
- `Tiers_AreListedInAscendingDisplayOrder_WithUniquePositions` — the list is
  already sorted by `Order`, so a host never sorts; positions are unique so no
  unstable tie-break can decide layout.
- `EveryOption_GroupsUnderARegisteredTier` — the grouped-picker walk itself: every
  knob lands in exactly one rendered group.
- `ByteDivergence_IsATierProperty` — each option's `ByteDivergent` equals its
  tier's, and the byte-divergent tier set equals the tiers of byte-divergent
  options (non-vacuity, so a tier cannot claim divergence with no knob to
  witness it).
- `GetTier_ResolvesEveryTier_AndRejectsAnUnregisteredOne` — a miss throws rather
  than degrading into an unlabeled group.

**Verified non-vacuous by tampering** (both reverted):

| Tamper | Result |
| --- | --- |
| File the byte-divergent `prefer-long-literal-suffix` under `Formatting` | 2 tests fail (`ByteDivergence_IsATierProperty`, and the pre-existing `ByteDivergent_IsExactlyTheLensTier`) |
| Delete the `Synthesis` descriptor from `Tiers` | 4 tests fail (coverage, grouping, `GetTier`, byte-divergence) |

Runs (Release, per repo policy):

```
dotnet build dotnet-inspect.slnx -c Release                       # 0 errors
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --gate fast
    # 4413 total, 0 failed
dotnet run --project src/ILInspector.Decompiler.Tests -c Release \
  -class StyleOptionCatalogTests -class ByteNeutralityGateTests \
  -class ExpressionTreeLambdaTests                                # 72 / 0 failed
dotnet run --project src/dotnet-inspect.Tests -c Release \
  -class AppliedTasteSectionTests -class RenderStyleConfigTests   # 79 / 0 failed
npx markdownlint-cli docs/decompiler-taste.md                     # clean
```

(The one `--gate fast` failure on the first pass was
`ExpressionTreeLambdaTests.LookalikeExpressionAssembly_StaysFactoryCalls`
reporting a missing fixture binary because only the test project had been built;
it passes after the full-solution build the error message prescribes.)

## Scope boundary / non-action

`#3486` names the WASM prototype's `TASTE_TIERS`
(`prototypes/inspect-web/src/app.js:6746`) as the consumer to retire. That file
is **not on `main`** — it lives on `prototype/wasm-command-ui` — so this PR
delivers the product registry only, and retiring `TASTE_TIERS` plus projecting
`Tiers` from the `ListStyleOptions` engine export is a follow-up on that branch.
Worth noting for whoever picks it up: the prototype's current `"Spelling (this.)"`
label is already stale, since the `Spelling` tier now also holds the
`var-spelling-style` axis — exactly the drift this registry removes.

Also out of scope, tracked separately: #3517 (product-owned *choice* identity —
selectability, stable choice ids, conflict semantics, the level below this one)
and #3516 (the prototype's annotated-source export discarding taste).

## Review

Additive, no behavior change, gated by set-equality tests verified non-vacuous —
the single-review tier. Requesting one MAI-Code review.
