### PR TITLE
Specify the caret stacking display model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Section Model](design/section-model.md) | Section selection design notes; use with [Progressive Disclosure](design/progressive-disclosure.md). |
 | [Schema Query](design/schema-query.md) | `-D`/`-S` schema/query implementation notes. |
 | [Hidden-Fact Annotations](design/hidden-fact-annotations.md) | Allocation/unsafety/lifetime annotation model and the static IL pair-agreement oracle strategy. |
-| [Caret Stacking](design/caret-stacking.md) | `--focus` display model: one caret per fact extent, its text on the same row, uncapped alignment. |
+| [Caret Stacking](design/caret-stacking.md) | `--focus` display model: one caret per fact extent, packed onto as few rows as fit, with the numbered fact texts listed below. |
 | [Decompiler Inspection & Oracle](design/decompiler-inspection-oracle.md) | Unifies single-method inspection (dump/stages) with the corpus-wide fidelity check oracle; product-vs-tool scoping. |
 | [ReturnToSender: Fact-Planned Compile-Back Harness](design/fact-planned-compile-back-harness.md) | Spec for a fresh tools-side compile-back harness with fact-planned TypeProducer/TypePrinter shells. |
 | [Method Body Inspection](design/method-body-inspection.md) | Target service seam for shared `member` and `library --il-offset` method-body facts and coordinate inspection. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Section Model](design/section-model.md) | Section selection design notes; use with [Progressive Disclosure](design/progressive-disclosure.md). |
 | [Schema Query](design/schema-query.md) | `-D`/`-S` schema/query implementation notes. |
 | [Hidden-Fact Annotations](design/hidden-fact-annotations.md) | Allocation/unsafety/lifetime annotation model and the static IL pair-agreement oracle strategy. |
+| [Caret Stacking](design/caret-stacking.md) | `--focus` display model: one caret per fact extent, its text on the same row, uncapped alignment. |
 | [Decompiler Inspection & Oracle](design/decompiler-inspection-oracle.md) | Unifies single-method inspection (dump/stages) with the corpus-wide fidelity check oracle; product-vs-tool scoping. |
 | [ReturnToSender: Fact-Planned Compile-Back Harness](design/fact-planned-compile-back-harness.md) | Spec for a fresh tools-side compile-back harness with fact-planned TypeProducer/TypePrinter shells. |
 | [Method Body Inspection](design/method-body-inspection.md) | Target service seam for shared `member` and `library --il-offset` method-body facts and coordinate inspection. |

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -286,12 +286,19 @@ line the moment any one label would start left of the gutter, so a broad focus
 can fall back to widening on account of a single early fact while a narrower
 focus, having dropped that fact, stacks the two later extents successfully.
 Naming the guard's rate against the lines that *stack* would be circular, since
-a line rule 8 rejects does not stack by construction. Measured against the set
-that **qualifies** to stack before rule 8 runs, the guard fires on **0 of
-2,842** — so all 2,842 qualifying lines do stack, no such line exists in this
-corpus, and the 2,842 does bound every narrower argument over CoreLib. That is a
-measurement, not a consequence of subsetting, and it would have to be
-re-measured on another assembly.
+a line rule 8 rejects does not stack by construction. The measurement is against
+the set that **qualifies** to stack before rule 8 runs, and a fallback is
+detected by the shape of the row: a stacked row always carries an `N.` label
+immediately before its caret run, and the widening row never does. Detecting it
+as "the block has no caret row" would be vacuous, because a fallback still
+renders the widening caret.
+
+So counted, the guard fires on **0 of 2,842** qualifying lines: all 2,842 do
+stack. That the gate can report a non-zero was checked by mutation — raising the
+guard's margin from `commentColumn + 2` to `+ 6` makes it fire on 306 of the
+2,842, and to `+ 200` on all 2,842. The zero is a property of the corpus, not of
+the probe. It is still a measurement rather than a consequence of subsetting,
+and it would have to be re-measured on another assembly.
 
 The bound is also specific to the **stacks** column. The other columns are not
 monotone in the same direction: dropping one of two disagreeing extents turns a
@@ -340,7 +347,7 @@ exactly where extents nest. The rule 8 gutter fallback fires on **0** of the
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `a14d3ddce`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `40bb4411d`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -12,6 +12,11 @@ which characters a fact is about — is described in
 per-fact extents already exist and are already correct; today's renderer
 discards them.
 
