### PR TITLE
Emit generic constraints in the single-member decompiled view

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1527,9 +1527,11 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     /// <summary>
-    /// An override inherits its constraints and may not restate them: `csc` rejects
-    /// a restated clause with CS0460. Both declaration paths have to omit it, so the
-    /// gate runs with and without a caller-supplied generic-parameter list.
+    /// An override inherits its constraints, and a type constraint may not be restated:
+    /// `csc` rejects it with CS0460. Both declaration paths have to omit it, so the gate
+    /// runs with and without a caller-supplied generic-parameter list.
+    /// (The `class`/`struct` carve-out C# does allow is covered separately, by
+    /// <see cref="OverrideGenericMethod_RestatesOnlyTheConstraintCSharpAllows"/>.)
     /// </summary>
     [Theory]
     [InlineData(true)]
@@ -1580,6 +1582,53 @@ public sealed class CSharpDeclarationWriterTests
             methodParameters: callerSuppliesTypeParameters ? ["T"] : null);
 
         Assert.DoesNotContain("where", declaration, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// C# permits exactly one restatement on a member that inherits its constraints —
+    /// a bare `class` or `struct` — and it is load-bearing, not cosmetic: it decides
+    /// whether `T?` means a nullable reference type or Nullable&lt;T&gt;. Dropping it
+    /// produced an override that no longer compiles (CS0453/CS0115), so the reduction
+    /// keeps it while omitting everything CS0460 forbids.
+    /// </summary>
+    [Theory]
+    // A reference-type constraint survives, without the annotation `class?` that is
+    // itself CS0460, and without the `new()` that may not be restated.
+    [InlineData(new[] { "class", "new()" }, "where T : class")]
+    [InlineData(new[] { "class?" }, "where T : class")]
+    // A value-type constraint reduces to the one spelling C# accepts here.
+    [InlineData(new[] { "struct" }, "where T : struct")]
+    [InlineData(new[] { "unmanaged" }, "where T : struct")]
+    // Nothing else may be named on an inheriting member.
+    [InlineData(new[] { "notnull" }, "")]
+    [InlineData(new[] { "System.IComparable<T>" }, "")]
+    public void OverrideGenericMethod_RestatesOnlyTheConstraintCSharpAllows(
+        string[] constraints,
+        string expectedClause)
+    {
+        var (type, member) = CreateConstrainedGenericMethod();
+        member.IsStatic = false;
+        member.IsOverride = true;
+        var typeParameter = member.SignatureModel!.TypeParameters[0];
+        typeParameter.Constraints = [.. constraints];
+        typeParameter.StructuredConstraints =
+        [
+            .. constraints.Select(constraint => new TypeParameterConstraint(
+                constraint,
+                IsTypeName: constraint is not ("class" or "class?" or "struct" or "unmanaged" or "notnull" or "new()"))),
+        ];
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            options: null,
+            methodParameters: ["T"]);
+
+        Assert.Equal(
+            string.IsNullOrEmpty(expectedClause)
+                ? "public override int Compare<T>(T a, T b)"
+                : $"public override int Compare<T>(T a, T b) {expectedClause}",
+            declaration);
     }
 
     static (ApiType Type, ApiMember Member) CreateConstrainedGenericMethod()

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1491,6 +1491,138 @@ public sealed class CSharpDeclarationWriterTests
         Assert.Equal("public class GlobalKeywordType<T> where T : struct, @struct", declaration);
     }
 
