### PR TITLE
Scope the package content cache to the source that filled it

### DIFF
--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -47,15 +47,19 @@ of the data.
 
 ### Known deviation: precedence between two entitled sources
 
-Slots are consulted in configured order, so when two configured feeds both hold
-a coordinate the higher-precedence one answers, as it would on a cold run. The
-case that still differs is when the higher-precedence feed holds the package but
-has no cached slot: a cold run downloads from it, a warm run answers from the
-lower-precedence feed's slot. Both are entitlement-correct — the caller reads
-both feeds — so this is precedence, not source confusion. Closing it requires
-probing the network on every request, which would defeat cache-first and offline
-operation, so it is left open deliberately and tracked as part of the broader
-source-support design.
+Slots are consulted in configured order, so when two configured feeds both have
+the coordinate cached, the higher-precedence one answers, as it would on a cold
+run. The case that still differs is when the higher-precedence feed holds the
+package but has no cached slot: a cold run downloads from it, a warm run answers
+from the lower-precedence feed's slot. Both are entitlement-correct — the caller
+reads both feeds — so this is precedence, not source confusion. Closing it
+requires probing the network on every request, which would defeat cache-first and
+offline operation, so it is left open deliberately and tracked as part of the
+broader source-support design.
+
+"Entitled" here means the source appears in the caller's configured sources.
+dotnet-inspect does not yet consult `<packageSourceMapping>`, which would narrow
+entitlement further, to the feeds mapped to a particular package id.
 
 A source is identified by a digest of its canonical URL, and canonicalization is
 shared with the credential scope's `IsSameEndpoint` rather than reimplemented, so

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -45,6 +45,18 @@ folder from lookup. Note that NuGet does record an installed package's source in
 `.nupkg.metadata`; the folder is treated as source-blind by choice, not for want
 of the data.
 
+### Known deviation: precedence between two entitled sources
+
+Slots are consulted in configured order, so when two configured feeds both hold
+a coordinate the higher-precedence one answers, as it would on a cold run. The
+case that still differs is when the higher-precedence feed holds the package but
+has no cached slot: a cold run downloads from it, a warm run answers from the
+lower-precedence feed's slot. Both are entitlement-correct — the caller reads
+both feeds — so this is precedence, not source confusion. Closing it requires
+probing the network on every request, which would defeat cache-first and offline
+operation, so it is left open deliberately and tracked as part of the broader
+source-support design.
+
 A source is identified by a digest of its canonical URL, and canonicalization is
 shared with the credential scope's `IsSameEndpoint` rather than reimplemented, so
 one URL cannot mean two things in one tool. Scheme, host, default port,

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -7,10 +7,10 @@ owns how content for an exact coordinate becomes visible safely.
 
 ## Source conformance
 
-Cached content is scoped to the source that supplied it. A request is served
-only the exact bytes downloaded from a source the current configuration lists.
-Content obtained from any other source is invisible to it, even for an
-identical package id and version.
+Content that dotnet-inspect downloaded is scoped to the source that supplied it.
+A request is served only the exact bytes downloaded from a source the current
+configuration lists. Content obtained from any other source is invisible to it,
+even for an identical package id and version.
 
 This is a correctness boundary, not an optimization. Two feeds may publish the
 same coordinate with different content, so serving one feed's bytes for another
@@ -28,13 +28,32 @@ should be read with them in mind:
 - in-flight acquisitions are shared only between callers with the same source
   configuration.
 
-A source is identified by a digest of its normalized URL. Scheme and host are
-case-insensitive by definition and are folded; path and query are not, because
-`/FeedA` and `/feeda` can be different feeds on a case-sensitive server. The
-digest keeps source URLs out of cache paths and makes every identity a valid
-path segment. It is opacity rather than confidentiality: a feed URL is low
-entropy, and a local reader who can see these paths can already see which
-packages were cached.
+### The NuGet global folder is outside this boundary
+
+`~/.nuget/packages` is read eagerly, ahead of source scoping, and a package
+found there answers regardless of the configured sources. This is deliberate.
+That folder holds what the user restored, not what dotnet-inspect fetched, and
+binding to it eagerly is what makes an inspection agree with the bytes a build
+actually consumed — the fidelity argument and the performance argument point the
+same way. The scoping above governs content dotnet-inspect acquired, where the
+tool chose the source and is accountable for the choice.
+
+The rule is therefore *strict conformance to the sources dotnet-inspect fetched
+from*, not *strict conformance to everything on the machine*. Callers that need
+only configured sources to answer pass `--no-nuget-cache`, which drops the
+folder from lookup. Note that NuGet does record an installed package's source in
+`.nupkg.metadata`; the folder is treated as source-blind by choice, not for want
+of the data.
+
+A source is identified by a digest of its canonical URL, and canonicalization is
+shared with the credential scope's `IsSameEndpoint` rather than reimplemented, so
+one URL cannot mean two things in one tool. Scheme, host, default port,
+percent-escape casing and a trailing path slash fold, because the URI grammar
+defines them as equivalent; path and query case do not, because `/FeedA` and
+`/feeda` can be different feeds on a case-sensitive server. The digest keeps
+source URLs out of cache paths and makes every identity a valid path segment. It
+is opacity rather than confidentiality: a feed URL is low entropy, and a local
+reader who can see these paths can already see which packages were cached.
 
 ## Guarantees
 

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -5,11 +5,44 @@ derived platform packs. [Version resolution](version-resolution.md) owns which
 package coordinate is selected and when network lookup occurs; this document
 owns how content for an exact coordinate becomes visible safely.
 
+## Source conformance
+
+Cached content is scoped to the source that supplied it. A request is served
+only the exact bytes downloaded from a source the current configuration lists.
+Content obtained from any other source is invisible to it, even for an
+identical package id and version.
+
+This is a correctness boundary, not an optimization. Two feeds may publish the
+same coordinate with different content, so serving one feed's bytes for another
+feed's request is package source confusion: the caller receives, and reports on,
+a package it never asked for and may not be entitled to read. Avoiding that
+outcome takes precedence over cache hit rate.
+
+The consequences run through the whole model, and the rest of this document
+should be read with them in mind:
+
+- the source is part of the cache path, so one coordinate held by two feeds
+  occupies two entries and the same bytes may be stored twice;
+- a lookup consults only the entries its configuration entitles it to, and
+  treats every other entry as absent; and
+- in-flight acquisitions are shared only between callers with the same source
+  configuration.
+
+A source is identified by a digest of its normalized URL. Scheme and host are
+case-insensitive by definition and are folded; path and query are not, because
+`/FeedA` and `/feeda` can be different feeds on a case-sensitive server. The
+digest keeps source URLs out of cache paths and makes every identity a valid
+path segment. It is opacity rather than confidentiality: a feed URL is low
+entropy, and a local reader who can see these paths can already see which
+packages were cached.
+
 ## Guarantees
 
 The cache model provides:
 
-- one shared acquisition task per exact coordinate within a process;
+- content scoped to the source that supplied it;
+- one shared acquisition task per exact coordinate *and source configuration*
+  within a process;
 - complete-tree visibility through marked, atomic directory publication;
 - convergence on one valid winner when processes publish concurrently; and
 - no lock ordering between package coordinates.
@@ -25,9 +58,9 @@ implement any of those architectures exactly.
 
 | Precedent | Pattern adopted by dotnet-inspect | Important difference |
 | --- | --- | --- |
-| NuGet global packages | Package id/version coordinates identify immutable entries, and readers require a completion marker. | NuGet.Client serializes installation with a cross-process file lock; dotnet-inspect allows independent staging and converges through atomic rename. |
+| NuGet global packages | Package id/version coordinates identify immutable entries, and readers require a completion marker. | NuGet.Client serializes installation with a cross-process file lock; dotnet-inspect allows independent staging and converges through atomic rename. NuGet's global folder is also source-blind, whereas dotnet-inspect's own cache is scoped by source. |
 | Docker daemon | Concurrent requests for one exact package coordinate share one in-process task. | dotnet-inspect has no daemon, so separate CLI processes can still duplicate download and extraction work. |
-| Git immutable objects | Writers build and validate complete content in a temporary sibling directory, then atomically rename it into place. | Entries are identified by the cache root, normalized package id, and version rather than by a content hash. |
+| Git immutable objects | Writers build and validate complete content in a temporary sibling directory, then atomically rename it into place. | Entries are identified by the cache root, normalized package id, version, and source rather than by a content hash. |
 | Git competing writers | One atomic rename wins; a losing publisher validates and uses the committed winner. | The loser may have performed duplicate work before converging. |
 | Git mutable-state locks | Immutable entries do not require a long-lived cross-process lock when publishers can converge on one valid result. | Explicit locking remains appropriate for future mutable state that cannot use winner convergence. |
 
@@ -45,8 +78,11 @@ work, but it permits duplicate download and extraction.
 
 ## Process-local single-flight
 
-The process-wide in-flight registry is keyed by the final cache path for one
-exact package coordinate. Concurrent callers receive the same task. The
+The process-wide in-flight registry is keyed by one exact package coordinate
+together with the caller's ordered source list. Concurrent callers receive the
+same task only when both match. Callers configured for different sources would
+otherwise be handed each other's bytes, which is the same confusion the cache
+scoping prevents, arriving by a different route. The
 registry entry is removed after completion, whether acquisition succeeds or
 fails, because the committed filesystem entry remains authoritative and is
 revalidated by later requests.
@@ -69,7 +105,7 @@ Package content publication follows this sequence:
 4. Write `.dotnet-inspect.complete` inside the staging directory.
 5. Close all files opened by dotnet-inspect.
 6. Move the staging directory atomically to its final
-   `package-content-v2/{id}/{version}` path.
+   `package-content-v4/{id}/{version}/{source}` path.
 7. If another publisher won, validate and use its committed directory.
 
 Readers accept only final directories with the expected structure and marker;
@@ -77,8 +113,9 @@ they never inspect staging paths. Platform-pack projection applies the same
 transaction separately under `packs-v2` with its own completion marker. It
 copies from committed package content and never mutates that package directory.
 
-The versioned `package-content-v2` and `packs-v2` namespaces fence these
-transactions from older direct-copy writers.
+The versioned `package-content-v4` and `packs-v2` namespaces fence these
+transactions from older direct-copy writers, and from earlier layouts that did
+not scope entries by source.
 
 ## Filesystem coordination
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -235,12 +235,18 @@ read as listed.
 | Cache | Location | TTL | Written by |
 | --- | --- | --- | --- |
 | NuGet global cache | `~/.nuget/packages/{name}/{version}/` | Permanent | `dotnet restore`, NuGet client |
-| App package cache | `$LOCAL_APP_DATA/dotnet-inspect/package-content-v2/{name}/{version}/` | Permanent | dotnet-inspect |
+| App package cache | `$LOCAL_APP_DATA/dotnet-inspect/package-content-v4/{name}/{version}/{source}/` | Permanent | dotnet-inspect |
 | Platform packs | `$LOCAL_APP_DATA/dotnet-inspect/packs-v2/{pack}/{version}/` | Permanent | dotnet-inspect |
 | Version resolution | `$LOCAL_APP_DATA/dotnet-inspect/versions-v2/` | 1 hour | dotnet-inspect |
 | Package metadata | `$LOCAL_APP_DATA/dotnet-inspect/metadata/` | 1 hour | dotnet-inspect |
 | Symbol miss markers | `$LOCAL_APP_DATA/dotnet-inspect/symbol-misses/` | 1 day | dotnet-inspect |
 | SourceLink availability markers | `$LOCAL_APP_DATA/dotnet-inspect/source-audit/` | Permanent for hits, 1 day for misses | dotnet-inspect |
