### PR TITLE
SCRATCH do not merge: control for #3614

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -12,3 +12,5 @@ MD034: false
 
 # Padded table cells OK (generated Markdown optimizes readability)
 MD060: false
+
+# scratch control - do not merge

--- a/eng/restore-ilassembler.sh
+++ b/eng/restore-ilassembler.sh
@@ -23,3 +23,5 @@ fi
 
 git -C "$root" worktree add "$dest" "$branch"
 echo "Restored $branch at $dest"
+
+# scratch control - do not merge


### PR DESCRIPTION
Throwaway control. Same two files, but against unfixed main. Expect docs=false, ilroundtrip=true, code=false, and every job skipped.