+    /// <summary>
+    /// A caller-supplied generic-parameter list (the decompiled-source `member`
+    /// view passes the names it resolved from metadata) makes the ApiSignature
+    /// renderer decline, so the declaration is composed on the text path instead.
+    /// That path used to drop the `where` clauses, emitting C# that no longer
+    /// states the constraint its body relies on (issue #3664).
+    /// </summary>
+    [Fact]
+    public void GenericMethod_WithCallerSuppliedTypeParameters_KeepsConstraints()
+    {
+        var (type, member) = CreateConstrainedGenericMethod();
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member, options: null, methodParameters: ["T"]);
+
+        Assert.Equal(
+            "public static int Compare<T>(T a, T b) where T : System.IComparable<T>",
+            declaration);
+    }
+
+    /// <summary>
+    /// The ApiSignature path renders the same constraints, so the two paths agree
+    /// on the clause rather than one of them silently dropping it.
+    /// </summary>
+    [Fact]
+    public void GenericMethod_WithoutCallerSuppliedTypeParameters_KeepsConstraints()
+    {
+        var (type, member) = CreateConstrainedGenericMethod();
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal(
+            "public static int Compare<T>(T a, T b) where T : System.IComparable<T>",
+            declaration);
+    }
+
+    /// <summary>
+    /// An override inherits its constraints and may not restate them: `csc` rejects
+    /// a restated clause with CS0460. Both declaration paths have to omit it, so the
+    /// gate runs with and without a caller-supplied generic-parameter list.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OverrideGenericMethod_OmitsInheritedConstraints(bool callerSuppliesTypeParameters)
+    {
+        var (type, member) = CreateConstrainedGenericMethod();
+        member.IsStatic = false;
+        member.IsOverride = true;
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            options: null,
+            methodParameters: callerSuppliesTypeParameters ? ["T"] : null);
+
+        Assert.Equal("public override int Compare<T>(T a, T b)", declaration);
+    }
+
+    /// <summary>
+    /// An explicit interface implementation inherits its constraints for the same
+    /// reason an override does, and restating them is the same CS0460.
+    /// </summary>
+    /// <remarks>
+    /// Only the caller-supplied case is load-bearing today: forcing the gate open
+    /// fails that case but not the ApiSignature one, because the ApiSignature method
+    /// branch keys on <c>Kind == "method"</c> and so never renders this kind at all.
+    /// The second case is therefore a pin, not a gate — it fails if a later change
+    /// routes explicit interface implementations through that branch without
+    /// teaching it about inherited constraints.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ExplicitInterfaceGenericMethod_OmitsInheritedConstraints(bool callerSuppliesTypeParameters)
+    {
+        var (type, member) = CreateConstrainedGenericMethod();
+        member.IsStatic = false;
+        member.Kind = "explicit-interface-implementation";
+        member.Name = "Samples.IComparer.Compare";
+        member.Signature = "int Samples.IComparer.Compare<T>(T a, T b)";
+        member.SignatureModel!.MemberName = "Samples.IComparer.Compare<T>";
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            options: null,
+            methodParameters: callerSuppliesTypeParameters ? ["T"] : null);
+
+        Assert.DoesNotContain("where", declaration, StringComparison.Ordinal);
+    }
+
+    static (ApiType Type, ApiMember Member) CreateConstrainedGenericMethod()
+    {
+        var member = new ApiMember
+        {
+            Name = "Compare",
+            Kind = "method",
+            IsStatic = true,
+            Signature = "int Compare<T>(T a, T b)",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Compare<T>",
+                TypeParameters =
+                [
+                    new TypeParameter
+                    {
+                        Name = "T",
+                        Constraints = ["System.IComparable<T>"],
+                        StructuredConstraints =
+                        [
+                            new TypeParameterConstraint("System.IComparable<T>", IsTypeName: true),
+                        ],
+                    },
+                ],
+                Parameters =
+                [
+                    new ApiParameter { Name = "a", Type = "T" },
+                    new ApiParameter { Name = "b", Type = "T" },
+                ],
+            },
+        };
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Values",
+            Kind = "class",
+            Members = [member],
+        };
+        return (type, member);
+    }
+
     static ApiType CreateSampleType()
         => new()
         {

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -788,8 +788,9 @@ internal static class CSharpDeclarationWriter
     /// rather than cosmetic: a bare <c>class</c> or <c>struct</c> constraint *may* be
     /// restated, and it is what decides how <c>T?</c> binds. Dropping it silently
     /// rewrites <c>T?</c> from a nullable reference type to <see cref="System.Nullable{T}"/>
-    /// (or the reverse), so those two are reduced to their legal spelling and kept
-    /// while every other constraint is omitted.
+    /// (or the reverse), so those two are reduced to their legal spelling and kept.
+    /// Constraints outside that pair are omitted here; see
+    /// <see cref="AppendInheritedConstraintRestatement"/> for the cases that leaves open.
     /// </summary>
     /// <remarks>
     /// Both member call sites (the <see cref="ApiSignature"/> renderer and the text
@@ -810,10 +811,22 @@ internal static class CSharpDeclarationWriter
     /// Restates only what C# permits on a member that inherits its constraints: the
     /// bare <c>class</c> or <c>struct</c> keyword. The annotated <c>class?</c> form is
     /// itself CS0460, and <c>unmanaged</c> is a value-type constraint, so both are
-    /// reduced to the legal spelling that preserves how <c>T?</c> binds. Every other
-    /// constraint — <c>notnull</c>, <c>new()</c>, and type constraints — is inherited
-    /// and cannot be named here.
+    /// reduced to the legal spelling that preserves how <c>T?</c> binds.
     /// </summary>
+    /// <remarks>
+    /// Every clause emitted here was compiled against csc as a restatement on an
+    /// override, and the reduction is gated by
+    /// <c>OverrideGenericMethod_RestatesOnlyTheConstraintCSharpAllows</c> plus the two
+    /// real-artifact canaries in <c>ApiOutputFormatterTests</c>. What is emitted is
+    /// therefore correct, but it is knowingly *incomplete*: a base constraint that is
+    /// not one of these keywords — <c>notnull</c>, a named class or interface type, or
+    /// no constraint at all — also needs a restatement (<c>class</c> or <c>default</c>,
+    /// per the table in issue #3721) once the signature spells <c>T?</c>, and none is
+    /// emitted for it. Deciding those rows needs a reference-/value-type fact about the
+    /// constraint type that <see cref="TypeParameter"/> does not carry and that Metadata
+    /// rather than this layer must own, so it is tracked as #3721 rather than guessed at
+    /// here. Those cases render exactly as they did before this reduction existed.
+    /// </remarks>
     static string AppendInheritedConstraintRestatement(
         string declaration,
         IReadOnlyList<TypeParameter> typeParameters)

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -782,25 +782,81 @@ internal static class CSharpDeclarationWriter
     }
 
     /// <summary>
