### PR TITLE
Bound an InertString to a budget without dividing a spelling

### DIFF
--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -371,6 +371,50 @@ you are about to apply, short of sweeping every scalar to compare their
 permitted sets — so the value would carry an extra field and still pay for the
 scan.
 
+## Bounding a value to a budget
+
+A sink that puts treated text in a column or a record field has a length limit,
+and applying it to the encoded text is not a substring operation. A spelling is
+between two and ten characters wide, so an arbitrary cut can land inside one and
+leave `\u2` behind.
+
+That is not merely ugly, it is unsound. `EnsurePermitted` treats text it cannot
+decode as raw and re-encodes it, so the surviving backslash doubles and `a\u2`
+becomes `a\\u2` — which is exactly what the untreated literal `a\u2` encodes to.
+Two unrelated inputs converge on one output, and the injectivity the repair path
+rests on is gone. The budget is enforced on the *encoded* length for the same
+reason it is in the escaper this replaces: encoding expands, so bounding the
+input bounds the wrong number.
+
+Two members divide a value, and they differ in what they do with a bad cut:
+
+| Member | Bad cut | For |
+| ------ | ------- | --- |
+| `Truncate(int maxLength)` | moved down to the nearest whole spelling | a budget |
+| `this[Range]` | refused, with `ArgumentException` | a cut the caller already chose |
+
+Moving the cut is right for a budget, where the number is a limit rather than a
+claim, and refusing is right for a range, where the caller has named a span and
+quietly returning a different one is the worse answer. `Truncate` therefore
+reports no truncation flag: `result.Length < Length` already answers it, and a
+flag that restates a comparison is a second thing to keep true.
+
+Neither member moves a **start**. Moving an end down returns less than was
+asked for, which a caller can detect; moving a start down returns *more*, which
+is the one direction it cannot check.
+
+A surrogate pair counts as one thing however it is spelled — raw, as `\U`, or as
+the two `\uXXXX` escapes that composition produces when the halves are encoded in
+separate fragments — so a boundary can never leave a lone surrogate behind.
+`Forms` is recomputed from what is kept, so a legend drawn from a bounded value
+cannot name a spelling that went with the tail.
+
+The walker that finds these boundaries lives beside the speller rather than on
+the currency type, because its widths are the speller's output read backwards; a
+new spelling added to one and not the other would make every boundary past it
+wrong. It is internal, and it adds nothing to the capability surface: it reports
+where text can be divided, never what any of it decodes to.
+
 ## Testing
 
 Two shapes, because they fail differently.

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -386,22 +386,30 @@ rests on is gone. The budget is enforced on the *encoded* length for the same
 reason it is in the escaper this replaces: encoding expands, so bounding the
 input bounds the wrong number.
 
-Two members divide a value, and they differ in what they do with a bad cut:
+Two members divide a value, and both are best-effort:
 
-| Member | Bad cut | For |
-| ------ | ------- | --- |
-| `Truncate(int maxLength)` | moved down to the nearest whole spelling | a budget |
-| `this[Range]` | refused, with `ArgumentException` | a cut the caller already chose |
+| Member | Takes |
+| ------ | ----- |
+| `Truncate(int maxLength)` | the longest prefix within the budget |
+| `Truncate(Range)` | the largest whole window inside the range |
 
-Moving the cut is right for a budget, where the number is a limit rather than a
-claim, and refusing is right for a range, where the caller has named a span and
-quietly returning a different one is the worse answer. `Truncate` therefore
-reports no truncation flag: `result.Length < Length` already answers it, and a
-flag that restates a comparison is a second thing to keep true.
+Both bounds move **inward** — the start forward to the next whole spelling, the
+end back to the previous one — so the result is always a subset of what was
+asked for. That asymmetry is the whole of the safety argument: returning less
+than a caller asked for is something it can detect from `Length`, while
+returning more is not. A window holding no whole spelling is therefore empty
+rather than widened to the spelling enclosing it.
 
-Neither member moves a **start**. Moving an end down returns less than was
-asked for, which a caller can detect; moving a start down returns *more*, which
-is the one direction it cannot check.
+Every range is answerable, including a reversed one and one that runs off
+either end. Neither member reports truncation separately, because
+`result.Length` against the width that was asked for already says whether
+anything moved.
+
+There is deliberately **no exact counterpart** that refuses an unusable window.
+An indexer would wear the syntax of ordinary slicing while throwing on bounds
+that look perfectly reasonable — six of the twelve positions in an
+eleven-character value divide a spelling — so the shape invites exactly the call
+it refuses. It would also buy nothing over the length comparison above.
 
 A surrogate pair counts as one thing however it is spelled — raw, as `\U`, or as
 the two `\uXXXX` escapes that composition produces when the halves are encoded in

--- a/src/InertText.Tests/BoundaryCorpus.cs
+++ b/src/InertText.Tests/BoundaryCorpus.cs
@@ -1,0 +1,80 @@
+namespace InertText.Tests;
+
+/// <summary>
+/// The values the boundary sweeps run over: every <see cref="AdversarialCorpus"/> payload
+/// encoded directly, plus the values only composition can produce.
+/// </summary>
+/// <remarks>
+/// Direct encoding cannot emit two adjacent <c>\uXXXX</c> escapes that together spell one astral
+/// scalar. A paired scalar is spelled as a single <c>\U</c> escape, and the corpus's lone
+/// surrogates have no partner to pair with. That token is twelve characters wide and is the only
+/// one in the alphabet whose width is not settled by its own prefix, so sweeping directly-encoded
+/// payloads alone leaves the walker's subtlest arm to whatever hand-written cases exist —
+/// breaking pair atomicity reddens those and nothing else, while every property sweep stays
+/// green.
+///
+/// Composition reaches it, because <see cref="InertString.Join"/> encodes each fragment on its
+/// own, so a surrogate pair split across two fragments arrives as two escapes.
+/// </remarks>
+public static class BoundaryCorpus
+{
+    private static readonly (string Name, InertString Value)[] Composed =
+    [
+        ("ComposedSurrogatePair", Compose("\uD83D", "\uDE00")),
+
+        // The grouping here is greedy but not blind: the first escape spells a high surrogate
+        // and so does the second, so they are not a pair and the first stands alone at six wide,
+        // while the second and third are a pair at twelve. Reading left to right and taking any
+        // two adjacent escapes as a pair would divide the real one.
+        ("ComposedLoneHighBeforePair", Compose("\uD834", "\uD834", "\uDD73")),
+
+        // The pair next to every other spelling in the alphabet, so a window can open and close
+        // on either side of it rather than only at the ends of the value.
+        ("ComposedPairAmongSpellings", Compose("a\u202E", "\uD83D", "\uDE00", "\\b\u0001")),
+    ];
+
+    public static TheoryData<string> Names
+    {
+        get
+        {
+            TheoryData<string> names = [];
+
+            foreach (Adversary adversary in AdversarialCorpus.All)
+            {
+                names.Add(adversary.Name);
+            }
+
+            foreach ((string name, _) in Composed)
+            {
+                names.Add(name);
+            }
+
+            return names;
+        }
+    }
+
+    public static InertString ByName(string name)
+    {
+        foreach ((string composed, InertString value) in Composed)
+        {
+            if (composed == name)
+            {
+                return value;
+            }
+        }
+
+        return new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+    }
+
+    private static InertString Compose(params string[] fragments)
+    {
+        InertString[] parts = new InertString[fragments.Length];
+
+        for (int i = 0; i < fragments.Length; i++)
+        {
+            parts[i] = new InertString(TextPolicy.Field, fragments[i]);
+        }
+
+        return InertString.Join(string.Empty, TextPolicy.Field, parts);
+    }
+}

--- a/src/InertText.Tests/BoundaryTests.cs
+++ b/src/InertText.Tests/BoundaryTests.cs
@@ -264,6 +264,11 @@ public class BoundaryTests
         // From-end indices, including one that runs off the front.
         Assert.Equal(@"b\\c", full.Truncate(^4..).ToString());
         Assert.Equal(full.ToString(), full.Truncate(^99..).ToString());
