### PR TITLE
Carry metadata text as InertString so a sink cannot be handed raw text

### DIFF
--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -235,6 +235,104 @@ text. Establishing that list is a prerequisite for the guarantee, not a detail
 of it — a chokepoint you have not finished enumerating is a chokepoint you
 cannot claim.
 
+## Carrying a contained value to the sink
+
+Containing text at the boundary answers *whether* a value was treated. It does
+not, on its own, get the value to the printer intact. The metadata table
+projection is the worked example, and it started out doing this:
+
+```csharp
+internal static string ContainCellText(string value, int maxChars, out bool truncated)
+{
+    var contained = new InertString(TextPolicy.Field, value, maxChars);
+    truncated = contained.IsTruncated;
+    return contained.ToString();
+}
+```
+
+That takes an `InertString` apart one line after building it, and it is worth
+being precise about the cost, because "it still returns treated text" is true and
+is not the point.
+
+**The type stops guarding the moment it is unwrapped.** A `string` field cannot
+say whether it was treated, so every later edit that assigns to it is
+unconstrained, and the only way to audit the field is to re-trace its producers.
+Carrying `InertString` instead makes that a compiler question: there is no
+conversion into the type that does not apply a policy, so a field of that type
+has no untreated inhabitants.
+
+**Splitting the pair invites the halves to disagree.** Truncation is not
+decoration on the text, it is the difference between a prefix and a whole value,
+and a sink that loses it renders a clipped name as though it were complete. Two
+fields can drift; one value cannot. `HandleRef` carried a `Display` and a
+`DisplayTruncated` that could be set independently — and a test constructed
+`Display: "", DisplayTruncated: true`, a state the projector cannot produce.
+Once `Display` is an `InertString`, that fixture has to be written as bounding
+real text to a real budget, because a value that was never cut cannot claim it
+was.
+
+So the rule is: **contain once, carry the contained value, and un-pair only at
+the sink.** The producer names the policy and nothing else; the sink decides what
+a partial value looks like, because notation is the sink's business and no
+producer should be guessing at an ellipsis.
+
+```csharp
+internal static InertString ContainCellText(string value, int maxChars)
+    => new(TextPolicy.Field, value, maxChars);
+```
+
+```csharp
+InertString text = ContainCellText(raw, options.MaxStringChars);
+return new MetadataValue.HeapReference(
+    HeapKind.String, HeapOffset(handle), raw.Length, text, text, text.IsTruncated);
+```
+
+### A partiality flag survives only where the text cannot know
+
+The tempting next step is to delete every truncation field and read
+`IsTruncated` off the text. That is right wherever the character budget is the
+only way a value can become partial, which is why `HandleRef.DisplayTruncated`
+and `MetadataImageOverview.MetadataVersionTruncated` are gone.
+
+It is wrong for `HeapReference`. A Blob preview is bounded by a **byte** budget,
+upstream of any text at all:
+
+```csharp
+int take = Math.Min(length, Math.Max(0, options.MaxPreviewBytes));
+byte[] bytes = blobReader.ReadBytes(take);
+```
+
+The hex that follows is a *complete* spelling of the bytes that were read, so its
+`IsTruncated` is `false` for a blob that lost most of its content. Deriving the
+flag there would report those blobs as whole. `HeapReference.Truncated` therefore
+stays a stored field meaning "this projected value is not the whole value", with
+two causes feeding it and only one of them visible in the text.
+
+The general form: a length or a flag is only meaningful in the units that
+produced it. `InertString` refuses to remember a source *length* for the same
+reason — re-spelling under a stricter policy makes text longer, so a length
+carried across a re-encode is compared against a different unit.
+
+### What this buys, and what still carries `string`
+
+Every field of the metadata projection that can hold artifact-derived text is
+now `InertString`: `HeapReference.Text` and `.Preview`, `HandleRef.Display`,
+`MetadataImageOverview.MetadataVersion`, and `Malformed.Detail`. The last one is
+included because it splices a third party's exception message into a diagnostic
+about an image that has already proved malformed; whether SRM ever puts artifact
+bytes into a message is not a property this repository can pin, and typing the
+field means it does not have to.
+
+`Scalar.Display` and `Flags.Decoded` remain `string` on purpose. They hold
+formatted numbers and BCL enum names — `0x{rva:X8}`, `TypeCode.Boolean` — and
+never heap content, so containing them would add ceremony without removing a
+hazard.
+
+The gate for "no untreated metadata text reaches a sink" is therefore the
+compiler: there is no conversion that would let a `string` into any of those
+fields. That is a stronger enforcement than a test, and it is the reason to
+prefer carrying the type over re-checking the text.
+
 ## Holding a value is not the same as being able to reverse it
 
 A type answers what a *sink* accepts. It does not answer what a *file* can do,

--- a/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
+++ b/src/DotnetInspector.MetadataRendering/MetadataProjectionRenderer.cs
@@ -1,5 +1,6 @@
 using System.Reflection.Metadata.Ecma335;
 using ILInspector.Metadata;
+using InertText;
 using Markout;
 
 namespace DotnetInspector.MetadataRendering;
@@ -334,11 +335,7 @@ public static class MetadataProjectionRenderer
         // A truncated stamp must carry the ellipsis for the same reason a
         // truncated handle display does: a prefix must never be mistaken for the
         // whole value.
-        Add(
-            "Metadata version",
-            overview.MetadataVersionTruncated
-                ? overview.MetadataVersion + Ellipsis
-                : overview.MetadataVersion);
+        Add("Metadata version", Display(overview.MetadataVersion));
         Add("Metadata kind", overview.Kind.ToString());
         Add("Has assembly manifest", overview.IsAssembly ? "yes" : "no");
         Add("Metadata offset", overview.MetadataOffset.ToString());
@@ -856,11 +853,28 @@ public static class MetadataProjectionRenderer
         _ => throw new InvalidOperationException($"Unhandled metadata value: {value.GetType().Name}"),
     };
 
+    /// <summary>
+    /// Turns a contained value into display text, marking a partial one so it can never
+    /// be read as whole.
+    /// </summary>
+    /// <remarks>
+    /// This is the boundary the projection carries <see cref="InertString"/> up to. The
+    /// model keeps the text and its truncation together precisely so that the decision
+    /// made here — what a clipped value looks like — is made once, by the sink that knows
+    /// its own notation, rather than by every producer guessing at it.
+    /// </remarks>
+    static string Display(InertString text, bool truncated)
+        => truncated ? text + Ellipsis : text.ToString();
+
+    /// <inheritdoc cref="Display(InertString, bool)"/>
+    static string Display(InertString text) => Display(text, text.IsTruncated);
+
     static string FormatHeap(MetadataValue.HeapReference heap)
     {
         // The Blob heap carries no decoded text; its bounded hex preview stands in.
-        string body = heap.Text ?? heap.Preview;
-        return heap.Truncated ? body + Ellipsis : body;
+        // Truncation comes off the reference rather than the text because a blob's
+        // preview is bounded in bytes, which the hex spelling cannot report.
+        return Display(heap.Text ?? heap.Preview, heap.Truncated);
     }
 
     static string FormatHandle(HandleRef reference)
@@ -870,17 +884,20 @@ public static class MetadataProjectionRenderer
 
         string target = $"{reference.TargetTable}[{reference.TargetRowId}]";
 
+        if (reference.Display is not { } display)
+            return target;
+
         // A truncated display must always carry the ellipsis so it is never
         // mistaken for a whole value — even when the budget clipped it to empty,
         // which must still render as "(…)" rather than a bare target that looks
         // like an unavailable display.
-        if (reference.DisplayTruncated)
-            return $"{target} ({reference.Display}{Ellipsis})";
+        if (display.IsTruncated)
+            return $"{target} ({Display(display)})";
 
