### PR TITLE
SCRATCH do not merge: probe for #3614

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,11 @@ jobs:
               .github/workflows/ci.yml) ILDIFF=true ;;
             esac
             case "$file" in
+              # The lint *configuration* is not a `.md` file, so it needs its
+              # own case: editing `.markdownlint.yaml` changes how every
+              # document is linted, and without this the lint job skips and the
+              # new configuration is never exercised.
+              .markdownlint.*|.markdownlint-cli2.*) DOCS=true ;;
               *.md|*.txt|docs/*|skills/*) DOCS=true ;;
             esac
             # The decompiler docket/byte-neutrality gates cost ~8 minutes, so
@@ -231,6 +236,20 @@ jobs:
               .github/workflows/ci.yml) SHIPPED=true ;;
             esac
           done <<< "$FILES"
+          # `ilroundtrip` does not have a job of its own: its two steps live
+          # inside the `test` job, which is gated on `code`. So an input that
+          # sets only `ilroundtrip` computes an output nothing can act on --
+          # the job never starts and the steps never run. Every other member of
+          # the ilroundtrip list happens to set `code` too, which is why this
+          # was invisible; `eng/restore-ilassembler.sh` did not, and its
+          # validation silently never ran.
+          #
+          # State the implication once here rather than duplicating `code` into
+          # each ilroundtrip case, so a future addition to that list cannot
+          # reintroduce the gap by forgetting it.
+          if [ "$ILROUNDTRIP" = true ]; then
+            CODE=true
+          fi
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
           echo "csharpdiff=$CSHARPDIFF" >> "$GITHUB_OUTPUT"
           echo "decompiler=$DECOMPILER" >> "$GITHUB_OUTPUT"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -12,3 +12,5 @@ MD034: false
 
 # Padded table cells OK (generated Markdown optimizes readability)
 MD060: false
+
+# scratch probe - do not merge

--- a/eng/restore-ilassembler.sh
+++ b/eng/restore-ilassembler.sh
@@ -23,3 +23,5 @@ fi
 
 git -C "$root" worktree add "$dest" "$branch"
 echo "Restored $branch at $dest"
+
+# scratch probe - do not merge


### PR DESCRIPTION
Throwaway. Touches only .markdownlint.yaml and eng/restore-ilassembler.sh, on top of the #3614 fix. Expect docs=true, ilroundtrip=true, code=true.