### PR TITLE
Point the --focus caret at the expression a fact is about

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -201,7 +201,7 @@ public class AnnotationAnchorTests
     {
         // A statement that wraps puts its narrow sub-expression on a later line
         // than the one the fact is attached to, so narrowing there would draw
-        // the caret under a line the fact does not belong to. 279 facts in
+        // the caret under a line the fact does not belong to. 283 facts in
         // System.Private.CoreLib take this path; all keep the statement-wide
         // caret. Only the if and the allocation carry the offset -- giving it to
         // the inner statement too would make Best pick that, and the owner line
@@ -411,13 +411,13 @@ public class AnnotationAnchorTests
     [InlineData("\tx\t", 0, 3, 1, 1)]
     [InlineData("\u00a0x", 0, 2, 1, 1)]
     // Reaching exactly the last character, so a clamp that stopped one short
-    // would silently drop it. 87,400 of the corpus's printed ranges end here.
+    // would silently drop it. 650 of the extents the caller delivers end here.
     [InlineData("    new object();", 4, 13, 4, 13)]
     // Overhanging the end of the line. ComputeCaretExtents cannot deliver this
     // today -- TryGetLineColumn rejects every range that crosses a line break,
-    // 16,895 of them in the corpus, so 0 of 359,584 survivors overhang -- but
-    // the clamp is the reason an overhang is survivable at all, and an internal
-    // helper is not entitled to assume it keeps only its current caller.
+    // so 0 of the 33,657 extents the caller delivers overhang -- but the clamp
+    // is the reason an overhang is survivable at all, and an internal helper is
+    // not entitled to assume it keeps only its current caller.
     [InlineData("    x", 4, 99, 4, 1)]
     public void TryTrimToPrinted_ShrinksOntoPrintedCharactersAtBothEnds(
         string lineText, int column, int length, int expectedColumn, int expectedLength)

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -87,19 +87,24 @@ public class AnnotationAnchorTests
         Assert.Contains(statementNodes, n => n is NewArray);
     }
 