+
+        // And both bounds past the end, which is what the walker's own bounds check answers
+        // rather than a clamp at the call site.
+        Assert.True(full.Truncate(99..100).IsEmpty);
+        Assert.Equal(full.ToString(), full.Truncate(0..int.MaxValue).ToString());
     }
 
     [Fact]

--- a/src/InertText.Tests/BoundaryTests.cs
+++ b/src/InertText.Tests/BoundaryTests.cs
@@ -56,10 +56,12 @@ public class BoundaryTests
             int kept = full.Truncate(budget).Length;
 
             // Snapping down is only defensible if it stops at the first position it can, so
-            // every position it skipped has to be one the exact slicer refuses.
+            // every position it skipped has to be one that divides a spelling. Opening a window
+            // at a position answers that: the start moves forward only when it has to, so it
+            // keeps the whole tail exactly when the position was already a boundary.
             for (int longer = kept + 1; longer <= budget; longer++)
             {
-                Assert.Throws<ArgumentException>(() => full[..longer]);
+                Assert.NotEqual(text.Length - longer, full.Truncate(longer..).Length);
             }
         }
     }
@@ -150,51 +152,12 @@ public class BoundaryTests
     }
 
     [Fact]
-    public void Indexer_RefusesABoundThatDividesASpelling()
-    {
-        InertString full = new InertString(TextPolicy.Field, Hazard);
-
-        Assert.Throws<ArgumentException>(() => full[..4]);
-        Assert.Throws<ArgumentException>(() => full[3..]);
-    }
-
-    [Fact]
-    public void Indexer_TakesTheNamedSpanWhenBothBoundsAreWhole()
-    {
-        InertString full = new InertString(TextPolicy.Field, Hazard);
-
-        Assert.Equal(@"\u202E", full[1..7].ToString());
-        Assert.Equal(VisualForm.BmpHex, full[1..7].Forms);
-        Assert.Equal(@"b\\", full[7..10].ToString());
-        Assert.Equal(VisualForm.Backslash, full[7..10].Forms);
-    }
-
-    [Fact]
-    public void Indexer_DoesNotMoveTheStart()
-    {
-        InertString full = new InertString(TextPolicy.Field, Hazard);
-
-        // Moving a start down to the nearest boundary would hand back more text than was asked
-        // for, which is the one direction a caller cannot check.
-        ArgumentException error = Assert.Throws<ArgumentException>(() => full[2..7]);
-        Assert.Equal("range", error.ParamName);
-    }
-
-    [Fact]
-    public void Indexer_RefusesABoundOutsideTheText()
-    {
-        InertString full = new InertString(TextPolicy.Field, Hazard);
-
-        Assert.Throws<ArgumentOutOfRangeException>(() => full[..(full.Length + 1)]);
-    }
-
-    [Fact]
-    public void Indexer_LeavesTheOriginalIntact()
+    public void TruncateRange_LeavesTheOriginalIntact()
     {
         InertString full = new InertString(TextPolicy.Field, Hazard);
         string before = full.ToString();
 
-        _ = full[1..7];
+        _ = full.Truncate(1..7);
 
         Assert.Equal(before, full.ToString());
         Assert.Equal(VisualForm.BmpHex | VisualForm.Backslash, full.Forms);
@@ -300,15 +263,16 @@ public class BoundaryTests
     }
 
     [Fact]
-    public void IndexOfFirstEncoded_LocatesAWindowTheExactSlicerAccepts()
+    public void IndexOfFirstEncoded_NamesABoundThatNeedsNoAdjustment()
     {
-        // The two members compose: the index names a bound, and taking from it succeeds
-        // without probing, which is what makes showing an untreated prefix a two-call job.
+        // The two members compose: the index is always a boundary, so taking up to it returns
+        // the untreated prefix whole rather than a shortened one.
         InertString full = new InertString(TextPolicy.Field, Hazard);
         int first = full.IndexOfFirstEncoded();
 
-        Assert.Equal("a", full[..first].ToString());
-        Assert.Equal(VisualForm.None, full[..first].Forms);
+        Assert.Equal("a", full.Truncate(..first).ToString());
+        Assert.Equal(first, full.Truncate(..first).Length);
+        Assert.Equal(VisualForm.None, full.Truncate(..first).Forms);
     }
 
     [Theory]

--- a/src/InertText.Tests/BoundaryTests.cs
+++ b/src/InertText.Tests/BoundaryTests.cs
@@ -212,11 +212,98 @@ public class BoundaryTests
         Assert.NotEqual(@"a\u2", reencoded.ToString());
     }
 
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void TruncateRange_ReturnsASubsetOfEveryWindowAsked(string name)
+    {
+        InertString full = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+        string text = full.ToString();
+
+        for (int start = 0; start <= text.Length; start++)
+        {
+            for (int end = 0; end <= text.Length; end++)
+            {
+                InertString window = full.Truncate(start..Math.Max(start, end));
+                string kept = window.ToString();
+
+                // Both bounds move inward, so what comes back must appear inside the window
+                // that was asked for -- never one character to the left of it, which is the
+                // direction a caller cannot check.
+                Assert.Contains(kept, text[start..Math.Max(start, end)]);
+
+                Assert.True(VisualEncoder.TryDecode(kept, out _));
+                Assert.Equal(window, window.EnsurePermitted(TextPolicy.Field));
+            }
+        }
+    }
+
+    [Fact]
+    public void TruncateRange_MovesTheStartForwardAndTheEndBack()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        // \u202E occupies 1..7, so a window opening inside it starts after it, not before.
+        Assert.Equal(@"b\\", full.Truncate(2..10).ToString());
+        Assert.Equal("b", full.Truncate(2..9).ToString());
+
+        // And a window wholly inside one spelling holds nothing whole, so it is empty rather
+        // than widened to the spelling that encloses it.
+        Assert.True(full.Truncate(2..6).IsEmpty);
+    }
+
+    [Fact]
+    public void TruncateRange_AnswersEveryRangeWithoutThrowing()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        // The three shapes the exact slicer refuses: past the end, reversed, and empty.
+        Assert.Equal(full.ToString(), full.Truncate(0..int.MaxValue).ToString());
+        Assert.True(full.Truncate(9..2).IsEmpty);
+        Assert.True(full.Truncate(4..4).IsEmpty);
+
+        // From-end indices, including one that runs off the front.
+        Assert.Equal(@"b\\c", full.Truncate(^4..).ToString());
+        Assert.Equal(full.ToString(), full.Truncate(^99..).ToString());
+    }
+
+    [Fact]
+    public void TruncateRange_AgreesWithTheBudgetForm()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        for (int budget = 0; budget <= full.Length; budget++)
+        {
+            Assert.Equal(full.Truncate(budget), full.Truncate(..budget));
+        }
+    }
+
+    [Fact]
+    public void TruncateRange_ReportsOnlyTheSpellingsInTheWindow()
+    {
+        InertString full = new InertString(TextPolicy.Field, "\u202E\u0001");
+
+        Assert.Equal(VisualForm.BmpHex | VisualForm.Caret, full.Forms);
+        Assert.Equal(VisualForm.Caret, full.Truncate(6..).Forms);
+        Assert.Equal(VisualForm.BmpHex, full.Truncate(..6).Forms);
+    }
+
     [Fact]
     public void IndexOfFirstEncoded_LocatesTheFirstSpelling()
     {
         Assert.Equal(1, new InertString(TextPolicy.Field, Hazard).IndexOfFirstEncoded());
         Assert.Equal(0, new InertString(TextPolicy.Field, "\u202Ea").IndexOfFirstEncoded());
+    }
+
+    [Fact]
+    public void IndexOfFirstEncoded_LocatesAWindowTheExactSlicerAccepts()
+    {
+        // The two members compose: the index names a bound, and taking from it succeeds
+        // without probing, which is what makes showing an untreated prefix a two-call job.
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+        int first = full.IndexOfFirstEncoded();
+
+        Assert.Equal("a", full[..first].ToString());
+        Assert.Equal(VisualForm.None, full[..first].Forms);
     }
 
     [Theory]