-        if (string.IsNullOrEmpty(reference.Display))
+        if (display.IsEmpty)
             return target;
 
-        return $"{target} ({reference.Display})";
+        return $"{target} ({display})";
     }
 
     static string FormatRange(HandleRange range)

--- a/src/ILInspector.Metadata/ILInspector.Metadata.csproj
+++ b/src/ILInspector.Metadata/ILInspector.Metadata.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet-inspect.Tests" />
     <InternalsVisibleTo Include="ILInspector.Metadata.Tests" />
+    <InternalsVisibleTo Include="DotnetInspector.MetadataRendering.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILInspector.Metadata/MetadataImageInspector.cs
+++ b/src/ILInspector.Metadata/MetadataImageInspector.cs
@@ -73,10 +73,11 @@ public static class MetadataImageInspector
     /// the stamp is a counted string read straight out of the image and this code
     /// does not get to assume the image conforms.
     ///
-    /// When the budget does bind, the overview reports it via
-    /// <see cref="MetadataImageOverview.MetadataVersionTruncated"/> rather than
-    /// silently returning a prefix, so a clipped stamp is never mistaken for a
-    /// whole one — the same rule every other truncated value in this layer
+    /// When the budget does bind, the clipped stamp says so itself: the value is
+    /// an <see cref="InertString"/>, and the character budget is the only way it
+    /// can become partial, so <c>IsTruncated</c> carries the fact rather than a
+    /// separate flag a caller could read without. A prefix is never mistaken for
+    /// a whole stamp — the same rule every other contained value in this layer
     /// follows.
     /// </summary>
     const int MetadataVersionBudget = 255 * 6;

--- a/src/ILInspector.Metadata/MetadataImageInspector.cs
+++ b/src/ILInspector.Metadata/MetadataImageInspector.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using InertText;
 
 namespace ILInspector.Metadata;
 
@@ -50,8 +51,8 @@ public static class MetadataImageInspector
         var reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
         var headers = peReader.PEHeaders;
 
-        string version = MetadataTableProjector.ContainCellText(
-            reader.MetadataVersion, MetadataVersionBudget, out bool versionTruncated);
+        InertString version = MetadataTableProjector.ContainCellText(
+            reader.MetadataVersion, MetadataVersionBudget);
 
         return new MetadataImageOverview(
             version,
@@ -61,8 +62,7 @@ public static class MetadataImageInspector
             headers.MetadataSize,
             DescribeHeaps(reader),
             DescribeTables(reader),
-            DescribeHeaders(headers),
-            versionTruncated);
+            DescribeHeaders(headers));
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/MetadataImageOverview.cs
+++ b/src/ILInspector.Metadata/MetadataImageOverview.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using InertText;
 
 namespace ILInspector.Metadata;
 
@@ -20,17 +21,15 @@ namespace ILInspector.Metadata;
 public sealed record MetadataImageOverview
 {
     public MetadataImageOverview(
-        string MetadataVersion,
+        InertString MetadataVersion,
         MetadataKind Kind,
         bool IsAssembly,
         int MetadataOffset,
         int MetadataSize,
         ImmutableArray<MetadataHeapSummary> Heaps,
         ImmutableArray<MetadataTableSummary> Tables,
-        MetadataImageHeaders Headers,
-        bool MetadataVersionTruncated = false)
+        MetadataImageHeaders Headers)
     {
-        ArgumentNullException.ThrowIfNull(MetadataVersion);
         ArgumentOutOfRangeException.ThrowIfNegative(MetadataOffset);
         ArgumentOutOfRangeException.ThrowIfNegative(MetadataSize);
         ArgumentNullException.ThrowIfNull(Headers);
@@ -47,29 +46,22 @@ public sealed record MetadataImageOverview
         this.Heaps = Heaps;
         this.Tables = Tables;
         this.Headers = Headers;
-        this.MetadataVersionTruncated = MetadataVersionTruncated;
     }
 
     /// <summary>
     /// The metadata root's version string (for example <c>v4.0.30319</c>). This
     /// is the metadata format stamp, not the assembly's target framework.
     /// </summary>
-    public string MetadataVersion { get; }
-
-    /// <summary>
-    /// True when <see cref="MetadataVersion"/> is a prefix of the stamp the image
-    /// actually carries, because neutralizing it exceeded the display budget.
-    /// A conforming stamp can never trip this: ECMA-335 II.24.2.1 bounds the
-    /// field at 255 bytes, which cannot outgrow the budget even if every byte is
-    /// a control character. It exists because the stamp is read straight out of
-    /// the image and a malformed image is exactly the case this type must survive
-    /// describing.
-    ///
-    /// Consumers must render a truncated value distinguishably — the renderer
-    /// appends an ellipsis — so a clipped stamp is never mistaken for a whole
-    /// one, matching <see cref="MetadataValue.HeapReference.Truncated"/>.
-    /// </summary>
-    public bool MetadataVersionTruncated { get; }
+    /// <remarks>
+    /// The stamp is read straight out of the image, so it is foreign text and is
+    /// carried contained. Its own <see cref="InertString.IsTruncated"/> reports
+    /// whether the retained value is a prefix, which consumers must render
+    /// distinguishably — the renderer appends an ellipsis — so that a clipped
+    /// stamp is never mistaken for a whole one. A conforming stamp can never be
+    /// clipped: ECMA-335 II.24.2.1 bounds the field at 255 bytes, which cannot
+    /// outgrow the budget even if every byte needs spelling out.
+    /// </remarks>
+    public InertString MetadataVersion { get; }
 
     /// <summary>Whether the metadata is plain ECMA-335 or a Windows-Runtime flavour.</summary>
     public MetadataKind Kind { get; }

--- a/src/ILInspector.Metadata/MetadataTableProjection.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjection.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata.Ecma335;
+using InertText;
 
 namespace ILInspector.Metadata;
 
@@ -170,20 +171,32 @@ public abstract record MetadataValue
     public sealed record Flags(long Raw, string Decoded) : MetadataValue;
 
     /// <summary>
-    /// A reference into a metadata heap. <see cref="Text"/> is the decoded,
-    /// control-escaped string for the String/Guid heaps (safe to render as data:
-    /// terminal control sequences are neutralized); it is null for the Blob heap,
-    /// whose <see cref="Preview"/> carries a bounded hex dump. <see cref="Length"/>
-    /// is the full decoded size; <see cref="Truncated"/> is true when the bounded
-    /// preview stopped short of it, so a preview is never mistaken for the whole
-    /// value. The complete heap value remains addressable via <see cref="Offset"/>.
+    /// A reference into a metadata heap. <see cref="Text"/> is the decoded value for
+    /// the String/Guid heaps and is null for the Blob heap, whose <see cref="Preview"/>
+    /// carries a bounded hex dump instead. <see cref="Length"/> is the full decoded
+    /// size, and the complete heap value remains addressable via <see cref="Offset"/>.
     /// </summary>
+    /// <remarks>
+    /// The text is carried as <see cref="InertString"/> rather than <see cref="string"/>
+    /// so that a sink cannot be handed an untreated heap value by accident: there is no
+    /// conversion into this type that does not apply a policy, so the containment is a
+    /// fact about the type rather than a discipline every call site has to keep.
+    /// <para>
+    /// <see cref="Truncated"/> is stored rather than read from <see cref="Text"/> because
+    /// partiality here has two causes and only one of them is visible in the text. A
+    /// String heap value is bounded by a character budget, which <see cref="Text"/> knows
+    /// about. A Blob preview is bounded by a <em>byte</em> budget upstream of any text at
+    /// all, and the hex it produces is a complete spelling of the bytes that were read —
+    /// so <c>Preview.IsTruncated</c> is false for a blob that lost most of its content.
+    /// Deriving this flag would report those blobs as whole.
+    /// </para>
+    /// </remarks>
     public sealed record HeapReference(
         HeapKind Heap,
         int Offset,
         int Length,
-        string? Text,
-        string Preview,
+        InertString? Text,
+        InertString Preview,
         bool Truncated) : MetadataValue;
 
     /// <summary>A single resolvable index into another table.</summary>
