### PR TITLE
Document private feed setup, and which flow supplies the credential

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Method Body Inspection](design/method-body-inspection.md) | Target service seam for shared `member` and `library --il-offset` method-body facts and coordinate inspection. |
 | [Member Body Substrate](design/member-body-substrate.md) | One base for skeleton/full/merged/diff body rendering: `ApiType` shape, `MemberAnchor` address, one scope, and `MemberBody`'s scalar (whole-body) and vector (offset-keyed) shapes. |
 | [NuGet API](design/nuget.md) | NuGet API endpoints used by the tool. |
-| [NuGet Feed Authentication](design/nuget-authentication.md) | How feeds are authenticated: `nuget.config` credentials, credential provider discovery and the 401-driven plugin protocol, which mechanisms are silently ignored, and the hermetic/live test tiers. |
+| [NuGet Feed Authentication](design/nuget-authentication.md) | How feeds are authenticated: `nuget.config` credentials, credential provider discovery and the 401-driven plugin protocol, which flow supplies the credential in each environment, which mechanisms are silently ignored, and the hermetic/live test tiers. |
 | [Version Resolution](design/version-resolution.md) | Package/platform version and cache behavior. |
 | [Cache concurrency and publication](design/cache-concurrency.md) | Process-local single-flight, cross-process atomic publication, dependency overlap, and filesystem guarantees. |
 | [Assembly Inspection Query Model](design/assembly-inspection-query.md) | Target boundary where the CLI forms a query and the metadata/service layer resolves, opens, and returns the final shape (why the CLI should not hold a `PEReader`). |

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Progressive Disclosure](design/progressive-disclosure.md) | Current model for verbosity, `-D`/`-S`, opt-in sections, `-S @All`, counts, and row limits. |
 | [Bare `-S` Default View](design/info-view.md) | Bullseye questions and section profiles for curated high-density default views. |
 | [Platform Components](platform-components.md) | Accessing SDK libraries vs NuGet packages. |
+| [Private NuGet Feeds](private-feeds.md) | How to give the tool access to a private feed: installing a credential provider, unattended and CI setup, and the `nuget.config` fallback. |
 | [Signals](assembly-audit.md) | Understanding Signals output and network scope flags. |
 | [SourceLink Exposure](sourcelink-exposure.md) | Where SourceLink appears in package/library/type/member flows and how PDB/network costs are controlled. |
 | [PDB Acquisition](pdb-acquisition.md) | How symbols and SourceLink are resolved. |
@@ -71,7 +72,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Method Body Inspection](design/method-body-inspection.md) | Target service seam for shared `member` and `library --il-offset` method-body facts and coordinate inspection. |
 | [Member Body Substrate](design/member-body-substrate.md) | One base for skeleton/full/merged/diff body rendering: `ApiType` shape, `MemberAnchor` address, one scope, and `MemberBody`'s scalar (whole-body) and vector (offset-keyed) shapes. |
 | [NuGet API](design/nuget.md) | NuGet API endpoints used by the tool. |
-| [NuGet Feed Authentication](design/nuget-authentication.md) | How feeds are authenticated: `nuget.config` credentials, credential provider discovery and the 401-driven plugin protocol, which flow supplies the credential in each environment, which mechanisms are silently ignored, and the hermetic/live test tiers. |
+| [NuGet Feed Authentication](design/nuget-authentication.md) | How feeds are authenticated: `nuget.config` credentials, credential provider discovery and the 401-driven plugin protocol, which flow supplies the credential in each environment, which credential forms are supported, and the hermetic/live test tiers. See [Private NuGet Feeds](private-feeds.md) for setup instructions. |
 | [Version Resolution](design/version-resolution.md) | Package/platform version and cache behavior. |
 | [Cache concurrency and publication](design/cache-concurrency.md) | Process-local single-flight, cross-process atomic publication, dependency overlap, and filesystem guarantees. |
 | [Assembly Inspection Query Model](design/assembly-inspection-query.md) | Target boundary where the CLI forms a query and the metadata/service layer resolves, opens, and returns the final shape (why the CLI should not hold a `PEReader`). |

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -3,7 +3,9 @@
 How `dotnet-inspect` authenticates to a NuGet feed, which credential mechanisms it honors,
 and which it silently ignores.
 
-This document describes *what the tool does*. For what you *should* do — choosing between
+For instructions on setting up access to a private feed, see
+[Private NuGet Feeds](../private-feeds.md). This document describes *what the tool does*. For
+what you *should* do — choosing between
 Microsoft Entra tokens, PATs, service principals, and workload identity federation — follow
 the Azure DevOps guidance, which is authoritative and kept current:
 

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -68,77 +68,34 @@ or from the user-level config. Parsing lives in
 Note that the `%TOKEN%` placeholder above is *not* expanded — see the next section. It is
 written that way only to keep a secret out of the example.
 