--- a/src/InertText.Tests/BoundaryTests.cs
+++ b/src/InertText.Tests/BoundaryTests.cs
@@ -1,0 +1,258 @@
+using InertText.Encoding;
+
+namespace InertText.Tests;
+
+/// <summary>
+/// Gates the boundary members: that a bounded value is still a well-formed one.
+/// </summary>
+/// <remarks>
+/// Truncation is where this library is easiest to break, because a spelling is several
+/// characters wide and a budget is not aware of that. Cutting <c>\u202E</c> anywhere but at its
+/// ends leaves text the decoder rejects, and <see cref="InertString.EnsurePermitted"/> treats
+/// text it cannot decode as raw — so the repair path re-encodes the surviving backslash and
+/// turns <c>\u2</c> into <c>\\u2</c>, which is also what an unrelated literal encodes to. Two
+/// inputs converge on one output, and the transform stops being invertible.
+///
+/// So the property these tests hold is not "the result is short enough". It is that the result
+/// is a fixpoint of <see cref="InertString.EnsurePermitted"/> — the same statement the encoder's
+/// own injectivity rests on — checked at every budget rather than at a chosen few.
+/// </remarks>
+public class BoundaryTests
+{
+    private const string Hazard = "a\u202Eb\\c";
+
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void Truncate_LeavesAWellFormedValueAtEveryBudget(string name)
+    {
+        InertString full = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+        string text = full.ToString();
+
+        // Past the end as well as inside it, because a budget is caller-supplied and an
+        // over-budget request is the common case rather than an edge one.
+        for (int budget = 0; budget <= text.Length + 1; budget++)
+        {
+            InertString cut = full.Truncate(budget);
+
+            Assert.True(cut.Length <= Math.Max(0, Math.Min(budget, text.Length)));
+            Assert.Equal(text[..cut.Length], cut.ToString());
+
+            // The whole point: what survives is still readable as encoded text, so the repair
+            // path leaves it alone instead of re-encoding its backslashes.
+            Assert.True(VisualEncoder.TryDecode(cut.ToString(), out _));
+            Assert.Equal(cut, cut.EnsurePermitted(TextPolicy.Field));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void Truncate_KeepsAsMuchAsTheBudgetAllows(string name)
+    {
+        InertString full = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+        string text = full.ToString();
+
+        for (int budget = 0; budget <= text.Length; budget++)
+        {
+            int kept = full.Truncate(budget).Length;
+
+            // Snapping down is only defensible if it stops at the first position it can, so
+            // every position it skipped has to be one the exact slicer refuses.
+            for (int longer = kept + 1; longer <= budget; longer++)
+            {
+                Assert.Throws<ArgumentException>(() => full[..longer]);
+            }
+        }
+    }
+
+    [Fact]
+    public void Truncate_DoesNotDivideASpelling()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        // "a" then \u202E (6) then "b" then \\ (2) then "c".
+        Assert.Equal(@"a\u202Eb\\c", full.ToString());
+
+        Assert.Equal("a", full.Truncate(1).ToString());
+        Assert.Equal("a", full.Truncate(6).ToString());
+        Assert.Equal(@"a\u202E", full.Truncate(7).ToString());
+        Assert.Equal(@"a\u202Eb", full.Truncate(8).ToString());
+        Assert.Equal(@"a\u202Eb", full.Truncate(9).ToString());
+        Assert.Equal(@"a\u202Eb\\", full.Truncate(10).ToString());
+    }
+
+    [Fact]
+    public void Truncate_KeepsARawSurrogatePairWhole()
+    {
+        // Grinning face, which Field permits: So is graphic, so it passes through as two raw
+        // code units rather than as a spelling.
+        InertString full = new InertString(TextPolicy.Field, "a\U0001F600b");
+
+        Assert.Equal("a", full.Truncate(2).ToString());
+        Assert.Equal("a\U0001F600", full.Truncate(3).ToString());
+    }
+
+    [Fact]
+    public void Truncate_KeepsASpelledSurrogatePairWhole()
+    {
+        // Composition encodes each fragment alone, so the halves of one astral scalar are
+        // spelled separately and arrive as two \uXXXX escapes rather than one \U.
+        InertString split = InertString.Join(
+            string.Empty,
+            TextPolicy.Field,
+            [
+                new InertString(TextPolicy.Field, "\uD83D"),
+                new InertString(TextPolicy.Field, "\uDE00"),
+            ]);
+
+        Assert.Equal(@"\uD83D\uDE00", split.ToString());
+
+        // Cutting between them would leave a lone surrogate in the decoded text, which is the
+        // atomicity the escaper this replaces guaranteed at its own budget boundary.
+        Assert.Equal(string.Empty, split.Truncate(11).ToString());
+        Assert.Equal(@"\uD83D\uDE00", split.Truncate(12).ToString());
+    }
+
+    [Fact]
+    public void Truncate_ReportsOnlyTheSpellingsItKept()
+    {
+        InertString full = new InertString(TextPolicy.Field, "\u202E\u0001");
+
+        Assert.Equal(VisualForm.BmpHex | VisualForm.Caret, full.Forms);
+
+        // A legend drawn from the result must not name a spelling that went with the tail.
+        Assert.Equal(VisualForm.BmpHex, full.Truncate(6).Forms);
+        Assert.Equal(VisualForm.None, full.Truncate(5).Forms);
+    }
+
+    [Fact]
+    public void Truncate_ReturnsThisValueWhenTheBudgetIsNotBinding()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        Assert.Same(full.ToString(), full.Truncate(full.Length).ToString());
+        Assert.Same(full.ToString(), full.Truncate(int.MaxValue).ToString());
+    }
+
+    [Fact]
+    public void Truncate_ReadsANegativeBudgetAsZero()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        Assert.True(full.Truncate(-5).IsEmpty);
+    }
+
+    [Fact]
+    public void Truncate_AgreesWithTheZeroValue()
+    {
+        // The zero value and Encode("") are one value everywhere else in the type, so a member
+        // that answered differently for the two would be the defect the equality gate exists for.
+        Assert.Equal(default(InertString).Truncate(4), InertString.Empty.Truncate(4));
+    }
+
+    [Fact]
+    public void Indexer_RefusesABoundThatDividesASpelling()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        Assert.Throws<ArgumentException>(() => full[..4]);
+        Assert.Throws<ArgumentException>(() => full[3..]);
+    }
+
+    [Fact]
+    public void Indexer_TakesTheNamedSpanWhenBothBoundsAreWhole()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        Assert.Equal(@"\u202E", full[1..7].ToString());
+        Assert.Equal(VisualForm.BmpHex, full[1..7].Forms);
+        Assert.Equal(@"b\\", full[7..10].ToString());
+        Assert.Equal(VisualForm.Backslash, full[7..10].Forms);
+    }
+
+    [Fact]
+    public void Indexer_DoesNotMoveTheStart()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        // Moving a start down to the nearest boundary would hand back more text than was asked
+        // for, which is the one direction a caller cannot check.
+        ArgumentException error = Assert.Throws<ArgumentException>(() => full[2..7]);
+        Assert.Equal("range", error.ParamName);
+    }
+
+    [Fact]
+    public void Indexer_RefusesABoundOutsideTheText()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => full[..(full.Length + 1)]);
+    }
+
+    [Fact]
+    public void Indexer_LeavesTheOriginalIntact()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+        string before = full.ToString();
+
+        _ = full[1..7];
+
+        Assert.Equal(before, full.ToString());
+        Assert.Equal(VisualForm.BmpHex | VisualForm.Backslash, full.Forms);
+    }
+
+    [Fact]
+    public void MidSpellingCutsAreWhyTheBoundaryIsChecked()
+    {
+        // The failure this exists to prevent, stated as a fact about the library rather than
+        // left implied: a raw mid-spelling cut is not a fixpoint of the repair path, so two
+        // unrelated inputs would converge on one encoded form.
+        InertString reencoded = new InertString(TextPolicy.Field, @"a\u2");
+
+        Assert.Equal(@"a\\u2", reencoded.ToString());
+        Assert.NotEqual(@"a\u2", reencoded.ToString());
+    }
+
+    [Fact]
+    public void IndexOfFirstEncoded_LocatesTheFirstSpelling()
+    {
+        Assert.Equal(1, new InertString(TextPolicy.Field, Hazard).IndexOfFirstEncoded());
+        Assert.Equal(0, new InertString(TextPolicy.Field, "\u202Ea").IndexOfFirstEncoded());
+    }
+
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void IndexOfFirstEncoded_AgreesWithWasEncoded(string name)
+    {
+        InertString value = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+
+        Assert.Equal(value.WasEncoded, value.IndexOfFirstEncoded() >= 0);
+
+        // Everything before it came through untouched, so a caller may show that much without
+        // asking what the value was built from.
+        if (value.IndexOfFirstEncoded() is int first and >= 0)
+        {
+            Assert.DoesNotContain('\\', value.ToString()[..first]);
+        }
+    }
+
+    [Fact]
+    public void IndexOfFirstEncoded_ReportsMinusOneForUntreatedText()
+    {
+        InertString value = new InertString(TextPolicy.Field, "nothing to encode");
+
+        Assert.Equal(-1, value.IndexOfFirstEncoded());
+        Assert.False(value.WasEncoded);
+    }
+
+    [Fact]
+    public void Length_MeasuresTheEncodedTextRatherThanTheOriginal()
+    {
+        InertString full = new InertString(TextPolicy.Field, Hazard);
+
+        // A budget bounds what a sink emits, so the number has to be the emitted one: five
+        // characters in, eleven out.
+        Assert.Equal(11, full.Length);
+        Assert.Equal(full.ToString().Length, full.Length);
+        Assert.Equal(0, default(InertString).Length);
+    }
+}

