### PR TITLE
Acquire ilasm/ildasm and mdv from one script instead of three CI copies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,11 @@ jobs:
               eng/prepare-decompiler-opt-in-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
               eng/report-decompiler-opt-in-corpus-drift.sh) CODE=true ;;
+              # The test lane is what actually runs this script (the
+              # `Install ilasm/ildasm` step), so it is the only thing that can
+              # catch a break in it. Without this, a PR touching only the
+              # script skips that lane and `ci-required` passes on a `skipped`.
+              eng/restore-iltools.sh) CODE=true ;;
               # GateExpectedClassesTests lives in the fast lane and is the only
               # thing keeping this file honest against the pre-merge preset, so
               # editing the file must run the lane that validates it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,10 +388,15 @@ jobs:
       # --mdv matters here and nowhere else: this is the only workflow that runs
       # tests/ILInspector.Metadata.Tests, whose cross-implementation oracle
       # skips without it -- and a skipped oracle is a green leg that compared
-      # nothing. continue-on-error keeps a feed outage degrading to those skips
-      # rather than failing the lane, so read the step log before treating this
-      # leg as oracle-backed.
+      # nothing.
+      #
+      # continue-on-error lets the rest of the lane still report, so a feed
+      # outage does not cost every other result in the job. It does not make
+      # the failure survivable: `Check ilasm/ildasm/mdv result` below fails the
+      # lane once the tests have run. Losing oracle coverage must be red, not a
+      # quietly shorter skip list.
       - name: Install ilasm/ildasm/mdv
+        id: iltools
         continue-on-error: true
         shell: bash
         run: eng/restore-iltools.sh --rid ${{ matrix.rid }} --mdv >> "$GITHUB_PATH"
@@ -450,6 +455,16 @@ jobs:
       - name: Run IL round-trip tests (fast)
         if: matrix.rid == 'linux-x64' && needs.changes.outputs.ilroundtrip == 'true'
         run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- -trait- "Speed=Slow"
+
+      # Deliberately last: the suites above still report their results when
+      # acquisition fails, but the lane must not go green having silently traded
+      # its oracle comparisons for skips.
+      - name: Check ilasm/ildasm/mdv result
+        if: steps.iltools.outcome == 'failure'
+        run: |
+          echo "::error::Restoring ilasm/ildasm/mdv failed, so every test that uses them skipped." >&2
+          echo "This lane cannot certify oracle-backed results. See the 'Install ilasm/ildasm/mdv' step." >&2
+          exit 1
 
   # net10.0 fallback build coverage. The official non-AOT "any" package targets
   # the net10.0 LTS floor (Directory.Build.props), but the full test lane builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,11 +124,13 @@ jobs:
               eng/prepare-decompiler-opt-in-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
               eng/report-decompiler-opt-in-corpus-drift.sh) CODE=true ;;
-              # The test lane is what actually runs this script (the
-              # `Install ilasm/ildasm` step), so it is the only thing that can
-              # catch a break in it. Without this, a PR touching only the
-              # script skips that lane and `ci-required` passes on a `skipped`.
+              # The test lane is what actually runs these scripts (the
+              # `Install ilasm/ildasm` step and IlToolsActivationTests), so it
+              # is the only thing that can catch a break in them. Without this,
+              # a PR touching only a script skips that lane and `ci-required`
+              # passes on a `skipped`.
               eng/restore-iltools.sh) CODE=true ;;
+              eng/activate-iltools.sh) CODE=true ;;
               # GateExpectedClassesTests lives in the fast lane and is the only
               # thing keeping this file honest against the pre-merge preset, so
               # editing the file must run the lane that validates it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,26 +381,7 @@ jobs:
       - name: Install ilasm/ildasm
         continue-on-error: true
         shell: bash
