### PR TITLE
Add trust and rendering axes to mdi for artifact text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,14 @@ on:
   # A PR retargeted from `main` onto a long-lived feature branch silently stops
   # matching `[main]`, so it reports no checks rather than failing ones -- and
   # once `ci-required` is a required check, "no checks reported" is
-  # indistinguishable at a glance from "not run yet". `feature/**` keeps the
-  # lower half of a stack covered while its base is still in review.
+  # indistinguishable at a glance from "not run yet".
+  #
+  # The list must therefore cover every prefix a *base* can have, which is every
+  # prefix a branch can have, since any branch under review can be stacked on.
+  # `feature/**` alone left `fix/**` uncovered, and that is not a hypothetical
+  # gap: #3684 opened onto `fix/3628-...` and reported no checks at all.
   pull_request:
-    branches: [main, 'feature/**']
+    branches: [main, 'feature/**', 'fix/**']
 
 env:
   DOTNET_NOLOGO: true

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -847,12 +847,17 @@ channel the check just closed.
 ### Status
 
 The bounded-traversal budgets, execution-incapable parsing, and opt-in heaps are
-implemented, with their gates named above. The identifier allow lists, the
-trust and rendering axes, `--survey`, the visual-encoding spelling and its
-decoder, and the failure-message rule are the **target model** and are not yet
-implemented; today the projector neutralizes control characters unconditionally
-and continues, and nothing validates an identifier's grammar at all. See the
-threat model's open work.
+implemented, with their gates named above. So are the visual-encoding spelling
+(#3636, extended to Unicode general categories in #3628), the failure-message
+rule, and both the trust and rendering axes, which `mdi` exposes as
+`--show-untrusted-text` and `--dangerously-print-raw`.
+
+The identifier allow lists and `--survey` remain the **target model**: nothing
+validates an identifier's grammar, and refusal stops at the first violation
+rather than surveying them all. The projector itself still encodes and
+continues by default — the axes are a property of the command line, not of the
+library, because containment is a guarantee every caller gets while refusing is
+a policy only a caller can choose. See the threat model's open work.
 
 ## Prior art: `mdv` / `MetadataVisualizer`
 

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -991,6 +991,22 @@ raw `string` — the shape `HardenedJson` already uses, where the guarantee come
 from choosing the type rather than from remembering the call. Auditing then
 becomes a search for a type rather than an argument about coverage.
 
+That durable fix shipped in #3687: `HeapReference.Text`/`.Preview`,
+`HandleRef.Display`, `MetadataImageOverview.MetadataVersion` and
+`Malformed.Detail` are `InertString`, and there is no conversion admitting a
+`string` into any of them. The enforcement is the compiler rather than a gate.
+
+It also decides where the rendering axis can act. Because the model cannot hold
+untreated text, `--dangerously-print-raw` cannot be served by carrying a second
+raw copy through the projection; raw output is produced at the sink by running
+the encoder backwards, which the encoding supports by construction — it is
+lossless and invertible, and a literal backslash is always rewritten so the
+inverse is unique. The trust axis is unaffected and still acts upstream, inside
+`ContainCellText`, because refusal asks about the raw text and must therefore
+see it before anything is spelled. That is why `ContainCellText` still takes a
+`string` while returning an `InertString`: the parameter is the last place the
+untreated value legitimately exists.
+
 That is also why the property needs its own gate rather than a comment.
 `MdiContainmentTests` splices a payload spanning all three control ranges the
 projector recognizes — a live `ESC [ 3 1 m` sequence, `BEL`, `DEL`, and a C1

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -768,6 +768,32 @@ and TSV replaces the line and paragraph separators, which it cannot carry in a
 record. Markdown carries everything. So the raw mode promises that `mdi` adds
 no encoding of its own, not that every scalar reaches the stream.
 
+**Raw output is produced by the decoder, at the sink.** Since #3687 the
+projection cannot hold untreated text at all: its text-bearing fields are
+`InertString`, and no conversion admits a `string` into one. That closes off the
+obvious implementation — keeping a second, raw copy of every value beside the
+contained one — and forces the honest one, which is to run the encoding
+backwards at the moment of printing. This is the `vis`/`unvis` pairing named
+below rather than a workaround for it: the encoding is lossless and invertible
+precisely so that a decoder can exist, and having the decoder is what makes raw
+output a *rendering* choice instead of a property of the model. A literal
+backslash is always rewritten on the way in, which is what keeps the inverse
+unique. Refusal is unaffected and still happens upstream, against the raw text,
+because the question it asks — does this artifact carry something concerning —
+is about the artifact rather than about the spelling.
+
+Placing the decode after the character budget also buys a property the earlier
+implementation lacked: **both modes cut the same value at the same point.**
+Bounding raw text separately, in its own units, made the rendering axis quietly
+a *content* axis too, so that asking for a different spelling changed how much
+of the value you saw — a subtler form of exactly the collapse this section
+warns about. `MdiUntrustedTextModeTests.RawAndEncodedRenderingsShowTheSamePrefix`
+gates it by re-encoding the raw cell and comparing it to the encoded one,
+running the encoder forward so the assertion is not a restatement of the
+decode. On an artifact carrying nothing that needs containment the three
+tiers are byte-identical; measured over a 2,031,325-byte assembly, all three
+agree exactly.
+
 The axes are independent, and that is the design. Visual encoding is the
 default on **every** artifact-text path, including underneath the trust-axis
 skip — which is precisely what makes that skip defensible: it means "do not

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -720,14 +720,20 @@ Artifact text can contain Markdown delimiters, newlines, terminal control
 characters, URLs, or prompt-like instructions. Renderers must preserve output
 structure and must not interpret inspected text as authority.
 
-> **Status.** The two axes below are the **target model**, not current
-> behavior. Today the metadata projector neutralizes control characters
-> unconditionally and continues, with no flags on either axis. See open work
-> item 10, and
-> [metadata-table-projection.md](metadata-table-projection.md#status).
+> **Status.** Both axes are built in `mdi`, which is the reference consumer:
+> the default refuses, `--show-untrusted-text` opts out of the trust axis, and
+> `--dangerously-print-raw` additionally opts out of the rendering axis. The
+> rendering axis rests on `InertText.InertString` (#3636), extended to Unicode
+> general categories in #3628.
 >
-> The rendering axis has a primitive as of #3636: `InertText.InertString`
-> supplies the encoded default. The flags, and the trust axis, remain unbuilt.
+> Two things remain unbuilt. **Survey mode** is not implemented: refusal stops
+> at the first violation rather than reporting every one, though
+> `InertString.IsPermitted` already returns a `ScalarViolation` shaped for it.
+> And **`dotnet-inspect` has neither flag**; the library default is to encode
+> and continue, so its behavior is the middle row of both tables. That default
+> is deliberate — containment is a safety property the library owes every
+> caller, while refusing is a policy only a caller can choose — but it means the
+> trust axis currently exists only where a command line can express it.
 
 Presentation is **two orthogonal decisions**, and collapsing them into one flag
 is a design error.
@@ -738,21 +744,38 @@ is a design error.
 | --- | --- |
 | *(default)* | abort at the first one |
 | survey mode | keep going; report location and pattern kind, never content, bounded by the traversal budget |
-| a `dangerously`-named skip | keep going and render the values anyway |
+| `--show-untrusted-text` | keep going and render the values anyway |
+
+The trust skip is **not** `dangerously`-named, which is a correction to an
+earlier draft of this section rather than a departure from it. The argument
+below is that the skip is defensible precisely because visual encoding still
+applies underneath it — it means "do not refuse," not "it is fine to put my
+terminal at risk." A name that called it dangerous would contradict that, and
+would spend the word on the safe path, leaving nothing louder for the flag that
+genuinely hands over live control characters.
 
 **Rendering** — how artifact text is spelled once something is printed:
 
 | Flag | Behavior |
 | --- | --- |
 | *(default)* | visually encoded into an inert form |
-| a `dangerously`-named raw mode | no visual encoding; the output format's own structural escaping still applies |
+| `--dangerously-print-raw` | no visual encoding; the output format's own structural escaping still applies |
+
+That last clause is load-bearing and measured: the format keeps itself well
+formed regardless of the flag. JSONL escapes scalars below U+0020 per RFC 8259,
+which is not containment — those escapes decode back to the original scalar —
+and TSV replaces the line and paragraph separators, which it cannot carry in a
+record. Markdown carries everything. So the raw mode promises that `mdi` adds
+no encoding of its own, not that every scalar reaches the stream.
 
 The axes are independent, and that is the design. Visual encoding is the
 default on **every** artifact-text path, including underneath the trust-axis
 skip — which is precisely what makes that skip defensible: it means "do not
 refuse," not "it is fine to put my terminal at risk." Reaching a live control
 character therefore requires opting out of both axes, two separately named
-mistakes.
+mistakes. `mdi` enforces exactly that: `--dangerously-print-raw` on its own is
+rejected rather than silently ignored, because refusal comes first and the flag
+would otherwise change nothing while appearing to.
 
 Rendering is **visual encoding, not neutralization**: control characters are
 re-spelled into an inert, lossless, invertible form rather than removed or

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -1,6 +1,7 @@
 using System.Reflection.Metadata.Ecma335;
 using ILInspector.Metadata;
 using InertText;
+using InertText.Encoding;
 using Markout;
 
 namespace DotnetInspector.MetadataRendering;
@@ -49,18 +50,19 @@ public static class MetadataProjectionRenderer
     public static void Render(
         MetadataTableProjection projection,
         TextWriter output,
-        MetadataTableFormat format = MetadataTableFormat.Markdown)
+        MetadataTableFormat format = MetadataTableFormat.Markdown,
+        UntrustedTextMode mode = UntrustedTextMode.Contain)
     {
         ArgumentNullException.ThrowIfNull(projection);
         ArgumentNullException.ThrowIfNull(output);
 
         if (format == MetadataTableFormat.Markdown)
-            RenderMarkdown(projection, output);
+            RenderMarkdown(projection, output, mode);
         else
-            RenderTabular(projection, output, format);
+            RenderTabular(projection, output, format, mode);
     }
 
-    static void RenderMarkdown(MetadataTableProjection projection, TextWriter output)
+    static void RenderMarkdown(MetadataTableProjection projection, TextWriter output, UntrustedTextMode mode)
     {
         var writer = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
 
@@ -72,13 +74,13 @@ public static class MetadataProjectionRenderer
             first = false;
 
             writer.WriteHeading(2, HeadingText(table));
-            WriteTable(writer, table, identifyTable: false);
+            WriteTable(writer, table, identifyTable: false, mode);
         }
 
         writer.Flush();
     }
 
-    static void RenderTabular(MetadataTableProjection projection, TextWriter output, MetadataTableFormat format)
+    static void RenderTabular(MetadataTableProjection projection, TextWriter output, MetadataTableFormat format, UntrustedTextMode mode)
     {
         var options = new MarkoutWriterOptions
         {
@@ -87,7 +89,7 @@ public static class MetadataProjectionRenderer
         var writer = new MarkoutWriter(output, new TableFormatter(showHeader: true), options);
 
         foreach (var table in projection.Tables)
-            WriteTable(writer, table, identifyTable: true);
+            WriteTable(writer, table, identifyTable: true, mode);
 
         writer.Flush();
     }
@@ -263,23 +265,24 @@ public static class MetadataProjectionRenderer
     public static void Render(
         MetadataImageOverview overview,
         TextWriter output,
-        MetadataTableFormat format = MetadataTableFormat.Markdown)
+        MetadataTableFormat format = MetadataTableFormat.Markdown,
+        UntrustedTextMode mode = UntrustedTextMode.Contain)
     {
         ArgumentNullException.ThrowIfNull(overview);
         ArgumentNullException.ThrowIfNull(output);
 
         if (format == MetadataTableFormat.Markdown)
-            RenderOverviewMarkdown(overview, output);
+            RenderOverviewMarkdown(overview, output, mode);
         else
-            RenderOverviewTabular(overview, output, format);
+            RenderOverviewTabular(overview, output, format, mode);
     }
 
-    static void RenderOverviewMarkdown(MetadataImageOverview overview, TextWriter output)
+    static void RenderOverviewMarkdown(MetadataImageOverview overview, TextWriter output, UntrustedTextMode mode)
     {
         var writer = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
 
         writer.WriteHeading(2, "Image");
-        WriteImageTable(writer, overview, identifySection: false);
+        WriteImageTable(writer, overview, identifySection: false, mode);
 
         writer.WriteBlankLine();
         writer.WriteHeading(2, "Heaps");
@@ -298,7 +301,7 @@ public static class MetadataProjectionRenderer
         writer.Flush();
     }
 
-    static void RenderOverviewTabular(MetadataImageOverview overview, TextWriter output, MetadataTableFormat format)
+    static void RenderOverviewTabular(MetadataImageOverview overview, TextWriter output, MetadataTableFormat format, UntrustedTextMode mode)
     {
         var options = new MarkoutWriterOptions
         {
@@ -309,18 +312,18 @@ public static class MetadataProjectionRenderer
         // The three parts have different shapes, so each keeps its own header and
         // carries a leading Section column, matching how the table renderer keeps
         // machine rows self-identifying.
-        WriteImageTable(writer, overview, identifySection: true);
+        WriteImageTable(writer, overview, identifySection: true, mode);
         WriteHeapTable(writer, overview, identifySection: true);
         WriteTableTable(writer, overview, identifySection: true);
 
         writer.Flush();
     }
 
-    static void WriteImageTable(MarkoutWriter writer, MetadataImageOverview overview, bool identifySection)
+    static void WriteImageTable(MarkoutWriter writer, MetadataImageOverview overview, bool identifySection, UntrustedTextMode mode)
     {
         WriteSectionTable(
             writer, identifySection, "image",
-            ["Property", "Value"], ["property", "value"], ImageFactRows(overview));
+            ["Property", "Value"], ["property", "value"], ImageFactRows(overview, mode));
     }
 
     /// <summary>
@@ -328,14 +331,14 @@ public static class MetadataProjectionRenderer
     /// multi-section overview and by <see cref="RenderImageFacts"/> so the two cannot report
     /// different facts about the same image.
     /// </summary>
-    static List<string[]> ImageFactRows(MetadataImageOverview overview)
+    static List<string[]> ImageFactRows(MetadataImageOverview overview, UntrustedTextMode mode)
     {
         var rows = new List<string[]>();
 
         // A truncated stamp must carry the ellipsis for the same reason a
         // truncated handle display does: a prefix must never be mistaken for the
         // whole value.
-        Add("Metadata version", Display(overview.MetadataVersion));
+        Add("Metadata version", Display(overview.MetadataVersion, mode));
         Add("Metadata kind", overview.Kind.ToString());
         Add("Has assembly manifest", overview.IsAssembly ? "yes" : "no");
         Add("Metadata offset", overview.MetadataOffset.ToString());
@@ -384,12 +387,13 @@ public static class MetadataProjectionRenderer
         MetadataImageOverview overview,
         TextWriter output,
         IReadOnlyCollection<string>? columns = null,
-        MetadataTableFormat format = MetadataTableFormat.Markdown)
+        MetadataTableFormat format = MetadataTableFormat.Markdown,
+        UntrustedTextMode mode = UntrustedTextMode.Contain)
     {
         ArgumentNullException.ThrowIfNull(overview);
         ArgumentNullException.ThrowIfNull(output);
 
-        var rows = ImageFactRows(overview);
+        var rows = ImageFactRows(overview, mode);
         foreach (var heap in overview.Heaps)
         {
             string addressing = heap.Addressing == MetadataHeapAddressing.Index ? "index" : "byte offset";
@@ -546,7 +550,8 @@ public static class MetadataProjectionRenderer
         HeapKind heap,
         int address,
         TextWriter output,
-        MetadataTableFormat format = MetadataTableFormat.Markdown)
+        MetadataTableFormat format = MetadataTableFormat.Markdown,
+        UntrustedTextMode mode = UntrustedTextMode.Contain)
     {
         ArgumentNullException.ThrowIfNull(value);
         ArgumentNullException.ThrowIfNull(output);
@@ -555,12 +560,12 @@ public static class MetadataProjectionRenderer
         {
             var markdown = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
             markdown.WriteHeading(2, $"{MetadataHeapCoordinate.StreamName(heap)} heap at {address}");
-            markdown.WriteTable(HeapValueHeaders, HeapValueHeaderNames, [HeapValueRow(value, heap, address)]);
+            markdown.WriteTable(HeapValueHeaders, HeapValueHeaderNames, [HeapValueRow(value, heap, address, mode)]);
             markdown.Flush();
             return;
         }
 
-        RenderHeapValue(value, heap, address, output, columns: null, format);
+        RenderHeapValue(value, heap, address, output, columns: null, format, mode);
     }
 
     static readonly string[] HeapValueHeaders = ["Heap", "Address", "Length", "Truncated", "Value"];
