### PR TITLE
Add structured single-image type declaration probe

### DIFF
--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -6,12 +6,13 @@
 
 ## Status
 
-Design for replacing the current collection of type-forwarder helpers and
-spelling-based caller matching with one structured reference-to-definition
-system.
+Design and staged implementation plan for replacing the current collection of
+type-forwarder helpers and spelling-based caller matching with one structured
+reference-to-definition system.
 
-The first implementation slice adds the model and the single-image metadata
-primitive only. It migrates no production caller. That boundary follows the
+The first implementation slice provides the structured lookup name, validated
+row tokens, closed declaration outcomes, and bounded single-image metadata
+probe. It migrates no production caller. That boundary follows the
 primitive-first approach used by `InertString` in
 [#3636](https://github.com/richlander/dotnet-inspect/pull/3636): establish the
 value, its invariants, and its gates before asking consumers to depend on it.

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -90,23 +90,31 @@ identity is required. The round-trip design calls that pairing
 `ModuleIdentity`; current product code has `MemberAnchor` and the tools-specific
 `RoundTripModuleIdentity`, not a shared product type named `ModuleIdentity`.
 
-### Proposed forwarding currencies
+### Structured forwarding currencies
 
-These contracts belong to the structured forwarding design and remain proposed
-until its delivery slices implement them.
+The first Metadata delivery slice implements the single-image declaration
+currencies. The Analysis provenance and cross-assembly resolution currencies
+remain proposed until later delivery slices implement them.
 
-#### `ILInspector.Analysis` forwarding provenance
+#### Proposed `ILInspector.Analysis` forwarding provenance
 
 | Currency | Scope | Answers | Does not answer |
 | --- | --- | --- | --- |
 | `ResolvableTypeReference` | Decoder-produced provenance plus lookup name | Whether a reference came from an assembly, current assembly, intrinsic core library, or module | Resolution without the source candidate, or structural `TypeRef` equality |
 
-#### `ILInspector.Metadata` forwarding resolution
+#### Current `ILInspector.Metadata` single-image declaration
 
 | Currency | Scope | Answers | Does not answer |
 | --- | --- | --- | --- |
-| `TypeDefinitionToken`, `ExportedTypeToken` | One registered candidate's manifest module; multi-module exports are rejected | Which validated metadata row the candidate contains | Definition correspondence by itself |
+| `TypeDefinitionToken`, `ExportedTypeToken` | One readable candidate's manifest module | Which validated metadata row the candidate contains | Definition correspondence or a live metadata handle |
 | `MetadataTypeDefinitionName` | Reader-independent lookup value | Which exact `TypeDef` / `ExportedType` name to probe, including nesting and arity | Assembly selection, signature shape, CLI selection, display, or universal identity |
+| `TypeDeclarationResult` and `TypeDeclarationCandidate` | One exact name in one readable image | Whether the image defines, forwards, misses, ambiguously declares, exports from a module, or rejects the name | Opening another assembly or resolving a target |
+| `ModuleFileReference` | One copied `File` row | Which module file an exported declaration names, including metadata and hash evidence | Module acquisition or readability |
+
+#### Proposed `ILInspector.Metadata` cross-assembly resolution
+
+| Currency | Scope | Answers | Does not answer |
+| --- | --- | --- | --- |
 | `TypeResolutionRequest` | One resolution operation | Which typed start candidate/binding target and exact name to resolve | Decoded provenance or reusable identity |
 | `ResolvedAssemblyCandidate` | One catalog | Which catalog-local descriptor identifies the candidate whose inventory/session state the catalog owns | Session ownership or durable identity outside the catalog |
 | `TypeResolutionOutcome` | One frozen catalog generation | The complete resolution verdict, non-success evidence, and ordered hops | Definition equality or a nullable success result |

--- a/src/ILInspector.Metadata/MetadataTypeDeclarationProbe.cs
+++ b/src/ILInspector.Metadata/MetadataTypeDeclarationProbe.cs
@@ -19,14 +19,15 @@ public static class MetadataTypeDeclarationProbe
 
         foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
         {
-            MetadataTypeDefinitionNameReadResult read =
-                MetadataTypeDefinitionNameReader.Read(reader, handle);
-            if (read is MetadataTypeDefinitionNameReadResult.Rejected rejected)
-                return new TypeDeclarationResult.Rejected(rejected.Failure);
-
-            var definitionName =
-                ((MetadataTypeDefinitionNameReadResult.Read)read).Name;
-            if (definitionName == name)
+            MetadataTypeDefinitionNameMatch match =
+                MetadataTypeDefinitionNameReader.Matches(
+                    reader,
+                    handle,
+                    name,
+                    out MetadataTypeNameFailure? failure);
+            if (match == MetadataTypeDefinitionNameMatch.Rejected)
+                return new TypeDeclarationResult.Rejected(failure!);
+            if (match == MetadataTypeDefinitionNameMatch.Match)
             {
                 candidates.Add(
                     new PendingValue(
@@ -37,18 +38,18 @@ public static class MetadataTypeDeclarationProbe
 
         foreach (ExportedTypeHandle handle in reader.ExportedTypes)
         {
-            MetadataTypeDefinitionNameReadResult read =
-                MetadataTypeDefinitionNameReader.Read(reader, handle);
-            if (read is MetadataTypeDefinitionNameReadResult.Rejected rejected)
-                return new TypeDeclarationResult.Rejected(rejected.Failure);
-
-            var exportedName =
-                ((MetadataTypeDefinitionNameReadResult.Read)read).Name;
-            if (exportedName != name)
+            MetadataTypeDefinitionNameMatch match =
+                MetadataTypeDefinitionNameReader.Matches(
+                    reader,
+                    handle,
+                    name,
+                    out MetadataTypeNameFailure? failure);
+            if (match == MetadataTypeDefinitionNameMatch.Rejected)
+                return new TypeDeclarationResult.Rejected(failure!);
+            if (match == MetadataTypeDefinitionNameMatch.NoMatch)
                 continue;
 
             TypeDeclarationCandidate? candidate;
-            MetadataTypeNameFailure? failure;
             if (!TryReadExportedCandidate(
                     reader,
                     handle,

--- a/src/ILInspector.Metadata/MetadataTypeDeclarationProbe.cs
+++ b/src/ILInspector.Metadata/MetadataTypeDeclarationProbe.cs
@@ -1,0 +1,258 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>Answers how one readable metadata image declares one exact type name.</summary>
+public static class MetadataTypeDeclarationProbe
+{
+    public static TypeDeclarationResult Probe(
+        MetadataReader reader,
+        MetadataTypeDefinitionName name)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(name);
+
+        var candidates = new List<PendingCandidate>();
+        var forwarders =
+            new Dictionary<AssemblyReferenceIdentity, PendingForwarder>();
+
+        foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
+        {
+            MetadataTypeDefinitionNameReadResult read =
+                MetadataTypeDefinitionNameReader.Read(reader, handle);
+            if (read is MetadataTypeDefinitionNameReadResult.Rejected rejected)
+                return new TypeDeclarationResult.Rejected(rejected.Failure);
+
+            var definitionName =
+                ((MetadataTypeDefinitionNameReadResult.Read)read).Name;
+            if (definitionName == name)
+            {
+                candidates.Add(
+                    new PendingValue(
+                        new TypeDeclarationCandidate.Definition(
+                            TypeDefinitionToken.FromHandle(reader, handle))));
+            }
+        }
+
+        foreach (ExportedTypeHandle handle in reader.ExportedTypes)
+        {
+            MetadataTypeDefinitionNameReadResult read =
+                MetadataTypeDefinitionNameReader.Read(reader, handle);
+            if (read is MetadataTypeDefinitionNameReadResult.Rejected rejected)
+                return new TypeDeclarationResult.Rejected(rejected.Failure);
+
+            var exportedName =
+                ((MetadataTypeDefinitionNameReadResult.Read)read).Name;
+            if (exportedName != name)
+                continue;
+
+            TypeDeclarationCandidate? candidate;
+            MetadataTypeNameFailure? failure;
+            if (!TryReadExportedCandidate(
+                    reader,
+                    handle,
+                    out candidate,
+                    out failure))
+            {
+                return new TypeDeclarationResult.Rejected(failure!);
+            }
+
+            AddCandidate(candidates, forwarders, candidate!);
+        }
+
+        return Complete(candidates);
+    }
+
+    static bool TryReadExportedCandidate(
+        MetadataReader reader,
+        ExportedTypeHandle handle,
+        out TypeDeclarationCandidate? candidate,
+        out MetadataTypeNameFailure? failure)
+    {
+        candidate = null;
+        failure = null;
+
+        var traversal =
+            MetadataRelationshipTraversal.WalkExportedTypeImplementationChain(
+                reader,
+                handle);
+        if (traversal is
+            RelationshipTraversalResult<RelationshipChain<ExportedTypeHandle>>.Rejected rejected)
+        {
+            failure = MetadataTypeNameFailure.From(rejected.Rejection);
+            return false;
+        }
+
+        RelationshipChain<ExportedTypeHandle> chain =
+            ((RelationshipTraversalResult<RelationshipChain<ExportedTypeHandle>>.Completed)
+                traversal).Value;
+        ImmutableArray<ExportedTypeToken> declarations =
+            [.. chain.Handles.Select(handle => ExportedTypeToken.FromHandle(reader, handle))];
+
+        try
+        {
+            switch (chain.Terminal.Kind)
+            {
+                case HandleKind.AssemblyReference:
+                    ExportedType root = reader.GetExportedType(chain.Handles[0]);
+                    if (!root.IsForwarder)
+                    {
+                        failure = MetadataTypeNameFailure.Malformed(
+                            chain.Handles[0],
+                            "An AssemblyRef-terminated ExportedType chain must "
+                            + "be marked as a forwarder.");
+                        return false;
+                    }
+
+                    AssemblyReferenceIdentity target =
+                        AssemblyReferenceIdentity.From(
+                            reader,
+                            (AssemblyReferenceHandle)chain.Terminal);
+                    if (string.IsNullOrEmpty(target.Name))
+                    {
+                        failure = MetadataTypeNameFailure.Malformed(
+                            chain.Terminal,
+                            "An assembly-reference target must have a name.");
+                        return false;
+                    }
+
+                    candidate = new TypeDeclarationCandidate.Forwarder(
+                        declarations,
+                        target);
+                    return true;
+
+                case HandleKind.AssemblyFile:
+                    AssemblyFile file =
+                        reader.GetAssemblyFile((AssemblyFileHandle)chain.Terminal);
+                    string moduleName = reader.GetString(file.Name);
+                    if (string.IsNullOrEmpty(moduleName))
+                    {
+                        failure = MetadataTypeNameFailure.Malformed(
+                            chain.Terminal,
+                            "A module file reference must have a name.");
+                        return false;
+                    }
+
+                    candidate = new TypeDeclarationCandidate.ModuleExport(
+                        declarations,
+                        new ModuleFileReference(
+                            moduleName,
+                            file.ContainsMetadata,
+                            ImmutableArray.Create(reader.GetBlobBytes(file.HashValue))));
+                    return true;
+
+                default:
+                    failure = MetadataTypeNameFailure.Malformed(
+                        handle,
+                        $"ExportedType implementation terminates at unsupported "
+                        + $"{chain.Terminal.Kind} metadata.");
+                    return false;
+            }
+        }
+        catch (BadImageFormatException ex)
+        {
+            failure = MetadataTypeNameFailure.Malformed(handle, ex.Message);
+            return false;
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            failure = MetadataTypeNameFailure.Malformed(handle, ex.Message);
+            return false;
+        }
+    }
+
+    static void AddCandidate(
+        List<PendingCandidate> candidates,
+        Dictionary<AssemblyReferenceIdentity, PendingForwarder> forwarders,
+        TypeDeclarationCandidate candidate)
+    {
+        if (candidate is not TypeDeclarationCandidate.Forwarder forwarder)
+        {
+            candidates.Add(new PendingValue(candidate));
+            return;
+        }
+
+        if (forwarders.TryGetValue(forwarder.Target, out PendingForwarder? existing))
+        {
+            foreach (ExportedTypeToken declaration in forwarder.Declarations)
+                existing.Add(declaration);
+            return;
+        }
+
+        var pending = new PendingForwarder(
+            forwarder.Target,
+            forwarder.Declarations);
+        forwarders.Add(forwarder.Target, pending);
+        candidates.Add(pending);
+    }
+
+    static TypeDeclarationResult Complete(
+        List<PendingCandidate> pending)
+    {
+        if (pending.Count == 0)
+            return new TypeDeclarationResult.Missing();
+
+        ImmutableArray<TypeDeclarationCandidate> candidates =
+            [.. pending.Select(candidate => candidate.Materialize())];
+        if (candidates.Length > 1)
+        {
+            return new TypeDeclarationResult.Ambiguous(
+                candidates);
+        }
+
+        return candidates[0] switch
+        {
+            TypeDeclarationCandidate.Definition definition =>
+                new TypeDeclarationResult.Defined(definition.Token),
+            TypeDeclarationCandidate.Forwarder forwarder =>
+                new TypeDeclarationResult.Forwarded(
+                    forwarder.Declarations,
+                    forwarder.Target),
+            TypeDeclarationCandidate.ModuleExport module =>
+                new TypeDeclarationResult.ExportedFromModule(
+                    module.Declarations,
+                    module.Module),
+            _ => throw new InvalidOperationException(
+                "Unknown type declaration candidate."),
+        };
+    }
+
+    abstract class PendingCandidate
+    {
+        internal abstract TypeDeclarationCandidate Materialize();
+    }
+
+    sealed class PendingValue(TypeDeclarationCandidate value) : PendingCandidate
+    {
+        internal override TypeDeclarationCandidate Materialize() => value;
+    }
+
+    sealed class PendingForwarder : PendingCandidate
+    {
+        readonly List<ExportedTypeToken> declarations;
+        readonly HashSet<ExportedTypeToken> declarationSet;
+
+        internal PendingForwarder(
+            AssemblyReferenceIdentity target,
+            ImmutableArray<ExportedTypeToken> declarations)
+        {
+            Target = target;
+            this.declarations = [.. declarations];
+            declarationSet = [.. declarations];
+        }
+
+        internal AssemblyReferenceIdentity Target { get; }
+
+        internal void Add(ExportedTypeToken declaration)
+        {
+            if (declarationSet.Add(declaration))
+                declarations.Add(declaration);
+        }
+
+        internal override TypeDeclarationCandidate Materialize() =>
+            new TypeDeclarationCandidate.Forwarder(
+                [.. declarations],
+                Target);
+    }
+}

--- a/src/ILInspector.Metadata/MetadataTypeDefinitionName.cs
+++ b/src/ILInspector.Metadata/MetadataTypeDefinitionName.cs
@@ -144,82 +144,264 @@ internal abstract record MetadataTypeDefinitionNameReadResult
         MetadataTypeDefinitionNameReadResult;
 }
 
+internal enum MetadataTypeDefinitionNameMatch
+{
+    NoMatch,
+    Match,
+    Rejected,
+}
+
 internal static class MetadataTypeDefinitionNameReader
 {
     internal static MetadataTypeDefinitionNameReadResult Read(
         MetadataReader reader,
-        TypeDefinitionHandle handle) =>
-        ReadChain(
-            reader,
-            MetadataRelationshipTraversal.WalkTypeDefinitionDeclaringChain(reader, handle),
-            current =>
-            {
-                TypeDefinition definition = reader.GetTypeDefinition(current);
-                return (definition.Namespace, definition.Name);
-            },
-            static current => current);
-
-    internal static MetadataTypeDefinitionNameReadResult Read(
-        MetadataReader reader,
-        TypeReferenceHandle handle) =>
-        ReadChain(
-            reader,
-            MetadataRelationshipTraversal.WalkTypeReferenceResolutionScope(reader, handle),
-            current =>
-            {
-                TypeReference reference = reader.GetTypeReference(current);
-                return (reference.Namespace, reference.Name);
-            },
-            static current => current);
-
-    internal static MetadataTypeDefinitionNameReadResult Read(
-        MetadataReader reader,
-        ExportedTypeHandle handle) =>
-        ReadChain(
-            reader,
-            MetadataRelationshipTraversal.WalkExportedTypeImplementationChain(reader, handle),
-            current =>
-            {
-                ExportedType exported = reader.GetExportedType(current);
-                return (exported.Namespace, exported.Name);
-            },
-            static current => current);
-
-    static MetadataTypeDefinitionNameReadResult ReadChain<THandle>(
-        MetadataReader reader,
-        RelationshipTraversalResult<RelationshipChain<THandle>> traversal,
-        Func<THandle, (StringHandle Namespace, StringHandle Name)> getName,
-        Func<THandle, EntityHandle> getSubject)
-        where THandle : struct
+        TypeDefinitionHandle handle)
     {
-        if (traversal is RelationshipTraversalResult<RelationshipChain<THandle>>.Rejected rejected)
+        Span<TypeDefinitionHandle> rootToLeaf =
+            stackalloc TypeDefinitionHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkTypeDefinitionDeclaringChain(
+                reader,
+                handle,
+                rootToLeaf,
+                out int consumedNodes,
+                out _,
+                out RelationshipTraversalRejection? rejection))
         {
-            return new MetadataTypeDefinitionNameReadResult.Rejected(
-                MetadataTypeNameFailure.From(rejected.Rejection));
+            return RejectedTraversal(rejection!);
         }
 
-        RelationshipChain<THandle> chain =
-            ((RelationshipTraversalResult<RelationshipChain<THandle>>.Completed)traversal).Value;
-        var segments = ImmutableArray.CreateBuilder<string>(chain.Handles.Length);
-        string? @namespace = null;
+        return ReadChain<TypeDefinitionHandle, TypeDefinitionNameRow>(
+            reader,
+            rootToLeaf[..consumedNodes]);
+    }
 
-        for (int i = 0; i < chain.Handles.Length; i++)
+    internal static MetadataTypeDefinitionNameMatch Matches(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        MetadataTypeDefinitionName name,
+        out MetadataTypeNameFailure? failure)
+    {
+        if (!LeafMatches<TypeDefinitionHandle, TypeDefinitionNameRow>(
+                reader,
+                handle,
+                name,
+                out MetadataTypeDefinitionNameMatch leafResult,
+                out failure))
         {
-            THandle handle = chain.Handles[i];
+            return leafResult;
+        }
+
+        Span<TypeDefinitionHandle> rootToLeaf =
+            stackalloc TypeDefinitionHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkTypeDefinitionDeclaringChain(
+                reader,
+                handle,
+                rootToLeaf,
+                out int consumedNodes,
+                out _,
+                out RelationshipTraversalRejection? rejection))
+        {
+            failure = MetadataTypeNameFailure.From(rejection!);
+            return MetadataTypeDefinitionNameMatch.Rejected;
+        }
+
+        return MatchChain<TypeDefinitionHandle, TypeDefinitionNameRow>(
+            reader,
+            rootToLeaf[..consumedNodes],
+            name,
+            out failure);
+    }
+
+    internal static MetadataTypeDefinitionNameMatch Matches(
+        MetadataReader reader,
+        ExportedTypeHandle handle,
+        MetadataTypeDefinitionName name,
+        out MetadataTypeNameFailure? failure)
+    {
+        if (!LeafMatches<ExportedTypeHandle, ExportedTypeNameRow>(
+                reader,
+                handle,
+                name,
+                out MetadataTypeDefinitionNameMatch leafResult,
+                out failure))
+        {
+            return leafResult;
+        }
+
+        Span<ExportedTypeHandle> rootToLeaf =
+            stackalloc ExportedTypeHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkExportedTypeImplementationChain(
+                reader,
+                handle,
+                rootToLeaf,
+                out int consumedNodes,
+                out _,
+                out RelationshipTraversalRejection? rejection))
+        {
+            failure = MetadataTypeNameFailure.From(rejection!);
+            return MetadataTypeDefinitionNameMatch.Rejected;
+        }
+
+        return MatchChain<ExportedTypeHandle, ExportedTypeNameRow>(
+            reader,
+            rootToLeaf[..consumedNodes],
+            name,
+            out failure);
+    }
+
+    static bool LeafMatches<THandle, TRow>(
+        MetadataReader reader,
+        THandle handle,
+        MetadataTypeDefinitionName name,
+        out MetadataTypeDefinitionNameMatch result,
+        out MetadataTypeNameFailure? failure)
+        where THandle : struct
+        where TRow : struct, IMetadataTypeNameRow<THandle>
+    {
+        failure = null;
+        try
+        {
+            var (_, leafName) = TRow.GetName(reader, handle);
+            if (!reader.StringComparer.Equals(leafName, name.Segments[^1]))
+            {
+                result = MetadataTypeDefinitionNameMatch.NoMatch;
+                return false;
+            }
+
+            result = MetadataTypeDefinitionNameMatch.Match;
+            return true;
+        }
+        catch (BadImageFormatException ex)
+        {
+            failure = RelationshipFailure(ex, TRow.ToEntity(handle), consumedNodes: 1);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            failure = RelationshipFailure(ex, TRow.ToEntity(handle), consumedNodes: 1);
+        }
+
+        result = MetadataTypeDefinitionNameMatch.Rejected;
+        return false;
+    }
+
+    static MetadataTypeDefinitionNameMatch MatchChain<THandle, TRow>(
+        MetadataReader reader,
+        ReadOnlySpan<THandle> rootToLeaf,
+        MetadataTypeDefinitionName name,
+        out MetadataTypeNameFailure? failure)
+        where THandle : struct
+        where TRow : struct, IMetadataTypeNameRow<THandle>
+    {
+        failure = null;
+        if (rootToLeaf.Length != name.Segments.Length)
+            return MetadataTypeDefinitionNameMatch.NoMatch;
+
+        for (int i = 0; i < rootToLeaf.Length; i++)
+        {
             try
             {
-                var (namespaceHandle, nameHandle) = getName(handle);
+                var (namespaceHandle, nameHandle) =
+                    TRow.GetName(reader, rootToLeaf[i]);
+                if (i == 0
+                    && !reader.StringComparer.Equals(namespaceHandle, name.Namespace))
+                {
+                    return MetadataTypeDefinitionNameMatch.NoMatch;
+                }
+
+                if (!reader.StringComparer.Equals(nameHandle, name.Segments[i]))
+                    return MetadataTypeDefinitionNameMatch.NoMatch;
+            }
+            catch (BadImageFormatException ex)
+            {
+                failure = RelationshipFailure(
+                    ex,
+                    TRow.ToEntity(rootToLeaf[i]),
+                    i + 1);
+                return MetadataTypeDefinitionNameMatch.Rejected;
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                failure = RelationshipFailure(
+                    ex,
+                    TRow.ToEntity(rootToLeaf[i]),
+                    i + 1);
+                return MetadataTypeDefinitionNameMatch.Rejected;
+            }
+        }
+
+        return MetadataTypeDefinitionNameMatch.Match;
+    }
+
+    internal static MetadataTypeDefinitionNameReadResult Read(
+        MetadataReader reader,
+        TypeReferenceHandle handle)
+    {
+        Span<TypeReferenceHandle> rootToLeaf =
+            stackalloc TypeReferenceHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkTypeReferenceResolutionScope(
+                reader,
+                handle,
+                rootToLeaf,
+                out int consumedNodes,
+                out _,
+                out RelationshipTraversalRejection? rejection))
+        {
+            return RejectedTraversal(rejection!);
+        }
+
+        return ReadChain<TypeReferenceHandle, TypeReferenceNameRow>(
+            reader,
+            rootToLeaf[..consumedNodes]);
+    }
+
+    internal static MetadataTypeDefinitionNameReadResult Read(
+        MetadataReader reader,
+        ExportedTypeHandle handle)
+    {
+        Span<ExportedTypeHandle> rootToLeaf =
+            stackalloc ExportedTypeHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkExportedTypeImplementationChain(
+                reader,
+                handle,
+                rootToLeaf,
+                out int consumedNodes,
+                out _,
+                out RelationshipTraversalRejection? rejection))
+        {
+            return RejectedTraversal(rejection!);
+        }
+
+        return ReadChain<ExportedTypeHandle, ExportedTypeNameRow>(
+            reader,
+            rootToLeaf[..consumedNodes]);
+    }
+
+    static MetadataTypeDefinitionNameReadResult ReadChain<THandle, TRow>(
+        MetadataReader reader,
+        ReadOnlySpan<THandle> rootToLeaf)
+        where THandle : struct
+        where TRow : struct, IMetadataTypeNameRow<THandle>
+    {
+        var segments = ImmutableArray.CreateBuilder<string>(rootToLeaf.Length);
+        string? @namespace = null;
+
+        for (int i = 0; i < rootToLeaf.Length; i++)
+        {
+            THandle handle = rootToLeaf[i];
+            try
+            {
+                var (namespaceHandle, nameHandle) = TRow.GetName(reader, handle);
                 if (i == 0)
                     @namespace = reader.GetString(namespaceHandle);
                 segments.Add(reader.GetString(nameHandle));
             }
             catch (BadImageFormatException ex)
             {
-                return Malformed(ex, getSubject(handle), i + 1);
+                return Malformed(ex, TRow.ToEntity(handle), i + 1);
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                return Malformed(ex, getSubject(handle), i + 1);
+                return Malformed(ex, TRow.ToEntity(handle), i + 1);
             }
         }
 
@@ -230,23 +412,86 @@ internal static class MetadataTypeDefinitionNameReader
 
         MetadataTypeNameRejection invalid =
             ((MetadataTypeDefinitionNameResult.Rejected)created).Rejection;
-        EntityHandle subject = getSubject(
-            chain.Handles[invalid.SegmentIndex ?? 0]);
+        EntityHandle subject =
+            TRow.ToEntity(rootToLeaf[invalid.SegmentIndex ?? 0]);
         return new MetadataTypeDefinitionNameReadResult.Rejected(
             MetadataTypeNameFailure.Malformed(
                 subject,
                 $"Invalid structured metadata type name: {invalid.Kind}."));
     }
 
+    static MetadataTypeDefinitionNameReadResult RejectedTraversal(
+        RelationshipTraversalRejection rejection) =>
+        new MetadataTypeDefinitionNameReadResult.Rejected(
+            MetadataTypeNameFailure.From(rejection));
+
     static MetadataTypeDefinitionNameReadResult Malformed(
         Exception exception,
         EntityHandle subject,
         int consumedNodes) =>
         new MetadataTypeDefinitionNameReadResult.Rejected(
-            MetadataTypeNameFailure.From(
-                new RelationshipTraversalRejection(
-                    RelationshipTraversalRejectionKind.MalformedMetadata,
-                    exception.Message,
-                    subject,
-                    consumedNodes)));
+            RelationshipFailure(exception, subject, consumedNodes));
+
+    static MetadataTypeNameFailure RelationshipFailure(
+        Exception exception,
+        EntityHandle subject,
+        int consumedNodes) =>
+        MetadataTypeNameFailure.From(
+            new RelationshipTraversalRejection(
+                RelationshipTraversalRejectionKind.MalformedMetadata,
+                exception.Message,
+                subject,
+                consumedNodes));
+
+    interface IMetadataTypeNameRow<THandle>
+        where THandle : struct
+    {
+        static abstract (StringHandle Namespace, StringHandle Name) GetName(
+            MetadataReader reader,
+            THandle handle);
+
+        static abstract EntityHandle ToEntity(THandle handle);
+    }
+
+    readonly struct TypeDefinitionNameRow :
+        IMetadataTypeNameRow<TypeDefinitionHandle>
+    {
+        public static (StringHandle Namespace, StringHandle Name) GetName(
+            MetadataReader reader,
+            TypeDefinitionHandle handle)
+        {
+            TypeDefinition definition = reader.GetTypeDefinition(handle);
+            return (definition.Namespace, definition.Name);
+        }
+
+        public static EntityHandle ToEntity(TypeDefinitionHandle handle) => handle;
+    }
+
+    readonly struct ExportedTypeNameRow :
+        IMetadataTypeNameRow<ExportedTypeHandle>
+    {
+        public static (StringHandle Namespace, StringHandle Name) GetName(
+            MetadataReader reader,
+            ExportedTypeHandle handle)
+        {
+            ExportedType exported = reader.GetExportedType(handle);
+            return (exported.Namespace, exported.Name);
+        }
+
+        public static EntityHandle ToEntity(ExportedTypeHandle handle) => handle;
+    }
+
+    readonly struct TypeReferenceNameRow :
+        IMetadataTypeNameRow<TypeReferenceHandle>
+    {
+        public static (StringHandle Namespace, StringHandle Name) GetName(
+            MetadataReader reader,
+            TypeReferenceHandle handle)
+        {
+            TypeReference reference = reader.GetTypeReference(handle);
+            return (reference.Namespace, reference.Name);
+        }
+
+        public static EntityHandle ToEntity(TypeReferenceHandle handle) => handle;
+    }
 }