@@ -196,7 +209,14 @@ public abstract record MetadataValue
     /// A cell that could not be trusted: SRM rejected the value or a handle was
     /// malformed. Never a success-shaped empty value.
     /// </summary>
-    public sealed record Malformed(string Detail) : MetadataValue;
+    /// <remarks>
+    /// The detail is contained for the same reason the cell values are, and the case for
+    /// it is stronger rather than weaker: it is produced only while describing an image
+    /// that has already proved malformed, and it splices in a third party's exception
+    /// message. Whether SRM ever puts artifact bytes in one is not a property this
+    /// repository can pin, so the type answers it instead of an assumption.
+    /// </remarks>
+    public sealed record Malformed(InertString Detail) : MetadataValue;
 }
 
 /// <summary>The metadata heaps a <see cref="MetadataValue.HeapReference"/> can point at.</summary>
@@ -215,14 +235,13 @@ public enum HeapKind
 /// </summary>
 public sealed record HandleRef
 {
-    public HandleRef(TableIndex TargetTable, int TargetRowId, int Token, string? Display = null, bool DisplayTruncated = false)
+    public HandleRef(TableIndex TargetTable, int TargetRowId, int Token, InertString? Display = null)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(TargetRowId);
         this.TargetTable = TargetTable;
         this.TargetRowId = TargetRowId;
         this.Token = Token;
         this.Display = Display;
-        this.DisplayTruncated = DisplayTruncated;
     }
 
     /// <summary>The table the edge points into.</summary>
@@ -234,14 +253,17 @@ public sealed record HandleRef
     /// <summary>The full metadata token of the target.</summary>
     public int Token { get; }
 
-    /// <summary>Best-effort display text for the target, or null when unavailable.</summary>
-    public string? Display { get; }
-
     /// <summary>
-    /// True when <see cref="Display"/> was bounded by the projection's string
-    /// budget, so the retained text is a prefix rather than the full name.
+    /// Best-effort display text for the target, or null when unavailable.
     /// </summary>
-    public bool DisplayTruncated { get; }
+    /// <remarks>
+    /// Unlike <see cref="MetadataValue.HeapReference"/>, this carries no separate
+    /// truncation flag: display text has exactly one way of becoming partial — the
+    /// projection's character budget — and <see cref="InertString.IsTruncated"/>
+    /// already records it. Storing a second copy would only create the opportunity
+    /// for the two to disagree.
+    /// </remarks>
+    public InertString? Display { get; }
 }
 
 /// <summary>

--- a/src/ILInspector.Metadata/MetadataTableProjector.cs
+++ b/src/ILInspector.Metadata/MetadataTableProjector.cs
@@ -481,7 +481,7 @@ public static class MetadataTableProjector
 
         if (!addressable)
             return new MetadataValue.Malformed(
-                $"{heap} heap address {address} is past the end of a {size}-byte heap.");
+                InertString.Format(TextPolicy.Field, $"{heap} heap address {address} is past the end of a {size}-byte heap."));
 
         try
         {
@@ -500,7 +500,7 @@ public static class MetadataTableProjector
             // so a rejected address is contained here rather than escaping as a
             // throw from a read-only query. An unknown HeapKind is not caught
             // here: ToHeapIndex above already rejected it.
-            return new MetadataValue.Malformed($"{heap} heap read failed: {ex.Message}");
+            return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"{heap} heap read failed: {ex.Message}"));
         }
     }
 
@@ -618,7 +618,7 @@ public static class MetadataTableProjector
             }
             catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
             {
-                value = new MetadataValue.Malformed($"Guid heap read failed at index {index}: {ex.Message}");
+                value = new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"Guid heap read failed at index {index}: {ex.Message}"));
             }
 
             entries.Add(new MetadataHeapEntry(
@@ -712,7 +712,7 @@ public static class MetadataTableProjector
             {
                 var malformed = ImmutableArray.CreateBuilder<MetadataValue>(spec.Columns.Length);
                 for (int column = 0; column < spec.Columns.Length; column++)
-                    malformed.Add(new MetadataValue.Malformed($"Row read failed: {ex.Message}"));
+                    malformed.Add(new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"Row read failed: {ex.Message}")));
 
                 rows.Add(new MetadataRow(rid, token, malformed.MoveToImmutable()));
             }
@@ -1082,13 +1082,13 @@ public static class MetadataTableProjector
         try
         {
             string raw = reader.GetString(handle);
-            string text = ContainCellText(raw, options.MaxStringChars, out bool truncated);
+            InertString text = ContainCellText(raw, options.MaxStringChars);
             return new MetadataValue.HeapReference(
-                HeapKind.String, HeapOffset(handle), raw.Length, text, text, truncated);
+                HeapKind.String, HeapOffset(handle), raw.Length, text, text, text.IsTruncated);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
-            return new MetadataValue.Malformed($"String heap read failed: {ex.Message}");
+            return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"String heap read failed: {ex.Message}"));
         }
     }
 
@@ -1100,13 +1100,13 @@ public static class MetadataTableProjector
         try
         {
             string raw = reader.GetUserString(handle);
-            string text = ContainCellText(raw, options.MaxStringChars, out bool truncated);
+            InertString text = ContainCellText(raw, options.MaxStringChars);
             return new MetadataValue.HeapReference(
-                HeapKind.UserString, MetadataTokens.GetHeapOffset(handle), raw.Length, text, text, truncated);
+                HeapKind.UserString, MetadataTokens.GetHeapOffset(handle), raw.Length, text, text, text.IsTruncated);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
-            return new MetadataValue.Malformed($"UserString heap read failed: {ex.Message}");
+            return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"UserString heap read failed: {ex.Message}"));
         }
     }
 
@@ -1117,13 +1117,16 @@ public static class MetadataTableProjector
 
         try
         {
-            string text = reader.GetGuid(handle).ToString();
+            // A GUID's own spelling is hex and dashes, so containment cannot change it;
+            // it goes through the same policy anyway so that no heap value reaches the
+            // projection as raw text and the type carries that uniformly.
+            InertString text = ContainCellText(reader.GetGuid(handle).ToString(), int.MaxValue);
             return new MetadataValue.HeapReference(
                 HeapKind.Guid, HeapOffset(handle), 16, text, text, Truncated: false);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
-            return new MetadataValue.Malformed($"Guid heap read failed: {ex.Message}");
+            return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"Guid heap read failed: {ex.Message}"));
         }
     }
 
@@ -1138,14 +1141,17 @@ public static class MetadataTableProjector
             int length = blobReader.Length;
             int take = Math.Min(length, Math.Max(0, options.MaxPreviewBytes));
             byte[] bytes = blobReader.ReadBytes(take);
-            string preview = Convert.ToHexString(bytes);
+            InertString preview = ContainCellText(Convert.ToHexString(bytes), int.MaxValue);
 
+            // The blob's partiality is a byte-level fact established before there was any
+            // text to bound, so it cannot be read back off the hex: that hex is a complete
+            // spelling of the bytes that were read.
             return new MetadataValue.HeapReference(
                 HeapKind.Blob, HeapOffset(handle), length, Text: null, preview, Truncated: take < length);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
-            return new MetadataValue.Malformed($"Blob heap read failed: {ex.Message}");
+            return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"Blob heap read failed: {ex.Message}"));
         }
     }
 