@@ -573,7 +578,7 @@ public static class MetadataProjectionRenderer
     /// </summary>
     public static IReadOnlyList<string> HeapValueColumns => HeapValueHeaders;
 
-    static string[] HeapValueRow(MetadataValue value, HeapKind heap, int address)
+    static string[] HeapValueRow(MetadataValue value, HeapKind heap, int address, UntrustedTextMode mode)
     {
         var heapReference = value as MetadataValue.HeapReference;
         return
@@ -582,7 +587,7 @@ public static class MetadataProjectionRenderer
             address.ToString(),
             heapReference is null ? string.Empty : heapReference.Length.ToString(),
             heapReference is { Truncated: true } ? "yes" : "no",
-            FormatCell(value),
+            FormatCell(value, mode),
         ];
     }
 
@@ -605,13 +610,14 @@ public static class MetadataProjectionRenderer
         int address,
         TextWriter output,
         IReadOnlyCollection<string>? columns = null,
-        MetadataTableFormat format = MetadataTableFormat.Markdown)
+        MetadataTableFormat format = MetadataTableFormat.Markdown,
+        UntrustedTextMode mode = UntrustedTextMode.Contain)
     {
         ArgumentNullException.ThrowIfNull(value);
         ArgumentNullException.ThrowIfNull(output);
 
         WriteNarrowedTable(
-            output, format, HeapValueHeaders, HeapValueHeaderNames, [HeapValueRow(value, heap, address)], columns);
+            output, format, HeapValueHeaders, HeapValueHeaderNames, [HeapValueRow(value, heap, address, mode)], columns);
     }
 
     static readonly string[] HeapEntryHeaders = ["Address", "Length", "Refs", "Truncated", "Value"];
@@ -632,7 +638,8 @@ public static class MetadataProjectionRenderer
         MetadataHeapEntrySet entries,
         TextWriter output,
         IReadOnlyCollection<string>? columns = null,
-        MetadataTableFormat format = MetadataTableFormat.Markdown)
+        MetadataTableFormat format = MetadataTableFormat.Markdown,
+        UntrustedTextMode mode = UntrustedTextMode.Contain)
     {
         ArgumentNullException.ThrowIfNull(entries);
         ArgumentNullException.ThrowIfNull(output);
@@ -646,7 +653,7 @@ public static class MetadataProjectionRenderer
                 heapReference is null ? string.Empty : heapReference.Length.ToString(),
                 entry.ReferenceCount.ToString(),
                 heapReference is { Truncated: true } ? "yes" : "no",
-                FormatCell(entry.Value),
+                FormatCell(entry.Value, mode),
             ]);
         }
 
@@ -743,13 +750,13 @@ public static class MetadataProjectionRenderer
     /// puts in its heading are not lost: they are available as caveats from
     /// <see cref="Caveats(MetadataTableView)"/>, which such a caller must render.
     /// </summary>
-    public static void RenderRows(MetadataTableView table, TextWriter output)
+    public static void RenderRows(MetadataTableView table, TextWriter output, UntrustedTextMode mode = UntrustedTextMode.Contain)
     {
         ArgumentNullException.ThrowIfNull(table);
         ArgumentNullException.ThrowIfNull(output);
 
         var writer = new MarkoutWriter(output, new MarkdownFormatter(), new MarkoutWriterOptions());
-        WriteTable(writer, table, identifyTable: false);
+        WriteTable(writer, table, identifyTable: false, mode);
         writer.Flush();
     }
 
@@ -797,7 +804,7 @@ public static class MetadataProjectionRenderer
             : $"{table.Name} (showing rows {first}\u2013{last} of {truncation.RowCount})";
     }
 
-    static void WriteTable(MarkoutWriter writer, MetadataTableView table, bool identifyTable)
+    static void WriteTable(MarkoutWriter writer, MetadataTableView table, bool identifyTable, UntrustedTextMode mode)
     {
         // Markdown identifies the table with a heading; the machine formats carry
         // a leading Table column instead so every row self-identifies. Both add a
@@ -834,22 +841,22 @@ public static class MetadataProjectionRenderer
                 cells[cellSlot++] = table.Name;
             cells[cellSlot++] = row.RowId.ToString();
             for (int i = 0; i < row.Cells.Length; i++)
-                cells[cellSlot + i] = FormatCell(row.Cells[i]);
+                cells[cellSlot + i] = FormatCell(row.Cells[i], mode);
             rows.Add(cells);
         }
 
         writer.WriteTable(headers, headerNames, rows);
     }
 
-    static string FormatCell(MetadataValue value) => value switch
+    static string FormatCell(MetadataValue value, UntrustedTextMode mode) => value switch
     {
         MetadataValue.Nil => "nil",
         MetadataValue.Scalar scalar => scalar.Display,
         MetadataValue.Flags flags => flags.Decoded,
-        MetadataValue.HeapReference heap => FormatHeap(heap),
-        MetadataValue.Handle handle => FormatHandle(handle.Reference),
+        MetadataValue.HeapReference heap => FormatHeap(heap, mode),
+        MetadataValue.Handle handle => FormatHandle(handle.Reference, mode),
         MetadataValue.Range range => FormatRange(range.Reference),
-        MetadataValue.Malformed malformed => $"!malformed: {malformed.Detail}",
+        MetadataValue.Malformed malformed => $"!malformed: {Display(malformed.Detail, mode)}",
         _ => throw new InvalidOperationException($"Unhandled metadata value: {value.GetType().Name}"),
     };
 