--- a/src/ILInspector.Metadata/MetadataTypeDefinitionName.cs
+++ b/src/ILInspector.Metadata/MetadataTypeDefinitionName.cs
@@ -1,0 +1,252 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>Why a structured metadata type-definition name could not be created.</summary>
+public enum MetadataTypeNameRejectionKind
+{
+    MissingNamespace,
+    MissingSegments,
+    MissingSegment,
+}
+
+/// <summary>Typed evidence for a rejected structured metadata type-definition name.</summary>
+public sealed record MetadataTypeNameRejection(
+    MetadataTypeNameRejectionKind Kind,
+    int? SegmentIndex = null);
+
+/// <summary>The result of validating a structured metadata type-definition name.</summary>
+public abstract class MetadataTypeDefinitionNameResult
+{
+    private protected MetadataTypeDefinitionNameResult()
+    {
+    }
+
+    public sealed class Valid : MetadataTypeDefinitionNameResult
+    {
+        internal Valid(MetadataTypeDefinitionName name) => Name = name;
+
+        public MetadataTypeDefinitionName Name { get; }
+    }
+
+    public sealed class Rejected : MetadataTypeDefinitionNameResult
+    {
+        internal Rejected(MetadataTypeNameRejection rejection) =>
+            Rejection = rejection;
+
+        public MetadataTypeNameRejection Rejection { get; }
+    }
+}
+
+/// <summary>
+/// An exact reader-independent metadata lookup name: namespace plus
+/// root-to-leaf metadata-name segments, including generic arity.
+/// </summary>
+public sealed class MetadataTypeDefinitionName : IEquatable<MetadataTypeDefinitionName>
+{
+    readonly int hashCode;
+
+    MetadataTypeDefinitionName(string @namespace, ImmutableArray<string> segments)
+    {
+        Namespace = @namespace;
+        Segments = segments;
+
+        var hash = new HashCode();
+        hash.Add(@namespace, StringComparer.Ordinal);
+        foreach (string segment in segments)
+            hash.Add(segment, StringComparer.Ordinal);
+        hashCode = hash.ToHashCode();
+    }
+
+    public string Namespace { get; }
+    public ImmutableArray<string> Segments { get; }
+
+    public static MetadataTypeDefinitionNameResult Create(
+        string? @namespace,
+        ImmutableArray<string> segments)
+    {
+        if (@namespace is null)
+        {
+            return new MetadataTypeDefinitionNameResult.Rejected(
+                new MetadataTypeNameRejection(
+                    MetadataTypeNameRejectionKind.MissingNamespace));
+        }
+
+        if (segments.IsDefaultOrEmpty)
+        {
+            return new MetadataTypeDefinitionNameResult.Rejected(
+                new MetadataTypeNameRejection(
+                    MetadataTypeNameRejectionKind.MissingSegments));
+        }
+
+        for (int i = 0; i < segments.Length; i++)
+        {
+            if (string.IsNullOrEmpty(segments[i]))
+            {
+                return new MetadataTypeDefinitionNameResult.Rejected(
+                    new MetadataTypeNameRejection(
+                        MetadataTypeNameRejectionKind.MissingSegment,
+                        i));
+            }
+        }
+
+        return new MetadataTypeDefinitionNameResult.Valid(
+            new MetadataTypeDefinitionName(@namespace, segments));
+    }
+
+    public bool Equals(MetadataTypeDefinitionName? other)
+    {
+        if (ReferenceEquals(this, other))
+            return true;
+        if (other is null
+            || !StringComparer.Ordinal.Equals(Namespace, other.Namespace)
+            || Segments.Length != other.Segments.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < Segments.Length; i++)
+        {
+            if (!StringComparer.Ordinal.Equals(Segments[i], other.Segments[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object? obj) =>
+        obj is MetadataTypeDefinitionName other && Equals(other);
+
+    public override int GetHashCode() => hashCode;
+
+    public static bool operator ==(
+        MetadataTypeDefinitionName? left,
+        MetadataTypeDefinitionName? right) =>
+        EqualityComparer<MetadataTypeDefinitionName>.Default.Equals(left, right);
+
+    public static bool operator !=(
+        MetadataTypeDefinitionName? left,
+        MetadataTypeDefinitionName? right) =>
+        !(left == right);
+}
+
+internal abstract record MetadataTypeDefinitionNameReadResult
+{
+    private protected MetadataTypeDefinitionNameReadResult()
+    {
+    }
+
+    internal sealed record Read(MetadataTypeDefinitionName Name) :
+        MetadataTypeDefinitionNameReadResult;
+
+    internal sealed record Rejected(MetadataTypeNameFailure Failure) :
+        MetadataTypeDefinitionNameReadResult;
+}
+
+internal static class MetadataTypeDefinitionNameReader
+{
+    internal static MetadataTypeDefinitionNameReadResult Read(
+        MetadataReader reader,
+        TypeDefinitionHandle handle) =>
+        ReadChain(
+            reader,
+            MetadataRelationshipTraversal.WalkTypeDefinitionDeclaringChain(reader, handle),
+            current =>
+            {
+                TypeDefinition definition = reader.GetTypeDefinition(current);
+                return (definition.Namespace, definition.Name);
+            },
+            static current => current);
+
+    internal static MetadataTypeDefinitionNameReadResult Read(
+        MetadataReader reader,
+        TypeReferenceHandle handle) =>
+        ReadChain(
+            reader,
+            MetadataRelationshipTraversal.WalkTypeReferenceResolutionScope(reader, handle),
+            current =>
+            {
+                TypeReference reference = reader.GetTypeReference(current);
+                return (reference.Namespace, reference.Name);
+            },
+            static current => current);
+
+    internal static MetadataTypeDefinitionNameReadResult Read(
+        MetadataReader reader,
+        ExportedTypeHandle handle) =>
+        ReadChain(
+            reader,
+            MetadataRelationshipTraversal.WalkExportedTypeImplementationChain(reader, handle),
+            current =>
+            {
+                ExportedType exported = reader.GetExportedType(current);
+                return (exported.Namespace, exported.Name);
+            },
+            static current => current);
+
+    static MetadataTypeDefinitionNameReadResult ReadChain<THandle>(
+        MetadataReader reader,
+        RelationshipTraversalResult<RelationshipChain<THandle>> traversal,
+        Func<THandle, (StringHandle Namespace, StringHandle Name)> getName,
+        Func<THandle, EntityHandle> getSubject)
+        where THandle : struct
+    {
+        if (traversal is RelationshipTraversalResult<RelationshipChain<THandle>>.Rejected rejected)
+        {
+            return new MetadataTypeDefinitionNameReadResult.Rejected(
+                MetadataTypeNameFailure.From(rejected.Rejection));
+        }
+
+        RelationshipChain<THandle> chain =
+            ((RelationshipTraversalResult<RelationshipChain<THandle>>.Completed)traversal).Value;
+        var segments = ImmutableArray.CreateBuilder<string>(chain.Handles.Length);
+        string? @namespace = null;
+
+        for (int i = 0; i < chain.Handles.Length; i++)
+        {
+            THandle handle = chain.Handles[i];
+            try
+            {
+                var (namespaceHandle, nameHandle) = getName(handle);
+                if (i == 0)
+                    @namespace = reader.GetString(namespaceHandle);
+                segments.Add(reader.GetString(nameHandle));
+            }
+            catch (BadImageFormatException ex)
+            {
+                return Malformed(ex, getSubject(handle), i + 1);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                return Malformed(ex, getSubject(handle), i + 1);
+            }
+        }
+
+        MetadataTypeDefinitionNameResult created =
+            MetadataTypeDefinitionName.Create(@namespace, segments.ToImmutable());
+        if (created is MetadataTypeDefinitionNameResult.Valid valid)
+            return new MetadataTypeDefinitionNameReadResult.Read(valid.Name);
+
+        MetadataTypeNameRejection invalid =
+            ((MetadataTypeDefinitionNameResult.Rejected)created).Rejection;
+        EntityHandle subject = getSubject(
+            chain.Handles[invalid.SegmentIndex ?? 0]);
+        return new MetadataTypeDefinitionNameReadResult.Rejected(
+            MetadataTypeNameFailure.Malformed(
+                subject,
+                $"Invalid structured metadata type name: {invalid.Kind}."));
+    }
+
+    static MetadataTypeDefinitionNameReadResult Malformed(
+        Exception exception,
+        EntityHandle subject,
+        int consumedNodes) =>
+        new MetadataTypeDefinitionNameReadResult.Rejected(
+            MetadataTypeNameFailure.From(
+                new RelationshipTraversalRejection(
+                    RelationshipTraversalRejectionKind.MalformedMetadata,
+                    exception.Message,
+                    subject,
+                    consumedNodes)));
+}

--- a/src/ILInspector.Metadata/TypeDeclaration.cs
+++ b/src/ILInspector.Metadata/TypeDeclaration.cs
@@ -1,0 +1,169 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Metadata;
+
+/// <summary>A validated TypeDef metadata token in one assembly candidate.</summary>
+public readonly record struct TypeDefinitionToken
+{
+    TypeDefinitionToken(int value) => Value = value;
+
+    public int Value { get; }
+
+    internal static TypeDefinitionToken FromHandle(
+        MetadataReader reader,
+        TypeDefinitionHandle handle)
+    {
+        if (handle.IsNil)
+            throw new ArgumentException("A TypeDef token cannot be nil.", nameof(handle));
+        reader.GetTypeDefinition(handle);
+        return new TypeDefinitionToken(MetadataTokens.GetToken(handle));
+    }
+}
+
+/// <summary>A validated ExportedType metadata token in one assembly candidate.</summary>
+public readonly record struct ExportedTypeToken
+{
+    ExportedTypeToken(int value) => Value = value;
+
+    public int Value { get; }
+
+    internal static ExportedTypeToken FromHandle(
+        MetadataReader reader,
+        ExportedTypeHandle handle)
+    {
+        if (handle.IsNil)
+            throw new ArgumentException("An ExportedType token cannot be nil.", nameof(handle));
+        reader.GetExportedType(handle);
+        return new ExportedTypeToken(MetadataTokens.GetToken(handle));
+    }
+}
+
+/// <summary>Copied evidence for a File row that carries a module export.</summary>
+public sealed class ModuleFileReference
+{
+    internal ModuleFileReference(
+        string name,
+        bool containsMetadata,
+        ImmutableArray<byte> hash)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        Name = name;
+        ContainsMetadata = containsMetadata;
+        Hash = hash;
+    }
+
+    public string Name { get; }
+    public bool ContainsMetadata { get; }
+    public ImmutableArray<byte> Hash { get; }
+}
+
+/// <summary>One declaration competing for an exact metadata type name.</summary>
+public abstract class TypeDeclarationCandidate
+{
+    private protected TypeDeclarationCandidate()
+    {
+    }
+
+    public sealed class Definition : TypeDeclarationCandidate
+    {
+        internal Definition(TypeDefinitionToken token) => Token = token;
+
+        public TypeDefinitionToken Token { get; }
+    }
+
+    public sealed class Forwarder : TypeDeclarationCandidate
+    {
+        internal Forwarder(
+            ImmutableArray<ExportedTypeToken> declarations,
+            AssemblyReferenceIdentity target)
+        {
+            Declarations = declarations;
+            Target = target;
+        }
+
+        public ImmutableArray<ExportedTypeToken> Declarations { get; }
+        public AssemblyReferenceIdentity Target { get; }
+    }
+
+    public sealed class ModuleExport : TypeDeclarationCandidate
+    {
+        internal ModuleExport(
+            ImmutableArray<ExportedTypeToken> declarations,
+            ModuleFileReference module)
+        {
+            Declarations = declarations;
+            Module = module;
+        }
+
+        public ImmutableArray<ExportedTypeToken> Declarations { get; }
+        public ModuleFileReference Module { get; }
+    }
+}
+
+/// <summary>The closed declaration answer for one exact name in one readable image.</summary>
+public abstract class TypeDeclarationResult
+{
+    private protected TypeDeclarationResult()
+    {
+    }
+
+    public sealed class Defined : TypeDeclarationResult
+    {
+        internal Defined(TypeDefinitionToken definition) => Definition = definition;
+
+        public TypeDefinitionToken Definition { get; }
+    }
+
+    public sealed class Forwarded : TypeDeclarationResult
+    {
+        internal Forwarded(
+            ImmutableArray<ExportedTypeToken> declarations,
+            AssemblyReferenceIdentity target)
+        {
+            Declarations = declarations;
+            Target = target;
+        }
+
+        public ImmutableArray<ExportedTypeToken> Declarations { get; }
+        public AssemblyReferenceIdentity Target { get; }
+    }
+
+    public sealed class ExportedFromModule : TypeDeclarationResult
+    {
+        internal ExportedFromModule(
+            ImmutableArray<ExportedTypeToken> declarations,
+            ModuleFileReference module)
+        {
+            Declarations = declarations;
+            Module = module;
+        }
+
+        public ImmutableArray<ExportedTypeToken> Declarations { get; }
+        public ModuleFileReference Module { get; }
+    }
+
+    public sealed class Missing : TypeDeclarationResult
+    {
+        internal Missing()
+        {
+        }
+    }
+
+    public sealed class Ambiguous : TypeDeclarationResult
+    {
+        internal Ambiguous(ImmutableArray<TypeDeclarationCandidate> candidates) =>
+            Candidates = candidates;
+
+        public ImmutableArray<TypeDeclarationCandidate> Candidates { get; }
+    }
+
+    public sealed class Rejected : TypeDeclarationResult
+    {
+        internal Rejected(MetadataTypeNameFailure rejection) =>
+            Rejection = rejection;
+
+        public MetadataTypeNameFailure Rejection { get; }
+    }
+}

--- a/src/ILInspector.Metadata/TypeDeclaration.cs
+++ b/src/ILInspector.Metadata/TypeDeclaration.cs
@@ -15,9 +15,14 @@ public readonly record struct TypeDefinitionToken
         MetadataReader reader,
         TypeDefinitionHandle handle)
     {
-        if (handle.IsNil)
-            throw new ArgumentException("A TypeDef token cannot be nil.", nameof(handle));
-        reader.GetTypeDefinition(handle);
+        int row = MetadataTokens.GetRowNumber(handle);
+        if (row <= 0 || row > reader.GetTableRowCount(TableIndex.TypeDef))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(handle),
+                "A TypeDef token must identify a row in the supplied reader.");
+        }
+
         return new TypeDefinitionToken(MetadataTokens.GetToken(handle));
     }
 }