-    [Fact]
-    public void CaretExtent_PrefersTheAllocation_OverAStackSlotStandInSharingItsOffset()
+    [Theory]
+    [InlineData("S_0")]
+    [InlineData("__exception")]
+    public void CaretExtent_PrefersTheAllocation_OverAStandInSharingItsOffset(string standInText)
     {
         // `return new Holder(S_0);` where the raise could not recover the
-        // argument, so it prints a stack-slot stand-in that carries the same
-        // instruction offset as the newobj it feeds. S_0 is the narrower node,
-        // so width alone would underline the argument instead of the allocation
-        // the fact reports. Measured over System.Private.CoreLib, that mistake
-        // affected 50 of 10,664 alloc.new underlines.
+        // argument, so it prints a stand-in that carries the same instruction
+        // offset as the newobj it feeds. The stand-in is the narrower node, so
+        // width alone would underline the argument instead of the allocation the
+        // fact reports. Measured over System.Private.CoreLib, that mistake
+        // affected 50 of 10,664 alloc.new underlines for the stack-slot form;
+        // __exception has the same shape and is excluded for the same reason.
         const int Offset = 5;
         var objectType = TypeRef.CoreLib("System", "Object");
         var holder = TypeRef.CoreLib("Test", "Holder");
-        var slot = new LoadStackSlot(0, objectType);
+        IrExpression slot = standInText == "S_0"
+            ? new LoadStackSlot(0, objectType)
+            : new CaughtException(objectType);
         slot.SetSourceOffset(Offset);
         var allocation = new NewObject(
             new MethodRef(holder, ".ctor", TypeRef.CoreLib("System", "Void"), [objectType], HasThis: true),
@@ -131,8 +136,64 @@ public class AnnotationAnchorTests
 
         // The stand-in is on the line and is the narrower node, so a width-only
         // rule underlines it; this asserts the allocation wins instead.
-        Assert.Contains("S_0", line, StringComparison.Ordinal);
+        Assert.Contains(standInText, line, StringComparison.Ordinal);
         Assert.StartsWith("new ", line.Substring(extent.Column, extent.Length), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CaretExtent_TrimsAStatementWideExtentOffTheLineIndent()
+    {
+        // When the statement itself is the narrowest node carrying the offset,
+        // its printed range starts at the line's indent, so an untrimmed extent
+        // would draw carets left of the code. Nest the statement so the indent
+        // is non-zero and give only the statement the offset, leaving the
+        // expression inside it without one.
+        const int Offset = 7;
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var holder = TypeRef.CoreLib("Test", "Holder");
+        var allocation = new NewObject(
+            new MethodRef(objectType, ".ctor", TypeRef.CoreLib("System", "Void"), [], HasThis: true),
+            []);
+        var statement = new ExpressionStatement(allocation);
+        statement.SetSourceOffset(Offset);
+
+        // A second offset inside the same block widens the if's span past the
+        // statement's, so Best picks the statement rather than the if.
+        var second = new ExpressionStatement(new NewObject(
+            new MethodRef(objectType, ".ctor", TypeRef.CoreLib("System", "Void"), [], HasThis: true),
+            []));
+        second.SetSourceOffset(Offset + 2);
+
+        var inner = new Block(1);
+        inner.Add(statement);
+        inner.Add(second);
+        var outer = new Block(0);
+        outer.Add(new IfStatement(new Constant(true, TypeRef.CoreLib("System", "Boolean")), inner, null));
+        outer.Add(new Return(null));
+        var container = new BlockContainer();
+        container.Add(outer);
+        var function = new IrFunction(
+            "M", holder,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [], container);
+
+        CSharpPrinter.PrintRaised(function, out var ranges);
+        var annotation = new Annotation(
+            new AnnotationDescriptor("alloc.new", AnnotationCategory.Allocation, "allocation"),
+            Offset);
+
+        var extents = AnnotationAnchor.ComputeCaretExtents(
+            [annotation], AnnotationAnchor.ComputeSpans(function), ranges);
+        var extent = Assert.Contains(annotation, (IDictionary<IAnnotation, AnnotationAnchor.CaretExtent>)extents);
+
+        Assert.True(AnnotationAnchor.TryGetPrintedLine(statement, ranges, out int lineIndex));
+        string line = ranges.Output.Split('\n')[lineIndex].TrimEnd('\r');
+
+        // The line is indented, so an untrimmed extent would start at column 0.
+        Assert.NotEqual(0, line.Length - line.AsSpan().TrimStart().Length);
+        Assert.False(char.IsWhiteSpace(line[extent.Column]));
+        Assert.False(char.IsWhiteSpace(line[extent.Column + extent.Length - 1]));
+        Assert.Equal(line.Trim(), line.Substring(extent.Column, extent.Length));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -248,6 +248,54 @@ public class AnnotationAnchorTests
         Assert.DoesNotContain(annotation, (IDictionary<IAnnotation, AnnotationAnchor.CaretExtent>)extents);
     }
 
+    [Fact]
+    public void CaretExtent_IsWithheldWhenTheTrimRejectsTheRange()
+    {
+        // The caller must honour a rejected trim rather than storing the raw
+        // range. The C# printer never emits a node as whitespace alone, so the
+        // rejection branch is unreachable through it; a hand-built range map is
+        // the only way to hold the caller to the helper's contract.
+        const int Offset = 7;
+        const string Output = "a   b\n";
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var holder = TypeRef.CoreLib("Test", "Holder");
+        var allocation = new NewObject(
+            new MethodRef(objectType, ".ctor", TypeRef.CoreLib("System", "Void"), [], HasThis: true),
+            []);
+        allocation.SetSourceOffset(Offset);
+        var statement = new ExpressionStatement(allocation);
+        statement.SetSourceOffset(Offset);
+
+        var block = new Block(0);
+        block.Add(statement);
+        var container = new BlockContainer();
+        container.Add(block);
+        var function = new IrFunction(
+            "M", holder,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [], container);
+
+        var ranges = new PrintedRangeMap();
+        ranges.Record(statement, 0, 5);
+        // Narrower than the statement and carrying the same offset, so it wins
+        // "narrowest" -- but it covers only the three spaces between a and b.
+        ranges.Record(allocation, 1, 4);
+        ranges.Complete(Output);
+
+        Assert.True(ranges.TryGetLineColumn(allocation, out int line, out int column, out int length));
+        Assert.Equal(0, line);
+        Assert.Equal("   ", Output.Substring(column, length));
+
+        var annotation = new Annotation(
+            new AnnotationDescriptor("alloc.new", AnnotationCategory.Allocation, "allocation"),
+            Offset);
+
+        var extents = AnnotationAnchor.ComputeCaretExtents(
+            [annotation], AnnotationAnchor.ComputeSpans(function), ranges);
+
+        Assert.DoesNotContain(annotation, (IDictionary<IAnnotation, AnnotationAnchor.CaretExtent>)extents);
+    }
+
     [Theory]
     // Leading indent only — what a statement's own printed range looks like.
     [InlineData("    new object();", 0, 17, 4, 13)]
@@ -258,6 +306,10 @@ public class AnnotationAnchorTests
     [InlineData("    x   ", 0, 8, 4, 1)]
     // Already tight: trimming must not move an extent that names an expression.
     [InlineData("    new object();", 4, 12, 4, 12)]
+    // Non-space whitespace. The C# printer indents with spaces, so only a
+    // direct gate can hold the helper to char.IsWhiteSpace rather than ' '.
+    [InlineData("\tx\t", 0, 3, 1, 1)]
+    [InlineData("\u00a0x", 0, 2, 1, 1)]
     // Reaching exactly the last character, so a clamp that stopped one short
     // would silently drop it. 87,400 of the corpus's printed ranges end here.
     [InlineData("    new object();", 4, 13, 4, 13)]

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -251,12 +251,13 @@ public class AnnotationAnchorTests
     [Fact]
     public void CaretExtent_KeepsTheRealExpression_WhenTheStandInIsRecordedAfterIt()
     {
-        // The printer records a parent before its children, so the existing
-        // stand-in test only ever sees the stand-in AFTER the allocation has
-        // won. The opposite order -- a stand-in arriving once a real expression
-        // already holds the offset -- is a different branch of the rule, and
-        // deleting it changes 8 extents in CoreLib. A hand-built map is the only
-        // way to pin the order.
+        // The printer records children before their parents -- verified against
+        // the real printer, which emits LoadStackSlot, then NewObject, then
+        // Return -- so the existing stand-in test only ever sees the stand-in
+        // BEFORE the allocation. The opposite order, a stand-in arriving once a
+        // real expression already holds the offset, is a different branch of the
+        // rule, and deleting it changes 8 extents in CoreLib. A hand-built map
+        // is the only way to pin the order.
         const int Offset = 5;
         const string Output = "return new Holder(S_0);\n";
         var objectType = TypeRef.CoreLib("System", "Object");
@@ -303,8 +304,8 @@ public class AnnotationAnchorTests
     public void CaretExtent_KeepsTheFirstOfTwoEqualWidthCandidates()
     {
         // Width is the tie-break, so two real expressions of equal width sharing
-        // an offset must not swap places on a later pass: the printer records
-        // outermost first, and the descendant that follows is no more precise.
+        // an offset must not swap places on a later pass: the one recorded first
+        // stays, and the equally wide candidate that follows is no more precise.
         // Loosening the comparison to a strict one moves 96 extents in CoreLib.
         const int Offset = 5;
         const string Output = "Sink(aaa, bbb);\n";

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -196,6 +196,58 @@ public class AnnotationAnchorTests
         Assert.Equal(line.Trim(), line.Substring(extent.Column, extent.Length));
     }
 
+    [Fact]
+    public void CaretExtent_IsWithheldWhenTheNarrowNodePrintsOnAContinuationLine()
+    {
+        // A statement that wraps puts its narrow sub-expression on a later line
+        // than the one the fact is attached to, so narrowing there would draw
+        // the caret under a line the fact does not belong to. 279 facts in
+        // System.Private.CoreLib take this path; all keep the statement-wide
+        // caret. Only the if and the allocation carry the offset -- giving it to
+        // the inner statement too would make Best pick that, and the owner line
+        // would agree, which is the case this test must avoid.
+        const int Offset = 7;
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var holder = TypeRef.CoreLib("Test", "Holder");
+        var allocation = new NewObject(
+            new MethodRef(objectType, ".ctor", TypeRef.CoreLib("System", "Void"), [], HasThis: true),
+            []);
+        allocation.SetSourceOffset(Offset);
+
+        var inner = new Block(1);
+        inner.Add(new ExpressionStatement(allocation));
+        var conditional = new IfStatement(
+            new Constant(true, TypeRef.CoreLib("System", "Boolean")), inner, null);
+        conditional.SetSourceOffset(Offset);
+
+        var outer = new Block(0);
+        outer.Add(conditional);
+        outer.Add(new Return(null));
+        var container = new BlockContainer();
+        container.Add(outer);
+        var function = new IrFunction(
+            "M", holder,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [], container);
+
+        CSharpPrinter.PrintRaised(function, out var ranges);
+
+        // Non-vacuity: the allocation must really print on a different line from
+        // the statement the fact anchors to, or this gates nothing.
+        Assert.True(AnnotationAnchor.TryGetPrintedLine(conditional, ranges, out int ownerLine));
+        Assert.True(ranges.TryGetLineColumn(allocation, out int nodeLine, out _, out _));
+        Assert.NotEqual(ownerLine, nodeLine);
+
+        var annotation = new Annotation(
+            new AnnotationDescriptor("alloc.new", AnnotationCategory.Allocation, "allocation"),
+            Offset);
+
+        var extents = AnnotationAnchor.ComputeCaretExtents(
+            [annotation], AnnotationAnchor.ComputeSpans(function), ranges);
+
+        Assert.DoesNotContain(annotation, (IDictionary<IAnnotation, AnnotationAnchor.CaretExtent>)extents);
+    }
+
     [Theory]
     // Leading indent only — what a statement's own printed range looks like.
     [InlineData("    new object();", 0, 17, 4, 13)]

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -196,6 +196,36 @@ public class AnnotationAnchorTests
         Assert.Equal(line.Trim(), line.Substring(extent.Column, extent.Length));
     }
 
+    [Theory]
+    // Leading indent only — what a statement's own printed range looks like.
+    [InlineData("    new object();", 0, 17, 4, 13)]
+    // Trailing padding. No printer output produces this today, which is exactly
+    // why it needs a direct gate: the corpus cannot tell whether the trailing
+    // loop still works, so a regression there would be invisible.
+    [InlineData("    x   ", 4, 4, 4, 1)]
+    [InlineData("    x   ", 0, 8, 4, 1)]
+    // Already tight: trimming must not move an extent that names an expression.
+    [InlineData("    new object();", 4, 12, 4, 12)]
+    public void TryTrimToPrinted_ShrinksOntoPrintedCharactersAtBothEnds(
+        string lineText, int column, int length, int expectedColumn, int expectedLength)
+    {
+        Assert.True(AnnotationAnchor.TryTrimToPrinted(lineText, ref column, ref length));
+        Assert.Equal(expectedColumn, column);
+        Assert.Equal(expectedLength, length);
+    }
+
+    [Theory]
+    // All whitespace, and a degenerate range: there is nothing to point at, so
+    // the caller must fall back to the statement rather than draw a caret.
+    [InlineData("        ", 0, 8)]
+    [InlineData("    x", 0, 4)]
+    [InlineData("    x", 2, 0)]
+    [InlineData("    x", -1, 3)]
+    [InlineData("    x", 9, 3)]
+    public void TryTrimToPrinted_RefusesARangeWithNoPrintedCharacters(
+        string lineText, int column, int length)
+        => Assert.False(AnnotationAnchor.TryTrimToPrinted(lineText, ref column, ref length));
+
     [Fact]
     public void ResearchRegistry_RunsAllocationProducer()
     {

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -249,6 +249,105 @@ public class AnnotationAnchorTests
     }
 
     [Fact]
+    public void CaretExtent_KeepsTheRealExpression_WhenTheStandInIsRecordedAfterIt()
+    {
+        // The printer records a parent before its children, so the existing
+        // stand-in test only ever sees the stand-in AFTER the allocation has
+        // won. The opposite order -- a stand-in arriving once a real expression
+        // already holds the offset -- is a different branch of the rule, and
+        // deleting it changes 8 extents in CoreLib. A hand-built map is the only
+        // way to pin the order.
+        const int Offset = 5;
+        const string Output = "return new Holder(S_0);\n";
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var holder = TypeRef.CoreLib("Test", "Holder");
+
+        IrExpression slot = new LoadStackSlot(0, objectType);
+        slot.SetSourceOffset(Offset);
+        var allocation = new NewObject(
+            new MethodRef(holder, ".ctor", TypeRef.CoreLib("System", "Void"), [objectType], HasThis: true),
+            [slot]);
+        allocation.SetSourceOffset(Offset);
+        var statement = new Return(allocation);
+        statement.SetSourceOffset(Offset);
+
+        var block = new Block(0);
+        block.Add(statement);
+        var container = new BlockContainer();
+        container.Add(block);
+        var function = new IrFunction(
+            "M", holder,
+            new MethodSignature(holder, [], HasThis: false, GenericParameterCount: 0),
+            [], container);
+
+        var ranges = new PrintedRangeMap();
+        ranges.Record(statement, 0, 23);
+        // The allocation first, so it holds the offset; then the narrower
+        // stand-in, which must not displace it on width.
+        ranges.Record(allocation, 7, 22);
+        ranges.Record(slot, 18, 21);
+        ranges.Complete(Output);
+
+        var annotation = new Annotation(
+            new AnnotationDescriptor("alloc.new", AnnotationCategory.Allocation, "allocation"),
+            Offset);
+
+        var extents = AnnotationAnchor.ComputeCaretExtents(
+            [annotation], AnnotationAnchor.ComputeSpans(function), ranges);
+
+        var extent = Assert.Contains(annotation, (IDictionary<IAnnotation, AnnotationAnchor.CaretExtent>)extents);
+        Assert.Equal("new Holder(S_0)", Output.Substring(extent.Column, extent.Length));
+    }
+
+    [Fact]
+    public void CaretExtent_KeepsTheFirstOfTwoEqualWidthCandidates()
+    {
+        // Width is the tie-break, so two real expressions of equal width sharing
+        // an offset must not swap places on a later pass: the printer records
+        // outermost first, and the descendant that follows is no more precise.
+        // Loosening the comparison to a strict one moves 96 extents in CoreLib.
+        const int Offset = 5;
+        const string Output = "Sink(aaa, bbb);\n";
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var holder = TypeRef.CoreLib("Test", "Holder");
+
+        var first = new NewObject(
+            new MethodRef(objectType, ".ctor", TypeRef.CoreLib("System", "Void"), [], HasThis: true), []);
+        first.SetSourceOffset(Offset);
+        var second = new NewObject(
+            new MethodRef(objectType, ".ctor", TypeRef.CoreLib("System", "Void"), [], HasThis: true), []);
+        second.SetSourceOffset(Offset);
+        var statement = new ExpressionStatement(first);
+        statement.SetSourceOffset(Offset);
+
+        var block = new Block(0);
+        block.Add(statement);
+        var container = new BlockContainer();
+        container.Add(block);
+        var function = new IrFunction(
+            "M", holder,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [], container);
+
+        var ranges = new PrintedRangeMap();
+        ranges.Record(statement, 0, 15);
+        // Both three characters wide: "aaa" then "bbb".
+        ranges.Record(first, 5, 8);
+        ranges.Record(second, 10, 13);
+        ranges.Complete(Output);
+
+        var annotation = new Annotation(
+            new AnnotationDescriptor("alloc.new", AnnotationCategory.Allocation, "allocation"),
+            Offset);
+
+        var extents = AnnotationAnchor.ComputeCaretExtents(
+            [annotation], AnnotationAnchor.ComputeSpans(function), ranges);
+
+        var extent = Assert.Contains(annotation, (IDictionary<IAnnotation, AnnotationAnchor.CaretExtent>)extents);
+        Assert.Equal("aaa", Output.Substring(extent.Column, extent.Length));
+    }
+
+    [Fact]
     public void CaretExtent_IsWithheldWhenTheTrimRejectsTheRange()
     {
         // The caller must honour a rejected trim rather than storing the raw

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -206,6 +206,15 @@ public class AnnotationAnchorTests
     [InlineData("    x   ", 0, 8, 4, 1)]
     // Already tight: trimming must not move an extent that names an expression.
     [InlineData("    new object();", 4, 12, 4, 12)]
+    // Reaching exactly the last character, so a clamp that stopped one short
+    // would silently drop it. 87,400 of the corpus's printed ranges end here.
+    [InlineData("    new object();", 4, 13, 4, 13)]
+    // Overhanging the end of the line. ComputeCaretExtents cannot deliver this
+    // today -- TryGetLineColumn rejects every range that crosses a line break,
+    // 16,895 of them in the corpus, so 0 of 359,584 survivors overhang -- but
+    // the clamp is the reason an overhang is survivable at all, and an internal
+    // helper is not entitled to assume it keeps only its current caller.
+    [InlineData("    x", 4, 99, 4, 1)]
     public void TryTrimToPrinted_ShrinksOntoPrintedCharactersAtBothEnds(
         string lineText, int column, int length, int expectedColumn, int expectedLength)
     {

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -88,6 +88,54 @@ public class AnnotationAnchorTests
     }
 
     [Fact]
+    public void CaretExtent_PrefersTheAllocation_OverAStackSlotStandInSharingItsOffset()
+    {
+        // `return new Holder(S_0);` where the raise could not recover the
+        // argument, so it prints a stack-slot stand-in that carries the same
+        // instruction offset as the newobj it feeds. S_0 is the narrower node,
+        // so width alone would underline the argument instead of the allocation
+        // the fact reports. Measured over System.Private.CoreLib, that mistake
+        // affected 50 of 10,664 alloc.new underlines.
+        const int Offset = 5;
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var holder = TypeRef.CoreLib("Test", "Holder");
+        var slot = new LoadStackSlot(0, objectType);
+        slot.SetSourceOffset(Offset);
+        var allocation = new NewObject(
+            new MethodRef(holder, ".ctor", TypeRef.CoreLib("System", "Void"), [objectType], HasThis: true),
+            [slot]);
+        allocation.SetSourceOffset(Offset);
+        var statement = new Return(allocation);
+        statement.SetSourceOffset(Offset);
+
+        var block = new Block(0);
+        block.Add(statement);
+        var container = new BlockContainer();
+        container.Add(block);
+        var function = new IrFunction(
+            "M", holder,
+            new MethodSignature(holder, [], HasThis: false, GenericParameterCount: 0),
+            [], container);
+
+        CSharpPrinter.PrintRaised(function, out var ranges);
+        var annotation = new Annotation(
+            new AnnotationDescriptor("alloc.new", AnnotationCategory.Allocation, "allocation"),
+            Offset);
+
+        var extents = AnnotationAnchor.ComputeCaretExtents(
+            [annotation], AnnotationAnchor.ComputeSpans(function), ranges);
+
+        var extent = Assert.Contains(annotation, (IDictionary<IAnnotation, AnnotationAnchor.CaretExtent>)extents);
+        Assert.True(AnnotationAnchor.TryGetPrintedLine(statement, ranges, out int lineIndex));
+        string line = ranges.Output.Split('\n')[lineIndex].TrimEnd('\r');
+
+        // The stand-in is on the line and is the narrower node, so a width-only
+        // rule underlines it; this asserts the allocation wins instead.
+        Assert.Contains("S_0", line, StringComparison.Ordinal);
+        Assert.StartsWith("new ", line.Substring(extent.Column, extent.Length), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ResearchRegistry_RunsAllocationProducer()
     {
         var source = MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location);

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -97,7 +97,7 @@ public class AnnotationAnchorTests
         // offset as the newobj it feeds. The stand-in is the narrower node, so
         // width alone would underline the argument instead of the allocation the
         // fact reports. Measured over System.Private.CoreLib, that mistake
-        // affected 50 of 10,664 alloc.new underlines for the stack-slot form;
+        // affected 50 of 10,646 alloc.new underlines for the stack-slot form;
         // __exception has the same shape and is excluded for the same reason.
         const int Offset = 5;
         var objectType = TypeRef.CoreLib("System", "Object");

--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -153,6 +153,69 @@ public class AnnotationGestureTests
     }
 
     [Fact]
+    public void CaretWidensWhenTwoFactsOnTheLineDisagreeAboutTheExtent()
+    {
+        // The other half of the all-or-nothing rule: both facts narrow, but to
+        // different characters. Stacking two carets was rejected as a design, so
+        // the only correct answer is the statement -- the smallest span true of
+        // both. Distinct from the partial case below, which is a missing entry
+        // rather than a conflicting one, and gated by a different branch.
+        const string Line = "        Sink(new object(), new int[1]);";
+        var first = Fact(Alloc, "object");
+        var second = Fact(Unsafety, "array");
+
+        int firstColumn = Line.IndexOf("new object()", StringComparison.Ordinal);
+        int secondColumn = Line.IndexOf("new int[1]", StringComparison.Ordinal);
+        var extents = new Dictionary<IAnnotation, AnnotationAnchor.CaretExtent>
+        {
+            [first] = new AnnotationAnchor.CaretExtent(firstColumn, "new object()".Length),
+            [second] = new AnnotationAnchor.CaretExtent(secondColumn, "new int[1]".Length),
+        };
+
+        // Non-vacuity: each extent narrows on its own, and to a different place.
+        Assert.NotEqual(firstColumn, secondColumn);
+        Assert.Equal(firstColumn, AnnotationCaret.Render(Line, "    ", [first], extents: extents)[0].IndexOf('^'));
+        Assert.Equal(secondColumn, AnnotationCaret.Render(Line, "    ", [second], extents: extents)[0].IndexOf('^'));
+
+        string shared = AnnotationCaret.Render(Line, "    ", [first, second], extents: extents)[0];
+        int statementColumn = Line.Length - Line.TrimStart().Length;
+        Assert.Equal(statementColumn, shared.IndexOf('^'));
+        Assert.Equal(Line.Trim().Length, shared.Count(c => c == '^'));
+    }
+
+    [Fact]
+    public void CaretWidensWhenOnlySomeFactsOnTheLineHaveAnExtent()
+    {
+        // The agreement rule is all-or-nothing, and the case that matters is
+        // PARTIAL: one fact narrows, another has no printed node to point at.
+        // Narrowing there would underline an expression that is true of only
+        // some of the facts sharing the caret. 609 lines in CoreLib mix facts
+        // with and without extents, 498 of them with a single surviving extent,
+        // so this is the difference between right and wrong on real output.
+        const string Line = "        Sink(new object());";
+        var narrowed = Fact(Alloc, "has-extent");
+        var bare = Fact(Unsafety, "no-extent");
+
+        int column = Line.IndexOf("new", StringComparison.Ordinal);
+        var extents = new Dictionary<IAnnotation, AnnotationAnchor.CaretExtent>
+        {
+            [narrowed] = new AnnotationAnchor.CaretExtent(column, "new object()".Length),
+        };
+
+        // Non-vacuity: alone, this fact really does narrow.
+        string alone = AnnotationCaret.Render(Line, "    ", [narrowed], extents: extents)[0];
+        Assert.Equal(column, alone.IndexOf('^'));
+        Assert.Equal("new object()".Length, alone.Count(c => c == '^'));
+
+        // Together with a fact that has no extent, the caret must widen back to
+        // the whole statement rather than keep the one extent that survived.
+        string shared = AnnotationCaret.Render(Line, "    ", [narrowed, bare], extents: extents)[0];
+        int statementColumn = Line.Length - Line.TrimStart().Length;
+        Assert.Equal(statementColumn, shared.IndexOf('^'));
+        Assert.Equal(Line.Trim().Length, shared.Count(c => c == '^'));
+    }
+
+    [Fact]
     public void NothingIsRenderedForABlankLineOrNoFacts()
     {
         Assert.Empty(AnnotationCaret.Render("        Work();", "    ", []));

--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -189,8 +189,8 @@ public class AnnotationGestureTests
         // The agreement rule is all-or-nothing, and the case that matters is
         // PARTIAL: one fact narrows, another has no printed node to point at.
         // Narrowing there would underline an expression that is true of only
-        // some of the facts sharing the caret. 609 lines in CoreLib mix facts
-        // with and without extents, 498 of them with a single surviving extent,
+        // some of the facts sharing the caret. 615 lines in CoreLib mix facts
+        // with and without extents, 499 of them with a single surviving extent,
         // so this is the difference between right and wrong on real output.
         const string Line = "        Sink(new object());";
         var narrowed = Fact(Alloc, "has-extent");

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -211,17 +211,21 @@ public static class AnnotationAnchor
     /// queries it.
     /// </summary>
     /// <remarks>
-    /// A <see cref="LoadStackSlot"/> prints as <c>S_n</c>: a stand-in the raise
-    /// emits where it could not recover the value an instruction produced. It
-    /// carries that instruction's offset, so on a line like
+    /// A <see cref="LoadStackSlot"/> prints as <c>S_n</c> and a
+    /// <see cref="CaughtException"/> as <c>__exception</c>: stand-ins the raise
+    /// emits where it could not recover the value an instruction produced, or
+    /// where the value has no C# spelling. Each carries the offset of the
+    /// instruction that consumed it, so on a line like
     /// <c>return new ConstructorInvoker(S_0);</c> it is narrower than the
     /// <c>new</c> it sits inside and would win on width alone, underlining the
     /// argument instead of the allocation the fact is about. Width is therefore
-    /// only the tie-break among real expressions; a slot stand-in wins only when
+    /// only the tie-break among real expressions; a stand-in wins only when
     /// nothing else carries the offset, which is the case where it genuinely is
     /// the value on the line (<c>_ = S_0;</c>). Measured over
     /// <c>System.Private.CoreLib</c>, preferring real expressions moves 50 of
-    /// 10,664 <c>alloc.new</c> underlines onto the allocation.
+    /// 10,664 <c>alloc.new</c> underlines onto the allocation; no fact in that
+    /// corpus shares an offset with a printed <c>__exception</c>, which is
+    /// excluded because it is the same shape, not because it was observed.
     /// </remarks>
     static Dictionary<int, IrNode> NarrowestPrintedByOffset(PrintedRangeMap printedRanges)
     {
@@ -233,7 +237,7 @@ public static class AnnotationAnchor
             int offset = printed.Node.SourceOffset;
             if (offset < 0)
                 continue;
-            bool slot = printed.Node is LoadStackSlot;
+            bool slot = printed.Node is LoadStackSlot or CaughtException;
             if (widths.TryGetValue(offset, out int best))
             {
                 bool bestIsSlot = standIn.Contains(offset);

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -164,6 +164,9 @@ public static class AnnotationAnchor
                 continue;
             if (!TryGetPrintedLine(owner, printedRanges, out int ownerLine))
                 continue;
+            // A failure here zeroes the out parameters, so dropping this guard
+            // would not change a result -- length 0 is rejected by the trim
+            // either way. It stays because relying on that is a trap.
             if (!printedRanges.TryGetLineColumn(node, out int line, out int column, out int length))
                 continue;
             if (line != ownerLine || line >= lines.Length)

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -246,7 +246,7 @@ public static class AnnotationAnchor
     /// nothing else carries the offset, which is the case where it genuinely is
     /// the value on the line (<c>_ = S_0;</c>). Measured over
     /// <c>System.Private.CoreLib</c>, preferring real expressions moves 50 of
-    /// 10,664 <c>alloc.new</c> underlines onto the allocation; no fact in that
+    /// 10,646 <c>alloc.new</c> underlines onto the allocation; no fact in that
     /// corpus shares an offset with a printed <c>__exception</c>, which is
     /// excluded because it is the same shape, not because it was observed.
     /// </remarks>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -97,6 +97,163 @@ public static class AnnotationAnchor
     }
 
     /// <summary>
+    /// The characters a caret should underline for one fact: a
+    /// <paramref name="Column"/> and <paramref name="Length"/> into the printed
+    /// line the fact is anchored to.
+    /// </summary>
+    /// <remarks>
+    /// This is deliberately in <em>line-relative text</em> coordinates rather
+    /// than node identity, so a consumer holding only the rendered line can
+    /// place the underline. It narrows the caret <em>within</em> the line the
+    /// fact already anchors to; it never moves a fact to another line.
+    /// </remarks>
+    public readonly record struct CaretExtent(int Column, int Length);
+
+    /// <summary>
+    /// The narrowest printed extent for each annotation that has one — the
+    /// printed node carrying exactly the fact's own IL offset, which is what the
+    /// fact is about, rather than the whole statement containing it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Anchoring answers <em>which line</em>; this answers <em>which characters
+    /// on it</em>. The two are separate because they fail separately: a fact
+    /// whose exact offset was erased by the raise still anchors to a covering
+    /// statement, but has no sub-token to point at, so it is simply absent here
+    /// and the caller keeps the statement-wide underline. Measured over
+    /// <c>System.Private.CoreLib</c>, 34,008 of 37,800 facts (89.97%) get an
+    /// extent.
+    /// </para>
+    /// <para>
+    /// Several printed nodes can carry one offset — the importer stamps a whole
+    /// subtree from a single instruction — so the narrowest printed range wins,
+    /// that being the one that names the fact most precisely.
+    /// </para>
+    /// <para>
+    /// An extent is produced only when the narrow node prints on the same line
+    /// as the statement the fact anchors to. Where a statement wraps and the
+    /// sub-expression prints on a continuation line (270 facts in the same
+    /// corpus), narrowing would put the underline under a line the fact is not
+    /// attached to; those keep the statement-wide caret until the caret block
+    /// can be emitted against the narrow node's own line.
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyDictionary<IAnnotation, CaretExtent> ComputeCaretExtents(
+        IReadOnlyList<IAnnotation> annotations,
+        List<StatementSpan> statements,
+        PrintedRangeMap printedRanges)
+    {
+        var extents = new Dictionary<IAnnotation, CaretExtent>();
+        if (annotations.Count == 0 || printedRanges.Count == 0)
+            return extents;
+
+        var narrowest = NarrowestPrintedByOffset(printedRanges);
+        if (narrowest.Count == 0)
+            return extents;
+
+        // Indexed by the same coordinates TryGetLineColumn reports, so a column
+        // from there indexes straight into these lines. Split on '\n' alone: a
+        // '\r' left at a line's end is whitespace and is trimmed below.
+        var lines = printedRanges.Output.Split('\n');
+
+        foreach (var annotation in annotations)
+        {
+            if (!narrowest.TryGetValue(annotation.SourceOffset, out var node))
+                continue;
+            if (Best(statements, annotation.SourceOffset) is not { } owner)
+                continue;
+            if (!TryGetPrintedLine(owner, printedRanges, out int ownerLine))
+                continue;
+            if (!printedRanges.TryGetLineColumn(node, out int line, out int column, out int length))
+                continue;
+            if (line != ownerLine || line >= lines.Length)
+                continue;
+            if (!TryTrimToPrinted(lines[line], ref column, ref length))
+                continue;
+            extents[annotation] = new CaretExtent(column, length);
+        }
+        return extents;
+    }
+
+    /// <summary>
+    /// Shrinks an extent onto the printed characters it covers, dropping
+    /// whitespace at either end.
+    /// </summary>
+    /// <remarks>
+    /// A statement's printed range begins at its line's indent, so when the
+    /// narrowest node carrying an offset is the statement itself the raw extent
+    /// covers the leading whitespace and a caret drawn from it would start left
+    /// of the code. Measured over <c>System.Private.CoreLib</c> that is 161 of
+    /// 25,682 narrowed lines. Trimming makes such an extent coincide with the
+    /// statement-wide default rather than mis-drawing, and leaves every extent
+    /// that already named an expression untouched.
+    /// </remarks>
+    static bool TryTrimToPrinted(string lineText, ref int column, ref int length)
+    {
+        if (column < 0 || length <= 0 || column >= lineText.Length)
+            return false;
+        int end = Math.Min(column + length, lineText.Length);
+        int start = column;
+        while (start < end && char.IsWhiteSpace(lineText[start]))
+            start++;
+        while (end > start && char.IsWhiteSpace(lineText[end - 1]))
+            end--;
+        if (end <= start)
+            return false;
+        column = start;
+        length = end - start;
+        return true;
+    }
+
+    /// <summary>
+    /// The narrowest printed node carrying each source offset. Built once per
+    /// function, because it is a scan of the whole range map and every fact
+    /// queries it.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="LoadStackSlot"/> prints as <c>S_n</c>: a stand-in the raise
+    /// emits where it could not recover the value an instruction produced. It
+    /// carries that instruction's offset, so on a line like
+    /// <c>return new ConstructorInvoker(S_0);</c> it is narrower than the
+    /// <c>new</c> it sits inside and would win on width alone, underlining the
+    /// argument instead of the allocation the fact is about. Width is therefore
+    /// only the tie-break among real expressions; a slot stand-in wins only when
+    /// nothing else carries the offset, which is the case where it genuinely is
+    /// the value on the line (<c>_ = S_0;</c>). Measured over
+    /// <c>System.Private.CoreLib</c>, preferring real expressions moves 50 of
+    /// 10,664 <c>alloc.new</c> underlines onto the allocation.
+    /// </remarks>
+    static Dictionary<int, IrNode> NarrowestPrintedByOffset(PrintedRangeMap printedRanges)
+    {
+        var narrowest = new Dictionary<int, IrNode>();
+        var widths = new Dictionary<int, int>();
+        var standIn = new HashSet<int>();
+        foreach (var printed in printedRanges)
+        {
+            int offset = printed.Node.SourceOffset;
+            if (offset < 0)
+                continue;
+            bool slot = printed.Node is LoadStackSlot;
+            if (widths.TryGetValue(offset, out int best))
+            {
+                bool bestIsSlot = standIn.Contains(offset);
+                if (slot && !bestIsSlot)
+                    continue;
+                int width = printed.Characters.End.Value - printed.Characters.Start.Value;
+                if (slot == bestIsSlot && best <= width)
+                    continue;
+            }
+            widths[offset] = printed.Characters.End.Value - printed.Characters.Start.Value;
+            narrowest[offset] = printed.Node;
+            if (slot)
+                standIn.Add(offset);
+            else
+                standIn.Remove(offset);
+        }
+        return narrowest;
+    }
+
+    /// <summary>
     /// Finds the printed line for an anchored statement, climbing to the nearest
     /// printed ancestor when the owner belongs to an inline expression body (for
     /// example, a raised lambda). Facts stay visible instead of being dropped.

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -121,7 +121,7 @@ public static class AnnotationAnchor
     /// whose exact offset was erased by the raise still anchors to a covering
     /// statement, but has no sub-token to point at, so it is simply absent here
     /// and the caller keeps the statement-wide underline. Measured over
-    /// <c>System.Private.CoreLib</c>, 34,008 of 37,800 facts (89.97%) get an
+    /// <c>System.Private.CoreLib</c>, 33,729 of 37,800 facts (89.23%) get an
     /// extent.
     /// </para>
     /// <para>
@@ -132,7 +132,7 @@ public static class AnnotationAnchor
     /// <para>
     /// An extent is produced only when the narrow node prints on the same line
     /// as the statement the fact anchors to. Where a statement wraps and the
-    /// sub-expression prints on a continuation line (270 facts in the same
+    /// sub-expression prints on a continuation line (279 facts in the same
     /// corpus), narrowing would put the underline under a line the fact is not
     /// attached to; those keep the statement-wide caret until the caret block
     /// can be emitted against the narrow node's own line.
@@ -183,16 +183,18 @@ public static class AnnotationAnchor
     /// A statement's printed range begins at its line's indent, so when the
     /// narrowest node carrying an offset is the statement itself the raw extent
     /// covers the leading whitespace and a caret drawn from it would start left
-    /// of the code. Measured over <c>System.Private.CoreLib</c> that is 161 of
-    /// 25,682 narrowed lines. Trimming makes such an extent coincide with the
-    /// statement-wide default rather than mis-drawing, and leaves every extent
-    /// that already named an expression untouched.
+    /// of the code. Measured over <c>System.Private.CoreLib</c>, the trim moves
+    /// 205 of the 33,729 extents and rejects none of them. Trimming makes such
+    /// an extent coincide with the statement-wide default rather than
+    /// mis-drawing, and leaves every extent that already named an expression
+    /// untouched.
     /// <para>
     /// The clamp on the far end is defensive rather than load-bearing today:
-    /// <see cref="PrintedRangeMap.TryGetLineColumn"/> refuses a range that
-    /// crosses a line break (16,895 in the same corpus), so none of the 359,584
-    /// that reach here overhang the line. It is kept, and gated, because this is
-    /// an internal helper taking a caller-supplied range: the cost is one
+    /// <see cref="PrintedRangeMap.TryGetLineColumn"/> refuses any range that
+    /// crosses a line break, so of the 33,729 ranges the caller delivers here,
+    /// 0 overhang the line and 652 end exactly on its last character. It is
+    /// kept, and gated, because this is an internal helper taking a
+    /// caller-supplied range: the cost is one
     /// <see cref="Math.Min(int, int)"/> and the alternative is an out-of-range
     /// read the first time a second caller passes a range this one would not.
     /// </para>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -121,8 +121,13 @@ public static class AnnotationAnchor
     /// whose exact offset was erased by the raise still anchors to a covering
     /// statement, but has no sub-token to point at, so it is simply absent here
     /// and the caller keeps the statement-wide underline. Measured over
-    /// <c>System.Private.CoreLib</c>, 33,729 of 37,800 facts (89.23%) get an
-    /// extent.
+    /// <c>System.Private.CoreLib</c> as the annotated-source view prints it —
+    /// that is, with callee bodies imported — 33,657 of 37,800 facts (89.04%)
+    /// get an extent. Every figure quoted in this file is from that render.
+    /// The C#-only overlay prints the same members without importing callee
+    /// bodies, which shifts a few printed ranges and yields 33,729; a figure
+    /// here is only meaningful against a stated render, because the printed
+    /// text is what extents are measured in.
     /// </para>
     /// <para>
     /// Several printed nodes can carry one offset — the importer stamps a whole
@@ -132,7 +137,7 @@ public static class AnnotationAnchor
     /// <para>
     /// An extent is produced only when the narrow node prints on the same line
     /// as the statement the fact anchors to. Where a statement wraps and the
-    /// sub-expression prints on a continuation line (279 facts in the same
+    /// sub-expression prints on a continuation line (283 facts in the same
     /// corpus), narrowing would put the underline under a line the fact is not
     /// attached to; those keep the statement-wide caret until the caret block
     /// can be emitted against the narrow node's own line.
@@ -186,16 +191,17 @@ public static class AnnotationAnchor
     /// A statement's printed range begins at its line's indent, so when the
     /// narrowest node carrying an offset is the statement itself the raw extent
     /// covers the leading whitespace and a caret drawn from it would start left
-    /// of the code. Measured over <c>System.Private.CoreLib</c>, the trim moves
-    /// 205 of the 33,729 extents and rejects none of them. Trimming makes such
+    /// of the code. Measured over <c>System.Private.CoreLib</c> as the
+    /// annotated-source view prints it, the trim moves 205 of the 33,657
+    /// extents and rejects none of them. Trimming makes such
     /// an extent coincide with the statement-wide default rather than
     /// mis-drawing, and leaves every extent that already named an expression
     /// untouched.
     /// <para>
     /// The clamp on the far end is defensive rather than load-bearing today:
     /// <see cref="PrintedRangeMap.TryGetLineColumn"/> refuses any range that
-    /// crosses a line break, so of the 33,729 ranges the caller delivers here,
-    /// 0 overhang the line and 652 end exactly on its last character. It is
+    /// crosses a line break, so of the 33,657 ranges the caller delivers here,
+    /// 0 overhang the line and 650 end exactly on its last character. It is
     /// kept, and gated, because this is an internal helper taking a
     /// caller-supplied range: the cost is one
     /// <see cref="Math.Min(int, int)"/> and the alternative is an out-of-range

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -187,9 +187,21 @@ public static class AnnotationAnchor
     /// 25,682 narrowed lines. Trimming makes such an extent coincide with the
     /// statement-wide default rather than mis-drawing, and leaves every extent
     /// that already named an expression untouched.
+    /// <para>
+    /// The clamp on the far end is defensive rather than load-bearing today:
+    /// <see cref="PrintedRangeMap.TryGetLineColumn"/> refuses a range that
+    /// crosses a line break (16,895 in the same corpus), so none of the 359,584
+    /// that reach here overhang the line. It is kept, and gated, because this is
+    /// an internal helper taking a caller-supplied range: the cost is one
+    /// <see cref="Math.Min(int, int)"/> and the alternative is an out-of-range
+    /// read the first time a second caller passes a range this one would not.
+    /// </para>
     /// </remarks>
     internal static bool TryTrimToPrinted(string lineText, ref int column, ref int length)
     {
+        // length <= 0 is redundant with the end <= start rejection below, and is
+        // kept because this is a documented precondition of an internal helper,
+        // not an accident of the loop bounds.
         if (column < 0 || length <= 0 || column >= lineText.Length)
             return false;
         int end = Math.Min(column + length, lineText.Length);

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -188,7 +188,7 @@ public static class AnnotationAnchor
     /// statement-wide default rather than mis-drawing, and leaves every extent
     /// that already named an expression untouched.
     /// </remarks>
-    static bool TryTrimToPrinted(string lineText, ref int column, ref int length)
+    internal static bool TryTrimToPrinted(string lineText, ref int column, ref int length)
     {
         if (column < 0 || length <= 0 || column >= lineText.Length)
             return false;

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -195,13 +195,14 @@ public static class AnnotationCaret
     /// <para>
     /// So narrowing is all-or-nothing per line, and the fallback is not a
     /// failure: the statement is exactly the smallest span that is true of every
-    /// fact on it. Measured over that corpus, 25,682 of 31,641 caret-bearing
-    /// lines (81.17%) narrow, 10.71% carry facts that disagree, and 8.12% have
-    /// no fact with a printed node to point at.
+    /// fact on it. Measured over that corpus as the annotated-source view
+    /// prints it, 25,628 of 31,640 caret-bearing lines (81.00%) narrow, 10.70%
+    /// carry facts that disagree, and 8.30% have no fact with a printed node to
+    /// point at.
     /// </para>
     /// <para>
     /// That headline is carried by the common case, and it is worth being plain
-    /// about the shape: 27,413 of those lines hold a single fact and 92.4% of
+    /// about the shape: 27,414 of those lines hold a single fact and 92.1% of
     /// them narrow, while narrowing falls to 12.1% at two facts, 1.1% at three,
     /// and 0% at four or more. Density and disagreement are the same thing —
     /// more facts on a line means more distinct offsets on it — so the dense

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -13,12 +13,15 @@ namespace ILInspector.Decompiler.Annotations;
 /// declaration</em> column, not to the annotated statement's own indent. Every
 /// injected comment in a member therefore shares one column, so the eye tracks a
 /// single gutter instead of a ragged staircase that follows nesting depth.</item>
-/// <item><b>Underline the whole statement.</b> An <see cref="IAnnotation"/> is
-/// keyed to an IL offset and carries no character span (see the contract in
-/// Annotations.cs), so there is no sub-token to point at. The underline covers
-/// the trimmed statement — exactly what the fact is known to be about, and no
-/// more. A span-carrying datum (a compiler diagnostic) can underline a narrower
-/// range; that is a property of the datum, not of this gesture.</item>
+/// <item><b>Underline what the fact is about.</b> An <see cref="IAnnotation"/>
+/// is keyed to an IL offset and carries no character span (see the contract in
+/// Annotations.cs), so the span has to be recovered from the printed tree: the
+/// narrowest printed node carrying that exact offset, supplied by
+/// <see cref="AnnotationAnchor.ComputeCaretExtents"/>. Where the raise erased
+/// the offset there is no sub-token to point at and the underline covers the
+/// trimmed statement instead — exactly what the fact is still known to be
+/// about, and no more. A span-carrying datum (a compiler diagnostic) brings its
+/// own range; that is a property of the datum, not of this gesture.</item>
 /// </list>
 /// </remarks>
 public static class AnnotationCaret
@@ -91,11 +94,18 @@ public static class AnnotationCaret
     /// and is laid out as if it will be rendered <see cref="BodyIndentWidth"/>
     /// columns left of the code lines. See the marker's remarks for why.
     /// </param>
+    /// <param name="extents">
+    /// Per-fact underline extents from
+    /// <see cref="AnnotationAnchor.ComputeCaretExtents"/>. The line narrows only
+    /// when every fact on it points at the same characters; see
+    /// <see cref="Agreed"/> for why disagreement widens rather than stacks.
+    /// </param>
     public static IReadOnlyList<string> Render(
         string lineText,
         string memberIndent,
         IReadOnlyList<IAnnotation> annotations,
-        bool hoist = false)
+        bool hoist = false,
+        IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null)
     {
         if (annotations.Count == 0)
             return [];
@@ -104,7 +114,9 @@ public static class AnnotationCaret
         if (trimmed.Length == 0)
             return [];
 
-        int caretStart = lineText.Length - lineText.AsSpan().TrimStart().Length;
+        int statementColumn = lineText.Length - lineText.AsSpan().TrimStart().Length;
+        var extent = Agreed(annotations, extents, lineText.Length)
+            ?? new AnnotationAnchor.CaretExtent(statementColumn, trimmed.Length);
 
         // "//" occupies two columns of the gutter, so the pad that carries the
         // caret out to the statement is measured from the end of that marker.
@@ -119,16 +131,11 @@ public static class AnnotationCaret
         // un-hoisted line is indented alongside the code, so the shift is zero
         // and the relative geometry is unchanged.
         int commentColumn = memberIndent.Length;
-        int caretColumn = caretStart + hoisted;
+        int caretColumn = extent.Column + hoisted;
 
-        // "//" occupies two columns of the gutter, so the pad that carries the
-        // caret out to the statement is measured from the end of that marker.
-        // Hoisting buys BodyIndentWidth columns of headroom, which is enough at
-        // every depth; without it a statement sitting on the gutter has none, so
-        // clamp — a caller can also render a fragment with no member line above.
         int pad = Math.Max(1, caretColumn - commentColumn - 2);
         string gutter = (hoist ? HoistMarker + memberIndent : memberIndent) + "//";
-        int caretEnd = commentColumn + 2 + pad + trimmed.Length;
+        int caretEnd = commentColumn + 2 + pad + extent.Length;
 
         // Prefer trailing the detail on the caret line. When the underline is so
         // long that doing so leaves no usable width, drop the detail to its own
@@ -141,7 +148,7 @@ public static class AnnotationCaret
         var caretLine = new StringBuilder()
             .Append(gutter)
             .Append(' ', pad)
-            .Append('^', trimmed.Length);
+            .Append('^', extent.Length);
 
         // Each fact starts on its own line so a multi-fact statement stays
         // readable; only the first can share the caret line.
@@ -169,6 +176,63 @@ public static class AnnotationCaret
         if (first)
             lines.Add(caretLine.ToString());
         return lines;
+    }
+
+    /// <summary>
+    /// The one extent every fact on the line points at, or null when they do not
+    /// agree and the whole statement is the honest underline.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A line is underlined once. Giving each distinct extent its own
+    /// <c>^^^^</c> row was tried and rejected on the evidence: of 5,848 extent
+    /// pairs sharing a line, 3,191 nest or overlap, so the rows would
+    /// re-underline the same characters at different widths and the reader would
+    /// have to count columns to tell which row named which fact. The worst line
+    /// in <c>System.Private.CoreLib</c> carries nine distinct extents, which
+    /// would bury one line of code under nine of carets.
+    /// </para>
+    /// <para>
+    /// So narrowing is all-or-nothing per line, and the fallback is not a
+    /// failure: the statement is exactly the smallest span that is true of every
+    /// fact on it. Measured over that corpus, 25,682 of 31,641 caret-bearing
+    /// lines (81.17%) narrow, 10.71% carry facts that disagree, and 8.12% have
+    /// no fact with a printed node to point at.
+    /// </para>
+    /// <para>
+    /// That headline is carried by the common case, and it is worth being plain
+    /// about the shape: 27,413 of those lines hold a single fact and 92.4% of
+    /// them narrow, while narrowing falls to 12.1% at two facts, 1.1% at three,
+    /// and 0% at four or more. Density and disagreement are the same thing —
+    /// more facts on a line means more distinct offsets on it — so the dense
+    /// lines are precisely the ones no single expression is true of.
+    /// </para>
+    /// </remarks>
+    static AnnotationAnchor.CaretExtent? Agreed(
+        IReadOnlyList<IAnnotation> annotations,
+        IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents,
+        int lineLength)
+    {
+        if (extents is null || extents.Count == 0)
+            return null;
+
+        AnnotationAnchor.CaretExtent? agreed = null;
+        foreach (var annotation in annotations)
+        {
+            if (!extents.TryGetValue(annotation, out var extent))
+                return null;
+            if (agreed is { } seen && seen != extent)
+                return null;
+            agreed = extent;
+        }
+
+        // An extent is measured against the printer's own output, so it can only
+        // disagree with the line handed here if a consumer re-wrapped the text.
+        // Widen to the statement rather than throw inside a display path.
+        return agreed is { } final && final.Column >= 0 && final.Length > 0
+            && final.Column + final.Length <= lineLength
+            ? final
+            : null;
     }
 
     /// <summary>Leading whitespace of the first non-blank line — the member declaration gutter.</summary>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -185,12 +185,12 @@ public static class AnnotationCaret
     /// <remarks>
     /// <para>
     /// A line is underlined once. Giving each distinct extent its own
-    /// <c>^^^^</c> row was tried and rejected on the evidence: of 5,848 extent
-    /// pairs sharing a line, 3,191 nest or overlap, so the rows would
+    /// <c>^^^^</c> row was tried and rejected on the evidence: of 5,816 extent
+    /// pairs sharing a line, 3,325 nest or overlap, so the rows would
     /// re-underline the same characters at different widths and the reader would
     /// have to count columns to tell which row named which fact. The worst line
-    /// in <c>System.Private.CoreLib</c> carries nine distinct extents, which
-    /// would bury one line of code under nine of carets.
+    /// in <c>System.Private.CoreLib</c> carries eight distinct extents, which
+    /// would bury one line of code under eight of carets.
     /// </para>
     /// <para>
     /// So narrowing is all-or-nothing per line, and the fallback is not a

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -291,7 +291,9 @@ public static partial class ResearchViews
                 : IlProjection.RenderIlBodyLines(source, methodToken.Value);
 
         var stream = CorrelateMixedSource(imported, csText, printedRanges, annotations, annotatedInstrLines);
-        return csResult with { Output = RenderMixedStream(stream, gestures ?? AnnotationGestureSelector.SideOnly) };
+        var extents = AnnotationAnchor.ComputeCaretExtents(
+            annotations, AnnotationAnchor.ComputeSpans(imported), printedRanges);
+        return csResult with { Output = RenderMixedStream(stream, gestures ?? AnnotationGestureSelector.SideOnly, extents) };
     }
 
     // The correlation layer: fold the printed C# body, its statement-line map, the
@@ -409,7 +411,10 @@ public static partial class ResearchViews
     // structured annotations into a trailing "// ..." comment; IL lines are framed
     // as "// ..." comments indented under the preceding C# line, reading the indent
     // straight from that line's leading whitespace.
-    static string RenderMixedStream(IReadOnlyList<AnnotatedSourceLine> stream, AnnotationGestureSelector gestures)
+    static string RenderMixedStream(
+        IReadOnlyList<AnnotatedSourceLine> stream,
+        AnnotationGestureSelector gestures,
+        IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null)
     {
         var sb = new StringBuilder();
         string csIndent = "";
@@ -429,7 +434,7 @@ public static partial class ResearchViews
             if (side.Count > 0)
                 text = $"{text}  // {string.Join("; ", side.Select(a => AnnotationText.Format(a)))}";
             sb.AppendLf(text);
-            foreach (string caretLine in AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true))
+            foreach (string caretLine in AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true, extents))
                 sb.AppendLf(caretLine);
         }
         return sb.ToString().TrimEnd();
@@ -491,7 +496,9 @@ public static partial class ResearchViews
         AnnotationGestureSelector gestures)
     {
         var stream = CorrelateOverlay(raised, output, printedRanges, annotations);
-        return RenderOverlayStream(output, stream, gestures);
+        var extents = AnnotationAnchor.ComputeCaretExtents(
+            annotations, AnnotationAnchor.ComputeSpans(raised), printedRanges);
+        return RenderOverlayStream(output, stream, gestures, extents);
     }
 
     // The C#-only correlation: anchor each annotation group to its printed C# line
@@ -547,7 +554,8 @@ public static partial class ResearchViews
     static string RenderOverlayStream(
         string output,
         IReadOnlyList<AnnotatedSourceLine> stream,
-        AnnotationGestureSelector gestures)
+        AnnotationGestureSelector gestures,
+        IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null)
     {
         bool any = false;
         foreach (var line in stream)
@@ -567,7 +575,7 @@ public static partial class ResearchViews
             lines.Add(side.Count > 0
                 ? $"{line.Text.TrimEnd()}  // {AnnotationText.Format(side)}"
                 : line.Text);
-            lines.AddRange(AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true));
+            lines.AddRange(AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true, extents));
         }
         return string.Join("\n", lines);
     }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -6096,15 +6096,43 @@ public partial class CommandExecutionTests
         Assert.DoesNotContain(ILInspector.Decompiler.Annotations.AnnotationCaret.HoistMarker, output);
 
         var lines = output.ReplaceLineEndings("\n").Split('\n');