@@ -1193,7 +1199,7 @@ public static class MetadataTableProjector
         try
         {
             if (!MetadataTokens.TryGetTableIndex(handle.Kind, out var table))
-                return new MetadataValue.Malformed($"Handle kind {handle.Kind} does not map to a table.");
+                return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"Handle kind {handle.Kind} does not map to a table."));
 
             int rid = MetadataTokens.GetRowNumber(handle);
             int token = MetadataTokens.GetToken(handle);
@@ -1203,18 +1209,18 @@ public static class MetadataTableProjector
             int targetRows = reader.GetTableRowCount(table);
             if (rid < 1 || rid > targetRows)
                 return new MetadataValue.Malformed(
-                    $"Handle 0x{token:X8} targets {table} row {rid}, outside [1, {targetRows}].");
+                    InertString.Format(TextPolicy.Field, $"Handle 0x{token:X8} targets {table} row {rid}, outside [1, {targetRows}]."));
 
-            string? display = ResolveHandleDisplay(reader, handle);
-            bool displayTruncated = false;
-            if (display is not null)
-                display = ContainCellText(display, options.MaxStringChars, out displayTruncated);
+            string? resolved = ResolveHandleDisplay(reader, handle);
+            InertString? display = resolved is null
+                ? null
+                : ContainCellText(resolved, options.MaxStringChars);
 
-            return new MetadataValue.Handle(new HandleRef(table, rid, token, display, displayTruncated));
+            return new MetadataValue.Handle(new HandleRef(table, rid, token, display));
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
-            return new MetadataValue.Malformed($"Handle resolution failed: {ex.Message}");
+            return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"Handle resolution failed: {ex.Message}"));
         }
     }
 
@@ -1236,7 +1242,7 @@ public static class MetadataTableProjector
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
-            return new MetadataValue.Malformed($"List column read failed: {ex.Message}");
+            return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"List column read failed: {ex.Message}"));
         }
     }
 
@@ -1258,7 +1264,7 @@ public static class MetadataTableProjector
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
-            return new MetadataValue.Malformed($"List column read failed: {ex.Message}");
+            return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"List column read failed: {ex.Message}"));
         }
     }
 
@@ -1280,7 +1286,7 @@ public static class MetadataTableProjector
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
         {
-            return new MetadataValue.Malformed($"List column read failed: {ex.Message}");
+            return new MetadataValue.Malformed(InertString.Format(TextPolicy.Field, $"List column read failed: {ex.Message}"));
         }
     }
 
@@ -1339,22 +1345,16 @@ public static class MetadataTableProjector
     /// primitive rather than a parallel one.
     /// </para>
     /// </summary>
-    /// <param name="truncated">
-    /// Whether any input was dropped to stay within budget. Read from the contained value
-    /// rather than computed here: bounding at construction does not leave this method
-    /// holding the unbounded value to subtract from, and the comparison it would reach for
-    /// instead — emitted length against <paramref name="value"/>'s — is wrong in the
-    /// direction that matters, because spelling a scalar makes the text longer.
-    /// </param>
-    internal static string ContainCellText(string value, int maxChars, out bool truncated)
-    {
-        // The budget goes in as configured: a negative one is read as zero rather than
-        // refused, so clamping here would be a line that never changes an answer.
-        var contained = new InertString(TextPolicy.Field, value, maxChars);
-
-        truncated = contained.IsTruncated;
-        return contained.ToString();
-    }
+    /// <returns>
+    /// The contained value, still paired with whether it was bounded. Returning
+    /// <see cref="InertString"/> rather than a <see cref="string"/> and an <c>out</c> flag
+    /// is the point: the pair travels together into the projection, and only a sink that
+    /// has decided how to mark a partial value takes it apart.
+    /// </returns>
+    // The budget goes in as configured: a negative one is read as zero rather than
+    // refused, so clamping here would be a line that never changes an answer.
+    internal static InertString ContainCellText(string value, int maxChars)
+        => new(TextPolicy.Field, value, maxChars);
 
     readonly record struct TableSpec(
         TableIndex Index,

--- a/src/dotnet-inspect.Tests/PositionalRecordPropertyOrderTests.cs
+++ b/src/dotnet-inspect.Tests/PositionalRecordPropertyOrderTests.cs
@@ -61,14 +61,6 @@ public class PositionalRecordPropertyOrderTests
         "ILInspector.Analysis.MethodIdentity",
         "ILInspector.Metadata.ClassifiedMethodObservation",
         "ILInspector.Metadata.ExtensionMemberObservation",
-
-        // Added by #3518, after this gate existed, and benign for a reason the
-        // others do not share: MetadataVersionTruncated qualifies
-        // MetadataVersion, so it is declared next to it, while being optional
-        // forces it last in the constructor. The two orders cannot agree, and
-        // the property the gate protects is unaffected -- the renderer consumes
-        // the flag to append an ellipsis rather than emitting it as a column.
-        "ILInspector.Metadata.MetadataImageOverview",
     ];
 
     [Theory]

--- a/tests/DotnetInspector.MetadataRendering.Tests/MdiContainmentTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MdiContainmentTests.cs
@@ -408,7 +408,7 @@ public sealed class HostileAssemblyFixture : IDisposable
                 foreach (var cell in row.Cells)
                 {
                     if (cell is MetadataValue.HeapReference { Heap: HeapKind.String, Text: { } text } heap
-                        && text.Contains(CanaryTail, StringComparison.Ordinal))
+                        && text.ToString().Contains(CanaryTail, StringComparison.Ordinal))
                     {
                         return (row.RowId, heap.Offset);
                     }

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs
@@ -2,6 +2,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using ILInspector.Metadata;
+using InertText;
 using Mdi;
 
 namespace DotnetInspector.MetadataRendering.Tests;
@@ -18,6 +19,14 @@ namespace DotnetInspector.MetadataRendering.Tests;
 /// </summary>
 public class MetadataImageOverviewRendererTests
 {
+
+    /// <summary>
+    /// Builds fixture cell text through the projector's own containment, so a fixture
+    /// can never assert on a spelling the product would not produce — and cannot
+    /// fabricate a value that claims to be truncated without having been cut.
+    /// </summary>
+    static InertString Cell(string value, int maxChars = int.MaxValue)
+        => MetadataTableProjector.ContainCellText(value, maxChars);
     static readonly string SelfPath = typeof(MetadataImageOverviewRendererTests).Assembly.Location;
 
     static MetadataImageOverview SelfOverview()
@@ -40,7 +49,7 @@ public class MetadataImageOverviewRendererTests
     /// The record's properties are get-only, so <c>with</c> is unavailable.
     /// </summary>
     static MetadataImageOverview WithVersion(
-        MetadataImageOverview overview, string version, bool truncated)
+        MetadataImageOverview overview, InertString version)
         => new(
             version,
             overview.Kind,
@@ -49,8 +58,7 @@ public class MetadataImageOverviewRendererTests
             overview.MetadataSize,
             overview.Heaps,
             overview.Tables,
-            overview.Headers,
-            truncated);
+            overview.Headers);
 
     /// <summary>
     /// The metadata root's version stamp is a counted string read out of the
@@ -64,7 +72,7 @@ public class MetadataImageOverviewRendererTests
     public void Markdown_MarksATruncatedVersionStampSoAPrefixIsNotReadAsTheWholeValue()
     {
         string markdown = Render(
-            WithVersion(SelfOverview(), "v4.0.303", truncated: true), MetadataTableFormat.Markdown);
+            WithVersion(SelfOverview(), Cell("v4.0.30319", 8)), MetadataTableFormat.Markdown);
 
         Assert.Contains("v4.0.303…", markdown, StringComparison.Ordinal);
     }