@@ -33,9 +38,14 @@ public readonly record struct ExportedTypeToken
         MetadataReader reader,
         ExportedTypeHandle handle)
     {
-        if (handle.IsNil)
-            throw new ArgumentException("An ExportedType token cannot be nil.", nameof(handle));
-        reader.GetExportedType(handle);
+        int row = MetadataTokens.GetRowNumber(handle);
+        if (row <= 0 || row > reader.GetTableRowCount(TableIndex.ExportedType))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(handle),
+                "An ExportedType token must identify a row in the supplied reader.");
+        }
+
         return new ExportedTypeToken(MetadataTokens.GetToken(handle));
     }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeDeclarationProbeTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeDeclarationProbeTests.cs
@@ -1,0 +1,632 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public class MetadataTypeDeclarationProbeTests
+{
+    const TypeAttributes Forwarder = (TypeAttributes)0x00200000;
+
+    [Fact]
+    public void StructuredName_HasOrdinalStructuralValueSemantics()
+    {
+        MetadataTypeDefinitionName first = Name("N", "Outer`1", "Inner`2");
+        MetadataTypeDefinitionName second = Name("N", "Outer`1", "Inner`2");
+        MetadataTypeDefinitionName differentCase = Name("N", "Outer`1", "inner`2");
+
+        Assert.Equal(first, second);
+        Assert.True(first == second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+        Assert.NotEqual(first, differentCase);
+        Assert.Equal(["Outer`1", "Inner`2"], first.Segments);
+
+        var cache = new Dictionary<MetadataTypeDefinitionName, string>
+        {
+            [first] = "value",
+        };
+        Assert.Equal("value", cache[second]);
+    }
+
+    [Fact]
+    public void StructuredName_RejectsMissingNamespace()
+    {
+        var rejected = Assert.IsType<MetadataTypeDefinitionNameResult.Rejected>(
+            MetadataTypeDefinitionName.Create(null, ["Type"]));
+
+        Assert.Equal(
+            MetadataTypeNameRejectionKind.MissingNamespace,
+            rejected.Rejection.Kind);
+    }
+
+    [Fact]
+    public void StructuredName_RejectsMissingSegments()
+    {
+        var nullSegments = Assert.IsType<MetadataTypeDefinitionNameResult.Rejected>(
+            MetadataTypeDefinitionName.Create("N", default));
+        var emptySegments = Assert.IsType<MetadataTypeDefinitionNameResult.Rejected>(
+            MetadataTypeDefinitionName.Create("N", []));
+
+        Assert.Equal(
+            MetadataTypeNameRejectionKind.MissingSegments,
+            nullSegments.Rejection.Kind);
+        Assert.Equal(
+            MetadataTypeNameRejectionKind.MissingSegments,
+            emptySegments.Rejection.Kind);
+    }
+
+    [Fact]
+    public void StructuredName_RejectsEmptySegment()
+    {
+        var rejected = Assert.IsType<MetadataTypeDefinitionNameResult.Rejected>(
+            MetadataTypeDefinitionName.Create("N", ["Outer", ""]));
+
+        Assert.Equal(
+            MetadataTypeNameRejectionKind.MissingSegment,
+            rejected.Rejection.Kind);
+        Assert.Equal(1, rejected.Rejection.SegmentIndex);
+    }
+
+    [Fact]
+    public void StructuredNameReader_PreservesNestedTypeReferenceSegments()
+    {
+        TypeReferenceHandle leaf = default;
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AssemblyReferenceHandle target = AddAssemblyReference(metadata, "Target");
+            TypeReferenceHandle root = metadata.AddTypeReference(
+                target,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Outer`1"));
+            leaf = metadata.AddTypeReference(
+                root,
+                default,
+                metadata.GetOrAddString("Inner`2"));
+        });
+
+        var read = Assert.IsType<MetadataTypeDefinitionNameReadResult.Read>(
+            MetadataTypeDefinitionNameReader.Read(image.Reader, leaf));
+
+        Assert.Equal(Name("N", "Outer`1", "Inner`2"), read.Name);
+    }
+
+    [Fact]
+    public void StructuredNameReader_RejectsEmptyTypeReferenceName()
+    {
+        TypeReferenceHandle reference = default;
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            reference = metadata.AddTypeReference(
+                AddAssemblyReference(metadata, "Target"),
+                metadata.GetOrAddString("N"),
+                name: default);
+        });
+
+        var rejected = Assert.IsType<MetadataTypeDefinitionNameReadResult.Rejected>(
+            MetadataTypeDefinitionNameReader.Read(image.Reader, reference));
+
+        Assert.Equal(
+            MetadataTypeNameFailureMechanism.Metadata,
+            rejected.Failure.Mechanism);
+    }
+
+    [Fact]
+    public void Probe_ReturnsTopLevelDefinition()
+    {
+        TypeDefinitionHandle expected = default;
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            expected = AddTypeDefinition(metadata, TypeAttributes.Public, "N", "Type");
+        });
+
+        var defined = Assert.IsType<TypeDeclarationResult.Defined>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Equal(MetadataTokens.GetToken(expected), defined.Definition.Value);
+    }
+
+    [Fact]
+    public void Probe_ReturnsNestedDefinition()
+    {
+        TypeDefinitionHandle inner = default;
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            TypeDefinitionHandle outer =
+                AddTypeDefinition(metadata, TypeAttributes.Public, "N", "Outer`1");
+            inner = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                "Inner`2");
+            metadata.AddNestedType(inner, outer);
+        });
+
+        var defined = Assert.IsType<TypeDeclarationResult.Defined>(
+            MetadataTypeDeclarationProbe.Probe(
+                image.Reader,
+                Name("N", "Outer`1", "Inner`2")));
+
+        Assert.Equal(MetadataTokens.GetToken(inner), defined.Definition.Value);
+    }
+
+    [Fact]
+    public void Probe_ReturnsTopLevelForwarder()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AssemblyReferenceHandle target = AddAssemblyReference(metadata, "Target");
+            metadata.AddExportedType(
+                TypeAttributes.Public | Forwarder,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Type"),
+                target,
+                typeDefinitionId: 0);
+        });
+
+        var forwarded = Assert.IsType<TypeDeclarationResult.Forwarded>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Equal("Target", forwarded.Target.Name);
+        Assert.Single(forwarded.Declarations);
+        Assert.Equal(
+            (int)TableIndex.ExportedType,
+            forwarded.Declarations[0].Value >> 24);
+    }
+
+    [Fact]
+    public void Probe_ReturnsNestedForwarderWithFullDeclarationChain()
+    {
+        ExportedTypeHandle outer = default;
+        ExportedTypeHandle inner = default;
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AssemblyReferenceHandle target = AddAssemblyReference(metadata, "Target");
+            outer = metadata.AddExportedType(
+                TypeAttributes.Public | Forwarder,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Outer"),
+                target,
+                typeDefinitionId: 0);
+            inner = metadata.AddExportedType(
+                TypeAttributes.NestedPublic,
+                default,
+                metadata.GetOrAddString("Inner"),
+                outer,
+                typeDefinitionId: 0);
+        });
+
+        var forwarded = Assert.IsType<TypeDeclarationResult.Forwarded>(
+            MetadataTypeDeclarationProbe.Probe(
+                image.Reader,
+                Name("N", "Outer", "Inner")));
+
+        Assert.Equal(
+            [MetadataTokens.GetToken(outer), MetadataTokens.GetToken(inner)],
+            forwarded.Declarations.Select(token => token.Value));
+    }
+
+    [Fact]
+    public void Probe_RejectsAssemblyReferenceExportWithoutForwarderFlag()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            metadata.AddExportedType(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Type"),
+                AddAssemblyReference(metadata, "Target"),
+                typeDefinitionId: 0);
+        });
+
+        var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Equal(
+            MetadataTypeNameFailureMechanism.Metadata,
+            rejected.Rejection.Mechanism);
+    }
+
+    [Fact]
+    public void Probe_CoalescesDuplicateForwardersToSameCompleteIdentity()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AssemblyReferenceHandle target = AddAssemblyReference(metadata, "Target");
+            AddForwarder(metadata, target, "N", "Type");
+            AddForwarder(metadata, target, "N", "Type");
+        });
+
+        var forwarded = Assert.IsType<TypeDeclarationResult.Forwarded>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Equal("Target", forwarded.Target.Name);
+        Assert.Equal(2, forwarded.Declarations.Length);
+    }
+
+    [Fact]
+    public void Probe_ReturnsAmbiguousForDifferentForwarderTargets()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AddForwarder(
+                metadata,
+                AddAssemblyReference(metadata, "TargetA"),
+                "N",
+                "Type");
+            AddForwarder(
+                metadata,
+                AddAssemblyReference(metadata, "TargetB"),
+                "N",
+                "Type");
+        });
+
+        var ambiguous = Assert.IsType<TypeDeclarationResult.Ambiguous>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Equal(2, ambiguous.Candidates.Length);
+        Assert.All(
+            ambiguous.Candidates,
+            candidate => Assert.IsType<TypeDeclarationCandidate.Forwarder>(candidate));
+    }
+
+    [Fact]
+    public void Probe_UsesCompleteAssemblyIdentityWhenCoalescingForwarders()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AddForwarder(
+                metadata,
+                AddAssemblyReference(metadata, "Target", new Version(1, 0, 0, 0)),
+                "N",
+                "Type");
+            AddForwarder(
+                metadata,
+                AddAssemblyReference(metadata, "Target", new Version(2, 0, 0, 0)),
+                "N",
+                "Type");
+        });
+
+        var ambiguous = Assert.IsType<TypeDeclarationResult.Ambiguous>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Equal(2, ambiguous.Candidates.Length);
+    }
+
+    [Fact]
+    public void Probe_ReturnsAmbiguousForDefinitionForwarderConflict()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AddTypeDefinition(metadata, TypeAttributes.Public, "N", "Type");
+            AddForwarder(
+                metadata,
+                AddAssemblyReference(metadata, "Target"),
+                "N",
+                "Type");
+        });
+
+        var ambiguous = Assert.IsType<TypeDeclarationResult.Ambiguous>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Collection(
+            ambiguous.Candidates,
+            candidate => Assert.IsType<TypeDeclarationCandidate.Definition>(candidate),
+            candidate => Assert.IsType<TypeDeclarationCandidate.Forwarder>(candidate));
+    }
+
+    [Fact]
+    public void Probe_ReturnsAmbiguousForCompetingDefinitions()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AddTypeDefinition(metadata, TypeAttributes.Public, "N", "Type");
+            AddTypeDefinition(metadata, TypeAttributes.Public, "N", "Type");
+        });
+
+        var ambiguous = Assert.IsType<TypeDeclarationResult.Ambiguous>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Equal(2, ambiguous.Candidates.Length);
+        Assert.All(
+            ambiguous.Candidates,
+            candidate => Assert.IsType<TypeDeclarationCandidate.Definition>(candidate));
+    }
+
+    [Fact]
+    public void Probe_ReturnsCopiedModuleExportEvidence()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AssemblyFileHandle module = metadata.AddAssemblyFile(
+                metadata.GetOrAddString("Part.netmodule"),
+                metadata.GetOrAddBlob(new byte[] { 1, 2, 3 }),
+                containsMetadata: true);
+            metadata.AddExportedType(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Type"),
+                module,
+                typeDefinitionId: 1);
+        });
+
+        var exported = Assert.IsType<TypeDeclarationResult.ExportedFromModule>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Equal("Part.netmodule", exported.Module.Name);
+        Assert.True(exported.Module.ContainsMetadata);
+        Assert.Equal([1, 2, 3], exported.Module.Hash);
+        Assert.Single(exported.Declarations);
+    }
+
+    [Fact]
+    public void Probe_ReturnsMissingForReadableImageWithoutDeclaration()
+    {
+        using MetadataImage image = BuildMetadata(_ => { });
+
+        Assert.IsType<TypeDeclarationResult.Missing>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Missing")));
+    }
+
+    [Fact]
+    public void Probe_RejectsCyclicExportedTypeRelationship()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            metadata.AddExportedType(
+                Forwarder,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("First"),
+                MetadataTokens.ExportedTypeHandle(2),
+                typeDefinitionId: 0);
+            metadata.AddExportedType(
+                Forwarder,
+                default,
+                metadata.GetOrAddString("Second"),
+                MetadataTokens.ExportedTypeHandle(1),
+                typeDefinitionId: 0);
+        });
+
+        var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
+            MetadataTypeDeclarationProbe.Probe(
+                image.Reader,
+                Name("N", "Unrelated")));
+
+        Assert.Equal(RelationshipTraversalRejectionKind.Cycle, rejected.Rejection.RelationshipKind);
+    }
+
+    [Fact]
+    public void Probe_RejectsEmptyMetadataNameSegment()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            metadata.AddExportedType(
+                Forwarder,
+                metadata.GetOrAddString("N"),
+                name: default,
+                AddAssemblyReference(metadata, "Target"),
+                typeDefinitionId: 0);
+        });
+
+        var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
+            MetadataTypeDeclarationProbe.Probe(
+                image.Reader,
+                Name("N", "Unrelated")));
+
+        Assert.Equal(
+            MetadataTypeNameFailureMechanism.Metadata,
+            rejected.Rejection.Mechanism);
+    }
+
+    [Fact]
+    public void Probe_RejectsEmptyTypeDefinitionName()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("N"),
+                name: default,
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+        });
+
+        var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
+            MetadataTypeDeclarationProbe.Probe(
+                image.Reader,
+                Name("N", "Unrelated")));
+
+        Assert.Equal(
+            MetadataTypeNameFailureMechanism.Metadata,
+            rejected.Rejection.Mechanism);
+    }
+
+    [Fact]
+    public void Probe_RejectsUnsupportedExportedTypeTerminal()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            metadata.AddExportedType(
+                Forwarder,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Type"),
+                implementation: default(AssemblyFileHandle),
+                typeDefinitionId: 0);
+        });
+
+        var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
+            MetadataTypeDeclarationProbe.Probe(image.Reader, Name("N", "Type")));
+
+        Assert.Equal(
+            MetadataTypeNameFailureMechanism.Metadata,
+            rejected.Rejection.Mechanism);
+    }
+
+    [Fact]
+    public void Probe_RejectsExportedTypeRelationshipOverNodeBudget()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            for (int row = 1; row <= MetadataSafetyPolicy.MaxRelationshipNodes + 1; row++)
+            {
+                metadata.AddExportedType(
+                    Forwarder,
+                    row == MetadataSafetyPolicy.MaxRelationshipNodes + 1
+                        ? metadata.GetOrAddString("N")
+                        : default,
+                    metadata.GetOrAddString($"Type{row}"),
+                    row == MetadataSafetyPolicy.MaxRelationshipNodes + 1
+                        ? AddAssemblyReference(metadata, "Target")
+                        : MetadataTokens.ExportedTypeHandle(row + 1),
+                    typeDefinitionId: 0);
+            }
+        });
+
+        var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
+            MetadataTypeDeclarationProbe.Probe(
+                image.Reader,
+                Name("N", "Unrelated")));
+
+        Assert.Equal(
+            RelationshipTraversalRejectionKind.NodeBudget,
+            rejected.Rejection.RelationshipKind);
+        Assert.Equal(
+            MetadataSafetyPolicy.MaxRelationshipNodes,
+            rejected.Rejection.ConsumedNodes);
+    }
+
+    [Fact]
+    public void Probe_RecognizesCompilerProducedForwarder()
+    {
+        using var stream = File.OpenRead(typeof(MetadataTypeDeclarationProbeTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var forwarded = Assert.IsType<TypeDeclarationResult.Forwarded>(
+            MetadataTypeDeclarationProbe.Probe(
+                peReader.GetMetadataReader(),
+                Name("ILInspector.Metadata", "MetadataTableProjector")));
+
+        Assert.Equal("ILInspector.Metadata", forwarded.Target.Name);
+    }
+
+    [Fact]
+    public void DeclarationResults_DoNotExposeReadersOrMetadataHandles()
+    {
+        Type[] resultTypes =
+        [
+            typeof(TypeDeclarationResult.Defined),
+            typeof(TypeDeclarationResult.Forwarded),
+            typeof(TypeDeclarationResult.ExportedFromModule),
+            typeof(TypeDeclarationResult.Missing),
+            typeof(TypeDeclarationResult.Ambiguous),
+            typeof(TypeDeclarationResult.Rejected),
+            typeof(TypeDeclarationCandidate.Definition),
+            typeof(TypeDeclarationCandidate.Forwarder),
+            typeof(TypeDeclarationCandidate.ModuleExport),
+            typeof(ModuleFileReference),
+        ];
+
+        foreach (Type type in resultTypes)
+        {
+            foreach (PropertyInfo property in type.GetProperties())
+                AssertClosedPropertyType(property.PropertyType);
+        }
+    }
+
+    static void AssertClosedPropertyType(Type type)
+    {
+        Assert.NotEqual(typeof(MetadataReader), type);
+        Assert.NotEqual(typeof(PEReader), type);
+        Assert.False(
+            type.Namespace == "System.Reflection.Metadata"
+            && type.Name.EndsWith("Handle", StringComparison.Ordinal));
+
+        if (type.HasElementType)
+            AssertClosedPropertyType(type.GetElementType()!);
+
+        foreach (Type argument in type.GetGenericArguments())
+            AssertClosedPropertyType(argument);
+    }
+
+    static MetadataTypeDefinitionName Name(string @namespace, params string[] segments)
+    {
+        var valid = Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create(@namespace, [.. segments]));
+        return valid.Name;
+    }
+
+    static TypeDefinitionHandle AddTypeDefinition(
+        MetadataBuilder metadata,
+        TypeAttributes attributes,
+        string @namespace,
+        string name) =>
+        metadata.AddTypeDefinition(
+            attributes,
+            @namespace.Length == 0 ? default : metadata.GetOrAddString(@namespace),
+            metadata.GetOrAddString(name),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+    static AssemblyReferenceHandle AddAssemblyReference(
+        MetadataBuilder metadata,
+        string name,
+        Version? version = null) =>
+        metadata.AddAssemblyReference(
+            metadata.GetOrAddString(name),
+            version ?? new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+
+    static ExportedTypeHandle AddForwarder(
+        MetadataBuilder metadata,
+        AssemblyReferenceHandle target,
+        string @namespace,
+        string name) =>
+        metadata.AddExportedType(
+            TypeAttributes.Public | Forwarder,
+            metadata.GetOrAddString(@namespace),
+            metadata.GetOrAddString(name),
+            target,
+            typeDefinitionId: 0);
+
+    static MetadataImage BuildMetadata(Action<MetadataBuilder> addRows)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        AddTypeDefinition(metadata, default, "", "<Module>");
+        addRows(metadata);
+
+        var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var image = new BlobBuilder();
+        rootBuilder.Serialize(image, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
+        return new MetadataImage(image.ToImmutableArray());
+    }
+
+    sealed class MetadataImage(ImmutableArray<byte> image) : IDisposable
+    {
+        readonly MetadataReaderProvider provider =
+            MetadataReaderProvider.FromMetadataImage(image);
+
+        public MetadataReader Reader => provider.GetMetadataReader();
+
+        public void Dispose() => provider.Dispose();
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeDeclarationProbeTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeDeclarationProbeTests.cs
@@ -153,6 +153,27 @@ public class MetadataTypeDeclarationProbeTests
     }
 
     [Fact]
+    public void Probe_DoesNotMatchCloseNestedDefinitionNames()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            TypeDefinitionHandle outer =
+                AddTypeDefinition(metadata, TypeAttributes.Public, "N", "Outer`1");
+            TypeDefinitionHandle inner = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                "Leaf");
+            metadata.AddNestedType(inner, outer);
+        });
+
+        AssertMissing(image.Reader, Name("Other", "Outer`1", "Leaf"));
+        AssertMissing(image.Reader, Name("N", "Other`1", "Leaf"));
+        AssertMissing(image.Reader, Name("N", "Outer`2", "Leaf"));
+        AssertMissing(image.Reader, Name("N", "Leaf"));
+    }
+
+    [Fact]
     public void Probe_ReturnsTopLevelForwarder()
     {
         using MetadataImage image = BuildMetadata(metadata =>
@@ -206,6 +227,32 @@ public class MetadataTypeDeclarationProbeTests
         Assert.Equal(
             [MetadataTokens.GetToken(outer), MetadataTokens.GetToken(inner)],
             forwarded.Declarations.Select(token => token.Value));
+    }
+
+    [Fact]
+    public void Probe_DoesNotMatchCloseNestedForwarderNames()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AssemblyReferenceHandle target = AddAssemblyReference(metadata, "Target");
+            ExportedTypeHandle outer = metadata.AddExportedType(
+                TypeAttributes.Public | Forwarder,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Outer`1"),
+                target,
+                typeDefinitionId: 0);
+            metadata.AddExportedType(
+                TypeAttributes.NestedPublic,
+                default,
+                metadata.GetOrAddString("Leaf"),
+                outer,
+                typeDefinitionId: 0);
+        });
+
+        AssertMissing(image.Reader, Name("Other", "Outer`1", "Leaf"));
+        AssertMissing(image.Reader, Name("N", "Other`1", "Leaf"));
+        AssertMissing(image.Reader, Name("N", "Outer`2", "Leaf"));
+        AssertMissing(image.Reader, Name("N", "Leaf"));
     }
 
     [Fact]
@@ -392,17 +439,18 @@ public class MetadataTypeDeclarationProbeTests
         var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
             MetadataTypeDeclarationProbe.Probe(
                 image.Reader,
-                Name("N", "Unrelated")));
+                Name("N", "First")));
 
         Assert.Equal(RelationshipTraversalRejectionKind.Cycle, rejected.Rejection.RelationshipKind);
     }
 
     [Fact]