+        int narrowed = 0;
+        int examined = 0;
         foreach (int i in Enumerable.Range(0, lines.Length)
             .Where(i => lines[i].Contains("^^^^", StringComparison.Ordinal)))
         {
             string statement = lines[i - 1];
             Assert.StartsWith("//", lines[i], StringComparison.Ordinal);
-            Assert.Equal(
-                statement.Length - statement.AsSpan().TrimStart().Length,
-                lines[i].IndexOf('^'));
+
+            int caretStart = lines[i].IndexOf('^');
+            int caretLength = lines[i].AsSpan(caretStart).IndexOfAnyExcept('^');
+            caretLength = caretLength < 0 ? lines[i].Length - caretStart : caretLength;
+            examined++;
+
+            // The underline is contained in the statement it points at. This is
+            // the whole placement contract: an expression-narrowed caret and a
+            // statement-wide fallback both satisfy it, and a caret drawn left of
+            // the code or running off its end does not.
+            int statementStart = statement.Length - statement.AsSpan().TrimStart().Length;
+            int statementEnd = statement.AsSpan().TrimEnd().Length;
+            Assert.InRange(caretStart, statementStart, statementEnd);
+            Assert.InRange(caretStart + caretLength, caretStart + 1, statementEnd);
+
+            // ...and it lands on printed characters, not on the whitespace
+            // between them. Trimming the extent is what makes this hold.
+            Assert.False(char.IsWhiteSpace(statement[caretStart]));
+            Assert.False(char.IsWhiteSpace(statement[caretStart + caretLength - 1]));
+
+            if (caretLength < statementEnd - statementStart)
+                narrowed++;
         }
