### PR TITLE
Adopt a printed descendant for facts whose node prints nothing

### DIFF
--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -9,8 +9,14 @@ It is the display half of the `--focus` gesture. The analysis half — deciding
 which characters a fact is about — is described in
 [hidden-fact-annotations.md](hidden-fact-annotations.md) and implemented by
 `AnnotationAnchor.ComputeCaretExtents`. **Stacking changes no analysis.** The
-per-fact extents already exist and are already correct; today's renderer
-discards them.
+per-fact extents already exist; today's renderer discards them.
+
+That separation held for the stacking change itself and no longer describes the
+current state of the anchor. [#3674](https://github.com/richlander/dotnet-inspect/pull/3674)
+went on to fix two anchoring defects — a fact whose own node prints nothing now
+adopts an extent from its nearest printed descendant, which gave 1,841 more
+facts an extent — and every figure in this document was re-measured against it.
+The design below is unchanged by that; only its numbers moved.
 
 Every figure in this document comes from the corpus named under
 [Measurements](#measurements): `System.Private.CoreLib`
@@ -101,7 +107,7 @@ depicts a layout that was never built. This one is
    row** (rule 5), and a nested extent that lands on a different row is not on
    its parent's row to cut anything. Nor does it order row widths overall: a
    later disjoint extent can be packed onto a lower row and reach further right
-   than anything above it, which happens on **50 of the 3,105** lines.
+   than anything above it, which happens on **50 of the 3,169** lines.
 3. **Number in that order,** `1.` upward, and label each caret with its number
    immediately before the trail.
 4. **Pack greedily onto rows.** An extent joins the first row where the
@@ -130,7 +136,7 @@ depicts a layout that was never built. This one is
    when any label on a line would begin left of the gutter, that line does not
    stack at all: it falls back to the widening render this document replaces.
    This is a guard rather than a path with traffic — it fires on **0 of the
-   3,105 lines that qualify to stack** in the corpus below, which is the
+   3,169 lines that qualify to stack** in the corpus below, which is the
    non-circular denominator, since a line it rejects does not stack by
    construction — but it is reachable, and a
    line is never rendered with a label that lies about its column.
@@ -176,21 +182,21 @@ they point at, and rule 8 refuses to shift a trail rightward to make room,
 bailing out instead. The rightmost column of a stacked row is therefore bounded
 by the code line by construction.
 
-The corpus agrees — 0 of the 3,105 lines carry a stacked caret row wider than
+The corpus agrees — 0 of the 3,169 lines carry a stacked caret row wider than
 their code line — but that count is a consistency check on the derivation above,
 not evidence for it, because no corpus could produce a counter-example.
 
 The comparison against the widening render is narrower than two earlier
 revisions of this section claimed, and the correction is worth stating plainly.
 **No caret glyph overhangs the code line in either render.** Measured over the
-same 3,105 lines, both are **0**, because the widening underline covers the
+same 3,169 lines, both are **0**, because the widening underline covers the
 trimmed statement, which ends inside the line. The widening render has no
 explicit bound, but it does not need one to stay within the line.
 
 What differs is the rendered **row**. Widening appends the first detail string
 to the caret row when it fits the inline budget, and that appended text carries
-the row past the end of the code line. Quoting this as **20 of 3,105 lines
-(0.64%)** pads the denominator with the 3,085 whose detail never goes inline and
+the row past the end of the code line. Quoting this as **20 of 3,169 lines
+(0.63%)** pads the denominator with the 3,149 whose detail never goes inline and
 which therefore cannot overhang at all. Inline detail appears on exactly **20**
 of these lines, and **all 20** overhang — the rate is **20/20**. It comes out
 whole because on the hoisted render these figures are taken from, widening
@@ -206,29 +212,29 @@ described a mechanism that does not occur.
 Widths below are **final rendered columns**, measured after the same projection
 `ApiOutputFormatter` applies — code lines receive `BodyIndentWidth`, hoisted
 caret lines do not — and the caret block is real rendered output, detail rows
-included. Whole rendered block on those 3,105 lines:
+included. Whole rendered block on those 3,169 lines:
 
 | terminal | widen (today) | stacked |
 | --- | ---: | ---: |
-| 80 cols | 21.3% | 21.4% |
-| 100 cols | 52.0% | 52.0% |
-| 120 cols | 68.3% | 68.3% |
-| 160 cols | 86.2% | 86.2% |
+| 80 cols | 20.9% | 21.0% |
+| 100 cols | 52.6% | 52.6% |
+| 120 cols | 68.7% | 68.7% |
+| 160 cols | 86.5% | 86.5% |
 
 That denominator is padded, and the padding is most of it: the block can never
 be narrower than the code line, so a line whose code alone overflows the
-terminal cannot fit under *any* caret model. At 80 columns only 923 of the 3,105
-have code that fits at all — the other 2,182 are structurally incapable of the
-outcome being counted. Restricted to the 923 that could fit, the rates are 71.6%
-widening and 72.0% stacked. At the wider terminals the padded rate and the
-code-fits share converge almost exactly (100 cols: 52.0% fit, 52.0% code-fits;
-120: 68.3% / 68.3%; 160: 86.2% / 86.2%), which says the block width simply *is*
+terminal cannot fit under *any* caret model. At 80 columns only 954 of the 3,169
+have code that fits at all — the other 2,215 are structurally incapable of the
+outcome being counted. Restricted to the 954 that could fit, the rates are 69.3%
+widening and 69.7% stacked. At the wider terminals the padded rate and the
+code-fits share converge almost exactly (100 cols: 52.6% fit, 52.7% code-fits;
+120: 68.7% / 68.8%; 160: 86.5% / 86.5%), which says the block width simply *is*
 the code width there.
 
 Terminal fit is unchanged, because on these dense lines the block width is set
 by the code line and the wrapped detail rows, which both models share. Nor does
-the block itself shrink much: it is the same width on 84.8% of these lines,
-narrower on 1.0%, and wider on 14.2% — the numbered labels cost a few columns
+the block itself shrink much: it is the same width on 83.4% of these lines,
+narrower on 1.3%, and wider on 15.3% — the numbered labels cost a few columns
 where the details were already the widest thing in the block.
 
 Those three shares are all padded, and quoting any of them as a rate invites the
@@ -238,20 +244,20 @@ than the percentages did:
 
 | population | unchanged | narrower | wider |
 | --- | ---: | ---: | ---: |
-| **2,638** pinned at the code width | 2,633 | — | 5 |
-| **467** with headroom above it | 0 | 30 | 437 |
+| **2,648** pinned at the code width | 2,643 | — | 5 |
+| **521** with headroom above it | 0 | 40 | 481 |
 
-Nothing happens on the pinned 2,638: five blocks grow and the rest are untouched.
-Every one of the 467 with headroom changes, and 437 of them get wider. So the
-aggregate "84.8% unchanged" is almost entirely the pinned population, and the
-real behaviour is confined to the 467. Growth turns out to be floor-limited too
-— 5 of 2,638 — so the earlier claim that "any block can grow", used to argue the
+Nothing happens on the pinned 2,648: five blocks grow and the rest are untouched.
+Every one of the 521 with headroom changes, and 481 of them get wider. So the
+aggregate "83.4% unchanged" is almost entirely the pinned population, and the
+real behaviour is confined to the 521. Growth turns out to be floor-limited too
+— 5 of 2,648 — so the earlier claim that "any block can grow", used to argue the
 shares were comparable, was wrong as well.
 
 **Stacking buys attribution, and costs a little width.** Fit does not move:
-unpadded, the 80-column rate goes from 71.6% to 72.0% on the 923 lines that could
-fit. Block width moves only on the 467 lines that have room to move, and it moves
-the wrong way far more often than the right one — 437 wider against 30 narrower.
+unpadded, the 80-column rate goes from 69.3% to 69.7% on the 954 lines that could
+fit. Block width moves only on the 521 lines that have room to move, and it moves
+the wrong way far more often than the right one — 481 wider against 40 narrower.
 Stated as counts within one population that is a clear result, and it is not the
 one the percentages suggested: the earlier text called the narrowing rounding
 noise and set 1.1% against 7.2% on an earlier corpus, which compared two shares of a denominator
@@ -265,16 +271,16 @@ padded — a line whose bare code already overflows 80 columns cannot fit
 side-aligned either. Conditioned on the 23,937 whose bare code does fit,
 side-alignment still fits only **30.4%**. Unpadding it makes the rejected
 alternative look better than the headline did, which is why it is stated: the
-rejection rests on 32.1% against 75.7%, not on the padded figure. See
+rejection rests on 30.4% against 76.4%, not on the padded figure. See
 [Side-aligned annotations](#side-aligned-annotations) for the measurement
 convention these depend on.
 
 ### Mixed lines
 
 A **mixed** line carries facts of both kinds: some with an extent, some
-without. Summed over the five focus families there are 355 of them, and 254
+without. Summed over the five focus families there are 356 of them, and 255
 have exactly one surviving extent, so this is not a corner. They are not spread
-evenly: 298 fall under `--focus alloc`, 47 under `safety`, 10 under `cost`, and
+evenly: 299 fall under `--focus alloc`, 47 under `safety`, 10 under `cost`, and
 none at all under `unsafe` or `lifetime`.
 
 Today they widen. The reasoning was sound while a caret was the only signal
@@ -320,19 +326,19 @@ extent still has nothing to point at, so it widens exactly as before.
 
 - Lines whose focused facts all agree on one extent, and lines carrying a
   single focused fact, keep exactly today's geometry, including the
-  inline-detail shortcut. That is **28,215 lines, 90.1%** of those carrying an
+  inline-detail shortcut. That is **28,151 lines, 89.9%** of those carrying an
   extent. Adding the **1,544** lines where no fact has an extent, which also
-  render exactly as they do today, **29,759 of 32,864 caret lines (90.6%) are
-  untouched** and 3,105 (9.4%) change; see [Measurements](#measurements) for how
+  render exactly as they do today, **29,695 of 32,864 caret lines (90.4%) are
+  untouched** and 3,169 (9.6%) change; see [Measurements](#measurements) for how
   that is counted and why the focus family has to be named before the number
   means anything. That denominator is the whole shipped population on purpose —
   the claim is how much existing output this changes, not a rate of some
   outcome among the cases capable of it. Read the other way it is close to a
-  mechanism: 28,215 + 1,544 is exactly 29,759, so the 3,105 is precisely the
+  mechanism: 28,151 + 1,544 is exactly 29,695, so the 3,169 is precisely the
   complement, and **every line that can stack does**. The selector is
   `Stack(...) is { Count: > 0 }`, not `Agreed`: `Agreed` returns null on
-  **4,649** lines, but 1,544 of those have no extent at all and so render
-  unchanged, leaving exactly the 3,105. The remaining gap is `Agreed`'s final
+  **4,713** lines, but 1,544 of those have no extent at all and so render
+  unchanged, leaving exactly the 3,169. The remaining gap is `Agreed`'s final
   bounds check, which could in principle reject a line that agrees; it rejects
   **0** on this corpus, so the identity is exact here by measurement rather
   than guaranteed by construction.
@@ -343,7 +349,11 @@ extent still has nothing to point at, so it widens exactly as before.
   caret. Lines where no fact has an extent widen exactly as today, as do lines
   rule 8 rejects.
 - Detail text stays left-aligned and wrapped to `Budget`.
-- `AnnotationAnchor` is untouched. This is a change to `AnnotationCaret` alone.
+- The stacking change itself is confined to `AnnotationCaret`; it reads extents
+  and does not compute them. The follow-up in
+  [#3674](https://github.com/richlander/dotnet-inspect/pull/3674) does change
+  `AnnotationAnchor`, which is why the figures here were re-measured, but it
+  changes no rule in this specification.
 
 ## Measurements
 
@@ -397,10 +407,10 @@ immediately before its caret run, and the widening row never does. Detecting it
 as "the block has no caret row" would be vacuous, because a fallback still
 renders the widening caret.
 
-So counted, the guard fires on **0 of 3,105** qualifying lines: all 3,105 do
+So counted, the guard fires on **0 of 3,169** qualifying lines: all 3,169 do
 stack. That the gate can report a non-zero was checked by mutation — raising the
 guard's margin from `commentColumn + 2` to `+ 6` makes it fire on 306 of the
-3,105, and to `+ 200` on all 3,105. The zero is a property of the corpus, not of
+3,169, and to `+ 200` on all 3,169. The zero is a property of the corpus, not of
 the probe. It is still a measurement rather than a consequence of subsetting,
 and it would have to be re-measured on another assembly.
 
@@ -408,7 +418,7 @@ The bound is also specific to the **stacks** column. The other columns are not
 monotone in the same direction: dropping one of two disagreeing extents turns a
 multi-extent line into a single-extent line, so `single extent` can *rise* under
 a narrower focus even as `multi-extent` and `stacks` fall. Read the table as
-what the five documented arguments produce, and the 3,105 as the corpus-measured
+what the five documented arguments produce, and the 3,169 as the corpus-measured
 ceiling on the rest.
 
 Extents are measured in printed characters, so a figure that does not name its
@@ -416,19 +426,19 @@ render is not a claim about anything.
 
 | focus | caret lines | …with an extent | single extent | multi-extent | mixed | stacks |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `alloc` | 14,789 | 14,123 | 13,484 | 639 | 299 | 857 |
+| `alloc` | 14,789 | 14,123 | 13,420 | 703 | 299 | 921 |
 | `safety` | 13,908 | 13,487 | 11,459 | 2,028 | 47 | 2,057 |
 | `cost` | 2,516 | 2,445 | 2,278 | 167 | 10 | 175 |
 | `lifetime` | 928 | 800 | 800 | 0 | 0 | 0 |
 | `unsafe` | 723 | 465 | 449 | 16 | 0 | 16 |
-| **total** | **32,864** | **31,320** | **28,470** | **2,850** | **356** | **3,105** |
+| **total** | **32,864** | **31,320** | **28,406** | **2,914** | **356** | **3,169** |
 
 A line stacks when its focused facts disagree about the extent, or when some
-carry one and some do not: 2,850 multi-extent lines plus the 255 mixed lines
-with a single surviving extent gives **3,105**. Everything else — **29,759
-lines, 90.6%** of all 32,864 caret lines — keeps exactly today's geometry,
+carry one and some do not: 2,914 multi-extent lines plus the 255 mixed lines
+with a single surviving extent gives **3,169**. Everything else — **29,695
+lines, 90.4%** of all 32,864 caret lines — keeps exactly today's geometry,
 including the inline-detail shortcut. Two populations make up that remainder and
-they keep it for different reasons: **28,215** lines narrow to one agreed extent,
+they keep it for different reasons: **28,151** lines narrow to one agreed extent,
 and **1,544** lines have no fact with an extent at all and widen to output
 identical to today's. An earlier revision quoted only the first of those as
 "everything else", which understated the unchanged share by the whole no-extent
@@ -445,51 +455,51 @@ that disagree about the extent. The gesture is worth having anyway, but this
 model is invisible under it, and a claim measured over all facts at once would
 have hidden that.
 
-Applying the specification to the 3,105 lines that stack:
+Applying the specification to the 3,169 lines that stack:
 
 | rows | lines | |
 | --- | ---: | ---: |
-| 1 | 2,806 | 90.4% |
-| 2 | 297 | 9.6% |
+| 1 | 2,870 | 90.6% |
+| 2 | 297 | 9.4% |
 | 3 | 1 | 0.0% |
 | 4 | 1 | 0.0% |
 
-That 90.4% is padded too: 255 of these lines carry a single extent group and
-cannot occupy more than one row. Among the **2,850** lines with two or more
-groups — the ones with something to pack — **2,551 (89.5%)** take a single row.
+That 90.6% is padded too: 255 of these lines carry a single extent group and
+cannot occupy more than one row. Among the **2,914** lines with two or more
+groups — the ones with something to pack — **2,615 (89.7%)** take a single row.
 
-And 2,850 is padded in turn, by a structural fact stated earlier in this
+And 2,914 is padded in turn, by a structural fact stated earlier in this
 document: extents sharing a start column can never share a row. **136** of those
 lines carry two distinct extents at one column and so cannot take a single row
-whatever the packer does. Among the remaining **2,714** the rate is **2,551
-(94.0%)**.
+whatever the packer does. Among the remaining **2,778** the rate is **2,615
+(94.1%)**.
 
-"Remaining" rather than "able to": 163 of those 2,714 also fail, refused by row
+"Remaining" rather than "able to": 163 of those 2,778 also fail, refused by row
 admission because their extents sit too close together. They are left in
 deliberately. Crowding is what this rate exists to measure, so excluding lines
 for being crowded would drive it to 100% and measure nothing. A shared start
 column is excluded because it is a different phenomenon — two extents anchored
 at one column are a nesting, not a packing failure.
 
-4,411 of 7,093 trails (62.2%) render at true width, but that headline rate is
+4,457 of 7,347 trails (60.7%) render at true width, but that headline rate is
 padded by a structural immunity and should not be read as a packing success
 rate. The last trail on a row has no successor, so its clip limit is
-`int.MaxValue` and it renders at true width by construction. Those 3,105 lines
-occupy **3,407 rows**, so 3,407 of the 7,093 trails could not have been clipped —
-they are 3,407 of the 4,411 counted as rendering at true width, and measurement
-confirms all 3,407 do. Of the **3,686** trails
-actually exposed to a successor, 1,004 (27.2%) survived at true width. Eight of
+`int.MaxValue` and it renders at true width by construction. Those 3,169 lines
+occupy **3,471 rows**, so 3,471 of the 7,347 trails could not have been clipped —
+they are 3,471 of the 4,457 counted as rendering at true width, and measurement
+confirms all 3,471 do. Of the **3,876** trails
+actually exposed to a successor, 986 (25.4%) survived at true width. Eight of
 those are immune as well, their extents being no longer than `MinTrail`, which
-row admission already reserves. Among the **3,678** trails that could genuinely
-be cut, **996 (27.1%)** survived and **2,682 (72.9%)** were clipped. That is the
+row admission already reserves. Among the **3,868** trails that could genuinely
+be cut, **978 (25.3%)** survived and **2,890 (74.7%)** were clipped. That is the
 informative rate; it took two passes to strip both layers of padding off it.
 
 A trail is cut
 short by the next label on its own row, which is the only thing that clips a
-trail. That successor is nested inside the trail it clips on **1,867 (69.6%)**
-of them and wholly disjoint from it on **815 (30.4%)**, so clipping is
+trail. That successor is nested inside the trail it clips on **2,075 (71.8%)**
+of them and wholly disjoint from it on **815 (28.2%)**, so clipping is
 concentrated at nestings but is not confined to them. The rule 8 gutter fallback
-fires on **0** of the 3,105 lines qualifying to stack before it runs.
+fires on **0** of the 3,169 lines qualifying to stack before it runs.
 
 ### Reproducing these figures
 
@@ -591,7 +601,7 @@ extent under the five focus families.
   the style. Over all 31,320 the wrap rate reads 76.4%, but 7,383 of those
   lines overflow 80 columns before any annotation is added and wrap under any
   style, so that figure measures the corpus rather than this one.
-- The annotation column passes 100 on **3,688 lines (11.8%)** — or **87.6%** of
+- The annotation column passes 100 on **3,691 lines (11.8%)** — or **87.7%** of
   the **4,211** lines long enough to push it that far at all, which is the rate
   that means something: when the style can hurt, it almost always does.
 - The maximum annotation column is **57,946**, on
@@ -601,7 +611,7 @@ extent under the five focus families.
   57,946. The line length is the figure that survives a change of convention.
 
 At a one-column gap every percentage above moves by under one percentage point
-(97.32%, 24.2%, 31.2%, 11.4%, 87.2%) and the maximum column moves by one, to
+(97.32%, 24.2%, 31.2%, 11.4%, 87.3%) and the maximum column moves by one, to
 57,945; the counts behind them shift, but the rejection is unaffected. The
 obvious first candidate for a wide style.
 

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -496,7 +496,7 @@ fires on **0** of the 3,105 lines qualifying to stack before it runs.
 The specification above is implemented in `AnnotationCaret` and shipped in
 [#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `721adb61a`.
 Every figure below it was re-measured after
-[#3661](https://github.com/richlander/dotnet-inspect/pull/3661) taught the
+[#3674](https://github.com/richlander/dotnet-inspect/pull/3674) taught the
 anchor to adopt a printed descendant for a fact whose own node prints nothing,
 which gave 1,841 more facts an extent and moved almost every number here. Each
 probe was first replayed against `74b4f546c` and reproduced the superseded

--- a/docs/design/caret-stacking.md
+++ b/docs/design/caret-stacking.md
@@ -101,7 +101,7 @@ depicts a layout that was never built. This one is
    row** (rule 5), and a nested extent that lands on a different row is not on
    its parent's row to cut anything. Nor does it order row widths overall: a
    later disjoint extent can be packed onto a lower row and reach further right
-   than anything above it, which happens on **50 of the 2,842** lines.
+   than anything above it, which happens on **50 of the 3,105** lines.
 3. **Number in that order,** `1.` upward, and label each caret with its number
    immediately before the trail.
 4. **Pack greedily onto rows.** An extent joins the first row where the
@@ -130,7 +130,7 @@ depicts a layout that was never built. This one is
    when any label on a line would begin left of the gutter, that line does not
    stack at all: it falls back to the widening render this document replaces.
    This is a guard rather than a path with traffic — it fires on **0 of the
-   2,842 lines that qualify to stack** in the corpus below, which is the
+   3,105 lines that qualify to stack** in the corpus below, which is the
    non-circular denominator, since a line it rejects does not stack by
    construction — but it is reachable, and a
    line is never rendered with a label that lies about its column.
@@ -176,21 +176,21 @@ they point at, and rule 8 refuses to shift a trail rightward to make room,
 bailing out instead. The rightmost column of a stacked row is therefore bounded
 by the code line by construction.
 
-The corpus agrees — 0 of the 2,842 lines carry a stacked caret row wider than
+The corpus agrees — 0 of the 3,105 lines carry a stacked caret row wider than
 their code line — but that count is a consistency check on the derivation above,
 not evidence for it, because no corpus could produce a counter-example.
 
 The comparison against the widening render is narrower than two earlier
 revisions of this section claimed, and the correction is worth stating plainly.
 **No caret glyph overhangs the code line in either render.** Measured over the
-same 2,842 lines, both are **0**, because the widening underline covers the
+same 3,105 lines, both are **0**, because the widening underline covers the
 trimmed statement, which ends inside the line. The widening render has no
 explicit bound, but it does not need one to stay within the line.
 
 What differs is the rendered **row**. Widening appends the first detail string
 to the caret row when it fits the inline budget, and that appended text carries
-the row past the end of the code line. Quoting this as **20 of 2,842 lines
-(0.70%)** pads the denominator with the 2,822 whose detail never goes inline and
+the row past the end of the code line. Quoting this as **20 of 3,105 lines
+(0.64%)** pads the denominator with the 3,085 whose detail never goes inline and
 which therefore cannot overhang at all. Inline detail appears on exactly **20**
 of these lines, and **all 20** overhang — the rate is **20/20**. It comes out
 whole because on the hoisted render these figures are taken from, widening
@@ -206,29 +206,29 @@ described a mechanism that does not occur.
 Widths below are **final rendered columns**, measured after the same projection
 `ApiOutputFormatter` applies — code lines receive `BodyIndentWidth`, hoisted
 caret lines do not — and the caret block is real rendered output, detail rows
-included. Whole rendered block on those 2,842 lines:
+included. Whole rendered block on those 3,105 lines:
 
 | terminal | widen (today) | stacked |
 | --- | ---: | ---: |
-| 80 cols | 23.3% | 23.4% |
-| 100 cols | 48.3% | 48.3% |
-| 120 cols | 65.9% | 65.9% |
-| 160 cols | 84.9% | 84.9% |
+| 80 cols | 21.3% | 21.4% |
+| 100 cols | 52.0% | 52.0% |
+| 120 cols | 68.3% | 68.3% |
+| 160 cols | 86.2% | 86.2% |
 
 That denominator is padded, and the padding is most of it: the block can never
 be narrower than the code line, so a line whose code alone overflows the
-terminal cannot fit under *any* caret model. At 80 columns only 730 of the 2,842
-have code that fits at all — the other 2,112 are structurally incapable of the
-outcome being counted. Restricted to the 730 that could fit, the rates are 90.5%
-widening and 91.1% stacked. At the wider terminals the padded rate and the
-code-fits share converge almost exactly (100 cols: 48.3% fit, 48.3% code-fits;
-120: 65.9% / 66.0%; 160: 84.9% / 84.9%), which says the block width simply *is*
+terminal cannot fit under *any* caret model. At 80 columns only 923 of the 3,105
+have code that fits at all — the other 2,182 are structurally incapable of the
+outcome being counted. Restricted to the 923 that could fit, the rates are 71.6%
+widening and 72.0% stacked. At the wider terminals the padded rate and the
+code-fits share converge almost exactly (100 cols: 52.0% fit, 52.0% code-fits;
+120: 68.3% / 68.3%; 160: 86.2% / 86.2%), which says the block width simply *is*
 the code width there.
 
 Terminal fit is unchanged, because on these dense lines the block width is set
 by the code line and the wrapped detail rows, which both models share. Nor does
-the block itself shrink much: it is the same width on 91.8% of these lines,
-narrower on 1.1%, and wider on 7.2% — the numbered labels cost a few columns
+the block itself shrink much: it is the same width on 84.8% of these lines,
+narrower on 1.0%, and wider on 14.2% — the numbered labels cost a few columns
 where the details were already the widest thing in the block.
 
 Those three shares are all padded, and quoting any of them as a rate invites the
@@ -238,32 +238,32 @@ than the percentages did:
 
 | population | unchanged | narrower | wider |
 | --- | ---: | ---: | ---: |
-| **2,612** pinned at the code width | 2,608 | — | 4 |
-| **230** with headroom above it | 0 | 30 | 200 |
+| **2,638** pinned at the code width | 2,633 | — | 5 |
+| **467** with headroom above it | 0 | 30 | 437 |
 
-Nothing happens on the pinned 2,612: four blocks grow and the rest are untouched.
-Every one of the 230 with headroom changes, and 200 of them get wider. So the
-aggregate "91.8% unchanged" is almost entirely the pinned population, and the
-real behaviour is confined to the 230. Growth turns out to be floor-limited too
-— 4 of 2,612 — so the earlier claim that "any block can grow", used to argue the
+Nothing happens on the pinned 2,638: five blocks grow and the rest are untouched.
+Every one of the 467 with headroom changes, and 437 of them get wider. So the
+aggregate "84.8% unchanged" is almost entirely the pinned population, and the
+real behaviour is confined to the 467. Growth turns out to be floor-limited too
+— 5 of 2,638 — so the earlier claim that "any block can grow", used to argue the
 shares were comparable, was wrong as well.
 
 **Stacking buys attribution, and costs a little width.** Fit does not move:
-unpadded, the 80-column rate goes from 90.5% to 91.1% on the 730 lines that could
-fit. Block width moves only on the 230 lines that have room to move, and it moves
-the wrong way far more often than the right one — 200 wider against 30 narrower.
+unpadded, the 80-column rate goes from 71.6% to 72.0% on the 923 lines that could
+fit. Block width moves only on the 467 lines that have room to move, and it moves
+the wrong way far more often than the right one — 437 wider against 30 narrower.
 Stated as counts within one population that is a clear result, and it is not the
 one the percentages suggested: the earlier text called the narrowing rounding
-noise and set 1.1% against 7.2%, which compared two shares of a denominator
+noise and set 1.1% against 7.2% on an earlier corpus, which compared two shares of a denominator
 dominated by lines that could do neither.
 
 The constraint still binds on the *alternatives*, which is why it is stated
-here: side-alignment overflows the code line on 97.52% of the 29,933 lines
-carrying an extent, by a mean of 81 columns over the 29,191 that overflow, and
-fits 24.7% of them at 80 columns against 75.7% for the bare code. That 24.7% is
+here: side-alignment overflows the code line on 97.63% of the 31,320 lines
+carrying an extent, by a mean of 85 columns over the 30,577 that overflow, and
+fits 23.6% of them at 80 columns against 76.4% for the bare code. That 23.6% is
 padded — a line whose bare code already overflows 80 columns cannot fit
-side-aligned either. Conditioned on the 22,662 whose bare code does fit,
-side-alignment still fits only **32.1%**. Unpadding it makes the rejected
+side-aligned either. Conditioned on the 23,937 whose bare code does fit,
+side-alignment still fits only **30.4%**. Unpadding it makes the rejected
 alternative look better than the headline did, which is why it is stated: the
 rejection rests on 32.1% against 75.7%, not on the padded figure. See
 [Side-aligned annotations](#side-aligned-annotations) for the measurement
@@ -320,19 +320,19 @@ extent still has nothing to point at, so it widens exactly as before.
 
 - Lines whose focused facts all agree on one extent, and lines carrying a
   single focused fact, keep exactly today's geometry, including the
-  inline-detail shortcut. That is **27,091 lines, 90.5%** of those carrying an
-  extent. Adding the **2,931** lines where no fact has an extent, which also
-  render exactly as they do today, **30,022 of 32,864 caret lines (91.4%) are
-  untouched** and 2,842 (8.6%) change; see [Measurements](#measurements) for how
+  inline-detail shortcut. That is **28,215 lines, 90.1%** of those carrying an
+  extent. Adding the **1,544** lines where no fact has an extent, which also
+  render exactly as they do today, **29,759 of 32,864 caret lines (90.6%) are
+  untouched** and 3,105 (9.4%) change; see [Measurements](#measurements) for how
   that is counted and why the focus family has to be named before the number
   means anything. That denominator is the whole shipped population on purpose —
   the claim is how much existing output this changes, not a rate of some
   outcome among the cases capable of it. Read the other way it is close to a
-  mechanism: 27,091 + 2,931 is exactly 30,022, so the 2,842 is precisely the
+  mechanism: 28,215 + 1,544 is exactly 29,759, so the 3,105 is precisely the
   complement, and **every line that can stack does**. The selector is
   `Stack(...) is { Count: > 0 }`, not `Agreed`: `Agreed` returns null on
-  **5,773** lines, but 2,931 of those have no extent at all and so render
-  unchanged, leaving exactly the 2,842. The remaining gap is `Agreed`'s final
+  **4,649** lines, but 1,544 of those have no extent at all and so render
+  unchanged, leaving exactly the 3,105. The remaining gap is `Agreed`'s final
   bounds check, which could in principle reject a line that agrees; it rejects
   **0** on this corpus, so the identity is exact here by measurement rather
   than guaranteed by construction.
@@ -397,10 +397,10 @@ immediately before its caret run, and the widening row never does. Detecting it
 as "the block has no caret row" would be vacuous, because a fallback still
 renders the widening caret.
 
-So counted, the guard fires on **0 of 2,842** qualifying lines: all 2,842 do
+So counted, the guard fires on **0 of 3,105** qualifying lines: all 3,105 do
 stack. That the gate can report a non-zero was checked by mutation — raising the
 guard's margin from `commentColumn + 2` to `+ 6` makes it fire on 306 of the
-2,842, and to `+ 200` on all 2,842. The zero is a property of the corpus, not of
+3,105, and to `+ 200` on all 3,105. The zero is a property of the corpus, not of
 the probe. It is still a measurement rather than a consequence of subsetting,
 and it would have to be re-measured on another assembly.
 
@@ -408,7 +408,7 @@ The bound is also specific to the **stacks** column. The other columns are not
 monotone in the same direction: dropping one of two disagreeing extents turns a
 multi-extent line into a single-extent line, so `single extent` can *rise* under
 a narrower focus even as `multi-extent` and `stacks` fall. Read the table as
-what the five documented arguments produce, and the 2,842 as the corpus-measured
+what the five documented arguments produce, and the 3,105 as the corpus-measured
 ceiling on the rest.
 
 Extents are measured in printed characters, so a figure that does not name its
@@ -416,20 +416,20 @@ render is not a claim about anything.
 
 | focus | caret lines | …with an extent | single extent | multi-extent | mixed | stacks |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `alloc` | 14,789 | 12,744 | 12,367 | 377 | 298 | 594 |
-| `safety` | 13,908 | 13,480 | 11,452 | 2,028 | 47 | 2,057 |
-| `cost` | 2,516 | 2,444 | 2,277 | 167 | 10 | 175 |
+| `alloc` | 14,789 | 14,123 | 13,484 | 639 | 299 | 857 |
+| `safety` | 13,908 | 13,487 | 11,459 | 2,028 | 47 | 2,057 |
+| `cost` | 2,516 | 2,445 | 2,278 | 167 | 10 | 175 |
 | `lifetime` | 928 | 800 | 800 | 0 | 0 | 0 |
 | `unsafe` | 723 | 465 | 449 | 16 | 0 | 16 |
-| **total** | **32,864** | **29,933** | **27,345** | **2,588** | **355** | **2,842** |
+| **total** | **32,864** | **31,320** | **28,470** | **2,850** | **356** | **3,105** |
 
 A line stacks when its focused facts disagree about the extent, or when some
-carry one and some do not: 2,588 multi-extent lines plus the 254 mixed lines
-with a single surviving extent gives **2,842**. Everything else — **30,022
-lines, 91.4%** of all 32,864 caret lines — keeps exactly today's geometry,
+carry one and some do not: 2,850 multi-extent lines plus the 255 mixed lines
+with a single surviving extent gives **3,105**. Everything else — **29,759
+lines, 90.6%** of all 32,864 caret lines — keeps exactly today's geometry,
 including the inline-detail shortcut. Two populations make up that remainder and
-they keep it for different reasons: **27,091** lines narrow to one agreed extent,
-and **2,931** lines have no fact with an extent at all and widen to output
+they keep it for different reasons: **28,215** lines narrow to one agreed extent,
+and **1,544** lines have no fact with an extent at all and widen to output
 identical to today's. An earlier revision quoted only the first of those as
 "everything else", which understated the unchanged share by the whole no-extent
 population.
@@ -445,43 +445,43 @@ that disagree about the extent. The gesture is worth having anyway, but this
 model is invisible under it, and a claim measured over all facts at once would
 have hidden that.
 
-Applying the specification to the 2,842 lines that stack:
+Applying the specification to the 3,105 lines that stack:
 
 | rows | lines | |
 | --- | ---: | ---: |
-| 1 | 2,543 | 89.5% |
-| 2 | 297 | 10.5% |
+| 1 | 2,806 | 90.4% |
+| 2 | 297 | 9.6% |
 | 3 | 1 | 0.0% |
 | 4 | 1 | 0.0% |
 
-That 89.5% is padded too: 254 of these lines carry a single extent group and
-cannot occupy more than one row. Among the **2,588** lines with two or more
-groups — the ones with something to pack — **2,289 (88.4%)** take a single row.
+That 90.4% is padded too: 255 of these lines carry a single extent group and
+cannot occupy more than one row. Among the **2,850** lines with two or more
+groups — the ones with something to pack — **2,551 (89.5%)** take a single row.
 
-And 2,588 is padded in turn, by a structural fact stated earlier in this
+And 2,850 is padded in turn, by a structural fact stated earlier in this
 document: extents sharing a start column can never share a row. **136** of those
 lines carry two distinct extents at one column and so cannot take a single row
-whatever the packer does. Among the remaining **2,452** the rate is **2,289
-(93.4%)**.
+whatever the packer does. Among the remaining **2,714** the rate is **2,551
+(94.0%)**.
 
-"Remaining" rather than "able to": 163 of those 2,452 also fail, refused by row
+"Remaining" rather than "able to": 163 of those 2,714 also fail, refused by row
 admission because their extents sit too close together. They are left in
 deliberately. Crowding is what this rate exists to measure, so excluding lines
 for being crowded would drive it to 100% and measure nothing. A shared start
 column is excluded because it is a different phenomenon — two extents anchored
 at one column are a nesting, not a packing failure.
 
-3,884 of 6,566 trails (59.2%) render at true width, but that headline rate is
+4,411 of 7,093 trails (62.2%) render at true width, but that headline rate is
 padded by a structural immunity and should not be read as a packing success
 rate. The last trail on a row has no successor, so its clip limit is
-`int.MaxValue` and it renders at true width by construction. Those 2,842 lines
-occupy **3,144 rows**, so 3,144 of the 6,566 trails could not have been clipped —
-they are 3,144 of the 3,884 counted as rendering at true width, and measurement
-confirms all 3,144 do. Of the **3,422** trails
-actually exposed to a successor, 740 (21.6%) survived at true width. Five of
+`int.MaxValue` and it renders at true width by construction. Those 3,105 lines
+occupy **3,407 rows**, so 3,407 of the 7,093 trails could not have been clipped —
+they are 3,407 of the 4,411 counted as rendering at true width, and measurement
+confirms all 3,407 do. Of the **3,686** trails
+actually exposed to a successor, 1,004 (27.2%) survived at true width. Eight of
 those are immune as well, their extents being no longer than `MinTrail`, which
-row admission already reserves. Among the **3,417** trails that could genuinely
-be cut, **735 (21.5%)** survived and **2,682 (78.5%)** were clipped. That is the
+row admission already reserves. Among the **3,678** trails that could genuinely
+be cut, **996 (27.1%)** survived and **2,682 (72.9%)** were clipped. That is the
 informative rate; it took two passes to strip both layers of padding off it.
 
 A trail is cut
@@ -489,12 +489,18 @@ short by the next label on its own row, which is the only thing that clips a
 trail. That successor is nested inside the trail it clips on **1,867 (69.6%)**
 of them and wholly disjoint from it on **815 (30.4%)**, so clipping is
 concentrated at nestings but is not confined to them. The rule 8 gutter fallback
-fires on **0** of the 2,842 lines qualifying to stack before it runs.
+fires on **0** of the 3,105 lines qualifying to stack before it runs.
 
 ### Reproducing these figures
 
 The specification above is implemented in `AnnotationCaret` and shipped in
 [#3656](https://github.com/richlander/dotnet-inspect/pull/3656) at `721adb61a`.
+Every figure below it was re-measured after
+[#3661](https://github.com/richlander/dotnet-inspect/pull/3661) taught the
+anchor to adopt a printed descendant for a fact whose own node prints nothing,
+which gave 1,841 more facts an extent and moved almost every number here. Each
+probe was first replayed against `74b4f546c` and reproduced the superseded
+figure exactly before its new result was trusted.
 
 Every code block in this document is a verbatim excerpt of `Annotated Source`
 output for the member and focus family named beside it:
@@ -573,20 +579,20 @@ section did not state it and quietly mixed two: **final rendered columns**,
 one row per fact, text set two columns past the widest caret, which is what
 the sketch above shows. Rendered column of code character *i* is
 `BodyIndentWidth + i`, so the body indent counts on both sides of every
-comparison. The population is the **29,933** lines carrying at least one
+comparison. The population is the **31,320** lines carrying at least one
 extent under the five focus families.
 
-- Text lands past the end of the code line on **29,191 lines (97.52%)**, and
-  over those 29,191 the mean overhang is **81 columns** — the mean is over the
-  lines that overflow, not over all 29,933.
-- **24.7%** of lines still fit 80 columns, against **75.7%** for the bare code.
-  Restricted to the 22,662 whose bare code fits at all, **32.1%** survive; the
-  other **67.9%** wrap, and the wrap destroys the very adjacency that motivates
-  the style. Over all 29,933 the wrap rate reads 75.3%, but 7,271 of those
+- Text lands past the end of the code line on **30,577 lines (97.63%)**, and
+  over those 30,577 the mean overhang is **85 columns** — the mean is over the
+  lines that overflow, not over all 31,320.
+- **23.6%** of lines still fit 80 columns, against **76.4%** for the bare code.
+  Restricted to the 23,937 whose bare code fits at all, **30.4%** survive; the
+  other **69.6%** wrap, and the wrap destroys the very adjacency that motivates
+  the style. Over all 31,320 the wrap rate reads 76.4%, but 7,383 of those
   lines overflow 80 columns before any annotation is added and wrap under any
   style, so that figure measures the corpus rather than this one.
-- The annotation column passes 100 on **3,655 lines (12.2%)** — or **87.6%** of
-  the **4,172** lines long enough to push it that far at all, which is the rate
+- The annotation column passes 100 on **3,688 lines (11.8%)** — or **87.6%** of
+  the **4,211** lines long enough to push it that far at all, which is the rate
   that means something: when the style can hurt, it almost always does.
 - The maximum annotation column is **57,946**, on
   `IcuLocaleData.get_NameIndexToNumericData`, the pathological line already
@@ -595,7 +601,7 @@ extent under the five focus families.
   57,946. The line length is the figure that survives a change of convention.
 
 At a one-column gap every percentage above moves by under one percentage point
-(97.20%, 25.3%, 33.0%, 11.8%, 87.2%) and the maximum column moves by one, to
+(97.32%, 24.2%, 31.2%, 11.4%, 87.2%) and the maximum column moves by one, to
 57,945; the counts behind them shift, but the rejection is unaffected. The
 obvious first candidate for a wide style.
 

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -415,7 +415,7 @@ public class AnnotationAnchorTests
     [InlineData("    new object();", 4, 13, 4, 13)]
     // Overhanging the end of the line. ComputeCaretExtents cannot deliver this
     // today -- TryGetLineColumn rejects every range that crosses a line break,
-    // so 0 of the 33,657 extents the caller delivers overhang -- but the clamp
+    // so 0 of the 35,498 extents the caller delivers overhang -- but the clamp
     // is the reason an overhang is survivable at all, and an internal helper is
     // not entitled to assume it keeps only its current caller.
     [InlineData("    x", 4, 99, 4, 1)]

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -122,10 +122,10 @@ public static class AnnotationAnchor
     /// statement, but has no sub-token to point at, so it is simply absent here
     /// and the caller keeps the statement-wide underline. Measured over
     /// <c>System.Private.CoreLib</c> as the annotated-source view prints it —
-    /// that is, with callee bodies imported — 33,657 of 37,800 facts (89.04%)
+    /// that is, with callee bodies imported — 35,498 of 37,800 facts (93.91%)
     /// get an extent. Every figure quoted in this file is from that render.
     /// The C#-only overlay prints the same members without importing callee
-    /// bodies, which shifts a few printed ranges and yields 33,729; a figure
+    /// bodies, which shifts a few printed ranges and yields 35,502; a figure
     /// here is only meaningful against a stated render, because the printed
     /// text is what extents are measured in.
     /// </para>
@@ -160,10 +160,12 @@ public static class AnnotationAnchor
         // from there indexes straight into these lines. Split on '\n' alone: a
         // '\r' left at a line's end is whitespace and is trimmed below.
         var lines = printedRanges.Output.Split('\n');
+        var adopted = AdoptedPrintedByOffset(annotations, statements, printedRanges, narrowest);
 
         foreach (var annotation in annotations)
         {
-            if (!narrowest.TryGetValue(annotation.SourceOffset, out var node))
+            if (!narrowest.TryGetValue(annotation.SourceOffset, out var node)
+                && !adopted.TryGetValue(annotation.SourceOffset, out node))
                 continue;
             if (Best(statements, annotation.SourceOffset) is not { } owner)
                 continue;
@@ -192,7 +194,7 @@ public static class AnnotationAnchor
     /// narrowest node carrying an offset is the statement itself the raw extent
     /// covers the leading whitespace and a caret drawn from it would start left
     /// of the code. Measured over <c>System.Private.CoreLib</c> as the
-    /// annotated-source view prints it, the trim moves 205 of the 33,657
+    /// annotated-source view prints it, the trim moves 205 of the 35,498
     /// extents and rejects none of them. Trimming makes such
     /// an extent coincide with the statement-wide default rather than
     /// mis-drawing, and leaves every extent that already named an expression
@@ -200,7 +202,7 @@ public static class AnnotationAnchor
     /// <para>
     /// The clamp on the far end is defensive rather than load-bearing today:
     /// <see cref="PrintedRangeMap.TryGetLineColumn"/> refuses any range that
-    /// crosses a line break, so of the 33,657 ranges the caller delivers here,
+    /// crosses a line break, so of the 35,498 ranges the caller delivers here,
     /// 0 overhang the line and 650 end exactly on its last character. It is
     /// kept, and gated, because this is an internal helper taking a
     /// caller-supplied range: the cost is one
@@ -278,6 +280,89 @@ public static class AnnotationAnchor
                 standIn.Remove(offset);
         }
         return narrowest;
+    }
+
+    /// <summary>
+    /// Extents for offsets whose owning node prints nothing, taken from the
+    /// narrowest printed node inside it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="NarrowestPrintedByOffset"/> can only answer for an offset some
+    /// printed node carries, and a whole class of facts is about a node C# has
+    /// no syntax for. Boxing is the case that dominates: <c>Box</c> emits no
+    /// characters, so an <c>alloc.box</c> fact stamped with the box's offset has
+    /// no printed owner, and before this the fact fell back to the
+    /// statement-wide underline. What the reader wants pointed at is the value
+    /// being boxed, and that node <em>is</em> printed, one level down.
+    /// </para>
+    /// <para>
+    /// Measured over <c>System.Private.CoreLib</c> as the annotated-source view
+    /// prints it: of 37,800 facts, 4,143 had no extent. For 2,573 the offset
+    /// belonged to a node that exists but prints nothing, and 1,907 of those
+    /// have a printed descendant — 1,899 of them boxes, whose descendants are
+    /// the boxed expression itself (1,234 <c>LoadArgument</c>, 510
+    /// <c>LoadLocal</c>, 104 <c>LoadIndirect</c>, 42 <c>Constant</c>, the rest
+    /// field and property loads). That is the population this recovers.
+    /// </para>
+    /// <para>
+    /// Descent only, never ascent. A printed <em>ancestor</em> is available for
+    /// a further 576, but an ancestor's range is wider than the fact — it is the
+    /// statement-wide underline this is trying to escape — so adopting it would
+    /// dress up today's fallback as a narrow extent while pointing at the same
+    /// characters. Those keep the fallback and are honest about it.
+    /// </para>
+    /// <para>
+    /// Built only for offsets the annotations actually ask about and that
+    /// <paramref name="narrowest"/> cannot answer, so a body whose facts all
+    /// anchor to printed nodes walks no extra tree.
+    /// </para>
+    /// </remarks>
+    static Dictionary<int, IrNode> AdoptedPrintedByOffset(
+        IReadOnlyList<IAnnotation> annotations,
+        List<StatementSpan> statements,
+        PrintedRangeMap printedRanges,
+        Dictionary<int, IrNode> narrowest)
+    {
+        var adopted = new Dictionary<int, IrNode>();
+        HashSet<int>? wanted = null;
+        foreach (var annotation in annotations)
+        {
+            if (narrowest.ContainsKey(annotation.SourceOffset) || annotation.SourceOffset < 0)
+                continue;
+            wanted ??= [];
+            wanted.Add(annotation.SourceOffset);
+        }
+        if (wanted is null)
+            return adopted;
+
+        var widths = new Dictionary<int, int>();
+        foreach (var span in statements)
+        {
+            foreach (var node in Self(span.Statement))
+            {
+                int offset = node.SourceOffset;
+                if (offset < 0 || !wanted.Contains(offset))
+                    continue;
+                // The owner prints nothing; look inside it for something that does.
+                if (printedRanges.TryGetRange(node, out _))
+                    continue;
+                foreach (var inner in node.Descendants)
+                {
+                    if (!printedRanges.TryGetRange(inner, out var range))
+                        continue;
+                    int width = range.End.Value - range.Start.Value;
+                    // A zero-width range names no characters to point at.
+                    if (width <= 0)
+                        continue;
+                    if (widths.TryGetValue(offset, out int best) && best <= width)
+                        continue;
+                    widths[offset] = width;
+                    adopted[offset] = inner;
+                }
+            }
+        }
+        return adopted;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -370,15 +370,15 @@ public static class AnnotationAnchor
                 // different nodes. Each is a group of `Box` nodes over the same
                 // local -- all 66 choose ranges of identical width printing
                 // identical text, differing only in column, so what is being
-                // chosen is which *occurrence* of that local gets underlined.
-                // None is more correct than another, and because the text is the
-                // same a reader cannot see which was taken; only the column
-                // moves. So the requirement is not that the choice be right but
-                // that it be a function of the ranges rather than of the walk:
-                // leftmost, and narrowest where two start together. On this
-                // corpus that agrees with what the unarbitrated walk already
-                // produced on all 66, so it changes no rendered output here; it
-                // exists so the choice cannot move when traversal order does.
+                // chosen is which visibly different *occurrence* of that local
+                // gets underlined. None is more semantically correct than
+                // another. The requirement is therefore not semantic
+                // superiority but that the visible choice be a function of the
+                // ranges rather than of the walk: leftmost, and narrowest where
+                // two start together. On this corpus that agrees with what the
+                // unarbitrated walk already produced on all 66, so it changes no
+                // rendered output here; it exists so traversal order cannot
+                // move the underline in the future.
                 if (chosen.TryGetValue(offset, out var best)
                     && (best.Start < innerRange.Start.Value
                         || (best.Start == innerRange.Start.Value

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -152,9 +152,13 @@ public static class AnnotationAnchor
         if (annotations.Count == 0 || printedRanges.Count == 0)
             return extents;
 
+        // No `narrowest.Count == 0` bail-out: an empty map means no printed node
+        // carries a source offset, which is exactly a case adoption can still
+        // answer, since it looks *inside* unprinted owners. Returning early
+        // would skip it. That never happens on System.Private.CoreLib -- 0
+        // functions of those the annotated-source view prints -- so this is a
+        // shape correction, not a behaviour change measurable on this corpus.
         var narrowest = NarrowestPrintedByOffset(printedRanges);
-        if (narrowest.Count == 0)
-            return extents;
 
         // Indexed by the same coordinates TryGetLineColumn reports, so a column
         // from there indexes straight into these lines. Split on '\n' alone: a
@@ -336,7 +340,8 @@ public static class AnnotationAnchor
         if (wanted is null)
             return adopted;
 
-        var widths = new Dictionary<int, int>();
+        var level = new List<IrNode>();
+        var next = new List<IrNode>();
         foreach (var span in statements)
         {
             foreach (var node in Self(span.Statement))
@@ -347,22 +352,77 @@ public static class AnnotationAnchor
                 // The owner prints nothing; look inside it for something that does.
                 if (printedRanges.TryGetRange(node, out _))
                     continue;
-                foreach (var inner in node.Descendants)
-                {
-                    if (!printedRanges.TryGetRange(inner, out var range))
-                        continue;
-                    int width = range.End.Value - range.Start.Value;
-                    // A zero-width range names no characters to point at.
-                    if (width <= 0)
-                        continue;
-                    if (widths.TryGetValue(offset, out int best) && best <= width)
-                        continue;
-                    widths[offset] = width;
+                if (NearestPrinted(node, printedRanges, ref level, ref next) is { } inner)
                     adopted[offset] = inner;
-                }
             }
         }
         return adopted;
+    }
+
+    /// <summary>
+    /// The shallowest printed descendant of <paramref name="node"/>, searched
+    /// breadth-first so depth decides and width only breaks a tie within one
+    /// level.
+    /// </summary>
+    /// <remarks>
+    /// Depth is the whole point, and an earlier revision of this helper got it
+    /// wrong by taking the narrowest printed descendant at any depth. For
+    /// <c>box(Foo(x))</c> the narrowest printed node under the box is the
+    /// argument <c>x</c>, not the call <c>Foo(x)</c> whose result is boxed, so
+    /// the caret underlined characters the fact is not about. Measured over
+    /// <c>System.Private.CoreLib</c> as the annotated-source view prints it,
+    /// the two rules disagree on 502 of the 4,262 offsets adoption resolves:
+    /// 240 <c>box</c>-over-<c>Call</c>, 112 and 38 over <c>Convert</c>, 72 and
+    /// 12 over <c>Binary</c>, and the rest single figures. Depth is right in
+    /// every one of them, because what a box boxes is its operand.
+    /// <para>
+    /// The width tie-break never runs on that corpus: no node has two printed
+    /// descendants at its shallowest printed level, all 4,262 times. It is kept
+    /// because "never here" is a measurement, not a guarantee, and a silent
+    /// dependence on traversal order is what the old rule died of — it left 231
+    /// of these offsets decided by which equally-narrow node the walk reached
+    /// first. Preferring the widest at a level keeps the caret over as much of
+    /// the expression as the printer will name.
+    /// </para>
+    /// </remarks>
+    static IrNode? NearestPrinted(
+        IrNode node,
+        PrintedRangeMap printedRanges,
+        ref List<IrNode> level,
+        ref List<IrNode> next)
+    {
+        level.Clear();
+        level.AddRange(node.Children);
+        while (level.Count > 0)
+        {
+            next.Clear();
+            IrNode? best = null;
+            int bestWidth = 0;
+            foreach (var candidate in level)
+            {
+                // A zero-width range names no characters to point at, so such a
+                // node is descended through rather than adopted.
+                int width = printedRanges.TryGetRange(candidate, out var range)
+                    ? range.End.Value - range.Start.Value
+                    : 0;
+                if (width > 0)
+                {
+                    if (width > bestWidth)
+                    {
+                        bestWidth = width;
+                        best = candidate;
+                    }
+                }
+                else if (best is null)
+                {
+                    next.AddRange(candidate.Children);
+                }
+            }
+            if (best is not null)
+                return best;
+            (level, next) = (next, level);
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -256,7 +256,7 @@ public static class AnnotationAnchor
     /// corpus shares an offset with a printed <c>__exception</c>, which is
     /// excluded because it is the same shape, not because it was observed.
     /// </remarks>
-    internal static Dictionary<int, IrNode> NarrowestPrintedByOffset(PrintedRangeMap printedRanges)
+    static Dictionary<int, IrNode> NarrowestPrintedByOffset(PrintedRangeMap printedRanges)
     {
         var narrowest = new Dictionary<int, IrNode>();
         var widths = new Dictionary<int, int>();
@@ -329,7 +329,7 @@ public static class AnnotationAnchor
     /// anchor to printed nodes walks no extra tree.
     /// </para>
     /// </remarks>
-    internal static Dictionary<int, IrNode> AdoptedPrintedByOffset(
+    static Dictionary<int, IrNode> AdoptedPrintedByOffset(
         IReadOnlyList<IAnnotation> annotations,
         List<StatementSpan> statements,
         PrintedRangeMap printedRanges,
@@ -367,14 +367,18 @@ public static class AnnotationAnchor
                 // different places. That is rare but never benign: of the 1,907
                 // offsets adoption resolves, 66 carry more than one distinct
                 // unprinted owner, and on every one of those 66 the owners pick
-                // different nodes -- each a group of `Box` nodes over different
-                // locals of equal width. No choice among them is more correct
-                // than another, so the requirement is only that it be a function
-                // of the ranges rather than of the walk: leftmost, and narrowest
-                // where two start together. On this corpus that agrees with what
-                // the unarbitrated walk already produced on all 66, so it changes
-                // no rendered output here; it exists so the choice cannot move
-                // when traversal order does.
+                // different nodes. Each is a group of `Box` nodes over the same
+                // local -- all 66 choose ranges of identical width printing
+                // identical text, differing only in column, so what is being
+                // chosen is which *occurrence* of that local gets underlined.
+                // None is more correct than another, and because the text is the
+                // same a reader cannot see which was taken; only the column
+                // moves. So the requirement is not that the choice be right but
+                // that it be a function of the ranges rather than of the walk:
+                // leftmost, and narrowest where two start together. On this
+                // corpus that agrees with what the unarbitrated walk already
+                // produced on all 66, so it changes no rendered output here; it
+                // exists so the choice cannot move when traversal order does.
                 if (chosen.TryGetValue(offset, out var best)
                     && (best.Start < innerRange.Start.Value
                         || (best.Start == innerRange.Start.Value

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -256,7 +256,7 @@ public static class AnnotationAnchor
     /// corpus shares an offset with a printed <c>__exception</c>, which is
     /// excluded because it is the same shape, not because it was observed.
     /// </remarks>
-    static Dictionary<int, IrNode> NarrowestPrintedByOffset(PrintedRangeMap printedRanges)
+    internal static Dictionary<int, IrNode> NarrowestPrintedByOffset(PrintedRangeMap printedRanges)
     {
         var narrowest = new Dictionary<int, IrNode>();
         var widths = new Dictionary<int, int>();
@@ -309,10 +309,12 @@ public static class AnnotationAnchor
     /// 107 <c>LoadIndirect</c>, 75 <c>Convert</c>, 42 <c>Binary</c>, 14
     /// <c>Constant</c>, 11 <c>LoadField</c>, 5 <c>LoadStackSlot</c> and three
     /// singletons. That is the population this recovers, and it is counted per
-    /// distinct (function, offset) pair: one offset is typically carried by
-    /// several unprinted owners — 1,858 of the 1,907 are — so a count of
-    /// matching nodes visited would be more than twice as large and would not
-    /// describe anything the renderer produces.
+    /// distinct (function, offset) pair. A count of matching nodes
+    /// <em>visited</em> is 4,262, more than twice as large, and describes
+    /// nothing the renderer produces: statement subtrees overlap, so the same
+    /// owner node is reached more than once (2,567 revisits), and separately
+    /// 66 offsets carry more than one distinct unprinted owner. Either way the
+    /// renderer draws one extent per offset, so the offset is the unit.
     /// </para>
     /// <para>
     /// Descent only, never ascent. A printed <em>ancestor</em> is available for
@@ -327,7 +329,7 @@ public static class AnnotationAnchor
     /// anchor to printed nodes walks no extra tree.
     /// </para>
     /// </remarks>
-    static Dictionary<int, IrNode> AdoptedPrintedByOffset(
+    internal static Dictionary<int, IrNode> AdoptedPrintedByOffset(
         IReadOnlyList<IAnnotation> annotations,
         List<StatementSpan> statements,
         PrintedRangeMap printedRanges,
@@ -362,16 +364,17 @@ public static class AnnotationAnchor
                     || !printedRanges.TryGetRange(inner, out var innerRange))
                     continue;
                 // One offset can be carried by several unprinted owners naming
-                // different places: 1,858 of the 1,907 offsets adoption resolves
-                // have more than one owner, and on 66 of them the owners pick
-                // different nodes -- every one a group of `Box` nodes over
-                // different locals of equal width. No choice among those is more
-                // correct than another, so the requirement is only that it be a
-                // function of the ranges rather than of the walk: leftmost, and
-                // narrowest where two start together. On this corpus that agrees
-                // with what the unarbitrated walk already produced on all 66, so
-                // this changes no rendered output here; it exists so that the
-                // choice cannot move when traversal order does.
+                // different places. That is rare but never benign: of the 1,907
+                // offsets adoption resolves, 66 carry more than one distinct
+                // unprinted owner, and on every one of those 66 the owners pick
+                // different nodes -- each a group of `Box` nodes over different
+                // locals of equal width. No choice among them is more correct
+                // than another, so the requirement is only that it be a function
+                // of the ranges rather than of the walk: leftmost, and narrowest
+                // where two start together. On this corpus that agrees with what
+                // the unarbitrated walk already produced on all 66, so it changes
+                // no rendered output here; it exists so the choice cannot move
+                // when traversal order does.
                 if (chosen.TryGetValue(offset, out var best)
                     && (best.Start < innerRange.Start.Value
                         || (best.Start == innerRange.Start.Value

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -288,7 +288,7 @@ public static class AnnotationAnchor
 
     /// <summary>
     /// Extents for offsets whose owning node prints nothing, taken from the
-    /// narrowest printed node inside it.
+    /// nearest printed node inside it.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -304,10 +304,15 @@ public static class AnnotationAnchor
     /// Measured over <c>System.Private.CoreLib</c> as the annotated-source view
     /// prints it: of 37,800 facts, 4,143 had no extent. For 2,573 the offset
     /// belonged to a node that exists but prints nothing, and 1,907 of those
-    /// have a printed descendant — 1,899 of them boxes, whose descendants are
-    /// the boxed expression itself (1,234 <c>LoadArgument</c>, 510
-    /// <c>LoadLocal</c>, 104 <c>LoadIndirect</c>, 42 <c>Constant</c>, the rest
-    /// field and property loads). That is the population this recovers.
+    /// have a printed descendant — 1,899 of them boxes. Those 1,907 offsets
+    /// adopt 1,023 <c>LoadArgument</c>, 498 <c>LoadLocal</c>, 129 <c>Call</c>,
+    /// 107 <c>LoadIndirect</c>, 75 <c>Convert</c>, 42 <c>Binary</c>, 14
+    /// <c>Constant</c>, 11 <c>LoadField</c>, 5 <c>LoadStackSlot</c> and three
+    /// singletons. That is the population this recovers, and it is counted per
+    /// distinct (function, offset) pair: one offset is typically carried by
+    /// several unprinted owners — 1,858 of the 1,907 are — so a count of
+    /// matching nodes visited would be more than twice as large and would not
+    /// describe anything the renderer produces.
     /// </para>
     /// <para>
     /// Descent only, never ascent. A printed <em>ancestor</em> is available for
@@ -342,6 +347,7 @@ public static class AnnotationAnchor
 
         var level = new List<IrNode>();
         var next = new List<IrNode>();
+        var chosen = new Dictionary<int, (int Start, int Width)>();
         foreach (var span in statements)
         {
             foreach (var node in Self(span.Statement))
@@ -352,8 +358,27 @@ public static class AnnotationAnchor
                 // The owner prints nothing; look inside it for something that does.
                 if (printedRanges.TryGetRange(node, out _))
                     continue;
-                if (NearestPrinted(node, printedRanges, ref level, ref next) is { } inner)
-                    adopted[offset] = inner;
+                if (NearestPrinted(node, printedRanges, ref level, ref next) is not { } inner
+                    || !printedRanges.TryGetRange(inner, out var innerRange))
+                    continue;
+                // One offset can be carried by several unprinted owners naming
+                // different places: 1,858 of the 1,907 offsets adoption resolves
+                // have more than one owner, and on 66 of them the owners pick
+                // different nodes -- every one a group of `Box` nodes over
+                // different locals of equal width. No choice among those is more
+                // correct than another, so the requirement is only that it be a
+                // function of the ranges rather than of the walk: leftmost, and
+                // narrowest where two start together. On this corpus that agrees
+                // with what the unarbitrated walk already produced on all 66, so
+                // this changes no rendered output here; it exists so that the
+                // choice cannot move when traversal order does.
+                if (chosen.TryGetValue(offset, out var best)
+                    && (best.Start < innerRange.Start.Value
+                        || (best.Start == innerRange.Start.Value
+                            && best.Width <= innerRange.End.Value - innerRange.Start.Value)))
+                    continue;
+                chosen[offset] = (innerRange.Start.Value, innerRange.End.Value - innerRange.Start.Value);
+                adopted[offset] = inner;
             }
         }
         return adopted;
@@ -371,18 +396,16 @@ public static class AnnotationAnchor
     /// argument <c>x</c>, not the call <c>Foo(x)</c> whose result is boxed, so
     /// the caret underlined characters the fact is not about. Measured over
     /// <c>System.Private.CoreLib</c> as the annotated-source view prints it,
-    /// the two rules disagree on 502 of the 4,262 offsets adoption resolves:
-    /// 240 <c>box</c>-over-<c>Call</c>, 112 and 38 over <c>Convert</c>, 72 and
-    /// 12 over <c>Binary</c>, and the rest single figures. Depth is right in
-    /// every one of them, because what a box boxes is its operand.
+    /// the two rules disagree on 252 of the 1,907 offsets adoption resolves:
+    /// 119 over <c>Call</c>, 56 and 19 over <c>Convert</c>, 36 and 6 over
+    /// <c>Binary</c>, and the rest single figures. Depth is right in every one
+    /// of them, because what a box boxes is its operand.
     /// <para>
-    /// The width tie-break never runs on that corpus: no node has two printed
-    /// descendants at its shallowest printed level, all 4,262 times. It is kept
-    /// because "never here" is a measurement, not a guarantee, and a silent
-    /// dependence on traversal order is what the old rule died of — it left 231
-    /// of these offsets decided by which equally-narrow node the walk reached
-    /// first. Preferring the widest at a level keeps the caret over as much of
-    /// the expression as the printer will name.
+    /// The width tie-break never runs on that corpus: at every descent, no node
+    /// had two printed descendants at its shallowest printed level. It is kept
+    /// because "never here" is a measurement rather than a guarantee, and
+    /// preferring the widest at a level keeps the caret over as much of the
+    /// expression as the printer will name.
     /// </para>
     /// </remarks>
     static IrNode? NearestPrinted(

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -233,23 +233,25 @@ public static class AnnotationCaret
     /// <c>System.Private.CoreLib</c> as the annotated-source view prints it,
     /// after the focus filter and summed over the five focus families —
     /// <c>--focus</c> promotes only one family to carets, so a count over every
-    /// collected fact describes a render no invocation produces — 28,215 of
-    /// 32,864 caret-bearing lines (85.85%) narrow to one agreed extent, 9.45%
+    /// collected fact describes a render no invocation produces — 28,151 of
+    /// 32,864 caret-bearing lines (85.66%) narrow to one agreed extent, 9.64%
     /// carry facts that disagree, and 4.70% have no fact with a printed node to
     /// point at. Only the middle group changes geometry: the narrowing lines and
-    /// the no-extent lines both render as they do today, so 29,759 of the 32,864
-    /// (90.55%) are untouched. The 85.85% is the narrowing share, not the
+    /// the no-extent lines both render as they do today, so 29,695 of the 32,864
+    /// (90.36%) are untouched. The 85.66% is the narrowing share, not the
     /// unchanged share, and must not be quoted as the latter. Agreement is
-    /// almost entirely a single-fact phenomenon here: 29,550 of those lines
-    /// hold one fact and 95.3% of them narrow, against 64 of the
-    /// 2,282 two-fact lines and none of the 714 three-fact or 318
-    /// four-or-more-fact ones. Those 64 are real agreement between two facts,
-    /// and they exist because an extent can be adopted rather than owned: two
-    /// facts whose own nodes print nothing can descend to the same printed node
-    /// — a boxed argument carrying both an <c>alloc.box</c> and a second fact at
-    /// the same offset — and then genuinely share one extent. Before adoption
-    /// no two facts of one family shared an extent in this corpus at all, so a
-    /// remark claiming that is stale rather than merely imprecise.
+    /// entirely a single-fact phenomenon here: 29,550 of those lines hold one
+    /// fact and 95.3% of them narrow, while none of the 2,282 two-fact, 714
+    /// three-fact or 318 four-or-more-fact lines narrows. Two facts of one
+    /// family on one line never share an extent in this corpus, so for them
+    /// the disagreement return below does all the work.
+    /// That claim briefly read as false, and the reason is worth keeping. When
+    /// <see cref="AnnotationAnchor"/> first learned to adopt an extent from a
+    /// printed descendant it took the <em>narrowest</em> one at any depth, which
+    /// collapsed two facts under one boxed call onto the same argument token and
+    /// produced 64 agreeing two-fact lines. Those agreements were the defect
+    /// reporting itself: descending by depth instead points each fact at the
+    /// expression it is actually about, they disagree again, and the count is 0.
     /// That 95.3% is itself padded: 1,399 of the 29,550 single-fact lines hold a
     /// fact with no extent, which cannot narrow. Conditioned on the 28,151 that
     /// could, every one does -- 100%. That is close to necessary but not quite:
@@ -260,13 +262,16 @@ public static class AnnotationCaret
     /// this corpus none of those occurs, so the rate is 100% as measured rather
     /// than 100% by construction. The 95.3% measures how
     /// often a single fact has an extent, not how often agreement holds.
-    /// The 85.85% headline is padded the other way: 29,550 of its lines carry a
-    /// single fact and cannot disagree at all. Conditioned on the 3,314 lines
-    /// that could, agreement is 64 (1.9%).
+    /// The 85.66% headline is padded the other way: 29,550 of its lines carry a
+    /// single fact and cannot disagree at all. That leaves 3,314, and it is
+    /// padded in turn: the loop above returns null on the first fact with no
+    /// extent, so a line where any fact lacks one cannot agree whatever its
+    /// extents say. Removing the 356 mixed lines and the 145 multi-fact lines
+    /// where no fact has an extent leaves 2,813 that could agree, and 0 do.
     /// That is what this measures, not a mechanism — what is compared is
     /// rendered extents, not offsets, and nothing prevents two facts sharing
     /// one. Density is not the only reason this returns null: 1,399 of the
-    /// 4,649 null lines carry a single fact that has no extent at all.
+    /// 4,713 null lines carry a single fact that has no extent at all.
     /// </remarks>
     static AnnotationAnchor.CaretExtent? Agreed(
         IReadOnlyList<IAnnotation> annotations,
@@ -305,7 +310,7 @@ public static class AnnotationCaret
     /// A line can be mixed: some facts are about an expression and some are only
     /// known to be about the statement. Widening the whole line because of the
     /// latter discards placement the anchoring layer successfully recovered for
-    /// the former, and 355 lines are mixed — 254 of them with a single surviving
+    /// the former, and 356 lines are mixed — 255 of them with a single surviving
     /// extent — measured over <c>System.Private.CoreLib</c> as the
     /// annotated-source view prints it, summed over the five focus families.
     /// The focus filter matters: <c>--focus</c> promotes only one family to
@@ -333,11 +338,11 @@ public static class AnnotationCaret
     /// extent sent to a different row never shortens its parent. Nor does it
     /// make each row narrower than the one above -- a later disjoint extent can
     /// be packed onto a lower row and reach further right than anything above
-    /// it, which happens on 50 of the 3,105 lines that stack in
+    /// it, which happens on 50 of the 3,169 lines that stack in
     /// System.Private.CoreLib, as the annotated-source view prints it, summed
-    /// over the five focus families. Of the 2,682 clipped trails, the successor
+    /// over the five focus families. Of the 2,890 clipped trails, the successor
     /// extent whose label does the clipping is nested inside the trail it clips
-    /// on 1,867 (69.6%) and disjoint from it on 815 (30.4%). The distinction
+    /// on 2,075 (71.8%) and disjoint from it on 815 (28.2%). The distinction
     /// matters: a disjoint successor's label reaches two columns left of the
     /// extent it belongs to, so it can still overlap and clip the trail before
     /// it.
@@ -395,52 +400,52 @@ public static class AnnotationCaret
     /// it, summed over the five focus families and counted after the focus
     /// filter, because <c>--focus</c> promotes only the requested family to
     /// carets and a figure taken over every collected fact describes a render
-    /// no invocation produces. Rendering each of the 3,105 lines that stack
-    /// through this method and reading the output back: 2,806 (90.4%) take a
+    /// no invocation produces. Rendering each of the 3,169 lines that stack
+    /// through this method and reading the output back: 2,870 (90.6%) take a
     /// single row, 297 take two, and two take more, neither above four. That
-    /// 90.4% is itself padded — 255 of those lines carry a single extent group
-    /// and cannot occupy more than one row — so the rate among the 2,850 lines
-    /// with something to pack is 2,551 (89.5%). That 2,850 is padded in turn, by
+    /// 90.6% is itself padded — 255 of those lines carry a single extent group
+    /// and cannot occupy more than one row — so the rate among the 2,914 lines
+    /// with something to pack is 2,615 (89.7%). That 2,914 is padded in turn, by
     /// the same structural fact this remark states below: extents sharing a start
     /// column can never share a row, so the 136 lines carrying two distinct
     /// extents at one column cannot take a single row whatever the packer does.
-    /// Among the remaining 2,714 the rate is 2,551 (94.0%). "Remaining" is the
-    /// careful word: those 2,714 are not all able to take one row either -- 163
+    /// Among the remaining 2,778 the rate is 2,615 (94.1%). "Remaining" is the
+    /// careful word: those 2,778 are not all able to take one row either -- 163
     /// of them are refused by the row admission below because their extents sit
     /// too close together. They are left in deliberately. Crowding is the thing
     /// this rate exists to measure, so excluding lines for being crowded would
     /// drive it to 100% and measure nothing. A shared start column is excluded
     /// because it is a different phenomenon: two extents anchored at one column
-    /// are a nesting, not a packing failure. 4,411
-    /// of 7,093 trails (62.2%) render at true width, but that rate is padded by
+    /// are a nesting, not a packing failure. 4,457
+    /// of 7,347 trails (60.7%) render at true width, but that rate is padded by
     /// a structural immunity: the last trail on a row has no successor, so its
     /// clip limit is <c>int.MaxValue</c> and it renders at true width by
-    /// construction. Those 3,105 lines occupy 3,407 rows, so 3,407 of the 4,411
-    /// could not have been clipped, and they are 3,407 of the 4,411 counted as
-    /// rendering at true width. Of the 3,686 trails that were actually
-    /// exposed to a successor, 1,004 (27.2%) survived at true width. Eight of those
+    /// construction. Those 3,169 lines occupy 3,471 rows, so 3,471 of the 4,457
+    /// could not have been clipped, and they are 3,471 of the 4,457 counted as
+    /// rendering at true width. Of the 3,876 trails that were actually
+    /// exposed to a successor, 986 (25.4%) survived at true width. Eight of those
     /// are immune too, their extents being no longer than <c>MinTrail</c>, which
-    /// row admission already reserves; among the 3,678 trails that could
-    /// genuinely be cut, 996 (27.1%) survived and 2,682 (72.9%) were clipped.
+    /// row admission already reserves; among the 3,868 trails that could
+    /// genuinely be cut, 978 (25.3%) survived and 2,890 (74.7%) were clipped.
     /// That is the figure with information in it.
     /// No stacked caret row is
     /// wider than the code line it annotates, which is structural rather than
     /// measured: <see cref="Stack"/> sends any extent reaching past
     /// <c>lineLength</c> to the unplaced list, labels grow leftward, and the
     /// gutter guard bails out rather than shifting a trail rightward, so the
-    /// rightmost column is bounded by the line. The 0 observed on those 3,105
+    /// rightmost column is bounded by the line. The 0 observed on those 3,169
     /// lines checks that derivation and cannot falsify it.
     /// </para>
     /// <para>
     /// The comparison against the widening render is narrower than it first
     /// looks, and an earlier revision of this remark overstated it twice. No
     /// caret <em>glyph</em> overhangs the code line in <em>either</em> render:
-    /// measured over the same 3,105 lines, both are 0, because the widening
+    /// measured over the same 3,169 lines, both are 0, because the widening
     /// underline covers the trimmed statement, which ends within the line. What
     /// differs is the rendered <em>row</em>. Widening appends the first detail
     /// string to the caret row when it fits the inline budget, and that appended
     /// text carries the row past the end of the code line. Quoting this as 20 of
-    /// 3,105 lines (0.64%) pads the denominator with the 3,085 whose detail never
+    /// 3,169 lines (0.63%) pads the denominator with the 3,149 whose detail never
     /// goes inline and which therefore cannot overhang at all: inline detail
     /// appears on exactly 20 of these lines and all 20 overhang, so the rate is
     /// 20/20. The reason it comes out whole is that on the hoisted render these
@@ -476,7 +481,7 @@ public static class AnnotationCaret
             // The gutter owns everything left of commentColumn + 2. A label that
             // will not fit after it cannot be drawn at the column it points at,
             // and shifting it would make it point somewhere else. This is a
-            // guard, not a path with known traffic: it fires on 0 of the 3,105
+            // guard, not a path with known traffic: it fires on 0 of the 3,169
             // lines that *qualify* to stack in System.Private.CoreLib, as the
             // annotated-source view prints it, summed over the five focus
             // families and counted after the focus filter. Qualifying is the
@@ -485,7 +490,7 @@ public static class AnnotationCaret
             // label before the caret run, not by the absence of a caret row --
             // falling back still renders the widening caret, so the latter
             // test could never fire. Raising the margin to +6 makes this fire
-            // on 306 of the 3,105 and to +200 on all of them, so the zero is a
+            // on 306 of the 3,169 and to +200 on all of them, so the zero is a
             // property of the corpus rather than of the measurement.
             if (LabelStart(i) < commentColumn + 2)
                 return null;

--- a/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationCaret.cs
@@ -233,34 +233,40 @@ public static class AnnotationCaret
     /// <c>System.Private.CoreLib</c> as the annotated-source view prints it,
     /// after the focus filter and summed over the five focus families —
     /// <c>--focus</c> promotes only one family to carets, so a count over every
-    /// collected fact describes a render no invocation produces — 27,091 of
-    /// 32,864 caret-bearing lines (82.43%) narrow to one agreed extent, 8.65%
-    /// carry facts that disagree, and 8.92% have no fact with a printed node to
+    /// collected fact describes a render no invocation produces — 28,215 of
+    /// 32,864 caret-bearing lines (85.85%) narrow to one agreed extent, 9.45%
+    /// carry facts that disagree, and 4.70% have no fact with a printed node to
     /// point at. Only the middle group changes geometry: the narrowing lines and
-    /// the no-extent lines both render as they do today, so 30,022 of the 32,864
-    /// (91.35%) are untouched. The 82.43% is the narrowing share, not the
-    /// unchanged share, and must not be quoted as the latter. Agreement is entirely a single-fact phenomenon here: 29,550 of
-    /// those lines hold one fact and 91.7% of them narrow, while none of
-    /// the 2,282 two-fact, 714 three-fact or 318 four-or-more-fact lines
-    /// narrows. Two facts of one family on one line never share an extent in
-    /// this corpus, so for them the disagreement return below does all the work.
-    /// That 91.7% is itself padded: 2,459 of the 29,550 single-fact lines hold a
-    /// fact with no extent, which cannot narrow. Conditioned on the 27,091 that
+    /// the no-extent lines both render as they do today, so 29,759 of the 32,864
+    /// (90.55%) are untouched. The 85.85% is the narrowing share, not the
+    /// unchanged share, and must not be quoted as the latter. Agreement is
+    /// almost entirely a single-fact phenomenon here: 29,550 of those lines
+    /// hold one fact and 95.3% of them narrow, against 64 of the
+    /// 2,282 two-fact lines and none of the 714 three-fact or 318
+    /// four-or-more-fact ones. Those 64 are real agreement between two facts,
+    /// and they exist because an extent can be adopted rather than owned: two
+    /// facts whose own nodes print nothing can descend to the same printed node
+    /// — a boxed argument carrying both an <c>alloc.box</c> and a second fact at
+    /// the same offset — and then genuinely share one extent. Before adoption
+    /// no two facts of one family shared an extent in this corpus at all, so a
+    /// remark claiming that is stale rather than merely imprecise.
+    /// That 95.3% is itself padded: 1,399 of the 29,550 single-fact lines hold a
+    /// fact with no extent, which cannot narrow. Conditioned on the 28,151 that
     /// could, every one does -- 100%. That is close to necessary but not quite:
     /// one fact with an extent is one extent and agrees with itself, so the loop
     /// above cannot reject it, but the bounds check below still can, and would
     /// on a negative column, a non-positive length, or an extent running past
     /// <paramref name="lineLength"/> because a consumer re-wrapped the line. In
     /// this corpus none of those occurs, so the rate is 100% as measured rather
-    /// than 100% by construction. The 91.7% measures how
+    /// than 100% by construction. The 95.3% measures how
     /// often a single fact has an extent, not how often agreement holds.
-    /// The 82.43% headline is padded the other way: 29,550 of its lines carry a
+    /// The 85.85% headline is padded the other way: 29,550 of its lines carry a
     /// single fact and cannot disagree at all. Conditioned on the 3,314 lines
-    /// that could, agreement is 0.
+    /// that could, agreement is 64 (1.9%).
     /// That is what this measures, not a mechanism — what is compared is
     /// rendered extents, not offsets, and nothing prevents two facts sharing
-    /// one. Density is not the only reason this returns null: 2,459 of the
-    /// 5,773 null lines carry a single fact that has no extent at all.
+    /// one. Density is not the only reason this returns null: 1,399 of the
+    /// 4,649 null lines carry a single fact that has no extent at all.
     /// </remarks>
     static AnnotationAnchor.CaretExtent? Agreed(
         IReadOnlyList<IAnnotation> annotations,
@@ -327,7 +333,7 @@ public static class AnnotationCaret
     /// extent sent to a different row never shortens its parent. Nor does it
     /// make each row narrower than the one above -- a later disjoint extent can
     /// be packed onto a lower row and reach further right than anything above
-    /// it, which happens on 50 of the 2,842 lines that stack in
+    /// it, which happens on 50 of the 3,105 lines that stack in
     /// System.Private.CoreLib, as the annotated-source view prints it, summed
     /// over the five focus families. Of the 2,682 clipped trails, the successor
     /// extent whose label does the clipping is nested inside the trail it clips
@@ -389,52 +395,52 @@ public static class AnnotationCaret
     /// it, summed over the five focus families and counted after the focus
     /// filter, because <c>--focus</c> promotes only the requested family to
     /// carets and a figure taken over every collected fact describes a render
-    /// no invocation produces. Rendering each of the 2,842 lines that stack
-    /// through this method and reading the output back: 2,543 (89.5%) take a
+    /// no invocation produces. Rendering each of the 3,105 lines that stack
+    /// through this method and reading the output back: 2,806 (90.4%) take a
     /// single row, 297 take two, and two take more, neither above four. That
-    /// 89.5% is itself padded — 254 of those lines carry a single extent group
-    /// and cannot occupy more than one row — so the rate among the 2,588 lines
-    /// with something to pack is 2,289 (88.4%). That 2,588 is padded in turn, by
+    /// 90.4% is itself padded — 255 of those lines carry a single extent group
+    /// and cannot occupy more than one row — so the rate among the 2,850 lines
+    /// with something to pack is 2,551 (89.5%). That 2,850 is padded in turn, by
     /// the same structural fact this remark states below: extents sharing a start
     /// column can never share a row, so the 136 lines carrying two distinct
     /// extents at one column cannot take a single row whatever the packer does.
-    /// Among the remaining 2,452 the rate is 2,289 (93.4%). "Remaining" is the
-    /// careful word: those 2,452 are not all able to take one row either -- 163
+    /// Among the remaining 2,714 the rate is 2,551 (94.0%). "Remaining" is the
+    /// careful word: those 2,714 are not all able to take one row either -- 163
     /// of them are refused by the row admission below because their extents sit
     /// too close together. They are left in deliberately. Crowding is the thing
     /// this rate exists to measure, so excluding lines for being crowded would
     /// drive it to 100% and measure nothing. A shared start column is excluded
     /// because it is a different phenomenon: two extents anchored at one column
-    /// are a nesting, not a packing failure. 3,884
-    /// of 6,566 trails (59.2%) render at true width, but that rate is padded by
+    /// are a nesting, not a packing failure. 4,411
+    /// of 7,093 trails (62.2%) render at true width, but that rate is padded by
     /// a structural immunity: the last trail on a row has no successor, so its
     /// clip limit is <c>int.MaxValue</c> and it renders at true width by
-    /// construction. Those 2,842 lines occupy 3,144 rows, so 3,144 of the 3,884
-    /// could not have been clipped, and they are 3,144 of the 3,884 counted as
-    /// rendering at true width. Of the 3,422 trails that were actually
-    /// exposed to a successor, 740 (21.6%) survived at true width. Five of those
+    /// construction. Those 3,105 lines occupy 3,407 rows, so 3,407 of the 4,411
+    /// could not have been clipped, and they are 3,407 of the 4,411 counted as
+    /// rendering at true width. Of the 3,686 trails that were actually
+    /// exposed to a successor, 1,004 (27.2%) survived at true width. Eight of those
     /// are immune too, their extents being no longer than <c>MinTrail</c>, which
-    /// row admission already reserves; among the 3,417 trails that could
-    /// genuinely be cut, 735 (21.5%) survived and 2,682 (78.5%) were clipped.
+    /// row admission already reserves; among the 3,678 trails that could
+    /// genuinely be cut, 996 (27.1%) survived and 2,682 (72.9%) were clipped.
     /// That is the figure with information in it.
     /// No stacked caret row is
     /// wider than the code line it annotates, which is structural rather than
     /// measured: <see cref="Stack"/> sends any extent reaching past
     /// <c>lineLength</c> to the unplaced list, labels grow leftward, and the
     /// gutter guard bails out rather than shifting a trail rightward, so the
-    /// rightmost column is bounded by the line. The 0 observed on those 2,842
+    /// rightmost column is bounded by the line. The 0 observed on those 3,105
     /// lines checks that derivation and cannot falsify it.
     /// </para>
     /// <para>
     /// The comparison against the widening render is narrower than it first
     /// looks, and an earlier revision of this remark overstated it twice. No
     /// caret <em>glyph</em> overhangs the code line in <em>either</em> render:
-    /// measured over the same 2,842 lines, both are 0, because the widening
+    /// measured over the same 3,105 lines, both are 0, because the widening
     /// underline covers the trimmed statement, which ends within the line. What
     /// differs is the rendered <em>row</em>. Widening appends the first detail
     /// string to the caret row when it fits the inline budget, and that appended
     /// text carries the row past the end of the code line. Quoting this as 20 of
-    /// 2,842 lines (0.70%) pads the denominator with the 2,822 whose detail never
+    /// 3,105 lines (0.64%) pads the denominator with the 3,085 whose detail never
     /// goes inline and which therefore cannot overhang at all: inline detail
     /// appears on exactly 20 of these lines and all 20 overhang, so the rate is
     /// 20/20. The reason it comes out whole is that on the hoisted render these
@@ -470,7 +476,7 @@ public static class AnnotationCaret
             // The gutter owns everything left of commentColumn + 2. A label that
             // will not fit after it cannot be drawn at the column it points at,
             // and shifting it would make it point somewhere else. This is a
-            // guard, not a path with known traffic: it fires on 0 of the 2,842
+            // guard, not a path with known traffic: it fires on 0 of the 3,105
             // lines that *qualify* to stack in System.Private.CoreLib, as the
             // annotated-source view prints it, summed over the five focus
             // families and counted after the focus filter. Qualifying is the
@@ -479,7 +485,7 @@ public static class AnnotationCaret
             // label before the caret run, not by the absence of a caret row --
             // falling back still renders the widening caret, so the latter
             // test could never fire. Raising the margin to +6 makes this fire
-            // on 306 of the 2,842 and to +200 on all of them, so the zero is a
+            // on 306 of the 3,105 and to +200 on all of them, so the zero is a
             // property of the corpus rather than of the measurement.
             if (LabelStart(i) < commentColumn + 2)
                 return null;


### PR DESCRIPTION
Facts whose own IR node prints nothing had no caret extent, so `--focus`
widened them to the statement-wide underline. This is chiefly `Box`: boxing
emits no characters of its own, so every `alloc.box` fact fell back to
underlining the whole statement.

`AnnotationAnchor` now descends from such an owner to a printed descendant
and adopts its range.

## The rule

**Nearest printed descendant, by depth.** The first draft took the *narrowest*
printed descendant at any depth, which is wrong: for `box(Foo(x))` it underlines
the argument `x` rather than the call whose result is boxed. Measured on
CoreLib, narrowest and nearest disagree on **252 of the 1,907** distinct
`(function, offset)` pairs adoption resolves — 119 over `Call`, 56 + 19 over
`Convert`, 36 + 6 over `Binary`, the rest singletons. Width is used only to
break ties *within* a level, which never occurs on this corpus.

**Descent only, never ascent.** A printed *ancestor* exists for a further 576
facts, but an ancestor's range **is** the statement-wide underline this change
exists to escape.

**Deterministic arbitration.** Of the 1,907 offsets, 66 carry more than one
distinct unprinted owner, and on **every one** of those 66 the owners pick
different nodes. Multiple owners are rare here, but they never agree.

Each of the 66 is a group of `Box` nodes over the **same local**: all the
candidate ranges have identical width and print identical text, differing only
in column. Arbitration therefore chooses which visibly different *occurrence*
of that local gets underlined. None is more semantically correct than another;
the requirement is that the visible choice be a function of the ranges rather
than of traversal order: leftmost, then narrowest on a tie.

(An earlier revision of this description said "different locals of equal width".
That was wrong, and I caught it by dumping the actual candidates rather than
trusting the summary: the choices all print `V_2`, three times over.) On this
corpus arbitration agrees with what the unarbitrated walk already produced on
all 66, so it moves no output; it exists so traversal order cannot move the
underline in the future.

## Effect

Extent coverage **33,657 / 37,800 (89.04%) → 35,498 (93.91%)**, +1,841.

The ceiling — facts that could possibly be placed this way — is 1,907, measured
independently. The 66-fact shortfall is *exactly* the already-documented
continuation-line guard: 1,907 = 1,841 + 66, with no residue. Nothing else is
being lost.

The gain is concentrated where the mechanism predicts. Adoption is a boxing
phenomenon, and `alloc` takes +1,379 of the extents and +327 of the new
stacking lines.

## Why the doc changed too

More facts with extents means more lines qualify to stack, which falsified
nearly every measured figure in `docs/design/caret-stacking.md` and in the
`AnnotationCaret` remarks — a document merged three commits earlier. Both were
fully re-measured rather than patched. Headline moves:

| | before | after |
|---|---|---|
| caret lines that stack | 2,842 (8.65%) | **3,169 (9.64%)** |
| lines with no extent | 2,931 (8.92%) | **1,544 (4.70%)** |
| trails clipped | 2,682 (78.5%) | **2,890 (74.7%)** |
| rule 8 gutter fallback | 0 | **0** |

Both baseline entries in that table were wrong in the first version of this
description — 2,932 and 2,614 (74.5%) — and the clipping error inverted the
result, making the rate look as though it rose when measured like-for-like it
**falls**, 78.5% → 74.7%. The 74.5% was the pre-unpadding historical figure, so
the row was comparing a padded baseline against an unpadded result.

Every probe behind those numbers was first replayed against `74b4f546c` and
required to reproduce the published figures exactly before its new output was
trusted. The five rendered snippets in the design doc were re-rendered from
this build; all are byte-identical, including the headline `Tuple.Equals`
example — still 8 numbered carets, 8 facts attributed, 8 marked `-`, caret row
ending at column 372.

## Two claims this PR made and then had to withdraw

The first draft reported that 64 lines now had two facts of one family
*agreeing* on an extent, where previously none did. Those 64 agreements **were
the bug**: two facts collapsing onto the same wrongly-chosen argument token.
Under depth-first descent they disagree again and agreement returns to **0 of
2,813 capable lines**.

The population `2,813` is itself a correction — the twelfth padded denominator
found in this area. `Agreed` returns null on the first fact lacking an extent,
so 356 mixed and 145 all-no-extent lines are structurally incapable of
agreeing and do not belong in the denominator.

## Verification

- Full decompiler suite: **4,713 pass**, 0 failed.
- Build clean, 0 warnings.
- Both gutter-guard mutations re-run with rebuilds, confirming the `0` is not
  vacuous: +6 columns of pressure yields 306 fallbacks, +200 yields all 3,169.

Part of #3570.


