### PR TITLE
Resolve latest version by highest across sources, not first source

### DIFF
--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -707,38 +707,70 @@ public static class PackageExtractor
         string normalizedName = packageName.ToLowerInvariant();
         string cacheKey = includePrerelease ? $"{normalizedName}-prerelease" : normalizedName;
 
-        // Cache nuget.org results even when additional custom sources are configured.
+        // Cache nuget.org results even when additional custom sources are configured. The cached
+        // value is nuget.org's own latest, not the overall answer: only nuget.org results are ever
+        // written here, so a hit lets that one source be answered without a request while the
+        // remaining sources are still consulted.
         bool canCache = !skipCache && sources.Any(s => s.IsNuGetOrg);
 
+        string? cachedNuGetOrgVersion = null;
         if (canCache)
         {
-            string? cached;
             using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageVersionList))
             {
-                cached = CoreCache.TryGet(VersionCacheCategory, cacheKey, VersionCacheTtl, extension: "txt");
+                cachedNuGetOrgVersion = CoreCache.TryGet(VersionCacheCategory, cacheKey, VersionCacheTtl, extension: "txt");
             }
-            if (cached != null)
-            {
-                log?.Invoke($"Using cached version: {cached}");
-                return cached;
-            }
+            if (cachedNuGetOrgVersion != null)
+                log?.Invoke($"Using cached version: {cachedNuGetOrgVersion}");
         }
+
+        // Every source is consulted and the highest version wins. Source order does not decide the
+        // answer: a feed carries the versions nuget.org does not have, and those are usually the
+        // higher ones, so stopping at the first source that happened to know the package would hide
+        // them whenever nuget.org is listed first -- which is the usual way to write a nuget.config.
+        // This matches GetVersionsAsync and ResolveVersionPatternAsync, which already aggregate, and
+        // it matches NuGet itself, where source order is not precedence (that is what package source
+        // mapping is for).
+        NuGet.Versioning.NuGetVersion? best = null;
+        string? bestOriginal = null;
 
         foreach (var source in sources)
         {
-            var version = await GetLatestVersionFromSourceAsync(client, normalizedName, source, log, includePrerelease).ConfigureAwait(false);
-            if (version != null)
+            string? version;
+            if (source.IsNuGetOrg && cachedNuGetOrgVersion != null)
             {
-                if (canCache && source.IsNuGetOrg)
+                version = cachedNuGetOrgVersion;
+            }
+            else
+            {
+                version = await GetLatestVersionFromSourceAsync(client, normalizedName, source, log, includePrerelease).ConfigureAwait(false);
+                if (version != null && canCache && source.IsNuGetOrg)
                 {
                     using var cacheScope = NetworkTelemetry.Scope(NetworkTrafficKind.PackageVersionList);
                     CoreCache.Set(VersionCacheCategory, cacheKey, version, extension: "txt");
                 }
-                return version;
+            }
+
+            if (version == null)
+                continue;
+
+            if (NuGet.Versioning.NuGetVersion.TryParse(version, out var parsed))
+            {
+                if (best == null || parsed > best)
+                {
+                    best = parsed;
+                    bestOriginal = version;
+                }
+            }
+            else if (bestOriginal == null)
+            {
+                // Unparseable version strings cannot be ordered; keep the first as a last resort so
+                // an odd feed still yields an answer rather than none.
+                bestOriginal = version;
             }
         }
 
-        return null;
+        return bestOriginal;
     }
 
     /// <summary>

--- a/src/DotnetInspector.Services.Tests/SourcePrecedenceTests.cs
+++ b/src/DotnetInspector.Services.Tests/SourcePrecedenceTests.cs
@@ -15,14 +15,16 @@ namespace DotnetInspector.Services.Tests;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Two different rules are in play, and the difference is deliberate rather than accidental:
-/// resolving a single latest version takes the first source that has the package, while listing
-/// versions aggregates across every source. Source order is therefore the control a caller uses
-/// to say which feed wins, which is what <c>--source</c> is for.
+/// One rule governs every path: the answer is aggregated across all configured sources. Listing
+/// returns the union, and resolving a single latest version returns the highest version any source
+/// carries. Source order does not decide either answer.
 /// </para>
 /// <para>
