### PR TITLE
Carry the Azure DevOps search fixes forward: string-serialised counts, and the real wire shape

### DIFF
--- a/src/NuGetFetch.Tests/NuGetApiTests.cs
+++ b/src/NuGetFetch.Tests/NuGetApiTests.cs
@@ -248,6 +248,59 @@ public class NuGetApiTests
     }
 
     [Fact]
+    public async Task GetSearchResponseAsync_StringSerialisedCounts_Parse()
+    {
+        // Azure DevOps proved a feed will spell a count as a string. Dropping totalHits
+        // from the model answered that field and only that field; totalDownloads and
+        // versions[].downloads are still counts, and both are Int64 -- the width most
+        // often serialised as a string to keep it out of a JavaScript double. A feed
+        // spelling either that way used to fail the whole document, taking every result
+        // with it. Issue #3417.
+        string json = """
+        {
+            "data": [
+                {
+                    "id": "Contoso.Internal",
+                    "version": "1.2.3",
+                    "totalDownloads": "9007199254740993",
+                    "versions": [{"version": "1.2.3", "downloads": "42"}]
+                }
+            ],
+            "totalHits": "0"
+        }
+        """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var result = await NuGetApi.GetSearchResponseAsync(stream, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        SearchResult hit = Assert.Single(result.Data);
+
+        // Larger than 2^53, so this also pins that the value survives as an Int64 rather
+        // than going through a double on the way in -- which is the reason a feed spells
+        // it as a string in the first place.
+        Assert.Equal(9007199254740993, hit.TotalDownloads);
+        Assert.Equal(42, Assert.Single(hit.Versions!).Downloads);
+    }
+
+    [Fact]
+    public async Task GetSearchResponseAsync_NumericCounts_StillParse()
+    {
+        // The other direction: nuget.org sends counts as numbers, and tolerating the
+        // string spelling must not cost that.
+        string json = """
+        {"data":[{"id":"Newtonsoft.Json","version":"13.0.3","totalDownloads":5000000,
+          "versions":[{"version":"13.0.3","downloads":7}]}]}
+        """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var result = await NuGetApi.GetSearchResponseAsync(stream, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        SearchResult hit = Assert.Single(result.Data);
+        Assert.Equal(5000000, hit.TotalDownloads);
+        Assert.Equal(7, Assert.Single(hit.Versions!).Downloads);
+    }
+
+    [Fact]
     public async Task GetVersionIndexAsync_MalformedJson_ReturnsNull()
     {
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes("{broken"));

--- a/src/NuGetFetch.Tests/NuGetApiTests.cs
+++ b/src/NuGetFetch.Tests/NuGetApiTests.cs
@@ -179,25 +179,72 @@ public class NuGetApiTests
         // Azure DevOps serialises totalHits as a string and reports "0" alongside a
         // populated data array. Modelling the field at all rejected the whole document.
         // Issue #3417.
+        //
+        // The payload is a real Azure DevOps Artifacts response captured off the wire,
+        // reduced only by sanitising the package identifiers. Keeping the members this
+        // host actually sends is the point: nuget.org sends none of "@context",
+        // "lastReopen" or "index", nor the empty "@id"/"registration"/"iconUrl" and the
+        // null "projectUrl"/"summary"/"title" on each hit. A fixture trimmed to the
+        // members the model happens to bind today would still pass if an unbound member
+        // later became bound to a non-nullable type, which is exactly how this feed
+        // broke the first time.
+        //
+        // Note "downloads" arrives as a real JSON number even on this host, so the
+        // string serialisation is specific to totalHits rather than general to the feed.
         string json = """
         {
+            "@context": {"@vocab": "http://schema.nuget.org/schema#"},
             "data": [
                 {
-                    "id": "Contoso.Internal",
-                    "version": "1.2.3",
-                    "versions": []
+                    "@id": "",
+                    "@type": "Package",
+                    "id": "Contoso.Internal.Core",
+                    "version": "9.0.0",
+                    "description": "Contoso.Internal.Core",
+                    "versions": [{"@id": "Contoso.Internal.Core", "downloads": 0, "version": "9.0.0"}],
+                    "authors": [],
+                    "iconUrl": "",
+                    "licenseUrl": "",
+                    "projectUrl": null,
+                    "registration": "",
+                    "summary": null,
+                    "tags": [],
+                    "title": null
+                },
+                {
+                    "@id": "",
+                    "@type": "Package",
+                    "id": "Contoso.Internal.Auth",
+                    "version": "13.4.0-preview.6",
+                    "description": "Contoso.Internal.Auth",
+                    "versions": [{"@id": "Contoso.Internal.Auth", "downloads": 0, "version": "13.4.0-preview.6"}],
+                    "authors": [],
+                    "iconUrl": "",
+                    "licenseUrl": "",
+                    "projectUrl": null,
+                    "registration": "",
+                    "summary": null,
+                    "tags": [],
+                    "title": null
                 }
             ],
+            "lastReopen": "2026-07-29T01:31:47.7885829Z",
+            "index": "PackageIndex",
             "totalHits": "0"
         }
         """;
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
         var result = await NuGetApi.GetSearchResponseAsync(stream, TestContext.Current.CancellationToken);
 
+        // Both hits survive a response whose own count claims there are none, which is
+        // the property that matters: Data is load bearing and totalHits is not merely
+        // mistyped on this host, it is wrong.
         Assert.NotNull(result);
-        Assert.Single(result.Data);
-        Assert.Equal("Contoso.Internal", result.Data[0].Id);
-        Assert.Equal("1.2.3", result.Data[0].Version);
+        Assert.Equal(2, result.Data.Count);
+        Assert.Equal("Contoso.Internal.Core", result.Data[0].Id);
+        Assert.Equal("9.0.0", result.Data[0].Version);
+        Assert.Equal("Contoso.Internal.Auth", result.Data[1].Id);
+        Assert.Equal("13.4.0-preview.6", result.Data[1].Version);
     }
 
     [Fact]

--- a/src/NuGetFetch/NuGetApi.cs
+++ b/src/NuGetFetch/NuGetApi.cs
@@ -43,7 +43,20 @@ public static class NuGetApi
         => await JsonSerializer.DeserializeAsync(json, NuGetJsonContext.Default.SearchResponse, cancellationToken).ConfigureAwait(false);
 }
 
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+// Feeds disagree about whether a JSON number is a number. Azure DevOps Artifacts
+// serialises counts as strings ("0"), which is a common way to keep 64-bit values
+// out of a JavaScript double; nuget.org sends them as numbers. Reading a count
+// strictly therefore rejects an otherwise valid document from a conforming feed,
+// and takes every result in it down with it -- that is how the Azure DevOps search
+// defect in issue #3417 presented. Modelling totalHits away fixed that field; the
+// remaining counts are the two members most likely to be spelled the same way,
+// because both are Int64. Accept either spelling for all of them, once, so the
+// next stringified count is not a second outage.
+//
+// This only affects reading. Nothing serialises through this context.
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    NumberHandling = JsonNumberHandling.AllowReadingFromString)]
 [JsonSerializable(typeof(ServiceIndex))]
 [JsonSerializable(typeof(VersionIndex))]
 [JsonSerializable(typeof(SearchResponse))]


