### PR TITLE
Derive local declaration placement from portable-PDB scopes (#3591)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -6493,3 +6493,38 @@ public sealed class DeclScopeClient
         }
     }
 }
+
+public sealed class DeclScopeLoopClient
+{
+    readonly DeclScopeOps _ops = new();
+
+    // The source declares the local inside the loop body and every use stays there,
+    // so the PDB scope and the IR agree and the declaration sinks to its store.
+    public int SumNarrow(int count)
+    {
+        int total = 0;
+        for (int i = 0; i < count; i++)
+        {
+            DeclScopeResult step = _ops.Create("s", i);
+            total += step.Raw + step.Value.Length;
+        }
+        return total;
+    }
+
+    // Close negative for the same PDB evidence. The scope is again nested (the using
+    // block), but the first store sits inside one arm of the if while the read is
+    // after it, so sinking the declaration onto that store would not compile. The IR
+    // guard must decline and leave the hoisted declaration alone.
+    public string CreateBranched(string name, int timeout, bool flag)
+    {
+        using (DeclScopeGuard scope = new DeclScopeGuard())
+        {
+            DeclScopeResult response;
+            if (flag)
+                response = _ops.Create(name, timeout);
+            else
+                response = _ops.Create(name, timeout + 1);
+            return response.Value + response.Raw;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/DeclarationPlacementTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeclarationPlacementTests.cs
@@ -9,65 +9,110 @@ namespace ILInspector.Decompiler.Tests;
 /// <summary>
 /// Declaration placement for a local the source declared inside a nested block
 /// (#3591). The portable PDB's <c>LocalScope</c> table records each local's true
-/// extent, but <c>MetadataSource.LocalNames</c> keeps only the variable names and
-/// drops <c>StartOffset</c>/<c>EndOffset</c>, so the printer hoists a narrowly
-/// scoped local to the top of the method. These tests pin that frontier and, just
-/// as importantly, pin the evidence that would close it: the PDB already
-/// distinguishes the two shapes that today print identically.
+/// extent; <c>MetadataSource.LocalScopes</c> reads it and the printer sinks the
+/// declaration onto its store when the IR independently proves that is valid.
 /// </summary>
 /// <remarks>
-/// Closing #3591 must flip <see cref="NarrowLocal_IsHoistedAboveTheUsing_WithPdb"/>
-/// and <see cref="NarrowLocal_PlacementIsIdenticalWithAndWithoutPdb"/>: with a PDB
-/// the declaration should merge into its store inside the try, which is exactly the
-/// masked equality this class currently asserts. The remaining tests are invariants
-/// and should keep passing.
+/// The two halves of that rule each have a dedicated negative here. Without a PDB
+/// there is no evidence of intent, so
+/// <see cref="NarrowLocal_StaysHoisted_WithoutPdb"/> pins the unchanged hoisted
+/// shape rather than a guess. With a PDB but a store the IR cannot prove dominates
+/// its uses, <see cref="BranchedStore_StaysHoisted_DespiteNestedPdbScope"/> pins the
+/// decline. This class was <c>DeclarationPlacementFrontierTests</c> in #3593, where
+/// it pinned the gap and named the two tests that closing it had to flip.
 /// </remarks>
-public class DeclarationPlacementFrontierTests
+public class DeclarationPlacementTests
 {
     static readonly IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.TrustedPlatformAssemblies();
 
     /// <summary>
-    /// The PDB names a local declared in the try block. The scope range that comes
-    /// with the name is what the printer never reads.
+    /// The PDB scopes the local to the try block, and every reference stays in that
+    /// block after the store, so the declaration merges into the store.
     /// </summary>
     [Fact]
-    public void NarrowLocal_IsHoistedAboveTheUsing_WithPdb()
+    public void NarrowLocal_DeclarationSinksToItsStore_WithPdb()
     {
         var output = Print(nameof(DeclScopeClient.CreateNarrow));
 
-        Assert.Contains("DeclScopeResult response;", output);
-        Assert.Contains("response = _ops.Create(name, timeout);", output);
-        AssertDeclarationPrecedesUsing(output, "DeclScopeResult response;");
+        Assert.Contains("DeclScopeResult response = _ops.Create(name, timeout);", output);
+        Assert.DoesNotContain("DeclScopeResult response;", output);
+        Assert.True(
+            output.IndexOf("using (", StringComparison.Ordinal)
+                < output.IndexOf("DeclScopeResult response =", StringComparison.Ordinal),
+            $"Expected the declaration inside the using.{Environment.NewLine}{output}");
     }
 
     /// <summary>
-    /// Same method with symbols withheld. The local loses its source name, and
-    /// nothing else moves.
+    /// Non-vacuity gate for the PDB evidence. With symbols withheld the same IR
+    /// reaches the printer with no scope facts, and the local keeps its hoisted
+    /// declaration: absent evidence the tool does not guess.
     /// </summary>
     [Fact]
-    public void NarrowLocal_IsHoistedAboveTheUsing_WithoutPdb()
+    public void NarrowLocal_StaysHoisted_WithoutPdb()
     {
         var output = PrintWithoutSymbols(nameof(DeclScopeClient.CreateNarrow));
 
         var declaration = Assert.Single(Regex.Matches(output, @"DeclScopeResult V_\d+;")).Value;
         Assert.DoesNotContain("response", output);
-        AssertDeclarationPrecedesUsing(output, declaration);
+        int declarationIndex = output.IndexOf(declaration, StringComparison.Ordinal);
+        int usingIndex = output.IndexOf("using (", StringComparison.Ordinal);
+        Assert.True(usingIndex >= 0, $"Missing using statement.{Environment.NewLine}{output}");
+        Assert.True(
+            declarationIndex < usingIndex,
+            $"Expected `{declaration}` hoisted above the using.{Environment.NewLine}{output}");
     }
 
     /// <summary>
-    /// The headline claim of #3591: a present PDB changes the local's *name* and
-    /// nothing about where it is declared. Masking every local identifier makes the
-    /// two renderings byte-identical, which is only possible because the scope
-    /// ranges are discarded.
+    /// The headline claim of #3591, inverted. A present PDB used to change the
+    /// local's name and nothing about where it is declared — masking every local
+    /// identifier made the two renderings byte-identical. Now placement differs too,
+    /// and masking no longer collapses them.
     /// </summary>
     [Fact]
-    public void NarrowLocal_PlacementIsIdenticalWithAndWithoutPdb()
+    public void NarrowLocal_PlacementDiffersWithAndWithoutPdb()
     {
         var withPdb = Print(nameof(DeclScopeClient.CreateNarrow));
         var withoutPdb = PrintWithoutSymbols(nameof(DeclScopeClient.CreateNarrow));
 
-        Assert.NotEqual(withPdb, withoutPdb);
-        Assert.Equal(MaskLocalNames(withPdb), MaskLocalNames(withoutPdb));
+        Assert.NotEqual(MaskLocalNames(withPdb), MaskLocalNames(withoutPdb));
+    }
+
+    /// <summary>
+    /// A loop body is the same evidence in its commonest form: the source declared
+    /// the local inside the body, so it belongs at its store rather than above the
+    /// loop where every iteration would appear to share it.
+    /// </summary>
+    [Fact]
+    public void LoopBodyLocal_DeclarationSinksToItsStore()
+    {
+        var output = Print<DeclScopeLoopClient>(nameof(DeclScopeLoopClient.SumNarrow));
+
+        Assert.Contains("DeclScopeResult step = _ops.Create(\"s\", i);", output);
+        Assert.DoesNotContain("DeclScopeResult step;", output);
+    }
+
+    /// <summary>
+    /// Non-vacuity gate for the IR guard. The PDB scopes this local to the using
+    /// block just as narrowly, but the first store is inside one arm of the if while
+    /// the read is after it, so sinking the declaration onto that store would not
+    /// compile. The scope is evidence of intent, not of validity, and the printer
+    /// declines.
+    /// </summary>
+    [Fact]
+    public void BranchedStore_StaysHoisted_DespiteNestedPdbScope()
+    {
+        var scope = PdbScope<DeclScopeLoopClient>(nameof(DeclScopeLoopClient.CreateBranched), "response");
+        Assert.True(
+            scope.Start > 0 || scope.End < scope.IlLength,
+            $"Expected a nested scope, got IL_{scope.Start:X4}..IL_{scope.End:X4} of 0x{scope.IlLength:X4}.");
+
+        var output = Print<DeclScopeLoopClient>(nameof(DeclScopeLoopClient.CreateBranched));
+
+        Assert.Contains("DeclScopeResult response;", output);
+        Assert.True(
+            output.IndexOf("DeclScopeResult response;", StringComparison.Ordinal)
+                < output.IndexOf("using (", StringComparison.Ordinal),
+            $"Expected the declaration to stay above the using.{Environment.NewLine}{output}");
     }
 
     /// <summary>
@@ -129,38 +174,28 @@ public class DeclarationPlacementFrontierTests
         Assert.All(unscoped, index => Assert.Null(function.LocalNames[index]));
     }
 
-    static void AssertDeclarationPrecedesUsing(string output, string declaration)
-    {
-        int declarationIndex = output.IndexOf(declaration, StringComparison.Ordinal);
-        int usingIndex = output.IndexOf("using (", StringComparison.Ordinal);
-
-        Assert.True(declarationIndex >= 0, $"Missing declaration `{declaration}`.{Environment.NewLine}{output}");
-        Assert.True(usingIndex >= 0, $"Missing using statement.{Environment.NewLine}{output}");
-        Assert.True(
-            declarationIndex < usingIndex,
-            $"Expected `{declaration}` hoisted above the using.{Environment.NewLine}{output}");
-    }
-
     // Every local identifier the two renderings can disagree on: the PDB source
     // names and the V_index fallbacks. Masking them isolates placement from naming.
     static string MaskLocalNames(string output)
-        => Regex.Replace(output, @"\b(?:V_\d+|response|scope|ex)\b", "N");
+        => Regex.Replace(output, @"\b(?:V_\d+|response|scope|ex|step|total)\b", "N");
 
-    static string Print(string methodName)
+    static string Print(string methodName) => Print<DeclScopeClient>(methodName);
+
+    static string Print<T>(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeResolver);
-        return Raise(source, methodName);
+        return Raise<T>(source, methodName);
     }
 
     static string PrintWithoutSymbols(string methodName)
     {
         using var source = MetadataSource.OpenWithoutSymbols(typeof(CfgSampleClass).Assembly.Location, RuntimeResolver);
-        return Raise(source, methodName);
+        return Raise<DeclScopeClient>(source, methodName);
     }
 
-    static string Raise(MetadataSource source, string methodName)
+    static string Raise<T>(MetadataSource source, string methodName)
     {
-        var function = IrImporter.Import(source, typeof(DeclScopeClient).FullName!, methodName);
+        var function = IrImporter.Import(source, typeof(T).FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
         function!.CheckInvariant();
@@ -168,8 +203,11 @@ public class DeclarationPlacementFrontierTests
     }
 
     static (int Start, int End, int IlLength) PdbScope(string methodName, string localName)
+        => PdbScope<DeclScopeClient>(methodName, localName);
+
+    static (int Start, int End, int IlLength) PdbScope<T>(string methodName, string localName)
     {
-        foreach (var (scope, ilLength, pdb) in Scopes(methodName))
+        foreach (var (scope, ilLength, pdb) in Scopes<T>(methodName))
         {
             foreach (var variableHandle in scope.GetLocalVariables())
             {
@@ -184,7 +222,7 @@ public class DeclarationPlacementFrontierTests
     static (int Index, string Name)[] PdbScopedSlots(string methodName)
     {
         var slots = new List<(int, string)>();
-        foreach (var (scope, _, pdb) in Scopes(methodName))
+        foreach (var (scope, _, pdb) in Scopes<DeclScopeClient>(methodName))
         {
             foreach (var variableHandle in scope.GetLocalVariables())
             {
@@ -196,7 +234,7 @@ public class DeclarationPlacementFrontierTests
         return [.. slots];
     }
 
-    static IEnumerable<(LocalScope Scope, int IlLength, MetadataReader Pdb)> Scopes(string methodName)
+    static IEnumerable<(LocalScope Scope, int IlLength, MetadataReader Pdb)> Scopes<T>(string methodName)
     {
         string assemblyPath = typeof(CfgSampleClass).Assembly.Location;
         string pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
@@ -213,7 +251,7 @@ public class DeclarationPlacementFrontierTests
             var method = metadata.GetMethodDefinition(handle);
             if (metadata.GetString(method.Name) != methodName)
                 continue;
-            if (metadata.GetString(metadata.GetTypeDefinition(method.GetDeclaringType()).Name) != nameof(DeclScopeClient))
+            if (metadata.GetString(metadata.GetTypeDefinition(method.GetDeclaringType()).Name) != typeof(T).Name)
                 continue;
 
             int ilLength = pe.GetMethodBody(method.RelativeVirtualAddress).GetILReader().Length;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1257,7 +1257,9 @@ public sealed partial class CSharpPrinter
     /// <summary>
     /// A local declares at its store when that store is the local's first
     /// program-order reference and sits at statement level in the entry
-    /// block — the current emitter's merged-declaration shape.
+    /// block — the current emitter's merged-declaration shape — or, when the
+    /// portable PDB says the source declared the local inside a nested block,
+    /// at the first store in a block that dominates every later reference.
     /// </summary>
     void CollectDeclaringStores(IrFunction function)
     {
@@ -1289,6 +1291,17 @@ public sealed partial class CSharpPrinter
                         // synthesizing Unsafe.NullRef<T>() changes IL. If the first
                         // definition dominates every reference inside one block, declare
                         // at that ref assignment instead.
+                        _declaringStores.Add(store);
+                    }
+                    else if (function.IsLocalDeclaredInNestedScope(store.Index)
+                        && LocalReferencesStayInsideStoreBlock(function, store))
+                    {
+                        // The PDB scoped this local to a nested block, so the source
+                        // declared it at its assignment rather than at method scope.
+                        // The scope is evidence of intent, not of validity, so it only
+                        // takes effect where the IR independently shows every reference
+                        // stays in the store's block after the store. Absent a PDB the
+                        // flag is false everywhere and the hoisted shape is unchanged.
                         _declaringStores.Add(store);
                     }
                     else if (store is { Parent: ForLoop forLoop, ChildIndex: 0 }
@@ -1438,6 +1451,42 @@ public sealed partial class CSharpPrinter
         if (HasBranchTargetAfterStatement(store))
             return false;
         return LocalReferencesStayInBlockAfterStatement(function, store, store.Index);
+    }
+
+    /// <summary>
+    /// Every reference to the local written by <paramref name="store"/> lies in the
+    /// run of statements from that store to the end of its enclosing block, so the
+    /// declaration can be merged into the store where it sits.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="LocalReferencesStayInBlockAfterStatement"/> answers the same question
+    /// only for a store in one of the body's own top-level blocks: it walks top-level
+    /// statements and requires each referencing one to be a *descendant* of an allowed
+    /// statement. For a store nested inside a <c>using</c>, <c>try</c>, or loop — the
+    /// shape a PDB-scoped declaration sinks into — the top-level statement is an
+    /// *ancestor* of the reference instead, so that test can never say yes. This walks
+    /// the reference nodes themselves, which is orientation-free.
+    /// </remarks>
+    bool LocalReferencesStayInsideStoreBlock(IrFunction function, StoreLocal store)
+    {
+        if (store.Parent is not Block block || store.ChildIndex < 0)
+            return false;
+        if (StoreValueReferencesLocal(store))
+            return false;
+        if (HasBranchTargetAfterStatement(store))
+            return false;
+
+        if (store.ChildIndex >= block.Children.Count || !ReferenceEquals(block.Children[store.ChildIndex], store))
+            return false;
+
+        var allowed = block.Children.Skip(store.ChildIndex).ToList();
+
+        foreach (var reference in IrFunction.LocalSlotReferencesInScope(function.Body, store.Index))
+        {
+            if (!allowed.Any(statement => IsDescendantOrSelf(reference, statement)))
+                return false;
+        }
+        return true;
     }
 
     bool LocalReferencesStayInBlockAfterStatement(IrFunction function, IrNode statement, int index)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -530,6 +530,7 @@ public static class IrImporter
             MethodKind = ClassifyMethodKind(method.Name),
             Regions = method.Body.Handlers,
             LocalNames = method.Body.LocalNames,
+            LocalDeclaredInNestedScope = method.Body.LocalDeclaredInNestedScope,
             UsesUpdatedMemorySafetyRules = source.SimulateNewRules || ModuleUsesUpdatedMemorySafetyRules(source.Reader),
             SkipLocalsInit = method.Body.SkipLocalsInit,
             CompilerGenerated = method.CompilerGenerated,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -328,6 +328,14 @@ public sealed class IrFunction : IrNode
         while (names.Length < index)
             names = names.Add(null);
         LocalNames = names.Add(name);
+        if (!LocalDeclaredInNestedScope.IsDefaultOrEmpty)
+        {
+            // A slot a pass invents has no PDB scope, so it is not nested.
+            var nested = LocalDeclaredInNestedScope;
+            while (nested.Length < index)
+                nested = nested.Add(false);
+            LocalDeclaredInNestedScope = nested.Add(false);
+        }
         return index;
     }
 
@@ -352,6 +360,10 @@ public sealed class IrFunction : IrNode
         while (aligned.Length < locals.Length)
             aligned = aligned.Add(null);
         LocalNames = aligned;
+        // The new numbering no longer names the same locals, so any scope evidence
+        // gathered for the old slots would be misattributed. Drop it: the printer then
+        // degrades to the byte-stable method-scope shape rather than guessing.
+        LocalDeclaredInNestedScope = [];
         _eliminatedLocalSlots = eliminatedSlots switch
         {
             null => ImmutableHashSet<int>.Empty,
@@ -406,23 +418,28 @@ public sealed class IrFunction : IrNode
     /// <c>NeedsNestedLocalFunctionScope</c> discriminators so the two never diverge.
     /// </summary>
     static bool LocalSlotReferencedInScope(IrNode node, int index)
+        => LocalSlotReferencesInScope(node, index).Any();
+
+    /// <summary>
+    /// Every node in <paramref name="node"/>'s subtree that binds or reads local slot
+    /// <paramref name="index"/>, under the same scope rules as
+    /// <see cref="LocalSlotReferencedInScope"/> — which delegates here, so the two
+    /// cannot drift. Yielding the nodes rather than a bool lets a caller ask *where*
+    /// the references are, which is what deciding a declaration's placement needs.
+    /// </summary>
+    internal static IEnumerable<IrNode> LocalSlotReferencesInScope(IrNode node, int index)
     {
         if (node is Lambda ownScopeLambda && CSharpPrinter.NeedsNestedLambdaScope(ownScopeLambda))
-            return false;
+            yield break;
         if (node is LocalFunctionStatement ownScopeLocalFunction && CSharpPrinter.NeedsNestedLocalFunctionScope(ownScopeLocalFunction))
-            return false;
+            yield break;
         if (NodeBindsLocalSlot(node, index))
-            return true;
+            yield return node;
         foreach (var child in node.Children)
         {
-            if (child is Lambda lambda && CSharpPrinter.NeedsNestedLambdaScope(lambda))
-                continue;
-            if (child is LocalFunctionStatement localFunction && CSharpPrinter.NeedsNestedLocalFunctionScope(localFunction))
-                continue;
-            if (LocalSlotReferencedInScope(child, index))
-                return true;
+            foreach (var reference in LocalSlotReferencesInScope(child, index))
+                yield return reference;
         }
-        return false;
     }
 
     /// <summary>
@@ -471,6 +488,25 @@ public sealed class IrFunction : IrNode
     /// printer renders a present name and falls back to <c>V_index</c> otherwise.
     /// </summary>
     public ImmutableArray<string?> LocalNames { get; set; } = [];
+
+    /// <summary>
+    /// Per entry in <see cref="Locals"/>, whether the portable PDB scoped the local to
+    /// something narrower than the whole method body — that is, whether the source
+    /// declared it inside a nested block. Empty when no PDB was available, which is
+    /// why placement never depends on a guess: with no evidence the printer keeps the
+    /// byte-stable hoisted shape. Length-aligned with <see cref="Locals"/> when
+    /// non-empty.
+    /// </summary>
+    public ImmutableArray<bool> LocalDeclaredInNestedScope { get; set; } = [];
+
+    /// <summary>
+    /// Whether the source declared local <paramref name="index"/> inside a nested
+    /// block. False when no PDB evidence exists for the slot, so callers degrade to
+    /// the method-scope shape rather than inferring placement.
+    /// </summary>
+    public bool IsLocalDeclaredInNestedScope(int index)
+        => index >= 0 && index < LocalDeclaredInNestedScope.Length && LocalDeclaredInNestedScope[index];
+
     public BlockContainer Body => (BlockContainer)Children[0];
     public List<DecompilerDiagnostic> Diagnostics { get; } = [];
 

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -921,6 +921,24 @@ public sealed class MetadataSource : IDisposable
     /// Names and scopes come from the same <c>LocalScope</c> rows, so they are read in
     /// one walk: splitting them would traverse the table twice per method and let the
     /// two views disagree about which entries were skipped.
+    /// <para>
+    /// The two halves fail differently, so a malformed table is not handled the same
+    /// way for both. A missing name degrades visibly to <c>V_index</c> and affects
+    /// nothing else, so a partial name array is kept. A scope drives where the printer
+    /// puts a declaration, so a <em>partial</em> scope array would make output shape a
+    /// function of where the corruption happened to stop. Scopes are therefore dropped
+    /// wholesale on a decode failure, which yields exactly the documented no-PDB
+    /// behavior: no evidence, no sinking, byte-stable output.
+    /// </para>
+    /// <para>
+    /// This fallback is <b>unverified by test</b>. It is not reachable from any
+    /// fixture the repository can build: a truncated or otherwise malformed portable
+    /// PDB throws in <c>MetadataReaderProvider.FromPortablePdbStream</c> and is handled
+    /// by <see cref="PdbReader"/>'s own catch, which disables symbols entirely, and a
+    /// PDB belonging to a different assembly returns empty scopes without throwing
+    /// (measured over 18,242 method handles). Reaching this catch needs a PDB that
+    /// opens cleanly and then fails mid-walk.
+    /// </para>
     /// </remarks>
     internal (ImmutableArray<string?> Names, ImmutableArray<LocalSlotScope?> Scopes) LocalDeclarations(
         MethodDefinitionHandle methodHandle,
@@ -934,6 +952,7 @@ public sealed class MetadataSource : IDisposable
 
         var names = new string?[localCount];
         var scopes = new LocalSlotScope?[localCount];
+        bool scopesUsable = true;
         try
         {
             foreach (var scopeHandle in pdb.GetLocalScopes(methodHandle))
@@ -956,10 +975,14 @@ public sealed class MetadataSource : IDisposable
                 }
             }
         }
-        catch
+        catch (BadImageFormatException)
         {
-            // Malformed scope table — keep whatever declarations were read.
+            // Malformed scope table. Keep the names read so far, but discard the
+            // scopes: a partial set would silently place some declarations from
+            // evidence and others from the fallback. Anything other than a decode
+            // failure is a bug here and is left to propagate.
+            scopesUsable = false;
         }
-        return ([.. names], [.. scopes]);
+        return ([.. names], scopesUsable ? [.. scopes] : []);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -909,21 +909,31 @@ public sealed class MetadataSource : IDisposable
     }
 
     /// <summary>
-    /// Source local-variable names for a method from its portable PDB, indexed
-    /// by IL local slot. No PDB returns an empty array. Present PDB entries with
-    /// no recorded name, a compiler-generated (debugger-hidden) local, or a name
-    /// that is not a usable identifier stay null, and the printer renders
-    /// <c>V_index</c>.
+    /// Source names and declaration scopes for a method's local slots from its
+    /// portable PDB, indexed by IL local slot. No PDB returns two empty arrays.
+    /// Present PDB entries with no recorded name, a compiler-generated
+    /// (debugger-hidden) local, or a name that is not a usable identifier stay null,
+    /// and the printer renders <c>V_index</c>. A slot with no scope entry at all — a
+    /// compiler temp the source never declared — keeps a null scope, which is itself
+    /// usable evidence that the slot is synthetic.
     /// </summary>
-    internal ImmutableArray<string?> LocalNames(MethodDefinitionHandle methodHandle, int localCount)
+    /// <remarks>
+    /// Names and scopes come from the same <c>LocalScope</c> rows, so they are read in
+    /// one walk: splitting them would traverse the table twice per method and let the
+    /// two views disagree about which entries were skipped.
+    /// </remarks>
+    internal (ImmutableArray<string?> Names, ImmutableArray<LocalSlotScope?> Scopes) LocalDeclarations(
+        MethodDefinitionHandle methodHandle,
+        int localCount)
     {
         if (localCount == 0)
-            return [];
+            return ([], []);
         var pdb = PdbReader();
         if (pdb is null)
-            return [];
+            return ([], []);
 
         var names = new string?[localCount];
+        var scopes = new LocalSlotScope?[localCount];
         try
         {
             foreach (var scopeHandle in pdb.GetLocalScopes(methodHandle))
@@ -934,15 +944,22 @@ public sealed class MetadataSource : IDisposable
                     var variable = pdb.GetLocalVariable(varHandle);
                     if ((variable.Attributes & LocalVariableAttributes.DebuggerHidden) != 0)
                         continue;
-                    if (variable.Index >= 0 && variable.Index < localCount)
-                        names[variable.Index] = pdb.GetString(variable.Name);
+                    if (variable.Index < 0 || variable.Index >= localCount)
+                        continue;
+                    names[variable.Index] = pdb.GetString(variable.Name);
+                    // A slot listed in more than one scope is malformed or merged
+                    // metadata. Keep the narrowest range: it is the weaker claim about
+                    // how far the declaration reaches, so it cannot widen a scope.
+                    var candidate = new LocalSlotScope(scope.StartOffset, scope.EndOffset);
+                    if (scopes[variable.Index] is not { } existing || candidate.Length < existing.Length)
+                        scopes[variable.Index] = candidate;
                 }
             }
         }
         catch
         {
-            // Malformed scope table — keep whatever names were read.
+            // Malformed scope table — keep whatever declarations were read.
         }
-        return [.. names];
+        return ([.. names], [.. scopes]);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
@@ -15,6 +15,24 @@ public sealed record HandlerRegion(
     TypeRef? CatchType);
 
 /// <summary>
+/// The IL range of one local slot's declaration scope, as recorded by a portable
+/// PDB's <c>LocalScope</c> table. <see cref="EndOffset"/> is exclusive. This is the
+/// evidence that separates a local the source declared at method scope from one it
+/// declared inside a nested block; IL alone carries only a flat slot list.
+/// </summary>
+public readonly record struct LocalSlotScope(int StartOffset, int EndOffset)
+{
+    public int Length => EndOffset - StartOffset;
+
+    /// <summary>
+    /// True when the scope spans the whole method body, i.e. the source declared the
+    /// local at method scope. Anything narrower means the source declared it inside a
+    /// nested block.
+    /// </summary>
+    public bool CoversMethodBody(int ilLength) => StartOffset <= 0 && EndOffset >= ilLength;
+}
+
+/// <summary>
 /// A method body as plain data: no metadata handles, no lifetime — safe to
 /// hold after its <see cref="MetadataSource"/> is disposed.
 /// </summary>
@@ -24,7 +42,17 @@ public sealed record MethodBody(
     ImmutableArray<TypeRef> Locals,
     ImmutableArray<string?> LocalNames,
     ImmutableArray<HandlerRegion> Handlers,
-    bool SkipLocalsInit = false);
+    bool SkipLocalsInit = false)
+{
+    /// <summary>
+    /// Per local slot, whether the portable PDB scoped the local to something
+    /// narrower than the whole method body — that is, whether the source declared it
+    /// inside a nested block. Empty when no PDB was available, and false for a slot
+    /// with no scope entry (a compiler temp the source never declared). Length-aligned
+    /// with <see cref="Locals"/> when non-empty.
+    /// </summary>
+    public ImmutableArray<bool> LocalDeclaredInNestedScope { get; init; } = [];
+}
 
 /// <summary>
 /// A parameter: name, symbolic type, whether metadata declares an optional

--- a/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -127,13 +127,18 @@ public static class MethodImporter
                 CatchType(reader, region.CatchType, scope)));
         }
 
+        var il = body.GetILBytes() ?? [];
+        var declarations = source.LocalDeclarations(methodHandle, locals.Length);
         var methodBody = new MethodBody(
-            [.. body.GetILBytes() ?? []],
+            [.. il],
             body.MaxStack,
             locals,
-            LocalNames: source.LocalNames(methodHandle, locals.Length),
+            LocalNames: declarations.Names,
             handlers.MoveToImmutable(),
-            SkipLocalsInit: !body.LocalVariablesInitialized);
+            SkipLocalsInit: !body.LocalVariablesInitialized)
+        {
+            LocalDeclaredInNestedScope = NestedScopeFlags(declarations.Scopes, il.Length),
+        };
 
         return new ImportedMethod(
             declaringType,
@@ -147,6 +152,23 @@ public static class MethodImporter
     }
 
     static MetadataFactState FactState(bool value) => value ? MetadataFactState.Yes : MetadataFactState.No;
+
+    /// <summary>
+    /// Reduces raw PDB declaration scopes to the fact the IR needs: per slot, whether
+    /// the source declared the local inside a nested block rather than at method
+    /// scope. A slot with no scope entry is a compiler temp, which the source never
+    /// declared anywhere, so it is not nested.
+    /// </summary>
+    static ImmutableArray<bool> NestedScopeFlags(ImmutableArray<LocalSlotScope?> scopes, int ilLength)
+    {
+        if (scopes.IsDefaultOrEmpty)
+            return [];
+
+        var flags = new bool[scopes.Length];
+        for (int i = 0; i < scopes.Length; i++)
+            flags[i] = scopes[i] is { } scope && !scope.CoversMethodBody(ilLength);
+        return [.. flags];
+    }
 
     static bool HasDefault(MetadataReader reader, System.Reflection.Metadata.Parameter parameter)
     {


### PR DESCRIPTION
Closes #3591.

The portable PDB's `LocalScope` table records each local's true declaration extent. `MetadataSource` read those rows for the variable *names* and threw `StartOffset`/`EndOffset` away, so a local the source declared inside a `try`, `using`, or loop was hoisted to the top of the method. #3593 pinned that gap and the evidence that closes it; this closes it.

**The headline is fidelity, not style.** The hoisted spelling was not merely uglier — it recompiled to *different IL*. Declaration order drives local-slot allocation, so the hoisted render swapped slot numbering against the original. The sunk render is byte-exact. Measured below.

**Benchmark target:** `Azure.Data.Tables@12.11.0`

**dotnet-inspect command:**

```bash
dotnet-inspect member Azure.Data.Tables.TableClient --package Azure.Data.Tables@12.11.0 -m Create -S "Decompiled Source"
```

## Original source

`-S "Original Source"`, SourceLink-backed.

```csharp
public virtual Response<TableItem> Create(CancellationToken cancellationToken = default)
{
    using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Create)}");
    scope.Start();
    try
    {
        var response = _tableOperations.Create(
            new TableProperties { TableName = Name },
            null,
            _defaultQueryOptions,
            cancellationToken);
        return Response.FromValue(response.Value as TableItem, response.GetRawResponse());
    }
    catch (Exception ex)
    {
        scope.Failed(ex);
        throw;
    }
}
```

## Before

```csharp
public virtual Azure.Response<Azure.Data.Tables.Models.TableItem> Create(System.Threading.CancellationToken cancellationToken = default)
{
    ResponseWithHeaders<TableResponse, TableCreateHeaders> response;

    using (DiagnosticScope scope = _diagnostics.CreateScope("TableClient.Create", (ActivityKind)0))
    {
        scope.Start();
        try
        {
            response = _tableOperations.Create(new TableProperties { TableName = Name }, default(Nullable<ResponseFormat>), _defaultQueryOptions, cancellationToken);
            return Response.FromValue<TableItem>(response.get_Value(), response.GetRawResponse());
        }
        catch (Exception ex)
        {
            scope.Failed(ex);
            throw;
        }
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: **False** — see the round-trip measurement below. The declaration order the hoist imposes reallocates local slots.
- Taste applied: none (`-S "Applied Taste"`: *No recorded style choices were applied to this member.*)
- Commit: `0e4c303ce`

## After

```csharp
public virtual Azure.Response<Azure.Data.Tables.Models.TableItem> Create(System.Threading.CancellationToken cancellationToken = default)
{
    using (DiagnosticScope scope = _diagnostics.CreateScope("TableClient.Create", (ActivityKind)0))
    {
        scope.Start();
        try
        {
            ResponseWithHeaders<TableResponse, TableCreateHeaders> response = _tableOperations.Create(new TableProperties { TableName = Name }, default(Nullable<ResponseFormat>), _defaultQueryOptions, cancellationToken);
            return Response.FromValue<TableItem>(response.get_Value(), response.GetRawResponse());
        }
        catch (Exception ex)
        {
            scope.Failed(ex);
            throw;
        }
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: **True** for the declaration placement itself — a minimal reproduction of this exact shape recompiles byte-for-byte after the change and did not before.
- Taste applied: none. This is derived from evidence, not chosen; there is no knob, matching the `## Names` precedent in `docs/decompiler-taste.md`.
- Commit: `d069dfdc4`

## Fully raised

The remaining deltas against Original source are all tracked separately and untouched here: `response.get_Value()` vs `.Value` (#2947), `default(Nullable<ResponseFormat>)` vs `null` (#3027), statement-`using` vs block-`using` (deliberate non-change; declared oracle `.editorconfig:92` `csharp_prefer_simple_using_statement = false:none`), and `var` spelling (#3169 family).

## Why this is a raising gap and not taste

Under the rule that we do not implement taste when the correct answer is PDB-knowable, this was never a style question. IL alone cannot express declaration position — `.locals init` is a flat slot list — but the PDB records it exactly, and dotnet-inspect had already fetched the PDB for this very package. The `response`, `scope`, and `ex` names in the Before render are themselves PDB-derived; only the scope ranges were dropped.

`docs/decompiler-taste.md:630` (`## Names`) sets the split this follows: PDB-present facts are simply *used*, with no knob; only *synthesizing* where no PDB exists is an opt-in knob. Declaration placement maps onto that exactly.

## Design

- `MetadataSource.LocalDeclarations` replaces `LocalNames` and returns names **and** scopes from one walk of the same `LocalScope` rows. Splitting them would traverse the table twice per method and let the two views disagree about which entries were skipped.
- `MethodImporter` reduces each raw scope to the one fact the IR needs — is this slot scoped narrower than the whole body — because mapping IL offsets onto IR nodes *after* passes rewrite the tree would be fragile. Metadata owns metadata facts; the importer converts them to an IR fact.
- `CSharpPrinter.CollectDeclaringStores` gains a branch that merges the declaration into its store when the flag is set.

**The safety split is the load-bearing part.** The PDB scope is evidence of *intent*; it is never evidence of *validity*. The branch only fires when the IR independently proves every reference to the local stays inside the store's block at or after the store. Both are required, and each has a dedicated negative test.

`LocalReferencesStayInBlockAfterStatement` could not serve as that proof: it walks *top-level* statements and requires each referencing one to be a **descendant** of an allowed statement. For a store nested inside a `using` or `try` the top-level statement is an **ancestor** of the reference instead, so it can never say yes. The new `LocalReferencesStayInsideStoreBlock` walks the reference nodes themselves, which is orientation-free, reusing `IrFunction`'s gate-enforced local-slot binding list rather than duplicating it.

## Evidence

Round-trip on a minimal reproduction of the witness shape (original compiled from the *sunk* source, decompiled with each build, recompiled, IL compared):

| Render | Recompiled IL identical to original |
| --- | --- |
| Before (`0e4c303ce`) | **False** — `stloc.1`/`ldloc.0` vs `stloc.0`/`ldloc.1` at 6 offsets |
| After (`ff695a216`) | **True** |

Both renders are Valid and Correct; only the After is opcode-faithful. This is the #3127 trap in reverse — the Before block's two `True`s were not enough.

| Gate | Result |
| --- | --- |
| `dotnet build dotnet-inspect.slnx -c Release` | clean |
| `--gate fast` | 4409 / 0 failed / 0 skipped |
| `-trait "Area=RoundTrip"` (incl. slow compile-back) | 568 / 0 |
| `-trait "Area=Fidelity"` (slow, 32 min) | 68 / 0 |
| `-trait "Area=Corpus"` | 348 / 0 |
| `-trait "Area=Validity"` | 103 / 0 |
| `dotnet run --project src/dotnet-inspect.Tests -c Release` | 2602 / 1 failed / 14 skipped |

The single CLI failure is `Layout_Count_CountsFilesRatherThanRenderedTreeLines`, pre-existing and reproduced byte-identically on a clean detached `origin/main` worktree.

### Adversarial shapes

Neither reviewer built counterexamples for the soundness claim, so I did. 15 real C# shapes compiled with a portable PDB, decompiled at this head, and the 13 compilable renders recompiled and executed against the original:

| Outcome | Shapes |
| --- | --- |
| Sank correctly, matching the original source | `LoopLocal`, `ForEachNested`, `PatternVar`, `GotoOut` |
| Correctly **declined** to sink | `CarryOut` (read after the loop), `BackEdge` (read before the store across a back-edge), `FinallyReads` (the `finally` reads it), `NestedEh` (the outer `catch` reads it), `TwoArms` (store in one `if` arm, read after), `OutArg`, `SiblingRead` |
| Unchanged and correct | `RefLocal` (ref local in a nested block), `SwitchSections` |
| Documented residual | `LambdaCapture`, `LocalFuncCapture` (display-class shapes) |

Behavior comparison, original assembly vs recompiled decompiled output, 22 invocations with fresh state per call: **22 identical, 0 different.**

### Blast radius

Across 4409 decompiler tests only the two #3593 named as having to flip changed behavior. That is small because most decompiler tests build IR by hand and carry no PDB flags — it is **not** evidence that the real-world reach is small. Measured over the 80 real portable PDBs in the local cache: 207,977 methods, 217,304 `LocalScope` rows, 92,269 local variables, of which **41,818 scopes start after IL offset 0**. Narrow scopes are pervasive in real code, so this changes a great deal of real output — which is what the corpus, fidelity, round-trip and validity gates are for.

That same sweep is the evidence for narrowing the `catch`: across all 207,977 methods, replaying `LocalDeclarations`' exact SRM call sequence threw **no exception of any type**, so restricting the catch to `BadImageFormatException` cannot regress well-formed input.

### Non-vacuity

Each half of the rule was tampered and the expected tests failed:

| Tamper | Failing tests |
| --- | --- |
| `IsLocalDeclaredInNestedScope` forced false | the 3 sinking positives |
| containment check removed from `LocalReferencesStayInsideStoreBlock` | `BranchedStore_StaysHoisted_DespiteNestedPdbScope` |

### Tests

`DeclarationPlacementFrontierTests` is renamed to `DeclarationPlacementTests` — it no longer pins a frontier. #3593's `<remarks>` named the two tests that closing this had to flip, and both flipped.

| Test | Claim |
| --- | --- |
| `NarrowLocal_DeclarationSinksToItsStore_WithPdb` | flipped: declaration merges into its store inside the `try` |
| `NarrowLocal_PlacementDiffersWithAndWithoutPdb` | flipped: masking local names no longer collapses the two renderings |
| `NarrowLocal_StaysHoisted_WithoutPdb` | **negative for the PDB half**: no evidence, no guess — output byte-identical to before |
| `BranchedStore_StaysHoisted_DespiteNestedPdbScope` | **negative for the IR half**: scope is equally narrow, but the store sits in one arm of an `if` and the read is after it, so sinking would not compile — the printer declines |
| `LoopBodyLocal_DeclarationSinksToItsStore` | new positive: the commonest form of the same evidence |
| `HoistedLocal_RoundTripsAtMethodTop` | control, unchanged |
| `PdbScopes_DistinguishTheNarrowAndHoistedShapes` | non-vacuity of the fixture pair |
| `PdbScopes_OmitCompilerTemps` | a compiler temp has no scope row at all |

## Style oracle

Both facets consulted, per `docs/decompiler-taste.md`.

- **Declared** — `dotnet/runtime` `.editorconfig` is **silent** on general declaration placement. L124 `csharp_style_inlined_variable_declaration = true:suggestion` covers `out` parameters only. (L52-54 `csharp_style_var_* = false` is why the render spells `ResponseWithHeaders<...> response` rather than `var`; that is #3169's business, not this PR's.)
- **Revealed** — `dotnet/runtime` declares at first use when use is confined to the block, and hoists only when a `catch`/`finally` or later code needs it: `HttpContent c = response.Content;` (`HttpClient.cs:199`) and `StringBuilder sb = new StringBuilder();` (`File.cs:1132`) against `HttpResponseMessage? response = null;` (`HttpClient.cs:189`) and `char[]? buffer = null;` (`File.cs:1126`). That is the narrowest scope covering all uses — exactly what the PDB encodes and what this PR emits.

The revealed facet agrees, but the claim here rests on the PDB, not on the oracle.

## Non-action boundary

- **No PDB, no change.** The flag is empty and output is byte-identical to before. Nothing is inferred from IL alone.
- **Lambdas and local functions.** `CSharpPrinter` builds sub-`IrFunction`s from `lambda.LocalNames` and does not carry the new flags, so locals inside them keep the hoisted shape. Not a regression; not addressed here.
- **Partial sinking is not attempted.** When the IR guard declines (`CreateBranched`), the declaration stays where it is today — at method top — rather than moving to the enclosing block the PDB names. Sinking to an intermediate block is a strictly larger change and is left out.
- **`ResetLocals` drops the flags.** A renumbering no longer names the same locals, so keeping scope evidence would misattribute it. The printer degrades to the byte-stable method-scope shape.