-    /// Appends a method's <c>where</c> clauses, except on the two member shapes that
-    /// inherit their constraints and may not restate them: an <c>override</c> and an
-    /// explicit interface implementation both reject a restated constraint with CS0460.
-    /// Omitting the clauses there is faithful as well as compilable, because the
-    /// inherited constraints are exactly the ones metadata recorded.
+    /// Appends a method's <c>where</c> clauses. An <c>override</c> and an explicit
+    /// interface implementation inherit their constraints and mostly may not restate
+    /// them (CS0460) — but C# carves out exactly one exception, and it is load-bearing
+    /// rather than cosmetic: a bare <c>class</c> or <c>struct</c> constraint *may* be
+    /// restated, and it is what decides how <c>T?</c> binds. Dropping it silently
+    /// rewrites <c>T?</c> from a nullable reference type to <see cref="System.Nullable{T}"/>
+    /// (or the reverse), so those two are reduced to their legal spelling and kept
+    /// while every other constraint is omitted.
     /// </summary>
     /// <remarks>
     /// Both member call sites (the <see cref="ApiSignature"/> renderer and the text
     /// path a caller-supplied generic-parameter list forces) route through here, so
-    /// the two cannot disagree about when a clause is legal. The type-declaration call
-    /// site does not: a type always owns, and so always restates, its own constraints.
+    /// the two cannot disagree about which clauses are legal. The type-declaration
+    /// call site does not: a type always owns, and so always restates, its own
+    /// constraints.
     /// </remarks>
     static string AppendMemberTypeParameterConstraints(
         string declaration,
         ApiMember member,
         IReadOnlyList<TypeParameter> typeParameters)
         => member.IsOverride || member.Kind == "explicit-interface-implementation"
-            ? declaration
+            ? AppendInheritedConstraintRestatement(declaration, typeParameters)
             : AppendTypeParameterConstraints(declaration, typeParameters);