-    public void Probe_RejectsEmptyMetadataNameSegment()
+    public void StructuredNameReader_RejectsEmptyExportedTypeName()
     {
+        ExportedTypeHandle exported = default;
         using MetadataImage image = BuildMetadata(metadata =>
         {
-            metadata.AddExportedType(
+            exported = metadata.AddExportedType(
                 Forwarder,
                 metadata.GetOrAddString("N"),
                 name: default,
@@ -410,22 +458,21 @@ public class MetadataTypeDeclarationProbeTests
                 typeDefinitionId: 0);
         });
 
-        var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
-            MetadataTypeDeclarationProbe.Probe(
-                image.Reader,
-                Name("N", "Unrelated")));
+        var rejected = Assert.IsType<MetadataTypeDefinitionNameReadResult.Rejected>(
+            MetadataTypeDefinitionNameReader.Read(image.Reader, exported));
 
         Assert.Equal(
             MetadataTypeNameFailureMechanism.Metadata,
-            rejected.Rejection.Mechanism);
+            rejected.Failure.Mechanism);
     }
 
     [Fact]
-    public void Probe_RejectsEmptyTypeDefinitionName()
+    public void StructuredNameReader_RejectsEmptyTypeDefinitionName()
     {
+        TypeDefinitionHandle definition = default;
         using MetadataImage image = BuildMetadata(metadata =>
         {
-            metadata.AddTypeDefinition(
+            definition = metadata.AddTypeDefinition(
                 TypeAttributes.Public,
                 metadata.GetOrAddString("N"),
                 name: default,
@@ -434,14 +481,12 @@ public class MetadataTypeDeclarationProbeTests
                 methodList: MetadataTokens.MethodDefinitionHandle(1));
         });
 
-        var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
-            MetadataTypeDeclarationProbe.Probe(
-                image.Reader,
-                Name("N", "Unrelated")));
+        var rejected = Assert.IsType<MetadataTypeDefinitionNameReadResult.Rejected>(
+            MetadataTypeDefinitionNameReader.Read(image.Reader, definition));
 
         Assert.Equal(
             MetadataTypeNameFailureMechanism.Metadata,
-            rejected.Rejection.Mechanism);
+            rejected.Failure.Mechanism);
     }
 
     [Fact]
