### PR TITLE
Design structured type-forwarder resolution

### DIFF
--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -166,26 +166,31 @@ only `Target.Location`; `AssemblyInspectionSession.Open` takes the resulting **r
 method-body session takes `Target.Selector` + the **facets**. One object crosses the CLI→service
 boundary; each service downstream receives just its own slice, not the whole request.
 
-### 2. `ResolvedAssemblyReference` — the resolution output (reuse what #2051 built)
+### 2. `ResolvedAssemblyReference` — the resolution output
 
 The resolver's answer: how to open the assembly *plus* everything it learned while finding it.
-This is the currency that replaces the bare `string`. **This type already exists** — #2051
-introduced `ResolvedAssemblyReference` in `ILInspector.Metadata` and the decompiler already
-resolves through it:
+This is the currency that replaces the bare `string`. #2051 introduced
+`ResolvedAssemblyReference` in `ILInspector.Metadata`, and the decompiler already resolves
+through it. The structured forwarding design evolves it in its second delivery slice from the
+original value-equal record to a registration-backed, non-equatable descriptor:
 
 ```csharp
-// ILInspector.Metadata/AssemblyReferenceIdentity.cs
-public sealed record ResolvedAssemblyReference(
-    AssemblyReferenceIdentity Identity,   // simple name, version, culture, public-key token
-    string? Path,
-    Func<Stream> OpenRead,                // both a path AND an opener — streams compose too
-    string? Provenance = null);
+var registration = new AssemblyAcquisitionRegistration(
+    selectedIdentity,
+    path,
+    () => File.OpenRead(path),
+    provenance);
+var reference = new ResolvedAssemblyReference(registration);
 ```
 
-So the inspection path **adopts this existing descriptor**, not a parallel one. It already
-answers "path vs stream vs opener" (it carries both). The one change: widen `string? Provenance`
-into a structured value — package@version, tfm, rid, platform-or-not, resolver source — so
-inspection reads provenance back instead of re-deriving it.
+The acquisition owner retains one registration per selected candidate; the descriptor exposes
+the selected image's identity, path, opener, provenance, and opaque registration handle, but the
+handle's payload remains internal. The incoming `AssemblyRef` identity remains request evidence,
+not descriptor identity. See
+[Type forwarding resolution](type-forwarding-resolution.md#assembly-candidate) for the
+authoritative identity, ownership, and migration contract. Provenance still widens from
+`string?` into a structured value — package@version, tfm, rid, platform-or-not, resolver source
+— so inspection reads provenance back instead of re-deriving it.
 
 **Multi-assembly locations (one query type).** There is a **single** `InspectionQuery`; there is
 no separate `PackageInspectionQuery`. Resolving `Target.Location` yields
@@ -386,12 +391,14 @@ Three rules keep the surface flat:
 1. **Inspection-time services take the session/owner — one signature.** A scanner or the
    method-body session consumes the already-open owner; it does not accept a path *or* a
    reference, because by then the assembly is open.
-2. **Value-boundary services take the `ResolvedAssemblyReference` — and a path lifts into one.**
+2. **Value-boundary services take the `ResolvedAssemblyReference` — and an acquisition owner
+   lifts a path into one.**
    Where a service genuinely accepts an assembly by value (the resolution boundary, or a
-   standalone call), it takes the reference. A path-only caller wraps it in a line —
-   `new ResolvedAssemblyReference(identity, path, () => File.OpenRead(path))`, exactly what the
-   #2051 `AssemblyLocator` adapter already does — so there is **one** input type, and "I only
-   have a path" is a trivial lift, not a second overload per service.
+   standalone call), it takes the reference. A path-only caller asks the local acquisition owner
+   to register the selected image and return `new ResolvedAssemblyReference(registration)`, so
+   there is **one** input type, not a second overload per service. The owner reads the selected
+   image identity and retains the registration; consumers do not synthesize request-shaped
+   descriptors.
 3. **Never take `(path, ResolvedAssemblyReference? reference = null)`.** That optional/nullable
    both-or-neither shape is precisely the loose-parameter smell this design removes; it invites
    callers to pass a path and re-open. Prefer one required, typed input.

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -175,6 +175,52 @@ through it. The structured forwarding design evolves it in its second delivery s
 original value-equal record to a registration-backed, non-equatable descriptor:
 
 ```csharp
+public abstract record AssemblyResolutionProvenance
+{
+    private protected AssemblyResolutionProvenance() { }
+
+    public static AssemblyResolutionProvenance Package(
+        string packageId,
+        string packageVersion,
+        string? tfm,
+        string? rid) =>
+        new PackageAsset(packageId, packageVersion, tfm, rid);
+
+    public static AssemblyResolutionProvenance Platform(
+        string framework,
+        string? frameworkVersion,
+        string resolverSource) =>
+        new PlatformAsset(framework, frameworkVersion, resolverSource);
+
+    public static AssemblyResolutionProvenance Project(
+        string project,
+        string? tfm,
+        string? rid) =>
+        new ProjectAsset(project, tfm, rid);
+
+    public static AssemblyResolutionProvenance Local(string resolverSource) =>
+        new LocalAsset(resolverSource);
+
+    public sealed record PackageAsset(
+        string PackageId,
+        string PackageVersion,
+        string? Tfm,
+        string? Rid) : AssemblyResolutionProvenance;
+
+    public sealed record PlatformAsset(
+        string Framework,
+        string? FrameworkVersion,
+        string ResolverSource) : AssemblyResolutionProvenance;
+
+    public sealed record ProjectAsset(
+        string Project,
+        string? Tfm,
+        string? Rid) : AssemblyResolutionProvenance;
+
+    public sealed record LocalAsset(
+        string ResolverSource) : AssemblyResolutionProvenance;
+}
+
 var reference = ResolvedAssemblyReference.Create(
     selectedIdentity,
     path,
@@ -552,11 +598,14 @@ The end state is large; get there without a big-bang rewrite. Suggested order:
    `MemberCodeProvider` and the current `ResearchViews.ProjectMember` implementation next (see
    [the sibling seam](#the-sibling-seam-method-body--coordinate-inspection)).
 
+The provenance breadth is resolved by `AssemblyResolutionProvenance`: package assets carry
+package/version/tfm/rid, platform assets carry framework/version/source, project assets carry
+project/tfm/rid, and local assets carry resolver source. This is the minimum current consumers
+read back; adding another field or arm requires a named consumer rather than turning provenance
+into a grab bag.
+
 ## Open questions
 
-- **Provenance breadth.** `ResolvedAssemblyReference.Provenance` is a single `string?` today.
-  How much structure does inspection actually need (package@version, tfm, rid, platform flag,
-  resolver source) before it becomes a grab bag? Prefer the minimum consumers read back.
 - **Query granularity.** Is `InspectionQuery.Facets` the right knob, or should the session be
   lazy (scan on first access) so the query only needs the target? Laziness may make the facet
   set redundant.

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -178,6 +178,7 @@ original value-equal record to a registration-backed, non-equatable descriptor:
 public abstract record AssemblyResolutionProvenance
 {
     private protected AssemblyResolutionProvenance() { }
+    private protected abstract int Discriminator { get; }
 
     public static AssemblyResolutionProvenance Package(
         string packageId,
@@ -205,20 +206,32 @@ public abstract record AssemblyResolutionProvenance
         string PackageId,
         string PackageVersion,
         string? Tfm,
-        string? Rid) : AssemblyResolutionProvenance;
+        string? Rid) : AssemblyResolutionProvenance
+    {
+        private protected override int Discriminator => 0;
+    }
 
     public sealed record PlatformAsset(
         string Framework,
         string? FrameworkVersion,
-        string ResolverSource) : AssemblyResolutionProvenance;
+        string ResolverSource) : AssemblyResolutionProvenance
+    {
+        private protected override int Discriminator => 1;
+    }
 
     public sealed record ProjectAsset(
         string Project,
         string? Tfm,
-        string? Rid) : AssemblyResolutionProvenance;
+        string? Rid) : AssemblyResolutionProvenance
+    {
+        private protected override int Discriminator => 2;
+    }
 
     public sealed record LocalAsset(
-        string ResolverSource) : AssemblyResolutionProvenance;
+        string ResolverSource) : AssemblyResolutionProvenance
+    {
+        private protected override int Discriminator => 3;
+    }
 }
 
 var reference = ResolvedAssemblyReference.Create(

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -175,18 +175,18 @@ through it. The structured forwarding design evolves it in its second delivery s
 original value-equal record to a registration-backed, non-equatable descriptor:
 
 ```csharp
-var registration = new AssemblyAcquisitionRegistration(
+var reference = ResolvedAssemblyReference.Create(
     selectedIdentity,
     path,
     () => File.OpenRead(path),
     provenance);
-var reference = new ResolvedAssemblyReference(registration);
 ```
 
-The acquisition owner retains one registration per selected candidate; the descriptor exposes
-the selected image's identity, path, opener, provenance, and opaque registration handle, but the
-handle's payload remains internal. The incoming `AssemblyRef` identity remains request evidence,
-not descriptor identity. See
+The acquisition owner retains the returned canonical descriptor and opaque registration per
+selected candidate. The handle contains no payload and cannot recreate the descriptor; the
+descriptor exposes the selected image's identity, path, opener, structured provenance, and
+registration. The incoming `AssemblyRef` identity remains request evidence, not descriptor
+identity. See
 [Type forwarding resolution](type-forwarding-resolution.md#assembly-candidate) for the
 authoritative identity, ownership, and migration contract. Provenance still widens from
 `string?` into a structured value — package@version, tfm, rid, platform-or-not, resolver source
@@ -395,10 +395,9 @@ Three rules keep the surface flat:
    lifts a path into one.**
    Where a service genuinely accepts an assembly by value (the resolution boundary, or a
    standalone call), it takes the reference. A path-only caller asks the local acquisition owner
-   to register the selected image and return `new ResolvedAssemblyReference(registration)`, so
-   there is **one** input type, not a second overload per service. The owner reads the selected
-   image identity and retains the registration; consumers do not synthesize request-shaped
-   descriptors.
+   to register the selected image through `ResolvedAssemblyReference.Create`, so there is **one**
+   input type, not a second overload per service. The owner reads the selected image identity and
+   retains the canonical descriptor; consumers do not synthesize request-shaped descriptors.
 3. **Never take `(path, ResolvedAssemblyReference? reference = null)`.** That optional/nullable
    both-or-neither shape is precisely the loose-parameter smell this design removes; it invites
    callers to pass a path and re-open. Prefer one required, typed input.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1725,7 +1725,9 @@ For one builder request:
    `Rejected(PlanExpansionRequired(Binding(request)))`.
 3. Open the selected assembly through the context.
 4. Probe the exact structured type name.
-5. On `Defined`, materialize the definition key and finish.
+5. On `Defined`, record the terminal candidate and `TypeDefinitionToken` in the
+   recipe and finish. Only freeze projects those coordinates into a
+   generation-scoped definition key.
 6. On `Missing`, return `NotFound`.
 7. On `Ambiguous`, return `Ambiguous`.
 8. On `Rejected`, return `Rejected`.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -362,14 +362,14 @@ public abstract class TypeResolutionStart
     public sealed class Assembly : TypeResolutionStart
     {
         internal Assembly(
-            ResolvedAssemblyCandidate value,
+            ResolvedAssemblyReference value,
             AssemblyResolutionScope scope)
         {
             Value = value;
             Scope = scope;
         }
 
-        public ResolvedAssemblyCandidate Value { get; }
+        public ResolvedAssemblyReference Value { get; }
         public AssemblyResolutionScope Scope { get; }
     }
 
@@ -390,7 +390,7 @@ public abstract class TypeResolutionStart
 
 public sealed class TypeResolutionRequest
 {
-    TypeResolutionRequest(
+    public TypeResolutionRequest(
         TypeResolutionStart start,
         MetadataTypeDefinitionName type)
     {
@@ -402,7 +402,7 @@ public sealed class TypeResolutionRequest
     public MetadataTypeDefinitionName Type { get; }
 
     public static TypeResolutionRequest FromAssembly(
-        ResolvedAssemblyCandidate value,
+        ResolvedAssemblyReference value,
         AssemblyResolutionScope scope,
         MetadataTypeDefinitionName type) =>
         new(new TypeResolutionStart.Assembly(value, scope), type);
@@ -415,9 +415,9 @@ public sealed class TypeResolutionRequest
 }
 ```
 
-`Assembly` means "probe this already-resolved assembly, then follow any
-forwarder." `Reference` means "first ask the binding policy to resolve this
-exact `AssemblyRef`, then probe the result."
+`Assembly` means "intern this already-resolved descriptor in the context's
+catalog, probe it, then follow any forwarder." `Reference` means "first ask the
+binding policy to resolve this exact `AssemblyRef`, then probe the result."
 
 This avoids an optional `(path, reference?)` or `(assembly?, identity?)` shape.
 Every request states exactly where resolution begins.
@@ -587,6 +587,75 @@ from an ambiguous scope or an unreadable candidate. It evolves rather than
 gaining a parallel resolver:
 
 ```csharp
+public abstract class AssemblyBindingSelection
+{
+    private protected AssemblyBindingSelection() { }
+
+    public static AssemblyBindingSelection Found(
+        ResolvedAssemblyReference assembly) =>
+        new Selected(assembly);
+
+    public static AssemblyBindingSelection NotFound() => new Missing();
+
+    public static AssemblyBindingSelection CannotSelect(
+        AssemblyBindingFailure failure) =>
+        new Unavailable(failure);
+
+    public static AssemblyBindingSelection Multiple(
+        ImmutableArray<ResolvedAssemblyReference> assemblies) =>
+        new Ambiguous(assemblies);
+
+    public static AssemblyBindingSelection Invalid(
+        AssemblyBindingFailure failure) =>
+        new Rejected(failure);
+
+    public sealed class Selected : AssemblyBindingSelection
+    {
+        internal Selected(ResolvedAssemblyReference assembly) =>
+            Assembly = assembly;
+
+        public ResolvedAssemblyReference Assembly { get; }
+    }
+
+    public sealed class Missing : AssemblyBindingSelection
+    {
+        internal Missing() { }
+    }
+
+    public sealed class Unavailable : AssemblyBindingSelection
+    {
+        internal Unavailable(AssemblyBindingFailure failure) =>
+            Failure = failure;
+
+        public AssemblyBindingFailure Failure { get; }
+    }
+
+    public sealed class Ambiguous : AssemblyBindingSelection
+    {
+        internal Ambiguous(
+            ImmutableArray<ResolvedAssemblyReference> assemblies) =>
+            Assemblies = assemblies;
+
+        public ImmutableArray<ResolvedAssemblyReference> Assemblies { get; }
+    }
+
+    public sealed class Rejected : AssemblyBindingSelection
+    {
+        internal Rejected(AssemblyBindingFailure failure) =>
+            Failure = failure;
+
+        public AssemblyBindingFailure Failure { get; }
+    }
+}
+
+public interface IAssemblyBindingPolicy
+{
+    AssemblyBindingSelection Select(
+        AssemblyReferenceIdentity identity,
+        AssemblyResolutionScope scope);
+}
+
+// Metadata-owned adapter result after descriptor interning.
 public abstract class AssemblyBindingOutcome
 {
     private protected AssemblyBindingOutcome() { }
@@ -630,7 +699,7 @@ public abstract class AssemblyBindingOutcome
     }
 }
 
-public interface IAssemblyBindingResolver
+internal interface IAssemblyBindingResolver
 {
     AssemblyBindingOutcome Resolve(
         AssemblyReferenceIdentity identity,
@@ -643,10 +712,19 @@ unordered directory containing several plausible candidates returns
 `Ambiguous`; the Metadata engine does not choose by enumeration order, file
 name, highest version, or nearest path.
 
-This is a new contract, not a same-name return-type change to
-`IAssemblyReferenceResolver`. The nullable resolver remains only as migration
-scaffolding and is deleted after its final consumer moves. A nullable
-implementation cannot accidentally satisfy the structured interface.
+Package, platform, project, and local acquisition owners implement the public
+`IAssemblyBindingPolicy` and return context-free descriptors through public
+factories. A Metadata-owned adapter interns those descriptors into the active
+catalog and produces the internal candidate-bearing
+`AssemblyBindingOutcome`. External policy assemblies never receive
+`InternalsVisibleTo` and cannot mint candidate ids, definition keys, or join
+tokens.
+
+This is a new public policy contract plus a Metadata-internal adapter, not a
+same-name return-type change to `IAssemblyReferenceResolver`. The nullable
+resolver remains only as migration scaffolding and is deleted after its final
+consumer moves. A nullable implementation cannot accidentally satisfy the
+structured policy interface.
 
 ### Resolution outcome
 
@@ -696,11 +774,25 @@ public sealed class ResolvedTypeDefinition
     public MetadataTypeDefinitionName Type { get; }
 }
 
-public sealed record TypeForwardingHop(
-    ResolvedAssemblyCandidate SourceAssembly,
-    ImmutableArray<ExportedTypeToken> Declarations,
-    AssemblyReferenceIdentity TargetReference,
-    AssemblyResolutionScope Scope);
+public sealed class TypeForwardingHop
+{
+    internal TypeForwardingHop(
+        ResolvedAssemblyCandidate sourceAssembly,
+        ImmutableArray<ExportedTypeToken> declarations,
+        AssemblyReferenceIdentity targetReference,
+        AssemblyResolutionScope scope)
+    {
+        SourceAssembly = sourceAssembly;
+        Declarations = declarations;
+        TargetReference = targetReference;
+        Scope = scope;
+    }
+
+    public ResolvedAssemblyCandidate SourceAssembly { get; }
+    public ImmutableArray<ExportedTypeToken> Declarations { get; }
+    public AssemblyReferenceIdentity TargetReference { get; }
+    public AssemblyResolutionScope Scope { get; }
+}
 
 public abstract class TypeResolutionAmbiguity
 {
@@ -861,12 +953,29 @@ public abstract class DefinitionCorrespondence
     }
 }
 
-public sealed record DuplicateArtifactCandidateEvidence(
-    ResolvedAssemblyReference Assembly,
-    MetadataTypeDefinitionAddress Address);
+public sealed class DuplicateArtifactCandidateEvidence
+{
+    internal DuplicateArtifactCandidateEvidence(
+        ResolvedAssemblyReference assembly,
+        MetadataTypeDefinitionAddress address)
+    {
+        Assembly = assembly;
+        Address = address;
+    }
 
-public sealed record DuplicateArtifactEvidence(
-    ImmutableArray<DuplicateArtifactCandidateEvidence> Candidates);
+    public ResolvedAssemblyReference Assembly { get; }
+    public MetadataTypeDefinitionAddress Address { get; }
+}
+
+public sealed class DuplicateArtifactEvidence
+{
+    internal DuplicateArtifactEvidence(
+        ImmutableArray<DuplicateArtifactCandidateEvidence> candidates) =>
+        Candidates = candidates;
+
+    public ImmutableArray<DuplicateArtifactCandidateEvidence> Candidates
+        { get; }
+}
 ```
 
 The catalog owns duplicate-artifact detection because it can inspect both
@@ -976,8 +1085,8 @@ catalog, and caches:
 - completed resolutions by
   `(AssemblyCatalogGenerationId, TypeResolutionCacheKey)`.
 
-`TypeResolutionCacheKey` is an internal projection, not the public request
-record's synthesized equality. Its start arm contains either the internal
+`TypeResolutionCacheKey` is an internal projection; it does not use the public
+request object's reference equality. Its start arm contains either the internal
 candidate id plus scope or the complete assembly reference identity plus scope,
 followed by the structurally equatable `MetadataTypeDefinitionName`.
 
@@ -988,7 +1097,7 @@ The catalog and resolution caches support concurrent Analysis. Candidate open,
 declaration probe, binding, and completed-resolution entries are single-flight:
 parallel body-analysis workers observe one result and one owned session.
 Synchronization does not hold a cache lock while invoking an external opener or
-binding resolver.
+binding policy.
 
 The public outcome contains no reader-backed value. Its descriptors, address,
 identities, name, and evidence can leave the context in the same sense that
@@ -1075,7 +1184,7 @@ The last rule intentionally narrows today's version-blind caller matching. A
 version-skewed local caller becomes an indeterminate diagnostic rather than a
 reported caller until acquisition policy can prove the binding. That behavior
 change is compatibility evidence, not a silent miss. An explicit future local
-roll-forward option belongs to the binding resolver and must carry its own
+roll-forward option belongs to the binding policy and must carry its own
 policy name and gates.
 
 An unavailable or ambiguous answer may therefore omit exact correspondence,
@@ -1097,15 +1206,31 @@ Analysis-owned and does not absorb resolution:
 ```csharp
 public abstract record TypeReferenceOrigin
 {
-    public sealed record AssemblyReference(
-        AssemblyReferenceIdentity Assembly) : TypeReferenceOrigin;
+    private protected TypeReferenceOrigin() { }
 
-    public sealed record CurrentAssembly : TypeReferenceOrigin;
+    public sealed record AssemblyReference : TypeReferenceOrigin
+    {
+        internal AssemblyReference(AssemblyReferenceIdentity assembly) =>
+            Assembly = assembly;
 
-    public sealed record IntrinsicCoreLibrary : TypeReferenceOrigin;
+        public AssemblyReferenceIdentity Assembly { get; }
+    }
 
-    public sealed record ModuleReference(
-        string ModuleName) : TypeReferenceOrigin;
+    public sealed record CurrentAssembly : TypeReferenceOrigin
+    {
+        internal CurrentAssembly() { }
+    }
+
+    public sealed record IntrinsicCoreLibrary : TypeReferenceOrigin
+    {
+        internal IntrinsicCoreLibrary() { }
+    }
+
+    public sealed record ModuleReference : TypeReferenceOrigin
+    {
+        internal ModuleReference(string moduleName) => ModuleName = moduleName;
+        public string ModuleName { get; }
+    }
 }
 
 public sealed record ResolvableTypeReference(
@@ -1117,6 +1242,10 @@ The origin is excluded from display and from existing shape equality. It is
 separate typed provenance and must not be recovered from, or cached by,
 structural `TypeRef` equality. Resolution caches key on
 `ResolvableTypeReference`, never on `TypeRef`.
+
+This is decoder-produced, output-only provenance. Analysis owns construction;
+external consumers may pattern-match the closed arms but cannot mint an origin
+that the metadata did not supply.
 
 This replaces #3476's proposed `RawAssembly` string with the full identity the
 metadata actually supplied. Two `AssemblyRef` rows with different identity
@@ -1626,7 +1755,8 @@ without returning a stringly or nullable result.
 
 - Extend `AssemblyInspectionSession` as the single candidate image owner, add
   the catalog lifetime, and compose `TypeResolutionContext` over those sessions.
-- Add `IAssemblyBindingResolver` with typed outcomes and explicit adapters from
+- Add public `IAssemblyBindingPolicy` descriptor selections and the
+  Metadata-internal candidate-interning adapter, with explicit adapters from
   existing resolvers.
 - Implement the iterative cross-assembly engine.
 - Make catalog and resolution caches safe for concurrent Analysis with
@@ -1703,6 +1833,12 @@ Claim: direct callers and transitive call graphs share one definition identity.
   `UnresolvedBindingKey` values agree across `Equals`, `==`, `!=`, and hashing.
 - Public result hierarchies cannot be externally extended, and product
   consumers cannot construct correspondence verdict arms.
+- An external fake `IAssemblyBindingPolicy` can return every public descriptor
+  selection through factories but cannot construct catalog candidates.
+- External consumers can create assembly-descriptor and assembly-reference
+  requests and can forward an existing `TypeResolutionStart` to another type.
+- External consumers can inspect but cannot forge decoder-produced
+  `TypeReferenceOrigin`.
 - Type name, assembly identity, assembly candidate, provenance, and hop evidence
   remain separate fields.
 
@@ -1803,6 +1939,9 @@ Prefer dependency and visibility constraints over source scans:
 - candidate ids and join-token constructors are internal, and the internal
   `CatalogMemberJoinKey` factory accepts only catalog-issued
   `DefinitionJoinToken` or `UnresolvedBindingKey` values;
+- external policy assemblies implement `IAssemblyBindingPolicy` without
+  `InternalsVisibleTo`; only the Metadata adapter constructs
+  `AssemblyBindingOutcome`;
 - correspondence-bearing result bases use `private protected` constructors and
   every verdict arm uses an internal constructor;
 - Analysis and the CLI cannot access the probe's reader-backed internals;
@@ -1826,6 +1965,9 @@ rejects `MetadataTypeDefinitionAddress` or bare `TypeDefinitionToken` equality
 in caller, source, API, and graph correspondence producers; those value
 equalities remain allowed only inside one known candidate for
 durable-coordinate handling, declaration probing, and reader-validation code.
+The same gate treats `TypeForwardingHop`, `DuplicateArtifactEvidence`, and
+`DuplicateArtifactCandidateEvidence` as evidence-only classes, never identity
+or correspondence keys.
 
 A second narrow source gate may forbid `Path.Combine` over
 `AssemblyReferenceIdentity.Name` in product code, but it is defense in depth,

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -318,52 +318,107 @@ provenance, and an `AssemblyAcquisitionRegistration`:
 ```csharp
 public sealed class AssemblyAcquisitionRegistration
 {
-    public AssemblyAcquisitionRegistration(
-        AssemblyReferenceIdentity selectedIdentity,
+    internal AssemblyAcquisitionRegistration() { }
+}
+
+public abstract record AssemblyResolutionProvenance
+{
+    private protected AssemblyResolutionProvenance() { }
+
+    public static AssemblyResolutionProvenance Package(
+        string packageId,
+        string packageVersion,
+        string? tfm,
+        string? rid) =>
+        new PackageAsset(packageId, packageVersion, tfm, rid);
+
+    public static AssemblyResolutionProvenance Platform(
+        string framework,
+        string? frameworkVersion,
+        string resolverSource) =>
+        new PlatformAsset(framework, frameworkVersion, resolverSource);
+
+    public static AssemblyResolutionProvenance Project(
+        string project,
+        string? tfm,
+        string? rid) =>
+        new ProjectAsset(project, tfm, rid);
+
+    public static AssemblyResolutionProvenance Local(string resolverSource) =>
+        new LocalAsset(resolverSource);
+
+    public sealed record PackageAsset(
+        string PackageId,
+        string PackageVersion,
+        string? Tfm,
+        string? Rid) : AssemblyResolutionProvenance;
+
+    public sealed record PlatformAsset(
+        string Framework,
+        string? FrameworkVersion,
+        string ResolverSource) : AssemblyResolutionProvenance;
+
+    public sealed record ProjectAsset(
+        string Project,
+        string? Tfm,
+        string? Rid) : AssemblyResolutionProvenance;
+
+    public sealed record LocalAsset(
+        string ResolverSource) : AssemblyResolutionProvenance;
+}
+
+public sealed class ResolvedAssemblyReference
+{
+    private ResolvedAssemblyReference(
+        AssemblyAcquisitionRegistration registration,
+        AssemblyReferenceIdentity identity,
         string? path,
         Func<Stream> openRead,
-        string? provenance)
+        AssemblyResolutionProvenance provenance)
     {
-        SelectedIdentity = selectedIdentity;
+        Registration = registration;
+        Identity = identity;
         Path = path;
         OpenRead = openRead;
         Provenance = provenance;
     }
 
-    internal AssemblyReferenceIdentity SelectedIdentity { get; }
-    internal string? Path { get; }
-    internal Func<Stream> OpenRead { get; }
-    internal string? Provenance { get; }
-}
-
-public sealed class ResolvedAssemblyReference
-{
-    public ResolvedAssemblyReference(
-        AssemblyAcquisitionRegistration registration) =>
-        Registration = registration;
+    public static ResolvedAssemblyReference Create(
+        AssemblyReferenceIdentity selectedIdentity,
+        string? path,
+        Func<Stream> openRead,
+        AssemblyResolutionProvenance provenance) =>
+        new(
+            new AssemblyAcquisitionRegistration(),
+            selectedIdentity,
+            path,
+            openRead,
+            provenance);
 
     public AssemblyAcquisitionRegistration Registration { get; }
-    public AssemblyReferenceIdentity Identity =>
-        Registration.SelectedIdentity;
-    public string? Path => Registration.Path;
-    public Func<Stream> OpenRead => Registration.OpenRead;
-    public string? Provenance => Registration.Provenance;
+    public AssemblyReferenceIdentity Identity { get; }
+    public string? Path { get; }
+    public Func<Stream> OpenRead { get; }
+    public AssemblyResolutionProvenance Provenance { get; }
 }
 ```
 
 The registration is a public opaque reference-identity handle because an
 external acquisition owner must mint, retain, and receive it as a requesting
-origin at the policy boundary. Its payload remains internal; consumers can
-compare the handle only by reference and cannot extract path, identity, opener,
-or provenance from it. It is not a definition key or a claim that visible
-descriptor fields identify a physical file. It owns the canonical
-selected-candidate descriptor so two wrappers carrying one registration cannot
-disagree about identity, path, opener, or provenance. `SelectedIdentity` is the
-selected image's `AssemblyDef` identity, never the incoming `AssemblyRef`
-identity that requested it. The request remains in the binding outcome and
-forwarding hop. An adapter over today's resolver must therefore normalize the
-legacy request-shaped descriptor from its selected inventory entry before
-registration.
+origin at the policy boundary. The handle contains no payload, its constructor
+is internal, and the descriptor constructor is private. An external owner mints
+the pair only through `ResolvedAssemblyReference.Create`, retains that one
+canonical descriptor per selected entry, and reuses it in policy selections.
+Given only an origin registration, another policy cannot reconstruct the
+descriptor or extract path, identity, opener, or provenance. The handle is not
+a definition key or a claim that visible descriptor fields identify a physical
+file.
+
+`ResolvedAssemblyReference.Identity` is the selected image's `AssemblyDef`
+identity, never the incoming `AssemblyRef` identity that requested it. The
+request remains in the binding outcome and forwarding hop. An adapter over
+today's resolver must therefore normalize the legacy request-shaped descriptor
+from its selected inventory entry before creating the canonical pair.
 
 The owner creates one handle per selected candidate and reuses it in every
 descriptor and request that it knows denotes that candidate. The inspection
@@ -395,13 +450,12 @@ descriptor object, but caches and correspondence still key on the internal id,
 not object equality.
 
 Within one catalog, `AssemblyAcquisitionRegistration` reference identity is the
-registration key. Descriptor object identity, descriptor fields, path, MVID,
-and opener-delegate equality never intern candidates. Returning
-`candidate.Assembly`, or another descriptor carrying the same registration,
-therefore recovers the existing candidate. A descriptor with a fresh
-registration remains a distinct conservative candidate even when all visible
-fields match. Conflicting wrappers are unrepresentable because the canonical
-payload belongs to the registration.
+registration key. Descriptor fields, path, MVID, and opener-delegate equality
+never intern candidates. Returning `candidate.Assembly` therefore recovers the
+existing candidate. Calling `Create` again produces a fresh registration and a
+distinct conservative candidate even when all visible fields match.
+Conflicting public wrappers are unrepresentable because each factory call makes
+one canonical pair.
 
 `InspectionAcquisitionPlan` owns one package, platform, project, and local
 adapter per inspection. Today's per-path `AssemblyDependencyResolver` instances
@@ -433,8 +487,10 @@ cross-catalog comparison into an ordinary "different definition" answer.
 
 Package coordinates, selected TFM, platform framework, and local path remain
 provenance, not fields in `AssemblyReferenceIdentity`. Structuring that
-provenance is owned by the assembly-inspection query model and is not duplicated
-here.
+provenance is owned by the assembly-inspection query model; the shared
+`AssemblyResolutionProvenance` declaration above is included here only to make
+the evolved descriptor contract complete and must remain identical to that
+owner's shape.
 
 ### Resolution start
 
@@ -739,6 +795,11 @@ public enum AssemblyBindingFailureKind
 public sealed record AssemblyBindingFailure(
     AssemblyBindingFailureKind Kind);
 
+public sealed class AssemblyBindingPolicyVersion
+{
+    public AssemblyBindingPolicyVersion() { }
+}
+
 public sealed class AssemblyBindingRequest
 {
     public AssemblyBindingRequest(
@@ -819,6 +880,7 @@ public abstract class AssemblyBindingSelection
 
 public interface IAssemblyBindingPolicy
 {
+    AssemblyBindingPolicyVersion Version { get; }
     AssemblyBindingSelection Select(AssemblyBindingRequest request);
 }
 
@@ -864,6 +926,14 @@ public abstract class AssemblyBindingOutcome
 
         public AssemblyBindingFailure Failure { get; }
     }
+
+    public sealed class ExpansionRequired : AssemblyBindingOutcome
+    {
+        internal ExpansionRequired(AssemblyBindingRequest request) =>
+            Request = request;
+
+        public AssemblyBindingRequest Request { get; }
+    }
 }
 
 internal interface IAssemblyBindingResolver
@@ -896,6 +966,23 @@ generation-scoped and is the only origin projection permitted in binding and
 resolution cache keys. `AssemblyBindingCacheKey` is the structural tuple of
 that domain key, complete reference identity, and scope; the containing cache
 supplies the generation.
+
+`AssemblyBindingOutcome.ExpansionRequired` is produced only by a frozen cache
+lookup for an absent binding-only root. External policies cannot return it.
+Type resolution maps it to
+`Rejected(PlanExpansionRequired(Binding(request)))`; adjacency orchestration
+adds the binding root and advances the generation before rendering.
+
+`AssemblyBindingPolicyVersion` is an opaque reference token for one stable
+policy snapshot. A policy returns the same instance while its inventories and
+selection behavior are unchanged and replaces it before a later call could
+produce a different answer. `InspectionAcquisitionPlanVersion` is the internal
+composite of the package, platform, project, and local policy-version
+references. Binding cache entries record their owning policy and version.
+Across discovery epochs, an unchanged policy version carries its frozen
+binding outcomes forward without invoking policy; a changed version refreshes
+only that owner's binding roots and invalidates recipes whose dependency
+snapshots differ. Policy selection must be deterministic within one version.
 
 Package, platform, project, and local acquisition owners implement the public
 `IAssemblyBindingPolicy` and return context-free descriptors through public
@@ -1405,7 +1492,9 @@ first supplies a manifest with two root kinds:
   references, and named signature types in graph edges being indexed;
 - binding-only `AssemblyBindingRequest` roots for every snapshotted
   `AssemblyRef` used to build caller-scope reverse adjacency, each carrying its
-  requesting candidate origin.
+  requesting candidate origin; selected candidates contribute only the
+  additional `AssemblyRef` targets used by their valid `ExportedType`
+  forwarders.
 
 The builder executes those roots provisionally, including every per-hop
 scope-tightening transition. Each encountered
@@ -1459,18 +1548,20 @@ It stores:
 and typed failure payload; it never compares public outcome objects or
 descriptors. Freeze stores recipes by
 `(AssemblyCatalogGenerationId, TypeResolutionCacheKey)` and materializes the
-public outcome and definition keys for that generation. A later epoch refreshes
-each recorded binding dependency and reuses the recipe only when every snapshot
-is structurally unchanged; otherwise it reruns that recipe. Invalidating an old
-context therefore does not discard the catalog-owned recipe store.
+public outcome and definition keys for that generation. A later epoch carries
+each dependency forward without a policy call while its owning policy version
+is unchanged. When that version changes, the builder refreshes the dependency
+and reuses the recipe only if the new snapshot is structurally equal; otherwise
+it reruns that recipe. Invalidating an old context therefore does not discard
+the catalog-owned recipe store.
 
 A request outside the frozen manifest returns the typed
 `PlanExpansionRequired` rejection to the inspection coordinator. The
 coordinator unions that request into the builder and advances the generation
 before rendering; it never treats the rejection as missing. A binding outcome
-inside the manifest can reference only candidates frozen with it. A volatile
-policy that changes its answer is observed only when a later discovery epoch
-refreshes that pair, never halfway through execution.
+inside the manifest can reference only candidates frozen with it. Policy
+changes require a new version and are observed only by the next discovery
+epoch, never halfway through execution.
 
 The internal `CatalogDiscoveryOutcome` is closed: `Ready` carries the frozen
 generation, while `Rejected` carries
@@ -1481,9 +1572,10 @@ than retrying or rendering an authoritative empty result.
 A later progressive lens first reopens the builder with the union of previous
 manifest and the new lens's requests. Graph planning first decodes the selected
 edge set, contributes all named signature requests, snapshots each scope
-candidate's assembly references, and contributes all adjacency binding roots.
-It then freezes, issues join tokens, and builds the graph. It never discovers a
-new binding while tokens are being issued. If fixed-point discovery adds a
+candidate's assembly references, contributes those adjacency binding roots, and
+expands forwarding-only adjacency for candidates selected by those roots. It
+then freezes, issues join tokens, and builds the graph. It never discovers a new
+binding while tokens are being issued. If fixed-point discovery adds a
 candidate, the catalog
 freezes a new generation and invalidates every
 `TypeResolutionContext`, resolution plan, join token, and `ScopeGraph` lease
@@ -1509,6 +1601,10 @@ The acquisition catalog caches:
 - frozen resolution recipes by
   `(AssemblyCatalogGenerationId, TypeResolutionCacheKey)`, with their binding
   dependency snapshots;
+
+A new discovery epoch seeds its provisional binding map from the preceding
+frozen map for every unchanged policy version. The epoch component isolates new
+writes and cancellation; it does not force another policy call.
 
 Each resolution context is bound to one frozen generation, composes that
 catalog, and caches:
@@ -1560,7 +1656,8 @@ For one builder request:
    populate the provisional binding outcome. Binding `Selected` continues;
    `Missing` returns `UnboundReference`; `Unavailable` returns `Unavailable`;
    `Ambiguous` returns `Ambiguous`; and binding `Rejected` returns
-   `Rejected(InvalidBindingPolicy)`.
+   `Rejected(InvalidBindingPolicy)`. Frozen-only `ExpansionRequired` maps to
+   `Rejected(PlanExpansionRequired(Binding(request)))`.
 3. Open the selected assembly through the context.
 4. Probe the exact structured type name.
 5. On `Defined`, materialize the definition key and finish.
@@ -1754,23 +1851,34 @@ under the inspection catalog:
 3. Bind assembly references to catalog candidates and build reverse adjacency.
    Every pair is contributed as a binding-only discovery root and frozen before
    reverse closure begins.
-4. Root graph reachability at the candidate owning the target definition and
+4. Expand assembly-level forwarding adjacency. For every candidate selected by
+   an adjacency edge or resolution root, read its `ExportedType` inventory and
+   collect only the `AssemblyRef` targets that terminate valid forwarder
+   declarations. Add those binding-only roots and edges, then repeat for newly
+   selected forwarder candidates to the discovery budget. This adds
+   `caller -> facade -> implementation` even when the caller's matching
+   `TypeRef` names some unrelated type.
+5. Root graph reachability at the candidate owning the target definition and
    every descriptor selection carrying that candidate's acquisition
    registration.
-5. Compute the transitive graph set as reverse-reference closure from the
+6. Compute the transitive graph set as reverse-reference closure from the
    target-assembly roots, direct facade seeds, and indeterminate seeds.
 
 An unread reference set or an unavailable, ambiguous, or rejected adjacency
-binding cannot prove a negative. Its carrier remains an indeterminate graph
-candidate and widens closure under its own candidate identity, matching the
-current rule that unknown reachability must not truncate everything above it.
+binding cannot prove a negative. Its incoming scope carriers remain
+indeterminate graph seeds and widen closure under their identities; an
+unreadable selected facade never relies on its unavailable `AssemblyDef`
+identity to retain callers above it. This matches the current rule that unknown
+reachability must not truncate everything above it.
 
 This replaces `CallerScopeFilter`'s assembly-spelling proof with a proof against
 definition correspondence. A facade need not be in the caller scope: resolving
 the matching reference may acquire and traverse it through binding policy. The
 work remains query-directed because it resolves only the target structured name
-through references actually present in scope candidates; it does not seed from
-or sweep every framework facade.
+through references actually present in scope candidates. Forwarding adjacency
+opens only candidates reached from those roots and reads only their
+`ExportedType` target references; it does not bind every dependency of those
+candidates or seed from every framework facade.
 
 Rooting at the target assembly is independent of the target type name. It keeps
 a scope candidate that references another type in the target assembly, and
@@ -2175,6 +2283,9 @@ Resolution is query-directed:
 - caller reachability binds each snapshotted scope-candidate `AssemblyRef` once
   in its requesting domain to build reverse adjacency, without opening every
   referenced image;
+- for candidates selected by those edges, reachability opens only the images
+  needed to read forwarding inventories and binds only their
+  `ExportedType`-target references;
 - graph signature correspondence resolves only named type occurrences in edges
   being indexed and caches each resolvable origin once.
 
@@ -2191,7 +2302,9 @@ forwarded `XmlReader` caller is:
 - each unique matching reference and signature origin is resolved at most once;
 - adjacency policy calls equal the distinct
   `(requesting candidate, reference identity, scope)` rows in the scope
-  snapshot, and no adjacency request is first discovered after freeze.
+  snapshot plus forwarding-adjacency rows over the whole inspection while
+  policy versions remain unchanged, and no adjacency request is first
+  discovered after freeze.
 
 Wall-clock measurements may accompany implementation evidence but do not
 replace these structural counts.
@@ -2305,12 +2418,11 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - An external fake `IAssemblyBindingPolicy` can return every public descriptor
   selection through factories but cannot construct catalog candidates.
 - An external fake policy can construct every `AssemblyBindingFailureKind`.
-- Two descriptor objects carrying the same
-  `AssemblyAcquisitionRegistration`, including `candidate.Assembly`, yield one
+- Reusing the canonical descriptor, including `candidate.Assembly`, yields one
   candidate id, one opened session, and `Same` correspondence.
-- A second descriptor with identical visible values and the identical
-  `Func<Stream>` instance but a fresh registration remains a distinct
-  candidate.
+- A second `ResolvedAssemblyReference.Create` call with identical visible
+  values and the identical `Func<Stream>` instance receives a fresh
+  registration and remains a distinct candidate.
 - Package, platform, project, and local migration adapters each return one
   stable registration when their owner selects the same candidate through
   different compatible reference requests.
@@ -2322,8 +2434,15 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - A user path found in the platform inventory and a forwarder binding to that
   entry share the platform registration; an unowned copied path remains local.
 - An external policy receives only the requesting registration, can use
-  reference identity to select its owner inventory, and cannot reach the
-  requesting descriptor or registration payload through the origin.
+  reference identity to select its owner inventory, and cannot construct a
+  descriptor from that handle or reach the requesting payload through the
+  origin.
+- External acquisition owners can construct every structured provenance arm;
+  no consumer parses a provenance string.
+- Unchanged `AssemblyBindingPolicyVersion` instances carry binding and
+  adjacency outcomes across progressive epochs without another policy call;
+  replacing one version refreshes only that owner's roots and dependent
+  recipes.
 - Two requesting-assembly origins with the same reference identity and scope
   occupy different binding-cache entries and may select different candidates;
   repeated requests from one origin reuse its outcome.
@@ -2369,6 +2488,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
   causes the once-only probe or resolution count gate to fail.
 - A request outside the frozen manifest returns `PlanExpansionRequired`, and
   presentation occurs only after the coordinator advances the generation.
+- An absent frozen binding-only root returns
+  `AssemblyBindingOutcome.ExpansionRequired`; type resolution maps that arm to
+  `PlanExpansionRequired(Binding(request))`.
 
 ### Consumer gates
 
@@ -2411,6 +2533,12 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Every scope-candidate `AssemblyRef` needed for reverse adjacency is present
   as a binding-only root before freeze; deleting those roots fails the
   depth-two reverse-closure fixture and the adjacency call-count pin.
+- A scope candidate references a facade only for a non-target type, the facade
+  is outside the scope and forwards to the target assembly, and a caller above
+  that candidate remains reachable through
+  `caller -> facade -> implementation`; the candidate is not a direct seed.
+- An unreadable selected facade retains its incoming scope carrier as an
+  indeterminate seed, so callers above the carrier are not truncated.
 - A depth-two graph caller that reaches the selected member through another
   method in the target assembly is retained even though it never names the
   target type.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -123,7 +123,7 @@ alias set.
 | **Definition address** | A durable MVID-scoped metadata token. It locates a definition but is not sufficient adversarial correspondence evidence. |
 | **Declaration probe** | The bounded single-image operation that says whether an assembly defines, forwards, or does not contain one type. |
 | **Resolution** | Repeated declaration probes joined by assembly-reference resolution until a definition or a typed non-success outcome is reached. |
-| **Binding policy** | The caller-supplied rule that maps an `AssemblyBindingRequest` (reference identity, binding origin, and scope) to zero, one, or several assembly candidates. |
+| **Binding policy** | The caller-supplied rule that maps an `AssemblyBindingRequest` (reference-or-core-library target, binding origin, and scope) to zero, one, or several assembly candidates. |
 | **Hop** | One verified `ExportedType` declaration and the `AssemblyRef` it names. |
 
 The vocabulary deliberately does not use **alias**. An alias is a derived set of
@@ -452,7 +452,7 @@ authoritative shape.
 
 ### Resolution start
 
-There are two legitimate starts and they stay explicit:
+There are three legitimate starts and they stay explicit:
 
 ```csharp
 public abstract class AssemblyBindingOrigin
@@ -461,7 +461,7 @@ public abstract class AssemblyBindingOrigin
 
     public static AssemblyBindingOrigin Global() => new GlobalOrigin();
 
-    public static AssemblyBindingOrigin FromAssembly(
+    public static RequestingAssembly FromAssembly(
         ResolvedAssemblyReference assembly) =>
         new RequestingAssembly(assembly.Registration);
 
@@ -514,6 +514,20 @@ public abstract class TypeResolutionStart
         public AssemblyBindingOrigin Origin { get; }
         public AssemblyResolutionScope Scope { get; }
     }
+
+    public sealed class CoreLibrary : TypeResolutionStart
+    {
+        internal CoreLibrary(
+            AssemblyBindingOrigin.RequestingAssembly origin,
+            AssemblyResolutionScope scope)
+        {
+            Origin = origin;
+            Scope = scope;
+        }
+
+        public AssemblyBindingOrigin.RequestingAssembly Origin { get; }
+        public AssemblyResolutionScope Scope { get; }
+    }
 }
 
 public sealed class TypeResolutionRequest