+
+    /// <summary>
+    /// Restates only what C# permits on a member that inherits its constraints: the
+    /// bare <c>class</c> or <c>struct</c> keyword. The annotated <c>class?</c> form is
+    /// itself CS0460, and <c>unmanaged</c> is a value-type constraint, so both are
+    /// reduced to the legal spelling that preserves how <c>T?</c> binds. Every other
+    /// constraint — <c>notnull</c>, <c>new()</c>, and type constraints — is inherited
+    /// and cannot be named here.
+    /// </summary>
+    static string AppendInheritedConstraintRestatement(
+        string declaration,
+        IReadOnlyList<TypeParameter> typeParameters)
+    {
+        foreach (var typeParameter in typeParameters)
+        {
+            if (RestatableConstraint(typeParameter) is not { } keyword)
+                continue;
+
+            declaration += $" where {SanitizeIdentifier(typeParameter.Name)} : {keyword}";
+        }
+
+        return declaration;
+    }
+
+    /// <summary>
+    /// The single keyword an inheriting member may restate for one type parameter, or
+    /// null when it has no reference- or value-type constraint to restate. Reads
+    /// <see cref="TypeParameter.StructuredConstraints"/> when the producer populated
+    /// it, so a constraint *type* literally named <c>class</c> is never mistaken for
+    /// the keyword.
+    /// </summary>
+    static string? RestatableConstraint(TypeParameter typeParameter)
+    {
+        var keywords = typeParameter.StructuredConstraints is { } structured
+            ? structured.Where(constraint => !constraint.IsTypeName).Select(constraint => constraint.Value)
+            : typeParameter.Constraints.Where(s_specialConstraintKeywords.Contains);
+
+        string? keyword = null;
+        foreach (var candidate in keywords)
+        {
+            switch (candidate)
+            {
+                case "class" or "class?":
+                    return "class";
+                case "struct" or "unmanaged":
+                    keyword = "struct";
+                    break;
+            }
+        }
+
+        return keyword;
+    }
 
     static string AppendTypeParameterConstraints(string declaration, IReadOnlyList<TypeParameter> typeParameters)
     {

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -351,7 +351,22 @@ internal static class CSharpDeclarationWriter
             && !IsExplicitInterfaceEvent(member))
         {
             if (methodParameters is { Count: > 0 })
+            {
                 signature = AddMethodGenericParameters(signature, member.Name, methodParameters);
+                // TryRenderSignatureModel appends the `where` clauses itself, but it
+                // declines whenever a caller supplies its own generic-parameter names,
+                // so this text path has to recover them. Without this a constrained
+                // generic method renders as uncompilable C# (the body may rely on a
+                // constraint the declaration no longer states). The caller's names come
+                // from the same GenericParameter rows in the same order as the model's,
+                // so the two line up by construction; requiring equal arity keeps a
+                // mismatched pairing from spelling a clause for the wrong parameter.
+                if (member.SignatureModel?.TypeParameters is { Count: > 0 } modelTypeParameters
+                    && modelTypeParameters.Count == methodParameters.Count)
+                {
+                    signature = AppendMemberTypeParameterConstraints(signature, member, modelTypeParameters);
+                }
+            }
             if (member.IsExtension)
                 signature = AddExtensionThisModifier(signature);
             signature = EscapeMemberNameInSignature(signature, member.Name);
@@ -766,6 +781,27 @@ internal static class CSharpDeclarationWriter
         }
     }
 