@@ -488,7 +533,7 @@ public class MetadataTypeDeclarationProbeTests
         var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
             MetadataTypeDeclarationProbe.Probe(
                 image.Reader,
-                Name("N", "Unrelated")));
+                Name("N", "Type1")));
 
         Assert.Equal(
             RelationshipTraversalRejectionKind.NodeBudget,
@@ -496,6 +541,103 @@ public class MetadataTypeDeclarationProbeTests
         Assert.Equal(
             MetadataSafetyPolicy.MaxRelationshipNodes,
             rejected.Rejection.ConsumedNodes);
+    }
+
+    [Fact]
+    public void Probe_SkipsUnrelatedMalformedRelationship()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AddTypeDefinition(metadata, TypeAttributes.Public, "N", "ValidType");
+            metadata.AddExportedType(
+                Forwarder,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("First"),
+                MetadataTokens.ExportedTypeHandle(2),
+                typeDefinitionId: 0);
+            metadata.AddExportedType(
+                Forwarder,
+                default,
+                metadata.GetOrAddString("Second"),
+                MetadataTokens.ExportedTypeHandle(1),
+                typeDefinitionId: 0);
+        });
+
+        Assert.IsType<TypeDeclarationResult.Defined>(
+            MetadataTypeDeclarationProbe.Probe(
+                image.Reader,
+                Name("N", "ValidType")));
+    }
+
+    [Fact]
+    public void Probe_RejectsSameLeafMalformedRelationshipBesideDefinition()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            AddTypeDefinition(metadata, TypeAttributes.Public, "N", "First");
+            metadata.AddExportedType(
+                Forwarder,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("First"),
+                MetadataTokens.ExportedTypeHandle(2),
+                typeDefinitionId: 0);
+            metadata.AddExportedType(
+                Forwarder,
+                default,
+                metadata.GetOrAddString("Second"),
+                MetadataTokens.ExportedTypeHandle(1),
+                typeDefinitionId: 0);
+        });
+
+        var rejected = Assert.IsType<TypeDeclarationResult.Rejected>(
+            MetadataTypeDeclarationProbe.Probe(
+                image.Reader,
+                Name("N", "First")));
+
+        Assert.Equal(
+            RelationshipTraversalRejectionKind.Cycle,
+            rejected.Rejection.RelationshipKind);
+    }
+
+    [Fact]
+    public void Probe_AbsentNameAllocationDoesNotScaleWithRowCount()
+    {
+        using MetadataImage image = BuildMetadata(metadata =>
+        {
+            for (int i = 0; i < 1_000; i++)
+            {
+                AddTypeDefinition(
+                    metadata,
+                    TypeAttributes.Public,
+                    "N",
+                    $"Type{i}");
+            }
+        });
+        MetadataTypeDefinitionName missing = Name("N", "Missing");
+
+        MetadataTypeDeclarationProbe.Probe(image.Reader, missing);
+        const int iterations = 20;
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+            MetadataTypeDeclarationProbe.Probe(image.Reader, missing);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.InRange(allocated, 0, iterations * 2_048);
+    }
+
+    [Fact]
+    public void MaterializedTokens_RejectRowsOutsideSuppliedReader()
+    {
+        using MetadataImage image = BuildMetadata(_ => { });
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TypeDefinitionToken.FromHandle(
+                image.Reader,
+                MetadataTokens.TypeDefinitionHandle(2)));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ExportedTypeToken.FromHandle(
+                image.Reader,
+                MetadataTokens.ExportedTypeHandle(1)));
     }
 
     [Fact]
