### PR TITLE
Add InertText: make untrusted text inert at the type level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+  # The base-branch filter also decides whether a *stacked* PR gets CI at all.
+  # A PR retargeted from `main` onto a long-lived feature branch silently stops
+  # matching `[main]`, so it reports no checks rather than failing ones -- and
+  # once `ci-required` is a required check, "no checks reported" is
+  # indistinguishable at a glance from "not run yet". `feature/**` keeps the
+  # lower half of a stack covered while its base is still in review.
   pull_request:
-    branches: [main]
+    branches: [main, 'feature/**']
 
 env:
   DOTNET_NOLOGO: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,12 @@ jobs:
       - name: Run NuGetFetch tests (offline)
         run: dotnet run --project src/NuGetFetch.Tests -c Release -- -trait- "Network=Live"
 
+      # InertText sits below every other project, so a regression here reaches every assembly
+      # that prints artifact-derived text. The gates are pure and fast — a full BMP sweep and a
+      # round-trip — so they run unconditionally rather than behind a path filter.
+      - name: Run InertText tests
+        run: dotnet run --project src/InertText.Tests -c Release
+
       # Fast decompiler unit tests: pass logic, printer, importer facts, identity,
       # and classification regressions. Slow compile-back/recompile, corpus-sweep,
       # and fidelity tests are tagged [Trait("Speed", "Slow")] and excluded here;

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -1,0 +1,186 @@
+# InertText
+
+A shared component for making untrusted text inert before it reaches a sink that
+can act on it.
+
+## The problem
+
+Text that comes out of an artifact — a package id, a type name, a file path, an
+assembly reference — is attacker-controlled. Printing it hands that control to
+whatever renders it. The attacks do not need malformed input; every payload in
+this component's test corpus is well-formed Unicode that a naive sink prints
+without complaint:
+
+- **Reordering.** `Cf` scalars drive the bidi algorithm. Trojan Source
+  (CVE-2021-42574) uses them to make source render differently from how it
+  compiles, and a right-to-left override in a name reorders the rest of the line.
+  `invoice\u202Egpj.exe` renders as `invoice.jpg`.
+- **Terminal control.** `Cc` scalars introduce escape sequences that clear the
+  screen, rewrite the window title, or make text a hyperlink to somewhere else.
+- **Line forgery.** A line terminator inside a value produces a second log line
+  that looks like the tool emitted it. `CR` alone rewinds so the truth is
+  overwritten. `NEL`, `LS` and `PS` are terminators that a `CR`/`LF` check misses.
+- **Invisibility.** Zero-width scalars, soft hyphens and word joiners split a
+  name for the eye while leaving it one token to a comparison. Tag characters
+  carry an invisible ASCII payload, which is how instructions get hidden in text
+  an agent will read.
+
+Percent-encoding, `Uri` normalization and HTML escaping each stop some of this
+and none of it. `Uri` percent-encodes `Cc` and passes `Cf` straight through.
+
+## What it does
+
+Refused scalars are rewritten in a visible spelling. The term and the contract
+come from BSD `vis(3)`: the output is **inert**, **lossless** and **invertible**.
+
+```text
+invoice\u202Egpj.exe   ->   invoice\u202Egpj.exe    (the override, spelled out)
+package<LF>Error: x    ->   package\^JError: x
+```
+
+This is not neutralization, which has none of the three properties. Dropping the
+hostile scalars would also produce safe output, but it destroys the evidence —
+and the reader is usually trying to work out what the artifact actually says.
+
+## The predicate and the speller are separate
+
+This is the central design split, and it is what lets one speller serve every
+sink:
+
+- The **predicate** (`ScalarPolicy`) answers "is this scalar permitted *here*". It
+  is per-sink and it is the caller's to choose. `TextPolicy.Field` is deny-shaped
+  and refuses `Cc`, `Cf`, `Cs`, `Zl` and `Zp`. `TextPolicy.Prose` is the same
+  minus a `CR`/`LF`/`TAB` exemption, for genuinely multi-line text.
+- The **speller** (`VisualEncoder`) answers "how is a refused scalar written
+  down". It is total over Unicode, and it never learns *why* a scalar was
+  refused.
+
+A speller with a built-in hazard set has absorbed policy and cannot serve a sink
+whose grammar is constrained. That case is not hypothetical: the central
+typosquatting vector is a homoglyph, and Cyrillic `а` and Latin `a` are the same
+glyph, both category `Ll`. No category rule catches that and none should —
+refusing every non-Latin letter would break most of the world's text. Only an
+allow-shaped policy catches it, and because the speller is total, such a sink
+needs no spelling table of its own.
+
+The speller's obligations:
+
+- **Total.** Defined on every Unicode scalar, including the 127 encoded scalars
+  above the BMP. A `\uXXXX`-only speller is neither total nor invertible on
+  exactly the inputs an attacker reaches for.
+- **Injective, in both directions.** One scalar has one spelling, so the decoder
+  refuses spellings the encoder never emits: `\U` for a BMP scalar, and `\uXXXX`
+  for a scalar with a canonical short form such as `\\`, `\^X` or `\^?`.
+- **Scalar-based, not code-unit-based.** An unpaired surrogate is not a scalar.
+  `Rune` cannot hold one and `EnumerateRunes` substitutes `U+FFFD`, so a speller
+  built on either is lossy on the one input that cannot be written any other way.
+- **Able to report what it emitted**, so a caller can print a legend without
+  keeping a second copy of the spelling table.
+- **Not responsible for structural escaping.** A `|` still breaks a Markdown
+  cell and a `"` still ends a JSON string. Neither is in an encoded category, and
+  neither should be — escaping for a grammar is the serializer's job. Visual
+  encoding and structural escaping compose; neither substitutes for the other.
+
+## Treated text is carried as a type
+
+Encoding on its own is transactional: a `string` goes in and a `string` comes
+out, so a treated value and an untreated one have the same type. Nothing stops a
+later edit from interpolating the untreated one, and nothing marks the difference
+at the sink. Auditing that means tracing every path that reaches a printer, again
+after every change.
+
+`InertString` is the currency form. It can only be built by applying a policy —
+there is no conversion *from* `string`, and a test asserts that no public entry
+point takes text without also taking a policy. A sink that accepts only this type
+cannot be handed raw text by accident, which answers **what a sink accepts** with
+a type search rather than a call-graph trace.
+
+Conversion *to* `string` is unrestricted, which is safe here in a way it usually
+is not. The customary objection to a wrapper is that `ToString` launders it, but
+that assumes the payload is dangerous and the wrapper is what holds it back. Here
+the payload is already inert. Losing the wrapper loses provenance, not
+protection.
+
+## Holding a value is not the same as being able to reverse it
+
+A type answers what a *sink* accepts. It does not answer what a *file* can do,
+and with the decoder as a member of the value type it cannot: every file holding
+a value would be one member access away from the original, so a search for the
+type name finds mentions rather than capabilities.
+
+So the decoder lives in its own namespace:
+
+| Namespace | Contains | A file that imports it can |
+| --- | --- | --- |
+| `InertText` | `InertString`, `ScalarPolicy`, `TextPolicy`, `VisualForm` | build, compose, compare and print inert text |
+| `InertText.Encoder` | `VisualEncoder` | additionally recover the original text |
+
+Text enters through `InertString`'s constructor and leaves through `ToString`
+already spelled, so the currency namespace is sufficient for every ordinary use.
+A file that imports `InertText` and not `InertText.Encoder` has no path back to
+the original of any value it handles — and that is legible in its import list.
+
+A reflection test enumerates every public member of the `InertText` namespace
+that returns text and accounts for each one: `ToString` (the encoded form),
+`DescribeLegend` (fixed strings naming spellings) and `ScalarViolation.ToString`
+(an index, a code point and a category — which is why a violation reports an
+`int` rather than the character, so a survey can name what it refused without
+echoing it). Adding a decode convenience to the currency type fails that test.
+
+**This is an audit boundary, not a capability barrier.** A file can add the
+import or write the name out in full, and nothing should stop it — decoding is a
+legitimate operation with legitimate callers. What the boundary buys is that the
+reversing half cannot arrive unnoticed.
+
+## Composition
+
+Composition has to work, or callers fall back to `$"...{treated}..."` and drop
+the guarantee at the moment it matters most. `InertString.Format` is an
+interpolated string handler that encodes each part as it is appended — holes
+because they are untrusted, and literals too, because an invariant with an
+exception in it has to be re-argued at every use.
+
+An already-inert hole is not encoded twice, but neither is it trusted. The type
+records that *a* policy was applied, not *which* one, and a value built for one
+sink is routinely spliced into a message bound for another. `Prose` permits the
+line feed that `Field` exists to remove, so splicing a `Prose` value into a
+`Field` message unexamined would put a raw newline into a single-line record and
+report no encoded forms for it — log injection, with the type appearing to vouch
+for it.
+
+Splices are therefore re-checked against the policy in force and re-spelled where
+they do not satisfy it, in `Format` and `Join` alike. That repair is the second
+thing invertibility buys, and it is worth noticing that the requirement is
+unsatisfiable without a decoder: a mismatched part can only be repaired if the
+original can be recovered exactly.
+
+The repair only ever **tightens**. A value encoded under a stricter policy keeps
+its spellings when spliced into a laxer sink, because composition making a value
+*less* inert would let a caller launder one by quoting it somewhere permissive.
+The cost is that the splice path is observable — the same source text can render
+differently depending on where it was encoded — which is a deliberate trade.
+
+## Testing
+
+Two shapes, because they fail differently.
+
+**Property tests** sweep every scalar for invertibility and injectivity. They
+prove the transform is total, and a regression reports that some scalar broke.
+
+**A corpus of named attacks** records what the properties are *for*. A regression
+there reports that Trojan Source works again, which is a sentence someone can
+act on. Each fixture records what it attacks, and six claims are asserted over
+every one of them, so adding a fixture is a single line that is immediately
+subject to all of them.
+
+The corpus also carries a payload nothing catches — the Cyrillic homoglyph — with
+both halves asserted: the category policy permits it, an allow-shaped policy
+refuses it. A corpus containing only what the default catches would quietly imply
+the default is sufficient.
+
+## Placement
+
+`InertText` sits below every other project and references nothing. Every assembly
+that prints artifact-derived text needs it, including the dependency-free leaves,
+so it has to sit below all of them. A reference added to it is a reference added
+to everything.

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -279,6 +279,36 @@ its spellings when spliced into a laxer sink, because composition making a value
 The cost is that the splice path is observable — the same source text can render
 differently depending on where it was encoded — which is a deliberate trade.
 
+### Asking whether a value suits your sink
+
+That repair is exposed as `EnsurePermitted(ScalarPolicy)`, because a sink that
+accepts an `InertString` has no other correct way to make one safe for itself.
+The obvious substitute is wrong: `new InertString(value.ToString(), policy)`
+hands already-encoded text back to the encoder, so the backslashes double on
+every pass — `a\u202Eb` becomes `a\\u202Eb`, then `a\\\\u202Eb`. Because
+`EnsurePermitted` decodes before re-spelling, repeating it is a no-op.
+
+What a sink must **not** use for this is `WasEncoded` or `Forms`. Those report
+what was *done* to a value, never what it *satisfies*, and as a conformance
+check they are wrong in both directions:
+
+| Value | `WasEncoded` | Satisfies `Field` |
+| ----- | ------------ | ----------------- |
+| `Prose`-encoded `"line1\nline2"` | `false` | **no** — it carries a raw line feed |
+| `Field`-encoded `"a\u202Eb"` | `true` | yes, and `Prose` too |
+
+Encoding makes a value *more* conformant, so the flag is close to
+anti-correlated with the property a sink cares about. The underlying reason is
+that conformance is a relation between a value and a policy rather than a
+property of the value, which is why it cannot be cached on one and why
+`EnsurePermitted` has to recompute it.
+
+Storing the producing policy on the value would not help either. Knowing which
+delegate produced a value says nothing about whether it is stricter than the
+delegate you are about to apply, short of sweeping every scalar to compare their
+permitted sets — so the value would carry an extra field and still pay for the
+scan.
+
 ## Testing
 
 Two shapes, because they fail differently.

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -252,22 +252,32 @@ So the decoder lives in its own namespace:
 Text enters through `InertString`'s constructor and leaves through `ToString`
 already spelled, so the currency namespace is sufficient for every ordinary use.
 
-**The audit is one search, and the string is `InertText.Encoder`.** Not
-`using InertText.Encoder` — a using directive is only one of the two ways to
-reach a namespace, and the other one leaves the import block untouched:
+**The audit is one search, and the string is `InertText.Encoder`.** Reaching the
+decoder means naming its namespace, and that act *is* the opt-in. Decoding is a
+legitimate operation with legitimate callers, so the design does not try to
+prevent it — only to make it impossible to do quietly.
+
+A namespace can be named in two places, and both are equally legitimate:
 
 ```csharp
-using InertText;                    // the only directive in the file
+using InertText.Encoder;            // named in the import block
+VisualEncoder.TryDecode(inert.ToString(), out string? original);
+```
 
+```csharp
+// no using directive of any kind in this file
 InertText.Encoder.VisualEncoder.TryDecode(inert.ToString(), out string? original);
 ```
 
-That compiles and recovers the original. A reviewer who greps for the directive
-sees a clean import list and concludes the file cannot decode, which is the
-opposite of the truth. Grepping the bare namespace catches both forms, because a
-fully-qualified call has to spell the namespace too.
+Neither is evasion. The second names the namespace at the call site rather than
+at the top of the file, in plain sight on the line that uses it. What matters is
+that the *audit* covers both, which is why the search is for the bare namespace
+and not for `using InertText.Encoder`: a fully-qualified call declares itself on
+its own line and needs no directive at all, so a reviewer grepping only the
+import block would read that file as clean and conclude it cannot decode.
 
-There is a third way, and it spells the namespace in a different file:
+There is a third way, and unlike those two it does not name the namespace in the
+file that decodes at all:
 
 ```csharp
 // one file, or a <Using Include="InertText.Encoder" /> item in the .csproj

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -247,12 +247,12 @@ So the decoder lives in its own namespace:
 | Namespace | Contains | A file naming it can |
 | --- | --- | --- |
 | `InertText` | `InertString`, `TextPolicy`, `VisualForm` | build, compose, compare and print inert text |
-| `InertText.Encoder` | `VisualEncoder` | additionally recover the original text |
+| `InertText.Encoding` | `VisualEncoder` | additionally recover the original text |
 
 Text enters through `InertString`'s constructor and leaves through `ToString`
 already spelled, so the currency namespace is sufficient for every ordinary use.
 
-**The audit is one search, and the string is `InertText.Encoder`.** Reaching the
+**The audit is one search, and the string is `InertText.Encoding`.** Reaching the
 decoder means naming its namespace, and that act *is* the opt-in. Decoding is a
 legitimate operation with legitimate callers, so the design does not try to
 prevent it — only to make it impossible to do quietly.
@@ -260,19 +260,20 @@ prevent it — only to make it impossible to do quietly.
 A namespace can be named in two places, and both are equally legitimate:
 
 ```csharp
-using InertText.Encoder;            // named in the import block
+using InertText.Encoding;            // named in the import block
 VisualEncoder.TryDecode(inert.ToString(), out string? original);
 ```
 
 ```csharp
-// no using directive of any kind in this file
-InertText.Encoder.VisualEncoder.TryDecode(inert.ToString(), out string? original);
+// no using directive of any kind in this file. InertText.Encoding here is the
+// namespace; there is no InertText type and no Encoder member on InertString.
+InertText.Encoding.VisualEncoder.TryDecode(inert.ToString(), out string? original);
 ```
 
 Neither is evasion. The second names the namespace at the call site rather than
 at the top of the file, in plain sight on the line that uses it. What matters is
 that the *audit* covers both, which is why the search is for the bare namespace
-and not for `using InertText.Encoder`: a fully-qualified call declares itself on
+and not for `using InertText.Encoding`: a fully-qualified call declares itself on
 its own line and needs no directive at all, so a reviewer grepping only the
 import block would read that file as clean and conclude it cannot decode.
 
@@ -280,8 +281,8 @@ There is a third way, and unlike those two it does not name the namespace in the
 file that decodes at all:
 
 ```csharp
