### PR TITLE
Run CI for stacked PR branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, 'feature/**']
 
 env:
   DOTNET_NOLOGO: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,14 +352,11 @@ round:
   bottom open slice takes `origin/main` as its base, and rebasing an upper slice
   onto `main` pulls in work its parent has not landed and makes the slice's diff
   report its parent's changes as its own.
-- **No checks reported is terminal, not pending.** A slice can report no checks
-  at all — `gh pr checks` prints "no checks reported" while the PR is
-  MERGEABLE/CLEAN. Whether a given base branch schedules runs is not something
-  to assume in either direction: read what the PR actually reports, and if
-  nothing is reported, do not wait for runs that may never come. In that state
-  the slice's evidence is the validation you ran locally plus the bottom slice's
-  CI, so say what you ran, and never report an unrun slice as green. Re-check
-  after the slice retargets `main`, where anything newly scheduled does gate.
+- **Every slice in a stack must report CI.** Stack branches use the `feature/`
+  prefix, so a child PR targeting its parent branch schedules the same CI as a
+  bottom slice targeting `main`. If `gh pr checks` reports no checks for a
+  stack slice, the slice is not green: verify the branch naming and workflow
+  scheduling before review.
 
 Do not integrate main under a reviewer mid-read. When integration is what moved
 the head, say so on the PR and name the merge commit, so the re-review reads as
@@ -462,6 +459,7 @@ until it is unreviewable, and over parallel PRs that race in the same files.
 - **Name the stack in every PR**: the slice's position, its parent PR, and the
   enumerated residual, which is the non-action boundary the PR-summary rule
   already requires.
+- **Name every slice branch `feature/<name>`** so child PRs targeting it run CI.
 - **One branch and one worktree per slice**, branched from the parent slice, and
   targeted at the parent branch (`gh pr create --base <parent-branch>`).
 - **Merge bottom-up, one at a time**, then confirm the next PR retargeted and

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -22,9 +22,12 @@ with the fixed-head review rule.
   boundary the PR-summary rule already requires, so declare them: a reviewer
   should read a declared residual as scope rather than as a defect. Each slice's
   residual is the next slice's opening move; keep it enumerated.
+- **Name every slice branch `feature/<name>`.** CI runs for PRs targeting
+  `main` or a `feature/**` branch, so this prefix ensures every layer receives
+  CI before and after its parent lands.
 - **One branch and one worktree per slice**, as for any PR. Branch slice N+1
   from slice N's branch rather than `origin/main`:
-  `git worktree add -b <branch> <path> <parent-branch>`.
+  `git worktree add -b feature/<name> <path> <parent-branch>`.
 - **Target the parent branch** so the PR diff shows only its own slice:
   `gh pr create --base <parent-branch>`.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost


### PR DESCRIPTION
## Summary

CI now runs for pull requests targeting `feature/**` branches as well as `main`, so every layer of a correctly named PR stack receives CI.

- require stacked PR branches to use `feature/<name>`
- treat missing checks on a stack slice as not green
- leave push-trigger behavior unchanged (`main` only)

## Validation

- `npx --yes markdownlint-cli AGENTS.md docs/stacked-prs.md`
- `git diff --check`