@@ -862,22 +869,52 @@ public static class MetadataProjectionRenderer
     /// model keeps the text and its truncation together precisely so that the decision
     /// made here — what a clipped value looks like — is made once, by the sink that knows
     /// its own notation, rather than by every producer guessing at it.
+    /// <para>
+    /// It is also the only place <see cref="UntrustedTextMode.Raw"/> can act. The projection
+    /// cannot carry untreated text — no conversion admits a <see cref="string"/> into an
+    /// <see cref="InertString"/> — so raw output is produced by running the encoder backwards
+    /// here rather than by keeping a second, untreated copy of every value upstream. That is
+    /// the <c>vis</c>/<c>unvis</c> pairing the threat model specifies: the encoding is lossless
+    /// and invertible, and the decoder is what makes raw output a rendering choice instead of a
+    /// property of the model.
+    /// </para>
+    /// <para>
+    /// Because the decode happens after bounding, the budget cuts the same value in both modes:
+    /// the axes differ in how text is spelled, not in how much of it is shown. Encoded and raw
+    /// output of a clipped cell therefore describe the same prefix.
+    /// </para>
     /// </remarks>
-    static string Display(InertString text, bool truncated)
-        => truncated ? text + Ellipsis : text.ToString();
+    static string Display(InertString text, bool truncated, UntrustedTextMode mode)
+    {
+        string body = mode is UntrustedTextMode.Raw ? Decode(text) : text.ToString();
+        return truncated ? body + Ellipsis : body;
+    }
 
-    /// <inheritdoc cref="Display(InertString, bool)"/>
-    static string Display(InertString text) => Display(text, text.IsTruncated);
+    /// <inheritdoc cref="Display(InertString, bool, UntrustedTextMode)"/>
+    static string Display(InertString text, UntrustedTextMode mode)
+        => Display(text, text.IsTruncated, mode);
 
-    static string FormatHeap(MetadataValue.HeapReference heap)
+    /// <summary>
+    /// Runs the visual encoding backwards, recovering the artifact's own spelling.
+    /// </summary>
+    /// <remarks>
+    /// Total for anything this library produced: every spelling the encoder emits is one the
+    /// decoder accepts. The fallback is unreachable rather than load-bearing, and it fails
+    /// toward the encoded form — the safe direction — so a value that somehow did not round-trip
+    /// is shown contained rather than raw.
+    /// </remarks>
+    static string Decode(InertString text)
+        => VisualEncoder.TryDecode(text.ToString(), out string? decoded) ? decoded : text.ToString();
+
+    static string FormatHeap(MetadataValue.HeapReference heap, UntrustedTextMode mode)
     {
         // The Blob heap carries no decoded text; its bounded hex preview stands in.
         // Truncation comes off the reference rather than the text because a blob's
         // preview is bounded in bytes, which the hex spelling cannot report.
-        return Display(heap.Text ?? heap.Preview, heap.Truncated);
+        return Display(heap.Text ?? heap.Preview, heap.Truncated, mode);
     }
 
-    static string FormatHandle(HandleRef reference)
+    static string FormatHandle(HandleRef reference, UntrustedTextMode mode)
     {
         if (reference.TargetRowId == 0)
             return "nil";
@@ -892,12 +929,12 @@ public static class MetadataProjectionRenderer
         // which must still render as "(…)" rather than a bare target that looks
         // like an unavailable display.
         if (display.IsTruncated)
-            return $"{target} ({Display(display)})";
+            return $"{target} ({Display(display, mode)})";
 
         if (display.IsEmpty)
             return target;
 
-        return $"{target} ({display})";
+        return $"{target} ({Display(display, mode)})";
     }
 
     static string FormatRange(HandleRange range)

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -179,8 +179,13 @@ public sealed class AssemblyInspectionSession : IDisposable
     /// (including tables the projection does not model), and PE/CLI header
     /// facts. Null when the image carries no metadata.
     /// </summary>
-    public MetadataImageOverview? MetadataImage()
-        => MetadataImageInspector.Describe(_image.PEReader);
+    /// <param name="untrustedText">
+    /// What to do with the metadata root's version stamp, which is artifact-controlled text.
+    /// Defaults to containment, matching the projection.
+    /// </param>
+    public MetadataImageOverview? MetadataImage(
+        UntrustedTextMode untrustedText = UntrustedTextMode.Contain)
+        => MetadataImageInspector.Describe(_image.PEReader, untrustedText);
 
     /// <summary>
     /// One heap value read by address, independent of any row that references

--- a/src/ILInspector.Metadata/MetadataImageInspector.cs
+++ b/src/ILInspector.Metadata/MetadataImageInspector.cs
@@ -38,7 +38,9 @@ public static class MetadataImageInspector
     /// renderer having to remember. A value that skips the projection must still
     /// not skip its containment.
     /// </summary>
-    public static MetadataImageOverview? Describe(PEReader peReader)
+    public static MetadataImageOverview? Describe(
+        PEReader peReader,
+        UntrustedTextMode untrustedText = UntrustedTextMode.Contain)
     {
         ArgumentNullException.ThrowIfNull(peReader);
 
@@ -52,7 +54,10 @@ public static class MetadataImageInspector
         var headers = peReader.PEHeaders;
 
         InertString version = MetadataTableProjector.ContainCellText(
-            reader.MetadataVersion, MetadataVersionBudget);
+            reader.MetadataVersion,
+            MetadataVersionBudget,
+            untrustedText,
+            TextOrigin.Named("the metadata root version stamp"));
 
         return new MetadataImageOverview(
             version,

--- a/src/ILInspector.Metadata/MetadataTableProjection.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjection.cs
@@ -371,6 +371,14 @@ public sealed record MetadataProjectionOptions
     public int MaxStringChars { get; init; } = DefaultMaxStringChars;
 
     /// <summary>
+    /// What the projection does with artifact text carrying scalars the rendering policy
+    /// refuses. Defaults to <see cref="UntrustedTextMode.Contain"/>, which is what every
+    /// consumer wants unless it has a reason not to: containment is the projection's safety
+    /// property, while refusing and raw output are policies a caller adds either side of it.
+    /// </summary>
+    public UntrustedTextMode UntrustedText { get; init; } = UntrustedTextMode.Contain;
+
+    /// <summary>
     /// When non-default, restricts projection to these tables. Default projects
     /// every supported table.
     /// </summary>

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -1082,9 +1082,14 @@ public static class MetadataTableProjector
         try
         {
             string raw = reader.GetString(handle);
-            InertString text = ContainCellText(raw, options.MaxStringChars);
+            int offset = HeapOffset(handle);
+            InertString text = ContainCellText(
+                raw,
+                options.MaxStringChars,
+                options.UntrustedText,
+                TextOrigin.At(HeapKind.String, offset));
             return new MetadataValue.HeapReference(
-                HeapKind.String, HeapOffset(handle), raw.Length, text, text, text.IsTruncated);
+                HeapKind.String, offset, raw.Length, text, text, text.IsTruncated);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
@@ -1100,9 +1105,14 @@ public static class MetadataTableProjector
         try
         {
             string raw = reader.GetUserString(handle);
-            InertString text = ContainCellText(raw, options.MaxStringChars);
+            int offset = MetadataTokens.GetHeapOffset(handle);
+            InertString text = ContainCellText(
+                raw,
+                options.MaxStringChars,
+                options.UntrustedText,
+                TextOrigin.At(HeapKind.UserString, offset));
             return new MetadataValue.HeapReference(
-                HeapKind.UserString, MetadataTokens.GetHeapOffset(handle), raw.Length, text, text, text.IsTruncated);
+                HeapKind.UserString, offset, raw.Length, text, text, text.IsTruncated);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
@@ -1214,7 +1224,11 @@ public static class MetadataTableProjector
             string? resolved = ResolveHandleDisplay(reader, handle);
             InertString? display = resolved is null
                 ? null
-                : ContainCellText(resolved, options.MaxStringChars);
+                : ContainCellText(
+                    resolved,
+                    options.MaxStringChars,
+                    options.UntrustedText,
+                    TextOrigin.Named("a resolved handle display"));
 
             return new MetadataValue.Handle(new HandleRef(table, rid, token, display));
         }
@@ -1328,21 +1342,27 @@ public static class MetadataTableProjector
         => new MetadataValue.Flags(raw, decoded);
 
     /// <summary>
-    /// Contains a decoded heap string for rendering and bounds the EMITTED text to
+    /// Applies <paramref name="mode"/> to a decoded heap string and bounds the EMITTED text to
     /// <paramref name="maxChars"/> characters.
     /// <para>
-    /// Every non-graphic scalar is spelled rather than emitted, by Unicode general
-    /// category (<c>Cc</c>, <c>Cf</c>, <c>Cs</c>, <c>Zl</c>, <c>Zp</c>) rather than by a
-    /// hand-written range. Category is what makes this correct where the range this
-    /// replaced was not: <c>U+202E</c> is <c>Cf</c> and <c>U+2028</c>/<c>U+2029</c> are
-    /// <c>Zl</c>/<c>Zp</c>, so none of them is below <c>U+0020</c> and all three reached
-    /// the terminal raw (issue #3628).
+    /// Under <see cref="UntrustedTextMode.Contain"/> and <see cref="UntrustedTextMode.Refuse"/>,
+    /// every non-graphic scalar is spelled rather than emitted, by Unicode general category
+    /// (<c>Cc</c>, <c>Cf</c>, <c>Cs</c>, <c>Zl</c>, <c>Zp</c>) rather than by a hand-written
+    /// range. Category is what makes this correct where the range this replaced was not:
+    /// <c>U+202E</c> is <c>Cf</c> and <c>U+2028</c>/<c>U+2029</c> are <c>Zl</c>/<c>Zp</c>, so
+    /// none of them is below <c>U+0020</c> and all three reached the terminal raw (issue #3628).
+    /// </para>
+    /// <para>
+    /// Refusal is checked against the raw text, before encoding, because the question it asks is
+    /// about the artifact rather than about the rendering. When it passes, the value renders
+    /// exactly as <see cref="UntrustedTextMode.Contain"/> would, so the two modes differ only in
+    /// whether they can fail.
     /// </para>
     /// <para>
     /// Internal rather than private because the image overview
-    /// (<see cref="MetadataImageInspector"/>) reports an artifact-derived string of its
-    /// own — the metadata root's version stamp — and must contain it with this same
-    /// primitive rather than a parallel one.
+    /// (<see cref="MetadataImageInspector"/>) reports an artifact-derived string of its own —
+    /// the metadata root's version stamp — and must apply this same treatment rather than a
+    /// parallel one.
     /// </para>
     /// </summary>
     /// <returns>
@@ -1351,10 +1371,27 @@ public static class MetadataTableProjector
     /// is the point: the pair travels together into the projection, and only a sink that
     /// has decided how to mark a partial value takes it apart.
     /// </returns>