+
+        // Non-vacuity. Every assertion above is also satisfied by a caret that
+        // spans the whole statement, which is what this view rendered before
+        // extents existed, so the gate has to insist that narrowing actually
+        // happened on every one of these cases.
+        Assert.True(examined > 0, "no caret lines were examined");
+        Assert.Equal(examined, narrowed);
     }
 
     [Fact]
@@ -6141,6 +6169,8 @@ public partial class CommandExecutionTests
             caretIndexes.Select(i => lines[i].IndexOf('^')).Distinct().Count() >= 2,
             "the two carets must sit at different columns");
 
+        var underlined = new List<string>();
+
         foreach (int i in caretIndexes)
         {
             string line = lines[i];
@@ -6149,16 +6179,65 @@ public partial class CommandExecutionTests
             // comments, and it sits on the member declaration column.
             Assert.StartsWith("//", line, StringComparison.Ordinal);
 
-            // Carets point at the statement on the preceding line, exactly.
+            // The caret names the expression the fact is about, not the
+            // statement containing it. Pinning the underlined text rather than a
+            // width is what makes this a placement gate: `new()` and
+            // `new object()` are the allocations the alloc.new facts report, and
+            // both sit mid-statement, so an off-by-anything reads as other text.
             string statement = lines[i - 1];
-            Assert.Equal(
-                statement.Length - statement.AsSpan().TrimStart().Length,
-                line.IndexOf('^'));
-            Assert.Equal(statement.Trim().Length, line.Count(c => c == '^'));
+            int caretStart = line.IndexOf('^');
+            int caretLength = line.AsSpan(caretStart).IndexOfAnyExcept('^');
+            caretLength = caretLength < 0 ? line.Length - caretStart : caretLength;
+            Assert.InRange(caretStart + caretLength, 0, statement.Length);
+            underlined.Add(statement.Substring(caretStart, caretLength));
         }
