### PR TITLE
Stack a caret per fact extent instead of widening the line

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -206,10 +206,13 @@ public class AnnotationGestureTests
         // narrowing would underline an expression true of only some of the
         // facts sharing the caret. Marking the extent-less fact '-' removes the
         // ambiguity that justified widening, so the surviving extent is drawn.
-        // 615 lines of System.Private.CoreLib, as the annotated-source view
-        // prints it, mix facts with and without extents; 499 of them have
-        // exactly one surviving extent, so this is the majority shape. (The
-        // overlay render is a different population: 609 and 498.)
+        // 355 lines of System.Private.CoreLib, as the annotated-source view
+        // prints it, mix facts with and without extents; 254 of them have
+        // exactly one surviving extent, so this is the majority shape. That is
+        // summed over the five focus families: --focus promotes only one family
+        // to carets, so a count over every collected fact would describe a
+        // render no invocation produces. The two categories below are a unit
+        // convenience -- Stack is category-agnostic and never sees the filter.
         const string Line = "        Sink(new object());";
         var narrowed = Fact(Alloc, "has-extent");
         var bare = Fact(Unsafety, "no-extent");

--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -206,8 +206,10 @@ public class AnnotationGestureTests
         // narrowing would underline an expression true of only some of the
         // facts sharing the caret. Marking the extent-less fact '-' removes the
         // ambiguity that justified widening, so the surviving extent is drawn.
-        // 615 CoreLib lines mix facts with and without extents; 499 of them
-        // have exactly one surviving extent, so this is the majority shape.
+        // 615 lines of System.Private.CoreLib, as the annotated-source view
+        // prints it, mix facts with and without extents; 499 of them have
+        // exactly one surviving extent, so this is the majority shape. (The
+        // overlay render is a different population: 609 and 498.)
         const string Line = "        Sink(new object());";
         var narrowed = Fact(Alloc, "has-extent");
         var bare = Fact(Unsafety, "no-extent");

--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -252,9 +252,12 @@ public class AnnotationGestureTests
         var first = Fact(Alloc, "one");
         var second = Fact(Unsafety, "two");
 
-        // The dictionary is member-wide, so it is non-empty even when no fact
-        // on *this* line has an extent. Passing an empty one instead would
-        // short-circuit inside Stack and never reach the guard under test.
+        // The dictionary is member-wide in production, so it is non-empty even
+        // when no fact on *this* line has an extent. That is the shape worth
+        // gating: it makes Stack return an empty group list, which is what the
+        // Count: > 0 guard has to reject. An empty dictionary would reach the
+        // same guard today, but only because the short-circuit that used to
+        // intercept it inside Stack has since been deleted.
         var elsewhere = Fact(Alloc, "on some other line");
         var extents = new Dictionary<IAnnotation, AnnotationAnchor.CaretExtent>
         {

--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -252,7 +252,15 @@ public class AnnotationGestureTests
         var first = Fact(Alloc, "one");
         var second = Fact(Unsafety, "two");
 
-        var extents = new Dictionary<IAnnotation, AnnotationAnchor.CaretExtent>();
+        // The dictionary is member-wide, so it is non-empty even when no fact
+        // on *this* line has an extent. Passing an empty one instead would
+        // short-circuit inside Stack and never reach the guard under test.
+        var elsewhere = Fact(Alloc, "on some other line");
+        var extents = new Dictionary<IAnnotation, AnnotationAnchor.CaretExtent>
+        {
+            [elsewhere] = new AnnotationAnchor.CaretExtent(0, 4),
+        };
+
         string caretLine = AnnotationCaret.Render(Line, "    ", [first, second], extents: extents)[0];
 
         int statementColumn = Line.Length - Line.TrimStart().Length;
@@ -284,8 +292,9 @@ public class AnnotationGestureTests
         var rendered = AnnotationCaret.Render(Line, "    ", [first, second, third], extents: extents);
         string caretLine = rendered[0];
 
-        // Three facts, two extents, so two carets and two numbers -- not three.
-        Assert.Equal(2, caretLine.Count(c => c == '.'));
+        // Three facts, two extents, so two numbered carets -- not three. The
+        // group count is pinned structurally by the caret runs below; this
+        // pins that the numbering agrees with it.
         Assert.Contains("1.", caretLine, StringComparison.Ordinal);
         Assert.Contains("2.", caretLine, StringComparison.Ordinal);
         Assert.DoesNotContain("3.", caretLine, StringComparison.Ordinal);

--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -261,6 +261,64 @@ public class AnnotationGestureTests
     }
 
     [Fact]
