### PR TITLE
Build the Native AOT tools with OptimizationPreference=Speed

### DIFF
--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -83,6 +83,7 @@
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/AnalysisHarness/AnalysisHarness.csproj" />
+    <Project Path="tools/AotProbe/AotProbe.csproj" />
     <Project Path="tools/CSharpDiffHarness/CSharpDiffHarness.csproj" />
     <Project Path="tools/DecompilerHarness/DecompilerHarness.csproj" />
     <Project Path="tools/DiffHarnessCommon/DiffHarnessCommon.csproj" />

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -9,13 +9,6 @@
     <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
-  <!-- Native AOT size optimizations (only apply when publishing with AOT) -->
-  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
-    <UseSystemResourceKeys>true</UseSystemResourceKeys>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <OptimizationPreference>Size</OptimizationPreference>
-  </PropertyGroup>
-
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet-inspect.Tests" />
   </ItemGroup>
@@ -37,6 +30,23 @@
     <!-- Keep debug symbols (.pdb/.dbg and the macOS .dSYM bundle) out of the
          published tool package. -->
     <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+  </PropertyGroup>
+
+  <!-- Native AOT publish settings. This group must come after PublishAot is set
+       above: MSBuild evaluates properties top to bottom, so a group conditioned on
+       PublishAot that sits earlier in the file is silently inert for a plain
+       `dotnet publish -r <rid>` (where PublishAot comes from this file rather than
+       from a global property or OfficialAotBuild). -->
+  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- Speed, not Size. Worth a measured 6-7% on real commands for about 9% more
+         binary size (issue #3675). The setting moves scalar codegen, which is what
+         this tool is: metadata walking is small reads, integer decoding and
+         dictionary lookups. Raising the x64 instruction-set baseline was measured
+         alongside it and deliberately not taken: it moves vectorized codegen
+         only, which is a null result here and would have cost pre-2013 hardware. -->
+    <OptimizationPreference>Speed</OptimizationPreference>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -33,6 +33,12 @@
   `Kind` column. The `type`/`member` `Performance Triage` lens is
   unchanged (#2833).
 
+### Native AOT codegen
+
+- Builds the Native AOT tools with `OptimizationPreference=Speed` instead of
+  `Size`, worth a measured 6-7% on real commands for about 9% more binary size
+  (#3675).
+
 ### Output and projections
 
 - Adds JSON array projection output and scalar URL/path shape projections,

--- a/src/mdi/mdi.csproj
+++ b/src/mdi/mdi.csproj
@@ -15,13 +15,6 @@
     <OwnsItsOwnStderr>true</OwnsItsOwnStderr>
   </PropertyGroup>
 
-  <!-- Native AOT size optimizations (only apply when publishing with AOT) -->
-  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
-    <UseSystemResourceKeys>true</UseSystemResourceKeys>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <OptimizationPreference>Size</OptimizationPreference>
-  </PropertyGroup>
-
   <ItemGroup>
     <InternalsVisibleTo Include="DotnetInspector.MetadataRendering.Tests" />
   </ItemGroup>
@@ -39,6 +32,16 @@
     <PublishAot>true</PublishAot>
     <!-- Keep debug symbols out of the published tool package. -->
     <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+  </PropertyGroup>
+
+  <!-- Native AOT publish settings. Must come after PublishAot is set above; see the
+       matching comment in dotnet-inspect.csproj for why the ordering matters.
+       mdi ships from the same RID list as dotnet-inspect, so the two tools carry the
+       same codegen settings. Rationale: issue #3675. -->
+  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Speed</OptimizationPreference>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tools/AotProbe/.gitignore
+++ b/tools/AotProbe/.gitignore
@@ -1,0 +1,2 @@
+# Published Native AOT output from run.sh.
+out-*/

--- a/tools/AotProbe/AotProbe.csproj
+++ b/tools/AotProbe/AotProbe.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Measures how the two Native AOT codegen knobs - the instruction-set baseline
+    (IlcInstructionSet) and OptimizationPreference - affect the two shapes of code the
+    CLI spends its text-handling time in: a scalar per-scalar walk and a vectorized
+    span search. dotnet-inspect ships primarily as Native AOT, so these are settled by
+    measurement on the AOT binary rather than by JIT benchmarks. See run.sh.
+
+    This is a contained runnable evaluation, not a shipping component.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>aot-probe</AssemblyName>
+    <RootNamespace>AotProbe</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/InertText/InertText.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/AotProbe/Program.cs
+++ b/tools/AotProbe/Program.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using InertText;
+
+// Two workloads, chosen because the two Native AOT codegen knobs move them independently:
+//
+//   scan - InertString.IsPermitted walks the string scalar by scalar. This is the shape of
+//          most of the CLI's text handling, and it is what OptimizationPreference moves.
+//   pre  - a printable-ASCII prefilter (IndexOfAnyExceptInRange) that falls back to the scan
+//          on a miss. A BCL vectorized helper, and it is what the instruction-set baseline
+//          moves. Included because it is the candidate replacement for the scan, so the
+//          question "does raising the baseline pay?" is only meaningful alongside it.
+//
+// Reported figures are the best of 9 timed repetitions. Minimum rather than mean: the
+// quantity of interest is the cost of the work itself, and every source of noise on a shared
+// machine only ever adds. Runs 1-2 of an earlier sweep on this hardware were inflated ~2x by
+// unrelated load, including in the instruction-set-independent column, which is what
+// motivated taking minima here.
+
+string typename = "System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator";
+string signature = "public static async System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<T>> "
+    + "LoadAsync(string path, CancellationToken token)";
+string long4k = string.Concat(Enumerable.Repeat("The quick brown fox jumps over the lazy dog. ", 93))[..4096];
+
+// Permitted by Field but not ASCII, so the prefilter misses and pays its overhead on top of
+// the scan. This is the case that bounds the prefilter's downside.
+string nonAscii = "Ярославль.Коллекции.Словарь`2+Перечислитель 中文名前 emoji \U0001F600 tail";
+
+string label = args.Length > 0 ? args[0] : "?";
+Console.WriteLine(
+    $"# {label,-14} {(RuntimeFeature.IsDynamicCodeCompiled ? "JIT " : "NAOT")} "
+    + $"v128={Flag(Vector128.IsHardwareAccelerated)} "
+    + $"v256={Flag(Vector256.IsHardwareAccelerated)} "
+    + $"v512={Flag(Vector512.IsHardwareAccelerated)}");
+
+Report("typename", typename);
+Report("signature", signature);
+Report("long4k", long4k);
+Report("nonAscii", nonAscii);
+
+void Report(string name, string value)
+{
+    double scan = Best(() => InertString.IsPermitted(TextPolicy.Field, value));
+    double prefiltered = Best(() => Prefilter(value));
+    Console.WriteLine(
+        $"{label,-14} {name,-10} {value.Length,5} scan={scan,9:F1} pre={prefiltered,8:F2} "
+        + $"x={scan / prefiltered,6:F0}");
+}
+
+static string Flag(bool value) => value ? "1" : "0";
+
+// Space (U+0020) through tilde (U+007E) are all graphic, so a string containing only them is
+// permitted by every policy and needs no scan. No surrogate is in that range, so a string
+// that passes has no multi-unit scalars either.
+static bool Prefilter(string value)
+    => value.AsSpan().IndexOfAnyExceptInRange(' ', '~') < 0
+    || InertString.IsPermitted(TextPolicy.Field, value);
+
+// Calibrates the iteration count to roughly 40 ms per repetition so that a 2 ns operation and
+// a 13 us one are both measured over a useful interval without either taking minutes.
+static double Best(Func<bool> operation)
+{
+    for (int i = 0; i < 50_000; i++)
+    {
+        _ = operation();
+    }
+
+    var probe = Stopwatch.StartNew();
+    for (int i = 0; i < 20_000; i++)
+    {
+        _ = operation();
+    }
+
+    probe.Stop();
+
+    double perOperation = Math.Max(probe.Elapsed.TotalNanoseconds / 20_000, 0.05);
+    int count = (int)Math.Clamp(40_000_000 / perOperation, 10_000, 5_000_000);
+
+    double best = double.MaxValue;
+    bool sink = false;
+    for (int repetition = 0; repetition < 9; repetition++)
+    {
+        var timer = Stopwatch.StartNew();
+        for (int i = 0; i < count; i++)
+        {
+            sink ^= operation();
+        }
+
+        timer.Stop();
+        best = Math.Min(best, timer.Elapsed.TotalNanoseconds / count);
+    }
+
+    GC.KeepAlive(sink);
+    return best;
+}

--- a/tools/AotProbe/README.md
+++ b/tools/AotProbe/README.md
@@ -1,0 +1,58 @@
+# AotProbe
+
+Measures how two Native AOT codegen settings affect the CLI's text-handling hot paths:
+
+- `IlcInstructionSet` — the instruction-set baseline the binary is compiled against.
+- `OptimizationPreference` — `Size` (what `src/dotnet-inspect/dotnet-inspect.csproj`
+  sets today) or `Speed`.
+
+`dotnet-inspect` is distributed primarily as Native AOT, so these are questions about
+the shipped binary. A JIT benchmark cannot answer them: the JIT selects vector widths
+at runtime from the actual CPU, whereas Native AOT bakes them in at compile time.
+
+## Running
+
+```bash
+tools/AotProbe/run.sh
+```
+
+The script picks the RID and the baseline list from the host architecture, publishes
+every combination, and runs each. It takes several minutes, mostly in `dotnet publish`.
+Close other work first — figures are best-of-9, but background load still perturbs them.
+
+Clean up with `rm -rf tools/AotProbe/out-*`.
+
+## Reading the output
+
+```text
+# x86-64-v3-Speed NAOT v128=1 v256=1 v512=0
+x86-64-v3-Speed typename      64 scan=    130.3 pre=    2.41 x=    54
+```
+
+`scan` is `InertString.IsPermitted`, a scalar per-scalar walk — representative of the
+CLI's text handling generally. `pre` is a printable-ASCII prefilter that falls back to
+the scan on a miss, representing a BCL vectorized helper. Both are nanoseconds per
+operation. The `v128`/`v256`/`v512` flags report which vector widths the compiled
+binary can actually use, which is the fact the baseline controls.
+
+The `nonAscii` row is the case the prefilter loses on: text that is permitted but not
+ASCII, so the prefilter misses and its cost lands on top of the scan.
+
+## Why the minimum rather than the mean
+
+The quantity of interest is the cost of the work itself, and every source of noise on a
+shared machine only ever adds. An early sweep on the AM5 host had two of six runs
+inflated roughly twofold by unrelated load — visible because the *instruction-set
+independent* column moved too. Minima across nine repetitions removed that artefact.
+
+## Interpreting a result
+
+The two settings move different code, so a result is two independent readings:
+
+- `OptimizationPreference` moves `scan` and barely touches `pre`.
+- The instruction-set baseline moves `pre` and does not touch `scan` at all — a scalar
+  loop cannot spend wider vector registers.
+
+A baseline that raises no vector width above the default therefore has nothing to offer
+here, however modern the hardware. That is the expected shape of the arm64 result,
+because AdvSimd/NEON is mandatory in ARMv8-A and .NET exposes no wider vector on arm64.

--- a/tools/AotProbe/run.sh
+++ b/tools/AotProbe/run.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Publishes tools/AotProbe as Native AOT across every combination of instruction-set
+# baseline and OptimizationPreference available on this platform, then runs each one.
+#
+#   ./run.sh
+#
+# The instruction-set list is chosen from the host architecture, so the same script
+# produces the x64 sweep and the arm64 sweep without editing. Close other work before
+# running: figures are best-of-9, but heavy background load still perturbs them.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64)  RID=osx-arm64;   ISAS=(default armv8.1-a armv8.2-a apple-m1) ;;
+  Linux-aarch64) RID=linux-arm64; ISAS=(default armv8.1-a armv8.2-a) ;;
+  Linux-x86_64)  RID=linux-x64;   ISAS=(x86-64-v2 x86-64-v3 x86-64-v4) ;;
+  Darwin-x86_64) RID=osx-x64;     ISAS=(x86-64-v2 x86-64-v3 x86-64-v4) ;;
+  Windows*|MINGW*|MSYS*) RID=win-x64; ISAS=(x86-64-v2 x86-64-v3 x86-64-v4) ;;
+  *) echo "unrecognised platform: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+echo "# host $(uname -s) $(uname -m), rid=$RID"
+echo "# baselines: ${ISAS[*]}"
+
+for isa in "${ISAS[@]}"; do
+  for opt in Size Speed; do
+    tag="$isa-$opt"
+    args=(-c Release -r "$RID" -p:PublishAot=true -p:OptimizationPreference="$opt"
+          -o "out-$tag" -v q --nologo)
+    # "default" means leave the baseline unpinned, which is what ships today.
+    if [[ "$isa" != "default" ]]; then
+      args+=(-p:IlcInstructionSet="$isa")
+    fi
+    echo "# publishing $tag" >&2
+    dotnet publish "${args[@]}" >/dev/null
+    printf '# %-16s binary=%s bytes\n' "$tag" "$(wc -c < "out-$tag/aot-probe" | tr -d ' ')"
+  done
+done
+
+for isa in "${ISAS[@]}"; do
+  for opt in Size Speed; do
+    "./out-$isa-$opt/aot-probe" "$isa-$opt"
+  done
+done
+
+echo "# done. remove the published output with: rm -rf $(dirname "$0")/out-*"