-        run: |
-          RID=${{ matrix.rid }}
-          VERSION=11.0.0-preview.1.26104.118
-          PACKAGES_DIR=$(mktemp -d)
-          PROJ_DIR=$(mktemp -d)
-          cat > "$PROJ_DIR/iltools.csproj" <<EOF
-          <Project Sdk="Microsoft.NET.Sdk">
-            <PropertyGroup><TargetFramework>net11.0</TargetFramework></PropertyGroup>
-            <ItemGroup>
-              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILAsm" Version="[${VERSION}]" />
-              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILDAsm" Version="[${VERSION}]" />
-            </ItemGroup>
-          </Project>
-          EOF
-          dotnet restore "$PROJ_DIR/iltools.csproj" --packages "$PACKAGES_DIR" --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --source https://api.nuget.org/v3/index.json
-          ILASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ilasm/$VERSION/runtimes/$RID/native"
-          ILDASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ildasm/$VERSION/runtimes/$RID/native"
-          chmod +x "$ILASM_DIR"/* "$ILDASM_DIR"/* 2>/dev/null || true
-          echo "$ILASM_DIR" >> "$GITHUB_PATH"
-          echo "$ILDASM_DIR" >> "$GITHUB_PATH"
+        run: eng/restore-iltools.sh --rid ${{ matrix.rid }} >> "$GITHUB_PATH"
 
       - name: Run CLI tests (fast)
         run: dotnet run --project src/dotnet-inspect.Tests -c Release -- -trait- "Speed=Slow"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,10 @@ jobs:
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
               eng/report-decompiler-opt-in-corpus-drift.sh) CODE=true ;;
               # The test lane is what actually runs these scripts (the
-              # `Install ilasm/ildasm` step and IlToolsActivationTests), so it
-              # is the only thing that can catch a break in them. Without this,
-              # a PR touching only a script skips that lane and `ci-required`
-              # passes on a `skipped`.
+              # `Install ilasm/ildasm/mdv` step and IlToolsActivationTests), so
+              # it is the only thing that can catch a break in them. Without
+              # this, a PR touching only a script skips that lane and
+              # `ci-required` passes on a `skipped`.
               eng/restore-iltools.sh) CODE=true ;;
               eng/activate-iltools.sh) CODE=true ;;
               # GateExpectedClassesTests lives in the fast lane and is the only
@@ -385,10 +385,16 @@ jobs:
         if: steps.decompiler_pr_corpus.outcome == 'failure'
         run: exit 1
 
-      - name: Install ilasm/ildasm
+      # --mdv matters here and nowhere else: this is the only workflow that runs
+      # tests/ILInspector.Metadata.Tests, whose cross-implementation oracle
+      # skips without it -- and a skipped oracle is a green leg that compared
+      # nothing. continue-on-error keeps a feed outage degrading to those skips
+      # rather than failing the lane, so read the step log before treating this
+      # leg as oracle-backed.
+      - name: Install ilasm/ildasm/mdv
         continue-on-error: true
         shell: bash
-        run: eng/restore-iltools.sh --rid ${{ matrix.rid }} >> "$GITHUB_PATH"
+        run: eng/restore-iltools.sh --rid ${{ matrix.rid }} --mdv >> "$GITHUB_PATH"
 
       - name: Run CLI tests (fast)
         run: dotnet run --project src/dotnet-inspect.Tests -c Release -- -trait- "Speed=Slow"

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -119,26 +119,7 @@ jobs:
       - name: Install ilasm/ildasm
         continue-on-error: true
         shell: bash
-        run: |
-          RID=linux-x64
-          VERSION=11.0.0-preview.1.26104.118
-          PACKAGES_DIR=$(mktemp -d)
-          PROJ_DIR=$(mktemp -d)
-          cat > "$PROJ_DIR/iltools.csproj" <<EOF
-          <Project Sdk="Microsoft.NET.Sdk">
-            <PropertyGroup><TargetFramework>net11.0</TargetFramework></PropertyGroup>
-            <ItemGroup>
-              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILAsm" Version="[${VERSION}]" />
-              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILDAsm" Version="[${VERSION}]" />
-            </ItemGroup>
-          </Project>
-          EOF
-          dotnet restore "$PROJ_DIR/iltools.csproj" --packages "$PACKAGES_DIR" --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --source https://api.nuget.org/v3/index.json
-          ILASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ilasm/$VERSION/runtimes/$RID/native"
-          ILDASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ildasm/$VERSION/runtimes/$RID/native"
-          chmod +x "$ILASM_DIR"/* "$ILDASM_DIR"/* 2>/dev/null || true
-          echo "$ILASM_DIR" >> "$GITHUB_PATH"
-          echo "$ILDASM_DIR" >> "$GITHUB_PATH"
+        run: eng/restore-iltools.sh --rid linux-x64 >> "$GITHUB_PATH"
 
       - name: Run decompiler tests (slow gates except the multi-hour corpus sweep)
         run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- --gate no-corpus

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,26 +69,7 @@ jobs:
       - name: Install ilasm/ildasm
         continue-on-error: true
         shell: bash
-        run: |
-          RID=linux-x64
-          VERSION=11.0.0-preview.1.26104.118
-          PACKAGES_DIR=$(mktemp -d)
-          PROJ_DIR=$(mktemp -d)
-          cat > "$PROJ_DIR/iltools.csproj" <<EOF
-          <Project Sdk="Microsoft.NET.Sdk">
-            <PropertyGroup><TargetFramework>net11.0</TargetFramework></PropertyGroup>
-            <ItemGroup>
-              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILAsm" Version="[${VERSION}]" />
-              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILDAsm" Version="[${VERSION}]" />
-            </ItemGroup>
-          </Project>
-          EOF
-          dotnet restore "$PROJ_DIR/iltools.csproj" --packages "$PACKAGES_DIR" --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --source https://api.nuget.org/v3/index.json
-          ILASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ilasm/$VERSION/runtimes/$RID/native"
-          ILDASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ildasm/$VERSION/runtimes/$RID/native"
-          chmod +x "$ILASM_DIR"/* "$ILDASM_DIR"/* 2>/dev/null || true
-          echo "$ILASM_DIR" >> "$GITHUB_PATH"
-          echo "$ILDASM_DIR" >> "$GITHUB_PATH"
+        run: eng/restore-iltools.sh --rid linux-x64 >> "$GITHUB_PATH"
 
       - name: Run decompiler tests (including slow, excluding corpus sweep)
         # The multi-hour corpus sweep runs in the decompiler-corpus job so it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,9 +219,13 @@ The script pins the `ilasm`/`ildasm` version for CI and local runs alike;
 `ci.yml`, `deep-inspect.yml`, and `release.yml` invoke `eng/restore-iltools.sh`
 directly, appending its output to `$GITHUB_PATH` so the runner does the joining.
 Only `ci.yml` passes `--mdv`, because it is the only workflow that runs the
-metadata oracle suite. Those workflow steps are `continue-on-error`, so an
-acquisition failure in CI degrades to skips rather than a red run -- check the
-step's log before reading a green decompiler, IL-diff, or metadata leg as proof.
+metadata oracle suite. Its install step is `continue-on-error` so that a feed
+outage does not cost every other result in the lane, but `Check
+ilasm/ildasm/mdv result` runs after the suites and fails the lane if
+acquisition failed: losing oracle coverage is red, not a quietly shorter skip
+list. `deep-inspect.yml` and `release.yml` still degrade to skips, so read
+their step logs before treating a green decompiler or IL-diff leg as
+oracle-backed.
 
 The IL round-trip project has separate dependency restore and fast/full test
 commands; follow `tests/DotnetInspector.ILRoundtrip.Tests/README.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,14 +201,17 @@ that proved less than it appears to, so restore them before trusting a clean
 result:
 
 ```bash
-iltools="$(eng/restore-iltools.sh --mdv)"
-export PATH="$(printf '%s\n' "$iltools" | tr '\n' ':')$PATH"
+iltools="$(eng/restore-iltools.sh --mdv)" && [ -n "$iltools" ] &&
+    export PATH="$(printf '%s\n' "$iltools" | tr '\n' ':')$PATH"
 ```
 
-Assign first and export second. `export PATH="$(eng/restore-iltools.sh ...)"`
+The chaining is deliberate. `export PATH="$(eng/restore-iltools.sh ...)"`
 reports `export`'s exit status, not the script's, so a failed restore would
 look like success and leave you running tests whose oracles silently skip --
-the exact failure the script exists to prevent.
+the exact failure the script exists to prevent. Splitting the assignment out is
+not enough on its own: outside `set -e` a failed assignment does not stop the
+next command, and empty output would prepend an empty PATH entry, which means
+the current directory.
 
 The script pins the `ilasm`/`ildasm` version for CI and local runs alike;
 `ci.yml`, `deep-inspect.yml`, and `release.yml` invoke it rather than

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,23 +201,26 @@ that proved less than it appears to, so restore them before trusting a clean
 result:
 
 ```bash
-iltools="$(eng/restore-iltools.sh --mdv)" && [ -n "$iltools" ] &&
-    export PATH="$(printf '%s\n' "$iltools" | tr '\n' ':')$PATH"
+source eng/activate-iltools.sh --mdv
 ```
 
-The chaining is deliberate. `export PATH="$(eng/restore-iltools.sh ...)"`
-reports `export`'s exit status, not the script's, so a failed restore would
-look like success and leave you running tests whose oracles silently skip --
-the exact failure the script exists to prevent. Splitting the assignment out is
-not enough on its own: outside `set -e` a failed assignment does not stop the
-next command, and empty output would prepend an empty PATH entry, which means
-the current directory.
+`eng/restore-iltools.sh` does the acquisition and prints the directories;
+`eng/activate-iltools.sh` is the sourceable wrapper that puts them on PATH.
+Source the wrapper rather than assembling PATH by hand. A child process cannot
+change its parent's PATH, so the assembly has to happen in your shell, and
+every way of getting it wrong is silent -- a masked exit status, a lost
+trailing newline, or empty output prepending an empty PATH entry, which means
+the current directory. Each leaves a plausible PATH with no oracles on it. The
+wrapper is the one tested copy of that logic; `IlToolsActivationTests` in
+`src/dotnet-inspect.Tests` is its gate, and also fails if this documentation
+goes back to hand-rolling the assembly.
 
 The script pins the `ilasm`/`ildasm` version for CI and local runs alike;
-`ci.yml`, `deep-inspect.yml`, and `release.yml` invoke it rather than
-duplicating the restore. Those workflow steps are `continue-on-error`, so an
-acquisition failure in CI degrades to skips rather than a red run — check the
-step's log before reading a green decompiler or IL-diff leg as proof.
+`ci.yml`, `deep-inspect.yml`, and `release.yml` invoke `eng/restore-iltools.sh`
+directly, appending its output to `$GITHUB_PATH` so the runner does the joining.
+Those workflow steps are `continue-on-error`, so an acquisition failure in CI
+degrades to skips rather than a red run -- check the step's log before reading
+a green decompiler or IL-diff leg as proof.
 
 The IL round-trip project has separate dependency restore and fast/full test
 commands; follow `tests/DotnetInspector.ILRoundtrip.Tests/README.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,23 @@ the shipped CLI) is the worked example, and
 `docs/decompiler-correctness-pipeline.md` owns its host contract, its structural
 and semantic levels, and what to do when a fixture trips one.
 
-Some CLI tests require `ilasm`/`ildasm` and skip when those tools are absent.
+Some tests use external tools as independent oracles and **skip** when those
+tools are absent: `ilasm`/`ildasm` (CLI and decompiler suites) and `mdv`
+(the metadata projection oracle). A machine without them reports a green run
+that proved less than it appears to, so restore them before trusting a clean
+result:
+
+```bash
+eng/restore-iltools.sh --mdv   # prints the directories to add to PATH
+export PATH="$(eng/restore-iltools.sh --mdv | tr '\n' ':')$PATH"
+```
+
+The script pins the `ilasm`/`ildasm` version for CI and local runs alike;
+`ci.yml`, `deep-inspect.yml`, and `release.yml` invoke it rather than
+duplicating the restore. Those workflow steps are `continue-on-error`, so an
+acquisition failure in CI degrades to skips rather than a red run — check the
+step's log before reading a green decompiler or IL-diff leg as proof.
+
 The IL round-trip project has separate dependency restore and fast/full test
 commands; follow `tests/DotnetInspector.ILRoundtrip.Tests/README.md`.
 `ILInspector.Decompiler.Tests` composes `Speed` and `Area` traits and offers a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,9 +218,10 @@ goes back to hand-rolling the assembly.
 The script pins the `ilasm`/`ildasm` version for CI and local runs alike;
 `ci.yml`, `deep-inspect.yml`, and `release.yml` invoke `eng/restore-iltools.sh`
 directly, appending its output to `$GITHUB_PATH` so the runner does the joining.
-Those workflow steps are `continue-on-error`, so an acquisition failure in CI
-degrades to skips rather than a red run -- check the step's log before reading
-a green decompiler or IL-diff leg as proof.
+Only `ci.yml` passes `--mdv`, because it is the only workflow that runs the
+metadata oracle suite. Those workflow steps are `continue-on-error`, so an
+acquisition failure in CI degrades to skips rather than a red run -- check the
+step's log before reading a green decompiler, IL-diff, or metadata leg as proof.
 
 The IL round-trip project has separate dependency restore and fast/full test
 commands; follow `tests/DotnetInspector.ILRoundtrip.Tests/README.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,9 +201,14 @@ that proved less than it appears to, so restore them before trusting a clean
 result:
 
 ```bash
-eng/restore-iltools.sh --mdv   # prints the directories to add to PATH
-export PATH="$(eng/restore-iltools.sh --mdv | tr '\n' ':')$PATH"
+iltools="$(eng/restore-iltools.sh --mdv)"
+export PATH="$(printf '%s\n' "$iltools" | tr '\n' ':')$PATH"
 ```
+
+Assign first and export second. `export PATH="$(eng/restore-iltools.sh ...)"`
+reports `export`'s exit status, not the script's, so a failed restore would
+look like success and leave you running tests whose oracles silently skip --
+the exact failure the script exists to prevent.
 
 The script pins the `ilasm`/`ildasm` version for CI and local runs alike;
 `ci.yml`, `deep-inspect.yml`, and `release.yml` invoke it rather than

--- a/eng/activate-iltools.sh
+++ b/eng/activate-iltools.sh
@@ -76,15 +76,31 @@ fi
 # containing a glob metacharacter would be matched as a pattern by the first
 # and mangled by the second. Uses only builtins, like the rest of this file, so
 # it still works when the PATH being repaired is itself unusable.
+# Exact-element membership test against a PATH-shaped string. Deliberately
+# avoids both `case` patterns and unquoted word splitting, because a directory
+# containing a glob metacharacter would be matched as a pattern by the first
+# and mangled by the second. Uses only builtins, like the rest of this file, so
+# it still works when the PATH being repaired is itself unusable.
+#
+# Walks the string colon by colon rather than translating colons to newlines and
+# reading lines. `read` ends an element at a newline, so the newline form tears a
+# directory containing one into two entries -- and a directory *ending* in one
+# yields an empty element, which means the current directory.
 __iltools_path_has() {
-    local needle="$1" element haystack
-    haystack="${2-}"
-    while IFS= read -r element; do
+    local needle="$1" rest="${2-}" element
+
+    while :; do
+        element="${rest%%:*}"
+
         if [ "$element" = "$needle" ]; then
             return 0
         fi
-    done <<< "${haystack//:/$'\n'}"
-    return 1
+
+        case "$rest" in
+            *:*) rest="${rest#*:}" ;;
+            *) return 1 ;;
+        esac
+    done
 }
 
 # Printed on every failure that could have been caused by arguments, because
@@ -107,7 +123,7 @@ __iltools_activate() {
     # A function body so `local` keeps the sourcing shell's namespace clean and
     # a failure can `return`; `exit` here would close an interactive shell.
     local self dir script_dir restore out status joined line saw_entry
-    local element tail first arg
+    local element tail first arg rest
     local -a args=()
 
     # `source file` with no arguments leaves the sourcing script's own
@@ -129,7 +145,13 @@ __iltools_activate() {
         dir="."
     fi
 
-    script_dir="$(cd "$dir" && pwd)" || return 1
+    # CDPATH= disables `cd`'s alternate-directory search. With CDPATH set -- a
+    # common interactive setting, and this file is meant to be sourced
+    # interactively -- a match there makes `cd` print the resolved directory on
+    # stdout, which command substitution then captures ahead of `pwd`. The
+    # result is a two-line script_dir that resolves to nothing. `--` keeps a
+    # directory starting with `-` from being read as an option.
+    script_dir="$(CDPATH= cd -- "$dir" && pwd)" || return 1
     restore="$script_dir/restore-iltools.sh"
 
     if [ ! -x "$restore" ]; then
@@ -212,18 +234,24 @@ __iltools_activate() {
     # deleting the caller's.
     tail=""
     first=1
-    while IFS= read -r element; do
-        if __iltools_path_has "$element" "$joined"; then
-            continue
+    rest="$PATH"
+    while :; do
+        element="${rest%%:*}"
+
+        if ! __iltools_path_has "$element" "$joined"; then
+            if [ "$first" -eq 1 ]; then
+                tail="$element"
+                first=0
+            else
+                tail="$tail:$element"
+            fi
         fi
 
-        if [ "$first" -eq 1 ]; then
-            tail="$element"
-            first=0
-        else
-            tail="$tail:$element"
-        fi
-    done <<< "${PATH//:/$'\n'}"
+        case "$rest" in
+            *:*) rest="${rest#*:}" ;;
+            *) break ;;
+        esac
+    done
 
     if [ "$first" -eq 1 ]; then
         export PATH="$joined"

--- a/eng/activate-iltools.sh
+++ b/eng/activate-iltools.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Sourceable companion to eng/restore-iltools.sh: restores the external oracle
+# tools and puts them on PATH in the *current* shell.
+#
+#   source eng/activate-iltools.sh --mdv
+#
+# A child process cannot change its parent's PATH, so restore-iltools.sh can
+# only print the directories it restored and leave the caller to assemble them.
+# That assembly is deceptively easy to get wrong, and every way of getting it
+# wrong is silent:
+#
+#   * `export PATH="$(restore-iltools.sh)"` reports export's exit status, not
+#     the script's, so a failed restore looks like success.
+#   * Splitting the assignment out only helps under `set -e`; an interactive
+#     shell runs the export anyway.
+#   * Losing the trailing newline glues the last directory to the first
+#     pre-existing PATH entry, corrupting both.
+#   * Empty or whitespace-only output prepends an empty PATH entry, which means
+#     the current directory.
+#
+# In each case PATH looks plausible, the oracles are missing, and the suites
+# report a green run that proved nothing -- the exact failure restore-iltools.sh
+# exists to prevent. This file is that assembly, written once and enforced by
+# IlToolsActivationTests in src/dotnet-inspect.Tests, so the failure modes stay
+# fixed instead of being retyped correctly by every caller.
+#
+# CI does not need this file: `eng/restore-iltools.sh >> "$GITHUB_PATH"` hands
+# the lines to the runner, which does the joining itself.
+#
+# Note that `source file` with no arguments leaves the sourcing script's own
+# positional parameters visible here, so pass arguments explicitly (or none
+# from a script that has its own). A stray argument is rejected loudly by
+# restore-iltools.sh rather than silently ignored.
+#
+# Deliberately does not `set -euo pipefail`: those would leak into the shell
+# that sourced it. For the same reason the helper functions are unset on the
+# way out; the one namespaced variable left behind, $__iltools_status, is the
+# price of returning the real exit code without an eval.
+
+if [ -z "${BASH_SOURCE[0]:-}" ]; then
+    echo "error: activate-iltools.sh needs bash; source it from a bash shell." >&2
+    return 2 2> /dev/null || exit 2
+fi
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    echo "error: activate-iltools.sh must be sourced, not executed -- a child" >&2
+    echo "       process cannot change this shell's PATH. Use:" >&2
+    echo "           source eng/activate-iltools.sh [--rid <rid>] [--mdv]" >&2
+    echo "       To capture the directories instead, run eng/restore-iltools.sh." >&2
+    exit 2
+fi
+
+# Exact-element membership test against PATH. Deliberately avoids both `case`
+# patterns and unquoted word splitting, because a directory containing a glob
+# metacharacter would be matched as a pattern by the first and mangled by the
+# second. Uses only builtins, like the rest of this file, so it still works
+# when the PATH being repaired is itself unusable.
+__iltools_path_has() {
+    local needle="$1" element haystack
+    haystack="${PATH:-}"
+    while IFS= read -r element; do
+        if [ "$element" = "$needle" ]; then
+            return 0
+        fi
+    done <<< "${haystack//:/$'\n'}"
+    return 1
+}
+
+__iltools_activate() {
+    # A function body so `local` keeps the sourcing shell's namespace clean and
+    # a failure can `return`; `exit` here would close an interactive shell.
+    local self dir script_dir restore out status joined line saw_entry
+
+    # `${var%/*}` rather than dirname(1): this file's whole job is fixing PATH,
+    # so it must not need PATH to work.
+    self="${BASH_SOURCE[0]}"
+    dir="${self%/*}"
+    if [ "$dir" = "$self" ]; then
+        dir="."
+    fi
+
+    script_dir="$(cd "$dir" && pwd)" || return 1
+    restore="$script_dir/restore-iltools.sh"
+
+    if [ ! -x "$restore" ]; then
+        printf 'error: %s is missing or not executable.\n' "$restore" >&2
+        return 1
+    fi
+
+    # Capture, then test the status on its own line. The caller may not be
+    # running under `set -e`, so nothing else will notice a failure for us --
+    # and if it is, `|| status=$?` keeps errexit from killing the caller's
+    # script before it can be told what went wrong.
+    status=0
+    out="$("$restore" "$@")" || status=$?
+    if [ "$status" -ne 0 ]; then
+        printf 'error: %s failed (exit %d); PATH left unchanged.\n' "$restore" "$status" >&2
+        return "$status"
+    fi
+
+    joined=""
+    saw_entry=0
+    while IFS= read -r line; do
+        # Drop blank and whitespace-only lines. restore-iltools.sh refuses to
+        # emit them, but joining one would produce an empty PATH element, which
+        # means the current directory -- too quiet a failure to depend on the
+        # producer for.
+        case "$line" in
+            *[![:space:]]*) saw_entry=1 ;;
+            *) continue ;;
+        esac
+
+        # Sourcing twice should not grow PATH without bound.
+        if __iltools_path_has "$line"; then
+            continue
+        fi
+
+        if [ -z "$joined" ]; then
+            joined="$line"
+        else
+            joined="$joined:$line"
+        fi
+    done <<< "$out"
+
+    if [ "$saw_entry" -eq 0 ]; then
+        printf 'error: %s printed no directories; PATH left unchanged.\n' "$restore" >&2
+        return 1
+    fi
+
+    if [ -z "$joined" ]; then
+        # Every directory was already present. PATH is already correct.
+        return 0
+    fi
+
+    if [ -n "${PATH:-}" ]; then
+        export PATH="$joined:$PATH"
+    else
+        # Appending ':$PATH' here would leave a trailing empty element.
+        export PATH="$joined"
+    fi
+}
+
+__iltools_activate "$@"
+__iltools_status=$?
+unset -f __iltools_activate __iltools_path_has
+return "$__iltools_status"

--- a/eng/activate-iltools.sh
+++ b/eng/activate-iltools.sh
@@ -83,9 +83,13 @@ fi
 # it still works when the PATH being repaired is itself unusable.
 #
 # Walks the string colon by colon rather than translating colons to newlines and
-# reading lines. `read` ends an element at a newline, so the newline form tears a
-# directory containing one into two entries -- and a directory *ending* in one
-# yields an empty element, which means the current directory.
+# reading lines, matching the PATH rebuild below. There the newline form was a
+# live defect: it tore a caller's directory containing a newline into two
+# entries, and a trailing one produced an empty element. Here the haystack is
+# always $joined, whose elements come from the producer's line-oriented output
+# and so can contain neither a newline nor a colon -- this form is consistency
+# and hardening for a future caller, not a property any test can currently
+# reach.
 __iltools_path_has() {
     local needle="$1" rest="${2-}" element
 

--- a/eng/activate-iltools.sh
+++ b/eng/activate-iltools.sh
@@ -28,18 +28,39 @@
 # the lines to the runner, which does the joining itself.
 #
 # Note that `source file` with no arguments leaves the sourcing script's own
-# positional parameters visible here, so pass arguments explicitly (or none
-# from a script that has its own). A stray argument is rejected loudly by
-# restore-iltools.sh rather than silently ignored.
+# positional parameters visible here, and bash gives no way to tell those apart
+# from arguments genuinely passed to `source`. Empty arguments are dropped, so
+# a script with its own parameters can ask for none deterministically:
+#
+#   source eng/activate-iltools.sh ""
+#
+# Anything else that leaks through is rejected by restore-iltools.sh with a
+# hint naming this trap, rather than silently ignored.
 #
 # Deliberately does not `set -euo pipefail`: those would leak into the shell
 # that sourced it. For the same reason the helper functions are unset on the
 # way out; the one namespaced variable left behind, $__iltools_status, is the
 # price of returning the real exit code without an eval.
 
-if [ -z "${BASH_SOURCE[0]:-}" ]; then
+# `${BASH_VERSION:-}` rather than `${BASH_SOURCE[0]:-}`: array syntax is a
+# substitution error in dash and other POSIX shells, which would abort with
+# "Bad substitution" before this guard could print anything useful.
+if [ -z "${BASH_VERSION:-}" ]; then
     echo "error: activate-iltools.sh needs bash; source it from a bash shell." >&2
     return 2 2> /dev/null || exit 2
+fi
+
+# Refuse to clobber a caller's function of the same name. Without this, a
+# readonly collision leaves the caller's function running in place of ours and
+# reports success having restored nothing -- the silent-green failure this file
+# exists to prevent, wearing a different hat. Re-sourcing is unaffected: the
+# helpers are unset on the way out.
+if declare -F __iltools_activate > /dev/null 2>&1 ||
+   declare -F __iltools_path_has > /dev/null 2>&1 ||
+   declare -F __iltools_hint_arguments > /dev/null 2>&1; then
+    echo "error: this shell already defines one of the __iltools_* helper functions;" >&2
+    echo "       activate-iltools.sh will not overwrite them. Unset them and retry." >&2
+    return 2
 fi
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
@@ -50,14 +71,14 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then
     exit 2
 fi
 
-# Exact-element membership test against PATH. Deliberately avoids both `case`
-# patterns and unquoted word splitting, because a directory containing a glob
-# metacharacter would be matched as a pattern by the first and mangled by the
-# second. Uses only builtins, like the rest of this file, so it still works
-# when the PATH being repaired is itself unusable.
+# Exact-element membership test against a PATH-shaped string. Deliberately
+# avoids both `case` patterns and unquoted word splitting, because a directory
+# containing a glob metacharacter would be matched as a pattern by the first
+# and mangled by the second. Uses only builtins, like the rest of this file, so
+# it still works when the PATH being repaired is itself unusable.
 __iltools_path_has() {
     local needle="$1" element haystack
-    haystack="${PATH:-}"
+    haystack="${2-}"
     while IFS= read -r element; do
         if [ "$element" = "$needle" ]; then
             return 0
@@ -66,10 +87,39 @@ __iltools_path_has() {
     return 1
 }
 
+# Printed on every failure that could have been caused by arguments, because
+# `source` makes the caller's own parameters indistinguishable from real ones.
+# Without this, a script that takes `--fast` gets "unknown argument '--fast'"
+# from a script it never invoked.
+__iltools_hint_arguments() {
+    local self="$1" count="$2"
+
+    if [ "$count" -eq 0 ]; then
+        return 0
+    fi
+
+    printf 'hint: %d argument(s) were forwarded. If you did not pass them, they are\n' "$count" >&2
+    printf '      your own script'"'"'s positional parameters, which `source` leaves\n' >&2
+    printf '      visible here. Use `source %s ""` to invoke it with none.\n' "$self" >&2
+}
+
 __iltools_activate() {
     # A function body so `local` keeps the sourcing shell's namespace clean and
     # a failure can `return`; `exit` here would close an interactive shell.
     local self dir script_dir restore out status joined line saw_entry
+    local element tail first arg
+    local -a args=()
+
+    # `source file` with no arguments leaves the sourcing script's own
+    # positional parameters visible here, and bash offers no way to tell those
+    # apart from arguments genuinely passed to `source`. Dropping empty
+    # arguments gives a script with its own parameters a deterministic way to
+    # ask for none: `source eng/activate-iltools.sh ""`.
+    for arg in "$@"; do
+        if [ -n "$arg" ]; then
+            args+=("$arg")
+        fi
+    done
 
     # `${var%/*}` rather than dirname(1): this file's whole job is fixing PATH,
     # so it must not need PATH to work.
@@ -92,9 +142,10 @@ __iltools_activate() {
     # and if it is, `|| status=$?` keeps errexit from killing the caller's
     # script before it can be told what went wrong.
     status=0
-    out="$("$restore" "$@")" || status=$?
+    out="$("$restore" ${args[@]+"${args[@]}"})" || status=$?
     if [ "$status" -ne 0 ]; then
         printf 'error: %s failed (exit %d); PATH left unchanged.\n' "$restore" "$status" >&2
+        __iltools_hint_arguments "$self" "${#args[@]}"
         return "$status"
     fi
 
@@ -110,8 +161,23 @@ __iltools_activate() {
             *) continue ;;
         esac
 
-        # Sourcing twice should not grow PATH without bound.
-        if __iltools_path_has "$line"; then
+        # A directory containing ':' cannot be represented in PATH at all: it
+        # would split into two elements, and a colon-only line would produce
+        # empty ones, which mean the current directory. Neither is something to
+        # paper over -- refuse rather than silently corrupt PATH or silently
+        # drop the directory.
+        case "$line" in
+            *:*)
+                printf 'error: %s emitted a directory containing ":" (%s), which\n' "$restore" "$line" >&2
+                printf '       cannot be represented in PATH; PATH left unchanged.\n' >&2
+                return 1
+                ;;
+        esac
+
+        # Guards only against the producer emitting one directory twice.
+        # Directories already on PATH are handled below by moving them, not by
+        # skipping them.
+        if __iltools_path_has "$line" "$joined"; then
             continue
         fi
 
@@ -124,23 +190,49 @@ __iltools_activate() {
 
     if [ "$saw_entry" -eq 0 ]; then
         printf 'error: %s printed no directories; PATH left unchanged.\n' "$restore" >&2
+        # `--help` leaking in as an inherited parameter lands here rather than
+        # on the usage-error path: restore exits 0 having printed only usage.
+        __iltools_hint_arguments "$self" "${#args[@]}"
         return 1
     fi
 
-    if [ -z "$joined" ]; then
-        # Every directory was already present. PATH is already correct.
+    if [ -z "${PATH:-}" ]; then
+        # Appending ':$PATH' here would leave a trailing empty element.
+        export PATH="$joined"
         return 0
     fi
 
-    if [ -n "${PATH:-}" ]; then
-        export PATH="$joined:$PATH"
-    else
-        # Appending ':$PATH' here would leave a trailing empty element.
+    # Rebuild the tail without the restored directories rather than skipping a
+    # directory that is already present. Skipping keeps PATH from growing on a
+    # repeat source, but it also leaves a stale or broken copy earlier in PATH
+    # shadowing the one just restored: success reported, wrong tool resolved.
+    # Removing and re-prepending gets both. Every other element is preserved
+    # verbatim and in order, including empty ones -- this file must not
+    # introduce an empty PATH element, but it is not in the business of
+    # deleting the caller's.
+    tail=""
+    first=1
+    while IFS= read -r element; do
+        if __iltools_path_has "$element" "$joined"; then
+            continue
+        fi
+
+        if [ "$first" -eq 1 ]; then
+            tail="$element"
+            first=0
+        else
+            tail="$tail:$element"
+        fi
+    done <<< "${PATH//:/$'\n'}"
+
+    if [ "$first" -eq 1 ]; then
         export PATH="$joined"
+    else
+        export PATH="$joined:$tail"
     fi
 }
 
 __iltools_activate "$@"
 __iltools_status=$?
-unset -f __iltools_activate __iltools_path_has
+unset -f __iltools_activate __iltools_path_has __iltools_hint_arguments
 return "$__iltools_status"

--- a/eng/restore-iltools.sh
+++ b/eng/restore-iltools.sh
@@ -100,10 +100,14 @@ emit_path() {
         emitted="$1"
     fi
 
-    # Never emit a blank line. A consumer joining these with ':' would turn one
-    # into an empty PATH entry, which means the current directory -- a silent
-    # correctness and safety hazard rather than a visible failure.
-    [ -n "$emitted" ] || { echo "error: refusing to emit an empty path for '$1'." >&2; exit 1; }
+    # Never emit a blank or whitespace-only line. A consumer joining these with
+    # ':' would turn one into an empty PATH entry, which means the current
+    # directory -- a silent correctness and safety hazard rather than a visible
+    # failure. Whitespace-only counts: it is equally unusable and equally quiet.
+    case "$emitted" in
+        *[![:space:]]*) ;;
+        *) echo "error: refusing to emit a blank path for '$1'." >&2; exit 1 ;;
+    esac
     printf '%s\n' "$emitted"
 }
 

--- a/eng/restore-iltools.sh
+++ b/eng/restore-iltools.sh
@@ -15,13 +15,16 @@
 # output can be consumed directly:
 #
 #   CI:     eng/restore-iltools.sh >> "$GITHUB_PATH"
-#   local:  iltools="$(eng/restore-iltools.sh --mdv)"
-#           export PATH="$(printf '%s\n' "$iltools" | tr '\n' ':')$PATH"
+#   local:  iltools="$(eng/restore-iltools.sh --mdv)" && [ -n "$iltools" ] &&
+#               export PATH="$(printf '%s\n' "$iltools" | tr '\n' ':')$PATH"
 #
-# Assign first and export second: `export PATH="$(...)"` would report export's
-# exit status, so a failed restore would look like success and leave the caller
-# running tests whose oracles silently skip -- the exact failure this script
-# exists to prevent.
+# The local form is chained deliberately. `export PATH="$(...)"` reports
+# export's exit status rather than the script's, so a failed restore would look
+# like success and leave the caller running tests whose oracles silently skip --
+# the exact failure this script exists to prevent. Splitting the assignment out
+# is not enough on its own: outside `set -e` a failed assignment does not stop
+# the next command, and empty output would prepend an empty PATH entry, which
+# means the current directory. `&&` plus the -n guard covers both.
 #
 # Packages land in artifacts/iltools (gitignored), so a re-run is a no-op.
 set -euo pipefail
@@ -90,11 +93,18 @@ packages_dir="$root/artifacts/iltools/packages"
 # separator and splits every directory into "C" and "/src/repo/...". Emit MSYS
 # form (/c/src/repo) where cygpath exists; elsewhere this is a no-op.
 emit_path() {
+    local emitted
     if [ -n "$cygpath" ]; then
-        "$cygpath" -u "$1"
+        emitted="$("$cygpath" -u "$1")"
     else
-        printf '%s\n' "$1"
+        emitted="$1"
     fi
+
+    # Never emit a blank line. A consumer joining these with ':' would turn one
+    # into an empty PATH entry, which means the current directory -- a silent
+    # correctness and safety hazard rather than a visible failure.
+    [ -n "$emitted" ] || { echo "error: refusing to emit an empty path for '$1'." >&2; exit 1; }
+    printf '%s\n' "$emitted"
 }
 
 cygpath="$(command -v cygpath 2> /dev/null || true)"

--- a/eng/restore-iltools.sh
+++ b/eng/restore-iltools.sh
@@ -15,7 +15,13 @@
 # output can be consumed directly:
 #
 #   CI:     eng/restore-iltools.sh >> "$GITHUB_PATH"
-#   local:  export PATH="$(eng/restore-iltools.sh --mdv | tr '\n' ':')$PATH"
+#   local:  iltools="$(eng/restore-iltools.sh --mdv)"
+#           export PATH="$(printf '%s\n' "$iltools" | tr '\n' ':')$PATH"
+#
+# Assign first and export second: `export PATH="$(...)"` would report export's
+# exit status, so a failed restore would look like success and leave the caller
+# running tests whose oracles silently skip -- the exact failure this script
+# exists to prevent.
 #
 # Packages land in artifacts/iltools (gitignored), so a re-run is a no-op.
 set -euo pipefail
@@ -78,6 +84,21 @@ fi
 root="$(git rev-parse --show-toplevel)"
 packages_dir="$root/artifacts/iltools/packages"
 
+# On Git Bash, `git rev-parse --show-toplevel` reports a Windows path
+# (C:/src/repo). Emitting that verbatim would break the documented
+# newline-to-colon PATH assembly, because the drive colon reads as a PATH
+# separator and splits every directory into "C" and "/src/repo/...". Emit MSYS
+# form (/c/src/repo) where cygpath exists; elsewhere this is a no-op.
+emit_path() {
+    if [ -n "$cygpath" ]; then
+        "$cygpath" -u "$1"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
+cygpath="$(command -v cygpath 2> /dev/null || true)"
+
 # The package payload's extension follows the RID being restored, not the host:
 # restoring win-x64 from Linux still yields ilasm.exe.
 case "$rid" in
@@ -119,8 +140,8 @@ for tool in "$ilasm_dir/ilasm$tool_ext" "$ildasm_dir/ildasm$tool_ext"; do
     [ -x "$tool" ] || { echo "error: expected an executable at $tool after restore." >&2; exit 1; }
 done
 
-echo "$ilasm_dir"
-echo "$ildasm_dir"
+emit_path "$ilasm_dir"
+emit_path "$ildasm_dir"
 
 if [ "$want_mdv" -eq 1 ]; then
     # `dotnet tool install --global` installs under $DOTNET_CLI_HOME/.dotnet/tools,
@@ -139,5 +160,5 @@ if [ "$want_mdv" -eq 1 ]; then
         echo "error: expected an executable at $tools_dir/mdv after install." >&2
         exit 1
     fi
-    echo "$tools_dir"
+    emit_path "$tools_dir"
 fi

--- a/eng/restore-iltools.sh
+++ b/eng/restore-iltools.sh
@@ -69,7 +69,9 @@ done
 command -v dotnet > /dev/null || { echo "error: dotnet is not on PATH." >&2; exit 1; }
 
 if [ -z "$rid" ]; then
-    rid="$(dotnet --info | sed -n 's/^[ ]*RID:[ ]*//p' | head -1)"
+    # `dotnet --info` emits CRLF on Windows, and a retained \r silently corrupts
+    # the package id (runtime.win-x64\r.Microsoft.NETCore.ILAsm), so strip it.
+    rid="$(dotnet --info | sed -n 's/^[ ]*RID:[ ]*//p' | head -1 | tr -d '\r' | tr -d '[:space:]')"
     [ -n "$rid" ] || { echo "error: could not determine the host RID; pass --rid." >&2; exit 1; }
 fi
 