+    /// <summary>
+    /// Appends a method's <c>where</c> clauses, except on the two member shapes that
+    /// inherit their constraints and may not restate them: an <c>override</c> and an
+    /// explicit interface implementation both reject a restated constraint with CS0460.
+    /// Omitting the clauses there is faithful as well as compilable, because the
+    /// inherited constraints are exactly the ones metadata recorded.
+    /// </summary>
+    /// <remarks>
+    /// Both member call sites (the <see cref="ApiSignature"/> renderer and the text
+    /// path a caller-supplied generic-parameter list forces) route through here, so
+    /// the two cannot disagree about when a clause is legal. The type-declaration call
+    /// site does not: a type always owns, and so always restates, its own constraints.
+    /// </remarks>
+    static string AppendMemberTypeParameterConstraints(
+        string declaration,
+        ApiMember member,
+        IReadOnlyList<TypeParameter> typeParameters)
+        => member.IsOverride || member.Kind == "explicit-interface-implementation"
+            ? declaration
+            : AppendTypeParameterConstraints(declaration, typeParameters);
+
     static string AppendTypeParameterConstraints(string declaration, IReadOnlyList<TypeParameter> typeParameters)
     {
         foreach (var typeParameter in typeParameters)
@@ -877,7 +913,7 @@ internal static class CSharpDeclarationWriter
         {
             if (memberName.Contains('<', StringComparison.Ordinal) && model.TypeParameters.Count == 0)
                 return false;
-            signature = AppendTypeParameterConstraints($"{returnType} {memberName}({parameters})", model.TypeParameters);
+            signature = AppendMemberTypeParameterConstraints($"{returnType} {memberName}({parameters})", member, model.TypeParameters);
             return true;
         }
         if ((member.Kind == "property" || IsExplicitInterfaceProperty(member))

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -306,6 +306,7 @@ internal static class CSharpDeclarationWriter
         IReadOnlyList<string>? methodParameters = null)
     {
         string signature;
+        var renderedFromModel = false;
         if (member.Kind == "field" && member.Signature == null && !string.IsNullOrWhiteSpace(member.ReturnType))
         {
             signature = $"{member.ReturnType} {member.Name}";
@@ -313,6 +314,7 @@ internal static class CSharpDeclarationWriter
         else if (TryRenderSignatureModel(type, member, options, methodParameters, out var modelSignature))
         {
             signature = modelSignature;
+            renderedFromModel = true;
         }
         else
         {
@@ -351,21 +353,27 @@ internal static class CSharpDeclarationWriter
             && !IsExplicitInterfaceEvent(member))
         {
             if (methodParameters is { Count: > 0 })
-            {
                 signature = AddMethodGenericParameters(signature, member.Name, methodParameters);
-                // TryRenderSignatureModel appends the `where` clauses itself, but it
-                // declines whenever a caller supplies its own generic-parameter names,
-                // so this text path has to recover them. Without this a constrained
-                // generic method renders as uncompilable C# (the body may rely on a
-                // constraint the declaration no longer states). The caller's names come
-                // from the same GenericParameter rows in the same order as the model's,
-                // so the two line up by construction; requiring equal arity keeps a
-                // mismatched pairing from spelling a clause for the wrong parameter.
-                if (member.SignatureModel?.TypeParameters is { Count: > 0 } modelTypeParameters
-                    && modelTypeParameters.Count == methodParameters.Count)
-                {
-                    signature = AppendMemberTypeParameterConstraints(signature, member, modelTypeParameters);
-                }
+
+            // TryRenderSignatureModel appends the `where` clauses itself, so only the
+            // text fallback has to recover them — and it is reached two different ways.
+            // A caller that supplies its own generic-parameter names makes the model
+            // path decline (the single-member view), and so does a member kind the
+            // model path does not render (an explicit interface implementation, in the
+            // whole-type view). Both used to lose the clauses, which renders a
+            // constrained generic member as uncompilable C#: the declaration stops
+            // stating a constraint its own signature and body still rely on.
+            //
+            // When the caller supplied names, they and the model's type parameters come
+            // from the same GenericParameter rows in the same order, so the two line up
+            // by construction; requiring equal arity keeps a mismatched pairing from
+            // spelling a clause for the wrong parameter. When the caller supplied none
+            // there is nothing to pair with, and the model's list stands alone.
+            if (!renderedFromModel
+                && member.SignatureModel?.TypeParameters is { Count: > 0 } modelTypeParameters
+                && (methodParameters is not { Count: > 0 } || methodParameters.Count == modelTypeParameters.Count))
+            {
+                signature = AppendMemberTypeParameterConstraints(signature, member, modelTypeParameters);
             }
             if (member.IsExtension)
                 signature = AddExtensionThisModifier(signature);

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -807,6 +807,29 @@ public class ApiOutputFormatterTests
         Assert.DoesNotContain("class?", typeSource, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// An explicit interface implementation reaches the text fallback by a second route:
+    /// the signature-model path renders only <c>method</c>, so this kind falls through it
+    /// even in the whole-type view, where no caller supplies a generic-parameter list.
+    /// The recovery has to fire on that route too — the rendered parameter is spelled
+    /// <c>Nullable&lt;T&gt;</c>, which is not even legal without the <c>struct</c> clause.
+    /// </summary>
+    [Fact]
+    public void ConstrainedGenericExplicitImplementation_KeepsItsConstraintInTheWholeTypeView()
+    {
+        string path = typeof(ConstraintFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(ConstraintFixture).FullName);
+
+        var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
+        Assert.NotNull(typeSource);
+        Assert.Contains("Wrap<T>", typeSource, StringComparison.Ordinal);
+        Assert.Contains("where T : struct", typeSource, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -1105,11 +1128,23 @@ public abstract class ConstraintFixtureBase
     public abstract T? Pick<T>(T? value) where T : class;
 }
 
-public class ConstraintFixture : ConstraintFixtureBase
+public class ConstraintFixture : ConstraintFixtureBase, IConstraintFixture
 {
     public static int Compare<T>(T a, T b) where T : IComparable<T> => a.CompareTo(b);
 
     public override void Run<T>(T value) => value.ToString();
 
     public override T? Pick<T>(T? value) where T : class => value;
+
+    void IConstraintFixture.Wrap<T>(T? value) { }
+}
+
+/// <summary>
+/// The explicit implementation of <see cref="Wrap"/> is rendered by the text fallback in
+/// the whole-type view — the signature-model path declines the kind — so it is the case
+/// that reaches the constraint recovery without a caller-supplied parameter list.
+/// </summary>
+public interface IConstraintFixture
+{
+    void Wrap<T>(T? value) where T : struct;
 }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -717,12 +717,12 @@ public class ApiOutputFormatterTests
     }
 
     /// <summary>
-    /// The same chain must omit the clauses an override inherits: restating them is
-    /// CS0460 ("constraints ... are inherited from the base method"), so emitting
-    /// them would trade one uncompilable render for another.
+    /// The same chain must drop the parts of an inherited constraint that C# forbids
+    /// restating: `Run&lt;T&gt;` is declared `where T : class, new()`, and `new()` is
+    /// CS0460 on an override while the bare `class` is the permitted carve-out.
     /// </summary>
     [Fact]
-    public void ConstrainedGenericOverride_OmitsInheritedConstraintsInBothDecompiledViews()
+    public void ConstrainedGenericOverride_OmitsTheConstraintsCSharpForbidsRestating()
     {
         string path = typeof(ConstraintFixture).Assembly.Location;
         using var pe = new PEReader(File.OpenRead(path));
@@ -751,12 +751,60 @@ public class ApiOutputFormatterTests
 
         Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, collected.Code));
         Assert.Contains("void Run<T>", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
-        Assert.DoesNotContain("where T", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+        Assert.Contains("where T : class", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+        Assert.DoesNotContain("new()", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
 
         var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
         Assert.NotNull(typeSource);
         Assert.Contains("void Run<T>", typeSource, StringComparison.Ordinal);
-        Assert.DoesNotContain("where T : class", typeSource, StringComparison.Ordinal);
+        Assert.Contains("where T : class", typeSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("class, new()", typeSource, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The same chain must reduce, not drop, the constraints an override inherits.
+    /// C# allows exactly a bare `class` or `struct` to be restated, and that carve-out
+    /// decides how `T?` binds: without it `T?` becomes Nullable&lt;T&gt; and the render
+    /// stops compiling (CS0453/CS0115). Real compiled metadata records the constraint
+    /// as `class?`, which is itself CS0460, so this also pins the normalization.
+    /// </summary>
+    [Fact]
+    public void ConstrainedGenericOverride_RestatesTheNullabilityDecidingConstraint()
+    {
+        string path = typeof(ConstraintFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(ConstraintFixture).FullName);
+        var member = Assert.Single(type.Members, candidate => candidate.Name == nameof(ConstraintFixture.Pick));
+        var collected = Assert.Single(MemberCodeProvider.Collect(
+            type,
+            [member],
+            path,
+            overloadIndex: 0,
+            new MemberCodeProvider.Request(
+                DecompiledSource: true,
+                AnnotatedSource: false,
+                CostOverlay: false,
+                SemanticsOverlay: false,
+                IL: false,
+                Attributes: false,
+                Calls: false,
+                Callers: false,
+                CallGraph: false,
+                UnsafeOperations: false)));
+        var sections = new MemberCodeView();
+
+        Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, collected.Code));
+        Assert.Contains("where T : class", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+        // The annotated spelling metadata records is itself CS0460 on an override.
+        Assert.DoesNotContain("class?", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+
+        var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
+        Assert.NotNull(typeSource);
+        Assert.Contains("where T : class", typeSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("class?", typeSource, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -1049,6 +1097,12 @@ public static class RuntimeAsyncHeaderFixture
 public abstract class ConstraintFixtureBase
 {
     public abstract void Run<T>(T value) where T : class, new();
+
+    /// <summary>
+    /// The `class` constraint here is what makes `T?` a nullable reference type rather
+    /// than Nullable&lt;T&gt;, so an override that drops it renders uncompilable C#.
+    /// </summary>
+    public abstract T? Pick<T>(T? value) where T : class;
 }
 
 public class ConstraintFixture : ConstraintFixtureBase
@@ -1056,4 +1110,6 @@ public class ConstraintFixture : ConstraintFixtureBase
     public static int Compare<T>(T a, T b) where T : IComparable<T> => a.CompareTo(b);
 
     public override void Run<T>(T value) => value.ToString();
+
+    public override T? Pick<T>(T? value) where T : class => value;
 }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -668,6 +668,97 @@ public class ApiOutputFormatterTests
         Assert.Contains("\"is_finalizer\": true", json, System.StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Real-artifact canary for issue #3664. The single-member decompiled-source
+    /// view supplies its own generic-parameter names, which makes the ApiSignature
+    /// renderer decline; the text path it falls back to used to drop the `where`
+    /// clauses, so a constrained generic method rendered as C# that no longer
+    /// compiles. Runs against this test assembly's own compiled metadata, so it
+    /// pins the whole chain — constraint decoding, the member view, and the
+    /// whole-type listing — rather than a hand-built signature model.
+    /// </summary>
+    [Fact]
+    public void ConstrainedGenericMethod_KeepsConstraintsInBothDecompiledViews()
+    {
+        string path = typeof(ConstraintFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(ConstraintFixture).FullName);
+        var member = Assert.Single(type.Members, candidate => candidate.Name == nameof(ConstraintFixture.Compare));
+        var collected = Assert.Single(MemberCodeProvider.Collect(
+            type,
+            [member],
+            path,
+            overloadIndex: 0,
+            new MemberCodeProvider.Request(
+                DecompiledSource: true,
+                AnnotatedSource: false,
+                CostOverlay: false,
+                SemanticsOverlay: false,
+                IL: false,
+                Attributes: false,
+                Calls: false,
+                Callers: false,
+                CallGraph: false,
+                UnsafeOperations: false)));
+        var sections = new MemberCodeView();
+
+        Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, collected.Code));
+        Assert.Contains(
+            "where T : System.IComparable<T>",
+            sections.DecompiledSourceCode.Content,
+            StringComparison.Ordinal);
+
+        var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
+        Assert.NotNull(typeSource);
+        Assert.Contains("where T : IComparable<T>", typeSource, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The same chain must omit the clauses an override inherits: restating them is
+    /// CS0460 ("constraints ... are inherited from the base method"), so emitting
+    /// them would trade one uncompilable render for another.
+    /// </summary>
+    [Fact]
+    public void ConstrainedGenericOverride_OmitsInheritedConstraintsInBothDecompiledViews()
+    {
+        string path = typeof(ConstraintFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(ConstraintFixture).FullName);
+        var member = Assert.Single(type.Members, candidate => candidate.Name == nameof(ConstraintFixture.Run));
+        var collected = Assert.Single(MemberCodeProvider.Collect(
+            type,
+            [member],
+            path,
+            overloadIndex: 0,
+            new MemberCodeProvider.Request(
+                DecompiledSource: true,
+                AnnotatedSource: false,
+                CostOverlay: false,
+                SemanticsOverlay: false,
+                IL: false,
+                Attributes: false,
+                Calls: false,
+                Callers: false,
+                CallGraph: false,
+                UnsafeOperations: false)));
+        var sections = new MemberCodeView();
+
+        Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, collected.Code));
+        Assert.Contains("void Run<T>", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+        Assert.DoesNotContain("where T", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+
+        var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
+        Assert.NotNull(typeSource);
+        Assert.Contains("void Run<T>", typeSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("where T : class", typeSource, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -948,4 +1039,21 @@ public static class RuntimeAsyncHeaderFixture
     }
 
     public static unsafe int ReadAddress(nint address) => *(int*)address;
+}
+
+/// <summary>
+/// Real compiled witness for issue #3664: generic methods whose constraints the
+/// decompiled-source views have to spell, and an override whose inherited
+/// constraints they must not restate (CS0460).
+/// </summary>
+public abstract class ConstraintFixtureBase
+{
+    public abstract void Run<T>(T value) where T : class, new();
+}
+
+public class ConstraintFixture : ConstraintFixtureBase
+{
+    public static int Compare<T>(T a, T b) where T : IComparable<T> => a.CompareTo(b);
+
+    public override void Run<T>(T value) => value.ToString();
 }


### PR DESCRIPTION
Fixes #3664.

## Conclusion

The single-member `Decompiled Source` view dropped generic constraints, rendering C# that does not compile. It now spells them, and both member paths stop restating the constraints an `override` or explicit interface implementation inherits (CS0460) — a second, pre-existing defect the fix would otherwise have propagated.

## What was actually wrong

Not what the issue's suggested direction assumed. Constraint decoding, the `TypeParameter` model, and the shared formatter were all already correct end-to-end — `MemberBodyProducer`, `ProduceMember`, and the whole-`type` listing all emit constraints today.

The gap is that the **single-member** view supplies its own generic-parameter names (`MethodBodySelection.GenericParameterNames`). `TryRenderSignatureModel` declines whenever a caller does that (`methodParameters is not { Count: > 0 }`, a deliberate scope limit from #2113), so the declaration is composed on the text fallback — which spliced `<T>` in via `AddMethodGenericParameters` but never appended the `where` clauses.

The two views therefore disagreed, which is why the gap survived:

| Path | Before |
| --- | --- |
| `type Plain -S "Decompiled Source"` | `public static int Compare<T>(T a, T b) where T : IComparable<T> => …` |
| `member Plain Compare:1 -S "Decompiled Source"` | `public static int Compare<T>(T a, T b) => …` ❌ |

## The second defect

Fixing that surfaced a pre-existing one in the model path: it restated an `override`'s constraints.

```
error CS0460: Constraints for override and explicit interface implementation methods are
inherited from the base method, so they cannot be specified directly …
```

The whole-type listing emitted `public override void Run<T>(T t) where T : class, new()` on `main`. No fixture had a constrained generic override, so nothing caught it. Both member call sites now route through one predicate, so they cannot drift; the type-declaration call site is deliberately unchanged (a type owns its own constraints).

## After

```csharp
public static int Compare<T>(T a, T b) where T : System.IComparable<T> => a.CompareTo(b);
public static T Make<T>() where T : class, new() => Activator.CreateInstance<T>();
public override void Run<T>(T t) => Console.WriteLine(t);
```

The `System.`-qualified constraint matches that view's existing convention — it already renders `System.IDisposable` and `System.Collections.Generic.List<int>` for parameter types.

## Evidence

Compile-back with `csc`: the before-render **fails** (`CS7036`, `CompareTo` binding to an unrelated extension); the after-render of both views **compiles clean**. CS0460 reproduced directly against a hand-written restatement.

| Suite | Result |
| --- | --- |
| `ILInspector.CSharp.Tests` | 455 / 0 |
| `dotnet-inspect.Tests` | 2845 / 1 / 14 — the 1 is the known pre-existing `Layout_Count_…` |
| Decompiler `--gate fast` | 4496 / 0 |
| `Area=Validity` / `Corpus` / `RoundTrip` / `Fidelity` | 103 / 367 / 568 / 68, all 0 failed |
| `ILInspector.Metadata.Tests` | 1397 / 0 |
| `DotnetInspector.MetadataRendering.Tests` | 187 / 0 |
| `DotnetInspector.Services.Tests` | 360 / 0 |

**Non-vacuity (each tamper reproduced):** removing the text-path recovery fails `GenericMethod_WithCallerSuppliedTypeParameters_KeepsConstraints` and the end-to-end `ConstrainedGenericMethod_…` canary; forcing the inherited-constraint gate open fails the three override / explicit-interface gates and the `ConstrainedGenericOverride_…` canary.

The two canaries are **real-artifact**: they run against this test assembly's own compiled metadata (`ConstraintFixture`), pinning constraint decoding, the member view, and the whole-type listing together rather than a hand-built signature model.

One case is honestly labelled a pin rather than a gate: the explicit-interface model-path case stays green under tamper, because that branch keys on `Kind == "method"` and never renders that kind. The doc comment says so.

## Non-action boundary

- An undecodable or unspellable constraint remains a silent omission rather than a fidelity downgrade. That channel belongs to the decompiler's fidelity machinery, not this formatter; happy to file it as a follow-up.
- The arity guard (`modelTypeParameters.Count == methodParameters.Count`) is defensive only — both lists come from the same `GenericParameter` rows in the same order.
- Type declarations, properties, events, fields, and constructors are untouched.