### PR DESCRIPTION
Closes #3675.

Switches both Native AOT tools from `OptimizationPreference=Size` to `Speed`,
and fixes an MSBuild ordering bug that made the setting inert for local
publishes. Also lands `tools/AotProbe`, the instrument used to measure it.

Raising the x64 instruction-set baseline to `x86-64-v3` was measured alongside
this and **deliberately not taken**. That negative result is written up below,
because it is the more surprising half.

## The change

`OptimizationPreference=Speed` for every AOT RID, on both `dotnet-inspect` and
`mdi` — they ship from the same RID list and should not disagree about codegen.

Timed on published `linux-x64` binaries, min of 25 alternating runs, warmed:

| workload | today (`Size`) | `Speed` | |
| --- | --: | --: | --: |
| `member System.Convert` | 455.3 ms | 427.2 ms | **1.066x** |
| `member System.String` | 454.7 ms | 424.3 ms | **1.072x** |
| `member System.Math` | 449.0 ms | 422.4 ms | **1.063x** |
| `member String.Substring -S "Decompiled Source"` | 458.9 ms | 431.8 ms | **1.063x** |
| `find Stream --platform` | 40.5 ms | 38.8 ms | 1.044x |

**A consistent 6-7% on real commands.** The isolated microbenchmark shows
1.5x-1.9x on both x64 and arm64, but only part of a command's runtime is that
scalar code, so 6-7% is the honest user-visible number.