+
+        // Pump allocates a List<object> at the body's base column and an object
+        // inside the loop; each is strictly inside its statement.
+        Assert.Equal(["new object()", "new()"], underlined.Order().ToArray());
 
         // The hoist marker is an internal layout signal; it must never survive
         // into rendered output, where it would print as a control character.
+        Assert.DoesNotContain(ILInspector.Decompiler.Annotations.AnnotationCaret.HoistMarker, output);
+    }
+
+    [Fact]
+    public async Task Member_AnnotatedSource_FocusWidensToTheStatementWhenFactsOnALineDisagree()
+    {
+        // The density case, reproduced from System.Tuple`8.Equals: several facts
+        // land on one line at distinct offsets, so no single expression is true
+        // of all of them. The line is underlined once, statement-wide, and every
+        // fact gets its own detail row beneath.
+        var (exit, output, _) = await RunAppAsync(
+            "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "DenseBoxes:1", "--index", "1", "-S", "Annotated Source", "--focus", "allocation", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        var lines = output.ReplaceLineEndings("\n").Split('\n');
+        var caretIndexes = Enumerable.Range(0, lines.Length)
+            .Where(i => lines[i].Contains("^^^^", StringComparison.Ordinal))
+            .ToList();
+
+        // One underline for the line, not one per fact. Stacking a row per
+        // distinct extent was tried and rejected; see AnnotationCaret.Agreed.
+        int i = Assert.Single(caretIndexes);
+
+        string statement = lines[i - 1];
+        int statementStart = statement.Length - statement.AsSpan().TrimStart().Length;
+        int caretStart = lines[i].IndexOf('^');
+        int caretLength = lines[i].AsSpan(caretStart).IndexOfAnyExcept('^');
+        caretLength = caretLength < 0 ? lines[i].Length - caretStart : caretLength;
+
+        // The statement is the smallest span that is true of all four facts, so
+        // widening to it is the correct answer here rather than a failure.
+        Assert.Equal(statementStart, caretStart);
+        Assert.Equal(statement.Trim().Length, caretLength);
+
+        // Each fact keeps its own detail rows under the shared underline: four
+        // boxes, four reports, none of them merged away.
+        foreach (string parameter in (string[])["T1", "T2", "T3", "T4"])
+            Assert.Contains($"alloc.box({parameter};", output, StringComparison.Ordinal);
+
         Assert.DoesNotContain(ILInspector.Decompiler.Annotations.AnnotationCaret.HoistMarker, output);
     }
 
@@ -14004,6 +14083,15 @@ public sealed class CommandCaretGestureFixture
     }
 
     public string Make() => new object().ToString() ?? "";