--- a/eng/restore-iltools.sh
+++ b/eng/restore-iltools.sh
@@ -15,16 +15,17 @@
 # output can be consumed directly:
 #
 #   CI:     eng/restore-iltools.sh >> "$GITHUB_PATH"
-#   local:  iltools="$(eng/restore-iltools.sh --mdv)" && [ -n "$iltools" ] &&
-#               export PATH="$(printf '%s\n' "$iltools" | tr '\n' ':')$PATH"
+#   local:  source eng/activate-iltools.sh --mdv
 #
-# The local form is chained deliberately. `export PATH="$(...)"` reports
-# export's exit status rather than the script's, so a failed restore would look
-# like success and leave the caller running tests whose oracles silently skip --
-# the exact failure this script exists to prevent. Splitting the assignment out
-# is not enough on its own: outside `set -e` a failed assignment does not stop
-# the next command, and empty output would prepend an empty PATH entry, which
-# means the current directory. `&&` plus the -n guard covers both.
+# Do not assemble PATH from this script's output by hand. A child process
+# cannot change its parent's PATH, so the joining has to happen in the calling
+# shell, and every way of getting it wrong is silent -- `export PATH="$(...)"`
+# reports export's status rather than this script's, a lost trailing newline
+# glues the last directory to the first pre-existing PATH entry, and empty
+# output prepends an empty PATH entry, which means the current directory. Each
+# leaves a plausible-looking PATH with no oracles on it, which is the exact
+# failure this script exists to prevent. eng/activate-iltools.sh is the one
+# tested copy of that logic; IlToolsActivationTests is its gate.
 #
 # Packages land in artifacts/iltools (gitignored), so a re-run is a no-op.
 set -euo pipefail