+    /// <exception cref="UntrustedTextException">
+    /// <paramref name="mode"/> is <see cref="UntrustedTextMode.Refuse"/> and the text carries a
+    /// scalar the policy does not permit.
+    /// </exception>
     // The budget goes in as configured: a negative one is read as zero rather than
     // refused, so clamping here would be a line that never changes an answer.
-    internal static InertString ContainCellText(string value, int maxChars)
-        => new(TextPolicy.Field, value, maxChars);
+    internal static InertString ContainCellText(
+        string value,
+        int maxChars,
+        UntrustedTextMode mode = UntrustedTextMode.Contain,
+        TextOrigin origin = default)
+    {
+        if (mode is UntrustedTextMode.Refuse
+            && !InertString.IsPermitted(TextPolicy.Field, value, out ScalarViolation? violation))
+        {
+            throw new UntrustedTextException(
+                origin, violation.Value.Index, violation.Value.Scalar, violation.Value.Category);
+        }
+
+        return new InertString(TextPolicy.Field, value, maxChars);
+    }
 
     readonly record struct TableSpec(
         TableIndex Index,

--- a/src/ILInspector.Metadata/UntrustedTextMode.cs
+++ b/src/ILInspector.Metadata/UntrustedTextMode.cs
@@ -1,0 +1,120 @@
+using System.Globalization;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// What a projection does with artifact text that is not permitted as it is.
+/// </summary>
+/// <remarks>
+/// The three values are a deliberate ladder, and the order of the members is the order of
+/// decreasing safety. Containment is the property the projection guarantees; refusal and raw
+/// output are policies layered either side of it, and only a caller — not a library — knows
+/// which one its situation wants.
+/// </remarks>
+public enum UntrustedTextMode
+{
+    /// <summary>
+    /// Render every scalar the policy refuses as an inert spelling. The default, and the only
+    /// value that is safe without qualification: output is legible, faithful about what the
+    /// artifact contains, and cannot reprogram a terminal or break the selected format.
+    /// </summary>
+    Contain,
+
+    /// <summary>
+    /// Fail rather than render an artifact containing text the policy refuses.
+    /// <para>
+    /// Strictly stronger than <see cref="Contain"/>, and different in kind: containment answers
+    /// "can this hurt the terminal", refusal answers "do I want to look at this at all". A
+    /// consumer piping metadata into something that is not a terminal — a diff, an index, a
+    /// build step — usually wants to hear that an artifact carries a bidi override rather than
+    /// to receive a faithful rendering of one.
+    /// </para>
+    /// <para>
+    /// Output is byte-identical to <see cref="Contain"/> whenever it succeeds, so this costs
+    /// nothing on the ordinary artifacts that carry no such text.
+    /// </para>
+    /// </summary>
+    Refuse,
+
+    /// <summary>
+    /// Render artifact text exactly as the artifact spells it, with no containment at all.
+    /// <para>
+    /// This is the unsafe value and it exists for one reason: a person studying a hostile
+    /// artifact sometimes needs to see the bytes, not a description of them. It reintroduces
+    /// precisely the terminal-control and format-injection exposure the rest of this type
+    /// exists to remove, so nothing selects it by default and nothing should select it on a
+    /// caller's behalf.
+    /// </para>
+    /// </summary>
+    Raw,
+}
+
+/// <summary>
+/// Thrown under <see cref="UntrustedTextMode.Refuse"/> when artifact text carries a scalar the
+/// policy does not permit.
+/// </summary>
+/// <remarks>
+/// Carries the location and the classification, never the offending text. That is the whole
+/// point of refusing: a caller that wanted to see the characters would have asked for them, and
+/// a diagnostic that echoed them would reintroduce the exposure through the error path — which
+/// is the more dangerous route of the two, because errors are read on terminals and are rarely
+/// piped through the same containment the output is.
+/// <para>
+/// The heap coordinate is kept structured rather than formatted because the stream spelling
+/// (<c>#Strings</c>, <c>#US</c>) belongs to the rendering layer, which sits above this one.
+/// </para>
+/// </remarks>
+public sealed class UntrustedTextException : Exception
+{
+    internal UntrustedTextException(TextOrigin origin, int index, int scalar, UnicodeCategory category)
+        : base(Describe(origin, index, scalar, category))
+    {
+        Heap = origin.Heap;
+        Offset = origin.Offset;
+        Index = index;
+        Scalar = scalar;
+        Category = category;
+    }
+
+    /// <summary>The heap the text was read from, or <see langword="null"/> for a resolved display.</summary>
+    public HeapKind? Heap { get; }
+
+    /// <summary>The heap address the text was read from, when <see cref="Heap"/> is known.</summary>
+    public int Offset { get; }
+
+    /// <summary>The UTF-16 index of the refused scalar within the decoded text.</summary>
+    public int Index { get; }
+
+    /// <summary>The refused scalar's code point.</summary>
+    public int Scalar { get; }
+
+    /// <summary>The refused scalar's Unicode general category.</summary>
+    public UnicodeCategory Category { get; }
+
+    static string Describe(TextOrigin origin, int index, int scalar, UnicodeCategory category)
+    {
+        string where = origin.Heap is { } heap
+            ? $"the {heap} heap value at address 0x{origin.Offset:X}"
+            : origin.Description ?? "artifact text";
+
+        return $"{where} contains U+{scalar:X4} ({category}) at index {index}, " +
+            "which is not permitted as rendered text.";
+    }
+}
+
+/// <summary>
+/// Where a piece of artifact text came from, for a diagnostic that must locate it without
+/// quoting it.
+/// </summary>
+/// <remarks>
+/// A struct carrying two integers and a literal, so naming the origin of every cell costs no
+/// allocation on the path that never fails — which is every path on an ordinary artifact.
+/// </remarks>
+internal readonly record struct TextOrigin(HeapKind? Heap, int Offset, string? Description)
+{
+    /// <summary>Text read from a heap at a known address, which a reader can go and inspect.</summary>
+    public static TextOrigin At(HeapKind heap, int offset) => new(heap, offset, null);
+
+    /// <summary>Text with no address of its own, named by what produced it.</summary>
+    public static TextOrigin Named(string description) => new(null, 0, description);
+}

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -56,8 +56,11 @@
   select the other treatments: `--show-untrusted-text` renders the inert
   spelling, which is byte for byte what previous versions produced, and
   `--dangerously-print-raw` hands the text over uncontained for studying a
-  hostile artifact. Ordinary assemblies are unaffected: the modes differ only in
-  whether they can fail, so output is unchanged wherever no such text exists.
+  hostile artifact, and must be combined with `--show-untrusted-text` because
+  refusal comes first. Both spellings show the same amount of a clipped value,
+  differing only in how it is written. Ordinary assemblies are unaffected: the
+  modes differ only in whether they can fail, so output is unchanged wherever no
+  such text exists.
 
 ### Output and projections
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -49,6 +49,15 @@
   contained keep the same meaning but change spelling, from `\u001B` to caret
   notation `\^[`; the quote is no longer escaped, because cells are not quote
   wrapped in any rendered format.
+- **Breaking:** `mdi` now refuses, rather than renders, when an assembly carries
+  text that a terminal would act on — bidi overrides, separators, and other
+  non-graphic scalars. It exits non-zero and reports the heap coordinate, the
+  code point and its Unicode category, without echoing the text. Two flags
+  select the other treatments: `--show-untrusted-text` renders the inert
+  spelling, which is byte for byte what previous versions produced, and
+  `--dangerously-print-raw` hands the text over uncontained for studying a
+  hostile artifact. Ordinary assemblies are unaffected: the modes differ only in
+  whether they can fail, so output is unchanged wherever no such text exists.
 
 ### Output and projections
 

--- a/src/mdi/MdiCommand.cs
+++ b/src/mdi/MdiCommand.cs
@@ -322,7 +322,7 @@ public static class MdiCommand
             return 0;
         }
 
-        MetadataProjectionRenderer.Render(projection, output, format);
+        MetadataProjectionRenderer.Render(projection, output, format, options.UntrustedText);
 
         // Markdown announces truncation inline in each table heading. The machine
         // formats carry no heading, so a bounded table would otherwise be
@@ -458,7 +458,7 @@ public static class MdiCommand
             return 1;
         }
 
-        MetadataProjectionRenderer.Render(overview, output, format);
+        MetadataProjectionRenderer.Render(overview, output, format, untrustedText);
 
         // Markdown carries the overview's caveats inline. The machine formats are
         // pure row streams, so the same facts go to the error writer rather than
@@ -529,7 +529,7 @@ public static class MdiCommand
             return 1;
         }
 