@@ -557,6 +699,12 @@ public class MetadataTypeDeclarationProbeTests
             MetadataTypeDefinitionName.Create(@namespace, [.. segments]));
         return valid.Name;
     }
+
+    static void AssertMissing(
+        MetadataReader reader,
+        MetadataTypeDefinitionName name) =>
+        Assert.IsType<TypeDeclarationResult.Missing>(
+            MetadataTypeDeclarationProbe.Probe(reader, name));
 
     static TypeDefinitionHandle AddTypeDefinition(
         MetadataBuilder metadata,


### PR DESCRIPTION
Adds the first implementation slice of the structured type-forwarding design: reader-independent metadata names, validated TypeDef/ExportedType tokens, closed declaration outcomes, and a bounded single-image probe that distinguishes definitions, forwarders, module exports, missing declarations, ambiguity, and typed rejection.

The probe supports top-level and nested declarations, coalesces duplicate forwarders only for equal complete assembly identities, preserves module-file evidence, and exposes no metadata readers or handles in its results. A compiler-produced forwarder canary complements synthetic malformed, cyclic, and node-budget fixtures.

This slice intentionally adds no production consumer and does not change `ResolvedAssemblyReference` or `IAssemblyReferenceResolver`; catalog, binding, and cross-assembly traversal remain later slices.

Validation:
- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` (1308 total, 1303 passed, 5 existing mdv-dependent skips)
- `npx markdownlint-cli docs/design/type-forwarding-resolution.md docs/design/type-member-api-representation.md`