@@ -77,7 +85,7 @@ public class MetadataImageOverviewRendererTests
     public void Markdown_LeavesAnUntruncatedVersionStampUnmarked()
     {
         string markdown = Render(
-            WithVersion(SelfOverview(), "v4.0.303", truncated: false), MetadataTableFormat.Markdown);
+            WithVersion(SelfOverview(), Cell("v4.0.303")), MetadataTableFormat.Markdown);
 
         Assert.Contains("v4.0.303", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("v4.0.303…", markdown, StringComparison.Ordinal);
@@ -98,7 +106,7 @@ public class MetadataImageOverviewRendererTests
         const int escapeExpansion = 6;
 
         var overview = SelfOverview();
-        Assert.False(overview.MetadataVersionTruncated);
+        Assert.False(overview.MetadataVersion.IsTruncated);
         Assert.True(overview.MetadataVersion.Length <= maxConformingBytes * escapeExpansion);
     }
 
@@ -212,7 +220,7 @@ public class MetadataImageOverviewRendererTests
     public void Caveats_AreEmptyOnlyWhenNothingWasLeftOut()
     {
         var complete = new MetadataImageOverview(
-            "v4.0.30319",
+            Cell("v4.0.30319"),
             MetadataKind.Ecma335,
             IsAssembly: true,
             MetadataOffset: 1,
@@ -234,7 +242,7 @@ public class MetadataImageOverviewRendererTests
     public void Markdown_ReportsAnAbsentCliHeaderRatherThanBlankFields()
     {
         var native = new MetadataImageOverview(
-            "v4.0.30319",
+            Cell("v4.0.30319"),
             MetadataKind.Ecma335,
             IsAssembly: false,
             MetadataOffset: 1,
@@ -262,7 +270,7 @@ public class MetadataImageOverviewRendererTests
     public void Markdown_DistinguishesAManagedEntryPointFromANativeOne(int raw, CorFlags flags, string expected)
     {
         var overview = new MetadataImageOverview(
-            "v4.0.30319",
+            Cell("v4.0.30319"),
             MetadataKind.Ecma335,
             IsAssembly: true,
             MetadataOffset: 1,
@@ -300,7 +308,7 @@ public class MetadataImageOverviewRendererTests
     [Fact]
     public void HeapValue_MarkdownEchoesTheAddressItAnswered()
     {
-        var value = new MetadataValue.HeapReference(HeapKind.String, 42, 5, "hello", "hello", Truncated: false);
+        var value = new MetadataValue.HeapReference(HeapKind.String, 42, 5, Cell("hello"), Cell("hello"), Truncated: false);
 
         string markdown = RenderHeap(value, HeapKind.String, 42, MetadataTableFormat.Markdown);
 
@@ -311,7 +319,7 @@ public class MetadataImageOverviewRendererTests
     [Fact]
     public void HeapValue_MarksATruncatedPreviewSoItIsNotReadAsWhole()
     {
-        var value = new MetadataValue.HeapReference(HeapKind.Blob, 7, 64, null, "0011", Truncated: true);
+        var value = new MetadataValue.HeapReference(HeapKind.Blob, 7, 64, null, Cell("0011"), Truncated: true);
 
         string markdown = RenderHeap(value, HeapKind.Blob, 7, MetadataTableFormat.Markdown);
 
@@ -322,7 +330,7 @@ public class MetadataImageOverviewRendererTests
     [Fact]
     public void HeapValue_KeepsAMalformedReadVisible()
     {
-        var value = new MetadataValue.Malformed("past the end");
+        var value = new MetadataValue.Malformed(Cell("past the end"));
 
         string markdown = RenderHeap(value, HeapKind.Guid, 99, MetadataTableFormat.Markdown);
 
@@ -341,7 +349,7 @@ public class MetadataImageOverviewRendererTests
     [Fact]
     public void HeapValue_JsonlIsSelfDescribing()
     {
-        var value = new MetadataValue.HeapReference(HeapKind.UserString, 1, 3, "abc", "abc", Truncated: false);
+        var value = new MetadataValue.HeapReference(HeapKind.UserString, 1, 3, Cell("abc"), Cell("abc"), Truncated: false);
 
         string jsonl = RenderHeap(value, HeapKind.UserString, 1, MetadataTableFormat.Jsonl);
 

--- a/tests/DotnetInspector.MetadataRendering.Tests/MetadataProjectionRendererTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/MetadataProjectionRendererTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata.Ecma335;
 using ILInspector.Metadata;
+using InertText;
 
 namespace DotnetInspector.MetadataRendering.Tests;
 
@@ -12,6 +13,14 @@ namespace DotnetInspector.MetadataRendering.Tests;
 /// </summary>
 public class MetadataProjectionRendererTests
 {
+
+    /// <summary>
+    /// Builds fixture cell text through the projector's own containment, so a fixture
+    /// can never assert on a spelling the product would not produce — and cannot
+    /// fabricate a value that claims to be truncated without having been cut.
+    /// </summary>
+    static InertString Cell(string value, int maxChars = int.MaxValue)
+        => MetadataTableProjector.ContainCellText(value, maxChars);
     static string Render(MetadataTableProjection projection, MetadataTableFormat format = MetadataTableFormat.Markdown)
     {
         var writer = new StringWriter();
@@ -42,7 +51,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Name", MetadataColumnKind.Heap),
-            new MetadataValue.HeapReference(HeapKind.String, 10, 6, "System", "System", Truncated: false));
+            new MetadataValue.HeapReference(HeapKind.String, 10, 6, Cell("System"), Cell("System"), Truncated: false));
 
         var markdown = Render(projection);
 
@@ -61,7 +70,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Extends", MetadataColumnKind.Handle),
-            new MetadataValue.Malformed("Handle 0x02000099 targets TypeDef row 153, outside [1, 40]."));
+            new MetadataValue.Malformed(Cell("Handle 0x02000099 targets TypeDef row 153, outside [1, 40].")));
 
         var markdown = Render(projection);
 
@@ -75,7 +84,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Name", MetadataColumnKind.Heap),
-            new MetadataValue.HeapReference(HeapKind.String, 0, 100, "abc", "abc", Truncated: true));
+            new MetadataValue.HeapReference(HeapKind.String, 0, 100, Cell("abc"), Cell("abc"), Truncated: true));
 
         Assert.Contains("abc\u2026", Render(projection));
     }
@@ -86,7 +95,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Signature", MetadataColumnKind.Heap),
-            new MetadataValue.HeapReference(HeapKind.Blob, 0, 3, Text: null, "0A1B2C", Truncated: false));
+            new MetadataValue.HeapReference(HeapKind.Blob, 0, 3, Text: null, Cell("0A1B2C"), Truncated: false));
 
         Assert.Contains("0A1B2C", Render(projection));
     }
@@ -97,7 +106,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Extends", MetadataColumnKind.Handle),
-            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 5, 0x01000005, "System.Object")));
+            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 5, 0x01000005, Cell("System.Object"))));
 
         Assert.Contains("TypeRef[5] (System.Object)", Render(projection));
     }
@@ -119,7 +128,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Extends", MetadataColumnKind.Handle),
-            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 19, 0x01000013, "Sys", DisplayTruncated: true)));
+            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 19, 0x01000013, Cell("System.Object", 3))));
 
         Assert.Contains("TypeRef[19] (Sys\u2026)", Render(projection));
     }
@@ -132,7 +141,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Extends", MetadataColumnKind.Handle),
-            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 19, 0x01000013, "", DisplayTruncated: true)));
+            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 19, 0x01000013, Cell("System.Object", 0))));
 
         Assert.Contains("TypeRef[19] (\u2026)", Render(projection));
     }