+
+    // Four boxes on one line, at four distinct IL offsets: the shape that makes
+    // a line's facts disagree about what to underline. System.Tuple`8.Equals is
+    // the extreme of it in the wild, with 16 facts on one line.
+    public static bool DenseBoxes<T1, T2, T3, T4>(
+        EqualityComparer<object> comparer, T1 a1, T2 a2, T3 a3, T4 a4,
+        object b1, object b2, object b3, object b4)
+        => comparer.Equals(a1, b1) && comparer.Equals(a2, b2)
+            && comparer.Equals(a3, b3) && comparer.Equals(a4, b4);
 }
 
 public sealed class CommandInitializerOnlyFixture


### PR DESCRIPTION
Slice 1b of #3570. #3574 fixed *which statement* a fact anchors to; this fixes *what the caret underlines*.

## Before / after

`--focus allocation` on a fixture that allocates at two depths:

**Before** — the caret spans the whole statement, so it says "something on this line allocates":

```csharp
    List<object> sink = new();
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ alloc.new(List<object>; ...)
        sink.Add(new object());
//      ^^^^^^^^^^^^^^^^^^^^^^^ alloc.new(object; alloc=System.Object; path=loop-body; ...)
```

**After** — it names the allocation:

```csharp
    List<object> sink = new();
//                      ^^^^^ alloc.new(List<object>; ...)
        sink.Add(new object());
//               ^^^^^^^^^^^^ alloc.new(object; alloc=System.Object; path=loop-body; ...)
```