--- a/src/InertText.Tests/BoundaryTests.cs
+++ b/src/InertText.Tests/BoundaryTests.cs
@@ -245,6 +245,33 @@ public class BoundaryTests
         }
     }
 
+    [Theory]
+    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    public void TruncateRange_ReportsTheSpellingsTheWalkerFindsAsTheEncoderWouldSpellThem(string name)
+    {
+        // The walker reads the speller's output backwards, so its widths and its form mapping
+        // are that method's table restated. Nothing makes the two move together, and a drift
+        // would not break a boundary -- it would make DescribeLegend name a spelling the text
+        // does not contain, which no length assertion can see.
+        //
+        // Ground truth has to come from outside the walker, so it is taken by decoding the
+        // window and encoding it again from scratch: that path runs AppendSpelling and never
+        // consults NextToken.
+        InertString full = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+        string text = full.ToString();
+
+        for (int start = 0; start <= text.Length; start++)
+        {
+            for (int end = start; end <= text.Length; end++)
+            {
+                InertString window = full.Truncate(start..end);
+
+                Assert.True(VisualEncoder.TryDecode(window.ToString(), out string? original));
+                Assert.Equal(VisualEncoder.Encode(TextPolicy.Field, original).Forms, window.Forms);
+            }
+        }
+    }
+
     [Fact]
     public void TruncateRange_ReportsOnlyTheSpellingsInTheWindow()
     {

--- a/src/InertText.Tests/BoundaryTests.cs
+++ b/src/InertText.Tests/BoundaryTests.cs
@@ -22,11 +22,16 @@ public class BoundaryTests
     private const string Hazard = "a\u202Eb\\c";
 
     [Theory]
-    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    [MemberData(nameof(BoundaryCorpus.Names), MemberType = typeof(BoundaryCorpus))]
     public void Truncate_LeavesAWellFormedValueAtEveryBudget(string name)
     {
-        InertString full = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+        InertString full = BoundaryCorpus.ByName(name);
         string text = full.ToString();
+
+        // The decoded text of the whole value, read once. A cut in the encoded text names a
+        // position in this string, and that is the coordinate system the atomicity guarantee
+        // is stated in.
+        Assert.True(VisualEncoder.TryDecode(text, out string? whole));
 
         // Past the end as well as inside it, because a budget is caller-supplied and an
         // over-budget request is the common case rather than an edge one.
@@ -39,16 +44,49 @@ public class BoundaryTests
 
             // The whole point: what survives is still readable as encoded text, so the repair
             // path leaves it alone instead of re-encoding its backslashes.
-            Assert.True(VisualEncoder.TryDecode(cut.ToString(), out _));
+            Assert.True(VisualEncoder.TryDecode(cut.ToString(), out string? kept));
             Assert.Equal(cut, cut.EnsurePermitted(TextPolicy.Field));
+
+            // Decoding a prefix of encoded text gives a prefix of the decoded text, which is
+            // what lets the cut be named as a single position in the whole value below.
+            Assert.True(kept.Length <= whole.Length);
+            Assert.Equal(whole[..kept.Length], kept);
+
+            // Well-formed encoded text is not enough on its own. Each half of a spelled
+            // surrogate pair is a well-formed \uXXXX escape, so a cut between them decodes and
+            // survives the repair path while still handing a sink a lone surrogate. The harm is
+            // only visible on the decoded side, so that is where it is asserted.
+            AssertNoScalarDivided(whole, 0, kept.Length);
+        }
+    }
+
+    /// <summary>
+    /// A window of encoded text names a range of the decoded text; that range must not fall
+    /// between the halves of a surrogate pair.
+    /// </summary>
+    /// <remarks>
+    /// This is the atomicity guarantee stated where it can be falsified. It says nothing about
+    /// lone surrogates the value already contained -- the corpus carries two of those on
+    /// purpose -- only that a bound may not create one that the whole value did not have.
+    /// </remarks>
+    private static void AssertNoScalarDivided(string decoded, int from, int to)
+    {
+        foreach (int at in (int[])[from, to])
+        {
+            Assert.False(
+                at > 0
+                    && at < decoded.Length
+                    && char.IsHighSurrogate(decoded[at - 1])
+                    && char.IsLowSurrogate(decoded[at]),
+                $"bound at {at} divides the surrogate pair at {at - 1}");
         }
     }
 
     [Theory]
-    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    [MemberData(nameof(BoundaryCorpus.Names), MemberType = typeof(BoundaryCorpus))]
     public void Truncate_KeepsAsMuchAsTheBudgetAllows(string name)
     {
-        InertString full = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+        InertString full = BoundaryCorpus.ByName(name);
         string text = full.ToString();
 
         for (int budget = 0; budget <= text.Length; budget++)
@@ -176,14 +214,22 @@ public class BoundaryTests
     }
 
     [Theory]
-    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    [MemberData(nameof(BoundaryCorpus.Names), MemberType = typeof(BoundaryCorpus))]
     public void TruncateRange_ReturnsASubsetOfEveryWindowAsked(string name)
     {
-        InertString full = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+        InertString full = BoundaryCorpus.ByName(name);
         string text = full.ToString();
+
+        Assert.True(VisualEncoder.TryDecode(text, out string? whole));
 
         for (int start = 0; start <= text.Length; start++)
         {
+            // Where the window's near bound landed after snapping, named in the decoded text.
+            // Opening a window at a position and measuring what is left reports the snapped
+            // start; the text before it decodes to everything the window drops.
+            int snapped = text.Length - full.Truncate(start..).Length;
+            Assert.True(VisualEncoder.TryDecode(text[..snapped], out string? dropped));
+
             for (int end = 0; end <= text.Length; end++)
             {
                 InertString window = full.Truncate(start..Math.Max(start, end));
@@ -194,8 +240,13 @@ public class BoundaryTests
                 // direction a caller cannot check.
                 Assert.Contains(kept, text[start..Math.Max(start, end)]);
 
-                Assert.True(VisualEncoder.TryDecode(kept, out _));
+                Assert.True(VisualEncoder.TryDecode(kept, out string? inside));
                 Assert.Equal(window, window.EnsurePermitted(TextPolicy.Field));
+
+                // Neither bound may divide a surrogate pair of the decoded text. The budget
+                // sweep can only ever check the far bound, because it cuts from zero; the near
+                // bound exists only here, and the same token walk places both.
+                AssertNoScalarDivided(whole, dropped.Length, dropped.Length + inside.Length);
             }
         }
     }