-        MetadataProjectionRenderer.Render(value, heap, address, output, format);
+        MetadataProjectionRenderer.Render(value, heap, address, output, format, options.UntrustedText);
 
         if (value is MetadataValue.Malformed malformed)
         {

--- a/src/mdi/MdiCommand.cs
+++ b/src/mdi/MdiCommand.cs
@@ -16,10 +16,19 @@ namespace Mdi;
 public static class MdiCommand
 {
     /// <summary>Builds and runs the command over <paramref name="args"/>.</summary>
-    public static int Invoke(string[] args) => CreateRootCommand().Parse(args).Invoke();
+    /// <remarks>
+    /// <paramref name="output"/> and <paramref name="error"/> default to the console. Tests pass
+    /// their own writers so the argv path — option parsing, the mutual-exclusion checks, and the
+    /// defaults, none of which are reachable through the <c>Execute*</c> entry points — can be
+    /// driven without redirecting <see cref="Console"/>, which is process-global and would make
+    /// parallel test execution unsound.
+    /// </remarks>
+    public static int Invoke(string[] args, TextWriter? output = null, TextWriter? error = null)
+        => CreateRootCommand(output, error).Parse(args).Invoke();
 
     /// <summary>Builds the System.CommandLine surface (also used by tests).</summary>
-    public static RootCommand CreateRootCommand()
+    /// <inheritdoc cref="Invoke" path="/remarks"/>
+    public static RootCommand CreateRootCommand(TextWriter? output = null, TextWriter? error = null)
     {
         var assemblyArgument = new Argument<string>("assembly")
         {
@@ -88,6 +97,26 @@ public static class MdiCommand
         };
         maxCharsOption.DefaultValueFactory = _ => MetadataProjectionOptions.DefaultMaxStringChars;
 
+        var showUntrustedOption = new Option<bool>("--show-untrusted-text")
+        {
+            Description =
+                "Render artifact text that carries bidi overrides, separators, or other "
+                + "non-graphic scalars instead of refusing. The rendering is still inert: every "
+                + "such scalar is spelled, never emitted, unless --dangerously-print-raw is "
+                + "also given.",
+        };
+
+        var rawOption = new Option<bool>("--dangerously-print-raw")
+        {
+            Description =
+                "Requires --show-untrusted-text. Spells artifact text exactly as the artifact "
+                + "does, with no visual encoding. Unsafe by design: hostile metadata can "
+                + "reprogram your terminal. Intended for studying a hostile artifact, ideally "
+                + "redirected to a file. The selected format still keeps itself well formed, so "
+                + "jsonl escapes control scalars (they decode back) and tsv replaces line and "
+                + "paragraph separators; md carries everything.",
+        };
+
         var root = new RootCommand("mdi \u2014 inspect the ECMA-335 metadata tables of a .NET assembly.");
         root.Arguments.Add(assemblyArgument);
         root.Options.Add(tableOption);
@@ -100,9 +129,13 @@ public static class MdiCommand
         root.Options.Add(heapOption);
         root.Options.Add(maxBytesOption);
         root.Options.Add(maxCharsOption);
+        root.Options.Add(showUntrustedOption);
+        root.Options.Add(rawOption);
 
         root.SetAction(parseResult =>
         {
+            TextWriter stdout = output ?? Console.Out;
+            TextWriter stderr = error ?? Console.Error;
             string assembly = parseResult.GetValue(assemblyArgument)!;
             string? tableSpec = parseResult.GetValue(tableOption);
             string formatText = parseResult.GetValue(formatOption)!;
@@ -114,28 +147,48 @@ public static class MdiCommand
             string? heapSpec = parseResult.GetValue(heapOption);
             int maxBytes = parseResult.GetValue(maxBytesOption);
             int maxChars = parseResult.GetValue(maxCharsOption);
+            bool showUntrusted = parseResult.GetValue(showUntrustedOption);
+            bool printRaw = parseResult.GetValue(rawOption);
+
+            // The two flags are separate axes, not a three-way choice, so they compose
+            // rather than conflict. --show-untrusted-text answers "do not refuse";
+            // --dangerously-print-raw answers "do not encode". Raw output needs both,
+            // which is the point: a live control character costs two separately named
+            // mistakes. See docs/design/untrusted-data-threat-model.md#presentation.
+            if (printRaw && !showUntrusted)
+            {
+                stderr.WriteLine(
+                    "Error: --dangerously-print-raw only chooses how text is spelled once it is "
+                    + "printed, and on its own it changes nothing, because refusing still comes "
+                    + "first. Add --show-untrusted-text to print the text at all.");
+                return 1;
+            }
+
+            UntrustedTextMode untrustedText = !showUntrusted ? UntrustedTextMode.Refuse
+                : printRaw ? UntrustedTextMode.Raw
+                : UntrustedTextMode.Contain;
 
             if (!TryParseFormat(formatText, out var format))
             {
-                Console.Error.WriteLine($"Error: unknown format '{formatText}'. Use md, tsv, or jsonl.");
+                stderr.WriteLine($"Error: unknown format '{formatText}'. Use md, tsv, or jsonl.");
                 return 1;
             }
 
             if (maxRows < 0 || maxBytes < 0 || maxChars < 0)
             {
-                Console.Error.WriteLine("Error: --max-rows, --max-bytes, and --max-chars must be non-negative.");
+                stderr.WriteLine("Error: --max-rows, --max-bytes, and --max-chars must be non-negative.");
                 return 1;
             }
 
             if (startRow < 1)
             {
-                Console.Error.WriteLine("Error: --start-row must be 1 or greater (row ids are 1-based).");
+                stderr.WriteLine("Error: --start-row must be 1 or greater (row ids are 1-based).");
                 return 1;
             }
 
             if (!TryParseTables(tableSpec, out var tables, out var badName))
             {
-                Console.Error.WriteLine(
+                stderr.WriteLine(
                     $"Error: unknown table '{badName}'. Table names are members of System.Reflection.Metadata.Ecma335.TableIndex (for example TypeDef, MethodDef, Field).");
                 return 1;
             }
@@ -153,24 +206,24 @@ public static class MdiCommand
 
             if (modes.Count > 1)
             {
-                Console.Error.WriteLine($"Error: {string.Join(" and ", modes)} cannot be combined; each selects a different view.");
+                stderr.WriteLine($"Error: {string.Join(" and ", modes)} cannot be combined; each selects a different view.");
                 return 1;
             }
 
             if (overview)
-                return ExecuteOverview(assembly, format, Console.Out, Console.Error);
+                return ExecuteOverview(assembly, format, stdout, stderr, untrustedText);
 
             if (heapSpec is not null)
             {
                 if (!MetadataHeapCoordinate.TryParse(heapSpec, out var heap, out int address, out string? heapError))
                 {
-                    Console.Error.WriteLine($"Error: {heapError}");
+                    stderr.WriteLine($"Error: {heapError}");
                     return 1;
                 }
 
                 if (maxBytes < 0 || maxChars < 0)
                 {
-                    Console.Error.WriteLine("Error: --max-bytes and --max-chars must be non-negative.");
+                    stderr.WriteLine("Error: --max-bytes and --max-chars must be non-negative.");
                     return 1;
                 }
 
@@ -178,27 +231,28 @@ public static class MdiCommand
                 {
                     MaxPreviewBytes = maxBytes,
                     MaxStringChars = maxChars,
+                    UntrustedText = untrustedText,
                 };
 
-                return ExecuteHeapValue(assembly, heap, address, heapOptions, format, Console.Out, Console.Error);
+                return ExecuteHeapValue(assembly, heap, address, heapOptions, format, stdout, stderr);
             }
 
             if (referenceSpec is not null)
             {
                 if (maxReferences < 0)
                 {
-                    Console.Error.WriteLine("Error: --max-references must be non-negative.");
+                    stderr.WriteLine("Error: --max-references must be non-negative.");
                     return 1;
                 }
 
                 if (!TryParseRowLocation(referenceSpec, out var targetTable, out int targetRowId, out string? specError))
                 {
-                    Console.Error.WriteLine($"Error: {specError}");
+                    stderr.WriteLine($"Error: {specError}");
                     return 1;
                 }
 
                 return ExecuteReferences(
-                    assembly, targetTable, targetRowId, maxReferences, format, Console.Out, Console.Error);
+                    assembly, targetTable, targetRowId, maxReferences, format, stdout, stderr);
             }
 
             var options = new MetadataProjectionOptions
@@ -208,9 +262,10 @@ public static class MdiCommand
                 MaxPreviewBytes = maxBytes,
                 MaxStringChars = maxChars,
                 Tables = tables,
+                UntrustedText = untrustedText,
             };
 
-            return Execute(assembly, options, format, Console.Out, Console.Error);
+            return Execute(assembly, options, format, stdout, stderr);
         });
 
         return root;
@@ -249,6 +304,11 @@ public static class MdiCommand
             }
 
             projection = session.MetadataTables(options);
+        }
+        catch (UntrustedTextException ex)
+        {
+            ReportRefusal(ex, assemblyPath, error);
+            return 1;
         }
         catch (Exception ex) when (IsExpectedReadFailure(ex))
         {
@@ -363,7 +423,8 @@ public static class MdiCommand
         string assemblyPath,
         MetadataTableFormat format,
         TextWriter output,
-        TextWriter error)
+        TextWriter error,
+        UntrustedTextMode untrustedText = UntrustedTextMode.Contain)
     {
         ArgumentNullException.ThrowIfNull(output);
         ArgumentNullException.ThrowIfNull(error);
@@ -378,7 +439,12 @@ public static class MdiCommand
         try
         {
             using var session = AssemblyInspectionSession.Open(assemblyPath);
-            overview = session.MetadataImage();
+            overview = session.MetadataImage(untrustedText);
+        }
+        catch (UntrustedTextException ex)
+        {
+            ReportRefusal(ex, assemblyPath, error);
+            return 1;
         }
         catch (Exception ex) when (IsExpectedReadFailure(ex))
         {
@@ -446,6 +512,11 @@ public static class MdiCommand
             using var session = AssemblyInspectionSession.Open(assemblyPath);
             value = session.MetadataHeapValue(heap, address, options);
         }
+        catch (UntrustedTextException ex)
+        {
+            ReportRefusal(ex, assemblyPath, error);
+            return 1;
+        }
         catch (Exception ex) when (IsExpectedReadFailure(ex))
         {
             error.WriteLine($"Error: cannot read metadata from '{assemblyPath}': {ex.Message}");
@@ -468,6 +539,41 @@ public static class MdiCommand
 
         return 0;
     }
+
+    /// <summary>
+    /// Reports a refusal: where the text is, what class of scalar was found, and the two ways to
+    /// proceed.
+    /// <para>
+    /// The message never contains the offending text, and it goes to the error writer, which is
+    /// exactly why that matters — stderr is read on a terminal and is almost never piped through
+    /// whatever containment the output stream got. A diagnostic that quoted the characters would
+    /// deliver the payload by the one route the user cannot redirect.
+    /// </para>
+    /// <para>
+    /// The heap coordinate is spelled the way <c>--heap</c> accepts it, so the way forward is a
+    /// command a reader can paste rather than assemble.
+    /// </para>
+    /// </summary>
+    static void ReportRefusal(UntrustedTextException refusal, string assemblyPath, TextWriter error)
+    {
+        error.WriteLine($"Error: '{assemblyPath}' contains text that is not safe to render as it is.");
+        error.WriteLine(
+            $"  {DescribeOrigin(refusal)} carries U+{refusal.Scalar:X4} ({refusal.Category}) " +
+            $"at index {refusal.Index}.");
+        error.WriteLine();
+        error.WriteLine("  --show-untrusted-text     render it inertly; every such scalar is spelled, never emitted");
+        error.WriteLine("  --show-untrusted-text --dangerously-print-raw");
+        error.WriteLine("                            render it verbatim; unsafe, and best redirected to a file");
+    }
+
+    /// <summary>
+    /// Names the location in the vocabulary the reader already has: a heap coordinate when the
+    /// text has an address, and what produced it when it does not.
+    /// </summary>
+    static string DescribeOrigin(UntrustedTextException refusal)
+        => refusal.Heap is { } heap
+            ? $"{MetadataHeapCoordinate.StreamName(heap)}:0x{refusal.Offset:x}"
+            : refusal.Message[..refusal.Message.IndexOf(" contains U+", StringComparison.Ordinal)];
 
     /// <summary>
     /// Whether <paramref name="ex"/> is an expected failure of opening or reading

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiContainmentTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiContainmentTests.cs
@@ -241,18 +241,7 @@ public sealed class MdiContainmentTests(HostileAssemblyFixture fixture)
         }
     }
 
-    /// <summary>
-    /// The categories that carry no glyph of their own: controls, formatting
-    /// characters (which includes every bidi override), unpaired surrogates, and
-    /// the line and paragraph separators.
-    /// </summary>
-    static bool IsNonGraphic(Rune rune)
-        => Rune.GetUnicodeCategory(rune)
-            is UnicodeCategory.Control
-            or UnicodeCategory.Format
-            or UnicodeCategory.Surrogate
-            or UnicodeCategory.LineSeparator
-            or UnicodeCategory.ParagraphSeparator;
+    static bool IsNonGraphic(Rune rune) => HostileAssemblyFixture.IsNonGraphic(rune);
 }
 
 /// <summary>
@@ -315,6 +304,25 @@ public sealed class HostileAssemblyFixture : IDisposable
         0xE2, 0x80, 0xAE, // U+202E
         0x07,
     ];