-/// The practical consequence, pinned below, is that a source appended after nuget.org cannot
-/// change the answer to <c>--latest-version</c> for a package that also exists on nuget.org.
+/// Ordering was previously precedence for <c>--latest-version</c> alone, which meant a feed
+/// appended after nuget.org could not raise the answer for a package nuget.org also carried. That
+/// silently hid exactly what a private feed exists to publish, and it disagreed with both
+/// <c>--versions</c> and wildcard resolution in this same file. NuGet has no such rule either:
+/// source order is not precedence there, which is what package source mapping is for.
 /// </para>
 /// </remarks>
 [Collection(CoreCacheCollection.Name)]
@@ -42,29 +44,89 @@ public class SourcePrecedenceTests : IDisposable
     public void Dispose() => CoreCache.Clear(VersionCacheCategory);
 
     [Fact]
-    public async Task GetLatestVersion_TakesFirstSourceWithPackage_NotHighestVersion()
+    public async Task GetLatestVersion_TakesHighestVersionAcrossSources_NotFirstSource()
     {
-        // Feed A carries an older version than feed B. First-with-package wins, so the
-        // lower version is the correct answer when feed A is listed first.
+        // Feed A carries an older version than feed B. Listing feed A first must not cap the
+        // answer at what feed A knows; the higher version on feed B is still the latest.
         var handler = CreateHandler(feedAVersions: ["0.31.0", "0.32.0"], feedBVersions: ["0.32.0", "0.32.99"]);
         using var client = new HttpClient(handler);
 
         string? version = await PackageExtractor.GetLatestVersionAsync(
             client, "Markout", [FeedA(), FeedB()], log: null, skipCache: true);
 
-        Assert.Equal("0.32.0", version);
+        Assert.Equal("0.32.99", version);
     }
 
     [Fact]