@@ -257,6 +308,13 @@ public class BoundaryTests
         // Ground truth has to come from outside the walker, so it is taken by decoding the
         // window and encoding it again from scratch: that path runs AppendSpelling and never
         // consults NextToken.
+        //
+        // That oracle is only sound for DIRECTLY-ENCODED values, which is why this sweep does
+        // not run over BoundaryCorpus like the others. Re-encoding asks what a fresh encode of
+        // the decoded text would spell, and for a composed value that is a different question
+        // from what the value was spelled with -- see
+        // TruncateRange_KeepsTheSpellingsCompositionEmitted, where the two disagree and the
+        // walker is right.
         InertString full = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
         string text = full.ToString();
 
@@ -283,6 +341,27 @@ public class BoundaryTests
     }
 
     [Fact]
+    public void TruncateRange_KeepsTheSpellingsCompositionEmitted()
+    {
+        // Forms names the spellings emitted while producing the value, and composition unions
+        // them -- so a window's Forms has to describe what a reader of that window actually
+        // sees. Here the reader sees two \uXXXX escapes, and the walker says BmpHex.
+        InertString split = BoundaryCorpus.ByName("ComposedSurrogatePair");
+
+        Assert.Equal(@"\uD83D\uDE00", split.ToString());
+        Assert.Equal(VisualForm.BmpHex, split.Forms);
+        Assert.Equal(VisualForm.BmpHex, split.Truncate(..split.Length).Forms);
+
+        // Decode-then-re-encode, the oracle the directly-encoded sweep uses, disagrees: the two
+        // escapes decode to one astral scalar, and Field permits So, so a fresh encode emits it
+        // raw and reports None. That is the answer to a different question -- what encoding
+        // this text again would spell, not what this value was spelled with -- and it is the
+        // wrong one here, because nothing re-encodes a value on its way to a sink.
+        Assert.True(VisualEncoder.TryDecode(split.ToString(), out string? decoded));
+        Assert.Equal(VisualForm.None, VisualEncoder.Encode(TextPolicy.Field, decoded).Forms);
+    }
+
+    [Fact]
     public void IndexOfFirstEncoded_LocatesTheFirstSpelling()
     {
         Assert.Equal(1, new InertString(TextPolicy.Field, Hazard).IndexOfFirstEncoded());
@@ -303,10 +382,10 @@ public class BoundaryTests
     }
 
     [Theory]