@@ -143,7 +152,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Extends", MetadataColumnKind.Handle),
-            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 19, 0x01000013, Display: null, DisplayTruncated: false)));
+            new MetadataValue.Handle(new HandleRef(TableIndex.TypeRef, 19, 0x01000013, Display: null)));
 
         var markdown = Render(projection);
 
@@ -179,7 +188,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Name", MetadataColumnKind.Heap),
-            new MetadataValue.HeapReference(HeapKind.String, 0, 6, "System", "System", Truncated: false),
+            new MetadataValue.HeapReference(HeapKind.String, 0, 6, Cell("System"), Cell("System"), Truncated: false),
             truncation: new MetadataTableTruncation(1, 40),
             rowCount: 40);
 
@@ -192,7 +201,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Name", MetadataColumnKind.Heap),
-            new MetadataValue.HeapReference(HeapKind.String, 0, 6, "System", "System", Truncated: false));
+            new MetadataValue.HeapReference(HeapKind.String, 0, 6, Cell("System"), Cell("System"), Truncated: false));
 
         var tsv = Render(projection, MetadataTableFormat.Tsv);
 
@@ -211,7 +220,7 @@ public class MetadataProjectionRendererTests
         var projection = OneCell(
             "TypeDef",
             Column("Name", MetadataColumnKind.Heap),
-            new MetadataValue.HeapReference(HeapKind.String, 0, 6, "System", "System", Truncated: false));
+            new MetadataValue.HeapReference(HeapKind.String, 0, 6, Cell("System"), Cell("System"), Truncated: false));
 
         var jsonl = Render(projection, MetadataTableFormat.Jsonl);
 

--- a/tests/DotnetInspector.MetadataRendering.Tests/OversizedMetadataVersionTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/OversizedMetadataVersionTests.cs
@@ -48,7 +48,7 @@ public sealed class OversizedMetadataVersionTests(OversizedVersionFixture fixtur
 
         Assert.NotNull(overview);
         Assert.True(
-            overview.MetadataVersionTruncated,
+            overview.MetadataVersion.IsTruncated,
             "A stamp too long to neutralize within the budget must be reported as truncated.");
         Assert.Equal(OversizedVersionFixture.Budget, overview.MetadataVersion.Length);
     }
@@ -88,8 +88,8 @@ public sealed class OversizedMetadataVersionTests(OversizedVersionFixture fixtur
         var overview = MetadataImageInspector.Describe(peReader);
 
         Assert.NotNull(overview);
-        Assert.False(overview.MetadataVersionTruncated);
-        Assert.DoesNotContain('…', overview.MetadataVersion);
+        Assert.False(overview.MetadataVersion.IsTruncated);
+        Assert.DoesNotContain('…', overview.MetadataVersion.ToString());
     }
 
     /// <summary>

--- a/tests/DotnetInspector.MetadataRendering.Tests/OversizedMetadataVersionTests.cs
+++ b/tests/DotnetInspector.MetadataRendering.Tests/OversizedMetadataVersionTests.cs
@@ -24,8 +24,8 @@ namespace DotnetInspector.MetadataRendering.Tests;
 /// That makes an oversized stamp reachable in exactly the population this code
 /// exists to survive — malformed images — so the truncation must be visible
 /// rather than silent. This fixture is what proves the state is reachable at
-/// all; without it, the `MetadataVersionTruncated` flag would be dead code that
-/// no test could distinguish from a constant `false`.
+/// all; without it, `MetadataVersion.IsTruncated` would be dead code that no
+/// test could distinguish from a constant `false`.
 /// </para>
 /// <para>
 /// The fixture technique came from the adversarial review of PR #3518, which
@@ -37,8 +37,9 @@ public sealed class OversizedMetadataVersionTests(OversizedVersionFixture fixtur
 {
     /// <summary>
     /// The metadata layer must report that it clipped the value. Everything
-    /// downstream keys off this flag, so if `Describe` does not set it, no
-    /// renderer can mark the value however carefully it is written.
+    /// downstream keys off the contained value's own `IsTruncated`, so if
+    /// `Describe` clips without recording it, no renderer can mark the value
+    /// however carefully it is written.
     /// </summary>
     [Fact]
     public void Describe_ReportsTheStampAsTruncated()
@@ -57,7 +58,7 @@ public sealed class OversizedMetadataVersionTests(OversizedVersionFixture fixtur
     /// The end-to-end claim, and the one that matters to a reader: the rendered
     /// stamp carries the ellipsis, so a 1530-character prefix cannot be mistaken
     /// for the whole 1547-character value. Asserted through `mdi` rather than the
-    /// renderer alone so the flag is proven to survive the whole path.
+    /// renderer alone so the truncation is proven to survive the whole path.
     /// </summary>
     [Fact]
     public void Overview_RendersTheTruncationMarkerSoAPrefixIsNotReadAsTheWholeStamp()

--- a/tests/ILInspector.Metadata.Tests/MdvOracleComparisonTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MdvOracleComparisonTests.cs
@@ -149,7 +149,7 @@ public class MdvOracleComparisonTests
         Assert.Equal(HeapKind.Guid, mvid.Heap);
 
         // Two independent Guid-heap decodes of the same image must agree.
-        Assert.Equal(guidMatch.Groups[1].Value, mvid.Text, ignoreCase: true);
+        Assert.Equal(guidMatch.Groups[1].Value, mvid.Text!.Value.ToString(), ignoreCase: true);
     }
 
     [Fact]
@@ -165,7 +165,7 @@ public class MdvOracleComparisonTests
 
         var assemblyRef = Assert.Single(Project().Tables, table => table.Name == "AssemblyRef");
         var names = assemblyRef.Rows
-            .Select(row => (Cell(assemblyRef, row, "Name") as MetadataValue.HeapReference)?.Text)
+            .Select(row => (Cell(assemblyRef, row, "Name") as MetadataValue.HeapReference)?.Text?.ToString())
             .Where(text => text is not null)
             .Select(text => text!)
             .ToHashSet(StringComparer.Ordinal);

--- a/tests/ILInspector.Metadata.Tests/MetadataCellContainmentTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataCellContainmentTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using InertText;
 
 namespace ILInspector.Metadata.Tests;
 
@@ -32,7 +33,7 @@ public class MetadataCellContainmentTests
     /// some fixture happens to hold.
     /// </summary>
     static string Contain(string value, int maxChars = 4096)
-        => MetadataTableProjector.ContainCellText(value, maxChars, out _);
+        => MetadataTableProjector.ContainCellText(value, maxChars).ToString();
 
     /// <summary>
     /// The categories a scalar must not reach a sink in, and why each one matters.
@@ -166,11 +167,13 @@ public class MetadataCellContainmentTests
     public void ATruncatedCellNeverStrandsAPartialSpelling()
     {
         const string raw = "ab\u202Ecd\u2028ef";
-        int whole = MetadataTableProjector.ContainCellText(raw, int.MaxValue, out _).Length;
+        int whole = MetadataTableProjector.ContainCellText(raw, int.MaxValue).Length;
 
         for (int budget = 0; budget <= 32; budget++)
         {
-            string emitted = MetadataTableProjector.ContainCellText(raw, budget, out bool truncated);
+            InertString contained = MetadataTableProjector.ContainCellText(raw, budget);
+            string emitted = contained.ToString();
+            bool truncated = contained.IsTruncated;
 
             Assert.True(emitted.Length <= budget, $"Budget {budget} emitted {emitted.Length} chars.");
             Assert.DoesNotContain('\u202E', emitted);

--- a/tests/ILInspector.Metadata.Tests/MetadataImageOverviewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataImageOverviewTests.cs
@@ -110,7 +110,7 @@ public class MetadataImageOverviewTests
 
         var overview = DescribeSelf(peReader);
 
-        Assert.StartsWith("v", overview.MetadataVersion);
+        Assert.StartsWith("v", overview.MetadataVersion.ToString());
         Assert.Equal(MetadataKind.Ecma335, overview.Kind);
         Assert.True(overview.IsAssembly);
     }
@@ -141,7 +141,7 @@ public class MetadataImageOverviewTests
 
         var overview = DescribeSelf(peReader);
 
-        Assert.Equal(reader.MetadataVersion, overview.MetadataVersion);
+        Assert.Equal(reader.MetadataVersion, overview.MetadataVersion.ToString());
         Assert.Equal(peReader.PEHeaders.MetadataStartOffset, overview.MetadataOffset);
         Assert.Equal(peReader.PEHeaders.MetadataSize, overview.MetadataSize);
     }
@@ -487,7 +487,7 @@ public class MetadataImageOverviewTests
         Assert.Equal(HeapKind.UserString, heapValue.Heap);
         Assert.Equal(1, heapValue.Offset);
         Assert.NotNull(heapValue.Text);
-        Assert.NotEmpty(heapValue.Text);
+        Assert.False(heapValue.Text!.Value.IsEmpty);
     }
 
     [Theory]
@@ -542,8 +542,8 @@ public class MetadataImageOverviewTests
         var value = MetadataTableProjector.ReadHeapValue(peReader, HeapKind.Guid, address);
 
         var heapValue = Assert.IsType<MetadataValue.HeapReference>(value);
-        Assert.Equal(reader.GetGuid(mvid).ToString(), heapValue.Text);
-        Assert.NotEqual(Guid.Empty.ToString(), heapValue.Text);
+        Assert.Equal(reader.GetGuid(mvid).ToString(), heapValue.Text!.Value.ToString());
+        Assert.NotEqual(Guid.Empty.ToString(), heapValue.Text!.Value.ToString());
     }
 
     /// <summary>

