### PR TITLE
Document why a renderer test assembly sees Metadata internals

### DIFF
--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -287,6 +287,17 @@ return new MetadataValue.HeapReference(
     HeapKind.String, HeapOffset(handle), raw.Length, text, text, text.IsTruncated);
 ```
 
+One consequence is worth stating, because it looks like an over-share until the
+alternative is written down. `ContainCellText` is `internal`, and the renderer's
+own test assembly reaches it through `InternalsVisibleTo` rather than
+constructing `new InertString(TextPolicy.Field, …)` in fixture code. A fixture
+spelled the second way pins the policy that was current when it was written, so
+changing `TextPolicy.Field` would leave every such fixture asserting the old
+policy while the product moved — the tests would stay green and mean less. The
+factory is the single place the policy is chosen, so tests should be made to go
+through it. Widening `InternalsVisibleTo` to the one assembly that needs it is a
+smaller surface than making the factory public.
+
 ### A partiality flag survives only where the text cannot know
 
 The tempting next step is to delete every truncation field and read

--- a/src/ILInspector.Metadata/ILInspector.Metadata.csproj
+++ b/src/ILInspector.Metadata/ILInspector.Metadata.csproj
@@ -16,6 +16,14 @@
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet-inspect.Tests" />
     <InternalsVisibleTo Include="ILInspector.Metadata.Tests" />
+    <!-- Crosses a subsystem boundary, unlike the two above, so it is worth
+         saying why. The renderer tests build projection fixtures, and a fixture
+         must be contained by the same policy the projector applies rather than
+         by a hand-rolled TextPolicy.Field in test code — otherwise the policy
+         could change and the fixtures would keep asserting the old one. This
+         grants exactly that: MetadataTableProjector.ContainCellText, the
+         product's own containment factory. Prefer widening this to making that
+         factory public; the alternative surface is larger, not smaller. -->
     <InternalsVisibleTo Include="DotnetInspector.MetadataRendering.Tests" />
   </ItemGroup>
 


### PR DESCRIPTION
Follow-up to #3687, raised from review feedback that the `InternalsVisibleTo` it added was an **undocumented widening**. That is a fair reading of the file:

```xml
<InternalsVisibleTo Include="dotnet-inspect.Tests" />
<InternalsVisibleTo Include="ILInspector.Metadata.Tests" />
<InternalsVisibleTo Include="DotnetInspector.MetadataRendering.Tests" />   <!-- why? -->
```

The first two are this project's own natural test assemblies. The third crosses a subsystem boundary, and it was the only entry with no justification — while the `ItemGroup` immediately below it does document its unusual cross-project `Compile Include`. The reason existed, but in the PR description, which is not where a reader of the csproj is standing.

## Why the widening is the right call

It grants exactly one thing: `MetadataTableProjector.ContainCellText`, the product's own containment factory, used by two renderer test files to build projection fixtures.

```
tests/DotnetInspector.MetadataRendering.Tests/MetadataProjectionRendererTests.cs:23
tests/DotnetInspector.MetadataRendering.Tests/MetadataImageOverviewRendererTests.cs:29
    => MetadataTableProjector.ContainCellText(value, maxChars);
```

This is the harness-boundary rule in `AGENTS.md`: a harness must exercise the product-owned capability rather than reconstructing it. The alternative is `new InertString(TextPolicy.Field, …)` spelled in fixture code — which pins the policy that was current when the fixture was written. Change `TextPolicy.Field` and every such fixture keeps asserting the old policy while the product moves. They stay green and mean less. The factory is the single place the policy is chosen, so fixtures should be made to go through it.

The other alternative is making `ContainCellText` public. That is a *larger* surface, not a smaller one — `InternalsVisibleTo` to the single assembly that needs it is the narrower option.

## Change

- Comment at the site in `src/ILInspector.Metadata/ILInspector.Metadata.csproj`, saying it crosses a boundary and why that is preferable to a public factory.
- A paragraph in `docs/design/inert-text.md`, in the "Carrying a contained value to the sink" section, since that section is written to read as the practice rather than as a changelog.

## Evidence

No behavior change — an XML comment and prose.

- `dotnet build dotnet-inspect.slnx -c Release` → **0 errors**
- `DotnetInspector.MetadataRendering.Tests` → **149 total, 0 failed** (the suite that would break if the grant stopped working)
- `npx markdownlint-cli docs/design/inert-text.md` → clean

## Review

**Trivial tier, no review round requested.** The diff is one XML comment and one documentation paragraph; there is no executable change, and the one thing that could plausibly break — the `InternalsVisibleTo` grant itself — is proven still working by the renderer suite compiling and passing.