-    [MemberData(nameof(AdversarialCorpus.Names), MemberType = typeof(AdversarialCorpus))]
+    [MemberData(nameof(BoundaryCorpus.Names), MemberType = typeof(BoundaryCorpus))]
     public void IndexOfFirstEncoded_AgreesWithWasEncoded(string name)
     {
-        InertString value = new InertString(TextPolicy.Field, AdversarialCorpus.ByName(name).Payload);
+        InertString value = BoundaryCorpus.ByName(name);
 
         Assert.Equal(value.WasEncoded, value.IndexOfFirstEncoded() >= 0);
 

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -147,6 +147,31 @@ public readonly struct InertString : IEquatable<InertString>
     /// <summary>Whether this value carries no text.</summary>
     public bool IsEmpty => Text.Length == 0;
 
+    /// <summary>The number of characters in the encoded text.</summary>
+    /// <remarks>
+    /// The encoded length, not the length of the text this was built from, because that is the
+    /// number a sink has a budget in: encoding expands, so a scalar that arrived as one
+    /// character can leave as ten, and a caller bounding what it emits has to measure what it
+    /// will emit. The original's length is not recoverable from here by design.
+    /// </remarks>
+    public int Length => Text.Length;
+
+    /// <summary>
+    /// The position of the first spelling this value emitted, or <c>-1</c> when it emitted none.
+    /// </summary>
+    /// <remarks>
+    /// Reports where treated text begins, so a caller can show a prefix it knows to be unchanged
+    /// — a survey listing where in a name the first hazard sits, for instance — without asking
+    /// what was there before. Every spelling is introduced by a backslash and a raw backslash is
+    /// always rewritten, so this is the first character of an escape and never text that merely
+    /// resembles one.
+    ///
+    /// Answers the same question as <see cref="WasEncoded"/> and locates it;
+    /// <c>IndexOfFirstEncoded() &gt;= 0</c> and <see cref="WasEncoded"/> agree. Like that member
+    /// it reports what was done to this value, never what it satisfies.
+    /// </remarks>
+    public int IndexOfFirstEncoded() => Text.IndexOf('\\');
+
     /// <summary>Whether any scalar was encoded on the way in.</summary>
     /// <remarks>
     /// Reports what was <em>done</em> to this value, never what it <em>satisfies</em>. It is not
@@ -164,6 +189,83 @@ public readonly struct InertString : IEquatable<InertString>
 
     /// <summary>The encoded text.</summary>
     public override string ToString() => Text;
+
+    /// <summary>
+    /// Shortens this value to at most <paramref name="maxLength"/> characters, cutting only
+    /// where a cut cannot divide a spelling.
+    /// </summary>
+    /// <remarks>
+    /// The budget-bounded form, for a sink that has to place treated text in a column or a
+    /// record field. The budget is on the encoded length, because that is what the sink emits.
+    ///
+    /// Cutting at the requested position is not an option worth offering. A spelling is several
+    /// characters wide, so an arbitrary cut can leave <c>\u2</c> behind, which is no longer
+    /// something this library can read back: <see cref="EnsurePermitted"/> treats text it cannot
+    /// decode as raw and re-encodes it, turning that into <c>\\u2</c> — the same text an entirely
+    /// different input encodes to. So the cut is moved down to the nearest position that keeps
+    /// every spelling whole, and a surrogate pair counts as one thing however it is spelled.
+    ///
+    /// A negative budget is read as zero rather than refused, and a budget at or above
+    /// <see cref="Length"/> returns this value unchanged, so a caller can hand a configured
+    /// limit straight in. Truncation is not reported separately because
+    /// <c>result.Length &lt; Length</c> already answers it, and a flag that restates a
+    /// comparison is a second thing to keep true.
+    ///
+    /// <see cref="Forms"/> is recomputed from what is kept, so a legend drawn from the result
+    /// cannot name a spelling that was dropped with the tail.
+    /// </remarks>
+    /// <param name="maxLength">The largest encoded length the caller can accept.</param>
+    public InertString Truncate(int maxLength)
+    {
+        string text = Text;
+
+        if (maxLength >= text.Length)
+        {
+            return this;
+        }
+
+        int boundary = VisualEncoder.BoundaryAtOrBefore(text, Math.Max(0, maxLength), out VisualForm forms);
+        return new InertString(text[..boundary], forms);
+    }
+
+    /// <summary>Takes the part of this value that <paramref name="range"/> names.</summary>
+    /// <remarks>
+    /// The exact form, for a caller that already knows where it wants to cut — and the reason
+    /// <see cref="Truncate"/> does not need a variant per budget shape. Where that member moves
+    /// an unusable cut, this one refuses it: a range given deliberately is a claim about the
+    /// text, and silently returning a different span than the one named would be the worse
+    /// answer. Neither bound is moved, in particular not the start, because moving a start down
+    /// would hand back more text than was asked for.
+    ///
+    /// Slicing yields a new value and leaves this one untouched, as it must — this is a
+    /// <see langword="readonly"/> <see langword="struct"/> over an immutable
+    /// <see cref="string"/>, so nothing here can be aliased.
+    /// </remarks>
+    /// <param name="range">The part to take, in encoded characters.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="range"/> falls outside the encoded text.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Either bound divides a spelling, so the result could not be read back.
+    /// </exception>
+    public InertString this[Range range]
+    {
+        get
+        {
+            string text = Text;
+            (int offset, int length) = range.GetOffsetAndLength(text.Length);
+
+            if (!VisualEncoder.TryFormsWithin(text, offset, offset + length, out VisualForm forms))
+            {
+                throw new ArgumentException(
+                    "The range divides an encoded spelling, so the result could not be decoded. "
+                        + $"Use {nameof(Truncate)} to cut at the nearest whole spelling instead.",
+                    nameof(range));
+            }
+
+            return new InertString(text.Substring(offset, length), forms);
+        }
+    }
 
     /// <summary>
     /// Builds a value from an interpolated string, encoding every part of it.

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -217,25 +217,64 @@ public readonly struct InertString : IEquatable<InertString>
     /// <param name="maxLength">The largest encoded length the caller can accept.</param>
     public InertString Truncate(int maxLength)
     {
+        // Clamped here rather than expressed as a Range, because Index refuses a negative value
+        // at construction and would turn a lenient budget into the exception this member exists
+        // not to throw.
+        string text = Text;
+        return Bound(0, Math.Clamp(maxLength, 0, text.Length));
+    }
+
+    /// <summary>
+    /// Takes as much of <paramref name="range"/> as can be taken without dividing a spelling.
+    /// </summary>
+    /// <remarks>
+    /// The general form of <see cref="Truncate(int)"/>, for a caller that wants a window rather
+    /// than a prefix, and the reason getting one does not require probing for a bound the exact
+    /// slicer will accept. Total: every range is answerable, including a reversed one and one
+    /// that runs off either end, both of which are read as the part that overlaps the text.
+    ///
+    /// Both bounds move inward — the start forward to the next whole spelling, the end back to
+    /// the previous one — so the result is always a subset of what was asked for. That
+    /// asymmetry is the point: returning less than a caller asked for is something it can
+    /// detect from <see cref="Length"/>, while returning more is not. A window that contains no
+    /// whole spelling is therefore empty rather than approximated.
+    ///
+    /// Use <see cref="this[Range]"/> instead when the bounds are a claim about the text rather
+    /// than a request, since that member refuses what this one adjusts.
+    /// </remarks>
+    /// <param name="range">The window to take, in encoded characters.</param>
+    public InertString Truncate(Range range)
+    {
         string text = Text;
 
-        if (maxLength >= text.Length)
-        {
-            return this;
-        }
+        // Index.GetOffset does not validate, so a from-end index past the start of the text
+        // arrives negative and an absolute one can run past the end. Clamping both is what
+        // makes every range answerable.
+        int start = Math.Clamp(range.Start.GetOffset(text.Length), 0, text.Length);
+        int end = Math.Clamp(range.End.GetOffset(text.Length), 0, text.Length);
 
-        int boundary = VisualEncoder.BoundaryAtOrBefore(text, Math.Max(0, maxLength), out VisualForm forms);
-        return new InertString(text[..boundary], forms);
+        return Bound(start, Math.Max(start, end));
+    }
+
+    private InertString Bound(int start, int end)
+    {
+        string text = Text;
+        (int from, int to, VisualForm forms) = VisualEncoder.WindowWithin(text, start, end);
+
+        // An unbounded request keeps this value rather than rebuilding an identical one, so the
+        // common case of a budget nobody is near costs nothing.
+        return from == 0 && to == text.Length
+            ? this
+            : new InertString(text[from..to], forms);
     }
 
     /// <summary>Takes the part of this value that <paramref name="range"/> names.</summary>
     /// <remarks>
-    /// The exact form, for a caller that already knows where it wants to cut — and the reason
-    /// <see cref="Truncate"/> does not need a variant per budget shape. Where that member moves
-    /// an unusable cut, this one refuses it: a range given deliberately is a claim about the
-    /// text, and silently returning a different span than the one named would be the worse
-    /// answer. Neither bound is moved, in particular not the start, because moving a start down
-    /// would hand back more text than was asked for.
+    /// The exact form, for a caller whose bounds are a claim about the text rather than a
+    /// request. Where <see cref="Truncate(Range)"/> adjusts an unusable cut, this one refuses
+    /// it: silently returning a different span than the one named would be the worse answer
+    /// when the span was chosen deliberately. Neither bound is moved here, in particular not
+    /// the start, because moving a start down would hand back more text than was asked for.
     ///
     /// Slicing yields a new value and leaves this one untouched, as it must — this is a
     /// <see langword="readonly"/> <see langword="struct"/> over an immutable
@@ -259,7 +298,7 @@ public readonly struct InertString : IEquatable<InertString>
             {
                 throw new ArgumentException(
                     "The range divides an encoded spelling, so the result could not be decoded. "
-                        + $"Use {nameof(Truncate)} to cut at the nearest whole spelling instead.",
+                        + $"Use {nameof(Truncate)}(Range) to take the largest whole window inside it instead.",
                     nameof(range));
             }
 

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -215,14 +215,7 @@ public readonly struct InertString : IEquatable<InertString>
     /// cannot name a spelling that was dropped with the tail.
     /// </remarks>
     /// <param name="maxLength">The largest encoded length the caller can accept.</param>
-    public InertString Truncate(int maxLength)
-    {
-        // Clamped here rather than expressed as a Range, because Index refuses a negative value
-        // at construction and would turn a lenient budget into the exception this member exists
-        // not to throw.
-        string text = Text;
-        return Bound(0, Math.Clamp(maxLength, 0, text.Length));
-    }
+    public InertString Truncate(int maxLength) => Bound(0, maxLength);
 
     /// <summary>
     /// Takes as much of <paramref name="range"/> as can be taken without dividing a spelling.
@@ -248,12 +241,10 @@ public readonly struct InertString : IEquatable<InertString>
         string text = Text;
 
         // Index.GetOffset does not validate, so a from-end index past the start of the text
-        // arrives negative and an absolute one can run past the end. Clamping both is what
-        // makes every range answerable.
-        int start = Math.Clamp(range.Start.GetOffset(text.Length), 0, text.Length);
-        int end = Math.Clamp(range.End.GetOffset(text.Length), 0, text.Length);
-
-        return Bound(start, Math.Max(start, end));
+        // arrives negative and an absolute one can run past the end. Neither is clamped here,
+        // because the walker is total in both bounds and a clamp that never changes an answer
+        // is a line nothing can hold true.
+        return Bound(range.Start.GetOffset(text.Length), range.End.GetOffset(text.Length));
     }
 
     private InertString Bound(int start, int end)

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -222,9 +222,8 @@ public readonly struct InertString : IEquatable<InertString>
     /// </summary>
     /// <remarks>
     /// The general form of <see cref="Truncate(int)"/>, for a caller that wants a window rather
-    /// than a prefix, and the reason getting one does not require probing for a bound the exact
-    /// slicer will accept. Total: every range is answerable, including a reversed one and one
-    /// that runs off either end, both of which are read as the part that overlaps the text.
+    /// than a prefix. Total: every range is answerable, including a reversed one and one that
+    /// runs off either end, both of which are read as the part that overlaps the text.
     ///
     /// Both bounds move inward — the start forward to the next whole spelling, the end back to
     /// the previous one — so the result is always a subset of what was asked for. That
@@ -232,8 +231,11 @@ public readonly struct InertString : IEquatable<InertString>
     /// detect from <see cref="Length"/>, while returning more is not. A window that contains no
     /// whole spelling is therefore empty rather than approximated.
     ///
-    /// Use <see cref="this[Range]"/> instead when the bounds are a claim about the text rather
-    /// than a request, since that member refuses what this one adjusts.
+    /// There is deliberately no exact counterpart that refuses an unusable window. An indexer
+    /// wears the syntax of ordinary slicing while throwing on bounds that look perfectly
+    /// reasonable — six of the twelve positions in an eleven-character value divide a spelling —
+    /// and it would buy nothing, because comparing <see cref="Length"/> against the width that
+    /// was asked for already reports whether anything had to move.
     /// </remarks>
     /// <param name="range">The window to take, in encoded characters.</param>
     public InertString Truncate(Range range)
@@ -257,44 +259,6 @@ public readonly struct InertString : IEquatable<InertString>
         return from == 0 && to == text.Length
             ? this
             : new InertString(text[from..to], forms);