+
+The app package cache carries a `{source}` segment because cached content is
+scoped to the source that supplied it; see
+[Source conformance](cache-concurrency.md#source-conformance). The NuGet global
+cache has no such segment — it is source-blind by NuGet's own design, and
+dotnet-inspect reads it as an ambient local store rather than as a feed.
 
 ## Network download/cache behavior
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -283,11 +283,17 @@ complete app-cache entries transactionally. Separate processes may duplicate
 immutable work, but readers observe only a marked, atomically published winner.
 Platform-pack projection uses the same model in a separate cache namespace.
 
-Cache identity is the cache root, normalized package id, and version.
-Source order selects the producer on a miss and is not a separate durable cache
-identity. See [cache concurrency and publication](cache-concurrency.md) for the
+Cache identity is the cache root, normalized package id, version, and the source
+that supplied the bytes. Source order selects the producer on a miss. See
+[cache concurrency and publication](cache-concurrency.md) for the
 single-flight boundary, dependency-overlap safety, filesystem rename semantics,
 failure model, and NuGet, Docker, and Git precedents.
+
+The NuGet global folder is deliberately outside this scheme. It is read eagerly,
+before source scoping is considered, because it is not a feed dotnet-inspect
+fetched from: the user populated it, normally by restoring, and binding to it is
+what makes inspection agree with what a build actually consumed. `--no-nuget-cache`
+excludes it for callers that need only configured sources to answer.
 
 ## Multiple sources
 

--- a/docs/private-feeds.md
+++ b/docs/private-feeds.md
@@ -162,10 +162,20 @@ Two practical consequences:
 - `--source` and `--add-source` take part in this. A run that replaces your sources will not read
   content cached under the sources it replaced.
 
-The NuGet global folder (`~/.nuget/packages`) is the exception. It records no source, because
-NuGet does not track one there, so dotnet-inspect reads it as a local store that `dotnet restore`
-also writes to rather than as a feed. If that distinction matters for what you are checking, use
-`--source` to name the feed explicitly and confirm the package is served from it.
+The NuGet global folder (`~/.nuget/packages`) is the exception, and it is read eagerly: a package
+found there is used whatever your sources say. That folder is not a feed dotnet-inspect fetched
+from — it is a local store you populated, mostly by `dotnet restore`. Its content is treated as
+yours, and reading it is what makes inspecting a package you have already restored both fast and
+faithful to the bytes your build actually used.
+
+The consequence is worth stating plainly: if a private package is in your global folder, a run
+configured only for nuget.org will still inspect it. `--source` chooses which feeds are consulted
+for a download; it does not hide content already in the global folder. To inspect strictly what
+your configured sources serve, add `--no-nuget-cache`:
+
+```bash
+dotnet-inspect package MyCompany.Widgets --source https://example.com/index.json --no-nuget-cache
+```
 
 ## Checking a source without changing your config
 

--- a/docs/private-feeds.md
+++ b/docs/private-feeds.md
@@ -143,6 +143,30 @@ sitting next to any of them. To keep it somewhere else entirely, point at it exp
 dotnet-inspect package MyCompany.Widgets --nugetconfig ~/private-feeds/nuget.config
 ```
 
+## Cached packages stay with their source
+
+Downloaded content is cached against the source it came from. A later run is served that content
+only if its configuration still lists that source; otherwise the package is fetched again, or
+reported as not found.
+
+This matters when a package id and version exist on more than one feed. Removing a private feed
+from your configuration does not leave its packages readable from cache, and adding a public feed
+does not let public content stand in for a package you previously read from a private one. Each
+source's copy is kept separately, so switching between configurations gives you what that
+configuration's sources actually serve.
+
+Two practical consequences:
+
+- Inspecting one package from two feeds stores it twice. This is deliberate — the two feeds may
+  not be publishing identical bytes.
+- `--source` and `--add-source` take part in this. A run that replaces your sources will not read
+  content cached under the sources it replaced.
+
+The NuGet global folder (`~/.nuget/packages`) is the exception. It records no source, because
+NuGet does not track one there, so dotnet-inspect reads it as a local store that `dotnet restore`
+also writes to rather than as a feed. If that distinction matters for what you are checking, use
+`--source` to name the feed explicitly and confirm the package is served from it.
+
 ## Checking a source without changing your config
 
 `--add-source` adds one feed for a single run, and `--source` replaces the configured sources

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -135,12 +135,11 @@ public static class NuGetCache
     /// Keys (per <see cref="GetSourceKey"/>) of the sources the caller is
     /// currently configured to read from, in configured order. Cached content
     /// committed by a source outside this set is treated as a miss, so an empty
-    /// or <see langword="null"/> list never hits the app cache. Content that
-    /// came from no NuGet source, such as a local <c>.nupkg</c>, is keyed
-    /// <c>local</c> and must be requested by including that key explicitly.
-    /// Order matters: slots are consulted in it, so a higher-precedence
-    /// source's cached copy answers ahead of a lower one's, matching the order
-    /// a cold run would have tried the feeds in.
+    /// or <see langword="null"/> list never hits the app cache. The reserved
+    /// <c>local</c> key must be included explicitly; <see langword="null"/> is
+    /// not shorthand for it. Order matters: slots are consulted in it, so a
+    /// higher-precedence source's cached copy answers ahead of a lower one's,
+    /// matching the order a cold run would have tried the feeds in.
     /// </param>
     /// <returns>The path to the cached package directory, or null if not found</returns>
     public static string? TryGetCachedPackage(
@@ -516,9 +515,11 @@ public static class NuGetCache
         => $"{PackageContentCategory}:{packageName}@{version}:{sourceKey}";
 
     /// <summary>
-    /// Identity used for content that did not come from a NuGet source at all,
-    /// such as a local <c>.nupkg</c> path. It occupies its own cache slot like
-    /// any other source.
+    /// Identity used when a source URL is absent or blank. It occupies its own
+    /// cache slot like any other source and is only matched when a caller asks
+    /// for it by name. Note that a local <c>.nupkg</c> path does not reach this
+    /// slot: <c>PackageExtractor.ExtractLocalPackage</c> unpacks it to a
+    /// temporary directory and never commits it to the content cache.
     /// </summary>
     private const string LocalSourceKey = "local";
 

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -20,7 +20,7 @@ public sealed record CommittedPackage(string ExtractPath, string? NupkgPath);
 /// </summary>
 public static class NuGetCache
 {
-    private const string PackageContentCategory = "package-content-v3";
+    private const string PackageContentCategory = "package-content-v4";
     private const string PackageContentCategoryPrefix = "package-content-v";
     public const string CommitMarkerFileName = ".dotnet-inspect.complete";
     private static string? _appName;
@@ -166,20 +166,31 @@ public static class NuGetCache
             }
         }
 
-        // Check app cache
+        // Check app cache. A read happens before the tool knows which source
+        // would serve the package, so it asks every source the caller is
+        // currently configured to read from. A slot belonging to any other
+        // source is not consulted: those bytes were fetched under an authority
+        // this caller no longer claims.
         var appCachePath = GetPackageContentCachePath();
         if (Directory.Exists(appCachePath))
         {
-            var appPackageDir = Path.Combine(appCachePath, normalizedName, normalizedVersion);
-            if (IsCommittedPackageValid(
-                appPackageDir,
-                normalizedName,
-                normalizedVersion,
-                allowedSourceKeys))
+            foreach (var sourceKey in allowedSourceKeys ?? [])
             {
-                InfoTracker.RecordCacheHit();
-                CacheTelemetry.Record("packages", cacheKey, CacheAccessResult.Hit);
-                return appPackageDir;
+                var appPackageDir = Path.Combine(
+                    appCachePath,
+                    normalizedName,
+                    normalizedVersion,
+                    sourceKey);
+                if (IsCommittedPackageValid(
+                    appPackageDir,
+                    normalizedName,
+                    normalizedVersion,
+                    sourceKey))
+                {
+                    InfoTracker.RecordCacheHit();
+                    CacheTelemetry.Record("packages", cacheKey, CacheAccessResult.Hit);
+                    return appPackageDir;
+                }
             }
         }
 
@@ -191,14 +202,26 @@ public static class NuGetCache
     /// <summary>
     /// Gets the final path for a package in the transactional content cache.
     /// </summary>
-    public static string GetPackageCachePath(string packageName, string version)
+    /// <remarks>
+    /// The source is part of the path, not merely recorded inside the entry, so
+    /// one coordinate served by two feeds occupies two slots. A single slot
+    /// cannot hold both: the second feed would have to either overwrite content
+    /// another feed is entitled to or fail to commit a package it downloaded
+    /// successfully. The cost is duplicated bytes when two feeds carry the same
+    /// package, which is cheaper than either alternative.
+    /// </remarks>
+    public static string GetPackageCachePath(string packageName, string version, string sourceKey)
     {
         ValidatePathComponent(packageName, "package name");
         ValidatePathComponent(version, "version");
+        ValidatePathComponent(sourceKey, "source key");
 
         var appCachePath = GetPackageContentCachePath();
-        var packageDir = Path.Combine(appCachePath, packageName.ToLowerInvariant(), version.ToLowerInvariant());
-        return packageDir;
+        return Path.Combine(
+            appCachePath,
+            packageName.ToLowerInvariant(),
+            version.ToLowerInvariant(),
+            sourceKey);
     }
 
     /// <summary>
@@ -229,7 +252,8 @@ public static class NuGetCache
         string normalizedVersion = version.ToLowerInvariant();
         string targetPath = GetPackageCachePath(
             normalizedName,
-            normalizedVersion);
+            normalizedVersion,
+            sourceKey);
         string? parentDir = Path.GetDirectoryName(targetPath)
             ?? throw new InvalidOperationException(
                 $"Package cache path has no parent: {targetPath}");
@@ -241,7 +265,7 @@ public static class NuGetCache
             targetPath,
             normalizedName,
             normalizedVersion,
-            [sourceKey]))
+            sourceKey))
         {
             return OpenCommittedPackage(
                 targetPath,
@@ -257,7 +281,7 @@ public static class NuGetCache
 
         string stagingPath = Path.Combine(
             parentDir,
-            $".{normalizedVersion}.tmp-{Guid.NewGuid():N}");
+            $".{sourceKey}.tmp-{Guid.NewGuid():N}");
         CoreCache.EnsurePathInCacheContext(stagingPath);
 
         try
@@ -301,7 +325,7 @@ public static class NuGetCache
                 targetPath,
                 normalizedName,
                 normalizedVersion,
-                [sourceKey]))
+                sourceKey))
             {
                 return OpenCommittedPackage(
                     targetPath,
@@ -357,8 +381,23 @@ public static class NuGetCache
             IsCachedPackageValid(dir, normalizedName);
         bool IsAppCacheValid(string dir)
         {
+            // A version directory now holds one slot per source. The version
+            // counts as cached only if a source this caller reads from
+            // committed it.
             string version = Path.GetFileName(dir);
-            return IsCommittedPackageValid(dir, normalizedName, version, allowedSourceKeys);
+            foreach (var sourceKey in allowedSourceKeys ?? [])
+            {
+                if (IsCommittedPackageValid(
+                        Path.Combine(dir, sourceKey),
+                        normalizedName,
+                        version,
+                        sourceKey))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
         VersionDir? best = null;
 
@@ -426,40 +465,21 @@ public static class NuGetCache
         string cachedPath,
         string packageName,
         string version,
-        IReadOnlyCollection<string>? allowedSourceKeys)
+        string sourceKey)
     {
         try
         {
             if (!IsCachedPackageValid(cachedPath))
                 return false;
 
-            var marker = File.ReadAllText(
-                Path.Combine(cachedPath, CommitMarkerFileName));
-
-            // A cache read happens before the tool knows which source would
-            // serve this package, so the question is not "does the marker name
-            // one source" but "is the source that wrote these bytes still one
-            // the caller is configured to read from". A marker naming a source
-            // outside that set is a miss, not a hit: those bytes were fetched
-            // under an authority the caller no longer claims.
-            if (allowedSourceKeys is null)
-            {
-                return marker.Equals(
-                    GetCommitMarkerContent(packageName, version, AnySourceKey),
+            // The source is already selected by the path; the marker restates it
+            // so an entry that was moved or hand-copied between slots is not
+            // mistaken for one this source committed.
+            return File.ReadAllText(
+                Path.Combine(cachedPath, CommitMarkerFileName))
+                .Equals(
+                    GetCommitMarkerContent(packageName, version, sourceKey),
                     StringComparison.Ordinal);
-            }
-
-            foreach (var sourceKey in allowedSourceKeys)
-            {
-                if (marker.Equals(
-                        GetCommitMarkerContent(packageName, version, sourceKey),
-                        StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
         catch (IOException)
         {
@@ -491,32 +511,74 @@ public static class NuGetCache
         => $"{PackageContentCategory}:{packageName}@{version}:{sourceKey}";
 
     /// <summary>
-    /// Marker component used when a package was not acquired from a NuGet
-    /// source at all (a local <c>.nupkg</c> path, say). Such content is not
-    /// attributable to any feed, so it is only ever a hit for a caller that
-    /// also supplies no source set.
+    /// Identity used for content that did not come from a NuGet source at all,
+    /// such as a local <c>.nupkg</c> path. It occupies its own cache slot like
+    /// any other source.
     /// </summary>
-    private const string AnySourceKey = "local";
+    private const string LocalSourceKey = "local";
 
     /// <summary>
-    /// Derives a stable, non-revealing identity for a NuGet source from its
-    /// URL. The URL itself is never written to the cache: a source URL can
-    /// carry userinfo credentials, and cache markers are world-readable files.
+    /// Derives a stable identity for a NuGet source from its URL, used as a
+    /// path segment in the content cache.
     /// </summary>
+    /// <remarks>
+    /// The digest keeps source URLs out of cache paths and makes every identity
+    /// a safe path segment regardless of the URL's characters. It is opacity,
+    /// not confidentiality: a feed URL is low entropy, and anyone who can read
+    /// the cache can already see which packages were fetched. Protecting feed
+    /// identity from a local reader would require cache permissions, not a hash.
+    ///
+    /// Only scheme and host are case-insensitive. Path and query are compared
+    /// as written, because <c>/FeedA</c> and <c>/feeda</c> are different feeds
+    /// on a case-sensitive server — the same reason
+    /// <c>NuGetSourceResolver.FindConfiguredSourceFor</c> refuses to match
+    /// whole URLs case-insensitively.
+    /// </remarks>
     /// <param name="sourceUrl">The source URL, or a local folder path.</param>
     /// <returns>A short hex digest identifying the source.</returns>
     public static string GetSourceKey(string? sourceUrl)
     {
         if (string.IsNullOrWhiteSpace(sourceUrl))
-            return AnySourceKey;
+            return LocalSourceKey;
 
-        // Normalize the spellings that denote the same feed: case, surrounding
-        // whitespace, and a trailing slash. Two configs that name one feed
-        // differently must share cached bytes, or the cache silently duplicates.
-        var normalized = sourceUrl.Trim().TrimEnd('/').ToLowerInvariant();
+        var trimmed = sourceUrl.Trim();
+        string normalized;
+
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) && !uri.IsFile)
+        {
+            // Scheme and host are case-insensitive by definition; the rest is
+            // not. A trailing slash is not a distinction any feed makes.
+            var origin = $"{uri.Scheme.ToLowerInvariant()}://{uri.Authority.ToLowerInvariant()}";
+            var rest = uri.GetComponents(
+                UriComponents.Path | UriComponents.Query,
+                UriFormat.UriEscaped);
+            normalized = $"{origin}/{rest}".TrimEnd('/');
+        }
+        else
+        {
+            // A local folder source. Resolve it so a relative and an absolute
+            // spelling of one directory share a slot, and respect the
+            // platform's own case rules rather than assuming.
+            string resolved;
+            try
+            {
+                resolved = Path.GetFullPath(uri?.IsFile == true ? uri.LocalPath : trimmed);
+            }
+            catch (ArgumentException)
+            {
+                resolved = trimmed;
+            }
+            catch (IOException)
+            {
+                resolved = trimmed;
+            }
+
+            resolved = resolved.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            normalized = OperatingSystem.IsLinux() ? resolved : resolved.ToLowerInvariant();
+        }
 
         var digest = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
-        return Convert.ToHexStringLower(digest.AsSpan(0, 8));
+        return Convert.ToHexStringLower(digest.AsSpan(0, 16));
     }
 
     private static void CopyDirectory(string sourceDir, string targetDir)

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using DotnetInspector.Core;
 using NuGet.Versioning;
 
@@ -18,7 +20,7 @@ public sealed record CommittedPackage(string ExtractPath, string? NupkgPath);
 /// </summary>
 public static class NuGetCache
 {
-    private const string PackageContentCategory = "package-content-v2";
+    private const string PackageContentCategory = "package-content-v3";
     private const string PackageContentCategoryPrefix = "package-content-v";
     public const string CommitMarkerFileName = ".dotnet-inspect.complete";
     private static string? _appName;
@@ -129,8 +131,17 @@ public static class NuGetCache
     /// </summary>
     /// <param name="packageName">The package name (case-insensitive)</param>
     /// <param name="version">The package version</param>
+    /// <param name="allowedSourceKeys">
+    /// Keys (per <see cref="GetSourceKey"/>) of the sources the caller is
+    /// currently configured to read from. Cached content committed by a source
+    /// outside this set is treated as a miss. Pass <see langword="null"/> only
+    /// for content that was never attributed to a source.
+    /// </param>
     /// <returns>The path to the cached package directory, or null if not found</returns>
-    public static string? TryGetCachedPackage(string packageName, string version)
+    public static string? TryGetCachedPackage(
+        string packageName,
+        string version,
+        IReadOnlyCollection<string>? allowedSourceKeys)
     {
         ValidatePathComponent(packageName, "package name");
         ValidatePathComponent(version, "version");
@@ -163,7 +174,8 @@ public static class NuGetCache
             if (IsCommittedPackageValid(
                 appPackageDir,
                 normalizedName,
-                normalizedVersion))
+                normalizedVersion,
+                allowedSourceKeys))
             {
                 InfoTracker.RecordCacheHit();
                 CacheTelemetry.Record("packages", cacheKey, CacheAccessResult.Hit);
@@ -198,11 +210,17 @@ public static class NuGetCache
     /// <param name="nupkgPath">Optional source archive to retain with the committed contents</param>
     /// <param name="packageName">The package name</param>
     /// <param name="version">The package version</param>
+    /// <param name="sourceKey">
+    /// Identity (per <see cref="GetSourceKey"/>) of the source that served
+    /// these bytes, recorded so a later read from a different source set does
+    /// not receive them.
+    /// </param>
     public static CommittedPackage CommitPackage(
         string extractedPath,
         string? nupkgPath,
         string packageName,
-        string version)
+        string version,
+        string sourceKey)
     {
         ValidatePathComponent(packageName, "package name");
         ValidatePathComponent(version, "version");
@@ -222,7 +240,8 @@ public static class NuGetCache
         if (IsCommittedPackageValid(
             targetPath,
             normalizedName,
-            normalizedVersion))
+            normalizedVersion,
+            [sourceKey]))
         {
             return OpenCommittedPackage(
                 targetPath,
@@ -270,7 +289,8 @@ public static class NuGetCache
                 writer.Write(
                     GetCommitMarkerContent(
                         normalizedName,
-                        normalizedVersion));
+                        normalizedVersion,
+                        sourceKey));
             }
 
             try
@@ -280,7 +300,8 @@ public static class NuGetCache
             catch (IOException) when (IsCommittedPackageValid(
                 targetPath,
                 normalizedName,
-                normalizedVersion))
+                normalizedVersion,
+                [sourceKey]))
             {
                 return OpenCommittedPackage(
                     targetPath,
@@ -325,7 +346,9 @@ public static class NuGetCache
     /// Returns the newest cached version of a package from the NuGet or app cache.
     /// Pure disk I/O — never hits the network.
     /// </summary>
-    public static string? TryGetLatestCachedVersion(string packageName)
+    public static string? TryGetLatestCachedVersion(
+        string packageName,
+        IReadOnlyCollection<string>? allowedSourceKeys)
     {
         var normalizedName = packageName.ToLowerInvariant();
 
@@ -335,7 +358,7 @@ public static class NuGetCache
         bool IsAppCacheValid(string dir)
         {
             string version = Path.GetFileName(dir);
-            return IsCommittedPackageValid(dir, normalizedName, version);
+            return IsCommittedPackageValid(dir, normalizedName, version, allowedSourceKeys);
         }
         VersionDir? best = null;
 
@@ -402,18 +425,41 @@ public static class NuGetCache
     private static bool IsCommittedPackageValid(
         string cachedPath,
         string packageName,
-        string version)
+        string version,
+        IReadOnlyCollection<string>? allowedSourceKeys)
     {
         try
         {
             if (!IsCachedPackageValid(cachedPath))
                 return false;
 
-            return File.ReadAllText(
-                Path.Combine(cachedPath, CommitMarkerFileName))
-                .Equals(
-                    GetCommitMarkerContent(packageName, version),
+            var marker = File.ReadAllText(
+                Path.Combine(cachedPath, CommitMarkerFileName));
+
+            // A cache read happens before the tool knows which source would
+            // serve this package, so the question is not "does the marker name
+            // one source" but "is the source that wrote these bytes still one
+            // the caller is configured to read from". A marker naming a source
+            // outside that set is a miss, not a hit: those bytes were fetched
+            // under an authority the caller no longer claims.
+            if (allowedSourceKeys is null)
+            {
+                return marker.Equals(
+                    GetCommitMarkerContent(packageName, version, AnySourceKey),
                     StringComparison.Ordinal);
+            }
+
+            foreach (var sourceKey in allowedSourceKeys)
+            {
+                if (marker.Equals(
+                        GetCommitMarkerContent(packageName, version, sourceKey),
+                        StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
         catch (IOException)
         {
@@ -440,8 +486,38 @@ public static class NuGetCache
 
     private static string GetCommitMarkerContent(
         string packageName,
-        string version)
-        => $"{PackageContentCategory}:{packageName}@{version}";
+        string version,
+        string sourceKey)
+        => $"{PackageContentCategory}:{packageName}@{version}:{sourceKey}";
+
+    /// <summary>
+    /// Marker component used when a package was not acquired from a NuGet
+    /// source at all (a local <c>.nupkg</c> path, say). Such content is not
+    /// attributable to any feed, so it is only ever a hit for a caller that
+    /// also supplies no source set.
+    /// </summary>
+    private const string AnySourceKey = "local";
+
+    /// <summary>
+    /// Derives a stable, non-revealing identity for a NuGet source from its
+    /// URL. The URL itself is never written to the cache: a source URL can
+    /// carry userinfo credentials, and cache markers are world-readable files.
+    /// </summary>
+    /// <param name="sourceUrl">The source URL, or a local folder path.</param>
+    /// <returns>A short hex digest identifying the source.</returns>
+    public static string GetSourceKey(string? sourceUrl)
+    {
+        if (string.IsNullOrWhiteSpace(sourceUrl))
+            return AnySourceKey;
+
+        // Normalize the spellings that denote the same feed: case, surrounding
+        // whitespace, and a trailing slash. Two configs that name one feed
+        // differently must share cached bytes, or the cache silently duplicates.
+        var normalized = sourceUrl.Trim().TrimEnd('/').ToLowerInvariant();
+
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+        return Convert.ToHexStringLower(digest.AsSpan(0, 8));
+    }
 
     private static void CopyDirectory(string sourceDir, string targetDir)
     {

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -133,15 +133,17 @@ public static class NuGetCache
     /// <param name="version">The package version</param>
     /// <param name="allowedSourceKeys">
     /// Keys (per <see cref="GetSourceKey"/>) of the sources the caller is
-    /// currently configured to read from. Cached content committed by a source
-    /// outside this set is treated as a miss. Pass <see langword="null"/> only
-    /// for content that was never attributed to a source.
+    /// currently configured to read from, in configured order. Cached content
+    /// committed by a source outside this set is treated as a miss. Order
+    /// matters: slots are consulted in it, so a higher-precedence source's
+    /// cached copy answers ahead of a lower one's, matching the order a cold
+    /// run would have tried the feeds in.
     /// </param>
     /// <returns>The path to the cached package directory, or null if not found</returns>
     public static string? TryGetCachedPackage(
         string packageName,
         string version,
-        IReadOnlyCollection<string>? allowedSourceKeys)
+        IReadOnlyList<string>? allowedSourceKeys)
     {
         ValidatePathComponent(packageName, "package name");
         ValidatePathComponent(version, "version");
@@ -168,9 +170,9 @@ public static class NuGetCache
 
         // Check app cache. A read happens before the tool knows which source
         // would serve the package, so it asks every source the caller is
-        // currently configured to read from. A slot belonging to any other
-        // source is not consulted: those bytes were fetched under an authority
-        // this caller no longer claims.
+        // currently configured to read from, in configured order. A slot
+        // belonging to any other source is not consulted: those bytes were
+        // fetched under an authority this caller no longer claims.
         var appCachePath = GetPackageContentCachePath();
         if (Directory.Exists(appCachePath))
         {
@@ -372,7 +374,7 @@ public static class NuGetCache
     /// </summary>
     public static string? TryGetLatestCachedVersion(
         string packageName,
-        IReadOnlyCollection<string>? allowedSourceKeys)
+        IReadOnlyList<string>? allowedSourceKeys)
     {
         var normalizedName = packageName.ToLowerInvariant();
 
@@ -528,11 +530,11 @@ public static class NuGetCache
     /// the cache can already see which packages were fetched. Protecting feed
     /// identity from a local reader would require cache permissions, not a hash.
     ///
-    /// Only scheme and host are case-insensitive. Path and query are compared
-    /// as written, because <c>/FeedA</c> and <c>/feeda</c> are different feeds
-    /// on a case-sensitive server — the same reason
-    /// <c>NuGetSourceResolver.FindConfiguredSourceFor</c> refuses to match
-    /// whole URLs case-insensitively.
+    /// Canonicalization is delegated to
+    /// <see cref="NuGetCredentialScope.CanonicalizeEndpoint"/> so a source has
+    /// one identity across the tool. Two feeds that method holds apart — such as
+    /// <c>/FeedA</c> and <c>/feeda</c>, which a case-sensitive server may serve
+    /// differently — get separate cache slots.
     /// </remarks>
     /// <param name="sourceUrl">The source URL, or a local folder path.</param>
     /// <returns>A short hex digest identifying the source.</returns>
@@ -546,19 +548,16 @@ public static class NuGetCache
 
         if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) && !uri.IsFile)
         {
-            // Scheme and host are case-insensitive by definition; the rest is
-            // not. A trailing slash is not a distinction any feed makes.
-            var origin = $"{uri.Scheme.ToLowerInvariant()}://{uri.Authority.ToLowerInvariant()}";
-            var rest = uri.GetComponents(
-                UriComponents.Path | UriComponents.Query,
-                UriFormat.UriEscaped);
-            normalized = $"{origin}/{rest}".TrimEnd('/');
+            normalized = NuGetCredentialScope.CanonicalizeEndpoint(uri);
         }
         else
         {
             // A local folder source. Resolve it so a relative and an absolute
-            // spelling of one directory share a slot, and respect the
-            // platform's own case rules rather than assuming.
+            // spelling of one directory share a slot. Case is preserved on
+            // every platform: case-insensitive volumes exist on all of them and
+            // case-sensitive ones do too, so the running OS does not answer
+            // whether two spellings name one directory. A spare slot costs a
+            // duplicate download; a folded one serves another directory's bytes.
             string resolved;
             try
             {
@@ -573,8 +572,8 @@ public static class NuGetCache
                 resolved = trimmed;
             }
 
-            resolved = resolved.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            normalized = OperatingSystem.IsLinux() ? resolved : resolved.ToLowerInvariant();
+            normalized = resolved.TrimEnd(
+                Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
 
         var digest = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -134,10 +134,13 @@ public static class NuGetCache
     /// <param name="allowedSourceKeys">
     /// Keys (per <see cref="GetSourceKey"/>) of the sources the caller is
     /// currently configured to read from, in configured order. Cached content
-    /// committed by a source outside this set is treated as a miss. Order
-    /// matters: slots are consulted in it, so a higher-precedence source's
-    /// cached copy answers ahead of a lower one's, matching the order a cold
-    /// run would have tried the feeds in.
+    /// committed by a source outside this set is treated as a miss, so an empty
+    /// or <see langword="null"/> list never hits the app cache. Content that
+    /// came from no NuGet source, such as a local <c>.nupkg</c>, is keyed
+    /// <c>local</c> and must be requested by including that key explicitly.
+    /// Order matters: slots are consulted in it, so a higher-precedence
+    /// source's cached copy answers ahead of a lower one's, matching the order
+    /// a cold run would have tried the feeds in.
     /// </param>
     /// <returns>The path to the cached package directory, or null if not found</returns>
     public static string? TryGetCachedPackage(

--- a/src/DotnetInspector.Packages/NuGetCredentialScope.cs
+++ b/src/DotnetInspector.Packages/NuGetCredentialScope.cs
@@ -80,13 +80,35 @@ public static class NuGetCredentialScope
             return string.Equals(a, b, StringComparison.Ordinal);
         }
 
-        return IsSameOrigin(a, b)
-            && string.Equals(
-                NormalizeEscapes(x.AbsolutePath.TrimEnd('/')),
-                NormalizeEscapes(y.AbsolutePath.TrimEnd('/')),
-                StringComparison.Ordinal)
-            && string.Equals(
-                NormalizeEscapes(x.Query), NormalizeEscapes(y.Query), StringComparison.Ordinal);
+        return string.Equals(
+            CanonicalizeEndpoint(x), CanonicalizeEndpoint(y), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Reduces a URL to the spelling-independent form <see cref="IsSameEndpoint"/> compares, so
+    /// two URLs name the same endpoint exactly when their canonical forms are equal.
+    /// </summary>
+    /// <remarks>
+    /// Callers that need an endpoint <em>identity</em> rather than a pairwise comparison — a
+    /// dictionary key or a cache path segment — must derive it from this method. A second
+    /// canonicalizer would be free to drift from this one, and the two failure directions are not
+    /// symmetric: folding a distinction this method preserves lets one feed answer for another.
+    /// </remarks>
+    /// <param name="url">An absolute URL.</param>
+    /// <returns>The canonical form of <paramref name="url"/>.</returns>
+    public static string CanonicalizeEndpoint(Uri url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+
+        // Scheme and host are case-insensitive by definition, so they fold. Path and query are
+        // not, and are preserved as written apart from the percent-escape hex casing that RFC
+        // 3986 defines as equivalent. The path's trailing slash is dropped; the query's is not,
+        // because a trailing slash inside a query is a value, not a path terminator.
+        var origin =
+            $"{url.Scheme.ToLowerInvariant()}://{url.IdnHost.ToLowerInvariant()}:{url.Port}";
+        var path = NormalizeEscapes(url.AbsolutePath.TrimEnd('/'));
+        var query = NormalizeEscapes(url.Query);
+        return $"{origin}{path}{query}";
     }
 
     /// <summary>

--- a/src/DotnetInspector.Packages/NuGetSourceCompat.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceCompat.cs
@@ -29,23 +29,36 @@ public static class NuGetSourceResolver
     /// <summary>
     /// Resolves sources and reduces them to the identities the package content
     /// cache records, so a caller can ask the cache for content this
-    /// configuration is actually entitled to.
+    /// configuration is actually entitled to. Configured order is preserved.
     /// </summary>
-    public static IReadOnlyCollection<string> ResolveSourceKeys(
+    public static IReadOnlyList<string> ResolveSourceKeys(
         NuGetSourceOptions? options,
         string? workingDirectory = null)
         => SourceKeys(ResolveSources(options, workingDirectory));
 
     /// <summary>
-    /// Reduces already-resolved sources to their cache identities.
+    /// Reduces already-resolved sources to their cache identities, preserving
+    /// configured order.
     /// </summary>
-    public static IReadOnlyCollection<string> SourceKeys(IEnumerable<NuGetSource> sources)
+    /// <remarks>
+    /// Order is part of the contract. Sources are consulted in configured order
+    /// on a miss, so a cache read that consults slots in some other order could
+    /// answer from a lower-precedence feed than the one a cold run would have
+    /// used. Returning a set rather than an ordered list would leave that
+    /// precedence undefined.
+    /// </remarks>
+    public static IReadOnlyList<string> SourceKeys(IEnumerable<NuGetSource> sources)
     {
         ArgumentNullException.ThrowIfNull(sources);
 
-        var keys = new HashSet<string>(StringComparer.Ordinal);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var keys = new List<string>();
         foreach (var source in sources)
-            keys.Add(NuGetCache.GetSourceKey(source.Url));
+        {
+            var key = NuGetCache.GetSourceKey(source.Url);
+            if (seen.Add(key))
+                keys.Add(key);
+        }
 
         return keys;
     }

--- a/src/DotnetInspector.Packages/NuGetSourceCompat.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceCompat.cs
@@ -26,6 +26,30 @@ public record NuGetSourceOptions
 /// </summary>
 public static class NuGetSourceResolver
 {
+    /// <summary>
+    /// Resolves sources and reduces them to the identities the package content
+    /// cache records, so a caller can ask the cache for content this
+    /// configuration is actually entitled to.
+    /// </summary>
+    public static IReadOnlyCollection<string> ResolveSourceKeys(
+        NuGetSourceOptions? options,
+        string? workingDirectory = null)
+        => SourceKeys(ResolveSources(options, workingDirectory));
+
+    /// <summary>
+    /// Reduces already-resolved sources to their cache identities.
+    /// </summary>
+    public static IReadOnlyCollection<string> SourceKeys(IEnumerable<NuGetSource> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var source in sources)
+            keys.Add(NuGetCache.GetSourceKey(source.Url));
+
+        return keys;
+    }
+
     public static List<NuGetSource> ResolveSources(NuGetSourceOptions? options, string? workingDirectory = null)
     {
         options ??= NuGetSourceOptions.Default;

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -282,6 +282,7 @@ public static class PackageExtractor
         IPackageContent? cached = s_packageStore.TryGetCached(
             normalizedName,
             normalizedVersion,
+            NuGetSourceResolver.SourceKeys(sources),
             log);
         if (cached != null)
         {
@@ -301,7 +302,7 @@ public static class PackageExtractor
             string nupkgPath = Path.Combine(
                 tempDir,
                 $"{packageName}.{version}.nupkg");
-            string? successfulSource = null;
+            NuGetSource? successfulSource = null;
 
             foreach (var source in sources)
             {
@@ -329,7 +330,7 @@ public static class PackageExtractor
                         .ConfigureAwait(false);
                     if (ok)
                     {
-                        successfulSource = source.Name;
+                        successfulSource = source;
                         break;
                     }
                 }
@@ -361,7 +362,7 @@ public static class PackageExtractor
                     $"Version '{version}' of package '{packageName}' not found. Use --versions to see available versions.");
             }
 
-            log?.Invoke($"Package downloaded successfully from {successfulSource}.");
+            log?.Invoke($"Package downloaded successfully from {successfulSource.Name}.");
 
             // Persist the downloaded nupkg through the package store. The
             // filesystem store extracts and transactionally commits it to the
@@ -373,6 +374,7 @@ public static class PackageExtractor
                 content = await s_packageStore.CommitAsync(
                     packageName,
                     version,
+                    NuGetCache.GetSourceKey(successfulSource.Url),
                     nupkgStream).ConfigureAwait(false);
             }
             log?.Invoke($"Cached to: {content.RootPath}");
@@ -492,7 +494,10 @@ public static class PackageExtractor
         string normalizedVersion = version.ToLowerInvariant();
 
         // Cache hit: read the nuspec straight from the already-extracted package.
-        var cachedPath = NuGetCache.TryGetCachedPackage(normalizedName, normalizedVersion);
+        var cachedPath = NuGetCache.TryGetCachedPackage(
+            normalizedName,
+            normalizedVersion,
+            NuGetSourceResolver.ResolveSourceKeys(sourceOptions));
         if (cachedPath != null && NuGetCache.IsCachedPackageValid(cachedPath))
         {
             var cachedNuspec = Directory

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -246,10 +246,10 @@ public static class PackageExtractor
         string normalizedVersion = version.ToLowerInvariant();
 
         var request = new PackageAcquisitionRequest(
-            Path.GetFullPath(
-                NuGetCache.GetPackageCachePath(
-                    normalizedName,
-                    normalizedVersion)));
+            $"{normalizedName}@{normalizedVersion}",
+            string.Join(
+                '|',
+                sources.Select(source => NuGetCache.GetSourceKey(source.Url))));
         return await s_packageRequests.GetOrAddAsync(
             request,
             _ => AcquireResolvedPackageAsync(
@@ -418,7 +418,14 @@ public static class PackageExtractor
         }
     }
 
-    private readonly record struct PackageAcquisitionRequest(string CachePath);
+    /// <summary>
+    /// Identifies one in-flight acquisition. The source scope is part of the
+    /// identity, not just the coordinate: callers configured for different
+    /// sources must not share a download, or one would receive bytes the other
+    /// was entitled to. Callers with the same ordered source list resolve
+    /// identically and can safely share.
+    /// </summary>
+    private readonly record struct PackageAcquisitionRequest(string CachePath, string SourceScope);
 
     /// <summary>
     /// Gets the download URL for a package from a specific source.

--- a/src/DotnetInspector.Packages/Storage/FileSystemPackageStore.cs
+++ b/src/DotnetInspector.Packages/Storage/FileSystemPackageStore.cs
@@ -16,7 +16,7 @@ public sealed class FileSystemPackageStore : IPackageStore
     public IPackageContent? TryGetCached(
         string packageName,
         string version,
-        IReadOnlyCollection<string>? allowedSourceKeys,
+        IReadOnlyList<string>? allowedSourceKeys,
         Action<string>? log = null)
     {
         var normalizedName = packageName.ToLowerInvariant();
@@ -103,7 +103,7 @@ public sealed class FileSystemPackageStore : IPackageStore
     /// <inheritdoc />
     public string? TryGetLatestCachedVersion(
         string packageName,
-        IReadOnlyCollection<string>? allowedSourceKeys)
+        IReadOnlyList<string>? allowedSourceKeys)
         => NuGetCache.TryGetLatestCachedVersion(packageName, allowedSourceKeys);
 
     private static string? FindNupkgInDirectory(string cacheDir, string packageName, string version)

--- a/src/DotnetInspector.Packages/Storage/FileSystemPackageStore.cs
+++ b/src/DotnetInspector.Packages/Storage/FileSystemPackageStore.cs
@@ -13,7 +13,11 @@ namespace DotnetInspector.Packages;
 public sealed class FileSystemPackageStore : IPackageStore
 {
     /// <inheritdoc />
-    public IPackageContent? TryGetCached(string packageName, string version, Action<string>? log = null)
+    public IPackageContent? TryGetCached(
+        string packageName,
+        string version,
+        IReadOnlyCollection<string>? allowedSourceKeys,
+        Action<string>? log = null)
     {
         var normalizedName = packageName.ToLowerInvariant();
         var normalizedVersion = version.ToLowerInvariant();
@@ -21,7 +25,10 @@ public sealed class FileSystemPackageStore : IPackageStore
         string? cachedPath;
         using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageLoad))
         {
-            cachedPath = NuGetCache.TryGetCachedPackage(normalizedName, normalizedVersion);
+            cachedPath = NuGetCache.TryGetCachedPackage(
+                normalizedName,
+                normalizedVersion,
+                allowedSourceKeys);
         }
 
         if (cachedPath == null || !NuGetCache.IsCachedPackageValid(cachedPath))
@@ -36,6 +43,7 @@ public sealed class FileSystemPackageStore : IPackageStore
     public async ValueTask<IPackageContent> CommitAsync(
         string packageName,
         string version,
+        string sourceKey,
         Stream nupkg,
         CancellationToken cancellationToken = default)
     {
@@ -65,7 +73,8 @@ public sealed class FileSystemPackageStore : IPackageStore
                 extractPath,
                 nupkgPath,
                 packageName,
-                version);
+                version,
+                sourceKey);
 
             return new FileSystemPackageContent(
                 committed.ExtractPath,
@@ -92,8 +101,10 @@ public sealed class FileSystemPackageStore : IPackageStore
     }
 
     /// <inheritdoc />
-    public string? TryGetLatestCachedVersion(string packageName)
-        => NuGetCache.TryGetLatestCachedVersion(packageName);
+    public string? TryGetLatestCachedVersion(
+        string packageName,
+        IReadOnlyCollection<string>? allowedSourceKeys)
+        => NuGetCache.TryGetLatestCachedVersion(packageName, allowedSourceKeys);
 
     private static string? FindNupkgInDirectory(string cacheDir, string packageName, string version)
     {

--- a/src/DotnetInspector.Packages/Storage/IPackageStore.cs
+++ b/src/DotnetInspector.Packages/Storage/IPackageStore.cs
@@ -20,15 +20,28 @@ public interface IPackageStore
     /// <paramref name="version"/> without touching the network, or <c>null</c>
     /// when the package is not cached.
     /// </summary>
-    IPackageContent? TryGetCached(string packageName, string version, Action<string>? log = null);
+    /// <param name="allowedSourceKeys">
+    /// Identities of the sources the caller is configured to read from.
+    /// Content committed by a source outside this set is not returned.
+    /// </param>
+    IPackageContent? TryGetCached(
+        string packageName,
+        string version,
+        IReadOnlyCollection<string>? allowedSourceKeys,
+        Action<string>? log = null);
 
     /// <summary>
     /// Persists a freshly downloaded package from its <paramref name="nupkg"/>
     /// payload stream and returns a handle to the committed content.
     /// </summary>
+    /// <param name="sourceKey">
+    /// Identity of the source that served <paramref name="nupkg"/>, recorded so
+    /// the content is not later served to a caller configured for other sources.
+    /// </param>
     ValueTask<IPackageContent> CommitAsync(
         string packageName,
         string version,
+        string sourceKey,
         Stream nupkg,
         CancellationToken cancellationToken = default);
 
@@ -36,5 +49,7 @@ public interface IPackageStore
     /// Returns the newest cached version of <paramref name="packageName"/> (pure
     /// cache lookup, never network), or <c>null</c> when none is cached.
     /// </summary>
-    string? TryGetLatestCachedVersion(string packageName);
+    string? TryGetLatestCachedVersion(
+        string packageName,
+        IReadOnlyCollection<string>? allowedSourceKeys);
 }

--- a/src/DotnetInspector.Packages/Storage/IPackageStore.cs
+++ b/src/DotnetInspector.Packages/Storage/IPackageStore.cs
@@ -27,7 +27,7 @@ public interface IPackageStore
     IPackageContent? TryGetCached(
         string packageName,
         string version,
-        IReadOnlyCollection<string>? allowedSourceKeys,
+        IReadOnlyList<string>? allowedSourceKeys,
         Action<string>? log = null);
 
     /// <summary>
@@ -51,5 +51,5 @@ public interface IPackageStore
     /// </summary>
     string? TryGetLatestCachedVersion(
         string packageName,
-        IReadOnlyCollection<string>? allowedSourceKeys);
+        IReadOnlyList<string>? allowedSourceKeys);
 }

--- a/src/DotnetInspector.Packages/Storage/InMemoryPackageStore.cs
+++ b/src/DotnetInspector.Packages/Storage/InMemoryPackageStore.cs
@@ -21,7 +21,7 @@ public sealed class InMemoryPackageStore : IPackageStore
     public IPackageContent? TryGetCached(
         string packageName,
         string version,
-        IReadOnlyCollection<string>? allowedSourceKeys,
+        IReadOnlyList<string>? allowedSourceKeys,
         Action<string>? log = null)
     {
         foreach (var sourceKey in allowedSourceKeys ?? [])
@@ -60,7 +60,7 @@ public sealed class InMemoryPackageStore : IPackageStore
     /// <inheritdoc />
     public string? TryGetLatestCachedVersion(
         string packageName,
-        IReadOnlyCollection<string>? allowedSourceKeys)
+        IReadOnlyList<string>? allowedSourceKeys)
     {
         var prefix = packageName.ToLowerInvariant() + "@";
         NuGetVersion? best = null;

--- a/src/DotnetInspector.Packages/Storage/InMemoryPackageStore.cs
+++ b/src/DotnetInspector.Packages/Storage/InMemoryPackageStore.cs
@@ -6,47 +6,61 @@ namespace DotnetInspector.Packages;
 /// <summary>
 /// In-memory <see cref="IPackageStore"/> for hosts without a persistent
 /// filesystem (browser/WASM) and for tests. Caches nupkg bytes keyed by
-/// lowercase <c>{name}@{version}</c>; content is read back via an in-memory
+/// lowercase <c>{name}@{version}</c> and the identity of the source that served
+/// them; content is read back via an in-memory
 /// <see cref="ZipArchive"/>. No files are ever written.
 /// </summary>
 public sealed class InMemoryPackageStore : IPackageStore
 {
     private readonly ConcurrentDictionary<string, byte[]> _packages = new(StringComparer.Ordinal);
 
-    private static string Key(string packageName, string version)
-        => $"{packageName.ToLowerInvariant()}@{version.ToLowerInvariant()}";
+    private static string Key(string packageName, string version, string sourceKey)
+        => $"{packageName.ToLowerInvariant()}@{version.ToLowerInvariant()}@{sourceKey}";
 
     /// <inheritdoc />
-    public IPackageContent? TryGetCached(string packageName, string version, Action<string>? log = null)
+    public IPackageContent? TryGetCached(
+        string packageName,
+        string version,
+        IReadOnlyCollection<string>? allowedSourceKeys,
+        Action<string>? log = null)
     {
-        if (!_packages.TryGetValue(Key(packageName, version), out var bytes))
-            return null;
+        foreach (var sourceKey in allowedSourceKeys ?? [])
+        {
+            if (!_packages.TryGetValue(Key(packageName, version, sourceKey), out var bytes))
+                continue;
 
-        log?.Invoke($"Using cached package: {packageName} {version}");
-        return new InMemoryPackageContent(bytes, fromCache: true);
+            log?.Invoke($"Using cached package: {packageName} {version}");
+            return new InMemoryPackageContent(bytes, fromCache: true);
+        }
+
+        return null;
     }
 
     /// <inheritdoc />
     public async ValueTask<IPackageContent> CommitAsync(
         string packageName,
         string version,
+        string sourceKey,
         Stream nupkg,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageName);
         ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceKey);
         ArgumentNullException.ThrowIfNull(nupkg);
 
         using var buffer = new MemoryStream();
         await nupkg.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
         var bytes = buffer.ToArray();
 
-        _packages[Key(packageName, version)] = bytes;
+        _packages[Key(packageName, version, sourceKey)] = bytes;
         return new InMemoryPackageContent(bytes, fromCache: true);
     }
 
     /// <inheritdoc />
-    public string? TryGetLatestCachedVersion(string packageName)
+    public string? TryGetLatestCachedVersion(
+        string packageName,
+        IReadOnlyCollection<string>? allowedSourceKeys)
     {
         var prefix = packageName.ToLowerInvariant() + "@";
         NuGetVersion? best = null;
@@ -57,7 +71,16 @@ public sealed class InMemoryPackageStore : IPackageStore
             if (!key.StartsWith(prefix, StringComparison.Ordinal))
                 continue;
 
-            var raw = key[prefix.Length..];
+            var remainder = key[prefix.Length..];
+            var separator = remainder.LastIndexOf('@');
+            if (separator < 0)
+                continue;
+
+            var sourceKey = remainder[(separator + 1)..];
+            if (allowedSourceKeys is null || !allowedSourceKeys.Contains(sourceKey))
+                continue;
+
+            var raw = remainder[..separator];
             if (!NuGetVersion.TryParse(raw, out var parsed) || parsed.IsPrerelease)
                 continue;
 

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -55,6 +55,15 @@ namespace ILInspector.Decompiler.Tests;
 [Trait("Area", "Corpus")]
 public class EvilPoolSweepGateTests
 {
+    /// <summary>
+    /// Identity of the source these fixtures speak for. Cached content is scoped
+    /// to the source that committed it, so a test that seeds the cache by hand
+    /// must use the same source the code under test resolves — otherwise the
+    /// seeded entry is correctly invisible.
+    /// </summary>
+    private static readonly string TestSourceKey =
+        NuGetCache.GetSourceKey("https://api.nuget.org/v3/index.json");
+
     const string FixturePackage = "sweep.fixture";
     const string FixtureVersion = "1.0.0";
     const string FixtureTfm = "net8.0";
@@ -1145,7 +1154,7 @@ public class EvilPoolSweepGateTests
         /// <c>!IsSelected</c> arm has something to be about.
         /// </summary>
         void CommitWithoutLibrary(string package) =>
-            NuGetCache.CommitPackage(Stage(package), null, package, FixtureVersion);
+            NuGetCache.CommitPackage(Stage(package), null, package, FixtureVersion, TestSourceKey);
 
         /// <summary>
         /// Stages one synthetic package and commits it, answering with the path the product
@@ -1163,7 +1172,7 @@ public class EvilPoolSweepGateTests
             Directory.CreateDirectory(Path.Combine(staged, "lib", FixtureTfm));
             File.WriteAllBytes(Path.Combine(staged, "lib", FixtureTfm, assembly), bytes);
 
-            NuGetCache.CommitPackage(staged, null, package, FixtureVersion);
+            NuGetCache.CommitPackage(staged, null, package, FixtureVersion, TestSourceKey);
 
             string committed = Path.Combine(
                 NuGetCache.GetPackageCachePath(package, FixtureVersion),

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -1175,7 +1175,7 @@ public class EvilPoolSweepGateTests
             NuGetCache.CommitPackage(staged, null, package, FixtureVersion, TestSourceKey);
 
             string committed = Path.Combine(
-                NuGetCache.GetPackageCachePath(package, FixtureVersion),
+                NuGetCache.GetPackageCachePath(package, FixtureVersion, TestSourceKey),
                 "lib",
                 FixtureTfm,
                 assembly);

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -73,7 +73,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             Assert.Equal(1, handler.RequestCount);
             Assert.False(
                 Directory.Exists(
-                    NuGetCache.GetPackageCachePath(packageName, Version)));
+                    NuGetCache.GetPackageCachePath(packageName, Version, TestSourceKey)));
         }
         finally
         {
@@ -94,7 +94,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             });
         Assert.Equal(1, handler.RequestCount);
         Assert.Equal(
-            NuGetCache.GetPackageCachePath(packageName, Version),
+            NuGetCache.GetPackageCachePath(packageName, Version, TestSourceKey),
             first.ExtractPath);
         Assert.True(File.Exists(first.NupkgPath));
         Assert.Equal(
@@ -197,7 +197,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         Assert.True(outcome.IsSuccess);
         Assert.Equal(PayloadPackage, outcome.Result!.PackageName);
         Assert.Equal(
-            NuGetCache.GetPackageCachePath(PayloadPackage, Version),
+            NuGetCache.GetPackageCachePath(PayloadPackage, Version, TestSourceKey),
             outcome.Result.ExtractPath);
         Assert.Equal(2, handler.RequestCount);
     }
@@ -374,7 +374,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
 
         Assert.False(
             Directory.Exists(
-                NuGetCache.GetPackageCachePath(packageName, Version)));
+                NuGetCache.GetPackageCachePath(packageName, Version, TestSourceKey)));
         AssertNoStagingDirectories(packageName);
     }
 
@@ -383,7 +383,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     {
         string packageName = $"corrupt.test.{Guid.NewGuid():N}";
         const string Version = "3.1.0";
-        string target = NuGetCache.GetPackageCachePath(packageName, Version);
+        string target = NuGetCache.GetPackageCachePath(packageName, Version, TestSourceKey);
         Directory.CreateDirectory(target);
         string existingFile = Path.Combine(target, "existing.txt");
         File.WriteAllText(existingFile, "preserve");
@@ -543,7 +543,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         Assert.False(failed.IsSuccess);
         Assert.False(
             Directory.Exists(
-                NuGetCache.GetPackageCachePath(packageName, Version)));
+                NuGetCache.GetPackageCachePath(packageName, Version, TestSourceKey)));
 
         var retried = await PackageExtractor.ExtractPackageAsync(
             client,
@@ -630,13 +630,26 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
 
     [Theory]
     [InlineData("https://pkgs.invalid/v3/index.json", "https://pkgs.invalid/v3/index.json/")]
-    [InlineData("https://pkgs.invalid/v3/index.json", "HTTPS://Pkgs.Invalid/V3/Index.json")]
+    [InlineData("https://pkgs.invalid/v3/index.json", "HTTPS://PKGS.INVALID/v3/index.json")]
     [InlineData("https://pkgs.invalid/v3/index.json", "  https://pkgs.invalid/v3/index.json  ")]
     public void GetSourceKey_TreatsSpellingsOfOneFeedAsOneSource(string left, string right)
     {
-        // Two configs naming one feed differently must share cached bytes, or
-        // scoping silently degrades into duplicated downloads.
+        // Scheme, host and a trailing slash are not distinctions any feed makes.
+        // Two configs naming one feed differently must share cached bytes.
         Assert.Equal(NuGetCache.GetSourceKey(left), NuGetCache.GetSourceKey(right));
+    }
+
+    [Theory]
+    [InlineData("https://pkgs.invalid/FeedA/v3/index.json", "https://pkgs.invalid/feeda/v3/index.json")]
+    [InlineData("https://pkgs.invalid/v3/index.json?feed=A", "https://pkgs.invalid/v3/index.json?feed=a")]
+    public void GetSourceKey_KeepsFeedsThatDifferOnlyByPathCaseApart(string left, string right)
+    {
+        // Only scheme and host are case-insensitive. /FeedA and /feeda are
+        // different feeds on a case-sensitive server, and aliasing them would
+        // serve one feed's bytes for the other — the bug this scoping exists to
+        // prevent. NuGetSourceResolver refuses whole-URL case-insensitive
+        // matching for the same reason.
+        Assert.NotEqual(NuGetCache.GetSourceKey(left), NuGetCache.GetSourceKey(right));
     }
 
     [Fact]
@@ -648,16 +661,132 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     }
 
     [Fact]
-    public void GetSourceKey_DoesNotRevealTheSourceUrl()
+    public void GetSourceKey_IsAnOpaquePathSafeIdentifier()
     {
-        // Commit markers are world-readable files and a source URL can carry
-        // userinfo credentials, so the key must be a digest, not the URL.
+        // The key becomes a directory name, so it must be a safe path segment
+        // for any URL and must not carry a URL's text into the cache layout.
+        // This is opacity, not confidentiality: a feed URL is low entropy, and
+        // a local reader who can see this can already see the cached packages.
         const string Secret = "s3cret-token";
         var key = NuGetCache.GetSourceKey($"https://user:{Secret}@pkgs.invalid/v3/index.json");
 
         Assert.DoesNotContain(Secret, key, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("pkgs.invalid", key, StringComparison.OrdinalIgnoreCase);
-        Assert.Matches("^[0-9a-f]{16}$", key);
+        Assert.Matches("^[0-9a-f]{32}$", key);
+        Assert.Equal(-1, key.IndexOfAny(Path.GetInvalidFileNameChars()));
+    }
+
+    [Fact]
+    public async Task ExtractPackageAsync_DoesNotShareOneDownloadAcrossDifferentSourceSets()
+    {
+        // Single-flight coalescing must not join callers whose configurations
+        // differ. If it did, a caller configured for one feed could be handed
+        // bytes fetched from a feed it does not read from — the same confusion
+        // the cache scoping prevents, arriving by a different route.
+        string packageName = $"flightscope.test.{Guid.NewGuid():N}";
+        const string Version = "1.0.0";
+        var handler = new GatedPackageHandler(CreatePackageArchive(packageName, Version));
+        using var client = new HttpClient(handler);
+        string tempPrefix = $"package-flight-scope-{Guid.NewGuid():N}-";
+
+        var feedB = new NuGetSourceOptions { Sources = ["https://feed-b.invalid/v3/index.json"] };
+
+        Task<PackageExtractionOutcome> viaNuGetOrg = PackageExtractor.ExtractPackageAsync(
+            client, packageName, tempDirPrefix: tempPrefix,
+            sourceOptions: s_nugetOrgSource, version: Version);
+        Task<PackageExtractionOutcome> viaFeedB = PackageExtractor.ExtractPackageAsync(
+            client, packageName, tempDirPrefix: tempPrefix,
+            sourceOptions: feedB, version: Version);
+
+        bool bothInFlight;
+        try
+        {
+            // The assertion: two callers with different source sets produce two
+            // concurrent downloads. If they shared a flight the count stays at
+            // 1 and this times out, which is the failure being guarded against.
+            bothInFlight = await WaitForRequestCountAsync(handler, 2, TimeSpan.FromSeconds(20));
+        }
+        finally
+        {
+            handler.Release();
+        }
+
+        Assert.True(
+            bothInFlight,
+            "Callers with different source sets shared one download; "
+                + $"observed {handler.RequestCount} request(s), expected 2.");
+
+        PackageExtractionOutcome[] outcomes = await Task.WhenAll(viaNuGetOrg, viaFeedB);
+
+        // Only the nuget.org flight is expected to complete: this fixture does
+        // not serve a parseable service index for the second feed. That is
+        // immaterial here — the point is that the flights were separate.
+        Assert.True(outcomes[0].IsSuccess);
+        AssertNoTemporaryDirectories(tempPrefix);
+    }
+
+    [Fact]
+    public void CommitPackage_SecondSourceCommitsAlongsideTheFirst()
+    {
+        // The same coordinate served by two configured feeds. The second feed
+        // correctly misses the first feed's slot, downloads, and must be able
+        // to commit. Holding both in one slot cannot work: the second feed
+        // would either overwrite content it is not entitled to serve, or fail
+        // to cache a package it just downloaded successfully.
+        string packageName = $"twofeeds.test.{Guid.NewGuid():N}";
+        const string Version = "1.0.0";
+        string keyA = NuGetCache.GetSourceKey("https://feed-a.invalid/v3/index.json");
+        string keyB = NuGetCache.GetSourceKey("https://feed-b.invalid/v3/index.json");
+
+        CommittedPackage a = NuGetCache.CommitPackage(
+            CreateExtractedPackage(Path.Combine(_testRoot, "two-a"), packageName, "A", 1),
+            nupkgPath: null, packageName, Version, keyA);
+
+        Assert.Null(NuGetCache.TryGetCachedPackage(packageName, Version, [keyB]));
+
+        CommittedPackage b = NuGetCache.CommitPackage(
+            CreateExtractedPackage(Path.Combine(_testRoot, "two-b"), packageName, "B", 1),
+            nupkgPath: null, packageName, Version, keyB);
+
+        Assert.NotEqual(a.ExtractPath, b.ExtractPath);
+        Assert.Equal(a.ExtractPath, NuGetCache.TryGetCachedPackage(packageName, Version, [keyA]));
+        Assert.Equal(b.ExtractPath, NuGetCache.TryGetCachedPackage(packageName, Version, [keyB]));
+
+        // Each slot keeps the bytes its own feed served.
+        Assert.Equal("A", File.ReadAllText(Path.Combine(a.ExtractPath, "payload", "0000.txt")));
+        Assert.Equal("B", File.ReadAllText(Path.Combine(b.ExtractPath, "payload", "0000.txt")));
+        AssertNoStagingDirectories(packageName);
+    }
+
+    [Fact]
+    public async Task CommitPackage_ConcurrentPublishersFromDifferentSourcesBothSucceed()
+    {
+        string packageName = $"twofeedsrace.test.{Guid.NewGuid():N}";
+        const string Version = "1.0.0";
+        string keyA = NuGetCache.GetSourceKey("https://feed-a.invalid/v3/index.json");
+        string keyB = NuGetCache.GetSourceKey("https://feed-b.invalid/v3/index.json");
+        string sourceA = CreateExtractedPackage(Path.Combine(_testRoot, "race-a"), packageName, "A", 64);
+        string sourceB = CreateExtractedPackage(Path.Combine(_testRoot, "race-b"), packageName, "B", 64);
+
+        using var ready = new CountdownEvent(2);
+        using var start = new ManualResetEventSlim();
+
+        Task<CommittedPackage> Publish(string dir, string key) => Task.Run(() =>
+        {
+            ready.Signal();
+            start.Wait();
+            return NuGetCache.CommitPackage(dir, nupkgPath: null, packageName, Version, key);
+        });
+
+        Task<CommittedPackage> publishA = Publish(sourceA, keyA);
+        Task<CommittedPackage> publishB = Publish(sourceB, keyB);
+
+        Assert.True(ready.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+        start.Set();
+        CommittedPackage[] committed = await Task.WhenAll(publishA, publishB);
+
+        Assert.NotEqual(committed[0].ExtractPath, committed[1].ExtractPath);
+        AssertNoStagingDirectories(packageName);
     }
 
     [Fact]
@@ -756,6 +885,22 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         writer.Write(content);
     }
 
+    private static async Task<bool> WaitForRequestCountAsync(
+        GatedPackageHandler handler,
+        int expected,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (handler.RequestCount >= expected)
+                return true;
+            await Task.Delay(25);
+        }
+
+        return handler.RequestCount >= expected;
+    }
+
     private static string CreateExtractedPackage(
         string path,
         string packageName,
@@ -788,14 +933,18 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
 
     private static void AssertNoStagingDirectories(string packageName)
     {
+        // Cache entries are {name}/{version}/{sourceKey}, so staging directories
+        // sit one level deeper than the package directory.
         string packagePath = NuGetCache.GetPackageCachePath(
             packageName,
-            "unused");
-        string parent = Path.GetDirectoryName(packagePath)!;
+            "unused",
+            TestSourceKey);
+        string parent = Path.GetDirectoryName(Path.GetDirectoryName(packagePath)!)!;
         if (!Directory.Exists(parent))
             return;
 
-        Assert.Empty(Directory.GetDirectories(parent, ".*.tmp-*"));
+        Assert.Empty(
+            Directory.GetDirectories(parent, ".*.tmp-*", SearchOption.AllDirectories));
     }
 
     private static void AssertNoPackStagingDirectories(string packageName)

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -558,6 +558,61 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     }
 
     [Fact]
+    public void TryGetCachedPackage_PrefersTheHigherPrecedenceSourcesCopy()
+    {
+        // When two configured feeds both have the coordinate cached, the read
+        // must answer from the one a cold run would have downloaded from —
+        // the first in configured order. Consulting slots in an undefined
+        // order (a set rather than a list) would let cache layout decide which
+        // feed's bytes get inspected, which is the confusion this scoping
+        // exists to prevent, just moved from across configs to within one.
+        string packageName = $"precedence.test.{Guid.NewGuid():N}";
+        const string Version = "1.0.0";
+        string firstKey = NuGetCache.GetSourceKey("https://feed-first.invalid/v3/index.json");
+        string secondKey = NuGetCache.GetSourceKey("https://feed-second.invalid/v3/index.json");
+
+        NuGetCache.CommitPackage(
+            CreateExtractedPackage(
+                Path.Combine(_testRoot, "precedence-first"), packageName, "first", payloadCount: 1),
+            nupkgPath: null, packageName, Version, firstKey);
+        NuGetCache.CommitPackage(
+            CreateExtractedPackage(
+                Path.Combine(_testRoot, "precedence-second"), packageName, "second", payloadCount: 1),
+            nupkgPath: null, packageName, Version, secondKey);
+
+        // Whichever source is listed first answers, regardless of which was
+        // cached first.
+        Assert.Equal(
+            firstKey,
+            Path.GetFileName(NuGetCache.TryGetCachedPackage(packageName, Version, [firstKey, secondKey])));
+        Assert.Equal(
+            secondKey,
+            Path.GetFileName(NuGetCache.TryGetCachedPackage(packageName, Version, [secondKey, firstKey])));
+    }
+
+    [Fact]
+    public void SourceKeys_PreservesConfiguredOrderAndDeduplicates()
+    {
+        // The ordering guarantee above is only worth anything if the keys reach
+        // the cache in configured order.
+        var sources = new List<NuGetFetch.PackageSource>
+        {
+            new("first", "https://feed-first.invalid/v3/index.json"),
+            new("second", "https://feed-second.invalid/v3/index.json"),
+            new("first-again", "https://feed-first.invalid/v3/index.json"),
+        };
+
+        var keys = NuGetSourceResolver.SourceKeys(sources);
+
+        Assert.Equal(
+            [
+                NuGetCache.GetSourceKey("https://feed-first.invalid/v3/index.json"),
+                NuGetCache.GetSourceKey("https://feed-second.invalid/v3/index.json"),
+            ],
+            keys);
+    }
+
+    [Fact]
     public void TryGetCachedPackage_DoesNotServeContentCommittedByAnotherSource()
     {
         // A private feed's bytes must not answer a request made under a
@@ -632,11 +687,72 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     [InlineData("https://pkgs.invalid/v3/index.json", "https://pkgs.invalid/v3/index.json/")]
     [InlineData("https://pkgs.invalid/v3/index.json", "HTTPS://PKGS.INVALID/v3/index.json")]
     [InlineData("https://pkgs.invalid/v3/index.json", "  https://pkgs.invalid/v3/index.json  ")]
+    [InlineData("https://pkgs.invalid/v3/index.json", "https://pkgs.invalid:443/v3/index.json")]
+    [InlineData("https://pkgs.invalid/a%2Fb/index.json", "https://pkgs.invalid/a%2fb/index.json")]
+    [InlineData("https://xn--bcher-kva.invalid/v3/index.json", "https://b\u00fccher.invalid/v3/index.json")]
+    [InlineData("https://pkgs.invalid/v3/?feed=A", "https://pkgs.invalid/v3?feed=A")]
     public void GetSourceKey_TreatsSpellingsOfOneFeedAsOneSource(string left, string right)
     {
         // Scheme, host and a trailing slash are not distinctions any feed makes.
         // Two configs naming one feed differently must share cached bytes.
+        // The default port, percent-escape hex casing and an IDN host written
+        // in unicode rather than punycode are equivalences the URI grammar
+        // itself defines, so they fold too.
         Assert.Equal(NuGetCache.GetSourceKey(left), NuGetCache.GetSourceKey(right));
+    }
+
+    [Fact]
+    public void GetSourceKey_TreatsATrailingSlashInsideAQueryAsAValue()
+    {
+        // A trailing slash folds because it terminates a *path*. Inside a query
+        // it is an ordinary character in a value, and two feeds whose tokens or
+        // parameters differ only by that character are two feeds. Trimming the
+        // recombined URL rather than its path alone folded these together.
+        Assert.NotEqual(
+            NuGetCache.GetSourceKey("https://pkgs.invalid/v3/index.json?feed=a/"),
+            NuGetCache.GetSourceKey("https://pkgs.invalid/v3/index.json?feed=a"));
+    }
+
+    [Fact]
+    public void GetSourceKey_DerivesWebSourceIdentityFromTheSharedCanonicalizer()
+    {
+        // The cache identity and the credential-scope comparison must agree
+        // about what "the same endpoint" means. A second canonicalizer would be
+        // free to drift, and the two directions are not symmetric: folding a
+        // distinction NuGetCredentialScope preserves lets one feed's slot
+        // answer for another. This asserts they are the same function, so the
+        // cases proven for IsSameEndpoint hold for cache slots too.
+        string[] urls =
+        [
+            "https://pkgs.invalid/v3/index.json",
+            "https://pkgs.invalid/v3/index.json/",
+            "HTTPS://PKGS.INVALID:443/v3/index.json",
+            "https://pkgs.invalid/FeedA/v3/index.json",
+            "https://pkgs.invalid/v3/index.json?feed=a/",
+            "https://pkgs.invalid/v3/index.json?feed=a",
+        ];
+
+        foreach (var left in urls)
+        {
+            foreach (var right in urls)
+            {
+                Assert.Equal(
+                    NuGetCredentialScope.IsSameEndpoint(left, right),
+                    NuGetCache.GetSourceKey(left) == NuGetCache.GetSourceKey(right));
+            }
+        }
+    }
+
+    [Fact]
+    public void GetSourceKey_KeepsLocalFolderCaseOnEveryPlatform()
+    {
+        // Case-sensitive and case-insensitive volumes exist on every OS, so the
+        // running platform does not answer whether two spellings name one
+        // directory. A spare slot costs a duplicate download; a folded one
+        // serves another directory's bytes.
+        Assert.NotEqual(
+            NuGetCache.GetSourceKey(Path.Combine(Path.GetTempPath(), "FeedA")),
+            NuGetCache.GetSourceKey(Path.Combine(Path.GetTempPath(), "feeda")));
     }
 
     [Theory]

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -9,6 +9,15 @@ namespace DotnetInspector.Tests;
 [Collection("Console")]
 public sealed class PackageAcquisitionConcurrencyTests : IDisposable
 {
+    /// <summary>
+    /// Identity of the source these fixtures speak for. Cached content is scoped
+    /// to the source that committed it, so a test that seeds the cache by hand
+    /// must use the same source the code under test resolves — otherwise the
+    /// seeded entry is correctly invisible.
+    /// </summary>
+    private static readonly string TestSourceKey =
+        NuGetCache.GetSourceKey("https://api.nuget.org/v3/index.json");
+
     private static readonly NuGetSourceOptions s_nugetOrgSource = new()
     {
         Sources = ["https://api.nuget.org/v3/index.json"],
@@ -90,7 +99,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         Assert.True(File.Exists(first.NupkgPath));
         Assert.Equal(
             first.ExtractPath,
-            NuGetCache.TryGetCachedPackage(packageName, Version));
+            NuGetCache.TryGetCachedPackage(packageName, Version, [TestSourceKey]));
         AssertNoStagingDirectories(packageName);
         AssertNoTemporaryDirectories(tempPrefix);
 
@@ -311,7 +320,8 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
                 sourceA,
                 nupkgPath: null,
                 packageName,
-                Version);
+                Version,
+                TestSourceKey);
         });
         Task<CommittedPackage> publishB = Task.Run(() =>
         {
@@ -321,7 +331,8 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
                 sourceB,
                 nupkgPath: null,
                 packageName,
-                Version);
+                Version,
+                TestSourceKey);
         });
 
         Assert.True(
@@ -358,7 +369,8 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
                 source,
                 nupkgPath: null,
                 packageName,
-                Version));
+                Version,
+                TestSourceKey));
 
         Assert.False(
             Directory.Exists(
@@ -386,7 +398,8 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
                 source,
                 nupkgPath: null,
                 packageName,
-                Version));
+                Version,
+                TestSourceKey));
 
         Assert.Equal("preserve", File.ReadAllText(existingFile));
         AssertNoStagingDirectories(packageName);
@@ -411,11 +424,12 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             source,
             nupkgPath: null,
             PackageName,
-            Version);
+            Version,
+            TestSourceKey);
 
         Assert.Equal(
             committed.ExtractPath,
-            NuGetCache.TryGetCachedPackage(PackageName, Version));
+            NuGetCache.TryGetCachedPackage(PackageName, Version, [TestSourceKey]));
     }
 
     [Fact]
@@ -438,7 +452,8 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             source,
             nupkgPath: null,
             PackageName,
-            Version);
+            Version,
+            TestSourceKey);
         using var client = new HttpClient(new FailingHandler());
 
         Task<string?>[] requests = Enumerable.Range(0, 16)
@@ -468,7 +483,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
                     "System.Runtime.dll")));
         Assert.Equal(
             committed.ExtractPath,
-            NuGetCache.TryGetCachedPackage(PackageName, Version));
+            NuGetCache.TryGetCachedPackage(PackageName, Version, [TestSourceKey]));
         AssertNoPackStagingDirectories(PackageName);
     }
 
@@ -486,7 +501,8 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             source,
             nupkgPath: null,
             PackageName,
-            Version);
+            Version,
+            TestSourceKey);
         string packPath = Path.Combine(
             PlatformPackService.GetPacksCachePath()!,
             PackageName,
@@ -542,6 +558,109 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     }
 
     [Fact]
+    public void TryGetCachedPackage_DoesNotServeContentCommittedByAnotherSource()
+    {
+        // A private feed's bytes must not answer a request made under a
+        // configuration that does not list that feed. The read happens before
+        // the tool knows which source would serve the package, so the cache is
+        // asked "is the committing source still one this caller reads from".
+        string packageName = $"crosssource.test.{Guid.NewGuid():N}";
+        const string Version = "1.0.0";
+        string privateFeedKey = NuGetCache.GetSourceKey("https://private.invalid/v3/index.json");
+        string publicFeedKey = NuGetCache.GetSourceKey("https://api.nuget.org/v3/index.json");
+
+        string staged = CreateExtractedPackage(
+            Path.Combine(_testRoot, "cross-source-stage"),
+            packageName,
+            "private",
+            payloadCount: 1);
+        NuGetCache.CommitPackage(staged, nupkgPath: null, packageName, Version, privateFeedKey);
+
+        Assert.Null(NuGetCache.TryGetCachedPackage(packageName, Version, [publicFeedKey]));
+        Assert.Null(NuGetCache.TryGetCachedPackage(packageName, Version, []));
+    }
+
+    [Fact]
+    public void TryGetCachedPackage_ServesContentWhenItsSourceIsStillConfigured()
+    {
+        // The converse of the cross-source miss. Without this, "scope the cache
+        // to its source" could be satisfied by never returning a hit at all,
+        // which would silently turn the cache off.
+        string packageName = $"samesource.test.{Guid.NewGuid():N}";
+        const string Version = "1.0.0";
+        string privateFeedKey = NuGetCache.GetSourceKey("https://private.invalid/v3/index.json");
+        string publicFeedKey = NuGetCache.GetSourceKey("https://api.nuget.org/v3/index.json");
+
+        string staged = CreateExtractedPackage(
+            Path.Combine(_testRoot, "same-source-stage"),
+            packageName,
+            "private",
+            payloadCount: 1);
+        CommittedPackage committed = NuGetCache.CommitPackage(
+            staged, nupkgPath: null, packageName, Version, privateFeedKey);
+
+        // Order matters: the committing source is not the first one offered.
+        Assert.Equal(
+            committed.ExtractPath,
+            NuGetCache.TryGetCachedPackage(packageName, Version, [publicFeedKey, privateFeedKey]));
+    }
+
+    [Fact]
+    public void TryGetLatestCachedVersion_IgnoresVersionsFromUnconfiguredSources()
+    {
+        string packageName = $"latestscope.test.{Guid.NewGuid():N}";
+        string privateFeedKey = NuGetCache.GetSourceKey("https://private.invalid/v3/index.json");
+        string publicFeedKey = NuGetCache.GetSourceKey("https://api.nuget.org/v3/index.json");
+
+        foreach (var (version, sourceKey) in
+            new[] { ("1.0.0", publicFeedKey), ("2.0.0", privateFeedKey) })
+        {
+            string staged = CreateExtractedPackage(
+                Path.Combine(_testRoot, $"latest-stage-{version}"),
+                packageName,
+                "payload",
+                payloadCount: 1);
+            NuGetCache.CommitPackage(staged, nupkgPath: null, packageName, version, sourceKey);
+        }
+
+        // 2.0.0 is newer but came from a feed this caller no longer reads.
+        Assert.Equal("1.0.0", NuGetCache.TryGetLatestCachedVersion(packageName, [publicFeedKey]));
+        Assert.Equal("2.0.0", NuGetCache.TryGetLatestCachedVersion(packageName, [publicFeedKey, privateFeedKey]));
+    }
+
+    [Theory]
+    [InlineData("https://pkgs.invalid/v3/index.json", "https://pkgs.invalid/v3/index.json/")]
+    [InlineData("https://pkgs.invalid/v3/index.json", "HTTPS://Pkgs.Invalid/V3/Index.json")]
+    [InlineData("https://pkgs.invalid/v3/index.json", "  https://pkgs.invalid/v3/index.json  ")]
+    public void GetSourceKey_TreatsSpellingsOfOneFeedAsOneSource(string left, string right)
+    {
+        // Two configs naming one feed differently must share cached bytes, or
+        // scoping silently degrades into duplicated downloads.
+        Assert.Equal(NuGetCache.GetSourceKey(left), NuGetCache.GetSourceKey(right));
+    }
+
+    [Fact]
+    public void GetSourceKey_DistinguishesDifferentFeeds()
+    {
+        Assert.NotEqual(
+            NuGetCache.GetSourceKey("https://pkgs.invalid/one/v3/index.json"),
+            NuGetCache.GetSourceKey("https://pkgs.invalid/two/v3/index.json"));
+    }
+
+    [Fact]
+    public void GetSourceKey_DoesNotRevealTheSourceUrl()
+    {
+        // Commit markers are world-readable files and a source URL can carry
+        // userinfo credentials, so the key must be a digest, not the URL.
+        const string Secret = "s3cret-token";
+        var key = NuGetCache.GetSourceKey($"https://user:{Secret}@pkgs.invalid/v3/index.json");
+
+        Assert.DoesNotContain(Secret, key, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("pkgs.invalid", key, StringComparison.OrdinalIgnoreCase);
+        Assert.Matches("^[0-9a-f]{16}$", key);
+    }
+
+    [Fact]
     public void TryGetCachedPackage_DoesNotUseLegacyDirectCopyNamespace()
     {
         string packageName = $"legacy.test.{Guid.NewGuid():N}";
@@ -555,7 +674,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             "legacy",
             payloadCount: 1);
 
-        Assert.Null(NuGetCache.TryGetCachedPackage(packageName, Version));
+        Assert.Null(NuGetCache.TryGetCachedPackage(packageName, Version, [TestSourceKey]));
     }
 
     private static byte[] CreatePackageArchive(

--- a/src/dotnet-inspect.Tests/PackageStoreTests.cs
+++ b/src/dotnet-inspect.Tests/PackageStoreTests.cs
@@ -5,6 +5,14 @@ namespace DotnetInspector.Tests;
 [Collection("Console")]
 public sealed class PackageStoreTests : IDisposable
 {
+    /// <summary>
+    /// Stands in for the source that served the fixture bytes. Cached content is
+    /// scoped to the source that committed it, so a test that seeds the cache
+    /// must also say which source it is speaking for.
+    /// </summary>
+    private static readonly string TestSourceKey =
+        NuGetCache.GetSourceKey("https://tests.invalid/v3/index.json");
+
     private readonly string _cacheDir =
         Path.Combine(Path.GetTempPath(), $"dotnet-inspect-pkgstore-{Guid.NewGuid():N}");
 
@@ -28,11 +36,11 @@ public sealed class PackageStoreTests : IDisposable
         var store = new InMemoryPackageStore();
         var nupkg = MakeNupkg("Example");
 
-        Assert.Null(store.TryGetCached("Foo.Bar", "2.0.0"));
+        Assert.Null(store.TryGetCached("Foo.Bar", "2.0.0", [TestSourceKey]));
 
         IPackageContent content;
         using (var stream = new MemoryStream(nupkg))
-            content = await store.CommitAsync("Foo.Bar", "2.0.0", stream, ct);
+            content = await store.CommitAsync("Foo.Bar", "2.0.0", TestSourceKey, stream, ct);
 
         // In-memory content is never materialized on disk.
         Assert.Null(content.RootPath);
@@ -54,8 +62,27 @@ public sealed class PackageStoreTests : IDisposable
         Assert.Contains("lib/net8.0/Example.dll", entries);
 
         // Lookup is case-insensitive on name and version.
-        Assert.NotNull(store.TryGetCached("foo.bar", "2.0.0"));
-        Assert.NotNull(store.TryGetCached("Foo.Bar", "2.0.0"));
+        Assert.NotNull(store.TryGetCached("foo.bar", "2.0.0", [TestSourceKey]));
+        Assert.NotNull(store.TryGetCached("Foo.Bar", "2.0.0", [TestSourceKey]));
+    }
+
+    [Fact]
+    public async Task InMemoryPackageStore_DoesNotServeContentCommittedByAnotherSource()
+    {
+        var store = new InMemoryPackageStore();
+        var ct = TestContext.Current.CancellationToken;
+        string privateFeedKey = NuGetCache.GetSourceKey("https://private.invalid/v3/index.json");
+        string publicFeedKey = NuGetCache.GetSourceKey("https://api.nuget.org/v3/index.json");
+
+        using (var stream = new MemoryStream(MakeNupkg("Foo.Bar")))
+        {
+            await store.CommitAsync("Foo.Bar", "2.0.0", privateFeedKey, stream, ct);
+        }
+
+        Assert.Null(store.TryGetCached("Foo.Bar", "2.0.0", [publicFeedKey]));
+        Assert.NotNull(store.TryGetCached("Foo.Bar", "2.0.0", [publicFeedKey, privateFeedKey]));
+        Assert.Null(store.TryGetLatestCachedVersion("Foo.Bar", [publicFeedKey]));
+        Assert.Equal("2.0.0", store.TryGetLatestCachedVersion("Foo.Bar", [privateFeedKey]));
     }
 
     [Fact]
@@ -67,11 +94,11 @@ public sealed class PackageStoreTests : IDisposable
         foreach (var version in new[] { "2.0.0", "2.1.0", "3.0.0-beta" })
         {
             using var stream = new MemoryStream(MakeNupkg("Example"));
-            await store.CommitAsync("Foo.Bar", version, stream, ct);
+            await store.CommitAsync("Foo.Bar", version, TestSourceKey, stream, ct);
         }
 
-        Assert.Equal("2.1.0", store.TryGetLatestCachedVersion("Foo.Bar"));
-        Assert.Null(store.TryGetLatestCachedVersion("Unknown.Package"));
+        Assert.Equal("2.1.0", store.TryGetLatestCachedVersion("Foo.Bar", [TestSourceKey]));
+        Assert.Null(store.TryGetLatestCachedVersion("Unknown.Package", [TestSourceKey]));
     }
 
     [Fact]
@@ -81,11 +108,11 @@ public sealed class PackageStoreTests : IDisposable
         var store = new FileSystemPackageStore();
         var nupkg = MakeNupkg("example.package");
 
-        Assert.Null(store.TryGetCached("example.package", "1.0.0"));
+        Assert.Null(store.TryGetCached("example.package", "1.0.0", [TestSourceKey]));
 
         IPackageContent committed;
         using (var stream = new MemoryStream(nupkg))
-            committed = await store.CommitAsync("example.package", "1.0.0", stream, ct);
+            committed = await store.CommitAsync("example.package", "1.0.0", TestSourceKey, stream, ct);
 
         Assert.NotNull(committed.RootPath);
         Assert.True(Directory.Exists(committed.RootPath));
@@ -99,12 +126,12 @@ public sealed class PackageStoreTests : IDisposable
         dll.Dispose();
 
         // A second lookup hits the committed cache entry at the same path.
-        var cached = store.TryGetCached("example.package", "1.0.0");
+        var cached = store.TryGetCached("example.package", "1.0.0", [TestSourceKey]);
         Assert.NotNull(cached);
         Assert.Equal(committed.RootPath, cached!.RootPath);
         Assert.True(cached.FromCache);
 
-        Assert.Equal("1.0.0", store.TryGetLatestCachedVersion("example.package"));
+        Assert.Equal("1.0.0", store.TryGetLatestCachedVersion("example.package", [TestSourceKey]));
     }
 
     [Theory]
@@ -124,7 +151,7 @@ public sealed class PackageStoreTests : IDisposable
         await Assert.ThrowsAsync<ArgumentException>(async () =>
         {
             using var stream = new MemoryStream(MakeNupkg("example.package"));
-            await store.CommitAsync(packageName, version, stream, ct);
+            await store.CommitAsync(packageName, version, TestSourceKey, stream, ct);
         });
     }
 
@@ -140,7 +167,7 @@ public sealed class PackageStoreTests : IDisposable
         await Assert.ThrowsAsync<ArgumentException>(async () =>
         {
             using var stream = new MemoryStream(MakeNupkg("example.package"));
-            await store.CommitAsync(packageName, version, stream, ct);
+            await store.CommitAsync(packageName, version, TestSourceKey, stream, ct);
         });
     }
 
@@ -152,7 +179,7 @@ public sealed class PackageStoreTests : IDisposable
 
         IPackageContent content;
         using (var stream = new MemoryStream(MakeNupkg("Example")))
-            content = await store.CommitAsync("Foo.Bar", "1.0.0", stream, ct);
+            content = await store.CommitAsync("Foo.Bar", "1.0.0", TestSourceKey, stream, ct);
 
         // Entry stored as lib/net8.0/Example.dll; a differently-cased request
         // must still resolve, mirroring the desktop filesystem.
@@ -168,7 +195,7 @@ public sealed class PackageStoreTests : IDisposable
 
         IPackageContent content;
         using (var stream = new MemoryStream(MakeNupkg("example.package")))
-            content = await store.CommitAsync("example.package", "1.0.0", stream, ct);
+            content = await store.CommitAsync("example.package", "1.0.0", TestSourceKey, stream, ct);
 
         Assert.Throws<ArgumentException>(() =>
             content.TryOpenEntry("../escape.dll", out _));

--- a/src/dotnet-inspect.Tests/PackageVersionTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionTests.cs
@@ -20,7 +20,9 @@ public class PackageVersionTests
     {
         await EnsurePackageCached("System.CommandLine");
 
-        var cachedVersion = NuGetCache.TryGetLatestCachedVersion("System.CommandLine");
+        var cachedVersion = NuGetCache.TryGetLatestCachedVersion(
+            "System.CommandLine",
+            NuGetSourceResolver.ResolveSourceKeys(null));
         Assert.NotNull(cachedVersion);
 
         var root = CommandLineBuilder.CreateRootCommand();

--- a/src/dotnet-inspect.Tests/RouterVersionTests.cs
+++ b/src/dotnet-inspect.Tests/RouterVersionTests.cs
@@ -23,7 +23,9 @@ public class RouterVersionTests
         // Ensure the package is cached by downloading it first
         await EnsurePackageCached("System.CommandLine");
 
-        var version = NuGetCache.TryGetLatestCachedVersion("System.CommandLine");
+        var version = NuGetCache.TryGetLatestCachedVersion(
+            "System.CommandLine",
+            NuGetSourceResolver.ResolveSourceKeys(null));
         Assert.NotNull(version);
 
         var root = CommandLineBuilder.CreateRootCommand();
@@ -57,7 +59,9 @@ public class RouterVersionTests
     {
         await EnsurePackageCached("System.CommandLine");
 
-        var version = NuGetCache.TryGetLatestCachedVersion("System.CommandLine");
+        var version = NuGetCache.TryGetLatestCachedVersion(
+            "System.CommandLine",
+            NuGetSourceResolver.ResolveSourceKeys(null));
 
         Assert.NotNull(version);
         Assert.Matches(@"^\d+\.\d+\.\d+", version);

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -264,7 +264,9 @@ public static class RouterCommandDefinition
 
         private static async Task<bool> PackageExistsAsync(string packageName, CommandContext context)
         {
-            if (NuGetCache.TryGetLatestCachedVersion(packageName) != null)
+            if (NuGetCache.TryGetLatestCachedVersion(
+                    packageName,
+                    NuGetSourceResolver.ResolveSourceKeys(null)) != null)
                 return true;
 
             try

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -293,7 +293,10 @@ public class PackageCommand
                 && !options.ForceLatest)
             {
                 if (!options.IncludeUnlisted
-                    && NuGetCache.TryGetCachedPackage(normalizedName, versionQueryPinned) != null)
+                    && NuGetCache.TryGetCachedPackage(
+                        normalizedName,
+                        versionQueryPinned,
+                        NuGetSourceResolver.ResolveSourceKeys(options.SourceOptions)) != null)
                 {
                     if (LensProjection.TryProject(options, "--versions", 1, out var cachedPinnedExit))
                         return cachedPinnedExit;
@@ -343,7 +346,9 @@ public class PackageCommand
             if (options.Limit == 1 && !options.ForceLatest && !options.IncludePrerelease
                 && !options.IncludeUnlisted)
             {
-                var cachedVersion = NuGetCache.TryGetLatestCachedVersion(normalizedName);
+                var cachedVersion = NuGetCache.TryGetLatestCachedVersion(
+                    normalizedName,
+                    NuGetSourceResolver.ResolveSourceKeys(options.SourceOptions));
                 if (cachedVersion != null)
                 {
                     if (LensProjection.TryProject(options, "--versions", 1, out var cachedLatestExit))

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -528,7 +528,9 @@ public static class TypeCommand
 
     private static async Task<bool> PackageExistsAsync(string packageName, TypeOptions options, CommandContext context)
     {
-        if (NuGetCache.TryGetLatestCachedVersion(packageName) != null)
+        if (NuGetCache.TryGetLatestCachedVersion(
+                packageName,
+                NuGetSourceResolver.ResolveSourceKeys(null)) != null)
             return true;
 
         try

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -530,7 +530,7 @@ public static class TypeCommand
     {
         if (NuGetCache.TryGetLatestCachedVersion(
                 packageName,
-                NuGetSourceResolver.ResolveSourceKeys(null)) != null)
+                NuGetSourceResolver.ResolveSourceKeys(options.SourceOptions)) != null)
             return true;
 
         try

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -441,7 +441,7 @@ internal static class SourceEnricher
             // that doesn't encode the version. Check the cache directory instead.
             if (packageVersion == null)
             {
-                packageVersion = FindCachedPackageVersion(packageName);
+                packageVersion = FindCachedPackageVersion(packageName, options);
             }
         }
         return (packageName, packageVersion);
@@ -450,10 +450,10 @@ internal static class SourceEnricher
     /// <summary>
     /// Finds the latest cached version for a package by checking the cache directory.
     /// </summary>
-    private static string? FindCachedPackageVersion(string packageName)
+    private static string? FindCachedPackageVersion(string packageName, ApiOptions options)
         => NuGetCache.TryGetLatestCachedVersion(
             packageName,
-            NuGetSourceResolver.ResolveSourceKeys(null));
+            NuGetSourceResolver.ResolveSourceKeys(options.SourceOptions));
 
     /// <summary>
     /// Enriches multiple types from a single XML doc file (loaded once).

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -451,7 +451,9 @@ internal static class SourceEnricher
     /// Finds the latest cached version for a package by checking the cache directory.
     /// </summary>
     private static string? FindCachedPackageVersion(string packageName)
-        => NuGetCache.TryGetLatestCachedVersion(packageName);
+        => NuGetCache.TryGetLatestCachedVersion(
+            packageName,
+            NuGetSourceResolver.ResolveSourceKeys(null));
 
     /// <summary>
     /// Enriches multiple types from a single XML doc file (loaded once).

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -95,7 +95,9 @@ public static class SourceResolver
             }
 
             // Space 2 & 3: dotnet-inspect cache + NuGet global cache
-            if (NuGetCache.TryGetLatestCachedVersion(candidate) != null)
+            if (NuGetCache.TryGetLatestCachedVersion(
+                    candidate,
+                    NuGetSourceResolver.ResolveSourceKeys(null)) != null)
             {
                 RequestTelemetry.Breadcrumb(
                     "qualified-type-split",

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -68,6 +68,10 @@ public static class SourceResolver
 
         string? platformCandidate = null;
 
+        // Resolved once: this walks the directory tree for nuget.config files
+        // and parses each one, and the answer cannot change between candidates.
+        var sourceKeys = NuGetSourceResolver.ResolveSourceKeys(null);
+
         for (int i = name.Length - 1; i >= 0; i--)
         {
             if (name[i] != '.') continue;
@@ -95,9 +99,7 @@ public static class SourceResolver
             }
 
             // Space 2 & 3: dotnet-inspect cache + NuGet global cache
-            if (NuGetCache.TryGetLatestCachedVersion(
-                    candidate,
-                    NuGetSourceResolver.ResolveSourceKeys(null)) != null)
+            if (NuGetCache.TryGetLatestCachedVersion(candidate, sourceKeys) != null)
             {
                 RequestTelemetry.Breadcrumb(
                     "qualified-type-split",


### PR DESCRIPTION
Fixes #3699.

## The defect

The package content cache was keyed by package id and version only. Bytes downloaded from one feed were served to answer a request made under a `nuget.config` that does not list that feed.

Reproduced on `main` before any change, as a three-step A/B/A:

| Step | Config | Result on `main` |
| --- | --- | --- |
| 1 | private feed only | exit 0, populates cache |
| 2 | nuget.org only, warm cache | **exit 0, full report** — the bug |
| 3 | nuget.org only, entry deleted | exit 1 |

Making the source parameter required rather than defaulted turned every call site into a compile error, which surfaced a second instance beyond the issue text: `package <id> --version` against a warm cache printed a private-feed-only version as the answer and returned 0.

## The fix

The source is part of the cache **path**: `{cache}/{id}/{version}/{sourceKey}`. Category bumped to `package-content-v4`, which retires v2 and v3 entries.

Recording the source *inside* a shared entry was tried first and is wrong — it fixes reads and breaks writes. One slot cannot hold one coordinate from two feeds: the second must either overwrite bytes it is not entitled to serve, or fail to cache what it just downloaded. That version threw `InvalidDataException` on a package it had downloaded successfully. Both reviewers caught it; the history is in the commits.

A read happens before the tool knows which source will serve the package, so the question it asks is "is this slot's source one this caller is configured to read from", consulted in configured order so the feed a cold run would have used answers first.

Source identity is a digest of the URL canonicalized by `NuGetCredentialScope.CanonicalizeEndpoint`, extracted from the existing `IsSameEndpoint` so credential scoping and cache identity cannot disagree about what one feed is. Scheme, host, default port, percent-escape casing and a trailing path slash fold; path and query case do not, because `/FeedA` and `/feeda` can be different feeds. Local folder paths preserve case on every platform.

In-flight acquisition is scoped too: `PackageAcquisitionRequest` carries the ordered source scope, so callers with different configurations cannot join one download.

## Scope of the guarantee

Strict conformance applies to content **dotnet-inspect fetched**. The NuGet global folder is deliberately outside it: it holds what the user restored, not what this tool downloaded, and binding to it eagerly is what makes an inspection agree with the bytes a build actually consumed. That is now stated plainly in the docs, including the consequence that a private package sitting there will answer a nuget.org-only run, with `--no-nuget-cache` as the escape hatch.

An earlier draft of these docs justified this with a false claim — that NuGet records no source in the global folder. It does, in `.nupkg.metadata`. The claim was written rather than checked, and is corrected in `1bfd9cd4f`.

## Verification

Live A/B/A against a real private feed passes, plus an offline control (`DOTNET_INSPECT_OFFLINE=1`) proving the entitled config is still served entirely from cache — distinguishing scoping from disabling. The two-feed case produces two sibling slots and no crash. `--no-nuget-cache` verified by A/B: offline, the same coordinate is served from the global folder without it and not found with it.

Mutation-gated, each caught by a different test: source-blind reads; a shared cache path; whole-URL lowercasing; an unscoped flight key; trimming the recombined URL; `Host` for `IdnHost`; lowercased local paths; reversed key list; reversed probe loop.

Suites: `dotnet-inspect.Tests` 2866 with 1 known local-only failure (#3592, confirmed across four runs), `DotnetInspector.Services.Tests` 360/0, `NuGetFetch.Tests` 295/0, `EvilPoolSweepGateTests` 19/0. markdownlint clean.

## Deliberately out of scope

- `<packageSourceMapping>` is not consulted — #3722.
- Precedence between two entitled sources when the higher-precedence one has no cached slot; closing it needs a network probe per request. Documented under "Known deviation" and tracked with the broader source-support design in #3723.