-// one file, or a <Using Include="InertText.Encoder" /> item in the .csproj
-global using InertText.Encoder;
+// one file, or a <Using Include="InertText.Encoding" /> item in the .csproj
+global using InertText.Encoding;
 ```
 
 Every other file in that project can then call `VisualEncoder.TryDecode` with no
@@ -297,7 +298,7 @@ language, so it is gated by a test
 one: production does not name the namespace at all, and the tests that
 legitimately decode use ordinary per-file directives.
 
-So, with that gate in place: a file that does not mention `InertText.Encoder` at
+So, with that gate in place: a file that does not mention `InertText.Encoding` at
 all has no path back to the original of any value it handles.
 
 A reflection test enumerates every public member of the `InertText` namespace

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -215,7 +215,7 @@ So the decoder lives in its own namespace:
 
 | Namespace | Contains | A file naming it can |
 | --- | --- | --- |
-| `InertText` | `InertString`, `ScalarPolicy`, `TextPolicy`, `VisualForm` | build, compose, compare and print inert text |
+| `InertText` | `InertString`, `TextPolicy`, `VisualForm` | build, compose, compare and print inert text |
 | `InertText.Encoder` | `VisualEncoder` | additionally recover the original text |
 
 Text enters through `InertString`'s constructor and leaves through `ToString`
@@ -233,11 +233,31 @@ InertText.Encoder.VisualEncoder.TryDecode(inert.ToString(), out string? original
 
 That compiles and recovers the original. A reviewer who greps for the directive
 sees a clean import list and concludes the file cannot decode, which is the
-opposite of the truth. Greping the bare namespace catches both forms, because a
-fully-qualified call has to spell the namespace too — there is no third way in.
+opposite of the truth. Grepping the bare namespace catches both forms, because a
+fully-qualified call has to spell the namespace too.
 
-So: a file that does not mention `InertText.Encoder` at all has no path back to
-the original of any value it handles.
+There is a third way, and it spells the namespace in a different file:
+
+```csharp
+// one file, or a <Using Include="InertText.Encoder" /> item in the .csproj
+global using InertText.Encoder;
+```
+
+Every other file in that project can then call `VisualEncoder.TryDecode` with no
+local mention of the namespace. The search still finds the import — it is still
+text in the repository — but it stops answering *which files* can decode and
+starts answering *which projects* can, and the file it points at is not the file
+doing the decoding.
+
+That granularity is therefore an invariant of the build rather than of the
+language, so it is gated by a test
+(`NoProjectImportsTheCapabilityNamespaceForEveryFileAtOnce`) that fails on a
+`global using` or a `<Using>` item naming the capability namespace. Nothing needs
+one: production does not name the namespace at all, and the tests that
+legitimately decode use ordinary per-file directives.
+
+So, with that gate in place: a file that does not mention `InertText.Encoder` at
+all has no path back to the original of any value it handles.
 
 A reflection test enumerates every public member of the `InertText` namespace
 that returns text and accounts for each one: `ToString` (the encoded form),

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -110,15 +110,31 @@ type name finds mentions rather than capabilities.
 
 So the decoder lives in its own namespace:
 
-| Namespace | Contains | A file that imports it can |
+| Namespace | Contains | A file naming it can |
 | --- | --- | --- |
 | `InertText` | `InertString`, `ScalarPolicy`, `TextPolicy`, `VisualForm` | build, compose, compare and print inert text |
 | `InertText.Encoder` | `VisualEncoder` | additionally recover the original text |
 
 Text enters through `InertString`'s constructor and leaves through `ToString`
 already spelled, so the currency namespace is sufficient for every ordinary use.
-A file that imports `InertText` and not `InertText.Encoder` has no path back to
-the original of any value it handles — and that is legible in its import list.
+
+**The audit is one search, and the string is `InertText.Encoder`.** Not
+`using InertText.Encoder` — a using directive is only one of the two ways to
+reach a namespace, and the other one leaves the import block untouched:
+
+```csharp
+using InertText;                    // the only directive in the file
+
+InertText.Encoder.VisualEncoder.TryDecode(inert.ToString(), out string? original);
+```
+
+That compiles and recovers the original. A reviewer who greps for the directive
+sees a clean import list and concludes the file cannot decode, which is the
+opposite of the truth. Greping the bare namespace catches both forms, because a
+fully-qualified call has to spell the namespace too — there is no third way in.
+
+So: a file that does not mention `InertText.Encoder` at all has no path back to
+the original of any value it handles.
 
 A reflection test enumerates every public member of the `InertText` namespace
 that returns text and accounts for each one: `ToString` (the encoded form),
@@ -127,10 +143,10 @@ that returns text and accounts for each one: `ToString` (the encoded form),
 `int` rather than the character, so a survey can name what it refused without
 echoing it). Adding a decode convenience to the currency type fails that test.
 
-**This is an audit boundary, not a capability barrier.** A file can add the
-import or write the name out in full, and nothing should stop it — decoding is a
-legitimate operation with legitimate callers. What the boundary buys is that the
-reversing half cannot arrive unnoticed.
+**This is an audit boundary, not a capability barrier.** A file can name the
+namespace either way, and nothing should stop it — decoding is a legitimate
+operation with legitimate callers. What the boundary buys is that the reversing
+half cannot arrive unnoticed *by a reviewer who searches correctly*.
 
 ## Composition
 

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -77,30 +77,61 @@ and the reader is usually trying to work out what the artifact actually says.
 This is the central design split, and it is what lets one speller serve every
 sink:
 
-- The **predicate** (`ScalarPolicy`) answers "is this scalar permitted *here*". It
-  is per-sink and it is the caller's to choose. `TextPolicy.Field` is deny-shaped
-  and refuses `Cc`, `Cf`, `Cs`, `Zl` and `Zp`. `TextPolicy.Prose` is the same
-  minus a `CR`/`LF`/`TAB` exemption, for genuinely multi-line text.
+- The **policy** (`TextPolicy`) answers "is this scalar permitted *here*". It is
+  per-sink, and it is a **closed enum** rather than a predicate the caller
+  supplies. `Field` is deny-shaped and refuses `Cc`, `Cf`, `Cs`, `Zl` and `Zp`.
+  `Prose` is the same minus a `CR`/`LF`/`TAB` exemption, for genuinely
+  multi-line text. The rule table behind it is an internal `ScalarPolicy`
+  delegate, so no caller code runs during encoding or repair.
 - The **speller** (`VisualEncoder`) answers "how is a refused scalar written
   down". It is total over Unicode, and it never learns *why* a scalar was
   refused.
 
-A speller with a built-in hazard set has absorbed policy and cannot serve a sink
-whose grammar is constrained. That case is not hypothetical: the central
-typosquatting vector is a homoglyph, and Cyrillic `а` and Latin `a` are the same
-glyph, both category `Ll`. No category rule catches that and none should —
-refusing every non-Latin letter would break most of the world's text. Only an
-allow-shaped policy catches it, and because the speller is total, such a sink
-needs no spelling table of its own.
+### Why the policy set is closed
+
+An open predicate is the more obvious design and it was the first one here. Two
+things ruled it out, both measured rather than argued.
+
+**Drift.** Before this component the tree had grown five independent hand-rolled
+hazard predicates, and they disagree by up to 48 BMP characters:
+`IsRenderingHazard` refuses 76, `NeedsEscape` 76, `MetadataTableProjector`'s
+control check 65, `Field` 110, `Prose` 107. That is not hypothetical drift — it
+had already shipped a defect, since the metadata layer escapes `Cc` and `C1`
+while emitting `U+202E`, `U+200D`, `U+FEFF` and `U+2028` verbatim. A per-caller
+predicate makes each new sink a fresh opportunity to disagree, and the whole
+point of a shared component is that the rules are written once.
+
+**Disclosure.** `EnsurePermitted` has to decode before it can re-spell. A
+caller-supplied predicate would then be handed the *decoded, hostile* original
+one scalar at a time, in a file that need never name the capability namespace —
+the audit boundary walked back out through a callback, invisible to any
+reflection test over return types because the leak is an argument rather than a
+result.
+
+A closed set answers both: the rules live in one table, and a repair runs no
+caller code. Adding a kind of text is an enum member and an arm in that table,
+with no new public member anywhere, so the set stays extensible without the
+type growing.
+
+Allow-shaped rules are deliberately not expressible, and encoding could not
+serve one anyway. Repairing `Nеwtonsoft.Json` to `N\u0435wtonsoft.Json` fails
+the same letters-only check that rejected the original: what such a sink wants
+is *rejection*, which is the threat model's "reject, do not sanitize" and a
+different operation from this one.
 
 The speller's obligations:
 
 - **Total.** Defined on every Unicode scalar, including the 127 encoded scalars
   above the BMP. A `\uXXXX`-only speller is neither total nor invertible on
   exactly the inputs an attacker reaches for.
-- **Injective, in both directions.** One scalar has one spelling, so the decoder
-  refuses spellings the encoder never emits: `\U` for a BMP scalar, and `\uXXXX`
-  for a scalar with a canonical short form such as `\\`, `\^X` or `\^?`.
+- **Injective, in both directions.** One scalar has one *emitted* spelling, so
+  the decoder refuses spellings the encoder never produces: `\U` for a BMP
+  scalar, `\uXXXX` for a scalar with a canonical short form such as `\\`, `\^X`
+  or `\^?`, lowercase hex in either width, and a raw unpaired surrogate in the
+  decoder's input. The one spelling accepted but never emitted is a surrogate
+  *pair* written as two `\uXXXX` escapes, because composition produces it: a
+  .NET string is UTF-16, so `"\uD83D" + "\uDE00"` *is* `"\U0001F600"`, and
+  `Join` encodes its fragments separately.
 - **Scalar-based, not code-unit-based.** An unpaired surrogate is not a scalar.
   `Rune` cannot hold one and `EnumerateRunes` substitutes `U+FFFD`, so a speller
   built on either is lossy on the one input that cannot be written any other way.
@@ -144,7 +175,7 @@ return it is asking for an input marker — *this text came from outside*. Those
 are different propositions, and only the second one is a property of a source.
 
 **A policy belongs to the sink, and acquisition does not know the sink.**
-`Encode` takes a `ScalarPolicy` because what may pass depends on where the text
+`Encode` takes a `TextPolicy` because what may pass depends on where the text
 is going: `Field` for a table cell, `Prose` for a paragraph, something else for
 a sink with no terminal at the end of it. Where a name is read out of metadata
 there is no sink yet, so the API would have to pick a policy arbitrarily and be
@@ -301,9 +332,9 @@ differently depending on where it was encoded — which is a deliberate trade.
 
 ### Asking whether a value suits your sink
 
-That repair is exposed as `EnsurePermitted(ScalarPolicy)`, because a sink that
+That repair is exposed as `EnsurePermitted(TextPolicy)`, because a sink that
 accepts an `InertString` has no other correct way to make one safe for itself.
-The obvious substitute is wrong: `new InertString(value.ToString(), policy)`
+The obvious substitute is wrong: `new InertString(policy, value.ToString())`
 hands already-encoded text back to the encoder, so the backslashes double on
 every pass — `a\u202Eb` becomes `a\\u202Eb`, then `a\\\\u202Eb`. Because
 `EnsurePermitted` decodes before re-spelling, repeating it is a no-op.
@@ -324,8 +355,8 @@ property of the value, which is why it cannot be cached on one and why
 `EnsurePermitted` has to recompute it.
 
 Storing the producing policy on the value would not help either. Knowing which
-delegate produced a value says nothing about whether it is stricter than the
-delegate you are about to apply, short of sweeping every scalar to compare their
+policy produced a value says nothing about whether it is stricter than the one
+you are about to apply, short of sweeping every scalar to compare their
 permitted sets — so the value would carry an extra field and still pay for the
 scan.
 
@@ -342,10 +373,12 @@ act on. Each fixture records what it attacks, and six claims are asserted over
 every one of them, so adding a fixture is a single line that is immediately
 subject to all of them.
 
-The corpus also carries a payload nothing catches — the Cyrillic homoglyph — with
-both halves asserted: the category policy permits it, an allow-shaped policy
-refuses it. A corpus containing only what the default catches would quietly imply
-the default is sufficient.
+The corpus also carries a payload nothing catches — the Cyrillic homoglyph —
+and asserts the boundary directly: *no* `TextPolicy` refuses it, swept over
+`Enum.GetValues<TextPolicy>()` so a policy added later is covered without an
+edit. Category rules cannot catch it and none should, since refusing every
+non-Latin letter would break most of the world's text. A corpus containing only
+what the policies catch would quietly imply they are sufficient.
 
 ## Placement
 

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -28,6 +28,36 @@ without complaint:
 Percent-encoding, `Uri` normalization and HTML escaping each stop some of this
 and none of it. `Uri` percent-encodes `Cc` and passes `Cf` straight through.
 
+## What we are protecting
+
+Three channels, kept separate because they have different blast radii and a
+mitigation for one is not automatically a mitigation for another.
+
+- **The terminal.** The only channel where foreign text reaches the machine
+  rather than the reader. `OSC 52` writes the user's clipboard, `CSI` and `DEC`
+  sequences repaint the screen and can forge a shell prompt, and terminals have
+  shipped answerback paths that reach command execution (iTerm2,
+  CVE-2019-9535). This is what makes containment a safety requirement rather
+  than a formatting preference.
+- **The reader.** Bidi and homoglyph attacks never touch the machine. They make
+  output mean something other than what it displays, so the harm lands on
+  whoever acts on it — a reordered assembly name in a dependency listing is a
+  supply-chain decision made on false information.
+- **An agent's context.** This tool ships a skill, so its output is deliberately
+  fed to language models. Tag characters carry an invisible ASCII payload and no
+  terminal is involved at any point, so a sink that is safe for the first two
+  channels can be wide open on this one.
+
+Deliberately out of scope:
+
+- **Structural escaping.** Markdown pipes, JSON quotes and CSV delimiters
+  restructure a document rather than attack a renderer. Different mechanism,
+  different inverse; it composes with this one rather than being replaced by it.
+- **Text used for identity or control flow.** A name being compared, parsed or
+  matched is not being presented, and encoding it changes the answer.
+- **Text that must stay byte-exact to function.** File paths, request URLs and
+  assembly names are consumed by APIs, not read by people.
+
 ## What it does
 
 Refused scalars are rewritten in a visible spelling. The term and the contract
@@ -100,6 +130,79 @@ is not. The customary objection to a wrapper is that `ToString` launders it, but
 that assumes the payload is dangerous and the wrapper is what holds it back. Here
 the payload is already inert. Losing the wrapper loses provenance, not
 protection.
+
+## Where text becomes inert
+
+The tempting answer is "as early as possible": have every API that returns
+foreign text return `InertString`, so no caller can hold raw text and every
+consumer is forced to participate. That is the wrong answer here, for three
+reasons.
+
+**`InertString` marks the wrong end of the pipeline.** It means *this text has
+been treated for a sink*, which is an output marker. Asking metadata APIs to
+return it is asking for an input marker — *this text came from outside*. Those
+are different propositions, and only the second one is a property of a source.
+
+**A policy belongs to the sink, and acquisition does not know the sink.**
+`Encode` takes a `ScalarPolicy` because what may pass depends on where the text
+is going: `Field` for a table cell, `Prose` for a paragraph, something else for
+a sink with no terminal at the end of it. Where a name is read out of metadata
+there is no sink yet, so the API would have to pick a policy arbitrarily and be
+wrong everywhere that wanted a different one. Encoding again later does not
+recover it, because encoding under two policies is not encoding under a union of
+them.
+
+**Encoding at acquisition corrupts identity, and does it invisibly.** A literal
+backslash is always rewritten whatever the policy says, as is any scalar the
+policy refuses. 318 sites in `ILInspector.Metadata` compare foreign names for
+control flow rather than display — `member.Name == ".ctor"`,
+`prop.Name.StartsWith("/_")`, the pairing loop in the diff analyzer. Against
+encoded text those comparisons answer differently, and they do so *only for the
+inputs that needed encoding*. Benign text encodes to itself, so every test still
+passes and the behaviour changes exactly on unusual or hostile input. That is
+the worst available failure distribution: invisible in CI, live in the field.
+
+So containment goes late — but not "as late as possible", which is just the
+per-site approach with better manners. It goes at **the last structural boundary
+every rendered value must cross**.
+
+### Why a structural boundary and not a rule
+
+A boundary is worth something only if it cannot be walked around, so the claim
+has to be measured rather than asserted. The table path holds up: of 113 direct
+`Console.Write` calls in the tree only 24 interpolate anything, and all 24 are
+in a cache command, an analysis dev app and a decompiler fixture. None are in
+`src/dotnet-inspect/Output/`, which writes content the serializer has already
+rendered. Foreign text cannot reach stdout as a table cell without passing
+through a row property.
+
+That is the difference from containing at each use site. A structural boundary
+is crossed whether or not anyone remembered it; a per-site rule is a memory
+obligation, which is why the earlier approach was forgotten across 359 columns.
+
+Late containment also buys three things early containment cannot:
+
+- comparisons upstream operate on true text, so identity stays correct;
+- the sink is known, so the policy is known;
+- volume is bounded by what is rendered rather than everything read — one
+  framework assembly exposes 144,854 metadata name slots, while a user asking
+  for one type's members renders a handful.
+
+### The boundaries are not yet fully enumerated
+
+Two are known, and neither is complete on its own:
+
+| Boundary | Measured size | Tracked by |
+| -------- | ------------- | ---------- |
+| Row and view types | 359 columns across 86 row types | #3463 |
+| Diagnostic and log callbacks | 97 `Action<string>` sites | #3606 |
+
+Those cover the table path and the logging path. They are not exhaustive: the
+tree also has 46 `Console.Error` calls, 93 `TextWriter` references and 8
+`File.WriteAllText` calls, and no one has yet shown which of those carry foreign
+text. Establishing that list is a prerequisite for the guarantee, not a detail
+of it — a chokepoint you have not finished enumerating is a chokepoint you
+cannot claim.
 
 ## Holding a value is not the same as being able to reverse it
 

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -60,6 +60,8 @@
     <Project Path="src/ILInspector.Research/ILInspector.Research.csproj" />
     <Project Path="src/ILInspector.Text.Tests/ILInspector.Text.Tests.csproj" />
     <Project Path="src/ILInspector.Text/ILInspector.Text.csproj" />
+    <Project Path="src/InertText.Tests/InertText.Tests.csproj" />
+    <Project Path="src/InertText/InertText.csproj" />
     <Project Path="src/mdi/mdi.csproj" />
     <Project Path="src/NuGetFetch.Tests/NuGetFetch.Tests.csproj" />
     <Project Path="src/NuGetFetch/NuGetFetch.csproj" />

--- a/src/InertText.Tests/AdversarialCorpus.cs
+++ b/src/InertText.Tests/AdversarialCorpus.cs
@@ -1,0 +1,168 @@
+namespace InertText.Tests;
+
+/// <summary>
+/// Named attacks, kept as data rather than as assertions.
+/// </summary>
+/// <remarks>
+/// The tests around this file are property tests: they sweep every scalar and check
+/// invertibility and injectivity, which is the right shape for proving the transform total.
+/// What a sweep does not do is say what any of it was <em>for</em>. A corpus of real attacks
+/// does, and it fails differently — a sweep regression says "some scalar broke", where a corpus
+/// regression says "Trojan Source works again".
+///
+/// Each entry records what the payload attacks, because the value of a fixture is mostly in
+/// knowing why it was added. Several of these are attacks on the reader of a terminal rather
+/// than on a parser, which is the class this library exists for: nothing here is malformed, and
+/// every payload is well-formed Unicode that a naive sink prints without complaint.
+/// </remarks>
+public sealed record Adversary(string Name, string Payload, string Attacks);
+
+public static class AdversarialCorpus
+{
+    public static IReadOnlyList<Adversary> All { get; } =
+    [
+        new("TrojanSourceCommentOut",
+            "if (isAdmin) {\u202E \u2066// safe\u2069\u2066",
+            "CVE-2021-42574. Bidi overrides reorder the rendering so a reviewer sees code that "
+            + "differs from what compiles. The text is unmodified; only its display order is."),
+
+        new("BidiOverrideRightToLeft",
+            "invoice\u202Egpj.exe",
+            "RLO makes a .exe render as a .jpg. The classic file-name spoof, and the reason Cf "
+            + "is refused wholesale rather than by an exception list."),
+
+        new("AnsiClearScreen",
+            "\u001B[2J\u001B[H owned",
+            "A C0 escape that clears the terminal and homes the cursor, erasing whatever "
+            + "diagnostics preceded it."),
+
+        new("AnsiWindowTitle",
+            "\u001B]0;rm -rf /\u0007",
+            "OSC sequence that rewrites the terminal title. BEL-terminated, so it leaves no "
+            + "visible trace in the transcript."),
+
+        new("AnsiHyperlinkSpoof",
+            "\u001B]8;;https://evil.example\u0007click here\u001B]8;;\u0007",
+            "OSC 8 makes arbitrary text a hyperlink to an unrelated target, so the rendered "
+            + "label and the destination disagree."),
+
+        new("LogInjectionForgedLine",
+            "package\nError: signature verified",
+            "A newline forges a second diagnostic line that appears to come from the tool. This "
+            + "is why the field policy refuses line terminators outright."),
+
+        new("CarriageReturnOverwrite",
+            "actual-package\rspoofed",
+            "CR without LF rewinds to the start of the line, so the second half overwrites the "
+            + "first and only the lie is visible."),
+
+        new("NextLineControl",
+            "package\u0085Error: forged",
+            "U+0085 NEL is a line terminator that is neither CR nor LF, so a check written "
+            + "against those two lets it through."),
+
+        new("LineAndParagraphSeparator",
+            "package\u2028forged\u2029second",
+            "U+2028 and U+2029 terminate lines for many renderers and for JavaScript string "
+            + "literals, while being category Zl and Zp rather than Cc."),
+
+        new("TagCharacterSmuggling",
+            "package\U000E0074\U000E0065\U000E0078\U000E0074",
+            "Tag characters carry an invisible ASCII payload, the technique used to smuggle "
+            + "instructions past a human reading an agent's transcript. They are astral, so a "
+            + "speller that stops at \\uXXXX cannot even write them down."),
+
+        new("LanguageTagPrefix",
+            "package\U000E0001",
+            "U+E0001 opens a tag sequence. Deprecated, invisible, and still assigned."),
+
+        new("ZeroWidthSplitting",
+            "mic\u200Broso\u200Cft\u200D.com",
+            "Zero-width space, non-joiner and joiner split a name for a reader's eye while "
+            + "leaving it a single token to anything doing string comparison."),
+
+        new("SoftHyphenAndWordJoiner",
+            "pack\u00ADage\u2060name",
+            "SHY renders only at a line break and WJ never renders at all, so both hide inside "
+            + "an identifier."),
+
+        new("ByteOrderMarkInline",
+            "\uFEFFpackage\uFEFFname",
+            "A BOM in the middle of text is a zero-width no-break space. Invisible, and often "
+            + "survives a round trip through tooling that strips only a leading one."),
+
+        new("MongolianVowelSeparator",
+            "pack\u180Eage",
+            "U+180E changed category across Unicode versions, so a hand-maintained hazard list "
+            + "written against an older table misses it. A category rule evaluated at runtime "
+            + "does not."),
+
+        new("InterlinearAnnotation",
+            "package\uFFF9hidden\uFFFAshown\uFFFB",
+            "Interlinear annotation marks let one run of text be displayed in place of another."),
+
+        new("DeprecatedFormatControls",
+            "package\u206Aname\u206E",
+            "The deprecated U+206A-U+206F block toggles symmetric swapping and digit shapes; "
+            + "still assigned, still Cf, and rarely on anyone's list."),
+
+        new("MusicalSymbolFormatControl",
+            "package\U0001D173name\U0001D17A",
+            "Astral Cf. These are among the 127 encoded scalars above the BMP that a "
+            + "\\uXXXX-only speller cannot represent, so it is neither total nor invertible."),
+
+        new("UnpairedHighSurrogate",
+            "package\uD83Dname",
+            "Not a scalar at all. Rune cannot hold it and string.EnumerateRunes substitutes "
+            + "U+FFFD for it, so a speller built on either is lossy on exactly this input."),
+
+        new("UnpairedLowSurrogate",
+            "package\uDE00name",
+            "The other half of the same problem, which a check written only for high "
+            + "surrogates misses."),
+
+        new("NullAndDelete",
+            "package\u0000name\u007F",
+            "NUL truncates in anything C-adjacent; DEL is a C0-adjacent control that sits "
+            + "outside the 0x00-0x1F range a range check usually covers."),
+
+        new("BackslashCollision",
+            "C:\\users\\\u202Efoo",
+            "A real override immediately after a literal backslash. If the speller did not "
+            + "double the backslash, the encoded form would read as \\\\u202E and decoding "
+            + "could not tell a path containing that text from an encoded override, so the "
+            + "transform would not invert."),
+    ];
+
+    /// <summary>
+    /// A payload that is <em>not</em> caught by a category policy, kept here deliberately.
+    /// </summary>
+    /// <remarks>
+    /// Cyrillic small a is category Ll, exactly like Latin a, and renders identically. No
+    /// category rule catches it and none should — the fix is an allow-shaped policy for sinks
+    /// with a constrained grammar, which is why the predicate is the caller's to choose. A
+    /// corpus that contained only things the default policy catches would quietly imply the
+    /// default is sufficient.
+    /// </remarks>
+    public static Adversary Homoglyph { get; } =
+        new("CyrillicHomoglyph",
+            "p\u0430ckage",
+            "Typosquatting by substituting a visually identical scalar from another script.");
+
+    public static TheoryData<string> Names
+    {
+        get
+        {
+            TheoryData<string> names = [];
+
+            foreach (Adversary adversary in All)
+            {
+                names.Add(adversary.Name);
+            }
+
+            return names;
+        }
+    }
+
+    public static Adversary ByName(string name) => All.Single(a => a.Name == name);
+}

--- a/src/InertText.Tests/AdversarialCorpus.cs
+++ b/src/InertText.Tests/AdversarialCorpus.cs
@@ -140,7 +140,8 @@ public static class AdversarialCorpus
     /// <remarks>
     /// Cyrillic small a is category Ll, exactly like Latin a, and renders identically. No
     /// category rule catches it and none should — the fix is an allow-shaped policy for sinks
-    /// with a constrained grammar, which is why the predicate is the caller's to choose. A
+    /// with a constrained grammar, which is why the policy set has room to grow a named member
+    /// for such a sink rather than treating the default as universal. A
     /// corpus that contained only things the default policy catches would quietly imply the
     /// default is sufficient.
     /// </remarks>

--- a/src/InertText.Tests/AdversarialCorpusTests.cs
+++ b/src/InertText.Tests/AdversarialCorpusTests.cs
@@ -20,13 +20,13 @@ public class AdversarialCorpusTests
     public void EveryAdversary_EncodesToSomethingThePolicyPermits(string name)
     {
         Adversary adversary = AdversarialCorpus.ByName(name);
-        InertString inert = new(adversary.Payload, TextPolicy.Field);
+        InertString inert = new(TextPolicy.Field, adversary.Payload);
 
         // The output is the whole point: whatever went in, what comes out contains nothing the
         // sink's policy refuses. Asserted through the predicate rather than by looking for
         // specific characters, so the claim cannot drift from the policy it is stated against.
         Assert.True(
-            InertString.IsPermitted(inert.ToString(), TextPolicy.Field, out ScalarViolation? violation),
+            InertString.IsPermitted(TextPolicy.Field, inert.ToString(), out ScalarViolation? violation),
             $"{name} left U+{violation?.Scalar:X4} ({violation?.Category}) at index {violation?.Index}");
     }
 
@@ -35,7 +35,7 @@ public class AdversarialCorpusTests
     public void EveryAdversary_RoundTripsExactly(string name)
     {
         Adversary adversary = AdversarialCorpus.ByName(name);
-        InertString inert = new(adversary.Payload, TextPolicy.Field);
+        InertString inert = new(TextPolicy.Field, adversary.Payload);
 
         // Losslessness is what separates this from neutralization. A filter that dropped the
         // hostile scalars would pass the test above and destroy the evidence, which matters
@@ -50,9 +50,9 @@ public class AdversarialCorpusTests
     {
         Adversary adversary = AdversarialCorpus.ByName(name);
 
-        Assert.False(InertString.IsPermitted(adversary.Payload, TextPolicy.Field));
+        Assert.False(InertString.IsPermitted(TextPolicy.Field, adversary.Payload));
 
-        InertString inert = new(adversary.Payload, TextPolicy.Field);
+        InertString inert = new(TextPolicy.Field, adversary.Payload);
 
         Assert.True(inert.WasEncoded);
         Assert.NotEqual(VisualForm.None, inert.Forms);
@@ -67,7 +67,7 @@ public class AdversarialCorpusTests
     public void EveryAdversary_BecomesASingleLine(string name)
     {
         Adversary adversary = AdversarialCorpus.ByName(name);
-        string encoded = new InertString(adversary.Payload, TextPolicy.Field).ToString();
+        string encoded = new InertString(TextPolicy.Field, adversary.Payload).ToString();
 
         // Stated separately from the policy check because line injection is the attack with a
         // consequence beyond display: a forged line is indistinguishable from a real one once
@@ -88,10 +88,10 @@ public class AdversarialCorpusTests
         // The composition path, which is where the reviewed defect lived. A value built under
         // the laxer prose policy and spliced into a field message must be re-spelled, not
         // trusted -- prose permits the line feed that field exists to remove.
-        InertString asProse = new(adversary.Payload, TextPolicy.Prose);
+        InertString asProse = new(TextPolicy.Prose, adversary.Payload);
         InertString message = InertString.Format(TextPolicy.Field, $"source '{asProse}' rejected");
 
-        Assert.True(InertString.IsPermitted(message.ToString(), TextPolicy.Field));
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, message.ToString()));
         Assert.DoesNotContain('\n', message.ToString());
     }
 
@@ -105,7 +105,7 @@ public class AdversarialCorpusTests
 
         foreach (Adversary adversary in AdversarialCorpus.All)
         {
-            string encoded = new InertString(adversary.Payload, TextPolicy.Field).ToString();
+            string encoded = new InertString(TextPolicy.Field, adversary.Payload).ToString();
 
             Assert.False(
                 byEncoding.TryGetValue(encoded, out string? collidesWith),
@@ -124,7 +124,7 @@ public class AdversarialCorpusTests
         // which is every fixture here, to catch a speller that emitted a non-ASCII escape.
         foreach (Adversary adversary in AdversarialCorpus.All)
         {
-            string encoded = new InertString(adversary.Payload, TextPolicy.Field).ToString();
+            string encoded = new InertString(TextPolicy.Field, adversary.Payload).ToString();
 
             Assert.True(
                 Ascii.IsValid(encoded),
@@ -133,24 +133,21 @@ public class AdversarialCorpusTests
     }
 
     [Fact]
-    public void Homoglyph_IsNotCaughtByACategoryPolicy_AndIsCaughtByAnAllowList()
+    public void Homoglyph_IsNotCaughtByAnyTextPolicy()
     {
         Adversary homoglyph = AdversarialCorpus.Homoglyph;
 
         // The documented limit. Cyrillic a is Ll, exactly like Latin a, so a category rule
         // passes it -- correctly, because refusing every non-Latin letter would break most of
-        // the world's text. Recorded as a test so the boundary of the default policy is a
-        // stated fact rather than an assumption a reader has to make.
-        Assert.True(InertString.IsPermitted(homoglyph.Payload, TextPolicy.Field));
-
-        ScalarPolicy asciiOnly = static scalar => scalar.Value is >= 0x20 and <= 0x7E;
-
-        Assert.False(InertString.IsPermitted(homoglyph.Payload, asciiOnly));
-
-        InertString inert = new(homoglyph.Payload, asciiOnly);
-
-        Assert.Equal(@"p\u0430ckage", inert.ToString());
-        Assert.True(VisualEncoder.TryDecode(inert.ToString(), out string? original));
-        Assert.Equal(homoglyph.Payload, original);
+        // the world's text. Recorded as a test so the boundary of the policy set is a stated
+        // fact rather than an assumption a reader has to make.
+        //
+        // Every member, not just Field: the set is deny-shaped throughout, so this is a property
+        // of the set rather than of one policy, and adding a member does not quietly change it.
+        foreach (TextPolicy policy in Enum.GetValues<TextPolicy>())
+        {
+            Assert.True(InertString.IsPermitted(policy, homoglyph.Payload));
+            Assert.Equal(homoglyph.Payload, new InertString(policy, homoglyph.Payload).ToString());
+        }
     }
 }

--- a/src/InertText.Tests/AdversarialCorpusTests.cs
+++ b/src/InertText.Tests/AdversarialCorpusTests.cs
@@ -1,0 +1,156 @@
+using System.Text;
+
+using InertText.Encoder;
+
+namespace InertText.Tests;
+
+/// <summary>
+/// Holds the named attacks in <see cref="AdversarialCorpus"/> to what the library claims.
+/// </summary>
+/// <remarks>
+/// One test per claim rather than one per payload, so a new fixture is a single line and is
+/// immediately subject to every claim at once. The claims are the four the design rests on:
+/// the output is inert, nothing is dropped, the original is recoverable, and the caller is told
+/// what happened.
+/// </remarks>
+public class AdversarialCorpusTests
+{
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void EveryAdversary_EncodesToSomethingThePolicyPermits(string name)
+    {
+        Adversary adversary = AdversarialCorpus.ByName(name);
+        InertString inert = new(adversary.Payload, TextPolicy.Field);
+
+        // The output is the whole point: whatever went in, what comes out contains nothing the
+        // sink's policy refuses. Asserted through the predicate rather than by looking for
+        // specific characters, so the claim cannot drift from the policy it is stated against.
+        Assert.True(
+            InertString.IsPermitted(inert.ToString(), TextPolicy.Field, out ScalarViolation? violation),
+            $"{name} left U+{violation?.Scalar:X4} ({violation?.Category}) at index {violation?.Index}");
+    }
+
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void EveryAdversary_RoundTripsExactly(string name)
+    {
+        Adversary adversary = AdversarialCorpus.ByName(name);
+        InertString inert = new(adversary.Payload, TextPolicy.Field);
+
+        // Losslessness is what separates this from neutralization. A filter that dropped the
+        // hostile scalars would pass the test above and destroy the evidence, which matters
+        // because the reader is usually trying to work out what the artifact actually says.
+        Assert.True(VisualEncoder.TryDecode(inert.ToString(), out string? original));
+        Assert.Equal(adversary.Payload, original);
+    }
+
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void EveryAdversary_IsRecognisedAndReported(string name)
+    {
+        Adversary adversary = AdversarialCorpus.ByName(name);
+
+        Assert.False(InertString.IsPermitted(adversary.Payload, TextPolicy.Field));
+
+        InertString inert = new(adversary.Payload, TextPolicy.Field);
+
+        Assert.True(inert.WasEncoded);
+        Assert.NotEqual(VisualForm.None, inert.Forms);
+
+        // A legend the caller can print. Every form reported has a line, so a sink can explain
+        // its own output without keeping a second copy of the spelling table.
+        Assert.NotEmpty(inert.DescribeLegend());
+    }
+
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void EveryAdversary_BecomesASingleLine(string name)
+    {
+        Adversary adversary = AdversarialCorpus.ByName(name);
+        string encoded = new InertString(adversary.Payload, TextPolicy.Field).ToString();
+
+        // Stated separately from the policy check because line injection is the attack with a
+        // consequence beyond display: a forged line is indistinguishable from a real one once
+        // it reaches a log. Covers the terminators a CR/LF check misses -- NEL, LS and PS.
+        Assert.DoesNotContain('\n', encoded);
+        Assert.DoesNotContain('\r', encoded);
+        Assert.DoesNotContain('\u0085', encoded);
+        Assert.DoesNotContain('\u2028', encoded);
+        Assert.DoesNotContain('\u2029', encoded);
+    }
+
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void EveryAdversary_SurvivesSplicingIntoAField(string name)
+    {
+        Adversary adversary = AdversarialCorpus.ByName(name);
+
+        // The composition path, which is where the reviewed defect lived. A value built under
+        // the laxer prose policy and spliced into a field message must be re-spelled, not
+        // trusted -- prose permits the line feed that field exists to remove.
+        InertString asProse = new(adversary.Payload, TextPolicy.Prose);
+        InertString message = InertString.Format(TextPolicy.Field, $"source '{asProse}' rejected");
+
+        Assert.True(InertString.IsPermitted(message.ToString(), TextPolicy.Field));
+        Assert.DoesNotContain('\n', message.ToString());
+    }
+
+    [Fact]
+    public void EveryAdversary_IsDistinctAfterEncoding()
+    {
+        // Injectivity, restated over the corpus rather than over an alphabet. Two different
+        // attacks must not collapse to the same rendering, or the encoded form cannot be used
+        // as evidence of which one arrived.
+        Dictionary<string, string> byEncoding = new(StringComparer.Ordinal);
+
+        foreach (Adversary adversary in AdversarialCorpus.All)
+        {
+            string encoded = new InertString(adversary.Payload, TextPolicy.Field).ToString();
+
+            Assert.False(
+                byEncoding.TryGetValue(encoded, out string? collidesWith),
+                $"{adversary.Name} encodes identically to {collidesWith}");
+
+            byEncoding[encoded] = adversary.Name;
+        }
+    }
+
+    [Fact]
+    public void EveryAdversary_EncodesToAsciiWhereItsPayloadIsAscii()
+    {
+        // A weaker claim than it looks, and deliberately so. The encoded spellings are ASCII,
+        // but the policy permits any graphic scalar, so text mixing hazards with CJK stays
+        // non-ASCII and should. Asserted only for payloads whose non-hostile part is ASCII,
+        // which is every fixture here, to catch a speller that emitted a non-ASCII escape.
+        foreach (Adversary adversary in AdversarialCorpus.All)
+        {
+            string encoded = new InertString(adversary.Payload, TextPolicy.Field).ToString();
+
+            Assert.True(
+                Ascii.IsValid(encoded),
+                $"{adversary.Name} produced a non-ASCII rendering: {encoded}");
+        }
+    }
+
+    [Fact]
+    public void Homoglyph_IsNotCaughtByACategoryPolicy_AndIsCaughtByAnAllowList()
+    {
+        Adversary homoglyph = AdversarialCorpus.Homoglyph;
+
+        // The documented limit. Cyrillic a is Ll, exactly like Latin a, so a category rule
+        // passes it -- correctly, because refusing every non-Latin letter would break most of
+        // the world's text. Recorded as a test so the boundary of the default policy is a
+        // stated fact rather than an assumption a reader has to make.
+        Assert.True(InertString.IsPermitted(homoglyph.Payload, TextPolicy.Field));
+
+        ScalarPolicy asciiOnly = static scalar => scalar.Value is >= 0x20 and <= 0x7E;
+
+        Assert.False(InertString.IsPermitted(homoglyph.Payload, asciiOnly));
+
+        InertString inert = new(homoglyph.Payload, asciiOnly);
+
+        Assert.Equal(@"p\u0430ckage", inert.ToString());
+        Assert.True(VisualEncoder.TryDecode(inert.ToString(), out string? original));
+        Assert.Equal(homoglyph.Payload, original);
+    }
+}

--- a/src/InertText.Tests/AdversarialCorpusTests.cs
+++ b/src/InertText.Tests/AdversarialCorpusTests.cs
@@ -1,6 +1,6 @@
 using System.Text;
 
-using InertText.Encoder;
+using InertText.Encoding;
 
 namespace InertText.Tests;
 

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -1038,4 +1038,95 @@ public class InertStringTests
                 + "which files can recover the original: "
                 + string.Join("; ", offenders));
     }
+
+    /// <summary>
+    /// No public documentation in the currency namespace names the encoder type, so the
+    /// currency type's use of it stays an implementation detail rather than an advertised one.
+    /// </summary>
+    /// <remarks>
+    /// The capability is deliberately public and deliberately opt-in: a caller who needs to
+    /// decode names <c>InertText.Encoder</c> and that act is what the audit searches for. What
+    /// must not happen is the currency type handing the capability over without that opt-in.
+    ///
+    /// A signature cannot: a separate test walks the public surface and fails any member that
+    /// mentions a type from the capability namespace. Documentation is the other route, and it
+    /// is easy to miss because it changes no signature. The public constructor used to open
+    /// with "Forwards to <![CDATA[<see cref="VisualEncoder"/>]]>", which is a *navigable
+    /// reference* — every consumer reading the constructor in IntelliSense was pointed straight
+    /// at the reversing half, and two more members described their internals the same way.
+    /// Documenting what a member delegates to is describing an implementation detail as though
+    /// it were part of the contract.
+    ///
+    /// Naming the <em>namespace</em> stays allowed, and the type-level remarks do it: saying
+    /// the decoder lives in <c>InertText.Encoder</c> and that nothing here reaches it is the
+    /// opt-in disclaimer rather than a shortcut to it. The line is drawn at the type name,
+    /// which is the thing a caller would have to write in order to use it.
+    /// </remarks>
+    [Fact]
+    public void NoPublicDocumentationInTheCurrencyNamespaceNamesTheEncoderType()
+    {
+        const string EncoderType = "VisualEncoder";
+
+        DirectoryInfo? root = new(AppContext.BaseDirectory);
+        while (root is not null && !File.Exists(Path.Combine(root.FullName, "dotnet-inspect.slnx")))
+        {
+            root = root.Parent;
+        }
+
+        Assert.True(root is not null, "could not locate the repository root from the test binary");
+
+        string library = Path.Combine(root!.FullName, "src", "InertText");
+        string[] files = Directory.GetFiles(library, "*.cs", SearchOption.AllDirectories);
+
+        // Non-vacuity: a wrong path would pass silently.
+        Assert.NotEmpty(files);
+
+        List<string> offenders = [];
+        int scanned = 0;
+
+        foreach (string file in files)
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string[] lines = File.ReadAllLines(file);
+
+            // The capability's own file documents itself; the rule is about the currency side.
+            if (lines.Any(l => l.StartsWith("namespace InertText.Encoder", StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            scanned++;
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string trimmed = lines[i].TrimStart();
+                if (!trimmed.StartsWith("///", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (trimmed.Contains(EncoderType, StringComparison.Ordinal))
+                {
+                    offenders.Add($"{Path.GetRelativePath(root.FullName, file)}:{i + 1}");
+                }
+            }
+        }
+
+        // The currency namespace is more than one file, so a rule that only ever saw
+        // InertString.cs would be weaker than it looks.
+        Assert.True(scanned > 1, $"expected to scan several currency-namespace files, scanned {scanned}");
+
+        Assert.True(
+            offenders.Count == 0,
+            $"Public documentation in the currency namespace names '{EncoderType}', which "
+                + "advertises the reversing half to every consumer reading these members and "
+                + "makes an implementation detail look like part of the contract. Describe what "
+                + "the member guarantees instead, and leave where the capability lives to the "
+                + $"type-level remarks: {string.Join("; ", offenders)}");
+    }
 }

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -17,9 +17,9 @@ public class InertStringTests
     [Fact]
     public void Encode_ProducesAPayloadThePolicyAccepts()
     {
-        InertString value = new InertString(Hazard, TextPolicy.Field);
+        InertString value = new InertString(TextPolicy.Field, Hazard);
 
-        Assert.True(InertString.IsPermitted(value.ToString(), TextPolicy.Field));
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, value.ToString()));
         Assert.True(value.WasEncoded);
         Assert.Equal(VisualForm.BmpHex, value.Forms);
     }
@@ -27,7 +27,7 @@ public class InertStringTests
     [Fact]
     public void Encode_RoundTripsThroughTheDecoder()
     {
-        InertString value = new InertString(Hazard, TextPolicy.Field);
+        InertString value = new InertString(TextPolicy.Field, Hazard);
 
         Assert.True(VisualEncoder.TryDecode(value.ToString(), out string? decoded));
         Assert.Equal(Hazard, decoded);
@@ -39,7 +39,7 @@ public class InertStringTests
         InertString message = InertString.Format(TextPolicy.Field, $"url: {Hazard}");
 
         Assert.Equal("url: a\\u202Eb", message.ToString());
-        Assert.True(InertString.IsPermitted(message.ToString(), TextPolicy.Field));
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, message.ToString()));
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class InertStringTests
     [Fact]
     public void Format_AlreadyInertHole_IsNotEncodedTwice()
     {
-        InertString inner = new InertString(Hazard, TextPolicy.Field);
+        InertString inner = new InertString(TextPolicy.Field, Hazard);
 
         InertString outer = InertString.Format(TextPolicy.Field, $"[{inner}]");
 
@@ -110,9 +110,9 @@ public class InertStringTests
     [Fact]
     public void Equality_ComparesTheEncodedText()
     {
-        InertString left = new InertString(Hazard, TextPolicy.Field);
-        InertString right = new InertString(Hazard, TextPolicy.Field);
-        InertString other = new InertString("b", TextPolicy.Field);
+        InertString left = new InertString(TextPolicy.Field, Hazard);
+        InertString right = new InertString(TextPolicy.Field, Hazard);
+        InertString other = new InertString(TextPolicy.Field, "b");
 
         Assert.True(left == right);
         Assert.True(left != other);
@@ -125,7 +125,7 @@ public class InertStringTests
         // Redaction returns InertString?, so without a dedicated overload this hole binds to the
         // generic case, whose ToString hands the encoded text straight back to the encoder and
         // doubles every backslash the first pass introduced.
-        InertString? inner = new InertString(Hazard, TextPolicy.Field);
+        InertString? inner = new InertString(TextPolicy.Field, Hazard);
 
         InertString outer = InertString.Format(TextPolicy.Field, $"[{inner}]");
 
@@ -149,7 +149,7 @@ public class InertStringTests
     {
         // The separator is encoded up front, so folding its forms in unconditionally would make
         // a one-element join advertise a spelling its output does not contain.
-        InertString only = new InertString("plain", TextPolicy.Field);
+        InertString only = new InertString(TextPolicy.Field, "plain");
 
         InertString joined = InertString.Join("\n", TextPolicy.Field, [only]);
 
@@ -161,8 +161,8 @@ public class InertStringTests
     [Fact]
     public void Join_MultipleValues_ReportsTheSeparatorForm()
     {
-        InertString first = new InertString("a", TextPolicy.Field);
-        InertString second = new InertString("b", TextPolicy.Field);
+        InertString first = new InertString(TextPolicy.Field, "a");
+        InertString second = new InertString(TextPolicy.Field, "b");
 
         InertString joined = InertString.Join("\n", TextPolicy.Field, [first, second]);
 
@@ -173,8 +173,8 @@ public class InertStringTests
     [Fact]
     public void Join_UnderProse_KeepsTheLineBreak()
     {
-        InertString first = new InertString("a", TextPolicy.Prose);
-        InertString second = new InertString("b", TextPolicy.Prose);
+        InertString first = new InertString(TextPolicy.Prose, "a");
+        InertString second = new InertString(TextPolicy.Prose, "b");
 
         InertString joined = InertString.Join(Environment.NewLine, TextPolicy.Prose, [first, second]);
 
@@ -210,7 +210,7 @@ public class InertStringTests
     public void Splice_ReEncodesAValueThatThisPolicyRefuses()
     {
         // Built for a multi-line sink, so the line feed survived encoding.
-        InertString prose = new InertString("first\nsecond", TextPolicy.Prose);
+        InertString prose = new InertString(TextPolicy.Prose, "first\nsecond");
         Assert.Equal("first\nsecond", prose.ToString());
 
         // Spliced into a single-line sink, it must not carry the line feed in with it.
@@ -218,14 +218,14 @@ public class InertStringTests
 
         Assert.DoesNotContain('\n', field.ToString());
         Assert.Contains(@"\^J", field.ToString(), StringComparison.Ordinal);
-        Assert.True(InertString.IsPermitted(field.ToString(), TextPolicy.Field));
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, field.ToString()));
         Assert.True(field.Forms.HasFlag(VisualForm.Caret));
     }
 
     [Fact]
     public void Splice_LeavesAConformingValueByteForByteAlone()
     {
-        InertString piece = new InertString("a\u202Eb", TextPolicy.Field);
+        InertString piece = new InertString(TextPolicy.Field, "a\u202Eb");
         InertString message = InertString.Format(TextPolicy.Field, $"{piece}");
 
         // The repair path must not fire here, or every splice would pay a decode/re-encode.
@@ -240,7 +240,7 @@ public class InertStringTests
         // the repair path never runs and the test passes vacuously. Prose refuses the bidi
         // override (so the value arrives already carrying a backslash escape) but permits the
         // line feed (which Field then refuses, forcing the repair).
-        InertString origin = new InertString("a\u202Eb\nc", TextPolicy.Prose);
+        InertString origin = new InertString(TextPolicy.Prose, "a\u202Eb\nc");
         Assert.Contains(@"\u202E", origin.ToString(), StringComparison.Ordinal);
         Assert.Contains('\n', origin.ToString());
 
@@ -259,7 +259,7 @@ public class InertStringTests
         Assert.DoesNotContain(@"\\u202E", once.ToString(), StringComparison.Ordinal);
 
         // Pin the failure this guards against: the substitute a caller would otherwise reach for.
-        InertString viaToString = new InertString(origin.ToString(), TextPolicy.Field);
+        InertString viaToString = new InertString(TextPolicy.Field, origin.ToString());
         Assert.Contains(@"\\u202E", viaToString.ToString(), StringComparison.Ordinal);
     }
 
@@ -272,7 +272,7 @@ public class InertStringTests
         // Field spellings would be undone into text Prose permits.
         foreach (string source in new[] { "a\u202Eb", "x\ny", "p\u0007q", "\uD800lone" })
         {
-            InertString strict = new InertString(source, TextPolicy.Field);
+            InertString strict = new InertString(TextPolicy.Field, source);
             InertString spliced = strict.EnsurePermitted(TextPolicy.Prose);
 
             Assert.Equal(strict.ToString(), spliced.ToString());
@@ -286,14 +286,14 @@ public class InertStringTests
         // WasEncoded reports what was done, not what is satisfied, and it is wrong in both
         // directions. A sink that used it as a conformance check would admit the first value and
         // needlessly repair the second.
-        InertString prose = new InertString("line1\nline2", TextPolicy.Prose);
+        InertString prose = new InertString(TextPolicy.Prose, "line1\nline2");
         Assert.False(prose.WasEncoded);
-        Assert.False(InertString.IsPermitted(prose.ToString(), TextPolicy.Field));
+        Assert.False(InertString.IsPermitted(TextPolicy.Field, prose.ToString()));
 
-        InertString field = new InertString("a\u202Eb", TextPolicy.Field);
+        InertString field = new InertString(TextPolicy.Field, "a\u202Eb");
         Assert.True(field.WasEncoded);
-        Assert.True(InertString.IsPermitted(field.ToString(), TextPolicy.Field));
-        Assert.True(InertString.IsPermitted(field.ToString(), TextPolicy.Prose));
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, field.ToString()));
+        Assert.True(InertString.IsPermitted(TextPolicy.Prose, field.ToString()));
     }
 
     [Fact]
@@ -301,21 +301,21 @@ public class InertStringTests
     {
         InertString[] values =
         [
-            new InertString("one\ntwo", TextPolicy.Prose),
-            new InertString("three", TextPolicy.Field),
+            new InertString(TextPolicy.Prose, "one\ntwo"),
+            new InertString(TextPolicy.Field, "three"),
         ];
 
         InertString joined = InertString.Join(", ", TextPolicy.Field, values);
 
         Assert.DoesNotContain('\n', joined.ToString());
-        Assert.True(InertString.IsPermitted(joined.ToString(), TextPolicy.Field));
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, joined.ToString()));
         Assert.True(joined.Forms.HasFlag(VisualForm.Caret));
     }
 
     [Fact]
     public void Splice_ReportsEveryFormTheRepairIntroduced()
     {
-        InertString prose = new InertString("a\nb", TextPolicy.Prose);
+        InertString prose = new InertString(TextPolicy.Prose, "a\nb");
         Assert.Equal(VisualForm.None, prose.Forms);
 
         InertString field = InertString.Format(TextPolicy.Field, $"{prose}");
@@ -328,7 +328,7 @@ public class InertStringTests
     [Fact]
     public void Empty_EqualsAnEncodedEmptyString()
     {
-        InertString encoded = new InertString("", TextPolicy.Field);
+        InertString encoded = new InertString(TextPolicy.Field, "");
 
         Assert.Equal(InertString.Empty, encoded);
         Assert.True(InertString.Empty == encoded);
@@ -359,7 +359,7 @@ public class InertStringTests
         // Field encoded the line feed; Prose would have permitted it. The repair must not
         // undo that: composition may make a value more inert, never less, or a value could be
         // laundered by quoting it into a laxer sink.
-        InertString strict = new InertString("a\nb", TextPolicy.Field);
+        InertString strict = new InertString(TextPolicy.Field, "a\nb");
         InertString lax = InertString.Format(TextPolicy.Prose, $"{strict}");
 
         Assert.Equal(@"a\^Jb", lax.ToString());
@@ -372,7 +372,7 @@ public class InertStringTests
     [Fact]
     public void Splice_IsAFixedPointUnderTheSamePolicy()
     {
-        InertString piece = new InertString("x\ny", TextPolicy.Prose);
+        InertString piece = new InertString(TextPolicy.Prose, "x\ny");
         InertString once = InertString.Format(TextPolicy.Field, $"{piece}");
         InertString twice = InertString.Format(TextPolicy.Field, $"{once}");
 
@@ -392,7 +392,7 @@ public class InertStringTests
         [
             default,
             InertString.Empty,
-            new InertString("", TextPolicy.Field),
+            new InertString(TextPolicy.Field, ""),
         ];
 
         InertString zero = empties[0];
@@ -438,7 +438,7 @@ public class InertStringTests
     [Fact]
     public void ToString_DoesNotCopy()
     {
-        InertString value = new InertString("nothing to encode", TextPolicy.Field);
+        InertString value = new InertString(TextPolicy.Field, "nothing to encode");
 
         Assert.Same(value.ToString(), value.ToString());
     }
@@ -452,8 +452,8 @@ public class InertStringTests
         string other = string.Concat("a\u202E", "b");
         Assert.False(ReferenceEquals(one, other));
 
-        InertString left = new InertString(one, TextPolicy.Field);
-        InertString right = new InertString(other, TextPolicy.Field);
+        InertString left = new InertString(TextPolicy.Field, one);
+        InertString right = new InertString(TextPolicy.Field, other);
 
         Assert.Equal(left, right);
         Assert.True(left == right);
@@ -497,7 +497,7 @@ public class InertStringTests
             || p.ParameterType == typeof(ReadOnlySpan<char>));
 
         static bool TakesPolicy(ParameterInfo[] parameters) => parameters.Any(p =>
-            p.ParameterType == typeof(ScalarPolicy)
+            p.ParameterType == typeof(TextPolicy)
             || p.ParameterType == typeof(InertStringHandler));
 
         static string Describe(ParameterInfo[] parameters)
@@ -603,7 +603,7 @@ public class InertStringTests
         Assert.NotNull(decode);
         Assert.Equal("InertText.Encoder", typeof(VisualEncoder).Namespace);
 
-        InertString inert = new("\u202Ecmd", TextPolicy.Field);
+        InertString inert = new(TextPolicy.Field, "\u202Ecmd");
         Assert.True(VisualEncoder.TryDecode(inert.ToString(), out string? original));
         Assert.Equal("\u202Ecmd", original);
     }
@@ -636,9 +636,9 @@ public class InertStringTests
     /// <list type="bullet">
     /// <item>Removing the public constructor in favour of an encoder factory, on the grounds
     /// that the constructor "just forwards".</item>
-    /// <item>Moving <c>ScalarPolicy</c> or <c>TextPolicy</c> next to the encoder, on the grounds
-    /// that the policy is "part of encoding". The creation path would still exist and would
-    /// still drag the namespace in with it.</item>
+    /// <item>Moving <c>TextPolicy</c> next to the encoder, on the grounds that the policy is
+    /// "part of encoding". The creation path would still exist and would still drag the
+    /// namespace in with it.</item>
     /// </list>
     /// </remarks>
     [Fact]
@@ -676,14 +676,13 @@ public class InertStringTests
                 + "running: "
                 + string.Join("; ", dragIn.Select(p => p.Name)));
 
-        // The policy a caller must pass has to be reachable from the currency namespace too --
-        // a self-contained signature is no use if the only ScalarPolicy values live next to the
+        // The policy a caller must name has to be reachable from the currency namespace too --
+        // a self-contained signature is no use if the only TextPolicy values live next to the
         // decoder.
-        Assert.Equal("InertText", typeof(ScalarPolicy).Namespace);
         Assert.Equal("InertText", typeof(TextPolicy).Namespace);
 
         // Smoke check that the reflected signature is actually callable as described.
-        InertString produced = new("\u202Ecmd", TextPolicy.Field);
+        InertString produced = new(TextPolicy.Field, "\u202Ecmd");
         Assert.True(produced.WasEncoded);
 
         static IEnumerable<string> Namespaces(Type type)
@@ -707,4 +706,155 @@ public class InertStringTests
 
     private const BindingFlags Declared =
         BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+    /// <summary>
+    /// An already-inert value reached through a generic parameter is not encoded a second time.
+    /// </summary>
+    /// <remarks>
+    /// Overload resolution binds on the <em>static</em> type of an interpolation hole, so the
+    /// dedicated <c>AppendFormatted(InertString)</c> is invisible from inside a generic method:
+    /// <c>T</c> is not <see cref="InertString"/> at the call site even when it is at run time.
+    /// The generic overload then called <c>ToString</c> on already-encoded text and handed it
+    /// back to the encoder, doubling every backslash. The trap was known for
+    /// <see cref="InertString"/> and <c>InertString?</c> and closed with overloads; those
+    /// overloads cannot reach this case, and only a type test can.
+    /// </remarks>
+    [Fact]
+    public void Format_DoesNotDoubleEncode_WhenReachedThroughAGenericParameter()
+    {
+        InertString inner = new(TextPolicy.Field, Hazard);
+
+        InertString direct = InertString.Format(TextPolicy.Field, $"{inner}");
+        InertString viaGeneric = Wrap(inner);
+
+        Assert.Equal(@"a\u202Eb", direct.ToString());
+        Assert.Equal(direct.ToString(), viaGeneric.ToString());
+
+        static InertString Wrap<T>(T value) => InertString.Format(TextPolicy.Field, $"{value}");
+    }
+
+    /// <summary>The same hole, reached through <see cref="object"/>.</summary>
+    [Fact]
+    public void Format_DoesNotDoubleEncode_WhenReachedThroughObject()
+    {
+        InertString inner = new(TextPolicy.Field, Hazard);
+        object boxed = inner;
+
+        Assert.Equal(
+            @"a\u202Eb",
+            InertString.Format(TextPolicy.Field, $"{boxed}").ToString());
+    }
+
+    /// <summary>The same hole again, through a hole that carries a format specifier.</summary>
+    /// <remarks>
+    /// A separate overload with its own body, so closing one and not the other is a live risk.
+    /// </remarks>
+    [Fact]
+    public void Format_DoesNotDoubleEncode_WhenTheHoleCarriesAFormatSpecifier()
+    {
+        object boxed = new InertString(TextPolicy.Field, Hazard);
+
+        Assert.Equal(
+            @"a\u202Eb",
+            InertString.Format(TextPolicy.Field, $"{boxed:X}").ToString());
+    }
+
+    /// <summary>
+    /// Repairing a value for a policy yields text that policy accepts, for every ordered pair.
+    /// </summary>
+    /// <remarks>
+    /// The property a caller-supplied predicate could not have. An allow-shaped predicate --
+    /// the shape needed to catch a homoglyph -- refuses the escape alphabet itself, so
+    /// <c>EnsurePermitted</c> returned text its own policy rejected, silently. Every
+    /// <see cref="TextPolicy"/> is deny-shaped and permits graphic punctuation, so the escape
+    /// spellings always conform, and the closed set is what makes that a checkable claim rather
+    /// than a hope about what callers will pass.
+    ///
+    /// Swept over the full cross product, so a policy added later is covered without an edit.
+    /// </remarks>
+    [Fact]
+    public void EnsurePermitted_AlwaysReturnsTextTheTargetPolicyAccepts()
+    {
+        const string Nasty = "a\u202Eb\u001B[31m\nc\td\\e\uD83D\uDE00";
+
+        foreach (TextPolicy from in Enum.GetValues<TextPolicy>())
+        {
+            foreach (TextPolicy to in Enum.GetValues<TextPolicy>())
+            {
+                InertString repaired = new InertString(from, Nasty).EnsurePermitted(to);
+
+                Assert.True(
+                    InertString.IsPermitted(to, repaired.ToString(), out ScalarViolation? violation),
+                    $"{from} -> {to} produced {violation}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Repair is idempotent for every ordered pair, not only the one the case above covers.
+    /// </summary>
+    /// <remarks>
+    /// This is what injectivity in the decoder buys, and it is why a second accepted spelling
+    /// there would be a defect here.
+    /// </remarks>
+    [Fact]
+    public void EnsurePermitted_IsIdempotent_ForEveryPolicyPair()
+    {
+        const string Nasty = "a\u202Eb\u001B[31m\nc\td\\e";
+
+        foreach (TextPolicy from in Enum.GetValues<TextPolicy>())
+        {
+            foreach (TextPolicy to in Enum.GetValues<TextPolicy>())
+            {
+                InertString once = new InertString(from, Nasty).EnsurePermitted(to);
+                InertString twice = once.EnsurePermitted(to);
+
+                Assert.Equal(once.ToString(), twice.ToString());
+            }
+        }
+    }
+
+    /// <summary>
+    /// No public member takes a delegate, which is what keeps a repair from running caller code.
+    /// </summary>
+    /// <remarks>
+    /// The reason <see cref="TextPolicy"/> is an enum rather than a predicate. A repair decodes
+    /// the value first -- it has to, or the backslashes double -- so a caller-supplied predicate
+    /// would be handed the hostile original one scalar at a time, in a file whose using block
+    /// names only the currency namespace. That is the audit boundary walked back out through a
+    /// callback, and no reflection test over return types can see it, because the disclosure is
+    /// an argument rather than a result.
+    ///
+    /// Stated over the whole public surface rather than as "EnsurePermitted takes an enum", so
+    /// that reintroducing a predicate anywhere -- as an overload, on the handler, as an optional
+    /// escape valve -- fails here.
+    /// </remarks>
+    [Fact]
+    public void NoPublicMemberOfTheCurrencyNamespaceTakesADelegate()
+    {
+        List<string> callbacks = [];
+
+        foreach (Type type in typeof(InertString).Assembly.GetExportedTypes()
+            .Where(t => t.Namespace == "InertText"))
+        {
+            foreach (MethodBase member in typeof(InertString).GetMethods(Declared)
+                .Cast<MethodBase>()
+                .Concat(type.GetConstructors(Declared)))
+            {
+                foreach (ParameterInfo parameter in member.GetParameters())
+                {
+                    Type bare = parameter.ParameterType.IsByRef
+                        ? parameter.ParameterType.GetElementType()!
+                        : parameter.ParameterType;
+
+                    if (typeof(Delegate).IsAssignableFrom(bare))
+                    {
+                        callbacks.Add($"{type.Name}.{member.Name}({bare.Name})");
+                    }
+                }
+            }
+        }
+
+        Assert.Empty(callbacks);
+    }
 }

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -458,9 +458,16 @@ public class InertStringTests
     /// guards against is an <em>addition</em> — a convenience overload that hands back the
     /// decoded form — and a test that asserts specific members exist would not notice one.
     ///
-    /// The boundary is auditable, not unforgeable. A file can add the import or write the name
-    /// out in full, and this test does not stop it. What it does stop is the capability
-    /// arriving somewhere that looks like it has not got it.
+    /// The boundary is auditable, not unforgeable. A file can name the capability namespace and
+    /// this test does not stop it. What it does stop is the capability arriving somewhere that
+    /// looks like it has not got it.
+    ///
+    /// The search string is <c>InertText.Encoder</c>, not <c>using InertText.Encoder</c>. A
+    /// using directive is one of two ways to reach a namespace, and the other leaves the import
+    /// block untouched — <c>InertText.Encoder.VisualEncoder.TryDecode(...)</c> compiles in a file
+    /// whose only directive is <c>using InertText</c>. Searching for the directive would show a
+    /// clean import list for a file that decodes. The bare namespace catches both, because a
+    /// fully-qualified call has to spell it too.
     /// </remarks>
     [Fact]
     public void NoPublicMemberOfTheCurrencyNamespaceReturnsText()
@@ -547,16 +554,16 @@ public class InertStringTests
     /// search is only worth running if its answer is small. That is a property of the
     /// <em>producing</em> side, not the decoding side. If the only way to make an
     /// <see cref="InertString"/> were to call the encoder, then every file that produces inert
-    /// text would carry <c>using InertText.Encoder</c>, the decoder would sit one member access
-    /// away in all of them, and the search would return the whole producer set. The signal would
-    /// survive in form and be worthless in practice.
+    /// text would name <c>InertText.Encoder</c>, the decoder would sit one member access away in
+    /// all of them, and the search would return the whole producer set. The signal would survive
+    /// in form and be worthless in practice.
     ///
     /// Measured on the tree that introduced this: four production files produce inert text and
-    /// <em>none</em> imports the capability namespace. Routing production through the encoder
+    /// <em>none</em> names the capability namespace. Routing production through the encoder
     /// would make that four out of five, so the constructor is not sugar over
     /// <c>VisualEncoder.Encode</c> — it is what keeps the false-positive rate at zero.
     ///
-    /// The claim is about <em>production</em> code, and deliberately so. This test file imports
+    /// The claim is about <em>production</em> code, and deliberately so. This test file names
     /// <c>InertText.Encoder</c> itself, as do the encoder's own tests: invertibility is a
     /// contract, so something has to decode in order to check it. A test that can decode is the
     /// system working, not a leak — the search that matters is over the files that ship. Read
@@ -568,7 +575,7 @@ public class InertStringTests
     /// that the constructor "just forwards".</item>
     /// <item>Moving <c>ScalarPolicy</c> or <c>TextPolicy</c> next to the encoder, on the grounds
     /// that the policy is "part of encoding". The creation path would still exist and would
-    /// still drag the import in with it.</item>
+    /// still drag the namespace in with it.</item>
     /// </list>
     /// </remarks>
     [Fact]

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Reflection;
 
-using InertText.Encoder;
+using InertText.Encoding;
 
 namespace InertText.Tests;
 
@@ -512,9 +512,9 @@ public class InertStringTests
     /// This is what the namespace split buys, and it is worth stating as a property rather than
     /// as a layout convention, because layout is what drifts. The decoder is the one operation
     /// that turns an inert value back into the hostile original, so it lives in
-    /// <c>InertText.Encoder</c> and nothing in the currency namespace may offer a way to reach
+    /// <c>InertText.Encoding</c> and nothing in the currency namespace may offer a way to reach
     /// it. A reviewer can then read a file's using block instead of tracing its call graph: no
-    /// <c>using InertText.Encoder</c> means no path back to the original, for every value that
+    /// <c>using InertText.Encoding</c> means no path back to the original, for every value that
     /// file touches.
     ///
     /// Enumerated rather than spot-checked, and accounted one by one, because the failure this
@@ -525,9 +525,9 @@ public class InertStringTests
     /// this test does not stop it. What it does stop is the capability arriving somewhere that
     /// looks like it has not got it.
     ///
-    /// The search string is <c>InertText.Encoder</c>, not <c>using InertText.Encoder</c>. A
+    /// The search string is <c>InertText.Encoding</c>, not <c>using InertText.Encoding</c>. A
     /// using directive is one of two ways to name a namespace, and the other needs no directive
-    /// at all — <c>InertText.Encoder.VisualEncoder.TryDecode(...)</c> compiles in a file with an
+    /// at all — <c>InertText.Encoding.VisualEncoder.TryDecode(...)</c> compiles in a file with an
     /// empty import block. Searching for the directive would show a clean import list for a file
     /// that decodes. The bare namespace catches both, because a fully-qualified call has to
     /// spell it too.
@@ -601,7 +601,7 @@ public class InertStringTests
         MethodInfo? decode = typeof(VisualEncoder).GetMethod(nameof(VisualEncoder.TryDecode));
 
         Assert.NotNull(decode);
-        Assert.Equal("InertText.Encoder", typeof(VisualEncoder).Namespace);
+        Assert.Equal("InertText.Encoding", typeof(VisualEncoder).Namespace);
 
         InertString inert = new(TextPolicy.Field, "\u202Ecmd");
         Assert.True(VisualEncoder.TryDecode(inert.ToString(), out string? original));
@@ -617,7 +617,7 @@ public class InertStringTests
     /// search is only worth running if its answer is small. That is a property of the
     /// <em>producing</em> side, not the decoding side. If the only way to make an
     /// <see cref="InertString"/> were to call the encoder, then every file that produces inert
-    /// text would name <c>InertText.Encoder</c>, the decoder would sit one member access away in
+    /// text would name <c>InertText.Encoding</c>, the decoder would sit one member access away in
     /// all of them, and the search would return the whole producer set. The signal would survive
     /// in form and be worthless in practice.
     ///
@@ -627,7 +627,7 @@ public class InertStringTests
     /// <c>VisualEncoder.Encode</c> — it is what keeps the false-positive rate at zero.
     ///
     /// The claim is about <em>production</em> code, and deliberately so. This test file names
-    /// <c>InertText.Encoder</c> itself, as do the encoder's own tests: invertibility is a
+    /// <c>InertText.Encoding</c> itself, as do the encoder's own tests: invertibility is a
     /// contract, so something has to decode in order to check it. A test that can decode is the
     /// system working, not a leak — the search that matters is over the files that ship. Read
     /// the counts above as production-only.
@@ -644,7 +644,7 @@ public class InertStringTests
     [Fact]
     public void InertTextCanBeProducedWithoutNamingTheCapabilityNamespace()
     {
-        const string Capability = "InertText.Encoder";
+        const string Capability = "InertText.Encoding";
 
         // Every public way to obtain an InertString: constructors, and static members that
         // hand one back. Enumerated so a creation path added later is covered without an edit.
@@ -950,18 +950,18 @@ public class InertStringTests
     }
 
     /// <summary>
-    /// No project imports <c>InertText.Encoder</c> for every file at once, so naming the
+    /// No project imports <c>InertText.Encoding</c> for every file at once, so naming the
     /// capability namespace stays a per-file act and the audit search keeps file granularity.
     /// </summary>
     /// <remarks>
     /// The audit sold by <c>docs/design/inert-text.md</c> is a search for the bare string
-    /// <c>InertText.Encoder</c>, on the reasoning that both ways to reach a namespace spell it:
+    /// <c>InertText.Encoding</c>, on the reasoning that both ways to reach a namespace spell it:
     /// a using directive, and a fully-qualified call. There is a third way, and it spells the
     /// namespace somewhere else entirely:
     ///
     /// <code>
-    /// // one file, or a &lt;Using Include="InertText.Encoder" /&gt; item in the .csproj
-    /// global using InertText.Encoder;
+    /// // one file, or a &lt;Using Include="InertText.Encoding" /&gt; item in the .csproj
+    /// global using InertText.Encoding;
     /// </code>
     ///
     /// Every other file in that project can then call <c>VisualEncoder.TryDecode</c> with no
@@ -979,7 +979,7 @@ public class InertStringTests
     [Fact]
     public void NoProjectImportsTheCapabilityNamespaceForEveryFileAtOnce()
     {
-        const string Capability = "InertText.Encoder";
+        const string Capability = "InertText.Encoding";
 
         DirectoryInfo? root = new(AppContext.BaseDirectory);
         while (root is not null && !File.Exists(Path.Combine(root.FullName, "dotnet-inspect.slnx")))
@@ -1045,7 +1045,7 @@ public class InertStringTests
     /// </summary>
     /// <remarks>
     /// The capability is deliberately public and deliberately opt-in: a caller who needs to
-    /// decode names <c>InertText.Encoder</c> and that act is what the audit searches for. What
+    /// decode names <c>InertText.Encoding</c> and that act is what the audit searches for. What
     /// must not happen is the currency type handing the capability over without that opt-in.
     ///
     /// A signature cannot: a separate test walks the public surface and fails any member that
@@ -1058,7 +1058,7 @@ public class InertStringTests
     /// it were part of the contract.
     ///
     /// Naming the <em>namespace</em> stays allowed, and the type-level remarks do it: saying
-    /// the decoder lives in <c>InertText.Encoder</c> and that nothing here reaches it is the
+    /// the decoder lives in <c>InertText.Encoding</c> and that nothing here reaches it is the
     /// opt-in disclaimer rather than a shortcut to it. The line is drawn at the type name,
     /// which is the thing a caller would have to write in order to use it.
     /// </remarks>
@@ -1095,7 +1095,7 @@ public class InertStringTests
             string[] lines = File.ReadAllLines(file);
 
             // The capability's own file documents itself; the rule is about the currency side.
-            if (lines.Any(l => l.StartsWith("namespace InertText.Encoder", StringComparison.Ordinal)))
+            if (lines.Any(l => l.StartsWith("namespace InertText.Encoding", StringComparison.Ordinal)))
             {
                 continue;
             }

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -857,4 +857,95 @@ public class InertStringTests
 
         Assert.Empty(callbacks);
     }
+
+    /// <summary>
+    /// A value composed from fragments that were each encoded separately still decodes, so the
+    /// repair in <see cref="InertString.EnsurePermitted"/> reaches its decode path.
+    /// </summary>
+    /// <remarks>
+    /// The invariant the fallback in <c>EnsurePermitted</c> rests on. When it broke, nothing
+    /// threw: the fallback treated the library's own encoded text as raw and encoded it a second
+    /// time, which is only visible by comparing against a directly encoded value.
+    ///
+    /// A lone high surrogate and a lone low surrogate are the case that broke it, because each
+    /// encodes to an escape alone and the two land adjacent once concatenated.
+    /// </remarks>
+    [Fact]
+    public void Compose_OfFragmentsEncodedSeparately_StillDecodes()
+    {
+        InertString composed = InertString.Join(
+            string.Empty,
+            TextPolicy.Prose,
+            [
+                new InertString(TextPolicy.Prose, "\uD834"),
+                new InertString(TextPolicy.Prose, "\uDD73"),
+                new InertString(TextPolicy.Prose, "\n"),
+            ]);
+
+        Assert.True(
+            VisualEncoder.TryDecode(composed.ToString(), out _),
+            "a value this library composed must decode, or EnsurePermitted over-encodes it");
+    }
+
+    /// <summary>
+    /// Splitting a surrogate pair across a composition boundary and repairing the result yields
+    /// the same value as encoding that astral scalar directly.
+    /// </summary>
+    /// <remarks>
+    /// "\uD834" + "\uDD73" is "\U0001D173" -- one scalar, not two halves -- so the two routes
+    /// describe the same text and must agree. They did not: the composed spelling failed to
+    /// decode, so the repair re-encoded its backslashes and produced \\uD834\\uDD73.
+    /// </remarks>
+    [Fact]
+    public void Compose_OfTwoLoneSurrogates_RepairsToTheSameValueAsEncodingThePairDirectly()
+    {
+        InertString composed = InertString.Join(
+            string.Empty,
+            TextPolicy.Prose,
+            [
+                new InertString(TextPolicy.Prose, "\uD834"),
+                new InertString(TextPolicy.Prose, "\uDD73"),
+                new InertString(TextPolicy.Prose, "\n"),
+            ]);
+
+        InertString repaired = composed.EnsurePermitted(TextPolicy.Field);
+        InertString direct = new(TextPolicy.Field, "\U0001D173\n");
+
+        Assert.Equal(direct, repaired);
+    }
+
+    /// <summary>
+    /// An astral scalar split across a composition boundary does not repair to the same value as
+    /// the ASCII text that spells its halves.
+    /// </summary>
+    /// <remarks>
+    /// The consequence of the two above, and the reason they are worth having. Encoding is meant
+    /// to be injective: distinct inputs keep distinct spellings, which is what lets a reader
+    /// treat the encoded form as evidence of what arrived. These two inputs converged on
+    /// <c>\\uD834\\uDD73\^J</c>, so the rendered output no longer said which one produced it.
+    /// </remarks>
+    [Fact]
+    public void Compose_DoesNotConverge_OnTheAsciiTextThatSpellsTheSurrogateHalves()
+    {
+        InertString newline = new(TextPolicy.Prose, "\n");
+
+        InertString fromScalar = InertString.Join(
+            string.Empty,
+            TextPolicy.Prose,
+            [
+                new InertString(TextPolicy.Prose, "\uD834"),
+                new InertString(TextPolicy.Prose, "\uDD73"),
+                newline,
+            ]).EnsurePermitted(TextPolicy.Field);
+
+        InertString fromAsciiText = InertString.Join(
+            string.Empty,
+            TextPolicy.Prose,
+            [
+                new InertString(TextPolicy.Prose, @"\uD834\uDD73"),
+                newline,
+            ]).EnsurePermitted(TextPolicy.Field);
+
+        Assert.NotEqual(fromAsciiText, fromScalar);
+    }
 }

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -948,4 +948,94 @@ public class InertStringTests
 
         Assert.NotEqual(fromAsciiText, fromScalar);
     }
+
+    /// <summary>
+    /// No project imports <c>InertText.Encoder</c> for every file at once, so naming the
+    /// capability namespace stays a per-file act and the audit search keeps file granularity.
+    /// </summary>
+    /// <remarks>
+    /// The audit sold by <c>docs/design/inert-text.md</c> is a search for the bare string
+    /// <c>InertText.Encoder</c>, on the reasoning that both ways to reach a namespace spell it:
+    /// a using directive, and a fully-qualified call. There is a third way, and it spells the
+    /// namespace somewhere else entirely:
+    ///
+    /// <code>
+    /// // one file, or a &lt;Using Include="InertText.Encoder" /&gt; item in the .csproj
+    /// global using InertText.Encoder;
+    /// </code>
+    ///
+    /// Every other file in that project can then call <c>VisualEncoder.TryDecode</c> with no
+    /// local mention of the namespace at all. The search still finds the import — it is still
+    /// text in the repository — but it stops answering "which files can decode?" and starts
+    /// answering "which projects can decode?", and the file it points at is not the file doing
+    /// the decoding. A reviewer reading a clean import list would conclude the file cannot
+    /// decode, which is the failure the bare-string rule exists to prevent.
+    ///
+    /// So the granularity is an invariant of the build, not of the language, and it is gated
+    /// here rather than asserted in prose. Nothing needs a project-wide encoder import:
+    /// production does not name the namespace at all, and the test projects that legitimately
+    /// decode do it with ordinary per-file directives.
+    /// </remarks>
+    [Fact]
+    public void NoProjectImportsTheCapabilityNamespaceForEveryFileAtOnce()
+    {
+        const string Capability = "InertText.Encoder";
+
+        DirectoryInfo? root = new(AppContext.BaseDirectory);
+        while (root is not null && !File.Exists(Path.Combine(root.FullName, "dotnet-inspect.slnx")))
+        {
+            root = root.Parent;
+        }
+
+        Assert.True(root is not null, "could not locate the repository root from the test binary");
+
+        string source = Path.Combine(root!.FullName, "src");
+        string[] candidates =
+        [
+            .. Directory.EnumerateFiles(source, "*.cs", SearchOption.AllDirectories),
+            .. Directory.EnumerateFiles(source, "*.csproj", SearchOption.AllDirectories),
+            .. Directory.EnumerateFiles(source, "*.props", SearchOption.AllDirectories),
+        ];
+
+        // Non-vacuity: a root that resolved to somewhere without sources would pass silently,
+        // which is the same shape of bug as the invariant being gated.
+        Assert.NotEmpty(candidates);
+
+        List<string> offenders = [];
+        foreach (string file in candidates)
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Line-wise, skipping comments, because the example in this test's own doc comment
+            // is the exact text being searched for -- and a commented-out import is not one.
+            bool offends = File.ReadLines(file).Any(line =>
+            {
+                string trimmed = line.TrimStart();
+                if (trimmed.StartsWith("//", StringComparison.Ordinal)
+                    || trimmed.StartsWith("<!--", StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                return trimmed.StartsWith($"global using {Capability};", StringComparison.Ordinal)
+                    || trimmed.Contains($"<Using Include=\"{Capability}\"", StringComparison.Ordinal);
+            });
+
+            if (offends)
+            {
+                offenders.Add(Path.GetRelativePath(root.FullName, file));
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            $"A project-wide import of '{Capability}' lets any file in that project decode with "
+                + "no local mention of the namespace, so grepping the bare string no longer says "
+                + "which files can recover the original: "
+                + string.Join("; ", offenders));
+    }
 }

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -581,9 +581,15 @@ public class InertStringTests
         {
             Type bare = type.IsByRef ? type.GetElementType()! : type;
 
+            // char-shaped returns count too. Span<char>/ReadOnlySpan<char>/Memory<char> and
+            // char[] hand back the same text a string would, and a gate whose whole value is
+            // catching a *future* addition should not be blind to the spellings an addition
+            // would plausibly use.
             return bare == typeof(string)
                 || bare == typeof(string[])
-                || (bare.IsGenericType && bare.GetGenericArguments().Contains(typeof(string)));
+                || bare == typeof(char[])
+                || (bare.IsGenericType
+                    && bare.GetGenericArguments().Any(a => a == typeof(string) || a == typeof(char)));
         }
     }
 
@@ -621,10 +627,12 @@ public class InertStringTests
     /// all of them, and the search would return the whole producer set. The signal would survive
     /// in form and be worthless in practice.
     ///
-    /// Measured on the tree that introduced this: four production files produce inert text and
-    /// <em>none</em> names the capability namespace. Routing production through the encoder
-    /// would make that four out of five, so the constructor is not sugar over
-    /// <c>VisualEncoder.Encode</c> — it is what keeps the false-positive rate at zero.
+    /// The measurement that matters is taken on a tree that has producers: every file that
+    /// produces inert text does so without naming the capability namespace, so routing production
+    /// through the encoder would turn each producer into a false positive. That is why the
+    /// constructor is not sugar over <c>VisualEncoder.Encode</c> — it is what keeps the
+    /// false-positive rate at zero. The count itself lives with the change that adds producers,
+    /// since this branch ships the library alone.
     ///
     /// The claim is about <em>production</em> code, and deliberately so. This test file names
     /// <c>InertText.Encoding</c> itself, as do the encoder's own tests: invertibility is a
@@ -837,7 +845,7 @@ public class InertStringTests
         foreach (Type type in typeof(InertString).Assembly.GetExportedTypes()
             .Where(t => t.Namespace == "InertText"))
         {
-            foreach (MethodBase member in typeof(InertString).GetMethods(Declared)
+            foreach (MethodBase member in type.GetMethods(Declared)
                 .Cast<MethodBase>()
                 .Concat(type.GetConstructors(Declared)))
             {
@@ -995,6 +1003,10 @@ public class InertStringTests
             .. Directory.EnumerateFiles(source, "*.cs", SearchOption.AllDirectories),
             .. Directory.EnumerateFiles(source, "*.csproj", SearchOption.AllDirectories),
             .. Directory.EnumerateFiles(source, "*.props", SearchOption.AllDirectories),
+            .. Directory.EnumerateFiles(source, "*.targets", SearchOption.AllDirectories),
+            // Repo-root build files are outside src/ but flow into every project under it, so a
+            // <Using Include> there is the widest-reaching version of exactly this hazard.
+            .. Directory.EnumerateFiles(root.FullName, "Directory.Build.*", SearchOption.TopDirectoryOnly),
         ];
 
         // Non-vacuity: a root that resolved to somewhere without sources would pass silently,
@@ -1021,8 +1033,26 @@ public class InertStringTests
                     return false;
                 }
 
-                return trimmed.StartsWith($"global using {Capability};", StringComparison.Ordinal)
-                    || trimmed.Contains($"<Using Include=\"{Capability}\"", StringComparison.Ordinal);
+                if (trimmed.Contains($"<Using Include=\"{Capability}\"", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+
+                // global:: is a legal and equivalent spelling of the same import, so match it too
+                // rather than letting one qualifier walk past the gate.
+                const string Directive = "global using ";
+                if (!trimmed.StartsWith(Directive, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                string imported = trimmed[Directive.Length..].TrimStart();
+                if (imported.StartsWith("global::", StringComparison.Ordinal))
+                {
+                    imported = imported["global::".Length..];
+                }
+
+                return imported.StartsWith($"{Capability};", StringComparison.Ordinal);
             });
 
             if (offends)

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -1,0 +1,640 @@
+using System.Globalization;
+using System.Reflection;
+
+using InertText.Encoder;
+
+namespace InertText.Tests;
+
+/// <summary>
+/// Gates the currency form: that a value cannot be built from untreated text without a policy,
+/// that composition does not launder or double-encode, and that the type stays distinct from
+/// <see cref="string"/>.
+/// </summary>
+public class InertStringTests
+{
+    private const string Hazard = "a\u202Eb";
+
+    [Fact]
+    public void Encode_ProducesAPayloadThePolicyAccepts()
+    {
+        InertString value = new InertString(Hazard, TextPolicy.Field);
+
+        Assert.True(InertString.IsPermitted(value.ToString(), TextPolicy.Field));
+        Assert.True(value.WasEncoded);
+        Assert.Equal(VisualForm.BmpHex, value.Forms);
+    }
+
+    [Fact]
+    public void Encode_RoundTripsThroughTheDecoder()
+    {
+        InertString value = new InertString(Hazard, TextPolicy.Field);
+
+        Assert.True(VisualEncoder.TryDecode(value.ToString(), out string? decoded));
+        Assert.Equal(Hazard, decoded);
+    }
+
+    [Fact]
+    public void Format_EncodesInterpolationHoles()
+    {
+        InertString message = InertString.Format(TextPolicy.Field, $"url: {Hazard}");
+
+        Assert.Equal("url: a\\u202Eb", message.ToString());
+        Assert.True(InertString.IsPermitted(message.ToString(), TextPolicy.Field));
+    }
+
+    [Fact]
+    public void Format_EncodesLiteralsToo()
+    {
+        // The invariant is unconditional on purpose. A bidi override is exactly as invisible in
+        // a C# source file as it is in a feed response, so "literals are trusted" would be an
+        // exemption that has to be re-argued at every call site.
+        InertString message = InertString.Format(TextPolicy.Field, $"a\u202Eb {1}");
+
+        Assert.Equal("a\\u202Eb 1", message.ToString());
+    }
+
+    [Fact]
+    public void Format_AlreadyInertHole_IsNotEncodedTwice()
+    {
+        InertString inner = new InertString(Hazard, TextPolicy.Field);
+
+        InertString outer = InertString.Format(TextPolicy.Field, $"[{inner}]");
+
+        Assert.Equal("[a\\u202Eb]", outer.ToString());
+        Assert.True(VisualEncoder.TryDecode(outer.ToString(), out string? decoded));
+        Assert.Equal($"[{Hazard}]", decoded);
+    }
+
+    [Fact]
+    public void Format_UnionsTheFormsOfEveryPart()
+    {
+        InertString message = InertString.Format(
+            TextPolicy.Field,
+            $"{"\u001B"} {"\u007F"} {"\U0001D173"} {"c:\\tmp"}");
+
+        Assert.Equal(
+            VisualForm.Caret | VisualForm.CaretDelete | VisualForm.AstralHex | VisualForm.Backslash,
+            message.Forms);
+        Assert.Equal(4, message.DescribeLegend().Count);
+    }
+
+    [Fact]
+    public void Format_OrdinaryText_IsUnchanged()
+    {
+        InertString message = InertString.Format(TextPolicy.Field, $"Package '{"Newtonsoft.Json"}' not found.");
+
+        Assert.Equal("Package 'Newtonsoft.Json' not found.", message.ToString());
+        Assert.False(message.WasEncoded);
+        Assert.Empty(message.DescribeLegend());
+    }
+
+    [Fact]
+    public void Format_RespectsThePolicyItIsGiven()
+    {
+        InertString field = InertString.Format(TextPolicy.Field, $"{"a\nb"}");
+        InertString prose = InertString.Format(TextPolicy.Prose, $"{"a\nb"}");
+
+        Assert.Equal("a\\^Jb", field.ToString());
+        Assert.Equal("a\nb", prose.ToString());
+    }
+
+    [Fact]
+    public void Empty_CarriesNoText()
+    {
+        Assert.True(InertString.Empty.IsEmpty);
+        Assert.False(InertString.Empty.WasEncoded);
+        Assert.Equal(string.Empty, InertString.Empty.ToString());
+        Assert.Equal(string.Empty, default(InertString).ToString());
+    }
+
+    [Fact]
+    public void Equality_ComparesTheEncodedText()
+    {
+        InertString left = new InertString(Hazard, TextPolicy.Field);
+        InertString right = new InertString(Hazard, TextPolicy.Field);
+        InertString other = new InertString("b", TextPolicy.Field);
+
+        Assert.True(left == right);
+        Assert.True(left != other);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    [Fact]
+    public void Format_NullableInertHole_IsNotEncodedTwice()
+    {
+        // Redaction returns InertString?, so without a dedicated overload this hole binds to the
+        // generic case, whose ToString hands the encoded text straight back to the encoder and
+        // doubles every backslash the first pass introduced.
+        InertString? inner = new InertString(Hazard, TextPolicy.Field);
+
+        InertString outer = InertString.Format(TextPolicy.Field, $"[{inner}]");
+
+        Assert.Equal("[a\\u202Eb]", outer.ToString());
+        Assert.True(VisualEncoder.TryDecode(outer.ToString(), out string? decoded));
+        Assert.Equal($"[{Hazard}]", decoded);
+    }
+
+    [Fact]
+    public void Format_NullInertHole_ContributesNothing()
+    {
+        InertString? missing = null;
+
+        InertString outer = InertString.Format(TextPolicy.Field, $"[{missing}]");
+
+        Assert.Equal("[]", outer.ToString());
+    }
+
+    [Fact]
+    public void Join_SingleValue_ReportsNoFormFromTheUnusedSeparator()
+    {
+        // The separator is encoded up front, so folding its forms in unconditionally would make
+        // a one-element join advertise a spelling its output does not contain.
+        InertString only = new InertString("plain", TextPolicy.Field);
+
+        InertString joined = InertString.Join("\n", TextPolicy.Field, [only]);
+
+        Assert.Equal("plain", joined.ToString());
+        Assert.Equal(VisualForm.None, joined.Forms);
+        Assert.Empty(joined.DescribeLegend());
+    }
+
+    [Fact]
+    public void Join_MultipleValues_ReportsTheSeparatorForm()
+    {
+        InertString first = new InertString("a", TextPolicy.Field);
+        InertString second = new InertString("b", TextPolicy.Field);
+
+        InertString joined = InertString.Join("\n", TextPolicy.Field, [first, second]);
+
+        Assert.Equal("a\\^Jb", joined.ToString());
+        Assert.Equal(VisualForm.Caret, joined.Forms);
+    }
+
+    [Fact]
+    public void Join_UnderProse_KeepsTheLineBreak()
+    {
+        InertString first = new InertString("a", TextPolicy.Prose);
+        InertString second = new InertString("b", TextPolicy.Prose);
+
+        InertString joined = InertString.Join(Environment.NewLine, TextPolicy.Prose, [first, second]);
+
+        Assert.Equal($"a{Environment.NewLine}b", joined.ToString());
+        Assert.Equal(VisualForm.None, joined.Forms);
+    }
+
+    [Fact]
+    public void Join_NoValues_IsEmpty()
+    {
+        InertString joined = InertString.Join("\n", TextPolicy.Field, []);
+
+        Assert.True(joined.IsEmpty);
+        Assert.Equal(VisualForm.None, joined.Forms);
+    }
+
+    [Fact]
+    public void NoConversionFromStringExists()
+    {
+        // The guard the whole design rests on. A conversion from string would let untreated
+        // text satisfy an InertString parameter silently, which is precisely the confusion the
+        // type was introduced to remove — so it is asserted rather than left to review.
+        MethodInfo[] conversions = typeof(InertString)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.Name is "op_Implicit" or "op_Explicit")
+            .Where(m => m.GetParameters() is [{ ParameterType.FullName: "System.String" }])
+            .ToArray();
+
+        Assert.Empty(conversions);
+    }
+
+    [Fact]
+    public void Splice_ReEncodesAValueThatThisPolicyRefuses()
+    {
+        // Built for a multi-line sink, so the line feed survived encoding.
+        InertString prose = new InertString("first\nsecond", TextPolicy.Prose);
+        Assert.Equal("first\nsecond", prose.ToString());
+
+        // Spliced into a single-line sink, it must not carry the line feed in with it.
+        InertString field = InertString.Format(TextPolicy.Field, $"source: {prose}");
+
+        Assert.DoesNotContain('\n', field.ToString());
+        Assert.Contains(@"\^J", field.ToString(), StringComparison.Ordinal);
+        Assert.True(InertString.IsPermitted(field.ToString(), TextPolicy.Field));
+        Assert.True(field.Forms.HasFlag(VisualForm.Caret));
+    }
+
+    [Fact]
+    public void Splice_LeavesAConformingValueByteForByteAlone()
+    {
+        InertString piece = new InertString("a\u202Eb", TextPolicy.Field);
+        InertString message = InertString.Format(TextPolicy.Field, $"{piece}");
+
+        // The repair path must not fire here, or every splice would pay a decode/re-encode.
+        Assert.Equal(piece.ToString(), message.ToString());
+        Assert.Equal(piece.Forms, message.Forms);
+    }
+
+    [Fact]
+    public void Join_ReEncodesValuesThatThePolicyRefuses()
+    {
+        InertString[] values =
+        [
+            new InertString("one\ntwo", TextPolicy.Prose),
+            new InertString("three", TextPolicy.Field),
+        ];
+
+        InertString joined = InertString.Join(", ", TextPolicy.Field, values);
+
+        Assert.DoesNotContain('\n', joined.ToString());
+        Assert.True(InertString.IsPermitted(joined.ToString(), TextPolicy.Field));
+        Assert.True(joined.Forms.HasFlag(VisualForm.Caret));
+    }
+
+    [Fact]
+    public void Splice_ReportsEveryFormTheRepairIntroduced()
+    {
+        InertString prose = new InertString("a\nb", TextPolicy.Prose);
+        Assert.Equal(VisualForm.None, prose.Forms);
+
+        InertString field = InertString.Format(TextPolicy.Field, $"{prose}");
+
+        // Forms would be None if the splice trusted the incoming value's flags.
+        Assert.NotEqual(VisualForm.None, field.Forms);
+        Assert.NotEmpty(field.DescribeLegend());
+    }
+
+    [Fact]
+    public void Empty_EqualsAnEncodedEmptyString()
+    {
+        InertString encoded = new InertString("", TextPolicy.Field);
+
+        Assert.Equal(InertString.Empty, encoded);
+        Assert.True(InertString.Empty == encoded);
+        Assert.Equal(InertString.Empty.GetHashCode(), encoded.GetHashCode());
+    }
+
+    [Fact]
+    public void Holes_FormatUnderTheInvariantCultureWithOrWithoutASpecifier()
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            double value = 1234.5;
+
+            Assert.Equal("1234.5", InertString.Format(TextPolicy.Field, $"{value}").ToString());
+            Assert.Equal("1234.5", InertString.Format(TextPolicy.Field, $"{value:F1}").ToString());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void Splice_TightensButNeverLoosens()
+    {
+        // Field encoded the line feed; Prose would have permitted it. The repair must not
+        // undo that: composition may make a value more inert, never less, or a value could be
+        // laundered by quoting it into a laxer sink.
+        InertString strict = new InertString("a\nb", TextPolicy.Field);
+        InertString lax = InertString.Format(TextPolicy.Prose, $"{strict}");
+
+        Assert.Equal(@"a\^Jb", lax.ToString());
+        Assert.DoesNotContain('\n', lax.ToString());
+
+        // So splice path is observable, and deliberately so.
+        Assert.NotEqual(InertString.Format(TextPolicy.Prose, $"{"a\nb"}"), lax);
+    }
+
+    [Fact]
+    public void Splice_IsAFixedPointUnderTheSamePolicy()
+    {
+        InertString piece = new InertString("x\ny", TextPolicy.Prose);
+        InertString once = InertString.Format(TextPolicy.Field, $"{piece}");
+        InertString twice = InertString.Format(TextPolicy.Field, $"{once}");
+
+        // Re-composing must not re-encode what the repair already spelled, or a value would
+        // drift every time it passed through a sink.
+        Assert.Equal(once, twice);
+        Assert.Equal(once.Forms, twice.Forms);
+    }
+
+    [Fact]
+    public void EmptyValuesAreIndistinguishableAcrossTheWholeSurface()
+    {
+        // Three field states now mean "empty": the CLR zero value, the constructed Empty, and
+        // an encode of "". Empty is deliberately no longer default, so their agreement is a
+        // real claim rather than a tautology, and every member has to honour it.
+        InertString[] empties =
+        [
+            default,
+            InertString.Empty,
+            new InertString("", TextPolicy.Field),
+        ];
+
+        InertString zero = empties[0];
+        InertString encoded = empties[2];
+
+        // Enumerated rather than spot-checked. The reviewed defect was exactly one member --
+        // equality -- disagreeing with the other three about whether these are the same value,
+        // so the bug class is "some member treats the zero value specially" and a hand-written
+        // list of members is the same gate that already failed to catch it once.
+        MethodInfo[] surface = typeof(InertString)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetParameters().Length == 0 && m.ReturnType != typeof(void))
+            .ToArray();
+
+        Assert.NotEmpty(surface);
+        foreach (MethodInfo member in surface)
+        {
+            string[] answers = empties.Select(e => Describe(member.Invoke(e, null))).ToArray();
+            Assert.Equal(answers.Length, answers.Count(a => a == answers[0]));
+        }
+
+        foreach (InertString left in empties)
+        {
+            foreach (InertString right in empties)
+            {
+                Assert.True(left.Equals(right));
+                Assert.True(left == right);
+                Assert.False(left != right);
+                Assert.Equal(left.GetHashCode(), right.GetHashCode());
+            }
+        }
+
+        Assert.True(zero.Equals(encoded));
+
+        static string Describe(object? value) => value switch
+        {
+            null => "<null>",
+            IEnumerable<string> lines => string.Join("|", lines),
+            _ => value.ToString() ?? "<null>",
+        };
+    }
+
+    [Fact]
+    public void ToString_DoesNotCopy()
+    {
+        InertString value = new InertString("nothing to encode", TextPolicy.Field);
+
+        Assert.Same(value.ToString(), value.ToString());
+    }
+
+    [Fact]
+    public void Equality_ComparesTextRatherThanTheBackingInstance()
+    {
+        // Equality is by text, not by instance. Cheap to state and cheap to keep, and it
+        // pins the property that a representation change must not quietly drop.
+        string one = "a\u202Eb";
+        string other = string.Concat("a\u202E", "b");
+        Assert.False(ReferenceEquals(one, other));
+
+        InertString left = new InertString(one, TextPolicy.Field);
+        InertString right = new InertString(other, TextPolicy.Field);
+
+        Assert.Equal(left, right);
+        Assert.True(left == right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    [Fact]
+    public void NoPublicEntryPointTakesTextWithoutAPolicy()
+    {
+        // The invariant is not "Encode is a static method." It is "text cannot become an
+        // InertString without a policy being applied to it." The conversion test above covers
+        // only op_Implicit and op_Explicit, so a public constructor or a factory taking a bare
+        // string would satisfy every other gate in this file while voiding the whole design.
+        List<string> unguarded = [];
+
+        foreach (ConstructorInfo ctor in typeof(InertString)
+            .GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (TakesText(ctor.GetParameters()) && !TakesPolicy(ctor.GetParameters()))
+            {
+                unguarded.Add($".ctor({Describe(ctor.GetParameters())})");
+            }
+        }
+
+        foreach (MethodInfo factory in typeof(InertString)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.ReturnType == typeof(InertString)))
+        {
+            if (TakesText(factory.GetParameters()) && !TakesPolicy(factory.GetParameters()))
+            {
+                unguarded.Add($"{factory.Name}({Describe(factory.GetParameters())})");
+            }
+        }
+
+        Assert.Empty(unguarded);
+
+        static bool TakesText(ParameterInfo[] parameters) => parameters.Any(p =>
+            p.ParameterType == typeof(string)
+            || p.ParameterType == typeof(char[])
+            || p.ParameterType == typeof(ReadOnlyMemory<char>)
+            || p.ParameterType == typeof(ReadOnlySpan<char>));
+
+        static bool TakesPolicy(ParameterInfo[] parameters) => parameters.Any(p =>
+            p.ParameterType == typeof(ScalarPolicy)
+            || p.ParameterType == typeof(InertStringHandler));
+
+        static string Describe(ParameterInfo[] parameters)
+            => string.Join(", ", parameters.Select(p => p.ParameterType.Name));
+    }
+
+    /// <summary>
+    /// The auditable invariant: holding an <see cref="InertString"/> does not let you recover
+    /// the text it was built from.
+    /// </summary>
+    /// <remarks>
+    /// This is what the namespace split buys, and it is worth stating as a property rather than
+    /// as a layout convention, because layout is what drifts. The decoder is the one operation
+    /// that turns an inert value back into the hostile original, so it lives in
+    /// <c>InertText.Encoder</c> and nothing in the currency namespace may offer a way to reach
+    /// it. A reviewer can then read a file's using block instead of tracing its call graph: no
+    /// <c>using InertText.Encoder</c> means no path back to the original, for every value that
+    /// file touches.
+    ///
+    /// Enumerated rather than spot-checked, and accounted one by one, because the failure this
+    /// guards against is an <em>addition</em> — a convenience overload that hands back the
+    /// decoded form — and a test that asserts specific members exist would not notice one.
+    ///
+    /// The boundary is auditable, not unforgeable. A file can add the import or write the name
+    /// out in full, and this test does not stop it. What it does stop is the capability
+    /// arriving somewhere that looks like it has not got it.
+    /// </remarks>
+    [Fact]
+    public void NoPublicMemberOfTheCurrencyNamespaceReturnsText()
+    {
+        List<string> crossings = [];
+
+        foreach (Type type in typeof(InertString).Assembly.GetExportedTypes()
+            .Where(t => t.Namespace == "InertText"))
+        {
+            foreach (MethodInfo method in type.GetMethods(Declared))
+            {
+                if (IsTextual(method.ReturnType)
+                    || method.GetParameters().Any(p => p.IsOut && IsTextual(p.ParameterType)))
+                {
+                    crossings.Add($"{type.Name}.{method.Name}");
+                }
+            }
+
+            foreach (PropertyInfo property in type.GetProperties(Declared))
+            {
+                if (IsTextual(property.PropertyType))
+                {
+                    crossings.Add($"{type.Name}.{property.Name}");
+                }
+            }
+        }
+
+        // Each of these hands back text, and each is accounted for by what that text is.
+        string[] accounted =
+        [
+            // The encoded form. Handing it back is the type's purpose, and it is the treated
+            // spelling rather than the original, so it is not a way back.
+            "InertString.ToString",
+
+            // Names the spellings emitted -- "\\uXXXX  the scalar at code point U+XXXX". Fixed
+            // strings chosen by VisualForm flags; no artifact text reaches them.
+            "InertString.DescribeLegend",
+
+            // The record's generated ToString. Its three fields are an index, a code point and
+            // a Unicode category, which is exactly why the violation reports an int rather than
+            // the character: a survey can name what it refused without echoing it.
+            "ScalarViolation.ToString",
+        ];
+
+        Assert.Equal(accounted.Order(), crossings.Order());
+
+        static bool IsTextual(Type type)
+        {
+            Type bare = type.IsByRef ? type.GetElementType()! : type;
+
+            return bare == typeof(string)
+                || bare == typeof(string[])
+                || (bare.IsGenericType && bare.GetGenericArguments().Contains(typeof(string)));
+        }
+    }
+
+    /// <summary>
+    /// The other half: the decoder is reachable, but only by naming the capability namespace.
+    /// </summary>
+    /// <remarks>
+    /// Without this, the test above could be satisfied by deleting the decoder outright, which
+    /// would take invertibility with it -- and invertibility is what lets <c>Conform</c> repair
+    /// a spliced value instead of rejecting it.
+    /// </remarks>
+    [Fact]
+    public void TheDecoderLivesInTheCapabilityNamespace()
+    {
+        MethodInfo? decode = typeof(VisualEncoder).GetMethod(nameof(VisualEncoder.TryDecode));
+
+        Assert.NotNull(decode);
+        Assert.Equal("InertText.Encoder", typeof(VisualEncoder).Namespace);
+
+        InertString inert = new("\u202Ecmd", TextPolicy.Field);
+        Assert.True(VisualEncoder.TryDecode(inert.ToString(), out string? original));
+        Assert.Equal("\u202Ecmd", original);
+    }
+
+    /// <summary>
+    /// The third leg, and the one that makes the other two worth having: producing inert text
+    /// never requires naming the capability namespace.
+    /// </summary>
+    /// <remarks>
+    /// The audit this design sells is a search — "which files can recover the original?" — and a
+    /// search is only worth running if its answer is small. That is a property of the
+    /// <em>producing</em> side, not the decoding side. If the only way to make an
+    /// <see cref="InertString"/> were to call the encoder, then every file that produces inert
+    /// text would carry <c>using InertText.Encoder</c>, the decoder would sit one member access
+    /// away in all of them, and the search would return the whole producer set. The signal would
+    /// survive in form and be worthless in practice.
+    ///
+    /// Measured on the tree that introduced this: four production files produce inert text and
+    /// <em>none</em> imports the capability namespace. Routing production through the encoder
+    /// would make that four out of five, so the constructor is not sugar over
+    /// <c>VisualEncoder.Encode</c> — it is what keeps the false-positive rate at zero.
+    ///
+    /// The claim is about <em>production</em> code, and deliberately so. This test file imports
+    /// <c>InertText.Encoder</c> itself, as do the encoder's own tests: invertibility is a
+    /// contract, so something has to decode in order to check it. A test that can decode is the
+    /// system working, not a leak — the search that matters is over the files that ship. Read
+    /// the counts above as production-only.
+    ///
+    /// Two distinct regressions are gated here, because both look like tidying:
+    /// <list type="bullet">
+    /// <item>Removing the public constructor in favour of an encoder factory, on the grounds
+    /// that the constructor "just forwards".</item>
+    /// <item>Moving <c>ScalarPolicy</c> or <c>TextPolicy</c> next to the encoder, on the grounds
+    /// that the policy is "part of encoding". The creation path would still exist and would
+    /// still drag the import in with it.</item>
+    /// </list>
+    /// </remarks>
+    [Fact]
+    public void InertTextCanBeProducedWithoutNamingTheCapabilityNamespace()
+    {
+        const string Capability = "InertText.Encoder";
+
+        // Every public way to obtain an InertString: constructors, and static members that
+        // hand one back. Enumerated so a creation path added later is covered without an edit.
+        List<(string Name, Type[] Needs)> paths =
+        [
+            .. typeof(InertString).GetConstructors(Declared)
+                .Select(c => ($".ctor({Describe(c.GetParameters())})",
+                    c.GetParameters().Select(p => p.ParameterType).ToArray())),
+            .. typeof(InertString).GetMethods(Declared)
+                .Where(m => m.IsStatic && m.ReturnType == typeof(InertString))
+                .Select(m => ($"{m.Name}({Describe(m.GetParameters())})",
+                    m.GetParameters().Select(p => p.ParameterType).ToArray())),
+        ];
+
+        // Non-vacuity. Without this the test passes by there being no creation path at all,
+        // which is precisely the regression it exists to catch.
+        Assert.NotEmpty(paths);
+
+        (string Name, Type[] Needs)[] dragIn = [.. paths
+            .Where(p => p.Needs.Any(t => Namespaces(t).Any(ns => ns == Capability)))];
+
+        // Every path, not merely one of them. "Some way in is clean" is not the property --
+        // a caller uses the path that fits its call site, so a single contaminated overload is
+        // a hole for everyone who reaches for it.
+        Assert.True(
+            dragIn.Length == 0,
+            $"These ways to build an InertString name a type from '{Capability}', so the files "
+                + "that use them must import the decoder and the audit search stops being worth "
+                + "running: "
+                + string.Join("; ", dragIn.Select(p => p.Name)));
+
+        // The policy a caller must pass has to be reachable from the currency namespace too --
+        // a self-contained signature is no use if the only ScalarPolicy values live next to the
+        // decoder.
+        Assert.Equal("InertText", typeof(ScalarPolicy).Namespace);
+        Assert.Equal("InertText", typeof(TextPolicy).Namespace);
+
+        // Smoke check that the reflected signature is actually callable as described.
+        InertString produced = new("\u202Ecmd", TextPolicy.Field);
+        Assert.True(produced.WasEncoded);
+
+        static IEnumerable<string> Namespaces(Type type)
+        {
+            Type bare = type.IsByRef ? type.GetElementType()! : type;
+
+            yield return bare.Namespace ?? string.Empty;
+
+            foreach (Type argument in bare.IsGenericType ? bare.GetGenericArguments() : [])
+            {
+                foreach (string nested in Namespaces(argument))
+                {
+                    yield return nested;
+                }
+            }
+        }
+
+        static string Describe(ParameterInfo[] parameters)
+            => string.Join(", ", parameters.Select(p => p.ParameterType.Name));
+    }
+
+    private const BindingFlags Declared =
+        BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+}

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -526,11 +526,11 @@ public class InertStringTests
     /// looks like it has not got it.
     ///
     /// The search string is <c>InertText.Encoder</c>, not <c>using InertText.Encoder</c>. A
-    /// using directive is one of two ways to reach a namespace, and the other leaves the import
-    /// block untouched — <c>InertText.Encoder.VisualEncoder.TryDecode(...)</c> compiles in a file
-    /// whose only directive is <c>using InertText</c>. Searching for the directive would show a
-    /// clean import list for a file that decodes. The bare namespace catches both, because a
-    /// fully-qualified call has to spell it too.
+    /// using directive is one of two ways to name a namespace, and the other needs no directive
+    /// at all — <c>InertText.Encoder.VisualEncoder.TryDecode(...)</c> compiles in a file with an
+    /// empty import block. Searching for the directive would show a clean import list for a file
+    /// that decodes. The bare namespace catches both, because a fully-qualified call has to
+    /// spell it too.
     /// </remarks>
     [Fact]
     public void NoPublicMemberOfTheCurrencyNamespaceReturnsText()

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -234,6 +234,69 @@ public class InertStringTests
     }
 
     [Fact]
+    public void EnsurePermitted_IsIdempotent()
+    {
+        // The input has to carry both a prior escape and a scalar the target policy refuses, or
+        // the repair path never runs and the test passes vacuously. Prose refuses the bidi
+        // override (so the value arrives already carrying a backslash escape) but permits the
+        // line feed (which Field then refuses, forcing the repair).
+        InertString origin = new InertString("a\u202Eb\nc", TextPolicy.Prose);
+        Assert.Contains(@"\u202E", origin.ToString(), StringComparison.Ordinal);
+        Assert.Contains('\n', origin.ToString());
+
+        InertString once = origin.EnsurePermitted(TextPolicy.Field);
+        InertString twice = once.EnsurePermitted(TextPolicy.Field);
+        InertString thrice = twice.EnsurePermitted(TextPolicy.Field);
+
+        // The repair must have fired, otherwise the assertions below prove nothing.
+        Assert.NotEqual(origin.ToString(), once.ToString());
+        Assert.Equal(once.ToString(), twice.ToString());
+        Assert.Equal(once.ToString(), thrice.ToString());
+
+        // Repair decodes before re-spelling, so the existing escape survives intact rather than
+        // having its backslash escaped again. Dropping the TryDecode step doubles it here.
+        Assert.Contains(@"\u202E", once.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(@"\\u202E", once.ToString(), StringComparison.Ordinal);
+
+        // Pin the failure this guards against: the substitute a caller would otherwise reach for.
+        InertString viaToString = new InertString(origin.ToString(), TextPolicy.Field);
+        Assert.Contains(@"\\u202E", viaToString.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnsurePermitted_LeavesAStricterValueAloneWhenTheSinkIsLaxer()
+    {
+        // The one splice production actually performs: Field-encoded lines joined under Prose
+        // (FeedFailureTelemetry.DescribeFailure). Field's output satisfies Prose, so the repair
+        // must not fire -- if it did, every failure message would pay a decode/re-encode and the
+        // Field spellings would be undone into text Prose permits.
+        foreach (string source in new[] { "a\u202Eb", "x\ny", "p\u0007q", "\uD800lone" })
+        {
+            InertString strict = new InertString(source, TextPolicy.Field);
+            InertString spliced = strict.EnsurePermitted(TextPolicy.Prose);
+
+            Assert.Equal(strict.ToString(), spliced.ToString());
+            Assert.Equal(strict.Forms, spliced.Forms);
+        }
+    }
+
+    [Fact]
+    public void WasEncoded_DoesNotAnswerWhetherAPolicyIsSatisfied()
+    {
+        // WasEncoded reports what was done, not what is satisfied, and it is wrong in both
+        // directions. A sink that used it as a conformance check would admit the first value and
+        // needlessly repair the second.
+        InertString prose = new InertString("line1\nline2", TextPolicy.Prose);
+        Assert.False(prose.WasEncoded);
+        Assert.False(InertString.IsPermitted(prose.ToString(), TextPolicy.Field));
+
+        InertString field = new InertString("a\u202Eb", TextPolicy.Field);
+        Assert.True(field.WasEncoded);
+        Assert.True(InertString.IsPermitted(field.ToString(), TextPolicy.Field));
+        Assert.True(InertString.IsPermitted(field.ToString(), TextPolicy.Prose));
+    }
+
+    [Fact]
     public void Join_ReEncodesValuesThatThePolicyRefuses()
     {
         InertString[] values =
@@ -529,7 +592,7 @@ public class InertStringTests
     /// </summary>
     /// <remarks>
     /// Without this, the test above could be satisfied by deleting the decoder outright, which
-    /// would take invertibility with it -- and invertibility is what lets <c>Conform</c> repair
+    /// would take invertibility with it -- and invertibility is what lets <c>EnsurePermitted</c> repair
     /// a spliced value instead of rejecting it.
     /// </remarks>
     [Fact]

--- a/src/InertText.Tests/InertText.Tests.csproj
+++ b/src/InertText.Tests/InertText.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <RootNamespace>InertText.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\InertText\InertText.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/InertText.Tests/VisualEncoderTests.cs
+++ b/src/InertText.Tests/VisualEncoderTests.cs
@@ -2,7 +2,7 @@ using System.Buffers;
 using System.Globalization;
 using System.Text;
 
-using InertText.Encoder;
+using InertText.Encoding;
 
 namespace InertText.Tests;
 

--- a/src/InertText.Tests/VisualEncoderTests.cs
+++ b/src/InertText.Tests/VisualEncoderTests.cs
@@ -1,0 +1,370 @@
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+
+using InertText.Encoder;
+
+namespace InertText.Tests;
+
+/// <summary>
+/// Gates the properties the encoding asserts: total, inert, lossless, and invertible.
+/// </summary>
+/// <remarks>
+/// Invertibility is the one that cannot be checked by inspection. A caret-introduced spelling
+/// looks correct and passes casual review, and only fails once a decoder exists and the sweep
+/// below runs it over the alphabet that can collide.
+/// </remarks>
+public class VisualEncoderTests
+{
+    [Fact]
+    public void RoundTrip_EveryScalar_RecoversTheOriginal()
+    {
+        // The whole plane, not just the BMP: 127 scalars in the encoded categories live above
+        // it, and a sweep that stops at U+FFFF is exactly why that gap survived review once.
+        for (int cp = 0; cp <= 0x10FFFF; cp++)
+        {
+            if (cp is >= 0xD800 and <= 0xDFFF)
+            {
+                continue;
+            }
+
+            string original = new Rune(cp).ToString();
+            string encoded = new InertString(original, TextPolicy.Field).ToString();
+
+            Assert.True(
+                VisualEncoder.TryDecode(encoded, out string? decoded),
+                $"U+{cp:X4} encoded as '{encoded}' and did not decode");
+            Assert.Equal(original, decoded);
+        }
+    }
+
+    [Fact]
+    public void RoundTrip_UnpairedSurrogates_RecoverExactly()
+    {
+        for (int cp = 0xD800; cp <= 0xDFFF; cp++)
+        {
+            string original = ((char)cp).ToString();
+            string encoded = new InertString(original, TextPolicy.Field).ToString();
+
+            Assert.NotEqual(original, encoded);
+            Assert.True(VisualEncoder.TryDecode(encoded, out string? decoded), encoded);
+            Assert.Equal(original, decoded);
+        }
+    }
+
+    [Fact]
+    public void Encode_IsInjective_OverTheCollidingAlphabet()
+    {
+        // Every character that can appear in a spelling, so a collision between two different
+        // inputs has somewhere to show up. 'U' is in here because the astral form introduced
+        // with it must not be confusable with the BMP form introduced with 'u'.
+        char[] alphabet = ['\\', '^', 'u', 'U', '?', '@', '[', '0', '9', 'A', 'F',
+                           '\u001B', '\u001E', '\u007F', '\u202E', '\uFEFF', '\u2028'];
+
+        Dictionary<string, string> seen = new(StringComparer.Ordinal);
+
+        foreach (string original in Strings(alphabet, 3))
+        {
+            string encoded = new InertString(original, TextPolicy.Field).ToString();
+
+            Assert.True(VisualEncoder.TryDecode(encoded, out string? decoded), encoded);
+            Assert.Equal(original, decoded);
+
+            if (seen.TryGetValue(encoded, out string? collision))
+            {
+                Assert.Fail(
+                    $"'{Describe(collision)}' and '{Describe(original)}' both encode to '{encoded}'");
+            }
+
+            seen[encoded] = original;
+        }
+    }
+
+    [Fact]
+    public void Encode_AstralScalars_UseTheEightDigitForm()
+    {
+        // U+13430 EGYPTIAN HIEROGLYPH VERTICAL JOINER is Cf and lives above the BMP. \uXXXX
+        // cannot express it, so an encoder built on four hex digits returns it untouched while
+        // reporting success.
+        Assert.Equal(@"A\U00013430B", new InertString("A\U00013430B", TextPolicy.Field).ToString());
+        Assert.False(InertString.IsPermitted("A\U00013430B", TextPolicy.Field, out var violation));
+        Assert.Equal(0x13430, violation!.Value.Scalar);
+        Assert.Equal(UnicodeCategory.Format, violation.Value.Category);
+    }
+
+    [Fact]
+    public void Encode_EveryEncodedScalarAboveTheBmp_IsEncoded()
+    {
+        int encodedCount = 0;
+
+        for (int cp = 0x10000; cp <= 0x10FFFF; cp++)
+        {
+            Rune scalar = new(cp);
+
+            if (!TextPolicy.IsNonGraphic(scalar))
+            {
+                continue;
+            }
+
+            encodedCount++;
+            string original = scalar.ToString();
+            Assert.NotEqual(original, new InertString(original, TextPolicy.Field).ToString());
+            Assert.False(InertString.IsPermitted(original, TextPolicy.Field));
+        }
+
+        // Pinned so a narrowing of the category rule fails here rather than quietly shrinking.
+        Assert.Equal(127, encodedCount);
+    }
+
+    [Fact]
+    public void Encode_PairedSurrogates_AreNotHazards()
+    {
+        // A loop over char calling GetUnicodeCategory per unit encodes every emoji, because
+        // both halves of a pair are Cs. Only an unpaired surrogate is a hazard.
+        foreach (string text in new[] { "\U0001F600", "\U0001F468\u200D\U0001F469", "\U00020BB7" })
+        {
+            string encoded = new InertString(text, TextPolicy.Field).ToString();
+            Assert.DoesNotContain(@"\uD8", encoded, StringComparison.Ordinal);
+            Assert.True(VisualEncoder.TryDecode(encoded, out string? decoded));
+            Assert.Equal(text, decoded);
+        }
+
+        Assert.Equal("\U0001F600", new InertString("\U0001F600", TextPolicy.Field).ToString());
+    }
+
+    [Fact]
+    public void CategoryRule_CoversTheRustcAndBidiControlSets_ByName()
+    {
+        // Named individually rather than looked up by category, so a future narrowing of the
+        // rule fails here instead of silently stopping at nine, or at zero.
+        int[] rustc =
+        [
+            0x202A, 0x202B, 0x202C, 0x202D, 0x202E,
+            0x2066, 0x2067, 0x2068, 0x2069,
+        ];
+        int[] bidiControlOnly = [0x200E, 0x200F, 0x061C];
+
+        foreach (int cp in rustc.Concat(bidiControlOnly))
+        {
+            Rune scalar = new(cp);
+            Assert.True(TextPolicy.IsNonGraphic(scalar), $"U+{cp:X4}");
+            Assert.False(InertString.IsPermitted(scalar.ToString(), TextPolicy.Field));
+        }
+
+        Assert.Equal(9, rustc.Length);
+        Assert.Equal(12, rustc.Length + bidiControlOnly.Length);
+    }
+
+    [Fact]
+    public void CategoryRule_CoversTheInvisibleFormatCharacters()
+    {
+        // Past bidi, the encoded set is all of Cf. These are the ones ApiOutputFormatter
+        // deliberately excludes; the divergence is recorded in the spec and resolved upward.
+        foreach (int cp in new[] { 0x200C, 0x200D, 0x2060, 0x00AD, 0xFEFF })
+        {
+            Assert.True(TextPolicy.IsNonGraphic(new Rune(cp)), $"U+{cp:X4}");
+        }
+    }
+
+    [Fact]
+    public void Spelling_MatchesCaretNotation()
+    {
+        Assert.Equal(@"\^[", new InertString("\u001B", TextPolicy.Field).ToString());
+        Assert.Equal(@"\^@", new InertString("\u0000", TextPolicy.Field).ToString());
+        Assert.Equal(@"\^?", new InertString("\u007F", TextPolicy.Field).ToString());
+        Assert.Equal(@"\\", new InertString("\\", TextPolicy.Field).ToString());
+        Assert.Equal(@"\u202E", new InertString("\u202E", TextPolicy.Field).ToString());
+
+        // The collision the backslash introducer exists to prevent: U+001E is 0x1E + 0x40 = '^',
+        // so a caret-introduced spelling gives RS and a literal caret the same output.
+        Assert.NotEqual(
+            new InertString("\u001E", TextPolicy.Field).ToString(),
+            new InertString("^", TextPolicy.Field).ToString());
+    }
+
+    [Fact]
+    public void Encode_OrdinaryText_IsUnchanged()
+    {
+        // Encoding everything would be safe and useless. Ordinary text has to survive intact,
+        // including scripts and marks that are not ASCII.
+        foreach (string text in new[]
+        {
+            "https://pkgs.dev.azure.com/org/proj/_packaging/feed/nuget/v3/index.json",
+            "Ünïcödé", "日本語", "emoji \U0001F600", "a\u0301",
+        })
+        {
+            Assert.Equal(text, new InertString(text, TextPolicy.Field).ToString());
+            Assert.True(InertString.IsPermitted(text, TextPolicy.Field));
+        }
+    }
+
+    [Fact]
+    public void IsPermitted_TreatsTheBackslashAsPermitted()
+    {
+        // A Windows path is the case that makes this matter: it is full of backslashes, none of
+        // them is a hazard, and a check derived from "would Encode change this" rejects them all.
+        const string path = @"C:\Users\rich\.nuget\packages";
+
+        Assert.True(InertString.IsPermitted(path, TextPolicy.Field));
+        Assert.NotEqual(path, new InertString(path, TextPolicy.Field).ToString());
+    }
+
+    [Fact]
+    public void Policy_IsTheCallersToChoose()
+    {
+        const string multiline = "line one\nline two\tindented";
+
+        Assert.True(InertString.IsPermitted(multiline, TextPolicy.Prose));
+        Assert.Equal(multiline, new InertString(multiline, TextPolicy.Prose).ToString());
+
+        Assert.False(InertString.IsPermitted(multiline, TextPolicy.Field));
+        Assert.Equal(@"line one\^Jline two\^Iindented", new InertString(multiline, TextPolicy.Field).ToString());
+
+        // No sink may exempt a bidi control, whatever else it exempts.
+        Assert.False(InertString.IsPermitted("\u202E", TextPolicy.Prose));
+    }
+
+    [Fact]
+    public void Policy_AllowShaped_CatchesAHomoglyphThatNoCategoryRuleCan()
+    {
+        // The attack the whole split exists for. Cyrillic е U+0435 and Latin e U+0065 are the
+        // same glyph, both category Ll, and neither is a hazard — so a deny-shaped policy
+        // renders the typosquat raw and the substitution stays invisible.
+        const string hijacked = "N\u0435wtonsoft.Json";
+
+        Assert.True(InertString.IsPermitted(hijacked, TextPolicy.Field));
+        Assert.Equal(hijacked, new InertString(hijacked, TextPolicy.Field).ToString());
+
+        // An allow list over the published grammar catches it, and the speller — which never
+        // learns why — spells it without needing a hazard set of its own.
+        static bool PackageId(Rune scalar)
+            => scalar.Value is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z')
+                or (>= '0' and <= '9') or '.' or '-' or '_';
+
+        Assert.False(InertString.IsPermitted(hijacked, PackageId, out var violation));
+        Assert.Equal(0x0435, violation!.Value.Scalar);
+        Assert.Equal(@"N\u0435wtonsoft.Json", new InertString(hijacked, PackageId).ToString());
+    }
+
+    [Fact]
+    public void Legend_NamesEveryFormTheOutputContains()
+    {
+        InertString value = new InertString("a\u001B\u007F\u202E\U00013430\\b", TextPolicy.Field);
+        string encoded = value.ToString();
+        VisualForm forms = value.Forms;
+
+        IReadOnlyList<string> legend = value.DescribeLegend();
+
+        // Derived from the enum rather than hand-listed: adding a VisualForm and forgetting
+        // either the sample input or its DescribeLegend arm has to fail here, not pass quietly.
+        VisualForm[] every = Enum.GetValues<VisualForm>().Where(f => f != VisualForm.None).ToArray();
+        Assert.Equal(every.Length, legend.Count);
+        foreach (VisualForm form in every)
+        {
+            Assert.True(forms.HasFlag(form), $"the sample input no longer produces {form}");
+            Assert.NotEmpty(VisualEncoder.DescribeLegend(form));
+        }
+
+        // The legend names forms, never values.
+        Assert.DoesNotContain(legend, line => line.Contains("13430", StringComparison.Ordinal));
+        Assert.Contains(@"\U00013430", encoded, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Legend_IsEmptyWhenNothingWasEncoded()
+    {
+        VisualForm forms = new InertString("ordinary text", TextPolicy.Field).Forms;
+
+        Assert.Equal(VisualForm.None, forms);
+        Assert.Empty(VisualEncoder.DescribeLegend(forms));
+    }
+
+    [Fact]
+    public void TryDecode_MalformedInput_IsRejected()
+    {
+        foreach (string malformed in new[]
+        {
+            @"\", @"\q", @"\^", @"\^!", @"\u12", @"\uZZZZ",
+            @"\U0001", @"\UZZZZZZZZ",
+            @"\U0000202E",  // an astral form naming a BMP scalar would be a second spelling
+            @"\U00110000",  // past the last scalar
+        })
+        {
+            Assert.False(VisualEncoder.TryDecode(malformed, out string? value), malformed);
+            Assert.Null(value);
+        }
+    }
+
+    private static string Describe(string value)
+        => string.Join(" ", value.Select(c => $"U+{(int)c:X4}"));
+
+    private static IEnumerable<string> Strings(char[] alphabet, int maxLength)
+    {
+        List<string> current = [string.Empty];
+
+        for (int length = 1; length <= maxLength; length++)
+        {
+            List<string> next = [];
+
+            foreach (string prefix in current)
+            {
+                foreach (char c in alphabet)
+                {
+                    string s = prefix + c;
+                    next.Add(s);
+                    yield return s;
+                }
+            }
+
+            current = next;
+        }
+    }
+
+    [Fact]
+    public void Violation_NamesTheActualCodeUnitForAnUnpairedSurrogate()
+    {
+        Assert.False(InertString.IsPermitted("ab\uD800cd", TextPolicy.Field, out ScalarViolation? violation));
+
+        // Rune cannot hold a lone surrogate, so reporting through it named U+FFFD here --
+        // one wrong answer, identically, for all 2048 values whose identity is the finding.
+        Assert.Equal(0xD800, violation!.Value.Scalar);
+        Assert.Equal(UnicodeCategory.Surrogate, violation.Value.Category);
+        Assert.Equal(2, violation.Value.Index);
+        Assert.Equal("U+D800 (Surrogate) at 2", violation.Value.ToString());
+    }
+
+    [Fact]
+    public void Violation_AgreesWithTheSpellingTheEncoderChooses()
+    {
+        const string input = "ab\uDFFFcd";
+        Assert.False(InertString.IsPermitted(input, TextPolicy.Field, out ScalarViolation? violation));
+
+        string encoded = new InertString(input, TextPolicy.Field).ToString();
+
+        Assert.Contains(
+            string.Create(CultureInfo.InvariantCulture, $"\\u{violation!.Value.Scalar:X4}"),
+            encoded,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(@"\u005C")]
+    [InlineData(@"\u0000")]
+    [InlineData(@"\u001B")]
+    [InlineData(@"\u007F")]
+    public void Decode_RejectsBmpHexForScalarsWithACanonicalSpelling(string encoded)
+    {
+        // Encode spells these \\, \^X and \^?, so accepting \uXXXX too would mean one scalar
+        // with two encodings.
+        Assert.False(VisualEncoder.TryDecode(encoded, out _));
+    }
+
+    [Fact]
+    public void Decode_StillAcceptsBmpHexForScalarsAPolicyMayRefuse()
+    {
+        // 'A' has no canonical short spelling, and a restrictive policy is free to encode it,
+        // so the canonicality check must not reach this far.
+        Assert.True(VisualEncoder.TryDecode(@"\u0041", out string? decoded));
+        Assert.Equal("A", decoded);
+    }
+}

--- a/src/InertText.Tests/VisualEncoderTests.cs
+++ b/src/InertText.Tests/VisualEncoderTests.cs
@@ -399,10 +399,31 @@ public class VisualEncoderTests
     [Theory]
     [InlineData(@"\u00ad", "lowercase BMP hex; AppendBmpHex emits X4, never x4")]
     [InlineData(@"\U0001f600", "lowercase astral hex; AppendSpelling emits X8")]
-    [InlineData(@"\uD83D\uDE00", "a surrogate pair as two escapes; the scalar spells as \\U0001F600")]
     public void Decode_RefusesANonCanonicalSpelling(string encoded, string why)
     {
         Assert.False(VisualEncoder.TryDecode(encoded, out _), why);
+    }
+
+    /// <summary>
+    /// A surrogate pair spelled as two escapes decodes to the astral scalar rather than being
+    /// refused as a non-canonical spelling of it.
+    /// </summary>
+    /// <remarks>
+    /// This spelling was refused when the rule above was written, on the reasoning that
+    /// <c>\U0001F600</c> is the canonical form and a second one costs injectivity. The premise
+    /// does not hold: a .NET string is UTF-16, so <c>"\uD83D" + "\uDE00"</c> <em>is</em>
+    /// <c>"\U0001F600"</c>, and no string exists that the refused spelling could denote instead.
+    /// Refusing it therefore rejected an input rather than disambiguating two.
+    ///
+    /// It also broke composition, which is what
+    /// <c>Compose_OfTwoLoneSurrogates_RepairsToTheSameValueAsEncodingThePairDirectly</c> covers:
+    /// the halves arrive from separate fragments, each encoded alone.
+    /// </remarks>
+    [Fact]
+    public void Decode_AcceptsASurrogatePairSpelledAsTwoEscapes()
+    {
+        Assert.True(VisualEncoder.TryDecode(@"\uD83D\uDE00", out string? decoded));
+        Assert.Equal("\U0001F600", decoded);
     }
 
     /// <summary>

--- a/src/InertText.Tests/VisualEncoderTests.cs
+++ b/src/InertText.Tests/VisualEncoderTests.cs
@@ -29,7 +29,7 @@ public class VisualEncoderTests
             }
 
             string original = new Rune(cp).ToString();
-            string encoded = new InertString(original, TextPolicy.Field).ToString();
+            string encoded = new InertString(TextPolicy.Field, original).ToString();
 
             Assert.True(
                 VisualEncoder.TryDecode(encoded, out string? decoded),
@@ -44,7 +44,7 @@ public class VisualEncoderTests
         for (int cp = 0xD800; cp <= 0xDFFF; cp++)
         {
             string original = ((char)cp).ToString();
-            string encoded = new InertString(original, TextPolicy.Field).ToString();
+            string encoded = new InertString(TextPolicy.Field, original).ToString();
 
             Assert.NotEqual(original, encoded);
             Assert.True(VisualEncoder.TryDecode(encoded, out string? decoded), encoded);
@@ -65,7 +65,7 @@ public class VisualEncoderTests
 
         foreach (string original in Strings(alphabet, 3))
         {
-            string encoded = new InertString(original, TextPolicy.Field).ToString();
+            string encoded = new InertString(TextPolicy.Field, original).ToString();
 
             Assert.True(VisualEncoder.TryDecode(encoded, out string? decoded), encoded);
             Assert.Equal(original, decoded);
@@ -86,8 +86,8 @@ public class VisualEncoderTests
         // U+13430 EGYPTIAN HIEROGLYPH VERTICAL JOINER is Cf and lives above the BMP. \uXXXX
         // cannot express it, so an encoder built on four hex digits returns it untouched while
         // reporting success.
-        Assert.Equal(@"A\U00013430B", new InertString("A\U00013430B", TextPolicy.Field).ToString());
-        Assert.False(InertString.IsPermitted("A\U00013430B", TextPolicy.Field, out var violation));
+        Assert.Equal(@"A\U00013430B", new InertString(TextPolicy.Field, "A\U00013430B").ToString());
+        Assert.False(InertString.IsPermitted(TextPolicy.Field, "A\U00013430B", out var violation));
         Assert.Equal(0x13430, violation!.Value.Scalar);
         Assert.Equal(UnicodeCategory.Format, violation.Value.Category);
     }
@@ -101,15 +101,15 @@ public class VisualEncoderTests
         {
             Rune scalar = new(cp);
 
-            if (!TextPolicy.IsNonGraphic(scalar))
+            if (!ScalarPolicies.IsNonGraphic(scalar))
             {
                 continue;
             }
 
             encodedCount++;
             string original = scalar.ToString();
-            Assert.NotEqual(original, new InertString(original, TextPolicy.Field).ToString());
-            Assert.False(InertString.IsPermitted(original, TextPolicy.Field));
+            Assert.NotEqual(original, new InertString(TextPolicy.Field, original).ToString());
+            Assert.False(InertString.IsPermitted(TextPolicy.Field, original));
         }
 
         // Pinned so a narrowing of the category rule fails here rather than quietly shrinking.
@@ -123,13 +123,13 @@ public class VisualEncoderTests
         // both halves of a pair are Cs. Only an unpaired surrogate is a hazard.
         foreach (string text in new[] { "\U0001F600", "\U0001F468\u200D\U0001F469", "\U00020BB7" })
         {
-            string encoded = new InertString(text, TextPolicy.Field).ToString();
+            string encoded = new InertString(TextPolicy.Field, text).ToString();
             Assert.DoesNotContain(@"\uD8", encoded, StringComparison.Ordinal);
             Assert.True(VisualEncoder.TryDecode(encoded, out string? decoded));
             Assert.Equal(text, decoded);
         }
 
-        Assert.Equal("\U0001F600", new InertString("\U0001F600", TextPolicy.Field).ToString());
+        Assert.Equal("\U0001F600", new InertString(TextPolicy.Field, "\U0001F600").ToString());
     }
 
     [Fact]
@@ -147,8 +147,8 @@ public class VisualEncoderTests
         foreach (int cp in rustc.Concat(bidiControlOnly))
         {
             Rune scalar = new(cp);
-            Assert.True(TextPolicy.IsNonGraphic(scalar), $"U+{cp:X4}");
-            Assert.False(InertString.IsPermitted(scalar.ToString(), TextPolicy.Field));
+            Assert.True(ScalarPolicies.IsNonGraphic(scalar), $"U+{cp:X4}");
+            Assert.False(InertString.IsPermitted(TextPolicy.Field, scalar.ToString()));
         }
 
         Assert.Equal(9, rustc.Length);
@@ -162,24 +162,24 @@ public class VisualEncoderTests
         // deliberately excludes; the divergence is recorded in the spec and resolved upward.
         foreach (int cp in new[] { 0x200C, 0x200D, 0x2060, 0x00AD, 0xFEFF })
         {
-            Assert.True(TextPolicy.IsNonGraphic(new Rune(cp)), $"U+{cp:X4}");
+            Assert.True(ScalarPolicies.IsNonGraphic(new Rune(cp)), $"U+{cp:X4}");
         }
     }
 
     [Fact]
     public void Spelling_MatchesCaretNotation()
     {
-        Assert.Equal(@"\^[", new InertString("\u001B", TextPolicy.Field).ToString());
-        Assert.Equal(@"\^@", new InertString("\u0000", TextPolicy.Field).ToString());
-        Assert.Equal(@"\^?", new InertString("\u007F", TextPolicy.Field).ToString());
-        Assert.Equal(@"\\", new InertString("\\", TextPolicy.Field).ToString());
-        Assert.Equal(@"\u202E", new InertString("\u202E", TextPolicy.Field).ToString());
+        Assert.Equal(@"\^[", new InertString(TextPolicy.Field, "\u001B").ToString());
+        Assert.Equal(@"\^@", new InertString(TextPolicy.Field, "\u0000").ToString());
+        Assert.Equal(@"\^?", new InertString(TextPolicy.Field, "\u007F").ToString());
+        Assert.Equal(@"\\", new InertString(TextPolicy.Field, "\\").ToString());
+        Assert.Equal(@"\u202E", new InertString(TextPolicy.Field, "\u202E").ToString());
 
         // The collision the backslash introducer exists to prevent: U+001E is 0x1E + 0x40 = '^',
         // so a caret-introduced spelling gives RS and a literal caret the same output.
         Assert.NotEqual(
-            new InertString("\u001E", TextPolicy.Field).ToString(),
-            new InertString("^", TextPolicy.Field).ToString());
+            new InertString(TextPolicy.Field, "\u001E").ToString(),
+            new InertString(TextPolicy.Field, "^").ToString());
     }
 
     [Fact]
@@ -193,8 +193,8 @@ public class VisualEncoderTests
             "Ünïcödé", "日本語", "emoji \U0001F600", "a\u0301",
         })
         {
-            Assert.Equal(text, new InertString(text, TextPolicy.Field).ToString());
-            Assert.True(InertString.IsPermitted(text, TextPolicy.Field));
+            Assert.Equal(text, new InertString(TextPolicy.Field, text).ToString());
+            Assert.True(InertString.IsPermitted(TextPolicy.Field, text));
         }
     }
 
@@ -205,8 +205,8 @@ public class VisualEncoderTests
         // them is a hazard, and a check derived from "would Encode change this" rejects them all.
         const string path = @"C:\Users\rich\.nuget\packages";
 
-        Assert.True(InertString.IsPermitted(path, TextPolicy.Field));
-        Assert.NotEqual(path, new InertString(path, TextPolicy.Field).ToString());
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, path));
+        Assert.NotEqual(path, new InertString(TextPolicy.Field, path).ToString());
     }
 
     [Fact]
@@ -214,42 +214,60 @@ public class VisualEncoderTests
     {
         const string multiline = "line one\nline two\tindented";
 
-        Assert.True(InertString.IsPermitted(multiline, TextPolicy.Prose));
-        Assert.Equal(multiline, new InertString(multiline, TextPolicy.Prose).ToString());
+        Assert.True(InertString.IsPermitted(TextPolicy.Prose, multiline));
+        Assert.Equal(multiline, new InertString(TextPolicy.Prose, multiline).ToString());
 
-        Assert.False(InertString.IsPermitted(multiline, TextPolicy.Field));
-        Assert.Equal(@"line one\^Jline two\^Iindented", new InertString(multiline, TextPolicy.Field).ToString());
+        Assert.False(InertString.IsPermitted(TextPolicy.Field, multiline));
+        Assert.Equal(@"line one\^Jline two\^Iindented", new InertString(TextPolicy.Field, multiline).ToString());
 
         // No sink may exempt a bidi control, whatever else it exempts.
-        Assert.False(InertString.IsPermitted("\u202E", TextPolicy.Prose));
+        Assert.False(InertString.IsPermitted(TextPolicy.Prose, "\u202E"));
     }
 
+    /// <summary>
+    /// The stated limit of every <see cref="TextPolicy"/>, and the reason the set does not try to
+    /// grow one that closes it.
+    /// </summary>
+    /// <remarks>
+    /// Recorded as a test so the boundary is a measured fact rather than an assumption a reader
+    /// has to make, and so that anyone tempted to add an allow-shaped member finds the argument
+    /// against it here.
+    /// </remarks>
     [Fact]
-    public void Policy_AllowShaped_CatchesAHomoglyphThatNoCategoryRuleCan()
+    public void NoTextPolicy_CatchesAHomoglyph_BecauseEveryOneIsDenyShaped()
     {
-        // The attack the whole split exists for. Cyrillic е U+0435 and Latin e U+0065 are the
-        // same glyph, both category Ll, and neither is a hazard — so a deny-shaped policy
-        // renders the typosquat raw and the substitution stays invisible.
+        // Cyrillic е U+0435 and Latin e U+0065 are the same glyph, both category Ll, and neither
+        // is a hazard. A deny-shaped rule renders the typosquat raw and the substitution stays
+        // invisible -- correctly, because refusing every non-Latin letter would break most of the
+        // world's text.
         const string hijacked = "N\u0435wtonsoft.Json";
 
-        Assert.True(InertString.IsPermitted(hijacked, TextPolicy.Field));
-        Assert.Equal(hijacked, new InertString(hijacked, TextPolicy.Field).ToString());
+        foreach (TextPolicy policy in Enum.GetValues<TextPolicy>())
+        {
+            Assert.True(InertString.IsPermitted(policy, hijacked));
+            Assert.Equal(hijacked, new InertString(policy, hijacked).ToString());
+        }
 
-        // An allow list over the published grammar catches it, and the speller — which never
-        // learns why — spells it without needing a hazard set of its own.
-        static bool PackageId(Rune scalar)
-            => scalar.Value is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z')
-                or (>= '0' and <= '9') or '.' or '-' or '_';
+        // An allow list over the published grammar would catch it, and that is exactly the shape
+        // this library stopped offering. Encoding cannot serve it: the spelling an allow-shaped
+        // rule would produce, \u0435, is itself outside the grammar, so the repaired value fails
+        // the same check that rejected the original. The operation such a rule wants is
+        // rejection, which is a different answer than "here is a safe rendering" and belongs in
+        // a different API.
+        const string spelled = @"N\u0435wtonsoft.Json";
 
-        Assert.False(InertString.IsPermitted(hijacked, PackageId, out var violation));
-        Assert.Equal(0x0435, violation!.Value.Scalar);
-        Assert.Equal(@"N\u0435wtonsoft.Json", new InertString(hijacked, PackageId).ToString());
+        static bool PackageId(char c)
+            => c is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9')
+                or '.' or '-' or '_';
+
+        Assert.Contains(hijacked, c => !PackageId(c));
+        Assert.Contains(spelled, c => !PackageId(c));
     }
 
     [Fact]
     public void Legend_NamesEveryFormTheOutputContains()
     {
-        InertString value = new InertString("a\u001B\u007F\u202E\U00013430\\b", TextPolicy.Field);
+        InertString value = new InertString(TextPolicy.Field, "a\u001B\u007F\u202E\U00013430\\b");
         string encoded = value.ToString();
         VisualForm forms = value.Forms;
 
@@ -273,7 +291,7 @@ public class VisualEncoderTests
     [Fact]
     public void Legend_IsEmptyWhenNothingWasEncoded()
     {
-        VisualForm forms = new InertString("ordinary text", TextPolicy.Field).Forms;
+        VisualForm forms = new InertString(TextPolicy.Field, "ordinary text").Forms;
 
         Assert.Equal(VisualForm.None, forms);
         Assert.Empty(VisualEncoder.DescribeLegend(forms));
@@ -323,7 +341,7 @@ public class VisualEncoderTests
     [Fact]
     public void Violation_NamesTheActualCodeUnitForAnUnpairedSurrogate()
     {
-        Assert.False(InertString.IsPermitted("ab\uD800cd", TextPolicy.Field, out ScalarViolation? violation));
+        Assert.False(InertString.IsPermitted(TextPolicy.Field, "ab\uD800cd", out ScalarViolation? violation));
 
         // Rune cannot hold a lone surrogate, so reporting through it named U+FFFD here --
         // one wrong answer, identically, for all 2048 values whose identity is the finding.
@@ -337,9 +355,9 @@ public class VisualEncoderTests
     public void Violation_AgreesWithTheSpellingTheEncoderChooses()
     {
         const string input = "ab\uDFFFcd";
-        Assert.False(InertString.IsPermitted(input, TextPolicy.Field, out ScalarViolation? violation));
+        Assert.False(InertString.IsPermitted(TextPolicy.Field, input, out ScalarViolation? violation));
 
-        string encoded = new InertString(input, TextPolicy.Field).ToString();
+        string encoded = new InertString(TextPolicy.Field, input).ToString();
 
         Assert.Contains(
             string.Create(CultureInfo.InvariantCulture, $"\\u{violation!.Value.Scalar:X4}"),
@@ -366,5 +384,82 @@ public class VisualEncoderTests
         // so the canonicality check must not reach this far.
         Assert.True(VisualEncoder.TryDecode(@"\u0041", out string? decoded));
         Assert.Equal("A", decoded);
+    }
+
+    /// <summary>
+    /// The decoder accepts exactly one spelling per scalar, which is what the repair in
+    /// <c>EnsurePermitted</c> rests on.
+    /// </summary>
+    /// <remarks>
+    /// A second accepted spelling is not leniency. <c>EnsurePermitted</c> decodes a value and
+    /// re-encodes it under the policy in force, so if two inputs decode to the same text they
+    /// converge on one output, and a value that survived one repair unchanged can change under
+    /// the next. Each case below was accepted before this test existed.
+    /// </remarks>
+    [Theory]
+    [InlineData(@"\u00ad", "lowercase BMP hex; AppendBmpHex emits X4, never x4")]
+    [InlineData(@"\U0001f600", "lowercase astral hex; AppendSpelling emits X8")]
+    [InlineData(@"\uD83D\uDE00", "a surrogate pair as two escapes; the scalar spells as \\U0001F600")]
+    public void Decode_RefusesANonCanonicalSpelling(string encoded, string why)
+    {
+        Assert.False(VisualEncoder.TryDecode(encoded, out _), why);
+    }
+
+    /// <summary>
+    /// The canonical spelling of each of those is still accepted, so the refusals above are
+    /// about spelling rather than about the scalar.
+    /// </summary>
+    [Theory]
+    [InlineData(@"\u00AD", "\u00ad")]
+    [InlineData(@"\U0001F600", "\U0001F600")]
+    public void Decode_AcceptsTheCanonicalSpelling(string encoded, string expected)
+    {
+        Assert.True(VisualEncoder.TryDecode(encoded, out string? decoded));
+        Assert.Equal(expected, decoded);
+    }
+
+    /// <summary>
+    /// A <em>lone</em> surrogate escape stays legal, which is why the pair above is refused
+    /// there rather than by banning the surrogate range outright.
+    /// </summary>
+    /// <remarks>
+    /// The obvious fix for the pair case -- reject every <c>\uXXXX</c> in D800-DFFF -- breaks
+    /// this, and this is a form <see cref="VisualEncoder.Encode"/> genuinely emits: an unpaired
+    /// surrogate is not a scalar, so it has no other representation at all. Encoder output that
+    /// its own decoder refuses would make the transform non-invertible on exactly the input
+    /// class that most needs it.
+    /// </remarks>
+    [Fact]
+    public void Decode_AcceptsALoneSurrogateEscape_BecauseEncodeEmitsOne()
+    {
+        InertString encoded = VisualEncoder.Encode(TextPolicy.Field, "a\uD83Db");
+
+        Assert.Equal(@"a\uD83Db", encoded.ToString());
+        Assert.True(VisualEncoder.TryDecode(encoded.ToString(), out string? decoded));
+        Assert.Equal("a\uD83Db", decoded);
+    }
+
+    /// <summary>
+    /// A raw unpaired surrogate in decoder input is refused, because <c>Encode</c> spells one as
+    /// <c>\uXXXX</c> and accepting both would be a second spelling again.
+    /// </summary>
+    [Fact]
+    public void Decode_RefusesARawUnpairedSurrogate()
+    {
+        Assert.False(VisualEncoder.TryDecode("a\uD83Db", out _));
+    }
+
+    /// <summary>
+    /// A raw surrogate <em>pair</em> passes through, because a graphic astral scalar is
+    /// permitted and <c>Encode</c> leaves it alone.
+    /// </summary>
+    [Fact]
+    public void Decode_AcceptsARawSurrogatePair()
+    {
+        const string emoji = "a\U0001F600b";
+
+        Assert.Equal(emoji, VisualEncoder.Encode(TextPolicy.Field, emoji).ToString());
+        Assert.True(VisualEncoder.TryDecode(emoji, out string? decoded));
+        Assert.Equal(emoji, decoded);
     }
 }

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -38,8 +38,8 @@ namespace InertText;
 ///
 /// The term and the contract are borrowed from BSD <c>vis(3)</c> ("visually encode
 /// characters"): the output is inert, lossless (nothing is dropped, so the reader still sees
-/// what was actually there), and invertible (<c>VisualEncoder.TryDecode</c> recovers the original
-/// exactly). This is not neutralization, which has none of the three.
+/// what was actually there), and invertible (the original can be recovered from it exactly).
+/// This is not neutralization, which has none of the three.
 ///
 /// "Inert" is scoped, and the scope matters: no terminal interprets the output as control and
 /// no bidi algorithm reorders it. It does <em>not</em> mean the output is safe to drop into a
@@ -90,9 +90,9 @@ public readonly struct InertString : IEquatable<InertString>
     /// The only way text enters the type, and the reason no member of it can take text without
     /// also naming a policy — a reflection test enforces that.
     ///
-    /// Forwards to <see cref="VisualEncoder"/> rather than duplicating the loop, and exists so
-    /// that producing inert text does not require naming the capability namespace. That is what
-    /// keeps the decoder out of the files that merely make inert text, and it is gated.
+    /// Exists so that producing inert text does not require naming the capability namespace,
+    /// which is what keeps the decoder out of the files that merely make inert text, and it is
+    /// gated. How the encoding is carried out is an implementation detail of this type.
     /// </remarks>
     /// <param name="policy">The kind of text this is, which decides what may pass through.</param>
     /// <param name="value">The untreated text.</param>
@@ -312,9 +312,9 @@ public readonly struct InertString : IEquatable<InertString>
     /// is the obvious substitute and is wrong: the text it re-encodes is already encoded, so the
     /// backslashes double on every pass. This decodes first, and so is idempotent.
     ///
-    /// This is the second thing invertibility buys. Because <c>VisualEncoder.TryDecode</c>
-    /// recovers the original exactly, a mismatched piece can be taken back to its source text
-    /// and re-spelled under the policy actually in force, rather than rejected or trusted.
+    /// This is the second thing invertibility buys. Because the encoding can be reversed
+    /// exactly, a mismatched piece can be taken back to its source text and re-spelled under
+    /// the policy actually in force, rather than rejected or trusted.
     ///
     /// The repair only ever tightens. A piece encoded under a stricter policy keeps its
     /// spellings when spliced into a laxer sink, because composition making a value <em>less</em>

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -53,7 +53,7 @@ namespace InertText;
 /// Note the "some": the type records that a policy was applied, not which one, because a value
 /// is routinely built for one sink and spliced into a message bound for another. That makes
 /// the useful invariant a property of composition rather than of storage — see
-/// <see cref="Conform"/>, which re-spells a spliced value under the policy actually in force.
+/// <see cref="EnsurePermitted"/>, which re-spells a spliced value under the policy in force.
 ///
 /// Conversion <em>to</em> <see cref="string"/> through <see cref="ToString"/> is unrestricted,
 /// which is safe here in a way it usually is not. The customary objection to a wrapper — that
@@ -140,6 +140,17 @@ public readonly struct InertString : IEquatable<InertString>
     public bool IsEmpty => Text.Length == 0;
 
     /// <summary>Whether any scalar was encoded on the way in.</summary>
+    /// <remarks>
+    /// Reports what was <em>done</em> to this value, never what it <em>satisfies</em>. It is not
+    /// a conformance check, and using it as one inverts the answer in both directions: text
+    /// encoded under <see cref="TextPolicy.Prose"/> can carry a raw line feed and report
+    /// <see langword="false"/> here while violating <see cref="TextPolicy.Field"/>, and text
+    /// encoded under <c>Field</c> reports <see langword="true"/> while satisfying every policy,
+    /// because the spellings it emits are plain ASCII.
+    ///
+    /// Conformance is a relation between a value and a policy rather than a property of the
+    /// value, so it cannot be cached on one. Ask <see cref="EnsurePermitted"/> instead.
+    /// </remarks>
     public bool WasEncoded => Forms != VisualForm.None;
 
     /// <summary>The encoded text.</summary>
@@ -208,7 +219,7 @@ public readonly struct InertString : IEquatable<InertString>
                 forms |= encodedSeparator.Forms;
             }
 
-            InertString conformed = Conform(value, permits);
+            InertString conformed = value.EnsurePermitted(permits);
             builder.Append(conformed.ToString());
             forms |= conformed.Forms;
             first = false;
@@ -228,6 +239,11 @@ public readonly struct InertString : IEquatable<InertString>
     /// rendering of it. This is deliberately not "would encoding change it": a
     /// backslash is permitted by any sane policy but is still rewritten, and a check derived
     /// from the encoder would reject every Windows path.
+    ///
+    /// Takes raw text rather than an <see cref="InertString"/> because the question it answers
+    /// is asked <em>before</em> treatment. A sink deciding whether text it already holds is safe
+    /// for it should call <see cref="EnsurePermitted"/> instead, which repairs rather than
+    /// reports.
     /// </remarks>
     public static bool IsPermitted(string value, ScalarPolicy permits)
         => IsPermitted(value, permits, out _);
@@ -275,7 +291,7 @@ public readonly struct InertString : IEquatable<InertString>
     }
 
     /// <summary>
-    /// Restates <paramref name="value"/> under <paramref name="permits"/>, re-encoding it if it
+    /// Returns this value restated under <paramref name="permits"/>, re-encoding it if it
     /// carries anything that policy refuses.
     /// </summary>
     /// <remarks>
@@ -285,6 +301,11 @@ public readonly struct InertString : IEquatable<InertString>
     /// exists to remove. Splicing such a value in unexamined would put a raw newline into a
     /// single-line message and report <see cref="VisualForm.None"/> for it, which is the log
     /// injection this library exists to prevent, with the type appearing to vouch for it.
+    ///
+    /// Public because a sink that accepts an <see cref="InertString"/> has no other correct way
+    /// to make one safe for itself. Re-encoding through <c>new InertString(value.ToString(), …)</c>
+    /// is the obvious substitute and is wrong: the text it re-encodes is already encoded, so the
+    /// backslashes double on every pass. This decodes first, and so is idempotent.
     ///
     /// This is the second thing invertibility buys. Because <c>VisualEncoder.TryDecode</c>
     /// recovers the original exactly, a mismatched piece can be taken back to its source text
@@ -296,13 +317,16 @@ public readonly struct InertString : IEquatable<InertString>
     /// splice path is observable — the same source text can render differently depending on
     /// where it was encoded — which is a deliberate trade, not an oversight.
     /// </remarks>
-    internal static InertString Conform(InertString value, ScalarPolicy permits)
+    /// <param name="permits">The policy of the sink about to receive this value.</param>
+    public InertString EnsurePermitted(ScalarPolicy permits)
     {
-        string text = value.ToString();
+        ArgumentNullException.ThrowIfNull(permits);
+
+        string text = Text;
 
         if (IsPermitted(text, permits))
         {
-            return value;
+            return this;
         }
 
         // Falling back to the encoded text when decoding fails cannot happen for a value this
@@ -392,11 +416,11 @@ public ref struct InertStringHandler
     /// Without this overload the generic case would run the encoder over text that has already
     /// been through it, doubling every backslash the first pass introduced. The value is still
     /// checked against this sink's policy, because being inert under some policy is not the
-    /// same as being inert under this one; see <see cref="InertString.Conform"/>.
+    /// same as being inert under this one; see <see cref="InertString.EnsurePermitted"/>.
     /// </remarks>
     public void AppendFormatted(InertString value)
     {
-        InertString conformed = InertString.Conform(value, _permits);
+        InertString conformed = value.EnsurePermitted(_permits);
         _builder.Append(conformed.ToString());
         _forms |= conformed.Forms;
     }

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -338,8 +338,13 @@ public readonly struct InertString : IEquatable<InertString>
             return this;
         }
 
-        // Falling back to the encoded text when decoding fails cannot happen for a value this
-        // library produced; it is here so the failure mode is over-encoding rather than a leak.
+        // Decoding cannot fail for a value this library produced: every spelling Encode emits is
+        // one TryDecode accepts, including the pair of adjacent surrogate escapes that Join and
+        // the interpolation handler produce when each half was encoded in a separate fragment.
+        // A gate test composes such a value and asserts it still decodes, because when that
+        // stopped holding the fallback silently re-encoded the escapes as literal text and two
+        // unrelated inputs converged. The fallback remains so the failure mode is over-encoding
+        // rather than a leak, but it is unreachable, not load-bearing.
         string original = VisualEncoder.TryDecode(text, out string? decoded) ? decoded : text;
         return VisualEncoder.Encode(policy, original);
     }

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -1,0 +1,421 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using InertText.Encoder;
+
+namespace InertText;
+
+/// <summary>
+/// Text with a <see cref="ScalarPolicy"/> applied to it, carried as a value rather than as a
+/// bare <see cref="string"/>.
+/// </summary>
+/// <remarks>
+/// This is the currency form, and it exists for auditability. Encoding on its own is
+/// transactional — a <see cref="string"/> goes in and a <see cref="string"/> comes out — so a
+/// treated value and an untreated one are the same type, and the only way to tell whether a
+/// sink is safe is to trace every call path that reaches it. A distinct type inverts that: the
+/// question becomes a type search, and a sink that accepts only <see cref="InertString"/>
+/// cannot be handed raw text by accident.
+///
+/// The second half of that is what this type does <em>not</em> offer. Holding one of these
+/// gives no way back to the text it was built from: the decoder lives in
+/// <c>InertText.Encoder</c>, in its own namespace, and nothing here reaches it. So a file that
+/// imports <c>InertText</c> and not <c>InertText.Encoder</c> cannot recover the original of any
+/// value it handles, and that fact is legible in its using block rather than by tracing calls.
+/// A reflection test enumerates the public surface of this namespace and accounts for every
+/// member that returns text, so the property is enforced rather than merely intended.
+///
+/// The boundary is an audit aid, not a capability barrier — a file can always add the import.
+/// The goal it does meet is that the dangerous half cannot arrive by accident or unnoticed.
+///
+/// Also genuinely separate is <see cref="ScalarPolicy"/>: the encoder never learns <em>why</em>
+/// a scalar was refused, which is what lets it serve a deny-shaped sink and an allow-shaped one
+/// alike. An encoder with a built-in hazard set has absorbed policy.
+///
+/// The term and the contract are borrowed from BSD <c>vis(3)</c> ("visually encode
+/// characters"): the output is inert, lossless (nothing is dropped, so the reader still sees
+/// what was actually there), and invertible (<c>VisualEncoder.TryDecode</c> recovers the original
+/// exactly). This is not neutralization, which has none of the three.
+///
+/// "Inert" is scoped, and the scope matters: no terminal interprets the output as control and
+/// no bidi algorithm reorders it. It does <em>not</em> mean the output is safe to drop into a
+/// structured format. A <c>|</c> still breaks a Markdown cell, a backtick still opens a span,
+/// and a <c>"</c> still terminates a JSON string — none is in any encoded category, and none
+/// should be, because escaping those for its own grammar is the serializer's job. Visual
+/// encoding and structural escaping compose; neither substitutes for the other.
+///
+/// There is deliberately no conversion <em>from</em> <see cref="string"/>, implicit or
+/// explicit. One would restore exactly the confusion the type removes. Text enters through
+/// the constructor, <see cref="Format"/> or <see cref="Join"/>, all of which apply a policy,
+/// so every value has been spelled under some policy.
+///
+/// Note the "some": the type records that a policy was applied, not which one, because a value
+/// is routinely built for one sink and spliced into a message bound for another. That makes
+/// the useful invariant a property of composition rather than of storage — see
+/// <see cref="Conform"/>, which re-spells a spliced value under the policy actually in force.
+///
+/// Conversion <em>to</em> <see cref="string"/> through <see cref="ToString"/> is unrestricted,
+/// which is safe here in a way it usually is not. The customary objection to a wrapper — that
+/// <c>ToString()</c> launders it — assumes the payload is dangerous and the wrapper is what
+/// holds it back. Here the payload is already inert, and the wrapper only records that fact.
+/// Losing the wrapper loses provenance, not protection.
+/// </remarks>
+public readonly struct InertString : IEquatable<InertString>
+{
+    private readonly string? _text;
+
+    /// <summary>
+    /// Encodes <paramref name="value"/> under <paramref name="permits"/>, yielding a value that
+    /// can be carried to a sink.
+    /// </summary>
+    /// <remarks>
+    /// The only way text enters the type, and the reason no member of it can take text without
+    /// also taking a policy — a reflection test enforces that. Encoding happens here rather
+    /// than through a factory because a factory would have been a constructor with a different
+    /// spelling; what is worth separating is not the call shape but the ability to reverse it,
+    /// which lives in <see cref="VisualEncoder"/> and in its own namespace.
+    /// </remarks>
+    /// <param name="value">The untreated text.</param>
+    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
+    public InertString(string value, ScalarPolicy permits)
+    {
+        _text = VisualEncoder.Encode(value, permits, out VisualForm forms);
+        Forms = forms;
+    }
+
+    // Takes text already spelled by the encoder, so it asserts rather than establishes the
+    // invariant. Internal because composition needs it: Join and the interpolation handler
+    // build their result piecewise and would otherwise have to re-encode an encoded string.
+    internal InertString(string text, VisualForm forms)
+    {
+        _text = text;
+        Forms = forms;
+    }
+
+    /// <summary>The text, with the zero value read as empty.</summary>
+    /// <remarks>
+    /// The single point where that translation happens. Every other member reads this rather
+    /// than the field, because spelling the translation at each use site is what let equality
+    /// disagree with the rest of the type about whether the zero value and <c>Encode("")</c>
+    /// are the same value. A reflection test enumerates the public surface and fails if any
+    /// member answers differently for the two, which is the gate that keeps this honest.
+    /// </remarks>
+    private string Text => _text ?? string.Empty;
+
+    /// <summary>The empty value, which trivially satisfies the invariant.</summary>
+    /// <remarks>
+    /// Constructed, not <c>default</c>. The zero value of a struct is an artifact of the CLR
+    /// rather than a statement of intent, and naming it as the definition of "empty" describes
+    /// how the runtime zeroes memory instead of what this value is. Stated properly, the
+    /// contract is: no text, and no spellings emitted.
+    ///
+    /// <c>default(InertString)</c> is still reachable — a struct cannot suppress it — and it is
+    /// still harmless, because empty text satisfies every policy <em>vacuously</em>: there is
+    /// no scalar for a policy to refuse. So it is tolerated rather than blessed. The one place
+    /// that tolerates it is <see cref="Text"/>, and a reflection test enumerates the public
+    /// surface to catch any member that reads around it. Spelling that translation at four
+    /// separate reads is what let equality disagree with <see cref="IsEmpty"/>,
+    /// <see cref="ToString"/> and <see cref="GetHashCode"/> about whether the zero value and
+    /// <c>Encode("")</c> are the same value.
+    /// </remarks>
+    public static InertString Empty { get; } = new(string.Empty, VisualForm.None);
+
+    /// <summary>The spellings <see cref="InertString"/> emitted while producing this value.</summary>
+    /// <remarks>
+    /// Retained so a sink can print a legend for what it is about to show without re-deriving
+    /// it. Composition unions the flags, so a message assembled from several pieces reports
+    /// every spelling it contains.
+    /// </remarks>
+    public VisualForm Forms { get; }
+
+    /// <summary>Whether this value carries no text.</summary>
+    public bool IsEmpty => Text.Length == 0;
+
+    /// <summary>Whether any scalar was encoded on the way in.</summary>
+    public bool WasEncoded => Forms != VisualForm.None;
+
+    /// <summary>The encoded text.</summary>
+    public override string ToString() => Text;
+
+    /// <summary>
+    /// Encodes <paramref name="value"/> under <paramref name="permits"/>.
+    /// </summary>
+    /// <param name="value">The untreated text.</param>
+    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
+    /// <summary>
+    /// Builds a value from an interpolated string, encoding every part of it.
+    /// </summary>
+    /// <remarks>
+    /// The composition path, and the reason the type is usable at a message-building site. A
+    /// sink that takes an <see cref="InertString"/> would otherwise force callers back to
+    /// <c>$"...{value}..."</c> on the encoded text, which produces a bare <see cref="string"/>
+    /// and drops the guarantee at the one moment it is most needed.
+    ///
+    /// Interpolation holes are encoded, which is the point. Literals are encoded too, even
+    /// though they come from source and are normally harmless, because an invariant with an
+    /// exception in it has to be reasoned about at every use, and a bidi override is as
+    /// invisible in a C# source file as it is anywhere else.
+    /// </remarks>
+    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
+    /// <param name="handler">The interpolated string, encoded piecewise as it is appended.</param>
+    public static InertString Format(
+        ScalarPolicy permits,
+        [InterpolatedStringHandlerArgument("permits")] ref InertStringHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(permits);
+        return handler.ToInertString();
+    }
+
+    /// <summary>
+    /// Concatenates <paramref name="values"/>, separated by <paramref name="separator"/>.
+    /// </summary>
+    /// <remarks>
+    /// The separator is encoded under <paramref name="permits"/> like everything else, so a
+    /// multi-line message must pass a policy that permits the line break it joins with.
+    /// Exempting the separator would be a hole exactly the size of one caller's mistake.
+    /// </remarks>
+    /// <param name="separator">The text placed between values.</param>
+    /// <param name="permits">
+    /// The per-sink policy, applied to <paramref name="separator"/> and to any value that does
+    /// not already satisfy it.
+    /// </param>
+    /// <param name="values">The values to join.</param>
+    public static InertString Join(string separator, ScalarPolicy permits, IEnumerable<InertString> values)
+    {
+        ArgumentNullException.ThrowIfNull(separator);
+        ArgumentNullException.ThrowIfNull(values);
+
+        string encodedSeparator = VisualEncoder.Encode(separator, permits, out VisualForm separatorForms);
+        StringBuilder builder = new();
+        VisualForm forms = VisualForm.None;
+        bool first = true;
+
+        foreach (InertString value in values)
+        {
+            // The separator's spellings are folded in only when one is actually emitted, so a
+            // single-element join cannot report a form the output does not contain.
+            if (!first)
+            {
+                builder.Append(encodedSeparator);
+                forms |= separatorForms;
+            }
+
+            builder.Append(Conform(value, permits, out VisualForm valueForms));
+            forms |= valueForms;
+            first = false;
+        }
+
+        return new InertString(builder.ToString(), forms);
+    }
+
+    /// <summary>Names the spellings this value contains, one line each.</summary>
+    public IReadOnlyList<string> DescribeLegend() => VisualEncoder.DescribeLegend(Forms);
+
+        /// <summary>
+    /// Reports whether every scalar in <paramref name="value"/> is permitted as it is.
+    /// </summary>
+    /// <remarks>
+    /// The early-fail check, for callers that would rather reject text than display an encoded
+    /// rendering of it. This is deliberately not "would encoding change it": a
+    /// backslash is permitted by any sane policy but is still rewritten, and a check derived
+    /// from the encoder would reject every Windows path.
+    /// </remarks>
+    public static bool IsPermitted(string value, ScalarPolicy permits)
+        => IsPermitted(value, permits, out _);
+
+    /// <summary>
+    /// Reports whether every scalar in <paramref name="value"/> is permitted as it is, naming
+    /// the first that is not.
+    /// </summary>
+    /// <remarks>
+    /// The violation names a position and a classification, never the rendered character, which
+    /// is what lets a survey mode report a finding without echoing artifact text.
+    /// </remarks>
+    public static bool IsPermitted(
+        string value,
+        ScalarPolicy permits,
+        [NotNullWhen(false)] out ScalarViolation? violation)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(permits);
+
+        int i = 0;
+        while (i < value.Length)
+        {
+            Rune scalar = VisualEncoder.DecodeAt(value, i, out int width, out bool isUnpairedSurrogate);
+
+            if (isUnpairedSurrogate)
+            {
+                // The raw code unit, not the decoded scalar: DecodeAt yields U+FFFD here,
+                // and the whole point of the report is to name the code point exactly.
+                violation = new ScalarViolation(i, value[i], UnicodeCategory.Surrogate);
+                return false;
+            }
+
+            if (!permits(scalar))
+            {
+                violation = new ScalarViolation(i, scalar.Value, Rune.GetUnicodeCategory(scalar));
+                return false;
+            }
+
+            i += width;
+        }
+
+        violation = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Restates <paramref name="value"/> under <paramref name="permits"/>, re-encoding it if it
+    /// carries anything that policy refuses.
+    /// </summary>
+    /// <remarks>
+    /// The type records that <em>a</em> policy was applied, not <em>which</em> one, so a value
+    /// produced under a laxer policy can carry a scalar a stricter sink refuses — <see
+    /// cref="TextPolicy.Prose"/> permits the line feed that <see cref="TextPolicy.Field"/>
+    /// exists to remove. Splicing such a value in unexamined would put a raw newline into a
+    /// single-line message and report <see cref="VisualForm.None"/> for it, which is the log
+    /// injection this library exists to prevent, with the type appearing to vouch for it.
+    ///
+    /// This is the second thing invertibility buys. Because <c>VisualEncoder.TryDecode</c>
+    /// recovers the original exactly, a mismatched piece can be taken back to its source text
+    /// and re-spelled under the policy actually in force, rather than rejected or trusted.
+    ///
+    /// The repair only ever tightens. A piece encoded under a stricter policy keeps its
+    /// spellings when spliced into a laxer sink, because composition making a value <em>less</em>
+    /// inert would let a caller launder one by quoting it somewhere permissive. The cost is that
+    /// splice path is observable — the same source text can render differently depending on
+    /// where it was encoded — which is a deliberate trade, not an oversight.
+    /// </remarks>
+    internal static string Conform(InertString value, ScalarPolicy permits, out VisualForm forms)
+    {
+        string text = value.ToString();
+
+        if (IsPermitted(text, permits))
+        {
+            forms = value.Forms;
+            return text;
+        }
+
+        // Falling back to the encoded text when decoding fails cannot happen for a value this
+        // library produced; it is here so the failure mode is over-encoding rather than a leak.
+        string original = VisualEncoder.TryDecode(text, out string? decoded) ? decoded : text;
+        return VisualEncoder.Encode(original, permits, out forms);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Reads through <see cref="Text"/> rather than the field, so the zero value and
+    /// <c>Encode("")</c> compare equal. Comparing <c>_text</c> directly is the defect this
+    /// replaced: <see langword="null"/> and <c>""</c> are not ordinally equal.
+    /// </remarks>
+    public bool Equals(InertString other) => string.Equals(Text, other.Text, StringComparison.Ordinal);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is InertString other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Text.GetHashCode(StringComparison.Ordinal);
+
+    /// <summary>Compares two values by their encoded text.</summary>
+    public static bool operator ==(InertString left, InertString right) => left.Equals(right);
+
+    /// <summary>Compares two values by their encoded text.</summary>
+    public static bool operator !=(InertString left, InertString right) => !left.Equals(right);
+}
+
+/// <summary>
+/// Assembles an <see cref="InertString"/> from an interpolated string, applying the policy to
+/// each piece as it arrives.
+/// </summary>
+/// <remarks>
+/// Encoding per piece rather than once at the end is what makes composition safe. Encoding the
+/// assembled string would be indistinguishable from encoding a concatenation, and would
+/// re-encode any already-inert part that was spliced in — turning <c>\u202E</c> into
+/// <c>\\u202E</c> and breaking invertibility.
+/// </remarks>
+[InterpolatedStringHandler]
+public ref struct InertStringHandler
+{
+    private readonly ScalarPolicy _permits;
+    private readonly StringBuilder _builder;
+    private VisualForm _forms;
+
+    /// <summary>Called by the compiler for an interpolated string argument.</summary>
+    /// <param name="literalLength">The total length of the literal parts.</param>
+    /// <param name="formattedCount">The number of interpolation holes.</param>
+    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
+    public InertStringHandler(int literalLength, int formattedCount, ScalarPolicy permits)
+    {
+        ArgumentNullException.ThrowIfNull(permits);
+
+        _permits = permits;
+        _builder = new StringBuilder(literalLength + (formattedCount * 12));
+        _forms = VisualForm.None;
+    }
+
+    /// <summary>Appends a literal part of the interpolated string.</summary>
+    public void AppendLiteral(string value) => Append(value);
+
+    /// <summary>Appends an interpolation hole.</summary>
+    /// <remarks>
+    /// Formatted under the invariant culture, matching the format-specifier overload. A message
+    /// whose decimal separator depends on the ambient culture is a message that cannot be
+    /// grepped, and these are diagnostics rather than presentation.
+    /// </remarks>
+    public void AppendFormatted<T>(T value)
+        => Append(value is IFormattable formattable
+            ? formattable.ToString(null, CultureInfo.InvariantCulture)
+            : value?.ToString());
+
+    /// <summary>Appends an interpolation hole that carries a format specifier.</summary>
+    public void AppendFormatted<T>(T value, string? format)
+        => Append(value is IFormattable formattable
+            ? formattable.ToString(format, CultureInfo.InvariantCulture)
+            : value?.ToString());
+
+    /// <summary>Appends a string-valued interpolation hole.</summary>
+    public void AppendFormatted(string? value) => Append(value);
+
+    /// <summary>
+    /// Appends a value that is already inert, without encoding it a second time.
+    /// </summary>
+    /// <remarks>
+    /// Without this overload the generic case would run the encoder over text that has already
+    /// been through it, doubling every backslash the first pass introduced. The value is still
+    /// checked against this sink's policy, because being inert under some policy is not the
+    /// same as being inert under this one; see <see cref="InertString.Conform"/>.
+    /// </remarks>
+    public void AppendFormatted(InertString value)
+    {
+        _builder.Append(InertString.Conform(value, _permits, out VisualForm forms));
+        _forms |= forms;
+    }
+
+    /// <summary>
+    /// Appends an optional already-inert value, without encoding it a second time.
+    /// </summary>
+    /// <remarks>
+    /// Needed as its own overload because a <c>InertString?</c> hole would otherwise bind to the
+    /// generic case, whose <c>ToString</c> yields the encoded text and hands it back to the
+    /// encoder. Redaction returns this shape, so the trap is on a live path rather than
+    /// hypothetical.
+    /// </remarks>
+    public void AppendFormatted(InertString? value)
+    {
+        if (value is { } inert)
+            AppendFormatted(inert);
+    }
+
+    internal InertString ToInertString() => new(_builder.ToString(), _forms);
+
+    private void Append(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return;
+
+        _builder.Append(VisualEncoder.Encode(value, _permits, out VisualForm forms));
+        _forms |= forms;
+    }
+}

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -53,9 +53,10 @@ namespace InertText;
 /// constructor, <see cref="Format"/> or <see cref="Join"/>, all of which name a policy, so every
 /// value has been spelled under some policy.
 ///
-/// Every one of those reads <c>(TextPolicy, payload)</c>, including <see cref="IsPermitted"/> and
-/// <see cref="EnsurePermitted"/>. One shape rather than one per member, and the policy set can
-/// grow without the type growing a member per policy.
+/// Every one of those reads <c>(TextPolicy, payload)</c>, including
+/// <see cref="IsPermitted(TextPolicy, string)"/> and <see cref="EnsurePermitted"/>. One shape
+/// rather than one per member, and the policy set can grow without the type growing a member
+/// per policy.
 ///
 /// Note the "some": the type records that a policy was applied, not which one, because a value
 /// is routinely built for one sink and spliced into a message bound for another. That makes
@@ -236,7 +237,7 @@ public readonly struct InertString : IEquatable<InertString>
     /// <summary>Names the spellings this value contains, one line each.</summary>
     public IReadOnlyList<string> DescribeLegend() => VisualEncoder.DescribeLegend(Forms);
 
-        /// <summary>
+    /// <summary>
     /// Reports whether every scalar in <paramref name="value"/> is permitted as it is.
     /// </summary>
     /// <remarks>
@@ -296,7 +297,7 @@ public readonly struct InertString : IEquatable<InertString>
     }
 
     /// <summary>
-    /// Returns this value restated under <paramref name="permits"/>, re-encoding it if it
+    /// Returns this value restated under <paramref name="policy"/>, re-encoding it if it
     /// carries anything that policy refuses.
     /// </summary>
     /// <remarks>

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -7,8 +7,8 @@ using InertText.Encoder;
 namespace InertText;
 
 /// <summary>
-/// Text with a <see cref="ScalarPolicy"/> applied to it, carried as a value rather than as a
-/// bare <see cref="string"/>.
+/// Text spelled under a <see cref="TextPolicy"/>, carried as a value rather than as a bare
+/// <see cref="string"/>.
 /// </summary>
 /// <remarks>
 /// This is the currency form, and it exists for auditability. Encoding on its own is
@@ -29,9 +29,12 @@ namespace InertText;
 /// The boundary is an audit aid, not a capability barrier — a file can always add the import.
 /// The goal it does meet is that the dangerous half cannot arrive by accident or unnoticed.
 ///
-/// Also genuinely separate is <see cref="ScalarPolicy"/>: the encoder never learns <em>why</em>
-/// a scalar was refused, which is what lets it serve a deny-shaped sink and an allow-shaped one
-/// alike. An encoder with a built-in hazard set has absorbed policy.
+/// The policy is named rather than supplied. An earlier shape took a caller-written predicate,
+/// which read as the more general design and was worse in both directions: rules drifted apart
+/// between sinks that should have shared them, and repairing a value meant handing the caller's
+/// predicate the decoded original — walking the audit boundary back out through a callback, in a
+/// file whose using block still named only the currency namespace. <see cref="TextPolicy"/> is
+/// closed, so the rules are shared and no caller code runs during a repair.
 ///
 /// The term and the contract are borrowed from BSD <c>vis(3)</c> ("visually encode
 /// characters"): the output is inert, lossless (nothing is dropped, so the reader still sees
@@ -46,9 +49,13 @@ namespace InertText;
 /// encoding and structural escaping compose; neither substitutes for the other.
 ///
 /// There is deliberately no conversion <em>from</em> <see cref="string"/>, implicit or
-/// explicit. One would restore exactly the confusion the type removes. Text enters through
-/// the constructor, <see cref="Format"/> or <see cref="Join"/>, all of which apply a policy,
-/// so every value has been spelled under some policy.
+/// explicit. One would restore exactly the confusion the type removes. Text enters through the
+/// constructor, <see cref="Format"/> or <see cref="Join"/>, all of which name a policy, so every
+/// value has been spelled under some policy.
+///
+/// Every one of those reads <c>(TextPolicy, payload)</c>, including <see cref="IsPermitted"/> and
+/// <see cref="EnsurePermitted"/>. One shape rather than one per member, and the policy set can
+/// grow without the type growing a member per policy.
 ///
 /// Note the "some": the type records that a policy was applied, not which one, because a value
 /// is routinely built for one sink and spliced into a message bound for another. That makes
@@ -76,20 +83,20 @@ public readonly struct InertString : IEquatable<InertString>
     private readonly string? _text;
 
     /// <summary>
-    /// Encodes <paramref name="value"/> under <paramref name="permits"/>, yielding a value that
-    /// can be carried to a sink.
+    /// Encodes <paramref name="value"/> as <paramref name="policy"/> requires, yielding a value
+    /// that can be carried to a sink.
     /// </summary>
     /// <remarks>
     /// The only way text enters the type, and the reason no member of it can take text without
-    /// also taking a policy — a reflection test enforces that.
+    /// also naming a policy — a reflection test enforces that.
     ///
     /// Forwards to <see cref="VisualEncoder"/> rather than duplicating the loop, and exists so
     /// that producing inert text does not require naming the capability namespace. That is what
     /// keeps the decoder out of the files that merely make inert text, and it is gated.
     /// </remarks>
+    /// <param name="policy">The kind of text this is, which decides what may pass through.</param>
     /// <param name="value">The untreated text.</param>
-    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
-    public InertString(string value, ScalarPolicy permits) => this = VisualEncoder.Encode(value, permits);
+    public InertString(TextPolicy policy, string value) => this = VisualEncoder.Encode(policy, value);
 
     // Takes text already spelled by the encoder, so it asserts rather than establishes the
     // invariant. Internal because composition needs it: Join and the interpolation handler
@@ -145,7 +152,8 @@ public readonly struct InertString : IEquatable<InertString>
     /// a conformance check, and using it as one inverts the answer in both directions: text
     /// encoded under <see cref="TextPolicy.Prose"/> can carry a raw line feed and report
     /// <see langword="false"/> here while violating <see cref="TextPolicy.Field"/>, and text
-    /// encoded under <c>Field</c> reports <see langword="true"/> while satisfying every policy,
+    /// encoded under <see cref="TextPolicy.Field"/> reports <see langword="true"/> while
+    /// satisfying every policy,
     /// because the spellings it emits are plain ASCII.
     ///
     /// Conformance is a relation between a value and a policy rather than a property of the
@@ -156,11 +164,6 @@ public readonly struct InertString : IEquatable<InertString>
     /// <summary>The encoded text.</summary>
     public override string ToString() => Text;
 
-    /// <summary>
-    /// Encodes <paramref name="value"/> under <paramref name="permits"/>.
-    /// </summary>
-    /// <param name="value">The untreated text.</param>
-    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
     /// <summary>
     /// Builds a value from an interpolated string, encoding every part of it.
     /// </summary>
@@ -175,36 +178,38 @@ public readonly struct InertString : IEquatable<InertString>
     /// exception in it has to be reasoned about at every use, and a bidi override is as
     /// invisible in a C# source file as it is anywhere else.
     /// </remarks>
-    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
+    /// <param name="policy">The kind of text being built.</param>
     /// <param name="handler">The interpolated string, encoded piecewise as it is appended.</param>
     public static InertString Format(
-        ScalarPolicy permits,
-        [InterpolatedStringHandlerArgument("permits")] ref InertStringHandler handler)
-    {
-        ArgumentNullException.ThrowIfNull(permits);
-        return handler.ToInertString();
-    }
+        TextPolicy policy,
+        [InterpolatedStringHandlerArgument(nameof(policy))] ref InertStringHandler handler)
+        => handler.ToInertString();
 
     /// <summary>
     /// Concatenates <paramref name="values"/>, separated by <paramref name="separator"/>.
     /// </summary>
     /// <remarks>
-    /// The separator is encoded under <paramref name="permits"/> like everything else, so a
-    /// multi-line message must pass a policy that permits the line break it joins with.
-    /// Exempting the separator would be a hole exactly the size of one caller's mistake.
+    /// The separator is encoded under <paramref name="policy"/> like everything else, so joining
+    /// with a line break requires a policy that permits one. Exempting it would be a hole exactly
+    /// the size of one caller's mistake, and it would contradict the handler, which encodes
+    /// source literals for the same reason.
+    ///
+    /// This is why <see cref="TextPolicy.Prose"/> still permits <c>CR</c>. Refusing it would
+    /// render <c>Environment.NewLine</c> as <c>\^M</c> on Windows for every caller who joins
+    /// with it, so dropping <c>CR</c> and encoding the separator cannot both hold.
     /// </remarks>
     /// <param name="separator">The text placed between values.</param>
-    /// <param name="permits">
-    /// The per-sink policy, applied to <paramref name="separator"/> and to any value that does
-    /// not already satisfy it.
+    /// <param name="policy">
+    /// The kind of text being built, applied to <paramref name="separator"/> and to any value
+    /// that does not already satisfy it.
     /// </param>
     /// <param name="values">The values to join.</param>
-    public static InertString Join(string separator, ScalarPolicy permits, IEnumerable<InertString> values)
+    public static InertString Join(string separator, TextPolicy policy, IEnumerable<InertString> values)
     {
         ArgumentNullException.ThrowIfNull(separator);
         ArgumentNullException.ThrowIfNull(values);
 
-        InertString encodedSeparator = VisualEncoder.Encode(separator, permits);
+        InertString encodedSeparator = VisualEncoder.Encode(policy, separator);
         StringBuilder builder = new();
         VisualForm forms = VisualForm.None;
         bool first = true;
@@ -219,7 +224,7 @@ public readonly struct InertString : IEquatable<InertString>
                 forms |= encodedSeparator.Forms;
             }
 
-            InertString conformed = value.EnsurePermitted(permits);
+            InertString conformed = value.EnsurePermitted(policy);
             builder.Append(conformed.ToString());
             forms |= conformed.Forms;
             first = false;
@@ -245,8 +250,8 @@ public readonly struct InertString : IEquatable<InertString>
     /// for it should call <see cref="EnsurePermitted"/> instead, which repairs rather than
     /// reports.
     /// </remarks>
-    public static bool IsPermitted(string value, ScalarPolicy permits)
-        => IsPermitted(value, permits, out _);
+    public static bool IsPermitted(TextPolicy policy, string value)
+        => IsPermitted(policy, value, out _);
 
     /// <summary>
     /// Reports whether every scalar in <paramref name="value"/> is permitted as it is, naming
@@ -257,13 +262,13 @@ public readonly struct InertString : IEquatable<InertString>
     /// is what lets a survey mode report a finding without echoing artifact text.
     /// </remarks>
     public static bool IsPermitted(
+        TextPolicy policy,
         string value,
-        ScalarPolicy permits,
         [NotNullWhen(false)] out ScalarViolation? violation)
     {
         ArgumentNullException.ThrowIfNull(value);
-        ArgumentNullException.ThrowIfNull(permits);
 
+        ScalarPolicy permits = ScalarPolicies.For(policy);
         int i = 0;
         while (i < value.Length)
         {
@@ -303,7 +308,7 @@ public readonly struct InertString : IEquatable<InertString>
     /// injection this library exists to prevent, with the type appearing to vouch for it.
     ///
     /// Public because a sink that accepts an <see cref="InertString"/> has no other correct way
-    /// to make one safe for itself. Re-encoding through <c>new InertString(value.ToString(), …)</c>
+    /// to make one safe for itself. Re-encoding through <c>new InertString(policy, value.ToString())</c>
     /// is the obvious substitute and is wrong: the text it re-encodes is already encoded, so the
     /// backslashes double on every pass. This decodes first, and so is idempotent.
     ///
@@ -316,15 +321,19 @@ public readonly struct InertString : IEquatable<InertString>
     /// inert would let a caller launder one by quoting it somewhere permissive. The cost is that
     /// splice path is observable — the same source text can render differently depending on
     /// where it was encoded — which is a deliberate trade, not an oversight.
+    ///
+    /// Taking a <see cref="TextPolicy"/> rather than a predicate is what keeps the repair inside
+    /// the library. The decode below recovers the hostile original, and with a caller-supplied
+    /// predicate that original would be passed to it scalar by scalar — so a file that imports
+    /// only the currency namespace could read back every character the value was built from. The
+    /// enum has no such reverse channel.
     /// </remarks>
-    /// <param name="permits">The policy of the sink about to receive this value.</param>
-    public InertString EnsurePermitted(ScalarPolicy permits)
+    /// <param name="policy">The kind of text the sink about to receive this value expects.</param>
+    public InertString EnsurePermitted(TextPolicy policy)
     {
-        ArgumentNullException.ThrowIfNull(permits);
-
         string text = Text;
 
-        if (IsPermitted(text, permits))
+        if (IsPermitted(policy, text))
         {
             return this;
         }
@@ -332,7 +341,7 @@ public readonly struct InertString : IEquatable<InertString>
         // Falling back to the encoded text when decoding fails cannot happen for a value this
         // library produced; it is here so the failure mode is over-encoding rather than a leak.
         string original = VisualEncoder.TryDecode(text, out string? decoded) ? decoded : text;
-        return VisualEncoder.Encode(original, permits);
+        return VisualEncoder.Encode(policy, original);
     }
 
     /// <inheritdoc/>
@@ -369,19 +378,17 @@ public readonly struct InertString : IEquatable<InertString>
 [InterpolatedStringHandler]
 public ref struct InertStringHandler
 {
-    private readonly ScalarPolicy _permits;
+    private readonly TextPolicy _policy;
     private readonly StringBuilder _builder;
     private VisualForm _forms;
 
     /// <summary>Called by the compiler for an interpolated string argument.</summary>
     /// <param name="literalLength">The total length of the literal parts.</param>
     /// <param name="formattedCount">The number of interpolation holes.</param>
-    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
-    public InertStringHandler(int literalLength, int formattedCount, ScalarPolicy permits)
+    /// <param name="policy">The kind of text being built.</param>
+    public InertStringHandler(int literalLength, int formattedCount, TextPolicy policy)
     {
-        ArgumentNullException.ThrowIfNull(permits);
-
-        _permits = permits;
+        _policy = policy;
         _builder = new StringBuilder(literalLength + (formattedCount * 12));
         _forms = VisualForm.None;
     }
@@ -395,16 +402,45 @@ public ref struct InertStringHandler
     /// whose decimal separator depends on the ambient culture is a message that cannot be
     /// grepped, and these are diagnostics rather than presentation.
     /// </remarks>
+    /// <remarks>
+    /// Tests for <see cref="InertString"/> first, because overload resolution cannot. The
+    /// dedicated overloads below bind on the <em>static</em> type of the hole, so a value reached
+    /// through a generic parameter or through <see cref="object"/> lands here instead, and
+    /// <c>ToString</c> would hand its already-encoded text back to the encoder — turning
+    /// <c>\u202E</c> into <c>\\u202E</c>. A type test is the only thing that sees through
+    /// either.
+    /// </remarks>
     public void AppendFormatted<T>(T value)
-        => Append(value is IFormattable formattable
+    {
+        if (value is InertString inert)
+        {
+            AppendFormatted(inert);
+            return;
+        }
+
+        Append(value is IFormattable formattable
             ? formattable.ToString(null, CultureInfo.InvariantCulture)
             : value?.ToString());
+    }
 
     /// <summary>Appends an interpolation hole that carries a format specifier.</summary>
+    /// <remarks>
+    /// Tests for <see cref="InertString"/> for the same reason as the overload above. The
+    /// specifier is discarded in that arm: an <see cref="InertString"/> has one rendering, and
+    /// honouring a format string would mean re-deriving it from the encoded text.
+    /// </remarks>
     public void AppendFormatted<T>(T value, string? format)
-        => Append(value is IFormattable formattable
+    {
+        if (value is InertString inert)
+        {
+            AppendFormatted(inert);
+            return;
+        }
+
+        Append(value is IFormattable formattable
             ? formattable.ToString(format, CultureInfo.InvariantCulture)
             : value?.ToString());
+    }
 
     /// <summary>Appends a string-valued interpolation hole.</summary>
     public void AppendFormatted(string? value) => Append(value);
@@ -420,7 +456,7 @@ public ref struct InertStringHandler
     /// </remarks>
     public void AppendFormatted(InertString value)
     {
-        InertString conformed = value.EnsurePermitted(_permits);
+        InertString conformed = value.EnsurePermitted(_policy);
         _builder.Append(conformed.ToString());
         _forms |= conformed.Forms;
     }
@@ -447,7 +483,7 @@ public ref struct InertStringHandler
         if (string.IsNullOrEmpty(value))
             return;
 
-        InertString encoded = VisualEncoder.Encode(value, _permits);
+        InertString encoded = VisualEncoder.Encode(_policy, value);
         _builder.Append(encoded.ToString());
         _forms |= encoded.Forms;
     }

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -63,6 +63,16 @@ namespace InertText;
 /// </remarks>
 public readonly struct InertString : IEquatable<InertString>
 {
+    // A constructor is the only thing that assigns this, and both constructors assign encoder
+    // output, so every value that a caller can build carries text. The `?` describes the single
+    // state no constructor can reach: default(InertString), whose field the CLR zeroes without
+    // running any constructor at all. A struct cannot suppress its zero value, so a non-nullable
+    // annotation here would be unverifiable -- it compiles without a warning, because the
+    // compiler does not track default(T) through to fields -- and would promise every reader
+    // something the runtime is free to contradict.
+    //
+    // No downstream code is defensive about it. Text is the sole reader and maps the zero value
+    // to empty; a reflection test fails any public member that reads around it.
     private readonly string? _text;
 
     /// <summary>
@@ -71,18 +81,15 @@ public readonly struct InertString : IEquatable<InertString>
     /// </summary>
     /// <remarks>
     /// The only way text enters the type, and the reason no member of it can take text without
-    /// also taking a policy — a reflection test enforces that. Encoding happens here rather
-    /// than through a factory because a factory would have been a constructor with a different
-    /// spelling; what is worth separating is not the call shape but the ability to reverse it,
-    /// which lives in <see cref="VisualEncoder"/> and in its own namespace.
+    /// also taking a policy — a reflection test enforces that.
+    ///
+    /// Forwards to <see cref="VisualEncoder"/> rather than duplicating the loop, and exists so
+    /// that producing inert text does not require naming the capability namespace. That is what
+    /// keeps the decoder out of the files that merely make inert text, and it is gated.
     /// </remarks>
     /// <param name="value">The untreated text.</param>
     /// <param name="permits">The per-sink policy deciding what may pass through.</param>
-    public InertString(string value, ScalarPolicy permits)
-    {
-        _text = VisualEncoder.Encode(value, permits, out VisualForm forms);
-        Forms = forms;
-    }
+    public InertString(string value, ScalarPolicy permits) => this = VisualEncoder.Encode(value, permits);
 
     // Takes text already spelled by the encoder, so it asserts rather than establishes the
     // invariant. Internal because composition needs it: Join and the interpolation handler
@@ -186,7 +193,7 @@ public readonly struct InertString : IEquatable<InertString>
         ArgumentNullException.ThrowIfNull(separator);
         ArgumentNullException.ThrowIfNull(values);
 
-        string encodedSeparator = VisualEncoder.Encode(separator, permits, out VisualForm separatorForms);
+        InertString encodedSeparator = VisualEncoder.Encode(separator, permits);
         StringBuilder builder = new();
         VisualForm forms = VisualForm.None;
         bool first = true;
@@ -197,12 +204,13 @@ public readonly struct InertString : IEquatable<InertString>
             // single-element join cannot report a form the output does not contain.
             if (!first)
             {
-                builder.Append(encodedSeparator);
-                forms |= separatorForms;
+                builder.Append(encodedSeparator.ToString());
+                forms |= encodedSeparator.Forms;
             }
 
-            builder.Append(Conform(value, permits, out VisualForm valueForms));
-            forms |= valueForms;
+            InertString conformed = Conform(value, permits);
+            builder.Append(conformed.ToString());
+            forms |= conformed.Forms;
             first = false;
         }
 
@@ -288,20 +296,19 @@ public readonly struct InertString : IEquatable<InertString>
     /// splice path is observable — the same source text can render differently depending on
     /// where it was encoded — which is a deliberate trade, not an oversight.
     /// </remarks>
-    internal static string Conform(InertString value, ScalarPolicy permits, out VisualForm forms)
+    internal static InertString Conform(InertString value, ScalarPolicy permits)
     {
         string text = value.ToString();
 
         if (IsPermitted(text, permits))
         {
-            forms = value.Forms;
-            return text;
+            return value;
         }
 
         // Falling back to the encoded text when decoding fails cannot happen for a value this
         // library produced; it is here so the failure mode is over-encoding rather than a leak.
         string original = VisualEncoder.TryDecode(text, out string? decoded) ? decoded : text;
-        return VisualEncoder.Encode(original, permits, out forms);
+        return VisualEncoder.Encode(original, permits);
     }
 
     /// <inheritdoc/>
@@ -389,8 +396,9 @@ public ref struct InertStringHandler
     /// </remarks>
     public void AppendFormatted(InertString value)
     {
-        _builder.Append(InertString.Conform(value, _permits, out VisualForm forms));
-        _forms |= forms;
+        InertString conformed = InertString.Conform(value, _permits);
+        _builder.Append(conformed.ToString());
+        _forms |= conformed.Forms;
     }
 
     /// <summary>
@@ -415,7 +423,8 @@ public ref struct InertStringHandler
         if (string.IsNullOrEmpty(value))
             return;
 
-        _builder.Append(VisualEncoder.Encode(value, _permits, out VisualForm forms));
-        _forms |= forms;
+        InertString encoded = VisualEncoder.Encode(value, _permits);
+        _builder.Append(encoded.ToString());
+        _forms |= encoded.Forms;
     }
 }

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
-using InertText.Encoder;
+using InertText.Encoding;
 
 namespace InertText;
 
@@ -20,8 +20,8 @@ namespace InertText;
 ///
 /// The second half of that is what this type does <em>not</em> offer. Holding one of these
 /// gives no way back to the text it was built from: the decoder lives in
-/// <c>InertText.Encoder</c>, in its own namespace, and nothing here reaches it. So a file that
-/// imports <c>InertText</c> and not <c>InertText.Encoder</c> cannot recover the original of any
+/// <c>InertText.Encoding</c>, in its own namespace, and nothing here reaches it. So a file that
+/// imports <c>InertText</c> and not <c>InertText.Encoding</c> cannot recover the original of any
 /// value it handles, and that fact is legible in its using block rather than by tracing calls.
 /// A reflection test enumerates the public surface of this namespace and accounts for every
 /// member that returns text, so the property is enforced rather than merely intended.

--- a/src/InertText/InertText.csproj
+++ b/src/InertText/InertText.csproj
@@ -14,6 +14,12 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- The rule table and the scalar predicate are internal so no caller can supply one; the
+         sweeps that assert the encoder is total and invertible have to reach them anyway. -->
+    <InternalsVisibleTo Include="InertText.Tests" />
+  </ItemGroup>
+
   <!-- Deliberately carries no ProjectReference. Every assembly that prints artifact-derived
        text needs this, including the dependency-free leaves, so it has to sit below all of
        them. Keep it that way: a reference added here is a reference added to everything. -->

--- a/src/InertText/InertText.csproj
+++ b/src/InertText/InertText.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Richard Lander</Authors>
+    <Description>Makes untrusted text inert, so a sink cannot be made to act on what it contains</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <!-- Deliberately carries no ProjectReference. Every assembly that prints artifact-derived
+       text needs this, including the dependency-free leaves, so it has to sit below all of
+       them. Keep it that way: a reference added here is a reference added to everything. -->
+
+</Project>

--- a/src/InertText/InertText.csproj
+++ b/src/InertText/InertText.csproj
@@ -6,6 +6,11 @@
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <IsAotCompatible>true</IsAotCompatible>
+    <!-- The audit story is carried in doc comments, so a cref that no longer resolves is a
+         defect and not a cosmetic one. With docs off, CS1574/CS1734/CS0419 are never raised
+         and the comments rot silently; a stale paramref and an ambiguous cref both survived
+         that way until review. On, they are build errors. -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/InertText/TextPolicy.cs
+++ b/src/InertText/TextPolicy.cs
@@ -1,0 +1,108 @@
+using System.Globalization;
+using System.Text;
+
+namespace InertText;
+
+/// <summary>
+/// Decides whether a scalar may be shown to a sink as it is.
+/// </summary>
+/// <remarks>
+/// The policy half of the split: it answers "is this scalar permitted <em>here</em>", which is
+/// a per-sink question, while <see cref="InertString"/> answers "how is a scalar that is not
+/// permitted written down" and never learns why. Deny-shaped policies suit free-form text;
+/// allow-shaped policies suit fields whose grammar is externally defined, and only an
+/// allow-shaped one can catch a homoglyph, because Cyrillic <c>а</c> and Latin <c>a</c> are
+/// both <c>Ll</c> and neither is a hazard.
+/// </remarks>
+/// <param name="scalar">The scalar to judge.</param>
+/// <returns>True when <paramref name="scalar"/> may be passed through unencoded.</returns>
+public delegate bool ScalarPolicy(Rune scalar);
+
+/// <summary>
+/// Identifies a scalar a policy refused, by position and classification rather than by content.
+/// </summary>
+/// <remarks>
+/// <paramref name="Scalar"/> is an <see cref="int"/> rather than a <see cref="Rune"/> because an
+/// unpaired surrogate is one of the things this has to name, and <see cref="Rune"/> cannot hold
+/// one — its invariant excludes <c>D800</c>–<c>DFFF</c>, so constructing it throws. Reporting
+/// through <see cref="Rune"/> forced the replacement character in that arm, which named the
+/// wrong code point for the 2048 values whose identity matters most.
+/// </remarks>
+/// <param name="Index">The index in the source string where the scalar begins.</param>
+/// <param name="Scalar">The refused scalar, or the raw code unit for an unpaired surrogate.</param>
+/// <param name="Category">The scalar's Unicode general category.</param>
+public readonly record struct ScalarViolation(int Index, int Scalar, UnicodeCategory Category)
+{
+    /// <summary>
+    /// Describes the violation without reproducing the character.
+    /// </summary>
+    /// <remarks>
+    /// <c>U+XXXX</c> is ASCII, so it is inert by construction, and for a homoglyph it says
+    /// strictly more than the character would: printing <c>е</c> conveys nothing, because it is
+    /// indistinguishable from <c>e</c>.
+    /// </remarks>
+    public override string ToString()
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"U+{Scalar:X4} ({Category}) at {Index}");
+}
+
+/// <summary>
+/// The deny-shaped policies, for text whose grammar is not externally defined.
+/// </summary>
+/// <remarks>
+/// What these refuse is defined by Unicode general category rather than by a list, because a
+/// list drifts invisibly: one written against terminal escapes will not contain the characters
+/// that attack a different sink. <c>Cf</c> is the category a hand-written list always misses,
+/// and it holds every code point rustc made a hard error after Trojan Source (CVE-2021-42574) —
+/// none of which is anywhere near the C0 range.
+///
+/// A field whose grammar <em>is</em> externally defined — a package id, a version — should not
+/// use these at all. It should supply an allow-shaped <see cref="ScalarPolicy"/> of its own,
+/// which is the only thing that catches a homoglyph typosquat.
+/// </remarks>
+public static class TextPolicy
+{
+    /// <summary>
+    /// Refuses every non-graphic scalar, with no exemptions.
+    /// </summary>
+    /// <remarks>
+    /// For a name or a URL, which has no business containing <c>CR</c>, <c>LF</c> or <c>TAB</c>.
+    /// </remarks>
+    public static ScalarPolicy Field { get; } = static scalar => !IsNonGraphic(scalar);
+
+    /// <summary>
+    /// Refuses every non-graphic scalar except <c>CR</c>, <c>LF</c> and <c>TAB</c>.
+    /// </summary>
+    /// <remarks>
+    /// For genuinely multi-line text such as a package description. The exempt set only ever
+    /// shrinks the C0 part: no sink may exempt a bidi control, because there is no rendering
+    /// context in which artifact text needs to reorder the reader's screen.
+    /// </remarks>
+    public static ScalarPolicy Prose { get; } = static scalar =>
+        scalar.Value is '\r' or '\n' or '\t' || !IsNonGraphic(scalar);
+
+    /// <summary>
+    /// Reports whether <paramref name="scalar"/> falls in a category that can act on a sink.
+    /// </summary>
+    /// <remarks>
+    /// <c>Cc</c> (C0, DEL, C1) attacks terminal control sequences; <c>Cf</c> attacks visual
+    /// order and includes every character Trojan Source used; <c>Zl</c> and <c>Zp</c> attack
+    /// line-oriented and JS-adjacent consumers.
+    ///
+    /// The <c>Cs</c> arm is unreachable and kept only for totality of the switch. No
+    /// <see cref="Rune"/> can carry that category, because the type's invariant excludes the
+    /// surrogate range outright. Unpaired surrogates are caught ahead of any policy, in the
+    /// decode step, so an allow-shaped policy written against this method does not need to —
+    /// and cannot — handle them itself.
+    /// </remarks>
+    public static bool IsNonGraphic(Rune scalar)
+        => Rune.GetUnicodeCategory(scalar) switch
+        {
+            UnicodeCategory.Control => true,
+            UnicodeCategory.Format => true,
+            UnicodeCategory.Surrogate => true,
+            UnicodeCategory.LineSeparator or UnicodeCategory.ParagraphSeparator => true,
+            _ => false,
+        };
+}

--- a/src/InertText/TextPolicy.cs
+++ b/src/InertText/TextPolicy.cs
@@ -4,19 +4,60 @@ using System.Text;
 namespace InertText;
 
 /// <summary>
-/// Decides whether a scalar may be shown to a sink as it is.
+/// Names the kind of text a value is, which is what decides the scalars it may show as they are.
 /// </summary>
 /// <remarks>
-/// The policy half of the split: it answers "is this scalar permitted <em>here</em>", which is
-/// a per-sink question, while <see cref="InertString"/> answers "how is a scalar that is not
-/// permitted written down" and never learns why. Deny-shaped policies suit free-form text;
-/// allow-shaped policies suit fields whose grammar is externally defined, and only an
-/// allow-shaped one can catch a homoglyph, because Cyrillic <c>а</c> and Latin <c>a</c> are
-/// both <c>Ll</c> and neither is a hazard.
+/// A closed set, and closed is the feature rather than a limitation. The obvious alternative —
+/// letting each caller pass a predicate — was tried first and fails twice over. It drifts,
+/// because a rule written at one sink is invisible to the next: five predicates in this
+/// repository answer "is this scalar dangerous" and disagree by up to 48 BMP characters, and one
+/// of them escapes ANSI but not bidi, so the layer that renders hostile assembly metadata misses
+/// the attack class Trojan Source is named after. And it leaks, because repairing a value that
+/// does not satisfy a caller-supplied predicate means handing that predicate the decoded
+/// original — the audit boundary the capability namespace exists to draw, crossed by a callback
+/// in a file whose using block says nothing.
+///
+/// A closed set removes both. The rules are written once and shared, so a fix reaches every sink
+/// at the same time; and no caller code runs during a repair, so no decoded scalar leaves the
+/// library. What the set costs is that a sink cannot express a rule of its own. That is the
+/// right price: a rule which really is unique to one sink — a package id's grammar, say — wants
+/// rejection rather than encoding, because there is no spelling of a homoglyph that satisfies an
+/// allow list, and rejection is a different operation that belongs in a different API.
+///
+/// Adding a kind is an enum member and an arm in the rule table, and no new public member
+/// anywhere. That is the whole extension mechanism.
+///
+/// Deny-shaped throughout, and defined by Unicode general category rather than by a list,
+/// because a list drifts invisibly: one written against terminal escapes will not contain the
+/// characters that attack a different sink. <c>Cf</c> is the category a hand-written list always
+/// misses, and it holds every code point rustc made a hard error after Trojan Source
+/// (CVE-2021-42574) — none of which is anywhere near the C0 range.
 /// </remarks>
-/// <param name="scalar">The scalar to judge.</param>
-/// <returns>True when <paramref name="scalar"/> may be passed through unencoded.</returns>
-public delegate bool ScalarPolicy(Rune scalar);
+public enum TextPolicy
+{
+    /// <summary>
+    /// Refuses every non-graphic scalar, with no exemptions.
+    /// </summary>
+    /// <remarks>
+    /// For a name or a URL, which has no business containing <c>CR</c>, <c>LF</c> or <c>TAB</c>.
+    ///
+    /// First, so it is what <c>default(TextPolicy)</c> resolves to. A zero value is reachable for
+    /// any enum whatever the declared members say — an unchecked cast or a deserializer will
+    /// produce one — so the only question is which rule it lands on, and the strictest is the one
+    /// where being wrong costs nothing.
+    /// </remarks>
+    Field,
+
+    /// <summary>
+    /// Refuses every non-graphic scalar except <c>CR</c>, <c>LF</c> and <c>TAB</c>.
+    /// </summary>
+    /// <remarks>
+    /// For genuinely multi-line text such as a package description. The exempt set only ever
+    /// shrinks the C0 part: no kind of text may exempt a bidi control, because there is no
+    /// rendering context in which artifact text needs to reorder the reader's screen.
+    /// </remarks>
+    Prose,
+}
 
 /// <summary>
 /// Identifies a scalar a policy refused, by position and classification rather than by content.
@@ -48,55 +89,57 @@ public readonly record struct ScalarViolation(int Index, int Scalar, UnicodeCate
 }
 
 /// <summary>
-/// The deny-shaped policies, for text whose grammar is not externally defined.
+/// Decides whether a scalar may be shown as it is.
 /// </summary>
 /// <remarks>
-/// What these refuse is defined by Unicode general category rather than by a list, because a
-/// list drifts invisibly: one written against terminal escapes will not contain the characters
-/// that attack a different sink. <c>Cf</c> is the category a hand-written list always misses,
-/// and it holds every code point rustc made a hard error after Trojan Source (CVE-2021-42574) —
-/// none of which is anywhere near the C0 range.
-///
-/// A field whose grammar <em>is</em> externally defined — a package id, a version — should not
-/// use these at all. It should supply an allow-shaped <see cref="ScalarPolicy"/> of its own,
-/// which is the only thing that catches a homoglyph typosquat.
+/// Internal, and that is the point of <see cref="TextPolicy"/>. The encoder still wants a
+/// predicate — it asks the question once per scalar in its hot loop — but no caller supplies one,
+/// so a repair never runs code the library did not write, and a decoded scalar never reaches a
+/// callback.
 /// </remarks>
-public static class TextPolicy
-{
-    /// <summary>
-    /// Refuses every non-graphic scalar, with no exemptions.
-    /// </summary>
-    /// <remarks>
-    /// For a name or a URL, which has no business containing <c>CR</c>, <c>LF</c> or <c>TAB</c>.
-    /// </remarks>
-    public static ScalarPolicy Field { get; } = static scalar => !IsNonGraphic(scalar);
+/// <param name="scalar">The scalar to judge.</param>
+/// <returns>True when <paramref name="scalar"/> may be passed through unencoded.</returns>
+internal delegate bool ScalarPolicy(Rune scalar);
 
-    /// <summary>
-    /// Refuses every non-graphic scalar except <c>CR</c>, <c>LF</c> and <c>TAB</c>.
-    /// </summary>
-    /// <remarks>
-    /// For genuinely multi-line text such as a package description. The exempt set only ever
-    /// shrinks the C0 part: no sink may exempt a bidi control, because there is no rendering
-    /// context in which artifact text needs to reorder the reader's screen.
-    /// </remarks>
-    public static ScalarPolicy Prose { get; } = static scalar =>
+/// <summary>
+/// The rule table: the single place each <see cref="TextPolicy"/> is defined.
+/// </summary>
+internal static class ScalarPolicies
+{
+    private static readonly ScalarPolicy FieldPolicy = static scalar => !IsNonGraphic(scalar);
+
+    private static readonly ScalarPolicy ProsePolicy = static scalar =>
         scalar.Value is '\r' or '\n' or '\t' || !IsNonGraphic(scalar);
+
+    /// <summary>Resolves the rule for <paramref name="policy"/>.</summary>
+    /// <remarks>
+    /// An unrecognised value falls to <see cref="TextPolicy.Field"/> rather than throwing. An
+    /// enum parameter is not a closed set at runtime — <c>(TextPolicy)42</c> is a legal value —
+    /// and a text-hardening library that throws on one has turned a rendering decision into an
+    /// availability bug. Falling to the strictest rule is wrong only in the direction that
+    /// over-encodes.
+    /// </remarks>
+    internal static ScalarPolicy For(TextPolicy policy)
+        => policy switch
+        {
+            TextPolicy.Prose => ProsePolicy,
+            _ => FieldPolicy,
+        };
 
     /// <summary>
     /// Reports whether <paramref name="scalar"/> falls in a category that can act on a sink.
     /// </summary>
     /// <remarks>
-    /// <c>Cc</c> (C0, DEL, C1) attacks terminal control sequences; <c>Cf</c> attacks visual
-    /// order and includes every character Trojan Source used; <c>Zl</c> and <c>Zp</c> attack
+    /// <c>Cc</c> (C0, DEL, C1) attacks terminal control sequences; <c>Cf</c> attacks visual order
+    /// and includes every character Trojan Source used; <c>Zl</c> and <c>Zp</c> attack
     /// line-oriented and JS-adjacent consumers.
     ///
     /// The <c>Cs</c> arm is unreachable and kept only for totality of the switch. No
     /// <see cref="Rune"/> can carry that category, because the type's invariant excludes the
     /// surrogate range outright. Unpaired surrogates are caught ahead of any policy, in the
-    /// decode step, so an allow-shaped policy written against this method does not need to —
-    /// and cannot — handle them itself.
+    /// decode step.
     /// </remarks>
-    public static bool IsNonGraphic(Rune scalar)
+    internal static bool IsNonGraphic(Rune scalar)
         => Rune.GetUnicodeCategory(scalar) switch
         {
             UnicodeCategory.Control => true,

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 
-namespace InertText.Encoder;
+namespace InertText.Encoding;
 
 /// <summary>
 /// The transform that makes text inert, and the decoder that recovers what it was given.
@@ -13,7 +13,7 @@ namespace InertText.Encoder;
 /// <see cref="InertString"/> can be carried, composed and printed without ever naming this
 /// type: text enters through its constructor, which calls in here, and leaves through
 /// <c>ToString</c> already spelled. So a file that imports <c>InertText</c> and not
-/// <c>InertText.Encoder</c> has no way to recover the original text of any value it handles,
+/// <c>InertText.Encoding</c> has no way to recover the original text of any value it handles,
 /// and that is visible in its using block rather than by tracing calls.
 ///
 /// The separation is an audit boundary, not a capability barrier. Nothing stops a file from

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -113,11 +113,7 @@ public static class VisualEncoder
         value = null;
         StringBuilder builder = new(encoded.Length);
 
-        // Where a \uXXXX that decoded to a high surrogate ended, so the \u arm below can tell a
-        // surrogate *pair* spelled as two escapes from two independently unpaired ones.
-        int highSurrogateEscapeEnd = -1;
-
-        for (int i = 0; i < encoded.Length; i++)
+                for (int i = 0; i < encoded.Length; i++)
         {
             if (encoded[i] != '\\')
             {
@@ -141,8 +137,6 @@ public static class VisualEncoder
                 builder.Append(encoded[i]);
                 continue;
             }
-
-            int escapeStart = i;
 
             if (++i == encoded.Length)
             {
@@ -191,18 +185,20 @@ public static class VisualEncoder
                         return false;
                     }
 
-                    if (char.IsLowSurrogate((char)bmp) && escapeStart == highSurrogateEscapeEnd)
-                    {
-                        // \uD83D\uDE00 would otherwise land a well-formed pair in the builder and
-                        // re-encode as \U0001F600, giving that astral scalar two spellings. The
-                        // lone-surrogate case below stays legal precisely because this one does
-                        // not: a pair is representable as \U, an unpaired half is not
-                        // representable any other way at all.
-                        return false;
-                    }
-
+                    // \uD83D\uDE00 decodes to the astral scalar rather than being refused as a
+                    // second spelling of \U0001F600. Refusing it looks like canonicalization but
+                    // is not expressible: a .NET string is UTF-16, so "\uD83D" + "\uDE00" *is*
+                    // "\U0001F600" -- there is no string in which those halves stay apart, and
+                    // no other text the spelling could denote. Encode still only ever emits \U
+                    // for a pair, so this arm is not a second output form; it is the input form
+                    // composition produces. Join and the interpolation handler concatenate
+                    // fragments that were each encoded alone, so a lone high surrogate encoded
+                    // in one fragment lands beside a lone low surrogate encoded in the next.
+                    // Refusing that made a value this library had just produced fail to decode,
+                    // and EnsurePermitted then re-encoded the escapes as literal text -- turning
+                    // \uD834\uDD73 into \\uD834\\uDD73, which is also what the ASCII text a user
+                    // typed encodes to. Two unrelated inputs converged on one output.
                     i += 4;
-                    highSurrogateEscapeEnd = char.IsHighSurrogate((char)bmp) ? i + 1 : -1;
                     builder.Append((char)bmp);
                     break;
                 case 'U':

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -29,10 +29,17 @@ namespace InertText.Encoder;
 public static class VisualEncoder
 {
     /// <summary>
-    /// Returns <paramref name="value"/> with every scalar <paramref name="permits"/> refuses
-    /// visually encoded, reporting which spellings were used.
+    /// Encodes <paramref name="value"/> under <paramref name="permits"/>, visually spelling every
+    /// scalar the policy refuses.
     /// </summary>
     /// <remarks>
+    /// Returns the currency type rather than a <see cref="string"/> and a form set, because the
+    /// two are one result: <see cref="InertString.Forms"/> is exactly what an <c>out</c>
+    /// parameter would have reported, and splitting them lets a caller keep the text while
+    /// dropping the record of what was done to it — which is the confusion this library exists to
+    /// remove. <see cref="InertString"/>'s constructor forwards here, so the two spellings cannot
+    /// diverge.
+    ///
     /// A literal backslash is always rewritten, whatever <paramref name="permits"/> says, because
     /// it introduces every other spelling and the transform would not otherwise invert. An
     /// unpaired surrogate is likewise always encoded: it is not a scalar at all, so no policy is
@@ -40,13 +47,16 @@ public static class VisualEncoder
     /// </remarks>
     /// <param name="value">The text to encode.</param>
     /// <param name="permits">The per-sink policy deciding what may pass through.</param>
-    /// <param name="formsUsed">The spellings actually emitted, for a caller-written legend.</param>
-    public static string Encode(string value, ScalarPolicy permits, out VisualForm formsUsed)
+    /// <returns>
+    /// The encoded text as an <see cref="InertString"/>, which carries the spellings that were
+    /// emitted. Text that needed no encoding is returned as the original instance.
+    /// </returns>
+    public static InertString Encode(string value, ScalarPolicy permits)
     {
         ArgumentNullException.ThrowIfNull(value);
         ArgumentNullException.ThrowIfNull(permits);
 
-        formsUsed = VisualForm.None;
+        VisualForm formsUsed = VisualForm.None;
         StringBuilder? builder = null;
 
         int i = 0;
@@ -79,7 +89,7 @@ public static class VisualEncoder
             i += width;
         }
 
-        return builder?.ToString() ?? value;
+        return new InertString(builder?.ToString() ?? value, formsUsed);
     }
 
     /// <summary>

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -1,0 +1,294 @@
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+
+namespace InertText.Encoder;
+
+/// <summary>
+/// The transform that makes text inert, and the decoder that recovers what it was given.
+/// </summary>
+/// <remarks>
+/// Deliberately in its own namespace, because that is what makes the guarantee auditable.
+/// <see cref="InertString"/> can be carried, composed and printed without ever naming this
+/// type: text enters through its constructor, which calls in here, and leaves through
+/// <c>ToString</c> already spelled. So a file that imports <c>InertText</c> and not
+/// <c>InertText.Encoder</c> has no way to recover the original text of any value it handles,
+/// and that is visible in its using block rather than by tracing calls.
+///
+/// The separation is an audit boundary, not a capability barrier. Nothing stops a file from
+/// adding the import or writing the name out in full — but it cannot do so invisibly, and
+/// making the dangerous half impossible to reach by accident is the achievable goal. A
+/// reflection test enforces the other half of it: no public member of <see cref="InertString"/>
+/// returns text derived from the original.
+///
+/// The name stays deliberately distinct from the currency type's. Two unrelated names give two
+/// independent searches — one for who carries inert text, one for who can recover it — where a
+/// shared prefix would blur both into a single noisy result.
+/// </remarks>
+public static class VisualEncoder
+{
+    /// <summary>
+    /// Returns <paramref name="value"/> with every scalar <paramref name="permits"/> refuses
+    /// visually encoded, reporting which spellings were used.
+    /// </summary>
+    /// <remarks>
+    /// A literal backslash is always rewritten, whatever <paramref name="permits"/> says, because
+    /// it introduces every other spelling and the transform would not otherwise invert. An
+    /// unpaired surrogate is likewise always encoded: it is not a scalar at all, so no policy is
+    /// consulted for it.
+    /// </remarks>
+    /// <param name="value">The text to encode.</param>
+    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
+    /// <param name="formsUsed">The spellings actually emitted, for a caller-written legend.</param>
+    public static string Encode(string value, ScalarPolicy permits, out VisualForm formsUsed)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(permits);
+
+        formsUsed = VisualForm.None;
+        StringBuilder? builder = null;
+
+        int i = 0;
+        while (i < value.Length)
+        {
+            Rune scalar = DecodeAt(value, i, out int width, out bool isUnpairedSurrogate);
+            bool encode = isUnpairedSurrogate || value[i] == '\\' || !permits(scalar);
+
+            if (!encode)
+            {
+                builder?.Append(value, i, width);
+                i += width;
+                continue;
+            }
+
+            // Only allocate once something actually needs encoding, so ordinary text — which is
+            // almost all text — is returned as it came in.
+            builder ??= new StringBuilder(value.Length + 8).Append(value, 0, i);
+
+            if (isUnpairedSurrogate)
+            {
+                AppendBmpHex(builder, value[i]);
+                formsUsed |= VisualForm.BmpHex;
+            }
+            else
+            {
+                formsUsed |= AppendSpelling(builder, scalar);
+            }
+
+            i += width;
+        }
+
+        return builder?.ToString() ?? value;
+    }
+
+    /// <summary>
+    /// Recovers the original text from <see cref="Encode"/>'s output.
+    /// </summary>
+    /// <remarks>
+    /// The reason this namespace exists. Every other operation in the library moves text
+    /// <em>toward</em> being inert; this is the one that moves it back, so it is the one whose
+    /// presence in a file is worth being able to see at a glance.
+    ///
+    /// It also exists because invertibility is an asserted property, and an encoder without a
+    /// decoder cannot demonstrate it: a caret-introduced spelling survives casual inspection
+    /// and only fails a round-trip that a decoder makes possible.
+    /// </remarks>
+    /// <returns>True when <paramref name="encoded"/> is well-formed.</returns>
+    public static bool TryDecode(string encoded, [NotNullWhen(true)] out string? value)
+    {
+        ArgumentNullException.ThrowIfNull(encoded);
+
+        value = null;
+        StringBuilder builder = new(encoded.Length);
+
+        for (int i = 0; i < encoded.Length; i++)
+        {
+            if (encoded[i] != '\\')
+            {
+                builder.Append(encoded[i]);
+                continue;
+            }
+
+            if (++i == encoded.Length)
+            {
+                return false;
+            }
+
+            switch (encoded[i])
+            {
+                case '\\':
+                    builder.Append('\\');
+                    break;
+                case '^':
+                    if (++i == encoded.Length)
+                    {
+                        return false;
+                    }
+
+                    char caret = encoded[i];
+
+                    if (caret == '?')
+                    {
+                        builder.Append('\u007F');
+                    }
+                    else if (caret is >= '@' and <= '_')
+                    {
+                        builder.Append((char)(caret - 0x40));
+                    }
+                    else
+                    {
+                        return false;
+                    }
+
+                    break;
+                case 'u':
+                    if (!TryReadHex(encoded, i + 1, 4, out uint bmp))
+                    {
+                        return false;
+                    }
+
+                    if (bmp <= 0x1F || bmp is 0x7F or '\\')
+                    {
+                        // Those three ranges have a canonical spelling — \^X, \^? and \\ — so
+                        // accepting \uXXXX for them too would give one scalar two encodings,
+                        // the same loss of injectivity the \U arm rejects below. Encode never
+                        // emits these, so no round trip depends on them.
+                        return false;
+                    }
+
+                    builder.Append((char)bmp);
+                    i += 4;
+                    break;
+                case 'U':
+                    if (!TryReadHex(encoded, i + 1, 8, out uint astral)
+                        || !Rune.IsValid((int)astral)
+                        || astral <= 0xFFFF)
+                    {
+                        // Rejecting the BMP range keeps the transform injective: a scalar has
+                        // exactly one spelling, so \U0000202E is not a second way to write
+                        // \u202E.
+                        return false;
+                    }
+
+                    builder.Append(new Rune((int)astral));
+                    i += 8;
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        // An unpaired surrogate decoded from a \uXXXX arm is deliberately accepted. Cs is one of
+        // the encoded categories, so Encode emits exactly this form for an unpaired surrogate,
+        // and rejecting it here would make the encoder non-invertible on the one input class
+        // that cannot be represented any other way.
+        value = builder.ToString();
+        return true;
+    }
+
+    /// <summary>
+    /// Names the spellings in <paramref name="forms"/>, one line each.
+    /// </summary>
+    /// <remarks>
+    /// Projected from the encoder rather than maintained separately, because a legend written
+    /// independently drifts. It names forms and never values: artifact data does not belong on
+    /// the diagnostic channel.
+    /// </remarks>
+    public static IReadOnlyList<string> DescribeLegend(VisualForm forms)
+    {
+        List<string> lines = [];
+
+        if (forms.HasFlag(VisualForm.Caret))
+        {
+            lines.Add(@"\^X         a C0 control in caret notation; \^[ is ESC");
+        }
+
+        if (forms.HasFlag(VisualForm.CaretDelete))
+        {
+            lines.Add(@"\^?         DEL");
+        }
+
+        if (forms.HasFlag(VisualForm.BmpHex))
+        {
+            lines.Add(@"\uXXXX      the scalar at code point U+XXXX");
+        }
+
+        if (forms.HasFlag(VisualForm.AstralHex))
+        {
+            lines.Add(@"\UXXXXXXXX  the scalar at code point U+XXXXXXXX");
+        }
+
+        if (forms.HasFlag(VisualForm.Backslash))
+        {
+            lines.Add(@"\\          a literal backslash");
+        }
+
+        return lines;
+    }
+
+    private static VisualForm AppendSpelling(StringBuilder builder, Rune scalar)
+    {
+        switch (scalar.Value)
+        {
+            case '\\':
+                builder.Append(@"\\");
+                return VisualForm.Backslash;
+            case <= 0x1F:
+                // Caret notation, introduced by a backslash. Introducing with the caret instead
+                // collides: U+001E is 0x1E + 0x40 = '^', so RS and a literal caret would spell
+                // the same thing.
+                builder.Append(@"\^").Append((char)(scalar.Value + 0x40));
+                return VisualForm.Caret;
+            case 0x7F:
+                builder.Append(@"\^?");
+                return VisualForm.CaretDelete;
+            case <= 0xFFFF:
+                AppendBmpHex(builder, (char)scalar.Value);
+                return VisualForm.BmpHex;
+            default:
+                // \uXXXX reaches only the BMP, and 127 scalars in the encoded categories live
+                // above it — U+110BD, the Egyptian hieroglyph format controls, the musical
+                // symbol format characters. A speller that stops at \uXXXX is neither total nor
+                // invertible on exactly the inputs an attacker would reach for.
+                builder.Append(@"\U").Append(scalar.Value.ToString("X8", CultureInfo.InvariantCulture));
+                return VisualForm.AstralHex;
+        }
+    }
+
+    private static void AppendBmpHex(StringBuilder builder, char c)
+        => builder.Append(@"\u").Append(((int)c).ToString("X4", CultureInfo.InvariantCulture));
+
+    // Rune.DecodeFromUtf16 reports an unpaired surrogate as InvalidData and hands back the
+    // replacement character, so the caller has to keep the original code unit itself.
+    // string.EnumerateRunes() cannot be used here: it silently substitutes U+FFFD, which would
+    // make the transform lossy on exactly the input that needs it most.
+    internal static Rune DecodeAt(string value, int index, out int width, out bool isUnpairedSurrogate)
+    {
+        OperationStatus status = Rune.DecodeFromUtf16(
+            value.AsSpan(index),
+            out Rune scalar,
+            out width);
+
+        isUnpairedSurrogate = status != OperationStatus.Done;
+
+        if (isUnpairedSurrogate)
+        {
+            width = 1;
+        }
+
+        return scalar;
+    }
+
+    private static bool TryReadHex(string text, int start, int length, out uint value)
+    {
+        value = 0;
+
+        return start + length <= text.Length
+            && uint.TryParse(
+                text.AsSpan(start, length),
+                NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture,
+                out value);
+    }
+}

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -113,7 +113,7 @@ public static class VisualEncoder
         value = null;
         StringBuilder builder = new(encoded.Length);
 
-                for (int i = 0; i < encoded.Length; i++)
+        for (int i = 0; i < encoded.Length; i++)
         {
             if (encoded[i] != '\\')
             {
@@ -223,8 +223,10 @@ public static class VisualEncoder
         // An *unpaired* surrogate decoded from a \uXXXX arm is deliberately accepted. Cs is one
         // of the encoded categories, so Encode emits exactly this form for an unpaired surrogate,
         // and rejecting it here would make the encoder non-invertible on the one input class that
-        // cannot be represented any other way. Two escapes forming a pair are rejected in that
-        // arm, which is what keeps accepting the lone case injective.
+        // cannot be represented any other way. Two escapes forming a pair are accepted as well and
+        // decode to the astral scalar, which is the only text that spelling can denote; injectivity
+        // survives because Encode never *emits* that form -- a paired scalar always comes back as a
+        // single \U escape -- so the two-escape spelling is an input form only.
         value = builder.ToString();
         return true;
     }

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -29,8 +29,8 @@ namespace InertText.Encoder;
 public static class VisualEncoder
 {
     /// <summary>
-    /// Encodes <paramref name="value"/> under <paramref name="permits"/>, visually spelling every
-    /// scalar the policy refuses.
+    /// Encodes <paramref name="value"/> as <paramref name="policy"/> requires, visually spelling
+    /// every scalar that kind of text may not show.
     /// </summary>
     /// <remarks>
     /// Returns the currency type rather than a <see cref="string"/> and a form set, because the
@@ -40,21 +40,22 @@ public static class VisualEncoder
     /// remove. <see cref="InertString"/>'s constructor forwards here, so the two spellings cannot
     /// diverge.
     ///
-    /// A literal backslash is always rewritten, whatever <paramref name="permits"/> says, because
+    /// A literal backslash is always rewritten, whatever <paramref name="policy"/> permits, because
     /// it introduces every other spelling and the transform would not otherwise invert. An
     /// unpaired surrogate is likewise always encoded: it is not a scalar at all, so no policy is
     /// consulted for it.
     /// </remarks>
+    /// <param name="policy">The kind of text this is, which decides what may pass through.</param>
     /// <param name="value">The text to encode.</param>
-    /// <param name="permits">The per-sink policy deciding what may pass through.</param>
     /// <returns>
     /// The encoded text as an <see cref="InertString"/>, which carries the spellings that were
     /// emitted. Text that needed no encoding is returned as the original instance.
     /// </returns>
-    public static InertString Encode(string value, ScalarPolicy permits)
+    public static InertString Encode(TextPolicy policy, string value)
     {
         ArgumentNullException.ThrowIfNull(value);
-        ArgumentNullException.ThrowIfNull(permits);
+
+        ScalarPolicy permits = ScalarPolicies.For(policy);
 
         VisualForm formsUsed = VisualForm.None;
         StringBuilder? builder = null;
@@ -112,13 +113,36 @@ public static class VisualEncoder
         value = null;
         StringBuilder builder = new(encoded.Length);
 
+        // Where a \uXXXX that decoded to a high surrogate ended, so the \u arm below can tell a
+        // surrogate *pair* spelled as two escapes from two independently unpaired ones.
+        int highSurrogateEscapeEnd = -1;
+
         for (int i = 0; i < encoded.Length; i++)
         {
             if (encoded[i] != '\\')
             {
+                if (char.IsHighSurrogate(encoded[i])
+                    && i + 1 < encoded.Length
+                    && char.IsLowSurrogate(encoded[i + 1]))
+                {
+                    // A raw astral scalar, which Encode passes through whenever the policy
+                    // permits it: an emoji is So, and So is graphic.
+                    builder.Append(encoded[i]).Append(encoded[++i]);
+                    continue;
+                }
+
+                if (char.IsSurrogate(encoded[i]))
+                {
+                    // Encode never emits a raw unpaired surrogate; it spells one as \uXXXX.
+                    // Accepting it here would give that input two encodings.
+                    return false;
+                }
+
                 builder.Append(encoded[i]);
                 continue;
             }
+
+            int escapeStart = i;
 
             if (++i == encoded.Length)
             {
@@ -167,8 +191,19 @@ public static class VisualEncoder
                         return false;
                     }
 
-                    builder.Append((char)bmp);
+                    if (char.IsLowSurrogate((char)bmp) && escapeStart == highSurrogateEscapeEnd)
+                    {
+                        // \uD83D\uDE00 would otherwise land a well-formed pair in the builder and
+                        // re-encode as \U0001F600, giving that astral scalar two spellings. The
+                        // lone-surrogate case below stays legal precisely because this one does
+                        // not: a pair is representable as \U, an unpaired half is not
+                        // representable any other way at all.
+                        return false;
+                    }
+
                     i += 4;
+                    highSurrogateEscapeEnd = char.IsHighSurrogate((char)bmp) ? i + 1 : -1;
+                    builder.Append((char)bmp);
                     break;
                 case 'U':
                     if (!TryReadHex(encoded, i + 1, 8, out uint astral)
@@ -189,10 +224,11 @@ public static class VisualEncoder
             }
         }
 
-        // An unpaired surrogate decoded from a \uXXXX arm is deliberately accepted. Cs is one of
-        // the encoded categories, so Encode emits exactly this form for an unpaired surrogate,
-        // and rejecting it here would make the encoder non-invertible on the one input class
-        // that cannot be represented any other way.
+        // An *unpaired* surrogate decoded from a \uXXXX arm is deliberately accepted. Cs is one
+        // of the encoded categories, so Encode emits exactly this form for an unpaired surrogate,
+        // and rejecting it here would make the encoder non-invertible on the one input class that
+        // cannot be represented any other way. Two escapes forming a pair are rejected in that
+        // arm, which is what keeps accepting the lone case injective.
         value = builder.ToString();
         return true;
     }
@@ -290,15 +326,36 @@ public static class VisualEncoder
         return scalar;
     }
 
+    // Uppercase only, and hand-rolled for that reason: uint.TryParse with HexNumber accepts
+    // "00ad" as readily as "00AD", which would give U+00AD two spellings when AppendBmpHex only
+    // ever emits the second. Injectivity is what EnsurePermitted's repair rests on, so a second
+    // accepted spelling is a defect rather than leniency.
     private static bool TryReadHex(string text, int start, int length, out uint value)
     {
         value = 0;
 
-        return start + length <= text.Length
-            && uint.TryParse(
-                text.AsSpan(start, length),
-                NumberStyles.HexNumber,
-                CultureInfo.InvariantCulture,
-                out value);
+        if (start + length > text.Length)
+        {
+            return false;
+        }
+
+        for (int i = start; i < start + length; i++)
+        {
+            uint digit = text[i] switch
+            {
+                >= '0' and <= '9' => (uint)(text[i] - '0'),
+                >= 'A' and <= 'F' => (uint)(text[i] - 'A' + 10),
+                _ => uint.MaxValue,
+            };
+
+            if (digit == uint.MaxValue)
+            {
+                return false;
+            }
+
+            value = (value << 4) | digit;
+        }
+
+        return true;
     }
 }

--- a/src/InertText/VisualForm.cs
+++ b/src/InertText/VisualForm.cs
@@ -1,0 +1,31 @@
+namespace InertText;
+
+/// <summary>
+/// The spellings <see cref="InertString"/> can emit.
+/// </summary>
+/// <remarks>
+/// Reported so a caller can print a legend derived from what was actually emitted rather than
+/// from a second copy of the table. A legend written independently drifts; one projected from
+/// the encoder cannot.
+/// </remarks>
+[Flags]
+public enum VisualForm
+{
+    /// <summary>Nothing was encoded.</summary>
+    None = 0,
+
+    /// <summary>Caret notation for a C0 control, as in <c>\^[</c> for <c>ESC</c>.</summary>
+    Caret = 1 << 0,
+
+    /// <summary>Caret notation for <c>DEL</c>, spelled <c>\^?</c>.</summary>
+    CaretDelete = 1 << 1,
+
+    /// <summary>A scalar in the BMP, spelled <c>\uXXXX</c>.</summary>
+    BmpHex = 1 << 2,
+
+    /// <summary>A scalar above the BMP, spelled <c>\UXXXXXXXX</c>.</summary>
+    AstralHex = 1 << 3,
+
+    /// <summary>A literal backslash, doubled so the transform stays invertible.</summary>
+    Backslash = 1 << 4,
+}


### PR DESCRIPTION
Part of #3635. Adds the primitive only — **no production caller is migrated here.** The NuGet work that motivated it stacks on top in #3563.

## Why a type and not another escaper

The repository has fixed this class six times. Each fix was correct and local, and the class survived every one, because the property being enforced is **syntactic**: *"is `Contain(...)` spelled at this site?"* That must be re-established at every producer, is forgettable at every producer, and composition discards it silently.

The cost is measurable. `MarkoutRowContainmentTests` pins **359 columns across 86 row types** (#3463) and asserts not that they are contained but that *the set has not changed*. Its own remarks are honest about this — "Not a leak list." It is a good ratchet, and it is a ratchet.

`InertString` moves the property from the call site to the **value**. Treated text has a different type from untreated text, so it survives composition and a site that merely passes it along cannot lose it. Forgetting becomes a compile error rather than a missing line in a hand-pinned list.

## The audit boundary

Encoding is invertible — that is what lets an already-treated value be re-treated for a different sink instead of double-encoded, and lets `EnsurePermitted` repair a spliced value rather than reject it.

Invertibility is also the risk, so the decoder lives in namespace `InertText.Encoding`. Text enters through `InertString`'s constructor and leaves through `ToString` already spelled, so the currency namespace covers every ordinary use and the reversing half is visible when a file reaches for it.

**The audit is one search, and the string is `InertText.Encoding`.** Reaching the decoder means naming its namespace, and that act *is* the opt-in. Decoding is legitimate and stays public; the design does not try to prevent it, only to make it impossible to do quietly.

A namespace can be named in two places, and both are equally legitimate:

```csharp
using InertText.Encoding;            // named in the import block
VisualEncoder.TryDecode(inert.ToString(), out string? original);
```

```csharp
// no using directive of any kind in this file. InertText.Encoding here is the
// namespace; there is no InertText type and no Encoder member on InertString.
InertText.Encoding.VisualEncoder.TryDecode(inert.ToString(), out string? original);
```

Neither is evasion — the second names the namespace at the call site instead of the top of the file, in plain sight on the line that uses it. What matters is that the *audit* covers both, which is why the search is for the bare namespace and not for `using InertText.Encoding`: a fully-qualified call declares itself on its own line and needs no directive at all, so a reviewer grepping only the import block would read that file as clean and conclude it cannot decode.

There is a third way, raised in review, and unlike those two it does not name the namespace in the file that decodes at all:

```csharp
// one file, or a <Using Include="InertText.Encoding" /> item in the .csproj
global using InertText.Encoding;
```

Every other file in that project can then call `VisualEncoder.TryDecode` with no local mention of the namespace. The search still finds the import — it is still text in the repository — but it stops answering *which files* can decode and starts answering *which projects* can, and the file it points at is not the one doing the decoding. That is the one spelling where the capability is genuinely not visible where it is used.

That granularity is an invariant of the build rather than of the language, so it is gated rather than asserted: `NoProjectImportsTheCapabilityNamespaceForEveryFileAtOnce` fails on a `global using` or a `<Using>` item naming the capability namespace anywhere under `src`, and is mutation-gated both ways. Nothing needs one — production never names the namespace, and the tests that legitimately decode use ordinary per-file directives.

This is an **audit boundary, not a capability barrier**. A file can name the namespace either way, and nothing should stop it — decoding is a legitimate operation with legitimate callers. Assembly separation would not change this; `ProjectReference` is transitively compile-visible. What the boundary buys is that the reversing half cannot arrive unnoticed by a reviewer who searches correctly.

This PR migrates no caller, so its own producer count is 0 by construction. Measured on the stacked branch that does adopt it (#3563): **5 production files produce inert text, 0 name the capability namespace.**

## Three gates, each mutation-proved

| Gate | Mutation | Result |
| --- | --- | --- |
| Nothing public in the currency namespace returns text | add a `TryDecode` forwarder to `InertString` | red |
| The decoder exists, and only in the capability namespace | — pins that gate 1 cannot be satisfied by deleting invertibility | — |
| Every public creation path is self-contained | move `TextPolicy` into `InertText.Encoding` | red |
| No public member takes a delegate | add an `EnsurePermitted(Func<Rune, bool>)` overload | red |

Gate 1 enumerates and accounts for each text-returning member one by one, because the failure it guards against is an *addition* — a convenience overload handing back the decoded form — which an existence assertion would not notice.

Gate 3 is the one that makes the other two worth having, and it is why `InertString` has a public constructor rather than an encoder factory. If producing inert text required calling the encoder, every producer would name the capability namespace, the decoder would sit one member access away in exactly the files handling hostile input, and the audit search would return the whole producer set — surviving in form, worthless in practice. Without the constructor the measurement above would be 5 of 5 instead of 0 of 5.

The gate requires that *every* creation path is self-contained, not that one is: a caller uses the overload that fits its call site, so a single contaminated overload is a hole for everyone who reaches for it.

## Policy is a closed set

**This reverses the position this PR opened with.** `ScalarPolicy` began as a public delegate, on the argument that the existing predicates disagree for good reasons and should keep their own rules — `CSharpIdentifier.IsRenderingHazard` excludes most of `Cf` **on purpose**, because ZWJ is meaningful in emoji sequences and in Indic and Persian text and ECMA-334 permits `Cf` in `identifier_part`. That reasoning about `Cf` is still correct. The conclusion drawn from it was not.

An open policy parameter fails twice over, and both failures were measured rather than argued.

**It drifts.** Five predicates in this repository answer "is this scalar dangerous" and disagree by up to **48 BMP characters**:

| Predicate | BMP characters claimed |
| --- | --- |
| `CSharpIdentifierCore.IsRenderingHazard` | 76 |
| `InspectionResultView.NeedsEscape` (local function) | 76 |
| `MetadataTableProjector.IsControl` (private) | 65 |
| `TextPolicy.Field` | 110 |
| `TextPolicy.Prose` | 107 |

That drift has already shipped a defect. Calling `MetadataTableProjector.NeutralizeControls` on code identical to `origin/main`:

```text
ESC / ANSI        -> name\u001B[31mRED      escaped
Trojan Source     -> Utils<202E>gnp.exe      EMITTED VERBATIM
zero-width joiner -> Mic<200D>rosoft         EMITTED VERBATIM
BOM inline        -> Micro<FEFF>soft         EMITTED VERBATIM
line separator    -> line<2028>forged        EMITTED VERBATIM
```

The metadata layer — the *first* place hostile assembly metadata is rendered — escapes ANSI but not bidi, missing the attack class Trojan Source is named after. `InspectionResultView.NeedsEscape` is meanwhile a local copy of `IsRenderingHazard` with U+2028/2029 added, a patch that never propagated back. An open parameter does not cause this, but it is the shape in which it stays invisible: a rule written at one sink cannot be reached from the next.

**It leaks.** `EnsurePermitted` must decode before it re-encodes, or backslashes double. With a caller-supplied predicate, that decoded original is then passed to the caller, one scalar at a time:

```csharp
using InertText;                     // the only directive in the file

StringBuilder recovered = new();
value.EnsurePermitted(r => { recovered.Append(r); return false; });
// recovered now holds the hostile original, byte for byte
```

`grep -c 'InertText.Encoding'` on that file returns **0**. This is the audit boundary walked back out through a callback, and no reflection test over return types can see it, because the disclosure is an *argument* rather than a result. The leak fires when the repair path actually runs — the realistic trigger is an allow-shaped policy on a `Field` value, since `\` is not in a letters-only allow set.

`TextPolicy` is therefore a **closed enum** and `ScalarPolicy` is internal. Rules are written once and shared; no caller code runs during a repair. Adding a kind of text is an enum member and an arm in the rule table — **no new public member anywhere**, which is what makes the closed set extensible without growing the type.

`Identifier` is that member, and it is deliberately **not** in this PR: nothing here migrates `CSharpIdentifier`, and a policy with no caller is speculative surface. It arrives with the migration that needs it, and #3380's decision about `Cf` is preserved by adding it, not by overwriting `Field`.

For adoption risk, unchanged: for each existing predicate, the count of characters it claims that `Field` does not is **0**. `Field` is a strict superset, so routing a producer through this cannot lose an escape it currently makes.

### The set does not try to hold an allow-shaped rule

A homoglyph needs an allow list, and no `TextPolicy` catches one — a test pins this across every member. That is a boundary rather than a gap. **Encoding cannot serve an allow-shaped rule**, because the spelling it produces is itself outside the grammar: repairing `Nеwtonsoft.Json` to `N\u0435wtonsoft.Json` fails the same letters-only check that rejected the original. Such a rule wants **rejection**, which is a different answer than "here is a safe rendering", and the threat model already says reject rather than sanitize.

This was not reasoning ahead of the code. An earlier revision let a caller pass an allow-shaped predicate, and `EnsurePermitted` returned text its own policy rejected — silently. Adding an allow-shaped member back to the enum turns **three** tests red today, including the conformance sweep.

## Asking whether a value suits your sink

`EnsurePermitted` is public and is the only member shipped for this. It takes the policy the *sink* requires and returns a value that satisfies it, decoding first so it is idempotent.

It takes a `TextPolicy` rather than a predicate, which is what keeps the decoded original inside the library.

The direct construction a caller would otherwise reach for is a trap: `new InertString(policy, value.ToString())` re-encodes text that is already encoded, and backslashes double on every pass — `a\u202Eb` grows 8 → 9 → 11 → 15 characters across three rounds. The failure direction is over-encoding rather than a leak, so it is a legibility bug and not a security one, which is exactly why it would survive review.

Three overloads were designed and then **not** shipped — `EnsurePermitted(policy, out bool)`, and instance `IsPermitted` with and without a `ScalarViolation`. Every existing caller discards the bool, and instance `IsPermitted` has zero callers in any form. One member, three tests, no speculative surface.

### One shape at every entry point

Every public entry point reads `(TextPolicy, payload)` — the constructor, `Format`, `Join`, `IsPermitted`, `EnsurePermitted`. Named producers (`InertString.Field(value)`) were prototyped and rejected: they are noun-shaped methods for a verb-shaped job, they read asymmetrically against `EnsurePermitted(policy)`, and each new policy would force a new public member. The enum is the extension mechanism, so the type does not grow when the set does.

Naming it `TextPolicy` rather than `TextSink` also keeps the migration small: the `Format` and `Join` call sites are **character-identical**, because that call was already policy-first. Only the five `new InertString` sites in `NetworkTelemetry` swap arguments.

**`WasEncoded` does not answer this question, and is close to an anti-signal.** Proved in both directions: `Prose`-encoded `"line1\nline2"` reports `WasEncoded=false` and still **violates** `Field`; `Field`-encoded `"a\u202Eb"` reports `WasEncoded=true` and satisfies **both** policies, because its escapes are plain ASCII. Conformance is a relation between a value and a policy, not a property of the value — so it cannot be cached, and storing the producing policy would not help either, since knowing which delegate produced a value says nothing about whether it is stricter than yours. `EnsurePermitted` recomputes, and a test pins the anti-correlation so the tempting shortcut stays closed.

Today the policies barely meet: **13 `Field` sites, 1 `Prose`**, touching at one splice (`FeedFailureTelemetry`, `Field` lines joined as `Prose`) in the safe direction. The repair path has never fired in production. It is here because the splice exists, not because it currently fails.

## Why `readonly struct`

A class can enforce the invariant that a struct cannot — `default(InertString)` bypasses every constructor by CLR design — which is the stronger argument, and it lost to measurement.

`Encode` returns the **original string instance** when nothing needed encoding. Across the whole shared framework that is **471,968 of 471,968 metadata names, 181 assemblies, 0 rewrites — 100.0000% unchanged**. Containment is free precisely when nothing needed containing, and a class would put ~32 bytes of Gen0 garbage on exactly that path; `System.Private.CoreLib` alone has 144,854 name slots. `InertString?` is also 24 bytes as `Nullable<T>` against 16 for the value.

The same measurement rules out a `ReadOnlySpan<char>` overload: it would force `new string(span)` on the 100% path to save an allocation on the 0% path. The caveat is that this corpus is Microsoft-signed and therefore benign by construction — it bounds the *cost* of containment, not its value.

`_text` stays `string?` for a reason worth one line of review: a non-nullable annotation on a struct field is unverifiable — it compiles with zero warnings and still NREs on `default(T)`, because the compiler does not track `default(T)` through to fields. The null is confined to one accessor; one declaration, one assignment, one read, and exactly one `??` in the file.

## Corpus

22 named attacks — Trojan Source, tag smuggling, zero-width splitters, homoglyphs, inline BOM — asserting six claims per fixture plus injectivity. It names what it caught: mutating `Cf` out of the hazard set turns it red **by attack name**, not by code point.

## Details worth a reviewer's attention

- **Scalars, not code units.** `Rune.DecodeFromUtf16` with `OperationStatus`, not `EnumerateRunes`, which substitutes `U+FFFD` for unpaired surrogates and is therefore lossy on exactly the class `Cs` exists for. Every `char`-based predicate in the tree is structurally blind to astral payloads such as tag smuggling.
- **`IsPermitted` stays outside the capability namespace.** It returns `bool` plus a `ScalarViolation(int index, int scalar, UnicodeCategory)` — an index and a code point, never the character — so a survey can name what it refused without echoing it. Moving it would force validate-only callers to take on decode and dilute the signal.
- **Backslash is an encoder property, not a policy one.** Without rewriting it, `\u0041` in a real name is indistinguishable from an encoded escape. It is not in any deny set.
- **The decoder refuses spellings the encoder never emits** — `\U` for a BMP scalar, `\uXXXX` for a scalar with a canonical short form such as `\\`, `\^X` or `\^?`, lowercase hex in either width, and a raw unpaired surrogate. One scalar, one encoding, in both directions. A **lone** surrogate escape stays legal, and the distinction matters: `Encode` genuinely emits that form, and an unpaired surrogate has no other representation at all, so refusing the whole surrogate range would make the encoder non-invertible on the one input class that needs it most.
- **An already-inert value reached through a generic parameter or through `object` is not encoded twice.** Overload resolution binds on the *static* type of an interpolation hole, so `AppendFormatted(InertString)` is invisible from inside a generic method and `AppendFormatted<T>` wins — handing already-encoded text back to the encoder. The trap was known and closed for `InertString` and `InertString?`; neither overload can reach the generic or boxed case, and only a type test can.
- **No `ProjectReference`.** This sits below every assembly that prints artifact-derived text, including the dependency-free leaves. A reference added here is a reference added to everything.

## Evidence

`InertText.Tests`: **190 tests, 0 failures**, Release. Library builds clean with 0 warnings (`TreatWarningsAsErrors` is set in `src/Directory.Build.props`, so it covers everything under `src/`; three spoof-fixture projects opt out). CI runs the suite unconditionally rather than behind a path filter — the gates are a BMP sweep and a round-trip, and are fast.

`ci.yml` carries one unrelated fix, called out so it is not mistaken for part of the primitive: the `pull_request` base filter was `[main]`, which also decides whether a *stacked* PR runs CI at all. #3563 was retargeted onto this branch and stopped matching, so it reported **no check-runs** rather than failing ones — invisible on the PR page, and indistinguishable from "not run yet" once `ci-required` is required. Adding `feature/**` restored it; #3563 now reports 8 checks.

## Review

Two-model tier per `AGENTS.md`: security-relevant code on a default output path.

A two-model round on the previous head found five defects. Three are fixed here (the callback disclosure, the generic/boxed double-encode, the non-canonical decoder spellings) and each new test is mutation-gated — the fix is reverted and the test observed to fail. Two were closed as **not defects**, with reasons:

- **`Prose` permits a lone `CR`.** Both reviewers called this blocking; it is not, and removing it would be worse. `Join` encodes its separator on purpose — the same reason the handler encodes source literals — so refusing `CR` would render `Environment.NewLine` as `\^M` on Windows for every caller who joins with it. The two cannot both hold, and the only production `Prose` site joins `Field`-encoded parts, where widening does not un-escape.
- **A proposed fix for the surrogate spelling was wrong.** Rejecting every surrogate-range `\uXXXX` would break the lone-unpaired-surrogate round-trip the encoder actually emits.

A second two-model round on the fixed head found one more, and it was caused by the round
before it. The rule added above — refuse a decoded high surrogate *immediately followed by* a
decoded low — made a value this library had just produced fail to decode. `Join` and the
interpolation handler concatenate fragments that were each encoded alone, so a lone high
surrogate encoded in one fragment lands beside a lone low surrogate encoded in the next.
`EnsurePermitted` falls back to treating undecodable text as raw, so the repair encoded the
escapes a second time and `\uD834\uDD73` became `\\uD834\\uDD73` — which is also what the
ASCII text a user typed encodes to. Two unrelated inputs converged on one output, and the
rendered form stopped being evidence of which one arrived.

The premise of the refusal did not hold. A .NET string is UTF-16, so `"\uD83D" + "\uDE00"` *is*
`"\U0001F600"`: there is no string in which the halves stay apart, and no other text the
spelling could denote. Refusing it rejected an input rather than disambiguating two. That
spelling now decodes, and because `Encode` still only ever emits `\U` for a pair, accepting it
is an input form rather than a second output form. Three regression tests cover it, all
mutation-gated against the exact prior decoder. A 300,000-case fuzz over composed values —
alphabet loaded with backslashes, `u`, `U`, `^`, hex digits and surrogates — now reports zero
undecodable compositions, zero round-trip mismatches, and zero repairs that return text their
target policy rejects.

### Third review round

An independent review found the delegate gate weaker than its remarks claimed, and I reproduced
it before fixing: inside a loop over every exported type it enumerated
`typeof(InertString).GetMethods`, so a delegate-taking `AppendFormatted` on `InertStringHandler`
left it green. The handler is precisely where an escape-valve predicate would land. The original
mutation proof used an `EnsurePermitted` overload on `InertString` — the one type the broken scan
did cover — so the proof passed while the gate was weaker than documented. Fixed to
`type.GetMethods`, re-proven with the handler mutation.

The project-wide-import gate scanned only `src/` for `.cs`/`.csproj`/`.props`, missing the repo
root's `Directory.Build.props`/`.targets`, which flow into every project under `src/`. That was
the widest-reaching version of the hazard the gate exists for. Now scans root-level
`Directory.Build.*` and `.targets`, and matches the `global::` spelling. Both mutation-proven.

Three doc comments were stale against the shipped design (the decoder's pair-rejection claim, the
corpus's caller-chosen-predicate claim, and a renamed `paramref`). Rather than sweep them and
leave the class open, `GenerateDocumentationFile` is now on for `InertText`, making CS1574/CS1734/
CS0419 build errors — which immediately caught an ambiguous `<see cref="IsPermitted"/>` the review
had not found. Zero CS1591: every public member was already documented.