-    }
-
-    /// <summary>Takes the part of this value that <paramref name="range"/> names.</summary>
-    /// <remarks>
-    /// The exact form, for a caller whose bounds are a claim about the text rather than a
-    /// request. Where <see cref="Truncate(Range)"/> adjusts an unusable cut, this one refuses
-    /// it: silently returning a different span than the one named would be the worse answer
-    /// when the span was chosen deliberately. Neither bound is moved here, in particular not
-    /// the start, because moving a start down would hand back more text than was asked for.
-    ///
-    /// Slicing yields a new value and leaves this one untouched, as it must — this is a
-    /// <see langword="readonly"/> <see langword="struct"/> over an immutable
-    /// <see cref="string"/>, so nothing here can be aliased.
-    /// </remarks>
-    /// <param name="range">The part to take, in encoded characters.</param>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// <paramref name="range"/> falls outside the encoded text.
-    /// </exception>
-    /// <exception cref="ArgumentException">
-    /// Either bound divides a spelling, so the result could not be read back.
-    /// </exception>
-    public InertString this[Range range]
-    {
-        get
-        {
-            string text = Text;
-            (int offset, int length) = range.GetOffsetAndLength(text.Length);
-
-            if (!VisualEncoder.TryFormsWithin(text, offset, offset + length, out VisualForm forms))
-            {
-                throw new ArgumentException(
-                    "The range divides an encoded spelling, so the result could not be decoded. "
-                        + $"Use {nameof(Truncate)}(Range) to take the largest whole window inside it instead.",
-                    nameof(range));
-            }
-
-            return new InertString(text.Substring(offset, length), forms);
-        }
     }
 
     /// <summary>

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -432,6 +432,11 @@ public static class VisualEncoder
     /// Both bounds move inward — the start forward, the end back — so the window is always a
     /// subset of the one asked for. Moving either bound outward would hand back text the caller
     /// did not ask for, which is the one direction it has no way to check.
+    ///
+    /// Total in both bounds, which is what lets a caller pass a range straight through without
+    /// clamping it first: a bound below zero or past the end is read as the nearest end of the
+    /// text, and an end below the start gives an empty window, because the end walks from the
+    /// start and only ever advances.
     /// </remarks>
     internal static (int Start, int End, VisualForm Forms) WindowWithin(string encoded, int start, int end)
     {
@@ -445,7 +450,7 @@ public static class VisualEncoder
         VisualForm forms = VisualForm.None;
         int to = from;
 
-        while (to < end)
+        while (to < end && to < encoded.Length)
         {
             int width = NextToken(encoded, to, out VisualForm form);
 

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -425,28 +425,40 @@ public static class VisualEncoder
             && char.IsLowSurrogate((char)low);
 
     /// <summary>
-    /// The largest index at or below <paramref name="limit"/> that does not divide a token,
-    /// reporting the spellings the text up to it contains.
+    /// The largest window inside <paramref name="start"/>..<paramref name="end"/> whose bounds
+    /// both fall between tokens, reporting the spellings it contains.
     /// </summary>
-    internal static int BoundaryAtOrBefore(string encoded, int limit, out VisualForm forms)
+    /// <remarks>
+    /// Both bounds move inward — the start forward, the end back — so the window is always a
+    /// subset of the one asked for. Moving either bound outward would hand back text the caller
+    /// did not ask for, which is the one direction it has no way to check.
+    /// </remarks>
+    internal static (int Start, int End, VisualForm Forms) WindowWithin(string encoded, int start, int end)
     {
-        forms = VisualForm.None;
-        int i = 0;
+        int from = 0;
 
-        while (i < encoded.Length)
+        while (from < start && from < encoded.Length)
         {
-            int width = NextToken(encoded, i, out VisualForm form);
+            from += NextToken(encoded, from, out _);
+        }
 
-            if (i + width > limit)
+        VisualForm forms = VisualForm.None;
+        int to = from;
+
+        while (to < end)
+        {
+            int width = NextToken(encoded, to, out VisualForm form);
+
+            if (to + width > end)
             {
                 break;
             }
 
             forms |= form;
-            i += width;
+            to += width;
         }
 
-        return i;
+        return (from, to, forms);
     }
 
     /// <summary>

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -356,4 +356,124 @@ public static class VisualEncoder
 
         return true;
     }
+
+    // Walks encoder output one token at a time, where a token is whatever the boundary members
+    // on InertString must not cut through: one escape, one raw scalar, or one raw character.
+    //
+    // Deliberately here rather than on the currency type, beside AppendSpelling, because the
+    // widths below are that method's output read backwards. A new spelling that lands there and
+    // not here would make every boundary past it wrong, and the two are only obviously coupled
+    // when they are adjacent. Internal, so it adds nothing to the capability surface: it reports
+    // where the text can be divided, never what any of it decodes to.
+    private static int NextToken(string encoded, int index, out VisualForm form)
+    {
+        char c = encoded[index];
+
+        if (c != '\\')
+        {
+            form = VisualForm.None;
+
+            // Encode never emits a raw unpaired surrogate -- it spells one as \uXXXX -- so a
+            // high surrogate here is always the first half of a scalar and is never divisible.
+            return char.IsHighSurrogate(c)
+                && index + 1 < encoded.Length
+                && char.IsLowSurrogate(encoded[index + 1])
+                    ? 2
+                    : 1;
+        }
+
+        int remaining = encoded.Length - index;
+
+        // Widths are clamped rather than trusted. Encode cannot emit a truncated escape, but the
+        // internal constructor asserts the invariant instead of establishing it, so a walk that
+        // read past the end here would turn a malformed value into an IndexOutOfRangeException
+        // at a boundary check rather than at the point it was built.
+        switch (remaining > 1 ? encoded[index + 1] : '\0')
+        {
+            case '\\':
+                form = VisualForm.Backslash;
+                return Math.Min(2, remaining);
+            case '^':
+                form = remaining > 2 && encoded[index + 2] == '?'
+                    ? VisualForm.CaretDelete
+                    : VisualForm.Caret;
+                return Math.Min(3, remaining);
+            case 'u':
+                form = VisualForm.BmpHex;
+
+                // Composition encodes each fragment on its own, so a surrogate pair split across
+                // two of them arrives as two \uXXXX escapes that together spell one astral
+                // scalar. Cutting between them would leave a lone surrogate in the text this
+                // decodes to, which is the atomicity the escaper this replaces guaranteed.
+                return IsEscapedSurrogatePair(encoded, index) ? 12 : Math.Min(6, remaining);
+            case 'U':
+                form = VisualForm.AstralHex;
+                return Math.Min(10, remaining);
+            default:
+                form = VisualForm.None;
+                return 1;
+        }
+    }
+
+    private static bool IsEscapedSurrogatePair(string encoded, int index)
+        => index + 12 <= encoded.Length
+            && encoded[index + 6] == '\\'
+            && encoded[index + 7] == 'u'
+            && TryReadHex(encoded, index + 2, 4, out uint high)
+            && TryReadHex(encoded, index + 8, 4, out uint low)
+            && char.IsHighSurrogate((char)high)
+            && char.IsLowSurrogate((char)low);
+
+    /// <summary>
+    /// The largest index at or below <paramref name="limit"/> that does not divide a token,
+    /// reporting the spellings the text up to it contains.
+    /// </summary>
+    internal static int BoundaryAtOrBefore(string encoded, int limit, out VisualForm forms)
+    {
+        forms = VisualForm.None;
+        int i = 0;
+
+        while (i < encoded.Length)
+        {
+            int width = NextToken(encoded, i, out VisualForm form);
+
+            if (i + width > limit)
+            {
+                break;
+            }
+
+            forms |= form;
+            i += width;
+        }
+
+        return i;
+    }
+
+    /// <summary>
+    /// Reports whether <paramref name="start"/> and <paramref name="end"/> both fall between
+    /// tokens, naming the spellings the text between them contains.
+    /// </summary>
+    internal static bool TryFormsWithin(string encoded, int start, int end, out VisualForm forms)
+    {
+        forms = VisualForm.None;
+        int i = 0;
+
+        while (i < start)
+        {
+            i += NextToken(encoded, i, out _);
+        }
+
+        if (i != start)
+        {
+            return false;
+        }
+
+        while (i < end)
+        {
+            i += NextToken(encoded, i, out VisualForm form);
+            forms |= form;
+        }
+
+        return i == end;
+    }
 }

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -465,32 +465,4 @@ public static class VisualEncoder
 
         return (from, to, forms);
     }