## The density case

The interesting demonstration is the opposite one. `System.Tuple`8.Equals` carries **16 facts on a single line** — each `comparer.Equals(m_ItemN, V_0.m_ItemN)` boxes *both* operands, so 8 items x 2. Reproduced in-repo as `CommandCaretGestureFixture.DenseBoxes` and pinned by a test:

```csharp
    return comparer.Equals(a1, b1) && comparer.Equals(a2, b2) && comparer.Equals(a3, b3) && comparer.Equals(a4, b4);
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//   alloc.box(T1; alloc=boxed T1; path=straight-line; path-confidence=dominates-return;
//   post-dominance=return-post-dominates; multiplicity=once)
//   alloc.box(T2; alloc=boxed T2; path=branch; path-confidence=behind-branch;
//   post-dominance=return-post-dominates; multiplicity=conditional)
//   alloc.box(T3; ...)
//   alloc.box(T4; ...)
```

One underline, four facts, each with its own detail rows. The four boxes are at four distinct offsets, so no single expression is true of all of them and the statement is the honest answer — it is exactly the smallest span true of every fact on the line.

## What it does

`AnnotationAnchor.ComputeCaretExtents` recovers a character span for each fact from the printed tree: the printed node carrying that offset exactly. `AnnotationCaret` uses it when every fact on the line agrees, and falls back to the statement otherwise.

## Measured — `System.Private.CoreLib` 11.0.0-preview.7.26366.102

37,866 facts across 41,952 imported methods — 40,917 of which print a body and 18,538 of which carry at least one fact — measured **as the annotated-source view prints them** — that is, with callee bodies imported, which is the render `--focus` produces.

| | |
|---|---|
| facts with an exact-offset printed node | 33,943 of 37,800 |
| ...that survive to a delivered extent | **33,657 (89.04%)** — 283 lost to a continuation line, 3 not line-positionable |
| ...none of which span a line break | 0 of 33,657 |
| caret-bearing lines that narrow | 25,628 / 31,640 (**81.00%**) |
| lines whose facts disagree | 3,385 (10.70%) |
| lines with no fact carrying a printed node | 2,627 (8.30%) |
| narrowed extents strictly inside their statement | 25,172 (98.22%) |
| invariant violations (outside statement, or underlining whitespace) | **0** |

The render matters, and round 6 is where that was established. The C#-only overlay prints the same members *without* importing callee bodies; a few printed ranges shift, and the same probe returns **33,729** there. Both are production paths and each computes extents against its own printed body, so neither is wrong — but a figure is only meaningful against a stated render, because extents are measured in printed characters. Every number in this PR and in the shipped XML is now the annotated-source figure, and says so.

Be plain about the shape of that headline: it is carried by the common case.

| facts on line | lines | narrowed |
|---|---|---|
| 1 | 27,414 | 92.1% |
| 2 | 2,987 | 12.1% |
| 3 | 852 | 1.1% |
| 4-5 | 340 | 0% |
| 6-9 | 42 | 0% |
| 10+ | 5 | 0% |

Density and disagreement are the same phenomenon — more facts on a line means more distinct offsets on it. And the width win is modest: 1,320,017 underlined characters against 1,626,528 statement characters, 81.2%. The value here is the **correct start column**, not a dramatic narrowing.

## Two rules, both forced by the corpus rather than chosen

**Narrowing is all-or-nothing per line.** A row per distinct extent was built first, then rejected: of 5,816 extent pairs sharing a line, **3,325 nest or overlap**, so the rows would re-underline the same characters at different widths and the reader would have to count columns to tell which row named which fact. The worst line in CoreLib carries eight distinct extents. The rejection and its evidence are recorded in `AnnotationCaret.Agreed` so it is not re-litigated.

**Width is only the tie-break among real expressions.** A `LoadStackSlot` prints as `S_n` — a stand-in the raise emits where it could not recover a value — and it carries the *producing* instruction's offset. It is narrower than the `new` it sits inside, so a width-only rule underlines the argument:

```
return new ConstructorInvoker(S_0);
//                            ^^^ alloc.new(ConstructorInvoker; ...)
```

Preferring real expressions moves 50 of 10,646 `alloc.new` underlines onto the allocation: **99.52% -> 99.99%** of them now begin with `new` (51 wrong of 10,659 with the rule disabled, 1 wrong of 10,646 with it on). The single remaining case is a printer `/* Unsupported IL ... */` comment that *is* the whole statement, so it is not a mis-selection.

Two further guards, both found by corpus sweeps rather than by reading:

- An extent is produced only when the narrow node prints on the **owner statement's line** (283 facts otherwise). Narrowing across lines would underline a line the fact is not attached to.
- Extents are **trimmed onto printed characters**. A statement that is its own narrowest node has a printed range starting at the line's indent, which drew carets left of the code on 205 extents. Sweep now reports 0 extents starting or ending on whitespace.

## Tests: rewritten to the new contract, not relaxed

Six existing caret tests asserted `caret column == statement indent` and `caret count == statement length` — they pinned the old contract exactly. Loosening them would have forfeited the gate, so they assert stronger properties instead:

- the underline is **contained** in the statement it points at;
- it **starts and ends on non-whitespace**;
- **non-vacuity**: every examined caret is *strictly narrower* than its statement.

Plus new tests: `Member_AnnotatedSource_FocusWidensToTheStatementWhenFactsOnALineDisagree` (the density case above, pinning the fallback branch), `CaretExtent_PrefersTheAllocation_OverAStandInSharingItsOffset` (a `[Theory]` over both stand-in kinds, on a synthetic `return new Holder(S_0);`), `CaretExtent_TrimsAStatementWideExtentOffTheLineIndent`, and two direct `[Theory]` gates on `TryTrimToPrinted` itself — 6 shrink cases and 5 rejection cases. **`AnnotationAnchorTests` is now 13 test methods / 25 executed cases, all green.**

`Member_AnnotatedSource_FocusPromotesFactsToAlignedCaretComments` now pins the underlined **text** — `new()` and `new object()` — rather than a width, which is what makes it a placement gate.

### Mutation-verified

Every gate below was mutated, rebuilt, and re-run. **No mutation broke the build** — which is the whole point: each of these would have shipped silently.

| mutation | result |
|---|---|
| `Render(..., extents)` -> `Render(..., null)` | **6 of 7 fail**; the density test correctly still passes, because it gates the fallback branch |
| `printed.Node is LoadStackSlot or CaughtException` -> `false` | stand-in `[Theory]` **fails both cases** |
| drop `CaughtException` from that pattern | the `__exception` case **fails** |
| delete the **leading** whitespace loop | **3 fail**, incl. `CaretExtent_TrimsAStatementWideExtentOffTheLineIndent` |
| delete the **trailing** whitespace loop | **exactly the 2 trailing-padding cases fail** |
| delete the `Math.Min` clamp | **exactly the overhang case fails** |
| clamp to `lineText.Length - 1` | **4 fail**, incl. both exact-end cases |
| delete the `line != ownerLine` filter | `CaretExtent_IsWithheldWhenTheNarrowNodePrintsOnAContinuationLine` **fails** |
| `char.IsWhiteSpace` -> `== ' '` | **exactly the tab and NBSP cases fail** |
| ignore `TryTrimToPrinted`'s return value | `CaretExtent_IsWithheldWhenTheTrimRejectsTheRange` **fails** |
| ignore `TryGetLineColumn`'s failure | **no test fails — equivalent mutant**, corpus output byte-identical |
| drop the **late stand-in** ordering guard | `CaretExtent_KeepsTheRealExpression_WhenTheStandInIsRecordedAfterIt` **fails** (8 corpus extents move) |
| `best <= width` -> `best < width` (equal-width tie) | `CaretExtent_KeepsTheFirstOfTwoEqualWidthCandidates` **fails** (96 corpus extents move) |
| `Agreed`, **missing** entry: `return null` -> `continue` | `CaretWidensWhenOnlySomeFactsOnTheLineHaveAnExtent` **fails** (annotated render: **499 of 615** mixed lines would narrow wrongly; overlay: 498 of 609) |
| `Agreed`, **disagreeing** entries: `seen != extent` -> `false` | `CaretWidensWhenTwoFactsOnTheLineDisagreeAboutTheExtent` **fails** |
| `caretColumn = extent.Column + hoisted` -> `hoisted` | **6 fail** — already gated before round 5; reported as a gap, did not reproduce |

All restored and rebuilt afterwards.

## Suites

| suite | result |
|---|---|
| `ILInspector.Decompiler.Tests` | 4,692 / **0 failed** |
| `ILInspector.Research.Tests` | 132 / **0 failed** |
| `dotnet-inspect.Tests` | 2,766 / **1 failed**, 14 skipped |

The one failure is `Layout_Count_CountsFilesRatherThanRenderedTreeLines`, **pre-existing**: verified failing on clean `main` (`7a14f1ff2`) in a separate worktree. Unrelated to this change.

Two further tests in that suite — `RouterVersionTests.Version_WithLatestTag_SkipsCacheAndQueriesVersionApi` and `PackageVersionTests.LatestVersion_AlwaysQueriesNuGet` — **query nuget.org live** and fail in an environment without network access. They pass here (two runs, `Failed: 1` both times) and neither file is touched by this PR, so the suite result is `1 failed` **with network** and `3 failed` without.

## Not fixed here

Caret width is unclamped. A user types one `--focus` at a time, so the figure is stated per focus, on the annotated-source render with `hoist: true` as `AnnotationCaret.Render` is actually called:

| `--focus` | caret rows | over 100 cols | worst |
|---|---:|---:|---:|
| `Semantics` | 13,908 | 2,350 (16.90%) | 27,676 |
| `Allocation` | 14,789 | 1,131 (7.65%) | 1,247 |
| `Cost` | 2,516 | 340 (13.51%) | 331 |
| `Lifetime` | 928 | 121 (13.04%) | **57,945** |
| `Unsafety` | 723 | 31 (4.29%) | 163 |

The worst case in the corpus is reachable with `--focus Lifetime`. Promoting *every* fact at once would give 3,739 of 31,640 rows (11.82%), but no single command produces that render, so it is recorded here only as the union bound and is not the user-facing number. It predates this change — the same worst case appears with extents disabled — and clamping is a layout decision with its own question (a truncated underline must signal that it was truncated). Filed as #3610.

Refs #3570.


## Review

Nine adversarial rounds, two models (Gemini 3.1 Pro, GPT-5.6 Sol), each in an isolated worktree pinned to the exact head. Every finding below was found by a reviewer, not by me — and every one was **a gate that passed for the wrong reason, or a number with the wrong denominator**, never a logic error in the shipped behaviour.

| round | finding | resolution |
|---|---|---|
| 1 | `TryTrimToPrinted` could be **deleted entirely** with no test failure. The non-whitespace assertion was true for the wrong reason: every CLI fixture narrows to a `new` expression, which has no leading whitespace either way. | added `CaretExtent_TrimsAStatementWideExtentOffTheLineIndent` |
| 1 | `CaughtException` (prints `__exception`) is a **second stand-in** of the same shape as `LoadStackSlot` | excluded, and generalized the test to a `[Theory]` over both |
| 2 | the **trailing** trim loop was still ungated — the round-1 fixture line ends on `;` | made the helper `internal`, added direct `[Theory]` gates for both edges |
| 3 | the `Math.Min` **clamp** was ungated | measured, then gated — see below |
| 4 | my clamp measurement counted **the wrong population**: every printed range, not the ranges the caller delivers | re-measured through the real internals; **three stale figures corrected in shipped XML** |
| 4 | the `line != ownerLine` **continuation-line filter** was ungated — 279 facts depend on it (237 later lines, 42 earlier) | added `CaretExtent_IsWithheldWhenTheNarrowNodePrintsOnAContinuationLine` |
| 4 | `char.IsWhiteSpace` could be narrowed to a literal `' '` with no test failure | added tab and no-break-space cases |
| 4 | the caller could **ignore a rejected trim** and store the raw range | added `CaretExtent_IsWithheldWhenTheTrimRejectsTheRange`, on a hand-built range map |
| 5 | `NarrowestPrintedByOffset` dropped a stand-in recorded **after** the real expression only because of the ordering guard | added `CaretExtent_KeepsTheRealExpression_WhenTheStandInIsRecordedAfterIt` |
| 5 | the **equal-width tie-break** was ungated — flipping it changed 96 corpus extents silently | added `CaretExtent_KeepsTheFirstOfTwoEqualWidthCandidates` |
| 5 | `Agreed` has **two** ungated branches — a fact with no extent, and two facts with conflicting extents. GPT found the first, Gemini the second; **neither found both** | added one test per branch |
| 5 | hoist marker `U+0011` leaks from hostile metadata | **pre-existing** — identical leak measured on clean `main`; filed as #3637 |
| 6 | the corpus figures were measured on the **C#-only overlay**, not the render `--focus` produces | every headline figure restated against the annotated-source render, and the render now named wherever a figure appears |
| 7 | round 6 restated the *headline* figures but left the **secondary** ones on the overlay path | methods 135,228 -> **41,952**; `alloc.new` denominator 10,664 -> **10,646**; extent pairs 5,848 -> **5,816**; continuation 270 -> **283** |
| 7 | the headline table **conflated two populations** — facts that *have* a printed node with facts that *survive* to a delivered extent | split into two rows (33,943 have a node, 33,657 survive) |
| 8 | the round-7 sweep fixed the PR body and `AnnotationAnchor.cs` but missed the same stale numbers in **`AnnotationCaret.cs` and test comments** | swept every remaining site |
| 8 | `3,169 nest or overlap` was not merely stale, it was **wrong for the claim it makes** | re-measured to **3,325 of 5,816** |
| 9 | four figures in the PR body were stale: over-budget carets, both suite totals, and the mutation table's mixed-line population | all four re-measured and corrected here |
| 9 | the over-budget figure was measured with **`hoist: false`** — a geometry the product never renders | re-measured under the shipped `hoist: true` call: 3,128 (9.89%) -> **3,739 (11.82%)** |

The two reviewers **disagreed** on that last one: Gemini called it a should-fix that prevents an out-of-range read for multi-line nodes; GPT called it unreachable, because `TryGetLineColumn` guarantees a line-bounded range. Rather than pick a side I measured — and **got the measurement wrong**, which Gemini then caught in round 4. See below.

Corrected: of the **33,657** ranges `ComputeCaretExtents` actually delivers to `TryTrimToPrinted` on the annotated-source path, **0 overhang** their line and **650** end exactly on its last character. (Round 4 published 33,729/652 for this, which is the overlay path; round 6 restated it against the render `--focus` actually produces.) GPT is right on reachability and Gemini's stated rationale does not hold — `TryGetLineColumn` rejects every line-crossing range, so multi-line nodes never arrive. The gate went in anyway, because the helper is now `internal` specifically so it can be tested apart from its caller, and it should not borrow that caller's bounds. The remarks say plainly that the clamp is defensive and never exercised in the corpus, so it is not mistaken later for a measured win.

Same honesty applies to `CaughtException`: **0 facts** in CoreLib share an offset with a printed `__exception`. It is excluded because it is the same shape, not because it was observed, and the XML says so.

Round 5 also produced the sharpest reviewer disagreement of the series. Gemini called the published corpus figures wrong (30,264 rather than 33,729) — but that contradicts **its own round-4 number**, and GPT reproduced 33,729 independently in rounds 4 and 5. The authoritative probe calls the production `ComputeCaretExtents` and sums `extents.Count`, replicating nothing, so a missing filter cannot be missing from it; the gap matches the ancestor-climb trap that produced my own wrong figure in round 4. Gemini also reported the caret-column arithmetic as ungated; applying that exact mutation at the head it reviewed fails four pre-existing tests. Both are answered with evidence in the [round-5 reconciliation](https://github.com/richlander/dotnet-inspect/pull/3617#issuecomment-5144766551) rather than conceded.

Reviewers approved at each fixed head after their findings were addressed.


## Correction: three published figures were stale

Gemini's round-4 review found that my clamp measurement counted every printed range `TryGetLineColumn` accepts across the whole tree, not the ranges `ComputeCaretExtents` actually hands to `TryTrimToPrinted`. Most printed nodes carry no fact and never reach the helper.

Re-measured by invoking the real private members through **reflection** rather than replicating them — my first hand-written replica silently missed the ancestor climb in `TryGetPrintedLine` and under-counted by 1,519, which is precisely the drift that produced the bad figure. Gemini's independent count of 33,729 is confirmed.

Three figures in the **shipped XML** had gone stale when the stand-in rule changed which node is narrowest, and are now corrected:

| claim | was | is |
|---|---|---|
| facts getting an extent | 34,008 (89.97%) | **33,729 (89.23%)** (overlay; the annotated figure is 33,657) |
| facts on a continuation line | 270 | 279 (overlay) / **283** (annotated) |
| trim effect | "161 of 25,682 narrowed lines" | **205 extents moved, 0 rejected** (both renders) |
| clamp population | "none of the 359,584" | **0 of 33,729 overhang; 652 end exactly at the line end** |

The conclusion is unchanged — 0 overhangs, so the clamp is defensive — but the numbers supporting it were wrong, and shipped documentation asserting a wrong number is a defect whether or not the conclusion survives.


Round 4 is also the round where the two reviewers **independently converged**: both arrived at 33,729 by different routes, and both flagged `line != ownerLine`. GPT additionally settled the CRLF question by construction — `TryGetLineColumn` strips terminal CR/LF while `Split('\n')` retains the CR, so a line is always one character *longer*, never shorter, and no overhang or off-by-one is possible.

One reported mutant was **not** a finding: ignoring `TryGetLineColumn`'s failure is *equivalent*, because that method zeroes its out parameters on every false return, so the resulting length of 0 is rejected downstream regardless. Verified by measurement — corpus output is byte-identical under the mutation — rather than by argument. The guard stays; a comment now records the equivalence so a fifth round does not re-derive it.