+
+    /// <summary>
+    /// The categories that carry no glyph of their own: controls, formatting
+    /// characters (which includes every bidi override), unpaired surrogates, and
+    /// the line and paragraph separators.
+    /// <para>
+    /// Defined once, here beside the payload, and shared by every gate over it.
+    /// A second copy would be a second oracle, and the failure this whole corpus
+    /// exists to prevent was two definitions of "dangerous" agreeing with each
+    /// other instead of with Unicode.
+    /// </para>
+    /// </summary>
+    public static bool IsNonGraphic(Rune rune)
+        => Rune.GetUnicodeCategory(rune)
+            is UnicodeCategory.Control
+            or UnicodeCategory.Format
+            or UnicodeCategory.Surrogate
+            or UnicodeCategory.LineSeparator
+            or UnicodeCategory.ParagraphSeparator;
 
     /// <summary>How each scalar in <see cref="Payload"/> must appear once contained.</summary>
     public static readonly string[] NeutralizedForms =

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiContainmentTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiContainmentTests.cs
@@ -347,6 +347,21 @@ public sealed class HostileAssemblyFixture : IDisposable
     /// </summary>
     static readonly string CanaryTail = CanaryName[(NamePayloadOffset + Payload.Length)..];
 
+    /// <summary>
+    /// The head of the canary name the splice leaves untouched, which is the only
+    /// graphic text guaranteed to survive every budget wide enough to show the row
+    /// at all. Locating the payload cell by this keeps the lookup independent of the
+    /// escaping under test, for the same reason <see cref="CanaryTail"/> exists.
+    /// <para>
+    /// It must come from the canary rather than be spelled again: an anchor that
+    /// merely <em>looks</em> distinctive can match innocent metadata elsewhere in
+    /// this assembly and silently address the wrong cell, which reduces a
+    /// comparison between the two renderings to a comparison of plain ASCII with
+    /// itself.
+    /// </para>
+    /// </summary>
+    public static string CanaryPrefix { get; } = CanaryName[..NamePayloadOffset];
+
     public HostileAssemblyFixture()
     {
         string source = typeof(HostileAssemblyFixture).Assembly.Location;

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiUntrustedTextModeTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiUntrustedTextModeTests.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
-using InertText;
+using ILInspector.Metadata;
 using Mdi;
 
 namespace DotnetInspector.MetadataRendering.Tests;
@@ -526,8 +526,10 @@ public sealed class MdiUntrustedTextModeTests(HostileAssemblyFixture fixture)
     [InlineData("jsonl")]
     public void RawAndEncodedRenderingsShowTheSamePrefix(string format)
     {
-        // From 8, so the shared graphic prefix "Hostile" is present and the cell is locatable.
-        for (int budget = 8; budget <= 30; budget++)
+        // From the width of the canary's untouched head, so the cell is locatable at
+        // every budget swept; below that neither rendering shows the anchor.
+        int first = HostileAssemblyFixture.CanaryPrefix.Length;
+        for (int budget = first; budget <= first + 22; budget++)
         {
             string[] common =
                 ["--table", "TypeDef", "--format", format, "--show-untrusted-text",
@@ -549,9 +551,13 @@ public sealed class MdiUntrustedTextModeTests(HostileAssemblyFixture fixture)
             string rawBody = rawClipped ? rawCell[..^1] : rawCell;
             string encodedBody = encodedClipped ? encodedCell[..^1] : encodedCell;
 
+            // Re-encoding runs the product's own containment factory forward, so the oracle
+            // tracks the policy instead of pinning the one that was current when this was
+            // written. The property under test is relational — same value, different spelling —
+            // so a policy change should flow through both sides rather than redden this.
             Assert.Equal(
                 encodedBody,
-                new InertString(TextPolicy.Field, rawBody, int.MaxValue).ToString());
+                MetadataTableProjector.ContainCellText(rawBody, int.MaxValue).ToString());
         }
     }
 
@@ -561,7 +567,7 @@ public sealed class MdiUntrustedTextModeTests(HostileAssemblyFixture fixture)
     /// </summary>
     static string PayloadCell(string output)
     {
-        int start = output.IndexOf("Hostile", StringComparison.Ordinal);
+        int start = output.IndexOf(HostileAssemblyFixture.CanaryPrefix, StringComparison.Ordinal);
         if (start < 0)
             return string.Empty;
 

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiUntrustedTextModeTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiUntrustedTextModeTests.cs
@@ -1,0 +1,494 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Mdi;
+
+namespace DotnetInspector.MetadataRendering.Tests;
+
+/// <summary>
+/// End-to-end gate over the three treatments <c>mdi</c> offers for text that came
+/// out of an artifact: refuse (the default), contain, and print raw.
+/// <para>
+/// These drive <see cref="MdiCommand.Invoke(string[], TextWriter?, TextWriter?)"/>
+/// with an argv, rather than the <c>Execute*</c> entry points the rest of the
+/// containment gate uses. That is the point: the mode is chosen by option
+/// parsing, and the CLI's default deliberately differs from the library's, so
+/// nothing below the argv layer can observe either. A test that called
+/// <c>Execute</c> with an explicit mode would pass no matter which default the
+/// command line picked, and would not notice the two flags being combined.
+/// </para>
+/// <para>
+/// The tiers are gated on <em>opposite</em> claims, because each has its own way
+/// of being vacuously satisfied. Refusal is asserted to produce no output, so it
+/// is also asserted to name where the text is — otherwise refusing everything
+/// unconditionally would pass. Containment is asserted to spell every scalar, so
+/// it is also asserted to emit none of them raw. Raw is asserted to emit the
+/// scalars verbatim, which is the only assertion here that would fail if the flag
+/// were quietly a no-op that fell back to containment.
+/// </para>
+/// </summary>
+public sealed class MdiUntrustedTextModeTests(HostileAssemblyFixture fixture)
+    : IClassFixture<HostileAssemblyFixture>
+{
+    /// <summary>
+    /// The scalars <see cref="HostileAssemblyFixture.Payload"/> carries, as text.
+    /// Decoded from the same bytes the fixture splices so the two cannot drift
+    /// apart; spelling them again here would be a second source of truth for the
+    /// same fact.
+    /// </summary>
+    static readonly string PayloadText = Encoding.UTF8.GetString(HostileAssemblyFixture.Payload);
+
+    /// <summary>
+    /// The scalars in the payload that actually constitute the threat.
+    /// <para>
+    /// The payload is a CSI sequence, so it also carries <c>[</c>, <c>3</c>,
+    /// <c>1</c> and <c>m</c> — ordinary graphic ASCII that appears throughout any
+    /// diagnostic, any table, and any offset. Asserting over the payload as a
+    /// whole would make "did the text leak?" indistinguishable from "does the
+    /// output contain the digit 3", which is both always true and never
+    /// interesting. What must never leak is the part a terminal would act on.
+    /// </para>
+    /// </summary>
+    static readonly Rune[] DangerousScalars =
+        [.. PayloadText.EnumerateRunes().Where(HostileAssemblyFixture.IsNonGraphic)];
+
+    /// <summary>
+    /// Scalars a format cannot carry verbatim without ceasing to be that format.
+    /// <para>
+    /// TSV is line oriented and delimits records by newline, so Markout replaces
+    /// the line and paragraph separators with a space when writing a cell.
+    /// Markdown has no such conflict and carries everything. JSONL escapes rather
+    /// than substitutes, so nothing is lost there — see
+    /// <see cref="AsConsumerReceivesIt"/>.
+    /// </para>
+    /// <para>
+    /// This is the serializer keeping its own output well-formed, one layer below
+    /// <c>mdi</c>, and it bounds what the raw tier can promise: the flag hands the
+    /// text over uncontained, which is not the same as guaranteeing every scalar
+    /// reaches the stream. The exceptions are listed rather than skipped so that a
+    /// format quietly dropping something <em>else</em> still fails here.
+    /// </para>
+    /// </summary>
+    static Rune[] ScalarsTheFormatCannotCarry(string format) => format switch
+    {
+        "tsv" => [new Rune(0x2028), new Rune(0x2029)],
+        _ => [],
+    };
+
+    /// <summary>
+    /// What a consumer of <paramref name="output"/> actually receives, which is the
+    /// only thing the threat model cares about.
+    /// <para>
+    /// Substring matching is not format-independent. JSON requires every scalar
+    /// below U+0020 to be escaped (RFC 8259), so a real ESC reaches a JSONL
+    /// consumer spelled <c>\u001B</c> — six characters that <em>parse back</em> to
+    /// the one dangerous scalar. That is the serializer keeping its own output
+    /// well-formed, not <c>mdi</c> containing anything, and a test that looked for
+    /// a literal ESC would call it containment and be wrong. Decoding first asks
+    /// the question that matters: what does the reader end up holding?
+    /// </para>
+    /// </summary>
+    static string AsConsumerReceivesIt(string output, string format)
+    {
+        if (format != "jsonl")
+            return output;
+
+        var decoded = new StringBuilder();
+        foreach (string line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (line.Length == 0 || line[0] != '{')
+            {
+                decoded.AppendLine(line);
+                continue;
+            }
+
+            using var document = JsonDocument.Parse(line);
+            foreach (JsonProperty property in document.RootElement.EnumerateObject())
+            {
+                if (property.Value.ValueKind == JsonValueKind.String)
+                    decoded.AppendLine(property.Value.GetString());
+            }
+        }
+
+        return decoded.ToString();
+    }
+
+    /// <summary>
+    /// Every view that renders artifact text, with the argv that reaches it.
+    /// Refusal has to hold on all of them: the table path projects rows, the heap
+    /// path reads one value by address, and the overview reports the metadata
+    /// version stamp on a route that bypasses row projection entirely — the route
+    /// that leaked a raw ESC once already.
+    /// </summary>
+    static readonly (string View, string[] Args)[] TextBearingViews =
+    [
+        ("table", ["--table", "TypeDef"]),
+        ("overview", ["--overview"]),
+    ];
+
+    public static TheoryData<string, string[], string> TextBearingViewsAndFormats()
+    {
+        var data = new TheoryData<string, string[], string>();
+        foreach (string format in (string[])["md", "tsv", "jsonl"])
+        {
+            foreach ((string view, string[] args) in TextBearingViews)
+                data.Add(view, args, format);
+        }
+
+        return data;
+    }
+
+    int Run(string[] args, out string output, out string error)
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        int code = MdiCommand.Invoke([fixture.Path, .. args], stdout, stderr);
+        output = stdout.ToString();
+        error = stderr.ToString();
+        return code;
+    }
+
+    /// <summary>
+    /// The default refuses, on every text-bearing view and in every format, and
+    /// says where the text is rather than only that something was wrong. The
+    /// coordinate is the whole value of refusing: a reader who cannot see the
+    /// text still has to be able to go look at it.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TextBearingViewsAndFormats))]
+    public void Default_Refuses_AndNamesWhereTheTextIs(string view, string[] args, string format)
+    {
+        int code = Run([.. args, "--format", format], out string output, out string error);
+
+        Assert.Equal(1, code);
+        Assert.Equal(string.Empty, output);
+
+        // The category is what makes the diagnostic actionable without the text:
+        // it distinguishes a bidi override from a stray control.
+        Assert.Contains("U+", error, StringComparison.Ordinal);
+        Assert.True(
+            error.Contains("Format", StringComparison.Ordinal)
+                || error.Contains("Control", StringComparison.Ordinal)
+                || error.Contains("LineSeparator", StringComparison.Ordinal),
+            $"The {view} refusal in {format} named no Unicode category: {error}");
+
+        // Both ways forward, so refusal is a fork in the road and not a dead end.
+        Assert.Contains("--show-untrusted-text", error, StringComparison.Ordinal);
+        Assert.Contains("--dangerously-print-raw", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The refusal must not deliver the payload it is refusing to deliver.
+    /// <para>
+    /// This is the case with real consequences. The diagnostic goes to stderr,
+    /// which is read on a terminal and is almost never piped through whatever
+    /// treatment the caller applied to stdout — so a message that quoted the
+    /// characters would hand a bidi override or a CSI sequence straight to the
+    /// terminal by the one route the user cannot redirect, and it would do it in
+    /// the mode chosen specifically to avoid that.
+    /// </para>
+    /// <para>
+    /// Asserted over the whole payload, raw <em>and</em> contained: the contained
+    /// spelling is safe to render but still echoes the artifact, and the point of
+    /// this tier is that the text does not appear at all.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TextBearingViewsAndFormats))]
+    public void Refusal_EchoesNeitherTheRawTextNorItsContainedForm(
+        string view, string[] args, string format)
+    {
+        Run([.. args, "--format", format], out _, out string error);
+
+        foreach (Rune rune in DangerousScalars)
+        {
+            Assert.False(
+                error.Contains(rune.ToString(), StringComparison.Ordinal),
+                $"The {view} refusal in {format} echoed U+{rune.Value:X4} raw.");
+        }
+
+        foreach (string contained in HostileAssemblyFixture.NeutralizedForms)
+        {
+            Assert.False(
+                error.Contains(contained, StringComparison.Ordinal),
+                $"The {view} refusal in {format} echoed the contained form {contained}.");
+        }
+    }
+
+    /// <summary>
+    /// The refusal reports the offending scalar as a code point, and that code
+    /// point is one the artifact actually carries. Without this, the "U+" the
+    /// first test looks for could be any constant.
+    /// </summary>
+    [Fact]
+    public void Refusal_ReportsACodePointThePayloadCarries()
+    {
+        Run(["--table", "TypeDef"], out _, out string error);
+
+        int marker = error.IndexOf("U+", StringComparison.Ordinal);
+        Assert.True(marker >= 0, error);
+
+        string digits = new([.. error.Skip(marker + 2).TakeWhile(Uri.IsHexDigit)]);
+        int reported = int.Parse(digits, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+
+        Assert.Contains(PayloadText.EnumerateRunes(), rune => rune.Value == reported);
+    }
+
+    /// <summary>
+    /// The contained tier renders, and renders inertly: every scalar in the
+    /// payload appears in its spelled form and none appears raw. This is the
+    /// behaviour that used to be unconditional, so it is also the compatibility
+    /// case — the output here is what every existing caller got.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TextBearingViewsAndFormats))]
+    public void ShowUntrustedText_RendersEveryScalarInItsContainedForm(
+        string view, string[] args, string format)
+    {
+        int code = Run(
+            [.. args, "--format", format, "--show-untrusted-text"],
+            out string output,
+            out string error);
+
+        Assert.Equal(0, code);
+        Assert.DoesNotContain("Error:", error, StringComparison.Ordinal);
+
+        string[] expected = view == "overview"
+            ? HostileAssemblyFixture.VersionNeutralizedForms
+            : HostileAssemblyFixture.NeutralizedForms;
+
+        foreach (string contained in expected)
+            Assert.Contains(contained, output, StringComparison.Ordinal);
+
+        string received = AsConsumerReceivesIt(output, format);
+        foreach (Rune rune in DangerousScalars)
+        {
+            Assert.False(
+                received.Contains(rune.ToString(), StringComparison.Ordinal),
+                $"The contained {view} rendering in {format} still delivered U+{rune.Value:X4}.");
+        }
+    }
+
+    /// <summary>
+    /// The raw tier prints the artifact text verbatim. Asserted positively,
+    /// because every other assertion in this file is satisfied by a mode that
+    /// contains — so a flag that silently fell back to containment would pass all
+    /// of them. This is the only case that can tell the escape hatch is real.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TextBearingViewsAndFormats))]
+    public void DangerouslyPrintRaw_EmitsTheArtifactTextVerbatim(
+        string view, string[] args, string format)
+    {
+        int code = Run(
+            [.. args, "--format", format, "--show-untrusted-text", "--dangerously-print-raw"],
+            out string output,
+            out string error);
+
+        Assert.Equal(0, code);
+        Assert.DoesNotContain("Error:", error, StringComparison.Ordinal);
+
+        string payload = view == "overview"
+            ? Encoding.UTF8.GetString(HostileAssemblyFixture.VersionPayload)
+            : PayloadText;
+
+        Rune[] unavailable = ScalarsTheFormatCannotCarry(format);
+        string received = AsConsumerReceivesIt(output, format);
+
+        // Whatever the format does to stay well-formed, mdi itself must have
+        // contained nothing: not one scalar arrives in its neutralized spelling.
+        //
+        // Asserted after decoding, because the two spellings collide on the wire.
+        // mdi neutralizes U+009F to the six characters \u009F, and JSON escapes a
+        // real U+009F to the same six. They are only distinguishable by what they
+        // parse back to: the escape yields the scalar, the containment yields the
+        // literal text — which is exactly the difference the two tiers exist to
+        // make, so this is the layer at which to ask.
+        foreach (string contained in HostileAssemblyFixture.NeutralizedForms)
+        {
+            Assert.False(
+                received.Contains(contained, StringComparison.Ordinal),
+                $"The raw {view} rendering in {format} still contained {contained}.");
+        }
+        foreach (Rune rune in payload.EnumerateRunes().Where(HostileAssemblyFixture.IsNonGraphic))
+        {
+            if (unavailable.Contains(rune))
+                continue;
+
+            Assert.True(
+                received.Contains(rune.ToString(), StringComparison.Ordinal),
+                $"The raw {view} rendering in {format} did not deliver U+{rune.Value:X4}, "
+                + "so the escape hatch is not actually handing over the text.");
+        }
+    }
+
+    /// <summary>
+    /// The flags are two axes rather than a three-way choice, and the raw one
+    /// alone is inert: refusing happens first, so nothing would ever reach the
+    /// spelling decision it governs.
+    /// <para>
+    /// A flag that silently does nothing is worse than one that is rejected,
+    /// because the user who reached for it believed they had asked for raw output
+    /// and would read contained output as the artifact's own text. Saying so is
+    /// also what keeps the two axes visible: reaching a live control character is
+    /// two separately named mistakes, not one. See
+    /// <c>docs/design/untrusted-data-threat-model.md#presentation</c>.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TheRawFlagAloneIsRejectedRatherThanSilentlyIgnored()
+    {
+        int code = Run(
+            ["--table", "TypeDef", "--dangerously-print-raw"],
+            out string output,
+            out string error);
+
+        Assert.Equal(1, code);
+        Assert.Equal(string.Empty, output);
+        Assert.Contains("--show-untrusted-text", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The trust axis is genuinely independent of the rendering axis: asking not
+    /// to refuse does not by itself ask for raw text. Without this, a change that
+    /// made <c>--show-untrusted-text</c> imply raw output would collapse the two
+    /// axes into one and nothing else here would notice, because every other case
+    /// passes the flags together.
+    /// </summary>
+    [Fact]
+    public void TheTrustOptOutDoesNotByItselfDisableEncoding()
+    {
+        Assert.Equal(0, Run(["--table", "TypeDef", "--show-untrusted-text"], out string output, out _));
+
+        foreach (Rune rune in DangerousScalars)
+        {
+            Assert.False(
+                output.Contains(rune.ToString(), StringComparison.Ordinal),
+                $"--show-untrusted-text alone emitted U+{rune.Value:X4} raw, "
+                + "so it is doing the rendering axis's job as well as its own.");
+        }
+
+        Assert.Contains(@"\u202E", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Refusal costs nothing on an artifact that carries no such text: the
+    /// default and the contained tier produce identical bytes.
+    /// <para>
+    /// This is the claim that makes a refusing default affordable to ship. The
+    /// modes differ only in whether they <em>can</em> fail, so on ordinary
+    /// assemblies — which is to say almost all of them — nobody sees a change.
+    /// The clean assembly used here is the very one the fixture splices its
+    /// payload into, so the pair differs in exactly the payload and nothing else.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [InlineData("md")]
+    [InlineData("tsv")]
+    [InlineData("jsonl")]
+    public void OnAnAssemblyWithNoSuchText_TheDefaultMatchesContainmentExactly(string format)
+    {
+        string clean = typeof(HostileAssemblyFixture).Assembly.Location;
+
+        var byDefault = new StringWriter();
+        int defaultCode = MdiCommand.Invoke(
+            [clean, "--table", "TypeDef", "--format", format], byDefault, new StringWriter());
+
+        var contained = new StringWriter();
+        int containedCode = MdiCommand.Invoke(
+            [clean, "--table", "TypeDef", "--format", format, "--show-untrusted-text"],
+            contained,
+            new StringWriter());
+
+        Assert.Equal(0, defaultCode);
+        Assert.Equal(0, containedCode);
+        Assert.NotEmpty(byDefault.ToString());
+        Assert.Equal(contained.ToString(), byDefault.ToString());
+    }
+
+    /// <summary>
+    /// The heap view reads one value straight out of <c>#Strings</c> by address,
+    /// so it reaches the text without going through row projection and needs its
+    /// own case at each tier rather than inheriting the table's result.
+    /// </summary>
+    [Fact]
+    public void TheHeapViewHonoursAllThreeTiers()
+    {
+        string[] heap = ["--heap", $"#Strings:0x{fixture.CanaryHeapOffset:x}"];
+
+        Assert.Equal(1, Run(heap, out string refused, out string error));
+        Assert.Equal(string.Empty, refused);
+        Assert.Contains("U+", error, StringComparison.Ordinal);
+
+        Assert.Equal(0, Run([.. heap, "--show-untrusted-text"], out string inert, out _));
+        foreach (string form in HostileAssemblyFixture.NeutralizedForms)
+            Assert.Contains(form, inert, StringComparison.Ordinal);
+
+        Assert.Equal(
+            0,
+            Run([.. heap, "--show-untrusted-text", "--dangerously-print-raw"], out string raw, out _));
+        Assert.Contains("\u202E", raw, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The coordinate in a refusal is spelled the way <c>--heap</c> accepts it, so
+    /// the way forward is a command a reader can paste rather than one they have
+    /// to assemble. Gated because the two spellings are produced by different code
+    /// and nothing else would notice them drifting apart.
+    /// </summary>
+    [Fact]
+    public void TheReportedCoordinateIsAcceptedByTheHeapOption()
+    {
+        Run(["--table", "TypeDef"], out _, out string error);
+
+        int start = error.IndexOf('#');
+        Assert.True(start >= 0, error);
+        string coordinate = new([.. error.Skip(start).TakeWhile(c => !char.IsWhiteSpace(c))]);
+
+        int code = Run(
+            ["--heap", coordinate, "--show-untrusted-text"], out string output, out string heapError);
+
+        Assert.Equal(0, code);
+        Assert.Equal(string.Empty, heapError);
+        Assert.Contains(@"\u202E", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Raw text is still bounded, and the bound still falls on a scalar boundary.
+    /// A budget that divided a surrogate pair would leave a lone surrogate in the
+    /// output, which cannot be encoded as UTF-8 and would corrupt the byte stream
+    /// of every format — a way for the unsafe tier to be unsafe to the
+    /// <em>tool</em> rather than merely to the reader.
+    /// </summary>
+    [Theory]
+    [InlineData("md")]
+    [InlineData("tsv")]
+    [InlineData("jsonl")]
+    public void RawTextIsNeverCutThroughASurrogatePair(string format)
+    {
+        // Sweep every budget across the payload so the astral scalar is bisected
+        // at some point in the range rather than only if a guessed budget lands on it.
+        for (int budget = 0; budget <= 40; budget++)
+        {
+            Run(
+                ["--table", "TypeDef", "--format", format, "--dangerously-print-raw",
+                 "--max-chars", budget.ToString(CultureInfo.InvariantCulture)],
+                out string output,
+                out _);
+
+            for (int i = 0; i < output.Length; i++)
+            {
+                if (!char.IsSurrogate(output[i]))
+                    continue;
+
+                bool paired = char.IsHighSurrogate(output[i])
+                    && i + 1 < output.Length
+                    && char.IsLowSurrogate(output[i + 1]);
+
+                Assert.True(
+                    paired || (char.IsLowSurrogate(output[i]) && i > 0 && char.IsHighSurrogate(output[i - 1])),
+                    $"A lone surrogate survived at index {i} with --max-chars {budget} in {format}.");
+            }
+        }
+    }
+}

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiUntrustedTextModeTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiUntrustedTextModeTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using InertText;
 using Mdi;
 
 namespace DotnetInspector.MetadataRendering.Tests;
@@ -460,6 +461,12 @@ public sealed class MdiUntrustedTextModeTests(HostileAssemblyFixture fixture)
     /// of every format — a way for the unsafe tier to be unsafe to the
     /// <em>tool</em> rather than merely to the reader.
     /// </summary>
+    /// <remarks>
+    /// Both flags are required. Passing <c>--dangerously-print-raw</c> alone is rejected, so a
+    /// sweep that omitted <c>--show-untrusted-text</c> would iterate an empty string and pass
+    /// without rendering anything — which is exactly what this test did before it was fixed.
+    /// The <c>Assert.NotEmpty</c> below is what keeps it honest.
+    /// </remarks>
     [Theory]
     [InlineData("md")]
     [InlineData("tsv")]
@@ -471,10 +478,13 @@ public sealed class MdiUntrustedTextModeTests(HostileAssemblyFixture fixture)
         for (int budget = 0; budget <= 40; budget++)
         {
             Run(
-                ["--table", "TypeDef", "--format", format, "--dangerously-print-raw",
+                ["--table", "TypeDef", "--format", format,
+                 "--show-untrusted-text", "--dangerously-print-raw",
                  "--max-chars", budget.ToString(CultureInfo.InvariantCulture)],
                 out string output,
                 out _);
+
+            Assert.NotEmpty(output);
 
             for (int i = 0; i < output.Length; i++)
             {
@@ -490,5 +500,72 @@ public sealed class MdiUntrustedTextModeTests(HostileAssemblyFixture fixture)
                     $"A lone surrogate survived at index {i} with --max-chars {budget} in {format}.");
             }
         }
+    }
+
+    /// <summary>
+    /// The two axes are independent: at the same budget, the encoded and raw renderings
+    /// describe the same prefix of the same value, differing only in how it is spelled.
+    /// </summary>
+    /// <remarks>
+    /// This is a property of where the decode happens. Raw output is produced by running the
+    /// encoder backwards at the sink, <em>after</em> the budget has been applied to the encoded
+    /// text, so both modes cut the same value at the same point. Bounding raw text separately —
+    /// in its own units, upstream — would make the rendering axis silently also a
+    /// <em>content</em> axis, so that asking for a different spelling changed how much of the
+    /// value was shown. The threat model calls collapsing the axes a design error; this is the
+    /// gate for the subtler form of it.
+    /// <para>
+    /// The comparison runs the encoder <em>forward</em> over the raw cell rather than decoding
+    /// the encoded one, so it is not a restatement of the implementation: it would still fail if
+    /// the decode were replaced by anything that happened to round-trip differently.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("md")]
+    [InlineData("tsv")]
+    [InlineData("jsonl")]
+    public void RawAndEncodedRenderingsShowTheSamePrefix(string format)
+    {
+        // From 8, so the shared graphic prefix "Hostile" is present and the cell is locatable.
+        for (int budget = 8; budget <= 30; budget++)
+        {
+            string[] common =
+                ["--table", "TypeDef", "--format", format, "--show-untrusted-text",
+                 "--max-chars", budget.ToString(CultureInfo.InvariantCulture)];
+
+            Run(common, out string encodedOutput, out _);
+            Run([.. common, "--dangerously-print-raw"], out string rawOutput, out _);
+
+            string encodedCell = PayloadCell(AsConsumerReceivesIt(encodedOutput, format));
+            string rawCell = PayloadCell(AsConsumerReceivesIt(rawOutput, format));
+
+            Assert.NotEmpty(encodedCell);
+            Assert.NotEmpty(rawCell);
+
+            bool encodedClipped = encodedCell.EndsWith('\u2026');
+            bool rawClipped = rawCell.EndsWith('\u2026');
+            Assert.Equal(encodedClipped, rawClipped);
+
+            string rawBody = rawClipped ? rawCell[..^1] : rawCell;
+            string encodedBody = encodedClipped ? encodedCell[..^1] : encodedCell;
+
+            Assert.Equal(
+                encodedBody,
+                new InertString(TextPolicy.Field, rawBody, int.MaxValue).ToString());
+        }
+    }
+
+    /// <summary>
+    /// The rendered cell carrying the payload, from its graphic prefix to the format's next
+    /// delimiter. Located by that prefix because the cell's own content is what is under test.
+    /// </summary>
+    static string PayloadCell(string output)
+    {
+        int start = output.IndexOf("Hostile", StringComparison.Ordinal);
+        if (start < 0)
+            return string.Empty;
+
+        int end = output.AsSpan(start).IndexOfAny(['|', '\t', '\n', '\r', '"']);
+        return end < 0 ? output[start..] : output.Substring(start, end).TrimEnd();
     }
 }


### PR DESCRIPTION
Builds the trust and rendering axes that `docs/design/untrusted-data-threat-model.md` has specified since #3636 and recorded as unbuilt.

Stacked on #3679 — review that first; this targets its branch and will retarget to `main` once it merges.

## The default refuses

`mdi` rendered everything it found, neutralizing control characters and continuing. That is sanitizing, and the same document opens with **"reject, do not sanitize."** Now, when an assembly carries text a terminal would act on, `mdi` exits non-zero:

```text
Error: '/tmp/MetaHostile.dll' contains text that is not safe to render as it is.
  #Strings:0x2d carries U+202E (Format) at index 7.

  --show-untrusted-text     render it inertly; every such scalar is spelled, never emitted
  --show-untrusted-text --dangerously-print-raw
                            render it verbatim; unsafe, and best redirected to a file
```

The message never contains the text. The diagnostic goes to stderr, which is read on a terminal and is almost never piped through whatever treatment stdout got — quoting the characters would deliver the payload by the one route the user cannot redirect, in the mode chosen specifically to avoid that. The coordinate is spelled the way `--heap` accepts it, so the way forward is a command to paste rather than assemble; a test pulls the coordinate out of the diagnostic and feeds it back in.

## The flags compose

They are two axes, not a three-way choice.

| | trust | rendering | result |
| --- | --- | --- | --- |
| *(default)* | refuse | — | exits 1, names the coordinate |
| `--show-untrusted-text` | continue | encoded | today's output, byte for byte |
| both flags | continue | raw | the artifact's own spelling |
| `--dangerously-print-raw` alone | — | — | **rejected** |

Raw output costs two separately named mistakes. The raw flag alone is rejected rather than silently ignored: refusal comes first, so it would otherwise change nothing while appearing to.

An earlier draft of this PR made the flags *mutually exclusive* — the exact inverse — and the design doc caught it.

## Nothing changes for ordinary assemblies

Refusal is checked on the raw text before encoding, and when it succeeds it is byte-for-byte identical to containment; the modes differ only in whether they can fail. Default output equals `--show-untrusted-text` output on every clean assembly measured, including `System.Private.CoreLib` at 5.4 MB of output. That equivalence is gated.

`dotnet-inspect` is unaffected. The library default stays `Contain`: containment is a safety property `ILInspector.Metadata` owes every caller, refusing is a policy only a caller can choose, and an internal projector scan must never refuse.

## What raw actually promises

That `mdi` adds no encoding — not that every scalar reaches the stream, because the format still keeps itself well formed. Measured:

| format | behavior under `--dangerously-print-raw` |
| --- | --- |
| md | carries everything |
| tsv | replaces U+2028/U+2029, which it cannot carry in a record |
| jsonl | escapes scalars below U+0020 per RFC 8259 — these **decode back**, so they are raw |

The gate decodes per format before asserting. It has to: `mdi` spells U+009F as `\u009F` and JSON escapes a real U+009F to the same six characters, so on the wire the tiers are indistinguishable and differ only in what they parse back to.

## Tests

35 new cases driving `MdiCommand.Invoke(string[], TextWriter?, TextWriter?)` with an argv, because the mode is chosen by option parsing and the CLI default deliberately differs from the library's — nothing below the argv layer can observe either. `Invoke` gained optional writers so this needs no `Console` redirection, which is process-global and would make parallel execution unsound.

Five mutations, each caught by a different case for a different reason:

| mutation | failures | reason |
| --- | --- | --- |
| default no longer refuses | 9 | exit code |
| raw falls back to containment | 7 | `still contained \^[` |
| diagnostic echoes the scalar | 6 | `echoed U+001B raw` |
| axes collapsed (trust opt-out implies raw) | 9 | `doing the rendering axis's job as well as its own` |
| raw flag alone silently accepted | 1 | not rejected |

`IsNonGraphic` moved onto `HostileAssemblyFixture` so one definition of "dangerous" serves every gate over that payload. Two copies would be two oracles, which is the failure this corpus exists to prevent.

Suites: MetadataRendering 184/0, Metadata 1283/0, InertText 330/0, CLI 2817 with only the known local #3592.

## Still unbuilt

`--survey` — refusal stops at the first violation rather than reporting all of them, though `InertString.IsPermitted` already returns a `ScalarViolation` shaped for it. Both status sections say so.