`Speed` is the setting that matters for this tool because the tool is scalar:
the ~420 ms above is ECMA-335 metadata walking — small reads, integer decoding,
dictionary lookups.

Cost is binary size: **+9.1%** on `linux-x64` (31,090,352 → 33,925,056 bytes),
+9.5% on arm64.

## Why not also raise the x64 baseline to x86-64-v3

The tempting argument: .NET 11 raised the Windows/Linux ReadyToRun target to
`x86-64-v3` ([dotnet/runtime#120826][1]), R2R only has to be conservative
because a v2 host falls back to jitting, and a developer CLI has a narrower
audience than the runtime's don't-break-anyone floor. On the isolated
benchmark, v2 → v3 is a **3.0x** win on vectorized code.

It does not survive contact with the shipped binary. Adding v3 on top of
`Speed` produced 1.086x, 1.062x, 1.065x, 1.082x against `Speed`'s 1.066x,
1.072x, 1.063x, 1.063x — scatter on both sides, not signal.

The obvious explanation is wrong, and worth recording. It is **not** that the
binary lacks vectorized code. Native AOT statically links the BCL and compiles
it at the chosen baseline — the BCL's whole premise is that it absorbs SIMD and
register-width variation on your behalf — so raising the baseline takes the
published binary from **390** to **31,025** `ymm` references. `IndexOf`,
`Contains` and `SequenceEqual` really do get wider.

The saving just scales with how much data each call scans: about **1.2 ns** on
a short type name against about **99 ns** on a 4 KB buffer. This tool handles
short identifiers and emits a few KB per command (largest output found: 5,389
bytes), so millions of calls would be needed to surface a millisecond.

So v3 would have cost pre-2013 Intel and pre-2015 AMD support — a hard startup
refusal, verified under emulation — to buy nothing measurable. The probe is
committed so the decision can be revisited if a long-buffer scan ever appears.

arm64 was never a candidate: AdvSimd is mandatory in the ARMv8-A baseline and
.NET exposes no wider vectors there, confirmed by all four arm64 baseline
binaries coming out byte-identical per optimization mode.

## The ordering bug

Both tools guarded these settings with a `PropertyGroup` conditioned on
`PublishAot` that sat **above** the line setting `PublishAot`. MSBuild evaluates
top to bottom, so for a plain `dotnet publish -r <rid>` the entire group was
silently inert:

```console
$ dotnet msbuild src/dotnet-inspect/dotnet-inspect.csproj -p:RuntimeIdentifier=linux-x64 \
    -getProperty:PublishAot -getProperty:OptimizationPreference
  "PublishAot": "true",
  "OptimizationPreference": "",
```

Official builds were unaffected, because `OfficialAotBuild` sets `PublishAot` in
`src/Directory.Build.props` first — which is why this never surfaced. Locally
published binaries were simply tuned differently from shipped ones. The groups
now sit below the property they test.

## tools/AotProbe

The instrument behind every number here. `run.sh` selects the RID and ISA list
from `uname` and sweeps ISA × Size/Speed; `Program.cs` uses adaptive iteration
counts and best-of-9, because the measurements are noisy enough that single runs
disagree. It is how the arm64 column was collected on hardware I do not have.

Its main lesson is the one above: a microbenchmark of a BCL primitive does not
predict an end-to-end gain in the tool that calls it.

[1]: https://github.com/dotnet/runtime/issues/120826