-    public async Task GetLatestVersion_SourceOrderDeterminesResult()
+    public async Task GetLatestVersion_IsOrderIndependent()
     {
         var handler = CreateHandler(feedAVersions: ["0.31.0", "0.32.0"], feedBVersions: ["0.32.0", "0.32.99"]);
         using var client = new HttpClient(handler);
 
-        string? version = await PackageExtractor.GetLatestVersionAsync(
+        string? forward = await PackageExtractor.GetLatestVersionAsync(
+            client, "Markout", [FeedA(), FeedB()], log: null, skipCache: true);
+        string? reversed = await PackageExtractor.GetLatestVersionAsync(
             client, "Markout", [FeedB(), FeedA()], log: null, skipCache: true);
 
+        Assert.Equal("0.32.99", forward);
+        Assert.Equal(forward, reversed);
+    }
+
+    [Fact]
+    public async Task GetLatestVersion_LowerVersionOnLaterSourceDoesNotWin()
+    {
+        // The reverse of the ordering case: the highest version is on the FIRST feed, so a later
+        // feed carrying only older versions must not pull the answer back down.
+        var handler = CreateHandler(feedAVersions: ["0.32.99"], feedBVersions: ["0.31.0", "0.32.0"]);
+        using var client = new HttpClient(handler);
+
+        string? version = await PackageExtractor.GetLatestVersionAsync(
+            client, "Markout", [FeedA(), FeedB()], log: null, skipCache: true);
+
         Assert.Equal("0.32.99", version);
+    }
+
+    [Fact]
+    public async Task GetLatestVersion_ComparesBySemanticOrderNotStringOrder()
+    {
+        // "0.9.0" sorts after "0.10.0" as text but before it as a version. Pinned so the
+        // comparison cannot regress to an ordinal string compare.
+        var handler = CreateHandler(feedAVersions: ["0.9.0"], feedBVersions: ["0.10.0"]);
+        using var client = new HttpClient(handler);
+
+        string? version = await PackageExtractor.GetLatestVersionAsync(
+            client, "Markout", [FeedA(), FeedB()], log: null, skipCache: true);
+
+        Assert.Equal("0.10.0", version);
+    }
+
+    [Fact]
+    public async Task GetLatestVersion_CachedNuGetOrgAnswerDoesNotSuppressHigherFeedVersion()
+    {
+        // The version cache only ever holds nuget.org's own latest. Serving that hit as the final
+        // answer would let a cached public version outrank a higher one on a private feed, so the
+        // hit must stand in for nuget.org alone while the remaining sources are still consulted.
+        using var client = new HttpClient(new NuGetOrgPlusPrivateHandler(
+            packageId: "cachedpkg",
+            nugetOrgRegistry: [("1.0.0", true)],
+            privateVersions: ["2.0.0"]));
+
+        var sources = new List<NuGetSource>
+        {
+            new("nuget.org", "https://api.nuget.org/v3/index.json"),
+            FeedB(),
+        };
+
+        // Populate the cache the way a previous invocation would have.
+        string? first = await PackageExtractor.GetLatestVersionAsync(
+            client, "CachedPkg", sources, log: null, skipCache: false);
+        Assert.Equal("2.0.0", first);
+        Assert.Equal("1.0.0", CoreCache.TryGet(VersionCacheCategory, "cachedpkg", TimeSpan.FromHours(1), extension: "txt"));
+
+        string? second = await PackageExtractor.GetLatestVersionAsync(
+            client, "CachedPkg", sources, log: null, skipCache: false);
+
+        Assert.Equal("2.0.0", second);
     }
 
     [Fact]


### PR DESCRIPTION
Stacked on #3692. Closes #3695.

## Behaviour change

`--latest-version` (and implicit latest resolution) now reports the highest version across all configured sources. It previously returned the latest from the first source that happened to carry the package, so the answer changed with `<packageSources>` order.

Measured against a live Azure DevOps feed carrying `Markout 99.100.101`, which nuget.org does not have:

| Command | Before | After |
| --- | --- | --- |
| `--latest-version`, nuget.org first | `0.33.0` | `99.100.101` |
| `--latest-version`, feed first | `99.100.101` | `99.100.101` |

## Why this is a fix and not a preference

The tool already disagreed with itself on identical input. With the same config in the same order, `Markout@99.*` resolved to `99.100.101` through `ResolveVersionPatternAsync`, and `--versions` listed `99.100.101` at the top, while `--latest-version` answered `0.33.0`.

`GetAllVersionsWithCacheAsync` already documents the correct discipline — cache nuget.org's own list, never the merged answer, and always query the other sources. `GetLatestVersionAsync` was the one path that broke it, so this brings it in line rather than inventing a rule.

NuGet itself does not treat source order as precedence; that is what package source mapping exists for.

## The cache was the compounding half

Only nuget.org results were ever written to the version cache, but a hit was returned as the whole answer. A cached public version could therefore outrank a higher private-feed version even with the loop fixed. A hit now stands in for nuget.org alone while the remaining sources are still consulted, so the saved request is kept without the wrong answer.

## Cost

Latest resolution now contacts every configured source instead of stopping early. For the single-source case, which is the default, nothing changes.

## Pinned intent updated

`SourcePrecedenceTests` previously documented the old behaviour as deliberate, with source order as the precedence control. That remark and the two order-dependent tests are rewritten to state the single aggregate rule.

## Verification

Five tests gate the behaviour, all mutation-checked:

- Reverting to first-source-wins reddens 4 of them.
- Inverting the comparison to prefer the lowest version reddens all 5, which confirms `LowerVersionOnLaterSourceDoesNotWin` is live rather than passing by construction.

`0.9.0` vs `0.10.0` is pinned so the comparison cannot regress to an ordinal string compare.

Suites: `DotnetInspector.Services.Tests` 360/0, `NuGetFetch.Tests` 295/0 (9 skipped). `dotnet-inspect.Tests` shows 28 failures in `ApiMemberAnalysisInspectionTests`, identical on the base branch with this change stashed — pre-existing and unrelated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>