### PR TITLE
Add assembly acquisition catalog foundation

### DIFF
--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1519,7 +1519,7 @@ sessions:
 ```text
 ResolvedAssemblyCandidate
   -> materialized AssemblyInventorySnapshot
-      -> identity, AssemblyRefs, ExportedType forwarding targets
+      -> identity, MVID, AssemblyRefs, ExportedType forwarding targets
   -> optional catalog-owned AssemblyInspectionSession
       -> declaration probe
       -> cached (assembly candidate, type name) result
@@ -1534,13 +1534,16 @@ later body/declaration consumer may open one durable
 `AssemblyInspectionSession`; the snapshot prevents decoding identity,
 references, or forwarding inventory again.
 
-Slice 2 evolves durable sessions to construct `PEReader` with
+Slice 2a evolves durable sessions to construct `PEReader` with
 `PEStreamOptions.PrefetchEntireImage` and close the source stream immediately
 after construction. The catalog may retain prefetched image memory, but holds
 no source file handle for the lifetime of a context. Candidate, retained-image
 byte, and source-open concurrency budgets are explicit plan inputs; budget
 exhaustion is a typed failure rather than an `IOException`-shaped partial
-answer.
+answer. A retained session must match both the selected `AssemblyDef` identity
+and the inventory MVID. A registration whose opener changes artifacts between
+inventory and session construction is rejected rather than combining adjacency
+from one module with declarations from another.
 
 This preserves the single PE-lifetime owner established by
 `AssemblyInspectionSession`; it does not lend a reader to a consumer or dispose
@@ -2432,18 +2435,30 @@ Each slice has one behavioral claim and can land independently.
 Claim: one readable image can answer "defines, forwards, misses, or rejects"
 without returning a stringly or nullable result.
 
-### Slice 2: context and resolution engine
+### Slice 2a: acquisition catalog foundation
 
 - Evolve `ResolvedAssemblyReference` to the non-equatable descriptor plus
   acquisition registration contract.
-- Add the resolution request, binding, failure, ambiguity, and outcome
-  hierarchies after their descriptor and catalog dependencies exist.
 - Add one `InspectionAcquisitionPlan` per inspection and collapse today's
   per-path resolver instances into its shared owner adapters.
 - Add catalog-owned `AssemblyInventorySnapshot` values for every discovered
   candidate and open prefetched `AssemblyInspectionSession` values only on
   demand; inventory reads and durable-session opens are separate single-flight
   operations sharing the source-open semaphore.
+- Verify retained sessions against the inventoried assembly identity and MVID,
+  and make the plan the sole owner of retained session lifetime.
+- Keep the plan and its result hierarchy internal until binding policy and
+  resolution outcomes establish the public context boundary.
+- Add no cross-assembly traversal or public binding policy.
+
+Claim: one acquisition registration maps to one catalog-local candidate,
+reader-independent inventory, and at most one lazily retained session under
+explicit resource budgets.
+
+### Slice 2b: context and resolution engine
+
+- Add the resolution request, binding, failure, ambiguity, and outcome
+  hierarchies after their descriptor and catalog dependencies exist.
 - Add the catalog lifetime and compose `TypeResolutionContext` over snapshots
   plus optional sessions without retaining adjacency-only readers.
 - Add public `IAssemblyBindingPolicy` descriptor selections and the

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1534,6 +1534,10 @@ later body/declaration consumer may open one durable
 `AssemblyInspectionSession`; the snapshot prevents decoding identity,
 references, or forwarding inventory again.
 
+Inventory stores distinct semantic `AssemblyRef` and forwarding-target
+identities in first-seen order. Repeated metadata rows and repeated forwarders
+to one target do not amplify the retained adjacency graph.
+
 Slice 2a evolves durable sessions to construct `PEReader` with
 `PEStreamOptions.PrefetchEntireImage` and close the source stream immediately
 after construction. The catalog may retain prefetched image memory, but holds

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -92,9 +92,10 @@ identity is required. The round-trip design calls that pairing
 
 ### Structured forwarding currencies
 
-The first Metadata delivery slice implements the single-image declaration
-currencies. The Analysis provenance and cross-assembly resolution currencies
-remain proposed until later delivery slices implement them.
+The first two Metadata delivery slices implement the single-image declaration
+and acquisition currencies. The Analysis provenance and cross-assembly
+resolution currencies remain proposed until later delivery slices implement
+them.
 
 #### Proposed `ILInspector.Analysis` forwarding provenance
 
@@ -111,12 +112,22 @@ remain proposed until later delivery slices implement them.
 | `TypeDeclarationResult` and `TypeDeclarationCandidate` | One exact name in one readable image | Whether the image defines, forwards, misses, ambiguously declares, exports from a module, or rejects the name | Opening another assembly or resolving a target |
 | `ModuleFileReference` | One copied `File` row | Which module file an exported declaration names, including metadata and hash evidence | Module acquisition or readability |
 
+#### Current `ILInspector.Metadata` acquisition
+
+| Currency | Scope | Answers | Does not answer |
+| --- | --- | --- | --- |
+| `AssemblyAcquisitionRegistration` | One acquisition-owner selection | Which repeated selections are the same registered acquisition | Artifact equality, persistence, or descriptor reconstruction |
+| `ResolvedAssemblyReference` | One registered acquisition | How to open the selected image and which identity and provenance evidence its owner supplied | Catalog membership or successful readability |
+| `AssemblyResolutionProvenance` | One registered acquisition | Whether package, platform, project, or local ownership selected the image | Candidate identity or binding policy |
+| `AssemblyCatalogId` | One inspection catalog | Which local key space owns candidates | Stable identity across catalogs or processes |
+| `ResolvedAssemblyCandidate` | One catalog | Which catalog-local descriptor identifies the candidate whose inventory and session state the catalog owns | Durable artifact identity outside the catalog |
+| `AssemblyInventorySnapshot` | One inventoried candidate | The copied assembly identity, MVID, references, forwarder targets, and image size | A live reader, declaration answer, or cross-assembly binding |
+
 #### Proposed `ILInspector.Metadata` cross-assembly resolution
 
 | Currency | Scope | Answers | Does not answer |
 | --- | --- | --- | --- |
 | `TypeResolutionRequest` | One resolution operation | Which typed start candidate/binding target and exact name to resolve | Decoded provenance or reusable identity |
-| `ResolvedAssemblyCandidate` | One catalog | Which catalog-local descriptor identifies the candidate whose inventory/session state the catalog owns | Session ownership or durable identity outside the catalog |
 | `TypeResolutionOutcome` | One frozen catalog generation | The complete resolution verdict, non-success evidence, and ordered hops | Definition equality or a nullable success result |
 | `TypeForwardingHop` | One resolution outcome | Which verified `ExportedType` declaration and exact target reference were encountered | Successful target binding, definition identity, or correspondence |
 | `ResolvedTypeDefinition` | One frozen catalog generation | The successful candidate, exact name, address, and opaque key | Forwarding hops, object equality, or persistence as a whole |

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -15,11 +15,20 @@ public class AssemblyDependencyResolverTests
             AllowPlatformAssemblyVersionRollForward = true,
         });
 
+        var requested = new AssemblyReferenceIdentity(
+            current.Name!,
+            new Version(1, 0, 0, 0),
+            null,
+            token);
         var resolved = resolver.Resolve(
-            new AssemblyReferenceIdentity(current.Name!, new Version(1, 0, 0, 0), null, token),
+            requested,
+            AssemblyResolutionScope.Platform);
+        var repeated = resolver.Resolve(
+            requested,
             AssemblyResolutionScope.Platform);
 
         Assert.NotNull(resolved);
+        Assert.Same(resolved, repeated);
         Assert.Equal(current.Name + ".dll", Path.GetFileName(resolved.Path));
 
         var future = resolver.Resolve(

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -1,6 +1,5 @@
 using System.Buffers;
-using System.Reflection.Metadata;
-using System.Security.Cryptography;
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Xml.Linq;
 using System.Runtime.InteropServices;
@@ -54,6 +53,10 @@ public sealed record AssemblyDependencyResolutionOptions(string TargetAssemblyPa
 public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
 {
     readonly AssemblyDependencyResolutionOptions _options;
+    readonly ConcurrentDictionary<
+        string,
+        Lazy<ResolvedAssemblyReference?>> _descriptors =
+            new(StringComparer.Ordinal);
     IReadOnlyList<ResolvedAssemblyDependency>? _resolved;
     IReadOnlyList<ResolvedAssemblyDependency>? _allCandidates;
 
@@ -165,17 +168,19 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
 
             bool allowVersionRollForward = scope == AssemblyResolutionScope.Platform
                 && _options.AllowPlatformAssemblyVersionRollForward;
-            if (!MatchesIdentity(identity, dependency.Path, allowVersionRollForward))
-                continue;
-
-            if (TryReadIdentity(dependency.Path) is not { } selectedIdentity)
-                continue;
-
-            return ResolvedAssemblyReference.Create(
-                selectedIdentity,
+            ResolvedAssemblyReference? selected = Descriptor(
                 dependency.Path,
-                () => File.OpenRead(dependency.Path),
                 ResolutionProvenance(dependency));
+            if (selected is null
+                || !MatchesIdentity(
+                    identity,
+                    selected.Identity,
+                    allowVersionRollForward))
+            {
+                continue;
+            }
+
+            return selected;
         }
 
         // The target may reference an older platform contract than the running
@@ -188,22 +193,22 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
             var (path, framework, _, _) = PlatformResolver.ResolveAssembly(
                 identity.Name,
                 useRuntimeAssemblies: _options.PreferImplementationAssemblies);
-            if (path is not null && MatchesIdentity(
-                identity,
-                path,
-                _options.AllowPlatformAssemblyVersionRollForward))
+            if (path is not null)
             {
-                if (TryReadIdentity(path) is not { } selectedIdentity)
-                    return null;
-
-                return ResolvedAssemblyReference.Create(
-                    selectedIdentity,
+                ResolvedAssemblyReference? selected = Descriptor(
                     path,
-                    () => File.OpenRead(path),
                     AssemblyResolutionProvenance.Platform(
                         framework ?? "InstalledPlatform",
                         frameworkVersion: null,
                         AssemblyDependencyProvenance.InstalledPlatformAssembly.ToString()));
+                if (selected is not null
+                    && MatchesIdentity(
+                        identity,
+                        selected.Identity,
+                        _options.AllowPlatformAssemblyVersionRollForward))
+                {
+                    return selected;
+                }
             }
         }
 
@@ -234,11 +239,29 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 dependency.Provenance.ToString()),
         };
 
+    ResolvedAssemblyReference? Descriptor(
+        string path,
+        AssemblyResolutionProvenance provenance) =>
+        _descriptors.GetOrAdd(
+            path,
+            static (path, provenance) =>
+                new Lazy<ResolvedAssemblyReference?>(
+                    () => ResolvedAssemblyReference.TryCreateFromPath(
+                        path,
+                        provenance,
+                        out ResolvedAssemblyReference? reference)
+                            ? reference
+                            : null,
+                    LazyThreadSafetyMode.ExecutionAndPublication),
+            provenance).Value;
+
     static bool MatchesIdentity(
         AssemblyReferenceIdentity expected,
-        string path,
+        AssemblyReferenceIdentity actual,
         bool allowVersionRollForward = false)
     {
+        if (!actual.Name.Equals(expected.Name, StringComparison.OrdinalIgnoreCase))
+            return false;
         if (expected.Version is null
             && string.IsNullOrEmpty(expected.Culture)
             && string.IsNullOrEmpty(expected.PublicKeyToken))
@@ -246,12 +269,6 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
             return true;
         }
 
-        var actual = TryReadIdentity(path);
-        if (actual is null)
-            return false;
-
-        if (!actual.Name.Equals(expected.Name, StringComparison.OrdinalIgnoreCase))
-            return false;
         if (expected.Version is not null
             && actual.Version != expected.Version
             && (!allowVersionRollForward || actual.Version < expected.Version))
@@ -776,39 +793,6 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
         if (NuGetPackageContext(path, packageRoots) is { } context)
             return (context.PackageId, context.PackageVersion);
         return (null, null);
-    }
-
-    static AssemblyReferenceIdentity? TryReadIdentity(string path)
-    {
-        try
-        {
-            using var stream = File.OpenRead(path);
-            using var pe = new System.Reflection.PortableExecutable.PEReader(stream);
-            if (!pe.HasMetadata)
-                return null;
-            var reader = pe.GetMetadataReader();
-            if (!reader.IsAssembly)
-                return null;
-            var assembly = reader.GetAssemblyDefinition();
-            return new AssemblyReferenceIdentity(
-                reader.GetString(assembly.Name),
-                assembly.Version,
-                string.IsNullOrWhiteSpace(reader.GetString(assembly.Culture)) ? null : reader.GetString(assembly.Culture),
-                assembly.PublicKey.IsNil ? null : PublicKeyToken(reader.GetBlobBytes(assembly.PublicKey)));
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or BadImageFormatException)
-        {
-            return null;
-        }
-    }
-
-    static string PublicKeyToken(byte[] publicKey)
-    {
-        var hash = SHA1.HashData(publicKey);
-        Span<byte> token = stackalloc byte[8];
-        for (int i = 0; i < token.Length; i++)
-            token[i] = hash[hash.Length - 1 - i];
-        return Convert.ToHexString(token).ToLowerInvariant();
     }
 
     readonly record struct NuGetFramework(string Family, int Major, int Minor)

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -168,11 +168,14 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
             if (!MatchesIdentity(identity, dependency.Path, allowVersionRollForward))
                 continue;
 
-            return new ResolvedAssemblyReference(
-                identity,
+            if (TryReadIdentity(dependency.Path) is not { } selectedIdentity)
+                continue;
+
+            return ResolvedAssemblyReference.Create(
+                selectedIdentity,
                 dependency.Path,
                 () => File.OpenRead(dependency.Path),
-                dependency.Provenance.ToString());
+                ResolutionProvenance(dependency));
         }
 
         // The target may reference an older platform contract than the running
@@ -190,16 +193,46 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 path,
                 _options.AllowPlatformAssemblyVersionRollForward))
             {
-                return new ResolvedAssemblyReference(
-                    identity,
+                if (TryReadIdentity(path) is not { } selectedIdentity)
+                    return null;
+
+                return ResolvedAssemblyReference.Create(
+                    selectedIdentity,
                     path,
                     () => File.OpenRead(path),
-                    $"{AssemblyDependencyProvenance.InstalledPlatformAssembly}:{framework}");
+                    AssemblyResolutionProvenance.Platform(
+                        framework ?? "InstalledPlatform",
+                        frameworkVersion: null,
+                        AssemblyDependencyProvenance.InstalledPlatformAssembly.ToString()));
             }
         }
 
         return null;
     }
+
+    static AssemblyResolutionProvenance ResolutionProvenance(
+        ResolvedAssemblyDependency dependency) =>
+        dependency.Provenance switch
+        {
+            AssemblyDependencyProvenance.PackageDependency
+                or AssemblyDependencyProvenance.DepsJsonAsset
+                or AssemblyDependencyProvenance.ProjectAsset
+                when dependency.PackageId is { Length: > 0 } packageId
+                    && dependency.PackageVersion is { Length: > 0 } packageVersion =>
+                AssemblyResolutionProvenance.Package(
+                    packageId,
+                    packageVersion,
+                    tfm: null,
+                    rid: null),
+            AssemblyDependencyProvenance.TrustedPlatformAssembly
+                or AssemblyDependencyProvenance.SharedFramework =>
+                AssemblyResolutionProvenance.Platform(
+                    dependency.FrameworkName ?? "Platform",
+                    frameworkVersion: null,
+                    dependency.Provenance.ToString()),
+            _ => AssemblyResolutionProvenance.Local(
+                dependency.Provenance.ToString()),
+        };
 
     static bool MatchesIdentity(
         AssemblyReferenceIdentity expected,

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -490,7 +490,9 @@ public class LibraryBodyIndexTests
         {
             string candidate = Path.Combine(directory, identity.Name + ".dll");
             return File.Exists(candidate)
-                ? new ResolvedAssemblyReference(identity, candidate, () => File.OpenRead(candidate), "test")
+                ? ResolvedAssemblyReference.CreateFromPath(
+                    candidate,
+                    AssemblyResolutionProvenance.Local("test"))
                 : null;
         }
     }
@@ -499,7 +501,9 @@ public class LibraryBodyIndexTests
     sealed class ConstantResolver(string path) : IAssemblyReferenceResolver
     {
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
-            => new(identity, path, () => File.OpenRead(path), "test");
+            => ResolvedAssemblyReference.CreateFromPath(
+                path,
+                AssemblyResolutionProvenance.Local("test"));
     }
 
     /// <summary>Records every identity and scope the builder asks for.</summary>

--- a/src/ILInspector.Decompiler.Tests/AssemblyReferenceResolverTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssemblyReferenceResolverTests.cs
@@ -1,0 +1,84 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class AssemblyReferenceResolverTests
+{
+    [Fact]
+    public void SiblingResolver_ReusesSelectedDescriptorWithoutReopeningPath()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"resolver-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string sibling = Path.Combine(
+            directory,
+            Path.GetFileName(typeof(object).Assembly.Location));
+        try
+        {
+            File.Copy(typeof(object).Assembly.Location, sibling);
+            AssemblyReferenceIdentity identity = ReadIdentity(sibling);
+            var resolver =
+                new MetadataSource.SiblingAssemblyReferenceResolver(
+                    Path.Combine(directory, "Owner.dll"));
+
+            ResolvedAssemblyReference? first = resolver.Resolve(
+                identity,
+                AssemblyResolutionScope.Any);
+            File.WriteAllText(sibling, "changed");
+            ResolvedAssemblyReference? second = resolver.Resolve(
+                identity,
+                AssemblyResolutionScope.Any);
+
+            Assert.NotNull(first);
+            Assert.Same(first, second);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SiblingResolver_InvalidImageReturnsNull()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"resolver-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(directory, "Invalid.dll"),
+                "not a PE image");
+            var resolver =
+                new MetadataSource.SiblingAssemblyReferenceResolver(
+                    Path.Combine(directory, "Owner.dll"));
+
+            ResolvedAssemblyReference? result = resolver.Resolve(
+                new AssemblyReferenceIdentity(
+                    "Invalid",
+                    Version: null,
+                    Culture: null,
+                    PublicKeyToken: null),
+                AssemblyResolutionScope.Any);
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    static AssemblyReferenceIdentity ReadIdentity(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        return AssemblyReferenceIdentity.FromAssemblyDefinition(
+            peReader.GetMetadataReader());
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/TestAssemblyReferenceResolvers.cs
+++ b/src/ILInspector.Decompiler.Tests/TestAssemblyReferenceResolvers.cs
@@ -36,7 +36,9 @@ static class TestAssemblyReferenceResolvers
     }
 
     static ResolvedAssemblyReference FromPath(AssemblyReferenceIdentity identity, string path, string provenance)
-        => new(identity, path, () => File.OpenRead(path), provenance);
+        => ResolvedAssemblyReference.CreateFromPath(
+            path,
+            AssemblyResolutionProvenance.Local(provenance));
 
     sealed class DelegateResolver(Func<AssemblyReferenceIdentity, AssemblyResolutionScope, ResolvedAssemblyReference?> resolve) : IAssemblyReferenceResolver
     {

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -215,11 +215,9 @@ public static class MemberBodyProducer
     /// </summary>
     public static DecompilerResult Project(ApiType type, string dllPath, string? pdbPath, IAssemblyReferenceResolver resolver, Pipeline.MetadataContext? context = null, Pipeline.PrinterOptions? printerOptions = null)
     {
-        var start = new ResolvedAssemblyReference(
-            new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(dllPath), Version: null, Culture: null, PublicKeyToken: null),
+        var start = ResolvedAssemblyReference.CreateFromPath(
             dllPath,
-            () => File.OpenRead(dllPath),
-            Provenance: "StartAssembly");
+            AssemblyResolutionProvenance.Local("StartAssembly"));
         var composed = ComposeCore(
             type,
             dllPath,
@@ -262,11 +260,9 @@ public static class MemberBodyProducer
     {
         ArgumentNullException.ThrowIfNull(type);
         ArgumentNullException.ThrowIfNull(member);
-        var start = new ResolvedAssemblyReference(
-            new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(dllPath), Version: null, Culture: null, PublicKeyToken: null),
+        var start = ResolvedAssemblyReference.CreateFromPath(
             dllPath,
-            () => File.OpenRead(dllPath),
-            Provenance: "StartAssembly");
+            AssemblyResolutionProvenance.Local("StartAssembly"));
         return ComposeMemberCore(
             type,
             member,
@@ -303,11 +299,9 @@ public static class MemberBodyProducer
     public static IReadOnlyDictionary<ApiMember, MemberRenderResult> ProduceMembers(ApiType type, string dllPath, string? pdbPath, IAssemblyReferenceResolver resolver, Pipeline.MetadataContext? context = null)
     {
         ArgumentNullException.ThrowIfNull(type);
-        var start = new ResolvedAssemblyReference(
-            new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(dllPath), Version: null, Culture: null, PublicKeyToken: null),
+        var start = ResolvedAssemblyReference.CreateFromPath(
             dllPath,
-            () => File.OpenRead(dllPath),
-            Provenance: "StartAssembly");
+            AssemblyResolutionProvenance.Local("StartAssembly"));
         return ComposeMembersBatch(
             type,
             () => TypeForwardResolver.LocateType(start, type.FullName, resolver),

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -200,9 +201,14 @@ public sealed class MetadataSource : IDisposable
     /// resolution (packages, deps.json, projects, shared frameworks) belongs to
     /// callers that inject a resolver.
     /// </summary>
-    sealed class SiblingAssemblyReferenceResolver(string path) : IAssemblyReferenceResolver
+    internal sealed class SiblingAssemblyReferenceResolver(string path)
+        : IAssemblyReferenceResolver
     {
         readonly string? _directory = System.IO.Path.GetDirectoryName(path);
+        readonly ConcurrentDictionary<
+            string,
+            Lazy<ResolvedAssemblyReference?>> _assemblies =
+                new(StringComparer.Ordinal);
 
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
         {
@@ -214,9 +220,17 @@ public sealed class MetadataSource : IDisposable
                 string sibling = System.IO.Path.Combine(_directory, identity.Name + ".dll");
                 if (File.Exists(sibling))
                 {
-                    return ResolvedAssemblyReference.CreateFromPath(
+                    return _assemblies.GetOrAdd(
                         sibling,
-                        AssemblyResolutionProvenance.Local("SiblingAssembly"));
+                        static path => new Lazy<ResolvedAssemblyReference?>(
+                            () => ResolvedAssemblyReference.TryCreateFromPath(
+                                path,
+                                AssemblyResolutionProvenance.Local(
+                                    "SiblingAssembly"),
+                                out ResolvedAssemblyReference? reference)
+                                    ? reference
+                                    : null,
+                            LazyThreadSafetyMode.ExecutionAndPublication)).Value;
                 }
             }
 

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -214,11 +214,9 @@ public sealed class MetadataSource : IDisposable
                 string sibling = System.IO.Path.Combine(_directory, identity.Name + ".dll");
                 if (File.Exists(sibling))
                 {
-                    return new ResolvedAssemblyReference(
-                        identity,
+                    return ResolvedAssemblyReference.CreateFromPath(
                         sibling,
-                        () => File.OpenRead(sibling),
-                        Provenance: "SiblingAssembly");
+                        AssemblyResolutionProvenance.Local("SiblingAssembly"));
                 }
             }
 

--- a/src/ILInspector.Metadata/AssemblyAcquisition.cs
+++ b/src/ILInspector.Metadata/AssemblyAcquisition.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
 
 namespace ILInspector.Metadata;
@@ -180,6 +181,29 @@ public sealed class ResolvedAssemblyReference
             fullPath,
             () => File.OpenRead(fullPath),
             provenance);
+    }
+
+    public static bool TryCreateFromPath(
+        string path,
+        AssemblyResolutionProvenance provenance,
+        [NotNullWhen(true)] out ResolvedAssemblyReference? reference)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(provenance);
+
+        try
+        {
+            reference = CreateFromPath(path, provenance);
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException)
+        {
+            reference = null;
+            return false;
+        }
     }
 
     public AssemblyAcquisitionRegistration Registration { get; }

--- a/src/ILInspector.Metadata/AssemblyAcquisition.cs
+++ b/src/ILInspector.Metadata/AssemblyAcquisition.cs
@@ -1,0 +1,213 @@
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>Structured evidence describing how an assembly candidate was selected.</summary>
+public abstract record AssemblyResolutionProvenance
+{
+    private protected AssemblyResolutionProvenance()
+    {
+    }
+
+    private protected abstract int Discriminator { get; }
+
+    public static AssemblyResolutionProvenance Package(
+        string packageId,
+        string packageVersion,
+        string? tfm,
+        string? rid) =>
+        new PackageAsset(packageId, packageVersion, tfm, rid);
+
+    public static AssemblyResolutionProvenance Platform(
+        string framework,
+        string? frameworkVersion,
+        string resolverSource) =>
+        new PlatformAsset(framework, frameworkVersion, resolverSource);
+
+    public static AssemblyResolutionProvenance Project(
+        string project,
+        string? tfm,
+        string? rid) =>
+        new ProjectAsset(project, tfm, rid);
+
+    public static AssemblyResolutionProvenance Local(string resolverSource) =>
+        new LocalAsset(resolverSource);
+
+    public sealed record PackageAsset : AssemblyResolutionProvenance
+    {
+        public PackageAsset(
+            string packageId,
+            string packageVersion,
+            string? tfm,
+            string? rid)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+            ArgumentException.ThrowIfNullOrWhiteSpace(packageVersion);
+            PackageId = packageId;
+            PackageVersion = packageVersion;
+            Tfm = tfm;
+            Rid = rid;
+        }
+
+        private protected override int Discriminator => 0;
+        public string PackageId { get; }
+        public string PackageVersion { get; }
+        public string? Tfm { get; }
+        public string? Rid { get; }
+    }
+
+    public sealed record PlatformAsset : AssemblyResolutionProvenance
+    {
+        public PlatformAsset(
+            string framework,
+            string? frameworkVersion,
+            string resolverSource)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(framework);
+            ArgumentException.ThrowIfNullOrWhiteSpace(resolverSource);
+            Framework = framework;
+            FrameworkVersion = frameworkVersion;
+            ResolverSource = resolverSource;
+        }
+
+        private protected override int Discriminator => 1;
+        public string Framework { get; }
+        public string? FrameworkVersion { get; }
+        public string ResolverSource { get; }
+    }
+
+    public sealed record ProjectAsset : AssemblyResolutionProvenance
+    {
+        public ProjectAsset(
+            string project,
+            string? tfm,
+            string? rid)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(project);
+            Project = project;
+            Tfm = tfm;
+            Rid = rid;
+        }
+
+        private protected override int Discriminator => 2;
+        public new string Project { get; }
+        public string? Tfm { get; }
+        public string? Rid { get; }
+    }
+
+    public sealed record LocalAsset : AssemblyResolutionProvenance
+    {
+        public LocalAsset(string resolverSource)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(resolverSource);
+            ResolverSource = resolverSource;
+        }
+
+        private protected override int Discriminator => 3;
+        public string ResolverSource { get; }
+    }
+}
+
+/// <summary>
+/// Opaque reference-identity handle minted with one canonical acquisition
+/// descriptor.
+/// </summary>
+public sealed class AssemblyAcquisitionRegistration
+{
+    internal AssemblyAcquisitionRegistration()
+    {
+    }
+}
+
+/// <summary>
+/// Roslyn-free descriptor for one assembly selected by an acquisition owner.
+/// </summary>
+public sealed class ResolvedAssemblyReference
+{
+    ResolvedAssemblyReference(
+        AssemblyAcquisitionRegistration registration,
+        AssemblyReferenceIdentity identity,
+        string? path,
+        Func<Stream> openRead,
+        AssemblyResolutionProvenance provenance)
+    {
+        Registration = registration;
+        Identity = identity;
+        Path = path;
+        OpenRead = openRead;
+        Provenance = provenance;
+    }
+
+    public static ResolvedAssemblyReference Create(
+        AssemblyReferenceIdentity selectedIdentity,
+        string? path,
+        Func<Stream> openRead,
+        AssemblyResolutionProvenance provenance)
+    {
+        ArgumentNullException.ThrowIfNull(selectedIdentity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(selectedIdentity.Name);
+        ArgumentNullException.ThrowIfNull(openRead);
+        ArgumentNullException.ThrowIfNull(provenance);
+
+        return new ResolvedAssemblyReference(
+            new AssemblyAcquisitionRegistration(),
+            selectedIdentity,
+            path,
+            openRead,
+            provenance);
+    }
+
+    public static ResolvedAssemblyReference CreateFromPath(
+        string path,
+        AssemblyResolutionProvenance provenance)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(provenance);
+
+        string fullPath = System.IO.Path.GetFullPath(path);
+        using var stream = File.OpenRead(fullPath);
+        using var peReader =
+            new System.Reflection.PortableExecutable.PEReader(stream);
+        if (!peReader.HasMetadata)
+            throw new BadImageFormatException(
+                "The selected image has no managed metadata.");
+
+        AssemblyReferenceIdentity identity =
+            AssemblyReferenceIdentity.FromAssemblyDefinition(
+                peReader.GetMetadataReader());
+        return Create(
+            identity,
+            fullPath,
+            () => File.OpenRead(fullPath),
+            provenance);
+    }
+
+    public AssemblyAcquisitionRegistration Registration { get; }
+    public AssemblyReferenceIdentity Identity { get; }
+    public string? Path { get; }
+    public Func<Stream> OpenRead { get; }
+    public AssemblyResolutionProvenance Provenance { get; }
+}
+
+/// <summary>Identifies one acquisition catalog's candidate key space.</summary>
+public readonly record struct AssemblyCatalogId(Guid Value);
+
+internal readonly record struct AssemblyCandidateId(Guid Value);
+
+/// <summary>One descriptor interned by a Metadata-owned acquisition catalog.</summary>
+public sealed class ResolvedAssemblyCandidate
+{
+    internal ResolvedAssemblyCandidate(
+        AssemblyCatalogId catalog,
+        AssemblyCandidateId id,
+        ResolvedAssemblyReference assembly)
+    {
+        Catalog = catalog;
+        Id = id;
+        Assembly = assembly;
+    }
+
+    internal AssemblyCatalogId Catalog { get; }
+    internal AssemblyCandidateId Id { get; }
+    public ResolvedAssemblyReference Assembly { get; }
+}

--- a/src/ILInspector.Metadata/AssemblyImage.cs
+++ b/src/ILInspector.Metadata/AssemblyImage.cs
@@ -16,14 +16,20 @@ public sealed class AssemblyImage : IDisposable
 {
     readonly Stream? _stream;
     readonly Action? _ensureLenderAlive;
+    readonly bool _ownsReader;
     bool _disposed;
 
     internal PEReader PEReader { get; }
 
-    AssemblyImage(Stream? stream, PEReader peReader, Action? ensureLenderAlive = null)
+    AssemblyImage(
+        Stream? stream,
+        PEReader peReader,
+        bool ownsReader,
+        Action? ensureLenderAlive = null)
     {
         _stream = stream;
         PEReader = peReader;
+        _ownsReader = ownsReader;
         _ensureLenderAlive = ensureLenderAlive;
     }
 
@@ -54,7 +60,7 @@ public sealed class AssemblyImage : IDisposable
     /// Gate: <c>BorrowedSession_FailsLoudlyAfterTheLenderIsDisposed</c>.
     /// </summary>
     internal static AssemblyImage Borrow(PEReader peReader, Action ensureLenderAlive)
-        => new(stream: null, peReader, ensureLenderAlive);
+        => new(stream: null, peReader, ownsReader: false, ensureLenderAlive);
 
     /// <summary>
     /// Opens an image from a resolved assembly reference, using its stream opener. This is the
@@ -62,13 +68,40 @@ public sealed class AssemblyImage : IDisposable
     /// </summary>
     public static AssemblyImage Open(ResolvedAssemblyReference reference) => FromStream(reference.OpenRead());
 
+    internal static AssemblyImage OpenPrefetched(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        PEReader? peReader = null;
+        try
+        {
+            peReader = new PEReader(
+                stream,
+                PEStreamOptions.PrefetchEntireImage | PEStreamOptions.LeaveOpen);
+            stream.Dispose();
+            return new AssemblyImage(
+                stream: null,
+                peReader,
+                ownsReader: true);
+        }
+        catch
+        {
+            peReader?.Dispose();
+            stream.Dispose();
+            throw;
+        }
+    }
+
     static AssemblyImage FromStream(Stream stream)
     {
         try
         {
             // LeaveOpen: this AssemblyImage is the sole owner of the stream and disposes it
             // explicitly in Dispose(), so the PEReader must not also take ownership.
-            return new AssemblyImage(stream, new PEReader(stream, PEStreamOptions.LeaveOpen));
+            return new AssemblyImage(
+                stream,
+                new PEReader(stream, PEStreamOptions.LeaveOpen),
+                ownsReader: true);
         }
         catch
         {
@@ -93,11 +126,8 @@ public sealed class AssemblyImage : IDisposable
             return;
         _disposed = true;
 
-        // A borrowed image owns neither the reader nor a stream; the opener disposes both.
-        if (_stream is null)
-            return;
-
-        PEReader.Dispose();
-        _stream.Dispose();
+        if (_ownsReader)
+            PEReader.Dispose();
+        _stream?.Dispose();
     }
 }

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -23,6 +23,9 @@ public sealed class AssemblyInspectionSession : IDisposable
     /// <summary>Opens a session from a resolved assembly reference (path or stream opener).</summary>
     public static AssemblyInspectionSession Open(ResolvedAssemblyReference reference) => new(AssemblyImage.Open(reference));
 
+    internal static AssemblyInspectionSession OpenPrefetched(Stream stream) =>
+        new(AssemblyImage.OpenPrefetched(stream));
+
     /// <summary>
     /// A session over an image a <see cref="PdbContext"/> already opened, so a caller that holds
     /// one can reach the facets without opening the path a second time.
@@ -202,6 +205,19 @@ public sealed class AssemblyInspectionSession : IDisposable
         HeapKind heap,
         MetadataProjectionOptions? options = null)
         => MetadataTableProjector.ReadHeapEntries(_image.PEReader, heap, options);
+
+    internal AssemblyReferenceIdentity AssemblyIdentity() =>
+        AssemblyReferenceIdentity.FromAssemblyDefinition(_image.GetMetadataReader());
+
+    internal Guid ModuleVersionId()
+    {
+        var reader = _image.GetMetadataReader();
+        return reader.GetGuid(reader.GetModuleDefinition().Mvid);
+    }
+
+    internal TypeDeclarationResult ProbeDeclaration(
+        MetadataTypeDefinitionName name) =>
+        MetadataTypeDeclarationProbe.Probe(_image.GetMetadataReader(), name);
 
     public void Dispose() => _image.Dispose();
 }

--- a/src/ILInspector.Metadata/AssemblyInventorySnapshot.cs
+++ b/src/ILInspector.Metadata/AssemblyInventorySnapshot.cs
@@ -1,0 +1,41 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Reader-independent assembly adjacency facts copied during a bounded
+/// inventory read.
+/// </summary>
+public sealed class AssemblyInventorySnapshot
+{
+    internal AssemblyInventorySnapshot(
+        AssemblyReferenceIdentity identity,
+        Guid moduleVersionId,
+        ImmutableArray<AssemblyReferenceIdentity> assemblyReferences,
+        ImmutableArray<AssemblyReferenceIdentity> forwarderTargets,
+        long imageSize)
+    {
+        Identity = identity;
+        ModuleVersionId = moduleVersionId;
+        AssemblyReferences = assemblyReferences;
+        ForwarderTargets = forwarderTargets;
+        ImageSize = imageSize;
+    }
+
+    public AssemblyReferenceIdentity Identity { get; }
+    public Guid ModuleVersionId { get; }
+    public ImmutableArray<AssemblyReferenceIdentity> AssemblyReferences { get; }
+    public ImmutableArray<AssemblyReferenceIdentity> ForwarderTargets { get; }
+    public long ImageSize { get; }
+}
+
+public enum CandidateOpenFailureKind
+{
+    Unreadable,
+    InvalidImage,
+    ResourceBudget,
+}
+
+public sealed record CandidateOpenFailure(
+    CandidateOpenFailureKind Kind,
+    string Detail);

--- a/src/ILInspector.Metadata/AssemblyReferenceIdentity.cs
+++ b/src/ILInspector.Metadata/AssemblyReferenceIdentity.cs
@@ -24,6 +24,19 @@ public sealed record AssemblyReferenceIdentity(
             TokenOrNull(reader, reference.PublicKeyOrToken, (reference.Flags & AssemblyFlags.PublicKey) != 0));
     }
 
+    public static AssemblyReferenceIdentity FromAssemblyDefinition(MetadataReader reader)
+    {
+        if (!reader.IsAssembly)
+            throw new BadImageFormatException("The metadata image is not an assembly.");
+
+        var definition = reader.GetAssemblyDefinition();
+        return new AssemblyReferenceIdentity(
+            reader.GetString(definition.Name),
+            definition.Version,
+            StringOrNull(reader, definition.Culture),
+            TokenOrNull(reader, definition.PublicKey, isPublicKey: true));
+    }
+
     static string? StringOrNull(MetadataReader reader, StringHandle handle)
         => handle.IsNil ? null : reader.GetString(handle);
 
@@ -53,15 +66,6 @@ public sealed record AssemblyReferenceIdentity(
         return Convert.ToHexString(token).ToLowerInvariant();
     }
 }
-
-/// <summary>
-/// Roslyn-free descriptor for an assembly resolved by identity.
-/// </summary>
-public sealed record ResolvedAssemblyReference(
-    AssemblyReferenceIdentity Identity,
-    string? Path,
-    Func<Stream> OpenRead,
-    string? Provenance = null);
 
 /// <summary>
 /// Callback boundary for consumers that know metadata assembly identity but not

--- a/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
+++ b/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
@@ -1,0 +1,519 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+internal sealed record InspectionAcquisitionPlanOptions
+{
+    internal const int DefaultMaxCandidates = 4_096;
+    internal const long DefaultMaxRetainedImageBytes = 512L * 1024 * 1024;
+    internal const int DefaultMaxConcurrentSourceOpens = 8;
+
+    internal int MaxCandidates { get; init; } = DefaultMaxCandidates;
+    internal long MaxRetainedImageBytes { get; init; } =
+        DefaultMaxRetainedImageBytes;
+    internal int MaxConcurrentSourceOpens { get; init; } =
+        DefaultMaxConcurrentSourceOpens;
+
+    internal void Validate()
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(MaxCandidates);
+        ArgumentOutOfRangeException.ThrowIfNegative(MaxRetainedImageBytes);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            MaxConcurrentSourceOpens);
+    }
+}
+
+internal abstract class CandidateRegistrationResult
+{
+    private protected CandidateRegistrationResult()
+    {
+    }
+
+    internal sealed class Ready : CandidateRegistrationResult
+    {
+        internal Ready(
+            ResolvedAssemblyCandidate candidate,
+            AssemblyInventorySnapshot inventory)
+        {
+            Candidate = candidate;
+            Inventory = inventory;
+        }
+
+        internal ResolvedAssemblyCandidate Candidate { get; }
+        internal AssemblyInventorySnapshot Inventory { get; }
+    }
+
+    internal sealed class Rejected : CandidateRegistrationResult
+    {
+        internal Rejected(
+            ResolvedAssemblyReference assembly,
+            CandidateOpenFailure failure)
+        {
+            Assembly = assembly;
+            Failure = failure;
+        }
+
+        internal ResolvedAssemblyReference Assembly { get; }
+        internal CandidateOpenFailure Failure { get; }
+    }
+}
+
+internal abstract class CandidateSessionResult
+{
+    private protected CandidateSessionResult()
+    {
+    }
+
+    internal sealed class Ready : CandidateSessionResult
+    {
+        internal Ready(AssemblyInspectionSession session) => Session = session;
+
+        internal AssemblyInspectionSession Session { get; }
+    }
+
+    internal sealed class Rejected : CandidateSessionResult
+    {
+        internal Rejected(CandidateOpenFailure failure) => Failure = failure;
+
+        internal CandidateOpenFailure Failure { get; }
+    }
+}
+
+internal sealed class InspectionAcquisitionPlan : IDisposable
+{
+    readonly object _gate = new();
+    readonly InspectionAcquisitionPlanOptions _options;
+    readonly SemaphoreSlim _sourceOpenGate;
+    readonly Dictionary<AssemblyAcquisitionRegistration, CandidateEntry>
+        _entriesByRegistration =
+            new(ReferenceEqualityComparer.Instance);
+    readonly Dictionary<AssemblyCandidateId, CandidateEntry> _entriesById = [];
+    long _retainedImageBytes;
+    int _activeOperations;
+    bool _disposed;
+
+    internal InspectionAcquisitionPlan(
+        InspectionAcquisitionPlanOptions? options = null)
+    {
+        _options = options ?? new InspectionAcquisitionPlanOptions();
+        _options.Validate();
+        CatalogId = new AssemblyCatalogId(Guid.NewGuid());
+        _sourceOpenGate =
+            new SemaphoreSlim(_options.MaxConcurrentSourceOpens);
+    }
+
+    internal AssemblyCatalogId CatalogId { get; }
+    internal int CandidateCount
+    {
+        get
+        {
+            lock (_gate)
+                return _entriesByRegistration.Count;
+        }
+    }
+
+    internal long RetainedImageBytes
+    {
+        get
+        {
+            lock (_gate)
+                return _retainedImageBytes;
+        }
+    }
+
+    internal CandidateRegistrationResult Register(
+        ResolvedAssemblyReference assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        CandidateEntry entry;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_entriesByRegistration.TryGetValue(
+                    assembly.Registration,
+                    out entry!))
+            {
+                // The single-flight value is evaluated after releasing the map lock.
+            }
+            else if (_entriesByRegistration.Count >= _options.MaxCandidates)
+            {
+                return new CandidateRegistrationResult.Rejected(
+                    assembly,
+                    ResourceFailure("The inspection candidate budget was exhausted."));
+            }
+            else
+            {
+                var id = new AssemblyCandidateId(Guid.NewGuid());
+                var candidate = new ResolvedAssemblyCandidate(
+                    CatalogId,
+                    id,
+                    assembly);
+                entry = new CandidateEntry(this, candidate);
+                _entriesByRegistration.Add(assembly.Registration, entry);
+                _entriesById.Add(id, entry);
+            }
+
+            _activeOperations++;
+        }
+
+        try
+        {
+            return entry.Inventory.Value;
+        }
+        finally
+        {
+            EndOperation();
+        }
+    }
+
+    internal CandidateSessionResult OpenSession(
+        ResolvedAssemblyCandidate candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        CandidateEntry entry;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (candidate.Catalog != CatalogId
+                || !_entriesById.TryGetValue(candidate.Id, out entry!)
+                || !ReferenceEquals(entry.Candidate, candidate))
+            {
+                throw new ArgumentException(
+                    "The candidate does not belong to this acquisition plan.",
+                    nameof(candidate));
+            }
+
+            _activeOperations++;
+        }
+
+        try
+        {
+            return entry.Session.Value;
+        }
+        finally
+        {
+            EndOperation();
+        }
+    }
+
+    CandidateRegistrationResult ReadInventory(CandidateEntry entry)
+    {
+        _sourceOpenGate.Wait();
+        try
+        {
+            using Stream stream = OpenSource(entry.Candidate.Assembly);
+            long imageSize = ReadRemainingLength(stream);
+            using var peReader = new PEReader(
+                stream,
+                PEStreamOptions.LeaveOpen | PEStreamOptions.PrefetchMetadata);
+            if (!peReader.HasMetadata)
+                return RejectInvalid(entry, "The selected image has no managed metadata.");
+
+            MetadataReader reader = peReader.GetMetadataReader();
+            AssemblyReferenceIdentity actual =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(reader);
+            if (!IdentityMatches(entry.Candidate.Assembly.Identity, actual))
+            {
+                return RejectInvalid(
+                    entry,
+                    "The selected image identity does not match its descriptor.");
+            }
+
+            var references =
+                ImmutableArray.CreateBuilder<AssemblyReferenceIdentity>();
+            foreach (AssemblyReferenceHandle handle in reader.AssemblyReferences)
+                references.Add(AssemblyReferenceIdentity.From(reader, handle));
+
+            var forwarderTargets =
+                ImmutableArray.CreateBuilder<AssemblyReferenceIdentity>();
+            Span<ExportedTypeHandle> rootToLeaf =
+                stackalloc ExportedTypeHandle[
+                    MetadataSafetyPolicy.MaxRelationshipNodes];
+            foreach (ExportedTypeHandle handle in reader.ExportedTypes)
+            {
+                if (!MetadataRelationshipTraversal
+                        .TryWalkExportedTypeImplementationChain(
+                            reader,
+                            handle,
+                            rootToLeaf,
+                            out _,
+                            out EntityHandle terminal,
+                            out _))
+                {
+                    return RejectInvalid(
+                        entry,
+                        "The selected image has an invalid ExportedType relationship.");
+                }
+
+                if (terminal.Kind == HandleKind.AssemblyReference)
+                {
+                    if (!reader.GetExportedType(rootToLeaf[0]).IsForwarder)
+                    {
+                        return RejectInvalid(
+                            entry,
+                            "An AssemblyRef-terminated ExportedType chain is not a forwarder.");
+                    }
+
+                    forwarderTargets.Add(
+                        AssemblyReferenceIdentity.From(
+                            reader,
+                            (AssemblyReferenceHandle)terminal));
+                }
+                else if (terminal.Kind != HandleKind.AssemblyFile)
+                {
+                    return RejectInvalid(
+                        entry,
+                        "The selected image has an unsupported ExportedType terminal.");
+                }
+            }
+
+            return new CandidateRegistrationResult.Ready(
+                entry.Candidate,
+                new AssemblyInventorySnapshot(
+                    actual,
+                    reader.GetGuid(reader.GetModuleDefinition().Mvid),
+                    references.ToImmutable(),
+                    forwarderTargets.ToImmutable(),
+                    imageSize));
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or NotSupportedException
+                or ObjectDisposedException)
+        {
+            return new CandidateRegistrationResult.Rejected(
+                entry.Candidate.Assembly,
+                new CandidateOpenFailure(
+                    CandidateOpenFailureKind.Unreadable,
+                    "The selected image could not be read."));
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentOutOfRangeException)
+        {
+            return RejectInvalid(
+                entry,
+                "The selected image contains invalid metadata.");
+        }
+        finally
+        {
+            _sourceOpenGate.Release();
+        }
+    }
+
+    CandidateSessionResult OpenSessionCore(CandidateEntry entry)
+    {
+        CandidateRegistrationResult inventoryResult = entry.Inventory.Value;
+        if (inventoryResult is CandidateRegistrationResult.Rejected rejected)
+            return new CandidateSessionResult.Rejected(rejected.Failure);
+
+        _sourceOpenGate.Wait();
+        long reservedBytes = 0;
+        try
+        {
+            Stream? stream = OpenSource(entry.Candidate.Assembly);
+            try
+            {
+                long imageSize = ReadRemainingLength(stream);
+                if (!TryReserveImage(imageSize))
+                {
+                    return new CandidateSessionResult.Rejected(
+                        ResourceFailure(
+                            "The retained-image budget was exhausted."));
+                }
+
+                reservedBytes = imageSize;
+                Stream sessionSource = stream;
+                stream = null;
+                AssemblyInspectionSession session =
+                    AssemblyInspectionSession.OpenPrefetched(sessionSource);
+                var inventory =
+                    (CandidateRegistrationResult.Ready)entry.Inventory.Value;
+                if (!session.HasMetadata
+                    || !IdentityMatches(
+                        entry.Candidate.Assembly.Identity,
+                        session.AssemblyIdentity())
+                    || session.ModuleVersionId()
+                        != inventory.Inventory.ModuleVersionId)
+                {
+                    session.Dispose();
+                    ReleaseImage(reservedBytes);
+                    return new CandidateSessionResult.Rejected(
+                        new CandidateOpenFailure(
+                            CandidateOpenFailureKind.InvalidImage,
+                            "The opened image does not match the inventoried candidate."));
+                }
+
+                return new CandidateSessionResult.Ready(session);
+            }
+            finally
+            {
+                stream?.Dispose();
+            }
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or NotSupportedException
+                or ObjectDisposedException)
+        {
+            ReleaseImage(reservedBytes);
+            return new CandidateSessionResult.Rejected(
+                new CandidateOpenFailure(
+                    CandidateOpenFailureKind.Unreadable,
+                    "The selected image could not be opened."));
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentOutOfRangeException)
+        {
+            ReleaseImage(reservedBytes);
+            return new CandidateSessionResult.Rejected(
+                new CandidateOpenFailure(
+                    CandidateOpenFailureKind.InvalidImage,
+                    "The selected image contains invalid metadata."));
+        }
+        finally
+        {
+            _sourceOpenGate.Release();
+        }
+    }
+
+    static Stream OpenSource(ResolvedAssemblyReference assembly)
+    {
+        Stream? stream = assembly.OpenRead();
+        if (stream is null || !stream.CanRead)
+        {
+            stream?.Dispose();
+            throw new IOException("The assembly opener did not return a readable stream.");
+        }
+
+        return stream;
+    }
+
+    static long ReadRemainingLength(Stream stream)
+    {
+        if (!stream.CanSeek)
+            throw new NotSupportedException(
+                "Assembly streams must support seeking for bounded inspection.");
+
+        long length = checked(stream.Length - stream.Position);
+        if (length <= 0)
+            throw new BadImageFormatException("The selected image is empty.");
+        return length;
+    }
+
+    bool TryReserveImage(long imageSize)
+    {
+        lock (_gate)
+        {
+            if (imageSize > _options.MaxRetainedImageBytes - _retainedImageBytes)
+                return false;
+            _retainedImageBytes += imageSize;
+            return true;
+        }
+    }
+
+    void ReleaseImage(long imageSize)
+    {
+        if (imageSize == 0)
+            return;
+        lock (_gate)
+            _retainedImageBytes -= imageSize;
+    }
+
+    void EndOperation()
+    {
+        lock (_gate)
+        {
+            _activeOperations--;
+            if (_activeOperations == 0)
+                Monitor.PulseAll(_gate);
+        }
+    }
+
+    static bool IdentityMatches(
+        AssemblyReferenceIdentity expected,
+        AssemblyReferenceIdentity actual) =>
+        StringComparer.OrdinalIgnoreCase.Equals(expected.Name, actual.Name)
+        && expected.Version == actual.Version
+        && CultureMatches(expected.Culture, actual.Culture)
+        && StringComparer.OrdinalIgnoreCase.Equals(
+            expected.PublicKeyToken ?? "",
+            actual.PublicKeyToken ?? "");
+
+    static bool CultureMatches(string? left, string? right)
+    {
+        static string Normalize(string? value) =>
+            string.IsNullOrEmpty(value)
+                || value.Equals("neutral", StringComparison.OrdinalIgnoreCase)
+                    ? ""
+                    : value;
+        return StringComparer.OrdinalIgnoreCase.Equals(
+            Normalize(left),
+            Normalize(right));
+    }
+
+    static CandidateRegistrationResult.Rejected RejectInvalid(
+        CandidateEntry entry,
+        string detail) =>
+        new(
+            entry.Candidate.Assembly,
+            new CandidateOpenFailure(
+                CandidateOpenFailureKind.InvalidImage,
+                detail));
+
+    static CandidateOpenFailure ResourceFailure(string detail) =>
+        new(CandidateOpenFailureKind.ResourceBudget, detail);
+
+    public void Dispose()
+    {
+        List<AssemblyInspectionSession> sessions = [];
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            while (_activeOperations != 0)
+                Monitor.Wait(_gate);
+
+            foreach (CandidateEntry entry in _entriesByRegistration.Values)
+            {
+                if (entry.Session.IsValueCreated
+                    && entry.Session.Value is CandidateSessionResult.Ready ready)
+                {
+                    sessions.Add(ready.Session);
+                }
+            }
+        }
+
+        foreach (AssemblyInspectionSession session in sessions)
+            session.Dispose();
+        _sourceOpenGate.Dispose();
+    }
+
+    sealed class CandidateEntry
+    {
+        internal CandidateEntry(
+            InspectionAcquisitionPlan owner,
+            ResolvedAssemblyCandidate candidate)
+        {
+            Candidate = candidate;
+            Inventory = new Lazy<CandidateRegistrationResult>(
+                () => owner.ReadInventory(this),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+            Session = new Lazy<CandidateSessionResult>(
+                () => owner.OpenSessionCore(this),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        internal ResolvedAssemblyCandidate Candidate { get; }
+        internal Lazy<CandidateRegistrationResult> Inventory { get; }
+        internal Lazy<CandidateSessionResult> Session { get; }
+    }
+}

--- a/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
+++ b/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 namespace ILInspector.Metadata;
@@ -225,11 +226,23 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
 
             var references =
                 ImmutableArray.CreateBuilder<AssemblyReferenceIdentity>();
+            var seenReferences = new HashSet<AssemblyReferenceIdentity>();
+            var referencesByRow = new AssemblyReferenceIdentity[
+                reader.GetTableRowCount(TableIndex.AssemblyRef)];
             foreach (AssemblyReferenceHandle handle in reader.AssemblyReferences)
-                references.Add(AssemblyReferenceIdentity.From(reader, handle));
+            {
+                AssemblyReferenceIdentity reference =
+                    AssemblyReferenceIdentity.From(reader, handle);
+                referencesByRow[MetadataTokens.GetRowNumber(handle) - 1] =
+                    reference;
+                if (seenReferences.Add(reference))
+                    references.Add(reference);
+            }
 
             var forwarderTargets =
                 ImmutableArray.CreateBuilder<AssemblyReferenceIdentity>();
+            var seenForwarderTargets =
+                new HashSet<AssemblyReferenceIdentity>();
             Span<ExportedTypeHandle> rootToLeaf =
                 stackalloc ExportedTypeHandle[
                     MetadataSafetyPolicy.MaxRelationshipNodes];
@@ -258,10 +271,13 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
                             "An AssemblyRef-terminated ExportedType chain is not a forwarder.");
                     }
 
-                    forwarderTargets.Add(
-                        AssemblyReferenceIdentity.From(
-                            reader,
-                            (AssemblyReferenceHandle)terminal));
+                    int targetIndex =
+                        MetadataTokens.GetRowNumber(
+                            (AssemblyReferenceHandle)terminal) - 1;
+                    AssemblyReferenceIdentity target =
+                        referencesByRow[targetIndex];
+                    if (seenForwarderTargets.Add(target))
+                        forwarderTargets.Add(target);
                 }
                 else if (terminal.Kind != HandleKind.AssemblyFile)
                 {
@@ -317,6 +333,7 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
         try
         {
             Stream? stream = OpenSource(entry.Candidate.Assembly);
+            AssemblyInspectionSession? session = null;
             try
             {
                 long imageSize = ReadRemainingLength(stream);
@@ -330,8 +347,7 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
                 reservedBytes = imageSize;
                 Stream sessionSource = stream;
                 stream = null;
-                AssemblyInspectionSession session =
-                    AssemblyInspectionSession.OpenPrefetched(sessionSource);
+                session = AssemblyInspectionSession.OpenPrefetched(sessionSource);
                 var inventory =
                     (CandidateRegistrationResult.Ready)entry.Inventory.Value;
                 if (!session.HasMetadata
@@ -341,7 +357,6 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
                     || session.ModuleVersionId()
                         != inventory.Inventory.ModuleVersionId)
                 {
-                    session.Dispose();
                     ReleaseImage(reservedBytes);
                     return new CandidateSessionResult.Rejected(
                         new CandidateOpenFailure(
@@ -349,10 +364,13 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
                             "The opened image does not match the inventoried candidate."));
                 }
 
-                return new CandidateSessionResult.Ready(session);
+                var ready = new CandidateSessionResult.Ready(session);
+                session = null;
+                return ready;
             }
             finally
             {
+                session?.Dispose();
                 stream?.Dispose();
             }
         }

--- a/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
+++ b/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 namespace ILInspector.Metadata;
@@ -227,14 +226,15 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
             var references =
                 ImmutableArray.CreateBuilder<AssemblyReferenceIdentity>();
             var seenReferences = new HashSet<AssemblyReferenceIdentity>();
-            var referencesByRow = new AssemblyReferenceIdentity[
-                reader.GetTableRowCount(TableIndex.AssemblyRef)];
+            var referencesByHandle =
+                new Dictionary<
+                    AssemblyReferenceHandle,
+                    AssemblyReferenceIdentity>();
             foreach (AssemblyReferenceHandle handle in reader.AssemblyReferences)
             {
                 AssemblyReferenceIdentity reference =
                     AssemblyReferenceIdentity.From(reader, handle);
-                referencesByRow[MetadataTokens.GetRowNumber(handle) - 1] =
-                    reference;
+                referencesByHandle.Add(handle, reference);
                 if (seenReferences.Add(reference))
                     references.Add(reference);
             }
@@ -271,11 +271,26 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
                             "An AssemblyRef-terminated ExportedType chain is not a forwarder.");
                     }
 
-                    int targetIndex =
-                        MetadataTokens.GetRowNumber(
-                            (AssemblyReferenceHandle)terminal) - 1;
-                    AssemblyReferenceIdentity target =
-                        referencesByRow[targetIndex];
+                    var targetHandle = (AssemblyReferenceHandle)terminal;
+                    if (!referencesByHandle.TryGetValue(
+                            targetHandle,
+                            out AssemblyReferenceIdentity? target))
+                    {
+                        target = AssemblyReferenceIdentity.From(
+                            reader,
+                            targetHandle);
+                        referencesByHandle.Add(targetHandle, target);
+                        if (seenReferences.Add(target))
+                            references.Add(target);
+                    }
+
+                    if (target is null)
+                    {
+                        return RejectInvalid(
+                            entry,
+                            "The selected image has an invalid AssemblyRef target.");
+                    }
+
                     if (seenForwarderTargets.Add(target))
                         forwarderTargets.Add(target);
                 }

--- a/src/ILInspector.Metadata/TypeForwardResolver.cs
+++ b/src/ILInspector.Metadata/TypeForwardResolver.cs
@@ -23,7 +23,7 @@ public sealed record TypeLocation(
     Func<Stream> OpenRead,
     string AssemblyKey,
     AssemblyReferenceIdentity? Identity = null,
-    string? Provenance = null)
+    AssemblyResolutionProvenance? Provenance = null)
 {
     public TypeLocation(string assemblyPath, string fullTypeName)
         : this(
@@ -32,7 +32,7 @@ public sealed record TypeLocation(
             () => File.OpenRead(assemblyPath),
             Path.GetFullPath(assemblyPath),
             new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(assemblyPath), Version: null, Culture: null, PublicKeyToken: null),
-            Provenance: "Path")
+            Provenance: AssemblyResolutionProvenance.Local("Path"))
     {
     }
 
@@ -40,7 +40,7 @@ public sealed record TypeLocation(
         => new(assembly.Path, fullTypeName, assembly.OpenRead, AssemblyKeyFor(assembly), assembly.Identity, assembly.Provenance);
 
     public ResolvedAssemblyReference ToResolvedAssemblyReference()
-        => new(
+        => ResolvedAssemblyReference.Create(
             Identity ?? new AssemblyReferenceIdentity(
                 AssemblyPath is { Length: > 0 } path ? Path.GetFileNameWithoutExtension(path) : AssemblyKey,
                 Version: null,
@@ -48,7 +48,7 @@ public sealed record TypeLocation(
                 PublicKeyToken: null),
             AssemblyPath,
             OpenRead,
-            Provenance);
+            Provenance ?? AssemblyResolutionProvenance.Local("TypeLocation"));
 
     internal static string AssemblyKeyFor(ResolvedAssemblyReference assembly)
         => assembly.Path is { Length: > 0 } path
@@ -83,11 +83,9 @@ public static class TypeForwardResolver
         string assemblyPath, string fullTypeName, IAssemblyReferenceResolver resolver,
         int maxHops = DefaultMaxHops, AssemblyResolutionScope scope = AssemblyResolutionScope.Any)
     {
-        var start = new ResolvedAssemblyReference(
-            new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(assemblyPath), Version: null, Culture: null, PublicKeyToken: null),
+        var start = ResolvedAssemblyReference.CreateFromPath(
             assemblyPath,
-            () => File.OpenRead(assemblyPath),
-            Provenance: "StartAssembly");
+            AssemblyResolutionProvenance.Local("StartAssembly"));
         return LocateType(start, fullTypeName, resolver, maxHops, scope);
     }
 

--- a/src/ILInspector.Metadata/TypeForwardResolver.cs
+++ b/src/ILInspector.Metadata/TypeForwardResolver.cs
@@ -83,9 +83,14 @@ public static class TypeForwardResolver
         string assemblyPath, string fullTypeName, IAssemblyReferenceResolver resolver,
         int maxHops = DefaultMaxHops, AssemblyResolutionScope scope = AssemblyResolutionScope.Any)
     {
-        var start = ResolvedAssemblyReference.CreateFromPath(
-            assemblyPath,
-            AssemblyResolutionProvenance.Local("StartAssembly"));
+        if (!ResolvedAssemblyReference.TryCreateFromPath(
+                assemblyPath,
+                AssemblyResolutionProvenance.Local("StartAssembly"),
+                out ResolvedAssemblyReference? start))
+        {
+            return null;
+        }
+
         return LocateType(start, fullTypeName, resolver, maxHops, scope);
     }
 

--- a/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Reflection.Metadata;
 
 namespace ILInspector.Metadata.Tests;
 
@@ -97,10 +98,11 @@ public class AssemblyInspectionSessionTests
     [Fact]
     public void Open_FromResolvedReference_MatchesPathOpen()
     {
-        var reference = new ResolvedAssemblyReference(
-            new AssemblyReferenceIdentity(SelfName, Version: null, Culture: null, PublicKeyToken: null),
+        var reference = ResolvedAssemblyReference.Create(
+            ReadIdentity(SelfPath),
             SelfPath,
-            () => File.OpenRead(SelfPath));
+            () => File.OpenRead(SelfPath),
+            AssemblyResolutionProvenance.Local("test"));
 
         using var fromRef = AssemblyInspectionSession.Open(reference);
         using var fromPath = AssemblyInspectionSession.Open(SelfPath);
@@ -123,10 +125,11 @@ public class AssemblyInspectionSessionTests
     public void AssemblyImage_DisposesBackingStreamExactlyOnce()
     {
         using var stream = new DisposeCountingStream(File.OpenRead(SelfPath));
-        var reference = new ResolvedAssemblyReference(
-            new AssemblyReferenceIdentity(SelfName, Version: null, Culture: null, PublicKeyToken: null),
+        var reference = ResolvedAssemblyReference.Create(
+            ReadIdentity(SelfPath),
             SelfPath,
-            () => stream);
+            () => stream,
+            AssemblyResolutionProvenance.Local("test"));
 
         var image = AssemblyImage.Open(reference);
         try
@@ -140,6 +143,14 @@ public class AssemblyInspectionSessionTests
         }
 
         Assert.Equal(1, stream.DisposeCount);
+    }
+
+    static AssemblyReferenceIdentity ReadIdentity(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var peReader = new System.Reflection.PortableExecutable.PEReader(stream);
+        return AssemblyReferenceIdentity.FromAssemblyDefinition(
+            peReader.GetMetadataReader());
     }
 
     sealed class DisposeCountingStream(Stream inner) : Stream

--- a/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
+++ b/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
@@ -1,0 +1,713 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public class InspectionAcquisitionPlanTests
+{
+    const TypeAttributes Forwarder = (TypeAttributes)0x00200000;
+    static string SelfPath => typeof(InspectionAcquisitionPlanTests).Assembly.Location;
+
+    [Fact]
+    public void DescriptorFactory_MintsOpaqueReferenceIdentityRegistration()
+    {
+        AssemblyReferenceIdentity identity = ReadIdentity(SelfBytes());
+        ResolvedAssemblyReference first = Descriptor(identity, SelfBytes);
+        ResolvedAssemblyReference second = Descriptor(identity, SelfBytes);
+
+        Assert.NotSame(first, second);
+        Assert.NotEqual(first, second);
+        Assert.NotSame(first.Registration, second.Registration);
+        Assert.Same(first.Registration, first.Registration);
+        Assert.Equal(identity, first.Identity);
+        Assert.IsType<AssemblyResolutionProvenance.LocalAsset>(first.Provenance);
+    }
+
+    [Fact]
+    public void StructuredProvenance_HasClosedTypedArms()
+    {
+        var package = AssemblyResolutionProvenance.Package(
+            "Example.Package",
+            "1.2.3",
+            "net10.0",
+            "linux-x64");
+        var samePackage = AssemblyResolutionProvenance.Package(
+            "Example.Package",
+            "1.2.3",
+            "net10.0",
+            "linux-x64");
+        var platform = AssemblyResolutionProvenance.Platform(
+            "Microsoft.NETCore.App",
+            "10.0.0",
+            "test");
+
+        Assert.Equal(package, samePackage);
+        Assert.NotEqual(package, platform);
+        Assert.Equal(
+            "Example.Package",
+            Assert.IsType<AssemblyResolutionProvenance.PackageAsset>(package)
+                .PackageId);
+    }
+
+    [Fact]
+    public void CreateFromPath_CapturesSelectedImageIdentity()
+    {
+        ResolvedAssemblyReference descriptor =
+            ResolvedAssemblyReference.CreateFromPath(
+                SelfPath,
+                AssemblyResolutionProvenance.Local("test"));
+
+        Assert.Equal(ReadIdentity(SelfBytes()), descriptor.Identity);
+        Assert.Equal(Path.GetFullPath(SelfPath), descriptor.Path);
+    }
+
+    [Fact]
+    public void Register_SameDescriptor_IsOneCandidateAndOneInventoryRead()
+    {
+        byte[] image = SelfBytes();
+        AssemblyReferenceIdentity identity = ReadIdentity(image);
+        int opens = 0;
+        var descriptor = Descriptor(
+            identity,
+            () =>
+            {
+                Interlocked.Increment(ref opens);
+                return image;
+            });
+        using var plan = new InspectionAcquisitionPlan();
+
+        var first = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(descriptor));
+        var second = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(descriptor));
+
+        Assert.Same(first, second);
+        Assert.Same(first.Candidate, second.Candidate);
+        Assert.Same(first.Inventory, second.Inventory);
+        Assert.Equal(1, opens);
+        Assert.Equal(1, plan.CandidateCount);
+    }
+
+    [Fact]
+    public void Register_EqualDescriptorFieldsWithFreshRegistrations_StayDistinct()
+    {
+        byte[] image = SelfBytes();
+        AssemblyReferenceIdentity identity = ReadIdentity(image);
+        using var plan = new InspectionAcquisitionPlan();
+
+        var first = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(Descriptor(identity, () => image)));
+        var second = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(Descriptor(identity, () => image)));
+
+        Assert.NotSame(first.Candidate, second.Candidate);
+        Assert.Equal(2, plan.CandidateCount);
+    }
+
+    [Fact]
+    public void Inventory_CopiesIdentityReferencesAndForwarderTargets()
+    {
+        byte[] image = SelfBytes();
+        using var plan = new InspectionAcquisitionPlan();
+
+        var ready = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(Descriptor(ReadIdentity(image), () => image)));
+
+        Assert.Equal("ILInspector.Metadata.Tests", ready.Inventory.Identity.Name);
+        Assert.Contains(
+            ready.Inventory.AssemblyReferences,
+            identity => identity.Name == "ILInspector.Metadata");
+        Assert.Contains(
+            ready.Inventory.ForwarderTargets,
+            identity => identity.Name == "ILInspector.Metadata");
+        Assert.Equal(
+            ReadModuleVersionId(image),
+            ready.Inventory.ModuleVersionId);
+        Assert.Equal(image.LongLength, ready.Inventory.ImageSize);
+    }
+
+    [Fact]
+    public void Register_DescriptorIdentityMismatch_IsTypedInvalidImage()
+    {
+        byte[] image = SelfBytes();
+        AssemblyReferenceIdentity identity = ReadIdentity(image) with
+        {
+            Name = "Different",
+        };
+        using var plan = new InspectionAcquisitionPlan();
+
+        var rejected = Assert.IsType<CandidateRegistrationResult.Rejected>(
+            plan.Register(Descriptor(identity, () => image)));
+
+        Assert.Equal(CandidateOpenFailureKind.InvalidImage, rejected.Failure.Kind);
+    }
+
+    [Fact]
+    public void Register_NonSeekableSource_IsTypedUnreadable()
+    {
+        byte[] image = SelfBytes();
+        int disposals = 0;
+        using var plan = new InspectionAcquisitionPlan();
+        var descriptor = ResolvedAssemblyReference.Create(
+            ReadIdentity(image),
+            path: null,
+            openRead: () => new NonSeekableReadStream(
+                new DisposeTrackingMemoryStream(
+                    image,
+                    () => Interlocked.Increment(ref disposals))),
+            provenance: AssemblyResolutionProvenance.Local("test"));
+
+        var rejected = Assert.IsType<CandidateRegistrationResult.Rejected>(
+            plan.Register(descriptor));
+
+        Assert.Equal(CandidateOpenFailureKind.Unreadable, rejected.Failure.Kind);
+        Assert.Equal(1, disposals);
+    }
+
+    [Fact]
+    public void Register_MalformedForwarderInventory_IsTypedInvalidImage()
+    {
+        byte[] image = BuildInvalidForwarderImage();
+        using var plan = new InspectionAcquisitionPlan();
+
+        var rejected = Assert.IsType<CandidateRegistrationResult.Rejected>(
+            plan.Register(
+                Descriptor(
+                    new AssemblyReferenceIdentity(
+                        "Synthetic",
+                        new Version(1, 0, 0, 0),
+                        Culture: null,
+                        PublicKeyToken: null),
+                    () => image)));
+
+        Assert.Equal(CandidateOpenFailureKind.InvalidImage, rejected.Failure.Kind);
+    }
+
+    [Fact]
+    public void Register_UnreadableSource_IsTypedFailureAndCached()
+    {
+        byte[] image = SelfBytes();
+        int opens = 0;
+        var descriptor = ResolvedAssemblyReference.Create(
+            ReadIdentity(image),
+            path: null,
+            openRead: () =>
+            {
+                Interlocked.Increment(ref opens);
+                throw new IOException("test");
+            },
+            provenance: AssemblyResolutionProvenance.Local("test"));
+        using var plan = new InspectionAcquisitionPlan();
+
+        var first = Assert.IsType<CandidateRegistrationResult.Rejected>(
+            plan.Register(descriptor));
+        var second = Assert.IsType<CandidateRegistrationResult.Rejected>(
+            plan.Register(descriptor));
+
+        Assert.Same(first, second);
+        Assert.Equal(CandidateOpenFailureKind.Unreadable, first.Failure.Kind);
+        Assert.Equal(1, opens);
+    }
+
+    [Fact]
+    public void Register_CandidateBudgetRejectsBeforeOpeningAnotherSource()
+    {
+        byte[] image = SelfBytes();
+        AssemblyReferenceIdentity identity = ReadIdentity(image);
+        int secondOpens = 0;
+        using var plan = new InspectionAcquisitionPlan(
+            new InspectionAcquisitionPlanOptions
+            {
+                MaxCandidates = 1,
+            });
+
+        Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(Descriptor(identity, () => image)));
+        var rejected = Assert.IsType<CandidateRegistrationResult.Rejected>(
+            plan.Register(
+                Descriptor(
+                    identity,
+                    () =>
+                    {
+                        Interlocked.Increment(ref secondOpens);
+                        return image;
+                    })));
+
+        Assert.Equal(CandidateOpenFailureKind.ResourceBudget, rejected.Failure.Kind);
+        Assert.Equal(0, secondOpens);
+        Assert.Equal(1, plan.CandidateCount);
+    }
+
+    [Fact]
+    public async Task Register_ConcurrentSameDescriptor_IsSingleFlight()
+    {
+        byte[] image = SelfBytes();
+        AssemblyReferenceIdentity identity = ReadIdentity(image);
+        using var release = new ManualResetEventSlim();
+        int opens = 0;
+        var descriptor = Descriptor(
+            identity,
+            () =>
+            {
+                Interlocked.Increment(ref opens);
+                release.Wait();
+                return image;
+            });
+        using var plan = new InspectionAcquisitionPlan();
+
+        Task<CandidateRegistrationResult>[] tasks =
+            [.. Enumerable.Range(0, 12).Select(
+                _ => Task.Run(() => plan.Register(descriptor)))];
+        Assert.True(
+            SpinWait.SpinUntil(() => Volatile.Read(ref opens) == 1, TimeSpan.FromSeconds(5)));
+        release.Set();
+        CandidateRegistrationResult[] results = await Task.WhenAll(tasks);
+
+        var first = Assert.IsType<CandidateRegistrationResult.Ready>(results[0]);
+        Assert.All(
+            results,
+            result => Assert.Same(
+                first,
+                Assert.IsType<CandidateRegistrationResult.Ready>(result)));
+        Assert.Equal(1, opens);
+    }
+
+    [Fact]
+    public async Task Register_SourceOpenConcurrencyNeverExceedsPlanLimit()
+    {
+        byte[] image = SelfBytes();
+        AssemblyReferenceIdentity identity = ReadIdentity(image);
+        using var release = new ManualResetEventSlim();
+        int entered = 0;
+        int active = 0;
+        int maximum = 0;
+        var descriptors = Enumerable.Range(0, 6)
+            .Select(_ => Descriptor(
+                identity,
+                () =>
+                {
+                    Interlocked.Increment(ref entered);
+                    int current = Interlocked.Increment(ref active);
+                    UpdateMaximum(ref maximum, current);
+                    release.Wait();
+                    Interlocked.Decrement(ref active);
+                    return image;
+                }))
+            .ToArray();
+        using var plan = new InspectionAcquisitionPlan(
+            new InspectionAcquisitionPlanOptions
+            {
+                MaxConcurrentSourceOpens = 2,
+            });
+
+        Task<CandidateRegistrationResult>[] tasks =
+            [.. descriptors.Select(
+                descriptor => Task.Run(() => plan.Register(descriptor)))];
+        Assert.True(
+            SpinWait.SpinUntil(() => Volatile.Read(ref entered) == 2, TimeSpan.FromSeconds(5)));
+        Assert.Equal(2, Volatile.Read(ref maximum));
+        release.Set();
+        CandidateRegistrationResult[] results = await Task.WhenAll(tasks);
+
+        Assert.All(
+            results,
+            result => Assert.IsType<CandidateRegistrationResult.Ready>(result));
+        Assert.Equal(2, maximum);
+    }
+
+    [Fact]
+    public void Session_IsLazySingleFlightPrefetchedAndPlanOwned()
+    {
+        byte[] image = SelfBytes();
+        AssemblyReferenceIdentity identity = ReadIdentity(image);
+        int opens = 0;
+        int disposals = 0;
+        var descriptor = ResolvedAssemblyReference.Create(
+            identity,
+            path: null,
+            openRead: () =>
+            {
+                Interlocked.Increment(ref opens);
+                return new DisposeTrackingMemoryStream(
+                    image,
+                    () => Interlocked.Increment(ref disposals));
+            },
+            provenance: AssemblyResolutionProvenance.Local("test"));
+        var plan = new InspectionAcquisitionPlan();
+        var registration = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(descriptor));
+
+        Assert.Equal(1, opens);
+        Assert.Equal(1, disposals);
+        Assert.Equal(0, plan.RetainedImageBytes);
+
+        var first = Assert.IsType<CandidateSessionResult.Ready>(
+            plan.OpenSession(registration.Candidate));
+        var second = Assert.IsType<CandidateSessionResult.Ready>(
+            plan.OpenSession(registration.Candidate));
+
+        Assert.Same(first, second);
+        Assert.Same(first.Session, second.Session);
+        Assert.Equal(2, opens);
+        Assert.Equal(2, disposals);
+        Assert.Equal(image.LongLength, plan.RetainedImageBytes);
+        Assert.Equal(
+            "ILInspector.Metadata.Tests",
+            first.Session.AssemblyInfo().AssemblyName);
+        Assert.IsType<TypeDeclarationResult.Forwarded>(
+            first.Session.ProbeDeclaration(
+                Name("ILInspector.Metadata", "MetadataTableProjector")));
+
+        MethodBodySource methodBodies = first.Session.MethodBodies;
+        plan.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(
+            () => methodBodies.EnumerateMethods());
+        Assert.Throws<ObjectDisposedException>(
+            () => plan.OpenSession(registration.Candidate));
+    }
+
+    [Fact]
+    public void Session_RetainedImageBudgetReturnsTypedFailure()
+    {
+        byte[] image = SelfBytes();
+        int opens = 0;
+        int disposals = 0;
+        var descriptor = ResolvedAssemblyReference.Create(
+            ReadIdentity(image),
+            path: null,
+            openRead: () =>
+            {
+                Interlocked.Increment(ref opens);
+                return new DisposeTrackingMemoryStream(
+                    image,
+                    () => Interlocked.Increment(ref disposals));
+            },
+            provenance: AssemblyResolutionProvenance.Local("test"));
+        using var plan = new InspectionAcquisitionPlan(
+            new InspectionAcquisitionPlanOptions
+            {
+                MaxRetainedImageBytes = image.LongLength - 1,
+            });
+        var registration = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(descriptor));
+
+        var rejected = Assert.IsType<CandidateSessionResult.Rejected>(
+            plan.OpenSession(registration.Candidate));
+
+        Assert.Equal(CandidateOpenFailureKind.ResourceBudget, rejected.Failure.Kind);
+        Assert.Equal(2, opens);
+        Assert.Equal(2, disposals);
+        Assert.Equal(0, plan.RetainedImageBytes);
+    }
+
+    [Fact]
+    public void Session_WhenSourceChangesAfterInventory_RejectsImage()
+    {
+        byte[] inventoried = BuildValidForwarderImage();
+        byte[] changed = BuildValidForwarderImage();
+        int opens = 0;
+        using var plan = new InspectionAcquisitionPlan();
+        var descriptor = Descriptor(
+            ReadIdentity(inventoried),
+            () => Interlocked.Increment(ref opens) == 1
+                ? inventoried
+                : changed);
+        var registration = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(descriptor));
+
+        var rejected = Assert.IsType<CandidateSessionResult.Rejected>(
+            plan.OpenSession(registration.Candidate));
+
+        Assert.Equal(CandidateOpenFailureKind.InvalidImage, rejected.Failure.Kind);
+        Assert.Equal(0, plan.RetainedImageBytes);
+    }
+
+    [Fact]
+    public async Task Session_ConcurrentRequestsShareOneOpen()
+    {
+        byte[] image = SelfBytes();
+        int opens = 0;
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        using var plan = new InspectionAcquisitionPlan();
+        var descriptor = Descriptor(
+            ReadIdentity(image),
+            () =>
+            {
+                if (Interlocked.Increment(ref opens) == 2)
+                {
+                    entered.Set();
+                    release.Wait();
+                }
+
+                return image;
+            });
+        var registration = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(descriptor));
+
+        Task<CandidateSessionResult>[] tasks =
+        [
+            .. Enumerable.Range(0, 8)
+                .Select(_ => Task.Run(
+                    () => plan.OpenSession(registration.Candidate))),
+        ];
+        Assert.True(entered.Wait(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken));
+        release.Set();
+        CandidateSessionResult[] results = await Task.WhenAll(tasks);
+
+        CandidateSessionResult.Ready first =
+            Assert.IsType<CandidateSessionResult.Ready>(results[0]);
+        Assert.All(
+            results,
+            result => Assert.Same(
+                first,
+                Assert.IsType<CandidateSessionResult.Ready>(result)));
+        Assert.Equal(2, opens);
+    }
+
+    [Fact]
+    public async Task Dispose_WaitsForInFlightSessionAndOwnsItsResult()
+    {
+        byte[] image = SelfBytes();
+        int opens = 0;
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var plan = new InspectionAcquisitionPlan();
+        var descriptor = Descriptor(
+            ReadIdentity(image),
+            () =>
+            {
+                if (Interlocked.Increment(ref opens) == 2)
+                {
+                    entered.Set();
+                    release.Wait();
+                }
+
+                return image;
+            });
+        var registration = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(descriptor));
+        Task<CandidateSessionResult> openTask = Task.Run(
+            () => plan.OpenSession(registration.Candidate));
+        Assert.True(entered.Wait(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken));
+
+        Task disposeTask = Task.Run(
+            plan.Dispose,
+            TestContext.Current.CancellationToken);
+        Assert.False(disposeTask.IsCompleted);
+        release.Set();
+        await Task.WhenAll(openTask, disposeTask);
+
+        var ready = Assert.IsType<CandidateSessionResult.Ready>(
+            await openTask);
+        Assert.Throws<ObjectDisposedException>(
+            () => ready.Session.MethodBodies);
+        plan.Dispose();
+    }
+
+    [Fact]
+    public void Session_RejectsCandidateFromAnotherPlan()
+    {
+        byte[] image = SelfBytes();
+        using var firstPlan = new InspectionAcquisitionPlan();
+        using var secondPlan = new InspectionAcquisitionPlan();
+        var registration = Assert.IsType<CandidateRegistrationResult.Ready>(
+            firstPlan.Register(
+                Descriptor(ReadIdentity(image), () => image)));
+
+        Assert.Throws<ArgumentException>(
+            () => secondPlan.OpenSession(registration.Candidate));
+    }
+
+    [Fact]
+    public void AcquisitionResults_DoNotExposeReadersOrHandles()
+    {
+        Type[] types =
+        [
+            typeof(AssemblyInventorySnapshot),
+            typeof(ResolvedAssemblyCandidate),
+            typeof(ResolvedAssemblyReference),
+            typeof(AssemblyAcquisitionRegistration),
+            typeof(CandidateOpenFailure),
+        ];
+
+        foreach (Type type in types)
+        {
+            foreach (PropertyInfo property in type.GetProperties())
+                AssertClosedPropertyType(property.PropertyType);
+        }
+    }
+
+    static ResolvedAssemblyReference Descriptor(
+        AssemblyReferenceIdentity identity,
+        Func<byte[]> image) =>
+        ResolvedAssemblyReference.Create(
+            identity,
+            path: null,
+            openRead: () => new MemoryStream(image(), writable: false),
+            provenance: AssemblyResolutionProvenance.Local("test"));
+
+    static byte[] SelfBytes() => File.ReadAllBytes(SelfPath);
+
+    static AssemblyReferenceIdentity ReadIdentity(byte[] image)
+    {
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        return AssemblyReferenceIdentity.FromAssemblyDefinition(
+            peReader.GetMetadataReader());
+    }
+
+    static Guid ReadModuleVersionId(byte[] image)
+    {
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        MetadataReader reader = peReader.GetMetadataReader();
+        return reader.GetGuid(reader.GetModuleDefinition().Mvid);
+    }
+
+    static MetadataTypeDefinitionName Name(
+        string @namespace,
+        params string[] segments) =>
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create(
+                @namespace,
+                [.. segments])).Name;
+
+    static byte[] BuildInvalidForwarderImage() =>
+        BuildForwarderImage(TypeAttributes.Public);
+
+    static byte[] BuildValidForwarderImage() =>
+        BuildForwarderImage(TypeAttributes.Public | Forwarder);
+
+    static byte[] BuildForwarderImage(TypeAttributes attributes)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        AssemblyReferenceHandle target = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Target"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        metadata.AddExportedType(
+            attributes,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("Type"),
+            target,
+            typeDefinitionId: 0);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static void UpdateMaximum(ref int target, int value)
+    {
+        int current;
+        do
+        {
+            current = Volatile.Read(ref target);
+            if (current >= value)
+                return;
+        }
+        while (Interlocked.CompareExchange(ref target, value, current) != current);
+    }
+
+    static void AssertClosedPropertyType(Type type)
+    {
+        Assert.NotEqual(typeof(MetadataReader), type);
+        Assert.NotEqual(typeof(PEReader), type);
+        Assert.False(
+            type.Namespace == "System.Reflection.Metadata"
+            && type.Name.EndsWith("Handle", StringComparison.Ordinal));
+
+        if (type.HasElementType)
+            AssertClosedPropertyType(type.GetElementType()!);
+        foreach (Type argument in type.GetGenericArguments())
+            AssertClosedPropertyType(argument);
+    }
+
+    sealed class DisposeTrackingMemoryStream(
+        byte[] image,
+        Action disposed) : MemoryStream(image, writable: false)
+    {
+        bool _disposed;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                _disposed = true;
+                disposed();
+            }
+            base.Dispose(disposing);
+        }
+    }
+
+    sealed class NonSeekableReadStream(Stream inner) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => inner.Flush();
+        public override int Read(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
+++ b/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
@@ -66,6 +66,30 @@ public class InspectionAcquisitionPlanTests
     }
 
     [Fact]
+    public void TryCreateFromPath_UnreadableOrInvalidImage_ReturnsFalse()
+    {
+        string missing = Path.Combine(
+            Path.GetTempPath(),
+            $"{Guid.NewGuid():N}.dll");
+        string invalid = Path.GetTempFileName();
+        try
+        {
+            Assert.False(ResolvedAssemblyReference.TryCreateFromPath(
+                missing,
+                AssemblyResolutionProvenance.Local("test"),
+                out _));
+            Assert.False(ResolvedAssemblyReference.TryCreateFromPath(
+                invalid,
+                AssemblyResolutionProvenance.Local("test"),
+                out _));
+        }
+        finally
+        {
+            File.Delete(invalid);
+        }
+    }
+
+    [Fact]
     public void Register_SameDescriptor_IsOneCandidateAndOneInventoryRead()
     {
         byte[] image = SelfBytes();
@@ -128,6 +152,24 @@ public class InspectionAcquisitionPlanTests
             ReadModuleVersionId(image),
             ready.Inventory.ModuleVersionId);
         Assert.Equal(image.LongLength, ready.Inventory.ImageSize);
+    }
+
+    [Fact]
+    public void Inventory_DeduplicatesRepeatedForwarderTargets()
+    {
+        byte[] image = BuildValidForwarderImage(
+            forwarderCount: 1_000,
+            assemblyReferenceCount: 1_000);
+        using var plan = new InspectionAcquisitionPlan();
+
+        var ready = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(Descriptor(ReadIdentity(image), () => image)));
+
+        Assert.Single(ready.Inventory.AssemblyReferences);
+        Assert.Single(ready.Inventory.ForwarderTargets);
+        Assert.Equal(
+            ready.Inventory.AssemblyReferences[0],
+            ready.Inventory.ForwarderTargets[0]);
     }
 
     [Fact]
@@ -428,6 +470,28 @@ public class InspectionAcquisitionPlanTests
     }
 
     [Fact]
+    public void Session_WhenPostOpenIdentityReadThrows_ReleasesImage()
+    {
+        byte[] inventoried = BuildValidForwarderImage();
+        byte[] changed = BuildModuleImage();
+        int opens = 0;
+        using var plan = new InspectionAcquisitionPlan();
+        var descriptor = Descriptor(
+            ReadIdentity(inventoried),
+            () => Interlocked.Increment(ref opens) == 1
+                ? inventoried
+                : changed);
+        var registration = Assert.IsType<CandidateRegistrationResult.Ready>(
+            plan.Register(descriptor));
+
+        var rejected = Assert.IsType<CandidateSessionResult.Rejected>(
+            plan.OpenSession(registration.Candidate));
+
+        Assert.Equal(CandidateOpenFailureKind.InvalidImage, rejected.Failure.Kind);
+        Assert.Equal(0, plan.RetainedImageBytes);
+    }
+
+    [Fact]
     public async Task Session_ConcurrentRequestsShareOneOpen()
     {
         byte[] image = SelfBytes();
@@ -585,10 +649,18 @@ public class InspectionAcquisitionPlanTests
     static byte[] BuildInvalidForwarderImage() =>
         BuildForwarderImage(TypeAttributes.Public);
 
-    static byte[] BuildValidForwarderImage() =>
-        BuildForwarderImage(TypeAttributes.Public | Forwarder);
+    static byte[] BuildValidForwarderImage(
+        int forwarderCount = 1,
+        int assemblyReferenceCount = 1) =>
+        BuildForwarderImage(
+            TypeAttributes.Public | Forwarder,
+            forwarderCount,
+            assemblyReferenceCount);
 
-    static byte[] BuildForwarderImage(TypeAttributes attributes)
+    static byte[] BuildForwarderImage(
+        TypeAttributes attributes,
+        int forwarderCount = 1,
+        int assemblyReferenceCount = 1)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -618,13 +690,51 @@ public class InspectionAcquisitionPlanTests
             publicKeyOrToken: default,
             flags: default,
             hashValue: default);
-        metadata.AddExportedType(
-            attributes,
-            metadata.GetOrAddString("N"),
-            metadata.GetOrAddString("Type"),
-            target,
-            typeDefinitionId: 0);
+        for (int i = 1; i < assemblyReferenceCount; i++)
+        {
+            metadata.AddAssemblyReference(
+                metadata.GetOrAddString("Target"),
+                new Version(1, 0, 0, 0),
+                culture: default,
+                publicKeyOrToken: default,
+                flags: default,
+                hashValue: default);
+        }
 
+        for (int i = 0; i < forwarderCount; i++)
+        {
+            metadata.AddExportedType(
+                attributes,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString(i == 0 ? "Type" : $"Type{i}"),
+                target,
+                typeDefinitionId: 0);
+        }
+
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildModuleImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Changed.netmodule"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        return Serialize(metadata);
+    }
+
+    static byte[] Serialize(MetadataBuilder metadata)
+    {
         var pe = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),
             new MetadataRootBuilder(metadata, suppressValidation: true),

--- a/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
+++ b/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
@@ -230,6 +230,20 @@ public class InspectionAcquisitionPlanTests
     }
 
     [Fact]
+    public void Register_OutOfRangeForwarderTarget_IsTypedInvalidImage()
+    {
+        byte[] image = BuildForwarderImage(
+            TypeAttributes.Public | Forwarder,
+            targetRow: 4);
+        using var plan = new InspectionAcquisitionPlan();
+
+        var rejected = Assert.IsType<CandidateRegistrationResult.Rejected>(
+            plan.Register(Descriptor(ReadIdentity(image), () => image)));
+
+        Assert.Equal(CandidateOpenFailureKind.InvalidImage, rejected.Failure.Kind);
+    }
+
+    [Fact]
     public void Register_UnreadableSource_IsTypedFailureAndCached()
     {
         byte[] image = SelfBytes();
@@ -660,7 +674,8 @@ public class InspectionAcquisitionPlanTests
     static byte[] BuildForwarderImage(
         TypeAttributes attributes,
         int forwarderCount = 1,
-        int assemblyReferenceCount = 1)
+        int assemblyReferenceCount = 1,
+        int? targetRow = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -683,24 +698,22 @@ public class InspectionAcquisitionPlanTests
             baseType: default,
             fieldList: MetadataTokens.FieldDefinitionHandle(1),
             methodList: MetadataTokens.MethodDefinitionHandle(1));
-        AssemblyReferenceHandle target = metadata.AddAssemblyReference(
-            metadata.GetOrAddString("Target"),
-            new Version(1, 0, 0, 0),
-            culture: default,
-            publicKeyOrToken: default,
-            flags: default,
-            hashValue: default);
-        for (int i = 1; i < assemblyReferenceCount; i++)
+        AssemblyReferenceHandle target = default;
+        for (int i = 0; i < assemblyReferenceCount; i++)
         {
-            metadata.AddAssemblyReference(
+            AssemblyReferenceHandle added = metadata.AddAssemblyReference(
                 metadata.GetOrAddString("Target"),
                 new Version(1, 0, 0, 0),
                 culture: default,
                 publicKeyOrToken: default,
                 flags: default,
                 hashValue: default);
+            if (i == 0)
+                target = added;
         }
 
+        if (targetRow is int row)
+            target = MetadataTokens.AssemblyReferenceHandle(row);
         for (int i = 0; i < forwarderCount; i++)
         {
             metadata.AddExportedType(

--- a/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
@@ -242,7 +242,9 @@ public sealed class SignatureSpellabilityTests
 
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
             => _paths.TryGetValue(identity.Name, out var path)
-                ? new ResolvedAssemblyReference(identity, path, () => File.OpenRead(path), "TestMap")
+                ? ResolvedAssemblyReference.CreateFromPath(
+                    path,
+                    AssemblyResolutionProvenance.Local("TestMap"))
                 : null;
     }
 
@@ -253,7 +255,9 @@ public sealed class SignatureSpellabilityTests
 
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
             => identity.Version is null && identity.Name.Equals(_assemblyName, StringComparison.OrdinalIgnoreCase)
-                ? new ResolvedAssemblyReference(identity, _path, () => File.OpenRead(_path), "VersionRelaxing")
+                ? ResolvedAssemblyReference.CreateFromPath(
+                    _path,
+                    AssemblyResolutionProvenance.Local("VersionRelaxing"))
                 : null;
     }
 

--- a/tests/ILInspector.Metadata.Tests/TypeForwardResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeForwardResolverTests.cs
@@ -70,6 +70,30 @@ public class TypeForwardResolverTests
     }
 
     [Fact]
+    public void LocateType_MissingOrInvalidStartingImage_ReturnsNull()
+    {
+        string missing = Path.Combine(
+            Path.GetTempPath(),
+            $"{Guid.NewGuid():N}.dll");
+        string invalid = Path.GetTempFileName();
+        try
+        {
+            Assert.Null(TypeForwardResolver.LocateType(
+                missing,
+                "N.Type",
+                new NullResolver()));
+            Assert.Null(TypeForwardResolver.LocateType(
+                invalid,
+                "N.Type",
+                new NullResolver()));
+        }
+        finally
+        {
+            File.Delete(invalid);
+        }
+    }
+
+    [Fact]
     public void LocateType_SelfLoop_Terminates()
     {
         // A locator that always points back at the facade would loop forever

--- a/tests/ILInspector.Metadata.Tests/TypeForwardResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeForwardResolverTests.cs
@@ -1,3 +1,6 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
 namespace ILInspector.Metadata.Tests;
 
 public class TypeForwardResolverTests
@@ -32,11 +35,11 @@ public class TypeForwardResolverTests
     [Fact]
     public void LocateType_ResolverOverload_FollowsForwarderThroughOpenReadWithoutPath()
     {
-        var start = new ResolvedAssemblyReference(
-            new AssemblyReferenceIdentity("netstandard", Version: null, Culture: null, PublicKeyToken: null),
-            Path: null,
-            OpenRead: () => File.OpenRead(NetstandardFacade),
-            Provenance: "test");
+        var start = ResolvedAssemblyReference.Create(
+            ReadIdentity(NetstandardFacade),
+            path: null,
+            openRead: () => File.OpenRead(NetstandardFacade),
+            provenance: AssemblyResolutionProvenance.Local("test"));
         var resolver = new FrameworkStreamResolver(pathBacked: false);
 
         var location = TypeForwardResolver.LocateType(
@@ -87,15 +90,28 @@ public class TypeForwardResolverTests
         Assert.True(TypeForwardResolver.ForwardsType(NetstandardFacade, "System.String"));
     }
 
+    static AssemblyReferenceIdentity ReadIdentity(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        return AssemblyReferenceIdentity.FromAssemblyDefinition(
+            peReader.GetMetadataReader());
+    }
+
     sealed class FrameworkStreamResolver(bool pathBacked) : IAssemblyReferenceResolver
     {
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
         {
             string candidate = Path.Combine(FrameworkDir, identity.Name + ".dll");
             return File.Exists(candidate)
-                ? new ResolvedAssemblyReference(identity, Path: pathBacked ? candidate : null, OpenRead: () => File.OpenRead(candidate), Provenance: "test")
+                ? ResolvedAssemblyReference.Create(
+                    ReadIdentity(candidate),
+                    path: pathBacked ? candidate : null,
+                    openRead: () => File.OpenRead(candidate),
+                    provenance: AssemblyResolutionProvenance.Local("test"))
                 : null;
         }
+
     }
 
     sealed class NullResolver : IAssemblyReferenceResolver
@@ -106,6 +122,10 @@ public class TypeForwardResolverTests
     sealed class SelfLoopResolver : IAssemblyReferenceResolver
     {
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
-            => new(identity, NetstandardFacade, () => File.OpenRead(NetstandardFacade), Provenance: "test");
+            => ResolvedAssemblyReference.Create(
+                ReadIdentity(NetstandardFacade),
+                NetstandardFacade,
+                () => File.OpenRead(NetstandardFacade),
+                AssemblyResolutionProvenance.Local("test"));
     }
 }

--- a/tools/DecompilerHarness/CorpusMetadata.cs
+++ b/tools/DecompilerHarness/CorpusMetadata.cs
@@ -1,7 +1,8 @@
+using System.Collections.Concurrent;
+using System.Reflection;
 using DotnetInspector.Services;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
-using System.Reflection;
 
 namespace ILInspector.DecompilerHarness;
 
@@ -47,6 +48,10 @@ static class CorpusMetadata
         IReadOnlyList<AssemblyDependencyResolver> dependencyResolvers,
         IReadOnlyDictionary<string, string> platformAssemblies) : IAssemblyReferenceResolver
     {
+        readonly ConcurrentDictionary<
+            (string Path, string Provenance),
+            Lazy<ResolvedAssemblyReference?>> _assemblies = [];
+
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
         {
             if (scope == AssemblyResolutionScope.Platform)
@@ -55,11 +60,17 @@ static class CorpusMetadata
                 {
                     string candidate = Path.Combine(directory!, identity.Name + ".dll");
                     if (File.Exists(candidate) && IsTrustedPlatformAssembly(candidate))
-                        return FromPath(identity, candidate, "CorpusPlatformSibling");
+                    {
+                        if (FromPath(candidate, "CorpusPlatformSibling")
+                            is { } resolved)
+                        {
+                            return resolved;
+                        }
+                    }
                 }
 
                 return platformAssemblies.TryGetValue(identity.Name, out var platformPath)
-                    ? FromPath(identity, platformPath, "TrustedPlatformAssembly")
+                    ? FromPath(platformPath, "TrustedPlatformAssembly")
                     : null;
             }
 
@@ -67,7 +78,10 @@ static class CorpusMetadata
             {
                 string candidate = Path.Combine(directory!, identity.Name + ".dll");
                 if (File.Exists(candidate))
-                    return FromPath(identity, candidate, "CorpusSibling");
+                {
+                    if (FromPath(candidate, "CorpusSibling") is { } resolved)
+                        return resolved;
+                }
             }
 
             foreach (var resolver in dependencyResolvers)
@@ -76,10 +90,17 @@ static class CorpusMetadata
             return null;
         }
 
-        static ResolvedAssemblyReference FromPath(AssemblyReferenceIdentity identity, string path, string provenance)
-            => ResolvedAssemblyReference.CreateFromPath(
-                path,
-                AssemblyResolutionProvenance.Local(provenance));
+        ResolvedAssemblyReference? FromPath(string path, string provenance) =>
+            _assemblies.GetOrAdd(
+                (path, provenance),
+                static key => new Lazy<ResolvedAssemblyReference?>(
+                    () => ResolvedAssemblyReference.TryCreateFromPath(
+                        key.Path,
+                        AssemblyResolutionProvenance.Local(key.Provenance),
+                        out ResolvedAssemblyReference? reference)
+                            ? reference
+                            : null,
+                    LazyThreadSafetyMode.ExecutionAndPublication)).Value;
     }
 
     static IReadOnlyDictionary<string, string> TrustedPlatformAssemblies()

--- a/tools/DecompilerHarness/CorpusMetadata.cs
+++ b/tools/DecompilerHarness/CorpusMetadata.cs
@@ -77,7 +77,9 @@ static class CorpusMetadata
         }
 
         static ResolvedAssemblyReference FromPath(AssemblyReferenceIdentity identity, string path, string provenance)
-            => new(identity, path, () => File.OpenRead(path), provenance);
+            => ResolvedAssemblyReference.CreateFromPath(
+                path,
+                AssemblyResolutionProvenance.Local(provenance));
     }
 
     static IReadOnlyDictionary<string, string> TrustedPlatformAssemblies()

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -4374,7 +4374,12 @@ static class FidelityCheck
                     builder.Add(reference);
                     if (TryReadAssemblyIdentity(fullPath) is { } identity)
                         resolvedReferences.Add(new CompilerReference(
-                            new ResolvedAssemblyReference(identity, fullPath, () => File.OpenRead(fullPath), provenance?.ToString() ?? "CompilerReference"),
+                            ResolvedAssemblyReference.Create(
+                                identity,
+                                fullPath,
+                                () => File.OpenRead(fullPath),
+                                AssemblyResolutionProvenance.Local(
+                                    provenance?.ToString() ?? "CompilerReference")),
                             PlatformTrusted: provenance is AssemblyDependencyProvenance.TrustedPlatformAssembly
                                 or AssemblyDependencyProvenance.SharedFramework));
                 }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -2079,11 +2079,16 @@ static class ReturnToSender
         if (originalReader.GetMethodDefinition(originalMethod).RelativeVirtualAddress == 0)
             return null;
 
-        var recompiledReference = new ResolvedAssemblyReference(
-            new AssemblyReferenceIdentity("return-to-sender", Version: null, Culture: null, PublicKeyToken: null),
-            Path: null,
-            OpenRead: () => new MemoryStream(recompiledAssembly, writable: false),
-            Provenance: "ReturnToSender");
+        using var recompiledIdentityStream =
+            new MemoryStream(recompiledAssembly, writable: false);
+        using var recompiledIdentityReader =
+            new PEReader(recompiledIdentityStream);
+        var recompiledReference = ResolvedAssemblyReference.Create(
+            AssemblyReferenceIdentity.FromAssemblyDefinition(
+                recompiledIdentityReader.GetMetadataReader()),
+            path: null,
+            openRead: () => new MemoryStream(recompiledAssembly, writable: false),
+            provenance: AssemblyResolutionProvenance.Local("ReturnToSender"));
         var resolver = MetadataSource.DefaultAssemblyReferenceResolver(assemblyPath);
         using var originalSource = MetadataSource.OpenWithoutSymbols(assemblyPath);
         using var recompiledSource = MetadataSource.OpenWithoutSymbols(recompiledReference, resolver);


### PR DESCRIPTION
## Summary

Establishes the acquisition and lifetime foundation for structured type-forwarder resolution: one opaque acquisition registration maps to one catalog-local candidate, copied adjacency inventory, and at most one lazily retained inspection session under explicit resource budgets.

- replaces value-equal resolved assembly descriptors with opaque registration identity and structured package/platform/project/local provenance
- inventories AssemblyDef identity, MVID, AssemblyRefs, and forwarder targets without retaining readers or streams
- opens prefetched sessions lazily, pins them to inventoried identity and MVID, and makes the plan their sole lifetime owner
- bounds candidates, retained image bytes, relationship walks, and concurrent source opens with typed failures
- migrates existing descriptor producers without changing the current forwarder resolver behavior
- splits the design's former Slice 2 into this acquisition foundation (2a) and the later binding/resolution engine (2b)

## Boundary

This PR intentionally does not add public binding policy, resolution requests/outcomes, catalog generations, or cross-assembly traversal. Issue #3671 can compose this catalog in pre-baked contexts later, but its static availability-index question remains orthogonal.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-restore` (1334 passed, 5 environment-dependent MDV tests skipped)
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release --no-restore` (357 passed)
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- --gate fast` (4496 passed)
- `npx markdownlint-cli docs/design/type-forwarding-resolution.md docs/design/type-member-api-representation.md`