@@ -541,6 +555,16 @@ public sealed class TypeResolutionRequest
         AssemblyResolutionScope scope,
         MetadataTypeDefinitionName type) =>
         new(new TypeResolutionStart.Reference(value, origin, scope), type);
+
+    public static TypeResolutionRequest FromCoreLibrary(
+        ResolvedAssemblyReference requestingAssembly,
+        AssemblyResolutionScope scope,
+        MetadataTypeDefinitionName type) =>
+        new(
+            new TypeResolutionStart.CoreLibrary(
+                AssemblyBindingOrigin.FromAssembly(requestingAssembly),
+                scope),
+            type);
 }
 ```
 
@@ -556,6 +580,12 @@ freeze, then policy receives only that opaque registration. A frozen context
 rejects an origin whose registration is absent from its generation as
 `UnregisteredAssembly` before invoking policy; it never mutates the catalog or
 degrades the origin to global routing.
+
+`CoreLibrary` asks policy for the requesting candidate's intrinsic core library
+without synthesizing an assembly identity. Policy derives the answer from that
+candidate's acquisition domain. The core-library target remains a distinct
+binding/cache arm even when policy selects the same candidate that an explicit
+`AssemblyRef` would select.
 
 This avoids an optional `(path, reference?)` or `(assembly?, identity?)` shape.
 Every request states exactly where resolution begins.
@@ -746,19 +776,36 @@ public sealed class AssemblyBindingPolicyVersion
     public AssemblyBindingPolicyVersion() { }
 }
 
+public abstract record AssemblyBindingTarget
+{
+    private protected AssemblyBindingTarget() { }
+
+    public static AssemblyBindingTarget Reference(
+        AssemblyReferenceIdentity identity) =>
+        new AssemblyReference(identity);
+
+    public static AssemblyBindingTarget CoreLibrary() =>
+        new IntrinsicCoreLibrary();
+
+    public sealed record AssemblyReference(
+        AssemblyReferenceIdentity Identity) : AssemblyBindingTarget;
+
+    public sealed record IntrinsicCoreLibrary : AssemblyBindingTarget;
+}
+
 public sealed class AssemblyBindingRequest
 {
     public AssemblyBindingRequest(
-        AssemblyReferenceIdentity identity,
+        AssemblyBindingTarget target,
         AssemblyBindingOrigin origin,
         AssemblyResolutionScope scope)
     {
-        Identity = identity;
+        Target = target;
         Origin = origin;
         Scope = scope;
     }
 
-    public AssemblyReferenceIdentity Identity { get; }
+    public AssemblyBindingTarget Target { get; }
     public AssemblyBindingOrigin Origin { get; }
     public AssemblyResolutionScope Scope { get; }
 }
@@ -885,7 +932,7 @@ public abstract class AssemblyBindingOutcome
 internal interface IAssemblyBindingResolver
 {
     AssemblyBindingOutcome Resolve(
-        AssemblyReferenceIdentity identity,
+        AssemblyBindingTarget target,
         AssemblyBindingOrigin origin,
         AssemblyResolutionScope scope);
 }
@@ -910,8 +957,8 @@ The internal structurally equatable `AssemblyBindingDomainKey` is a closed
 value with `Global` and `RequestingCandidate(AssemblyCandidateId)` arms. It is
 generation-scoped and is the only origin projection permitted in binding and
 resolution cache keys. `AssemblyBindingCacheKey` is the structural tuple of
-that domain key, complete reference identity, and scope; the containing cache
-supplies the generation.
+that domain key, closed binding target, and scope; the containing cache supplies
+the generation.
 
 `AssemblyBindingOutcome.ExpansionRequired` is produced only by a frozen cache
 lookup for an absent binding-only root. External policies cannot return it.
@@ -958,7 +1005,8 @@ Resolution rejection is a closed, inspectable hierarchy:
 public enum CandidateOpenFailureKind
 {
     Unreadable,
-    InvalidImage
+    InvalidImage,
+    ResourceBudget
 }
 
 public sealed record CandidateOpenFailure(
@@ -1144,18 +1192,18 @@ public abstract class TypeResolutionAmbiguity
     public sealed class AssemblyBinding : TypeResolutionAmbiguity
     {
         internal AssemblyBinding(
-            AssemblyReferenceIdentity reference,
+            AssemblyBindingTarget target,
             AssemblyBindingOrigin origin,
             AssemblyResolutionScope scope,
             ImmutableArray<ResolvedAssemblyCandidate> candidates)
         {
-            Reference = reference;
+            Target = target;
             Origin = origin;
             Scope = scope;
             Candidates = candidates;
         }
 
-        public AssemblyReferenceIdentity Reference { get; }
+        public AssemblyBindingTarget Target { get; }
         public AssemblyBindingOrigin Origin { get; }
         public AssemblyResolutionScope Scope { get; }
         public ImmutableArray<ResolvedAssemblyCandidate> Candidates { get; }
@@ -1207,20 +1255,20 @@ public abstract class TypeResolutionOutcome
         public ResolvedAssemblyCandidate LastAssembly { get; }
     }
 
-    public sealed class UnboundReference : TypeResolutionOutcome
+    public sealed class UnboundBinding : TypeResolutionOutcome
     {
-        internal UnboundReference(
-            AssemblyReferenceIdentity reference,
+        internal UnboundBinding(
+            AssemblyBindingTarget target,
             AssemblyBindingOrigin origin,
             AssemblyResolutionScope scope,
             ImmutableArray<TypeForwardingHop> hops) : base(hops)
         {
-            Reference = reference;
+            Target = target;
             Origin = origin;
             Scope = scope;
         }
 
-        public AssemblyReferenceIdentity Reference { get; }
+        public AssemblyBindingTarget Target { get; }
         public AssemblyBindingOrigin Origin { get; }
         public AssemblyResolutionScope Scope { get; }
     }
@@ -1228,19 +1276,19 @@ public abstract class TypeResolutionOutcome
     public sealed class Unavailable : TypeResolutionOutcome
     {
         internal Unavailable(
-            AssemblyReferenceIdentity reference,
+            AssemblyBindingTarget target,
             AssemblyBindingOrigin origin,
             AssemblyResolutionScope scope,
             AssemblyBindingFailure failure,
             ImmutableArray<TypeForwardingHop> hops) : base(hops)
         {
-            Reference = reference;
+            Target = target;
             Origin = origin;
             Scope = scope;
             Failure = failure;
         }
 
-        public AssemblyReferenceIdentity Reference { get; }
+        public AssemblyBindingTarget Target { get; }
         public AssemblyBindingOrigin Origin { get; }
         public AssemblyResolutionScope Scope { get; }
         public AssemblyBindingFailure Failure { get; }
@@ -1396,8 +1444,9 @@ The distinction between the five non-success outcomes is load-bearing:
 
 - `NotFound` means a readable assembly authoritatively neither defined nor
   forwarded the requested type.
-- `UnboundReference` means policy authoritatively found no candidate for the
-  exact reference and scope; no readable last assembly is invented.
+- `UnboundBinding` means policy authoritatively found no candidate for the
+  exact reference or core-library target and scope; no readable last assembly
+  is invented.
 - `Unavailable` means policy could not supply or select an assembly needed to
   continue and carries the binding-policy reason.
 - `Ambiguous` means policy found several assembly candidates or one image
@@ -1411,23 +1460,39 @@ source" as a complete answer.
 
 ## Resolution context and lifetime
 
-The acquisition catalog owns one `AssemblyInspectionSession` for every opened
-candidate. `TypeResolutionContext` composes those sessions and owns only
-resolution state:
+The acquisition catalog separates adjacency inventory from durable inspection
+sessions:
 
 ```text
 ResolvedAssemblyCandidate