-
-    /// <summary>
-    /// Reports whether <paramref name="start"/> and <paramref name="end"/> both fall between
-    /// tokens, naming the spellings the text between them contains.
-    /// </summary>
-    internal static bool TryFormsWithin(string encoded, int start, int end, out VisualForm forms)
-    {
-        forms = VisualForm.None;
-        int i = 0;
-
-        while (i < start)
-        {
-            i += NextToken(encoded, i, out _);
-        }
-
-        if (i != start)
-        {
-            return false;
-        }
-
-        while (i < end)
-        {
-            i += NextToken(encoded, i, out VisualForm form);
-            forms |= form;
-        }
-
-        return i == end;
-    }
 }


### PR DESCRIPTION
Adds the two members that let a sink bound an `InertString` to a length budget, stacked on #3636.

## Why this is not a substring

A spelling is between two and ten characters wide — `\\`, `\^X`, `\uXXXX`, `\UXXXXXXXX` — so an arbitrary cut can land inside one and leave `\u2` behind.

That is unsound rather than merely ugly. `EnsurePermitted` treats text it cannot decode as raw and re-encodes it, so the surviving backslash doubles and `a\u2` becomes `a\\u2` — which is exactly what the untreated literal `a\u2` encodes to. Two unrelated inputs converge on one output, and the injectivity the repair path rests on is gone. That is the same convergence failure fixed during review on #3636, arriving through a new door.

Measured on encoded `a\u202Eb\\c` (length 11): **6 of the 12 cut points are undecodable.**

## Surface

| Member | Contract |
| ------ | -------- |
| `int Length` | encoded length — what a sink emits, not what it was given |
| `int IndexOfFirstEncoded()` | position of the first spelling, `-1` when there is none |
| `InertString Truncate(int maxLength)` | the longest prefix within the budget |
| `InertString Truncate(Range)` | the largest whole window inside the range |

Both are best-effort and total: every range is answerable, including a reversed one and one that runs off either end.

Both bounds move **inward** — the start forward to the next whole spelling, the end back to the previous one — so the result is always a subset of what was asked for. That asymmetry is the whole of the safety argument: returning less than a caller asked for is something it can detect from `Length`, while returning more is not. A window holding no whole spelling is empty rather than widened to the spelling enclosing it.

Neither reports truncation separately, because `result.Length` against the width asked for already says whether anything moved.

**There is no exact counterpart that throws.** An earlier revision had `this[Range]` refuse an unusable window. It wore the syntax of ordinary slicing while throwing on bounds that look perfectly reasonable — 6 of the 12 positions above divide a spelling — so the shape invited exactly the call it refuses, and it bought nothing over the length comparison.

```csharp
InertString cell = inert.Truncate(options.MaxStringChars);
bool truncated = cell.Length < inert.Length;
```

## Details worth review

- **A surrogate pair is one thing however it is spelled.** Raw, as `\U`, or as the two `\uXXXX` escapes composition produces when the halves are encoded in separate fragments — `Join` of `"\uD83D"` and `"\uDE00"` gives `\uD83D\uDE00`, and cutting between them would leave a lone surrogate in the decoded text. That atomicity is a guarantee the escaper this replaces documented, so dropping it would be a regression.
- **`Forms` is recomputed from what is kept**, so a legend drawn from a bounded value cannot name a spelling that went with the tail.
- **The token walker lives beside `AppendSpelling`**, because its widths are that method's output read backwards; a new spelling added to one and not the other would make every boundary past it wrong. It is `internal` and adds nothing to the capability surface: it reports where text divides, never what it decodes to.
- **The walker is total**, so no caller clamps. Mutation testing found the first version's reversed-range guard and negative-budget clamp were both dead — the end walks from the start and only advances, so each already gave an empty window. A line no mutation can falsify is a line nothing holds true, so both are gone.
- **Escape widths are clamped, not trusted.** `Encode` cannot emit a truncated escape, but the internal constructor asserts the invariant rather than establishing it, so an unclamped walk would surface a malformed value as an `IndexOutOfRangeException` at a boundary check instead of where it was built.

## Naming

`Slice(int)` was considered and rejected: `Span<T>.Slice(int start)` "forms a slice … that begins at a specified index", so a one-`int` `Slice` means a **start** everywhere in .NET. `inert.Slice(1000)` would read as "skip 1000 characters" while meaning "keep at most 1000" — both compile, opposite contents.

## Testing

330 tests, up from 190. The central property is not "the result is short enough" but that the result is a **fixpoint of `EnsurePermitted`** — the same statement the encoder's injectivity rests on — checked over the whole adversarial corpus at *every* budget from 0 past the end, together with the claim that the cut is maximal. Removing the indexer meant restating maximality without it: opening a window at a position is its own boundary oracle, since the start moves forward only when it must and so keeps the whole tail exactly when the position was already whole.

The range form adds a subset property swept over every `(start, end)` pair in the corpus: what comes back must appear inside the window that was asked for.

The walker restates `AppendSpelling`'s table backwards, and the boundary assertions only cover the widths half of it. The mapping from escape to `VisualForm` had no gate at all — three of the five forms could report `None`, and `CaretDelete` could collapse into `Caret`, with everything still green. That drift breaks no boundary; it makes the value describe itself wrongly. It is now pinned by decoding each window and encoding it again from scratch, which runs `AppendSpelling` and never consults the walker. `EnsurePermitted` cannot serve as that oracle: it short-circuits on an already-permitted value and hands back the value's own metadata.

Each behavior was mutation-tested; every mutation below turned the suite red.

Two of those sweeps could not see the shape they were meant to protect. Their inputs came from the adversarial corpus, whose values are all encoded directly, and direct encoding never emits the width-12 token: `Field` permits an astral graphic scalar, so it goes raw rather than as two `\uXXXX` escapes. Only `Join` composes that shape, so the sweeps now draw from a corpus of named `InertString` *values* that includes three composed ones.

Widening the inputs was necessary but not sufficient. Each half of a divided pair is itself a well-formed `\uXXXX` escape, so a cut between them still decodes, still satisfies `IsPermitted`, and is therefore still an `EnsurePermitted` fixpoint — every property the sweeps asserted lives on the **encoded** side, while the harm, handing a sink a lone surrogate, is only visible on the **decoded** side. The guarantee is now stated where it can fail: a bound may not fall between the halves of a surrogate pair of the decoded text. That forbids only creating a lone surrogate, not carrying one — the corpus holds two on purpose. The range sweep carries it too, since the near bound exists only there while the same token walk places both.

| Mutation | Caught by |
| -------- | --------- |
| escaped surrogate pair divisible | 7 tests |
| raw surrogate pair divisible | `Truncate_KeepsARawSurrogatePairWhole` |
| cut exactly at the limit | 25 tests |
| end bound unchecked | 23 tests |
| start snapped backward instead of forward | 23 tests |
| over-conservative by one token | 31 tests |
| start or end bounds check removed | 25 tests |
| full-window fast path always taken | 53 tests |
| `Forms` not recomputed | 3 tests |
| `IndexOfFirstEncoded` constant | 3 tests |
| `Backslash` reported as `None` | 1 test |
| `AstralHex` reported as `None` | 3 tests |
| `CaretDelete` collapsed into `Caret` | 1 test |
| `BmpHex` reported as `None` | 15 tests |
| `Caret` reported as `None` | 7 tests |

## Scope

No caller yet. These exist for the #3628 metadata migration, where `EscapeText(raw, max, out bool truncated)` becomes the two lines above; that migration is a separate PR.