### PR DESCRIPTION
Follows up [richlander/nuget-fetch#18](https://github.com/richlander/nuget-fetch/pull/18) by @rjmurillo, now that the standalone repo is retired and the vendored copy here is the surviving one.

Two commits, deliberately attributed differently:

- **Commit 2 transplants his test payload and is authored by him**, because it is his work carried across unchanged.
- **Commit 1 credits him as co-author, authored here.** The mechanism is his: he diagnosed the defect against a live feed and fixed it with `JsonNumberHandling.AllowReadingFromString`. What differs is placement — he annotated a single property, and that property does not exist in this copy, so the same option is set on the context instead. The scoping decision came out of reviewing his PR rather than from it, which is why the trailer says co-author rather than author.

## 1. Accept string-serialised counts from any feed

Issue #3417 was answered by **dropping `totalHits` from the model**. That was right for that member — nothing consumed it, and Azure DevOps reports `"0"` next to a populated `data` array, so it is untrustworthy even when it parses.

But it fixed the *instance*, not the *class*. Azure DevOps demonstrated that a feed will spell a count as a JSON string, and two counts are still modelled strictly: `SearchResult.TotalDownloads` and `SearchVersion.Downloads`. Both are `Int64` — the width most often serialised as a string precisely because it does not survive a JavaScript double.

Measured against the model as it stands today:

```text
totalHits as string (already fixed)  -> ok
totalDownloads as string             -> THREW JsonException
versions[].downloads as string       -> THREW JsonException
```

The throw is no longer silent, since swallowing was removed. But it still fails the whole document over a member nothing needed, and on the nuget.org fast path it surfaces as a bare parser message naming no feed (#3691).

Setting `NumberHandling` once on the context accepts either spelling for every number it reads. Reading only — nothing serialises through this context.

His PR fixed this with a per-property annotation. That spelling cannot come across, because the property it annotated no longer exists here; this generalises it to the members that remain.

## 2. Pin the fixture to the real wire shape

The existing Azure DevOps regression fixture was trimmed to the members the model binds today:

```json
{"data":[{"id":"Contoso.Internal","version":"1.2.3","versions":[]}],"totalHits":"0"}
```

Enough to show a string `totalHits` no longer rejects the document; not enough once the model changes. Every Azure DevOps-only member was absent — `@context`, `lastReopen`, `index`, the empty `@id`/`registration`/`iconUrl`, the null `projectUrl`/`summary`/`title`. Binding one of those to a non-nullable type would pass the old fixture and fail against the feed, which is the shape of the original defect rather than a hypothetical.

His payload is a real response captured off a live private Azure DevOps feed, reduced only by sanitising identifiers. It also carries a prerelease version next to a stable one, and asserts **two** hits survive a response whose own count claims there are none.

**Authored by @rjmurillo** — this is his payload, transplanted rather than rewritten.

## Verification

| Check | Result |
| --- | --- |
| `NuGetFetch.Tests` | 295 passed, 0 failed, 9 skipped |
| Mutation: remove `NumberHandling` | reddens `GetSearchResponseAsync_StringSerialisedCounts_Parse` |
| Mutation: re-model `TotalHits` as `int` | reddens the fixture test **and** `SearchAsync_AzureDevOpsResponse_ReturnsResults` |

Both directions are pinned: `..._StringSerialisedCounts_Parse` covers the feeds that stringify, `..._NumericCounts_StillParse` guards nuget.org against the added tolerance. The string case uses a value above 2^53 so it also pins that the count arrives as an `Int64`.

## Not in this PR

Reviewing #18 surfaced a live diagnostics defect: the nuget.org fast path lets `JsonException` out without naming the feed, while the multi-source path converts it into structured per-source detail. Filed as #3691.