--- a/eng/restore-iltools.sh
+++ b/eng/restore-iltools.sh
@@ -114,6 +114,22 @@ emit_path() {
 
 cygpath="$(command -v cygpath 2> /dev/null || true)"
 
+# The MSYS form above is right for a shell and wrong for a GitHub Actions lane.
+# $GITHUB_PATH feeds PATH for *every* later step, including pwsh steps and the
+# .NET processes they spawn, and Win32 CreateProcess cannot resolve /c/... -- so
+# the tools would be unfindable and every oracle test would skip, green. No
+# Windows lane exists today (the test matrix is linux-x64 only), so rather than
+# ship an unexercised native-path mode, refuse loudly: whoever adds that lane
+# gets this message instead of a silently uncompared run.
+if [ -n "$cygpath" ] && [ -n "${GITHUB_PATH:-}" ]; then
+    echo "error: refusing to write MSYS-style paths to \$GITHUB_PATH." >&2
+    echo "  This script emits /c/... form on Git Bash, which .NET cannot resolve" >&2
+    echo "  when a later pwsh step spawns a process. Adding a Windows CI lane" >&2
+    echo "  requires emitting native paths here first; see the emit_path comment" >&2
+    echo "  above for why the MSYS form exists (drive colons split a PATH)." >&2
+    exit 1
+fi
+
 # The package payload's extension follows the RID being restored, not the host:
 # restoring win-x64 from Linux still yields ilasm.exe.
 case "$rid" in
@@ -151,9 +167,39 @@ fi
 # layout moved would otherwise put a non-existent directory on PATH, and every
 # test that needs these tools would skip -- reporting the same green run as a
 # machine that never tried.
+#
+# The executable bit is necessary but not sufficient: a tool can be present and
+# +x yet still fail to start -- a native dependency missing from the image, or,
+# for a `dotnet tool` shim, no runtime it will roll forward to. That failure is
+# invisible to a mode check, and lands as the very skip this script exists to
+# prevent. So run each tool and require a marker from its *own* help text.
+#
+# Match the help text, not the exit status and not the tool name. ilasm exits 1
+# when invoked with no arguments while ildasm and mdv exit 0, so status carries
+# no signal; and the host's startup failure names the app it could not launch
+# ("App: /path/to/mdv"), so a marker of "mdv" would match the broken case too.
+smoke_tool() {
+    tool_path="$1"
+    tool_marker="$2"
+    tool_output="$("$tool_path" < /dev/null 2>&1)" || true
+
+    case "$tool_output" in
+        *"$tool_marker"*) ;;
+        *)
+            echo "error: $tool_path is installed but did not run." >&2
+            echo "  expected its help output to contain: $tool_marker" >&2
+            echo "  got: $(printf '%s' "$tool_output" | head -3)" >&2
+            exit 1
+            ;;
+    esac
+}
+
 for tool in "$ilasm_dir/ilasm$tool_ext" "$ildasm_dir/ildasm$tool_ext"; do
     [ -x "$tool" ] || { echo "error: expected an executable at $tool after restore." >&2; exit 1; }
 done
