### PR TITLE
Stop two package tests from asserting host filesystem and restore layout

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4651,7 +4651,13 @@ public partial class CommandExecutionTests
         Assert.True(
             renderedLines > count,
             $"expected the tree to render more lines ({renderedLines}) than the {count} files it counts");
-        Assert.Contains("Newtonsoft.Json.nuspec", rendered, StringComparison.Ordinal);
+
+        // The manifest is a reachable package file, which is the claim; its filename casing is
+        // not. A package restored into the NuGet global packages folder carries the manifest under
+        // the normalized (lowercased) id, while one expanded from the .nupkg keeps the authored
+        // casing, so pinning "Newtonsoft.Json.nuspec" ordinally asserts which source resolved the
+        // package rather than that the nuspec is listed.
+        Assert.Contains("Newtonsoft.Json.nuspec", rendered, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -12171,6 +12177,16 @@ public partial class CommandExecutionTests
         // something else. The role answers a document's kind only where the name is silent;
         // letting a declaration override a stated kind would run the link rewriter over a PNG
         // and hand back a corrupted file, which is the outcome this command prevents.
+
+        // Win32 strips trailing dots from a path before it reaches the filesystem, so a package
+        // entry named "logo.png." lands on disk as "logo.png" no matter who expands it -- both
+        // this fixture and the product's own extraction. The declared path then names nothing the
+        // package lists, and the case cannot be staged on Windows at all rather than behaving
+        // differently there. It stays covered on every other platform.
+        Assert.SkipWhen(
+            OperatingSystem.IsWindows() && readmePath.EndsWith('.'),
+            "Windows cannot hold a file whose name ends in a dot: the name is normalized away before it reaches the filesystem.");
+
         var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
         var packageRoot = Path.Combine(tempDir, "content");
         var declared = Path.Combine(packageRoot, readmePath.Replace('/', Path.DirectorySeparatorChar));


### PR DESCRIPTION
Fixes #3519.

Both `CommandExecutionTests` failures on Windows are the test over-specifying its environment, not product behavior.

## `Layout_Count_CountsFilesRatherThanRenderedTreeLines`

The test pinned the manifest as `Newtonsoft.Json.nuspec` with `StringComparison.Ordinal`. The nuspec filename casing is a property of the **source the package resolved from**, not of the package:

- expanded from the `.nupkg` -> authored casing (`Newtonsoft.Json.nuspec`)
- restored into the NuGet global packages folder -> normalized, lowercased id (`newtonsoft.json.nuspec`)

Instrumenting `extractPath` at the `--layout` early exit showed the resolver returning the global packages folder on this host, because `NUGET_PACKAGES=C:\Nuget` is set:

```
PROBE extractPath=C:\Nuget\newtonsoft.json\13.0.4
PROBE nuspec=C:\Nuget\newtonsoft.json\13.0.4\newtonsoft.json.nuspec
```

The rendered tree was correct; the assertion was asserting which source resolved the package. Renaming the `.nupkg`-expanded copy under `package-content-v2` (and moving that directory aside entirely) left the output unchanged, confirming that copy is not what the run reads.

The claim the assertion carries is that the nuspec is a reachable package file, so it now compares case-insensitively. The two assertions that carry the test's actual point -- `count == 20` and `renderedLines > count` -- are untouched and passed throughout.

## `Package_DeclaredNonMarkdownReadme_IsStillNotMarkdown(readmePath: "images/logo.png.")`

Win32 strips trailing dots before a path reaches the filesystem:

```
[IO.File]::WriteAllText("\logo.png.", "x")
created: 'logo.png'
Exists('logo.png.') = True
Exists('logo.png')  = True
```

So the fixture's declared readme lands on disk as `logo.png`, the declared path names nothing the package lists, and `--content --path "images/logo.png."` exits 1.

This is not a fixture artifact that a better fixture can dodge. Staging a `.nupkg` whose zip entry really is `images/logo.png.` and running the product against it fails the same way, because the product re-extracts to disk and loses the dot identically:

```
Error: --bare found no selected package content.
exit=1
```

The case therefore cannot be staged on Windows rather than behaving differently there, so it skips with that reason via the suite's existing `Assert.SkipWhen` convention. It stays covered on `linux`/`macOS` and the other three theory cases (`images/logo.png`, `.png`, `.README`) still run on Windows.

## Validation

`dotnet run --project src/dotnet-inspect.Tests -c Release` on Windows, after a full `dotnet build dotnet-inspect.slnx -c Release`:

```
dotnet-inspect.Tests  Total: 2609, Errors: 0, Failed: 0, Skipped: 11, Not Run: 0, Time: 422.674s
```

Previously 2 failed. No product code changes; no other platform's behavior changes.
