### PR TITLE
Give two changed-file classifications a consumer that actually runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,14 @@ jobs:
               # exists today, but a `case` pattern is anchored at the start of
               # the path, so match nested ones too rather than leaving the same
               # hole open one directory down.
+              #
+              # These patterns over-match slightly: `*` spans `/`, so a path
+              # like `x/.markdownlint.d/y.cs` also trips them. That is the
+              # deliberate direction to err in -- over-matching costs one short
+              # lint run, while under-matching silently skips the job and, since
+              # `ci-required` counts `skipped` as passing, hides it. `case` has
+              # no way to anchor the basename, so tightening this would cost
+              # more legibility than the false positive is worth.
               .markdownlint.*|.markdownlint-cli2.*) DOCS=true ;;
               */.markdownlint.*|*/.markdownlint-cli2.*) DOCS=true ;;
               *.md|*.txt|docs/*|skills/*) DOCS=true ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,11 @@ jobs:
               .github/workflows/ci.yml) ILDIFF=true ;;
             esac
             case "$file" in
+              # The lint *configuration* is not a `.md` file, so it needs its
+              # own case: editing `.markdownlint.yaml` changes how every
+              # document is linted, and without this the lint job skips and the
+              # new configuration is never exercised.
+              .markdownlint.*|.markdownlint-cli2.*) DOCS=true ;;
               *.md|*.txt|docs/*|skills/*) DOCS=true ;;
             esac
             # The decompiler docket/byte-neutrality gates cost ~8 minutes, so
@@ -231,6 +236,20 @@ jobs:
               .github/workflows/ci.yml) SHIPPED=true ;;
             esac
           done <<< "$FILES"
+          # `ilroundtrip` does not have a job of its own: its two steps live
+          # inside the `test` job, which is gated on `code`. So an input that
+          # sets only `ilroundtrip` computes an output nothing can act on --
+          # the job never starts and the steps never run. Every other member of
+          # the ilroundtrip list happens to set `code` too, which is why this
+          # was invisible; `eng/restore-ilassembler.sh` did not, and its
+          # validation silently never ran.
+          #
+          # State the implication once here rather than duplicating `code` into
+          # each ilroundtrip case, so a future addition to that list cannot
+          # reintroduce the gap by forgetting it.
+          if [ "$ILROUNDTRIP" = true ]; then
+            CODE=true
+          fi
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
           echo "csharpdiff=$CSHARPDIFF" >> "$GITHUB_OUTPUT"
           echo "decompiler=$DECOMPILER" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,12 @@ jobs:
               # The lint *configuration* is not a `.md` file, so it needs its
               # own case: editing `.markdownlint.yaml` changes how every
               # document is linted, and without this the lint job skips and the
-              # new configuration is never exercised.
+              # new configuration is never exercised. Only a root-level config
+              # exists today, but a `case` pattern is anchored at the start of
+              # the path, so match nested ones too rather than leaving the same
+              # hole open one directory down.
               .markdownlint.*|.markdownlint-cli2.*) DOCS=true ;;
+              */.markdownlint.*|*/.markdownlint-cli2.*) DOCS=true ;;
               *.md|*.txt|docs/*|skills/*) DOCS=true ;;
             esac
             # The decompiler docket/byte-neutrality gates cost ~8 minutes, so


### PR DESCRIPTION
Two entries in the `changes` filter computed an output that nothing could act
on, so the validation they were supposed to trigger silently never ran. Now
that `ci-required` treats `skipped` as passing (#3523), a misclassification is
no longer a wasted signal — it is a hole in the merge gate.

`Closes #3614.`

## What was wrong

**`.markdownlint.yaml` / `.markdownlint-cli2.jsonc` set no flag at all.** The
`DOCS` cases were `*.md|*.txt|docs/*|skills/*`; the lint *configuration* matches
none of them. Editing the rules that govern every Markdown file in the repo did
not run `markdownlint`.

**`eng/restore-ilassembler.sh` set `ilroundtrip` and nothing else.**
`ilroundtrip` has no job of its own — its two steps live *inside* the `test`
job, which is gated on `code`. An input that sets only `ilroundtrip` therefore
produces an output no job consumes: `test` never starts, so the steps never
run. Every *other* member of the ilroundtrip list happens to match a `code`
case as well, which is exactly why this stayed invisible.

## The fix

One new `DOCS` case, and — rather than patching `code` into the one case that
missed it — the `ilroundtrip → code` relationship stated once, after the loop:

```sh
if [ "$ILROUNDTRIP" = true ]; then
  CODE=true
fi
```

That is the structural fact (`ilroundtrip`'s steps live in the `code` job), not
a coincidence of today's list, so a future addition to the ilroundtrip cases
cannot reintroduce the gap by forgetting to also set `code`.

The fail-open path is unaffected: it `exit 0`s at line 92 before the
classification block, so nothing added after the loop can weaken it.

## Evidence

### 1. Isolated A/B of the real block

A PR-based probe **cannot** isolate this: any PR carrying the fix necessarily
also edits `.github/workflows/ci.yml`, which sets `CODE` (and nearly everything
else) on its own. So the harness locates the classification block *inside the
real workflow file* by content markers — no reimplementation, no copy — dedents
it, and evals it against a synthetic file list, at both revisions.

| Changed file | before (`ec7b254e`) | after (this PR) |
| --- | --- | --- |
| `.markdownlint.yaml` | `code=false docs=false ilrt=false` | `code=false **docs=true** ilrt=false` |
| `eng/restore-ilassembler.sh` | `code=false docs=false ilrt=true` | `**code=true** docs=false ilrt=true` |
| `.markdownlint-cli2.jsonc` | `code=false docs=false ilrt=false` | `code=false **docs=true** ilrt=false` |
| `tools/DecompilerHarness/.markdownlint.yaml` | `code=true docs=false ilrt=false` | `code=true **docs=true** ilrt=false` |
| `a/b/.markdownlint-cli2.jsonc` | `code=false docs=false ilrt=false` | `code=false **docs=true** ilrt=false` |
| `src/Foo.markdownlint.cs` *(not a config)* | `code=true docs=false ilrt=false` | *unchanged* |
| `eng/restore-ilassembler.sh.bak` | `code=false docs=false ilrt=false` | *unchanged* |
| `docs/overview.md` | `code=false docs=true ilrt=false` | *unchanged* |
| `README.md` | `code=false docs=true ilrt=false` | *unchanged* |
| `src/Foo/Bar.cs` | `code=true docs=false ilrt=false` | *unchanged* |
| `tests/DotnetInspector.ILRoundtrip.Tests/X.cs` | `code=true docs=false ilrt=true` | *unchanged* |
| `src/DotnetInspector.Core/Y.cs` | `code=true docs=false ilrt=true` | *unchanged* |
| *(empty list)* | `code=false docs=false ilrt=false` | *unchanged* |

Exactly the intended inputs change; every previously-working input is
byte-identical, and near-miss names (`src/Foo.markdownlint.cs`,
`eng/restore-ilassembler.sh.bak`) correctly do not match.

### 2. Control PR on unfixed `main` — the hole, demonstrated

A throwaway PR off `ec7b254e` touching only `.markdownlint.yaml` and
`eng/restore-ilassembler.sh` (run `30673793133`) classified as:

```text
code=false csharpdiff=false decompiler=false docs=false ildiff=false ilroundtrip=true packaging=false shipped=false
```

…and produced **`ci-required` = SUCCESS with all nine validation jobs
`skipped`**. A green, mergeable PR that ran zero validation. That is the
failure mode this change closes.

### 3. Probe PR with the fix

The same two files plus this change (run `30673791580`): all jobs green,
`markdownlint` **ran** (vs `skipped` on the control), and the `test` job
executed `Restore vendored ILAssembler` and the IL round-trip steps — the
consumer chain works end to end.

Both throwaway PRs (#3646, #3647) are closed unmerged and their branches and
worktrees removed.

## Risk

This only ever *widens* triggers — it turns `false` into `true` for a handful of
inputs and changes nothing else, so it cannot cause validation that runs today
to be skipped.

Review flagged my original wording here ("cannot wedge merges") as overstated,
and it was. To be precise: this change **can** newly block a merge, and that is
the intended effect. A PR touching `eng/restore-ilassembler.sh` now runs the
`test` lane, and that lane can fail or time out — `ci-required` treats both
`failure` and `cancelled` as blocking. That is the entire point: validation that
should have been running now runs, and can now report. What the change cannot do
is *wedge* the gate — `ci-required` names no path-gated job, so no required
check can sit in "Expected" forever with no path forward.

## Review

One adversarial review (MAI-Code), on an isolated read-only worktree at the
exact head. Two NON-BLOCKING findings, both acted on:

- **Nested lint configs.** A `case` pattern is anchored at the start of the
  path, so `.markdownlint.*` matched only a root-level config — the same hole,
  one directory down. Fixed in `13be23e4` by also matching `*/.markdownlint.*`.
  Latent rather than live (only a root config exists today).
- **The "cannot wedge merges" claim.** Overstated; rewritten above.

The reviewer independently enumerated all eight flags against their consumers
and confirmed `ilroundtrip` was the only one whose consumer sits inside a job
gated on a different flag — i.e. there is no third instance of this defect.