+
+smoke_tool "$ilasm_dir/ilasm$tool_ext" "Usage: ilasm"
+smoke_tool "$ildasm_dir/ildasm$tool_ext" "Usage: ildasm"
 
 emit_path "$ilasm_dir"
 emit_path "$ildasm_dir"
@@ -175,5 +221,15 @@ if [ "$want_mdv" -eq 1 ]; then
         echo "error: expected an executable at $tools_dir/mdv after install." >&2
         exit 1
     fi
+
+    # "Parameters:" heads mdv's own usage listing. The runtime's startup failure
+    # does not contain it, so this separates "installed and working" from
+    # "installed and inert" -- the case that otherwise skips the oracle quietly.
+    if [ -x "$tools_dir/mdv" ]; then
+        smoke_tool "$tools_dir/mdv" "Parameters:"
+    else
+        smoke_tool "$tools_dir/mdv.exe" "Parameters:"
+    fi
+
     emit_path "$tools_dir"
 fi

--- a/eng/restore-iltools.sh
+++ b/eng/restore-iltools.sh
@@ -76,10 +76,17 @@ fi
 root="$(git rev-parse --show-toplevel)"
 packages_dir="$root/artifacts/iltools/packages"
 
+# The package payload's extension follows the RID being restored, not the host:
+# restoring win-x64 from Linux still yields ilasm.exe.
+case "$rid" in
+    win-*) tool_ext=".exe" ;;
+    *)     tool_ext="" ;;
+esac
+
 ilasm_dir="$packages_dir/runtime.$rid.microsoft.netcore.ilasm/$ILTOOLS_VERSION/runtimes/$rid/native"
 ildasm_dir="$packages_dir/runtime.$rid.microsoft.netcore.ildasm/$ILTOOLS_VERSION/runtimes/$rid/native"
 
-if [ ! -x "$ilasm_dir/ilasm" ] || [ ! -x "$ildasm_dir/ildasm" ]; then
+if [ ! -x "$ilasm_dir/ilasm$tool_ext" ] || [ ! -x "$ildasm_dir/ildasm$tool_ext" ]; then
     echo "Restoring ilasm/ildasm $ILTOOLS_VERSION for $rid..." >&2
 
     proj_dir="$(mktemp -d)"
@@ -106,7 +113,7 @@ fi
 # layout moved would otherwise put a non-existent directory on PATH, and every
 # test that needs these tools would skip -- reporting the same green run as a
 # machine that never tried.
-for tool in "$ilasm_dir/ilasm" "$ildasm_dir/ildasm"; do
+for tool in "$ilasm_dir/ilasm$tool_ext" "$ildasm_dir/ildasm$tool_ext"; do
     [ -x "$tool" ] || { echo "error: expected an executable at $tool after restore." >&2; exit 1; }
 done
 
@@ -114,15 +121,21 @@ echo "$ilasm_dir"
 echo "$ildasm_dir"
 
 if [ "$want_mdv" -eq 1 ]; then
-    tools_dir="${DOTNET_TOOLS_PATH:-$HOME/.dotnet/tools}"
+    # `dotnet tool install --global` installs under $DOTNET_CLI_HOME/.dotnet/tools,
+    # falling back to $HOME. The shim is mdv.exe on a Windows host -- and unlike
+    # the RID-keyed packages above, that follows the host, not --rid.
+    tools_dir="${DOTNET_CLI_HOME:-$HOME}/.dotnet/tools"
 
-    if [ ! -x "$tools_dir/mdv" ]; then
+    if [ ! -x "$tools_dir/mdv" ] && [ ! -x "$tools_dir/mdv.exe" ]; then
         echo "Installing the mdv global tool..." >&2
         # mdv ships prerelease-only from the dotnet-tools feed; it is not on
         # nuget.org under any id.
         dotnet tool install mdv --global --prerelease --add-source "$DOTNET_TOOLS_FEED" >&2
     fi
 
-    [ -x "$tools_dir/mdv" ] || { echo "error: expected an executable at $tools_dir/mdv after install." >&2; exit 1; }
+    if [ ! -x "$tools_dir/mdv" ] && [ ! -x "$tools_dir/mdv.exe" ]; then
+        echo "error: expected an executable at $tools_dir/mdv after install." >&2
+        exit 1
+    fi
     echo "$tools_dir"
 fi