-## Credential forms that are silently ignored
+## Supported credential forms
 
-A `nuget.config` can carry a credential in several forms. This tool parses one of them. The rest
-are read past without a word — no warning, no error — so someone whose credential works for
-`dotnet restore` can get an authentication failure here with nothing pointing at the cause.
-
-NuGet's own guidance in
+Two forms are supported: a credential provider, and `Username` with `ClearTextPassword` in
+`nuget.config`. NuGet's guidance in
 [Consuming packages from authenticated feeds](https://learn.microsoft.com/nuget/consume-packages/consuming-packages-authenticated-feeds#security-best-practices-for-managing-credentials)
-ranks those forms from most to least secure. Lining that ranking up against what this tool honors
-is the clearest statement of the gap:
+ranks the available forms from most to least secure. The two supported here are that ranking's
+first and last:
 
-| NuGet's rank | Mechanism | Supported here |
+| NuGet's rank | Mechanism | Supported |
 | --- | --- | --- |
-| 1, "highly recommended" | Credential provider | **Yes** — see [Credential providers](#credential-providers). |
-| 2 | Encrypted `<Password>` in `nuget.config` | **No** — only `ClearTextPassword` is parsed. `dotnet nuget add source --password` writes this form by default on Windows. |
-| 3 | `%VAR%` macros in `nuget.config` | **No** — values are taken verbatim, so the placeholder is sent as the password. |
-| 4 | `NuGetPackageSourceCredentials_<name>` | **No** — the environment is never consulted for credentials. |
-| 5, "only ... where no other secure option is available" | `Username` + `ClearTextPassword` | **Yes.** |
+| 1, "highly recommended" | Credential provider | Yes — see [Credential providers](#credential-providers). |
+| 2 | Encrypted `<Password>` in `nuget.config` | No. `dotnet nuget add source --password` writes this form by default on Windows. |
+| 3 | `%VAR%` macros in `nuget.config` | No. Values are taken verbatim, so the placeholder itself is sent as the password. |
+| 4 | `NuGetPackageSourceCredentials_<name>` | No. The environment is not consulted for credentials. |
+| 5, "only ... where no other secure option is available" | `Username` + `ClearTextPassword` | Yes. |
 
-The two supported mechanisms are the ranking's top and bottom. Rank 1 is the most secure where
-it is available; rank 5 is available everywhere. Ranks 2 through 4 remain unsupported, and are
-still dropped in silence.
+Rank 5 is supported because many feeds offer nothing else. Only three credential providers exist
+in the ecosystem — Azure Artifacts, AWS CodeArtifact, and MyGet, the last of which is Visual
+Studio-only. GitHub Packages, GitLab, Artifactory, Nexus, ProGet, Cloudsmith and Artifact
+Registry all authenticate with a token in `nuget.config`.
 
-### Why clear text is still supported
+Two forms absent from NuGet's list are also unsupported: a `ClearTextPassword` with no
+`Username`, since both halves are required even though Azure DevOps ignores the username, and
+userinfo in the source URL (`******host/...`), which is never turned into a header.
 
-The table invites the conclusion that `ClearTextPassword` should be dropped in favour of
-requiring a credential provider. It is worth recording why that has not been done: NuGet's
-ranking is security guidance, not availability guidance.
-
-NuGet's [list of credential providers](https://learn.microsoft.com/nuget/consume-packages/consuming-packages-authenticated-feeds#list-of-credential-providers)
-names three in the entire ecosystem — Azure Artifacts, AWS CodeArtifact, and MyGet, the last of
-which is Visual Studio-only and so does not apply to a CLI. Other feeds authenticate by putting
-a token in `nuget.config`:
-
-| Feed | If rank 5 were dropped |
-| --- | --- |
-| Azure Artifacts | Works — a cross-platform provider exists. |
-| AWS CodeArtifact | Mixed. Works with the provider; not with `aws codeartifact login`, which writes a plaintext token into the user-level `nuget.config` on Linux and macOS. |
-| GitHub Packages | Unsupported. PAT-only, no provider, and the documented setup command is `dotnet nuget add source --username U --password T --store-password-in-clear-text`. |
-| GitLab, Artifactory, Nexus, ProGet, Cloudsmith, Artifact Registry | Unsupported. No NuGet credential providers exist. |
-
-The mechanism NuGet ranks last is therefore the one with the widest reach, and for GitHub
-Packages it is the only documented option.
-
-The gap this document describes is not that rank 5 is supported. It is that rank 5 was, until
-recently, the only supported mechanism, and that a dropped credential cannot be told apart from
-a missing package. Credential provider support addresses the first point for Azure Artifacts and
-AWS CodeArtifact. It does not help GitHub Packages, where better diagnosis is the only remedy.
-
-Two mechanisms that are not on NuGet's list are also worth stating, because both look plausible
-and neither works: a `ClearTextPassword` with no `Username` (both halves are required, even
-though Azure DevOps ignores the username), and userinfo in the source URL
-(`https://user:pass@host/...`, which is never turned into a header).
-
-Every one of these is dropped without a diagnostic, so a source configured through an
-unsupported mechanism is read as though no credential were supplied at all.
-
-What that then looks like has changed. A source that answers 401 or 403 is now reported as
-unreadable rather than as a missing package, naming the source, the status, and the phase:
-
-```console
-$ dotnet-inspect package Markout --source https://pkgs.dev.azure.com/<org>/<project>/_packaging/<feed>/nuget/v3/index.json
-Error: Package 'markout' could not be resolved because a source requires credentials.
-  https://pkgs.dev.azure.com/<org>/<project>/_packaging/<feed>/nuget/v3/index.json — HTTP 401 Unauthorized while reading the service index
-The package may exist; the source was not readable. Supply credentials for this source and retry.
-```
-
-A genuine 404 still reports as *not found*, because that is the one status that means the
-package is actually absent. The remaining gap is narrower than it was: the credential is still
-dropped silently, but the resulting failure is no longer indistinguishable from a typo in the
-package name.
+A credential in an unsupported form is treated as though no credential were supplied. The form
+itself draws no diagnostic; what surfaces is the feed's response to an unauthenticated request,
+described under [Reporting an unreadable source](#reporting-an-unreadable-source).
 
 ## Credential providers
 

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -195,9 +195,85 @@ Credentials are requested with `IsNonInteractive` set and `CanShowDialog` clear,
 prompt. Cached credentials and tokens supplied through the environment still work; only
 interactive sign-in is withheld.
 
-On Linux the v2.0.2 Azure Artifacts tool package ships no `msalruntime.so`, so its interactive
-and broker paths throw `DllNotFoundException` regardless. Supplying
-`ARTIFACTS_CREDENTIALPROVIDER_ACCESSTOKEN` avoids those paths entirely.
+### How credentials arrive
+
+Everything above describes the channel. This describes who speaks on it, because the answer
+differs by environment, and "a credential provider supplies it" is not specific enough to act on.
+
+The Azure Artifacts provider resolves in two levels. The outer level chooses a *credential
+provider*, consulting the environment first and the hostname last:
+
+| Order | Provider | Selected when |
+| --- | --- | --- |
+| 1 | `VstsBuildTaskServiceEndpointCredentialProvider` | `ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS` is set |
+| 2 | `VstsBuildTaskCredentialProvider` | `ARTIFACTS_CREDENTIALPROVIDER_URI_PREFIXES` and `..._ACCESSTOKEN` are set |
+| 3 | `VstsCredentialProvider` | the host is a well-known Azure DevOps hostname |
+
+Only when the first two decline does the third run, and only then does MSAL enter the picture at
+all. Its inner chain of bearer token providers is tried in this order:
+
+`MSAL Service Principal` → `MSAL Managed Identity` → `MSAL Silent` → `MSAL Broker Interactive` →
+`MSAL Interactive` → `MSAL Device Code`
+
+Each inner provider logs itself as skipped when its configuration is absent, so `-V Debug` shows
+which link answered without needing source access.
+
+`VstsCredentialProvider` also issues its own unauthenticated request and reads the Entra authority
+out of the **401 response headers**. It is 401-driven internally, independently of
+[our handler](#preemptive-credentials-versus-401-driven-credentials).
+
+The flows, distinguished by what supplies the secret:
+
+| Flow | Driven by | Unattended |
+| --- | --- | --- |
+| `nuget.config` credential | the config file; no provider runs at all | yes |
+| Pipeline build identity | `ARTIFACTS_CREDENTIALPROVIDER_URI_PREFIXES` and `..._ACCESSTOKEN`, set by `NuGetAuthenticate@1` | yes |
+| Pre-minted token, supplied by hand | the same two variables, exported by a script | yes |
+| External feed endpoints | `ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS`: endpoint, username, password | yes |
+| Service principal and certificate | `ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS`: `clientId` plus `clientCertificateSubjectName` or `clientCertificateFilePath` | yes |
+| Silent | the MSAL token cache, populated by an earlier sign-in | only if warm |
+| Broker interactive, interactive, device code | a human | no |
+
+`MSAL Managed Identity` sits in the chain between the service principal and silent providers, but
+the provider's README documents no configuration for it, so it is deliberately absent from the
+table above rather than guessed at.
+
+Three consequences are worth stating plainly:
+
+- **In an Azure DevOps pipeline there is no secret to configure.** `NuGetAuthenticate@1` installs
+  the provider onto the agent for that run and points it at the build service identity, scoped by
+  **URL prefix** — a semicolon-separated host list, not a feed list. A feed outside those prefixes
+  falls through to the next provider, which is why a feed in another organization needs the
+  external-endpoints variable instead.
+- **`az login` does not help.** There is no Azure CLI credential provider, and the two token
+  caches are unrelated. A token from `az account get-access-token` has to be handed over
+  explicitly, either through the build-provider variables or as a `ClearTextPassword`.
+- **The certificate flow is the one that generalises.** It is configured once through an
+  environment variable, needs no interactive session, and every NuGet-aware tool on the machine
+  reads it from the same place. That is the mechanism for sharing one short-lived credential
+  across build tools, rather than teaching each tool separately.
+
+### The broker on Linux
+
+The MSAL paths of the v2.0.2 Azure Artifacts tool package do not work on a current Ubuntu, for two
+independent reasons that surface in that order:
+
+1. The package ships `runtimes/linux-x64/native/libmsalruntime.so`, but nothing places it beside
+   the entry assembly, so the load fails on a path that does not exist:
+   `.../tools/net8.0/any/libmsalruntime: cannot open shared object file`.
+2. Pointing `LD_LIBRARY_PATH` at that `runtimes/linux-x64/native` directory gets past the first
+   failure, and the load then fails on `libwebkit2gtk-4.0.so.37`. Ubuntu 24.04 ships only
+   `libwebkit2gtk-4.1-0`; the 4.0 ABI is gone, and only a transitional documentation package
+   still carries the old name.
+
+The consequence is worse than "interactive sign-in is unavailable", which would be unremarkable on
+a headless machine. The broker is initialised *before* `MSAL Silent` is attempted, so a GUI
+dependency removes the one MSAL path that is meant to be headless-safe, and the provider gives up
+having tried nothing that could have succeeded.
+
+Every unattended flow in the table above except `MSAL Silent` is unaffected, because none of them
+constructs an MSAL public client. Supplying a token through the build-provider variables sidesteps
+the area entirely.
 
 ## Preemptive credentials versus 401-driven credentials
 

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -68,12 +68,16 @@ or from the user-level config. Parsing lives in
 Note that the `%TOKEN%` placeholder above is *not* expanded — see the next section. It is
 written that way only to keep a secret out of the example.
 
-## What is ignored
+## Credential forms that are silently ignored
+
+A `nuget.config` can carry a credential in several forms. This tool parses one of them. The rest
+are read past without a word — no warning, no error — so someone whose credential works for
+`dotnet restore` can get an authentication failure here with nothing pointing at the cause.
 
 NuGet's own guidance in
 [Consuming packages from authenticated feeds](https://learn.microsoft.com/nuget/consume-packages/consuming-packages-authenticated-feeds#security-best-practices-for-managing-credentials)
-ranks credential mechanisms from most to least secure. Lining that ranking up against what this
-tool honors is the clearest statement of the gap:
+ranks those forms from most to least secure. Lining that ranking up against what this tool honors
+is the clearest statement of the gap:
 
 | NuGet's rank | Mechanism | Supported here |
 | --- | --- | --- |

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -191,7 +191,6 @@ The flows, distinguished by what supplies the secret:
 | --- | --- | --- |
 | `nuget.config` credential | the config file; no provider runs at all | yes |
 | Pipeline build identity | `ARTIFACTS_CREDENTIALPROVIDER_URI_PREFIXES` and `..._ACCESSTOKEN`, set by `NuGetAuthenticate@1` | yes |
-| Pre-minted token, supplied by hand | the same two variables, exported by a script | yes |
 | External feed endpoints | `ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS`: endpoint, username, password | yes |
 | Service principal and certificate | `ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS`: `clientId` plus `clientCertificateSubjectName` or `clientCertificateFilePath` | yes |
 | Silent | the MSAL token cache, populated by an earlier sign-in | only if warm |
@@ -206,8 +205,10 @@ Three consequences are worth stating plainly:
 - **In an Azure DevOps pipeline there is no secret to configure.** `NuGetAuthenticate@1` installs
   the provider onto the agent for that run and points it at the build service identity, scoped by
   **URL prefix** — a semicolon-separated host list, not a feed list. A feed outside those prefixes
-  falls through to the next provider, which is why a feed in another organization needs the
-  external-endpoints variable instead.
+  falls through to the next provider. The two build-provider variables can be exported by hand and
+  the provider honors them, but the provider's own documentation describes them only as the task's
+  mechanism; `ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS` is what it directs unattended
+  callers outside Azure DevOps Pipelines to use.
 - **`az login` does not help.** There is no Azure CLI credential provider, and the two token
   caches are unrelated. A token from `az account get-access-token` has to be handed over
   explicitly, either through the build-provider variables or as a `ClearTextPassword`.

--- a/docs/private-feeds.md
+++ b/docs/private-feeds.md
@@ -1,8 +1,8 @@
 # Using a Private NuGet Feed
 
-This document explains how to give dotnet-inspect access to a private NuGet feed.
+This document explains how to give `dotnet-inspect` access to a private NuGet feed.
 
-dotnet-inspect reads packages from the sources in your `nuget.config` — the same file
+`dotnet-inspect` reads packages from the sources in your `nuget.config` — the same file
 `dotnet restore` uses — so a feed that already works for `dotnet restore` usually works here too.
 A private feed needs credentials. There are two ways to supply them, and a credential provider is
 the one to prefer.
@@ -26,11 +26,15 @@ dotnet tool install --global Microsoft.Artifacts.CredentialProvider.NuGet.Tool
 There is no registration step, and nothing to add to `nuget.config`. NuGet discovers the provider
 by name on `PATH`.
 
-dotnet-inspect finds a provider the same way `dotnet restore` does: the `NUGET_NETCORE_PLUGIN_PATHS`
-and `NUGET_PLUGIN_PATHS` variables, then `~/.nuget/plugins/netcore/` and executables named
-`nuget-plugin-*` on `PATH`. It launches the one it finds as a separate process and asks it for
-credentials over the standard NuGet plugin protocol. A provider that already works for
-`dotnet restore` works here, with nothing further to install or configure.
+`dotnet-inspect` finds a provider the same way `dotnet restore` does: the
+`NUGET_NETCORE_PLUGIN_PATHS` and `NUGET_PLUGIN_PATHS` variables, then `~/.nuget/plugins/netcore/`
+and executables named `nuget-plugin-*` on `PATH`. It launches the one it finds as a separate
+process and asks it for credentials over the standard NuGet plugin protocol. Those routes are the
+ones implemented by NuGet's own
+[`PluginDiscoverer`](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs),
+which reads the same variables, scans `PATH`, and matches the same `nuget-plugin-` prefix. A
+provider that already works for `dotnet restore` works here, with nothing further to install or
+configure.
 
 Add the feed, with no credential in it:
 
@@ -38,7 +42,7 @@ Add the feed, with no credential in it:
 dotnet nuget add source https://pkgs.dev.azure.com/<org>/<project>/_packaging/<feed>/nuget/v3/index.json --name my-feed
 ```
 
-Then use dotnet-inspect normally:
+Then use `dotnet-inspect` normally:
 
 ```bash
 dotnet-inspect package MyCompany.Widgets
@@ -50,19 +54,23 @@ reuse it. On a headless machine, supply a token through the environment as shown
 
 ## Unattended and CI
 
-In Azure Pipelines, add `NuGetAuthenticate@1` before any step that runs dotnet-inspect. It
-installs the provider on the agent and points it at the build identity, so there is no token to
+In Azure Pipelines, add `NuGetAuthenticate@1` before any step that runs `dotnet-inspect` or
+`dotnet restore`. Both consume the same credentials from the same place, so one task covers both.
+It installs the provider on the agent and points it at the build identity, so there is no token to
 store anywhere:
 
 ```yaml
 - task: NuGetAuthenticate@1
+- script: dotnet restore
 - script: dotnet-inspect package MyCompany.Widgets
 ```
 
-Elsewhere, supply the token through `ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS`, the
-documented mechanism for unattended agents outside Azure DevOps Pipelines. It takes the feed's
-index URL as it appears in your `nuget.config`, so one form covers Azure Artifacts and every
-other feed the provider serves:
+Elsewhere, you need to supply the token yourself, through
+`ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS`. This is what the provider's documentation
+directs unattended agents outside Azure DevOps Pipelines to use — see
+[Other automated build scenarios](https://github.com/microsoft/artifacts-credprovider#other-automated-build-scenarios).
+It takes the feed's index URL as it appears in your `nuget.config`, so one form covers Azure
+Artifacts and every other feed the provider serves:
 
 ```bash
 export ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS='{"endpointCredentials":[{"endpoint":"https://example.com/index.json","username":"unused","password":"'"$TOKEN"'"}]}'
@@ -80,6 +88,11 @@ export ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS='{"endpointCredentials":[{"en
 
 Use `clientCertificateFilePath` instead of `clientCertificateSubjectName` to point at a
 certificate file rather than the certificate store.
+
+The examples above use `export`, the shell syntax. In PowerShell, set the same variables with
+`$env:ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS = '...'`, and in `cmd.exe` with
+`set ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS=...`. The variable names and the JSON
+are identical on every platform.
 
 ## Alternative: a credential in `nuget.config`
 
@@ -105,9 +118,18 @@ Four forms look like they should work here and do not:
 | Form | What happens |
 | --- | --- |
 | `%TOKEN%` macro | Not expanded. The literal text `%TOKEN%` is sent as the password. |
-| Encrypted `<Password>` | Not read. `dotnet nuget add source --password` writes this form by default on Windows; add `--store-password-in-clear-text`. |
+| Encrypted `<Password>` | Not read. See below. |
 | `NuGetPackageSourceCredentials_<name>` environment variable | Not read. |
 | A token in the source URL, `https://user:token@host/...` | Not read. Put it in `packageSourceCredentials`. |
+
+The encrypted `<Password>` form is the one most likely to catch you out, because
+`dotnet nuget add source --password` writes it by default on Windows. It is encrypted with a
+Windows-only, user-specific mechanism, so the value cannot be read on Linux or macOS, cannot be
+read by a different user, and cannot be copied between machines. NuGet itself gives up on it with
+*"Password decryption is not supported on .NET Core for this platform … You can use a clear text
+password as a workaround"*, and that workaround is what this tool supports. Pass
+`--store-password-in-clear-text` when adding the source, or write the `ClearTextPassword` entry
+by hand.
 
 This file holds a token in plain text, so it should not live inside a repository at all. NuGet
 discovers `nuget.config` by walking up from the working directory, which makes a working tree a

--- a/docs/private-feeds.md
+++ b/docs/private-feeds.md
@@ -1,0 +1,152 @@
+# Using a Private NuGet Feed
+
+This document explains how to give dotnet-inspect access to a private NuGet feed.
+
+dotnet-inspect reads packages from the sources in your `nuget.config` — the same file
+`dotnet restore` uses — so a feed that already works for `dotnet restore` usually works here too.
+A private feed needs credentials. There are two ways to supply them, and a credential provider is
+the one to prefer.
+
+Examples below run `dotnet-inspect` directly. With `dnx`, prefix each command with
+`dnx dotnet-inspect -y --`.
+
+## Recommended: a credential provider
+
+A credential provider is a small executable that NuGet asks for credentials when a feed answers
+401. It keeps the token out of your files, so there is nothing to accidentally commit, and it
+refreshes expired tokens without you editing anything.
+
+Providers exist for Azure Artifacts and AWS CodeArtifact. Install the Azure Artifacts one as a
+global tool:
+
+```bash
+dotnet tool install --global Microsoft.Artifacts.CredentialProvider.NuGet.Tool
+```
+
+There is no registration step, and nothing to add to `nuget.config`. NuGet discovers the provider
+by name on `PATH`.
+
+Add the feed, with no credential in it:
+
+```bash
+dotnet nuget add source https://pkgs.dev.azure.com/<org>/<project>/_packaging/<feed>/nuget/v3/index.json --name my-feed
+```
+
+Then use dotnet-inspect normally:
+
+```bash
+dotnet-inspect package MyCompany.Widgets
+```
+
+On a desktop machine the first run signs you in interactively and caches the token; later runs
+reuse it. On a headless machine, supply a token through the environment as shown under
+[Unattended and CI](#unattended-and-ci).
+
+## Unattended and CI
+
+In Azure Pipelines, add `NuGetAuthenticate@1` before any step that runs dotnet-inspect. It
+installs the provider on the agent and points it at the build identity, so there is no token to
+store anywhere:
+
+```yaml
+- task: NuGetAuthenticate@1
+- script: dotnet-inspect package MyCompany.Widgets
+```
+
+Elsewhere, set the token in the environment. For feeds in one Azure DevOps organization:
+
+```bash
+export ARTIFACTS_CREDENTIALPROVIDER_URI_PREFIXES="https://pkgs.dev.azure.com/<org>/"
+export ARTIFACTS_CREDENTIALPROVIDER_ACCESSTOKEN="$TOKEN"
+```
+
+For any other feed, including one in a different organization:
+
+```bash
+export ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS='{"endpointCredentials":[{"endpoint":"https://example.com/index.json","username":"unused","password":"'"$TOKEN"'"}]}'
+```
+
+To authenticate as a service principal with a certificate — no interactive session, and every
+NuGet tool on the machine picks it up from the same place:
+
+```bash
+export ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS='{"endpointCredentials":[{"endpoint":"https://example.com/index.json","clientId":"<app-id>","clientCertificateSubjectName":"<subject>"}]}'
+```
+
+Use `clientCertificateFilePath` instead of `clientCertificateSubjectName` to point at a
+certificate file rather than the certificate store.
+
+## Alternative: a credential in `nuget.config`
+
+Use this when your feed has no credential provider. GitHub Packages, GitLab, Artifactory, Nexus,
+ProGet, Cloudsmith and Artifact Registry are all in this category.
+
+Both `Username` and `ClearTextPassword` are required, even for feeds that ignore the username:
+
+```xml
+<packageSourceCredentials>
+  <my-feed>
+    <add key="Username" value="unused" />
+    <add key="ClearTextPassword" value="YOUR_TOKEN" />
+  </my-feed>
+</packageSourceCredentials>
+```
+
+The source name inside `<packageSourceCredentials>` must match the `key` of the entry in
+`<packageSources>`.
+
+Four forms look like they should work here and do not:
+
+| Form | What happens |
+| --- | --- |
+| `%TOKEN%` macro | Not expanded. The literal text `%TOKEN%` is sent as the password. |
+| Encrypted `<Password>` | Not read. `dotnet nuget add source --password` writes this form by default on Windows; add `--store-password-in-clear-text`. |
+| `NuGetPackageSourceCredentials_<name>` environment variable | Not read. |
+| A token in the source URL, `https://user:token@host/...` | Not read. Put it in `packageSourceCredentials`. |
+
+This file holds a token in plain text, so keep it out of source control. If you keep it outside
+the normal discovery path, point at it explicitly:
+
+```bash
+dotnet-inspect package MyCompany.Widgets --nugetconfig ./private.nuget.config
+```
+
+## Checking a source without changing your config
+
+`--add-source` adds one feed for a single run, and `--source` replaces the configured sources
+entirely. Both are useful for confirming which feed answers:
+
+```bash
+dotnet-inspect package MyCompany.Widgets --add-source https://example.com/index.json
+```
+
+## When a feed cannot be read
+
+A source that requires credentials you have not supplied is reported as unreadable, naming the
+source and the status:
+
+```text
+Error: Package 'mycompany.widgets' could not be resolved because a source requires credentials.
+  https://example.com/index.json — HTTP 401 Unauthorized while reading the service index
+The package may exist; the source was not readable. Supply credentials for this source and retry.
+```
+
+This means the credential was missing, rejected, or written in one of the unsupported forms
+above. A package that is genuinely absent reports *not found* instead, so the two cases are
+distinguishable.
+
+### Linux
+
+Version 2.0.2 of the Azure Artifacts provider cannot start its MSAL paths on a current Ubuntu,
+because it depends on `libwebkit2gtk-4.0`, which Ubuntu 24.04 no longer ships. This affects
+interactive sign-in *and* the silent token-cache read, so the provider fails even when a valid
+cached token exists.
+
+Set the token in the environment instead, as under [Unattended and CI](#unattended-and-ci). The
+environment-driven paths do not use MSAL and are unaffected.
+
+## See also
+
+- [NuGet Feed Authentication](design/nuget-authentication.md) — how the tool authenticates, which
+  flow supplies the credential in each environment, and why each unsupported form behaves as it
+  does.

--- a/docs/private-feeds.md
+++ b/docs/private-feeds.md
@@ -53,18 +53,17 @@ store anywhere:
 - script: dotnet-inspect package MyCompany.Widgets
 ```
 
-Elsewhere, set the token in the environment. For feeds in one Azure DevOps organization:
-
-```bash
-export ARTIFACTS_CREDENTIALPROVIDER_URI_PREFIXES="https://pkgs.dev.azure.com/<org>/"
-export ARTIFACTS_CREDENTIALPROVIDER_ACCESSTOKEN="$TOKEN"
-```
-
-For any other feed, including one in a different organization:
+Elsewhere, supply the token through `ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS`, the
+documented mechanism for unattended agents outside Azure DevOps Pipelines. It takes the feed's
+index URL as it appears in your `nuget.config`, so one form covers Azure Artifacts and every
+other feed the provider serves:
 
 ```bash
 export ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS='{"endpointCredentials":[{"endpoint":"https://example.com/index.json","username":"unused","password":"'"$TOKEN"'"}]}'
 ```
+
+The username is not used by Azure DevOps. Any token the feed accepts works as the password,
+including a Microsoft Entra access token where personal access tokens are disabled.
 
 To authenticate as a service principal with a certificate — no interactive session, and every
 NuGet tool on the machine picks it up from the same place:

--- a/docs/private-feeds.md
+++ b/docs/private-feeds.md
@@ -26,6 +26,12 @@ dotnet tool install --global Microsoft.Artifacts.CredentialProvider.NuGet.Tool
 There is no registration step, and nothing to add to `nuget.config`. NuGet discovers the provider
 by name on `PATH`.
 
+dotnet-inspect finds a provider the same way `dotnet restore` does: the `NUGET_NETCORE_PLUGIN_PATHS`
+and `NUGET_PLUGIN_PATHS` variables, then `~/.nuget/plugins/netcore/` and executables named
+`nuget-plugin-*` on `PATH`. It launches the one it finds as a separate process and asks it for
+credentials over the standard NuGet plugin protocol. A provider that already works for
+`dotnet restore` works here, with nothing further to install or configure.
+
 Add the feed, with no credential in it:
 
 ```bash
@@ -103,11 +109,16 @@ Four forms look like they should work here and do not:
 | `NuGetPackageSourceCredentials_<name>` environment variable | Not read. |
 | A token in the source URL, `https://user:token@host/...` | Not read. Put it in `packageSourceCredentials`. |
 
-This file holds a token in plain text, so keep it out of source control. If you keep it outside
-the normal discovery path, point at it explicitly:
+This file holds a token in plain text, so it should not live inside a repository at all. NuGet
+discovers `nuget.config` by walking up from the working directory, which makes a working tree a
+convenient place to put one and a dangerous one — a config written next to your code can be
+committed and published along with it.
+
+Put it in your user-level NuGet configuration instead, which applies to every project without
+sitting next to any of them. To keep it somewhere else entirely, point at it explicitly:
 
 ```bash
-dotnet-inspect package MyCompany.Widgets --nugetconfig ./private.nuget.config
+dotnet-inspect package MyCompany.Widgets --nugetconfig ~/private-feeds/nuget.config
 ```
 
 ## Checking a source without changing your config


### PR DESCRIPTION
Closes #3700.

The authentication design doc described the channel thoroughly and the speakers not at all. It
explained that the tool sends Basic and only Basic, how plugins are discovered, the JSON protocol,
and the 401-driven acquisition loop — but not which participant actually supplies a credential in
a given environment. The question that exposed the gap was "how does this work in a non-interactive
environment?", which the doc could not answer.

## What the new section says

The Azure Artifacts provider resolves in **two levels**, and the distinction carries the whole
answer. The outer level chooses a credential provider, consulting the environment first and the
hostname last:

| Order | Provider | Selected when |
| --- | --- | --- |
| 1 | `VstsBuildTaskServiceEndpointCredentialProvider` | `ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS` is set |
| 2 | `VstsBuildTaskCredentialProvider` | `ARTIFACTS_CREDENTIALPROVIDER_URI_PREFIXES` and `..._ACCESSTOKEN` are set |
| 3 | `VstsCredentialProvider` | the host is a well-known Azure DevOps hostname |

MSAL is reached only through #3. That is why an unattended caller which sets either of the first
two never constructs a public client, and never touches a token cache, a broker, or a browser.

The section then tabulates the flows by what supplies the secret, and records three consequences:
a pipeline has no secret to configure and is scoped by URL *prefix* rather than by feed; `az login`
does not help, because there is no Azure CLI provider and the caches are unrelated; and the
certificate flow is the one that generalises, since it is set once in the environment and every
NuGet-aware tool on the machine reads it from the same place.

## A correction

The doc claimed:

> On Linux the v2.0.2 Azure Artifacts tool package ships no `msalruntime.so`, so its interactive
> and broker paths throw `DllNotFoundException` regardless.

Wrong premise, right conclusion. The package **does** ship
`runtimes/linux-x64/native/libmsalruntime.so`, 35 MB of it. There are two ordered blockers:

1. Nothing places the library beside the entry assembly, so the probe fails on a path that does
   not exist — `.../tools/net8.0/any/libmsalruntime: cannot open shared object file`.
2. Pointing `LD_LIBRARY_PATH` at the native directory clears that, and the load then fails on
   `libwebkit2gtk-4.0.so.37`. Ubuntu 24.04 ships only `libwebkit2gtk-4.1-0`; the 4.0 ABI is gone
   and only a transitional documentation package still carries the name.

The detail worth keeping is not that interactive sign-in is unavailable — that is unremarkable on
a headless machine — but that the broker is initialised **before** `MSAL Silent` is attempted. A
GUI dependency removes the one MSAL path that is meant to be headless-safe, and the provider gives
up having tried nothing that could have worked.

## Restraint

`MSAL Managed Identity` appears in the observed chain, but the provider's README documents no
configuration for it. It is named as present and deliberately left out of the flow table rather
than guessed at.

## Verification

Every claim was measured on this machine rather than taken from documentation: the provider chain
and its skip messages from a standalone run at `-V Debug`; the two load failures from the run and
from a second run with `LD_LIBRARY_PATH` set; the shipped `.so` and its size from the tool store;
the absent 4.0 ABI from `apt-cache`; the variable names and JSON shapes from the provider's own
README. `markdownlint` passes on both changed files.

Docs only. No product change, so no tests were added.