-  -> catalog-owned AssemblyInspectionSession
+  -> materialized AssemblyInventorySnapshot
+      -> identity, AssemblyRefs, ExportedType forwarding targets
+  -> optional catalog-owned AssemblyInspectionSession
       -> declaration probe
       -> cached (assembly candidate, type name) result
 ```
 
-This extends the single PE-lifetime owner established by
-`AssemblyInspectionSession`; it does not create a parallel `PEReader` owner.
-The catalog outlives every `TypeResolutionContext` and graph cache that contains
-its keys. The engine never opens a second stream, lends a reader to a consumer,
-or disposes a session that a consumer cache expects to retain. This removes the
-reason `LibraryBodyIndex` currently repeats the traversal beside
+`AssemblyInventoryReader` is a bounded, non-owning operation, not a second
+reader owner. It opens at most `MaxConcurrentInventoryOpens` source streams
+(default 8), materializes the snapshot, and disposes both stream and temporary
+`PEReader` immediately. Adjacency-only candidates retain no session or OS file
+handle. A later body/declaration consumer may open one durable
+`AssemblyInspectionSession`; the snapshot prevents decoding identity,
+references, or forwarding inventory again.
+
+Slice 2 evolves durable sessions to construct `PEReader` with
+`PEStreamOptions.PrefetchEntireImage` and close the source stream immediately
+after construction. The catalog may retain prefetched image memory, but holds
+no source file handle for the lifetime of a context. Candidate, retained-image
+byte, and inventory-open concurrency budgets are explicit plan inputs; budget
+exhaustion is a typed failure rather than an `IOException`-shaped partial
+answer.
+
+This preserves the single PE-lifetime owner established by
+`AssemblyInspectionSession`; it does not lend a reader to a consumer or dispose
+a session that a consumer cache expects to retain. The catalog outlives every
+`TypeResolutionContext` and graph cache containing its keys. This removes the
+reason `LibraryBodyIndex` currently repeats traversal beside
 `TypeForwardResolver`.
 
 Candidate discovery and correspondence are separate phases.
@@ -1444,16 +1509,17 @@ first supplies a manifest with two root kinds:
 
 The builder executes those roots provisionally, including every per-hop
 scope-tightening transition. Each encountered
-`(AssemblyBindingDomainKey, AssemblyReferenceIdentity,
+`(AssemblyBindingDomainKey, AssemblyBindingTarget,
 AssemblyResolutionScope)` binding is added to the manifest; each selected
 registration and forwarded continuation extends the work queue. It does not
 bind references outside the explicit type and adjacency roots or sweep
 framework assemblies.
 
-Provisional resolution uses catalog-owned sessions and candidate ids but does
-not issue definition keys, join tokens, graph leases, or a public
-`TypeResolutionContext`. Discovery reaches a fixed point when a complete queue
-pass adds no request, binding pair, or registration.
+Provisional resolution uses materialized inventories, optional catalog-owned
+sessions, and candidate ids but does not issue definition keys, join tokens,
+graph leases, or a public `TypeResolutionContext`. Discovery reaches a fixed
+point when a complete queue pass adds no request, binding pair, or
+registration.
 
 The builder is bounded by the plan's candidate and relationship budgets.
 Stable acquisition registrations make repeated selections idempotent; an owner
@@ -1533,17 +1599,18 @@ therefore converge on the same fixed-point candidate set and answers.
 The acquisition catalog caches:
 
 - candidate ids by `AssemblyAcquisitionRegistration` reference identity;
-- opened sessions by `AssemblyCandidateId`;
+- materialized inventory snapshots by `AssemblyCandidateId`;
+- durable sessions, only when demanded, by `AssemblyCandidateId`;
 - declaration results by
   `(AssemblyCandidateId, MetadataTypeDefinitionName)`;
 - provisional discovery bindings by
-  `(discovery epoch, AssemblyBindingDomainKey, AssemblyReferenceIdentity,
+  `(discovery epoch, AssemblyBindingDomainKey, AssemblyBindingTarget,
   AssemblyResolutionScope)`;
 - provisional resolution recipes by
   `(discovery epoch, TypeResolutionCacheKey)`;
 - binding outcomes by
   `(AssemblyCatalogGenerationId, AssemblyBindingDomainKey,
-  AssemblyReferenceIdentity, AssemblyResolutionScope)`;
+  AssemblyBindingTarget, AssemblyResolutionScope)`;
 - frozen resolution recipes by
   `(AssemblyCatalogGenerationId, TypeResolutionCacheKey)`, with their binding
   dependency snapshots;
@@ -1560,15 +1627,16 @@ catalog, and caches:
 
 `TypeResolutionCacheKey` is an internal projection; it does not use the public
 request object's reference equality. Its start arm contains either the internal
-candidate id plus scope or the complete assembly reference identity plus
-binding-domain key plus scope, followed by the structurally equatable
+candidate id plus scope or the closed binding target plus binding-domain key
+plus scope, followed by the structurally equatable
 `MetadataTypeDefinitionName`.
 
 The cache retains typed failures as well as successes. Re-running a rejected
 probe must not turn it into a success-shaped miss.
 
-The catalog and resolution caches support concurrent Analysis. Candidate open,
-declaration probe, binding, and completed-resolution entries are single-flight:
+The catalog and resolution caches support concurrent Analysis. Inventory read,
+durable-session open, declaration probe, binding, and completed-resolution
+entries are single-flight:
 parallel body-analysis workers observe one result and one owned session.
 Synchronization does not hold a cache lock while invoking an external opener or
 binding policy.
@@ -1595,12 +1663,13 @@ For one builder request:
 
 1. Require the type request in the discovery manifest; otherwise return
    `Rejected(PlanExpansionRequired(Type(request)))`.
-2. Resolve the start when it is an assembly reference. First validate a
+2. Resolve the start when it is a reference or core-library binding. First
+   validate a
    requesting-assembly origin against the active builder catalog and return
    `Rejected(UnregisteredAssembly)` if absent. Construct its
    `AssemblyBindingCacheKey`, add it to the discovery manifest, and read or
    populate the provisional binding outcome. Binding `Selected` continues;
-   `Missing` returns `UnboundReference`; `Unavailable` returns `Unavailable`;
+   `Missing` returns `UnboundBinding`; `Unavailable` returns `Unavailable`;
    `Ambiguous` returns `Ambiguous`; and binding `Rejected` returns
    `Rejected(InvalidBindingPolicy)`. Frozen-only `ExpansionRequired` maps to
    `Rejected(PlanExpansionRequired(Binding(request)))`.
@@ -1614,9 +1683,10 @@ For one builder request:
    `Rejected(UnsupportedModuleExport(module))`.
 10. On `Forwarded`, append one hop.
 11. Tighten, but never loosen, `AssemblyResolutionScope` for the next reference.
-12. Construct the target binding request, add its key to the discovery
-    manifest, read or populate its provisional cache entry, and apply the same
-    exhaustive outcome mapping as step 2.
+12. Wrap the forwarder's exact target identity in
+    `AssemblyBindingTarget.Reference`, construct the binding request, add its
+    key to the discovery manifest, read or populate its provisional cache
+    entry, and apply the same exhaustive outcome mapping as step 2.
 13. Stop on repeated assembly candidate or the hop budget with the corresponding
     `Rejected` failure.
 14. Otherwise repeat at step 3.
@@ -1758,7 +1828,8 @@ canonicalizes their simple names together.
 The resolution plan combines `CurrentAssembly` with the candidate that supplied
 the row and starts from that candidate. `IntrinsicCoreLibrary` covers signature
 primitive type codes that have no `TypeRef` row and resolves through the
-candidate's core-library binding policy. `ModuleReference` remains typed and
+candidate's `AssemblyBindingTarget.IntrinsicCoreLibrary` policy request; it
+never synthesizes an assembly identity. `ModuleReference` remains typed and
 maps to module acquisition or the explicit unsupported-module outcome; it is
 never invented as an assembly identity. Intrinsic, nil, module, and assembly
 scopes therefore do not collapse into a nullable assembly field.
@@ -1988,7 +2059,7 @@ permissiveness rule to keep synchronized with the matcher.
 - a `DegradedMemberCorrespondenceKey` substitutes a
   catalog-owned `UnresolvedBindingKey` plus structured type name only for an
   unavailable named type. The binding key represents the exact cached
-  `(AssemblyBindingDomainKey, AssemblyReferenceIdentity,
+  `(AssemblyBindingDomainKey, AssemblyBindingTarget,
   AssemblyResolutionScope)` request, preserving the complete
   assembly/module/current origin instead of collapsing failures into one
   bucket.
@@ -2227,7 +2298,10 @@ Resolution is query-directed:
   local inventories to one Metadata-owned catalog;
 - the engine opens only the starting assembly and assemblies named by the
   forwarder chain;
-- each assembly image is opened once per catalog;
+- each candidate inventory is read once; a candidate that later needs a
+  durable session incurs at most one additional prefetched-image open;
+- source streams close immediately after inventory or prefetched-session
+  construction;
 - each `(assembly, type)` declaration probe runs once;
 - callers in the same source candidate sharing a resolvable reference reuse the
   completed resolution; different source candidates remain distinct binding
@@ -2252,6 +2326,9 @@ forwarded `XmlReader` caller is:
 - the real caller is found;
 - forwarding-inventory opens equal the distinct candidates selected by scope
   adjacency plus newly selected forwarder targets;
+- peak live source streams never exceed `MaxConcurrentInventoryOpens`, and no
+  adjacency-only stream or durable-session source stream remains open after
+  construction;
 - framework traversal does not expand through ordinary dependencies of those
   candidates;
 - no target file is reopened by the forwarder engine;
@@ -2291,8 +2368,12 @@ without returning a stringly or nullable result.
   hierarchies after their descriptor and catalog dependencies exist.
 - Add one `InspectionAcquisitionPlan` per inspection and collapse today's
   per-path resolver instances into its shared owner adapters.
-- Extend `AssemblyInspectionSession` as the single candidate image owner, add
-  the catalog lifetime, and compose `TypeResolutionContext` over those sessions.
+- Add catalog-owned `AssemblyInventorySnapshot` values for every discovered
+  candidate and open prefetched `AssemblyInspectionSession` values only on
+  demand; inventory reads and durable-session opens are separate single-flight
+  operations.
+- Add the catalog lifetime and compose `TypeResolutionContext` over snapshots
+  plus optional sessions without retaining adjacency-only readers.
 - Add public `IAssemblyBindingPolicy` descriptor selections and the
   Metadata-internal candidate-interning adapter, with explicit adapters from
   existing resolvers.
@@ -2371,13 +2452,20 @@ Claim: direct callers and transitive call graphs share one definition identity.
   declaration/resolution cache entry; `!=` returns false.
 - Independently minted equal `DefinitionJoinToken` and
   `UnresolvedBindingKey` values agree across `Equals`, `==`, `!=`, and hashing.
+- Independently constructed equal reference and intrinsic-core-library
+  `AssemblyBindingTarget` values compare and hash equally and hit one binding
+  cache entry per source domain.
 - Public result hierarchies cannot be externally extended, and product
   consumers cannot construct correspondence verdict arms.
 - An external fake `IAssemblyBindingPolicy` can return every public descriptor
   selection through factories but cannot construct catalog candidates.
+- An external fake policy receives and distinguishes explicit reference and
+  intrinsic-core-library binding targets; no core-library identity is
+  synthesized.
 - An external fake policy can construct every `AssemblyBindingFailureKind`.
 - Reusing the canonical descriptor, including `candidate.Assembly`, yields one
-  candidate id, one opened session, and `Same` correspondence.
+  candidate id, one inventory snapshot, at most one demanded durable session,
+  and `Same` correspondence.
 - A second `ResolvedAssemblyReference.Create` call with identical visible
   values and the identical `Func<Stream>` instance receives a fresh
   registration and remains a distinct candidate.
@@ -2425,8 +2513,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - A definition/forwarder conflict is ambiguous.
 - Missing type.
 - Missing target assembly.
-- A missing initial or forwarded binding returns `UnboundReference` with the
-  exact reference and scope, not `NotFound` or `CandidateUnavailable`.
+- A missing initial, forwarded, or core-library binding returns
+  `UnboundBinding` with the exact target and scope, not `NotFound` or
+  `CandidateUnavailable`.
 - Ambiguous target assembly.
 - Malformed metadata.
 - A `File`-row-terminated `ExportedType` chain produces
@@ -2468,8 +2557,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
   assembly-sensitive prefilter pins move to this end-to-end gate.
 - Two local or project binding domains resolve the same `AssemblyRef` to their
   respective private copies without sharing a binding outcome or candidate.
-- A candidate image is not reread after its reference identities were
-  snapshotted.
+- A candidate's identity, references, and forwarding inventory are decoded
+  once from its snapshot; opening a later durable session does not decode them
+  again.
 - Resolution caches distinguish origins that structural `TypeRef` equality
   canonicalizes together.
 - Two source candidates carrying the same structured name and equal
@@ -2533,7 +2623,13 @@ Claim: direct callers and transitive call graphs share one definition identity.
   `List`/`List\`1` lookup behavior through `PlatformTypeLookupPattern`.
 - Platform lookup retains case-insensitive, nested `+`/`.`, and primitive-alias
   behavior.
-- Parallel body analysis opens and probes each candidate once.
+- Parallel analysis performs one inventory read per candidate, opens at most
+  one demanded durable session, and shares each declaration probe
+  single-flight.
+- A scope wider than the process file-handle limit still holds at most
+  `MaxConcurrentInventoryOpens` source streams, releases every adjacency-only
+  stream, and reports retained-image budget exhaustion as
+  `CandidateOpenFailureKind.ResourceBudget`.
 
 ### Architecture gates
 

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1,0 +1,937 @@
+# Structured type-forwarding resolution
+
+## Status
+
+Design for replacing the current collection of type-forwarder helpers and
+spelling-based caller matching with one structured reference-to-definition
+system.
+
+The first implementation slice adds the model and the single-image metadata
+primitive only. It migrates no production caller. That boundary follows the
+primitive-first approach used by `InertString` in
+[#3636](https://github.com/richlander/dotnet-inspect/pull/3636): establish the
+value, its invariants, and its gates before asking consumers to depend on it.
+
+## The problem
+
+Type forwarding is one metadata relationship:
+
+```text
+TypeRef
+  -> AssemblyRef
+      -> assembly
+          -> ExportedType
+              -> AssemblyRef
+                  -> ...
+                      -> TypeDef
+```
+
+The product currently represents different parts of that relationship as
+assembly-name strings, canonicalized strings, file paths, and nullable returns.
+Each consumer then reconstructs the relationship it needs:
+
+- `TypeForwardResolver` follows forwarders and returns `TypeLocation`.
+- `LibraryBodyIndex` repeats the traversal because it needs readers with a
+  different lifetime.
+- `PdbContext`, `SourceLinkService`, `SourceEnricher`, and `ApiServices`
+  recover a target assembly name and construct a sibling path.
+- `CallerScopeFilter`, `CallerScopeTypeFilter`, and
+  `MemberPattern.MatchesCrossAssembly` compare different projections of a
+  type's assembly spelling.
+- `TypeRef.CanonicalAssembly` deliberately erases which core-library facade a
+  reference named.
+
+Recent PRs expose the cost of that representation:
+
+- [#3437](https://github.com/richlander/dotnet-inspect/pull/3437) is the
+  successful shape. It reused the Metadata forwarder decoder and
+  the assembly resolver boundary, then centralized hop bounds, cycle detection,
+  and scope tightening.
+- [#3449](https://github.com/richlander/dotnet-inspect/pull/3449) open-coded the
+  same traversal in Analysis and was correctly closed as superseded by #3437.
+- [#3476](https://github.com/richlander/dotnet-inspect/pull/3476) started as one
+  forwarded-caller fix and grew to three consumer gates, an alias graph, a
+  claimant census, version ceilings, path canonicalization, and
+  filesystem-identity questions. Repeated review findings fabricated callers
+  because each new rule reconstructed another part of binding from partial
+  strings.
+- [#3460](https://github.com/richlander/dotnet-inspect/pull/3460) found several
+  forwarder-related path sinks. Guarding the path component is useful general
+  hardening, but the forwarder seam should not construct a path from inspected
+  metadata in the first place.
+
+The defect is therefore not a missing alias rule. It is the absence of a value
+that means:
+
+> This exact metadata reference resolved, under this explicit policy, to this
+> exact type definition.
+
+## Design lessons from recent structured systems
+
+Two recent systems establish the pattern this design follows.
+
+### Put the property on the value
+
+[#3636](https://github.com/richlander/dotnet-inspect/pull/3636) moves inertness
+from a syntactic call-site obligation to `InertString`. Once text enters that
+type, composition cannot silently discard the property. The equivalent move
+here is to stop making consumers prove that two assembly spellings denote one
+type. They receive a `ResolvedTypeDefinition` or they do not.
+
+### Materialize what crosses the owner boundary
+
+[#3461](https://github.com/richlander/dotnet-inspect/pull/3461) keeps the rich
+`IrNode`-keyed map inside the decompiler and projects it to `PrintedBodyMap`, a
+payload containing only durable text coordinates and names. A consumer can
+render that payload without reconstructing decompiler state.
+
+Type resolution has the same two altitudes:
+
+- while resolving, Metadata may hold live readers and metadata handles in one
+  owned context;
+- after resolving, consumers receive materialized assembly candidate ids,
+  metadata tokens, names, identities, outcomes, and hop evidence -- never a
+  borrowed `MetadataReader` or handle.
+
+### Carry every discriminator the consumer needs
+
+`PrintedBodyMap` added category and conditionality after end-to-end consumers
+proved that omitting either changed the answer. Forwarder resolution must carry
+the complete `AssemblyReferenceIdentity`, not just its simple name, and must
+retain the spelling the metadata actually used rather than only its canonical
+comparison projection.
+
+### Degradation is data
+
+`PrintedBodyMap` uses an explicit degraded position instead of dropping a fact.
+Forwarder resolution similarly distinguishes absence, unavailable evidence,
+ambiguity, and rejection. None is represented as an ordinary null or an empty
+alias set.
+
+## Vocabulary
+
+| Term | Meaning |
+| --- | --- |
+| **Type definition name** | Metadata namespace plus root-to-leaf metadata type-name segments. This is a lookup value, not a display spelling or universal type identity. |
+| **Assembly reference identity** | The ECMA-335 name, version, culture, and public-key token from one `AssemblyRef`. |
+| **Assembly candidate** | One assembly selected by one acquisition catalog. It is not inferred from a path or from simple-name equality. |
+| **Definition key** | The catalog-local identity of one `TypeDef`: assembly candidate plus metadata token. |
+| **Definition address** | A durable MVID-scoped metadata token. It locates a definition but is not sufficient adversarial correspondence evidence. |
+| **Declaration probe** | The bounded single-image operation that says whether an assembly defines, forwards, or does not contain one type. |
+| **Resolution** | Repeated declaration probes joined by assembly-reference resolution until a definition or a typed non-success outcome is reached. |
+| **Binding policy** | The caller-supplied rule that maps an `AssemblyReferenceIdentity` and scope to zero, one, or several assembly candidates. |
+| **Hop** | One verified `ExportedType` declaration and the `AssemblyRef` it names. |
+
+The vocabulary deliberately does not use **alias**. An alias is a derived set of
+names. The product question is resolution to a definition.
+
+## Ownership
+
+```text
+ILInspector.Analysis / ILInspector.Decompiler / product services
+                              |
+                              v
+                    ILInspector.Metadata
+              request, outcomes, engine, context
+                              |
+                              v
+             ILInspector.MetadataPrimitives
+         bounded ExportedType relationship traversal
+```
+
+`ILInspector.MetadataPrimitives` owns only mechanical traversal:
+
+- iterative `ExportedType` implementation-chain walking;
+- cycle and node budgets;
+- typed relationship rejection.
+
+`ILInspector.Metadata` owns metadata meaning:
+
+- type definition names;
+- declaration probes;
+- assembly reference identities;
+- resolution requests and outcomes;
+- hop evidence;
+- PE/session lifetime while resolving.
+
+Assembly acquisition remains policy. Package, platform, project, and local-scope
+resolvers decide which assembly candidates an `AssemblyRef` may bind to.
+Metadata never searches a directory, guesses a sibling file name, or implements
+general CLR roll-forward policy.
+
+Analysis owns call-site evidence, not forwarding. Decompiler owns its symbolic
+type model, not forwarding. The CLI owns neither.
+
+## Structured model
+
+The declarations below specify shape and ownership. Exact member names may
+change during implementation, but weakening a discriminated result back to
+nullable strings is not an implementation detail.
+
+### Type definition name
+
+```csharp
+public sealed record MetadataTypeDefinitionName(
+    string Namespace,
+    ImmutableArray<string> Segments);
+```
+
+`Segments` is root-to-leaf and retains metadata names, including generic arity.
+For `Namespace.Outer<T>.Inner`, it contains ``Outer`1`` and `Inner`.
+
+This type does not introduce "the canonical type spelling." Consumers still own
+their display, XML documentation, API identity, and body identity projections.
+It is the structured input to one metadata lookup operation.
+
+Construction from `TypeDef`, `TypeRef`, and `ExportedType` uses the existing
+bounded relationship traversals. A rejected relationship walk cannot construct
+a `MetadataTypeDefinitionName`.
+
+### Assembly candidate
+
+```csharp
+public readonly record struct AssemblyCandidateId(Guid Value);
+
+public sealed record ResolvedAssemblyCandidate(
+    AssemblyCandidateId Id,
+    ResolvedAssemblyReference Assembly);
+```
+
+`ResolvedAssemblyReference` remains the context-free descriptor it is today:
+identity, optional path, opener, and provenance. It does not contain an id that
+can only be minted after a context exists.
+
+`AssemblyCandidateId` is minted by the package, platform, project, or local
+acquisition catalog. Equality means "the same acquired assembly in this
+catalog." A single caller operation builds one catalog and uses it for the
+target and every candidate; it never compares ids minted by separate catalogs.
+The id does not mean:
+
+- the same simple name;
+- the same path spelling;
+- the same MVID;
+- byte-identical content;
+- the same physical file reached through another path.
+
+When an acquisition layer cannot prove that two inputs are one candidate, it
+keeps them distinct. Splitting can cause a conservative miss; merging distinct
+assemblies can fabricate a resolution.
+
+The id is operation currency, not a persisted identity or sort key. It uses a
+globally unique value so accidental comparison across catalogs cannot produce a
+false equality, but the same assembly acquired in two operations normally has
+two ids.
+
+Package coordinates, selected TFM, platform framework, and local path remain
+provenance, not fields in `AssemblyReferenceIdentity`. Structuring that
+provenance is owned by the assembly-inspection query model and is not duplicated
+here.
+
+### Resolution start
+
+There are two legitimate starts and they stay explicit:
+
+```csharp
+public abstract record TypeResolutionStart
+{
+    public sealed record Assembly(
+        ResolvedAssemblyCandidate Value,
+        AssemblyResolutionScope Scope) : TypeResolutionStart;
+
+    public sealed record Reference(
+        AssemblyReferenceIdentity Value,
+        AssemblyResolutionScope Scope) : TypeResolutionStart;
+}
+
+public sealed record TypeResolutionRequest(
+    TypeResolutionStart Start,
+    MetadataTypeDefinitionName Type);
+```
+
+`Assembly` means "probe this already-resolved assembly, then follow any
+forwarder." `Reference` means "first ask the binding policy to resolve this
+exact `AssemblyRef`, then probe the result."
+
+This avoids an optional `(path, reference?)` or `(assembly?, identity?)` shape.
+Every request states exactly where resolution begins.
+
+### Single-image declaration
+
+```csharp
+public readonly record struct TypeDefinitionToken(int Value);
+public readonly record struct ExportedTypeToken(int Value);
+
+public sealed record ModuleFileReference(
+    string Name,
+    bool ContainsMetadata,
+    ImmutableArray<byte> Hash);
+
+public abstract record TypeDeclarationCandidate
+{
+    public sealed record Definition(
+        TypeDefinitionToken Token) : TypeDeclarationCandidate;
+
+    public sealed record Forwarder(
+        ImmutableArray<ExportedTypeToken> Declarations,
+        AssemblyReferenceIdentity Target) : TypeDeclarationCandidate;
+
+    public sealed record ModuleExport(
+        ImmutableArray<ExportedTypeToken> Declarations,
+        ModuleFileReference Module) : TypeDeclarationCandidate;
+}
+
+public abstract record TypeDeclarationResult
+{
+    public sealed record Defined(
+        TypeDefinitionToken Definition) : TypeDeclarationResult;
+
+    public sealed record Forwarded(
+        ImmutableArray<ExportedTypeToken> Declarations,
+        AssemblyReferenceIdentity Target) : TypeDeclarationResult;
+
+    public sealed record ExportedFromModule(
+        ImmutableArray<ExportedTypeToken> Declarations,
+        ModuleFileReference Module) : TypeDeclarationResult;
+
+    public sealed record Missing : TypeDeclarationResult;
+
+    public sealed record Ambiguous(
+        ImmutableArray<TypeDeclarationCandidate> Candidates)
+        : TypeDeclarationResult;
+
+    public sealed record Rejected(
+        MetadataTraversalRejection Rejection) : TypeDeclarationResult;
+}
+```
+
+The declaration probe:
+
+1. searches exact `TypeDef` identity;
+2. searches exact `ExportedType` identity;
+3. follows the intra-image `ExportedType` implementation chain for nested
+   forwarded types;
+4. collects every declaration for the requested identity;
+5. coalesces duplicate forwarder rows only when their complete target
+   `AssemblyReferenceIdentity` agrees;
+6. returns `Ambiguous` for competing definitions, definition/forwarder
+   conflicts, or different forwarder targets;
+7. returns `ExportedFromModule` when the chain terminates at a `File` row rather
+   than pretending a multi-module export is a cross-assembly forwarder;
+8. never opens another assembly.
+
+`Missing` is authoritative only for the readable image that was probed.
+`Ambiguous` and `Rejected` are not missing.
+
+The first engine does not resolve multi-module exports. It maps
+`ExportedFromModule` to a typed `UnsupportedModuleExport` failure carrying the
+`ModuleFileReference`. Supporting module acquisition later does not require
+changing the declaration probe's answer.
+
+`TypeDefinitionToken` and `ExportedTypeToken` are materialized metadata tokens,
+validated for their expected metadata table, not arbitrary integers and not
+live handles. They are meaningful only beside the assembly candidate that
+owns them.
+
+`ModuleFileReference` copies the relevant `File` row. It carries evidence for a
+future module resolver without lending a `FileHandle` or claiming that the
+module can currently be opened.
+
+### Assembly binding
+
+The current nullable resolver result cannot distinguish a missing dependency
+from an ambiguous scope or an unreadable candidate. It evolves rather than
+gaining a parallel resolver:
+
+```csharp
+public abstract record AssemblyBindingOutcome
+{
+    public sealed record Resolved(
+        ResolvedAssemblyCandidate Candidate) : AssemblyBindingOutcome;
+
+    public sealed record Missing : AssemblyBindingOutcome;
+
+    public sealed record Ambiguous(
+        ImmutableArray<ResolvedAssemblyCandidate> Candidates)
+        : AssemblyBindingOutcome;
+
+    public sealed record Rejected(
+        AssemblyBindingFailure Failure) : AssemblyBindingOutcome;
+}
+
+public interface IAssemblyBindingResolver
+{
+    AssemblyBindingOutcome Resolve(
+        AssemblyReferenceIdentity identity,
+        AssemblyResolutionScope scope);
+}
+```
+
+A package or platform resolver normally returns one selected assembly. A local
+unordered directory containing several plausible candidates returns
+`Ambiguous`; the Metadata engine does not choose by enumeration order, file
+name, highest version, or nearest path.
+
+This is a new contract, not a same-name return-type change to
+`IAssemblyReferenceResolver`. The nullable resolver remains only as migration
+scaffolding and is deleted after its final consumer moves. A nullable
+implementation cannot accidentally satisfy the structured interface.
+
+### Resolution outcome
+
+```csharp
+public readonly record struct ResolvedTypeDefinitionKey(
+    AssemblyCandidateId Assembly,
+    TypeDefinitionToken Definition);
+
+public readonly record struct MetadataTypeDefinitionAddress(
+    Guid ModuleVersionId,
+    TypeDefinitionToken Definition);
+
+public sealed record ResolvedTypeDefinition(
+    ResolvedTypeDefinitionKey Key,
+    MetadataTypeDefinitionAddress Address,
+    ResolvedAssemblyCandidate Assembly,
+    MetadataTypeDefinitionName Type);
+
+public sealed record TypeForwardingHop(
+    ResolvedAssemblyCandidate SourceAssembly,
+    ImmutableArray<ExportedTypeToken> Declarations,
+    AssemblyReferenceIdentity TargetReference,
+    AssemblyResolutionScope Scope);
+
+public abstract record TypeResolutionAmbiguity
+{
+    public sealed record AssemblyBinding(
+        AssemblyReferenceIdentity Reference,
+        ImmutableArray<ResolvedAssemblyCandidate> Candidates)
+        : TypeResolutionAmbiguity;
+
+    public sealed record TypeDeclaration(
+        ResolvedAssemblyCandidate Assembly,
+        MetadataTypeDefinitionName Type,
+        ImmutableArray<TypeDeclarationCandidate> Candidates)
+        : TypeResolutionAmbiguity;
+}
+
+public abstract record TypeResolutionOutcome
+{
+    public sealed record Resolved(
+        ResolvedTypeDefinition Definition,
+        ImmutableArray<TypeForwardingHop> Hops)
+        : TypeResolutionOutcome;
+
+    public sealed record NotFound(
+        ResolvedAssemblyCandidate LastAssembly,
+        ImmutableArray<TypeForwardingHop> Hops)
+        : TypeResolutionOutcome;
+
+    public sealed record Unavailable(
+        AssemblyReferenceIdentity Reference,
+        ImmutableArray<TypeForwardingHop> Hops)
+        : TypeResolutionOutcome;
+
+    public sealed record Ambiguous(
+        TypeResolutionAmbiguity Ambiguity,
+        ImmutableArray<TypeForwardingHop> Hops)
+        : TypeResolutionOutcome;
+
+    public sealed record Rejected(
+        TypeResolutionFailure Failure,
+        ImmutableArray<TypeForwardingHop> Hops)
+        : TypeResolutionOutcome;
+}
+```
+
+The hop list is evidence, not identity. `ResolvedTypeDefinitionKey` answers
+exact correspondence inside one acquisition catalog. A `Callers` operation and
+its graph cache keep that catalog alive and use one key space for the target and
+all candidates. The key is never serialized or reused after the catalog is
+released.
+
+`MetadataTypeDefinitionAddress` is the durable coordinate precedent established
+by `MetadataMethodAddress`: MVID plus metadata token. It can be rendered,
+persisted, and checked against a reader before dereferencing. It is not
+cryptographic identity; two adversarial modules can share an MVID, so the
+address alone must not establish cross-artifact correspondence. The exact
+operation-local key remains separate.
+
+The assembly descriptor and type name are materialized provenance. Stable
+projections may render or persist the descriptor's identity and provenance;
+they exclude its catalog-local candidate id and opener.
+
+The distinction between the four non-success outcomes is load-bearing:
+
+- `NotFound` means a readable assembly authoritatively neither defined nor
+  forwarded the requested type.
+- `Unavailable` means policy could not supply an assembly needed to continue.
+- `Ambiguous` means policy found several assembly candidates or one image
+  contained competing declarations and the engine could not select one.
+- `Rejected` means malformed metadata, a cycle, an exhausted budget, an open
+  failure, an unsupported multi-module export, or another failure that must
+  remain visible.
+
+No consumer may convert all four to `null` and present "no callers" or "no
+source" as a complete answer.
+
+## Resolution context and lifetime
+
+`TypeResolutionContext` owns every opened image for one operation:
+
+```text
+ResolvedAssemblyCandidate
+  -> context-owned AssemblyImage
+      -> declaration probe
+      -> cached (assembly candidate, type name) result
+```
+
+The engine never opens a stream and lends its reader to a consumer. It never
+disposes a reader that a consumer cache expects to retain. This removes the
+reason `LibraryBodyIndex` currently repeats the traversal beside
+`TypeForwardResolver`.
+
+The context consumes one acquisition catalog and caches:
+
+- opened images by `AssemblyCandidateId`;
+- declaration probes by `(AssemblyCandidateId, MetadataTypeDefinitionName)`;
+- binding outcomes by `(AssemblyReferenceIdentity, AssemblyResolutionScope)`;
+- completed resolutions by `TypeResolutionRequest`.
+
+The cache retains typed failures as well as successes. Re-running a rejected
+probe must not turn it into a success-shaped miss.
+
+The public outcome contains no reader-backed value. Its descriptors, address,
+identities, name, and evidence can leave the context in the same sense that
+`PrintedBodyMap` can leave the decompiler. Its catalog-local definition key may
+be compared only with another key produced under the same catalog.
+
+## Resolution algorithm
+
+For one request:
+
+1. Resolve the start when it is an assembly reference.
+2. Open the selected assembly through the context.
+3. Probe the exact structured type name.
+4. On `Defined`, materialize the definition key and finish.
+5. On `Missing`, return `NotFound`.
+6. On `Ambiguous`, return `Ambiguous`.
+7. On `Rejected`, return `Rejected`.
+8. On `Forwarded`, append one hop.
+9. Tighten, but never loosen, `AssemblyResolutionScope` for the next reference.
+10. Resolve the complete target `AssemblyReferenceIdentity` through policy.
+11. Stop on missing, ambiguous, rejected, repeated assembly candidate, or the hop
+    budget.
+12. Otherwise repeat at step 2.
+
+The traversal is iterative. It has both:
+
+- identity-based cycle detection over `AssemblyCandidateId`;
+- an explicit hop budget as defense in depth.
+
+The nested `ExportedType` relationship walk has its own handle-identity cycle
+guard and node budget. The two bounds protect different graphs and neither
+substitutes for the other.
+
+Scope tightening is one Metadata-owned operation used at every hop. The #3437
+property remains: a forwarder may tighten an unconstrained lookup to platform
+scope when the reference identity requires it, and can never loosen platform
+scope back to an unconstrained lookup.
+
+The engine accepts cancellation for interactive operations. Cancellation is not
+converted to a metadata result and does not replace either hard budget.
+
+The catalog must return the same candidate id when one catalog entry is reached
+again. If it conservatively represents one physical file as two candidates, the
+cycle guard may not recognize that physical revisit; the independent hop budget
+still terminates it without fabricating a definition.
+
+## Binding policy is not reconstructed from a directory
+
+The generic engine does not model CLR binding from an unordered set of files.
+In particular it does not infer:
+
+- unsigned roll-forward from observed versions;
+- a winner from two same-named files;
+- assembly identity from a file name;
+- physical file identity from path equality;
+- target self-exemption from one path spelling;
+- loadability from the fact that SRM can read an `AssemblyDef`.
+
+Those were recurring sources of complexity in #3476 because an alias census was
+being asked to answer a binding-policy question.
+
+The acquisition owner supplies the policy:
+
+- platform resolution selects from trusted installed framework sources;
+- package resolution selects from the chosen asset set;
+- project resolution uses restored assets;
+- a local caller scope uses its acquired catalog and reports ambiguity when the
+  catalog cannot prove one binding.
+
+An unavailable or ambiguous answer may lose a caller, but it is reported as
+incomplete evidence. It cannot fabricate one.
+
+## Consumer model
+
+### Analysis type provenance
+
+Analysis keeps its own `TypeRef`; this design does not unify it with the
+Decompiler `TypeRef`.
+
+When `TypeRefDecoder` decodes a metadata `TypeRef`, it also retains the complete
+originating `AssemblyReferenceIdentity` as typed provenance. Structural
+`TypeRef` equality remains Analysis-owned and does not absorb resolution:
+
+```csharp
+public sealed record TypeReferenceOrigin(
+    AssemblyReferenceIdentity Assembly,
+    MetadataTypeDefinitionName Type);
+```
+
+The origin is excluded from display and from existing shape equality. It is
+separate typed provenance and must not be recovered from, or cached by,
+structural `TypeRef` equality. Resolution caches key on
+`TypeReferenceOrigin`, never on `TypeRef`.
+
+This replaces #3476's proposed `RawAssembly` string with the full identity the
+metadata actually supplied. Two `AssemblyRef` rows with different identity
+therefore remain different resolution inputs even when Analysis shape equality
+canonicalizes their simple names together.
+
+### Caller matching
+
+The target member's declaring `TypeDef` produces one
+`ResolvedTypeDefinitionKey`. Each candidate call site's open declaring type is
+resolved through its `TypeReferenceOrigin`.
+
+The correspondence rule is then:
+
+```text
+candidate resolved definition key == target resolved definition key
+```
+
+There is no facade-name membership test.
+
+Generic member matching, parameter arity, and signature comparison remain
+Analysis concerns after the declaring definitions correspond.
+
+### The three caller gates
+
+Assembly selection, type prefiltering, and member matching must not each derive
+forwarder reachability. The cheap first gate remains metadata-only:
+
+1. Decode the candidate image's `TypeRef` rows.
+2. Compare the structured namespace and nested-name segments with the target,
+   deliberately ignoring assembly spelling.
+3. Rule the image out only when every readable row has a different structured
+   type name and the image does not define that name itself.
+4. Retain malformed or undecidable rows.
+
+Forwarding changes which assembly defines a type, not the namespace and metadata
+name a call site records. This name-only negative therefore remains sound while
+avoiding forwarder resolution for the majority of a scope. It is wider than
+today's assembly-qualified filter, which is the safe direction.
+
+Only images admitted by that gate resolve the complete
+`TypeReferenceOrigin`. One `CallerResolutionPlan` owns those resolutions for a
+candidate image:
+
+```csharp
+public abstract record CandidateTypeRelation
+{
+    public sealed record SameDefinition : CandidateTypeRelation;
+    public sealed record DifferentDefinition : CandidateTypeRelation;
+    public sealed record Indeterminate(
+        TypeResolutionOutcome Outcome) : CandidateTypeRelation;
+}
+```
+
+The direct-caller path replaces its assembly-spelling closure gate with this
+structured-name gate; otherwise a facade-only caller would still be discarded
+before resolution. All remaining gates consume projections of this relation:
+
+- `SameDefinition` stays in scope and may match.
+- `DifferentDefinition` may be ruled out.
+- `Indeterminate` must not be ruled out by a prefilter. The final consumer
+  retains the diagnostic and does not fabricate a match.
+
+At image scope, relations combine without losing the row that supplied them:
+
+- any `SameDefinition` keeps the image;
+- all `DifferentDefinition` rules it out;
+- otherwise the image is `Indeterminate`.
+
+The final matcher still resolves the exact origin carried by the call site's
+declaring `TypeRef`; one genuine row cannot vouch for a differently identified
+row beside it.
+
+The prefilter's soundness is therefore structural: there is no second
+permissiveness rule to keep synchronized with the matcher.
+
+### Call graph
+
+`CallerGraphKey` eventually replaces its assembly-spelling component with
+`ResolvedTypeDefinitionKey`. `Callers` and `Call Graph` then join on the same
+definition relation.
+
+This is a separate migration slice because it changes graph-key construction
+and cache identity. The graph cache retains the acquisition catalog that minted
+its keys; it neither serializes them nor mixes keys from another catalog. It is
+not a separate forwarding model.
+
+### Source and API consumers
+
+Source and API consumers receive `ResolvedAssemblyReference` or
+`ResolvedTypeDefinition`, never a forwarder target string:
+
+- `PdbContext.ResolveImplementationAssemblyPath` is deleted.
+- `SourceLinkService.OpenImplementation` opens the resolved descriptor.
+- `SourceEnricher` and `SourceFileCollector` do not construct sibling paths.
+- `ApiServices.ResolveForwardedTypes` resolves each structured type through the
+  engine and opens the returned descriptor.
+
+The forwarder-related path sinks in #3460 disappear by construction. General
+artifact-derived path components elsewhere still need `HardenedPath`; that is a
+different system.
+
+## Determinism
+
+The resolver returns one route selected by explicit policy, not by collection
+enumeration. Ambiguous candidates are projected and ordered deterministically
+for diagnostics by:
+
+1. assembly identity;
+2. structured provenance;
+3. path, when provenance includes one.
+
+Candidates whose complete diagnostic projection is equal remain equal because
+their serialized rows are indistinguishable. The operation-local candidate id
+is never used to make persisted output appear stable.
+
+Hop evidence is naturally ordered from the starting assembly to the defining
+assembly. It is not sorted after the fact.
+
+Any persisted projection defines a total order over all distinguishing fields,
+following `PrintedBodyMap`'s rule that unstable producer enumeration must not
+become a false change.
+
+## Safety and failure rules
+
+- Product code remains SRM-only and never loads inspected assemblies.
+- Every artifact-derived graph is iterative and bounded.
+- Cycles are detected by typed identity, not display text.
+- Metadata relationship rejection remains typed through the public outcome.
+- Assembly open failures remain distinct from authoritative absence.
+- Unknown evidence never widens a resolution.
+- Ambiguous binding never picks a convenient candidate.
+- Platform scope only tightens across hops.
+- No metadata name is used as a filesystem path component by the resolution
+  engine.
+- No result that escapes the context holds a metadata handle or reader.
+
+## Performance model
+
+Resolution is query-directed:
+
+- the acquisition owner may build one assembly catalog for a package, platform,
+  project, or local scope;
+- the engine opens only the starting assembly and assemblies named by the
+  forwarder chain;
+- each assembly image is opened once per context;
+- each `(assembly, type)` declaration probe runs once;
+- callers sharing a reference reuse the completed resolution.
+
+The design does not require a sweep over every framework assembly and does not
+re-seed the caller-scope closure from every facade. The structural performance
+gate for the forwarded `XmlReader` caller is:
+
+- the real caller is found;
+- the same number of caller sessions are opened as the exact query requires;
+- the framework scope does not saturate;
+- no target file is reopened by the forwarder engine.
+
+Wall-clock measurements may accompany implementation evidence but do not
+replace these structural counts.
+
+## Delivery plan
+
+Each slice has one behavioral claim and can land independently.
+
+### Slice 1: model and declaration primitive
+
+- Add the structured names, tokens, declaration result, resolution request, and
+  outcome types.
+- Build the bounded single-image declaration probe.
+- Support top-level and nested forwarded types.
+- Represent multi-module exports explicitly.
+- Add no production consumer.
+- Do not change `ResolvedAssemblyReference` or
+  `IAssemblyReferenceResolver`.
+
+Claim: one readable image can answer "defines, forwards, misses, or rejects"
+without returning a stringly or nullable result.
+
+### Slice 2: context and resolution engine
+
+- Add `TypeResolutionContext`.
+- Add `IAssemblyBindingResolver` with typed outcomes and explicit adapters from
+  existing resolvers.
+- Implement the iterative cross-assembly engine.
+- Route current `TypeForwardResolver` tests through the engine.
+- Keep compatibility adapters only where needed for the next migration.
+
+Claim: one typed request resolves to one typed definition or one explicit
+non-success outcome, with one lifetime owner.
+
+### Slice 3: existing definition consumers
+
+- Migrate `LibraryBodyIndex`, `MemberBodyProducer`, and
+  `CrossAssemblyTypeResolver`.
+- Delete Analysis's duplicate forwarder loop.
+- Preserve current decompiler and Analysis answers.
+
+Claim: existing cross-assembly definition lookups use one engine without
+changing their successful results.
+
+### Slice 4: source and API consumers
+
+- Migrate `PdbContext`, `SourceLinkService`, `SourceEnricher`,
+  `SourceFileCollector`, and `ApiServices`.
+- Delete forwarder-target sibling-path construction.
+
+Claim: forwarded source and API resolution consume descriptors and cannot turn
+an inspected assembly name into a path.
+
+### Slice 5: direct caller correspondence
+
+- Retain typed `TypeReferenceOrigin` during Analysis decoding.
+- Build `CallerResolutionPlan`.
+- Migrate assembly selection, type prefiltering, and
+  `MatchesCrossAssembly`.
+- Port #3476's real framework fixture and close negative controls.
+- Do not port `ForwardedTypeAliases`.
+
+Claim: `Callers` finds a caller compiled through a facade by comparing resolved
+definition keys, with no spelling alias model.
+
+### Slice 6: graph correspondence and cleanup
+
+- Migrate `CallerGraphKey`.
+- Remove legacy path, alias, and compatibility helpers.
+- Add architecture gates that prevent direct resolution logic from returning
+  to Analysis or the CLI.
+
+Claim: direct callers and transitive call graphs share one definition identity.
+
+## Gates
+
+### Model gates
+
+- Every public outcome arm is enumerated by tests.
+- No public result exposes `MetadataReader`, `PEReader`, or metadata handles.
+- `MetadataTypeDefinitionName` cannot be constructed from a rejected
+  relationship chain.
+- Type name, assembly identity, assembly candidate, provenance, and hop evidence
+  remain separate fields.
+
+### Metadata gates
+
+- Top-level definition.
+- Top-level one-hop and multi-hop forwarders.
+- Nested `Outer+Inner` forwarder.
+- Duplicate forwarder rows to one target do not multiply work.
+- Forwarder rows to different targets are ambiguous.
+- A definition/forwarder conflict is ambiguous.
+- Missing type.
+- Missing target assembly.
+- Ambiguous target assembly.
+- Malformed metadata.
+- Intra-image `ExportedType` cycle.
+- Cross-assembly cycle.
+- Relationship-node and hop-budget exhaustion.
+- Platform-scope tightening at the actual loop call site.
+
+### Consumer gates
+
+- The `System.Xml.ReaderWriter` to `System.Private.Xml` real-artifact caller.
+- Same simple name with a different token does not match.
+- Different culture does not match.
+- An ambiguous local scope does not fabricate a caller.
+- An indeterminate relation is not rejected by a prefilter.
+- A candidate with no matching structured type name is rejected without
+  forwarder resolution.
+- A candidate with a matching name through any assembly spelling reaches the
+  shared resolver.
+- A candidate image is not reread after its reference identities were
+  snapshotted.
+- Resolution caches distinguish origins that structural `TypeRef` equality
+  canonicalizes together.
+- `Callers` and `Call Graph` agree after the graph migration.
+- Forwarded source acquisition opens the resolver-selected descriptor.
+
+### Architecture gates
+
+Prefer dependency and visibility constraints over source scans:
+
+- the single-image probe is the only public Metadata API that interprets a
+  forwarder declaration for resolution;
+- the cross-assembly engine is the only product API that follows hops;
+- Analysis and the CLI cannot access the probe's reader-backed internals;
+- path-only compatibility adapters are internal and deleted with their final
+  consumer.
+
+A narrow source gate may additionally forbid `Path.Combine` over
+`AssemblyReferenceIdentity.Name` in product code, but it is defense in depth,
+not the owner of the invariant.
+
+Every asserted property names a test that fails when the relevant call site,
+result arm, bound, or discriminator is removed. Existence-only tests do not
+count.
+
+## Disposition of current work
+
+- Keep #3437 as the working substrate until Slice 2 replaces its implementation
+  behind the structured contract.
+- Leave #3449 closed.
+- Preserve #3476's real-artifact fixtures, hostile cases, measurements, and
+  review findings as requirements. Do not make its alias engine the product
+  architecture.
+- Split #3460's general path hardening from forwarder resolution. The
+  forwarder-specific sinks are removed by Slice 4 rather than permanently
+  guarded in place.
+
+The open issues found during #3476 become model requirements:
+
+- #3479: assembly lookup uses resolver-owned identities, not file names.
+- #3480: the declaration probe follows nested `ExportedType` chains.
+- #3485: the full originating `AssemblyReferenceIdentity` survives decoding.
+- #3598: SRM readability is not claimed as CLR loadability.
+- #3627: open and path failures are typed non-success outcomes.
+- #3650: path spelling is not used as type-definition identity.
+
+## Non-goals
+
+- A universal type representation shared by Metadata, Analysis, and
+  Decompiler.
+- A universal canonical type spelling.
+- Loading inspected assemblies to ask the CLR what it would bind.
+- Reimplementing CLR binding policy in Metadata.
+- Treating a directory as an ordered deployment.
+- Solving general physical-file identity.
+- Changing user-visible command defaults or output sections in the primitive
+  slices.
+- Retaining compatibility with internal nullable helper APIs after their final
+  consumer migrates.
+
+## Review questions
+
+1. Does one catalog per caller operation provide the right lifetime and scope
+   for `AssemblyCandidateId`, including the call-graph cache that consumes it?
+2. Is MVID plus `TypeDef` token the right durable, explicitly non-cryptographic
+   address, or should the first slice reuse a more general existing metadata
+   address type?
+3. Which existing assembly-image owner should `TypeResolutionContext` compose
+   so Slice 2 extends the single-open architecture rather than creating another
+   lifetime owner?
+4. Which non-success outcomes must become user-visible Finding failures in the
+   first consumer migration, and which can remain typed internal diagnostics
+   until their section is migrated?

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1937,14 +1937,16 @@ under the inspection catalog:
    selected forwarder candidates to the discovery budget. This adds
    `caller -> facade -> implementation` even when the caller's matching
    `TypeRef` names some unrelated type.
-5. Root graph reachability at the candidate owning the target definition and
-   every descriptor selection carrying that candidate's acquisition
-   registration.
+5. Root graph reachability at every candidate in the target definition's
+   generation-stable correspondence class: the exact owning candidate plus all
+   candidates carrying the catalog's class-scoped
+   `IndeterminateDuplicateArtifact` evidence.
 6. Compute the transitive graph set as reverse-reference closure from the
    target-assembly roots, direct facade seeds, and indeterminate seeds.
 
-An unread reference set or an unavailable, ambiguous, or rejected adjacency
-binding cannot prove a negative. Its incoming scope carriers remain
+An unread reference set or a missing/unbound, unavailable, ambiguous, or
+rejected adjacency binding cannot prove a negative. Its incoming scope carriers
+remain
 indeterminate graph seeds and widen closure under their identities; an
 unreadable selected facade never relies on its unavailable `AssemblyDef`
 identity to retain callers above it. This matches the current rule that unknown
@@ -1961,9 +1963,12 @@ candidates or seed from every framework facade.
 
 Rooting at the target assembly is independent of the target type name. It keeps
 a scope candidate that references another type in the target assembly, and
-therefore keeps callers above that intermediate method. The direct facade seeds
-add the case the assembly graph cannot express: a matching type reference whose
-facade is outside the caller scope but resolves to the target definition.
+therefore keeps callers above that intermediate method. The correspondence-class
+root includes independently registered duplicate copies, so an unrelated-type
+edge into a duplicate cannot truncate callers merely because it was not a
+direct type seed. The direct facade seeds add the case the assembly graph cannot
+express: a matching type reference whose facade is outside the caller scope but
+resolves to the target definition.
 
 The plan exposes two projections from one catalog and one metadata snapshot:
 
@@ -2577,6 +2582,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - A missing initial, forwarded, or core-library binding returns
   `UnboundBinding` with the exact target and scope, not `NotFound` or
   `CandidateUnavailable`.
+- A descriptor whose verified selected-entry identity disagrees with the
+  opened image's `AssemblyDef` returns
+  `CandidateOpenFailed(InvalidImage)` before contributing a declaration, hop,
+  or adjacency edge.
 - Ambiguous target assembly.
 - Malformed metadata.
 - A `File`-row-terminated `ExportedType` chain produces
@@ -2649,6 +2658,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Every scope-candidate `AssemblyRef` needed for reverse adjacency is present
   as a binding-only root before freeze; deleting those roots fails the
   depth-two reverse-closure fixture and the adjacency call-count pin.
+- A scope candidate whose only possible route is an adjacency binding reported
+  `Missing` remains an indeterminate seed, and reverse closure retains callers
+  above it.
 - A scope candidate references a facade only for a non-target type, the facade
   is outside the scope and forwards to the target assembly, and a caller above
   that candidate remains reachable through
@@ -2658,6 +2670,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
   fixture supplies verified inventory identity and a failing opener; an
   unidentifiable local file instead fails before selection as
   `CandidateUnavailable`.
+- A scope candidate that references only an unrelated type in a separately
+  registered duplicate of the target assembly remains reachable because every
+  candidate in the target's duplicate-artifact correspondence class is a graph
+  root.
 - A depth-two graph caller that reaches the selected member through another
   method in the target assembly is retained even though it never names the
   target type.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -123,7 +123,7 @@ alias set.
 | **Definition address** | A durable MVID-scoped metadata token. It locates a definition but is not sufficient adversarial correspondence evidence. |
 | **Declaration probe** | The bounded single-image operation that says whether an assembly defines, forwards, or does not contain one type. |
 | **Resolution** | Repeated declaration probes joined by assembly-reference resolution until a definition or a typed non-success outcome is reached. |
-| **Binding policy** | The caller-supplied rule that maps an `AssemblyReferenceIdentity` and scope to zero, one, or several assembly candidates. |
+| **Binding policy** | The caller-supplied rule that maps an `AssemblyBindingRequest` (reference identity, binding origin, and scope) to zero, one, or several assembly candidates. |
 | **Hop** | One verified `ExportedType` declaration and the `AssemblyRef` it names. |
 
 The vocabulary deliberately does not use **alias**. An alias is a derived set of
@@ -318,41 +318,58 @@ provenance, and an `AssemblyAcquisitionRegistration`:
 ```csharp
 public sealed class AssemblyAcquisitionRegistration
 {
-    public AssemblyAcquisitionRegistration() { }
-}
-
-public sealed class ResolvedAssemblyReference
-{
-    public ResolvedAssemblyReference(
-        AssemblyAcquisitionRegistration registration,
-        AssemblyReferenceIdentity identity,
+    public AssemblyAcquisitionRegistration(
+        AssemblyReferenceIdentity selectedIdentity,
         string? path,
         Func<Stream> openRead,
         string? provenance)
     {
-        Registration = registration;
-        Identity = identity;
+        SelectedIdentity = selectedIdentity;
         Path = path;
         OpenRead = openRead;
         Provenance = provenance;
     }
 
+    internal AssemblyReferenceIdentity SelectedIdentity { get; }
+    internal string? Path { get; }
+    internal Func<Stream> OpenRead { get; }
+    internal string? Provenance { get; }
+}
+
+public sealed class ResolvedAssemblyReference
+{
+    public ResolvedAssemblyReference(
+        AssemblyAcquisitionRegistration registration) =>
+        Registration = registration;
+
     public AssemblyAcquisitionRegistration Registration { get; }
-    public AssemblyReferenceIdentity Identity { get; }
-    public string? Path { get; }
-    public Func<Stream> OpenRead { get; }
-    public string? Provenance { get; }
+    public AssemblyReferenceIdentity Identity =>
+        Registration.SelectedIdentity;
+    public string? Path => Registration.Path;
+    public Func<Stream> OpenRead => Registration.OpenRead;
+    public string? Provenance => Registration.Provenance;
 }
 ```
 
 The registration is a public opaque reference-identity handle because an
-external acquisition owner must mint it. It is not a definition key or a claim
-that visible descriptor fields identify a physical file. The owner creates one
-handle per selected candidate and reuses it in every descriptor and request
-that it knows denotes that candidate. The inspection plan routes target
-acquisition and later binding through the same package, platform, project, or
-local owner; independently authoritative owners remain conservatively
-distinct.
+external acquisition owner must mint, retain, and recover it from a requesting
+descriptor at the policy boundary. Its payload remains internal; consumers can
+compare the handle only by reference and cannot extract path, identity, opener,
+or provenance from it. It is not a definition key or a claim that visible
+descriptor fields identify a physical file. It owns the canonical
+selected-candidate descriptor so two wrappers carrying one registration cannot
+disagree about identity, path, opener, or provenance. `SelectedIdentity` is the
+selected image's `AssemblyDef` identity, never the incoming `AssemblyRef`
+identity that requested it. The request remains in the binding outcome and
+forwarding hop. An adapter over today's resolver must therefore normalize the
+legacy request-shaped descriptor from its selected inventory entry before
+registration.
+
+The owner creates one handle per selected candidate and reuses it in every
+descriptor and request that it knows denotes that candidate. The inspection
+plan routes target acquisition and later binding through the same package,
+platform, project, or local owner; independently authoritative owners remain
+conservatively distinct.
 
 `AssemblyCatalogId` identifies the key space. `AssemblyCandidateId` is minted
 only by the single Metadata-owned catalog after a package, platform, project,
@@ -383,16 +400,28 @@ and opener-delegate equality never intern candidates. Returning
 `candidate.Assembly`, or another descriptor carrying the same registration,
 therefore recovers the existing candidate. A descriptor with a fresh
 registration remains a distinct conservative candidate even when all visible
-fields match. Reusing one registration with conflicting identity or provenance
-is an `InvalidPolicyResult`, not permission to merge the descriptors.
+fields match. Conflicting wrappers are unrepresentable because the canonical
+payload belongs to the registration.
 
-The migration adapters retain one registration per candidate selected by their
-own resolver. In particular, the platform adapter keys registrations by the
-platform catalog's selected entry, not by the incoming reference identity or a
-new descriptor returned from the legacy resolver. The inspection target is
-also acquired through that adapter when its scope is platform. This makes a
-target start and a later platform forwarder selection converge on one
-registration even under framework roll-forward.
+`InspectionAcquisitionPlan` owns one package, platform, project, and local
+adapter per inspection. Today's per-path `AssemblyDependencyResolver` instances
+are inventory inputs to those shared adapters, not independent registration
+owners. Each adapter retains one registration per canonical selected entry. In
+particular, the platform adapter keys registrations by the platform catalog's
+selected entry, reads that entry's definition identity, and ignores the
+incoming reference identity when constructing the canonical descriptor. This
+makes requests for different compatible versions converge on one registration
+under framework roll-forward.
+
+The plan classifies the initial target through the same inventories: a selected
+platform entry uses the platform owner, a selected package asset uses the
+package owner, a project output uses the project owner, and an otherwise
+unowned path uses the local owner. Classification is acquisition, not
+correspondence; path may locate an inventory entry at this boundary but no
+consumer later compares paths. Thus a target selected from the platform
+catalog and a later platform forwarder selection share one owner and
+registration. An arbitrary copied platform file remains a distinct local
+candidate unless its acquisition owner can prove it is the catalog entry.
 
 The ids are inspection currency, not persisted identities or sort keys.
 Candidate identity is internal; consumers receive the descriptor but cannot
@@ -412,6 +441,31 @@ here.
 There are two legitimate starts and they stay explicit:
 
 ```csharp
+public abstract class AssemblyBindingOrigin
+{
+    private protected AssemblyBindingOrigin() { }
+
+    public static AssemblyBindingOrigin Global() => new GlobalOrigin();
+
+    public static AssemblyBindingOrigin FromAssembly(
+        ResolvedAssemblyReference assembly) =>
+        new RequestingAssembly(assembly);
+
+    public sealed class GlobalOrigin : AssemblyBindingOrigin
+    {
+        internal GlobalOrigin() { }
+    }
+
+    public sealed class RequestingAssembly : AssemblyBindingOrigin
+    {
+        internal RequestingAssembly(
+            ResolvedAssemblyReference assembly) =>
+            Assembly = assembly;
+
+        public ResolvedAssemblyReference Assembly { get; }
+    }
+}
+
 public abstract class TypeResolutionStart
 {
     private protected TypeResolutionStart() { }
@@ -434,13 +488,16 @@ public abstract class TypeResolutionStart
     {
         internal Reference(
             AssemblyReferenceIdentity value,
+            AssemblyBindingOrigin origin,
             AssemblyResolutionScope scope)
         {
             Value = value;
+            Origin = origin;
             Scope = scope;
         }
 
         public AssemblyReferenceIdentity Value { get; }
+        public AssemblyBindingOrigin Origin { get; }
         public AssemblyResolutionScope Scope { get; }
     }
 }
@@ -466,9 +523,10 @@ public sealed class TypeResolutionRequest
 
     public static TypeResolutionRequest FromReference(
         AssemblyReferenceIdentity value,
+        AssemblyBindingOrigin origin,
         AssemblyResolutionScope scope,
         MetadataTypeDefinitionName type) =>
-        new(new TypeResolutionStart.Reference(value, scope), type);
+        new(new TypeResolutionStart.Reference(value, origin, scope), type);
 }
 ```
 
@@ -476,7 +534,13 @@ public sealed class TypeResolutionRequest
 context's frozen catalog, probe it, then follow any forwarder." An unregistered
 handle is a typed `UnregisteredAssembly` rejection; resolution never mutates a
 frozen catalog. `Reference` means "first ask the binding policy to resolve this
-exact `AssemblyRef`, then probe the result."
+exact `AssemblyRef` from this binding origin, then probe the result." Forwarder
+hops always use the current candidate as `RequestingAssembly`; a global origin
+is explicit and a policy may reject it for a source-relative scope. The builder
+registers a reference start's requesting descriptor as a plan root before
+freeze. A frozen context rejects an origin whose registration is absent from
+its generation as `UnregisteredAssembly` before invoking policy; it never
+mutates the catalog or degrades the origin to global routing.
 
 This avoids an optional `(path, reference?)` or `(assembly?, identity?)` shape.
 Every request states exactly where resolution begins.
@@ -674,6 +738,23 @@ public enum AssemblyBindingFailureKind
 public sealed record AssemblyBindingFailure(
     AssemblyBindingFailureKind Kind);
 
+public sealed class AssemblyBindingRequest
+{
+    public AssemblyBindingRequest(
+        AssemblyReferenceIdentity identity,
+        AssemblyBindingOrigin origin,
+        AssemblyResolutionScope scope)
+    {
+        Identity = identity;
+        Origin = origin;
+        Scope = scope;
+    }
+
+    public AssemblyReferenceIdentity Identity { get; }
+    public AssemblyBindingOrigin Origin { get; }
+    public AssemblyResolutionScope Scope { get; }
+}
+
 public abstract class AssemblyBindingSelection
 {
     private protected AssemblyBindingSelection() { }
@@ -737,9 +818,7 @@ public abstract class AssemblyBindingSelection
 
 public interface IAssemblyBindingPolicy
 {
-    AssemblyBindingSelection Select(
-        AssemblyReferenceIdentity identity,
-        AssemblyResolutionScope scope);
+    AssemblyBindingSelection Select(AssemblyBindingRequest request);
 }
 
 // Metadata-owned adapter result after descriptor interning.
@@ -790,6 +869,7 @@ internal interface IAssemblyBindingResolver
 {
     AssemblyBindingOutcome Resolve(
         AssemblyReferenceIdentity identity,
+        AssemblyBindingOrigin origin,
         AssemblyResolutionScope scope);
 }
 ```
@@ -798,6 +878,21 @@ A package or platform resolver normally returns one selected assembly. A local
 unordered directory containing several plausible candidates returns
 `Ambiguous`; the Metadata engine does not choose by enumeration order, file
 name, highest version, or nearest path.
+
+Binding is source-relative. The Metadata adapter projects
+`AssemblyBindingOrigin.RequestingAssembly` to its internal candidate id and
+uses a distinct global-domain arm for `GlobalOrigin`; it never keys policy
+results by identity and scope alone. The shared local and project adapters use
+the requesting registration to select the appropriate dependency inventory, so
+the same `AssemblyRef` may correctly bind to different private copies in two
+domains. Platform binding remains global after scope tightening, but retains
+the requesting origin in the request and cache key; different origins may reuse
+the same selected registration without sharing a cached policy decision.
+
+The internal structurally equatable `AssemblyBindingDomainKey` is a closed
+value with `Global` and `RequestingCandidate(AssemblyCandidateId)` arms. It is
+generation-scoped and is the only origin projection permitted in binding and
+resolution cache keys.
 
 Package, platform, project, and local acquisition owners implement the public
 `IAssemblyBindingPolicy` and return context-free descriptors through public
@@ -824,6 +919,16 @@ structured policy interface.
 Resolution rejection is a closed, inspectable hierarchy:
 
 ```csharp
+public enum CandidateOpenFailureKind
+{
+    Unreadable,
+    InvalidImage
+}
+
+public sealed record CandidateOpenFailure(
+    CandidateOpenFailureKind Kind,
+    string Detail);
+
 public abstract class TypeResolutionFailure
 {
     private protected TypeResolutionFailure() { }
@@ -873,21 +978,45 @@ public abstract class TypeResolutionFailure
         public AssemblyBindingFailure Failure { get; }
     }
 
+    public sealed class CandidateOpenFailed : TypeResolutionFailure
+    {
+        internal CandidateOpenFailed(
+            ResolvedAssemblyReference assembly,
+            CandidateOpenFailure failure)
+        {
+            Assembly = assembly;
+            Failure = failure;
+        }
+
+        public ResolvedAssemblyReference Assembly { get; }
+        public CandidateOpenFailure Failure { get; }
+    }
+
     public sealed class DiscoveryBudgetExceeded : TypeResolutionFailure
     {
         internal DiscoveryBudgetExceeded(int budget) => Budget = budget;
         public int Budget { get; }
     }
+
+    public sealed class PlanExpansionRequired : TypeResolutionFailure
+    {
+        internal PlanExpansionRequired(TypeResolutionRequest request) =>
+            Request = request;
+
+        public TypeResolutionRequest Request { get; }
+    }
 }
 ```
 
-Open or acquisition failures while selecting a reference use `Unavailable`
-with `CandidateUnavailable`. Declaration rejection preserves its typed
+Acquisition failures before selection use `Unavailable` with
+`CandidateUnavailable`; opening a selected descriptor uses
+`CandidateOpenFailed`. Declaration rejection preserves its typed
 cycle/node-budget/malformed-metadata discriminator. Cross-assembly cycles,
 hop-budget exhaustion, unsupported modules, invalid starts, invalid policy
 responses, and discovery exhaustion use the other corresponding `Rejected`
-arms. Constructors remain internal because consumers inspect failures but do
-not manufacture engine verdicts.
+arms. `PlanExpansionRequired` is an orchestration signal that must advance the
+generation before presentation. Constructors remain internal because consumers
+inspect failures but do not manufacture engine verdicts.
 
 ```csharp
 public sealed class ResolvedTypeDefinitionKey
@@ -963,13 +1092,19 @@ public abstract class TypeResolutionAmbiguity
     {
         internal AssemblyBinding(
             AssemblyReferenceIdentity reference,
+            AssemblyBindingOrigin origin,
+            AssemblyResolutionScope scope,
             ImmutableArray<ResolvedAssemblyCandidate> candidates)
         {
             Reference = reference;
+            Origin = origin;
+            Scope = scope;
             Candidates = candidates;
         }
 
         public AssemblyReferenceIdentity Reference { get; }
+        public AssemblyBindingOrigin Origin { get; }
+        public AssemblyResolutionScope Scope { get; }
         public ImmutableArray<ResolvedAssemblyCandidate> Candidates { get; }
     }
 
@@ -1019,18 +1154,42 @@ public abstract class TypeResolutionOutcome
         public ResolvedAssemblyCandidate LastAssembly { get; }
     }
 
+    public sealed class UnboundReference : TypeResolutionOutcome
+    {
+        internal UnboundReference(
+            AssemblyReferenceIdentity reference,
+            AssemblyBindingOrigin origin,
+            AssemblyResolutionScope scope,
+            ImmutableArray<TypeForwardingHop> hops) : base(hops)
+        {
+            Reference = reference;
+            Origin = origin;
+            Scope = scope;
+        }
+
+        public AssemblyReferenceIdentity Reference { get; }
+        public AssemblyBindingOrigin Origin { get; }
+        public AssemblyResolutionScope Scope { get; }
+    }
+
     public sealed class Unavailable : TypeResolutionOutcome
     {
         internal Unavailable(
             AssemblyReferenceIdentity reference,
+            AssemblyBindingOrigin origin,
+            AssemblyResolutionScope scope,
             AssemblyBindingFailure failure,
             ImmutableArray<TypeForwardingHop> hops) : base(hops)
         {
             Reference = reference;
+            Origin = origin;
+            Scope = scope;
             Failure = failure;
         }
 
         public AssemblyReferenceIdentity Reference { get; }
+        public AssemblyBindingOrigin Origin { get; }
+        public AssemblyResolutionScope Scope { get; }
         public AssemblyBindingFailure Failure { get; }
     }
 
@@ -1180,19 +1339,21 @@ The assembly descriptor and type name are materialized provenance. Stable
 projections may render or persist the descriptor's identity and provenance;
 they exclude its catalog-local candidate id and opener.
 
-The distinction between the four non-success outcomes is load-bearing:
+The distinction between the five non-success outcomes is load-bearing:
 
 - `NotFound` means a readable assembly authoritatively neither defined nor
   forwarded the requested type.
+- `UnboundReference` means policy authoritatively found no candidate for the
+  exact reference and scope; no readable last assembly is invented.
 - `Unavailable` means policy could not supply or select an assembly needed to
   continue and carries the binding-policy reason.
 - `Ambiguous` means policy found several assembly candidates or one image
   contained competing declarations and the engine could not select one.
 - `Rejected` means malformed metadata, a cycle, an exhausted budget, an open
-  failure, an unsupported multi-module export, or another failure that must
-  remain visible.
+  failure after selection, an unsupported multi-module export, or another
+  failure that must remain visible.
 
-No consumer may convert all four to `null` and present "no callers" or "no
+No consumer may convert all five to `null` and present "no callers" or "no
 source" as a complete answer.
 
 ## Resolution context and lifetime
@@ -1217,22 +1378,39 @@ reason `LibraryBodyIndex` currently repeats the traversal beside
 `TypeForwardResolver`.
 
 Candidate discovery and correspondence are separate phases.
-`AssemblyCatalogBuilder` is the discovery-phase vehicle. It registers plan
-roots, binds references, and runs declaration/forwarder probes over provisional
-candidate ids and catalog-owned sessions without issuing definition keys, join
-tokens, graph leases, or a public `TypeResolutionContext`. A newly selected
-registration extends the builder's candidate set and work queue. Discovery
-reaches a fixed point when a complete queue pass adds no registration.
+`AssemblyCatalogBuilder` is the discovery-phase vehicle. The consumer planner
+first supplies a manifest of concrete `TypeResolutionRequest` roots: the target,
+matching caller references, and the named signature types in graph edges being
+indexed. The builder executes those requests provisionally, including every
+per-hop scope-tightening transition. Each encountered
+`(AssemblyBindingDomainKey, AssemblyReferenceIdentity,
+AssemblyResolutionScope)` binding is added to the manifest; each selected
+registration and forwarded continuation extends the work queue. It does not
+bind unrelated `AssemblyRef` rows or sweep framework assemblies.
+
+Provisional resolution uses catalog-owned sessions and candidate ids but does
+not issue definition keys, join tokens, graph leases, or a public
+`TypeResolutionContext`. Discovery reaches a fixed point when a complete queue
+pass adds no request, binding pair, or registration.
 
 The builder is bounded by the plan's candidate and relationship budgets.
 Stable acquisition registrations make repeated selections idempotent; an owner
 that keeps minting registrations eventually produces
 `DiscoveryBudgetExceeded`, not an infinite rebuild loop. At the fixed point the
-builder freezes an `AssemblyCatalogGenerationId`, clears provisional binding
-results, and creates contexts whose binding cache is scoped to that generation.
-Definition keys and join tokens are minted only against this frozen candidate
-set, so duplicate correspondence classes are complete and token arms cannot
-change beneath a cache.
+builder freezes an `AssemblyCatalogGenerationId` and promotes the exact
+provisional binding outcomes into that generation's immutable binding cache.
+Execution never calls policy for a binding pair absent from that snapshot.
+Definition keys and join tokens are minted only against this frozen manifest
+and candidate set, so duplicate correspondence classes are complete and token
+arms cannot change beneath a cache.
+
+A request outside the frozen manifest returns the typed
+`PlanExpansionRequired` rejection to the inspection coordinator. The
+coordinator unions that request into the builder and advances the generation
+before rendering; it never treats the rejection as missing. A binding outcome
+inside the manifest can reference only candidates frozen with it. A volatile
+policy that changes its answer is observed only when a later discovery epoch
+refreshes that pair, never halfway through execution.
 
 The internal `CatalogDiscoveryOutcome` is closed: `Ready` carries the frozen
 generation, while `Rejected` carries
@@ -1241,8 +1419,11 @@ a rejected discovery plan, and the inspection surfaces that diagnostic rather
 than retrying or rendering an authoritative empty result.
 
 A later progressive lens first reopens the builder with the union of previous
-roots and the new lens's roots. If fixed-point discovery adds a candidate, the
-catalog freezes a new generation and invalidates every
+manifest and the new lens's requests. Graph planning first decodes the selected
+edge set and contributes all named signature requests, then freezes, then
+issues join tokens and builds the graph. It never discovers a new binding while
+tokens are being issued. If fixed-point discovery adds a candidate, the catalog
+freezes a new generation and invalidates every
 `TypeResolutionContext`, resolution plan, join token, and `ScopeGraph` lease
 from the previous generation. It never mutates or reclassifies an issued token.
 The number of passes is data-dependent and bounded; no one-rebuild claim is
@@ -1254,10 +1435,11 @@ The acquisition catalog caches:
 - candidate ids by `AssemblyAcquisitionRegistration` reference identity;
 - opened sessions by `AssemblyCandidateId`;
 - provisional discovery bindings by
-  `(discovery epoch, AssemblyReferenceIdentity, AssemblyResolutionScope)`;
-- binding outcomes by
-  `(AssemblyCatalogGenerationId, AssemblyReferenceIdentity,
+  `(discovery epoch, AssemblyBindingDomainKey, AssemblyReferenceIdentity,
   AssemblyResolutionScope)`;
+- binding outcomes by
+  `(AssemblyCatalogGenerationId, AssemblyBindingDomainKey,
+  AssemblyReferenceIdentity, AssemblyResolutionScope)`;
 
 Each resolution context is bound to one frozen generation, composes that
 catalog, and caches:
@@ -1270,8 +1452,9 @@ catalog, and caches:
 
 `TypeResolutionCacheKey` is an internal projection; it does not use the public
 request object's reference equality. Its start arm contains either the internal
-candidate id plus scope or the complete assembly reference identity plus scope,
-followed by the structurally equatable `MetadataTypeDefinitionName`.
+candidate id plus scope or the complete assembly reference identity plus
+binding-domain key plus scope, followed by the structurally equatable
+`MetadataTypeDefinitionName`.
 
 The cache retains typed failures as well as successes. Re-running a rejected
 probe must not turn it into a success-shaped miss.
@@ -1291,7 +1474,12 @@ be compared only through the catalog correspondence API.
 
 For one request:
 
-1. Resolve the start when it is an assembly reference.
+1. Resolve the start when it is an assembly reference. First validate a
+   requesting-assembly origin against the frozen generation and return
+   `Rejected(UnregisteredAssembly)` if absent. Otherwise binding `Selected`
+   continues; `Missing` returns `UnboundReference`; `Unavailable` returns
+   `Unavailable`; `Ambiguous` returns `Ambiguous`; and binding `Rejected`
+   returns `Rejected(InvalidBindingPolicy)`.
 2. Open the selected assembly through the context.
 3. Probe the exact structured type name.
 4. On `Defined`, materialize the definition key and finish.
@@ -1300,9 +1488,10 @@ For one request:
 7. On `Rejected`, return `Rejected`.
 8. On `Forwarded`, append one hop.
 9. Tighten, but never loosen, `AssemblyResolutionScope` for the next reference.
-10. Resolve the complete target `AssemblyReferenceIdentity` through policy.
-11. Stop on missing, ambiguous, rejected, repeated assembly candidate, or the hop
-    budget.
+10. Resolve the complete target `AssemblyReferenceIdentity` through policy,
+    applying the same exhaustive binding-outcome mapping as step 1.
+11. Stop on repeated assembly candidate or the hop budget with the corresponding
+    `Rejected` failure.
 12. Otherwise repeat at step 2.
 
 The traversal is iterative. It has both:
@@ -1655,9 +1844,10 @@ permissiveness rule to keep synchronized with the matcher.
 - a `DegradedMemberCorrespondenceKey` substitutes a
   catalog-owned `UnresolvedBindingKey` plus structured type name only for an
   unavailable named type. The binding key represents the exact cached
-  `(AssemblyReferenceIdentity, AssemblyResolutionScope)` request, preserving
-  the complete assembly/module/current origin instead of collapsing failures
-  into one bucket.
+  `(AssemblyBindingDomainKey, AssemblyReferenceIdentity,
+  AssemblyResolutionScope)` request, preserving the complete
+  assembly/module/current origin instead of collapsing failures into one
+  bucket.
 
 `UnresolvedBindingKey` has the same internal-constructor and generation scope
 as `DefinitionJoinToken`; it cannot survive or compare across a generation
@@ -1889,8 +2079,8 @@ become a false change.
 
 Resolution is query-directed:
 
-- the acquisition owner may build one assembly catalog for a package, platform,
-  project, or local scope;
+- the inspection acquisition plan contributes package, platform, project, and
+  local inventories to one Metadata-owned catalog;
 - the engine opens only the starting assembly and assemblies named by the
   forwarder chain;
 - each assembly image is opened once per catalog;
@@ -1938,6 +2128,8 @@ without returning a stringly or nullable result.
 
 - Evolve `ResolvedAssemblyReference` to the non-equatable descriptor plus
   acquisition registration contract.
+- Add one `InspectionAcquisitionPlan` per inspection and collapse today's
+  per-path resolver instances into its shared owner adapters.
 - Extend `AssemblyInspectionSession` as the single candidate image owner, add
   the catalog lifetime, and compose `TypeResolutionContext` over those sessions.
 - Add public `IAssemblyBindingPolicy` descriptor selections and the
@@ -2028,12 +2220,27 @@ Claim: direct callers and transitive call graphs share one definition identity.
   candidate id, one opened session, and `Same` correspondence.
 - A second descriptor with identical visible values and the identical
   `Func<Stream>` instance but a fresh registration remains a distinct
-  candidate; changing the descriptor fields does not alter that result.
-- Reusing one registration with conflicting descriptor identity or provenance
-  is `InvalidPolicyResult`.
+  candidate.
 - Package, platform, project, and local migration adapters each return one
   stable registration when their owner selects the same candidate through
   different compatible reference requests.
+- Two version-skewed platform requests that roll forward to one selected entry
+  expose that entry's one `AssemblyDef` identity, canonical provenance, opener,
+  and registration; neither request identity is stored in the descriptor.
+- Per-path legacy resolver instances feed one per-inspection adapter set and
+  cannot mint independent registrations for the same owner-selected entry.
+- A user path found in the platform inventory and a forwarder binding to that
+  entry share the platform registration; an unowned copied path remains local.
+- An external policy can recover the requesting descriptor's registration and
+  use reference identity to select its owner inventory, but cannot read the
+  registration payload.
+- Two requesting-assembly origins with the same reference identity and scope
+  occupy different binding-cache entries and may select different candidates;
+  repeated requests from one origin reuse its outcome.
+- A global-origin request remains a distinct cache arm and local policy may
+  return `UnsupportedScope` rather than guessing a source domain.
+- A frozen context rejects an unregistered requesting-assembly origin before
+  policy invocation and neither mutates the catalog nor routes it as global.
 - External consumers can create assembly-descriptor and assembly-reference
   requests and can forward an existing `TypeResolutionStart` to another type.
 - External consumers can inspect but cannot forge decoder-produced
@@ -2051,6 +2258,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - A definition/forwarder conflict is ambiguous.
 - Missing type.
 - Missing target assembly.
+- A missing initial or forwarded binding returns `UnboundReference` with the
+  exact reference and scope, not `NotFound` or `CandidateUnavailable`.
 - Ambiguous target assembly.
 - Malformed metadata.
 - A `File`-row-terminated `ExportedType` chain produces
@@ -2062,6 +2271,11 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Cross-assembly cycle.
 - Relationship-node and hop-budget exhaustion.
 - Platform-scope tightening at the actual loop call site.
+- Discovery records and promotes the tightened-scope binding outcome before
+  freeze; execution performs no new policy call and selects no unregistered
+  candidate.
+- A request outside the frozen manifest returns `PlanExpansionRequired`, and
+  presentation occurs only after the coordinator advances the generation.
 
 ### Consumer gates
 
@@ -2079,6 +2293,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - A same-named type from another assembly passes the name-only prefilter but is
   rejected by resolved definition correspondence; the current
   assembly-sensitive prefilter pins move to this end-to-end gate.
+- Two local or project binding domains resolve the same `AssemblyRef` to their
+  respective private copies without sharing a binding outcome or candidate.
 - A candidate image is not reread after its reference identities were
   snapshotted.
 - Resolution caches distinguish origins that structural `TypeRef` equality
@@ -2148,7 +2364,8 @@ Prefer dependency and visibility constraints over source scans:
   `DefinitionJoinToken` or `UnresolvedBindingKey` values;
 - external policy assemblies implement `IAssemblyBindingPolicy` without
   `InternalsVisibleTo`; only the Metadata adapter constructs
-  `AssemblyBindingOutcome`;
+  `AssemblyBindingOutcome`, and every policy request carries an explicit
+  `AssemblyBindingOrigin`;
 - correspondence-bearing result bases use `private protected` constructors and
   every verdict arm uses an internal constructor;
 - Analysis and the CLI cannot access the probe's reader-backed internals;
@@ -2175,10 +2392,11 @@ equalities remain allowed only inside one known candidate for
 durable-coordinate handling, declaration probing, and reader-validation code.
 The same gate treats `TypeForwardingHop`, `DuplicateArtifactEvidence`, and
 `DuplicateArtifactCandidateEvidence` as evidence-only classes, never identity
-or correspondence keys. Outside the catalog's registration map, it also rejects
-equality or hashing over `ResolvedAssemblyReference` or
-`AssemblyAcquisitionRegistration`; acquisition owners retain handles, and
-consumers do not compare them to infer correspondence.
+or correspondence keys. Outside the catalog's registration map and
+acquisition-policy domain routing, it also rejects equality or hashing over
+`ResolvedAssemblyReference` or `AssemblyAcquisitionRegistration`; acquisition
+owners retain handles, and other consumers do not compare them to infer
+correspondence.
 
 A second narrow source gate may forbid `Path.Combine` over
 `AssemblyReferenceIdentity.Name` in product code, but it is defense in depth,

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -337,6 +337,15 @@ The catalog interns exactly one `ResolvedAssemblyCandidate` object per
 descriptor object, but caches and correspondence still key on the internal id,
 not object equality.
 
+Within one catalog, `ResolvedAssemblyReference` object identity is the
+acquisition registration handle. The catalog uses reference identity, never
+record/value equality, to map that stable descriptor instance to one candidate
+id. An acquisition owner creates one descriptor object per candidate and reuses
+that object in policy selections and public assembly-start requests. Returning
+`candidate.Assembly` therefore recovers the existing candidate. A newly
+constructed descriptor remains a distinct conservative candidate even when all
+of its visible fields match; descriptor identity is not physical-file identity.
+
 The ids are inspection currency, not persisted identities or sort keys.
 Candidate identity is internal; consumers receive the descriptor but cannot
 reconstruct a candidate key from it. Both ids use globally unique values, but
@@ -587,6 +596,17 @@ from an ambiguous scope or an unreadable candidate. It evolves rather than
 gaining a parallel resolver:
 
 ```csharp
+public enum AssemblyBindingFailureKind
+{
+    IdentityPolicyRequired,
+    CandidateUnavailable,
+    UnsupportedScope,
+    InvalidPolicyResult
+}
+
+public sealed record AssemblyBindingFailure(
+    AssemblyBindingFailureKind Kind);
+
 public abstract class AssemblyBindingSelection
 {
     private protected AssemblyBindingSelection() { }
@@ -719,6 +739,12 @@ catalog and produces the internal candidate-bearing
 `AssemblyBindingOutcome`. External policy assemblies never receive
 `InternalsVisibleTo` and cannot mint candidate ids, definition keys, or join
 tokens.
+
+`AssemblyBindingFailure` is a public policy diagnostic because external policy
+owners must construct `CannotSelect` and `Invalid` selections.
+`IdentityPolicyRequired` is the explicit local version-skew outcome; the other
+kinds distinguish unavailable acquisition, unsupported scope, and an invalid
+policy response without using free-form text as identity.
 
 This is a new public policy contract plus a Metadata-internal adapter, not a
 same-name return-type change to `IAssemblyReferenceResolver`. The nullable
@@ -1071,6 +1097,7 @@ generation and answers.
 
 The acquisition catalog caches:
 
+- candidate ids by `ResolvedAssemblyReference` reference identity;
 - opened sessions by `AssemblyCandidateId`;
 - binding outcomes by
   `(AssemblyCatalogGenerationId, AssemblyReferenceIdentity,
@@ -1835,6 +1862,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
   consumers cannot construct correspondence verdict arms.
 - An external fake `IAssemblyBindingPolicy` can return every public descriptor
   selection through factories but cannot construct catalog candidates.
+- An external fake policy can construct every `AssemblyBindingFailureKind`.
+- Interning the same descriptor object twice, including
+  `candidate.Assembly`, yields one candidate id, one opened session, and `Same`
+  correspondence; a new value-equal descriptor object remains distinct.
 - External consumers can create assembly-descriptor and assembly-reference
   requests and can forward an existing `TypeResolutionStart` to another type.
 - External consumers can inspect but cannot forge decoder-produced

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -178,23 +178,35 @@ nullable strings is not an implementation detail.
 public sealed class MetadataTypeDefinitionName :
     IEquatable<MetadataTypeDefinitionName>
 {
-    public MetadataTypeDefinitionName(
+    MetadataTypeDefinitionName(
         string @namespace,
         ImmutableArray<string> segments)
     {
-        ArgumentNullException.ThrowIfNull(@namespace);
-        if (segments.IsDefaultOrEmpty)
-            throw new ArgumentException("Segments must not be empty.", nameof(segments));
-        foreach (string segment in segments)
-        {
-            if (string.IsNullOrEmpty(segment))
-                throw new ArgumentException(
-                    "Segments must not contain empty names.",
-                    nameof(segments));
-        }
-
         Namespace = @namespace;
         Segments = segments;
+    }
+
+    public static MetadataTypeDefinitionNameResult Create(
+        string? @namespace,
+        ImmutableArray<string> segments)
+    {
+        if (@namespace is null)
+            return new MetadataTypeDefinitionNameResult.Rejected(
+                new(MetadataTypeNameRejectionKind.MissingNamespace));
+        if (segments.IsDefaultOrEmpty)
+            return new MetadataTypeDefinitionNameResult.Rejected(
+                new(MetadataTypeNameRejectionKind.MissingSegments));
+        for (int i = 0; i < segments.Length; i++)
+        {
+            if (string.IsNullOrEmpty(segments[i]))
+            {
+                return new MetadataTypeDefinitionNameResult.Rejected(
+                    new(MetadataTypeNameRejectionKind.MissingSegment, i));
+            }
+        }
+
+        return new MetadataTypeDefinitionNameResult.Valid(
+            new MetadataTypeDefinitionName(@namespace, segments));
     }
 
     public string Namespace { get; }
@@ -227,6 +239,32 @@ public sealed class MetadataTypeDefinitionName :
         return hash.ToHashCode();
     }
 }
+
+public enum MetadataTypeNameRejectionKind
+{
+    MissingNamespace,
+    MissingSegments,
+    MissingSegment
+}
+
+public sealed record MetadataTypeNameRejection(
+    MetadataTypeNameRejectionKind Kind,
+    int? SegmentIndex = null);
+
+public abstract class MetadataTypeDefinitionNameResult
+{
+    public sealed class Valid(MetadataTypeDefinitionName name)
+        : MetadataTypeDefinitionNameResult
+    {
+        public MetadataTypeDefinitionName Name { get; } = name;
+    }
+
+    public sealed class Rejected(MetadataTypeNameRejection rejection)
+        : MetadataTypeDefinitionNameResult
+    {
+        public MetadataTypeNameRejection Rejection { get; } = rejection;
+    }
+}
 ```
 
 `Segments` is root-to-leaf and retains metadata names, including generic arity.
@@ -239,8 +277,10 @@ their display, XML documentation, API identity, and body identity projections.
 It is the structured input to one metadata lookup operation.
 
 Construction from `TypeDef`, `TypeRef`, and `ExportedType` uses the existing
-bounded relationship traversals. A rejected relationship walk cannot construct
-a `MetadataTypeDefinitionName`.
+bounded relationship traversals and the typed `Create` result. A rejected
+relationship walk or empty metadata name cannot construct a
+`MetadataTypeDefinitionName`; the declaration probe carries the rejection and
+the caller prefilter retains that row as undecidable.
 
 ### Assembly candidate
 
@@ -512,47 +552,101 @@ public sealed record TypeForwardingHop(
     AssemblyReferenceIdentity TargetReference,
     AssemblyResolutionScope Scope);
 
-public abstract record TypeResolutionAmbiguity
+public abstract class TypeResolutionAmbiguity
 {
-    public sealed record AssemblyBinding(
-        AssemblyReferenceIdentity Reference,
-        ImmutableArray<ResolvedAssemblyCandidate> Candidates)
-        : TypeResolutionAmbiguity;
+    public sealed class AssemblyBinding : TypeResolutionAmbiguity
+    {
+        internal AssemblyBinding(
+            AssemblyReferenceIdentity reference,
+            ImmutableArray<ResolvedAssemblyCandidate> candidates)
+        {
+            Reference = reference;
+            Candidates = candidates;
+        }
 
-    public sealed record TypeDeclaration(
-        ResolvedAssemblyCandidate Assembly,
-        MetadataTypeDefinitionName Type,
-        ImmutableArray<TypeDeclarationCandidate> Candidates)
-        : TypeResolutionAmbiguity;
+        public AssemblyReferenceIdentity Reference { get; }
+        public ImmutableArray<ResolvedAssemblyCandidate> Candidates { get; }
+    }
+
+    public sealed class TypeDeclaration : TypeResolutionAmbiguity
+    {
+        internal TypeDeclaration(
+            ResolvedAssemblyCandidate assembly,
+            MetadataTypeDefinitionName type,
+            ImmutableArray<TypeDeclarationCandidate> candidates)
+        {
+            Assembly = assembly;
+            Type = type;
+            Candidates = candidates;
+        }
+
+        public ResolvedAssemblyCandidate Assembly { get; }
+        public MetadataTypeDefinitionName Type { get; }
+        public ImmutableArray<TypeDeclarationCandidate> Candidates { get; }
+    }
 }
 
-public abstract record TypeResolutionOutcome
+public abstract class TypeResolutionOutcome
 {
-    public sealed record Resolved(
-        ResolvedTypeDefinition Definition,
-        ImmutableArray<TypeForwardingHop> Hops)
-        : TypeResolutionOutcome;
+    protected TypeResolutionOutcome(ImmutableArray<TypeForwardingHop> hops) =>
+        Hops = hops;
 
-    public sealed record NotFound(
-        ResolvedAssemblyCandidate LastAssembly,
-        ImmutableArray<TypeForwardingHop> Hops)
-        : TypeResolutionOutcome;
+    public ImmutableArray<TypeForwardingHop> Hops { get; }
 
-    public sealed record Unavailable(
-        AssemblyReferenceIdentity Reference,
-        AssemblyBindingFailure Failure,
-        ImmutableArray<TypeForwardingHop> Hops)
-        : TypeResolutionOutcome;
+    public sealed class Resolved : TypeResolutionOutcome
+    {
+        internal Resolved(
+            ResolvedTypeDefinition definition,
+            ImmutableArray<TypeForwardingHop> hops) : base(hops) =>
+            Definition = definition;
 
-    public sealed record Ambiguous(
-        TypeResolutionAmbiguity Ambiguity,
-        ImmutableArray<TypeForwardingHop> Hops)
-        : TypeResolutionOutcome;
+        public ResolvedTypeDefinition Definition { get; }
+    }
 
-    public sealed record Rejected(
-        TypeResolutionFailure Failure,
-        ImmutableArray<TypeForwardingHop> Hops)
-        : TypeResolutionOutcome;
+    public sealed class NotFound : TypeResolutionOutcome
+    {
+        internal NotFound(
+            ResolvedAssemblyCandidate lastAssembly,
+            ImmutableArray<TypeForwardingHop> hops) : base(hops) =>
+            LastAssembly = lastAssembly;
+
+        public ResolvedAssemblyCandidate LastAssembly { get; }
+    }
+
+    public sealed class Unavailable : TypeResolutionOutcome
+    {
+        internal Unavailable(
+            AssemblyReferenceIdentity reference,
+            AssemblyBindingFailure failure,
+            ImmutableArray<TypeForwardingHop> hops) : base(hops)
+        {
+            Reference = reference;
+            Failure = failure;
+        }
+
+        public AssemblyReferenceIdentity Reference { get; }
+        public AssemblyBindingFailure Failure { get; }
+    }
+
+    public sealed class Ambiguous : TypeResolutionOutcome
+    {
+        internal Ambiguous(
+            TypeResolutionAmbiguity ambiguity,
+            ImmutableArray<TypeForwardingHop> hops) : base(hops) =>
+            Ambiguity = ambiguity;
+
+        public TypeResolutionAmbiguity Ambiguity { get; }
+    }
+
+    public sealed class Rejected : TypeResolutionOutcome
+    {
+        internal Rejected(
+            TypeResolutionFailure failure,
+            ImmutableArray<TypeForwardingHop> hops) : base(hops) =>
+            Failure = failure;
+
+        public TypeResolutionFailure Failure { get; }
+    }
 }
 ```
 
@@ -561,19 +655,55 @@ opaque input to exact correspondence inside one acquisition catalog generation.
 The catalog exposes the only comparison operation:
 
 ```csharp
-public abstract record DefinitionCorrespondence
+public abstract class DefinitionCorrespondence
 {
-    public sealed record Same : DefinitionCorrespondence;
-    public sealed record Different : DefinitionCorrespondence;
-    public sealed record IndeterminateDuplicateArtifact(
-        DuplicateArtifactEvidence Evidence)
-        : DefinitionCorrespondence;
-    public sealed record IncomparableCatalogs(
-        AssemblyCatalogId Left,
-        AssemblyCatalogId Right) : DefinitionCorrespondence;
-    public sealed record StaleGeneration(
-        AssemblyCatalogGenerationId Left,
-        AssemblyCatalogGenerationId Right) : DefinitionCorrespondence;
+    public sealed class Same : DefinitionCorrespondence
+    {
+        internal Same() { }
+    }
+
+    public sealed class Different : DefinitionCorrespondence
+    {
+        internal Different() { }
+    }
+
+    public sealed class IndeterminateDuplicateArtifact
+        : DefinitionCorrespondence
+    {
+        internal IndeterminateDuplicateArtifact(
+            DuplicateArtifactEvidence evidence) =>
+            Evidence = evidence;
+
+        public DuplicateArtifactEvidence Evidence { get; }
+    }
+
+    public sealed class IncomparableCatalogs : DefinitionCorrespondence
+    {
+        internal IncomparableCatalogs(
+            AssemblyCatalogId left,
+            AssemblyCatalogId right)
+        {
+            Left = left;
+            Right = right;
+        }
+
+        public AssemblyCatalogId Left { get; }
+        public AssemblyCatalogId Right { get; }
+    }
+
+    public sealed class StaleGeneration : DefinitionCorrespondence
+    {
+        internal StaleGeneration(
+            AssemblyCatalogGenerationId left,
+            AssemblyCatalogGenerationId right)
+        {
+            Left = left;
+            Right = right;
+        }
+
+        public AssemblyCatalogGenerationId Left { get; }
+        public AssemblyCatalogGenerationId Right { get; }
+    }
 }
 
 public sealed record DuplicateArtifactCandidateEvidence(
@@ -597,9 +727,10 @@ consumers can retain the key and pass it back to catalog APIs, but cannot hash,
 order, or field-compare its internal candidate/token tuple to reconstruct
 correspondence.
 
-`ResolvedTypeDefinition` is also a non-equatable result container. Equality of
-that object or of a `TypeResolutionOutcome.Resolved` wrapper is not definition
-correspondence; only the catalog comparison API answers that question.
+`ResolvedTypeDefinition`, `TypeResolutionOutcome`, and
+`DefinitionCorrespondence` are non-equatable class hierarchies. Result
+containers support pattern matching, not semantic equality; only the catalog
+comparison API answers definition correspondence.
 
 The inspection and its graph cache keep the catalog generation alive and use
 one key space for the target and all candidates. A key is never serialized or
@@ -945,30 +1076,48 @@ Only matching or indeterminate rows proceed to step 2. One
 reachability; final call-site matching does not run a second resolution pass:
 
 ```csharp
-public abstract record TypeCorrespondenceFailure
+public abstract class TypeCorrespondenceFailure
 {
-    public sealed record Resolution(
-        TypeResolutionOutcome NonSuccess) : TypeCorrespondenceFailure;
+    public sealed class Resolution(TypeResolutionOutcome nonSuccess)
+        : TypeCorrespondenceFailure
+    {
+        public TypeResolutionOutcome NonSuccess { get; } = nonSuccess;
+    }
 
-    public sealed record DuplicateArtifact(
-        DefinitionCorrespondence.IndeterminateDuplicateArtifact Evidence)
-        : TypeCorrespondenceFailure;
+    public sealed class DuplicateArtifact(
+        DefinitionCorrespondence.IndeterminateDuplicateArtifact evidence)
+        : TypeCorrespondenceFailure
+    {
+        public DefinitionCorrespondence.IndeterminateDuplicateArtifact Evidence
+            { get; } = evidence;
+    }
 
-    public sealed record IncomparableCatalogs(
-        AssemblyCatalogId Left,
-        AssemblyCatalogId Right) : TypeCorrespondenceFailure;
+    public sealed class IncomparableCatalogs(
+        AssemblyCatalogId left,
+        AssemblyCatalogId right) : TypeCorrespondenceFailure
+    {
+        public AssemblyCatalogId Left { get; } = left;
+        public AssemblyCatalogId Right { get; } = right;
+    }
 
-    public sealed record StaleGeneration(
-        AssemblyCatalogGenerationId Left,
-        AssemblyCatalogGenerationId Right) : TypeCorrespondenceFailure;
+    public sealed class StaleGeneration(
+        AssemblyCatalogGenerationId left,
+        AssemblyCatalogGenerationId right) : TypeCorrespondenceFailure
+    {
+        public AssemblyCatalogGenerationId Left { get; } = left;
+        public AssemblyCatalogGenerationId Right { get; } = right;
+    }
 }
 
-public abstract record CandidateTypeRelation
+public abstract class CandidateTypeRelation
 {
-    public sealed record SameDefinition : CandidateTypeRelation;
-    public sealed record DifferentDefinition : CandidateTypeRelation;
-    public sealed record Indeterminate(
-        TypeCorrespondenceFailure Failure) : CandidateTypeRelation;
+    public sealed class SameDefinition : CandidateTypeRelation { }
+    public sealed class DifferentDefinition : CandidateTypeRelation { }
+    public sealed class Indeterminate(TypeCorrespondenceFailure failure)
+        : CandidateTypeRelation
+    {
+        public TypeCorrespondenceFailure Failure { get; } = failure;
+    }
 }
 ```
 
@@ -1311,6 +1460,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
   table, and row bounds all validate against the target reader.
 - `MetadataTypeDefinitionName` cannot be constructed from a rejected
   relationship chain.
+- Empty `TypeDef`, `TypeRef`, or `ExportedType` names produce typed
+  `MetadataTypeNameRejection`; they do not throw from untrusted metadata.
 - Independently constructed equal `MetadataTypeDefinitionName` values compare
   equal through both `Equals` and `==`, hash equally, and hit one
   declaration/resolution cache entry; `!=` returns false.
@@ -1329,6 +1480,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Missing target assembly.
 - Ambiguous target assembly.
 - Malformed metadata.
+- A zero `#Strings` name index is rejected by name construction and retained as
+  undecidable by the caller prefilter.
 - Intra-image `ExportedType` cycle.
 - Cross-assembly cycle.
 - Relationship-node and hop-budget exhaustion.
@@ -1424,9 +1577,13 @@ factories consume `ResolvedTypeDefinitionKey`,
 that part because durable addresses are public by design.
 
 `DefinitionCorrespondenceUsageTests` rejects product uses of equality or
-hashing over `ResolvedTypeDefinitionKey`, `ResolvedTypeDefinition`, or
-`TypeResolutionOutcome.Resolved`; the catalog comparison and join-token APIs
-are the only semantic correspondence surfaces.
+hashing over `ResolvedTypeDefinitionKey`, `ResolvedTypeDefinition`,
+`TypeResolutionOutcome`, `DefinitionCorrespondence`,
+`TypeCorrespondenceFailure`, or `CandidateTypeRelation`; the catalog comparison
+and join-token APIs are the only semantic correspondence surfaces. It also
+rejects `MetadataTypeDefinitionAddress` equality in caller, source, API, and
+graph correspondence producers; address equality remains allowed only for
+durable-coordinate handling and reader-validation code.
 
 A second narrow source gate may forbid `Path.Combine` over
 `AssemblyReferenceIdentity.Name` in product code, but it is defense in depth,

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -92,9 +92,9 @@ Type resolution has the same two altitudes:
 
 - while resolving, Metadata may hold live readers and metadata handles in one
   owned context;
-- after resolving, consumers receive materialized assembly candidate ids,
-  metadata tokens, names, identities, outcomes, and hop evidence -- never a
-  borrowed `MetadataReader` or handle.
+- after resolving, consumers receive materialized opaque candidate-bearing
+  values, metadata tokens, names, identities, outcomes, and hop evidence --
+  never a borrowed `MetadataReader` or handle.
 
 ### Carry every discriminator the consumer needs
 
@@ -118,7 +118,7 @@ alias set.
 | **Type definition name** | Metadata namespace plus root-to-leaf metadata type-name segments. This is a lookup value, not a display spelling or universal type identity. |
 | **Assembly reference identity** | The ECMA-335 name, version, culture, and public-key token from one `AssemblyRef`. |
 | **Assembly catalog** | The lifetime and identity boundary for acquired candidates, opened images, and every cache containing candidate-local keys. |
-| **Assembly candidate** | One assembly selected by one acquisition catalog. It is not inferred from a path or from simple-name equality. |
+| **Assembly candidate** | One assembly registered by the Metadata-owned catalog from an acquisition-owner-issued handle. It is not inferred from a path or from simple-name equality. |
 | **Definition key** | The catalog-local identity of one `TypeDef`: assembly candidate plus metadata token. |
 | **Definition address** | A durable MVID-scoped metadata token. It locates a definition but is not sufficient adversarial correspondence evidence. |
 | **Declaration probe** | The bounded single-image operation that says whether an assembly defines, forwards, or does not contain one type. |
@@ -311,16 +311,56 @@ public sealed class ResolvedAssemblyCandidate
 }
 ```
 
-`ResolvedAssemblyReference` remains the context-free descriptor it is today:
-identity, optional path, opener, and provenance. It does not contain an id that
-can only be minted after a context exists.
+`ResolvedAssemblyReference` evolves in slice 2 from a value-equal record to a
+non-equatable sealed class containing identity, optional path, opener,
+provenance, and an `AssemblyAcquisitionRegistration`:
+
+```csharp
+public sealed class AssemblyAcquisitionRegistration
+{
+    public AssemblyAcquisitionRegistration() { }
+}
+
+public sealed class ResolvedAssemblyReference
+{
+    public ResolvedAssemblyReference(
+        AssemblyAcquisitionRegistration registration,
+        AssemblyReferenceIdentity identity,
+        string? path,
+        Func<Stream> openRead,
+        string? provenance)
+    {
+        Registration = registration;
+        Identity = identity;
+        Path = path;
+        OpenRead = openRead;
+        Provenance = provenance;
+    }
+
+    public AssemblyAcquisitionRegistration Registration { get; }
+    public AssemblyReferenceIdentity Identity { get; }
+    public string? Path { get; }
+    public Func<Stream> OpenRead { get; }
+    public string? Provenance { get; }
+}
+```
+
+The registration is a public opaque reference-identity handle because an
+external acquisition owner must mint it. It is not a definition key or a claim
+that visible descriptor fields identify a physical file. The owner creates one
+handle per selected candidate and reuses it in every descriptor and request
+that it knows denotes that candidate. The inspection plan routes target
+acquisition and later binding through the same package, platform, project, or
+local owner; independently authoritative owners remain conservatively
+distinct.
 
 `AssemblyCatalogId` identifies the key space. `AssemblyCandidateId` is minted
-by the package, platform, project, or local acquisition catalog. Equality means
+only by the single Metadata-owned catalog after a package, platform, project,
+or local acquisition owner supplies a registered descriptor. Equality means
 "the same acquired assembly in this catalog." One caller inspection, including
 all progressive `Callers` and `Call Graph` renders and their reusable graph
-caches, retains one catalog and uses it for the target and every candidate.
-The id does not mean:
+caches, retains one catalog and uses it for the target and every candidate. The
+id does not mean:
 
 - the same simple name;
 - the same path spelling;
@@ -337,14 +377,22 @@ The catalog interns exactly one `ResolvedAssemblyCandidate` object per
 descriptor object, but caches and correspondence still key on the internal id,
 not object equality.
 
-Within one catalog, `ResolvedAssemblyReference` object identity is the
-acquisition registration handle. The catalog uses reference identity, never
-record/value equality, to map that stable descriptor instance to one candidate
-id. An acquisition owner creates one descriptor object per candidate and reuses
-that object in policy selections and public assembly-start requests. Returning
-`candidate.Assembly` therefore recovers the existing candidate. A newly
-constructed descriptor remains a distinct conservative candidate even when all
-of its visible fields match; descriptor identity is not physical-file identity.
+Within one catalog, `AssemblyAcquisitionRegistration` reference identity is the
+registration key. Descriptor object identity, descriptor fields, path, MVID,
+and opener-delegate equality never intern candidates. Returning
+`candidate.Assembly`, or another descriptor carrying the same registration,
+therefore recovers the existing candidate. A descriptor with a fresh
+registration remains a distinct conservative candidate even when all visible
+fields match. Reusing one registration with conflicting identity or provenance
+is an `InvalidPolicyResult`, not permission to merge the descriptors.
+
+The migration adapters retain one registration per candidate selected by their
+own resolver. In particular, the platform adapter keys registrations by the
+platform catalog's selected entry, not by the incoming reference identity or a
+new descriptor returned from the legacy resolver. The inspection target is
+also acquired through that adapter when its scope is platform. This makes a
+target start and a later platform forwarder selection converge on one
+registration even under framework roll-forward.
 
 The ids are inspection currency, not persisted identities or sort keys.
 Candidate identity is internal; consumers receive the descriptor but cannot
@@ -424,9 +472,11 @@ public sealed class TypeResolutionRequest
 }
 ```
 
-`Assembly` means "intern this already-resolved descriptor in the context's
-catalog, probe it, then follow any forwarder." `Reference` means "first ask the
-binding policy to resolve this exact `AssemblyRef`, then probe the result."
+`Assembly` means "look up this already-registered acquisition handle in the
+context's frozen catalog, probe it, then follow any forwarder." An unregistered
+handle is a typed `UnregisteredAssembly` rejection; resolution never mutates a
+frozen catalog. `Reference` means "first ask the binding policy to resolve this
+exact `AssemblyRef`, then probe the result."
 
 This avoids an optional `(path, reference?)` or `(assembly?, identity?)` shape.
 Every request states exactly where resolution begins.
@@ -436,6 +486,18 @@ Every request states exactly where resolution begins.
 ```csharp
 public readonly record struct TypeDefinitionToken(int Value);
 public readonly record struct ExportedTypeToken(int Value);
+
+public enum MetadataTraversalRejectionKind
+{
+    Cycle,
+    NodeBudget,
+    MalformedMetadata
+}
+
+public sealed record MetadataTraversalRejection(
+    MetadataTraversalRejectionKind Kind,
+    string Detail,
+    int ConsumedNodes);
 
 public sealed class ModuleFileReference
 {
@@ -588,6 +650,11 @@ owns them.
 `ModuleFileReference` copies the relevant `File` row. It carries evidence for a
 future module resolver without lending a `FileHandle` or claiming that the
 module can currently be opened.
+
+`MetadataTraversalRejection` is the Metadata-owned materialization of
+MetadataPrimitives' reader-bound `RelationshipTraversalRejection`. It preserves
+kind, diagnostic detail, and consumed work but deliberately omits the live
+`EntityHandle`.
 
 ### Assembly binding
 
@@ -753,6 +820,74 @@ consumer moves. A nullable implementation cannot accidentally satisfy the
 structured policy interface.
 
 ### Resolution outcome
+
+Resolution rejection is a closed, inspectable hierarchy:
+
+```csharp
+public abstract class TypeResolutionFailure
+{
+    private protected TypeResolutionFailure() { }
+
+    public sealed class DeclarationRejected : TypeResolutionFailure
+    {
+        internal DeclarationRejected(
+            MetadataTraversalRejection rejection) =>
+            Rejection = rejection;
+
+        public MetadataTraversalRejection Rejection { get; }
+    }
+
+    public sealed class ForwarderCycle : TypeResolutionFailure
+    {
+        internal ForwarderCycle() { }
+    }
+
+    public sealed class HopBudgetExceeded : TypeResolutionFailure
+    {
+        internal HopBudgetExceeded(int budget) => Budget = budget;
+        public int Budget { get; }
+    }
+
+    public sealed class UnsupportedModuleExport : TypeResolutionFailure
+    {
+        internal UnsupportedModuleExport(ModuleFileReference module) =>
+            Module = module;
+
+        public ModuleFileReference Module { get; }
+    }
+
+    public sealed class UnregisteredAssembly : TypeResolutionFailure
+    {
+        internal UnregisteredAssembly(
+            ResolvedAssemblyReference assembly) =>
+            Assembly = assembly;
+
+        public ResolvedAssemblyReference Assembly { get; }
+    }
+
+    public sealed class InvalidBindingPolicy : TypeResolutionFailure
+    {
+        internal InvalidBindingPolicy(AssemblyBindingFailure failure) =>
+            Failure = failure;
+
+        public AssemblyBindingFailure Failure { get; }
+    }
+
+    public sealed class DiscoveryBudgetExceeded : TypeResolutionFailure
+    {
+        internal DiscoveryBudgetExceeded(int budget) => Budget = budget;
+        public int Budget { get; }
+    }
+}
+```
+
+Open or acquisition failures while selecting a reference use `Unavailable`
+with `CandidateUnavailable`. Declaration rejection preserves its typed
+cycle/node-budget/malformed-metadata discriminator. Cross-assembly cycles,
+hop-budget exhaustion, unsupported modules, invalid starts, invalid policy
+responses, and discovery exhaustion use the other corresponding `Rejected`
+arms. Constructors remain internal because consumers inspect failures but do
+not manufacture engine verdicts.
 
 ```csharp
 public sealed class ResolvedTypeDefinitionKey
@@ -1081,24 +1216,45 @@ or disposes a session that a consumer cache expects to retain. This removes the
 reason `LibraryBodyIndex` currently repeats the traversal beside
 `TypeForwardResolver`.
 
-Candidate discovery and correspondence are separate phases. A caller or graph
-plan first acquires every candidate needed by its scope, forwarder chains,
-adjacency, and signature binding requests, then freezes an
-`AssemblyCatalogGenerationId`. Definition keys and join tokens are minted only
-against that frozen candidate set, so duplicate correspondence classes are
-complete and token arms cannot change beneath a cache.
+Candidate discovery and correspondence are separate phases.
+`AssemblyCatalogBuilder` is the discovery-phase vehicle. It registers plan
+roots, binds references, and runs declaration/forwarder probes over provisional
+candidate ids and catalog-owned sessions without issuing definition keys, join
+tokens, graph leases, or a public `TypeResolutionContext`. A newly selected
+registration extends the builder's candidate set and work queue. Discovery
+reaches a fixed point when a complete queue pass adds no registration.
 
-A later progressive lens may discover additional candidates. The catalog then
-starts a new generation and invalidates every `TypeResolutionContext`,
-resolution plan, join token, and `ScopeGraph` lease from the previous
-generation. It never mutates or reclassifies an issued token. Callers-first and
-graph-first execution may pay for one rebuild, but converge on the same frozen
-generation and answers.
+The builder is bounded by the plan's candidate and relationship budgets.
+Stable acquisition registrations make repeated selections idempotent; an owner
+that keeps minting registrations eventually produces
+`DiscoveryBudgetExceeded`, not an infinite rebuild loop. At the fixed point the
+builder freezes an `AssemblyCatalogGenerationId`, clears provisional binding
+results, and creates contexts whose binding cache is scoped to that generation.
+Definition keys and join tokens are minted only against this frozen candidate
+set, so duplicate correspondence classes are complete and token arms cannot
+change beneath a cache.
+
+The internal `CatalogDiscoveryOutcome` is closed: `Ready` carries the frozen
+generation, while `Rejected` carries
+`TypeResolutionFailure.DiscoveryBudgetExceeded`. No context is published from
+a rejected discovery plan, and the inspection surfaces that diagnostic rather
+than retrying or rendering an authoritative empty result.
+
+A later progressive lens first reopens the builder with the union of previous
+roots and the new lens's roots. If fixed-point discovery adds a candidate, the
+catalog freezes a new generation and invalidates every
+`TypeResolutionContext`, resolution plan, join token, and `ScopeGraph` lease
+from the previous generation. It never mutates or reclassifies an issued token.
+The number of passes is data-dependent and bounded; no one-rebuild claim is
+made. Callers-first and graph-first plans use the same union of roots and
+therefore converge on the same fixed-point candidate set and answers.
 
 The acquisition catalog caches:
 
-- candidate ids by `ResolvedAssemblyReference` reference identity;
+- candidate ids by `AssemblyAcquisitionRegistration` reference identity;
 - opened sessions by `AssemblyCandidateId`;
+- provisional discovery bindings by
+  `(discovery epoch, AssemblyReferenceIdentity, AssemblyResolutionScope)`;
 - binding outcomes by
   `(AssemblyCatalogGenerationId, AssemblyReferenceIdentity,
   AssemblyResolutionScope)`;
@@ -1326,8 +1482,8 @@ under the inspection catalog:
    indeterminate seed.
 3. Bind assembly references to catalog candidates and build reverse adjacency.
 4. Root graph reachability at the candidate owning the target definition and
-   every catalog candidate that binding policy proves denotes that target
-   assembly.
+   every descriptor selection carrying that candidate's acquisition
+   registration.
 5. Compute the transitive graph set as reverse-reference closure from the
    target-assembly roots, direct facade seeds, and indeterminate seeds.
 
@@ -1780,6 +1936,8 @@ without returning a stringly or nullable result.
 
 ### Slice 2: context and resolution engine
 
+- Evolve `ResolvedAssemblyReference` to the non-equatable descriptor plus
+  acquisition registration contract.
 - Extend `AssemblyInspectionSession` as the single candidate image owner, add
   the catalog lifetime, and compose `TypeResolutionContext` over those sessions.
 - Add public `IAssemblyBindingPolicy` descriptor selections and the
@@ -1846,6 +2004,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
 ### Model gates
 
 - Every public outcome arm is enumerated by tests.
+- Every public `TypeResolutionFailure` arm is produced by a focused negative
+  fixture and remains distinguishable to an external consumer.
 - No public result exposes `MetadataReader`, `PEReader`, or metadata handles.
 - `MetadataTypeDefinitionAddress` cannot be dereferenced until MVID, token
   table, and row bounds all validate against the target reader.
@@ -1863,9 +2023,17 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - An external fake `IAssemblyBindingPolicy` can return every public descriptor
   selection through factories but cannot construct catalog candidates.
 - An external fake policy can construct every `AssemblyBindingFailureKind`.
-- Interning the same descriptor object twice, including
-  `candidate.Assembly`, yields one candidate id, one opened session, and `Same`
-  correspondence; a new value-equal descriptor object remains distinct.
+- Two descriptor objects carrying the same
+  `AssemblyAcquisitionRegistration`, including `candidate.Assembly`, yield one
+  candidate id, one opened session, and `Same` correspondence.
+- A second descriptor with identical visible values and the identical
+  `Func<Stream>` instance but a fresh registration remains a distinct
+  candidate; changing the descriptor fields does not alter that result.
+- Reusing one registration with conflicting descriptor identity or provenance
+  is `InvalidPolicyResult`.
+- Package, platform, project, and local migration adapters each return one
+  stable registration when their owner selects the same candidate through
+  different compatible reference requests.
 - External consumers can create assembly-descriptor and assembly-reference
   requests and can forward an existing `TypeResolutionStart` to another type.
 - External consumers can inspect but cannot forge decoder-produced
@@ -1885,6 +2053,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Missing target assembly.
 - Ambiguous target assembly.
 - Malformed metadata.
+- A `File`-row-terminated `ExportedType` chain produces
+  `ExportedFromModule`, and the cross-assembly engine produces
+  `UnsupportedModuleExport` carrying the same `ModuleFileReference`.
 - A zero `#Strings` name index is rejected by name construction and retained as
   undecidable by the caller prefilter.
 - Intra-image `ExportedType` cycle.
@@ -1894,7 +2065,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
 
 ### Consumer gates
 
-- The `System.Xml.ReaderWriter` to `System.Private.Xml` real-artifact caller.
+- The `System.Xml.ReaderWriter` to `System.Private.Xml` real-artifact caller
+  resolves through the real platform adapter as `SameDefinition`, not merely
+  as an indeterminate caller retained by a conservative prefilter.
 - Same simple name with a different token does not match.
 - Different culture does not match.
 - An ambiguous local scope does not fabricate a caller.
@@ -1934,6 +2107,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Discovering an additional candidate advances the catalog generation,
   invalidates old contexts and graph tokens, and rebuilds instead of
   reclassifying a token.
+- Fixed-point discovery terminates for stable registrations regardless of root
+  order, and a policy that continually mints registrations reaches the
+  candidate budget and returns `DiscoveryBudgetExceeded`.
 - A completed non-success cached in one generation is not replayed after
   candidate discovery advances the generation.
 - Definitely unopenable, unknown, unknown-reference, and known-but-ruled-out
@@ -1983,8 +2159,9 @@ Prefer dependency and visibility constraints over source scans:
 for the intentionally public durable address: it fails if graph key or join
 factories consume `ResolvedTypeDefinitionKey`,
 `MetadataTypeDefinitionAddress`, `TypeDefinitionToken`,
-`ResolvedAssemblyReference`, or descriptor provenance. Visibility cannot own
-that part because durable addresses are public by design.
+`ResolvedAssemblyReference`, `AssemblyAcquisitionRegistration`, or descriptor
+provenance. Visibility cannot own that part because durable addresses are
+public by design.
 
 `DefinitionCorrespondenceUsageTests` rejects product uses of equality or
 hashing over `ResolvedTypeDefinitionKey`, `ResolvedTypeDefinition`,
@@ -1998,7 +2175,10 @@ equalities remain allowed only inside one known candidate for
 durable-coordinate handling, declaration probing, and reader-validation code.
 The same gate treats `TypeForwardingHop`, `DuplicateArtifactEvidence`, and
 `DuplicateArtifactCandidateEvidence` as evidence-only classes, never identity
-or correspondence keys.
+or correspondence keys. Outside the catalog's registration map, it also rejects
+equality or hashing over `ResolvedAssemblyReference` or
+`AssemblyAcquisitionRegistration`; acquisition owners retain handles, and
+consumers do not compare them to infer correspondence.
 
 A second narrow source gate may forbid `Path.Combine` over
 `AssemblyReferenceIdentity.Name` in product code, but it is defense in depth,

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -271,6 +271,11 @@ public abstract class MetadataTypeDefinitionNameResult
 }
 ```
 
+`MetadataTypeNameRejection` is limited to validating logical name parts without
+a metadata subject. A reader owner maps that rejection, and relationship
+traversal failures, into the existing `MetadataTypeNameFailure`, including its
+subject token and mechanism; the two results do not represent the same stage.
+
 `Segments` is root-to-leaf and retains metadata names, including generic arity.
 For `Namespace.Outer<T>.Inner`, it contains ``Outer`1`` and `Inner`.
 Equality is ordinal and structural over the segment sequence; it does not use
@@ -319,52 +324,6 @@ provenance, and an `AssemblyAcquisitionRegistration`:
 public sealed class AssemblyAcquisitionRegistration
 {
     internal AssemblyAcquisitionRegistration() { }
-}
-
-public abstract record AssemblyResolutionProvenance
-{
-    private protected AssemblyResolutionProvenance() { }
-
-    public static AssemblyResolutionProvenance Package(
-        string packageId,
-        string packageVersion,
-        string? tfm,
-        string? rid) =>
-        new PackageAsset(packageId, packageVersion, tfm, rid);
-
-    public static AssemblyResolutionProvenance Platform(
-        string framework,
-        string? frameworkVersion,
-        string resolverSource) =>
-        new PlatformAsset(framework, frameworkVersion, resolverSource);
-
-    public static AssemblyResolutionProvenance Project(
-        string project,
-        string? tfm,
-        string? rid) =>
-        new ProjectAsset(project, tfm, rid);
-
-    public static AssemblyResolutionProvenance Local(string resolverSource) =>
-        new LocalAsset(resolverSource);
-
-    public sealed record PackageAsset(
-        string PackageId,
-        string PackageVersion,
-        string? Tfm,
-        string? Rid) : AssemblyResolutionProvenance;
-
-    public sealed record PlatformAsset(
-        string Framework,
-        string? FrameworkVersion,
-        string ResolverSource) : AssemblyResolutionProvenance;
-
-    public sealed record ProjectAsset(
-        string Project,
-        string? Tfm,
-        string? Rid) : AssemblyResolutionProvenance;
-
-    public sealed record LocalAsset(
-        string ResolverSource) : AssemblyResolutionProvenance;
 }
 
 public sealed class ResolvedAssemblyReference
@@ -487,10 +446,9 @@ cross-catalog comparison into an ordinary "different definition" answer.
 
 Package coordinates, selected TFM, platform framework, and local path remain
 provenance, not fields in `AssemblyReferenceIdentity`. Structuring that
-provenance is owned by the assembly-inspection query model; the shared
-`AssemblyResolutionProvenance` declaration above is included here only to make
-the evolved descriptor contract complete and must remain identical to that
-owner's shape.
+provenance is owned by the assembly-inspection query model; its
+`AssemblyResolutionProvenance` hierarchy is the descriptor property's
+authoritative shape.
 
 ### Resolution start
 
@@ -608,18 +566,6 @@ Every request states exactly where resolution begins.
 public readonly record struct TypeDefinitionToken(int Value);
 public readonly record struct ExportedTypeToken(int Value);
 
-public enum MetadataTraversalRejectionKind
-{
-    Cycle,
-    NodeBudget,
-    MalformedMetadata
-}
-
-public sealed record MetadataTraversalRejection(
-    MetadataTraversalRejectionKind Kind,
-    string Detail,
-    int ConsumedNodes);
-
 public sealed class ModuleFileReference
 {
     internal ModuleFileReference(
@@ -732,10 +678,10 @@ public abstract class TypeDeclarationResult
 
     public sealed class Rejected : TypeDeclarationResult
     {
-        internal Rejected(MetadataTraversalRejection rejection) =>
+        internal Rejected(MetadataTypeNameFailure rejection) =>
             Rejection = rejection;
 
-        public MetadataTraversalRejection Rejection { get; }
+        public MetadataTypeNameFailure Rejection { get; }
     }
 }
 ```
@@ -772,10 +718,10 @@ owns them.
 future module resolver without lending a `FileHandle` or claiming that the
 module can currently be opened.
 
-`MetadataTraversalRejection` is the Metadata-owned materialization of
-MetadataPrimitives' reader-bound `RelationshipTraversalRejection`. It preserves
-kind, diagnostic detail, and consumed work but deliberately omits the live
-`EntityHandle`.
+The probe reuses the existing `MetadataTypeNameFailure.From` materialization of
+`RelationshipTraversalRejection`. It preserves mechanism, relationship kind,
+diagnostic detail, consumed work, and the subject metadata token without
+exposing an `EntityHandle` or adding a parallel failure model.
 
 ### Assembly binding
 
@@ -1043,10 +989,10 @@ public abstract class TypeResolutionFailure
     public sealed class DeclarationRejected : TypeResolutionFailure
     {
         internal DeclarationRejected(
-            MetadataTraversalRejection rejection) =>
+            MetadataTypeNameFailure rejection) =>
             Rejection = rejection;
 
-        public MetadataTraversalRejection Rejection { get; }
+        public MetadataTypeNameFailure Rejection { get; }
     }
 
     public sealed class ForwarderCycle : TypeResolutionFailure
@@ -2283,7 +2229,9 @@ Resolution is query-directed:
   forwarder chain;
 - each assembly image is opened once per catalog;
 - each `(assembly, type)` declaration probe runs once;
-- callers sharing a reference reuse the completed resolution;
+- callers in the same source candidate sharing a resolvable reference reuse the
+  completed resolution; different source candidates remain distinct binding
+  domains;
 - caller reachability resolves only target-name references present in the scope
   snapshot;
 - caller reachability binds each snapshotted scope-candidate `AssemblyRef` once
@@ -2293,7 +2241,7 @@ Resolution is query-directed:
   reachability follows only its `ExportedType`-target references and does not
   traverse its ordinary dependency graph;
 - graph signature correspondence resolves only named type occurrences in edges
-  being indexed and caches each resolvable origin once.
+  being indexed and caches each `(source candidate, resolvable origin)` once.
 
 The cross-assembly engine does not require a sweep over every framework assembly
 and does not re-seed the caller-scope closure from every facade. The platform
@@ -2307,7 +2255,8 @@ forwarded `XmlReader` caller is:
 - framework traversal does not expand through ordinary dependencies of those
   candidates;
 - no target file is reopened by the forwarder engine;
-- each unique matching reference and signature origin is resolved at most once;
+- each unique `(source candidate, matching reference or signature origin)` is
+  resolved at most once;
 - adjacency policy calls equal the distinct
   `(requesting candidate, reference identity, scope)` rows in the scope
   snapshot plus forwarding-adjacency rows over the whole inspection while

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -35,6 +35,9 @@ Each consumer then reconstructs the relationship it needs:
   different lifetime.
 - `PdbContext`, `SourceLinkService`, `SourceEnricher`, and `ApiServices`
   recover a target assembly name and construct a sibling path.
+- `PlatformResolver.FindLibraryContainingType` sweeps framework files and
+  returns the first defining or forwarding assembly name, while
+  `IsFacadeOnlyAssembly` separately interprets forwarder rows.
 - `CallerScopeFilter`, `CallerScopeTypeFilter`, and
   `MemberPattern.MatchesCrossAssembly` compare different projections of a
   type's assembly spelling.
@@ -114,6 +117,7 @@ alias set.
 | --- | --- |
 | **Type definition name** | Metadata namespace plus root-to-leaf metadata type-name segments. This is a lookup value, not a display spelling or universal type identity. |
 | **Assembly reference identity** | The ECMA-335 name, version, culture, and public-key token from one `AssemblyRef`. |
+| **Assembly catalog** | The lifetime and identity boundary for acquired candidates, opened images, and every cache containing candidate-local keys. |
 | **Assembly candidate** | One assembly selected by one acquisition catalog. It is not inferred from a path or from simple-name equality. |
 | **Definition key** | The catalog-local identity of one `TypeDef`: assembly candidate plus metadata token. |
 | **Definition address** | A durable MVID-scoped metadata token. It locates a definition but is not sufficient adversarial correspondence evidence. |
@@ -190,9 +194,11 @@ a `MetadataTypeDefinitionName`.
 ### Assembly candidate
 
 ```csharp
+public readonly record struct AssemblyCatalogId(Guid Value);
 public readonly record struct AssemblyCandidateId(Guid Value);
 
 public sealed record ResolvedAssemblyCandidate(
+    AssemblyCatalogId Catalog,
     AssemblyCandidateId Id,
     ResolvedAssemblyReference Assembly);
 ```
@@ -201,10 +207,11 @@ public sealed record ResolvedAssemblyCandidate(
 identity, optional path, opener, and provenance. It does not contain an id that
 can only be minted after a context exists.
 
-`AssemblyCandidateId` is minted by the package, platform, project, or local
-acquisition catalog. Equality means "the same acquired assembly in this
-catalog." A single caller operation builds one catalog and uses it for the
-target and every candidate; it never compares ids minted by separate catalogs.
+`AssemblyCatalogId` identifies the key space. `AssemblyCandidateId` is minted
+by the package, platform, project, or local acquisition catalog. Equality means
+"the same acquired assembly in this catalog." One caller inspection, including
+all progressive `Callers` and `Call Graph` renders and their reusable graph
+caches, retains one catalog and uses it for the target and every candidate.
 The id does not mean:
 
 - the same simple name;
@@ -217,10 +224,11 @@ When an acquisition layer cannot prove that two inputs are one candidate, it
 keeps them distinct. Splitting can cause a conservative miss; merging distinct
 assemblies can fabricate a resolution.
 
-The id is operation currency, not a persisted identity or sort key. It uses a
-globally unique value so accidental comparison across catalogs cannot produce a
-false equality, but the same assembly acquired in two operations normally has
-two ids.
+The ids are inspection currency, not persisted identities or sort keys. Both
+use globally unique values, but uniqueness is not the mismatch detector:
+correspondence APIs first compare `AssemblyCatalogId` and return a typed
+`IncomparableCatalogs` result. Consumers do not use record equality to turn a
+cross-catalog comparison into an ordinary "different definition" answer.
 
 Package coordinates, selected TFM, platform framework, and local path remain
 provenance, not fields in `AssemblyReferenceIdentity`. Structuring that
@@ -380,6 +388,7 @@ implementation cannot accidentally satisfy the structured interface.
 
 ```csharp
 public readonly record struct ResolvedTypeDefinitionKey(
+    AssemblyCatalogId Catalog,
     AssemblyCandidateId Assembly,
     TypeDefinitionToken Definition);
 
@@ -443,17 +452,37 @@ public abstract record TypeResolutionOutcome
 ```
 
 The hop list is evidence, not identity. `ResolvedTypeDefinitionKey` answers
-exact correspondence inside one acquisition catalog. A `Callers` operation and
-its graph cache keep that catalog alive and use one key space for the target and
-all candidates. The key is never serialized or reused after the catalog is
-released.
+exact correspondence inside one acquisition catalog. The catalog exposes the
+only comparison operation:
+
+```csharp
+public abstract record DefinitionCorrespondence
+{
+    public sealed record Same : DefinitionCorrespondence;
+    public sealed record Different : DefinitionCorrespondence;
+    public sealed record IncomparableCatalogs(
+        AssemblyCatalogId Left,
+        AssemblyCatalogId Right) : DefinitionCorrespondence;
+}
+```
+
+The inspection and its graph cache keep the catalog alive and use one key space
+for the target and all candidates. A key is never serialized or reused after
+the cache and catalog are released. A cross-catalog comparison is visible data,
+not a false-valued equality.
 
 `MetadataTypeDefinitionAddress` is the durable coordinate precedent established
 by `MetadataMethodAddress`: MVID plus metadata token. It can be rendered,
 persisted, and checked against a reader before dereferencing. It is not
 cryptographic identity; two adversarial modules can share an MVID, so the
 address alone must not establish cross-artifact correspondence. The exact
-operation-local key remains separate.
+catalog-local key remains separate.
+
+The address exposes no handle. Metadata owns an internal dereference operation
+that first verifies the MVID, validates that the token denotes a `TypeDef`, and
+checks its row against the target reader's `TypeDef` table before constructing
+a transient handle. No consumer may cast `TypeDefinitionToken.Value` directly
+to a handle.
 
 The assembly descriptor and type name are materialized provenance. Stable
 projections may render or persist the descriptor's identity and provenance;
@@ -475,34 +504,48 @@ source" as a complete answer.
 
 ## Resolution context and lifetime
 
-`TypeResolutionContext` owns every opened image for one operation:
+The acquisition catalog owns one `AssemblyInspectionSession` for every opened
+candidate. `TypeResolutionContext` composes those sessions and owns only
+resolution state:
 
 ```text
 ResolvedAssemblyCandidate
-  -> context-owned AssemblyImage
+  -> catalog-owned AssemblyInspectionSession
       -> declaration probe
       -> cached (assembly candidate, type name) result
 ```
 
-The engine never opens a stream and lends its reader to a consumer. It never
-disposes a reader that a consumer cache expects to retain. This removes the
+This extends the single PE-lifetime owner established by
+`AssemblyInspectionSession`; it does not create a parallel `PEReader` owner.
+The catalog outlives every `TypeResolutionContext` and graph cache that contains
+its keys. The engine never opens a second stream, lends a reader to a consumer,
+or disposes a session that a consumer cache expects to retain. This removes the
 reason `LibraryBodyIndex` currently repeats the traversal beside
 `TypeForwardResolver`.
 
-The context consumes one acquisition catalog and caches:
+The acquisition catalog caches:
 
-- opened images by `AssemblyCandidateId`;
-- declaration probes by `(AssemblyCandidateId, MetadataTypeDefinitionName)`;
+- opened sessions by `AssemblyCandidateId`;
 - binding outcomes by `(AssemblyReferenceIdentity, AssemblyResolutionScope)`;
+
+Each resolution context composes that catalog and caches:
+
+- declaration probes by `(AssemblyCandidateId, MetadataTypeDefinitionName)`;
 - completed resolutions by `TypeResolutionRequest`.
 
 The cache retains typed failures as well as successes. Re-running a rejected
 probe must not turn it into a success-shaped miss.
 
+The catalog and resolution caches support concurrent Analysis. Candidate open,
+declaration probe, binding, and completed-resolution entries are single-flight:
+parallel body-analysis workers observe one result and one owned session.
+Synchronization does not hold a cache lock while invoking an external opener or
+binding resolver.
+
 The public outcome contains no reader-backed value. Its descriptors, address,
 identities, name, and evidence can leave the context in the same sense that
 `PrintedBodyMap` can leave the decompiler. Its catalog-local definition key may
-be compared only with another key produced under the same catalog.
+be compared only through the catalog correspondence API.
 
 ## Resolution algorithm
 
@@ -575,56 +618,119 @@ incomplete evidence. It cannot fabricate one.
 ### Analysis type provenance
 
 Analysis keeps its own `TypeRef`; this design does not unify it with the
-Decompiler `TypeRef`.
+Decompiler `TypeRef`. The metadata lookup value introduced here is not a
+CLI/type-level selector and does not answer that separate open design question.
 
-When `TypeRefDecoder` decodes a metadata `TypeRef`, it also retains the complete
-originating `AssemblyReferenceIdentity` as typed provenance. Structural
-`TypeRef` equality remains Analysis-owned and does not absorb resolution:
+When `TypeRefDecoder` decodes a metadata `TypeRef`, it also retains its complete
+resolution scope as typed provenance. Structural `TypeRef` equality remains
+Analysis-owned and does not absorb resolution:
 
 ```csharp
-public sealed record TypeReferenceOrigin(
-    AssemblyReferenceIdentity Assembly,
+public abstract record TypeReferenceOrigin
+{
+    public sealed record AssemblyReference(
+        AssemblyReferenceIdentity Assembly) : TypeReferenceOrigin;
+
+    public sealed record CurrentAssembly : TypeReferenceOrigin;
+
+    public sealed record ModuleReference(
+        string ModuleName) : TypeReferenceOrigin;
+}
+
+public sealed record ResolvableTypeReference(
+    TypeReferenceOrigin Origin,
     MetadataTypeDefinitionName Type);
 ```
 
 The origin is excluded from display and from existing shape equality. It is
 separate typed provenance and must not be recovered from, or cached by,
 structural `TypeRef` equality. Resolution caches key on
-`TypeReferenceOrigin`, never on `TypeRef`.
+`ResolvableTypeReference`, never on `TypeRef`.
 
 This replaces #3476's proposed `RawAssembly` string with the full identity the
 metadata actually supplied. Two `AssemblyRef` rows with different identity
 therefore remain different resolution inputs even when Analysis shape equality
 canonicalizes their simple names together.
 
+The resolution plan combines `CurrentAssembly` with the candidate that supplied
+the row and starts from that candidate. `ModuleReference` remains typed and maps
+to module acquisition or the explicit unsupported-module outcome; it is never
+invented as an assembly identity. Nil, module, and assembly scopes therefore do
+not collapse into a nullable assembly field.
+
 ### Caller matching
 
 The target member's declaring `TypeDef` produces one
 `ResolvedTypeDefinitionKey`. Each candidate call site's open declaring type is
-resolved through its `TypeReferenceOrigin`.
+resolved through its `ResolvableTypeReference`. A callee declared by a
+`TypeDef` in the candidate image starts from that candidate and materializes its
+own definition key; it does not need a `TypeReferenceOrigin`.
 
 The correspondence rule is then:
 
 ```text
-candidate resolved definition key == target resolved definition key
+catalog.Compare(candidate definition key, target definition key)
 ```
 
 There is no facade-name membership test.
 
+Two distinct candidates that carry the same assembly identity, MVID, and
+`TypeDef` token are not silently called either same or different. Unless the
+catalog proves they are one candidate, correspondence is `Indeterminate` with
+duplicate-artifact evidence. This preserves exact correspondence without
+turning the scope-contains-a-copy case into a success-shaped miss.
+
 Generic member matching, parameter arity, and signature comparison remain
 Analysis concerns after the declaring definitions correspond.
 
-### The three caller gates
+### Caller scope reachability and the three gates
 
 Assembly selection, type prefiltering, and member matching must not each derive
-forwarder reachability. The cheap first gate remains metadata-only:
+forwarder reachability. One `CallerScopeReachabilityPlan` snapshots the scope
+under the inspection catalog:
+
+1. Read each candidate's own identity, assembly references, matching structured
+   `TypeRef` names, and matching own `TypeDef` names.
+2. Resolve the target type through only those matching references. A candidate
+   whose matching reference resolves to the target definition is a direct
+   seed. A candidate with indeterminate matching evidence is retained as an
+   indeterminate seed.
+3. Bind assembly references to catalog candidates and build reverse adjacency.
+4. Compute the transitive graph set as reverse-reference closure from all
+   direct and indeterminate seeds.
+
+An unread reference set or an unavailable, ambiguous, or rejected adjacency
+binding cannot prove a negative. Its carrier remains an indeterminate graph
+candidate and widens closure under its own candidate identity, matching the
+current rule that unknown reachability must not truncate everything above it.
+
+This replaces `CallerScopeFilter`'s assembly-spelling proof with a proof against
+definition correspondence. A facade need not be in the caller scope: resolving
+the matching reference may acquire and traverse it through binding policy. The
+work remains query-directed because it resolves only the target structured name
+through references actually present in scope candidates; it does not seed from
+or sweep every framework facade.
+
+The plan exposes two projections from one catalog and one metadata snapshot:
+
+- direct callers use the seed set and then the structured-name negative below;
+- call graph uses the reverse closure.
+
+The graph projection is therefore never narrower than the direct projection.
+If graph sessions were opened first, direct callers may reuse them. If direct
+callers were opened first, the graph opens the additional closure candidates.
+The current `_selectedScopePaths`, `_graphScopes`, and graph-first reuse cache
+must migrate together; replacing only `CallerScopeTypeFilter` is not sound.
+
+The cheap direct-caller negative is:
 
 1. Decode the candidate image's `TypeRef` rows.
 2. Compare the structured namespace and nested-name segments with the target,
    deliberately ignoring assembly spelling.
-3. Rule the image out only when every readable row has a different structured
+3. Compare the candidate's own `TypeDef` structured names as well.
+4. Rule the image out only when every readable row has a different structured
    type name and the image does not define that name itself.
-4. Retain malformed or undecidable rows.
+5. Retain malformed or undecidable rows.
 
 Forwarding changes which assembly defines a type, not the namespace and metadata
 name a call site records. This name-only negative therefore remains sound while
@@ -632,51 +738,82 @@ avoiding forwarder resolution for the majority of a scope. It is wider than
 today's assembly-qualified filter, which is the safe direction.
 
 Only images admitted by that gate resolve the complete
-`TypeReferenceOrigin`. One `CallerResolutionPlan` owns those resolutions for a
-candidate image:
+`ResolvableTypeReference`. One `CallerResolutionPlan` owns those resolutions
+for a candidate image:
 
 ```csharp
+public abstract record TypeCorrespondenceFailure
+{
+    public sealed record Resolution(
+        TypeResolutionOutcome NonSuccess) : TypeCorrespondenceFailure;
+
+    public sealed record DuplicateArtifact(
+        ResolvedTypeDefinition Left,
+        ResolvedTypeDefinition Right) : TypeCorrespondenceFailure;
+
+    public sealed record IncomparableCatalogs(
+        AssemblyCatalogId Left,
+        AssemblyCatalogId Right) : TypeCorrespondenceFailure;
+}
+
 public abstract record CandidateTypeRelation
 {
     public sealed record SameDefinition : CandidateTypeRelation;
     public sealed record DifferentDefinition : CandidateTypeRelation;
     public sealed record Indeterminate(
-        TypeResolutionOutcome Outcome) : CandidateTypeRelation;
+        TypeCorrespondenceFailure Failure) : CandidateTypeRelation;
 }
 ```
 
-The direct-caller path replaces its assembly-spelling closure gate with this
-structured-name gate; otherwise a facade-only caller would still be discarded
-before resolution. All remaining gates consume projections of this relation:
+All remaining gates consume projections of this relation:
 
 - `SameDefinition` stays in scope and may match.
 - `DifferentDefinition` may be ruled out.
 - `Indeterminate` must not be ruled out by a prefilter. The final consumer
   retains the diagnostic and does not fabricate a match.
 
-At image scope, relations combine without losing the row that supplied them:
+At image scope, relations combine without losing the row or `TypeDef` that
+supplied them:
 
 - any `SameDefinition` keeps the image;
 - all `DifferentDefinition` rules it out;
 - otherwise the image is `Indeterminate`.
 
-The final matcher still resolves the exact origin carried by the call site's
-declaring `TypeRef`; one genuine row cannot vouch for a differently identified
-row beside it.
+The final matcher still resolves the exact origin or own definition carried by
+the call site; one genuine row cannot vouch for a differently identified row
+beside it.
 
 The prefilter's soundness is therefore structural: there is no second
 permissiveness rule to keep synchronized with the matcher.
 
 ### Call graph
 
-`CallerGraphKey` eventually replaces its assembly-spelling component with
-`ResolvedTypeDefinitionKey`. `Callers` and `Call Graph` then join on the same
-definition relation.
+`CallerGraphKey` is split into two concepts:
+
+- a total `GraphNodeStorageKey`, scoped by source candidate and metadata
+  location, retains every node and edge even when correspondence cannot be
+  established;
+- an optional `ResolvedMemberCorrespondenceKey` exists only when the declaring
+  type and every identity-bearing named type in the open parameter and return
+  signature have a resolved definition key.
+
+Named types nested under generic instances, arrays, byrefs, and pointers use the
+same recursive correspondence projection. Replacing only the declaring
+assembly fragment would leave forwarded parameter and return types stringly and
+is not a migration.
+
+Graph joins use only `ResolvedMemberCorrespondenceKey`. An unresolved,
+unavailable, ambiguous, rejected, or cross-catalog type use remains attached to
+its storage node and produces incomplete-graph evidence; it never enters a
+shared unresolved bucket and never becomes an ordinary "no edge." This makes
+the graph storage total without fabricating correspondence.
 
 This is a separate migration slice because it changes graph-key construction
-and cache identity. The graph cache retains the acquisition catalog that minted
-its keys; it neither serializes them nor mixes keys from another catalog. It is
-not a separate forwarding model.
+and cache identity. The `ScopeGraph` cache owns a lease on the acquisition
+catalog that minted its keys; cache reuse checks `AssemblyCatalogId` and reports
+a typed mismatch rather than returning misses from a dead key space. It neither
+serializes keys nor mixes keys from another catalog. It is not a separate
+forwarding model.
 
 ### Source and API consumers
 
@@ -688,6 +825,14 @@ Source and API consumers receive `ResolvedAssemblyReference` or
 - `SourceEnricher` and `SourceFileCollector` do not construct sibling paths.
 - `ApiServices.ResolveForwardedTypes` resolves each structured type through the
   engine and opens the returned descriptor.
+- `PlatformResolver.FindLibraryContainingType` becomes a typed platform-catalog
+  query. Its trusted ref-pack index returns all defining and forwarding
+  candidates deterministically; explicit platform source policy selects one or
+  reports ambiguity. It never returns a first-enumerated simple-name string.
+- `PlatformResolver.IsFacadeOnlyAssembly` moves to a Metadata-owned surface
+  classification that consumes typed declaration inventory. Classification is
+  not cross-assembly resolution, but Services may not interpret raw forwarder
+  rows after the architecture gate lands.
 
 The forwarder-related path sinks in #3460 disappear by construction. General
 artifact-derived path components elsewhere still need `HardenedPath`; that is a
@@ -704,7 +849,7 @@ for diagnostics by:
 3. path, when provenance includes one.
 
 Candidates whose complete diagnostic projection is equal remain equal because
-their serialized rows are indistinguishable. The operation-local candidate id
+their serialized rows are indistinguishable. The catalog-local candidate id
 is never used to make persisted output appear stable.
 
 Hop evidence is naturally ordered from the starting assembly to the defining
@@ -736,18 +881,25 @@ Resolution is query-directed:
   project, or local scope;
 - the engine opens only the starting assembly and assemblies named by the
   forwarder chain;
-- each assembly image is opened once per context;
+- each assembly image is opened once per catalog;
 - each `(assembly, type)` declaration probe runs once;
-- callers sharing a reference reuse the completed resolution.
+- callers sharing a reference reuse the completed resolution;
+- caller reachability resolves only target-name references present in the scope
+  snapshot;
+- graph signature correspondence resolves only named type occurrences in edges
+  being indexed and caches each resolvable origin once.
 
-The design does not require a sweep over every framework assembly and does not
-re-seed the caller-scope closure from every facade. The structural performance
-gate for the forwarded `XmlReader` caller is:
+The cross-assembly engine does not require a sweep over every framework assembly
+and does not re-seed the caller-scope closure from every facade. The platform
+type-to-library discovery capability is separately explicit and uses its
+catalog's cached ref-pack index. The structural performance gate for the
+forwarded `XmlReader` caller is:
 
 - the real caller is found;
 - the same number of caller sessions are opened as the exact query requires;
 - the framework scope does not saturate;
-- no target file is reopened by the forwarder engine.
+- no target file is reopened by the forwarder engine;
+- each unique matching reference and signature origin is resolved at most once.
 
 Wall-clock measurements may accompany implementation evidence but do not
 replace these structural counts.
@@ -772,10 +924,13 @@ without returning a stringly or nullable result.
 
 ### Slice 2: context and resolution engine
 
-- Add `TypeResolutionContext`.
+- Extend `AssemblyInspectionSession` as the single candidate image owner, add
+  the catalog lifetime, and compose `TypeResolutionContext` over those sessions.
 - Add `IAssemblyBindingResolver` with typed outcomes and explicit adapters from
   existing resolvers.
 - Implement the iterative cross-assembly engine.
+- Make catalog and resolution caches safe for concurrent Analysis with
+  single-flight opens and probes.
 - Route current `TypeForwardResolver` tests through the engine.
 - Keep compatibility adapters only where needed for the next migration.
 
@@ -796,6 +951,8 @@ changing their successful results.
 
 - Migrate `PdbContext`, `SourceLinkService`, `SourceEnricher`,
   `SourceFileCollector`, and `ApiServices`.
+- Migrate `PlatformResolver.FindLibraryContainingType` to the typed platform
+  catalog and `IsFacadeOnlyAssembly` to Metadata-owned classification.
 - Delete forwarder-target sibling-path construction.
 
 Claim: forwarded source and API resolution consume descriptors and cannot turn
@@ -804,9 +961,9 @@ an inspected assembly name into a path.
 ### Slice 5: direct caller correspondence
 
 - Retain typed `TypeReferenceOrigin` during Analysis decoding.
-- Build `CallerResolutionPlan`.
-- Migrate assembly selection, type prefiltering, and
-  `MatchesCrossAssembly`.
+- Build `CallerScopeReachabilityPlan` and `CallerResolutionPlan`.
+- Replace `_selectedScopePaths`, direct/graph scope reuse, type prefiltering,
+  and `MatchesCrossAssembly` as one coherent gate migration.
 - Port #3476's real framework fixture and close negative controls.
 - Do not port `ForwardedTypeAliases`.
 
@@ -815,7 +972,10 @@ definition keys, with no spelling alias model.
 
 ### Slice 6: graph correspondence and cleanup
 
-- Migrate `CallerGraphKey`.
+- Split total graph storage identity from optional resolved member
+  correspondence, including every named signature type.
+- Make unresolved edges visible as incomplete graph evidence.
+- Bind `ScopeGraph` cache lifetime and reuse to its catalog.
 - Remove legacy path, alias, and compatibility helpers.
 - Add architecture gates that prevent direct resolution logic from returning
   to Analysis or the CLI.
@@ -828,6 +988,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
 
 - Every public outcome arm is enumerated by tests.
 - No public result exposes `MetadataReader`, `PEReader`, or metadata handles.
+- `MetadataTypeDefinitionAddress` cannot be dereferenced until MVID, token
+  table, and row bounds all validate against the target reader.
 - `MetadataTypeDefinitionName` cannot be constructed from a rejected
   relationship chain.
 - Type name, assembly identity, assembly candidate, provenance, and hop evidence
@@ -861,12 +1023,29 @@ Claim: direct callers and transitive call graphs share one definition identity.
   forwarder resolution.
 - A candidate with a matching name through any assembly spelling reaches the
   shared resolver.
+- A same-named type from another assembly passes the name-only prefilter but is
+  rejected by resolved definition correspondence; the current
+  assembly-sensitive prefilter pins move to this end-to-end gate.
 - A candidate image is not reread after its reference identities were
   snapshotted.
 - Resolution caches distinguish origins that structural `TypeRef` equality
   canonicalizes together.
+- Nil, module, and assembly reference origins remain distinct.
+- The target candidate's own `TypeDef` is retained without a `TypeRef`.
+- A duplicate candidate that the catalog cannot unify is indeterminate rather
+  than same or different by spelling.
+- A facade outside the caller scope seeds a direct caller through typed
+  resolution, and reverse closure retains callers above it.
+- Rendering `Call Graph` before `Callers` and in the opposite order produces
+  the same direct caller set.
+- A cross-catalog definition comparison is a typed mismatch, not `false`.
+- Unresolved graph edges remain visible and cannot join through a shared key.
+- Forwarded declaring, parameter, and return types use resolved correspondence.
 - `Callers` and `Call Graph` agree after the graph migration.
 - Forwarded source acquisition opens the resolver-selected descriptor.
+- Platform type-to-library lookup is deterministic under multiple definition or
+  forwarder candidates and returns typed ambiguity.
+- Parallel body analysis opens and probes each candidate once.
 
 ### Architecture gates
 
@@ -875,6 +1054,8 @@ Prefer dependency and visibility constraints over source scans:
 - the single-image probe is the only public Metadata API that interprets a
   forwarder declaration for resolution;
 - the cross-assembly engine is the only product API that follows hops;
+- graph correspondence cannot compare catalog-local keys without the catalog
+  comparison API;
 - Analysis and the CLI cannot access the probe's reader-backed internals;
 - path-only compatibility adapters are internal and deleted with their final
   consumer.
@@ -924,14 +1105,12 @@ The open issues found during #3476 become model requirements:
 
 ## Review questions
 
-1. Does one catalog per caller operation provide the right lifetime and scope
-   for `AssemblyCandidateId`, including the call-graph cache that consumes it?
-2. Is MVID plus `TypeDef` token the right durable, explicitly non-cryptographic
+1. Is MVID plus `TypeDef` token the right durable, explicitly non-cryptographic
    address, or should the first slice reuse a more general existing metadata
    address type?
-3. Which existing assembly-image owner should `TypeResolutionContext` compose
-   so Slice 2 extends the single-open architecture rather than creating another
-   lifetime owner?
-4. Which non-success outcomes must become user-visible Finding failures in the
+2. Should the platform type-to-library index be a capability on the platform
+   acquisition catalog or a reusable Metadata declaration index consumed by
+   that catalog?
+3. Which non-success outcomes must become user-visible Finding failures in the
    first consumer migration, and which can remain typed internal diagnostics
    until their section is migrated?

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1113,10 +1113,10 @@ public abstract class TypeResolutionFailure
     public sealed class UnregisteredAssembly : TypeResolutionFailure
     {
         internal UnregisteredAssembly(
-            ResolvedAssemblyReference assembly) =>
-            Assembly = assembly;
+            AssemblyAcquisitionRegistration registration) =>
+            Registration = registration;
 
-        public ResolvedAssemblyReference Assembly { get; }
+        public AssemblyAcquisitionRegistration Registration { get; }
     }
 
     public sealed class InvalidBindingPolicy : TypeResolutionFailure
@@ -1994,9 +1994,12 @@ The cheap direct-caller negative is step 1 of the plan:
 2. Compare the structured namespace and nested-name segments with the target,
    deliberately ignoring assembly spelling.
 3. Compare the candidate's own `TypeDef` structured names as well.
-4. Rule the image out only when every readable row has a different structured
-   type name and the image does not define that name itself.
-5. Retain malformed or undecidable rows.
+4. Rule the image out only when both row enumerations completed, no row is
+   undecidable, every row has a different structured type name, and the image
+   does not define that name itself.
+5. If either enumeration fails, retain the candidate itself as indeterminate in
+   both direct-caller and graph projections. Retain individual malformed or
+   undecidable rows when enumeration otherwise continues.
 
 Forwarding changes which assembly defines a type, not the namespace and metadata
 name a call site records. This name-only negative therefore remains sound while
@@ -2562,6 +2565,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
   return `UnsupportedScope` rather than guessing a source domain.
 - A frozen context rejects an unregistered requesting-assembly origin before
   policy invocation and neither mutates the catalog nor routes it as global.
+- Unregistered assembly starts and binding origins both produce the
+  registration-bearing `UnregisteredAssembly` arm without reconstructing a
+  descriptor from the opaque handle.
 - External consumers can create assembly-descriptor and assembly-reference
   requests and can forward an existing `TypeResolutionStart` to another type.
 - External consumers can inspect but cannot forge decoder-produced
@@ -2623,6 +2629,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - An indeterminate relation is not rejected by a prefilter.
 - A candidate with no matching structured type name is rejected without
   forwarder resolution.
+- A candidate whose `TypeRef` or `TypeDef` enumeration fails is retained as an
+  indeterminate candidate in both direct and graph projections; the
+  no-matching-name negative gate applies only to complete readable
+  enumerations.
 - A candidate with a matching name through any assembly spelling reaches the
   shared resolver.
 - A same-named type from another assembly passes the name-only prefilter but is

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -175,13 +175,47 @@ nullable strings is not an implementation detail.
 ### Type definition name
 
 ```csharp
-public sealed record MetadataTypeDefinitionName(
-    string Namespace,
-    ImmutableArray<string> Segments);
+public sealed class MetadataTypeDefinitionName :
+    IEquatable<MetadataTypeDefinitionName>
+{
+    public MetadataTypeDefinitionName(
+        string @namespace,
+        ImmutableArray<string> segments)
+    {
+        ArgumentNullException.ThrowIfNull(@namespace);
+        if (segments.IsDefault)
+            throw new ArgumentException("Segments must be initialized.", nameof(segments));
+
+        Namespace = @namespace;
+        Segments = segments;
+    }
+
+    public string Namespace { get; }
+    public ImmutableArray<string> Segments { get; }
+
+    public bool Equals(MetadataTypeDefinitionName? other) =>
+        other is not null
+        && StringComparer.Ordinal.Equals(Namespace, other.Namespace)
+        && Segments.AsSpan().SequenceEqual(other.Segments.AsSpan());
+
+    public override bool Equals(object? obj) =>
+        obj is MetadataTypeDefinitionName other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Namespace, StringComparer.Ordinal);
+        foreach (string segment in Segments)
+            hash.Add(segment, StringComparer.Ordinal);
+        return hash.ToHashCode();
+    }
+}
 ```
 
 `Segments` is root-to-leaf and retains metadata names, including generic arity.
 For `Namespace.Outer<T>.Inner`, it contains ``Outer`1`` and `Inner`.
+Equality is ordinal and structural over the segment sequence; it does not use
+`ImmutableArray<T>`'s backing-array identity.
 
 This type does not introduce "the canonical type spelling." Consumers still own
 their display, XML documentation, API identity, and body identity projections.
@@ -236,6 +270,11 @@ The id does not mean:
 When an acquisition layer cannot prove that two inputs are one candidate, it
 keeps them distinct. Splitting can cause a conservative miss; merging distinct
 assemblies can fabricate a resolution.
+
+The catalog interns exactly one `ResolvedAssemblyCandidate` object per
+`AssemblyCandidateId`. Reference equality therefore denotes the same interned
+descriptor object, but caches and correspondence still key on the internal id,
+not object equality.
 
 The ids are inspection currency, not persisted identities or sort keys.
 Candidate identity is internal; consumers receive the descriptor but cannot
@@ -594,10 +633,11 @@ against that frozen candidate set, so duplicate correspondence classes are
 complete and token arms cannot change beneath a cache.
 
 A later progressive lens may discover additional candidates. The catalog then
-starts a new generation and invalidates every resolution plan, join token, and
-`ScopeGraph` lease from the previous generation. It never mutates or reclassifies
-an issued token. Callers-first and graph-first execution may pay for one rebuild,
-but converge on the same frozen generation and answers.
+starts a new generation and invalidates every `TypeResolutionContext`,
+resolution plan, join token, and `ScopeGraph` lease from the previous
+generation. It never mutates or reclassifies an issued token. Callers-first and
+graph-first execution may pay for one rebuild, but converge on the same frozen
+generation and answers.
 
 The acquisition catalog caches:
 
@@ -606,10 +646,19 @@ The acquisition catalog caches:
   `(AssemblyCatalogGenerationId, AssemblyReferenceIdentity,
   AssemblyResolutionScope)`;
 
-Each resolution context composes that catalog and caches:
+Each resolution context is bound to one frozen generation, composes that
+catalog, and caches:
 
-- declaration probes by `(AssemblyCandidateId, MetadataTypeDefinitionName)`;
-- completed resolutions by `TypeResolutionRequest`.
+- declaration probes by
+  `(AssemblyCatalogGenerationId, AssemblyCandidateId,
+  MetadataTypeDefinitionName)`;
+- completed resolutions by
+  `(AssemblyCatalogGenerationId, TypeResolutionCacheKey)`.
+
+`TypeResolutionCacheKey` is an internal projection, not the public request
+record's synthesized equality. Its start arm contains either the internal
+candidate id plus scope or the complete assembly reference identity plus scope,
+followed by the structurally equatable `MetadataTypeDefinitionName`.
 
 The cache retains typed failures as well as successes. Re-running a rejected
 probe must not turn it into a success-shaped miss.
@@ -1227,6 +1276,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
   table, and row bounds all validate against the target reader.
 - `MetadataTypeDefinitionName` cannot be constructed from a rejected
   relationship chain.
+- Independently constructed equal `MetadataTypeDefinitionName` values compare
+  equal, hash equally, and hit one declaration/resolution cache entry.
 - Type name, assembly identity, assembly candidate, provenance, and hop evidence
   remain separate fields.
 
@@ -1287,7 +1338,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Rendering `Call Graph` before `Callers` and in the opposite order produces
   the same direct caller set.
 - Discovering an additional candidate advances the catalog generation,
-  invalidates old graph tokens, and rebuilds instead of reclassifying a token.
+  invalidates old contexts and graph tokens, and rebuilds instead of
+  reclassifying a token.
+- A completed non-success cached in one generation is not replayed after
+  candidate discovery advances the generation.
 - Definitely unopenable, unknown, unknown-reference, and known-but-ruled-out
   candidates preserve the current caller-tree builder choice.
 - A cross-catalog definition comparison is a typed mismatch, not `false`.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -183,8 +183,15 @@ public sealed class MetadataTypeDefinitionName :
         ImmutableArray<string> segments)
     {
         ArgumentNullException.ThrowIfNull(@namespace);
-        if (segments.IsDefault)
-            throw new ArgumentException("Segments must be initialized.", nameof(segments));
+        if (segments.IsDefaultOrEmpty)
+            throw new ArgumentException("Segments must not be empty.", nameof(segments));
+        foreach (string segment in segments)
+        {
+            if (string.IsNullOrEmpty(segment))
+                throw new ArgumentException(
+                    "Segments must not contain empty names.",
+                    nameof(segments));
+        }
 
         Namespace = @namespace;
         Segments = segments;
@@ -200,6 +207,16 @@ public sealed class MetadataTypeDefinitionName :
 
     public override bool Equals(object? obj) =>
         obj is MetadataTypeDefinitionName other && Equals(other);
+
+    public static bool operator ==(
+        MetadataTypeDefinitionName? left,
+        MetadataTypeDefinitionName? right) =>
+        ReferenceEquals(left, right) || left?.Equals(right) is true;
+
+    public static bool operator !=(
+        MetadataTypeDefinitionName? left,
+        MetadataTypeDefinitionName? right) =>
+        !(left == right);
 
     public override int GetHashCode()
     {
@@ -469,11 +486,25 @@ public readonly record struct MetadataTypeDefinitionAddress(
     Guid ModuleVersionId,
     TypeDefinitionToken Definition);
 
-public sealed record ResolvedTypeDefinition(
-    ResolvedTypeDefinitionKey Key,
-    MetadataTypeDefinitionAddress Address,
-    ResolvedAssemblyCandidate Assembly,
-    MetadataTypeDefinitionName Type);
+public sealed class ResolvedTypeDefinition
+{
+    internal ResolvedTypeDefinition(
+        ResolvedTypeDefinitionKey key,
+        MetadataTypeDefinitionAddress address,
+        ResolvedAssemblyCandidate assembly,
+        MetadataTypeDefinitionName type)
+    {
+        Key = key;
+        Address = address;
+        Assembly = assembly;
+        Type = type;
+    }
+
+    public ResolvedTypeDefinitionKey Key { get; }
+    public MetadataTypeDefinitionAddress Address { get; }
+    public ResolvedAssemblyCandidate Assembly { get; }
+    public MetadataTypeDefinitionName Type { get; }
+}
 
 public sealed record TypeForwardingHop(
     ResolvedAssemblyCandidate SourceAssembly,
@@ -565,6 +596,10 @@ record. Candidate and token are internal to the catalog implementation. Product
 consumers can retain the key and pass it back to catalog APIs, but cannot hash,
 order, or field-compare its internal candidate/token tuple to reconstruct
 correspondence.
+
+`ResolvedTypeDefinition` is also a non-equatable result container. Equality of
+that object or of a `TypeResolutionOutcome.Resolved` wrapper is not definition
+correspondence; only the catalog comparison API answers that question.
 
 The inspection and its graph cache keep the catalog generation alive and use
 one key space for the target and all candidates. A key is never serialized or
@@ -1277,7 +1312,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - `MetadataTypeDefinitionName` cannot be constructed from a rejected
   relationship chain.
 - Independently constructed equal `MetadataTypeDefinitionName` values compare
-  equal, hash equally, and hit one declaration/resolution cache entry.
+  equal through both `Equals` and `==`, hash equally, and hit one
+  declaration/resolution cache entry; `!=` returns false.
 - Type name, assembly identity, assembly candidate, provenance, and hop evidence
   remain separate fields.
 
@@ -1386,6 +1422,11 @@ factories consume `ResolvedTypeDefinitionKey`,
 `MetadataTypeDefinitionAddress`, `TypeDefinitionToken`,
 `ResolvedAssemblyReference`, or descriptor provenance. Visibility cannot own
 that part because durable addresses are public by design.
+
+`DefinitionCorrespondenceUsageTests` rejects product uses of equality or
+hashing over `ResolvedTypeDefinitionKey`, `ResolvedTypeDefinition`, or
+`TypeResolutionOutcome.Resolved`; the catalog comparison and join-token APIs
+are the only semantic correspondence surfaces.
 
 A second narrow source gate may forbid `Path.Combine` over
 `AssemblyReferenceIdentity.Name` in product code, but it is defense in depth,

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -460,11 +460,22 @@ public abstract record DefinitionCorrespondence
 {
     public sealed record Same : DefinitionCorrespondence;
     public sealed record Different : DefinitionCorrespondence;
+    public sealed record IndeterminateDuplicateArtifact(
+        ResolvedTypeDefinitionKey Left,
+        ResolvedTypeDefinitionKey Right,
+        MetadataTypeDefinitionAddress SharedAddress,
+        AssemblyReferenceIdentity SharedIdentity)
+        : DefinitionCorrespondence;
     public sealed record IncomparableCatalogs(
         AssemblyCatalogId Left,
         AssemblyCatalogId Right) : DefinitionCorrespondence;
 }
 ```
+
+The catalog owns duplicate-artifact detection because it can inspect both
+candidates and their addresses. Consumers never derive that relation from MVID,
+token, identity, or path. `Different` is returned only after the catalog rules
+out the duplicate-artifact condition, so it remains a safe negative.
 
 The inspection and its graph cache keep the catalog alive and use one key space
 for the target and all candidates. A key is never serialized or reused after
@@ -633,6 +644,8 @@ public abstract record TypeReferenceOrigin
 
     public sealed record CurrentAssembly : TypeReferenceOrigin;
 
+    public sealed record IntrinsicCoreLibrary : TypeReferenceOrigin;
+
     public sealed record ModuleReference(
         string ModuleName) : TypeReferenceOrigin;
 }
@@ -653,10 +666,12 @@ therefore remain different resolution inputs even when Analysis shape equality
 canonicalizes their simple names together.
 
 The resolution plan combines `CurrentAssembly` with the candidate that supplied
-the row and starts from that candidate. `ModuleReference` remains typed and maps
-to module acquisition or the explicit unsupported-module outcome; it is never
-invented as an assembly identity. Nil, module, and assembly scopes therefore do
-not collapse into a nullable assembly field.
+the row and starts from that candidate. `IntrinsicCoreLibrary` covers signature
+primitive type codes that have no `TypeRef` row and resolves through the
+candidate's core-library binding policy. `ModuleReference` remains typed and
+maps to module acquisition or the explicit unsupported-module outcome; it is
+never invented as an assembly identity. Intrinsic, nil, module, and assembly
+scopes therefore do not collapse into a nullable assembly field.
 
 ### Caller matching
 
@@ -696,8 +711,11 @@ under the inspection catalog:
    seed. A candidate with indeterminate matching evidence is retained as an
    indeterminate seed.
 3. Bind assembly references to catalog candidates and build reverse adjacency.
-4. Compute the transitive graph set as reverse-reference closure from all
-   direct and indeterminate seeds.
+4. Root graph reachability at the candidate owning the target definition and
+   every catalog candidate that binding policy proves denotes that target
+   assembly.
+5. Compute the transitive graph set as reverse-reference closure from the
+   target-assembly roots, direct facade seeds, and indeterminate seeds.
 
 An unread reference set or an unavailable, ambiguous, or rejected adjacency
 binding cannot prove a negative. Its carrier remains an indeterminate graph
@@ -711,9 +729,15 @@ work remains query-directed because it resolves only the target structured name
 through references actually present in scope candidates; it does not seed from
 or sweep every framework facade.
 
+Rooting at the target assembly is independent of the target type name. It keeps
+a scope candidate that references another type in the target assembly, and
+therefore keeps callers above that intermediate method. The direct facade seeds
+add the case the assembly graph cannot express: a matching type reference whose
+facade is outside the caller scope but resolves to the target definition.
+
 The plan exposes two projections from one catalog and one metadata snapshot:
 
-- direct callers use the seed set and then the structured-name negative below;
+- direct callers use the direct and indeterminate seed set;
 - call graph uses the reverse closure.
 
 The graph projection is therefore never narrower than the direct projection.
@@ -722,7 +746,14 @@ callers were opened first, the graph opens the additional closure candidates.
 The current `_selectedScopePaths`, `_graphScopes`, and graph-first reuse cache
 must migrate together; replacing only `CallerScopeTypeFilter` is not sound.
 
-The cheap direct-caller negative is:
+The plan also retains whether each ruled-out candidate was not definitely
+unopenable. `HasRuledOutCandidateNotDefinitelyUnopenable` replaces
+`_ruledOutScopeIsOpenable` and preserves its current weaker contract for
+`Unknown` and `UnknownReferences`, as well as the null-versus-empty choice that
+selects the caller-tree builder. Scope selection cannot discard or strengthen
+that routing signal as an incidental side effect.
+
+The cheap direct-caller negative is step 1 of the plan:
 
 1. Decode the candidate image's `TypeRef` rows.
 2. Compare the structured namespace and nested-name segments with the target,
@@ -737,9 +768,9 @@ name a call site records. This name-only negative therefore remains sound while
 avoiding forwarder resolution for the majority of a scope. It is wider than
 today's assembly-qualified filter, which is the safe direction.
 
-Only images admitted by that gate resolve the complete
-`ResolvableTypeReference`. One `CallerResolutionPlan` owns those resolutions
-for a candidate image:
+Only matching or indeterminate rows proceed to step 2. One
+`CallerResolutionPlan` owns and reuses the resolutions performed while building
+reachability; final call-site matching does not run a second resolution pass:
 
 ```csharp
 public abstract record TypeCorrespondenceFailure
@@ -748,8 +779,8 @@ public abstract record TypeCorrespondenceFailure
         TypeResolutionOutcome NonSuccess) : TypeCorrespondenceFailure;
 
     public sealed record DuplicateArtifact(
-        ResolvedTypeDefinition Left,
-        ResolvedTypeDefinition Right) : TypeCorrespondenceFailure;
+        DefinitionCorrespondence.IndeterminateDuplicateArtifact Evidence)
+        : TypeCorrespondenceFailure;
 
     public sealed record IncomparableCatalogs(
         AssemblyCatalogId Left,
@@ -788,25 +819,46 @@ permissiveness rule to keep synchronized with the matcher.
 
 ### Call graph
 
-`CallerGraphKey` is split into two concepts:
+`CallerGraphKey` is split into three concepts:
 
 - a total `GraphNodeStorageKey`, scoped by source candidate and metadata
   location, retains every node and edge even when correspondence cannot be
   established;
 - an optional `ResolvedMemberCorrespondenceKey` exists only when the declaring
   type and every identity-bearing named type in the open parameter and return
-  signature have a resolved definition key.
+  signature have a resolved definition key;
+- a `DegradedMemberCorrespondenceKey` substitutes a
+  catalog-owned `UnresolvedBindingKey` plus structured type name only for an
+  unavailable named type. The binding key represents the exact cached
+  `(AssemblyReferenceIdentity, AssemblyResolutionScope)` request, preserving
+  the complete assembly/module/current origin instead of collapsing failures
+  into one bucket.
 
 Named types nested under generic instances, arrays, byrefs, and pointers use the
 same recursive correspondence projection. Replacing only the declaring
 assembly fragment would leave forwarded parameter and return types stringly and
 is not a migration.
 
-Graph joins use only `ResolvedMemberCorrespondenceKey`. An unresolved,
-unavailable, ambiguous, rejected, or cross-catalog type use remains attached to
-its storage node and produces incomplete-graph evidence; it never enters a
-shared unresolved bucket and never becomes an ordinary "no edge." This makes
-the graph storage total without fabricating correspondence.
+Exact graph joins use `ResolvedMemberCorrespondenceKey`. When both sides have
+the same degraded key under one catalog and binding scope, the graph retains an
+`IndeterminateCorrespondence` edge and emits incomplete-graph evidence; it does
+not report exact definition correspondence. `NotFound`, ambiguous, rejected, or
+cross-catalog uses do not degraded-join. Every non-success remains attached to
+its storage node, never enters a shared unresolved bucket, and never becomes an
+ordinary "no edge."
+
+This preserves today's useful join when a local scope omits platform
+dependencies while making its confidence explicit. Different complete
+reference identities, names, origins, or scopes remain different, and a known
+resolution never joins through the degraded projection.
+
+For `CurrentAssembly` and `ModuleReference`, the degraded component also carries
+the source candidate (and module name where present); those origins cannot join
+across candidate images. `IntrinsicCoreLibrary` carries the candidate's binding
+scope. An unavailable `AssemblyReference` may join across source candidates
+only when the catalog returns the same `UnresolvedBindingKey`; distinct source
+binding domains therefore remain distinct. The total storage keys remain
+separate even when an indeterminate correspondence edge joins them.
 
 This is a separate migration slice because it changes graph-key construction
 and cache identity. The `ScopeGraph` cache owns a lease on the acquisition
@@ -833,6 +885,18 @@ Source and API consumers receive `ResolvedAssemblyReference` or
   classification that consumes typed declaration inventory. Classification is
   not cross-assembly resolution, but Services may not interpret raw forwarder
   rows after the architecture gate lands.
+
+The current consumers migrate with those contracts:
+
+- both `SourceResolver` platform probes consume `Resolved`, `Missing`,
+  `Ambiguous`, and `Rejected` explicitly; only `Resolved` supplies a descriptor,
+  `Missing` continues ordinary not-found handling, and the other arms surface
+  source-resolution diagnostics rather than choosing a string;
+- `ApiServices` and `LibraryMetadataService` carry typed facade classification
+  and its Finding instead of reducing rejection to nullable `bool`;
+- `RouterCommandDefinition` routes a proven facade to `type` and a proven
+  implementation to `library`; an indeterminate or rejected classification
+  does not auto-reroute and reports the routing diagnostic.
 
 The forwarder-related path sinks in #3460 disappear by construction. General
 artifact-derived path components elsewhere still need `HardenedPath`; that is a
@@ -950,7 +1014,8 @@ changing their successful results.
 ### Slice 4: source and API consumers
 
 - Migrate `PdbContext`, `SourceLinkService`, `SourceEnricher`,
-  `SourceFileCollector`, and `ApiServices`.
+  `SourceFileCollector`, `ApiServices`, `SourceResolver`,
+  `LibraryMetadataService`, and `RouterCommandDefinition`.
 - Migrate `PlatformResolver.FindLibraryContainingType` to the typed platform
   catalog and `IsFacadeOnlyAssembly` to Metadata-owned classification.
 - Delete forwarder-target sibling-path construction.
@@ -963,7 +1028,8 @@ an inspected assembly name into a path.
 - Retain typed `TypeReferenceOrigin` during Analysis decoding.
 - Build `CallerScopeReachabilityPlan` and `CallerResolutionPlan`.
 - Replace `_selectedScopePaths`, direct/graph scope reuse, type prefiltering,
-  and `MatchesCrossAssembly` as one coherent gate migration.
+  `_ruledOutScopeIsOpenable`, caller-tree builder routing, and
+  `MatchesCrossAssembly` as one coherent gate migration.
 - Port #3476's real framework fixture and close negative controls.
 - Do not port `ForwardedTypeAliases`.
 
@@ -1030,16 +1096,25 @@ Claim: direct callers and transitive call graphs share one definition identity.
   snapshotted.
 - Resolution caches distinguish origins that structural `TypeRef` equality
   canonicalizes together.
-- Nil, module, and assembly reference origins remain distinct.
+- Intrinsic, nil, module, and assembly reference origins remain distinct.
 - The target candidate's own `TypeDef` is retained without a `TypeRef`.
 - A duplicate candidate that the catalog cannot unify is indeterminate rather
   than same or different by spelling.
 - A facade outside the caller scope seeds a direct caller through typed
   resolution, and reverse closure retains callers above it.
+- A depth-two graph caller that reaches the selected member through another
+  method in the target assembly is retained even though it never names the
+  target type.
 - Rendering `Call Graph` before `Callers` and in the opposite order produces
   the same direct caller set.
+- Definitely unopenable, unknown, unknown-reference, and known-but-ruled-out
+  candidates preserve the current caller-tree builder choice.
 - A cross-catalog definition comparison is a typed mismatch, not `false`.
-- Unresolved graph edges remain visible and cannot join through a shared key.
+- A scope without platform acquisition retains current full-identity graph
+  joins as explicitly indeterminate edges; unavailable types with different
+  complete origins do not join.
+- Ambiguous, rejected, and cross-catalog graph types remain visible and cannot
+  join through a shared key.
 - Forwarded declaring, parameter, and return types use resolved correspondence.
 - `Callers` and `Call Graph` agree after the graph migration.
 - Forwarded source acquisition opens the resolver-selected descriptor.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -373,11 +373,15 @@ descriptor or extract path, identity, opener, or provenance. The handle is not
 a definition key or a claim that visible descriptor fields identify a physical
 file.
 
-`ResolvedAssemblyReference.Identity` is the selected image's `AssemblyDef`
-identity, never the incoming `AssemblyRef` identity that requested it. The
-request remains in the binding outcome and forwarding hop. An adapter over
-today's resolver must therefore normalize the legacy request-shaped descriptor
-from its selected inventory entry before creating the canonical pair.
+`ResolvedAssemblyReference.Identity` is verified selected-entry identity
+evidence, never the incoming `AssemblyRef` identity that requested it. Package,
+platform, and project owners may obtain it from a trusted inventory before the
+selected file can be opened. On a successful open, Metadata validates the
+actual `AssemblyDef` against that evidence before using the candidate; mismatch
+is `CandidateOpenFailureKind.InvalidImage`. An owner may select an unreadable
+descriptor only when it has such independent identity evidence. An arbitrary
+local file whose identity cannot be read is `CandidateUnavailable` before
+selection. The request remains in the binding outcome and forwarding hop.
 
 The owner creates one handle per selected candidate and reuses it in every
 descriptor and request that it knows denotes that candidate. The inspection
@@ -421,10 +425,10 @@ adapter per inspection. Today's per-path `AssemblyDependencyResolver` instances
 are inventory inputs to those shared adapters, not independent registration
 owners. Each adapter retains one registration per canonical selected entry. In
 particular, the platform adapter keys registrations by the platform catalog's
-selected entry, reads that entry's definition identity, and ignores the
-incoming reference identity when constructing the canonical descriptor. This
-makes requests for different compatible versions converge on one registration
-under framework roll-forward.
+selected entry, uses that inventory entry's verified definition identity, and
+ignores the incoming reference identity when constructing the canonical
+descriptor. This makes requests for different compatible versions converge on
+one registration under framework roll-forward.
 
 The plan classifies the initial target through the same inventories: a selected
 platform entry uses the platform owner, a selected package asset uses the
@@ -452,7 +456,7 @@ authoritative shape.
 
 ### Resolution start
 
-There are three legitimate starts and they stay explicit:
+There are four legitimate starts and they stay explicit:
 
 ```csharp
 public abstract class AssemblyBindingOrigin
@@ -528,6 +532,20 @@ public abstract class TypeResolutionStart
         public AssemblyBindingOrigin.RequestingAssembly Origin { get; }
         public AssemblyResolutionScope Scope { get; }
     }
+
+    public sealed class Module : TypeResolutionStart
+    {
+        internal Module(
+            string name,
+            AssemblyBindingOrigin.RequestingAssembly origin)
+        {
+            Name = name;
+            Origin = origin;
+        }
+
+        public string Name { get; }
+        public AssemblyBindingOrigin.RequestingAssembly Origin { get; }
+    }
 }
 
 public sealed class TypeResolutionRequest
@@ -565,6 +583,16 @@ public sealed class TypeResolutionRequest
                 AssemblyBindingOrigin.FromAssembly(requestingAssembly),
                 scope),
             type);
+
+    public static TypeResolutionRequest FromModule(
+        ResolvedAssemblyReference requestingAssembly,
+        string moduleName,
+        MetadataTypeDefinitionName type) =>
+        new(
+            new TypeResolutionStart.Module(
+                moduleName,
+                AssemblyBindingOrigin.FromAssembly(requestingAssembly)),
+            type);
 }
 ```
 
@@ -586,6 +614,11 @@ without synthesizing an assembly identity. Policy derives the answer from that
 candidate's acquisition domain. The core-library target remains a distinct
 binding/cache arm even when policy selects the same candidate that an explicit
 `AssemblyRef` would select.
+
+`Module` preserves a decoded `ModuleRef` name and requesting candidate. The
+first engine has no module acquisition policy, so it returns the typed
+`UnsupportedModuleReference` rejection; Analysis never fabricates that verdict
+or turns the module into an assembly identity.
 
 This avoids an optional `(path, reference?)` or `(assembly?, identity?)` shape.
 Every request states exactly where resolution begins.
@@ -779,6 +812,7 @@ public sealed class AssemblyBindingPolicyVersion
 public abstract record AssemblyBindingTarget
 {
     private protected AssemblyBindingTarget() { }
+    private protected abstract int Discriminator { get; }
 
     public static AssemblyBindingTarget Reference(
         AssemblyReferenceIdentity identity) =>
@@ -788,9 +822,15 @@ public abstract record AssemblyBindingTarget
         new IntrinsicCoreLibrary();
 
     public sealed record AssemblyReference(
-        AssemblyReferenceIdentity Identity) : AssemblyBindingTarget;
+        AssemblyReferenceIdentity Identity) : AssemblyBindingTarget
+    {
+        private protected override int Discriminator => 0;
+    }
 
-    public sealed record IntrinsicCoreLibrary : AssemblyBindingTarget;
+    public sealed record IntrinsicCoreLibrary : AssemblyBindingTarget
+    {
+        private protected override int Discriminator => 1;
+    }
 }
 
 public sealed class AssemblyBindingRequest
@@ -1060,6 +1100,14 @@ public abstract class TypeResolutionFailure
             Module = module;
 
         public ModuleFileReference Module { get; }
+    }
+
+    public sealed class UnsupportedModuleReference : TypeResolutionFailure
+    {
+        internal UnsupportedModuleReference(string moduleName) =>
+            ModuleName = moduleName;
+
+        public string ModuleName { get; }
     }
 
     public sealed class UnregisteredAssembly : TypeResolutionFailure
@@ -1473,10 +1521,11 @@ ResolvedAssemblyCandidate
 ```
 
 `AssemblyInventoryReader` is a bounded, non-owning operation, not a second
-reader owner. It opens at most `MaxConcurrentInventoryOpens` source streams
-(default 8), materializes the snapshot, and disposes both stream and temporary
-`PEReader` immediately. Adjacency-only candidates retain no session or OS file
-handle. A later body/declaration consumer may open one durable
+reader owner. Inventory reads and durable-session construction share one
+`MaxConcurrentSourceOpens` semaphore (default 8). The inventory reader
+materializes the snapshot and disposes both stream and temporary `PEReader`
+immediately. Adjacency-only candidates retain no session or OS file handle. A
+later body/declaration consumer may open one durable
 `AssemblyInspectionSession`; the snapshot prevents decoding identity,
 references, or forwarding inventory again.
 
@@ -1484,7 +1533,7 @@ Slice 2 evolves durable sessions to construct `PEReader` with
 `PEStreamOptions.PrefetchEntireImage` and close the source stream immediately
 after construction. The catalog may retain prefetched image memory, but holds
 no source file handle for the lifetime of a context. Candidate, retained-image
-byte, and inventory-open concurrency budgets are explicit plan inputs; budget
+byte, and source-open concurrency budgets are explicit plan inputs; budget
 exhaustion is a typed failure rather than an `IOException`-shaped partial
 answer.
 
@@ -1628,8 +1677,8 @@ catalog, and caches:
 `TypeResolutionCacheKey` is an internal projection; it does not use the public
 request object's reference equality. Its start arm contains either the internal
 candidate id plus scope or the closed binding target plus binding-domain key
-plus scope, followed by the structurally equatable
-`MetadataTypeDefinitionName`.
+plus scope, or the source candidate plus module name, followed by the
+structurally equatable `MetadataTypeDefinitionName`.
 
 The cache retains typed failures as well as successes. Re-running a rejected
 probe must not turn it into a success-shaped miss.
@@ -1663,8 +1712,9 @@ For one builder request:
 
 1. Require the type request in the discovery manifest; otherwise return
    `Rejected(PlanExpansionRequired(Type(request)))`.
-2. Resolve the start when it is a reference or core-library binding. First
-   validate a
+2. If the start is `Module`, return
+   `Rejected(UnsupportedModuleReference(name))`. Otherwise resolve the start
+   when it is a reference or core-library binding. First validate a
    requesting-assembly origin against the active builder catalog and return
    `Rejected(UnregisteredAssembly)` if absent. Construct its
    `AssemblyBindingCacheKey`, add it to the discovery manifest, and read or
@@ -1776,6 +1826,7 @@ Analysis-owned and does not absorb resolution:
 public abstract record TypeReferenceOrigin
 {
     private protected TypeReferenceOrigin() { }
+    private protected abstract int Discriminator { get; }
 
     public sealed record AssemblyReference : TypeReferenceOrigin
     {
@@ -1783,22 +1834,26 @@ public abstract record TypeReferenceOrigin
             Assembly = assembly;
 
         public AssemblyReferenceIdentity Assembly { get; }
+        private protected override int Discriminator => 0;
     }
 
     public sealed record CurrentAssembly : TypeReferenceOrigin
     {
         internal CurrentAssembly() { }
+        private protected override int Discriminator => 1;
     }
 
     public sealed record IntrinsicCoreLibrary : TypeReferenceOrigin
     {
         internal IntrinsicCoreLibrary() { }
+        private protected override int Discriminator => 2;
     }
 
     public sealed record ModuleReference : TypeReferenceOrigin
     {
         internal ModuleReference(string moduleName) => ModuleName = moduleName;
         public string ModuleName { get; }
+        private protected override int Discriminator => 3;
     }
 }
 
@@ -1830,7 +1885,8 @@ the row and starts from that candidate. `IntrinsicCoreLibrary` covers signature
 primitive type codes that have no `TypeRef` row and resolves through the
 candidate's `AssemblyBindingTarget.IntrinsicCoreLibrary` policy request; it
 never synthesizes an assembly identity. `ModuleReference` remains typed and
-maps to module acquisition or the explicit unsupported-module outcome; it is
+maps to `TypeResolutionStart.Module` and the explicit
+`UnsupportedModuleReference` outcome until module acquisition exists; it is
 never invented as an assembly identity. Intrinsic, nil, module, and assembly
 scopes therefore do not collapse into a nullable assembly field.
 
@@ -2196,13 +2252,14 @@ Trusted platform policy resolves supported core-library facade differences
 before this fallback. This compatibility narrowing is explicit and gated; it is
 not described as preservation of the old graph.
 
-For `CurrentAssembly` and `ModuleReference`, the degraded component also carries
-the source candidate (and module name where present); those origins cannot join
-across candidate images. `IntrinsicCoreLibrary` carries the candidate's binding
-scope. An unavailable `AssemblyReference` may join across source candidates
-only when the catalog returns the same `UnresolvedBindingKey`; distinct source
-binding domains therefore remain distinct. The total storage keys remain
-separate even when an indeterminate correspondence edge joins them.
+Every metadata-driven degraded component carries the source candidate through
+`AssemblyBindingDomainKey`. `CurrentAssembly` and `ModuleReference` additionally
+retain the module/current arm and module name where present;
+`IntrinsicCoreLibrary` retains its distinct target and scope. An unavailable
+`AssemblyReference` degraded-joins only within the same source domain when its
+complete identity and scope also agree. Cross-source fragmentation is the
+intentional soundness boundary: without resolved correspondence, the catalog
+has no proof that two private binding domains denote one type.
 
 This is a separate migration slice because it changes graph-key construction
 and cache identity. The `ScopeGraph` cache owns a lease on the acquisition
@@ -2326,7 +2383,7 @@ forwarded `XmlReader` caller is:
 - the real caller is found;
 - forwarding-inventory opens equal the distinct candidates selected by scope
   adjacency plus newly selected forwarder targets;
-- peak live source streams never exceed `MaxConcurrentInventoryOpens`, and no
+- peak live source streams never exceed `MaxConcurrentSourceOpens`, and no
   adjacency-only stream or durable-session source stream remains open after
   construction;
 - framework traversal does not expand through ordinary dependencies of those
@@ -2371,7 +2428,7 @@ without returning a stringly or nullable result.
 - Add catalog-owned `AssemblyInventorySnapshot` values for every discovered
   candidate and open prefetched `AssemblyInspectionSession` values only on
   demand; inventory reads and durable-session opens are separate single-flight
-  operations.
+  operations sharing the source-open semaphore.
 - Add the catalog lifetime and compose `TypeResolutionContext` over snapshots
   plus optional sessions without retaining adjacency-only readers.
 - Add public `IAssemblyBindingPolicy` descriptor selections and the
@@ -2457,6 +2514,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
   cache entry per source domain.
 - Public result hierarchies cannot be externally extended, and product
   consumers cannot construct correspondence verdict arms.
+- External-compilation gates cannot derive from `AssemblyBindingTarget`,
+  `TypeReferenceOrigin`, or `AssemblyResolutionProvenance`; their
+  private-protected abstract discriminators close the synthesized record copy
+  constructor path.
 - An external fake `IAssemblyBindingPolicy` can return every public descriptor
   selection through factories but cannot construct catalog candidates.
 - An external fake policy receives and distinguishes explicit reference and
@@ -2521,6 +2582,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - A `File`-row-terminated `ExportedType` chain produces
   `ExportedFromModule`, and the cross-assembly engine produces
   `UnsupportedModuleExport` carrying the same `ModuleFileReference`.
+- A decoded `ModuleRef` origin produces
+  `UnsupportedModuleReference(moduleName)` through `FromModule`; Analysis
+  neither manufactures the failure nor treats the name as an assembly.
 - A zero `#Strings` name index is rejected by name construction and retained as
   undecidable by the caller prefilter.
 - Intra-image `ExportedType` cycle.
@@ -2590,7 +2654,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
   that candidate remains reachable through
   `caller -> facade -> implementation`; the candidate is not a direct seed.
 - An unreadable selected facade retains its incoming scope carrier as an
-  indeterminate seed, so callers above the carrier are not truncated.
+  indeterminate seed, so callers above the carrier are not truncated. The
+  fixture supplies verified inventory identity and a failing opener; an
+  unidentifiable local file instead fails before selection as
+  `CandidateUnavailable`.
 - A depth-two graph caller that reaches the selected member through another
   method in the target assembly is retained even though it never names the
   target type.
@@ -2607,8 +2674,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Definitely unopenable, unknown, unknown-reference, and known-but-ruled-out
   candidates preserve the current caller-tree builder choice.
 - A cross-catalog definition comparison is a typed mismatch, not `false`.
-- A scope without platform acquisition joins the same complete unavailable
-  binding request as an explicitly indeterminate edge.
+- Within one source candidate, a scope without platform acquisition joins the
+  same complete unavailable binding request as an explicitly indeterminate
+  edge; equal requests from different source candidates remain distinct and
+  surface the compatibility diagnostic.
 - Current canonical-simple-name-only joins with different versions, cultures,
   tokens, or unsupported local facade identities no longer join; both storage
   nodes and the compatibility diagnostic remain visible.
@@ -2627,7 +2696,7 @@ Claim: direct callers and transitive call graphs share one definition identity.
   one demanded durable session, and shares each declaration probe
   single-flight.
 - A scope wider than the process file-handle limit still holds at most
-  `MaxConcurrentInventoryOpens` source streams, releases every adjacency-only
+  `MaxConcurrentSourceOpens` source streams, releases every adjacency-only
   stream, and reports retained-image budget exhaustion as
   `CandidateOpenFailureKind.ResourceBudget`.
 

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -195,12 +195,25 @@ a `MetadataTypeDefinitionName`.
 
 ```csharp
 public readonly record struct AssemblyCatalogId(Guid Value);
-public readonly record struct AssemblyCandidateId(Guid Value);
+public readonly record struct AssemblyCatalogGenerationId(Guid Value);
+internal readonly record struct AssemblyCandidateId(Guid Value);
 
-public sealed record ResolvedAssemblyCandidate(
-    AssemblyCatalogId Catalog,
-    AssemblyCandidateId Id,
-    ResolvedAssemblyReference Assembly);
+public sealed class ResolvedAssemblyCandidate
+{
+    internal ResolvedAssemblyCandidate(
+        AssemblyCatalogId catalog,
+        AssemblyCandidateId id,
+        ResolvedAssemblyReference assembly)
+    {
+        Catalog = catalog;
+        Id = id;
+        Assembly = assembly;
+    }
+
+    internal AssemblyCatalogId Catalog { get; }
+    internal AssemblyCandidateId Id { get; }
+    public ResolvedAssemblyReference Assembly { get; }
+}
 ```
 
 `ResolvedAssemblyReference` remains the context-free descriptor it is today:
@@ -224,8 +237,10 @@ When an acquisition layer cannot prove that two inputs are one candidate, it
 keeps them distinct. Splitting can cause a conservative miss; merging distinct
 assemblies can fabricate a resolution.
 
-The ids are inspection currency, not persisted identities or sort keys. Both
-use globally unique values, but uniqueness is not the mismatch detector:
+The ids are inspection currency, not persisted identities or sort keys.
+Candidate identity is internal; consumers receive the descriptor but cannot
+reconstruct a candidate key from it. Both ids use globally unique values, but
+uniqueness is not the mismatch detector:
 correspondence APIs first compare `AssemblyCatalogId` and return a typed
 `IncomparableCatalogs` result. Consumers do not use record equality to turn a
 cross-catalog comparison into an ordinary "different definition" answer.
@@ -394,16 +409,19 @@ public sealed class ResolvedTypeDefinitionKey
 {
     internal ResolvedTypeDefinitionKey(
         AssemblyCatalogId catalog,
+        AssemblyCatalogGenerationId generation,
         AssemblyCandidateId assembly,
         TypeDefinitionToken definition)
     {
         Catalog = catalog;
+        Generation = generation;
         Assembly = assembly;
         Definition = definition;
     }
 
     public AssemblyCatalogId Catalog { get; }
 
+    internal AssemblyCatalogGenerationId Generation { get; }
     internal AssemblyCandidateId Assembly { get; }
     internal TypeDefinitionToken Definition { get; }
 }
@@ -468,9 +486,9 @@ public abstract record TypeResolutionOutcome
 }
 ```
 
-The hop list is evidence, not identity. `ResolvedTypeDefinitionKey` answers
-exact correspondence inside one acquisition catalog. The catalog exposes the
-only comparison operation:
+The hop list is evidence, not identity. `ResolvedTypeDefinitionKey` is the
+opaque input to exact correspondence inside one acquisition catalog generation.
+The catalog exposes the only comparison operation:
 
 ```csharp
 public abstract record DefinitionCorrespondence
@@ -478,31 +496,42 @@ public abstract record DefinitionCorrespondence
     public sealed record Same : DefinitionCorrespondence;
     public sealed record Different : DefinitionCorrespondence;
     public sealed record IndeterminateDuplicateArtifact(
-        ResolvedTypeDefinitionKey Left,
-        ResolvedTypeDefinitionKey Right,
-        MetadataTypeDefinitionAddress SharedAddress,
-        AssemblyReferenceIdentity SharedIdentity)
+        DuplicateArtifactEvidence Evidence)
         : DefinitionCorrespondence;
     public sealed record IncomparableCatalogs(
         AssemblyCatalogId Left,
         AssemblyCatalogId Right) : DefinitionCorrespondence;
+    public sealed record StaleGeneration(
+        AssemblyCatalogGenerationId Left,
+        AssemblyCatalogGenerationId Right) : DefinitionCorrespondence;
 }
+
+public sealed record DuplicateArtifactCandidateEvidence(
+    ResolvedAssemblyReference Assembly,
+    MetadataTypeDefinitionAddress Address);
+
+public sealed record DuplicateArtifactEvidence(
+    ImmutableArray<DuplicateArtifactCandidateEvidence> Candidates);
 ```
 
 The catalog owns duplicate-artifact detection because it can inspect both
-candidates and their addresses. Consumers never derive that relation from MVID,
-token, identity, or path. `Different` is returned only after the catalog rules
-out the duplicate-artifact condition, so it remains a safe negative.
+candidates and their addresses. Evidence is class-scoped: a deterministic,
+complete candidate set rather than the pair that happened to be compared.
+Consumers never derive that relation from MVID, token, identity, or path.
+`Different` is returned only after the catalog rules out the duplicate-artifact
+condition, so it remains a safe negative.
 
 `ResolvedTypeDefinitionKey` is an opaque capability, not a value-equatable
 record. Candidate and token are internal to the catalog implementation. Product
 consumers can retain the key and pass it back to catalog APIs, but cannot hash,
-order, or field-compare it to reconstruct correspondence.
+order, or field-compare its internal candidate/token tuple to reconstruct
+correspondence.
 
-The inspection and its graph cache keep the catalog alive and use one key space
-for the target and all candidates. A key is never serialized or reused after
-the cache and catalog are released. A cross-catalog comparison is visible data,
-not a false-valued equality.
+The inspection and its graph cache keep the catalog generation alive and use
+one key space for the target and all candidates. A key is never serialized or
+reused after its generation is invalidated or the catalog is released. A
+cross-catalog or stale-generation comparison is visible data, not a false-valued
+equality.
 
 `MetadataTypeDefinitionAddress` is the durable coordinate precedent established
 by `MetadataMethodAddress`: MVID plus metadata token. It can be rendered,
@@ -557,10 +586,25 @@ or disposes a session that a consumer cache expects to retain. This removes the
 reason `LibraryBodyIndex` currently repeats the traversal beside
 `TypeForwardResolver`.
 
+Candidate discovery and correspondence are separate phases. A caller or graph
+plan first acquires every candidate needed by its scope, forwarder chains,
+adjacency, and signature binding requests, then freezes an
+`AssemblyCatalogGenerationId`. Definition keys and join tokens are minted only
+against that frozen candidate set, so duplicate correspondence classes are
+complete and token arms cannot change beneath a cache.
+
+A later progressive lens may discover additional candidates. The catalog then
+starts a new generation and invalidates every resolution plan, join token, and
+`ScopeGraph` lease from the previous generation. It never mutates or reclassifies
+an issued token. Callers-first and graph-first execution may pay for one rebuild,
+but converge on the same frozen generation and answers.
+
 The acquisition catalog caches:
 
 - opened sessions by `AssemblyCandidateId`;
-- binding outcomes by `(AssemblyReferenceIdentity, AssemblyResolutionScope)`;
+- binding outcomes by
+  `(AssemblyCatalogGenerationId, AssemblyReferenceIdentity,
+  AssemblyResolutionScope)`;
 
 Each resolution context composes that catalog and caches:
 
@@ -829,6 +873,10 @@ public abstract record TypeCorrespondenceFailure
     public sealed record IncomparableCatalogs(
         AssemblyCatalogId Left,
         AssemblyCatalogId Right) : TypeCorrespondenceFailure;
+
+    public sealed record StaleGeneration(
+        AssemblyCatalogGenerationId Left,
+        AssemblyCatalogGenerationId Right) : TypeCorrespondenceFailure;
 }
 
 public abstract record CandidateTypeRelation
@@ -881,23 +929,61 @@ permissiveness rule to keep synchronized with the matcher.
   the complete assembly/module/current origin instead of collapsing failures
   into one bucket.
 
-```csharp
-public abstract record DefinitionJoinToken(AssemblyCatalogId Catalog, Guid Value)
-{
-    public sealed record Exact(AssemblyCatalogId Catalog, Guid Value)
-        : DefinitionJoinToken(Catalog, Value);
+`UnresolvedBindingKey` has the same internal-constructor and generation scope
+as `DefinitionJoinToken`; it cannot survive or compare across a generation
+advance.
 
-    public sealed record IndeterminateDuplicateArtifact(
-        AssemblyCatalogId Catalog,
-        Guid Value,
-        DefinitionCorrespondence.IndeterminateDuplicateArtifact Evidence)
-        : DefinitionJoinToken(Catalog, Value);
+```csharp
+public enum DefinitionJoinKind
+{
+    Exact,
+    IndeterminateDuplicateArtifact
+}
+
+public sealed class DefinitionJoinToken : IEquatable<DefinitionJoinToken>
+{
+    readonly AssemblyCatalogId _catalog;
+    readonly AssemblyCatalogGenerationId _generation;
+    readonly Guid _value;
+
+    internal DefinitionJoinToken(
+        AssemblyCatalogId catalog,
+        AssemblyCatalogGenerationId generation,
+        Guid value,
+        DefinitionJoinKind kind,
+        DuplicateArtifactEvidence? evidence)
+    {
+        _catalog = catalog;
+        _generation = generation;
+        _value = value;
+        Kind = kind;
+        Evidence = evidence;
+    }
+
+    public DefinitionJoinKind Kind { get; }
+    public DuplicateArtifactEvidence? Evidence { get; }
+
+    public bool Equals(DefinitionJoinToken? other) =>
+        other is not null
+        && _catalog == other._catalog
+        && _generation == other._generation
+        && _value == other._value
+        && Kind == other.Kind;
+
+    public override bool Equals(object? obj) =>
+        obj is DefinitionJoinToken other && Equals(other);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(_catalog, _generation, _value, Kind);
 }
 ```
 
-The catalog returns the same token value for definitions in one correspondence
-class. Duplicate-artifact tokens deliberately join but retain an indeterminate
-arm; they never masquerade as exact tokens.
+The constructor and `(catalog, generation, value)` fields are internal. Equality
+and hashing use that triple plus `Kind`; class-scoped `Evidence` is excluded.
+The catalog returns one token class for every definition correspondence class
+in a frozen generation. Duplicate-artifact tokens deliberately join but retain
+an indeterminate kind; consumers cannot construct an exact token or change an
+issued token's kind.
 
 Named types nested under generic instances, arrays, byrefs, and pointers use the
 same recursive correspondence projection. Replacing only the declaring
@@ -905,9 +991,9 @@ assembly fragment would leave forwarded parameter and return types stringly and
 is not a migration.
 
 Graph joins hash only catalog-issued join tokens, never
-`ResolvedTypeDefinitionKey`. A member key containing only `Exact` tokens yields
-an exact edge. Matching keys containing any
-`IndeterminateDuplicateArtifact` token yield an
+`ResolvedTypeDefinitionKey`. A member key containing only tokens whose kind is
+`Exact` yields an exact edge. Matching keys containing any token whose kind is
+`IndeterminateDuplicateArtifact` yield an
 `IndeterminateCorrespondence` edge carrying the catalog's duplicate evidence.
 
 When both sides have the same degraded key under one catalog and binding scope,
@@ -917,11 +1003,14 @@ incomplete-graph evidence; it does not report exact definition correspondence.
 Every non-success remains attached to its storage node, never enters a shared
 unresolved bucket, and never becomes an ordinary "no edge."
 
-This preserves today's full-identity join when a local scope omits platform
-dependencies while making its confidence explicit. Version-skewed identities
-follow the explicit local binding policy above instead of this fallback.
-Different complete reference identities, names, origins, or scopes remain
-different, and a known resolution never joins through the degraded projection.
+Today's graph joins on canonical simple assembly names and therefore merges
+version, culture, token, and several core-library facade spellings. The
+degraded projection is intentionally narrower: it preserves an unavailable join
+only when the complete binding request agrees. Version-skewed or differently
+identified references remain separate storage nodes with incomplete evidence.
+Trusted platform policy resolves supported core-library facade differences
+before this fallback. This compatibility narrowing is explicit and gated; it is
+not described as preservation of the old graph.
 
 For `CurrentAssembly` and `ModuleReference`, the degraded component also carries
 the source candidate (and module name where present); those origins cannot join
@@ -933,10 +1022,10 @@ separate even when an indeterminate correspondence edge joins them.
 
 This is a separate migration slice because it changes graph-key construction
 and cache identity. The `ScopeGraph` cache owns a lease on the acquisition
-catalog that minted its keys; cache reuse checks `AssemblyCatalogId` and reports
-a typed mismatch rather than returning misses from a dead key space. It neither
-serializes keys nor mixes keys from another catalog. It is not a separate
-forwarding model.
+catalog that minted its keys; cache reuse checks both `AssemblyCatalogId` and
+`AssemblyCatalogGenerationId`, reporting a typed mismatch rather than returning
+misses from a dead key space. It neither serializes keys nor mixes keys from
+another catalog or generation. It is not a separate forwarding model.
 
 ### Source and API consumers
 
@@ -960,9 +1049,11 @@ Source and API consumers receive `ResolvedAssemblyReference` or
 Platform type-to-library discovery keeps its user-query contract separate from
 `MetadataTypeDefinitionName`. `PlatformTypeLookupPattern` is parsed from user
 input and preserves the current exact-name, dotted-suffix/unqualified-name, and
-generic-arity-normalized matching semantics. It queries an index of structured
-definition names and returns every match as typed candidates; it does not
-pretend an unqualified pattern is an exact metadata identity.
+generic-arity-normalized matching semantics, plus ordinal-ignore-case
+comparison, `+`/`.` nested-name equivalence, and primitive-alias normalization.
+It queries an index of structured definition names and returns every match as
+typed candidates; it does not pretend an unqualified pattern is an exact
+metadata identity.
 
 The current consumers migrate with those contracts:
 
@@ -1181,6 +1272,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Direct callers and graph joins report the same catalog-owned
   duplicate-artifact evidence; neither hashes raw definition keys or drops the
   edge.
+- A three-copy duplicate class receives one generation-stable indeterminate join
+  token and class-scoped evidence regardless of discovery order.
 - A version-skewed local `--bin` reference is an explicit
   `IdentityPolicyRequired` incomplete result, not a version-blind caller or an
   authoritative empty answer.
@@ -1193,12 +1286,16 @@ Claim: direct callers and transitive call graphs share one definition identity.
   target type.
 - Rendering `Call Graph` before `Callers` and in the opposite order produces
   the same direct caller set.
+- Discovering an additional candidate advances the catalog generation,
+  invalidates old graph tokens, and rebuilds instead of reclassifying a token.
 - Definitely unopenable, unknown, unknown-reference, and known-but-ruled-out
   candidates preserve the current caller-tree builder choice.
 - A cross-catalog definition comparison is a typed mismatch, not `false`.
-- A scope without platform acquisition retains current full-identity graph
-  joins as explicitly indeterminate edges; unavailable types with different
-  complete origins do not join.
+- A scope without platform acquisition joins the same complete unavailable
+  binding request as an explicitly indeterminate edge.
+- Current canonical-simple-name-only joins with different versions, cultures,
+  tokens, or unsupported local facade identities no longer join; both storage
+  nodes and the compatibility diagnostic remain visible.
 - Ambiguous, rejected, and cross-catalog graph types remain visible and cannot
   join through a shared key.
 - Forwarded declaring, parameter, and return types use resolved correspondence.
@@ -1208,6 +1305,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
   forwarder candidates and returns typed ambiguity.
 - Unqualified and generic platform patterns retain the current `INumber<T>` and
   `List`/`List\`1` lookup behavior through `PlatformTypeLookupPattern`.
+- Platform lookup retains case-insensitive, nested `+`/`.`, and primitive-alias
+  behavior.
 - Parallel body analysis opens and probes each candidate once.
 
 ### Architecture gates
@@ -1220,11 +1319,21 @@ Prefer dependency and visibility constraints over source scans:
 - `ResolvedTypeDefinitionKey` has no value equality available to consumers;
   graph correspondence can hash only catalog-issued join tokens and all other
   correspondence goes through the catalog comparison API;
+- candidate ids and join-token constructors are internal, and the internal
+  `CatalogMemberJoinKey` factory accepts only catalog-issued
+  `DefinitionJoinToken` or `UnresolvedBindingKey` values;
 - Analysis and the CLI cannot access the probe's reader-backed internals;
 - path-only compatibility adapters are internal and deleted with their final
   consumer.
 
-A narrow source gate may additionally forbid `Path.Combine` over
+`GraphCorrespondenceArchitectureTests` is the named narrow source/API-usage gate
+for the intentionally public durable address: it fails if graph key or join
+factories consume `ResolvedTypeDefinitionKey`,
+`MetadataTypeDefinitionAddress`, `TypeDefinitionToken`,
+`ResolvedAssemblyReference`, or descriptor provenance. Visibility cannot own
+that part because durable addresses are public by design.
+
+A second narrow source gate may forbid `Path.Combine` over
 `AssemblyReferenceIdentity.Name` in product code, but it is defense in depth,
 not the owner of the invariant.
 

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1664,14 +1664,16 @@ For one builder request:
 6. On `Missing`, return `NotFound`.
 7. On `Ambiguous`, return `Ambiguous`.
 8. On `Rejected`, return `Rejected`.
-9. On `Forwarded`, append one hop.
-10. Tighten, but never loosen, `AssemblyResolutionScope` for the next reference.
-11. Construct the target binding request, add its key to the discovery
+9. On `ExportedFromModule`, return
+   `Rejected(UnsupportedModuleExport(module))`.
+10. On `Forwarded`, append one hop.
+11. Tighten, but never loosen, `AssemblyResolutionScope` for the next reference.
+12. Construct the target binding request, add its key to the discovery
     manifest, read or populate its provisional cache entry, and apply the same
     exhaustive outcome mapping as step 2.
-12. Stop on repeated assembly candidate or the hop budget with the corresponding
+13. Stop on repeated assembly candidate or the hop budget with the corresponding
     `Rejected` failure.
-13. Otherwise repeat at step 3.
+14. Otherwise repeat at step 3.
 
 The traversal is iterative. It has both:
 
@@ -1791,8 +1793,12 @@ public sealed record ResolvableTypeReference(
 
 The origin is excluded from display and from existing shape equality. It is
 separate typed provenance and must not be recovered from, or cached by,
-structural `TypeRef` equality. Resolution caches key on
-`ResolvableTypeReference`, never on `TypeRef`.
+structural `TypeRef` equality. Caller resolution caches key on
+`(AssemblyCandidateId source, ResolvableTypeReference reference)`, never on
+`TypeRef` or `ResolvableTypeReference` alone. The source candidate supplies the
+domain for assembly, current-assembly, module, and intrinsic-core-library
+origins. The engine projects that pair to its generation-scoped
+`TypeResolutionCacheKey`.
 
 This is decoder-produced, output-only provenance. Analysis owns construction;
 external consumers may pattern-match the closed arms but cannot mint an origin
@@ -2281,11 +2287,11 @@ Resolution is query-directed:
 - caller reachability resolves only target-name references present in the scope
   snapshot;
 - caller reachability binds each snapshotted scope-candidate `AssemblyRef` once
-  in its requesting domain to build reverse adjacency, without opening every
-  referenced image;
-- for candidates selected by those edges, reachability opens only the images
-  needed to read forwarding inventories and binds only their
-  `ExportedType`-target references;
+  in its requesting domain to build reverse adjacency;
+- correctness requires opening each distinct candidate selected by those edges
+  once to determine whether it has forwarding adjacency; after that read,
+  reachability follows only its `ExportedType`-target references and does not
+  traverse its ordinary dependency graph;
 - graph signature correspondence resolves only named type occurrences in edges
   being indexed and caches each resolvable origin once.
 
@@ -2296,8 +2302,10 @@ catalog's cached ref-pack index. The structural performance gate for the
 forwarded `XmlReader` caller is:
 
 - the real caller is found;
-- the same number of caller sessions are opened as the exact query requires;
-- the framework scope does not saturate;
+- forwarding-inventory opens equal the distinct candidates selected by scope
+  adjacency plus newly selected forwarder targets;
+- framework traversal does not expand through ordinary dependencies of those
+  candidates;
 - no target file is reopened by the forwarder engine;
 - each unique matching reference and signature origin is resolved at most once;
 - adjacency policy calls equal the distinct
@@ -2315,8 +2323,7 @@ Each slice has one behavioral claim and can land independently.
 
 ### Slice 1: model and declaration primitive
 
-- Add the structured names, tokens, declaration result, resolution request, and
-  outcome types.
+- Add the structured names, tokens, and declaration result types.
 - Build the bounded single-image declaration probe.
 - Support top-level and nested forwarded types.
 - Represent multi-module exports explicitly.
@@ -2331,6 +2338,8 @@ without returning a stringly or nullable result.
 
 - Evolve `ResolvedAssemblyReference` to the non-equatable descriptor plus
   acquisition registration contract.
+- Add the resolution request, binding, failure, ambiguity, and outcome
+  hierarchies after their descriptor and catalog dependencies exist.
 - Add one `InspectionAcquisitionPlan` per inspection and collapse today's
   per-path resolver instances into its shared owner adapters.
 - Extend `AssemblyInspectionSession` as the single candidate image owner, add
@@ -2514,6 +2523,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
   snapshotted.
 - Resolution caches distinguish origins that structural `TypeRef` equality
   canonicalizes together.
+- Two source candidates carrying the same structured name and equal
+  `CurrentAssembly`, `IntrinsicCoreLibrary`, `ModuleReference`, or
+  `AssemblyReference` origin values do not share a caller-resolution cache
+  entry.
 - Intrinsic, nil, module, and assembly reference origins remain distinct.
 - The target candidate's own `TypeDef` is retained without a `TypeRef`.
 - A duplicate candidate that the catalog cannot unify is indeterminate rather

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -352,8 +352,8 @@ public sealed class ResolvedAssemblyReference
 ```
 
 The registration is a public opaque reference-identity handle because an
-external acquisition owner must mint, retain, and recover it from a requesting
-descriptor at the policy boundary. Its payload remains internal; consumers can
+external acquisition owner must mint, retain, and receive it as a requesting
+origin at the policy boundary. Its payload remains internal; consumers can
 compare the handle only by reference and cannot extract path, identity, opener,
 or provenance from it. It is not a definition key or a claim that visible
 descriptor fields identify a physical file. It owns the canonical
@@ -449,7 +449,7 @@ public abstract class AssemblyBindingOrigin
 
     public static AssemblyBindingOrigin FromAssembly(
         ResolvedAssemblyReference assembly) =>
-        new RequestingAssembly(assembly);
+        new RequestingAssembly(assembly.Registration);
 
     public sealed class GlobalOrigin : AssemblyBindingOrigin
     {
@@ -459,10 +459,10 @@ public abstract class AssemblyBindingOrigin
     public sealed class RequestingAssembly : AssemblyBindingOrigin
     {
         internal RequestingAssembly(
-            ResolvedAssemblyReference assembly) =>
-            Assembly = assembly;
+            AssemblyAcquisitionRegistration registration) =>
+            Registration = registration;
 
-        public ResolvedAssemblyReference Assembly { get; }
+        public AssemblyAcquisitionRegistration Registration { get; }
     }
 }
 
@@ -537,10 +537,11 @@ frozen catalog. `Reference` means "first ask the binding policy to resolve this
 exact `AssemblyRef` from this binding origin, then probe the result." Forwarder
 hops always use the current candidate as `RequestingAssembly`; a global origin
 is explicit and a policy may reject it for a source-relative scope. The builder
-registers a reference start's requesting descriptor as a plan root before
-freeze. A frozen context rejects an origin whose registration is absent from
-its generation as `UnregisteredAssembly` before invoking policy; it never
-mutates the catalog or degrades the origin to global routing.
+registers a reference start's requesting registration as a plan root before
+freeze, then policy receives only that opaque registration. A frozen context
+rejects an origin whose registration is absent from its generation as
+`UnregisteredAssembly` before invoking policy; it never mutates the catalog or
+degrades the origin to global routing.
 
 This avoids an optional `(path, reference?)` or `(assembly?, identity?)` shape.
 Every request states exactly where resolution begins.
@@ -892,7 +893,9 @@ the same selected registration without sharing a cached policy decision.
 The internal structurally equatable `AssemblyBindingDomainKey` is a closed
 value with `Global` and `RequestingCandidate(AssemblyCandidateId)` arms. It is
 generation-scoped and is the only origin projection permitted in binding and
-resolution cache keys.
+resolution cache keys. `AssemblyBindingCacheKey` is the structural tuple of
+that domain key, complete reference identity, and scope; the containing cache
+supplies the generation.
 
 Package, platform, project, and local acquisition owners implement the public
 `IAssemblyBindingPolicy` and return context-free descriptors through public
@@ -928,6 +931,23 @@ public enum CandidateOpenFailureKind
 public sealed record CandidateOpenFailure(
     CandidateOpenFailureKind Kind,
     string Detail);
+
+public abstract class ResolutionPlanRequest
+{
+    private protected ResolutionPlanRequest() { }
+
+    public sealed class Type : ResolutionPlanRequest
+    {
+        internal Type(TypeResolutionRequest request) => Request = request;
+        public TypeResolutionRequest Request { get; }
+    }
+
+    public sealed class Binding : ResolutionPlanRequest
+    {
+        internal Binding(AssemblyBindingRequest request) => Request = request;
+        public AssemblyBindingRequest Request { get; }
+    }
+}
 
 public abstract class TypeResolutionFailure
 {
@@ -1000,10 +1020,10 @@ public abstract class TypeResolutionFailure
 
     public sealed class PlanExpansionRequired : TypeResolutionFailure
     {
-        internal PlanExpansionRequired(TypeResolutionRequest request) =>
+        internal PlanExpansionRequired(ResolutionPlanRequest request) =>
             Request = request;
 
-        public TypeResolutionRequest Request { get; }
+        public ResolutionPlanRequest Request { get; }
     }
 }
 ```
@@ -1379,14 +1399,21 @@ reason `LibraryBodyIndex` currently repeats the traversal beside
 
 Candidate discovery and correspondence are separate phases.
 `AssemblyCatalogBuilder` is the discovery-phase vehicle. The consumer planner
-first supplies a manifest of concrete `TypeResolutionRequest` roots: the target,
-matching caller references, and the named signature types in graph edges being
-indexed. The builder executes those requests provisionally, including every
-per-hop scope-tightening transition. Each encountered
+first supplies a manifest with two root kinds:
+
+- concrete `TypeResolutionRequest` roots for the target, matching caller
+  references, and named signature types in graph edges being indexed;
+- binding-only `AssemblyBindingRequest` roots for every snapshotted
+  `AssemblyRef` used to build caller-scope reverse adjacency, each carrying its
+  requesting candidate origin.
+
+The builder executes those roots provisionally, including every per-hop
+scope-tightening transition. Each encountered
 `(AssemblyBindingDomainKey, AssemblyReferenceIdentity,
 AssemblyResolutionScope)` binding is added to the manifest; each selected
 registration and forwarded continuation extends the work queue. It does not
-bind unrelated `AssemblyRef` rows or sweep framework assemblies.
+bind references outside the explicit type and adjacency roots or sweep
+framework assemblies.
 
 Provisional resolution uses catalog-owned sessions and candidate ids but does
 not issue definition keys, join tokens, graph leases, or a public
@@ -1397,12 +1424,45 @@ The builder is bounded by the plan's candidate and relationship budgets.
 Stable acquisition registrations make repeated selections idempotent; an owner
 that keeps minting registrations eventually produces
 `DiscoveryBudgetExceeded`, not an infinite rebuild loop. At the fixed point the
-builder freezes an `AssemblyCatalogGenerationId` and promotes the exact
-provisional binding outcomes into that generation's immutable binding cache.
-Execution never calls policy for a binding pair absent from that snapshot.
-Definition keys and join tokens are minted only against this frozen manifest
-and candidate set, so duplicate correspondence classes are complete and token
-arms cannot change beneath a cache.
+builder freezes an `AssemblyCatalogGenerationId` and atomically promotes:
+
+- exact provisional binding outcomes into the generation's immutable binding
+  cache;
+- catalog-level declaration results for direct reuse by frozen contexts;
+- completed resolution recipes into the resolution cache, projecting their
+  candidate/token coordinates into generation-scoped definition keys only
+  after freeze.
+
+Typed non-successes are promoted with successes. Execution neither calls policy
+for a binding pair absent from that snapshot nor repeats a promoted probe or
+resolution. Definition keys and join tokens are minted only against this frozen
+manifest and candidate set, so duplicate correspondence classes are complete
+and token arms cannot change beneath a cache.
+
+Discovery epochs do not invalidate image-local declaration results. A later
+epoch seeds unchanged roots from the previous frozen recipes and reruns only a
+recipe whose recorded binding dependency changed when policy was refreshed.
+With a stable acquisition plan, adding a progressive lens therefore preserves
+the once-per-catalog probe count and once-per-distinct-request resolution count.
+
+An internal `FrozenResolutionRecipe` is the generation-neutral cache payload.
+It stores:
+
+- the `TypeResolutionCacheKey`;
+- the terminal raw arm and its candidate/token coordinates or typed
+  non-success payload;
+- raw hop evidence without generation-scoped definition keys;
+- the exact `AssemblyBindingCacheKey` dependencies and their closed,
+  structurally comparable `AssemblyBindingSnapshot` values.
+
+`AssemblyBindingSnapshot` contains only the binding arm, selected candidate ids,
+and typed failure payload; it never compares public outcome objects or
+descriptors. Freeze stores recipes by
+`(AssemblyCatalogGenerationId, TypeResolutionCacheKey)` and materializes the
+public outcome and definition keys for that generation. A later epoch refreshes
+each recorded binding dependency and reuses the recipe only when every snapshot
+is structurally unchanged; otherwise it reruns that recipe. Invalidating an old
+context therefore does not discard the catalog-owned recipe store.
 
 A request outside the frozen manifest returns the typed
 `PlanExpansionRequired` rejection to the inspection coordinator. The
@@ -1420,9 +1480,11 @@ than retrying or rendering an authoritative empty result.
 
 A later progressive lens first reopens the builder with the union of previous
 manifest and the new lens's requests. Graph planning first decodes the selected
-edge set and contributes all named signature requests, then freezes, then
-issues join tokens and builds the graph. It never discovers a new binding while
-tokens are being issued. If fixed-point discovery adds a candidate, the catalog
+edge set, contributes all named signature requests, snapshots each scope
+candidate's assembly references, and contributes all adjacency binding roots.
+It then freezes, issues join tokens, and builds the graph. It never discovers a
+new binding while tokens are being issued. If fixed-point discovery adds a
+candidate, the catalog
 freezes a new generation and invalidates every
 `TypeResolutionContext`, resolution plan, join token, and `ScopeGraph` lease
 from the previous generation. It never mutates or reclassifies an issued token.
@@ -1434,19 +1496,23 @@ The acquisition catalog caches:
 
 - candidate ids by `AssemblyAcquisitionRegistration` reference identity;
 - opened sessions by `AssemblyCandidateId`;
+- declaration results by
+  `(AssemblyCandidateId, MetadataTypeDefinitionName)`;
 - provisional discovery bindings by
   `(discovery epoch, AssemblyBindingDomainKey, AssemblyReferenceIdentity,
   AssemblyResolutionScope)`;
+- provisional resolution recipes by
+  `(discovery epoch, TypeResolutionCacheKey)`;
 - binding outcomes by
   `(AssemblyCatalogGenerationId, AssemblyBindingDomainKey,
   AssemblyReferenceIdentity, AssemblyResolutionScope)`;
+- frozen resolution recipes by
+  `(AssemblyCatalogGenerationId, TypeResolutionCacheKey)`, with their binding
+  dependency snapshots;
 
 Each resolution context is bound to one frozen generation, composes that
 catalog, and caches:
 
-- declaration probes by
-  `(AssemblyCatalogGenerationId, AssemblyCandidateId,
-  MetadataTypeDefinitionName)`;
 - completed resolutions by
   `(AssemblyCatalogGenerationId, TypeResolutionCacheKey)`.
 
@@ -1472,27 +1538,43 @@ be compared only through the catalog correspondence API.
 
 ## Resolution algorithm
 
-For one request:
+The builder runs the state machine below provisionally for every type root. A
+binding cache miss in discovery first adds the binding request to the manifest,
+then invokes policy once and records the outcome. Freeze requires one completed
+recipe for every type root.
 
-1. Resolve the start when it is an assembly reference. First validate a
-   requesting-assembly origin against the frozen generation and return
-   `Rejected(UnregisteredAssembly)` if absent. Otherwise binding `Selected`
-   continues; `Missing` returns `UnboundReference`; `Unavailable` returns
-   `Unavailable`; `Ambiguous` returns `Ambiguous`; and binding `Rejected`
-   returns `Rejected(InvalidBindingPolicy)`.
-2. Open the selected assembly through the context.
-3. Probe the exact structured type name.
-4. On `Defined`, materialize the definition key and finish.
-5. On `Missing`, return `NotFound`.
-6. On `Ambiguous`, return `Ambiguous`.
-7. On `Rejected`, return `Rejected`.
-8. On `Forwarded`, append one hop.
-9. Tighten, but never loosen, `AssemblyResolutionScope` for the next reference.
-10. Resolve the complete target `AssemblyReferenceIdentity` through policy,
-    applying the same exhaustive binding-outcome mapping as step 1.
-11. Stop on repeated assembly candidate or the hop budget with the corresponding
+A frozen context does not rerun this traversal: it validates manifest
+membership and materializes the frozen recipe. A type request absent from the
+manifest returns `PlanExpansionRequired(Type(request))`; a binding-only
+consumer whose cache key is absent returns
+`PlanExpansionRequired(Binding(request))`. Neither path invokes policy.
+
+For one builder request:
+
+1. Require the type request in the discovery manifest; otherwise return
+   `Rejected(PlanExpansionRequired(Type(request)))`.
+2. Resolve the start when it is an assembly reference. First validate a
+   requesting-assembly origin against the active builder catalog and return
+   `Rejected(UnregisteredAssembly)` if absent. Construct its
+   `AssemblyBindingCacheKey`, add it to the discovery manifest, and read or
+   populate the provisional binding outcome. Binding `Selected` continues;
+   `Missing` returns `UnboundReference`; `Unavailable` returns `Unavailable`;
+   `Ambiguous` returns `Ambiguous`; and binding `Rejected` returns
+   `Rejected(InvalidBindingPolicy)`.
+3. Open the selected assembly through the context.
+4. Probe the exact structured type name.
+5. On `Defined`, materialize the definition key and finish.
+6. On `Missing`, return `NotFound`.
+7. On `Ambiguous`, return `Ambiguous`.
+8. On `Rejected`, return `Rejected`.
+9. On `Forwarded`, append one hop.
+10. Tighten, but never loosen, `AssemblyResolutionScope` for the next reference.
+11. Construct the target binding request, add its key to the discovery
+    manifest, read or populate its provisional cache entry, and apply the same
+    exhaustive outcome mapping as step 2.
+12. Stop on repeated assembly candidate or the hop budget with the corresponding
     `Rejected` failure.
-12. Otherwise repeat at step 2.
+13. Otherwise repeat at step 3.
 
 The traversal is iterative. It has both:
 
@@ -1670,6 +1752,8 @@ under the inspection catalog:
    seed. A candidate with indeterminate matching evidence is retained as an
    indeterminate seed.
 3. Bind assembly references to catalog candidates and build reverse adjacency.
+   Every pair is contributed as a binding-only discovery root and frozen before
+   reverse closure begins.
 4. Root graph reachability at the candidate owning the target definition and
    every descriptor selection carrying that candidate's acquisition
    registration.
@@ -2088,6 +2172,9 @@ Resolution is query-directed:
 - callers sharing a reference reuse the completed resolution;
 - caller reachability resolves only target-name references present in the scope
   snapshot;
+- caller reachability binds each snapshotted scope-candidate `AssemblyRef` once
+  in its requesting domain to build reverse adjacency, without opening every
+  referenced image;
 - graph signature correspondence resolves only named type occurrences in edges
   being indexed and caches each resolvable origin once.
 
@@ -2101,7 +2188,10 @@ forwarded `XmlReader` caller is:
 - the same number of caller sessions are opened as the exact query requires;
 - the framework scope does not saturate;
 - no target file is reopened by the forwarder engine;
-- each unique matching reference and signature origin is resolved at most once.
+- each unique matching reference and signature origin is resolved at most once;
+- adjacency policy calls equal the distinct
+  `(requesting candidate, reference identity, scope)` rows in the scope
+  snapshot, and no adjacency request is first discovered after freeze.
 
 Wall-clock measurements may accompany implementation evidence but do not
 replace these structural counts.
@@ -2231,9 +2321,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
   cannot mint independent registrations for the same owner-selected entry.
 - A user path found in the platform inventory and a forwarder binding to that
   entry share the platform registration; an unowned copied path remains local.
-- An external policy can recover the requesting descriptor's registration and
-  use reference identity to select its owner inventory, but cannot read the
-  registration payload.
+- An external policy receives only the requesting registration, can use
+  reference identity to select its owner inventory, and cannot reach the
+  requesting descriptor or registration payload through the origin.
 - Two requesting-assembly origins with the same reference identity and scope
   occupy different binding-cache entries and may select different candidates;
   repeated requests from one origin reuse its outcome.
@@ -2274,6 +2364,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Discovery records and promotes the tightened-scope binding outcome before
   freeze; execution performs no new policy call and selects no unregistered
   candidate.
+- Discovery retains catalog-level declaration results and promotes completed
+  resolution recipes as well as binding outcomes; removing either reuse path
+  causes the once-only probe or resolution count gate to fail.
 - A request outside the frozen manifest returns `PlanExpansionRequired`, and
   presentation occurs only after the coordinator advances the generation.
 
@@ -2315,6 +2408,9 @@ Claim: direct callers and transitive call graphs share one definition identity.
   when the generic local resolver's roll-forward default is disabled.
 - A facade outside the caller scope seeds a direct caller through typed
   resolution, and reverse closure retains callers above it.
+- Every scope-candidate `AssemblyRef` needed for reverse adjacency is present
+  as a binding-only root before freeze; deleting those roots fails the
+  depth-two reverse-closure fixture and the adjacency call-count pin.
 - A depth-two graph caller that reaches the selected member through another
   method in the target assembly is retained even though it never names the
   target type.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -253,16 +253,20 @@ public sealed record MetadataTypeNameRejection(
 
 public abstract class MetadataTypeDefinitionNameResult
 {
-    public sealed class Valid(MetadataTypeDefinitionName name)
-        : MetadataTypeDefinitionNameResult
+    private protected MetadataTypeDefinitionNameResult() { }
+
+    public sealed class Valid : MetadataTypeDefinitionNameResult
     {
-        public MetadataTypeDefinitionName Name { get; } = name;
+        internal Valid(MetadataTypeDefinitionName name) => Name = name;
+        public MetadataTypeDefinitionName Name { get; }
     }
 
-    public sealed class Rejected(MetadataTypeNameRejection rejection)
-        : MetadataTypeDefinitionNameResult
+    public sealed class Rejected : MetadataTypeDefinitionNameResult
     {
-        public MetadataTypeNameRejection Rejection { get; } = rejection;
+        internal Rejected(MetadataTypeNameRejection rejection) =>
+            Rejection = rejection;
+
+        public MetadataTypeNameRejection Rejection { get; }
     }
 }
 ```
@@ -351,20 +355,64 @@ here.
 There are two legitimate starts and they stay explicit:
 
 ```csharp
-public abstract record TypeResolutionStart
+public abstract class TypeResolutionStart
 {
-    public sealed record Assembly(
-        ResolvedAssemblyCandidate Value,
-        AssemblyResolutionScope Scope) : TypeResolutionStart;
+    private protected TypeResolutionStart() { }
 
-    public sealed record Reference(
-        AssemblyReferenceIdentity Value,
-        AssemblyResolutionScope Scope) : TypeResolutionStart;
+    public sealed class Assembly : TypeResolutionStart
+    {
+        internal Assembly(
+            ResolvedAssemblyCandidate value,
+            AssemblyResolutionScope scope)
+        {
+            Value = value;
+            Scope = scope;
+        }
+
+        public ResolvedAssemblyCandidate Value { get; }
+        public AssemblyResolutionScope Scope { get; }
+    }
+
+    public sealed class Reference : TypeResolutionStart
+    {
+        internal Reference(
+            AssemblyReferenceIdentity value,
+            AssemblyResolutionScope scope)
+        {
+            Value = value;
+            Scope = scope;
+        }
+
+        public AssemblyReferenceIdentity Value { get; }
+        public AssemblyResolutionScope Scope { get; }
+    }
 }
 
-public sealed record TypeResolutionRequest(
-    TypeResolutionStart Start,
-    MetadataTypeDefinitionName Type);
+public sealed class TypeResolutionRequest
+{
+    TypeResolutionRequest(
+        TypeResolutionStart start,
+        MetadataTypeDefinitionName type)
+    {
+        Start = start;
+        Type = type;
+    }
+
+    public TypeResolutionStart Start { get; }
+    public MetadataTypeDefinitionName Type { get; }
+
+    public static TypeResolutionRequest FromAssembly(
+        ResolvedAssemblyCandidate value,
+        AssemblyResolutionScope scope,
+        MetadataTypeDefinitionName type) =>
+        new(new TypeResolutionStart.Assembly(value, scope), type);
+
+    public static TypeResolutionRequest FromReference(
+        AssemblyReferenceIdentity value,
+        AssemblyResolutionScope scope,
+        MetadataTypeDefinitionName type) =>
+        new(new TypeResolutionStart.Reference(value, scope), type);
+}
 ```
 
 `Assembly` means "probe this already-resolved assembly, then follow any
@@ -380,46 +428,123 @@ Every request states exactly where resolution begins.
 public readonly record struct TypeDefinitionToken(int Value);
 public readonly record struct ExportedTypeToken(int Value);
 
-public sealed record ModuleFileReference(
-    string Name,
-    bool ContainsMetadata,
-    ImmutableArray<byte> Hash);
-
-public abstract record TypeDeclarationCandidate
+public sealed class ModuleFileReference
 {
-    public sealed record Definition(
-        TypeDefinitionToken Token) : TypeDeclarationCandidate;
+    internal ModuleFileReference(
+        string name,
+        bool containsMetadata,
+        ImmutableArray<byte> hash)
+    {
+        Name = name;
+        ContainsMetadata = containsMetadata;
+        Hash = hash;
+    }
 
-    public sealed record Forwarder(
-        ImmutableArray<ExportedTypeToken> Declarations,
-        AssemblyReferenceIdentity Target) : TypeDeclarationCandidate;
-
-    public sealed record ModuleExport(
-        ImmutableArray<ExportedTypeToken> Declarations,
-        ModuleFileReference Module) : TypeDeclarationCandidate;
+    public string Name { get; }
+    public bool ContainsMetadata { get; }
+    public ImmutableArray<byte> Hash { get; }
 }
 
-public abstract record TypeDeclarationResult
+public abstract class TypeDeclarationCandidate
 {
-    public sealed record Defined(
-        TypeDefinitionToken Definition) : TypeDeclarationResult;
+    private protected TypeDeclarationCandidate() { }
 
-    public sealed record Forwarded(
-        ImmutableArray<ExportedTypeToken> Declarations,
-        AssemblyReferenceIdentity Target) : TypeDeclarationResult;
+    public sealed class Definition : TypeDeclarationCandidate
+    {
+        internal Definition(TypeDefinitionToken token) => Token = token;
+        public TypeDefinitionToken Token { get; }
+    }
 
-    public sealed record ExportedFromModule(
-        ImmutableArray<ExportedTypeToken> Declarations,
-        ModuleFileReference Module) : TypeDeclarationResult;
+    public sealed class Forwarder : TypeDeclarationCandidate
+    {
+        internal Forwarder(
+            ImmutableArray<ExportedTypeToken> declarations,
+            AssemblyReferenceIdentity target)
+        {
+            Declarations = declarations;
+            Target = target;
+        }
 
-    public sealed record Missing : TypeDeclarationResult;
+        public ImmutableArray<ExportedTypeToken> Declarations { get; }
+        public AssemblyReferenceIdentity Target { get; }
+    }
 
-    public sealed record Ambiguous(
-        ImmutableArray<TypeDeclarationCandidate> Candidates)
-        : TypeDeclarationResult;
+    public sealed class ModuleExport : TypeDeclarationCandidate
+    {
+        internal ModuleExport(
+            ImmutableArray<ExportedTypeToken> declarations,
+            ModuleFileReference module)
+        {
+            Declarations = declarations;
+            Module = module;
+        }
 
-    public sealed record Rejected(
-        MetadataTraversalRejection Rejection) : TypeDeclarationResult;
+        public ImmutableArray<ExportedTypeToken> Declarations { get; }
+        public ModuleFileReference Module { get; }
+    }
+}
+
+public abstract class TypeDeclarationResult
+{
+    private protected TypeDeclarationResult() { }
+
+    public sealed class Defined : TypeDeclarationResult
+    {
+        internal Defined(TypeDefinitionToken definition) =>
+            Definition = definition;
+
+        public TypeDefinitionToken Definition { get; }
+    }
+
+    public sealed class Forwarded : TypeDeclarationResult
+    {
+        internal Forwarded(
+            ImmutableArray<ExportedTypeToken> declarations,
+            AssemblyReferenceIdentity target)
+        {
+            Declarations = declarations;
+            Target = target;
+        }
+
+        public ImmutableArray<ExportedTypeToken> Declarations { get; }
+        public AssemblyReferenceIdentity Target { get; }
+    }
+
+    public sealed class ExportedFromModule : TypeDeclarationResult
+    {
+        internal ExportedFromModule(
+            ImmutableArray<ExportedTypeToken> declarations,
+            ModuleFileReference module)
+        {
+            Declarations = declarations;
+            Module = module;
+        }
+
+        public ImmutableArray<ExportedTypeToken> Declarations { get; }
+        public ModuleFileReference Module { get; }
+    }
+
+    public sealed class Missing : TypeDeclarationResult
+    {
+        internal Missing() { }
+    }
+
+    public sealed class Ambiguous : TypeDeclarationResult
+    {
+        internal Ambiguous(
+            ImmutableArray<TypeDeclarationCandidate> candidates) =>
+            Candidates = candidates;
+
+        public ImmutableArray<TypeDeclarationCandidate> Candidates { get; }
+    }
+
+    public sealed class Rejected : TypeDeclarationResult
+    {
+        internal Rejected(MetadataTraversalRejection rejection) =>
+            Rejection = rejection;
+
+        public MetadataTraversalRejection Rejection { get; }
+    }
 }
 ```
 
@@ -462,22 +587,47 @@ from an ambiguous scope or an unreadable candidate. It evolves rather than
 gaining a parallel resolver:
 
 ```csharp
-public abstract record AssemblyBindingOutcome
+public abstract class AssemblyBindingOutcome
 {
-    public sealed record Resolved(
-        ResolvedAssemblyCandidate Candidate) : AssemblyBindingOutcome;
+    private protected AssemblyBindingOutcome() { }
 
-    public sealed record Missing : AssemblyBindingOutcome;
+    public sealed class Resolved : AssemblyBindingOutcome
+    {
+        internal Resolved(ResolvedAssemblyCandidate candidate) =>
+            Candidate = candidate;
 
-    public sealed record Unavailable(
-        AssemblyBindingFailure Failure) : AssemblyBindingOutcome;
+        public ResolvedAssemblyCandidate Candidate { get; }
+    }
 
-    public sealed record Ambiguous(
-        ImmutableArray<ResolvedAssemblyCandidate> Candidates)
-        : AssemblyBindingOutcome;
+    public sealed class Missing : AssemblyBindingOutcome
+    {
+        internal Missing() { }
+    }
 
-    public sealed record Rejected(
-        AssemblyBindingFailure Failure) : AssemblyBindingOutcome;
+    public sealed class Unavailable : AssemblyBindingOutcome
+    {
+        internal Unavailable(AssemblyBindingFailure failure) =>
+            Failure = failure;
+
+        public AssemblyBindingFailure Failure { get; }
+    }
+
+    public sealed class Ambiguous : AssemblyBindingOutcome
+    {
+        internal Ambiguous(
+            ImmutableArray<ResolvedAssemblyCandidate> candidates) =>
+            Candidates = candidates;
+
+        public ImmutableArray<ResolvedAssemblyCandidate> Candidates { get; }
+    }
+
+    public sealed class Rejected : AssemblyBindingOutcome
+    {
+        internal Rejected(AssemblyBindingFailure failure) =>
+            Failure = failure;
+
+        public AssemblyBindingFailure Failure { get; }
+    }
 }
 
 public interface IAssemblyBindingResolver
@@ -554,6 +704,8 @@ public sealed record TypeForwardingHop(
 
 public abstract class TypeResolutionAmbiguity
 {
+    private protected TypeResolutionAmbiguity() { }
+
     public sealed class AssemblyBinding : TypeResolutionAmbiguity
     {
         internal AssemblyBinding(
@@ -588,7 +740,8 @@ public abstract class TypeResolutionAmbiguity
 
 public abstract class TypeResolutionOutcome
 {
-    protected TypeResolutionOutcome(ImmutableArray<TypeForwardingHop> hops) =>
+    private protected TypeResolutionOutcome(
+        ImmutableArray<TypeForwardingHop> hops) =>
         Hops = hops;
 
     public ImmutableArray<TypeForwardingHop> Hops { get; }
@@ -657,6 +810,8 @@ The catalog exposes the only comparison operation:
 ```csharp
 public abstract class DefinitionCorrespondence
 {
+    private protected DefinitionCorrespondence() { }
+
     public sealed class Same : DefinitionCorrespondence
     {
         internal Same() { }
@@ -1078,45 +1233,75 @@ reachability; final call-site matching does not run a second resolution pass:
 ```csharp
 public abstract class TypeCorrespondenceFailure
 {
-    public sealed class Resolution(TypeResolutionOutcome nonSuccess)
-        : TypeCorrespondenceFailure
+    private protected TypeCorrespondenceFailure() { }
+
+    public sealed class Resolution : TypeCorrespondenceFailure
     {
-        public TypeResolutionOutcome NonSuccess { get; } = nonSuccess;
+        internal Resolution(TypeResolutionOutcome nonSuccess) =>
+            NonSuccess = nonSuccess;
+
+        public TypeResolutionOutcome NonSuccess { get; }
     }
 
-    public sealed class DuplicateArtifact(
-        DefinitionCorrespondence.IndeterminateDuplicateArtifact evidence)
-        : TypeCorrespondenceFailure
+    public sealed class DuplicateArtifact : TypeCorrespondenceFailure
     {
+        internal DuplicateArtifact(
+            DefinitionCorrespondence.IndeterminateDuplicateArtifact evidence) =>
+            Evidence = evidence;
+
         public DefinitionCorrespondence.IndeterminateDuplicateArtifact Evidence
-            { get; } = evidence;
+            { get; }
     }
 
-    public sealed class IncomparableCatalogs(
-        AssemblyCatalogId left,
-        AssemblyCatalogId right) : TypeCorrespondenceFailure
+    public sealed class IncomparableCatalogs : TypeCorrespondenceFailure
     {
-        public AssemblyCatalogId Left { get; } = left;
-        public AssemblyCatalogId Right { get; } = right;
+        internal IncomparableCatalogs(
+            AssemblyCatalogId left,
+            AssemblyCatalogId right)
+        {
+            Left = left;
+            Right = right;
+        }
+
+        public AssemblyCatalogId Left { get; }
+        public AssemblyCatalogId Right { get; }
     }
 
-    public sealed class StaleGeneration(
-        AssemblyCatalogGenerationId left,
-        AssemblyCatalogGenerationId right) : TypeCorrespondenceFailure
+    public sealed class StaleGeneration : TypeCorrespondenceFailure
     {
-        public AssemblyCatalogGenerationId Left { get; } = left;
-        public AssemblyCatalogGenerationId Right { get; } = right;
+        internal StaleGeneration(
+            AssemblyCatalogGenerationId left,
+            AssemblyCatalogGenerationId right)
+        {
+            Left = left;
+            Right = right;
+        }
+
+        public AssemblyCatalogGenerationId Left { get; }
+        public AssemblyCatalogGenerationId Right { get; }
     }
 }
 
 public abstract class CandidateTypeRelation
 {
-    public sealed class SameDefinition : CandidateTypeRelation { }
-    public sealed class DifferentDefinition : CandidateTypeRelation { }
-    public sealed class Indeterminate(TypeCorrespondenceFailure failure)
-        : CandidateTypeRelation
+    private protected CandidateTypeRelation() { }
+
+    public sealed class SameDefinition : CandidateTypeRelation
     {
-        public TypeCorrespondenceFailure Failure { get; } = failure;
+        internal SameDefinition() { }
+    }
+
+    public sealed class DifferentDefinition : CandidateTypeRelation
+    {
+        internal DifferentDefinition() { }
+    }
+
+    public sealed class Indeterminate : CandidateTypeRelation
+    {
+        internal Indeterminate(TypeCorrespondenceFailure failure) =>
+            Failure = failure;
+
+        public TypeCorrespondenceFailure Failure { get; }
     }
 }
 ```
@@ -1206,8 +1391,57 @@ public sealed class DefinitionJoinToken : IEquatable<DefinitionJoinToken>
     public override bool Equals(object? obj) =>
         obj is DefinitionJoinToken other && Equals(other);
 
+    public static bool operator ==(
+        DefinitionJoinToken? left,
+        DefinitionJoinToken? right) =>
+        ReferenceEquals(left, right) || left?.Equals(right) is true;
+
+    public static bool operator !=(
+        DefinitionJoinToken? left,
+        DefinitionJoinToken? right) =>
+        !(left == right);
+
     public override int GetHashCode() =>
         HashCode.Combine(_catalog, _generation, _value, Kind);
+}
+
+public sealed class UnresolvedBindingKey : IEquatable<UnresolvedBindingKey>
+{
+    readonly AssemblyCatalogId _catalog;
+    readonly AssemblyCatalogGenerationId _generation;
+    readonly Guid _value;
+
+    internal UnresolvedBindingKey(
+        AssemblyCatalogId catalog,
+        AssemblyCatalogGenerationId generation,
+        Guid value)
+    {
+        _catalog = catalog;
+        _generation = generation;
+        _value = value;
+    }
+
+    public bool Equals(UnresolvedBindingKey? other) =>
+        other is not null
+        && _catalog == other._catalog
+        && _generation == other._generation
+        && _value == other._value;
+
+    public override bool Equals(object? obj) =>
+        obj is UnresolvedBindingKey other && Equals(other);
+
+    public static bool operator ==(
+        UnresolvedBindingKey? left,
+        UnresolvedBindingKey? right) =>
+        ReferenceEquals(left, right) || left?.Equals(right) is true;
+
+    public static bool operator !=(
+        UnresolvedBindingKey? left,
+        UnresolvedBindingKey? right) =>
+        !(left == right);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(_catalog, _generation, _value);
 }
 ```
 
@@ -1465,6 +1699,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Independently constructed equal `MetadataTypeDefinitionName` values compare
   equal through both `Equals` and `==`, hash equally, and hit one
   declaration/resolution cache entry; `!=` returns false.
+- Independently minted equal `DefinitionJoinToken` and
+  `UnresolvedBindingKey` values agree across `Equals`, `==`, `!=`, and hashing.
+- Public result hierarchies cannot be externally extended, and product
+  consumers cannot construct correspondence verdict arms.
 - Type name, assembly identity, assembly candidate, provenance, and hop evidence
   remain separate fields.
 
@@ -1565,6 +1803,8 @@ Prefer dependency and visibility constraints over source scans:
 - candidate ids and join-token constructors are internal, and the internal
   `CatalogMemberJoinKey` factory accepts only catalog-issued
   `DefinitionJoinToken` or `UnresolvedBindingKey` values;
+- correspondence-bearing result bases use `private protected` constructors and
+  every verdict arm uses an internal constructor;
 - Analysis and the CLI cannot access the probe's reader-backed internals;
 - path-only compatibility adapters are internal and deleted with their final
   consumer.
@@ -1579,11 +1819,13 @@ that part because durable addresses are public by design.
 `DefinitionCorrespondenceUsageTests` rejects product uses of equality or
 hashing over `ResolvedTypeDefinitionKey`, `ResolvedTypeDefinition`,
 `TypeResolutionOutcome`, `DefinitionCorrespondence`,
-`TypeCorrespondenceFailure`, or `CandidateTypeRelation`; the catalog comparison
+`TypeCorrespondenceFailure`, `CandidateTypeRelation`,
+`TypeDeclarationResult`, or `TypeDeclarationCandidate`; the catalog comparison
 and join-token APIs are the only semantic correspondence surfaces. It also
-rejects `MetadataTypeDefinitionAddress` equality in caller, source, API, and
-graph correspondence producers; address equality remains allowed only for
-durable-coordinate handling and reader-validation code.
+rejects `MetadataTypeDefinitionAddress` or bare `TypeDefinitionToken` equality
+in caller, source, API, and graph correspondence producers; those value
+equalities remain allowed only inside one known candidate for
+durable-coordinate handling, declaration probing, and reader-validation code.
 
 A second narrow source gate may forbid `Path.Combine` over
 `AssemblyReferenceIdentity.Name` in product code, but it is defense in depth,

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -358,6 +358,9 @@ public abstract record AssemblyBindingOutcome
 
     public sealed record Missing : AssemblyBindingOutcome;
 
+    public sealed record Unavailable(
+        AssemblyBindingFailure Failure) : AssemblyBindingOutcome;
+
     public sealed record Ambiguous(
         ImmutableArray<ResolvedAssemblyCandidate> Candidates)
         : AssemblyBindingOutcome;
@@ -387,10 +390,23 @@ implementation cannot accidentally satisfy the structured interface.
 ### Resolution outcome
 
 ```csharp
-public readonly record struct ResolvedTypeDefinitionKey(
-    AssemblyCatalogId Catalog,
-    AssemblyCandidateId Assembly,
-    TypeDefinitionToken Definition);
+public sealed class ResolvedTypeDefinitionKey
+{
+    internal ResolvedTypeDefinitionKey(
+        AssemblyCatalogId catalog,
+        AssemblyCandidateId assembly,
+        TypeDefinitionToken definition)
+    {
+        Catalog = catalog;
+        Assembly = assembly;
+        Definition = definition;
+    }
+
+    public AssemblyCatalogId Catalog { get; }
+
+    internal AssemblyCandidateId Assembly { get; }
+    internal TypeDefinitionToken Definition { get; }
+}
 
 public readonly record struct MetadataTypeDefinitionAddress(
     Guid ModuleVersionId,
@@ -436,6 +452,7 @@ public abstract record TypeResolutionOutcome
 
     public sealed record Unavailable(
         AssemblyReferenceIdentity Reference,
+        AssemblyBindingFailure Failure,
         ImmutableArray<TypeForwardingHop> Hops)
         : TypeResolutionOutcome;
 
@@ -477,6 +494,11 @@ candidates and their addresses. Consumers never derive that relation from MVID,
 token, identity, or path. `Different` is returned only after the catalog rules
 out the duplicate-artifact condition, so it remains a safe negative.
 
+`ResolvedTypeDefinitionKey` is an opaque capability, not a value-equatable
+record. Candidate and token are internal to the catalog implementation. Product
+consumers can retain the key and pass it back to catalog APIs, but cannot hash,
+order, or field-compare it to reconstruct correspondence.
+
 The inspection and its graph cache keep the catalog alive and use one key space
 for the target and all candidates. A key is never serialized or reused after
 the cache and catalog are released. A cross-catalog comparison is visible data,
@@ -503,7 +525,8 @@ The distinction between the four non-success outcomes is load-bearing:
 
 - `NotFound` means a readable assembly authoritatively neither defined nor
   forwarded the requested type.
-- `Unavailable` means policy could not supply an assembly needed to continue.
+- `Unavailable` means policy could not supply or select an assembly needed to
+  continue and carries the binding-policy reason.
 - `Ambiguous` means policy found several assembly candidates or one image
   contained competing declarations and the engine could not select one.
 - `Rejected` means malformed metadata, a cycle, an exhausted budget, an open
@@ -621,8 +644,29 @@ The acquisition owner supplies the policy:
 - a local caller scope uses its acquired catalog and reports ambiguity when the
   catalog cannot prove one binding.
 
-An unavailable or ambiguous answer may lose a caller, but it is reported as
-incomplete evidence. It cannot fabricate one.
+The caller policies are explicit:
+
+- package and project catalogs bind through the restored asset selection that
+  acquired the candidate, including its selected TFM;
+- platform catalogs may apply trusted framework roll-forward while preserving
+  public-key token and culture; this policy owns the
+  `System.Xml.ReaderWriter` to `System.Private.Xml` case and does not depend on
+  the local resolver's current default;
+- an unordered local `--bin` catalog requires complete identity agreement. More
+  than one plausible simple-name candidate is `Ambiguous`. A sole candidate
+  with version-skewed identity is `Unavailable(IdentityPolicyRequired)`, not an
+  inferred roll-forward.
+
+The last rule intentionally narrows today's version-blind caller matching. A
+version-skewed local caller becomes an indeterminate diagnostic rather than a
+reported caller until acquisition policy can prove the binding. That behavior
+change is compatibility evidence, not a silent miss. An explicit future local
+roll-forward option belongs to the binding resolver and must carry its own
+policy name and gates.
+
+An unavailable or ambiguous answer may therefore omit exact correspondence,
+but every affected caller or graph edge retains incomplete evidence. It cannot
+fabricate one or present the omission as an authoritative empty result.
 
 ## Consumer model
 
@@ -819,14 +863,17 @@ permissiveness rule to keep synchronized with the matcher.
 
 ### Call graph
 
-`CallerGraphKey` is split into three concepts:
+`CallerGraphKey` is split into four concepts:
 
 - a total `GraphNodeStorageKey`, scoped by source candidate and metadata
   location, retains every node and edge even when correspondence cannot be
   established;
-- an optional `ResolvedMemberCorrespondenceKey` exists only when the declaring
-  type and every identity-bearing named type in the open parameter and return
-  signature have a resolved definition key;
+- a catalog-issued `DefinitionJoinToken` projects an opaque definition key into
+  either `Exact` or `IndeterminateDuplicateArtifact`. Tokens are stable only for
+  that catalog and are the only hashable definition correspondence values;
+- an optional `CatalogMemberJoinKey` exists when the declaring type
+  and every identity-bearing named type in the open parameter and return
+  signature have a catalog-issued join token;
 - a `DegradedMemberCorrespondenceKey` substitutes a
   catalog-owned `UnresolvedBindingKey` plus structured type name only for an
   unavailable named type. The binding key represents the exact cached
@@ -834,23 +881,47 @@ permissiveness rule to keep synchronized with the matcher.
   the complete assembly/module/current origin instead of collapsing failures
   into one bucket.
 
+```csharp
+public abstract record DefinitionJoinToken(AssemblyCatalogId Catalog, Guid Value)
+{
+    public sealed record Exact(AssemblyCatalogId Catalog, Guid Value)
+        : DefinitionJoinToken(Catalog, Value);
+
+    public sealed record IndeterminateDuplicateArtifact(
+        AssemblyCatalogId Catalog,
+        Guid Value,
+        DefinitionCorrespondence.IndeterminateDuplicateArtifact Evidence)
+        : DefinitionJoinToken(Catalog, Value);
+}
+```
+
+The catalog returns the same token value for definitions in one correspondence
+class. Duplicate-artifact tokens deliberately join but retain an indeterminate
+arm; they never masquerade as exact tokens.
+
 Named types nested under generic instances, arrays, byrefs, and pointers use the
 same recursive correspondence projection. Replacing only the declaring
 assembly fragment would leave forwarded parameter and return types stringly and
 is not a migration.
 
-Exact graph joins use `ResolvedMemberCorrespondenceKey`. When both sides have
-the same degraded key under one catalog and binding scope, the graph retains an
-`IndeterminateCorrespondence` edge and emits incomplete-graph evidence; it does
-not report exact definition correspondence. `NotFound`, ambiguous, rejected, or
-cross-catalog uses do not degraded-join. Every non-success remains attached to
-its storage node, never enters a shared unresolved bucket, and never becomes an
-ordinary "no edge."
+Graph joins hash only catalog-issued join tokens, never
+`ResolvedTypeDefinitionKey`. A member key containing only `Exact` tokens yields
+an exact edge. Matching keys containing any
+`IndeterminateDuplicateArtifact` token yield an
+`IndeterminateCorrespondence` edge carrying the catalog's duplicate evidence.
 
-This preserves today's useful join when a local scope omits platform
-dependencies while making its confidence explicit. Different complete
-reference identities, names, origins, or scopes remain different, and a known
-resolution never joins through the degraded projection.
+When both sides have the same degraded key under one catalog and binding scope,
+the graph likewise retains an `IndeterminateCorrespondence` edge and emits
+incomplete-graph evidence; it does not report exact definition correspondence.
+`NotFound`, ambiguous, rejected, or cross-catalog uses do not degraded-join.
+Every non-success remains attached to its storage node, never enters a shared
+unresolved bucket, and never becomes an ordinary "no edge."
+
+This preserves today's full-identity join when a local scope omits platform
+dependencies while making its confidence explicit. Version-skewed identities
+follow the explicit local binding policy above instead of this fallback.
+Different complete reference identities, names, origins, or scopes remain
+different, and a known resolution never joins through the degraded projection.
 
 For `CurrentAssembly` and `ModuleReference`, the degraded component also carries
 the source candidate (and module name where present); those origins cannot join
@@ -885,6 +956,13 @@ Source and API consumers receive `ResolvedAssemblyReference` or
   classification that consumes typed declaration inventory. Classification is
   not cross-assembly resolution, but Services may not interpret raw forwarder
   rows after the architecture gate lands.
+
+Platform type-to-library discovery keeps its user-query contract separate from
+`MetadataTypeDefinitionName`. `PlatformTypeLookupPattern` is parsed from user
+input and preserves the current exact-name, dotted-suffix/unqualified-name, and
+generic-arity-normalized matching semantics. It queries an index of structured
+definition names and returns every match as typed candidates; it does not
+pretend an unqualified pattern is an exact metadata identity.
 
 The current consumers migrate with those contracts:
 
@@ -1100,6 +1178,14 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - The target candidate's own `TypeDef` is retained without a `TypeRef`.
 - A duplicate candidate that the catalog cannot unify is indeterminate rather
   than same or different by spelling.
+- Direct callers and graph joins report the same catalog-owned
+  duplicate-artifact evidence; neither hashes raw definition keys or drops the
+  edge.
+- A version-skewed local `--bin` reference is an explicit
+  `IdentityPolicyRequired` incomplete result, not a version-blind caller or an
+  authoritative empty answer.
+- Trusted platform roll-forward resolves the forwarded `XmlReader` fixture even
+  when the generic local resolver's roll-forward default is disabled.
 - A facade outside the caller scope seeds a direct caller through typed
   resolution, and reverse closure retains callers above it.
 - A depth-two graph caller that reaches the selected member through another
@@ -1120,6 +1206,8 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - Forwarded source acquisition opens the resolver-selected descriptor.
 - Platform type-to-library lookup is deterministic under multiple definition or
   forwarder candidates and returns typed ambiguity.
+- Unqualified and generic platform patterns retain the current `INumber<T>` and
+  `List`/`List\`1` lookup behavior through `PlatformTypeLookupPattern`.
 - Parallel body analysis opens and probes each candidate once.
 
 ### Architecture gates
@@ -1129,8 +1217,9 @@ Prefer dependency and visibility constraints over source scans:
 - the single-image probe is the only public Metadata API that interprets a
   forwarder declaration for resolution;
 - the cross-assembly engine is the only product API that follows hops;
-- graph correspondence cannot compare catalog-local keys without the catalog
-  comparison API;
+- `ResolvedTypeDefinitionKey` has no value equality available to consumers;
+  graph correspondence can hash only catalog-issued join tokens and all other
+  correspondence goes through the catalog comparison API;
 - Analysis and the CLI cannot access the probe's reader-backed internals;
 - path-only compatibility adapters are internal and deleted with their final
   consumer.

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -369,6 +369,7 @@ This document is the map. Each document below keeps its own mechanics.
 | `il-diff-canonicalization.md` | IL operation canonicalization; why raw tokens and `IL_####` offsets are not durable identity |
 | `csharp-member-recompilation.md` | Round-trip scope selection; `ModuleIdentity` (name + MVID) as the scope a member anchor is interpreted within |
 | `source-finding-producers.md` | Source-document identity vs member-source identity; token-scoped PDB lookup instead of overload ordinals |
+| `type-forwarding-resolution.md` | Metadata lookup names, reference provenance, catalog-local definition correspondence, and forwarder resolution; these are not display spellings or CLI selectors |
 
 ## Open questions
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -31,6 +31,7 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
 
 - [Architecture](architecture.md): command and metadata architecture.
 - [Inspection layers](design/inspection-layers.md): layer split for multiple consumers, vocabulary, and seam rules.
+- [Structured type-forwarding resolution](design/type-forwarding-resolution.md): typed reference-to-definition resolution, forwarding evidence, binding policy, outcomes, and consumer migration.
 - [Signals](assembly-audit.md): package/library signal semantics and network scope.
 - [PDB acquisition](pdb-acquisition.md): symbols and SourceLink acquisition.
 - [Untrusted data threat model](design/untrusted-data-threat-model.md): trust boundaries and security rules for inspected artifacts, network input, caches, output paths, and rendering.


### PR DESCRIPTION
Defines a Metadata-owned structured reference-to-definition model for type forwarding, replacing assembly-spelling aliases and consumer-owned path reconstruction with typed candidates, outcomes, hop evidence, and definition correspondence.

The design derives requirements from #3437, #3449, #3460, and #3476, and follows the primitive-first/materialized-payload patterns from #3636 and #3461. It specifies ownership, lifetime, binding policy, caller filtering, failure semantics, determinism, performance constraints, architecture gates, and a six-slice migration plan.

This PR changes documentation only. It does not migrate production consumers or change current command behavior. The remaining design decisions are listed explicitly under Review questions.

Validation: `npx markdownlint-cli docs/design/type-forwarding-resolution.md docs/overview.md` and `git diff --check`.