--- a/eng/restore-iltools.sh
+++ b/eng/restore-iltools.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Acquires the optional external tools that several test suites use as
+# independent oracles, and prints the directories to put on PATH.
+#
+#   ilasm/ildasm  the native CoreCLR IL assembler/disassembler, restored from
+#                 the runtime.<rid>.Microsoft.NETCore.IL{,D}Asm packages.
+#   mdv           Roslyn's metadata visualizer (--mdv), installed as a .NET
+#                 global tool from the dnceng dotnet-tools feed.
+#
+# Tests that need these tools skip when they are absent, so a machine without
+# them reports a green run that proved less than it appears to. Restoring them
+# is the difference between "nothing failed" and "the oracle agreed".
+#
+# Diagnostics go to stderr and PATH entries to stdout, one per line, so the
+# output can be consumed directly:
+#
+#   CI:     eng/restore-iltools.sh >> "$GITHUB_PATH"
+#   local:  export PATH="$(eng/restore-iltools.sh --mdv | tr '\n' ':')$PATH"
+#
+# Packages land in artifacts/iltools (gitignored), so a re-run is a no-op.
+set -euo pipefail
+
+# Pinned so every workflow and every developer measures against the same
+# assembler. Bumping it here bumps it everywhere.
+ILTOOLS_VERSION=11.0.0-preview.1.26104.118
+
+DOTNET11_FEED=https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
+NUGET_FEED=https://api.nuget.org/v3/index.json
+DOTNET_TOOLS_FEED=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+
+rid=""
+want_mdv=0
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: eng/restore-iltools.sh [--rid <rid>] [--mdv]
+
+  --rid <rid>  Runtime identifier to restore ilasm/ildasm for
+               (default: the host RID reported by `dotnet --info`).
+  --mdv        Also install the `mdv` global tool.
+
+Prints the directories to add to PATH, one per line.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --rid)
+            [ $# -ge 2 ] || { echo "error: --rid requires a value." >&2; exit 2; }
+            rid="$2"
+            shift 2
+            ;;
+        --mdv)
+            want_mdv=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument '$1'." >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+command -v dotnet > /dev/null || { echo "error: dotnet is not on PATH." >&2; exit 1; }
+
+if [ -z "$rid" ]; then
+    rid="$(dotnet --info | sed -n 's/^[ ]*RID:[ ]*//p' | head -1)"
+    [ -n "$rid" ] || { echo "error: could not determine the host RID; pass --rid." >&2; exit 1; }
+fi
+
+root="$(git rev-parse --show-toplevel)"
+packages_dir="$root/artifacts/iltools/packages"
+
+ilasm_dir="$packages_dir/runtime.$rid.microsoft.netcore.ilasm/$ILTOOLS_VERSION/runtimes/$rid/native"
+ildasm_dir="$packages_dir/runtime.$rid.microsoft.netcore.ildasm/$ILTOOLS_VERSION/runtimes/$rid/native"
+
+if [ ! -x "$ilasm_dir/ilasm" ] || [ ! -x "$ildasm_dir/ildasm" ]; then
+    echo "Restoring ilasm/ildasm $ILTOOLS_VERSION for $rid..." >&2
+
+    proj_dir="$(mktemp -d)"
+    trap 'rm -rf "$proj_dir"' EXIT
+    cat > "$proj_dir/iltools.csproj" <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net11.0</TargetFramework></PropertyGroup>
+  <ItemGroup>
+    <PackageDownload Include="runtime.$rid.Microsoft.NETCore.ILAsm" Version="[$ILTOOLS_VERSION]" />
+    <PackageDownload Include="runtime.$rid.Microsoft.NETCore.ILDAsm" Version="[$ILTOOLS_VERSION]" />
+  </ItemGroup>
+</Project>
+EOF
+
+    dotnet restore "$proj_dir/iltools.csproj" \
+        --packages "$packages_dir" \
+        --source "$DOTNET11_FEED" \
+        --source "$NUGET_FEED" >&2
+
+    chmod +x "$ilasm_dir"/* "$ildasm_dir"/* 2> /dev/null || true
+fi
+
+# Verify rather than trust the restore. A feed that serves a package whose
+# layout moved would otherwise put a non-existent directory on PATH, and every
+# test that needs these tools would skip -- reporting the same green run as a
+# machine that never tried.
+for tool in "$ilasm_dir/ilasm" "$ildasm_dir/ildasm"; do
+    [ -x "$tool" ] || { echo "error: expected an executable at $tool after restore." >&2; exit 1; }
+done
+
+echo "$ilasm_dir"
+echo "$ildasm_dir"
+
+if [ "$want_mdv" -eq 1 ]; then
+    tools_dir="${DOTNET_TOOLS_PATH:-$HOME/.dotnet/tools}"
+
+    if [ ! -x "$tools_dir/mdv" ]; then
+        echo "Installing the mdv global tool..." >&2
+        # mdv ships prerelease-only from the dotnet-tools feed; it is not on
+        # nuget.org under any id.
+        dotnet tool install mdv --global --prerelease --add-source "$DOTNET_TOOLS_FEED" >&2
+    fi
+
+    [ -x "$tools_dir/mdv" ] || { echo "error: expected an executable at $tools_dir/mdv after install." >&2; exit 1; }
+    echo "$tools_dir"
+fi

--- a/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
+++ b/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
@@ -27,7 +27,7 @@ public class ILDisassemblerComparisonTests
     [MemberData(nameof(ILAsmAssemblyCases))]
     public void ILAsm_Roundtrip_ProducesValidAssembly(string assembly)
     {
-        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install via runtime.{rid}.Microsoft.NETCore.ILAsm/ILDAsm NuGet packages");
+        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install them with `eng/restore-iltools.sh`");
 
         var assemblyPath = ResolveAssembly(assembly);
         var outputDll = RoundtripWithILAsm(assemblyPath);
@@ -45,7 +45,7 @@ public class ILDisassemblerComparisonTests
     [MemberData(nameof(ILAsmAssemblyCases))]
     public void ILAsm_Roundtrip_MethodCountPreserved(string assembly)
     {
-        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install via runtime.{rid}.Microsoft.NETCore.ILAsm/ILDAsm NuGet packages");
+        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install them with `eng/restore-iltools.sh`");
 
         var assemblyPath = ResolveAssembly(assembly);
         int originalCount = CountMethods(assemblyPath);
@@ -59,7 +59,7 @@ public class ILDisassemblerComparisonTests
     [MemberData(nameof(ILAsmMethodCases))]
     public void ILAsm_Roundtrip_OpcodesPreserved(string assembly, string typeName, string methodName)
     {
-        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install via runtime.{rid}.Microsoft.NETCore.ILAsm/ILDAsm NuGet packages");
+        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install them with `eng/restore-iltools.sh`");
 
         var assemblyPath = ResolveAssembly(assembly);
         var outputDll = RoundtripWithILAsm(assemblyPath);

--- a/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
+++ b/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
@@ -27,7 +27,7 @@ public class ILDisassemblerComparisonTests
     [MemberData(nameof(ILAsmAssemblyCases))]
     public void ILAsm_Roundtrip_ProducesValidAssembly(string assembly)
     {
-        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install them with `eng/restore-iltools.sh`");
+        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install them with `source eng/activate-iltools.sh`");
 
         var assemblyPath = ResolveAssembly(assembly);
         var outputDll = RoundtripWithILAsm(assemblyPath);
@@ -45,7 +45,7 @@ public class ILDisassemblerComparisonTests
     [MemberData(nameof(ILAsmAssemblyCases))]
     public void ILAsm_Roundtrip_MethodCountPreserved(string assembly)
     {
-        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install them with `eng/restore-iltools.sh`");
+        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install them with `source eng/activate-iltools.sh`");
 
         var assemblyPath = ResolveAssembly(assembly);
         int originalCount = CountMethods(assemblyPath);
@@ -59,7 +59,7 @@ public class ILDisassemblerComparisonTests
     [MemberData(nameof(ILAsmMethodCases))]
     public void ILAsm_Roundtrip_OpcodesPreserved(string assembly, string typeName, string methodName)
     {
-        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install them with `eng/restore-iltools.sh`");
+        Assert.SkipUnless(HasILAsm, "ildasm/ilasm not found — install them with `source eng/activate-iltools.sh`");
 
         var assemblyPath = ResolveAssembly(assembly);
         var outputDll = RoundtripWithILAsm(assemblyPath);

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -371,23 +371,36 @@ public class IlToolsActivationTests
     /// the resolved directory on stdout, which command substitution captures
     /// ahead of `pwd` -- leaving a two-line script directory that resolves to
     /// nothing, so activation fails on a machine where nothing is wrong.
+    ///
+    /// The script must be sourced by a *relative* path for this to bite: `cd`
+    /// consults CDPATH only for a relative target, so an absolute `source`
+    /// would exercise nothing. The layout mirrors the documented invocation --
+    /// `source eng/activate-iltools.sh` from the repository root, with CDPATH
+    /// naming a directory that also holds an `eng`.
     /// </summary>
     [Fact]
     public void Activate_WithCdpathSet_StillResolvesItsOwnDirectory()
     {
         Assert.SkipUnless(HasBash, SkipReason);
 
-        using var scratch = new ScratchDirectory(TwoDirectoryProducer);
+        using var scratch = new ScratchDirectory(producer: null);
 
-        // CDPATH names the scratch directory's own parent, so a relative `cd`
-        // to the script's directory can resolve through it.
+        var eng = Directory.CreateDirectory(Path.Combine(scratch.Path, "eng")).FullName;
+        var activate = Path.Combine(eng, "activate-iltools.sh");
+        File.Copy(ActivateScript, activate);
+        ScratchDirectory.MakeExecutablePublic(activate);
+
+        var stub = Path.Combine(eng, "restore-iltools.sh");
+        File.WriteAllText(stub, TwoDirectoryProducer + "\n");
+        ScratchDirectory.MakeExecutablePublic(stub);
+
         var script = string.Join('\n', [
-            $"export CDPATH=\"{Path.GetDirectoryName(scratch.Path)}\"",
+            $"export CDPATH=\"{scratch.Path}\"",
             ReportPathOnExit,
-            $"source \"{scratch.ActivatePath}\"",
+            "source eng/activate-iltools.sh",
         ]);
 
-        var result = RunBash(script, "/orig1");
+        var result = RunBash(script, "/orig1", workingDirectory: scratch.Path);
 
         Assert.Equal(0, result.ExitCode);
         Assert.Equal(["/tmp/iltools-a", "/tmp/iltools-b", "/orig1"], result.PathEntries);
@@ -711,10 +724,10 @@ public class IlToolsActivationTests
         return RunBash(string.Join('\n', lines), initialPath);
     }
 
-    static ActivationResult RunBash(string script, string? initialPath) =>
-        Run("bash", script, initialPath);
+    static ActivationResult RunBash(string script, string? initialPath, string? workingDirectory = null) =>
+        Run("bash", script, initialPath, workingDirectory);
 
-    static ActivationResult Run(string shell, string script, string? initialPath)
+    static ActivationResult Run(string shell, string script, string? initialPath, string? workingDirectory = null)
     {
         var info = new ProcessStartInfo(shell)
         {
@@ -722,6 +735,9 @@ public class IlToolsActivationTests
             RedirectStandardError = true,
             UseShellExecute = false,
         };
+
+        if (workingDirectory is not null)
+            info.WorkingDirectory = workingDirectory;
         info.ArgumentList.Add("-c");
         info.ArgumentList.Add(script);
 

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -1,0 +1,465 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// The gate for <c>eng/activate-iltools.sh</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A child process cannot change its parent's PATH, so <c>eng/restore-iltools.sh</c>
+/// can only print the directories it restored and leave the caller to assemble
+/// them. That assembly used to live in a documentation snippet, where nothing
+/// executed it: three consecutive review rounds found three separate silent
+/// defects in it (a lost trailing newline gluing the last directory to the
+/// first pre-existing PATH entry, an exit status masked outside
+/// <c>set -e</c>, and whitespace-only output prepending an empty PATH element,
+/// which means the current directory). Each failure left a plausible-looking
+/// PATH with no oracles on it, so the suites that depend on those oracles
+/// reported a green run that proved nothing.
+/// </para>
+/// <para>
+/// These tests are what makes that assembly a verified property rather than a
+/// carefully worded claim. Each one drives the real
+/// <c>eng/activate-iltools.sh</c> through a stub producer and asserts on the
+/// resulting PATH, so a regression in any of those failure modes fails here.
+/// <see cref="Activate_WhenRestoreScriptIsMissing_ReportsThePathItLookedIn"/>
+/// is the non-vacuity test: it fails if the file stops resolving
+/// <c>restore-iltools.sh</c> next to itself, which is the wiring the rest of
+/// the class stubs out.
+/// </para>
+/// </remarks>
+public class IlToolsActivationTests
+{
+    static readonly string RepoRoot = FindRepoRoot();
+    static readonly string ActivateScript = Path.Combine(RepoRoot, "eng", "activate-iltools.sh");
+    static readonly string RestoreScript = Path.Combine(RepoRoot, "eng", "restore-iltools.sh");
+
+    static readonly bool HasBash = CanRunBash();
+
+    const string SkipReason = "bash is not available on this machine";
+
+    // Reports the sourcing shell's PATH without swallowing a failure. Wrapping
+    // the `source` in `|| true` instead would both hide its status and disable
+    // the caller's errexit for the sourced file, which is the condition under
+    // test in the errexit cases.
+    const string ReportPathOnExit = """trap 'printf "PATH=%s\n" "$PATH"' EXIT""";
+
+    // A stub that emits two directories the way restore-iltools.sh does.
+    const string TwoDirectoryProducer = """
+        #!/bin/sh
+        echo "ARGS:[$*]" >&2
+        printf '%s\n' /tmp/iltools-a /tmp/iltools-b
+        """;
+
+    [Fact]
+    public void RepositoryShipsBothScripts()
+    {
+        Assert.True(File.Exists(ActivateScript), $"Expected {ActivateScript} to exist.");
+        Assert.True(File.Exists(RestoreScript), $"Expected {RestoreScript} to exist.");
+    }
+
+    [Fact]
+    public void Activate_PrependsEmittedDirectoriesInOrder()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(TwoDirectoryProducer, initialPath: "/orig1:/orig2");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/iltools-a", "/tmp/iltools-b", "/orig1", "/orig2"], result.PathEntries);
+    }
+
+    [Fact]
+    public void Activate_ForwardsItsArgumentsToTheRestoreScript()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(TwoDirectoryProducer, initialPath: "/orig1", arguments: "--rid linux-x64 --mdv");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("ARGS:[--rid linux-x64 --mdv]", result.Stderr);
+    }
+
+    /// <summary>
+    /// The trailing-newline defect: joining without one glues the last emitted
+    /// directory to the first pre-existing PATH entry, corrupting both.
+    /// </summary>
+    [Fact]
+    public void Activate_KeepsTheLastEmittedDirectorySeparateFromExistingEntries()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        // This producer deliberately omits the final newline, so the defect
+        // cannot be masked by the producer being well behaved.
+        var result = Activate(
+            """
+            #!/bin/sh
+            printf '%s\n%s' /tmp/iltools-a /tmp/iltools-b
+            """,
+            initialPath: "/orig1");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/iltools-a", "/tmp/iltools-b", "/orig1"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// The empty-element defect: an empty PATH entry means the current
+    /// directory, so it is a correctness and safety hazard, not cosmetic.
+    /// </summary>
+    [Fact]
+    public void Activate_WhenPathWasEmpty_DoesNotLeaveAnEmptyElement()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(TwoDirectoryProducer, initialPath: "");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/iltools-a", "/tmp/iltools-b"], result.PathEntries);
+        Assert.All(result.PathEntries, entry => Assert.NotEqual("", entry));
+    }
+
+    [Fact]
+    public void Activate_SourcedTwice_DoesNotDuplicateEntries()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(TwoDirectoryProducer, initialPath: "/orig1", sourceCount: 2);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/iltools-a", "/tmp/iltools-b", "/orig1"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// The status-masking defect, in the shell where it actually bites: without
+    /// <c>set -e</c> nothing else notices a failed restore, so the file has to
+    /// notice it itself.
+    /// </summary>
+    [Fact]
+    public void Activate_WhenRestoreFails_ReportsItsStatusAndLeavesPathUnchanged()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(
+            """
+            #!/bin/sh
+            echo "restore blew up" >&2
+            exit 3
+            """,
+            initialPath: "/orig1:/orig2");
+
+        Assert.Equal(3, result.ExitCode);
+        Assert.Equal(["/orig1", "/orig2"], result.PathEntries);
+        Assert.Contains("PATH left unchanged", result.Stderr);
+    }
+
+    [Fact]
+    public void Activate_WhenRestoreFails_UnderErrexit_StillReportsBeforeUnwinding()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(
+            """
+            #!/bin/sh
+            exit 3
+            """,
+            initialPath: "/orig1",
+            callerOptions: "set -euo pipefail");
+
+        Assert.Equal(3, result.ExitCode);
+        Assert.Equal(["/orig1"], result.PathEntries);
+        Assert.Contains("PATH left unchanged", result.Stderr);
+    }
+
+    [Fact]
+    public void Activate_UnderErrexitAndNounset_SucceedsOnTheHappyPath()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(TwoDirectoryProducer, initialPath: "/orig1", callerOptions: "set -euo pipefail");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/iltools-a", "/tmp/iltools-b", "/orig1"], result.PathEntries);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(@"   \n\t\n\n")]
+    public void Activate_WhenRestorePrintsNoUsableDirectories_FailsAndLeavesPathUnchanged(string output)
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        // `output` is a printf *format*, so its escapes are interpreted by the
+        // stub rather than by C#.
+        var result = Activate(
+            $"""
+            #!/bin/sh
+            printf '{output}'
+            """,
+            initialPath: "/orig1");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal(["/orig1"], result.PathEntries);
+        Assert.Contains("PATH left unchanged", result.Stderr);
+    }
+
+    /// <summary>
+    /// Directories are compared and joined as literal strings. A repository
+    /// checked out under a path containing a glob metacharacter must not have
+    /// its PATH entries treated as patterns.
+    /// </summary>
+    [Fact]
+    public void Activate_TreatsGlobMetacharactersInDirectoriesLiterally()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(
+            """
+            #!/bin/sh
+            printf '%s\n' '/tmp/we[i]rd*dir' '/tmp/plain'
+            """,
+            initialPath: "/orig1");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/we[i]rd*dir", "/tmp/plain", "/orig1"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// The file's whole job is repairing PATH, so it must not need a working
+    /// PATH to run: it uses shell builtins rather than dirname(1) and tr(1).
+    /// </summary>
+    [Fact]
+    public void Activate_WithAnUnusablePath_StillWorks()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(
+            """
+            #!/bin/sh
+            printf '%s\n' /tmp/iltools-a
+            """,
+            initialPath: "/nonexistent-directory");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/iltools-a", "/nonexistent-directory"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// Executing rather than sourcing the file cannot work, so it must say so
+    /// rather than exit 0 having changed nothing.
+    /// </summary>
+    [Fact]
+    public void Activate_WhenExecutedInsteadOfSourced_FailsWithGuidance()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        using var scratch = new ScratchDirectory(TwoDirectoryProducer);
+        var result = RunBash($"\"{scratch.ActivatePath}\"", initialPath: null);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("must be sourced, not executed", result.Stderr);
+    }
+
+    /// <summary>
+    /// Non-vacuity: the other tests stub <c>restore-iltools.sh</c>, so they
+    /// would keep passing if the file stopped looking for it next to itself.
+    /// This one fails when that wiring dies.
+    /// </summary>
+    [Fact]
+    public void Activate_WhenRestoreScriptIsMissing_ReportsThePathItLookedIn()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        using var scratch = new ScratchDirectory(producer: null);
+        var result = RunBash($"{ReportPathOnExit}\nsource \"{scratch.ActivatePath}\"", initialPath: "/orig1");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(Path.Combine(scratch.Path, "restore-iltools.sh"), result.Stderr);
+        Assert.Equal(["/orig1"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// Keeps the documentation pointing at the tested artifact. The defect
+    /// class these tests close was a hand-written PATH incantation in a doc
+    /// snippet, and it comes straight back if one is reintroduced.
+    /// </summary>
+    [Fact]
+    public void AgentsMarkdown_DelegatesIlToolsPathAssemblyToTheScript()
+    {
+        var agents = File.ReadAllText(Path.Combine(RepoRoot, "AGENTS.md"));
+
+        Assert.Contains("source eng/activate-iltools.sh", agents);
+
+        foreach (var block in FencedBashBlocks(agents).Where(b => b.Contains("iltools")))
+        {
+            Assert.False(
+                block.Contains("export PATH") || block.Contains("tr '\\n'"),
+                $"AGENTS.md assembles PATH by hand instead of sourcing eng/activate-iltools.sh:\n{block}");
+        }
+    }
+
+    static IEnumerable<string> FencedBashBlocks(string markdown)
+    {
+        var lines = markdown.Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].TrimEnd() is not "```bash" && lines[i].TrimEnd() is not "```sh")
+                continue;
+
+            int end = i + 1;
+            while (end < lines.Length && lines[end].TrimEnd() != "```")
+                end++;
+
+            yield return string.Join('\n', lines[(i + 1)..Math.Min(end, lines.Length)]);
+            i = end;
+        }
+    }
+
+    // --- harness ---
+
+    sealed record ActivationResult(int ExitCode, string Stdout, string Stderr)
+    {
+        // The script reports the sourcing shell's PATH on a marker line, so the
+        // test observes that shell rather than this process's environment.
+        public string[] PathEntries
+        {
+            get
+            {
+                var line = Stdout.Split('\n')
+                    .FirstOrDefault(l => l.StartsWith("PATH=", StringComparison.Ordinal));
+
+                if (line is null)
+                    return [];
+
+                var path = line["PATH=".Length..].TrimEnd('\r');
+                return path.Length == 0 ? [] : path.Split(':');
+            }
+        }
+    }
+
+    /// <summary>
+    /// A directory holding a copy of the real activate script next to a stub
+    /// <c>restore-iltools.sh</c>, so the script under test is the shipped one
+    /// while its producer is controlled.
+    /// </summary>
+    sealed class ScratchDirectory : IDisposable
+    {
+        public string Path { get; }
+        public string ActivatePath { get; }
+
+        public ScratchDirectory(string? producer)
+        {
+            Path = Directory.CreateTempSubdirectory("iltools-activate-").FullName;
+            ActivatePath = System.IO.Path.Combine(Path, "activate-iltools.sh");
+            File.Copy(ActivateScript, ActivatePath);
+            MakeExecutable(ActivatePath);
+
+            if (producer is not null)
+            {
+                var stub = System.IO.Path.Combine(Path, "restore-iltools.sh");
+                File.WriteAllText(stub, producer + "\n");
+                MakeExecutable(stub);
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A leaked temp directory is not worth failing a test over.
+            }
+        }
+
+        static void MakeExecutable(string path)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
+    }
+
+    static ActivationResult Activate(
+        string producer,
+        string initialPath,
+        string arguments = "",
+        int sourceCount = 1,
+        string callerOptions = "")
+    {
+        using var scratch = new ScratchDirectory(producer);
+
+        // The EXIT trap reports PATH without swallowing the failure.
+        var lines = new List<string>();
+        if (callerOptions.Length > 0)
+            lines.Add(callerOptions);
+        lines.Add(ReportPathOnExit);
+        for (int i = 0; i < sourceCount; i++)
+            lines.Add($"source \"{scratch.ActivatePath}\" {arguments}");
+
+        return RunBash(string.Join('\n', lines), initialPath);
+    }
+
+    static ActivationResult RunBash(string script, string? initialPath)
+    {
+        var info = new ProcessStartInfo("bash")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        info.ArgumentList.Add("-c");
+        info.ArgumentList.Add(script);
+
+        if (initialPath is not null)
+            info.Environment["PATH"] = initialPath;
+
+        using var process = Process.Start(info)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return new ActivationResult(process.ExitCode, stdout, stderr);
+    }
+
+    static bool CanRunBash()
+    {
+        try
+        {
+            var info = new ProcessStartInfo("bash")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            info.ArgumentList.Add("-c");
+            info.ArgumentList.Add("exit 0");
+
+            using var process = Process.Start(info)!;
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "dotnet-inspect.slnx")))
+            dir = dir.Parent;
+
+        Assert.True(dir != null, "Could not locate the repository root (dotnet-inspect.slnx) from the test output directory.");
+        return dir!.FullName;
+    }
+}

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -47,6 +47,11 @@ public class IlToolsActivationTests
     // test in the errexit cases.
     const string ReportPathOnExit = """trap 'printf "PATH=%s\n" "$PATH"' EXIT""";
 
+    // %q renders the whole PATH as one shell-quoted token, so a newline inside
+    // an entry survives the trip as a `\n` escape instead of ending the report
+    // line. Plain %s cannot express the case these tests exist to pin.
+    const string ReportQuotedPathOnExit = """trap 'printf "PATHQ=%q\n" "$PATH"' EXIT""";
+
     // A stub that emits two directories the way restore-iltools.sh does.
     // Reports the argument *count* as well as the values: a single empty
     // argument and no arguments at all are indistinguishable in "$*".
@@ -320,6 +325,119 @@ public class IlToolsActivationTests
     }
 
     /// <summary>
+    /// A directory containing a newline is legal and must survive verbatim. The
+    /// colon-to-newline rewrite this file used to rely on tore such an entry in
+    /// two and rejoined the halves with a colon; when the newline was trailing,
+    /// the second half was empty -- an empty PATH element, which means the
+    /// current directory. Activation reported success either way.
+    /// </summary>
+    [Fact]
+    public void Activate_WhenAnExistingEntryContainsANewline_PreservesItAndAddsNoEmptyElement()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var quoted = ActivateReportingQuotedPath(
+            TwoDirectoryProducer,
+            initialPath: "/before:/tmp/has\nnewline:/after");
+
+        Assert.Contains(@"\n", quoted);
+        Assert.DoesNotContain("::", quoted);
+
+        // The newline must still be inside a single entry, not promoted to a
+        // separator: '/tmp/has' and 'newline' must not have become siblings.
+        Assert.DoesNotContain("/tmp/has:", quoted);
+    }
+
+    /// <summary>
+    /// A trailing newline is the variant that produced an empty element, so it
+    /// gets its own case rather than riding on the interior one.
+    /// </summary>
+    [Fact]
+    public void Activate_WhenAnExistingEntryEndsWithANewline_AddsNoEmptyElement()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var quoted = ActivateReportingQuotedPath(
+            TwoDirectoryProducer,
+            initialPath: "/tmp/trailing\n:/after");
+
+        Assert.DoesNotContain("::", quoted);
+        Assert.Contains(@"\n", quoted);
+    }
+
+    /// <summary>
+    /// This file is meant to be sourced interactively, and CDPATH is an
+    /// interactive setting. When `cd` finds the target through CDPATH it prints
+    /// the resolved directory on stdout, which command substitution captures
+    /// ahead of `pwd` -- leaving a two-line script directory that resolves to
+    /// nothing, so activation fails on a machine where nothing is wrong.
+    /// </summary>
+    [Fact]
+    public void Activate_WithCdpathSet_StillResolvesItsOwnDirectory()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        using var scratch = new ScratchDirectory(TwoDirectoryProducer);
+
+        // CDPATH names the scratch directory's own parent, so a relative `cd`
+        // to the script's directory can resolve through it.
+        var script = string.Join('\n', [
+            $"export CDPATH=\"{Path.GetDirectoryName(scratch.Path)}\"",
+            ReportPathOnExit,
+            $"source \"{scratch.ActivatePath}\"",
+        ]);
+
+        var result = RunBash(script, "/orig1");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/iltools-a", "/tmp/iltools-b", "/orig1"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// The producer emits MSYS-form paths on Git Bash so drive colons cannot
+    /// split a PATH. That form is unusable in $GITHUB_PATH, where a later pwsh
+    /// step's .NET processes resolve it through Win32 -- the tools would go
+    /// unfound and every oracle test would skip, green, which is the exact
+    /// failure these scripts exist to prevent. No Windows lane exists today, so
+    /// the producer must refuse rather than emit something silently inert.
+    /// </summary>
+    [Fact]
+    public void Restore_WhenEmittingMsysPathsIntoGithubPath_RefusesInsteadOfSkippingQuietly()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        using var stubs = new ScratchDirectory(producer: null);
+
+        // Stand in for Git Bash: the producer keys the MSYS rewrite on cygpath
+        // being present, so a stub on PATH reaches the guard on any host.
+        var cygpath = Path.Combine(stubs.Path, "cygpath");
+        File.WriteAllText(cygpath, "#!/bin/sh\nshift; echo \"$1\"\n");
+        ScratchDirectory.MakeExecutablePublic(cygpath);
+
+        var info = new ProcessStartInfo("bash")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = RepoRoot,
+        };
+        info.ArgumentList.Add(RestoreScript);
+        info.ArgumentList.Add("--rid");
+        info.ArgumentList.Add("linux-x64");
+        info.Environment["PATH"] = stubs.Path + ":" + Environment.GetEnvironmentVariable("PATH");
+        info.Environment["GITHUB_PATH"] = Path.Combine(stubs.Path, "github_path");
+
+        using var process = Process.Start(info)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.NotEqual(0, process.ExitCode);
+        Assert.Contains("GITHUB_PATH", stderr);
+        Assert.Equal("", stdout.Trim());
+    }
+
+    /// <summary>
     /// `source file` with no arguments leaves the sourcing script's own
     /// positional parameters visible to the sourced file, and bash offers no
     /// way to tell those apart from real arguments. An empty argument is the
@@ -545,6 +663,32 @@ public class IlToolsActivationTests
                 UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
                 UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
         }
+
+        public static void MakeExecutablePublic(string path) => MakeExecutable(path);
+    }
+
+    /// <summary>
+    /// Sources the script and returns the caller shell's PATH in shell-quoted
+    /// form, so entries containing newlines stay observable.
+    /// </summary>
+    static string ActivateReportingQuotedPath(string producer, string initialPath)
+    {
+        using var scratch = new ScratchDirectory(producer);
+
+        var script = string.Join('\n', [
+            ReportQuotedPathOnExit,
+            $"source \"{scratch.ActivatePath}\"",
+        ]);
+
+        var result = RunBash(script, initialPath);
+
+        Assert.Equal(0, result.ExitCode);
+
+        var line = result.Stdout.Split('\n')
+            .FirstOrDefault(l => l.StartsWith("PATHQ=", StringComparison.Ordinal));
+
+        Assert.NotNull(line);
+        return line["PATHQ=".Length..];
     }
 
     static ActivationResult Activate(

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -37,6 +37,7 @@ public class IlToolsActivationTests
     static readonly string RestoreScript = Path.Combine(RepoRoot, "eng", "restore-iltools.sh");
 
     static readonly bool HasBash = CanRunBash();
+    static readonly bool HasDash = CanRun("dash");
 
     const string SkipReason = "bash is not available on this machine";
 
@@ -47,9 +48,11 @@ public class IlToolsActivationTests
     const string ReportPathOnExit = """trap 'printf "PATH=%s\n" "$PATH"' EXIT""";
 
     // A stub that emits two directories the way restore-iltools.sh does.
+    // Reports the argument *count* as well as the values: a single empty
+    // argument and no arguments at all are indistinguishable in "$*".
     const string TwoDirectoryProducer = """
         #!/bin/sh
-        echo "ARGS:[$*]" >&2
+        echo "ARGC:[$#] ARGS:[$*]" >&2
         printf '%s\n' /tmp/iltools-a /tmp/iltools-b
         """;
 
@@ -79,7 +82,7 @@ public class IlToolsActivationTests
         var result = Activate(TwoDirectoryProducer, initialPath: "/orig1", arguments: "--rid linux-x64 --mdv");
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("ARGS:[--rid linux-x64 --mdv]", result.Stderr);
+        Assert.Contains("ARGC:[3] ARGS:[--rid linux-x64 --mdv]", result.Stderr);
     }
 
     /// <summary>
@@ -280,9 +283,160 @@ public class IlToolsActivationTests
     }
 
     /// <summary>
+    /// Round 7: skipping a directory already on PATH is not the same as
+    /// putting it first. A stale or broken copy earlier in PATH would keep
+    /// shadowing the tool just restored, with success reported.
+    /// </summary>
+    [Fact]
+    public void Activate_WhenARestoredDirectoryIsAlreadyOnPath_MovesItAheadOfTheRest()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(
+            """
+            #!/bin/sh
+            printf '%s\n' /tmp/iltools-good
+            """,
+            initialPath: "/tmp/iltools-stale:/tmp/iltools-good:/orig1");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/iltools-good", "/tmp/iltools-stale", "/orig1"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// Reordering must not otherwise rewrite the caller's PATH. This file must
+    /// not introduce an empty element, but it is not in the business of
+    /// deleting one the caller already had.
+    /// </summary>
+    [Fact]
+    public void Activate_PreservesUnrelatedEntriesVerbatimAndInOrder()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(TwoDirectoryProducer, initialPath: "/z:/tmp/iltools-b::/a");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(["/tmp/iltools-a", "/tmp/iltools-b", "/z", "", "/a"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// `source file` with no arguments leaves the sourcing script's own
+    /// positional parameters visible to the sourced file, and bash offers no
+    /// way to tell those apart from real arguments. An empty argument is the
+    /// documented escape hatch for a caller that has its own.
+    /// </summary>
+    [Fact]
+    public void Activate_TreatsAnEmptyArgumentAsNoArguments()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(TwoDirectoryProducer, initialPath: "/orig1", arguments: "\"\"");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("ARGC:[0]", result.Stderr);
+        Assert.Equal(["/tmp/iltools-a", "/tmp/iltools-b", "/orig1"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// When parameters do leak through, the failure has to name the trap;
+    /// "unknown argument '--fast'" from a script the caller never invoked is
+    /// otherwise unattributable.
+    /// </summary>
+    [Fact]
+    public void Activate_WhenAnArgumentIsRejected_NamesThePositionalParameterTrap()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(
+            """
+            #!/bin/sh
+            echo "error: unknown argument '$1'." >&2
+            exit 2
+            """,
+            initialPath: "/orig1",
+            arguments: "--fast");
+
+        Assert.Equal(2, result.ExitCode);
+        Assert.Contains("positional parameters", result.Stderr);
+        Assert.Equal(["/orig1"], result.PathEntries);
+    }
+
+    /// <summary>
+    /// The non-bash guard has to survive being read by a POSIX shell. Array
+    /// syntax is a substitution error in dash, which aborts before any guard
+    /// can print anything useful.
+    /// </summary>
+    [Fact]
+    public void Activate_SourcedFromAPosixShell_ExplainsItselfInsteadOfCrashing()
+    {
+        Assert.SkipUnless(HasDash, "dash is not available on this machine");
+
+        using var scratch = new ScratchDirectory(TwoDirectoryProducer);
+        var result = Run("dash", $". \"{scratch.ActivatePath}\"", initialPath: null);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("needs bash", result.Stderr);
+        Assert.DoesNotContain("Bad substitution", result.Stderr);
+    }
+
+    /// <summary>
+    /// Round 7: a nonblank line containing ':' passes the whitespace guard but
+    /// splits into multiple PATH elements, and a colon-only line produces empty
+    /// ones -- the current-directory hazard, reintroduced through the producer.
+    /// </summary>
+    [Theory]
+    [InlineData(":")]
+    [InlineData("/tmp/we:ird")]
+    [InlineData("/tmp/ok:/tmp/smuggled")]
+    public void Activate_WhenAProducedDirectoryContainsAColon_FailsAndLeavesPathUnchanged(string emitted)
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        var result = Activate(
+            $"""
+            #!/bin/sh
+            printf '%s\n' '{emitted}'
+            """,
+            initialPath: "/orig1");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal(["/orig1"], result.PathEntries);
+        Assert.Contains("PATH left unchanged", result.Stderr);
+    }
+
+    /// <summary>
+    /// Round 7: a shell that already defines one of the helper names would
+    /// otherwise have it silently destroyed -- or, if it is readonly, would run
+    /// its own function in place of ours and report success having restored
+    /// nothing.
+    /// </summary>
+    [Fact]
+    public void Activate_WhenTheHelperNamesAreTaken_RefusesRatherThanRunningTheCallersFunction()
+    {
+        Assert.SkipUnless(HasBash, SkipReason);
+
+        using var scratch = new ScratchDirectory(TwoDirectoryProducer);
+        var result = RunBash(
+            $$"""
+            __iltools_activate() { printf 'CALLER FUNCTION RAN\n'; return 0; }
+            readonly -f __iltools_activate
+            {{ReportPathOnExit}}
+            source "{{scratch.ActivatePath}}"
+            """,
+            initialPath: "/orig1");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.DoesNotContain("CALLER FUNCTION RAN", result.Stdout);
+        Assert.Contains("__iltools_", result.Stderr);
+        Assert.Equal(["/orig1"], result.PathEntries);
+    }
+
+    /// <summary>
     /// Keeps the documentation pointing at the tested artifact. The defect
     /// class these tests close was a hand-written PATH incantation in a doc
-    /// snippet, and it comes straight back if one is reintroduced.
+    /// snippet, so the gate rejects any runnable snippet that invokes the
+    /// producer directly -- `PATH="$(eng/restore-iltools.sh):$PATH"` never
+    /// mentions `export` and would otherwise sail through.
     /// </summary>
     [Fact]
     public void AgentsMarkdown_DelegatesIlToolsPathAssemblyToTheScript()
@@ -294,7 +448,12 @@ public class IlToolsActivationTests
         foreach (var block in FencedBashBlocks(agents).Where(b => b.Contains("iltools")))
         {
             Assert.False(
-                block.Contains("export PATH") || block.Contains("tr '\\n'"),
+                block.Contains("restore-iltools.sh"),
+                $"AGENTS.md tells the reader to run the producer directly instead of sourcing\n" +
+                $"eng/activate-iltools.sh, which puts the PATH assembly back outside the gate:\n{block}");
+
+            Assert.False(
+                block.Contains("PATH="),
                 $"AGENTS.md assembles PATH by hand instead of sourcing eng/activate-iltools.sh:\n{block}");
         }
     }
@@ -408,9 +567,12 @@ public class IlToolsActivationTests
         return RunBash(string.Join('\n', lines), initialPath);
     }
 
-    static ActivationResult RunBash(string script, string? initialPath)
+    static ActivationResult RunBash(string script, string? initialPath) =>
+        Run("bash", script, initialPath);
+
+    static ActivationResult Run(string shell, string script, string? initialPath)
     {
-        var info = new ProcessStartInfo("bash")
+        var info = new ProcessStartInfo(shell)
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -430,11 +592,13 @@ public class IlToolsActivationTests
         return new ActivationResult(process.ExitCode, stdout, stderr);
     }
 
-    static bool CanRunBash()
+    static bool CanRunBash() => CanRun("bash");
+
+    static bool CanRun(string shell)
     {
         try
         {
-            var info = new ProcessStartInfo("bash")
+            var info = new ProcessStartInfo(shell)
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,

--- a/tests/ILInspector.Metadata.Tests/MdvOracleComparisonTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MdvOracleComparisonTests.cs
@@ -273,7 +273,7 @@ public class MdvOracleComparisonTests
         Assert.SkipUnless(
             MdvOutput.Value is not null,
             "mdv (Roslyn metadata viewer) is not installed or did not run; " +
-            "install it with `eng/restore-iltools.sh --mdv`.");
+            "install it with `source eng/activate-iltools.sh --mdv`.");
         return MdvOutput.Value!;
     }
 

--- a/tests/ILInspector.Metadata.Tests/MdvOracleComparisonTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MdvOracleComparisonTests.cs
@@ -273,7 +273,7 @@ public class MdvOracleComparisonTests
         Assert.SkipUnless(
             MdvOutput.Value is not null,
             "mdv (Roslyn metadata viewer) is not installed or did not run; " +
-            "install it with `dotnet tool install --global Microsoft.Metadata.Visualizer`.");
+            "install it with `eng/restore-iltools.sh --mdv`.");
         return MdvOutput.Value!;
     }
 


### PR DESCRIPTION
## Conclusion

Optional external-oracle tools now have a single, scripted acquisition path. Restoring them unmasked **35 tests that had been silently skipping** — all pass.

## Problem

`ilasm`/`ildasm` acquisition was an inline bash block duplicated **verbatim in three workflows** (`ci.yml`, `deep-inspect.yml`, `release.yml`), with **no local equivalent**. A version bump meant editing three places, and a developer running the suites got a green result whose oracle-backed tests never ran.

`mdv` was worse: no automation anywhere, and the skip message named `Microsoft.Metadata.Visualizer`, **which does not exist on any feed under that id**. `mdv` ships prerelease-only from the dnceng `dotnet-tools` feed as package id `mdv`. Anyone following the message would have failed to install it, so the metadata-projection cross-implementation oracle had apparently never run.

## Change

`eng/restore-iltools.sh` restores the pinned `ilasm`/`ildasm` packages into `artifacts/iltools` (gitignored, so a re-run is a no-op) and prints the directories to put on PATH, one per line, diagnostics on stderr:

```bash
# CI
eng/restore-iltools.sh --rid linux-x64 >> "$GITHUB_PATH"
# local
export PATH="$(eng/restore-iltools.sh --mdv | tr '\n' ':')$PATH"
```

The three workflows now call it. `--mdv` additionally installs the `mdv` global tool, and the two wrong/vague skip messages now name the script.

The script **verifies** the binaries are executable after restore rather than trusting the package layout — a moved layout fails loudly instead of putting a non-existent directory on PATH and degrading every dependent test to a skip.

## Evidence

Release build, this branch's head, tools on PATH:

| Suite | Result | Skips before → after |
| --- | --- | --- |
| `dotnet-inspect.Tests` | 2843 passed, 0 failed | 14 → 4 |
| `ILInspector.Decompiler.Tests` | 4742 passed, 0 failed | 8 → 1 |
| `ILInspector.Metadata.Tests` | 1397 passed, 0 failed | 5 → 0 |

The 35 newly-running tests all pass — including the `mdv` row-count/MVID/AssemblyRef oracle comparisons and the 7 hand-authored-IL `ReturnToSender` regressions. Remaining skips are genuinely environmental (Windows-only P/Invoke, native PE image, NuGet-cache isolation), not tool acquisition.

Also: script is idempotent (second run restores nothing, emits only PATH lines); `markdownlint` clean on `AGENTS.md`; all three workflows parse as YAML; committed mode is `100755`.

Baseline for comparison: the same suites on `main` (`251bd3e0`) — all green, but with those 27 tool-gated skips.

## Non-action boundary

The workflow steps stay `continue-on-error: true`, so **CI still degrades to skips when acquisition fails** rather than failing the run. That pre-existing behavior is deliberately unchanged here to keep this PR's blast radius to acquisition mechanics; `AGENTS.md` now warns readers to check the step log before trusting a green decompiler or IL-diff leg. Narrowing it is a reasonable follow-up.

No product code changes — workflows, one script, one doc section, and two test skip messages.