--- a/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTableProjectionTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata.Ecma335;
+using InertText;
 
 namespace ILInspector.Metadata.Tests;
 
@@ -38,7 +39,7 @@ public class MetadataTableProjectionTests
         => row.Cells[ColumnIndex(table, column)];
 
     static string? StringText(MetadataTableView table, MetadataRow row, string column)
-        => (Cell(table, row, column) as MetadataValue.HeapReference)?.Text;
+        => (Cell(table, row, column) as MetadataValue.HeapReference)?.Text?.ToString();
 
     [Fact]
     public void Project_ProducesTablesInEcmaOrder()
@@ -70,7 +71,7 @@ public class MetadataTableProjectionTests
 
         var name = Assert.IsType<MetadataValue.HeapReference>(Cell(module, row, "Name"));
         Assert.Equal(HeapKind.String, name.Heap);
-        Assert.False(string.IsNullOrEmpty(name.Text));
+        Assert.False(name.Text!.Value.IsEmpty);
 
         var mvid = Assert.IsType<MetadataValue.HeapReference>(Cell(module, row, "Mvid"));
         Assert.Equal(HeapKind.Guid, mvid.Heap);
@@ -94,7 +95,7 @@ public class MetadataTableProjectionTests
         var extends = Assert.IsType<MetadataValue.Handle>(Cell(typeDef, row, "Extends"));
         Assert.Equal(TableIndex.TypeRef, extends.Reference.TargetTable);
         Assert.True(extends.Reference.TargetRowId >= 1);
-        Assert.Contains("Object", extends.Reference.Display);
+        Assert.Contains("Object", extends.Reference.Display!.Value.ToString());
 
         // MethodList is a contiguous run in the MethodDef table; this type has methods.
         var methods = Assert.IsType<MetadataValue.Range>(Cell(typeDef, row, "MethodList"));
@@ -112,7 +113,7 @@ public class MetadataTableProjectionTests
         var signature = Assert.IsType<MetadataValue.HeapReference>(Cell(methodDef, row, "Signature"));
         Assert.Equal(HeapKind.Blob, signature.Heap);
         Assert.Null(signature.Text);
-        Assert.False(string.IsNullOrEmpty(signature.Preview));
+        Assert.False(signature.Preview.IsEmpty);
     }
 
     [Fact]
@@ -220,7 +221,7 @@ public class MetadataTableProjectionTests
 
         var name = Assert.IsType<MetadataValue.HeapReference>(Cell(assembly, row, "Name"));
         Assert.Equal(HeapKind.String, name.Heap);
-        Assert.Equal("ILInspector.Metadata.Tests", name.Text);
+        Assert.Equal("ILInspector.Metadata.Tests", name.Text!.Value.ToString());
 
         // HashAlgId is a single-valued enum surfaced as a scalar with an additive
         // decoded name (SHA-1 is the csc default), not a bitflag set.
@@ -249,7 +250,7 @@ public class MetadataTableProjectionTests
         Assert.IsType<MetadataValue.Flags>(Cell(exportedType, row, "Attributes"));
 
         var @namespace = Assert.IsType<MetadataValue.HeapReference>(Cell(exportedType, row, "Namespace"));
-        Assert.Equal("ILInspector.Metadata", @namespace.Text);
+        Assert.Equal("ILInspector.Metadata", @namespace.Text!.Value.ToString());
 
         // A forwarded type's Implementation is an AssemblyRef edge to the defining
         // assembly; the column advertises the full Implementation coded-index set.
@@ -277,7 +278,7 @@ public class MetadataTableProjectionTests
             Assert.Contains(owner.Reference.TargetTable, new[] { TableIndex.TypeDef, TableIndex.MethodDef });
 
             var name = Assert.IsType<MetadataValue.HeapReference>(Cell(genericParam, row, "Name"));
-            Assert.False(string.IsNullOrEmpty(name.Text));
+            Assert.False(name.Text!.Value.IsEmpty);
         }
 
         var ownerColumn = genericParam.Columns[ColumnIndex(genericParam, "Owner")];
@@ -359,7 +360,7 @@ public class MetadataTableProjectionTests
         {
             // Length reports the full decoded size; the retained preview is bounded.
             Assert.True(heap.Length > 1);
-            Assert.False(string.IsNullOrEmpty(heap.Text));
+            Assert.False(heap.Text!.Value.IsEmpty);
         });
     }
 
@@ -386,6 +387,37 @@ public class MetadataTableProjectionTests
         });
     }
 
+    /// <summary>
+    /// A blob's partiality is established in bytes, before there is any text to bound,
+    /// so it cannot be recovered from the hex the projection carries.
+    /// </summary>
+    /// <remarks>
+    /// This is the gate for the claim in <c>docs/design/inert-text.md</c> that
+    /// <see cref="MetadataValue.HeapReference.Truncated"/> must stay a stored field
+    /// rather than being derived from its text the way <see cref="HandleRef.Display"/>'s
+    /// truncation now is. Deriving it would report a blob that lost most of its content
+    /// as whole, because the hex is a complete spelling of the bytes that were actually
+    /// read. If this test fails, the two notions of truncation have been conflated.
+    /// </remarks>
+    [Fact]
+    public void BlobTruncation_IsInvisibleToTheHexItProduces()
+    {
+        var methodDef = Table(
+            Project(new MetadataProjectionOptions { MaxPreviewBytes = 2 }),
+            TableIndex.MethodDef);
+
+        var clipped = methodDef.Rows
+            .Select(row => Cell(methodDef, row, "Signature"))
+            .OfType<MetadataValue.HeapReference>()
+            .Where(heap => heap.Truncated)
+            .ToList();
+
+        Assert.NotEmpty(clipped);
+        Assert.All(clipped, heap => Assert.False(
+            heap.Preview.IsTruncated,
+            "The hex spells every byte that was read, so the text cannot know bytes were dropped."));
+    }
+
     [Fact]
     public void HandleDisplay_RespectsStringBudgetWithExplicitTruncation()
     {
@@ -405,9 +437,9 @@ public class MetadataTableProjectionTests
 
         Assert.NotEmpty(references);
         Assert.All(references, reference => Assert.True(
-            reference.Display!.Length <= budget,
+            reference.Display!.Value.Length <= budget,
             $"Display '{reference.Display}' exceeds the {budget}-char budget."));
-        Assert.Contains(references, reference => reference.DisplayTruncated);
+        Assert.Contains(references, reference => reference.Display!.Value.IsTruncated);
     }
 
     [Fact]