+    public void FactsSharingAnExtentShareOneCaretAndOneNumber()
+    {
+        // Rule 1 of the display model: the unit is the extent, not the fact.
+        // Two facts about the same characters get one caret and one number,
+        // with both texts listed under it -- otherwise a line would grow a
+        // redundant caret per fact and re-underline the same characters.
+        const string Line = "        Sink(new object(), new int[1]);";
+        var first = Fact(Alloc, "one");
+        var second = Fact(Alloc, "two");
+        var third = Fact(Unsafety, "three");
+
+        int shared = Line.IndexOf("new object()", StringComparison.Ordinal);
+        int other = Line.IndexOf("new int[1]", StringComparison.Ordinal);
+        var extents = new Dictionary<IAnnotation, AnnotationAnchor.CaretExtent>
+        {
+            [first] = new AnnotationAnchor.CaretExtent(shared, "new object()".Length),
+            [second] = new AnnotationAnchor.CaretExtent(shared, "new object()".Length),
+            [third] = new AnnotationAnchor.CaretExtent(other, "new int[1]".Length),
+        };
+
+        var rendered = AnnotationCaret.Render(Line, "    ", [first, second, third], extents: extents);
+        string caretLine = rendered[0];
+
+        // Three facts, two extents, so two carets and two numbers -- not three.
+        Assert.Equal(2, caretLine.Count(c => c == '.'));
+        Assert.Contains("1.", caretLine, StringComparison.Ordinal);
+        Assert.Contains("2.", caretLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("3.", caretLine, StringComparison.Ordinal);
+
+        // Non-vacuity: the two carets really are at the two distinct extents.
+        // The first trail collides with the second caret's label, so rule 5
+        // clips its last column to the truncation glyph rather than overrun it;
+        // the second trail is last on the row and keeps its true width.
+        Assert.Equal(shared, caretLine.IndexOf('^'));
+        Assert.Equal(1, caretLine.Count(c => c == '~'));
+
+        var runs = new List<int>();
+        for (int c = 0; c < caretLine.Length; c++)
+        {
+            if (caretLine[c] != '^' || (c > 0 && caretLine[c - 1] == '^'))
+                continue;
+            int width = caretLine.AsSpan(c).IndexOfAnyExcept('^');
+            runs.Add(width < 0 ? caretLine.Length - c : width);
+        }
+
+        Assert.Equal(2, runs.Count);
+        Assert.True(runs[0] < "new object()".Length, "the colliding trail must be clipped");
+        Assert.Equal("new int[1]".Length, runs[1]);
+
+        // Both facts sharing the extent are listed, and only the first carries
+        // the number: the second is indented to sit under it.
+        Assert.Contains(rendered, l => l.Contains("1. alloc.new(one)", StringComparison.Ordinal));
+        Assert.Contains(rendered, l => l.Contains("alloc.new(two)", StringComparison.Ordinal)
+            && !l.Contains("2.", StringComparison.Ordinal));
+        Assert.Contains(rendered, l => l.Contains("2. unsafe.stackalloc(three)", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void NothingIsRenderedForABlankLineOrNoFacts()
     {
         Assert.Empty(AnnotationCaret.Render("        Work();", "    ", []));

--- a/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationGestureTests.cs
@@ -153,13 +153,12 @@ public class AnnotationGestureTests
     }
 
     [Fact]
-    public void CaretWidensWhenTwoFactsOnTheLineDisagreeAboutTheExtent()
+    public void CaretsStackWhenTwoFactsOnTheLineDisagreeAboutTheExtent()
     {
-        // The other half of the all-or-nothing rule: both facts narrow, but to
-        // different characters. Stacking two carets was rejected as a design, so
-        // the only correct answer is the statement -- the smallest span true of
-        // both. Distinct from the partial case below, which is a missing entry
-        // rather than a conflicting one, and gated by a different branch.
+        // Both facts narrow, but to different characters. Widening to the
+        // statement was the old answer; it points at everything and therefore
+        // at nothing, and leaves the details below unattributable. Each extent
+        // now gets its own numbered caret. See docs/design/caret-stacking.md.
         const string Line = "        Sink(new object(), new int[1]);";
         var first = Fact(Alloc, "object");
         var second = Fact(Unsafety, "array");
@@ -177,21 +176,38 @@ public class AnnotationGestureTests
         Assert.Equal(firstColumn, AnnotationCaret.Render(Line, "    ", [first], extents: extents)[0].IndexOf('^'));
         Assert.Equal(secondColumn, AnnotationCaret.Render(Line, "    ", [second], extents: extents)[0].IndexOf('^'));
 
-        string shared = AnnotationCaret.Render(Line, "    ", [first, second], extents: extents)[0];
+        var rendered = AnnotationCaret.Render(Line, "    ", [first, second], extents: extents);
+        string caretLine = rendered[0];
+
+        // Two carets on one row, each still at the column of its own extent and
+        // at its own true width -- not one widened underline.
+        Assert.Equal(2, caretLine.Count(c => c == '.'));
+        Assert.Equal(firstColumn, caretLine.IndexOf('^'));
+        Assert.Equal(secondColumn, caretLine.LastIndexOf('^') - "new int[1]".Length + 1);
+
+        // The statement underline is precisely what must no longer appear.
         int statementColumn = Line.Length - Line.TrimStart().Length;
-        Assert.Equal(statementColumn, shared.IndexOf('^'));
-        Assert.Equal(Line.Trim().Length, shared.Count(c => c == '^'));
+        Assert.NotEqual(Line.Trim().Length, caretLine.Count(c => c == '^'));
+        Assert.NotEqual(statementColumn, caretLine.IndexOf('^'));
+
+        // Each caret is labelled, and each label has a matching numbered detail
+        // row, so a reader can attribute every fact to a specific expression.
+        Assert.Contains("1.", caretLine, StringComparison.Ordinal);
+        Assert.Contains("2.", caretLine, StringComparison.Ordinal);
+        Assert.Contains(rendered, l => l.Contains("1. alloc.new(object)", StringComparison.Ordinal));
+        Assert.Contains(rendered, l => l.Contains("2. unsafe.stackalloc(array)", StringComparison.Ordinal));
     }
 
     [Fact]
-    public void CaretWidensWhenOnlySomeFactsOnTheLineHaveAnExtent()
+    public void CaretIsDrawnAndFactsWithoutAnExtentAreMarkedWhenTheLineIsMixed()
     {
-        // The agreement rule is all-or-nothing, and the case that matters is
-        // PARTIAL: one fact narrows, another has no printed node to point at.
-        // Narrowing there would underline an expression that is true of only
-        // some of the facts sharing the caret. 615 lines in CoreLib mix facts
-        // with and without extents, 499 of them with a single surviving extent,
-        // so this is the difference between right and wrong on real output.
+        // The PARTIAL case: one fact narrows, another has no printed node to
+        // point at. This used to widen to the statement, on the reasoning that
+        // narrowing would underline an expression true of only some of the
+        // facts sharing the caret. Marking the extent-less fact '-' removes the
+        // ambiguity that justified widening, so the surviving extent is drawn.
+        // 615 CoreLib lines mix facts with and without extents; 499 of them
+        // have exactly one surviving extent, so this is the majority shape.
         const string Line = "        Sink(new object());";
         var narrowed = Fact(Alloc, "has-extent");
         var bare = Fact(Unsafety, "no-extent");
@@ -202,17 +218,46 @@ public class AnnotationGestureTests
             [narrowed] = new AnnotationAnchor.CaretExtent(column, "new object()".Length),
         };
 
-        // Non-vacuity: alone, this fact really does narrow.
+        // Non-vacuity: alone, this fact really does narrow, and the statement
+        // underline it must not fall back to is a different geometry entirely.
         string alone = AnnotationCaret.Render(Line, "    ", [narrowed], extents: extents)[0];
         Assert.Equal(column, alone.IndexOf('^'));
         Assert.Equal("new object()".Length, alone.Count(c => c == '^'));
 
-        // Together with a fact that has no extent, the caret must widen back to
-        // the whole statement rather than keep the one extent that survived.
-        string shared = AnnotationCaret.Render(Line, "    ", [narrowed, bare], extents: extents)[0];
+        var rendered = AnnotationCaret.Render(Line, "    ", [narrowed, bare], extents: extents);
+        string caretLine = rendered[0];
+
+        // The surviving extent keeps its own column and width.
+        Assert.Equal(column, caretLine.IndexOf('^'));
+        Assert.Equal("new object()".Length, caretLine.Count(c => c == '^'));
+
         int statementColumn = Line.Length - Line.TrimStart().Length;
-        Assert.Equal(statementColumn, shared.IndexOf('^'));
-        Assert.Equal(Line.Trim().Length, shared.Count(c => c == '^'));
+        Assert.NotEqual(statementColumn, caretLine.IndexOf('^'));
+        Assert.NotEqual(Line.Trim().Length, caretLine.Count(c => c == '^'));
+
+        // The placed fact is numbered; the fact with nowhere to point is listed
+        // under the unplaced marker rather than silently sharing the caret.
+        Assert.Contains(rendered, l => l.Contains("1. alloc.new(has-extent)", StringComparison.Ordinal));
+        Assert.Contains(rendered, l => l.Contains("-  unsafe.stackalloc(no-extent)", StringComparison.Ordinal));
+        Assert.DoesNotContain(rendered, l => l.Contains("1. unsafe.stackalloc", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CaretStillWidensWhenNoFactOnTheLineHasAnExtent()
+    {
+        // The boundary of the rule above: stacking needs at least one placeable
+        // fact. With none, there is nothing to number and nothing to point at,
+        // so the statement underline remains the only honest answer.
+        const string Line = "        Sink(new object());";
+        var first = Fact(Alloc, "one");
+        var second = Fact(Unsafety, "two");
+
+        var extents = new Dictionary<IAnnotation, AnnotationAnchor.CaretExtent>();
+        string caretLine = AnnotationCaret.Render(Line, "    ", [first, second], extents: extents)[0];
+
+        int statementColumn = Line.Length - Line.TrimStart().Length;
+        Assert.Equal(statementColumn, caretLine.IndexOf('^'));
+        Assert.Equal(Line.Trim().Length, caretLine.Count(c => c == '^'));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -249,7 +249,7 @@ public static class AnnotationCaret
     /// could, every one does -- 100%. That is close to necessary but not quite:
     /// one fact with an extent is one extent and agrees with itself, so the loop
     /// above cannot reject it, but the bounds check below still can, and would
-    /// on a negative column, an empty extent, or an extent running past
+    /// on a negative column, a non-positive length, or an extent running past
     /// <paramref name="lineLength"/> because a consumer re-wrapped the line. In
     /// this corpus none of those occurs, so the rate is 100% as measured rather
     /// than 100% by construction. The 91.7% measures how
@@ -398,7 +398,14 @@ public static class AnnotationCaret
     /// the same structural fact this remark states below: extents sharing a start
     /// column can never share a row, so the 136 lines carrying two distinct
     /// extents at one column cannot take a single row whatever the packer does.
-    /// Among the 2,452 that can, the rate is 2,289 (93.4%). 3,884
+    /// Among the remaining 2,452 the rate is 2,289 (93.4%). "Remaining" is the
+    /// careful word: those 2,452 are not all able to take one row either -- 163
+    /// of them are refused by the row admission below because their extents sit
+    /// too close together. They are left in deliberately. Crowding is the thing
+    /// this rate exists to measure, so excluding lines for being crowded would
+    /// drive it to 100% and measure nothing. A shared start column is excluded
+    /// because it is a different phenomenon: two extents anchored at one column
+    /// are a nesting, not a packing failure. 3,884
     /// of 6,566 trails (59.2%) render at true width, but that rate is padded by
     /// a structural immunity: the last trail on a row has no successor, so its
     /// clip limit is <c>int.MaxValue</c> and it renders at true width by

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -37,6 +37,23 @@ public static class AnnotationCaret
     // the carets instead. Short underlines keep the compact trailing form.
     const int InlineDetailMaxColumn = 40;
 
+    // A clipped trail spends its last column on the glyph, so below two columns
+    // it could not signal that it was clipped; such a caret spills to a new row
+    // instead. This is a spill threshold, not a render floor — a genuinely
+    // one-character expression renders one caret, never a padded two.
+    const int MinTrail = 2;
+
+    // One blank column between a trail and the next label. Without it adjacent
+    // carets render as "3.^^^^4.^^^^", where the boundary is invisible.
+    const int TrailGap = 1;
+
+    // Marks a fact the anchoring layer could not place on an expression. It has
+    // no number because there is no caret for a number to point at.
+    const char UnplacedMarker = '-';
+
+    // Marks a trail that could not be drawn at the width of its expression.
+    const char TruncationGlyph = '~';
+
     /// <summary>
     /// Marks a caret line as already positioned at the enclosing member
     /// declaration column. A consumer that indents the projected body must strip
@@ -96,9 +113,11 @@ public static class AnnotationCaret
     /// </param>
     /// <param name="extents">
     /// Per-fact underline extents from
-    /// <see cref="AnnotationAnchor.ComputeCaretExtents"/>. The line narrows only
-    /// when every fact on it points at the same characters; see
-    /// <see cref="Agreed"/> for why disagreement widens rather than stacks.
+    /// <see cref="AnnotationAnchor.ComputeCaretExtents"/>. When every fact on
+    /// the line points at the same characters the line narrows to that one
+    /// extent; otherwise it stacks a numbered caret per distinct extent and
+    /// lists any fact with no extent under <see cref="UnplacedMarker"/>. See
+    /// <see cref="Agreed"/> and <see cref="Stack"/>.
     /// </param>
     public static IReadOnlyList<string> Render(
         string lineText,
@@ -115,8 +134,6 @@ public static class AnnotationCaret
             return [];
 
         int statementColumn = lineText.Length - lineText.AsSpan().TrimStart().Length;
-        var extent = Agreed(annotations, extents, lineText.Length)
-            ?? new AnnotationAnchor.CaretExtent(statementColumn, trimmed.Length);
 
         // "//" occupies two columns of the gutter, so the pad that carries the
         // caret out to the statement is measured from the end of that marker.
@@ -131,10 +148,25 @@ public static class AnnotationCaret
         // un-hoisted line is indented alongside the code, so the shift is zero
         // and the relative geometry is unchanged.
         int commentColumn = memberIndent.Length;
+        string gutter = (hoist ? HoistMarker + memberIndent : memberIndent) + "//";
+
+        // Agreement is the common case and keeps the compact single-underline
+        // geometry. Only where it fails is there anything to stack: the facts
+        // point at different characters, or some fact has no extent at all. A
+        // line with no placeable fact still has nothing to point at, so it
+        // widens as before — that is the Count: > 0 guard.
+        var agreed = Agreed(annotations, extents, lineText.Length);
+        if (agreed is null
+            && Stack(annotations, extents, lineText.Length, out var unplaced) is { Count: > 0 } stacked
+            && RenderStacked(stacked, unplaced, gutter, commentColumn, hoisted, hoist ? 1 : 0) is { } stackedLines)
+        {
+            return stackedLines;
+        }
+
+        var extent = agreed ?? new AnnotationAnchor.CaretExtent(statementColumn, trimmed.Length);
         int caretColumn = extent.Column + hoisted;
 
         int pad = Math.Max(1, caretColumn - commentColumn - 2);
-        string gutter = (hoist ? HoistMarker + memberIndent : memberIndent) + "//";
         int caretEnd = commentColumn + 2 + pad + extent.Length;
 
         // Prefer trailing the detail on the caret line. When the underline is so
@@ -180,34 +212,19 @@ public static class AnnotationCaret
 
     /// <summary>
     /// The one extent every fact on the line points at, or null when they do not
-    /// agree and the whole statement is the honest underline.
+    /// agree — in which case the line either stacks a caret per extent, or
+    /// widens to the whole statement. See <see cref="Stack"/>.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// A line is underlined once. Giving each distinct extent its own
-    /// <c>^^^^</c> row was tried and rejected on the evidence: of 5,816 extent
-    /// pairs sharing a line, 3,325 nest or overlap, so the rows would
-    /// re-underline the same characters at different widths and the reader would
-    /// have to count columns to tell which row named which fact. The worst line
-    /// in <c>System.Private.CoreLib</c> carries eight distinct extents, which
-    /// would bury one line of code under eight of carets.
-    /// </para>
-    /// <para>
-    /// So narrowing is all-or-nothing per line, and the fallback is not a
-    /// failure: the statement is exactly the smallest span that is true of every
-    /// fact on it. Measured over that corpus as the annotated-source view
-    /// prints it, 25,628 of 31,640 caret-bearing lines (81.00%) narrow, 10.70%
-    /// carry facts that disagree, and 8.30% have no fact with a printed node to
-    /// point at.
-    /// </para>
-    /// <para>
-    /// That headline is carried by the common case, and it is worth being plain
-    /// about the shape: 27,414 of those lines hold a single fact and 92.1% of
-    /// them narrow, while narrowing falls to 12.1% at two facts, 1.1% at three,
-    /// and 0% at four or more. Density and disagreement are the same thing —
-    /// more facts on a line means more distinct offsets on it — so the dense
-    /// lines are precisely the ones no single expression is true of.
-    /// </para>
+    /// Agreement is the common case and is worth keeping separate: measured over
+    /// <c>System.Private.CoreLib</c> as the annotated-source view prints it,
+    /// 25,628 of 31,640 caret-bearing lines (81.00%) narrow to one agreed
+    /// extent, 10.70% carry facts that disagree, and 8.30% have no fact with a
+    /// printed node to point at. Density and disagreement are the same
+    /// phenomenon — more facts on a line means more distinct offsets on it — so
+    /// 27,414 of those lines hold a single fact and 92.1% of them narrow, while
+    /// narrowing falls to 12.1% at two facts, 1.1% at three, and 0% at four or
+    /// more. The lines this returns null for are precisely the dense ones.
     /// </remarks>
     static AnnotationAnchor.CaretExtent? Agreed(
         IReadOnlyList<IAnnotation> annotations,
@@ -234,6 +251,175 @@ public static class AnnotationCaret
             && final.Column + final.Length <= lineLength
             ? final
             : null;
+    }
+
+    /// <summary>
+    /// Groups the line's facts by the characters they point at, ordered by start
+    /// column and widest first at a tie. Facts with no recoverable extent are
+    /// returned separately in <paramref name="unplaced"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A line can be mixed: some facts are about an expression and some are only
+    /// known to be about the statement. Widening the whole line because of the
+    /// latter discards placement the anchoring layer successfully recovered for
+    /// the former — and the densest lines in the corpus are exactly the mixed
+    /// ones. <c>System.Tuple&lt;…&gt;.Equals</c> carries 16 facts of which 8
+    /// have an extent; widening renders one 331-column caret and attributes
+    /// nothing. So the placeable facts stack, and the rest are listed against
+    /// the line without a caret, which is precisely what is known about them.
+    /// </para>
+    /// <para>
+    /// Extents sharing a start column are always a nesting, so they can never
+    /// share a row. Widest first makes each row narrower than the one above it,
+    /// so reading down the rows is zooming in, and it matches the order the
+    /// printer records nesting in.
+    /// </para>
+    /// </remarks>
+    static List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)>? Stack(
+        IReadOnlyList<IAnnotation> annotations,
+        IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents,
+        int lineLength,
+        out List<IAnnotation> unplaced)
+    {
+        unplaced = [];
+        if (extents is null || extents.Count == 0)
+            return null;
+
+        var groups = new List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)>();
+        foreach (var annotation in annotations)
+        {
+            // Same bound as Agreed: an extent is measured against the printer's
+            // own output, so it can only fall outside the line handed here if a
+            // consumer re-wrapped the text. Treat it as unplaceable rather than
+            // throw inside a display path.
+            if (!extents.TryGetValue(annotation, out var extent)
+                || extent.Column < 0 || extent.Length <= 0
+                || extent.Column + extent.Length > lineLength)
+            {
+                unplaced.Add(annotation);
+                continue;
+            }
+
+            int existing = groups.FindIndex(group => group.Extent == extent);
+            if (existing < 0)
+                groups.Add((extent, [annotation]));
+            else
+                groups[existing].Facts.Add(annotation);
+        }
+
+        groups.Sort((left, right) => left.Extent.Column != right.Extent.Column
+            ? left.Extent.Column.CompareTo(right.Extent.Column)
+            : right.Extent.Length.CompareTo(left.Extent.Length));
+        return groups;
+    }
+
+    /// <summary>
+    /// Packs the stacked carets onto as few rows as fit and renders them above
+    /// the numbered fact list, or null when a caret has no room for its label.
+    /// </summary>
+    /// <remarks>
+    /// A caret is drawn at its true width. It is clipped — its last column
+    /// becoming <c>~</c> — only where the trail would collide with the label of
+    /// the next caret on the same row, because width is information
+    /// <see cref="AnnotationAnchor.ComputeCaretExtents"/> worked to recover, so
+    /// this either states it truthfully or marks that it could not. Measured
+    /// over <c>System.Private.CoreLib</c> as the annotated-source view prints
+    /// it, this puts 2,557 of the 2,886 multi-extent lines (88.6%) on a single
+    /// row and none above four, with 3,949 of 6,986 trails (56.5%) at true
+    /// width.
+    /// </remarks>
+    static IReadOnlyList<string>? RenderStacked(
+        List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)> groups,
+        IReadOnlyList<IAnnotation> unplaced,
+        string gutter,
+        int commentColumn,
+        int hoisted,
+        int markerWidth)
+    {
+        int Column(int index) => groups[index].Extent.Column + hoisted;
+        string Label(int index) => $"{index + 1}.";
+        int LabelStart(int index) => Column(index) - Label(index).Length;
+
+        // A trail must keep MinTrail columns for a later caret to be clipped
+        // into rather than overwritten, unless the expression is genuinely
+        // shorter than that — in which case its own width is the whole trail.
+        int Reserved(int index) => Math.Min(groups[index].Extent.Length, MinTrail);
+
+        var rows = new List<List<int>>();
+        for (int i = 0; i < groups.Count; i++)
+        {
+            // The gutter owns everything left of commentColumn + 2. A label that
+            // will not fit after it cannot be drawn at the column it points at,
+            // and shifting it would make it point somewhere else.
+            if (LabelStart(i) < commentColumn + 2)
+                return null;
+
+            var row = rows.Find(candidate =>
+                Column(candidate[^1]) + Reserved(candidate[^1]) + TrailGap <= LabelStart(i));
+            if (row is null)
+                rows.Add(row = []);
+            row.Add(i);
+        }
+
+        var lines = new List<string>();
+        foreach (var row in rows)
+        {
+            var caretLine = new StringBuilder(gutter);
+            for (int position = 0; position < row.Count; position++)
+            {
+                int index = row[position];
+                int length = groups[index].Extent.Length;
+
+                // The next label on this row is the only thing a trail can run
+                // into; the last trail on a row has the rest of the line.
+                int limit = position + 1 < row.Count
+                    ? LabelStart(row[position + 1]) - TrailGap - Column(index)
+                    : int.MaxValue;
+                int width = Math.Min(length, limit);
+
+                while (caretLine.Length - markerWidth < LabelStart(index))
+                    caretLine.Append(' ');
+                caretLine.Append(Label(index));
+                caretLine.Append('^', width < length ? width - 1 : width);
+                if (width < length)
+                    caretLine.Append(TruncationGlyph);
+            }
+            lines.Add(caretLine.ToString());
+        }
+
+        // Every fact is left-aligned under one column so the numbers line up and
+        // wrapping stays predictable, which a column-aligned list cannot offer:
+        // its texts would stagger across the width of the line and each wrap.
+        int labelWidth = $"{groups.Count}.".Length + 1;
+        int detailColumn = commentColumn + 4 + labelWidth;
+        int width2 = Math.Max(MinDetailWidth, Budget - detailColumn);
+        for (int i = 0; i < groups.Count; i++)
+        {
+            string prefix = Label(i).PadRight(labelWidth);
+            foreach (var annotation in groups[i].Facts)
+            {
+                foreach (string chunk in Wrap(AnnotationText.Format(annotation), width2))
+                {
+                    lines.Add(gutter + "  " + prefix + chunk);
+                    prefix = new string(' ', labelWidth);
+                }
+            }
+        }
+
+        // A fact with no recoverable extent gets no number, because there is no
+        // caret for a number to refer to. UnplacedMarker says what is true of
+        // it: this line, and nothing narrower.
+        foreach (var annotation in unplaced)
+        {
+            string prefix = $"{UnplacedMarker}".PadRight(labelWidth);
+            foreach (string chunk in Wrap(AnnotationText.Format(annotation), width2))
+            {
+                lines.Add(gutter + "  " + prefix + chunk);
+                prefix = new string(' ', labelWidth);
+            }
+        }
+        return lines;
     }
 
     /// <summary>Leading whitespace of the first non-blank line — the member declaration gutter.</summary>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -296,7 +296,10 @@ public static class AnnotationCaret
     /// carets, so counting over every collected fact describes a render no
     /// invocation produces. <c>System.Tuple&lt;…&gt;.Equals</c> is the
     /// extreme: 16 facts of which 8 have an extent, so widening renders one
-    /// 330-column caret and attributes nothing. So the placeable facts stack,
+    /// 370-column caret and attributes nothing (measured off the render, which
+    /// is the only way this figure has ever been got right: it was recorded as
+    /// 370, "corrected" to 330 on a recapture of the wrong render, and measured
+    /// back to 370 -- re-measure before changing it). So the placeable facts stack,
     /// and the rest are listed against the line without a caret, which is
     /// precisely what is known about them.
     /// </para>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -366,7 +366,8 @@ public static class AnnotationCaret
             // will not fit after it cannot be drawn at the column it points at,
             // and shifting it would make it point somewhere else. This is a
             // guard, not a path with known traffic: it fires on 0 of the 3,385
-            // CoreLib lines that stack.
+            // lines that stack in System.Private.CoreLib, as the
+            // annotated-source view prints it.
             if (LabelStart(i) < commentColumn + 2)
                 return null;
 

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -335,12 +335,15 @@ public static class AnnotationCaret
     /// <see cref="AnnotationAnchor.ComputeCaretExtents"/> worked to recover, so
     /// this either states it truthfully or marks that it could not. Measured
     /// over <c>System.Private.CoreLib</c> as the annotated-source view prints
-    /// it, by rendering each of the 3,385 lines that stack through this method
-    /// and reading the output back: 3,056 (90.3%) take a single row, 326 take
-    /// two, and three take more, none above four. Restricted to the 2,886
-    /// multi-extent lines, 2,557 (88.6%) take one row, and 3,949 of 6,986
-    /// trails (56.5%) render at true width. No stacked caret row is wider than
-    /// the code line it annotates, on any of those 3,385 lines.
+    /// it, summed over the five focus families and counted after the focus
+    /// filter, because <c>--focus</c> promotes only the requested family to
+    /// carets and a figure taken over every collected fact describes a render
+    /// no invocation produces. Rendering each of the 2,842 lines that stack
+    /// through this method and reading the output back: 2,543 (89.5%) take a
+    /// single row, 297 take two, and two take more, neither above four. 3,884
+    /// of 6,566 trails (59.2%) render at true width. No stacked caret row is
+    /// wider than the code line it annotates, on any of those 2,842 lines,
+    /// against 20 (0.70%) under the widening render this replaces.
     /// </remarks>
     static IReadOnlyList<string>? RenderStacked(
         List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)> groups,
@@ -365,9 +368,10 @@ public static class AnnotationCaret
             // The gutter owns everything left of commentColumn + 2. A label that
             // will not fit after it cannot be drawn at the column it points at,
             // and shifting it would make it point somewhere else. This is a
-            // guard, not a path with known traffic: it fires on 0 of the 3,385
+            // guard, not a path with known traffic: it fires on 0 of the 2,842
             // lines that stack in System.Private.CoreLib, as the
-            // annotated-source view prints it.
+            // annotated-source view prints it, summed over the five focus
+            // families and counted after the focus filter.
             if (LabelStart(i) < commentColumn + 2)
                 return null;
 

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -289,7 +289,7 @@ public static class AnnotationCaret
         out List<IAnnotation> unplaced)
     {
         unplaced = [];
-        if (extents is null || extents.Count == 0)
+        if (extents is null)
             return null;
 
         var groups = new List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)>();

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -349,8 +349,16 @@ public static class AnnotationCaret
     /// through this method and reading the output back: 2,543 (89.5%) take a
     /// single row, 297 take two, and two take more, neither above four. 3,884
     /// of 6,566 trails (59.2%) render at true width. No stacked caret row is
-    /// wider than the code line it annotates, on any of those 2,842 lines,
-    /// against 20 (0.70%) under the widening render this replaces.
+    /// wider than the code line it annotates, which is structural rather than
+    /// measured: <see cref="Stack"/> sends any extent reaching past
+    /// <c>lineLength</c> to the unplaced list, labels grow leftward, and the
+    /// gutter guard bails out rather than shifting a trail rightward, so the
+    /// rightmost column is bounded by the line. The 0 observed on those 2,842
+    /// lines checks that derivation and cannot falsify it. The figure that does
+    /// carry information is the comparison: the widening render this replaces
+    /// overhangs on 20 lines (0.70%), because it shifts the start column
+    /// rightward while keeping the full extent length — the freedom given up
+    /// here.
     /// </remarks>
     static IReadOnlyList<string>? RenderStacked(
         List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)> groups,

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -20,11 +20,12 @@ namespace ILInspector.Decompiler.Annotations;
 /// <see cref="AnnotationAnchor.ComputeCaretExtents"/>. Where the raise erased
 /// the offset there is no sub-token to point at. Such a fact is listed under
 /// <see cref="UnplacedMarker"/> if some other fact on the line was placed, and
-/// only where <em>no</em> fact on the line has an extent does the underline
-/// cover the trimmed statement instead — exactly what the facts are still known
-/// to be about, and no more. A span-carrying datum (a compiler diagnostic)
-/// brings its own range; that is a property of the datum, not of this
-/// gesture.</item>
+/// where <em>no</em> fact on the line has an extent the underline covers the
+/// trimmed statement instead — exactly what the facts are still known to be
+/// about, and no more. Statement width is also the defensive answer when a
+/// stacked label would not fit beside the gutter, which no CoreLib line
+/// currently reaches. A span-carrying datum (a compiler diagnostic) brings its
+/// own range; that is a property of the datum, not of this gesture.</item>
 /// </list>
 /// </remarks>
 public static class AnnotationCaret

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -124,10 +124,12 @@ public static class AnnotationCaret
     /// Per-fact underline extents from
     /// <see cref="AnnotationAnchor.ComputeCaretExtents"/>. When every fact on
     /// the line points at the same characters the line narrows to that one
-    /// extent; otherwise it stacks a numbered caret per distinct extent and
-    /// lists any fact with no extent under <see cref="UnplacedMarker"/>. If the
-    /// stacked layout is rejected — a label that will not clear the gutter — the
-    /// line widens instead and no fact is marked unplaced. See
+    /// extent; otherwise, when at least one distinct extent is placeable and
+    /// every label clears the gutter, it stacks a numbered caret per distinct
+    /// extent and lists any fact with no extent under
+    /// <see cref="UnplacedMarker"/>. If no fact has a usable extent, or a label
+    /// will not clear the gutter, the line widens instead and no fact is marked
+    /// unplaced. See
     /// <see cref="Agreed"/> and <see cref="Stack"/>.
     /// </param>
     public static IReadOnlyList<string> Render(
@@ -239,6 +241,9 @@ public static class AnnotationCaret
     /// the 2,282 two-fact, 714 three-fact or 318 four-or-more-fact lines
     /// narrows. Two facts of one family on one line never share an extent in
     /// this corpus, so for them the disagreement return below does all the work.
+    /// The 82.43% headline is therefore padded: 29,550 of its lines carry a
+    /// single fact and cannot disagree at all. Conditioned on the 3,314 lines
+    /// that could, agreement is 0.
     /// That is what this measures, not a mechanism — what is compared is
     /// rendered extents, not offsets, and nothing prevents two facts sharing
     /// one. Density is not the only reason this returns null: 2,459 of the
@@ -288,7 +293,7 @@ public static class AnnotationCaret
     /// carets, so counting over every collected fact describes a render no
     /// invocation produces. <c>System.Tuple&lt;…&gt;.Equals</c> is the
     /// extreme: 16 facts of which 8 have an extent, so widening renders one
-    /// 370-column caret and attributes nothing. So the placeable facts stack,
+    /// 330-column caret and attributes nothing. So the placeable facts stack,
     /// and the rest are listed against the line without a caret, which is
     /// precisely what is known about them.
     /// </para>
@@ -370,30 +375,39 @@ public static class AnnotationCaret
     /// carets and a figure taken over every collected fact describes a render
     /// no invocation produces. Rendering each of the 2,842 lines that stack
     /// through this method and reading the output back: 2,543 (89.5%) take a
-    /// single row, 297 take two, and two take more, neither above four. 3,884
+    /// single row, 297 take two, and two take more, neither above four. That
+    /// 89.5% is itself padded — 254 of those lines carry a single extent group
+    /// and cannot occupy more than one row — so the rate among the 2,588 lines
+    /// with something to pack is 2,289 (88.4%). 3,884
     /// of 6,566 trails (59.2%) render at true width, but that rate is padded by
     /// a structural immunity: the last trail on a row has no successor, so its
     /// clip limit is <c>int.MaxValue</c> and it renders at true width by
     /// construction. Those 2,842 lines occupy 3,144 rows, so 3,144 of the 3,884
     /// could not have been clipped. Of the 3,422 trails that were actually
-    /// exposed to a successor, only 740 (21.6%) survived at true width and
-    /// 2,682 (78.4%) were cut short. That is the figure with information in it.
+    /// exposed to a successor, 740 (21.6%) survived at true width. Five of those
+    /// are immune too, their extents being no longer than <c>MinTrail</c>, which
+    /// row admission already reserves; among the 3,417 trails that could
+    /// genuinely be cut, 735 (21.5%) survived and 2,682 (78.5%) were clipped.
+    /// That is the figure with information in it.
     /// No stacked caret row is
     /// wider than the code line it annotates, which is structural rather than
     /// measured: <see cref="Stack"/> sends any extent reaching past
     /// <c>lineLength</c> to the unplaced list, labels grow leftward, and the
     /// gutter guard bails out rather than shifting a trail rightward, so the
     /// rightmost column is bounded by the line. The 0 observed on those 2,842
-    /// lines checks that derivation and cannot falsify it. The figure that does
-    /// carry information is the comparison: the widening render this replaces
-    /// overhangs on 20 lines (0.70%). Its underline is not a fact's extent at
-    /// all — with no agreement it falls back to
-    /// <c>new CaretExtent(statementColumn, trimmed.Length)</c>, the whole
-    /// trimmed statement — and it is placed at
-    /// <c>pad = Math.Max(1, caretColumn - commentColumn - 2)</c>, whose floor of
-    /// 1 shifts the underline rightward when the statement starts near the
-    /// gutter. Nothing then bounds or clips it against the line, which is the
-    /// freedom given up here.
+    /// lines checks that derivation and cannot falsify it.
+    /// </para>
+    /// <para>
+    /// The comparison against the widening render is narrower than it first
+    /// looks, and an earlier revision of this remark overstated it twice. No
+    /// caret <em>glyph</em> overhangs the code line in <em>either</em> render:
+    /// measured over the same 2,842 lines, both are 0, because the widening
+    /// underline covers the trimmed statement, which ends within the line. What
+    /// differs is the rendered <em>row</em>. Widening appends the first detail
+    /// string to the caret row when it fits the inline budget, and on 20 lines
+    /// (0.70%) that appended text carries the row past the end of the code line.
+    /// Stacking never appends detail to a caret row, so it is 0. The contrast is
+    /// about where detail is placed, not about bounding the underline.
     /// </remarks>
     static IReadOnlyList<string>? RenderStacked(
         List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)> groups,

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -411,10 +411,16 @@ public static class AnnotationCaret
     /// measured over the same 2,842 lines, both are 0, because the widening
     /// underline covers the trimmed statement, which ends within the line. What
     /// differs is the rendered <em>row</em>. Widening appends the first detail
-    /// string to the caret row when it fits the inline budget, and on 20 lines
-    /// (0.70%) that appended text carries the row past the end of the code line.
-    /// Stacking never appends detail to a caret row, so it is 0. The contrast is
-    /// about where detail is placed, not about bounding the underline.
+    /// string to the caret row when it fits the inline budget, and that appended
+    /// text carries the row past the end of the code line. Quoting this as 20 of
+    /// 2,842 lines (0.70%) pads the denominator with the 2,822 whose detail never
+    /// goes inline and which therefore cannot overhang at all: inline detail
+    /// appears on exactly 20 of these lines and all 20 overhang, so the rate is
+    /// 20/20. That is structural rather than lucky -- widening underlines the
+    /// whole trimmed statement, so the caret ends where the code line ends, and
+    /// anything appended after it is past the end. Stacking never appends detail
+    /// to a caret row, so it is 0. The contrast is about where detail is placed,
+    /// not about bounding the underline.
     /// </remarks>
     static IReadOnlyList<string>? RenderStacked(
         List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)> groups,

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -297,9 +297,12 @@ public static class AnnotationCaret
     /// be packed onto a lower row and reach further right than anything above
     /// it, which happens on 50 of the 2,842 lines that stack in
     /// System.Private.CoreLib, as the annotated-source view prints it, summed
-    /// over the five focus families. Of the 2,682 clipped trails, the label
-    /// doing the clipping sits inside the trail it clips on 1,867 (69.6%) and
-    /// is disjoint from it on 815 (30.4%).
+    /// over the five focus families. Of the 2,682 clipped trails, the successor
+    /// extent whose label does the clipping is nested inside the trail it clips
+    /// on 1,867 (69.6%) and disjoint from it on 815 (30.4%). The distinction
+    /// matters: a disjoint successor's label reaches two columns left of the
+    /// extent it belongs to, so it can still overlap and clip the trail before
+    /// it.
     /// </para>
     /// </remarks>
     static List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)>? Stack(

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -246,8 +246,13 @@ public static class AnnotationCaret
     /// this corpus, so for them the disagreement return below does all the work.
     /// That 91.7% is itself padded: 2,459 of the 29,550 single-fact lines hold a
     /// fact with no extent, which cannot narrow. Conditioned on the 27,091 that
-    /// could, every one does -- 100%, and necessarily so, because one fact with
-    /// an extent is one extent and agrees with itself. The 91.7% measures how
+    /// could, every one does -- 100%. That is close to necessary but not quite:
+    /// one fact with an extent is one extent and agrees with itself, so the loop
+    /// above cannot reject it, but the bounds check below still can, and would
+    /// on a negative column, an empty extent, or an extent running past
+    /// <paramref name="lineLength"/> because a consumer re-wrapped the line. In
+    /// this corpus none of those occurs, so the rate is 100% as measured rather
+    /// than 100% by construction. The 91.7% measures how
     /// often a single fact has an extent, not how often agreement holds.
     /// The 82.43% headline is padded the other way: 29,550 of its lines carry a
     /// single fact and cannot disagree at all. Conditioned on the 3,314 lines
@@ -389,7 +394,11 @@ public static class AnnotationCaret
     /// single row, 297 take two, and two take more, neither above four. That
     /// 89.5% is itself padded — 254 of those lines carry a single extent group
     /// and cannot occupy more than one row — so the rate among the 2,588 lines
-    /// with something to pack is 2,289 (88.4%). 3,884
+    /// with something to pack is 2,289 (88.4%). That 2,588 is padded in turn, by
+    /// the same structural fact this remark states below: extents sharing a start
+    /// column can never share a row, so the 136 lines carrying two distinct
+    /// extents at one column cannot take a single row whatever the packer does.
+    /// Among the 2,452 that can, the rate is 2,289 (93.4%). 3,884
     /// of 6,566 trails (59.2%) render at true width, but that rate is padded by
     /// a structural immunity: the last trail on a row has no successor, so its
     /// clip limit is <c>int.MaxValue</c> and it renders at true width by

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -244,7 +244,12 @@ public static class AnnotationCaret
     /// the 2,282 two-fact, 714 three-fact or 318 four-or-more-fact lines
     /// narrows. Two facts of one family on one line never share an extent in
     /// this corpus, so for them the disagreement return below does all the work.
-    /// The 82.43% headline is therefore padded: 29,550 of its lines carry a
+    /// That 91.7% is itself padded: 2,459 of the 29,550 single-fact lines hold a
+    /// fact with no extent, which cannot narrow. Conditioned on the 27,091 that
+    /// could, every one does -- 100%, and necessarily so, because one fact with
+    /// an extent is one extent and agrees with itself. The 91.7% measures how
+    /// often a single fact has an extent, not how often agreement holds.
+    /// The 82.43% headline is padded the other way: 29,550 of its lines carry a
     /// single fact and cannot disagree at all. Conditioned on the 3,314 lines
     /// that could, agreement is 0.
     /// That is what this measures, not a mechanism — what is compared is
@@ -416,9 +421,13 @@ public static class AnnotationCaret
     /// 2,842 lines (0.70%) pads the denominator with the 2,822 whose detail never
     /// goes inline and which therefore cannot overhang at all: inline detail
     /// appears on exactly 20 of these lines and all 20 overhang, so the rate is
-    /// 20/20. That is structural rather than lucky -- widening underlines the
-    /// whole trimmed statement, so the caret ends where the code line ends, and
-    /// anything appended after it is past the end. Stacking never appends detail
+    /// 20/20. The reason it comes out whole is that on the hoisted render these
+    /// figures are taken from, widening underlines the whole trimmed statement,
+    /// so the caret ends where the code line ends and any appended text lands
+    /// past it. That is not a universal guarantee, and should not be stated as
+    /// one: a fact whose formatted text is empty appends nothing, and an
+    /// un-hoisted render can clamp <c>pad</c> to its floor of 1 and push the
+    /// caret past the code with no detail appended at all. Stacking never appends detail
     /// to a caret row, so it is 0. The contrast is about where detail is placed,
     /// not about bounding the underline.
     /// </remarks>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -23,9 +23,10 @@ namespace ILInspector.Decompiler.Annotations;
 /// where <em>no</em> fact on the line has an extent the underline covers the
 /// trimmed statement instead — exactly what the facts are still known to be
 /// about, and no more. Statement width is also the defensive answer when a
-/// stacked label would not fit beside the gutter, which no CoreLib line
-/// currently reaches. A span-carrying datum (a compiler diagnostic) brings its
-/// own range; that is a property of the datum, not of this gesture.</item>
+/// stacked label would not fit beside the gutter, which no line of
+/// <c>System.Private.CoreLib</c> reaches as the annotated-source view prints
+/// it. A span-carrying datum (a compiler diagnostic) brings its own range;
+/// that is a property of the datum, not of this gesture.</item>
 /// </list>
 /// </remarks>
 public static class AnnotationCaret
@@ -224,12 +225,13 @@ public static class AnnotationCaret
     /// <c>System.Private.CoreLib</c> as the annotated-source view prints it,
     /// 25,628 of 31,640 caret-bearing lines (81.00%) narrow to one agreed
     /// extent, 10.70% carry facts that disagree, and 8.30% have no fact with a
-    /// printed node to point at. Density and disagreement are the same
-    /// phenomenon — more facts on a line means more distinct offsets on it — so
-    /// 27,414 of those lines hold a single fact and 92.1% of them narrow, while
-    /// narrowing falls to 12.1% at two facts, 1.1% at three, and 0% at four or
-    /// more. Density is not the only reason this returns null, though: 2,156 of
-    /// the 6,012 null lines carry a single fact that has no extent at all.
+    /// printed node to point at. Agreement falls as fact count rises: 27,414 of
+    /// those lines hold a single fact and 92.1% of them narrow, while narrowing
+    /// falls to 12.1% at two facts, 1.1% at three, and 0% at four or more. That
+    /// is a correlation this measures, not a mechanism — what is compared here
+    /// is rendered extents, not offsets, and two facts can share one extent.
+    /// Density is not the only reason this returns null: 2,156 of the 6,012
+    /// null lines carry a single fact that has no extent at all.
     /// </remarks>
     static AnnotationAnchor.CaretExtent? Agreed(
         IReadOnlyList<IAnnotation> annotations,
@@ -268,8 +270,10 @@ public static class AnnotationCaret
     /// A line can be mixed: some facts are about an expression and some are only
     /// known to be about the statement. Widening the whole line because of the
     /// latter discards placement the anchoring layer successfully recovered for
-    /// the former, and 615 lines in the corpus are mixed — 499 of them with a
-    /// single surviving extent. <c>System.Tuple&lt;…&gt;.Equals</c> is the
+    /// the former, and 615 lines are mixed — 499 of them with a single surviving
+    /// extent — measured over <c>System.Private.CoreLib</c> as the
+    /// annotated-source view prints it. (The overlay render is a different
+    /// population: 609 and 498.) <c>System.Tuple&lt;…&gt;.Equals</c> is the
     /// extreme: 16 facts of which 8 have an extent, so widening renders one
     /// 330-column caret and attributes nothing. So the placeable facts stack,
     /// and the rest are listed against the line without a caret, which is

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -19,13 +19,17 @@ namespace ILInspector.Decompiler.Annotations;
 /// narrowest printed node carrying that exact offset, supplied by
 /// <see cref="AnnotationAnchor.ComputeCaretExtents"/>. Where the raise erased
 /// the offset there is no sub-token to point at. Such a fact is listed under
-/// <see cref="UnplacedMarker"/> if some other fact on the line was placed, and
-/// where <em>no</em> fact on the line has an extent the underline covers the
+/// <see cref="UnplacedMarker"/> when the line stacks and some other fact on it
+/// was placed, and where <em>no</em> fact on the line has an extent the
+/// underline covers the
 /// trimmed statement instead — exactly what the facts are still known to be
 /// about, and no more. Statement width is also the defensive answer when a
-/// stacked label would not fit beside the gutter, which no line of
-/// <c>System.Private.CoreLib</c> reaches as the annotated-source view prints
-/// it. A span-carrying datum (a compiler diagnostic) brings its own range;
+/// stacked label would not fit beside the gutter: that rejects the stacked
+/// layout for the whole line, so the line widens and no fact on it is marked
+/// unplaced. No line of
+/// <c>System.Private.CoreLib</c> reaches that case as the annotated-source view
+/// prints it. A span-carrying datum (a compiler diagnostic) brings its own
+/// range;
 /// that is a property of the datum, not of this gesture.</item>
 /// </list>
 /// </remarks>
@@ -121,7 +125,9 @@ public static class AnnotationCaret
     /// <see cref="AnnotationAnchor.ComputeCaretExtents"/>. When every fact on
     /// the line points at the same characters the line narrows to that one
     /// extent; otherwise it stacks a numbered caret per distinct extent and
-    /// lists any fact with no extent under <see cref="UnplacedMarker"/>. See
+    /// lists any fact with no extent under <see cref="UnplacedMarker"/>. If the
+    /// stacked layout is rejected — a label that will not clear the gutter — the
+    /// line widens instead and no fact is marked unplaced. See
     /// <see cref="Agreed"/> and <see cref="Stack"/>.
     /// </param>
     public static IReadOnlyList<string> Render(
@@ -288,8 +294,13 @@ public static class AnnotationCaret
     /// </para>
     /// <para>
     /// Extents sharing a start column are always a nesting, so they can never
-    /// share a row. Widest first puts the outer extent on the upper row, which
-    /// matches the order the printer records nesting in. That orders
+    /// share a row. Widest first puts the outer extent on the upper row, so
+    /// reading down the rows moves inward. That is a presentation choice, and
+    /// it is the <em>reverse</em> of the order the printer records nesting in:
+    /// <c>RecordExpressionRanges</c> reverses its parent-first walk precisely so
+    /// that a node is recorded after every one of its descendants, which is the
+    /// descendants-before-ancestors contract the anchor relies on. Nothing here
+    /// inherits that order. Widest-first orders
     /// <i>same-start</i> extents only, and it is not what clips anything: a
     /// trail is cut short only by the next label on its own row, so a nested
     /// extent sent to a different row never shortens its parent. Nor does it
@@ -360,7 +371,14 @@ public static class AnnotationCaret
     /// no invocation produces. Rendering each of the 2,842 lines that stack
     /// through this method and reading the output back: 2,543 (89.5%) take a
     /// single row, 297 take two, and two take more, neither above four. 3,884
-    /// of 6,566 trails (59.2%) render at true width. No stacked caret row is
+    /// of 6,566 trails (59.2%) render at true width, but that rate is padded by
+    /// a structural immunity: the last trail on a row has no successor, so its
+    /// clip limit is <c>int.MaxValue</c> and it renders at true width by
+    /// construction. Those 2,842 lines occupy 3,144 rows, so 3,144 of the 3,884
+    /// could not have been clipped. Of the 3,422 trails that were actually
+    /// exposed to a successor, only 740 (21.6%) survived at true width and
+    /// 2,682 (78.4%) were cut short. That is the figure with information in it.
+    /// No stacked caret row is
     /// wider than the code line it annotates, which is structural rather than
     /// measured: <see cref="Stack"/> sends any extent reaching past
     /// <c>lineLength</c> to the unplaced list, labels grow leftward, and the
@@ -368,9 +386,14 @@ public static class AnnotationCaret
     /// rightmost column is bounded by the line. The 0 observed on those 2,842
     /// lines checks that derivation and cannot falsify it. The figure that does
     /// carry information is the comparison: the widening render this replaces
-    /// overhangs on 20 lines (0.70%), because it shifts the start column
-    /// rightward while keeping the full extent length — the freedom given up
-    /// here.
+    /// overhangs on 20 lines (0.70%). Its underline is not a fact's extent at
+    /// all — with no agreement it falls back to
+    /// <c>new CaretExtent(statementColumn, trimmed.Length)</c>, the whole
+    /// trimmed statement — and it is placed at
+    /// <c>pad = Math.Max(1, caretColumn - commentColumn - 2)</c>, whose floor of
+    /// 1 shifts the underline rightward when the statement starts near the
+    /// gutter. Nothing then bounds or clips it against the line, which is the
+    /// freedom given up here.
     /// </remarks>
     static IReadOnlyList<string>? RenderStacked(
         List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)> groups,

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -223,15 +223,20 @@ public static class AnnotationCaret
     /// <remarks>
     /// Agreement is the common case and is worth keeping separate: measured over
     /// <c>System.Private.CoreLib</c> as the annotated-source view prints it,
-    /// 25,628 of 31,640 caret-bearing lines (81.00%) narrow to one agreed
-    /// extent, 10.70% carry facts that disagree, and 8.30% have no fact with a
-    /// printed node to point at. Agreement falls as fact count rises: 27,414 of
-    /// those lines hold a single fact and 92.1% of them narrow, while narrowing
-    /// falls to 12.1% at two facts, 1.1% at three, and 0% at four or more. That
-    /// is a correlation this measures, not a mechanism — what is compared here
-    /// is rendered extents, not offsets, and two facts can share one extent.
-    /// Density is not the only reason this returns null: 2,156 of the 6,012
-    /// null lines carry a single fact that has no extent at all.
+    /// after the focus filter and summed over the five focus families —
+    /// <c>--focus</c> promotes only one family to carets, so a count over every
+    /// collected fact describes a render no invocation produces — 27,091 of
+    /// 32,864 caret-bearing lines (82.43%) narrow to one agreed extent, 8.65%
+    /// carry facts that disagree, and 8.92% have no fact with a printed node to
+    /// point at. Agreement is entirely a single-fact phenomenon here: 29,550 of
+    /// those lines hold one fact and 91.7% of them narrow, while none of
+    /// the 2,282 two-fact, 714 three-fact or 318 four-or-more-fact lines
+    /// narrows. Two facts of one family on one line never share an extent in
+    /// this corpus, so for them the disagreement return below does all the work.
+    /// That is what this measures, not a mechanism — what is compared is
+    /// rendered extents, not offsets, and nothing prevents two facts sharing
+    /// one. Density is not the only reason this returns null: 2,459 of the
+    /// 5,773 null lines carry a single fact that has no extent at all.
     /// </remarks>
     static AnnotationAnchor.CaretExtent? Agreed(
         IReadOnlyList<IAnnotation> annotations,

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -288,14 +288,18 @@ public static class AnnotationCaret
     /// </para>
     /// <para>
     /// Extents sharing a start column are always a nesting, so they can never
-    /// share a row. Widest first puts the outer extent first, so the inner
-    /// caret is clipped into its parent's trail rather than overwriting it,
-    /// and it matches the order the printer records nesting in. That orders
-    /// <i>same-start</i> extents only. It does not make each row narrower than
-    /// the one above: a later disjoint extent can be packed onto a lower row
-    /// and reach further right than anything above it, which happens on 50 of
-    /// the 2,842 lines that stack in System.Private.CoreLib, as the
-    /// annotated-source view prints it, summed over the five focus families.
+    /// share a row. Widest first puts the outer extent on the upper row, which
+    /// matches the order the printer records nesting in. That orders
+    /// <i>same-start</i> extents only, and it is not what clips anything: a
+    /// trail is cut short only by the next label on its own row, so a nested
+    /// extent sent to a different row never shortens its parent. Nor does it
+    /// make each row narrower than the one above -- a later disjoint extent can
+    /// be packed onto a lower row and reach further right than anything above
+    /// it, which happens on 50 of the 2,842 lines that stack in
+    /// System.Private.CoreLib, as the annotated-source view prints it, summed
+    /// over the five focus families. Of the 2,682 clipped trails, the label
+    /// doing the clipping sits inside the trail it clips on 1,867 (69.6%) and
+    /// is disjoint from it on 815 (30.4%).
     /// </para>
     /// </remarks>
     static List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)>? Stack(

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -376,9 +376,16 @@ public static class AnnotationCaret
             // will not fit after it cannot be drawn at the column it points at,
             // and shifting it would make it point somewhere else. This is a
             // guard, not a path with known traffic: it fires on 0 of the 2,842
-            // lines that stack in System.Private.CoreLib, as the
+            // lines that *qualify* to stack in System.Private.CoreLib, as the
             // annotated-source view prints it, summed over the five focus
-            // families and counted after the focus filter.
+            // families and counted after the focus filter. Qualifying is the
+            // right denominator because a line this rejects does not stack by
+            // construction. A fallback is detected by the absence of an "N."
+            // label before the caret run, not by the absence of a caret row --
+            // falling back still renders the widening caret, so the latter
+            // test could never fire. Raising the margin to +6 makes this fire
+            // on 306 of the 2,842 and to +200 on all of them, so the zero is a
+            // property of the corpus rather than of the measurement.
             if (LabelStart(i) < commentColumn + 2)
                 return null;
 

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -270,12 +270,14 @@ public static class AnnotationCaret
     /// A line can be mixed: some facts are about an expression and some are only
     /// known to be about the statement. Widening the whole line because of the
     /// latter discards placement the anchoring layer successfully recovered for
-    /// the former, and 615 lines are mixed — 499 of them with a single surviving
+    /// the former, and 355 lines are mixed — 254 of them with a single surviving
     /// extent — measured over <c>System.Private.CoreLib</c> as the
-    /// annotated-source view prints it. (The overlay render is a different
-    /// population: 609 and 498.) <c>System.Tuple&lt;…&gt;.Equals</c> is the
+    /// annotated-source view prints it, summed over the five focus families.
+    /// The focus filter matters: <c>--focus</c> promotes only one family to
+    /// carets, so counting over every collected fact describes a render no
+    /// invocation produces. <c>System.Tuple&lt;…&gt;.Equals</c> is the
     /// extreme: 16 facts of which 8 have an extent, so widening renders one
-    /// 330-column caret and attributes nothing. So the placeable facts stack,
+    /// 370-column caret and attributes nothing. So the placeable facts stack,
     /// and the rest are listed against the line without a caret, which is
     /// precisely what is known about them.
     /// </para>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -18,10 +18,13 @@ namespace ILInspector.Decompiler.Annotations;
 /// Annotations.cs), so the span has to be recovered from the printed tree: the
 /// narrowest printed node carrying that exact offset, supplied by
 /// <see cref="AnnotationAnchor.ComputeCaretExtents"/>. Where the raise erased
-/// the offset there is no sub-token to point at and the underline covers the
-/// trimmed statement instead — exactly what the fact is still known to be
-/// about, and no more. A span-carrying datum (a compiler diagnostic) brings its
-/// own range; that is a property of the datum, not of this gesture.</item>
+/// the offset there is no sub-token to point at. Such a fact is listed under
+/// <see cref="UnplacedMarker"/> if some other fact on the line was placed, and
+/// only where <em>no</em> fact on the line has an extent does the underline
+/// cover the trimmed statement instead — exactly what the facts are still known
+/// to be about, and no more. A span-carrying datum (a compiler diagnostic)
+/// brings its own range; that is a property of the datum, not of this
+/// gesture.</item>
 /// </list>
 /// </remarks>
 public static class AnnotationCaret
@@ -224,7 +227,8 @@ public static class AnnotationCaret
     /// phenomenon — more facts on a line means more distinct offsets on it — so
     /// 27,414 of those lines hold a single fact and 92.1% of them narrow, while
     /// narrowing falls to 12.1% at two facts, 1.1% at three, and 0% at four or
-    /// more. The lines this returns null for are precisely the dense ones.
+    /// more. Density is not the only reason this returns null, though: 2,156 of
+    /// the 6,012 null lines carry a single fact that has no extent at all.
     /// </remarks>
     static AnnotationAnchor.CaretExtent? Agreed(
         IReadOnlyList<IAnnotation> annotations,
@@ -263,11 +267,12 @@ public static class AnnotationCaret
     /// A line can be mixed: some facts are about an expression and some are only
     /// known to be about the statement. Widening the whole line because of the
     /// latter discards placement the anchoring layer successfully recovered for
-    /// the former — and the densest lines in the corpus are exactly the mixed
-    /// ones. <c>System.Tuple&lt;…&gt;.Equals</c> carries 16 facts of which 8
-    /// have an extent; widening renders one 331-column caret and attributes
-    /// nothing. So the placeable facts stack, and the rest are listed against
-    /// the line without a caret, which is precisely what is known about them.
+    /// the former, and 615 lines in the corpus are mixed — 499 of them with a
+    /// single surviving extent. <c>System.Tuple&lt;…&gt;.Equals</c> is the
+    /// extreme: 16 facts of which 8 have an extent, so widening renders one
+    /// 330-column caret and attributes nothing. So the placeable facts stack,
+    /// and the rest are listed against the line without a caret, which is
+    /// precisely what is known about them.
     /// </para>
     /// <para>
     /// Extents sharing a start column are always a nesting, so they can never
@@ -325,9 +330,12 @@ public static class AnnotationCaret
     /// <see cref="AnnotationAnchor.ComputeCaretExtents"/> worked to recover, so
     /// this either states it truthfully or marks that it could not. Measured
     /// over <c>System.Private.CoreLib</c> as the annotated-source view prints
-    /// it, this puts 2,557 of the 2,886 multi-extent lines (88.6%) on a single
-    /// row and none above four, with 3,949 of 6,986 trails (56.5%) at true
-    /// width.
+    /// it, by rendering each of the 3,385 lines that stack through this method
+    /// and reading the output back: 3,056 (90.3%) take a single row, 326 take
+    /// two, and three take more, none above four. Restricted to the 2,886
+    /// multi-extent lines, 2,557 (88.6%) take one row, and 3,949 of 6,986
+    /// trails (56.5%) render at true width. No stacked caret row is wider than
+    /// the code line it annotates, on any of those 3,385 lines.
     /// </remarks>
     static IReadOnlyList<string>? RenderStacked(
         List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)> groups,
@@ -351,7 +359,9 @@ public static class AnnotationCaret
         {
             // The gutter owns everything left of commentColumn + 2. A label that
             // will not fit after it cannot be drawn at the column it points at,
-            // and shifting it would make it point somewhere else.
+            // and shifting it would make it point somewhere else. This is a
+            // guard, not a path with known traffic: it fires on 0 of the 3,385
+            // CoreLib lines that stack.
             if (LabelStart(i) < commentColumn + 2)
                 return null;
 

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -288,9 +288,14 @@ public static class AnnotationCaret
     /// </para>
     /// <para>
     /// Extents sharing a start column are always a nesting, so they can never
-    /// share a row. Widest first makes each row narrower than the one above it,
-    /// so reading down the rows is zooming in, and it matches the order the
-    /// printer records nesting in.
+    /// share a row. Widest first puts the outer extent first, so the inner
+    /// caret is clipped into its parent's trail rather than overwriting it,
+    /// and it matches the order the printer records nesting in. That orders
+    /// <i>same-start</i> extents only. It does not make each row narrower than
+    /// the one above: a later disjoint extent can be packed onto a lower row
+    /// and reach further right than anything above it, which happens on 50 of
+    /// the 2,842 lines that stack in System.Private.CoreLib, as the
+    /// annotated-source view prints it, summed over the five focus families.
     /// </para>
     /// </remarks>
     static List<(AnnotationAnchor.CaretExtent Extent, List<IAnnotation> Facts)>? Stack(

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -236,7 +236,10 @@ public static class AnnotationCaret
     /// collected fact describes a render no invocation produces — 27,091 of
     /// 32,864 caret-bearing lines (82.43%) narrow to one agreed extent, 8.65%
     /// carry facts that disagree, and 8.92% have no fact with a printed node to
-    /// point at. Agreement is entirely a single-fact phenomenon here: 29,550 of
+    /// point at. Only the middle group changes geometry: the narrowing lines and
+    /// the no-extent lines both render as they do today, so 30,022 of the 32,864
+    /// (91.35%) are untouched. The 82.43% is the narrowing share, not the
+    /// unchanged share, and must not be quoted as the latter. Agreement is entirely a single-fact phenomenon here: 29,550 of
     /// those lines hold one fact and 91.7% of them narrow, while none of
     /// the 2,282 two-fact, 714 three-fact or 318 four-or-more-fact lines
     /// narrows. Two facts of one family on one line never share an extent in
@@ -383,7 +386,8 @@ public static class AnnotationCaret
     /// a structural immunity: the last trail on a row has no successor, so its
     /// clip limit is <c>int.MaxValue</c> and it renders at true width by
     /// construction. Those 2,842 lines occupy 3,144 rows, so 3,144 of the 3,884
-    /// could not have been clipped. Of the 3,422 trails that were actually
+    /// could not have been clipped, and they are 3,144 of the 3,884 counted as
+    /// rendering at true width. Of the 3,422 trails that were actually
     /// exposed to a successor, 740 (21.6%) survived at true width. Five of those
     /// are immune too, their extents being no longer than <c>MinTrail</c>, which
     /// row admission already reserves; among the 3,417 trails that could

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -6220,7 +6220,9 @@ public partial class CommandExecutionTests
             .ToList();
 
         // Still one caret row: all four extents are disjoint and short enough to
-        // pack onto a single line, which is the 88.6% case in CoreLib.
+        // pack onto a single line. That is the 88.6% case among the 2,886
+        // multi-extent lines of System.Private.CoreLib, as the annotated-source
+        // view prints it.
         int i = Assert.Single(caretIndexes);
         string caretRow = lines[i];
         string statement = lines[i - 1];

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -6220,9 +6220,10 @@ public partial class CommandExecutionTests
             .ToList();
 
         // Still one caret row: all four extents are disjoint and short enough to
-        // pack onto a single line. That is the 88.6% case among the 2,886
-        // multi-extent lines of System.Private.CoreLib, as the annotated-source
-        // view prints it.
+        // pack onto a single line. That is the 89.5% case among the 2,842 lines
+        // of System.Private.CoreLib that stack, as the annotated-source view
+        // prints it, summed over the five focus families and counted after the
+        // focus filter that --focus applies.
         int i = Assert.Single(caretIndexes);
         string caretRow = lines[i];
         string statement = lines[i - 1];

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -6202,12 +6202,13 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Member_AnnotatedSource_FocusWidensToTheStatementWhenFactsOnALineDisagree()
+    public async Task Member_AnnotatedSource_FocusStacksACaretPerExtentWhenFactsOnALineDisagree()
     {
-        // The density case, reproduced from System.Tuple`8.Equals: several facts
+        // The density case, reproduced from System.Tuple`8.Equals: four facts
         // land on one line at distinct offsets, so no single expression is true
-        // of all of them. The line is underlined once, statement-wide, and every
-        // fact gets its own detail row beneath.
+        // of all of them. This used to render one statement-wide underline with
+        // four unattributable details beneath it. Each extent now gets its own
+        // numbered caret, so a reader can tell which box is which.
         var (exit, output, _) = await RunAppAsync(
             "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
             "DenseBoxes:1", "--index", "1", "-S", "Annotated Source", "--focus", "allocation", "--tips", "q");
@@ -6215,28 +6216,41 @@ public partial class CommandExecutionTests
         Assert.Equal(0, exit);
         var lines = output.ReplaceLineEndings("\n").Split('\n');
         var caretIndexes = Enumerable.Range(0, lines.Length)
-            .Where(i => lines[i].Contains("^^^^", StringComparison.Ordinal))
+            .Where(i => lines[i].Contains('^', StringComparison.Ordinal))
             .ToList();
 
-        // One underline for the line, not one per fact. Stacking a row per
-        // distinct extent was tried and rejected; see AnnotationCaret.Agreed.
+        // Still one caret row: all four extents are disjoint and short enough to
+        // pack onto a single line, which is the 88.6% case in CoreLib.
         int i = Assert.Single(caretIndexes);
-
+        string caretRow = lines[i];
         string statement = lines[i - 1];
+
+        // Every caret points at the boxed argument it is about. This is the
+        // assertion the old statement-wide underline could not make.
+        var underlined = new List<string>();
+        for (int c = 0; c < caretRow.Length; c++)
+        {
+            if (caretRow[c] != '^' || (c > 0 && caretRow[c - 1] == '^'))
+                continue;
+            int width = caretRow.AsSpan(c).IndexOfAnyExcept('^');
+            width = width < 0 ? caretRow.Length - c : width;
+            underlined.Add(statement.Substring(c, width));
+        }
+
+        Assert.Equal(["a1", "a2", "a3", "a4"], underlined.ToArray());
+
+        // The statement-wide underline is precisely what must no longer appear.
         int statementStart = statement.Length - statement.AsSpan().TrimStart().Length;
-        int caretStart = lines[i].IndexOf('^');
-        int caretLength = lines[i].AsSpan(caretStart).IndexOfAnyExcept('^');
-        caretLength = caretLength < 0 ? lines[i].Length - caretStart : caretLength;
+        Assert.NotEqual(statementStart, caretRow.IndexOf('^'));
+        Assert.NotEqual(statement.Trim().Length, caretRow.Count(c => c == '^'));
 
-        // The statement is the smallest span that is true of all four facts, so
-        // widening to it is the correct answer here rather than a failure.
-        Assert.Equal(statementStart, caretStart);
-        Assert.Equal(statement.Trim().Length, caretLength);
-
-        // Each fact keeps its own detail rows under the shared underline: four
-        // boxes, four reports, none of them merged away.
-        foreach (string parameter in (string[])["T1", "T2", "T3", "T4"])
-            Assert.Contains($"alloc.box({parameter};", output, StringComparison.Ordinal);
+        // Each caret carries a number, and each number has its own detail rows,
+        // so all four boxes stay distinguishable rather than merged away.
+        foreach (var (number, parameter) in ((int, string)[])[(1, "T1"), (2, "T2"), (3, "T3"), (4, "T4")])
+        {
+            Assert.Contains($"{number}.^", caretRow, StringComparison.Ordinal);
+            Assert.Contains(lines, l => l.Contains($"{number}. alloc.box({parameter};", StringComparison.Ordinal));
+        }
 
         Assert.DoesNotContain(ILInspector.Decompiler.Annotations.AnnotationCaret.HoistMarker, output);
     }


### PR DESCRIPTION
Stacks a caret per fact extent instead of widening the line to the statement.
Slice of #3570. #3617 (caret extent narrowing), which this used to be stacked on, has
merged as `fbabdf6d0`; this now targets `main` directly. Design and rationale: #3657.

## The defect

`--focus` renders one caret per line. When the facts on a line pointed at
different characters, the caret widened to the whole statement: it pointed at
everything and therefore at nothing, above details with no way to tell which
detail belonged to which expression.

`System.Tuple<…>.Equals` is the extreme in CoreLib — 16 facts, one 370-column
caret, nothing attributed. The facts were right and the anchoring was right.
Only the render threw the information away.

## After

```text
    return comparer.Equals(a1, b1) && comparer.Equals(a2, b2) && comparer.Equals(a3, b3) && comparer.Equals(a4, b4);
//                       1.^^                       2.^^                       3.^^                       4.^^
//  1. alloc.box(T1; alloc=boxed T1; path=straight-line; path-confidence=dominates-return; …)
//  2. alloc.box(T2; alloc=boxed T2; path=branch; path-confidence=behind-branch; …)
//  3. alloc.box(T3; …)
//  4. alloc.box(T4; …)
```

That is the real render of `CommandCaretGestureFixture.DenseBoxes` through
`member … -S "Annotated Source" --focus allocation`, not a mockup.

Facts the anchoring layer could not place are listed under `-` rather than
widening the caret on their account. That is what lets a **mixed** line — some
facts with an extent, some without — keep the placement that was recovered:

```text
        Span<char> V_0 = stackalloc char[256];
    //                 1.^^^^^^^^^^^^^^^^^^^^
    //  1. lifetime.stack-bound(Span<char>)
    //  -  unsafe.stackalloc(byte*)
```

Both facts there are about `stackalloc char[256]`. Widening also underlined
`Span<char> V_0 = `, which neither fact claims. The `-` says the second fact has
no characters to point at — a different claim from "it is about the statement".

## The rules

1. Group facts **by extent**, not per fact — same characters, one caret, one number.
2. Order by start column, **widest first** at a tie. Extents sharing a start column
   are always a nesting and can never share a row, so the outer one goes above the
   inner one. That orders *same-start* extents only. It does **not** order row widths
   overall — a later disjoint extent can be packed onto a lower row and reach further
   right than anything above it, on 50 of the 2,842 lines — and it is the *reverse* of
   the order the printer records nesting in, which is descendants-before-ancestors.
3. Number in that order; the label sits immediately left of the trail.
4. Pack greedily onto rows.
5. Draw each trail at **true width**, clipped to `~` only where it would collide
   with the next label on its row.
6. List facts below, numbered to match, wrapped to `Budget`.
7. A fact with no extent is **listed, not drawn** — marked `-`. That holds only when
   the line stacks; a line rule 8 rejects widens and marks nothing.
8. **The gutter wins.** If any label would begin left of the comment gutter, the
   stacked layout is rejected for the whole line and it widens instead.

Width is information `ComputeCaretExtents` worked to recover, so rule 5 states it
truthfully or marks that it could not. Rule 4's two-column threshold is a *spill*
threshold, not a render floor: a one-character expression renders one caret, never
a padded two.

Design doc: `docs/design/caret-stacking.md` (separate PR).

## Why this layout and not a nicer one

The primary consumer is a terminal. A layout wider than the terminal wraps, and a
wrapped caret row lands under characters it has nothing to do with — worse than no
caret, because it actively misleads.

**Every stacked caret row lies within the code line it annotates**, and that is
*structural*, not a corpus result — an earlier revision of this section presented it as
a measurement, which is exactly backwards. `Stack` sends any extent reaching past the
line length to the unplaced list, labels grow leftward, and rule 8 bails rather than
shifting a trail right. No corpus could produce a counter-example.

The contrast with widening is narrower than two earlier revisions claimed. **No caret
glyph overhangs the code line in either render** — measured over the same 2,842 lines,
both are **0**, because the widening underline covers the trimmed statement, which ends
inside the line. What differs is the rendered *row*: widening appends the first detail
string to the caret row when it fits the inline budget, and on **all 20** of the lines
where that happens the text carries the row past the
end of the code line. Stacking never appends detail to a caret row, so it is 0. The
contrast is about where detail goes, not about bounding the underline.

All widths below are **final rendered columns**, measured after the same projection
`ApiOutputFormatter` applies — code lines receive `BodyIndentWidth`, hoisted caret
lines do not (`ApiOutputFormatter.cs:2504-2514`) — and the caret block is the
renderer's real output including detail rows, not a re-derived model. Two earlier
revisions of this section were withdrawn: one compared pre-projection code width against
post-hoist caret width and omitted detail rows; the other measured the whole population
instead of the focused one.

Whole rendered block, on the 2,842 lines this PR changes, old versus new:

| terminal | old (widen) | new (stacked) |
| --- | ---: | ---: |
| 80 cols | 23.3% | **23.4%** |
| 100 cols | 48.3% | 48.3% |
| 120 cols | 65.9% | 65.9% |
| 160 cols | 84.9% | 84.9% |

That denominator is padded, and the padding is most of it: a block can never be
narrower than its code line, so a line whose code alone overflows cannot fit under
*any* caret model. At 80 columns only **730 of the 2,842** have code that fits at all;
among those the rates are **90.5%** widening and **91.1%** stacked. At the wider
terminals the fit rate and the code-fits share converge almost exactly (100: 48.3% /
48.3%; 120: 65.9% / 66.0%; 160: 84.9% / 84.9%), which says the block width simply *is*
the code width there.

Terminal fit is unchanged, because on these dense lines the block width is set by the
code line and the wrapped detail rows (`Budget` = 100), which both renders share. Nor does the block
shrink: it is the same width on **91.8%** of these lines, narrower on **1.1%**, and
wider on **7.2%** — the numbered labels cost a few columns where the details were
already the widest thing in the block.

All three shares are padded, and three review rounds each found a different one, which
was the signal that shares were the wrong presentation. A block is never narrower than
its code line, so splitting on that floor settles it:

| population | unchanged | narrower | wider |
| --- | ---: | ---: | ---: |
| **2,612** pinned at the code width | 2,608 | — | 4 |
| **230** with headroom above it | 0 | 30 | 200 |

The "91.8% unchanged" is almost entirely the pinned population. Every line with room to
move moves, and 200 of the 230 move the wrong way. This also refuted my own earlier
correction — I had argued growth has no structural floor, and it does: only 4 of the
2,612 pinned blocks grow.

**Stacking buys attribution, and costs a little width.** Unpadded, fit goes 90.5% →
91.1% on the 730 lines that could fit. Block width moves only on the 230 with room to
move, 200 wider against 30 narrower. An
earlier revision claimed stacking "does not improve fit and does not narrow the block",
which was categorical where the data is marginal; and a revision before that claimed it
strictly improved fit, which was simply wrong.

The constraint still binds on the *alternatives*, which is why it is stated here.
Side-aligned annotations (each caret's text beside it) are the nicer picture, and were
mocked up against real CoreLib lines and rejected as the **default** purely on fit: they
overflow the code line on **97.52%** of the 29,933 lines carrying an extent, by a mean of
**81 columns** over the 29,191 that overflow, and fit **24.7%** of them at 80 columns —
**32.1%** unpadded — against **75.7%** for the bare
code.

## Measurements

CoreLib `11.0.0-preview.7.26366.102`, **annotated-source render** (the one `--focus`
produces), **summed over the five focus families** (`alloc`, `safety`, `cost`,
`lifetime`, `unsafe`).

Three hazards that silently corrupt figures here, all avoided. `ComputeSpans` must run
**after** `PrintRaised`, and an `IrFunction` must not be reused across renders (23 of
200 members render differently on a second `PrintRaised`). The third was found by
review, in an earlier revision of this very section: **the focus filter has to be
applied before anything is counted.** `ResearchViews.CollectFacts` returns every fact,
but `--focus` promotes only one family to carets, so counting pre-filter describes a
render no invocation produces. Earlier revisions of this PR body quoted that
pre-filter population (615 mixed / 499 single-extent / 3,385 stacking). Those numbers
were measured correctly and were answers to the wrong question. The figures below are
post-filter.

| | |
| --- | ---: |
| caret lines | 32,864 |
| …carrying at least one extent | 29,933 |
| …with a single distinct extent | 27,345 (91.4%) |
| …with two or more distinct extents | 2,588 (8.6%) |
| worst line | 8 distinct extents |
| mixed lines (facts with **and** without an extent) | 355 |
| …with exactly one surviving extent | 254 |

The worst line is 8 and it is reproducible by name — `System.Tuple`8.Equals` line 9
under `--focus alloc`, and `System.SpanHelpers.NonPackedContainsValueType` line 17 under
`--focus safety`. The distinct-extent distribution is 1: 27,345 · 2: 1,772 · 3: 608 ·
4: 135 · 5: 45 · 6: 19 · 7: 7 · 8: 2, and the multi-extent tail sums to 2,588.

### What this PR actually renders

The population that stacks is **2,842 lines** — the 2,588 multi-extent lines plus the
254 mixed single-extent lines that rule 7 promotes. Measured by calling
`AnnotationCaret.Render` on every one of them through the shipped geometry
(`hoist: true`, real member indent) and reading the output back:

| caret rows | lines | |
| --- | ---: | ---: |
| 1 | 2,543 | 89.5% |
| 2 | 297 | 10.5% |
| 3 | 1 | 0.0% |
| 4 | 1 | 0.0% |

That 89.5% is padded: 254 of these lines carry a single extent group and cannot occupy
two rows. Among the **2,588** lines with something to pack, **2,289 (88.4%)** take one
row.

**30,022 of the 32,864 caret lines (91.4%) keep today's geometry exactly** — the
complement of the 2,842 that stack. Two populations, unchanged for different reasons:
**27,091** narrow to one agreed extent, and **2,931** have no fact with an extent and
widen as they always did. An earlier revision quoted only the first (82.4%) as the
unchanged share, which dropped the entire no-extent population.

#### Trail widths, with the padding removed

3,884 of 6,566 trails (59.2%) render at true width. That headline is **padded by a
structural immunity** and review was right to reject it as a packing success rate: the
last trail on a row has no successor, so its clip limit is `int.MaxValue` and it renders
at true width *by construction*.

Measured rather than derived: those 2,842 lines occupy **3,144 rows**, and all **3,144
of 3,144** last-on-row trails render at true width — exactly as the derivation predicts.
Of the **3,422** trails actually exposed to a successor, 740 (21.6%) survived at true
width. Five of those are immune too — their extents are no longer than `MinTrail`, which
row admission already reserves — so among the **3,417** trails that could genuinely be
cut, **735 (21.5%)** survived and **2,682 (78.5%)** were clipped. It reconciles:
3,144 + 3,422 = 6,566 and 3,144 + 740 = 3,884.

Of those 2,682 clipped trails, the successor extent whose label does the clipping is
nested inside the trail on **1,867 (69.6%)** and wholly disjoint from it on **815
(30.4%)**. A disjoint successor still clips because its label is written two columns
left of the extent it belongs to. Clipping is concentrated at nestings but is not caused
by nesting — a trail is cut short only by the next label **on its own row**, and two
extents sharing a start column can never share a row, so a nested extent is never
positioned to clip its parent.

#### Widest-first does not order row widths

An earlier revision claimed reading down the rows was zooming in. It is not: a later
disjoint extent can be packed onto a lower row and reach further right than anything
above it. That happens on **50 of the 2,842** lines.

#### The stacked block never overhangs — structurally, not measurably

No stacked caret row is wider than the code line it annotates. This is **structural**,
so the corpus sweep confirming it could not have failed: `Stack` sends any extent with
`Column + Length > lineLength` to the unplaced list, labels grow leftward, and rule 8
bails rather than shifting a trail rightward.

The contrast with widening is narrower than it looks, and review corrected it twice.
**No caret glyph overhangs in either render** — 0 and 0 over the same 2,842 lines,
because widening underlines the trimmed statement, which ends inside the line. An
earlier revision claimed the widening underline "shifts rightward while preserving the
full extent length", which describes a mechanism that does not occur; the probe behind
it measured the whole rendered row, and on the widening path the first detail string is
appended *after* the caret, so it never measured a caret at all.

What differs is the rendered **row**. Widening appends that first detail string when it
fits the inline budget, carrying the row past the code line. Quoting this as **20 of
2,842 (0.70%)** pads the denominator with the 2,822 whose detail never goes inline and
so cannot overhang: inline detail appears on exactly **20** of these lines and **all 20**
overhang, so the rate is **20/20**. It is structural — widening underlines the whole
trimmed statement, so the caret ends where the code line ends, and anything appended
lands past it.

#### The whole-line fallback never fires — and the first probe for it was vacuous

`RenderStacked` returns null — discarding every caret on the line and widening — when an
extent starts too close to the gutter for its own label to fit.

The first probe for this **could not have detected it**. It tested for a rendered block
with no caret row, but falling back still renders the widening caret, so the reported
zero was unfalsifiable. Re-measured by testing for the absence of an `N.` label before
the caret run: **0 firings**, and the row histogram is unchanged.

The denominator was also circular in an earlier revision — "0 of the lines that stack"
is empty by construction, because a line the guard rejects does not stack. The 0 is over
the **2,842 lines that qualify to stack before the guard runs**.

Non-vacuity was then proved by mutating only the guard margin:

| margin | lines that hit the fallback |
| --- | ---: |
| `+2` (shipped) | 0 |
| `+6` | 306 |
| `+200` | 2,842 |

Graded, not binary. The guard is a real branch with a reachable boundary; this corpus
sits below it.

## Non-action boundary

- Lines whose facts **agree**, and lines carrying a single fact, keep exactly today's
  geometry including the inline-detail shortcut.
- Lines where **no** fact has an extent still widen — there is nothing to point at.
- `AnnotationAnchor` is untouched. No fact moves, no extent changes. This is a change
  to `AnnotationCaret` alone.
- The eight `alloc.box` facts on `Tuple`8.Equals`'s *first* operands still arrive
  without an extent. That is an anchoring gap this PR makes visible rather than causes.

## Validation

Five gates, each proven non-vacuous by mutation:

| gate | pins |
| --- | --- |
| `CaretsStackWhenTwoFactsOnTheLineDisagreeAboutTheExtent` | disagreement stacks rather than widens |
| `CaretIsDrawnAndFactsWithoutAnExtentAreMarkedWhenTheLineIsMixed` | the mixed line draws its caret and marks the rest `-` |
| `FactsSharingAnExtentShareOneCaretAndOneNumber` | rule 1: the unit is the extent, so two facts about the same characters get one caret and one number |
| `CaretStillWidensWhenNoFactOnTheLineHasAnExtent` | the boundary: a line with nothing placeable still widens |
| `Member_AnnotatedSource_FocusStacksACaretPerExtentWhenFactsOnALineDisagree` | end-to-end through the CLI: each caret underlines `a1`…`a4` |

Mutants, each rebuilt and re-run:

- restoring the old `Count: > 1` threshold kills **only** the mixed gate — so that gate
  pins the 254-line decision specifically and nothing else;
- disabling stacking entirely kills the first three;
- dropping `extents` at the CLI call site (`ResearchViews.cs:437`, passing `extents: null`)
  kills **only** the end-to-end gate: all 30 renderer gates stay green, because they call
  `AnnotationCaret.Render` directly and never exercise that wiring. So the CLI gate is not
  a duplicate of the renderer gates — it is the only thing pinning that the extents
  actually reach the renderer in the shipped path;
- replacing the extent-grouping lookup with a constant `-1`, so every fact gets its own
  caret, kills **only** `FactsSharingAnExtentShareOneCaretAndOneNumber`. Before that gate
  existed this mutant was **green on all 29 other tests**: rule 1 was ungated;
- relaxing the `Count: > 0` guard to `{ }` kills **only**
  `CaretStillWidensWhenNoFactOnTheLineHasAnExtent`, and only after that test was
  corrected. It previously passed an *empty* extent dictionary, which short-circuits
  inside `Stack` before the guard is reached, so it survived this mutant and gated
  nothing. It now passes the production shape — a member-wide dictionary carrying no
  entry for this line's facts.

Two of the five gates were therefore vacuous or absent until review pressed on them.

Suites (`dotnet run --project … -c Release`, since `dotnet test` runs zero tests here):

- Decompiler **4,713 / 0 failed / 0 skipped** at this head. Reproduced independently by
  a reviewer in its own worktree (4,713 / 0), and again by me after the rebase onto
  `main`. The base `fbabdf6d0` measures **4,711 / 0 failed / 0 skipped**, so the delta is
  **+2** — measured, not inferred from the diff. The figure rose from the 4,694 quoted in
  earlier revisions of this body because #3617 merged into the base and brought its own
  tests; it is not growth in this PR.
- CLI **2,794 total, 1 failed, 14 skipped** — `Layout_Count_CountsFilesRatherThanRenderedTreeLines`.
  That test lives in `CommandExecutionTests.cs`, which this PR edits, so "unrelated" was
  checked rather than asserted: `main` at `fbabdf6d0` produces **2,794 / 1 failed / 14
  skipped** with the same test failing. Identical totals, identical failure.

That +2 is exactly what the diff predicts: it adds four gates and
retires two older ones that pinned the widening behaviour it replaces
(`CaretWidensWhenTwoFactsOnTheLineDisagreeAboutTheExtent`,
`CaretWidensWhenOnlySomeFactsOnTheLineHaveAnExtent`). The CLI count is unchanged at +0 —
`Member_AnnotatedSource_FocusWidensToTheStatementWhenFactsOnALineDisagree` became
`Member_AnnotatedSource_FocusStacksACaretPerExtentWhenFactsOnALineDisagree`.

## What review changed

Ten rounds against fixed heads. The comments in this PR were wrong in eight places, and
every one was a claim about behaviour that had never been tested against the code
implementing it:

1. **Wrong population** — every figure was measured before the focus filter, describing a
   render no invocation produces (615/499/3,385 → 355/254/2,842).
2. **A vacuous gate** — the fallback probe tested for a missing caret row, but a fallback
   still renders the widening caret, so it could never fire.
3. **A second vacuous claim** — zero stacked overhang is structural, not measured.
4. **A circular denominator** — "0 of the lines that stack", when a rejected line does not
   stack by construction.
5. **A false structural claim** — widest-first does not order row widths (50 violations).
6. **A mechanism error** — clipping is caused by the next label on the row, not by nesting.
7. **A false provenance claim** — widest-first is the *reverse* of the printer's record
   order, which is descendants-before-ancestors.
8. **Padded denominators**, found in two passes — the 59.2% true-width rate counts 3,144
   trails structurally immune to clipping, and the 21.6% replacement still counted five
   more; the clip-capable rate is 21.5%. The 89.5% one-row rate counts 254 lines that
   cannot take two rows (88.4% among those that can), and the 82.43% agreement rate
   counts 29,550 single-fact lines that cannot disagree (0% among the 3,314 that can).
9. **A figure corrected into an error, twice** — the Tuple caret is **370** columns.
   It was recorded as 370, an earlier round "corrected" it to 330 on a recapture of the
   wrong render, and a falsification pass caught that and measured it back to 370. It
   survived because nothing else depended on it, so it stayed internally consistent
   while being false. Both the doc and the remark now say to re-derive it from the
   render, never from the surrounding prose.
10. **A false comparison** — no caret glyph overhangs the code line in *either* render.
   The 20 overhangs are whole-row, caused by inline detail text, and my probe had
   silently measured the detail along with the caret.

Plus two unqualified guarantees (the `-` marker holds only when the line stacks) and one
false mechanism for the widening overhang.

Two of the five gates were vacuous or absent until review pressed on them, and the
non-vacuity of the rule 8 guard is now demonstrated by margin mutation rather than
asserted.