+Every figure in this document comes from the corpus named under
+[Measurements](#measurements): `System.Private.CoreLib`
+`11.0.0-preview.7.26366.102`, rendered by the annotated-source view. Extents
+are measured in printed characters, so the render is part of the figure.
+
 ## The problem
 
 `AnnotationCaret.Agreed` returns an extent only when every fact on the line
@@ -21,7 +26,7 @@ several different sub-expressions, that produces a caret that points at
 everything and therefore at nothing, above a stack of details with no way to
 tell which detail belongs to which expression.
 
-`System.Tuple<…>.Equals` is the worst real case in CoreLib — 16 facts, one
+`System.Tuple<…>.Equals` is the worst real case in the corpus — 16 facts, one
 330-column caret:
 
 ```csharp
@@ -141,8 +146,9 @@ the bare code.
 ### Mixed lines
 
 A **mixed** line carries facts of both kinds: some with an extent, some
-without. There are 615 of them in CoreLib, and 499 have exactly one surviving
-extent, so this is not a corner.
+without. There are 615 of them in the corpus, and 499 have exactly one
+surviving extent, so this is not a corner. (The overlay render is a different
+population: 609 and 498.)
 
 Today they widen. The reasoning was sound while a caret was the only signal
 available: narrowing to the one surviving extent would underline an expression

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -188,9 +188,14 @@ trimmed statement, which ends inside the line. The widening render has no
 explicit bound, but it does not need one to stay within the line.
 
 What differs is the rendered **row**. Widening appends the first detail string
-to the caret row when it fits the inline budget, and on **20 lines (0.70%)**
-that appended text carries the row past the end of the code line. Stacking never
-appends detail to a caret row, so it is 0. The contrast is about where detail is
+to the caret row when it fits the inline budget, and that appended text carries
+the row past the end of the code line. Quoting this as **20 of 2,842 lines
+(0.70%)** pads the denominator with the 2,822 whose detail never goes inline and
+which therefore cannot overhang at all. Inline detail appears on exactly **20**
+of these lines, and **all 20** overhang — the rate is **20/20**, and it is
+structural rather than lucky: widening underlines the whole trimmed statement,
+so the caret ends where the code line ends and anything appended after it is
+past the end. Stacking never appends detail to a caret row, so it is 0. The contrast is about where detail is
 placed, not about bounding the underline — and the earlier claim that the
 widening underline "shifts rightward while preserving the full extent length"
 described a mechanism that does not occur.
@@ -437,7 +442,7 @@ fires on **0** of the 2,842 lines qualifying to stack before it runs.
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `89c56d1bd`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `102c73f8f`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -81,12 +81,13 @@ depicts a layout that was never built. This one is
    for its 16 facts.
 2. **Order by start column, widest first at a tie.** Extents sharing a start
    column are always a nesting, so they cannot share a row; widest-first puts
-   the outer one first, so the inner caret is clipped into its parent's trail
-   rather than overwriting it, and it matches the order the printer records
-   nesting in. This orders *same-start* extents only and says nothing about row
-   widths overall: a later disjoint extent can be packed onto a lower row and
-   reach further right than anything above it, which happens on **50 of the
-   2,842** lines.
+   the outer one on the upper row, which matches the order the printer records
+   nesting in. This orders *same-start* extents only, and it is not what causes
+   clipping — a trail is only ever cut short by the next label **on its own
+   row** (rule 5), and a nested extent that lands on a different row is not on
+   its parent's row to cut anything. Nor does it order row widths overall: a
+   later disjoint extent can be packed onto a lower row and reach further right
+   than anything above it, which happens on **50 of the 2,842** lines.
 3. **Number in that order,** `1.` upward, and label each caret with its number
    immediately before the trail.
 4. **Pack greedily onto rows.** An extent joins the first row where the
@@ -292,7 +293,9 @@ equal here. On an assembly that produced them, `semantics` would be a strict
 superset of `safety` and would need measuring separately.
 
 Any other argument is a narrower id prefix, such as `alloc.box`, and selects a
-strict subset of one family. Dropping facts can only remove distinct extents and
+subset of one family — not necessarily a *strict* one, since `safety.callee` is
+the only `safety.*` descriptor CoreLib produces and so selects exactly what
+`safety` does. Dropping facts can only remove distinct extents and
 remove extent-less facts, and a line qualifies to stack only when it has two of
 the former or one of each — so the *qualifying* set shrinks under a subset.
 
@@ -356,14 +359,17 @@ Applying the specification to the 2,842 lines that stack:
 | 3 | 1 | 0.0% |
 | 4 | 1 | 0.0% |
 
-3,884 of 6,566 trails (59.2%) render at true width. Clipping concentrates
-exactly where extents nest. The rule 8 gutter fallback fires on **0** of the
-2,842 lines qualifying to stack before it runs.
+3,884 of 6,566 trails (59.2%) render at true width. The other 2,682 are cut
+short by the next label on their own row, which is the only thing that clips a
+trail. That successor is nested inside the trail it clips on **1,867 (69.6%)**
+of them and wholly disjoint from it on **815 (30.4%)**, so clipping is
+concentrated at nestings but is not confined to them. The rule 8 gutter fallback
+fires on **0** of the 2,842 lines qualifying to stack before it runs.
 
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `3d0e2afb0`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `8fa2bf44a`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -80,9 +80,13 @@ depicts a layout that was never built. This one is
    together under it. Under `--focus alloc`, `Tuple.Equals` renders 8 carets
    for its 16 facts.
 2. **Order by start column, widest first at a tie.** Extents sharing a start
-   column are always a nesting, so they cannot share a row; widest-first makes
-   each row narrower than the one above, and matches the order the printer
-   records nesting in.
+   column are always a nesting, so they cannot share a row; widest-first puts
+   the outer one first, so the inner caret is clipped into its parent's trail
+   rather than overwriting it, and it matches the order the printer records
+   nesting in. This orders *same-start* extents only and says nothing about row
+   widths overall: a later disjoint extent can be packed onto a lower row and
+   reach further right than anything above it, which happens on **50 of the
+   2,842** lines.
 3. **Number in that order,** `1.` upward, and label each caret with its number
    immediately before the trail.
 4. **Pack greedily onto rows.** An extent joins the first row where the
@@ -110,7 +114,9 @@ depicts a layout that was never built. This one is
    when any label on a line would begin left of the gutter, that line does not
    stack at all: it falls back to the widening render this document replaces.
    This is a guard rather than a path with traffic — it fires on **0 of the
-   2,842 lines that stack** in the corpus below — but it is reachable, and a
+   2,842 lines that qualify to stack** in the corpus below, which is the
+   non-circular denominator, since a line it rejects does not stack by
+   construction — but it is reachable, and a
    line is never rendered with a label that lies about its column.
 
 Rule 4's two-column threshold is a *spill* threshold, not a render floor: a
@@ -352,12 +358,12 @@ Applying the specification to the 2,842 lines that stack:
 
 3,884 of 6,566 trails (59.2%) render at true width. Clipping concentrates
 exactly where extents nest. The rule 8 gutter fallback fires on **0** of the
-2,842.
+2,842 lines qualifying to stack before it runs.
 
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `2294697d9`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `3d0e2afb0`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -269,8 +269,11 @@ extent still has nothing to point at, so it widens exactly as before.
 - Lines whose focused facts all agree on one extent, and lines carrying a
   single focused fact, keep exactly today's geometry, including the
   inline-detail shortcut. That is **27,091 lines, 90.5%** of those carrying an
-  extent; see [Measurements](#measurements) for how that is counted and why the
-  focus family has to be named before the number means anything.
+  extent. Adding the **2,931** lines where no fact has an extent, which also
+  render exactly as they do today, **30,022 of 32,864 caret lines (91.4%) are
+  untouched** and 2,842 (8.6%) change; see [Measurements](#measurements) for how
+  that is counted and why the focus family has to be named before the number
+  means anything.
 - A fact whose expression has no printed node, or prints on a continuation
   line, still gets no extent. What changes is only how it is *shown* on a line
   where some other fact does have one, and only when that line stacks: it is
@@ -360,10 +363,13 @@ render is not a claim about anything.
 
 A line stacks when its focused facts disagree about the extent, or when some
 carry one and some do not: 2,588 multi-extent lines plus the 254 mixed lines
-with a single surviving extent gives **2,842**. Everything else — **27,091
-lines, 90.5%** of the 29,933 carrying an extent, or **82.4%** of all 32,864
-caret lines — keeps exactly today's geometry, including the inline-detail
-shortcut.
+with a single surviving extent gives **2,842**. Everything else — **30,022
+lines, 91.4%** of all 32,864 caret lines — keeps exactly today's geometry,
+including the inline-detail shortcut. Two populations make up that remainder and
+they keep it for different reasons: **27,091** lines narrow to one agreed extent,
+and **2,931** lines have no fact with an extent at all and widen exactly as they
+do today. An earlier revision quoted only the first of those as "everything
+else", which understated the unchanged share by the whole no-extent population.
 
 `--focus lifetime` never stacks: no line in CoreLib carries two lifetime facts
 that disagree about the extent. The gesture is worth having anyway, but this
@@ -388,7 +394,8 @@ padded by a structural immunity and should not be read as a packing success
 rate. The last trail on a row has no successor, so its clip limit is
 `int.MaxValue` and it renders at true width by construction. Those 2,842 lines
 occupy **3,144 rows**, so 3,144 of the 6,566 trails could not have been clipped —
-and measurement confirms all 3,144 render at true width. Of the **3,422** trails
+they are 3,144 of the 3,884 counted as rendering at true width, and measurement
+confirms all 3,144 do. Of the **3,422** trails
 actually exposed to a successor, 740 (21.6%) survived at true width. Five of
 those are immune as well, their extents being no longer than `MinTrail`, which
 row admission already reserves. Among the **3,417** trails that could genuinely
@@ -405,7 +412,7 @@ fires on **0** of the 2,842 lines qualifying to stack before it runs.
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `5e73a22bb`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `21b57ab91`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -226,17 +226,28 @@ code-fits share converge almost exactly (100 cols: 48.3% fit, 48.3% code-fits;
 the code width there.
 
 Terminal fit is unchanged, because on these dense lines the block width is set
-by the code line and the wrapped detail rows, which both models share. Nor does the block itself
-shrink: it is the same width on 91.8% of these lines, narrower on 1.1%, and
-wider on 7.2% — the numbered labels cost a few columns where the details were
-already the widest thing in the block.
+by the code line and the wrapped detail rows, which both models share. Nor does
+the block itself shrink much: it is the same width on 91.8% of these lines,
+narrower on 1.1%, and wider on 7.2% — the numbered labels cost a few columns
+where the details were already the widest thing in the block.
 
-**Stacking buys attribution, and essentially nothing else.** There is no
-material aggregate improvement in either fit or block width: 1.1% of blocks do
-get narrower and the 80-column fit does tick from 23.3% to 23.4%, but those are
-rounding-scale movements against a 7.2% share that gets wider. The honest
-summary is that fit and block width are unchanged, and this document should not
-claim more.
+That 1.1% is padded, and by an order of magnitude. A block is never narrower
+than its code line, so a block already *at* the code width cannot shrink at all,
+and **2,612 of the 2,842 are**. Only **230** could shrink; **30** did, which is
+**13.0%**, not 1.1%. The 7.2% that get wider are not padded the same way — any
+block can grow — so the two shares are not comparable as stated, and the
+narrowing is a real effect on the small population where narrowing is even
+possible.
+
+**Stacking buys attribution, and little else.** Fit does not move: unpadded, the
+80-column rate goes from 90.5% to 91.1% on the 730 lines that could fit, and the
+padded 23.3% → 23.4% should not be quoted as the takeaway when the partitioned
+figures sit a paragraph above. Block width moves on a small population and in
+both directions: 13.0% of the blocks that could narrow do, against 7.2% of all
+blocks getting wider. The honest summary is that neither fit nor block width
+changes materially in aggregate, and this document should not claim more — but
+it should not claim the narrowing is rounding noise either, because on the
+lines where narrowing is possible it is not.
 
 The constraint still binds on the *alternatives*, which is why it is stated
 here: side-alignment overflows the code line on 96.61% of the 29,933 lines
@@ -553,9 +564,15 @@ Compact, supposedly. An earlier revision claimed a 4-wide trail fits 87.5% of
 multi-extent lines on one row. That figure has no probe behind it anywhere and
 does not reproduce, so it is withdrawn rather than replaced: a fixed-width
 packer is not implemented here, and two independent reconstructions of what it
-would do disagreed with each other (88.4% and 87.2% on the same corpus). The
-honest statement is that its packing advantage over the shipped model is
-unmeasured and was never established. Nothing below depends on it.
+would do disagreed with each other (88.4% and 87.2% on the same corpus).
+
+It can be settled without a figure, though, and against the alternative. Row
+admission reserves `Math.Min(Extent.Length, MinTrail)` columns — capped at
+`MinTrail`, which is 2. **The shipped packer is already width-independent above
+two columns**: a trail's real width never affects whether the next one joins its
+row. A fixed 4-wide trail would reserve *more*, so it packs no better than what
+ships and, where it reserves 4 against a 2-column extent, worse. The claimed
+compactness advantage runs backwards.
 
 Rejected because it **misstates width**. A 4-wide trail under the single
 character `y` in `ArgumentOutOfRangeException(varName, y, …)` claims a

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -26,16 +26,20 @@ several different sub-expressions, that produces a caret that points at
 everything and therefore at nothing, above a stack of details with no way to
 tell which detail belongs to which expression.
 
-`System.Tuple<…>.Equals` is the worst real case in the corpus — 16 facts, one
-330-column caret:
-
-The line is 330 columns wide, so it is elided here at the `…`:
+`System.Tuple<…>.Equals` is the worst real case in the corpus. Under
+`--focus alloc` its comparison line carries 16 facts under a single caret 370
+columns wide, above 106 wrapped detail rows, and attributes none of them. The
+code line is 374 columns, so it is elided here at the `…`:
 
 ```csharp
-return comparer.Equals(m_Item1, V_0.m_Item1) && comparer.Equals(m_Item2, V_0.m_Item2) && … (330 cols)
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (330 carets)
-//   alloc.box(T1; …)   ×16, unattributed
+    return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, … (374 cols)
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (370 carets)
+//   alloc.box(T1; alloc=boxed T1; path=branch; path-confidence=behind-branch; …  ×16, unattributed
 ```
+
+Under the model specified below the same line renders 8 numbered carets on a
+single row, with 8 of the 16 facts attributed to the expression each is about
+and the other 8 marked `-`.
 
 The facts are right. The anchoring is right. Only the render throws the
 information away.
@@ -60,8 +64,8 @@ depicts a layout that was never built. This one is
 [Reproducing these figures](#reproducing-these-figures).
 
 ```csharp
-    if (!V_0.IsMemberRef && !V_0.IsMethodDef && !V_0.IsTypeSpec && !V_0.IsSignature && !V_0.IsFieldDef)
-//     1.^^^^^^^^^^^^^^^   2.^^^^^^^^^^^^^^^   3.^^^^^^^^^^^^^^   4.^^^^^^^^^^^^^^^   5.^^^^^^^^^^^^^^
+    if (!tk.IsMemberRef && !tk.IsMethodDef && !tk.IsTypeSpec && !tk.IsSignature && !tk.IsFieldDef)
+//     1.^^^^^^^^^^^^^^   2.^^^^^^^^^^^^^^   3.^^^^^^^^^^^^^   4.^^^^^^^^^^^^^^   5.^^^^^^^^^^^^^
 //  1. cost.callee(callee get_IsMemberRef: reflection)
 //  2. cost.callee(callee get_IsMethodDef: reflection)
 //  3. cost.callee(callee get_IsTypeSpec: reflection)
@@ -73,7 +77,8 @@ depicts a layout that was never built. This one is
 
 1. **Group facts by extent.** The unit is the extent, not the fact. Facts about
    the same characters share one caret and one number, their texts listed
-   together under it. `Tuple.Equals` renders 8 carets for its 16 facts.
+   together under it. Under `--focus alloc`, `Tuple.Equals` renders 8 carets
+   for its 16 facts.
 2. **Order by start column, widest first at a tie.** Extents sharing a start
    column are always a nesting, so they cannot share a row; widest-first makes
    each row narrower than the one above, and matches the order the printer
@@ -105,7 +110,7 @@ depicts a layout that was never built. This one is
    when any label on a line would begin left of the gutter, that line does not
    stack at all: it falls back to the widening render this document replaces.
    This is a guard rather than a path with traffic — it fires on **0 of the
-   3,385 lines that stack** in the corpus below — but it is reachable, and a
+   2,842 lines that stack** in the corpus below — but it is reachable, and a
    line is never rendered with a label that lies about its column.
 
 Rule 4's two-column threshold is a *spill* threshold, not a render floor: a
@@ -143,39 +148,43 @@ worse than no caret, because it is actively misleading.
 
 Every caret lies within the code line and a row cannot extend past its last
 caret, so **a stacked caret row never adds width the code line did not already
-have.** Measured on all 3,385 lines this model changes: 0 have a stacked caret
-row wider than their code line, against 137 (4.05%) under the widening render
-it replaces.
+have.** Measured on all 2,842 lines this model changes: 0 have a stacked caret
+row wider than their code line, against 20 (0.70%) under the widening render it
+replaces.
 
 Widths below are **final rendered columns**, measured after the same projection
 `ApiOutputFormatter` applies — code lines receive `BodyIndentWidth`, hoisted
 caret lines do not — and the caret block is real rendered output, detail rows
-included. Whole rendered block on those 3,385 lines:
+included. Whole rendered block on those 2,842 lines:
 
 | terminal | widen (today) | stacked |
 | --- | ---: | ---: |
-| 80 cols | 27.8% | 28.0% |
-| 100 cols | 53.3% | 53.3% |
-| 120 cols | 69.5% | 69.5% |
-| 160 cols | 86.5% | 86.5% |
+| 80 cols | 23.3% | 23.4% |
+| 100 cols | 48.3% | 48.3% |
+| 120 cols | 65.9% | 65.9% |
+| 160 cols | 84.9% | 84.9% |
 
 Terminal fit is unchanged, because on these dense lines the block width is set
-by the wrapped detail rows, which both models share. What changes is the block:
-91.0% narrower, 0.4% the same, 8.6% wider. So stacking buys attribution at no
-cost in fit — it does not improve fit, and this document should not claim it
-does.
+by the wrapped detail rows, which both models share. Nor does the block itself
+shrink: it is the same width on 91.8% of these lines, narrower on 1.1%, and
+wider on 7.2% — the numbered labels cost a few columns where the details were
+already the widest thing in the block.
+
+**Stacking buys attribution, and nothing else.** It does not improve fit, it
+does not narrow the block, and this document should not claim either.
 
 The constraint still binds on the *alternatives*, which is why it is stated
-here: side-alignment overflows the code line on 97.28% of caret-bearing lines
-by a mean of 81 columns, and fits 25.4% of them at 80 columns against 76.5% for
-the bare code.
+here: side-alignment overflows the code line on 96.61% of the 29,933 lines
+carrying an extent, by a mean of 77 columns, and fits 28.1% of them at 80
+columns against 75.7% for the bare code.
 
 ### Mixed lines
 
 A **mixed** line carries facts of both kinds: some with an extent, some
-without. There are 615 of them in the corpus, and 499 have exactly one
-surviving extent, so this is not a corner. (The overlay render is a different
-population: 609 and 498.)
+without. Summed over the five focus families there are 355 of them, and 254
+have exactly one surviving extent, so this is not a corner. They are not spread
+evenly: 298 fall under `--focus alloc`, 47 under `safety`, 10 under `cost`, and
+none at all under `unsafe` or `lifetime`.
 
 Today they widen. The reasoning was sound while a caret was the only signal
 available: narrowing to the one surviving extent would underline an expression
@@ -184,29 +193,32 @@ ambiguity that argument rests on — an extent-less fact is now visibly marked
 `-` rather than silently sharing an underline — so the surviving extent is
 drawn.
 
-The dominant shape, and the reason this matters, is `stackalloc` — here in
-`Interop.CallStringMethod` under `--focus lifetime`, first as it renders today:
+A throw helper in `System.MemoryExtensions` is the shape this matters for.
+Under `--focus alloc` it renders today as:
 
 ```csharp
-    Span<char> V_0 = stackalloc char[256];
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//   unsafe.stackalloc(byte*)
-//   lifetime.stack-bound(Span<char>)
+    throw new ArgumentNullException((lowInclusive) is null ? "lowInclusive" : "highInclusive");
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//   alloc.box(T; alloc=boxed T; path=straight-line)
+//   alloc.new(ArgumentNullException; alloc=System.ArgumentNullException; path=error-path;
+//   escape=throw-path; multiplicity=conditional)
 ```
 
-Both facts are about `stackalloc char[256]`, but only `lifetime.stack-bound`
-carries an extent; `AnnotationAnchor` does not place `unsafe.stackalloc`. So the
-`-` is a statement about *this pipeline's* knowledge, not about the fact — it
-says no characters were identified for it, which is weaker than and different
-from a claim that it covers the whole statement. Widening, meanwhile,
-underlines `Span<char> V_0 =` as well, which neither fact claims. Under
-rule 7:
+The `alloc.new` is about `new ArgumentNullException(…)` and carries an extent.
+The `alloc.box` is about the boxing of `lowInclusive` for the `is null` test,
+and `AnnotationAnchor` does not place it. Widening underlines the `throw`
+keyword as well, which neither fact claims, and gives the reader no way to tell
+that only one of the two facts was ever located. The `-` is a statement about
+*this pipeline's* knowledge, not about the fact: it says no characters were
+identified, which is weaker than and different from a claim that the fact
+covers the whole statement. Under rule 7:
 
 ```csharp
-    Span<char> V_0 = stackalloc char[256];
-//                 1.^^^^^^^^^^^^^^^^^^^^
-//  1. lifetime.stack-bound(Span<char>)
-//  -  unsafe.stackalloc(byte*)
+    throw new ArgumentNullException((lowInclusive) is null ? "lowInclusive" : "highInclusive");
+//      1.^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//  1. alloc.new(ArgumentNullException; alloc=System.ArgumentNullException; path=error-path;
+//     escape=throw-path; multiplicity=conditional)
+//  -  alloc.box(T; alloc=boxed T; path=straight-line)
 ```
 
 The `-` is doing real work here: it says the second fact has no characters to
@@ -215,12 +227,11 @@ point at, which is a different claim from "it is about the whole statement".
 Stacking needs at least one placeable fact. A line where *no* fact has an
 extent still has nothing to point at, so it widens exactly as before.
 
-- Lines whose facts all agree on one extent, and lines carrying a single fact,
-  keep exactly today's geometry, including the inline-detail shortcut. That is
-  25,628 lines: **88.3%** of the 29,013 lines carrying at least one extent, or
-  **81.0%** of all 31,640 caret-bearing lines. (It is *not* 90.1% — that is the
-  single-distinct-extent share, 26,127 of 29,013, and 499 of those are mixed
-  lines whose geometry does change. See [Measurements](#measurements).)
+- Lines whose focused facts all agree on one extent, and lines carrying a
+  single focused fact, keep exactly today's geometry, including the
+  inline-detail shortcut. That is **27,091 lines, 90.5%** of those carrying an
+  extent; see [Measurements](#measurements) for how that is counted and why the
+  focus family has to be named before the number means anything.
 - A fact whose expression has no printed node, or prints on a continuation
   line, still gets no extent. What changes is only how it is *shown* on a line
   where some other fact does have one: it is marked `-` instead of widening the
@@ -231,39 +242,57 @@ extent still has nothing to point at, so it widens exactly as before.
 ## Measurements
 
 CoreLib `11.0.0-preview.7.26366.102`, measured on the **annotated-source**
-render (`importMethodBody: ImportMethodBody`) — the one `--focus` produces.
+render — the one `--focus` produces.
+
+Two things decide what these figures mean, and both were got wrong in an
+earlier draft of this document:
+
+- **The focus filter comes first.** `--focus` promotes only the facts of the
+  requested family to carets; everything else stays a side comment and never
+  reaches `AnnotationCaret`. Counting every collected fact describes a render
+  no invocation produces, and inflates every figure here. Each line below is
+  counted **after** the filter, once per family.
+- **A user asks for one family at a time,** so there is no single corpus-wide
+  population. The totals are sums over the five families, and a line carrying
+  both an `alloc` and a `safety` fact is counted once under each — because that
+  is two different renders, and it is the render that is being measured.
+
 Extents are measured in printed characters, so a figure that does not name its
 render is not a claim about anything.
 
-| | |
-| --- | ---: |
-| caret-bearing lines | 31,640 |
-| …carrying at least one extent | 29,013 |
-| …with a single distinct extent | 26,127 (90.1%) |
-| …with two or more distinct extents | 2,886 (9.9%) |
-| worst line | 8 distinct extents |
+| focus | caret lines | …with an extent | single extent | multi-extent | mixed | stacks |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `alloc` | 14,789 | 12,744 | 12,367 | 377 | 298 | 594 |
+| `safety` | 13,908 | 13,480 | 11,452 | 2,028 | 47 | 2,057 |
+| `cost` | 2,516 | 2,444 | 2,277 | 167 | 10 | 175 |
+| `lifetime` | 928 | 800 | 800 | 0 | 0 | 0 |
+| `unsafe` | 723 | 465 | 449 | 16 | 0 | 16 |
+| **total** | **32,864** | **29,933** | **27,345** | **2,588** | **355** | **2,842** |
 
-Of the 26,127 single-extent lines, all but 499 carry no extent-less fact and so
-keep today's geometry exactly — 25,628 lines, the 88.3% quoted above. The 499 are the mixed lines of rule 7, which gain a
-drawn caret and a `-` row where they previously widened:
+A line stacks when its focused facts disagree about the extent, or when some
+carry one and some do not: 2,588 multi-extent lines plus the 254 mixed lines
+with a single surviving extent gives **2,842**. Everything else — **27,091
+lines, 90.5%** of the 29,933 carrying an extent, or **82.4%** of all 32,864
+caret lines — keeps exactly today's geometry, including the inline-detail
+shortcut.
 
-| | |
-| --- | ---: |
-| mixed lines (facts both with and without an extent) | 615 |
-| …with exactly one surviving extent | 499 |
-| …with two or more | 116 |
+`--focus lifetime` never stacks: no line in CoreLib carries two lifetime facts
+that disagree about the extent. The gesture is worth having anyway, but this
+model is invisible under it, and a claim measured over all facts at once would
+have hidden that.
 
-Applying the specification above to those 2,886 multi-extent lines:
+Applying the specification to the 2,842 lines that stack:
 
 | rows | lines | |
 | --- | ---: | ---: |
-| 1 | 2,557 | 88.6% |
-| 2 | 326 | 11.3% |
-| 3 | 2 | 0.1% |
+| 1 | 2,543 | 89.5% |
+| 2 | 297 | 10.5% |
+| 3 | 1 | 0.0% |
 | 4 | 1 | 0.0% |
 
-3,949 of 6,986 trails (56.5%) render at true width, and 527 lines (18.3%) have
-no clipped trail at all. Clipping concentrates exactly where extents nest.
+3,884 of 6,566 trails (59.2%) render at true width. Clipping concentrates
+exactly where extents nest. The rule 8 gutter fallback fires on **0** of the
+2,842.
 
 ### Reproducing these figures
 
@@ -274,17 +303,28 @@ Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:
 
 ```bash
-dotnet-inspect member "System.Reflection.RuntimeModule" ResolveSignature \
-    --all --focus cost -S "Annotated Source"
-dotnet-inspect member "System.Globalization.HebrewCalendar" CheckHebrewYearValue \
-    --all --focus alloc -S "Annotated Source"
-dotnet-inspect member "System.Numerics.Vector" IsSubnormal \
-    --all --focus safety -S "Annotated Source"
-dotnet-inspect member "Interop" CallStringMethod \
-    --all --focus lifetime -S "Annotated Source"
+dotnet-inspect member RuntimeModule ResolveSignature \
+    --all --platform System.Private.CoreLib --focus cost -S "Annotated Source"
+dotnet-inspect member HebrewCalendar CheckHebrewYearValue \
+    --all --platform System.Private.CoreLib --focus alloc -S "Annotated Source"
+dotnet-inspect member Vector IsSubnormal \
+    --all --platform System.Private.CoreLib --focus safety -S "Annotated Source"
+dotnet-inspect member MemoryExtensions ThrowNullLowHighInclusive \
+    --all --platform System.Private.CoreLib --focus alloc -S "Annotated Source"
+dotnet-inspect member "System.Tuple<T1,T2,T3,T4,T5,T6,T7,TRest>" Equals:1 \
+    --all --platform System.Private.CoreLib --focus alloc -S "Annotated Source"
 ```
 
-`--all` is required: all but one of these members are non-public.
+Both flags matter. `--all` is required because all but one of these members are
+non-public. `--platform System.Private.CoreLib` is required because without it
+`RuntimeModule` does not resolve at all and `Interop`-style names resolve to a
+different assembly — and because the platform scope loads the PDB, so locals
+print as `tk` and `buffer` rather than `V_0`. A render taken without it will
+disagree with every snippet here.
+
+The two blocks labelled as today's render are the **widening** renderer, which
+is the behaviour this document replaces; they were taken at `f26fa8e0a`, the
+commit before the implementation.
 
 Columns in a snippet are **final rendered columns**, which is not the geometry
 the research render produces. Three coordinate systems exist and mixing them is
@@ -331,8 +371,9 @@ in this document the following is a mockup, not a render:
 ```
 
 Rejected as *the* style on measurement, not taste: aligning after the widest
-caret pushes text a mean **81 columns** past the end of the code line and
-overflows it on **97.28%** of caret lines, leaving 25.4% intact at 80 columns.
+caret pushes text a mean **77 columns** past the end of the code line and
+overflows it on **96.61%** of the lines carrying an extent, leaving 28.1%
+intact at 80 columns against 75.7% for the bare code.
 Its annotation column exceeds 100 on 10.5% of lines, with a maximum of 57,942
 on `IcuLocaleData.get_NameIndexToNumericData` — the pathological line already
 filed as #3610. It wraps three lines in four, and the wrap destroys the very

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -192,10 +192,13 @@ to the caret row when it fits the inline budget, and that appended text carries
 the row past the end of the code line. Quoting this as **20 of 2,842 lines
 (0.70%)** pads the denominator with the 2,822 whose detail never goes inline and
 which therefore cannot overhang at all. Inline detail appears on exactly **20**
-of these lines, and **all 20** overhang — the rate is **20/20**, and it is
-structural rather than lucky: widening underlines the whole trimmed statement,
-so the caret ends where the code line ends and anything appended after it is
-past the end. Stacking never appends detail to a caret row, so it is 0. The contrast is about where detail is
+of these lines, and **all 20** overhang — the rate is **20/20**. It comes out
+whole because on the hoisted render these figures are taken from, widening
+underlines the whole trimmed statement, so the caret ends where the code line
+ends and any appended text lands past it. That is not a universal guarantee and
+is not claimed as one: a fact whose formatted text is empty appends nothing, and
+an un-hoisted render can clamp `pad` to its floor of 1 and push the caret past
+the code with no detail appended at all. Stacking never appends detail to a caret row, so it is 0. The contrast is about where detail is
 placed, not about bounding the underline — and the earlier claim that the
 widening underline "shifts rightward while preserving the full extent length"
 described a mechanism that does not occur.
@@ -442,7 +445,7 @@ fires on **0** of the 2,842 lines qualifying to stack before it runs.
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `102c73f8f`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `9d4b6a12a`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -146,11 +146,21 @@ The primary consumer is a terminal. A layout wider than the terminal wraps, and
 a wrapped caret row lands underneath characters it has nothing to do with —
 worse than no caret, because it is actively misleading.
 
-Every caret lies within the code line and a row cannot extend past its last
-caret, so **a stacked caret row never adds width the code line did not already
-have.** Measured on all 2,842 lines this model changes: 0 have a stacked caret
-row wider than their code line, against 20 (0.70%) under the widening render it
-replaces.
+**A stacked caret row never adds width the code line did not already have.**
+That is a structural guarantee rather than a lucky corpus. `Stack` sends any
+extent with `Column + Length > lineLength` to the unplaced list, so every caret
+it does place ends within the line; labels are grown leftward from the column
+they point at, and rule 8 refuses to shift a trail rightward to make room,
+bailing out instead. The rightmost column of a stacked row is therefore bounded
+by the code line by construction.
+
+The corpus agrees — 0 of the 2,842 lines carry a stacked caret row wider than
+their code line — but that count is a consistency check on the derivation above,
+not evidence for it, because no corpus could produce a counter-example. The
+comparison figure is the one that carries information: the widening render this
+replaces overhangs on **20 lines (0.70%)**, because it shifts the caret's start
+column rightward while preserving the full extent length, which is exactly the
+freedom stacking gives up.
 
 Widths below are **final rendered columns**, measured after the same projection
 `ApiOutputFormatter` applies — code lines receive `BodyIndentWidth`, hoisted
@@ -347,7 +357,7 @@ exactly where extents nest. The rule 8 gutter fallback fires on **0** of the
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `40bb4411d`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `2294697d9`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -81,8 +81,13 @@ depicts a layout that was never built. This one is
    for its 16 facts.
 2. **Order by start column, widest first at a tie.** Extents sharing a start
    column are always a nesting, so they cannot share a row; widest-first puts
-   the outer one on the upper row, which matches the order the printer records
-   nesting in. This orders *same-start* extents only, and it is not what causes
+   the outer one on the upper row, so reading down the rows moves inward. That
+   is a presentation choice, and it is the *reverse* of the order the printer
+   records nesting in — `RecordExpressionRanges` reverses its parent-first walk
+   precisely so a node is recorded after every one of its descendants, the
+   descendants-before-ancestors contract the anchor depends on. Nothing here
+   inherits that order.
+   This orders *same-start* extents only, and it is not what causes
    clipping — a trail is only ever cut short by the next label **on its own
    row** (rule 5), and a nested extent that lands on a different row is not on
    its parent's row to cut anything. Nor does it order row widths overall: a
@@ -108,7 +113,8 @@ depicts a layout that was never built. This one is
    fact keeps its place in the list below the carets, marked `-` instead of a
    number. A line may carry both kinds at once — a **mixed** line — and
    stacking still engages: the placeable facts get numbered carets, the rest
-   are listed under `-`.
+   are listed under `-`. This holds only when the line actually stacks; if
+   rule 8 rejects the layout the line widens and *no* fact on it is marked.
 8. **The gutter wins.** A label is drawn immediately before the characters it
    points at, so a caret near the start of a line can push its label left into
    the comment gutter. Moving the label would make it point somewhere else, so
@@ -165,9 +171,14 @@ The corpus agrees — 0 of the 2,842 lines carry a stacked caret row wider than
 their code line — but that count is a consistency check on the derivation above,
 not evidence for it, because no corpus could produce a counter-example. The
 comparison figure is the one that carries information: the widening render this
-replaces overhangs on **20 lines (0.70%)**, because it shifts the caret's start
-column rightward while preserving the full extent length, which is exactly the
-freedom stacking gives up.
+replaces overhangs on **20 lines (0.70%)**. Its underline is not any fact's
+extent — on a line whose facts disagree there is no agreed extent, so it falls
+back to `new CaretExtent(statementColumn, trimmed.Length)`, the whole trimmed
+statement — and it is positioned at
+`pad = Math.Max(1, caretColumn - commentColumn - 2)`, whose floor of 1 pushes
+the underline rightward when the statement starts near the gutter. Nothing then
+bounds or clips it against the line. That absence of any bound, not the
+underline's length, is what stacking gives up.
 
 Widths below are **final rendered columns**, measured after the same projection
 `ApiOutputFormatter` applies — code lines receive `BodyIndentWidth`, hoisted
@@ -255,8 +266,10 @@ extent still has nothing to point at, so it widens exactly as before.
   focus family has to be named before the number means anything.
 - A fact whose expression has no printed node, or prints on a continuation
   line, still gets no extent. What changes is only how it is *shown* on a line
-  where some other fact does have one: it is marked `-` instead of widening the
-  caret. Lines where no fact has an extent widen exactly as today.
+  where some other fact does have one, and only when that line stacks: it is
+  marked `-` instead of widening the
+  caret. Lines where no fact has an extent widen exactly as today, as do lines
+  rule 8 rejects.
 - Detail text stays left-aligned and wrapped to `Budget`.
 - `AnnotationAnchor` is untouched. This is a change to `AnnotationCaret` alone.
 
@@ -359,8 +372,17 @@ Applying the specification to the 2,842 lines that stack:
 | 3 | 1 | 0.0% |
 | 4 | 1 | 0.0% |
 
-3,884 of 6,566 trails (59.2%) render at true width. The other 2,682 are cut
-short by the next label on their own row, which is the only thing that clips a
+3,884 of 6,566 trails (59.2%) render at true width, but that headline rate is
+padded by a structural immunity and should not be read as a packing success
+rate. The last trail on a row has no successor, so its clip limit is
+`int.MaxValue` and it renders at true width by construction. Those 2,842 lines
+occupy **3,144 rows**, so 3,144 of the 6,566 trails could not have been clipped —
+and measurement confirms all 3,144 render at true width. Of the **3,422** trails
+actually exposed to a successor, only **740 (21.6%)** survived at true width;
+**2,682 (78.4%)** were cut short. The exposed rate is the informative one.
+
+A trail is cut
+short by the next label on its own row, which is the only thing that clips a
 trail. That successor is nested inside the trail it clips on **1,867 (69.6%)**
 of them and wholly disjoint from it on **815 (30.4%)**, so clipping is
 concentrated at nestings but is not confined to them. The rule 8 gutter fallback
@@ -369,7 +391,7 @@ fires on **0** of the 2,842 lines qualifying to stack before it runs.
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `1d39ad054`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `6f8adac49`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -325,12 +325,15 @@ extent still has nothing to point at, so it widens exactly as before.
   that is counted and why the focus family has to be named before the number
   means anything. That denominator is the whole shipped population on purpose —
   the claim is how much existing output this changes, not a rate of some
-  outcome among the cases capable of it. Read the other way it is a mechanism
-  rather than a measurement: 27,091 + 2,931 is exactly 30,022, so the 2,842 is
-  precisely the complement, and **every line that can stack does**. `Agreed`
-  returns null on exactly the lines this model treats differently — any fact
-  missing an extent, or two extents disagreeing — so the two populations are
-  the same set by construction, not by coincidence.
+  outcome among the cases capable of it. Read the other way it is close to a
+  mechanism: 27,091 + 2,931 is exactly 30,022, so the 2,842 is precisely the
+  complement, and **every line that can stack does**. The selector is
+  `Stack(...) is { Count: > 0 }`, not `Agreed`: `Agreed` returns null on
+  **5,773** lines, but 2,931 of those have no extent at all and so render
+  unchanged, leaving exactly the 2,842. The remaining gap is `Agreed`'s final
+  bounds check, which could in principle reject a line that agrees; it rejects
+  **0** on this corpus, so the identity is exact here by measurement rather
+  than guaranteed by construction.
 - A fact whose expression has no printed node, or prints on a continuation
   line, still gets no extent. What changes is only how it is *shown* on a line
   where some other fact does have one, and only when that line stacks: it is
@@ -562,19 +565,25 @@ in this document the following is a mockup, not a render:
 //                   ^^^^^^^^^^^^^^^^^^^^  lifetime.stack-bound(Span<char>)
 ```
 
-Rejected as *the* style on measurement, not taste: aligning after the widest
-caret pushes text a mean **77 columns** past the end of the code line and
-overflows it on **96.61%** of the lines carrying an extent, leaving 28.1%
-intact at 80 columns against 75.7% for the bare code — or **36.4%** once the
-denominator is restricted to the 22,662 lines whose bare code fits at all.
+Rejected as *the* style on measurement, not taste. Every figure here is one
+row per fact with a one-column gap after the widest caret, which is what the
+sketch above shows; a two-column gap moves each of them by a few tenths and
+changes nothing. Aligning after the widest caret pushes text a mean **77
+columns** past the end of the code line and overflows it on **96.61%** of the
+lines carrying an extent, leaving 28.1% intact at 80 columns against 75.7%
+for the bare code — or **36.4%** once the denominator is restricted to the
+22,662 lines whose bare code fits at all. The other 63.6% of those lines wrap,
+and the wrap destroys the very adjacency that motivates the style. Quoting a
+wrap rate over all 29,933 lines instead would read 71.9%, but 7,271 of them
+overflow 80 columns before any annotation is added and wrap whatever style is
+chosen, so that number measures the corpus rather than the style.
 Its annotation column exceeds 100 on 10.5% of lines, with a maximum of 57,942
 on `IcuLocaleData.get_NameIndexToNumericData` — the pathological line already
 filed as #3610. That number is derived, not measured directly: the line is
-**57,940** characters, one extent covers all of it, and the style above sets
-text two columns past the caret. At a one-column gap it is 57,941; the gap is
-a style parameter, so the line length is the figure that means anything. It
-wraps 71.9% of lines, and the wrap destroys the very adjacency that motivates
-it. The obvious first candidate for a wide style.
+**57,940** characters, one extent covers all of it, and 57,942 is where a
+two-column gap would land. At the one-column gap used everywhere else here it
+is 57,941. The gap is a style parameter, so the line length is the figure that
+means anything. The obvious first candidate for a wide style.
 
 ### Constant-width caret trails
 

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -594,9 +594,10 @@ extent under the five focus families.
   **57,940** characters, one extent covers all of it, and 4 + 57,940 + 2 is
   57,946. The line length is the figure that survives a change of convention.
 
-At a one-column gap every number above moves by under a point (97.20%, 25.3%,
-33.0%, 11.8%, 87.2%, 57,945) and the rejection is unaffected. The obvious
-first candidate for a wide style.
+At a one-column gap every percentage above moves by under one percentage point
+(97.20%, 25.3%, 33.0%, 11.8%, 87.2%) and the maximum column moves by one, to
+57,945; the counts behind them shift, but the rejection is unaffected. The
+obvious first candidate for a wide style.
 
 ### Constant-width caret trails
 

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -27,20 +27,28 @@ everything and therefore at nothing, above a stack of details with no way to
 tell which detail belongs to which expression.
 
 `System.Tuple<…>.Equals` is the worst real case in the corpus. Under
-`--focus alloc` its comparison line carries 16 facts under a single caret 330
+`--focus alloc` its comparison line carries 16 facts under a single caret 370
 columns wide, above 32 wrapped detail rows, and attributes none of them. The
-code line is 330 columns, reaching final column 334 after the body indent, so it
+code line is 370 columns, reaching final column 374 after the body indent, so it
 is elided here at the `…`:
 
 ```csharp
-    return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, … (330 cols)
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (330 carets)
+    return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, … (370 cols)
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (370 carets)
 //   alloc.box(T1; alloc=boxed T1; path=branch; path-confidence=behind-branch; …  ×16, unattributed
 ```
 
 Under the model specified below the same line renders 8 numbered carets on a
 single row, with 8 of the 16 facts attributed to the expression each is about
-and the other 8 marked `-`.
+and the other 8 marked `-`. The block does not grow: both renders are one caret
+row above the same 32 detail rows, and the stacked caret row ends at column 372
+rather than 374.
+
+> This width has now been mis-stated in two directions across review rounds —
+> recorded as 370, "corrected" to 330, and measured back to 370. It is 370. The
+> value was re-derived from the render itself rather than from agreement with
+> the rest of this document; internal consistency was what let the wrong value
+> survive. Re-measure before changing it again.
 
 The facts are right. The anchoring is right. Only the render throws the
 information away.
@@ -58,7 +66,7 @@ of them.
 
 Every code block showing behaviour that exists is verbatim `Annotated Source`
 output rather than a sketch. The two exceptions are marked where they appear:
-the `Tuple.Equals` line below is elided because it is 330 columns wide, and the
+the `Tuple.Equals` line below is elided because it is 370 columns wide, and the
 side-aligned block under [Rejected alternatives](#side-aligned-annotations)
 depicts a layout that was never built. This one is
 `System.Reflection.RuntimeModule.ResolveSignature` under `--focus cost`; see
@@ -199,8 +207,18 @@ included. Whole rendered block on those 2,842 lines:
 | 120 cols | 65.9% | 65.9% |
 | 160 cols | 84.9% | 84.9% |
 
+That denominator is padded, and the padding is most of it: the block can never
+be narrower than the code line, so a line whose code alone overflows the
+terminal cannot fit under *any* caret model. At 80 columns only 730 of the 2,842
+have code that fits at all — the other 2,112 are structurally incapable of the
+outcome being counted. Restricted to the 730 that could fit, the rates are 90.5%
+widening and 91.1% stacked. At the wider terminals the padded rate and the
+code-fits share converge almost exactly (100 cols: 48.3% fit, 48.3% code-fits;
+120: 65.9% / 66.0%; 160: 84.9% / 84.9%), which says the block width simply *is*
+the code width there.
+
 Terminal fit is unchanged, because on these dense lines the block width is set
-by the wrapped detail rows, which both models share. Nor does the block itself
+by the code line and the wrapped detail rows, which both models share. Nor does the block itself
 shrink: it is the same width on 91.8% of these lines, narrower on 1.1%, and
 wider on 7.2% — the numbered labels cost a few columns where the details were
 already the widest thing in the block.
@@ -367,9 +385,16 @@ with a single surviving extent gives **2,842**. Everything else — **30,022
 lines, 91.4%** of all 32,864 caret lines — keeps exactly today's geometry,
 including the inline-detail shortcut. Two populations make up that remainder and
 they keep it for different reasons: **27,091** lines narrow to one agreed extent,
-and **2,931** lines have no fact with an extent at all and widen exactly as they
-do today. An earlier revision quoted only the first of those as "everything
-else", which understated the unchanged share by the whole no-extent population.
+and **2,931** lines have no fact with an extent at all and widen to output
+identical to today's. An earlier revision quoted only the first of those as
+"everything else", which understated the unchanged share by the whole no-extent
+population.
+
+"Unchanged" here is a claim about rendered output, not about the code path. A
+no-extent line now enters `Stack`, which walks the facts, finds no extent for
+any of them, collects them all as unplaced and returns an empty group list; the
+`{ Count: > 0 }` guard then fails and the widening branch runs exactly as
+before. The bytes are the same; the work done to reach them is not.
 
 `--focus lifetime` never stacks: no line in CoreLib carries two lifetime facts
 that disagree about the extent. The gesture is worth having anyway, but this
@@ -412,7 +437,7 @@ fires on **0** of the 2,842 lines qualifying to stack before it runs.
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `21b57ab91`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `89c56d1bd`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -276,10 +276,27 @@ equal here. On an assembly that produced them, `semantics` would be a strict
 superset of `safety` and would need measuring separately.
 
 Any other argument is a narrower id prefix, such as `alloc.box`, and selects a
-strict subset of one family. Stacking cannot increase under a subset: dropping
-facts can only remove distinct extents and remove extent-less facts, and a line
-stacks only when it has two of the former or one of each. So the figures below
-are an upper bound on what any `--focus` argument produces.
+strict subset of one family. Dropping facts can only remove distinct extents and
+remove extent-less facts, and a line qualifies to stack only when it has two of
+the former or one of each — so the *qualifying* set shrinks under a subset.
+
+That is not by itself enough to make the **stacks** column an upper bound,
+because rule 8 is not monotone. `RenderStacked` returns `null` for the whole
+line the moment any one label would start left of the gutter, so a broad focus
+can fall back to widening on account of a single early fact while a narrower
+focus, having dropped that fact, stacks the two later extents successfully.
+Rule 8 fires on **0 of the 2,842** lines that stack under any of the five
+families here, so no such line exists in this corpus and the 2,842 does bound
+every narrower argument over CoreLib — but that is a measurement, not a
+consequence of subsetting, and it would have to be re-measured on another
+assembly.
+
+The bound is also specific to the **stacks** column. The other columns are not
+monotone in the same direction: dropping one of two disagreeing extents turns a
+multi-extent line into a single-extent line, so `single extent` can *rise* under
+a narrower focus even as `multi-extent` and `stacks` fall. Read the table as
+what the five documented arguments produce, and the 2,842 as the corpus-measured
+ceiling on the rest.
 
 Extents are measured in printed characters, so a figure that does not name its
 render is not a claim about anything.
@@ -321,7 +338,7 @@ exactly where extents nest. The rule 8 gutter fallback fires on **0** of the
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `8c17dcb35`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `372c15593`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -430,8 +430,15 @@ groups — the ones with something to pack — **2,289 (88.4%)** take a single r
 And 2,588 is padded in turn, by a structural fact stated earlier in this
 document: extents sharing a start column can never share a row. **136** of those
 lines carry two distinct extents at one column and so cannot take a single row
-whatever the packer does. Among the **2,452** that can, the rate is **2,289
+whatever the packer does. Among the remaining **2,452** the rate is **2,289
 (93.4%)**.
+
+"Remaining" rather than "able to": 163 of those 2,452 also fail, refused by row
+admission because their extents sit too close together. They are left in
+deliberately. Crowding is what this rate exists to measure, so excluding lines
+for being crowded would drive it to 100% and measure nothing. A shared start
+column is excluded because it is a different phenomenon — two extents anchored
+at one column are a nesting, not a packing failure.
 
 3,884 of 6,566 trails (59.2%) render at true width, but that headline rate is
 padded by a structural immunity and should not be read as a packing success
@@ -456,7 +463,7 @@ fires on **0** of the 2,842 lines qualifying to stack before it runs.
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `3e13e5e24`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `721adb61a`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:
@@ -542,13 +549,13 @@ adjacency that motivates it. The obvious first candidate for a wide style.
 ### Constant-width caret trails
 
 Render every caret at a fixed width so packing depends only on start columns.
-Compact — but not more compact than what ships. An earlier revision claimed a
-4-wide trail fits 87.5% of multi-extent lines on one row, with no probe behind
-it; the figure does not reproduce. Packing 4-wide trails by start column with a
-one-column gap fits **2,289 of 2,588** (88.4%), or **93.4%** of the 2,452 that
-are not forced onto multiple rows by a shared start column — which is exactly
-what the shipped variable-width model achieves on the same corpus. Fixing the
-width buys no packing.
+Compact, supposedly. An earlier revision claimed a 4-wide trail fits 87.5% of
+multi-extent lines on one row. That figure has no probe behind it anywhere and
+does not reproduce, so it is withdrawn rather than replaced: a fixed-width
+packer is not implemented here, and two independent reconstructions of what it
+would do disagreed with each other (88.4% and 87.2% on the same corpus). The
+honest statement is that its packing advantage over the shipped model is
+unmeasured and was never established. Nothing below depends on it.
 
 Rejected because it **misstates width**. A 4-wide trail under the single
 character `y` in `ArgumentOutOfRangeException(varName, y, …)` claims a

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -369,7 +369,7 @@ fires on **0** of the 2,842 lines qualifying to stack before it runs.
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `8fa2bf44a`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `1d39ad054`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -323,7 +323,14 @@ extent still has nothing to point at, so it widens exactly as before.
   render exactly as they do today, **30,022 of 32,864 caret lines (91.4%) are
   untouched** and 2,842 (8.6%) change; see [Measurements](#measurements) for how
   that is counted and why the focus family has to be named before the number
-  means anything.
+  means anything. That denominator is the whole shipped population on purpose —
+  the claim is how much existing output this changes, not a rate of some
+  outcome among the cases capable of it. Read the other way it is a mechanism
+  rather than a measurement: 27,091 + 2,931 is exactly 30,022, so the 2,842 is
+  precisely the complement, and **every line that can stack does**. `Agreed`
+  returns null on exactly the lines this model treats differently — any fact
+  missing an extent, or two extents disagreeing — so the two populations are
+  the same set by construction, not by coincidence.
 - A fact whose expression has no printed node, or prints on a continuation
   line, still gets no extent. What changes is only how it is *shown* on a line
   where some other fact does have one, and only when that line stacks: it is
@@ -562,8 +569,12 @@ intact at 80 columns against 75.7% for the bare code — or **36.4%** once the
 denominator is restricted to the 22,662 lines whose bare code fits at all.
 Its annotation column exceeds 100 on 10.5% of lines, with a maximum of 57,942
 on `IcuLocaleData.get_NameIndexToNumericData` — the pathological line already
-filed as #3610. It wraps 71.9% of lines, and the wrap destroys the very
-adjacency that motivates it. The obvious first candidate for a wide style.
+filed as #3610. That number is derived, not measured directly: the line is
+**57,940** characters, one extent covers all of it, and the style above sets
+text two columns past the caret. At a one-column gap it is 57,941; the gap is
+a style parameter, so the line length is the figure that means anything. It
+wraps 71.9% of lines, and the wrap destroys the very adjacency that motivates
+it. The obvious first candidate for a wide style.
 
 ### Constant-width caret trails
 

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -257,6 +257,21 @@ earlier draft of this document:
   both an `alloc` and a `safety` fact is counted once under each — because that
   is two different renders, and it is the render that is being measured.
 
+Those five families cover every argument that can widen this table. They
+**partition** the corpus: `alloc`, `unsafe`, `lifetime`, `cost` and `safety`
+select 16,328 + 749 + 928 + 2,820 + 17,041 facts, which is exactly the 37,866
+facts CoreLib yields, with no fact in two families and none outside them.
+`AnnotationGestureSelector.Focus` also matches a category name, and those are
+aliases of the same sets — `allocation` selects the same 16,328 as `alloc`,
+`unsafety` the same 749 as `unsafe`, and `semantics` the same 17,041 as
+`safety`.
+
+Any other argument is a narrower id prefix, such as `alloc.box`, and selects a
+strict subset of one family. Stacking cannot increase under a subset: dropping
+facts can only remove distinct extents and remove extent-less facts, and a line
+stacks only when it has two of the former or one of each. So the figures below
+are an upper bound on what any `--focus` argument produces.
+
 Extents are measured in printed characters, so a figure that does not name its
 render is not a claim about anything.
 

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -231,23 +231,31 @@ the block itself shrink much: it is the same width on 91.8% of these lines,
 narrower on 1.1%, and wider on 7.2% — the numbered labels cost a few columns
 where the details were already the widest thing in the block.
 
-That 1.1% is padded, and by an order of magnitude. A block is never narrower
-than its code line, so a block already *at* the code width cannot shrink at all,
-and **2,612 of the 2,842 are**. Only **230** could shrink; **30** did, which is
-**13.0%**, not 1.1%. The 7.2% that get wider are not padded the same way — any
-block can grow — so the two shares are not comparable as stated, and the
-narrowing is a real effect on the small population where narrowing is even
-possible.
+Those three shares are all padded, and quoting any of them as a rate invites the
+next correction. A block is never narrower than its code line, so a block already
+*at* the code width can only stay or grow. Splitting on that floor says far more
+than the percentages did:
 
-**Stacking buys attribution, and little else.** Fit does not move: unpadded, the
-80-column rate goes from 90.5% to 91.1% on the 730 lines that could fit, and the
-padded 23.3% → 23.4% should not be quoted as the takeaway when the partitioned
-figures sit a paragraph above. Block width moves on a small population and in
-both directions: 13.0% of the blocks that could narrow do, against 7.2% of all
-blocks getting wider. The honest summary is that neither fit nor block width
-changes materially in aggregate, and this document should not claim more — but
-it should not claim the narrowing is rounding noise either, because on the
-lines where narrowing is possible it is not.
+| population | unchanged | narrower | wider |
+| --- | ---: | ---: | ---: |
+| **2,612** pinned at the code width | 2,608 | — | 4 |
+| **230** with headroom above it | 0 | 30 | 200 |
+
+Nothing happens on the pinned 2,612: four blocks grow and the rest are untouched.
+Every one of the 230 with headroom changes, and 200 of them get wider. So the
+aggregate "91.8% unchanged" is almost entirely the pinned population, and the
+real behaviour is confined to the 230. Growth turns out to be floor-limited too
+— 4 of 2,612 — so the earlier claim that "any block can grow", used to argue the
+shares were comparable, was wrong as well.
+
+**Stacking buys attribution, and costs a little width.** Fit does not move:
+unpadded, the 80-column rate goes from 90.5% to 91.1% on the 730 lines that could
+fit. Block width moves only on the 230 lines that have room to move, and it moves
+the wrong way far more often than the right one — 200 wider against 30 narrower.
+Stated as counts within one population that is a clear result, and it is not the
+one the percentages suggested: the earlier text called the narrowing rounding
+noise and set 1.1% against 7.2%, which compared two shares of a denominator
+dominated by lines that could do neither.
 
 The constraint still binds on the *alternatives*, which is why it is stated
 here: side-alignment overflows the code line on 96.61% of the 29,933 lines
@@ -554,7 +562,7 @@ intact at 80 columns against 75.7% for the bare code — or **36.4%** once the
 denominator is restricted to the 22,662 lines whose bare code fits at all.
 Its annotation column exceeds 100 on 10.5% of lines, with a maximum of 57,942
 on `IcuLocaleData.get_NameIndexToNumericData` — the pathological line already
-filed as #3610. It wraps three lines in four, and the wrap destroys the very
+filed as #3610. It wraps 71.9% of lines, and the wrap destroys the very
 adjacency that motivates it. The obvious first candidate for a wide style.
 
 ### Constant-width caret trails
@@ -566,13 +574,16 @@ does not reproduce, so it is withdrawn rather than replaced: a fixed-width
 packer is not implemented here, and two independent reconstructions of what it
 would do disagreed with each other (88.4% and 87.2% on the same corpus).
 
-It can be settled without a figure, though, and against the alternative. Row
-admission reserves `Math.Min(Extent.Length, MinTrail)` columns — capped at
-`MinTrail`, which is 2. **The shipped packer is already width-independent above
-two columns**: a trail's real width never affects whether the next one joins its
-row. A fixed 4-wide trail would reserve *more*, so it packs no better than what
-ships and, where it reserves 4 against a 2-column extent, worse. The claimed
-compactness advantage runs backwards.
+One thing about it can be settled without a figure, because it is a fact about
+the *shipped* packer rather than the unbuilt one. Row admission reserves
+`Math.Min(Extent.Length, MinTrail)` columns — capped at `MinTrail`, which is 2 —
+and nothing else in the admission test reads a length. **The shipped packer is
+already width-independent above two columns**: a trail's real width never affects
+whether the next one joins its row. So there is no packing headroom for a
+fixed-width variant to recover by narrowing trails; a variant that reserved four
+columns would admit strictly less. Whether such a model could win by *grouping*
+differently — merging distinct extents that share a start column, which this
+model keeps separate — is a real question and is not answered here.
 
 Rejected because it **misstates width**. A 4-wide trail under the single
 character `y` in `ArgumentOutOfRangeException(varName, y, …)` claims a

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -285,11 +285,13 @@ because rule 8 is not monotone. `RenderStacked` returns `null` for the whole
 line the moment any one label would start left of the gutter, so a broad focus
 can fall back to widening on account of a single early fact while a narrower
 focus, having dropped that fact, stacks the two later extents successfully.
-Rule 8 fires on **0 of the 2,842** lines that stack under any of the five
-families here, so no such line exists in this corpus and the 2,842 does bound
-every narrower argument over CoreLib — but that is a measurement, not a
-consequence of subsetting, and it would have to be re-measured on another
-assembly.
+Naming the guard's rate against the lines that *stack* would be circular, since
+a line rule 8 rejects does not stack by construction. Measured against the set
+that **qualifies** to stack before rule 8 runs, the guard fires on **0 of
+2,842** — so all 2,842 qualifying lines do stack, no such line exists in this
+corpus, and the 2,842 does bound every narrower argument over CoreLib. That is a
+measurement, not a consequence of subsetting, and it would have to be
+re-measured on another assembly.
 
 The bound is also specific to the **stacks** column. The other columns are not
 monotone in the same direction: dropping one of two disagreeing extents turns a
@@ -338,7 +340,7 @@ exactly where extents nest. The rule 8 gutter fallback fires on **0** of the
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `372c15593`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `a14d3ddce`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -28,7 +28,7 @@ tell which detail belongs to which expression.
 
 `System.Tuple<…>.Equals` is the worst real case in the corpus. Under
 `--focus alloc` its comparison line carries 16 facts under a single caret 370
-columns wide, above 106 wrapped detail rows, and attributes none of them. The
+columns wide, above 32 wrapped detail rows, and attributes none of them. The
 code line is 374 columns, so it is elided here at the `…`:
 
 ```csharp
@@ -57,7 +57,7 @@ of them.
 
 Every code block showing behaviour that exists is verbatim `Annotated Source`
 output rather than a sketch. The two exceptions are marked where they appear:
-the `Tuple.Equals` line below is elided because it is 330 columns wide, and the
+the `Tuple.Equals` line below is elided because it is 374 columns wide, and the
 side-aligned block under [Rejected alternatives](#side-aligned-annotations)
 depicts a layout that was never built. This one is
 `System.Reflection.RuntimeModule.ResolveSignature` under `--focus cost`; see
@@ -170,8 +170,12 @@ shrink: it is the same width on 91.8% of these lines, narrower on 1.1%, and
 wider on 7.2% — the numbered labels cost a few columns where the details were
 already the widest thing in the block.
 
-**Stacking buys attribution, and nothing else.** It does not improve fit, it
-does not narrow the block, and this document should not claim either.
+**Stacking buys attribution, and essentially nothing else.** There is no
+material aggregate improvement in either fit or block width: 1.1% of blocks do
+get narrower and the 80-column fit does tick from 23.3% to 23.4%, but those are
+rounding-scale movements against a 7.2% share that gets wider. The honest
+summary is that fit and block width are unchanged, and this document should not
+claim more.
 
 The constraint still binds on the *alternatives*, which is why it is stated
 here: side-alignment overflows the code line on 96.61% of the 29,933 lines
@@ -264,7 +268,12 @@ facts CoreLib yields, with no fact in two families and none outside them.
 `AnnotationGestureSelector.Focus` also matches a category name, and those are
 aliases of the same sets — `allocation` selects the same 16,328 as `alloc`,
 `unsafety` the same 749 as `unsafe`, and `semantics` the same 17,041 as
-`safety`.
+`safety`. That last one is a coincidence of this corpus rather than a
+definition: the `Semantics` category declares both `safety.callee` and
+`semantics.callee`, and `--focus semantics` would select the union of the two —
+but CoreLib yields **0** `semantics.callee` facts, so the two selections are
+equal here. On an assembly that produced them, `semantics` would be a strict
+superset of `safety` and would need measuring separately.
 
 Any other argument is a narrower id prefix, such as `alloc.box`, and selects a
 strict subset of one family. Stacking cannot increase under a subset: dropping

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -29,6 +29,8 @@ tell which detail belongs to which expression.
 `System.Tuple<…>.Equals` is the worst real case in the corpus — 16 facts, one
 330-column caret:
 
+The line is 330 columns wide, so it is elided here at the `…`:
+
 ```csharp
 return comparer.Equals(m_Item1, V_0.m_Item1) && comparer.Equals(m_Item2, V_0.m_Item2) && … (330 cols)
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (330 carets)
@@ -48,6 +50,14 @@ work everywhere, and makes it the only behaviour: **`stacked`**.
 Anything else is a later style added beside it. Nothing here is contingent on
 those styles existing, and nothing here should be generalised in anticipation
 of them.
+
+Every code block showing behaviour that exists is verbatim `Annotated Source`
+output rather than a sketch. The two exceptions are marked where they appear:
+the `Tuple.Equals` line below is elided because it is 330 columns wide, and the
+side-aligned block under [Rejected alternatives](#side-aligned-annotations)
+depicts a layout that was never built. This one is
+`System.Reflection.RuntimeModule.ResolveSignature` under `--focus cost`; see
+[Reproducing these figures](#reproducing-these-figures).
 
 ```csharp
     if (!V_0.IsMemberRef && !V_0.IsMethodDef && !V_0.IsTypeSpec && !V_0.IsSignature && !V_0.IsFieldDef)
@@ -79,34 +89,51 @@ of them.
    Width is information the anchoring layer worked to compute, so the renderer
    states it truthfully or marks that it could not.
 6. **List the facts below,** left-aligned in the existing gutter, numbered to
-   match, wrapped to `Budget`.
+   match, wrapped to `Budget`. One row per fact, in input order within an
+   extent group; the number is written once, on the group's first fact, and the
+   groups appear in the rule 2 order the carets were numbered in. Rows for
+   facts with no extent are appended after all numbered rows.
 7. **A fact with no extent is listed, not drawn.** `AnnotationAnchor` withholds
    an extent when it cannot identify the characters a fact is about. Such a
    fact keeps its place in the list below the carets, marked `-` instead of a
    number. A line may carry both kinds at once — a **mixed** line — and
    stacking still engages: the placeable facts get numbered carets, the rest
    are listed under `-`.
+8. **The gutter wins.** A label is drawn immediately before the characters it
+   points at, so a caret near the start of a line can push its label left into
+   the comment gutter. Moving the label would make it point somewhere else, so
+   when any label on a line would begin left of the gutter, that line does not
+   stack at all: it falls back to the widening render this document replaces.
+   This is a guard rather than a path with traffic — it fires on **0 of the
+   3,385 lines that stack** in the corpus below — but it is reachable, and a
+   line is never rendered with a label that lies about its column.
 
 Rule 4's two-column threshold is a *spill* threshold, not a render floor: a
 genuinely one-character expression renders one caret, never a padded two.
-`HebrewCalendar.CheckHebrewYearValue` is the case that proves it — caret `2.`
-is the single argument `y`, and the mix of clipped and full trails on one row
-is what the rules produce:
+`System.Globalization.HebrewCalendar.CheckHebrewYearValue` under `--focus
+alloc` is the case that proves it — caret `2.` is the single argument `y`, and
+the mix of clipped and full trails on one row is what the rules produce (detail
+rows omitted here; the carets are verbatim):
 
 ```csharp
-    throw new ArgumentOutOfRangeException(varName, y, SR.Format(SR.ArgumentOutOfRange_Range, 5343, 5999));
+        throw new ArgumentOutOfRangeException(varName, y, SR.Format(SR.ArgumentOutOfRange_Range, 5343, 5999));
 //          1.^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^~ 2.^                                       3.^^~ 4.^^^^
 ```
 
-And rule 2, on a line with two nested pairs:
+And rule 2, on a line with two nested pairs —
+`System.Numerics.Vector.IsSubnormal` under `--focus safety`:
 
 ```csharp
         return LessThan<uint>(Abs<T>(vector).As<T, uint>() - Vector<uint>.One, Create<uint>(8388607)).As<uint, T>();
-//             1.^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//             2.^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//                            3.^^^^^^^^^^^^^^^^^^^^^^^^^^^^                   5.^^^^^^^^^^^^^^^^^^^^^
-//                            4.^^^^^^^^^^^^^^
+//           1.^^^^^^^^^^^~ 3.^^^^^^^^^^^^^^^^^^^^^^^^^^^^                   5.^^^^^^^^^^^^^^^^^^^^^
+//           2.^^^^^^^^^^^~ 4.^^^^^^^^^^^^^^
 ```
+
+Carets `1.` and `2.` share a start column, as do `3.` and `4.`, so neither pair
+can share a row. The outer member of each pair is drawn first and the row below
+carries the inner one, which is why the second row is the shorter of the two.
+Both members of the first pair clip to `~`: `3.`'s label is the next thing on
+row one, and rule 4 packs `4.` onto row two directly beneath it.
 
 ### Why this is the style that has to work
 
@@ -127,7 +154,7 @@ included. Whole rendered block on those 3,385 lines:
 
 | terminal | widen (today) | stacked |
 | --- | ---: | ---: |
-| 80 cols | 27.8% | **28.0%** |
+| 80 cols | 27.8% | 28.0% |
 | 100 cols | 53.3% | 53.3% |
 | 120 cols | 69.5% | 69.5% |
 | 160 cols | 86.5% | 86.5% |
@@ -157,23 +184,29 @@ ambiguity that argument rests on — an extent-less fact is now visibly marked
 `-` rather than silently sharing an underline — so the surviving extent is
 drawn.
 
-The dominant shape, and the reason this matters, is `stackalloc`:
+The dominant shape, and the reason this matters, is `stackalloc` — here in
+`Interop.CallStringMethod` under `--focus lifetime`, first as it renders today:
 
 ```csharp
-        Span<char> V_0 = stackalloc char[256];
-    //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    //   lifetime.stack-bound(Span<char>)
-    //   unsafe.stackalloc(byte*)
+    Span<char> V_0 = stackalloc char[256];
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//   unsafe.stackalloc(byte*)
+//   lifetime.stack-bound(Span<char>)
 ```
 
-Both facts are about `stackalloc char[256]`. Widening underlines
-`Span<char> V_0 =` as well, which neither fact claims. Under rule 7:
+Both facts are about `stackalloc char[256]`, but only `lifetime.stack-bound`
+carries an extent; `AnnotationAnchor` does not place `unsafe.stackalloc`. So the
+`-` is a statement about *this pipeline's* knowledge, not about the fact — it
+says no characters were identified for it, which is weaker than and different
+from a claim that it covers the whole statement. Widening, meanwhile,
+underlines `Span<char> V_0 =` as well, which neither fact claims. Under
+rule 7:
 
 ```csharp
-        Span<char> V_0 = stackalloc char[256];
-    //                 1.^^^^^^^^^^^^^^^^^^^^
-    //  1. lifetime.stack-bound(Span<char>)
-    //  -  unsafe.stackalloc(byte*)
+    Span<char> V_0 = stackalloc char[256];
+//                 1.^^^^^^^^^^^^^^^^^^^^
+//  1. lifetime.stack-bound(Span<char>)
+//  -  unsafe.stackalloc(byte*)
 ```
 
 The `-` is doing real work here: it says the second fact has no characters to
@@ -182,9 +215,12 @@ point at, which is a different claim from "it is about the whole statement".
 Stacking needs at least one placeable fact. A line where *no* fact has an
 extent still has nothing to point at, so it widens exactly as before.
 
-- Lines whose facts all agree on one extent, and lines carrying a single fact —
-  **90.1%** of caret-bearing lines — keep exactly today's geometry, including
-  the inline-detail shortcut.
+- Lines whose facts all agree on one extent, and lines carrying a single fact,
+  keep exactly today's geometry, including the inline-detail shortcut. That is
+  25,628 lines: **88.3%** of the 29,013 lines carrying at least one extent, or
+  **81.0%** of all 31,640 caret-bearing lines. (It is *not* 90.1% — that is the
+  single-distinct-extent share, 26,127 of 29,013, and 499 of those are mixed
+  lines whose geometry does change. See [Measurements](#measurements).)
 - A fact whose expression has no printed node, or prints on a continuation
   line, still gets no extent. What changes is only how it is *shown* on a line
   where some other fact does have one: it is marked `-` instead of widening the
@@ -201,13 +237,14 @@ render is not a claim about anything.
 
 | | |
 | --- | ---: |
-| caret lines carrying at least one extent | 29,013 |
+| caret-bearing lines | 31,640 |
+| …carrying at least one extent | 29,013 |
 | …with a single distinct extent | 26,127 (90.1%) |
 | …with two or more distinct extents | 2,886 (9.9%) |
 | worst line | 8 distinct extents |
 
-Of the single-extent lines, all but 499 carry no extent-less fact and so keep
-today's geometry exactly. The 499 are the mixed lines of rule 7, which gain a
+Of the 26,127 single-extent lines, all but 499 carry no extent-less fact and so
+keep today's geometry exactly — 25,628 lines, the 88.3% quoted above. The 499 are the mixed lines of rule 7, which gain a
 drawn caret and a `-` row where they previously widened:
 
 | | |
@@ -228,6 +265,46 @@ Applying the specification above to those 2,886 multi-extent lines:
 3,949 of 6,986 trails (56.5%) render at true width, and 527 lines (18.3%) have
 no clipped trail at all. Clipping concentrates exactly where extents nest.
 
+### Reproducing these figures
+
+The specification above is implemented in `AnnotationCaret` and shipped in
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `8c17dcb35`.
+
+Every code block in this document is a verbatim excerpt of `Annotated Source`
+output for the member and focus family named beside it:
+
+```bash
+dotnet-inspect member "System.Reflection.RuntimeModule" ResolveSignature \
+    --all --focus cost -S "Annotated Source"
+dotnet-inspect member "System.Globalization.HebrewCalendar" CheckHebrewYearValue \
+    --all --focus alloc -S "Annotated Source"
+dotnet-inspect member "System.Numerics.Vector" IsSubnormal \
+    --all --focus safety -S "Annotated Source"
+dotnet-inspect member "Interop" CallStringMethod \
+    --all --focus lifetime -S "Annotated Source"
+```
+
+`--all` is required: all but one of these members are non-public.
+
+Columns in a snippet are **final rendered columns**, which is not the geometry
+the research render produces. Three coordinate systems exist and mixing them is
+the easiest way to read a correct caret as a misaligned one:
+
+1. The **research render** emits the code line at its own nesting indent and
+   prefixes each hoisted caret row with a `HoistMarker` control character.
+2. `ApiOutputFormatter` adds `BodyIndentWidth` (4) to **code lines only**, drops
+   the marker, and leaves hoisted caret rows at column 0.
+3. What a snippet shows is therefore a code line indented four columns further
+   than the raw render, above caret rows that were not moved at all.
+
+A caret verified against the raw code line will appear four columns off. Verify
+against the rendered pair, both taken from the same output.
+
+The corpus figures come from the probes described in #3656; they walk
+`System.Private.CoreLib` with `IrImporter.ImportAssembly`, call the production
+`AnnotationAnchor` and `AnnotationCaret` entry points rather than reimplementing
+them, and read every width back off rendered output.
+
 ## Rejected alternatives
 
 Each was mocked up against real CoreLib lines before being rejected. Several
@@ -244,6 +321,9 @@ One caret per row with its text beside it. Genuinely attractive — association
 becomes spatial, so numbering disappears, and with one caret per row there is
 no neighbour to collide with, so clipping disappears too. A single-extent line
 collapses to one row.
+
+The layout this rejects was never implemented, so unlike every other code block
+in this document the following is a mockup, not a render:
 
 ```csharp
     Span<char> V_0 = stackalloc char[256];

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -241,7 +241,12 @@ claim more.
 The constraint still binds on the *alternatives*, which is why it is stated
 here: side-alignment overflows the code line on 96.61% of the 29,933 lines
 carrying an extent, by a mean of 77 columns, and fits 28.1% of them at 80
-columns against 75.7% for the bare code.
+columns against 75.7% for the bare code. That 28.1% is padded — a line whose
+bare code already overflows 80 columns cannot fit side-aligned either.
+Conditioned on the 22,662 whose bare code does fit, side-alignment still fits
+only 8,257, or **36.4%**. Unpadding it makes the rejected alternative look
+better than the headline did, which is why it is stated: the rejection rests on
+36.4% against 75.7%, not on the padded figure.
 
 ### Mixed lines
 
@@ -422,6 +427,12 @@ That 89.5% is padded too: 254 of these lines carry a single extent group and
 cannot occupy more than one row. Among the **2,588** lines with two or more
 groups — the ones with something to pack — **2,289 (88.4%)** take a single row.
 
+And 2,588 is padded in turn, by a structural fact stated earlier in this
+document: extents sharing a start column can never share a row. **136** of those
+lines carry two distinct extents at one column and so cannot take a single row
+whatever the packer does. Among the **2,452** that can, the rate is **2,289
+(93.4%)**.
+
 3,884 of 6,566 trails (59.2%) render at true width, but that headline rate is
 padded by a structural immunity and should not be read as a packing success
 rate. The last trail on a row has no successor, so its clip limit is
@@ -445,7 +456,7 @@ fires on **0** of the 2,842 lines qualifying to stack before it runs.
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `9d4b6a12a`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `3e13e5e24`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:
@@ -521,7 +532,8 @@ in this document the following is a mockup, not a render:
 Rejected as *the* style on measurement, not taste: aligning after the widest
 caret pushes text a mean **77 columns** past the end of the code line and
 overflows it on **96.61%** of the lines carrying an extent, leaving 28.1%
-intact at 80 columns against 75.7% for the bare code.
+intact at 80 columns against 75.7% for the bare code — or **36.4%** once the
+denominator is restricted to the 22,662 lines whose bare code fits at all.
 Its annotation column exceeds 100 on 10.5% of lines, with a maximum of 57,942
 on `IcuLocaleData.get_NameIndexToNumericData` — the pathological line already
 filed as #3610. It wraps three lines in four, and the wrap destroys the very
@@ -530,7 +542,13 @@ adjacency that motivates it. The obvious first candidate for a wide style.
 ### Constant-width caret trails
 
 Render every caret at a fixed width so packing depends only on start columns.
-Compact — a 4-wide trail fits 87.5% of multi-extent lines on one row.
+Compact — but not more compact than what ships. An earlier revision claimed a
+4-wide trail fits 87.5% of multi-extent lines on one row, with no probe behind
+it; the figure does not reproduce. Packing 4-wide trails by start column with a
+one-column gap fits **2,289 of 2,588** (88.4%), or **93.4%** of the 2,452 that
+are not forced onto multiple rows by a shared start column — which is exactly
+what the shipped variable-width model achieves on the same corpus. Fixing the
+width buys no packing.
 
 Rejected because it **misstates width**. A 4-wide trail under the single
 character `y` in `ArgumentOutOfRangeException(varName, y, …)` claims a

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -27,13 +27,14 @@ everything and therefore at nothing, above a stack of details with no way to
 tell which detail belongs to which expression.
 
 `System.Tuple<…>.Equals` is the worst real case in the corpus. Under
-`--focus alloc` its comparison line carries 16 facts under a single caret 370
+`--focus alloc` its comparison line carries 16 facts under a single caret 330
 columns wide, above 32 wrapped detail rows, and attributes none of them. The
-code line is 374 columns, so it is elided here at the `…`:
+code line is 330 columns, reaching final column 334 after the body indent, so it
+is elided here at the `…`:
 
 ```csharp
-    return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, … (374 cols)
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (370 carets)
+    return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, … (330 cols)
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (330 carets)
 //   alloc.box(T1; alloc=boxed T1; path=branch; path-confidence=behind-branch; …  ×16, unattributed
 ```
 
@@ -57,7 +58,7 @@ of them.
 
 Every code block showing behaviour that exists is verbatim `Annotated Source`
 output rather than a sketch. The two exceptions are marked where they appear:
-the `Tuple.Equals` line below is elided because it is 374 columns wide, and the
+the `Tuple.Equals` line below is elided because it is 330 columns wide, and the
 side-aligned block under [Rejected alternatives](#side-aligned-annotations)
 depicts a layout that was never built. This one is
 `System.Reflection.RuntimeModule.ResolveSignature` under `--focus cost`; see
@@ -169,16 +170,22 @@ by the code line by construction.
 
 The corpus agrees — 0 of the 2,842 lines carry a stacked caret row wider than
 their code line — but that count is a consistency check on the derivation above,
-not evidence for it, because no corpus could produce a counter-example. The
-comparison figure is the one that carries information: the widening render this
-replaces overhangs on **20 lines (0.70%)**. Its underline is not any fact's
-extent — on a line whose facts disagree there is no agreed extent, so it falls
-back to `new CaretExtent(statementColumn, trimmed.Length)`, the whole trimmed
-statement — and it is positioned at
-`pad = Math.Max(1, caretColumn - commentColumn - 2)`, whose floor of 1 pushes
-the underline rightward when the statement starts near the gutter. Nothing then
-bounds or clips it against the line. That absence of any bound, not the
-underline's length, is what stacking gives up.
+not evidence for it, because no corpus could produce a counter-example.
+
+The comparison against the widening render is narrower than two earlier
+revisions of this section claimed, and the correction is worth stating plainly.
+**No caret glyph overhangs the code line in either render.** Measured over the
+same 2,842 lines, both are **0**, because the widening underline covers the
+trimmed statement, which ends inside the line. The widening render has no
+explicit bound, but it does not need one to stay within the line.
+
+What differs is the rendered **row**. Widening appends the first detail string
+to the caret row when it fits the inline budget, and on **20 lines (0.70%)**
+that appended text carries the row past the end of the code line. Stacking never
+appends detail to a caret row, so it is 0. The contrast is about where detail is
+placed, not about bounding the underline — and the earlier claim that the
+widening underline "shifts rightward while preserving the full extent length"
+described a mechanism that does not occur.
 
 Widths below are **final rendered columns**, measured after the same projection
 `ApiOutputFormatter` applies — code lines receive `BodyIndentWidth`, hoisted
@@ -372,14 +379,21 @@ Applying the specification to the 2,842 lines that stack:
 | 3 | 1 | 0.0% |
 | 4 | 1 | 0.0% |
 
+That 89.5% is padded too: 254 of these lines carry a single extent group and
+cannot occupy more than one row. Among the **2,588** lines with two or more
+groups — the ones with something to pack — **2,289 (88.4%)** take a single row.
+
 3,884 of 6,566 trails (59.2%) render at true width, but that headline rate is
 padded by a structural immunity and should not be read as a packing success
 rate. The last trail on a row has no successor, so its clip limit is
 `int.MaxValue` and it renders at true width by construction. Those 2,842 lines
 occupy **3,144 rows**, so 3,144 of the 6,566 trails could not have been clipped —
 and measurement confirms all 3,144 render at true width. Of the **3,422** trails
-actually exposed to a successor, only **740 (21.6%)** survived at true width;
-**2,682 (78.4%)** were cut short. The exposed rate is the informative one.
+actually exposed to a successor, 740 (21.6%) survived at true width. Five of
+those are immune as well, their extents being no longer than `MinTrail`, which
+row admission already reserves. Among the **3,417** trails that could genuinely
+be cut, **735 (21.5%)** survived and **2,682 (78.5%)** were clipped. That is the
+informative rate; it took two passes to strip both layers of padding off it.
 
 A trail is cut
 short by the next label on its own row, which is the only thing that clips a
@@ -391,7 +405,7 @@ fires on **0** of the 2,842 lines qualifying to stack before it runs.
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
-[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `6f8adac49`.
+[#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `5e73a22bb`.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -1,0 +1,279 @@
+# Caret stacking
+
+This document specifies **caret stacking**: rendering one caret per *fact
+extent* on a line, each keeping the width of the expression it is about,
+instead of widening to a single statement-length caret whenever the facts on a
+line disagree.
+
+It is the display half of the `--focus` gesture. The analysis half — deciding
+which characters a fact is about — is described in
+[hidden-fact-annotations.md](hidden-fact-annotations.md) and implemented by
+`AnnotationAnchor.ComputeCaretExtents`. **Stacking changes no analysis.** The
+per-fact extents already exist and are already correct; today's renderer
+discards them.
+
+## The problem
+
+`AnnotationCaret.Agreed` returns an extent only when every fact on the line
+points at the *same* characters. When they disagree it returns `null` and the
+caret widens to the whole statement. On a line carrying several facts about
+several different sub-expressions, that produces a caret that points at
+everything and therefore at nothing, above a stack of details with no way to
+tell which detail belongs to which expression.
+
+`System.Tuple<…>.Equals` is the worst real case in CoreLib — 16 facts, one
+330-column caret:
+
+```csharp
+return comparer.Equals(m_Item1, V_0.m_Item1) && comparer.Equals(m_Item2, V_0.m_Item2) && … (330 cols)
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (330 carets)
+//   alloc.box(T1; …)   ×16, unattributed
+```
+
+The facts are right. The anchoring is right. Only the render throws the
+information away.
+
+## One style, specified
+
+Caret layout will eventually be a **style** dimension — a terminal, a wide
+editor, and rendered Markdown do not want the same picture. This document does
+not try to design that dimension. It locks **one** style, the one that has to
+work everywhere, and makes it the only behaviour: **`stacked`**.
+
+Anything else is a later style added beside it. Nothing here is contingent on
+those styles existing, and nothing here should be generalised in anticipation
+of them.
+
+```csharp
+    if (!V_0.IsMemberRef && !V_0.IsMethodDef && !V_0.IsTypeSpec && !V_0.IsSignature && !V_0.IsFieldDef)
+//     1.^^^^^^^^^^^^^^^   2.^^^^^^^^^^^^^^^   3.^^^^^^^^^^^^^^   4.^^^^^^^^^^^^^^^   5.^^^^^^^^^^^^^^
+//  1. cost.callee(callee get_IsMemberRef: reflection)
+//  2. cost.callee(callee get_IsMethodDef: reflection)
+//  3. cost.callee(callee get_IsTypeSpec: reflection)
+//  4. cost.callee(callee get_IsSignature: reflection)
+//  5. cost.callee(callee get_IsFieldDef: reflection)
+```
+
+### Specification
+
+1. **Group facts by extent.** The unit is the extent, not the fact. Facts about
+   the same characters share one caret and one number, their texts listed
+   together under it. `Tuple.Equals` renders 8 carets for its 16 facts.
+2. **Order by start column, widest first at a tie.** Extents sharing a start
+   column are always a nesting, so they cannot share a row; widest-first makes
+   each row narrower than the one above, and matches the order the printer
+   records nesting in.
+3. **Number in that order,** `1.` upward, and label each caret with its number
+   immediately before the trail.
+4. **Pack greedily onto rows.** An extent joins the first row where the
+   previous caret on that row can still render `^~` — or its full width, if
+   that is shorter than two — followed by one blank column, before this
+   caret's label begins. Otherwise it opens a new row.
+5. **Render each trail at true width,** clipped only where it would collide
+   with the next label on its row, in which case the last column becomes `~`.
+   Width is information the anchoring layer worked to compute, so the renderer
+   states it truthfully or marks that it could not.
+6. **List the facts below,** left-aligned in the existing gutter, numbered to
+   match, wrapped to `Budget`.
+7. **A fact with no extent is listed, not drawn.** `AnnotationAnchor` withholds
+   an extent when it cannot identify the characters a fact is about. Such a
+   fact keeps its place in the list below the carets, marked `-` instead of a
+   number. A line may carry both kinds at once — a **mixed** line — and
+   stacking still engages: the placeable facts get numbered carets, the rest
+   are listed under `-`.
+
+Rule 4's two-column threshold is a *spill* threshold, not a render floor: a
+genuinely one-character expression renders one caret, never a padded two.
+`HebrewCalendar.CheckHebrewYearValue` is the case that proves it — caret `2.`
+is the single argument `y`, and the mix of clipped and full trails on one row
+is what the rules produce:
+
+```csharp
+    throw new ArgumentOutOfRangeException(varName, y, SR.Format(SR.ArgumentOutOfRange_Range, 5343, 5999));
+//          1.^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^~ 2.^                                       3.^^~ 4.^^^^
+```
+
+And rule 2, on a line with two nested pairs:
+
+```csharp
+        return LessThan<uint>(Abs<T>(vector).As<T, uint>() - Vector<uint>.One, Create<uint>(8388607)).As<uint, T>();
+//             1.^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//             2.^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//                            3.^^^^^^^^^^^^^^^^^^^^^^^^^^^^                   5.^^^^^^^^^^^^^^^^^^^^^
+//                            4.^^^^^^^^^^^^^^
+```
+
+### Why this is the style that has to work
+
+The primary consumer is a terminal. A layout wider than the terminal wraps, and
+a wrapped caret row lands underneath characters it has nothing to do with —
+worse than no caret, because it is actively misleading.
+
+Every caret lies within the code line and a row cannot extend past its last
+caret, so **a stacked caret row never adds width the code line did not already
+have.** Measured on all 3,385 lines this model changes: 0 have a stacked caret
+row wider than their code line, against 137 (4.05%) under the widening render
+it replaces.
+
+Widths below are **final rendered columns**, measured after the same projection
+`ApiOutputFormatter` applies — code lines receive `BodyIndentWidth`, hoisted
+caret lines do not — and the caret block is real rendered output, detail rows
+included. Whole rendered block on those 3,385 lines:
+
+| terminal | widen (today) | stacked |
+| --- | ---: | ---: |
+| 80 cols | 27.8% | **28.0%** |
+| 100 cols | 53.3% | 53.3% |
+| 120 cols | 69.5% | 69.5% |
+| 160 cols | 86.5% | 86.5% |
+
+Terminal fit is unchanged, because on these dense lines the block width is set
+by the wrapped detail rows, which both models share. What changes is the block:
+91.0% narrower, 0.4% the same, 8.6% wider. So stacking buys attribution at no
+cost in fit — it does not improve fit, and this document should not claim it
+does.
+
+The constraint still binds on the *alternatives*, which is why it is stated
+here: side-alignment overflows the code line on 97.28% of caret-bearing lines
+by a mean of 81 columns, and fits 25.4% of them at 80 columns against 76.5% for
+the bare code.
+
+### Mixed lines
+
+A **mixed** line carries facts of both kinds: some with an extent, some
+without. There are 615 of them in CoreLib, and 499 have exactly one surviving
+extent, so this is not a corner.
+
+Today they widen. The reasoning was sound while a caret was the only signal
+available: narrowing to the one surviving extent would underline an expression
+true of only *some* of the facts sharing the caret. Rule 7 removes the
+ambiguity that argument rests on — an extent-less fact is now visibly marked
+`-` rather than silently sharing an underline — so the surviving extent is
+drawn.
+
+The dominant shape, and the reason this matters, is `stackalloc`:
+
+```csharp
+        Span<char> V_0 = stackalloc char[256];
+    //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //   lifetime.stack-bound(Span<char>)
+    //   unsafe.stackalloc(byte*)
+```
+
+Both facts are about `stackalloc char[256]`. Widening underlines
+`Span<char> V_0 =` as well, which neither fact claims. Under rule 7:
+
+```csharp
+        Span<char> V_0 = stackalloc char[256];
+    //                 1.^^^^^^^^^^^^^^^^^^^^
+    //  1. lifetime.stack-bound(Span<char>)
+    //  -  unsafe.stackalloc(byte*)
+```
+
+The `-` is doing real work here: it says the second fact has no characters to
+point at, which is a different claim from "it is about the whole statement".
+
+Stacking needs at least one placeable fact. A line where *no* fact has an
+extent still has nothing to point at, so it widens exactly as before.
+
+- Lines whose facts all agree on one extent, and lines carrying a single fact —
+  **90.1%** of caret-bearing lines — keep exactly today's geometry, including
+  the inline-detail shortcut.
+- A fact whose expression has no printed node, or prints on a continuation
+  line, still gets no extent. What changes is only how it is *shown* on a line
+  where some other fact does have one: it is marked `-` instead of widening the
+  caret. Lines where no fact has an extent widen exactly as today.
+- Detail text stays left-aligned and wrapped to `Budget`.
+- `AnnotationAnchor` is untouched. This is a change to `AnnotationCaret` alone.
+
+## Measurements
+
+CoreLib `11.0.0-preview.7.26366.102`, measured on the **annotated-source**
+render (`importMethodBody: ImportMethodBody`) — the one `--focus` produces.
+Extents are measured in printed characters, so a figure that does not name its
+render is not a claim about anything.
+
+| | |
+| --- | ---: |
+| caret lines carrying at least one extent | 29,013 |
+| …with a single distinct extent | 26,127 (90.1%) |
+| …with two or more distinct extents | 2,886 (9.9%) |
+| worst line | 8 distinct extents |
+
+Of the single-extent lines, all but 499 carry no extent-less fact and so keep
+today's geometry exactly. The 499 are the mixed lines of rule 7, which gain a
+drawn caret and a `-` row where they previously widened:
+
+| | |
+| --- | ---: |
+| mixed lines (facts both with and without an extent) | 615 |
+| …with exactly one surviving extent | 499 |
+| …with two or more | 116 |
+
+Applying the specification above to those 2,886 multi-extent lines:
+
+| rows | lines | |
+| --- | ---: | ---: |
+| 1 | 2,557 | 88.6% |
+| 2 | 326 | 11.3% |
+| 3 | 2 | 0.1% |
+| 4 | 1 | 0.0% |
+
+3,949 of 6,986 trails (56.5%) render at true width, and 527 lines (18.3%) have
+no clipped trail at all. Clipping concentrates exactly where extents nest.
+
+## Rejected alternatives
+
+Each was mocked up against real CoreLib lines before being rejected. Several
+are plausible *styles* for later; none can be the one style.
+
+### Widen on disagreement (today)
+
+The caret points at the whole statement, so it carries no information, and the
+details below it are unattributable. This is the defect.
+
+### Side-aligned annotations
+
+One caret per row with its text beside it. Genuinely attractive — association
+becomes spatial, so numbering disappears, and with one caret per row there is
+no neighbour to collide with, so clipping disappears too. A single-extent line
+collapses to one row.
+
+```csharp
+    Span<char> V_0 = stackalloc char[256];
+//                   ^^^^^^^^^^^^^^^^^^^^  lifetime.stack-bound(Span<char>)
+```
+
+Rejected as *the* style on measurement, not taste: aligning after the widest
+caret pushes text a mean **81 columns** past the end of the code line and
+overflows it on **97.28%** of caret lines, leaving 25.4% intact at 80 columns.
+Its annotation column exceeds 100 on 10.5% of lines, with a maximum of 57,942
+on `IcuLocaleData.get_NameIndexToNumericData` — the pathological line already
+filed as #3610. It wraps three lines in four, and the wrap destroys the very
+adjacency that motivates it. The obvious first candidate for a wide style.
+
+### Constant-width caret trails
+
+Render every caret at a fixed width so packing depends only on start columns.
+Compact — a 4-wide trail fits 87.5% of multi-extent lines on one row.
+
+Rejected because it **misstates width**. A 4-wide trail under the single
+character `y` in `ArgumentOutOfRangeException(varName, y, …)` claims a
+four-character expression that does not exist.
+
+### Annotations column-aligned under their own caret
+
+Indent each fact's text to start under the caret it explains.
+
+Rejected for side-alignment's reason: on a line whose facts sit at columns 12
+through 87, the texts stagger across the width of the line and each then wraps.
+Left-aligning the numbered list keeps every fact starting in the same column,
+where wrapping is predictable and cheap.
+
+### Interleaved ladder with left-aligned details
+
+One caret row per extent, each followed immediately by its detail lines.
+
+Rejected: `alloc.box` details run past 200 characters, so consecutive carets end
+up separated by paragraphs, destroying the side-by-side comparison that makes a
+multi-fact line legible in the first place.

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -258,14 +258,16 @@ noise and set 1.1% against 7.2%, which compared two shares of a denominator
 dominated by lines that could do neither.
 
 The constraint still binds on the *alternatives*, which is why it is stated
-here: side-alignment overflows the code line on 96.61% of the 29,933 lines
-carrying an extent, by a mean of 77 columns, and fits 28.1% of them at 80
-columns against 75.7% for the bare code. That 28.1% is padded — a line whose
-bare code already overflows 80 columns cannot fit side-aligned either.
-Conditioned on the 22,662 whose bare code does fit, side-alignment still fits
-only 8,257, or **36.4%**. Unpadding it makes the rejected alternative look
-better than the headline did, which is why it is stated: the rejection rests on
-36.4% against 75.7%, not on the padded figure.
+here: side-alignment overflows the code line on 97.52% of the 29,933 lines
+carrying an extent, by a mean of 81 columns over the 29,191 that overflow, and
+fits 24.7% of them at 80 columns against 75.7% for the bare code. That 24.7% is
+padded — a line whose bare code already overflows 80 columns cannot fit
+side-aligned either. Conditioned on the 22,662 whose bare code does fit,
+side-alignment still fits only **32.1%**. Unpadding it makes the rejected
+alternative look better than the headline did, which is why it is stated: the
+rejection rests on 32.1% against 75.7%, not on the padded figure. See
+[Side-aligned annotations](#side-aligned-annotations) for the measurement
+convention these depend on.
 
 ### Mixed lines
 
@@ -565,25 +567,36 @@ in this document the following is a mockup, not a render:
 //                   ^^^^^^^^^^^^^^^^^^^^  lifetime.stack-bound(Span<char>)
 ```
 
-Rejected as *the* style on measurement, not taste. Every figure here is one
-row per fact with a one-column gap after the widest caret, which is what the
-sketch above shows; a two-column gap moves each of them by a few tenths and
-changes nothing. Aligning after the widest caret pushes text a mean **77
-columns** past the end of the code line and overflows it on **96.61%** of the
-lines carrying an extent, leaving 28.1% intact at 80 columns against 75.7%
-for the bare code — or **36.4%** once the denominator is restricted to the
-22,662 lines whose bare code fits at all. The other 63.6% of those lines wrap,
-and the wrap destroys the very adjacency that motivates the style. Quoting a
-wrap rate over all 29,933 lines instead would read 71.9%, but 7,271 of them
-overflow 80 columns before any annotation is added and wrap whatever style is
-chosen, so that number measures the corpus rather than the style.
-Its annotation column exceeds 100 on 10.5% of lines, with a maximum of 57,942
-on `IcuLocaleData.get_NameIndexToNumericData` — the pathological line already
-filed as #3610. That number is derived, not measured directly: the line is
-**57,940** characters, one extent covers all of it, and 57,942 is where a
-two-column gap would land. At the one-column gap used everywhere else here it
-is 57,941. The gap is a style parameter, so the line length is the figure that
-means anything. The obvious first candidate for a wide style.
+Rejected as *the* style on measurement, not taste. Every figure below shares
+one convention, and it has to be stated because an earlier revision of this
+section did not state it and quietly mixed two: **final rendered columns**,
+one row per fact, text set two columns past the widest caret, which is what
+the sketch above shows. Rendered column of code character *i* is
+`BodyIndentWidth + i`, so the body indent counts on both sides of every
+comparison. The population is the **29,933** lines carrying at least one
+extent under the five focus families.
+
+- Text lands past the end of the code line on **29,191 lines (97.52%)**, and
+  over those 29,191 the mean overhang is **81 columns** — the mean is over the
+  lines that overflow, not over all 29,933.
+- **24.7%** of lines still fit 80 columns, against **75.7%** for the bare code.
+  Restricted to the 22,662 whose bare code fits at all, **32.1%** survive; the
+  other **67.9%** wrap, and the wrap destroys the very adjacency that motivates
+  the style. Over all 29,933 the wrap rate reads 75.3%, but 7,271 of those
+  lines overflow 80 columns before any annotation is added and wrap under any
+  style, so that figure measures the corpus rather than this one.
+- The annotation column passes 100 on **3,655 lines (12.2%)** — or **87.6%** of
+  the **4,172** lines long enough to push it that far at all, which is the rate
+  that means something: when the style can hurt, it almost always does.
+- The maximum annotation column is **57,946**, on
+  `IcuLocaleData.get_NameIndexToNumericData`, the pathological line already
+  filed as #3610. That is derived rather than measured directly: the line is
+  **57,940** characters, one extent covers all of it, and 4 + 57,940 + 2 is
+  57,946. The line length is the figure that survives a change of convention.
+
+At a one-column gap every number above moves by under a point (97.20%, 25.3%,
+33.0%, 11.8%, 87.2%, 57,945) and the rejection is unaffected. The obvious
+first candidate for a wide style.
 
 ### Constant-width caret trails
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -54,7 +54,7 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
 - [Section model](design/section-model.md): section selection and query behavior.
 - [Capability section registry spike](design/capability-section-registry-spike.md): measured static lambda-table and precompiled-plan pilot layered on `SectionPipeline`.
 - [Hidden-fact annotations](design/hidden-fact-annotations.md): offset-keyed fact overlay semantics, validation, and projections.
-- [Caret stacking](design/caret-stacking.md): `--focus` caret display model — one caret per fact extent, annotation on the same row.
+- [Caret stacking](design/caret-stacking.md): `--focus` caret display model — one numbered caret per fact extent, with the fact texts listed below.
 - [Member Index](design/member-index.md): overload selector and digest contract.
 - [Member target resolution](design/member-target-resolution.md): typed member selector, anchor, and body-target resolution.
 - [Member ordering](design/member-order.md): canonical type/member section order and member-kind mapping.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -54,6 +54,7 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
 - [Section model](design/section-model.md): section selection and query behavior.
 - [Capability section registry spike](design/capability-section-registry-spike.md): measured static lambda-table and precompiled-plan pilot layered on `SectionPipeline`.
 - [Hidden-fact annotations](design/hidden-fact-annotations.md): offset-keyed fact overlay semantics, validation, and projections.
+- [Caret stacking](design/caret-stacking.md): `--focus` caret display model — one caret per fact extent, annotation on the same row.
 - [Member Index](design/member-index.md): overload selector and digest contract.
 - [Member target resolution](design/member-target-resolution.md): typed member selector, anchor, and body-target resolution.
 - [Member ordering](design/member-order.md): canonical type/member section order and member-kind mapping.


### PR DESCRIPTION
Specifies **caret stacking** — the display model for `--focus`, which renders one
caret per fact extent on a line instead of widening to a statement-length caret
whenever the facts on a line disagree.

Documentation only. No code, no behaviour change. The implementation is #3656.

## Why a design doc

Caret layout is UX, and it had never been designed — it had accreted. The
existing behaviour (widen on disagreement) was a reasonable local decision that
turned out to be wrong on exactly the lines that carry the most information:
`System.Tuple<…>.Equals` renders 16 facts under one 370-column caret and
attributes none of them.

The doc locks **one** style, specified as eight numbered rules — six for the
core layout, one for mixed lines, and one for the gutter-fit fallback — and
records what was rejected and on what evidence.

## What it settles

- **The unit is the extent, not the fact.** Facts about the same characters share
  one caret and one number.
- **Ordering** is start column ascending, widest first at a tie. Extents sharing a
  start column are always a nesting and cannot share a row, so the outer one goes
  above the inner one. That orders *same-start* extents only: it does not order row
  widths overall (50 of 2,842 lines have a lower row wider than the row above), and
  it is the reverse of the printer's record order, which is
  descendants-before-ancestors.
- **True width, clipped only on collision.** Width is information the anchoring
  layer worked to recover, so the renderer states it truthfully or marks with `~`
  that it could not.
- **Mixed lines** — some facts with an extent, some without — draw the carets they
  can and mark the rest `-`. This reverses the previous rule, and the doc says why:
  the `-` marker removes the ambiguity that justified widening. The marker applies
  only when the line stacks; a line the gutter rule rejects widens and marks nothing.
- **A spill threshold is not a render floor.** A one-character expression renders
  one caret, never a padded two.

## The measurement that decided the style

The primary consumer is a terminal. A layout wider than the terminal wraps, and a
wrapped caret row lands under characters it has nothing to do with — worse than no
caret, because it actively misleads.

All widths are **final rendered columns**, after the same projection
`ApiOutputFormatter` applies: code lines receive `BodyIndentWidth`, hoisted caret
lines do not. The caret block is real rendered output, detail rows included.

**A stacked caret row never adds width the code line did not already have** — and
that is *structural*, which is the correction review forced. `Stack` sends any extent
reaching past the line length to the unplaced list, labels grow leftward, and the
gutter rule bails rather than shifting a trail right, so no corpus could produce a
counter-example. The document now derives the bound and says the observed 0 cannot
falsify it.

The contrast with widening is narrower than two revisions of the doc claimed, and the
final round corrected it: **no caret glyph overhangs the code line in either render**
(0 and 0 over the same 2,842 lines), because the widening underline covers the trimmed
statement, which ends inside the line. What differs is the rendered *row* — widening
appends the first detail string to the caret row when it fits the inline budget, and
that text carries the row past the code line. Quoting that as **20 of 2,842 (0.70%)**
pads the denominator with the 2,822 whose detail never goes inline and so cannot
overhang; inline detail appears on exactly **20** lines and **all 20** overhang, so the
rate is **20/20** and it is structural. Stacking never appends detail to a caret row.
The contrast is about detail placement, not underline bounding.

Side-aligned annotations (each caret's text beside it) are genuinely the nicer
picture: association becomes spatial, numbering disappears, and clipping disappears.
They are rejected as the **default** purely on fit — they overflow the code line on
**97.52%** of the 29,933 lines carrying an extent, by a mean of **81 columns** over the
29,191 that overflow, and fit **24.7%** of them at 80 columns against **75.7%** for the
bare code — **32.1%** once the denominator drops the lines whose bare code already
overflows.

The doc keeps side-alignment on the record as a plausible later *style*, not as a
mistake. It is rejected as the one style that has to work everywhere, not outright.

### What stacking does not buy

Whole rendered block on those 2,842 lines, widening versus stacking:

| terminal | widen (today) | stacked |
| --- | ---: | ---: |
| 80 cols | 23.3% | **23.4%** |
| 100 cols | 48.3% | 48.3% |
| 120 cols | 65.9% | 65.9% |
| 160 cols | 84.9% | 84.9% |

That denominator is padded: a block is never narrower than its code line, so a line
whose code alone overflows cannot fit under any caret model. At 80 columns only **730
of the 2,842** could fit at all; among those, 90.5% → 91.1%. The doc now discloses this
rather than quoting the padded rate bare.

Terminal fit is **unchanged**. On these dense lines the block width is set by the code
line and the wrapped detail rows, which both models share. Nor does the block shrink: same width on
**91.8%**, narrower on **1.1%**, wider on **7.2%** — but all three shares are padded,
and the doc now gives the partition instead: of **2,612** blocks pinned at the code
width, 2,608 are unchanged and 4 grow; of the **230** with headroom, **0** are unchanged,
**30** narrow and **200** widen. Stacking buys attribution and
essentially nothing else, and the doc says exactly that — an earlier revision claimed
it strictly improved fit, and the revision after that overcorrected into a categorical
denial.

## Measurements

CoreLib `11.0.0-preview.7.26366.102`, annotated-source render (the one `--focus`
produces), spans computed after `PrintRaised` with a fresh import per render, **summed
over the five focus families with the focus filter applied before counting**. That last
condition was the single largest correction in review: `CollectFacts` returns every
fact, but `--focus` promotes only one family, so a pre-filter count describes a render
no invocation produces.

| | |
| --- | ---: |
| caret-bearing lines | 32,864 |
| …carrying at least one extent | 29,933 |
| …with a single distinct extent | 27,345 (91.4%) |
| …with two or more distinct extents | 2,588 (8.6%) |
| worst line | 8 distinct extents |
| mixed lines | 355 |
| …with exactly one surviving extent | 254 |

**30,022 of the 32,864 caret-bearing lines (91.4%) keep exactly today's geometry** —
the complement of the 2,842 that stack. It splits into **27,091** lines that narrow to
one agreed extent and **2,931** with no extent at all, which widen as they always did.
An earlier revision quoted the 27,091 alone (82.4%) as the unchanged share; review
caught that it drops the whole no-extent population. The claim is about *output*: a
no-extent line now runs through `Stack` and collects every fact as unplaced before the
widening branch takes over, so the bytes match but the path does not. Note also that the 27,091 is *not*
the 27,345 single-extent count: 254 of those are mixed lines whose geometry does
change.

Applying the rules to the resulting **2,842** stacking lines puts 2,543 (89.5%) on a
single row and none above four — though that rate is padded by 254 single-group lines
that cannot take two rows; among the 2,588 lines with something to pack it is **88.4%**.

Trail widths came back through review twice. 3,884 of 6,566 trails (59.2%) render at
true width, but that rate is **padded by a structural immunity**: the last trail on a
row has no successor, so its clip limit is `int.MaxValue` and it cannot be clipped.
Measured, not derived — those 2,842 lines occupy **3,144 rows** and all 3,144
last-on-row trails render at true width. Of the **3,422** trails actually exposed to a
successor, 740 (21.6%) survived — and five of *those* are immune as well, their extents
being no longer than `MinTrail`. Among the **3,417** trails that could genuinely be cut,
**735 (21.5%)** survived and **2,682 (78.5%)** were clipped. It took two passes to strip
both layers of padding off that one rate.

## Every figure is verbatim output

Each code block in the doc is a verbatim excerpt of `Annotated Source` output,
attributed to the member and focus family that produces it, with runnable
commands in a *Reproducing these figures* section. Two blocks are declared
mockups: the 374-column `Tuple.Equals` line is elided, and the side-aligned
block depicts a layout that was never implemented.

Three blocks were corrected after review. The `Vector.IsSubnormal` example was
substantively wrong — it claimed four caret rows with ~100- and ~84-column
trails, where the renderer emits two rows and clips the first nesting pair to
11 columns and a `~`. The `stackalloc` mixed-line pair had a hand-indented
gutter and the two facts in the opposite order to the render.

The `HebrewCalendar` block's carets were correct all along; only its code line
was under-indented, which made it *look* misaligned and led two reviewers to
report a caret defect that did not exist. The doc now names all three coordinate
systems — research render, `ApiOutputFormatter` projection, and the snippet —
so the next reader does not repeat that diagnosis.

## Validation

`npx markdownlint-cli docs/design/caret-stacking.md` — clean. Index entries added to
`docs/README.md` and `docs/overview.md`, both of which had described the
annotation as sitting on the same row as its caret — the side-aligned layout this
doc rejects.