@@ -427,7 +459,7 @@ public class MetadataTableProjectionTests
 
         Assert.NotEmpty(strings);
         Assert.All(strings, heap => Assert.True(
-            heap.Text!.Length <= budget,
+            heap.Text!.Value.Length <= budget,
             $"String preview '{heap.Text}' exceeds the {budget}-char budget."));
     }
 
@@ -445,20 +477,19 @@ public class MetadataTableProjectionTests
         const string emoji = "\U0001F600"; // one scalar, two UTF-16 code units
 
         // Budget 2: 'A' fits (1); the pair needs 2 more and is dropped as a unit.
-        string droppedText = MetadataTableProjector.ContainCellText(
-            "A" + emoji, 2, out bool droppedTruncated);
+        InertString dropped = MetadataTableProjector.ContainCellText("A" + emoji, 2);
+        string droppedText = dropped.ToString();
         Assert.Equal("A", droppedText);
-        Assert.True(droppedTruncated);
+        Assert.True(dropped.IsTruncated);
         Assert.DoesNotContain(droppedText, char.IsSurrogate);
 
         // Budget 3: 'A' plus the atomic pair fit exactly; nothing is truncated.
-        string keptText = MetadataTableProjector.ContainCellText(
-            "A" + emoji, 3, out bool keptTruncated);
-        Assert.Equal("A" + emoji, keptText);
-        Assert.False(keptTruncated);
+        InertString kept = MetadataTableProjector.ContainCellText("A" + emoji, 3);
+        Assert.Equal("A" + emoji, kept.ToString());
+        Assert.False(kept.IsTruncated);
 
         // A lone (unpaired) surrogate is contained, never emitted as raw text.
-        string loneText = MetadataTableProjector.ContainCellText("\uD83D", 10, out _);
+        string loneText = MetadataTableProjector.ContainCellText("\uD83D", 10).ToString();
         Assert.Equal(@"\uD83D", loneText);
         Assert.DoesNotContain(loneText, char.IsSurrogate);
     }


### PR DESCRIPTION
**Stack position: slice 2 of 2.** Parent: #3679 (targets `main`). This PR targets `fix/3628-metadata-lens-inert-text` and will retarget `main` when #3679 merges.

## What changes

#3679 fixed the leak: metadata cells are contained by category through `InertText` instead of a hand-written control-character range. This slice makes that containment a property of the model rather than a discipline each producer keeps.

Every field of the metadata projection that can hold artifact-derived text was a `string`, and the containment helper took an `InertString` apart one line after building it:

```csharp
internal static string ContainCellText(string value, int maxChars, out bool truncated)
{
    var contained = new InertString(TextPolicy.Field, value, maxChars);
    truncated = contained.IsTruncated;
    return contained.ToString();
}
```

Its only real content is the choice of `TextPolicy.Field`; the rest exists to split the value into a string and a flag that three records then stored separately. Now:

```csharp
internal static InertString ContainCellText(string value, int maxChars)
    => new(TextPolicy.Field, value, maxChars);
```

| Field | Was | Now |
| --- | --- | --- |
| `HeapReference.Text` / `.Preview` | `string?` / `string` | `InertString?` / `InertString` |
| `HandleRef.Display` | `string?` + `DisplayTruncated` | `InertString?` (flag deleted) |
| `MetadataImageOverview.MetadataVersion` | `string` + `MetadataVersionTruncated` | `InertString` (flag deleted) |
| `Malformed.Detail` | `string` | `InertString` |

`Malformed.Detail` is included because it splices a third party's exception message into a diagnostic produced *only* while describing an image that has already proved malformed, and the renderer prints it raw as `!malformed: {Detail}`. Whether SRM ever puts artifact bytes into a message is not a property this repository can pin; typing the field means it does not have to.

`Scalar.Display` and `Flags.Decoded` stay `string` — formatted numbers and BCL enum names, never heap content.

**The enforcement is now the compiler.** There is no conversion admitting a `string` into any of those fields, which is a stronger gate than any test for "no untreated metadata text reaches a sink".

## The one flag that survives, and why

The obvious next step is to delete every truncation field and read `IsTruncated` off the text. That is right for `HandleRef` and `MetadataImageOverview`, where a character budget is the only way a value can become partial. It is **wrong** for `HeapReference`:

```csharp
int take = Math.Min(length, Math.Max(0, options.MaxPreviewBytes));
byte[] bytes = blobReader.ReadBytes(take);
```

A blob preview is bounded in *bytes*, before there is any text at all, and `Convert.ToHexString` then produces a **complete** spelling of the bytes that were read. So `Preview.IsTruncated` is `false` for a blob that lost most of its content, and deriving the flag would report those blobs as whole. Confirmed live:

```
--max-bytes 2   | method\u202EINJECTED | 2000…  |
--max-bytes 64  | method\u202EINJECTED | 200001 |
```

`HeapReference.Truncated` therefore stays stored, meaning "this projected value is not the whole value", with two causes feeding it and only one visible in the text.

This is the same shape as the `_sourceLength` finding in #3679: a length or a flag is only meaningful in the units that produced it.

## Evidence

`BlobTruncation_IsInvisibleToTheHexItProduces` gates the distinction, and names itself as that gate in its doc comment. Tampering `BlobCell` to derive the flag from the hex **compiles** and reddens it plus `BlobBudget_ProjectsBoundedHexPreviewWithExplicitTruncation` and `ReadHeapValue_HonoursTheBlobPreviewBudget`.

End-to-end against an assembly carrying `U+202E`, `U+2028` and ESC in type, field and method names — **0** raw hazard bytes across Markdown, TSV and JSONL for TypeDef, Field, MethodDef and #Strings. Positive control: the payload renders as `Hostile\u202EINJECTED\u2028NEXT\^[ESC`. Truncation intact through every retyped path — heap text `Hostile…`, handle display `TypeRef[1] (Syst…)`, blob `2000…`.

Suites: Metadata **1302**, MetadataRendering **149**, InertText **362**, Services **357**, Analysis **584**, CLI **2008** — 0 failed. `-t:Rebuild` 9 warnings, matching baseline.

## Two things the retype surfaced

**A pinned invariant dissolved.** `MetadataImageOverview` was on the positional-record property-order deny list, with a comment explaining that `MetadataVersionTruncated` had to be declared next to `MetadataVersion` while being optional forced it last in the constructor — "the two orders cannot agree". They cannot agree *while the pair is split*. Uniting them removes the divergence, and the set-equality gate correctly failed until the entry was removed.

**A fixture was asserting an impossible state.** A renderer test built `Display: "", DisplayTruncated: true` — empty text claiming to have been cut. With `InertString` that cannot be written; the fixture now bounds real text to a real budget, so it exercises a value the projector can actually produce.

## Residual — deliberately not in this PR

- Containment boundaries beyond the metadata lens remain un-enumerated (`docs/design/inert-text.md` tracks 359 row-type columns via #3463 and 97 `Action<string>` sites via #3606).
- `MetadataRowReferences.ColumnName` stays `string`: column names are product-authored, not artifact-derived.

Refs #3628.
