### PR TITLE
Make CI block merges through one aggregate required check (#3523)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,14 @@ env:
 # (test/pack are PR-only), so there is little to cancel. release.yml
 # builds all release packages fresh at publish time and does not consume CI
 # artifacts.
+#
+# The group keys on the pull request *number*, not `github.head_ref`. Branch
+# names are not unique across forks, so two PRs both branched as `patch-1`
+# would share a group and cancel each other. That was merely wasteful while CI
+# was advisory; now that `ci-required` gates merges, the loser's required check
+# would land as `cancelled` and block that PR until someone re-ran it by hand.
 concurrency:
-  group: ci-${{ github.head_ref || github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -888,13 +894,18 @@ jobs:
       - name: Uninstall tool
         run: dotnet tool uninstall --global dotnet-inspect
 
-  # The single check the `main` ruleset requires.
+  # The one check the `main` ruleset is meant to require, and the only one that
+  # safely can be.
   #
   # Every other job here is path-gated, so none of them can be required
   # directly: a required check that does not run on a given PR is reported as
   # "Expected" forever and blocks the merge permanently. This job always runs
   # and collapses the others into one result, so the ruleset has exactly one
-  # stable context to require.
+  # stable context to name.
+  #
+  # Adding the `required_status_checks` rule is a repository-settings change
+  # applied once this job exists on `main`; requiring it earlier would block
+  # every open PR with no way forward.
   #
   # Three details carry the whole contract, and each is easy to get backwards:
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,3 +887,118 @@ jobs:
 
       - name: Uninstall tool
         run: dotnet tool uninstall --global dotnet-inspect
+
+  # The single check the `main` ruleset requires.
+  #
+  # Every other job here is path-gated, so none of them can be required
+  # directly: a required check that does not run on a given PR is reported as
+  # "Expected" forever and blocks the merge permanently. This job always runs
+  # and collapses the others into one result, so the ruleset has exactly one
+  # stable context to require.
+  #
+  # Three details carry the whole contract, and each is easy to get backwards:
+  #
+  # 1. `if: always()` is mandatory. Without it this job inherits the default
+  #    `success()` condition, is skipped the moment any dependency fails, and a
+  #    skipped required check does not block a merge -- the failure it exists to
+  #    catch would be exactly what silences it.
+  #
+  # 2. `skipped` must pass but `cancelled` must not. Path-gated jobs are skipped
+  #    on most PRs and that is correct. A cancelled job is a job that hit its
+  #    timeout, and this repository has already been burned by that distinction
+  #    twice: the Deep Inspect notifier stayed silent because a cancelled job
+  #    satisfies neither `failure()` nor a failed conclusion (#3432), and seven
+  #    decompiler test classes sat at a 45-minute timeout unnoticed (#3489-#3493).
+  #    Treating `cancelled` as success would rebuild that hole at the merge gate.
+  #
+  # 3. The check is an allow list, not a deny list. Only `success` and `skipped`
+  #    pass; anything else blocks. A deny list of `failure|cancelled` would admit
+  #    any result state GitHub adds later, which is the fail-open direction. This
+  #    fails closed, matching the repository rule that failure stays visible.
+  #
+  # `changes` is in `needs` deliberately. If it fails, every downstream job is
+  # skipped, so a check that looked only at the gated jobs would see nothing but
+  # `skipped` and pass a PR on which no test ran at all. `changes` reporting
+  # `failure` is what closes that path.
+  ci-required:
+    needs:
+      - changes
+      - markdownlint
+      - test
+      - build-net10
+      - decompiler-gates
+      - csharp-diff-smoke
+      - il-diff-smoke
+      - pack
+    if: always()
+    runs-on: ubuntu-26.04
+    timeout-minutes: 5
+    env:
+      # Defined once and consumed by both the self-test and the real check, so
+      # the thing proven non-vacuous is the same thing that gates the merge.
+      RESULT_FILTER: >-
+        to_entries[]
+        | select(.value.result != "success" and .value.result != "skipped")
+        | "\(.key)=\(.value.result)"
+    steps:
+      - uses: actions/checkout@v6
+
+      # A hand-maintained `needs` list is an allow list, and an allow list that
+      # nothing checks goes stale silently: add a job to this workflow, forget
+      # this line, and the merge gate stops covering it while still reporting
+      # green. That is the same shape as #3584, where a one-directional docket
+      # un-gated 46 fixture rows. So the workflow's own job list drives the
+      # required set, and both directions fail -- a job missing from `needs`
+      # and a `needs` entry naming a job that no longer exists.
+      - name: Verify this gate depends on every other job
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          python3 -c '
+          import json, os, sys, yaml
+          with open(".github/workflows/ci.yml") as f:
+              jobs = set(yaml.safe_load(f)["jobs"])
+          jobs.discard("ci-required")
+          needs = set(json.loads(os.environ["NEEDS"]))
+          missing = sorted(jobs - needs)
+          extra = sorted(needs - jobs)
+          if missing:
+              print("::error::ci-required does not depend on: " + ", ".join(missing))
+          if extra:
+              print("::error::ci-required depends on unknown jobs: " + ", ".join(extra))
+          sys.exit(1 if missing or extra else 0)
+          '
+          echo "Gate covers every job in the workflow."
+
+      # A gate that accepted everything would be indistinguishable from a green
+      # run, so the filter's discrimination is asserted rather than assumed.
+      # This is that assertion: if the filter stops selecting bad results, this
+      # step fails even when every real job is green.
+      - name: Self-test the result filter
+        run: |
+          set -euo pipefail
+          probe='{"ok":{"result":"success"},"gated":{"result":"skipped"},"broke":{"result":"failure"},"timeout":{"result":"cancelled"},"future":{"result":"neutral"}}'
+          got=$(printf '%s' "$probe" | jq -r "$RESULT_FILTER" | paste -sd, -)
+          expected='broke=failure,timeout=cancelled,future=neutral'
+          if [ "$got" != "$expected" ]; then
+            echo "::error::Result filter no longer discriminates. Expected [$expected], got [$got]."
+            exit 1
+          fi
+          echo "Filter discriminates correctly: [$got]"
+
+      - name: Verify no required job failed or was cancelled
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script body so job outputs can never terminate the shell string.
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS"
+          blocking=$(printf '%s' "$NEEDS" | jq -r "$RESULT_FILTER")
+          if [ -n "$blocking" ]; then
+            echo "::error::CI is not green; these jobs did not succeed or skip:"
+            printf '%s\n' "$blocking"
+            exit 1
+          fi
+          echo "All required jobs succeeded or were correctly skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,8 +464,9 @@ jobs:
   # directly. A required check that does not run on a given PR is reported as
   # "Expected" forever and blocks that merge permanently, and this job is
   # skipped on any PR that touches no decompiler-relevant path. Its result
-  # reaches the merge gate through the aggregate `ci-required` job at the end
-  # of this file, which is the single context the ruleset is meant to require.
+  # reaches `ci-required`, the aggregate job at the end of this file that is
+  # intended to serve as the merge gate and be the one context the ruleset
+  # requires.
   #
   # The remaining Fidelity-area classes are excluded on cost, not principle:
   # ClusterCaptureTests and PrinterPrecedenceTests alone are ~21 minutes for two

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ env:
 # The group keys on the pull request *number*, not `github.head_ref`. Branch
 # names are not unique across forks, so two PRs both branched as `patch-1`
 # would share a group and cancel each other. That was merely wasteful while CI
-# was advisory; now that `ci-required` gates merges, the loser's required check
-# would land as `cancelled` and block that PR until someone re-ran it by hand.
+# was advisory; once `ci-required` is required, the loser's check would land as
+# `cancelled` and block that PR until someone re-ran it by hand.
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,10 +460,12 @@ jobs:
   # passes nor fails, so the pin list is a ratchet in both directions rather
   # than a permanent exemption.
   #
-  # NOTE: this job is not merge-blocking today, because the `main` ruleset
-  # declares no required status checks at all — no job in this workflow blocks
-  # a merge. That is a repository-wide gap tracked separately; this job is
-  # exactly as enforcing as the existing `test` job until it is closed.
+  # NOTE: this path-gated job must never be named as a required status check
+  # directly. A required check that does not run on a given PR is reported as
+  # "Expected" forever and blocks that merge permanently, and this job is
+  # skipped on any PR that touches no decompiler-relevant path. Its result
+  # reaches the merge gate through the aggregate `ci-required` job at the end
+  # of this file, which is the single context the ruleset is meant to require.
   #
   # The remaining Fidelity-area classes are excluded on cost, not principle:
   # ClusterCaptureTests and PrinterPrecedenceTests alone are ~21 minutes for two

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,11 @@ until every required fixed-head review is clean.
   [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues).
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
 - Treat CI as confirmation, not discovery: run relevant local checks first.
+- One check blocks merges: `ci-required`, an aggregate that fails if any job in
+  `ci.yml` failed or was cancelled. It passes `skipped`, because most jobs are
+  path-gated, so a green `ci-required` means "nothing that ran went wrong", not
+  "everything ran". Never require a path-gated job directly — a required check
+  that does not run blocks the merge forever.
 - Do not broaden CI without a measured need. The PR `test` job validates the
   merge path; `pack` is path-gated; release artifacts are built by
   `release.yml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,8 +434,9 @@ until every required fixed-head review is clean.
   [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues).
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
 - Treat CI as confirmation, not discovery: run relevant local checks first.
-- One check blocks merges: `ci-required`, an aggregate that fails if any job in
-  `ci.yml` failed or was cancelled. It passes `skipped`, because most jobs are
+- One check gates merges: `ci-required`, an aggregate that fails if any job in
+  `ci.yml` failed or was cancelled, and which the `main` ruleset names as its
+  required status check. It passes `skipped`, because most jobs are
   path-gated, so a green `ci-required` means "nothing that ran went wrong", not
   "everything ran". Never require a path-gated job directly — a required check
   that does not run blocks the merge forever.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,9 +434,9 @@ until every required fixed-head review is clean.
   [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues).
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
 - Treat CI as confirmation, not discovery: run relevant local checks first.
-- One check gates merges: `ci-required`, an aggregate that fails if any job in
-  `ci.yml` failed or was cancelled, and which the `main` ruleset names as its
-  required status check. It passes `skipped`, because most jobs are
+- `ci-required` is the only check that may gate merges, and the one the `main`
+  ruleset is meant to require: an aggregate that fails if any job in `ci.yml`
+  failed or was cancelled. It passes `skipped`, because most jobs are
   path-gated, so a green `ci-required` means "nothing that ran went wrong", not
   "everything ran". Never require a path-gated job directly — a required check
   that does not run blocks the merge forever.

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -434,11 +434,11 @@ the job survives, letting the checker run and fail loudly on the missing or
 truncated report.
 
 > [!NOTE]
-> This job blocks merges through the aggregate `ci-required` job in `ci.yml`,
-> which is the single context the `main` ruleset requires. It cannot be
-> required directly: it is path-gated, and a required check that does not run
-> on a given PR is reported as "Expected" forever and blocks the merge
-> permanently. `ci-required` passes a `skipped` dependency and fails a
+> This job gates merges through the aggregate `ci-required` job in `ci.yml`,
+> which is the single context the `main` ruleset names as its required status
+> check. It cannot be required directly: it is path-gated, and a required check
+> that does not run on a given PR is reported as "Expected" forever and blocks
+> the merge permanently. `ci-required` passes a `skipped` dependency and fails a
 > `cancelled` one, so this gate skipping on a docs-only PR is fine while this
 > gate hitting its timeout is not (#3523).
 

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -434,8 +434,9 @@ the job survives, letting the checker run and fail loudly on the missing or
 truncated report.
 
 > [!NOTE]
-> This job reaches the merge gate through the aggregate `ci-required` job in
-> `ci.yml`, the single context the `main` ruleset is meant to require. It cannot
+> This job is intended to reach the merge gate through the aggregate
+> `ci-required` job in `ci.yml`, the single context the `main` ruleset is meant
+> to require. It cannot
 > be required directly: it is path-gated, and a required check that does not run
 > on a given PR is reported as "Expected" forever and blocks the merge
 > permanently. `ci-required` passes a `skipped` dependency and fails a

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -434,10 +434,13 @@ the job survives, letting the checker run and fail loudly on the missing or
 truncated report.
 
 > [!NOTE]
-> This job does not block merges today. The `main` ruleset declares no required
-> status checks at all, so no job in `ci.yml` blocks a merge; this one is
-> exactly as enforcing as the existing `test` job. Closing that gap is a
-> repository-wide change tracked separately.
+> This job blocks merges through the aggregate `ci-required` job in `ci.yml`,
+> which is the single context the `main` ruleset requires. It cannot be
+> required directly: it is path-gated, and a required check that does not run
+> on a given PR is reported as "Expected" forever and blocks the merge
+> permanently. `ci-required` passes a `skipped` dependency and fails a
+> `cancelled` one, so this gate skipping on a docs-only PR is fine while this
+> gate hitting its timeout is not (#3523).
 
 `pre-merge` deliberately selects three classes rather than the whole `Fidelity`
 area. The area is ~31 minutes; these three are ~8. The exclusions are cost, not

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -434,11 +434,11 @@ the job survives, letting the checker run and fail loudly on the missing or
 truncated report.
 
 > [!NOTE]
-> This job gates merges through the aggregate `ci-required` job in `ci.yml`,
-> which is the single context the `main` ruleset names as its required status
-> check. It cannot be required directly: it is path-gated, and a required check
-> that does not run on a given PR is reported as "Expected" forever and blocks
-> the merge permanently. `ci-required` passes a `skipped` dependency and fails a
+> This job reaches the merge gate through the aggregate `ci-required` job in
+> `ci.yml`, the single context the `main` ruleset is meant to require. It cannot
+> be required directly: it is path-gated, and a required check that does not run
+> on a given PR is reported as "Expected" forever and blocks the merge
+> permanently. `ci-required` passes a `skipped` dependency and fails a
 > `cancelled` one, so this gate skipping on a docs-only PR is fine while this
 > gate hitting its timeout is not (#3523).
 


### PR DESCRIPTION
## The gap

The `main` ruleset has `enforcement: active` with rules for `deletion`, `non_fast_forward`, and `pull_request` — but **no `required_status_checks` rule**. The legacy branch-protection API returns 404 because protection is by ruleset, not the legacy API, which makes this easy to miss.

```console
$ gh api repos/richlander/dotnet-inspect/rulesets/12507218 --jq '[.rules[].type]'
["deletion","non_fast_forward","pull_request"]

$ gh api repos/richlander/dotnet-inspect/branches/main/protection
gh: Branch not protected (HTTP 404)
```

**No job in `ci.yml` blocks a merge.** Not `test`, not `markdownlint`, not `pack`, not `decompiler-gates`. A red PR is mergeable. Every gate this repository has built — the fidelity dockets, the byte-neutrality gate, the decompiler lane ratchet — is advisory, and merge safety rests on whoever clicks merge noticing a red check.

That is #3432 one level up. There, gate tests carried doc comments asserting "fails CI" while no pre-merge lane ran them, so five regressions (#3489–#3493) landed unseen. Here the checks run and report, and nothing consumes the report.

## Why an aggregate job

No existing job can be required directly. All of them are path-gated, and **a required check that does not run on a given PR is reported as "Expected" forever and blocks the merge permanently.** So this adds `ci-required`: it always runs, depends on every other job, and collapses them into one stable context for the ruleset to require.

Three details carry the whole contract, and each is easy to get backwards:

| Detail | Why |
| --- | --- |
| `if: always()` | Without it the job inherits the default `success()` condition and is skipped the moment a dependency fails. A skipped required check does not block a merge — the failure it exists to catch would be exactly what silences it. |
| `skipped` passes, `cancelled` fails | Path-gated jobs skip on most PRs and that is correct. A cancelled job is one that hit its timeout. This repo has been burned by that distinction twice: the Deep Inspect notifier stayed silent because a cancelled job satisfies no `failure()` condition (#3432), and seven decompiler classes sat at a 45-minute timeout unnoticed (#3489–#3493). |
| Allow list, not deny list | Only `success` and `skipped` pass. A deny list of `failure\|cancelled` would admit any result state GitHub adds later — the fail-open direction. This fails closed. |

`changes` is among the dependencies deliberately. If it fails, every downstream job is skipped, so a check reading only the gated jobs would see nothing but `skipped` and pass a PR on which no test ran at all.

## Keeping the gate from rotting

A merge gate that quietly becomes a no-op is worse than none, because it reads as protection. Two self-checks run inside the job:

- **`Verify this gate depends on every other job`** parses the workflow and asserts set equality between its job list and this job's `needs`, failing in *both* directions — a job missing from `needs`, and a `needs` entry naming a job that no longer exists. A hand-maintained `needs` list is an allow list, and an unchecked allow list goes stale silently; that is precisely the shape of #3584, where a one-directional docket un-gated 46 fixture rows.
- **`Self-test the result filter`** runs the same filter the gate uses over a synthetic payload carrying one of each result state (`success`, `skipped`, `failure`, `cancelled`, and an unknown `neutral`) and asserts it selects exactly the blocking ones. A filter that accepted everything would be indistinguishable from a green run.

Both consume the filter from a single `RESULT_FILTER` definition, so the expression proven non-vacuous is the expression that gates the merge.

## Validation

- YAML parsed with YamlDotNet; `needs` contains all 8 sibling jobs, and each `run:` block was dumped post-parse to confirm the embedded Python lands at column 0 after block-scalar indentation stripping.
- The remaining behavior is runner-side by nature, so **this PR's own CI run is the evidence**: `ci-required` must report, its two self-checks must pass, and the coverage check must agree with the workflow. Additionally I will force a real dependency failure on a scratch commit to confirm the gate *blocks* rather than merely reports, then restore the reviewed head.

## Rollout, and what it costs

**Merging this PR changes nothing by itself.** The ruleset rule is a repository-settings change applied *after* this lands, deliberately in that order: requiring `ci-required` before the job exists on `main` would block every open PR with no path forward.

Two things to know before enabling it:

- The ruleset has `bypass_actors: []` and `current_user_can_bypass: "never"`. There is no escape hatch, so the check must be correct before it is required.
- There are currently 15 open PRs. Their heads predate this job, so after the rule is enabled each will show `ci-required` as "Expected" until it merges `main` — a one-time, unavoidable cost of turning required checks on.

Closes #3523.
