### PR TITLE
Restate the constraint fact C# requires on an inheriting member (#3721)

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1531,7 +1531,7 @@ public sealed class CSharpDeclarationWriterTests
     /// `csc` rejects it with CS0460. Both declaration paths have to omit it, so the gate
     /// runs with and without a caller-supplied generic-parameter list.
     /// (The `class`/`struct` carve-out C# does allow is covered separately, by
-    /// <see cref="OverrideGenericMethod_RestatesOnlyTheConstraintCSharpAllows"/>.)
+    /// <see cref="OverrideGenericMethod_RestatesWhatTheClassifiedKindRequires"/>.)
     /// </summary>
     [Theory]
     [InlineData(true)]
@@ -1585,38 +1585,41 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     /// <summary>
-    /// C# permits exactly one restatement on a member that inherits its constraints —
-    /// a bare `class` or `struct` — and it is load-bearing, not cosmetic: it decides
-    /// whether `T?` means a nullable reference type or Nullable&lt;T&gt;. Dropping it
-    /// produced an override that no longer compiles (CS0453/CS0115), so the reduction
-    /// keeps it while omitting everything CS0460 forbids.
+    /// The restatement C# permits on a member that inherits its constraints is decided
+    /// by one fact -- whether the type parameter is known to be a reference type, known
+    /// to be a value type, or neither -- and it is load-bearing, not cosmetic: it decides
+    /// whether <c>T?</c> means a nullable reference type or Nullable&lt;T&gt;. Omitting
+    /// it produces an override that does not compile (CS0453/CS0115/CS0534), and naming
+    /// the wrong one is CS8822 or CS8665, so the writer reduces from the classified fact
+    /// rather than from the constraint spelling.
     /// </summary>
+    /// <remarks>
+    /// This gate owns the reduction only. That the classifier assigns the right
+    /// <see cref="TypeParameterTypeKind"/> to compiler-produced metadata -- including the
+    /// System.Enum row, where a class constraint nonetheless requires <c>default</c> -- is
+    /// gated separately against a real compiled artifact by
+    /// <c>ApiOutputFormatterTests.ConstraintRestatement_MatchesWhatCSharpRequires</c>.
+    /// </remarks>
     [Theory]
-    // A reference-type constraint survives, without the annotation `class?` that is
-    // itself CS0460, and without the `new()` that may not be restated.
-    [InlineData(new[] { "class", "new()" }, "where T : class")]
-    [InlineData(new[] { "class?" }, "where T : class")]
-    // A value-type constraint reduces to the one spelling C# accepts here.
-    [InlineData(new[] { "struct" }, "where T : struct")]
-    [InlineData(new[] { "unmanaged" }, "where T : struct")]
-    // Nothing else may be named on an inheriting member.
-    [InlineData(new[] { "notnull" }, "")]
-    [InlineData(new[] { "System.IComparable<T>" }, "")]
-    public void OverrideGenericMethod_RestatesOnlyTheConstraintCSharpAllows(
-        string[] constraints,
+    // Known to be a reference type: the bare keyword, never the annotated `class?`
+    // metadata records, because the annotated form is itself CS0460 here.
+    [InlineData(TypeParameterTypeKind.ReferenceType, "where T : class")]
+    // Known to be a value type.
+    [InlineData(TypeParameterTypeKind.ValueType, "where T : struct")]
+    // Neither: `default` is the only spelling that keeps `T?` meaning a nullable
+    // reference type, and omitting the clause entirely does not compile.
+    [InlineData(TypeParameterTypeKind.NeitherReferenceNorValue, "where T : default")]
+    // Not classified. Both concrete answers are compile errors when guessed wrong, so
+    // the clause is omitted and the render stays as it was before this rule existed.
+    [InlineData(TypeParameterTypeKind.Undetermined, "")]
+    public void OverrideGenericMethod_RestatesWhatTheClassifiedKindRequires(
+        TypeParameterTypeKind typeKind,
         string expectedClause)
     {
         var (type, member) = CreateConstrainedGenericMethod();
         member.IsStatic = false;
         member.IsOverride = true;
-        var typeParameter = member.SignatureModel!.TypeParameters[0];
-        typeParameter.Constraints = [.. constraints];
-        typeParameter.StructuredConstraints =
-        [
-            .. constraints.Select(constraint => new TypeParameterConstraint(
-                constraint,
-                IsTypeName: constraint is not ("class" or "class?" or "struct" or "unmanaged" or "notnull" or "new()"))),
-        ];
+        member.SignatureModel!.TypeParameters[0].TypeKind = typeKind;
 
         var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
             type,

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -1441,6 +1441,51 @@ public sealed class CSharpTypePrinterTests
         Assert.Contains("null member collection", exception.Message, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The snapshot has to carry the classified reference-/value-type fact, not just the
+    /// constraint strings. An inheriting member must restate that fact -- it decides
+    /// whether `T?` binds as a nullable reference type or Nullable&lt;T&gt; -- so a
+    /// snapshot that drops it renders an override that does not compile (CS0115/CS0453),
+    /// silently, across the whole type-printer path.
+    /// </summary>
+    [Fact]
+    public void SnapshotTypeForRendering_CarriesTheClassifiedTypeParameterKind()
+    {
+        var typeParameter = new TypeParameter
+        {
+            Name = "T",
+            Constraints = ["Samples.BaseType"],
+            TypeKind = TypeParameterTypeKind.ReferenceType
+        };
+        var method = new ApiMember
+        {
+            Name = "Pick",
+            Kind = "method",
+            IsOverride = true,
+            Signature = "this text must not be used",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "T?",
+                MemberName = "Pick<T>",
+                TypeParameters = [typeParameter],
+                Parameters = [new ApiParameter { Type = "T?", Name = "value" }]
+            }
+        };
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Holder",
+            Kind = "class",
+            Members = [method]
+        };
+
+        var snapshot = CSharpTypePrinter.SnapshotTypeForRendering(type, type.Members);
+
+        Assert.Equal(
+            TypeParameterTypeKind.ReferenceType,
+            snapshot.Members[0].SignatureModel!.TypeParameters[0].TypeKind);
+    }
+
     [Fact]
     public void RenderingSnapshotDoesNotRetainMutableMetadataAliases()
     {

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -816,24 +816,26 @@ internal static class CSharpDeclarationWriter
             : AppendTypeParameterConstraints(declaration, typeParameters);
 
     /// <summary>
-    /// Restates only what C# permits on a member that inherits its constraints: the
-    /// bare <c>class</c> or <c>struct</c> keyword. The annotated <c>class?</c> form is
-    /// itself CS0460, and <c>unmanaged</c> is a value-type constraint, so both are
-    /// reduced to the legal spelling that preserves how <c>T?</c> binds.
+    /// Restates what C# permits on a member that inherits its constraints. The
+    /// inherited constraints themselves may not be repeated -- that is CS0460 -- but
+    /// exactly one fact about each type parameter must be, because it decides whether
+    /// <c>T?</c> in the signature binds as a nullable reference type or as
+    /// Nullable&lt;T&gt;: whether the parameter is known to be a reference type
+    /// (<c>class</c>), known to be a value type (<c>struct</c>), or neither
+    /// (<c>default</c>).
     /// </summary>
     /// <remarks>
     /// Every clause emitted here was compiled against csc as a restatement on an
     /// override, and the reduction is gated by
-    /// <c>OverrideGenericMethod_RestatesOnlyTheConstraintCSharpAllows</c> plus the two
-    /// real-artifact canaries in <c>ApiOutputFormatterTests</c>. What is emitted is
-    /// therefore correct, but it is knowingly *incomplete*: a base constraint that is
-    /// not one of these keywords — <c>notnull</c>, a named class or interface type, or
-    /// no constraint at all — also needs a restatement (<c>class</c> or <c>default</c>,
-    /// per the table in issue #3721) once the signature spells <c>T?</c>, and none is
-    /// emitted for it. Deciding those rows needs a reference-/value-type fact about the
-    /// constraint type that <see cref="TypeParameter"/> does not carry and that Metadata
-    /// rather than this layer must own, so it is tracked as #3721 rather than guessed at
-    /// here. Those cases render exactly as they did before this reduction existed.
+    /// <c>OverrideGenericMethod_RestatesWhatTheClassifiedKindRequires</c> plus the
+    /// real-artifact canaries in <c>ApiOutputFormatterTests</c>. Note that the fact
+    /// cannot be recovered from the constraint spelling: <c>System.Enum</c> is a class
+    /// yet requires <c>default</c>, while any other named class requires <c>class</c>,
+    /// so a name-based guess gets that row backwards. <see cref="TypeParameter.TypeKind"/>
+    /// carries the classified answer instead, decided in Metadata where the constraint
+    /// type can actually be resolved. When Metadata could not classify it the clause is
+    /// omitted, which renders exactly as this member did before the rule existed --
+    /// guessing would be CS8822 or CS8665 rather than merely incomplete.
     /// </remarks>
     static string AppendInheritedConstraintRestatement(
         string declaration,
@@ -851,33 +853,29 @@ internal static class CSharpDeclarationWriter
     }
 
     /// <summary>
-    /// The single keyword an inheriting member may restate for one type parameter, or
-    /// null when it has no reference- or value-type constraint to restate. Reads
-    /// <see cref="TypeParameter.StructuredConstraints"/> when the producer populated
-    /// it, so a constraint *type* literally named <c>class</c> is never mistaken for
-    /// the keyword.
+    /// The single keyword an inheriting member must restate for one type parameter, or
+    /// null when Metadata could not classify it and no clause can be emitted safely.
     /// </summary>
     static string? RestatableConstraint(TypeParameter typeParameter)
-    {
-        var keywords = typeParameter.StructuredConstraints is { } structured
-            ? structured.Where(constraint => !constraint.IsTypeName).Select(constraint => constraint.Value)
-            : typeParameter.Constraints.Where(s_specialConstraintKeywords.Contains);
-
-        string? keyword = null;
-        foreach (var candidate in keywords)
+        => typeParameter.TypeKind switch
         {
-            switch (candidate)
-            {
-                case "class" or "class?":
-                    return "class";
-                case "struct" or "unmanaged":
-                    keyword = "struct";
-                    break;
-            }
-        }
+            // The bare keyword, never the annotated `class?` metadata records: the
+            // annotated form is itself CS0460 here.
+            TypeParameterTypeKind.ReferenceType => "class",
+            TypeParameterTypeKind.ValueType => "struct",
 
-        return keyword;
-    }
+            // Nothing is proven about T, so `T?` in the signature would bind to
+            // Nullable<T> unless the override says otherwise. `default` is the only
+            // spelling that says it, and it is legal only on a member that inherits its
+            // constraints -- which is the only place this runs.
+            TypeParameterTypeKind.NeitherReferenceNorValue => "default",
+
+            // A constraint type this assembly could not classify. Both concrete answers
+            // are compile errors when guessed wrong (CS8822 restating `default` against
+            // a reference type, CS8665 restating `class` against System.Enum), so the
+            // clause is omitted and the render stays as it was before #3721.
+            _ => null,
+        };
 
     static string AppendTypeParameterConstraints(string declaration, IReadOnlyList<TypeParameter> typeParameters)
     {

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -619,7 +619,11 @@ public sealed class CSharpTypePrinter
             Name = parameter.Name,
             Variance = parameter.Variance,
             Constraints = constraints?.ToList()!,
-            StructuredConstraints = parameter.StructuredConstraints
+            StructuredConstraints = parameter.StructuredConstraints,
+            // Carried like StructuredConstraints: the snapshot feeds the declaration
+            // writer, which cannot restate the constraint an inheriting member requires
+            // without it, and losing it renders an override that does not compile.
+            TypeKind = parameter.TypeKind
         };
     }
 

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -227,6 +227,28 @@ public class TypeParameter
     public IReadOnlyList<TypeParameterConstraint>? StructuredConstraints { get; set; }
 
     /// <summary>
+    /// Whether the constraint set proves this type parameter is a reference type, a
+    /// value type, or neither — the metadata fact behind C#'s "known to be a reference
+    /// type" rule, which is not the same question as which constraint keywords are
+    /// present. A named <em>class</em> constraint proves reference-ness without any
+    /// keyword, while <c>System.Enum</c> is a class that proves nothing, because a type
+    /// parameter constrained to it may still be a value type.
+    /// </summary>
+    /// <remarks>
+    /// Consumers need this to decide the one constraint an <c>override</c> may restate,
+    /// which is what disambiguates <c>T?</c> between a nullable reference type and
+    /// <see cref="System.Nullable{T}"/>. Populated by metadata producers and left at
+    /// <see cref="TypeParameterTypeKind.Undetermined"/> when a constraint type could not
+    /// be classified — an external <see cref="System.Reflection.Metadata.TypeReference"/>
+    /// whose interface flag this assembly cannot read, or a signature the blob guards
+    /// refused to decode. Undetermined is the fail-closed default, so a producer that
+    /// does not populate it reads as "do not know" rather than as "neither". Not
+    /// serialized.
+    /// </remarks>
+    [JsonIgnore]
+    public TypeParameterTypeKind TypeKind { get; set; } = TypeParameterTypeKind.Undetermined;
+
+    /// <summary>
     /// Returns the parameter name with variance prefix (e.g., "out T", "in TKey").
     /// </summary>
     /// <remarks>
@@ -253,6 +275,36 @@ public class TypeParameter
 /// constraints untouched.
 /// </summary>
 public readonly record struct TypeParameterConstraint(string Value, bool IsTypeName);
+
+/// <summary>
+/// Whether a type parameter's constraints prove it is a reference type, a value type,
+/// or neither. This mirrors the rule C# uses for "known to be a reference type" — the
+/// reference-type constraint flag, or an effective base class other than
+/// <c>System.Object</c>, <c>System.ValueType</c> and <c>System.Enum</c> — rather than
+/// the surface spelling of the constraint list.
+/// </summary>
+public enum TypeParameterTypeKind
+{
+    /// <summary>
+    /// A constraint type could not be classified, so nothing is proven either way. The
+    /// fail-closed default: an unpopulated or degraded read must never be mistaken for
+    /// <see cref="NeitherReferenceNorValue"/>, which is a positive finding.
+    /// </summary>
+    Undetermined = 0,
+
+    /// <summary>
+    /// Every constraint was classified and none proves the parameter is a reference or
+    /// a value type — an unconstrained parameter, or one constrained only by interfaces,
+    /// <c>notnull</c>, <c>new()</c> or <c>System.Enum</c>.
+    /// </summary>
+    NeitherReferenceNorValue,
+
+    /// <summary>Proven a reference type, by the constraint flag or a class constraint.</summary>
+    ReferenceType,
+
+    /// <summary>Proven a value type, by the constraint flag (<c>struct</c> or <c>unmanaged</c>).</summary>
+    ValueType,
+}
 
 public class ApiSignature
 {

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -711,6 +711,11 @@ public static class ApiSurfaceExtractor
             }
 
             typeParam.StructuredConstraints = structured;
+            typeParam.TypeKind = TypeParameterKindClassifier.Classify(
+                reader,
+                param,
+                hasValueTypeConstraint: (attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0,
+                hasReferenceTypeConstraint: (attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0);
             parameters.Add(typeParam);
         }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -732,7 +732,7 @@ public static class ApiSurfaceExtractor
             typeParam.StructuredConstraints = structured;
             typeParam.TypeKind = TypeParameterKindClassifier.Classify(
                 reader,
-                param,
+                paramHandle,
                 hasValueTypeConstraint: (attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0,
                 hasReferenceTypeConstraint: (attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
                 chain);

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -662,6 +662,11 @@ public static class ApiSurfaceExtractor
         bool includeVariance)
     {
         var parameters = new List<TypeParameter>();
+
+        // Shared across the list because `where T : U` chains run through it: answering
+        // each parameter from scratch would rewalk the chain's whole tail, which is
+        // quadratic in the number of parameters.
+        var chain = new TypeParameterKindClassifier.ChainState();
         foreach (var paramHandle in handles)
         {
             var param = reader.GetGenericParameter(paramHandle);
@@ -715,7 +720,8 @@ public static class ApiSurfaceExtractor
                 reader,
                 param,
                 hasValueTypeConstraint: (attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0,
-                hasReferenceTypeConstraint: (attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0);
+                hasReferenceTypeConstraint: (attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
+                chain);
             parameters.Add(typeParam);
         }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1121,7 +1121,7 @@ public static class ApiSurfaceExtractor
     /// impersonates a core-library name but lacks (or forges) a matching
     /// public-key token is rejected.
     /// </summary>
-    private static bool ResolvesThroughCoreLibrary(MetadataReader reader, EntityHandle resolutionScope)
+    internal static bool ResolvesThroughCoreLibrary(MetadataReader reader, EntityHandle resolutionScope)
     {
         if (resolutionScope.Kind != HandleKind.AssemblyReference)
             return false;

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -796,7 +796,7 @@ public static class MetadataDeclarationQuery
                 Variance = GenericConstraintKeywords.VarianceKeyword(attributes),
                 TypeKind = TypeParameterKindClassifier.Classify(
                     reader,
-                    parameter,
+                    handle,
                     hasValueTypeConstraint: isStruct,
                     hasReferenceTypeConstraint: (attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
                     chain),

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -752,6 +752,11 @@ public static class MetadataDeclarationQuery
         GenericContext context)
     {
         var parameters = new List<TypeParameter>();
+
+        // Shared across the list for the same reason `ApiSurfaceExtractor` shares one:
+        // `where T : U` chains run through it, and answering each parameter from scratch
+        // rewalks the chain's whole tail, which is quadratic in the number of parameters.
+        var chain = new TypeParameterKindClassifier.ChainState();
         foreach (var handle in handles)
         {
             var parameter = reader.GetGenericParameter(handle);
@@ -793,7 +798,8 @@ public static class MetadataDeclarationQuery
                     reader,
                     parameter,
                     hasValueTypeConstraint: isStruct,
-                    hasReferenceTypeConstraint: (attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0),
+                    hasReferenceTypeConstraint: (attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
+                    chain),
             });
         }
 

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -789,6 +789,11 @@ public static class MetadataDeclarationQuery
                 Constraints = constraints,
                 StructuredConstraints = structured,
                 Variance = GenericConstraintKeywords.VarianceKeyword(attributes),
+                TypeKind = TypeParameterKindClassifier.Classify(
+                    reader,
+                    parameter,
+                    hasValueTypeConstraint: isStruct,
+                    hasReferenceTypeConstraint: (attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0),
             });
         }
 

--- a/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
+++ b/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
@@ -36,20 +36,20 @@ internal static class TypeParameterKindClassifier
         GenericParameter parameter,
         bool hasValueTypeConstraint,
         bool hasReferenceTypeConstraint)
-        => Classify(reader, parameter, hasValueTypeConstraint, hasReferenceTypeConstraint, visited: null);
+        => Classify(reader, parameter, hasValueTypeConstraint, hasReferenceTypeConstraint, new ChainState());
 
-    /// <param name="visited">
-    /// The parameters already being classified on this chain. `where T : U` makes T only
-    /// as known as U, so classification follows the chain, and this set stops a cyclic
-    /// or self-referential chain -- which metadata can express even though C# cannot --
-    /// from recursing forever.
+    /// <param name="chain">
+    /// State for following `where T : U`, which makes T only as known as U. Carries the
+    /// parameters on the *current* path, so a cyclic or self-referential chain -- which
+    /// metadata can express even though C# cannot -- terminates, and the answers already
+    /// computed, so a chain that reconverges is answered rather than re-walked.
     /// </param>
-    static TypeParameterTypeKind Classify(
+    internal static TypeParameterTypeKind Classify(
         MetadataReader reader,
         GenericParameter parameter,
         bool hasValueTypeConstraint,
         bool hasReferenceTypeConstraint,
-        HashSet<GenericParameterHandle>? visited)
+        ChainState chain)
     {
         // The attribute flags are decisive on their own and need no constraint types.
         if (hasValueTypeConstraint)
@@ -83,7 +83,7 @@ internal static class TypeParameterKindClassifier
 
                 // `where T : U` -- T is exactly as known as U, so follow the chain.
                 case ConstraintClass.DeferToTypeParameter:
-                    switch (ClassifySibling(reader, parameter, constraint.Type, visited))
+                    switch (ClassifySibling(reader, parameter, constraint.Type, chain))
                     {
                         case TypeParameterTypeKind.ReferenceType:
                             return TypeParameterTypeKind.ReferenceType;
@@ -121,7 +121,7 @@ internal static class TypeParameterKindClassifier
         MetadataReader reader,
         GenericParameter parameter,
         EntityHandle constraintType,
-        HashSet<GenericParameterHandle>? visited)
+        ChainState chain)
     {
         if (constraintType.Kind != HandleKind.TypeSpecification)
             return TypeParameterTypeKind.Undetermined;
@@ -142,18 +142,38 @@ internal static class TypeParameterKindClassifier
                 return TypeParameterTypeKind.Undetermined;
 
             var siblingHandle = handles[target.Index];
-            visited ??= [];
-            if (!visited.Add(siblingHandle))
+            // Already answered on another branch. Reusing it is what keeps a chain that
+            // reconverges from being mistaken for a cycle, and what keeps a long chain
+            // linear instead of quadratic.
+            if (chain.Answers.TryGetValue(siblingHandle, out var answered))
+                return answered;
+
+            // Only the current path guards against cycles, so a parameter is released
+            // once its own subtree is done and stays reachable from a sibling branch.
+            // A cyclic chain answers Undetermined, and caching that can carry the
+            // cycle's verdict to a parameter that merely reaches it -- fail-closed in
+            // the same direction the rest of this classifier takes, and unreachable
+            // from C#, which cannot express a cyclic constraint chain at all.
+            if (!chain.Path.Add(siblingHandle))
                 return TypeParameterTypeKind.Undetermined;
 
-            var sibling = reader.GetGenericParameter(siblingHandle);
-            var special = sibling.Attributes & GenericParameterAttributes.SpecialConstraintMask;
-            return Classify(
-                reader,
-                sibling,
-                (special & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0,
-                (special & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
-                visited);
+            try
+            {
+                var sibling = reader.GetGenericParameter(siblingHandle);
+                var special = sibling.Attributes & GenericParameterAttributes.SpecialConstraintMask;
+                var kind = Classify(
+                    reader,
+                    sibling,
+                    (special & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0,
+                    (special & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
+                    chain);
+                chain.Answers[siblingHandle] = kind;
+                return kind;
+            }
+            finally
+            {
+                chain.Path.Remove(siblingHandle);
+            }
         }
         catch (BadImageFormatException)
         {
@@ -187,6 +207,19 @@ internal static class TypeParameterKindClassifier
             default:
                 return null;
         }
+    }
+
+    /// <summary>
+    /// The two things following a `where T : U` chain needs: the parameters on the path
+    /// currently being walked, and the answers already reached. Answers outlive a single
+    /// walk -- a handle identifies the same parameter for the whole module -- so a caller
+    /// classifying a parameter list reuses one instance across it.
+    /// </summary>
+    internal sealed class ChainState
+    {
+        public HashSet<GenericParameterHandle> Path { get; } = [];
+
+        public Dictionary<GenericParameterHandle, TypeParameterTypeKind> Answers { get; } = [];
     }
 
     readonly record struct TypeParameterReference(int Index, bool IsMethodParameter);
@@ -290,9 +323,52 @@ internal static class TypeParameterKindClassifier
         if ((definition.Attributes & TypeAttributes.Interface) != 0)
             return ConstraintClass.ProvesNothing;
 
-        return IsClassThatProvesNothing(fullName)
+        // Same-module, so the name is checked against the module's own identity rather
+        // than against a resolution scope: an ordinary assembly may declare a type
+        // called `System.Enum`, and that type is a plain class, so a parameter
+        // constrained to it IS known to be a reference type.
+        return IsClassThatProvesNothing(fullName) && DeclaresCoreLibraryRoot(reader)
             ? ConstraintClass.ProvesNothing
             : ConstraintClass.ProvesReferenceType;
+    }
+
+    /// <summary>
+    /// True when the module being read is itself a core library — the only module whose
+    /// own <c>System.Object</c>, <c>System.ValueType</c> and <c>System.Enum</c> are the
+    /// special types C# treats as proving nothing about a type parameter.
+    /// </summary>
+    /// <remarks>
+    /// A core library is recognized the way <c>ApiSurfaceExtractor</c> already
+    /// recognizes the genuine root object: it declares a <c>System.Object</c> with no
+    /// base type, which only the root can have. An assembly that merely declares
+    /// <c>System.Enum</c> inherits its object from elsewhere and is rejected. An
+    /// assembly that declares a nil-base <c>System.Object</c> is structurally a core
+    /// library, and a compilation against it really does treat its <c>System.Enum</c> as
+    /// the special type, so accepting that case tracks the compiler rather than
+    /// trusting the assembly.
+    /// </remarks>
+    static bool DeclaresCoreLibraryRoot(MetadataReader reader)
+    {
+        try
+        {
+            foreach (var handle in reader.TypeDefinitions)
+            {
+                var candidate = reader.GetTypeDefinition(handle);
+                if (candidate.BaseType.IsNil
+                    && (candidate.Attributes & TypeAttributes.Interface) == 0
+                    && string.Equals(reader.GetString(candidate.Namespace), "System", StringComparison.Ordinal)
+                    && string.Equals(reader.GetString(candidate.Name), "Object", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            return false;
+        }
+
+        return false;
     }
 
     static bool IsClassThatProvesNothing(string? fullName)

--- a/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
+++ b/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
@@ -36,6 +36,20 @@ internal static class TypeParameterKindClassifier
         GenericParameter parameter,
         bool hasValueTypeConstraint,
         bool hasReferenceTypeConstraint)
+        => Classify(reader, parameter, hasValueTypeConstraint, hasReferenceTypeConstraint, visited: null);
+
+    /// <param name="visited">
+    /// The parameters already being classified on this chain. `where T : U` makes T only
+    /// as known as U, so classification follows the chain, and this set stops a cyclic
+    /// or self-referential chain -- which metadata can express even though C# cannot --
+    /// from recursing forever.
+    /// </param>
+    static TypeParameterTypeKind Classify(
+        MetadataReader reader,
+        GenericParameter parameter,
+        bool hasValueTypeConstraint,
+        bool hasReferenceTypeConstraint,
+        HashSet<GenericParameterHandle>? visited)
     {
         // The attribute flags are decisive on their own and need no constraint types.
         if (hasValueTypeConstraint)
@@ -66,10 +80,145 @@ internal static class TypeParameterKindClassifier
                     break;
                 case ConstraintClass.ProvesNothing:
                     break;
+
+                // `where T : U` -- T is exactly as known as U, so follow the chain.
+                case ConstraintClass.DeferToTypeParameter:
+                    switch (ClassifySibling(reader, parameter, constraint.Type, visited))
+                    {
+                        case TypeParameterTypeKind.ReferenceType:
+                            return TypeParameterTypeKind.ReferenceType;
+
+                        // A value-type parameter cannot be a constraint in C#, so this
+                        // is malformed rather than a row of the table; fail closed.
+                        case TypeParameterTypeKind.ValueType:
+                        case TypeParameterTypeKind.Undetermined:
+                            kind = TypeParameterTypeKind.Undetermined;
+                            break;
+                        case TypeParameterTypeKind.NeitherReferenceNorValue:
+                            break;
+                    }
+
+                    break;
             }
         }
 
         return kind;
+    }
+
+    /// <summary>
+    /// Classifies the generic parameter that <paramref name="constraintType"/> names,
+    /// so that `where T : U` inherits U's answer. Both parameters belong to the same
+    /// declaration, so U is found among the siblings of <paramref name="parameter"/>
+    /// rather than by resolving anything -- a method type parameter among the owning
+    /// method's, a type type parameter among the declaring type's.
+    /// </summary>
+    /// <remarks>
+    /// Fails closed on anything unexpected: a signature that does not decode to a single
+    /// parameter index, an index outside the owning collection, an owner this assembly
+    /// cannot read, or a chain that revisits a parameter it is already classifying.
+    /// </remarks>
+    static TypeParameterTypeKind ClassifySibling(
+        MetadataReader reader,
+        GenericParameter parameter,
+        EntityHandle constraintType,
+        HashSet<GenericParameterHandle>? visited)
+    {
+        if (constraintType.Kind != HandleKind.TypeSpecification)
+            return TypeParameterTypeKind.Undetermined;
+
+        var reference = GuardedProviderDecode.TypeSpec(
+            reader,
+            (TypeSpecificationHandle)constraintType,
+            TypeParameterReferenceProvider.Instance,
+            (GenericContext?)null,
+            fallback: null);
+        if (reference is not { } target)
+            return TypeParameterTypeKind.Undetermined;
+
+        try
+        {
+            var siblings = SiblingParameters(reader, parameter, target.IsMethodParameter);
+            if (siblings is not { } handles || target.Index < 0 || target.Index >= handles.Count)
+                return TypeParameterTypeKind.Undetermined;
+
+            var siblingHandle = handles[target.Index];
+            visited ??= [];
+            if (!visited.Add(siblingHandle))
+                return TypeParameterTypeKind.Undetermined;
+
+            var sibling = reader.GetGenericParameter(siblingHandle);
+            var special = sibling.Attributes & GenericParameterAttributes.SpecialConstraintMask;
+            return Classify(
+                reader,
+                sibling,
+                (special & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0,
+                (special & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
+                visited);
+        }
+        catch (BadImageFormatException)
+        {
+            return TypeParameterTypeKind.Undetermined;
+        }
+    }
+
+    /// <summary>
+    /// The generic parameters a sibling reference indexes into: the owning method's when
+    /// the reference is to a method type parameter, otherwise the declaring type's.
+    /// </summary>
+    static GenericParameterHandleCollection? SiblingParameters(
+        MetadataReader reader,
+        GenericParameter parameter,
+        bool isMethodParameter)
+    {
+        switch (parameter.Parent.Kind)
+        {
+            case HandleKind.MethodDefinition:
+                var method = reader.GetMethodDefinition((MethodDefinitionHandle)parameter.Parent);
+                return isMethodParameter
+                    ? method.GetGenericParameters()
+                    : reader.GetTypeDefinition(method.GetDeclaringType()).GetGenericParameters();
+
+            case HandleKind.TypeDefinition:
+                // A type's own parameter cannot name a method parameter.
+                return isMethodParameter
+                    ? null
+                    : reader.GetTypeDefinition((TypeDefinitionHandle)parameter.Parent).GetGenericParameters();
+
+            default:
+                return null;
+        }
+    }
+
+    readonly record struct TypeParameterReference(int Index, bool IsMethodParameter);
+
+    /// <summary>
+    /// Decodes a constraint signature that is expected to be exactly one generic
+    /// parameter reference, yielding null for every other shape so the caller fails
+    /// closed rather than mistaking a composed type for a bare parameter.
+    /// </summary>
+    sealed class TypeParameterReferenceProvider
+        : ISignatureTypeProvider<TypeParameterReference?, GenericContext?>
+    {
+        internal static readonly TypeParameterReferenceProvider Instance = new();
+
+        public TypeParameterReference? GetGenericMethodParameter(GenericContext? context, int index)
+            => new TypeParameterReference(index, IsMethodParameter: true);
+
+        public TypeParameterReference? GetGenericTypeParameter(GenericContext? context, int index)
+            => new TypeParameterReference(index, IsMethodParameter: false);
+
+        public TypeParameterReference? GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => null;
+        public TypeParameterReference? GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => null;
+        public TypeParameterReference? GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind) => null;
+        public TypeParameterReference? GetGenericInstantiation(TypeParameterReference? genericType, ImmutableArray<TypeParameterReference?> typeArguments) => null;
+        public TypeParameterReference? GetModifiedType(TypeParameterReference? modifier, TypeParameterReference? unmodifiedType, bool isRequired) => null;
+        public TypeParameterReference? GetPinnedType(TypeParameterReference? elementType) => null;
+        public TypeParameterReference? GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
+        public TypeParameterReference? GetSZArrayType(TypeParameterReference? elementType) => null;
+        public TypeParameterReference? GetArrayType(TypeParameterReference? elementType, ArrayShape shape) => null;
+        public TypeParameterReference? GetByReferenceType(TypeParameterReference? elementType) => null;
+        public TypeParameterReference? GetPointerType(TypeParameterReference? elementType) => null;
+        public TypeParameterReference? GetFunctionPointerType(MethodSignature<TypeParameterReference?> signature) => null;
     }
 
     enum ConstraintClass
@@ -77,6 +226,13 @@ internal static class TypeParameterKindClassifier
         ProvesNothing,
         ProvesReferenceType,
         Unreadable,
+
+        /// <summary>
+        /// The constraint names another generic parameter, so the answer is that
+        /// parameter's answer. Resolved by <see cref="ClassifySibling"/> rather than
+        /// here, because the provider that decodes the signature sees only an index.
+        /// </summary>
+        DeferToTypeParameter,
     }
 
     static ConstraintClass ClassifyConstraintType(MetadataReader reader, EntityHandle handle)
@@ -90,11 +246,17 @@ internal static class TypeParameterKindClassifier
                 return ClassifyDefinition(reader, (TypeDefinitionHandle)handle);
 
             // Another module owns the interface flag, and a name is not a substitute for
-            // it: an unknown external type could be either.
+            // it: an unknown external type could be either. The three core types that
+            // prove nothing are the one exception, and even they are accepted only on
+            // typed identity -- an assembly may declare its own `System.Enum`, and
+            // treating that as the real one would emit `default` for a type parameter
+            // that is genuinely known to be a reference type (CS8822).
             case HandleKind.TypeReference:
+                var typeReference = reader.GetTypeReference((TypeReferenceHandle)handle);
                 return IsClassThatProvesNothing(TypeReferenceFullName(reader, (TypeReferenceHandle)handle))
-                    ? ConstraintClass.ProvesNothing
-                    : ConstraintClass.Unreadable;
+                    && ApiSurfaceExtractor.ResolvesThroughCoreLibrary(reader, typeReference.ResolutionScope)
+                        ? ConstraintClass.ProvesNothing
+                        : ConstraintClass.Unreadable;
 
             // A generic instantiation constrains to the instantiated type, so the
             // question is about its generic type definition.
@@ -178,10 +340,11 @@ internal static class TypeParameterKindClassifier
 
         public ConstraintClass GetPinnedType(ConstraintClass elementType) => elementType;
 
-        // A constraint naming another type parameter is only as known as that parameter,
-        // which this pass does not resolve.
-        public ConstraintClass GetGenericMethodParameter(GenericContext? context, int index) => ConstraintClass.Unreadable;
-        public ConstraintClass GetGenericTypeParameter(GenericContext? context, int index) => ConstraintClass.Unreadable;
+        // A constraint naming another type parameter is only as known as that parameter.
+        // The index alone cannot be resolved here, so the answer is deferred to
+        // ClassifySibling, which has the owning parameter and can find its siblings.
+        public ConstraintClass GetGenericMethodParameter(GenericContext? context, int index) => ConstraintClass.DeferToTypeParameter;
+        public ConstraintClass GetGenericTypeParameter(GenericContext? context, int index) => ConstraintClass.DeferToTypeParameter;
 
         public ConstraintClass GetPrimitiveType(PrimitiveTypeCode typeCode) => ConstraintClass.Unreadable;
         public ConstraintClass GetSZArrayType(ConstraintClass elementType) => ConstraintClass.Unreadable;

--- a/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
+++ b/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
@@ -31,20 +31,19 @@ internal static class TypeParameterKindClassifier
     static readonly string[] s_classesThatProveNothing =
         ["System.Object", "System.ValueType", "System.Enum"];
 
-    public static TypeParameterTypeKind Classify(
-        MetadataReader reader,
-        GenericParameter parameter,
-        bool hasValueTypeConstraint,
-        bool hasReferenceTypeConstraint)
-        => Classify(reader, parameter, hasValueTypeConstraint, hasReferenceTypeConstraint, new ChainState());
-
     /// <param name="chain">
     /// State for following `where T : U`, which makes T only as known as U. Carries the
     /// parameters on the *current* path, so a cyclic or self-referential chain -- which
     /// metadata can express even though C# cannot -- terminates, and the answers already
     /// computed, so a chain that reconverges is answered rather than re-walked.
+    /// <para>
+    /// Required rather than optional, and one instance is meant to serve a whole parameter
+    /// list: a caller that allocates one per parameter rewalks each chain's entire tail
+    /// and is quadratic in the number of parameters. There is deliberately no overload
+    /// that allocates one per call, so that cost cannot be reintroduced by accident.
+    /// </para>
     /// </param>
-    internal static TypeParameterTypeKind Classify(
+    public static TypeParameterTypeKind Classify(
         MetadataReader reader,
         GenericParameter parameter,
         bool hasValueTypeConstraint,
@@ -142,21 +141,35 @@ internal static class TypeParameterKindClassifier
                 return TypeParameterTypeKind.Undetermined;
 
             var siblingHandle = handles[target.Index];
-            // Already answered on another branch. Reusing it is what keeps a chain that
-            // reconverges from being mistaken for a cycle, and what keeps a long chain
-            // linear instead of quadratic.
+            // Already answered. Reusing it is what keeps a chain that reconverges from
+            // being mistaken for a cycle, and what keeps a long chain linear rather
+            // than quadratic. Only answers reached without cutting the walk are stored,
+            // so this cannot hand back a path-dependent verdict -- see below.
             if (chain.Answers.TryGetValue(siblingHandle, out var answered))
                 return answered;
 
+            // Malformed metadata can make the walk unbounded in ways the path guard
+            // alone does not bound, because a cut answer cannot be cached and so is
+            // recomputed for every parameter that reaches it. Spending a shared budget
+            // keeps a whole parameter list linear in the worst case; running out is a
+            // cut like any other and fails closed.
+            if (chain.Budget <= 0)
+            {
+                chain.Cuts++;
+                return TypeParameterTypeKind.Undetermined;
+            }
+
+            chain.Budget--;
+
             // Only the current path guards against cycles, so a parameter is released
             // once its own subtree is done and stays reachable from a sibling branch.
-            // A cyclic chain answers Undetermined, and caching that can carry the
-            // cycle's verdict to a parameter that merely reaches it -- fail-closed in
-            // the same direction the rest of this classifier takes, and unreachable
-            // from C#, which cannot express a cyclic constraint chain at all.
             if (!chain.Path.Add(siblingHandle))
+            {
+                chain.Cuts++;
                 return TypeParameterTypeKind.Undetermined;
+            }
 
+            int cutsBefore = chain.Cuts;
             try
             {
                 var sibling = reader.GetGenericParameter(siblingHandle);
@@ -167,7 +180,15 @@ internal static class TypeParameterKindClassifier
                     (special & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0,
                     (special & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
                     chain);
-                chain.Answers[siblingHandle] = kind;
+
+                // A subtree that was cut answers for the path it was reached by, not for
+                // the parameter itself: the cut hid constraints that a different path
+                // would have followed. Caching that would carry one parameter's verdict
+                // to another that merely reaches it, which is how a parameter whose real
+                // answer is `class` can come back unclassified and lose its clause.
+                if (chain.Cuts == cutsBefore)
+                    chain.Answers[siblingHandle] = kind;
+
                 return kind;
             }
             finally
@@ -217,9 +238,27 @@ internal static class TypeParameterKindClassifier
     /// </summary>
     internal sealed class ChainState
     {
+        /// <summary>The parameters on the walk currently in progress.</summary>
         public HashSet<GenericParameterHandle> Path { get; } = [];
 
+        /// <summary>
+        /// Answers reached without cutting the walk, and therefore independent of the
+        /// parameter the walk started from.
+        /// </summary>
         public Dictionary<GenericParameterHandle, TypeParameterTypeKind> Answers { get; } = [];
+
+        /// <summary>
+        /// How many times the walk has been cut short, by a cycle or by the budget. A
+        /// subtree spanning a cut is path-dependent and must not be cached.
+        /// </summary>
+        public int Cuts { get; set; }
+
+        /// <summary>
+        /// Sibling classifications left before the walk gives up. Only chains that are
+        /// cut can consume this, since an uncut chain is answered once and then cached;
+        /// the bound exists so malformed metadata cannot make a parameter list quadratic.
+        /// </summary>
+        public int Budget { get; set; } = 100_000;
     }
 
     readonly record struct TypeParameterReference(int Index, bool IsMethodParameter);

--- a/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
+++ b/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
@@ -32,20 +32,15 @@ internal static class TypeParameterKindClassifier
         ["System.Object", "System.ValueType", "System.Enum"];
 
     /// <param name="chain">
-    /// State for following `where T : U`, which makes T only as known as U. Carries the
-    /// parameters on the *current* path, so a cyclic or self-referential chain -- which
-    /// metadata can express even though C# cannot -- terminates, and the answers already
-    /// computed, so a chain that reconverges is answered rather than re-walked.
-    /// <para>
-    /// Required rather than optional, and one instance is meant to serve a whole parameter
-    /// list: a caller that allocates one per parameter rewalks each chain's entire tail
-    /// and is quadratic in the number of parameters. There is deliberately no overload
-    /// that allocates one per call, so that cost cannot be reintroduced by accident.
-    /// </para>
+    /// The answers for the parameter list <paramref name="handle"/> belongs to. One
+    /// instance is meant to serve a whole list: `where T : U` makes the list a graph, and
+    /// this holds the graph's answers, so it is resolved once rather than re-resolved from
+    /// every parameter that reaches it. There is deliberately no overload that allocates
+    /// one per call, so that cost cannot be reintroduced by accident.
     /// </param>
     public static TypeParameterTypeKind Classify(
         MetadataReader reader,
-        GenericParameter parameter,
+        GenericParameterHandle handle,
         bool hasValueTypeConstraint,
         bool hasReferenceTypeConstraint,
         ChainState chain)
@@ -56,74 +51,110 @@ internal static class TypeParameterKindClassifier
         if (hasReferenceTypeConstraint)
             return TypeParameterTypeKind.ReferenceType;
 
-        var kind = TypeParameterTypeKind.NeitherReferenceNorValue;
-        foreach (var constraintHandle in parameter.GetConstraints())
-        {
-            GenericParameterConstraint constraint;
-            try
-            {
-                constraint = reader.GetGenericParameterConstraint(constraintHandle);
-            }
-            catch (BadImageFormatException)
-            {
-                return TypeParameterTypeKind.Undetermined;
-            }
-
-            switch (ClassifyConstraintType(reader, constraint.Type))
-            {
-                // One class constraint settles it; nothing later can unprove it.
-                case ConstraintClass.ProvesReferenceType:
-                    return TypeParameterTypeKind.ReferenceType;
-                case ConstraintClass.Unreadable:
-                    kind = TypeParameterTypeKind.Undetermined;
-                    break;
-                case ConstraintClass.ProvesNothing:
-                    break;
-
-                // `where T : U` -- T is exactly as known as U, so follow the chain.
-                case ConstraintClass.DeferToTypeParameter:
-                    switch (ClassifySibling(reader, parameter, constraint.Type, chain))
-                    {
-                        case TypeParameterTypeKind.ReferenceType:
-                            return TypeParameterTypeKind.ReferenceType;
-
-                        // A value-type parameter cannot be a constraint in C#, so this
-                        // is malformed rather than a row of the table; fail closed.
-                        case TypeParameterTypeKind.ValueType:
-                        case TypeParameterTypeKind.Undetermined:
-                            kind = TypeParameterTypeKind.Undetermined;
-                            break;
-                        case TypeParameterTypeKind.NeitherReferenceNorValue:
-                            break;
-                    }
-
-                    break;
-            }
-        }
-
-        return kind;
+        return chain.Answer(reader, handle);
     }
 
     /// <summary>
-    /// Classifies the generic parameter that <paramref name="constraintType"/> names,
-    /// so that `where T : U` inherits U's answer. Both parameters belong to the same
+    /// Reads one parameter into the facts the two closures need: whether it is settled by
+    /// its own flags or by a constraint that proves reference-ness on its own, whether
+    /// anything about it was unreadable, and which sibling parameters it defers to.
+    /// </summary>
+    /// <remarks>
+    /// Unreadability is recorded rather than returned, so that a constraint this assembly
+    /// cannot read does not hide a later one that proves reference-ness outright. A proof
+    /// is a proof wherever it sits in the list, and nothing unreadable can unprove it;
+    /// answering otherwise would make the verdict depend on constraint order.
+    /// </remarks>
+    static Node Describe(MetadataReader reader, GenericParameterHandle handle)
+    {
+        var node = new Node(handle);
+        GenericParameter parameter;
+        try
+        {
+            parameter = reader.GetGenericParameter(handle);
+        }
+        catch (BadImageFormatException)
+        {
+            node.Unreadable = true;
+            return node;
+        }
+
+        var special = parameter.Attributes & GenericParameterAttributes.SpecialConstraintMask;
+        if ((special & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
+        {
+            node.IsValueType = true;
+            return node;
+        }
+
+        if ((special & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
+        {
+            node.ProvesReference = true;
+            return node;
+        }
+
+        try
+        {
+            foreach (var constraintHandle in parameter.GetConstraints())
+            {
+                GenericParameterConstraint constraint;
+                try
+                {
+                    constraint = reader.GetGenericParameterConstraint(constraintHandle);
+                }
+                catch (BadImageFormatException)
+                {
+                    node.Unreadable = true;
+                    continue;
+                }
+
+                switch (ClassifyConstraintType(reader, constraint.Type))
+                {
+                    case ConstraintClass.ProvesReferenceType:
+                        node.ProvesReference = true;
+                        break;
+                    case ConstraintClass.Unreadable:
+                        node.Unreadable = true;
+                        break;
+                    case ConstraintClass.ProvesNothing:
+                        break;
+
+                    // `where T : U` -- T is exactly as known as U, so record the edge.
+                    case ConstraintClass.DeferToTypeParameter:
+                        if (SiblingHandle(reader, parameter, constraint.Type) is { } target)
+                            node.Defers.Add(target);
+                        else
+                            node.Unreadable = true;
+                        break;
+                }
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            node.Unreadable = true;
+        }
+
+        return node;
+    }
+
+    /// <summary>
+    /// The generic parameter that <paramref name="constraintType"/> names, so that
+    /// `where T : U` can be recorded as an edge to U. Both parameters belong to the same
     /// declaration, so U is found among the siblings of <paramref name="parameter"/>
     /// rather than by resolving anything -- a method type parameter among the owning
     /// method's, a type type parameter among the declaring type's.
     /// </summary>
     /// <remarks>
-    /// Fails closed on anything unexpected: a signature that does not decode to a single
-    /// parameter index, an index outside the owning collection, an owner this assembly
-    /// cannot read, or a chain that revisits a parameter it is already classifying.
+    /// Yields null, and so fails closed, on anything unexpected: a signature that does not
+    /// decode to a single parameter index, an index outside the owning collection, or an
+    /// owner this assembly cannot read.
     /// </remarks>
-    static TypeParameterTypeKind ClassifySibling(
+    static GenericParameterHandle? SiblingHandle(
         MetadataReader reader,
         GenericParameter parameter,
-        EntityHandle constraintType,
-        ChainState chain)
+        EntityHandle constraintType)
     {
         if (constraintType.Kind != HandleKind.TypeSpecification)
-            return TypeParameterTypeKind.Undetermined;
+            return null;
 
         var reference = GuardedProviderDecode.TypeSpec(
             reader,
@@ -132,74 +163,44 @@ internal static class TypeParameterKindClassifier
             (GenericContext?)null,
             fallback: null);
         if (reference is not { } target)
-            return TypeParameterTypeKind.Undetermined;
+            return null;
 
         try
         {
             var siblings = SiblingParameters(reader, parameter, target.IsMethodParameter);
             if (siblings is not { } handles || target.Index < 0 || target.Index >= handles.Count)
-                return TypeParameterTypeKind.Undetermined;
+                return null;
 
-            var siblingHandle = handles[target.Index];
-            // Already answered. Reusing it is what keeps a chain that reconverges from
-            // being mistaken for a cycle, and what keeps a long chain linear rather
-            // than quadratic. Only answers reached without cutting the walk are stored,
-            // so this cannot hand back a path-dependent verdict -- see below.
-            if (chain.Answers.TryGetValue(siblingHandle, out var answered))
-                return answered;
-
-            // Malformed metadata can make the walk unbounded in ways the path guard
-            // alone does not bound, because a cut answer cannot be cached and so is
-            // recomputed for every parameter that reaches it. Spending a shared budget
-            // keeps a whole parameter list linear in the worst case; running out is a
-            // cut like any other and fails closed.
-            if (chain.Budget <= 0)
-            {
-                chain.Cuts++;
-                return TypeParameterTypeKind.Undetermined;
-            }
-
-            chain.Budget--;
-
-            // Only the current path guards against cycles, so a parameter is released
-            // once its own subtree is done and stays reachable from a sibling branch.
-            if (!chain.Path.Add(siblingHandle))
-            {
-                chain.Cuts++;
-                return TypeParameterTypeKind.Undetermined;
-            }
-
-            int cutsBefore = chain.Cuts;
-            try
-            {
-                var sibling = reader.GetGenericParameter(siblingHandle);
-                var special = sibling.Attributes & GenericParameterAttributes.SpecialConstraintMask;
-                var kind = Classify(
-                    reader,
-                    sibling,
-                    (special & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0,
-                    (special & GenericParameterAttributes.ReferenceTypeConstraint) != 0,
-                    chain);
-
-                // A subtree that was cut answers for the path it was reached by, not for
-                // the parameter itself: the cut hid constraints that a different path
-                // would have followed. Caching that would carry one parameter's verdict
-                // to another that merely reaches it, which is how a parameter whose real
-                // answer is `class` can come back unclassified and lose its clause.
-                if (chain.Cuts == cutsBefore)
-                    chain.Answers[siblingHandle] = kind;
-
-                return kind;
-            }
-            finally
-            {
-                chain.Path.Remove(siblingHandle);
-            }
+            return handles[target.Index];
         }
         catch (BadImageFormatException)
         {
-            return TypeParameterTypeKind.Undetermined;
+            return null;
         }
+    }
+
+    /// <summary>
+    /// One parameter as the constraint graph sees it.
+    /// </summary>
+    sealed class Node(GenericParameterHandle handle)
+    {
+        public GenericParameterHandle Handle { get; } = handle;
+
+        /// <summary>The sibling parameters this one defers to, one entry per constraint.</summary>
+        public List<GenericParameterHandle> Defers { get; } = [];
+
+        /// <summary>Reference-ness is settled by this parameter alone, with no edge followed.</summary>
+        public bool ProvesReference { get; set; }
+
+        /// <summary>The value-type flag, which settles the parameter and admits no constraints.</summary>
+        public bool IsValueType { get; set; }
+
+        /// <summary>
+        /// Something about this parameter could not be read, so it can never be proven to
+        /// constrain nothing. Left unanswered by both closures, which is what fails it
+        /// closed to <see cref="TypeParameterTypeKind.Undetermined"/>.
+        /// </summary>
+        public bool Unreadable { get; set; }
     }
 
     /// <summary>
@@ -231,34 +232,251 @@ internal static class TypeParameterKindClassifier
     }
 
     /// <summary>
-    /// The two things following a `where T : U` chain needs: the parameters on the path
-    /// currently being walked, and the answers already reached. Answers outlive a single
-    /// walk -- a handle identifies the same parameter for the whole module -- so a caller
-    /// classifying a parameter list reuses one instance across it.
+    /// The answers for one declaration's type parameters, and the resolution that computes
+    /// them. A caller classifying a parameter list reuses one instance across it; answers
+    /// outlive a single resolution, since a handle identifies the same parameter for the
+    /// whole module.
     /// </summary>
+    /// <remarks>
+    /// `where T : U` makes a declaration's parameters a directed graph rather than a tree,
+    /// and metadata can make that graph cyclic even though C# rejects it (CS0454). This
+    /// resolves it as a graph -- two closures over explicit worklists, no recursion and no
+    /// walk order -- so every answer is a function of the graph alone and all of them can
+    /// be cached unconditionally.
+    /// <para>
+    /// That property is the point. An earlier design walked depth-first and cut the walk at
+    /// a parameter already on the path, which made an answer depend on where the walk
+    /// started and so forced a rule about which answers were safe to keep. It also turned
+    /// depth into stack frames and repeated work into a budget to be rationed, and valid
+    /// metadata could reach both bounds: a long chain overflowed the stack, and a wide
+    /// acyclic graph exhausted the budget and lost a clause it had already proven. Neither
+    /// bound exists here, because neither quantity is consumed.
+    /// </para>
+    /// </remarks>
     internal sealed class ChainState
     {
-        /// <summary>The parameters on the walk currently in progress.</summary>
-        public HashSet<GenericParameterHandle> Path { get; } = [];
+        readonly Dictionary<GenericParameterHandle, TypeParameterTypeKind> _answers = [];
+
+        internal TypeParameterTypeKind Answer(MetadataReader reader, GenericParameterHandle handle)
+        {
+            if (_answers.TryGetValue(handle, out var answer))
+                return answer;
+
+            Resolve(reader, handle);
+
+            // Resolve answers everything it reached, so the miss below cannot happen; it
+            // fails closed rather than asserting.
+            return _answers.TryGetValue(handle, out var resolved)
+                ? resolved
+                : TypeParameterTypeKind.Undetermined;
+        }
 
         /// <summary>
-        /// Answers reached without cutting the walk, and therefore independent of the
-        /// parameter the walk started from.
+        /// Answers <paramref name="root"/> and everything reachable from it, by resolving
+        /// the constraint graph that contains it.
         /// </summary>
-        public Dictionary<GenericParameterHandle, TypeParameterTypeKind> Answers { get; } = [];
+        void Resolve(MetadataReader reader, GenericParameterHandle root)
+        {
+            var nodes = Discover(reader, root);
+            var predecessors = Predecessors(nodes);
+
+            ProveReferenceTypes(nodes, predecessors);
+            ProveConstrainsNothing(nodes, predecessors);
+
+            // Whatever neither closure could prove. A parameter lands here by deferring,
+            // however indirectly, to something unreadable or to a cycle -- in both cases
+            // its answer is genuinely unknown, and both wrong guesses are compile errors
+            // in the consumer, so it stays unclassified.
+            foreach (var handle in nodes.Keys)
+            {
+                if (!_answers.ContainsKey(handle))
+                    _answers[handle] = TypeParameterTypeKind.Undetermined;
+            }
+        }
 
         /// <summary>
-        /// How many times the walk has been cut short, by a cycle or by the budget. A
-        /// subtree spanning a cut is path-dependent and must not be cached.
+        /// The parameters reachable from <paramref name="root"/> that are not answered
+        /// already, read once each. Cycles terminate because a parameter is described
+        /// before its edges are followed.
         /// </summary>
-        public int Cuts { get; set; }
+        Dictionary<GenericParameterHandle, Node> Discover(MetadataReader reader, GenericParameterHandle root)
+        {
+            var nodes = new Dictionary<GenericParameterHandle, Node>();
+            var pending = new Stack<GenericParameterHandle>();
+            pending.Push(root);
+
+            while (pending.Count > 0)
+            {
+                var handle = pending.Pop();
+                if (_answers.ContainsKey(handle) || nodes.ContainsKey(handle))
+                    continue;
+
+                var node = Describe(reader, handle);
+                nodes[handle] = node;
+                foreach (var target in node.Defers)
+                {
+                    if (!_answers.ContainsKey(target) && !nodes.ContainsKey(target))
+                        pending.Push(target);
+                }
+            }
+
+            return nodes;
+        }
 
         /// <summary>
-        /// Sibling classifications left before the walk gives up. Only chains that are
-        /// cut can consume this, since an uncut chain is answered once and then cached;
-        /// the bound exists so malformed metadata cannot make a parameter list quadratic.
+        /// Reverses the edges, so a proof can be pushed to everything that defers to the
+        /// parameter it was proven about. Edges leaving the discovered graph point at
+        /// parameters already answered, so they are folded into the deferring node here as
+        /// the constants they are.
         /// </summary>
-        public int Budget { get; set; } = 100_000;
+        Dictionary<GenericParameterHandle, List<Node>> Predecessors(Dictionary<GenericParameterHandle, Node> nodes)
+        {
+            var predecessors = new Dictionary<GenericParameterHandle, List<Node>>();
+            foreach (var node in nodes.Values)
+            {
+                foreach (var target in node.Defers)
+                {
+                    if (!nodes.ContainsKey(target))
+                    {
+                        switch (_answers.TryGetValue(target, out var settled)
+                            ? settled
+                            : TypeParameterTypeKind.Undetermined)
+                        {
+                            case TypeParameterTypeKind.ReferenceType:
+                                node.ProvesReference = true;
+                                break;
+                            case TypeParameterTypeKind.NeitherReferenceNorValue:
+                                break;
+
+                            // A value-type parameter cannot be a constraint in C#, so
+                            // this is malformed rather than a row of the table.
+                            default:
+                                node.Unreadable = true;
+                                break;
+                        }
+
+                        continue;
+                    }
+
+                    if (!predecessors.TryGetValue(target, out var waiting))
+                        predecessors[target] = waiting = [];
+
+                    waiting.Add(node);
+                }
+            }
+
+            return predecessors;
+        }
+
+        /// <summary>
+        /// Settles every parameter the value-type flag settles, then spreads reference-ness
+        /// backwards: a parameter that defers to one known to be a reference type is itself
+        /// known to be one, however long the chain and whether or not it rejoins itself.
+        /// </summary>
+        void ProveReferenceTypes(
+            Dictionary<GenericParameterHandle, Node> nodes,
+            Dictionary<GenericParameterHandle, List<Node>> predecessors)
+        {
+            var proven = new Queue<Node>();
+            foreach (var node in nodes.Values)
+            {
+                if (node.IsValueType)
+                {
+                    _answers[node.Handle] = TypeParameterTypeKind.ValueType;
+                    continue;
+                }
+
+                if (node.ProvesReference)
+                {
+                    _answers[node.Handle] = TypeParameterTypeKind.ReferenceType;
+                    proven.Enqueue(node);
+                }
+            }
+
+            while (proven.Count > 0)
+            {
+                var settled = proven.Dequeue();
+                if (!predecessors.TryGetValue(settled.Handle, out var waiting))
+                    continue;
+
+                foreach (var node in waiting)
+                {
+                    if (_answers.ContainsKey(node.Handle))
+                        continue;
+
+                    _answers[node.Handle] = TypeParameterTypeKind.ReferenceType;
+                    proven.Enqueue(node);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Proves the remaining parameters constrain nothing, which -- unlike reference-ness
+        /// -- takes agreement from every edge rather than one witness: a parameter
+        /// constrains nothing only once all of its own deferrals are known to.
+        /// </summary>
+        /// <remarks>
+        /// Counting down outstanding deferrals is what makes a cycle answer correctly
+        /// without being detected as one. A parameter on a cycle can never reach zero,
+        /// because that would require the cycle to have already been proven through itself,
+        /// so it is left for the caller to fail closed. A parameter that reaches a cycle,
+        /// or anything unreadable, is stranded the same way and for the same reason.
+        /// </remarks>
+        void ProveConstrainsNothing(
+            Dictionary<GenericParameterHandle, Node> nodes,
+            Dictionary<GenericParameterHandle, List<Node>> predecessors)
+        {
+            var outstanding = new Dictionary<GenericParameterHandle, int>();
+            var proven = new Queue<Node>();
+            foreach (var node in nodes.Values)
+            {
+                if (_answers.ContainsKey(node.Handle))
+                    continue;
+
+                int pending = 0;
+                foreach (var target in node.Defers)
+                {
+                    if (!nodes.ContainsKey(target))
+                        continue;
+
+                    // Settled already, and only the value-type flag can have settled it:
+                    // a parameter deferring to a proven reference type was itself proven
+                    // one, so it is not here.
+                    if (_answers.ContainsKey(target))
+                    {
+                        node.Unreadable = true;
+                        continue;
+                    }
+
+                    pending++;
+                }
+
+                outstanding[node.Handle] = pending;
+                if (pending == 0 && !node.Unreadable)
+                    proven.Enqueue(node);
+            }
+
+            while (proven.Count > 0)
+            {
+                var settled = proven.Dequeue();
+                _answers[settled.Handle] = TypeParameterTypeKind.NeitherReferenceNorValue;
+                if (!predecessors.TryGetValue(settled.Handle, out var waiting))
+                    continue;
+
+                foreach (var node in waiting)
+                {
+                    if (_answers.ContainsKey(node.Handle)
+                        || !outstanding.TryGetValue(node.Handle, out var pending))
+                    {
+                        continue;
+                    }
+
+                    outstanding[node.Handle] = --pending;
+                    if (pending == 0 && !node.Unreadable)
+                        proven.Enqueue(node);
+                }
+            }
+        }
     }
 
     readonly record struct TypeParameterReference(int Index, bool IsMethodParameter);

--- a/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
+++ b/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
@@ -1,0 +1,193 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Decides whether a generic parameter's constraints prove it is a reference type, a
+/// value type, or neither — C#'s "known to be a reference type" question, which the
+/// constraint keywords alone cannot answer. A named class constraint proves
+/// reference-ness with no keyword present, and <c>System.Enum</c> is the trap in the
+/// other direction: it is a class, yet a parameter constrained to it may still be a
+/// value type, so it proves nothing.
+/// </summary>
+/// <remarks>
+/// Classification is fail-closed. Anything this assembly cannot read for itself — an
+/// external <see cref="TypeReference"/> whose interface flag lives in another module, a
+/// constraint naming another type parameter, or a signature the blob guards refused —
+/// yields <see cref="TypeParameterTypeKind.Undetermined"/> rather than a guess, because
+/// both wrong answers are compile errors in the consumer (CS8822 one way, CS8665 the
+/// other).
+/// </remarks>
+internal static class TypeParameterKindClassifier
+{
+    /// <summary>
+    /// Class types that are spellable as a constraint yet do not prove the parameter is
+    /// a reference type. <c>System.Object</c> and <c>System.ValueType</c> are dropped
+    /// from the constraint list before it reaches here; <c>System.Enum</c> survives and
+    /// is the one that matters.
+    /// </summary>
+    static readonly string[] s_classesThatProveNothing =
+        ["System.Object", "System.ValueType", "System.Enum"];
+
+    public static TypeParameterTypeKind Classify(
+        MetadataReader reader,
+        GenericParameter parameter,
+        bool hasValueTypeConstraint,
+        bool hasReferenceTypeConstraint)
+    {
+        // The attribute flags are decisive on their own and need no constraint types.
+        if (hasValueTypeConstraint)
+            return TypeParameterTypeKind.ValueType;
+        if (hasReferenceTypeConstraint)
+            return TypeParameterTypeKind.ReferenceType;
+
+        var kind = TypeParameterTypeKind.NeitherReferenceNorValue;
+        foreach (var constraintHandle in parameter.GetConstraints())
+        {
+            GenericParameterConstraint constraint;
+            try
+            {
+                constraint = reader.GetGenericParameterConstraint(constraintHandle);
+            }
+            catch (BadImageFormatException)
+            {
+                return TypeParameterTypeKind.Undetermined;
+            }
+
+            switch (ClassifyConstraintType(reader, constraint.Type))
+            {
+                // One class constraint settles it; nothing later can unprove it.
+                case ConstraintClass.ProvesReferenceType:
+                    return TypeParameterTypeKind.ReferenceType;
+                case ConstraintClass.Unreadable:
+                    kind = TypeParameterTypeKind.Undetermined;
+                    break;
+                case ConstraintClass.ProvesNothing:
+                    break;
+            }
+        }
+
+        return kind;
+    }
+
+    enum ConstraintClass
+    {
+        ProvesNothing,
+        ProvesReferenceType,
+        Unreadable,
+    }
+
+    static ConstraintClass ClassifyConstraintType(MetadataReader reader, EntityHandle handle)
+    {
+        if (handle.IsNil)
+            return ConstraintClass.Unreadable;
+
+        switch (handle.Kind)
+        {
+            case HandleKind.TypeDefinition:
+                return ClassifyDefinition(reader, (TypeDefinitionHandle)handle);
+
+            // Another module owns the interface flag, and a name is not a substitute for
+            // it: an unknown external type could be either.
+            case HandleKind.TypeReference:
+                return IsClassThatProvesNothing(TypeReferenceFullName(reader, (TypeReferenceHandle)handle))
+                    ? ConstraintClass.ProvesNothing
+                    : ConstraintClass.Unreadable;
+
+            // A generic instantiation constrains to the instantiated type, so the
+            // question is about its generic type definition.
+            case HandleKind.TypeSpecification:
+                return GuardedProviderDecode.TypeSpec(
+                    reader,
+                    (TypeSpecificationHandle)handle,
+                    ConstraintRootProvider.Instance,
+                    (GenericContext?)null,
+                    fallback: ConstraintClass.Unreadable);
+
+            default:
+                return ConstraintClass.Unreadable;
+        }
+    }
+
+    static ConstraintClass ClassifyDefinition(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        TypeDefinition definition;
+        string fullName;
+        try
+        {
+            definition = reader.GetTypeDefinition(handle);
+            fullName = TypeResolver.GetFullName(reader, definition);
+        }
+        catch (BadImageFormatException)
+        {
+            return ConstraintClass.Unreadable;
+        }
+
+        if ((definition.Attributes & TypeAttributes.Interface) != 0)
+            return ConstraintClass.ProvesNothing;
+
+        return IsClassThatProvesNothing(fullName)
+            ? ConstraintClass.ProvesNothing
+            : ConstraintClass.ProvesReferenceType;
+    }
+
+    static bool IsClassThatProvesNothing(string? fullName)
+        => fullName is not null && Array.IndexOf(s_classesThatProveNothing, fullName) >= 0;
+
+    static string? TypeReferenceFullName(MetadataReader reader, TypeReferenceHandle handle)
+    {
+        try
+        {
+            return TypeResolver.GetFullName(reader, reader.GetTypeReference(handle));
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Classifies the type at the root of a constraint signature. Only the named-type
+    /// and instantiation callbacks can be reached by a well-formed constraint; every
+    /// other shape is not a legal constraint and is reported unreadable rather than
+    /// guessed at.
+    /// </summary>
+    sealed class ConstraintRootProvider : ISignatureTypeProvider<ConstraintClass, GenericContext?>
+    {
+        public static ConstraintRootProvider Instance { get; } = new();
+
+        public ConstraintClass GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+            => ClassifyDefinition(reader, handle);
+
+        public ConstraintClass GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => IsClassThatProvesNothing(TypeReferenceFullName(reader, handle))
+                ? ConstraintClass.ProvesNothing
+                : ConstraintClass.Unreadable;
+
+        public ConstraintClass GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
+            => GuardedProviderDecode.TypeSpec(reader, handle, this, context, fallback: ConstraintClass.Unreadable);
+
+        // A generic instantiation is classified by the type being instantiated.
+        public ConstraintClass GetGenericInstantiation(ConstraintClass genericType, ImmutableArray<ConstraintClass> typeArguments)
+            => genericType;
+
+        public ConstraintClass GetModifiedType(ConstraintClass modifier, ConstraintClass unmodifiedType, bool isRequired)
+            => unmodifiedType;
+
+        public ConstraintClass GetPinnedType(ConstraintClass elementType) => elementType;
+
+        // A constraint naming another type parameter is only as known as that parameter,
+        // which this pass does not resolve.
+        public ConstraintClass GetGenericMethodParameter(GenericContext? context, int index) => ConstraintClass.Unreadable;
+        public ConstraintClass GetGenericTypeParameter(GenericContext? context, int index) => ConstraintClass.Unreadable;
+
+        public ConstraintClass GetPrimitiveType(PrimitiveTypeCode typeCode) => ConstraintClass.Unreadable;
+        public ConstraintClass GetSZArrayType(ConstraintClass elementType) => ConstraintClass.Unreadable;
+        public ConstraintClass GetArrayType(ConstraintClass elementType, ArrayShape shape) => ConstraintClass.Unreadable;
+        public ConstraintClass GetByReferenceType(ConstraintClass elementType) => ConstraintClass.Unreadable;
+        public ConstraintClass GetPointerType(ConstraintClass elementType) => ConstraintClass.Unreadable;
+        public ConstraintClass GetFunctionPointerType(MethodSignature<ConstraintClass> signature) => ConstraintClass.Unreadable;
+    }
+}

--- a/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
+++ b/src/ILInspector.Metadata/TypeParameterKindClassifier.cs
@@ -348,6 +348,25 @@ internal static class TypeParameterKindClassifier
     /// trusting the assembly.
     /// </remarks>
     static bool DeclaresCoreLibraryRoot(MetadataReader reader)
+        => s_coreLibraryRoots.GetValue(reader, static key => ScanForCoreLibraryRoot(key) ? s_true : s_false) == s_true;
+
+    /// <summary>
+    /// Memoized because the answer is a pure function of the module and the scan walks the
+    /// whole type table: without this, a module pairing many constrained parameters with a
+    /// large type table costs the product of the two. Measured on a synthesized module of
+    /// 2,000 constrained parameters and 20,001 types, extraction fell from 0.74s to 0.21s.
+    /// That cost reduction is measured, not gated -- no test pins it, because a module
+    /// large enough to separate the two reliably would dominate the suite's run time. The
+    /// classification itself is gated by
+    /// <c>ConstraintRestatement_RejectsASameModuleCoreLibraryLookalike</c>.
+    /// </summary>
+    static readonly System.Runtime.CompilerServices.ConditionalWeakTable<MetadataReader, object> s_coreLibraryRoots = new();
+
+    static readonly object s_true = new();
+
+    static readonly object s_false = new();
+
+    static bool ScanForCoreLibraryRoot(MetadataReader reader)
     {
         try
         {

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -877,6 +877,190 @@ public class ApiOutputFormatterTests
     }
 
     /// <summary>
+    /// The gate for the same-module half of core-type identity. An ordinary assembly may
+    /// declare its own <c>System.Enum</c>; that type is a plain class, so a parameter
+    /// constrained to it IS known to be a reference type and the override must restate
+    /// <c>class</c>. Matching the name alone yields <c>default</c>, which is CS8822.
+    /// </summary>
+    [Fact]
+    public void ConstraintRestatement_RejectsASameModuleCoreLibraryLookalike()
+    {
+        string dllPath = EmitSameModuleLookalikeSample();
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var surface = ApiSurfaceExtractor.Extract(pe);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "SameModuleLookalikeSample");
+            var member = Assert.Single(type.Members, candidate => candidate.Name == "Pick");
+            var typeParameter = Assert.Single(member.SignatureModel!.TypeParameters);
+
+            // The constraint really is spelled `System.Enum`, and it really is a
+            // same-module TypeDefinition, so neither the name nor the handle kind
+            // distinguishes it from the core library's.
+            Assert.Contains(
+                typeParameter.StructuredConstraints ?? [],
+                constraint => constraint.Value.Contains("Enum", StringComparison.Ordinal));
+
+            Assert.Equal(TypeParameterTypeKind.ReferenceType, typeParameter.TypeKind);
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
+    /// <summary>
+    /// The gate for reconvergence. Two `where T : U` branches that meet at the same
+    /// parameter must both be answered: the shared parameter is not on the second
+    /// branch's path, so treating it as a cycle would drop a clause C# requires
+    /// (CS0115/CS0534 on the override).
+    /// </summary>
+    /// <remarks>
+    /// Two mechanisms in <c>TypeParameterKindClassifier.ClassifySibling</c> are each
+    /// independently sufficient here -- releasing a parameter from the path once its own
+    /// subtree is done, and reusing an answer already reached -- so this fails only when
+    /// both are absent, which is the state it was written against. The long-chain gate
+    /// below isolates the answer cache.
+    /// </remarks>
+    [Fact]
+    public void ConstraintRestatement_AnswersAReconvergingConstraintChain()
+    {
+        string dllPath = EmitConstraintChainSample(
+            static parameters =>
+            {
+                parameters[0].SetInterfaceConstraints(parameters[1], parameters[2]);
+                parameters[1].SetInterfaceConstraints(parameters[3]);
+                parameters[2].SetInterfaceConstraints(parameters[3]);
+            },
+            "T", "A", "B", "X");
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var surface = ApiSurfaceExtractor.Extract(pe);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "ChainSample");
+            var member = Assert.Single(type.Members, candidate => candidate.Name == "Pick");
+            var typeParameter = member.SignatureModel!.TypeParameters[0];
+
+            Assert.Equal(TypeParameterTypeKind.NeitherReferenceNorValue, typeParameter.TypeKind);
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
+    /// <summary>
+    /// The gate for memoization. Following `where T : U` without reusing answers
+    /// reclassifies the whole remaining chain from every parameter, which is quadratic:
+    /// a 4,000-parameter chain measured over twenty seconds before answers were cached.
+    /// The bound is loose enough that only the missing cache can trip it -- the cached
+    /// walk finishes in milliseconds.
+    /// </summary>
+    [Fact]
+    public void ConstraintRestatement_ClassifiesALongConstraintChainWithoutRewalkingIt()
+    {
+        const int Length = 4000;
+        string[] names = [.. Enumerable.Range(0, Length).Select(index => $"T{index}")];
+        string dllPath = EmitConstraintChainSample(
+            static parameters =>
+            {
+                for (int index = 0; index < parameters.Length - 1; index++)
+                    parameters[index].SetInterfaceConstraints(parameters[index + 1]);
+            },
+            names);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var surface = ApiSurfaceExtractor.Extract(pe);
+            stopwatch.Stop();
+
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "ChainSample");
+            var member = Assert.Single(type.Members, candidate => candidate.Name == "Pick");
+            Assert.Equal(Length, member.SignatureModel!.TypeParameters.Count);
+            Assert.All(
+                member.SignatureModel.TypeParameters,
+                typeParameter => Assert.Equal(TypeParameterTypeKind.NeitherReferenceNorValue, typeParameter.TypeKind));
+
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"Classifying a {Length}-parameter constraint chain took {stopwatch.Elapsed}.");
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
+    /// <summary>
+    /// Emits one assembly declaring its own <c>System.Enum</c> alongside a generic
+    /// virtual method constrained to it, so the constraint is a same-module
+    /// TypeDefinition rather than a cross-assembly TypeReference.
+    /// </summary>
+    static string EmitSameModuleLookalikeSample()
+    {
+        var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("SameModuleLookalikeEmit"), typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("SameModuleLookalikeEmit");
+        var impostor = module.DefineType(
+            "System.Enum",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Abstract
+                | System.Reflection.TypeAttributes.Class);
+        var tb = module.DefineType(
+            "SameModuleLookalikeSample",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        var mb = tb.DefineMethod(
+            "Pick",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Virtual);
+        var typeParameters = mb.DefineGenericParameters("T");
+        typeParameters[0].SetBaseTypeConstraint(impostor);
+        mb.SetReturnType(typeParameters[0]);
+        mb.SetParameters(typeParameters[0]);
+        var il = mb.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldarg_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        impostor.CreateType();
+        tb.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"same-module-lookalike-{Guid.NewGuid():N}.dll");
+        ab.Save(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Emits a generic virtual method whose type parameters are wired to each other by
+    /// <paramref name="constrain"/>, which is how `where T : U` chains -- absent from
+    /// every assembly measured, but expressible -- reach the classifier.
+    /// </summary>
+    static string EmitConstraintChainSample(
+        Action<System.Reflection.Emit.GenericTypeParameterBuilder[]> constrain,
+        params string[] names)
+    {
+        var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("ChainEmit"), typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("ChainEmit");
+        var tb = module.DefineType(
+            "ChainSample",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        var mb = tb.DefineMethod(
+            "Pick",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Virtual);
+        var typeParameters = mb.DefineGenericParameters(names);
+        constrain(typeParameters);
+        mb.SetReturnType(typeParameters[0]);
+        mb.SetParameters(typeParameters[0]);
+        var il = mb.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldarg_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        tb.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"chain-{Guid.NewGuid():N}.dll");
+        ab.Save(path);
+        return path;
+    }
+
+    /// <summary>
     /// Emits two assemblies: one declaring a <c>System.Enum</c> that is not the core
     /// library's, and one whose generic virtual method is constrained to it. Returns the
     /// path of the second.

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -995,20 +995,20 @@ public class ApiOutputFormatterTests
     }
 
     /// <summary>
-    /// The gate against caching a path-dependent answer. A parameter reached through a
-    /// cycle answers for the path it was reached by, not for itself, because the cut hid
-    /// constraints another path would have followed. Caching that carries one parameter's
-    /// verdict to another that merely reaches it.
+    /// A parameter whose only route to a proof runs through a cycle still gets the proof.
+    /// Both parameters here are reference types, and the cycle between them is incidental
+    /// to that; an answer that came out different depending on which parameter was asked
+    /// first would drop a <c>class</c> clause C# requires (CS0115/CS0534).
     /// </summary>
     /// <remarks>
     /// The shape: <c>T1 : T2</c>, <c>T2 : T1, T4</c>, <c>T3 : T1</c>, <c>T4 : class</c>.
-    /// Classifying T1 walks into T2, back to T1 -- which is on the path, so that branch is
-    /// cut -- and then on to T4, so T1 really is a reference type. T3's only route is
-    /// through T1, so T3 is one too. If the cut answer for T1 is cached, T3 reads it, comes
-    /// back unclassified, and loses the <c>class</c> clause C# requires (CS0115/CS0534).
+    /// T1 reaches T4 by way of T2, so T1 is a reference type; T3's only route is through
+    /// T1, so T3 is one too. This was the counterexample that retired a design in which
+    /// meeting the <c>T2 : T1</c> edge made T1's answer belong to the route rather than
+    /// to T1 -- T3 then inherited a verdict that was never about it.
     /// </remarks>
     [Fact]
-    public void ConstraintRestatement_DoesNotCacheAnAnswerReachedThroughACycle()
+    public void ConstraintRestatement_AnswersEveryParameterOnARouteThroughACycle()
     {
         string dllPath = EmitConstraintChainSample(
             static parameters =>
@@ -1031,7 +1031,7 @@ public class ApiOutputFormatterTests
             Assert.Equal(TypeParameterTypeKind.ReferenceType, typeParameters[0].TypeKind);
 
             // T3's only route is through T1, so it must reach the same answer rather than
-            // the cut verdict cached while T1 was still being classified.
+            // one that belonged to the route T1 was reached by.
             Assert.Equal(TypeParameterTypeKind.ReferenceType, typeParameters[2].TypeKind);
         }
         finally
@@ -1041,13 +1041,13 @@ public class ApiOutputFormatterTests
     }
 
     /// <summary>
-    /// The gate for the walk budget. An answer reached through a cycle cannot be cached,
-    /// so a long cyclic chain would otherwise be recomputed from every parameter --
-    /// quadratic, and reachable from malformed metadata. The budget bounds it, and
-    /// giving up is a cut like any other, so the result fails closed rather than guessing.
+    /// A parameter list that is one long cycle. Nothing in it is knowable, and finding
+    /// that out has to cost about what reading the list costs -- a cycle is the shape that
+    /// invites re-deriving the same parameters once per parameter, which is quadratic and
+    /// reachable from malformed metadata.
     /// </summary>
     [Fact]
-    public void ConstraintRestatement_BoundsALongCyclicConstraintChain()
+    public void ConstraintRestatement_ResolvesALongCyclicConstraintChain()
     {
         const int Length = 4000;
         string[] names = [.. Enumerable.Range(0, Length).Select(index => $"T{index}")];
@@ -1172,6 +1172,165 @@ public class ApiOutputFormatterTests
     /// <paramref name="constrain"/>, which is how `where T : U` chains -- absent from
     /// every assembly measured, but expressible -- reach the classifier.
     /// </summary>
+    /// <summary>
+    /// The gate on resolving the constraint graph without recursion. A chain this long
+    /// exhausts the call stack when each link is a stack frame -- measured at roughly
+    /// 21,000 frames, which a 30,000-link chain passes -- and the process dies rather
+    /// than answering. Nothing about such a chain is invalid: it is acyclic, every link
+    /// is readable, and the proof at the far end is real, so the answer is required to
+    /// arrive.
+    /// </summary>
+    /// <remarks>
+    /// Asserting the proof reaches every link, rather than merely that the call returns,
+    /// is what keeps this from passing on a depth-limited walk that fails closed instead
+    /// of overflowing. A limit would answer <c>Undetermined</c> here and drop 30,000
+    /// required clauses.
+    /// </remarks>
+    [Fact]
+    public void ConstraintRestatement_ResolvesADeepConstraintChainWithoutRecursion()
+    {
+        const int Length = 30_000;
+        string[] names = [.. Enumerable.Range(0, Length).Select(index => $"T{index}")];
+        string dllPath = EmitConstraintChainSample(
+            static parameters =>
+            {
+                for (int index = 0; index < parameters.Length - 1; index++)
+                    parameters[index].SetInterfaceConstraints(parameters[index + 1]);
+
+                // The one witness, as far from the start of the chain as it can be.
+                parameters[^1].SetGenericParameterAttributes(
+                    System.Reflection.GenericParameterAttributes.ReferenceTypeConstraint);
+            },
+            names,
+            onType: true);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var surface = ApiSurfaceExtractor.Extract(pe);
+
+            var type = Assert.Single(surface.Types, candidate => candidate.Name.StartsWith("ChainSample", StringComparison.Ordinal));
+            Assert.Equal(Length, type.TypeParameters.Count);
+
+            // Every link inherits the far end's answer, however far away it is.
+            Assert.All(
+                type.TypeParameters,
+                typeParameter => Assert.Equal(TypeParameterTypeKind.ReferenceType, typeParameter.TypeKind));
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
+    /// <summary>
+    /// A proof that sits past a cycle still arrives. Parameters here reach both a cycle
+    /// and, further on, a parameter constrained to <c>class</c>; the cycle is genuinely
+    /// unanswerable, and the proof is genuinely a proof, so the two must not contaminate
+    /// each other.
+    /// </summary>
+    /// <remarks>
+    /// The shape, from adversarial review: <c>TCycle : TCycle</c>, then a fan of
+    /// <c>Ti : TCycle, Ti+1, Ti+2</c>, with <c>T0 : T1, TClass</c> and
+    /// <c>TClass : class</c>. A design that treats meeting a cycle as a reason to
+    /// distrust everything computed around it answers <c>T0</c> as <c>Undetermined</c>
+    /// and drops its required clause; one that re-derives the fan for every path through
+    /// it does not finish. Both were real behaviors of the walk this replaced, which is
+    /// why the assertions below pin the answer and the time together.
+    /// </remarks>
+    [Fact]
+    public void ConstraintRestatement_ProvesAReferenceTypeReachedPastACycle()
+    {
+        const int Depth = 30;
+
+        // T0 .. T31, then TCycle, then TClass.
+        string[] names =
+        [
+            .. Enumerable.Range(0, Depth + 2).Select(index => $"T{index}"),
+            "TCycle",
+            "TClass",
+        ];
+        string dllPath = EmitConstraintChainSample(
+            static parameters =>
+            {
+                var cycle = parameters[^2];
+                var proof = parameters[^1];
+                cycle.SetInterfaceConstraints(cycle);
+                proof.SetGenericParameterAttributes(
+                    System.Reflection.GenericParameterAttributes.ReferenceTypeConstraint);
+
+                for (int index = 1; index < Depth; index++)
+                    parameters[index].SetInterfaceConstraints(cycle, parameters[index + 1], parameters[index + 2]);
+
+                parameters[0].SetInterfaceConstraints(parameters[1], proof);
+            },
+            names,
+            onType: true);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var surface = ApiSurfaceExtractor.Extract(pe);
+            stopwatch.Stop();
+
+            var type = Assert.Single(surface.Types, candidate => candidate.Name.StartsWith("ChainSample", StringComparison.Ordinal));
+            var byName = type.TypeParameters.ToDictionary(typeParameter => typeParameter.Name);
+
+            // The proof is reached, past the cycle every parameter between also reaches.
+            Assert.Equal(TypeParameterTypeKind.ReferenceType, byName["T0"].TypeKind);
+            Assert.Equal(TypeParameterTypeKind.ReferenceType, byName["TClass"].TypeKind);
+
+            // The cycle itself remains unanswerable, and says nothing about anything else.
+            Assert.Equal(TypeParameterTypeKind.Undetermined, byName["TCycle"].TypeKind);
+
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"Classifying a {names.Length}-parameter graph around a cycle took {stopwatch.Elapsed}.");
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
+    /// <summary>
+    /// Many declarations, each with its own cyclic parameter list. Resolution is per
+    /// declaration, so a module pays for each one; this pins that the per-declaration
+    /// cost stays proportional to that declaration rather than to a fixed allowance that
+    /// each list is free to spend in full.
+    /// </summary>
+    [Fact]
+    public void ConstraintRestatement_ResolvesManyCyclicListsWithoutPerListWaste()
+    {
+        const int Lists = 512;
+        const int Length = 317;
+        string dllPath = EmitManyCyclicListsSample(Lists, Length);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var surface = ApiSurfaceExtractor.Extract(pe);
+            stopwatch.Stop();
+
+            var types = surface.Types
+                .Where(candidate => candidate.Name.StartsWith("Many", StringComparison.Ordinal))
+                .ToList();
+            Assert.Equal(Lists, types.Count);
+            Assert.All(
+                types,
+                type => Assert.All(
+                    type.TypeParameters,
+                    typeParameter => Assert.Equal(TypeParameterTypeKind.Undetermined, typeParameter.TypeKind)));
+
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"Classifying {Lists} cyclic lists of {Length} parameters took {stopwatch.Elapsed}.");
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
     static string EmitConstraintChainSample(
         Action<System.Reflection.Emit.GenericTypeParameterBuilder[]> constrain,
         string[] names,
@@ -1205,6 +1364,34 @@ public class ApiOutputFormatterTests
         tb.CreateType();
 
         string path = Path.Combine(Path.GetTempPath(), $"chain-{Guid.NewGuid():N}.dll");
+        ab.Save(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Emits one module holding <paramref name="lists"/> generic types, each with its own
+    /// self-contained cycle of <paramref name="length"/> type parameters.
+    /// </summary>
+    static string EmitManyCyclicListsSample(int lists, int length)
+    {
+        var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("ManyEmit"), typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("ManyEmit");
+        string[] names = [.. Enumerable.Range(0, length).Select(index => $"T{index}")];
+
+        for (int list = 0; list < lists; list++)
+        {
+            var tb = module.DefineType(
+                $"Many{list}",
+                System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+            var parameters = tb.DefineGenericParameters(names);
+            for (int index = 0; index < parameters.Length; index++)
+                parameters[index].SetInterfaceConstraints(parameters[(index + 1) % parameters.Length]);
+
+            tb.CreateType();
+        }
+
+        string path = Path.Combine(Path.GetTempPath(), $"many-{Guid.NewGuid():N}.dll");
         ab.Save(path);
         return path;
     }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -790,6 +790,10 @@ public class ApiOutputFormatterTests
     [InlineData(nameof(RestatementRowFixture.Enumish), "default")]
     // Any other named class constraint does make T known to be a reference type.
     [InlineData(nameof(RestatementRowFixture.Named), "class")]
+    // `where T : U` inherits U's answer, so the chain has to be followed rather than
+    // treated as unknowable: U is class-constrained here and unconstrained below.
+    [InlineData(nameof(RestatementRowFixture.Transitive), "class")]
+    [InlineData(nameof(RestatementRowFixture.OpenChain), "default")]
     public void ConstraintRestatement_MatchesWhatCSharpRequires(string memberName, string expected)
     {
         string path = typeof(RestatementRowFixture).Assembly.Location;
@@ -817,18 +821,103 @@ public class ApiOutputFormatterTests
                 UnsafeOperations: false)));
         var sections = new MemberCodeView();
 
+        // A second type parameter exists only on the rows that need one to constrain T.
+        string signature = memberName is nameof(RestatementRowFixture.Transitive)
+            or nameof(RestatementRowFixture.OpenChain)
+            ? $"{memberName}<T, U>(T? value) where T : {expected} where U : {expected}"
+            : $"{memberName}<T>(T? value) where T : {expected}";
+
         Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, collected.Code));
-        Assert.Contains(
-            $"{memberName}<T>(T? value) where T : {expected}",
-            sections.DecompiledSourceCode.Content,
-            StringComparison.Ordinal);
+        Assert.Contains(signature, sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
 
         var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
         Assert.NotNull(typeSource);
-        Assert.Contains(
-            $"{memberName}<T>(T? value) where T : {expected}",
-            typeSource,
-            StringComparison.Ordinal);
+        Assert.Contains(signature, typeSource, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The three core types that prove nothing about a type parameter are recognized by
+    /// typed identity, never by display name. An assembly may declare its own
+    /// <c>System.Enum</c>, and a parameter constrained to that type IS known to be a
+    /// reference type -- so treating the impostor as the real one would emit
+    /// <c>where T : default</c> and produce CS8822 rather than merely incomplete output.
+    /// </summary>
+    /// <remarks>
+    /// Non-vacuous: dropping the resolution-scope check from the classifier's
+    /// <c>TypeReference</c> arm classifies this parameter as
+    /// <see cref="TypeParameterTypeKind.NeitherReferenceNorValue"/> and fails this test.
+    /// The metadata is synthesized because the attack needs a second assembly that
+    /// declares <c>System.Enum</c> without a core-library strong name, which a compiled
+    /// in-repo fixture cannot express.
+    /// </remarks>
+    [Fact]
+    public void ConstraintRestatement_RejectsACoreLibraryLookalike()
+    {
+        string dllPath = EmitCoreLibraryLookalikeSample();
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var surface = ApiSurfaceExtractor.Extract(pe);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "LookalikeSample");
+            var member = Assert.Single(type.Members, candidate => candidate.Name == "Pick");
+            var typeParameter = Assert.Single(member.SignatureModel!.TypeParameters);
+
+            // The constraint really is a TypeReference spelled `System.Enum`, so the
+            // display name alone would have matched.
+            Assert.Contains(
+                typeParameter.StructuredConstraints ?? [],
+                constraint => constraint.Value.Contains("Enum", StringComparison.Ordinal));
+
+            Assert.Equal(TypeParameterTypeKind.Undetermined, typeParameter.TypeKind);
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
+    /// <summary>
+    /// Emits two assemblies: one declaring a <c>System.Enum</c> that is not the core
+    /// library's, and one whose generic virtual method is constrained to it. Returns the
+    /// path of the second.
+    /// </summary>
+    static string EmitCoreLibraryLookalikeSample()
+    {
+        var fakeCore = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName($"FakeCoreLib{Guid.NewGuid():N}"), typeof(object).Assembly);
+        var fakeModule = fakeCore.DefineDynamicModule("FakeCoreLib");
+        fakeModule.DefineType(
+            "System.Enum",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Abstract
+                | System.Reflection.TypeAttributes.Class)
+            .CreateType();
+        string fakePath = Path.Combine(Path.GetTempPath(), $"fake-corelib-{Guid.NewGuid():N}.dll");
+        fakeCore.Save(fakePath);
+
+        var impostor = System.Reflection.Assembly.LoadFrom(fakePath).GetType("System.Enum")!;
+
+        var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("LookalikeEmit"), typeof(object).Assembly);
+        var module = ab.DefineDynamicModule("LookalikeEmit");
+        var tb = module.DefineType(
+            "LookalikeSample",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        var mb = tb.DefineMethod(
+            "Pick",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Virtual);
+        var typeParameters = mb.DefineGenericParameters("T");
+        typeParameters[0].SetBaseTypeConstraint(impostor);
+        mb.SetReturnType(typeParameters[0]);
+        mb.SetParameters(typeParameters[0]);
+        var il = mb.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldarg_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        tb.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"lookalike-{Guid.NewGuid():N}.dll");
+        ab.Save(path);
+        return path;
     }
 
     /// <summary>
@@ -1238,6 +1327,14 @@ public class RestatementRowBase
     public virtual T? Named<T>(T? value) where T : ConstraintFixtureBase => value;
 
     public virtual T? Ctor<T>(T? value) where T : new() => value;
+
+    /// <summary>
+    /// `where T : U` makes T exactly as known as U, so these two rows differ only in
+    /// what the *other* parameter is constrained to.
+    /// </summary>
+    public virtual T? Transitive<T, U>(T? value) where T : U where U : ConstraintFixtureBase => value;
+
+    public virtual T? OpenChain<T, U>(T? value) where T : U => value;
 }
 
 public class RestatementRowFixture : RestatementRowBase
@@ -1253,4 +1350,8 @@ public class RestatementRowFixture : RestatementRowBase
     public override T? Named<T>(T? value) where T : class => value;
 
     public override T? Ctor<T>(T? value) where T : default => value;
+
+    public override T? Transitive<T, U>(T? value) where T : class where U : class => value;
+
+    public override T? OpenChain<T, U>(T? value) where T : default where U : default => value;
 }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
@@ -932,7 +934,7 @@ public class ApiOutputFormatterTests
                 parameters[1].SetInterfaceConstraints(parameters[3]);
                 parameters[2].SetInterfaceConstraints(parameters[3]);
             },
-            "T", "A", "B", "X");
+            ["T", "A", "B", "X"]);
         try
         {
             using var pe = new PEReader(File.OpenRead(dllPath));
@@ -993,6 +995,143 @@ public class ApiOutputFormatterTests
     }
 
     /// <summary>
+    /// The gate against caching a path-dependent answer. A parameter reached through a
+    /// cycle answers for the path it was reached by, not for itself, because the cut hid
+    /// constraints another path would have followed. Caching that carries one parameter's
+    /// verdict to another that merely reaches it.
+    /// </summary>
+    /// <remarks>
+    /// The shape: <c>T1 : T2</c>, <c>T2 : T1, T4</c>, <c>T3 : T1</c>, <c>T4 : class</c>.
+    /// Classifying T1 walks into T2, back to T1 -- which is on the path, so that branch is
+    /// cut -- and then on to T4, so T1 really is a reference type. T3's only route is
+    /// through T1, so T3 is one too. If the cut answer for T1 is cached, T3 reads it, comes
+    /// back unclassified, and loses the <c>class</c> clause C# requires (CS0115/CS0534).
+    /// </remarks>
+    [Fact]
+    public void ConstraintRestatement_DoesNotCacheAnAnswerReachedThroughACycle()
+    {
+        string dllPath = EmitConstraintChainSample(
+            static parameters =>
+            {
+                parameters[3].SetGenericParameterAttributes(GenericParameterAttributes.ReferenceTypeConstraint);
+                parameters[0].SetInterfaceConstraints(parameters[1]);
+                parameters[1].SetInterfaceConstraints(parameters[0], parameters[3]);
+                parameters[2].SetInterfaceConstraints(parameters[0]);
+            },
+            ["T1", "T2", "T3", "T4"],
+            onType: true);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var surface = ApiSurfaceExtractor.Extract(pe);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name.StartsWith("ChainSample", StringComparison.Ordinal));
+            var typeParameters = type.TypeParameters;
+
+            // T1 is a reference type by way of T2 -> T4, despite the T2 -> T1 cycle.
+            Assert.Equal(TypeParameterTypeKind.ReferenceType, typeParameters[0].TypeKind);
+
+            // T3's only route is through T1, so it must reach the same answer rather than
+            // the cut verdict cached while T1 was still being classified.
+            Assert.Equal(TypeParameterTypeKind.ReferenceType, typeParameters[2].TypeKind);
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
+    /// <summary>
+    /// The gate for the walk budget. An answer reached through a cycle cannot be cached,
+    /// so a long cyclic chain would otherwise be recomputed from every parameter --
+    /// quadratic, and reachable from malformed metadata. The budget bounds it, and
+    /// giving up is a cut like any other, so the result fails closed rather than guessing.
+    /// </summary>
+    [Fact]
+    public void ConstraintRestatement_BoundsALongCyclicConstraintChain()
+    {
+        const int Length = 4000;
+        string[] names = [.. Enumerable.Range(0, Length).Select(index => $"T{index}")];
+        string dllPath = EmitConstraintChainSample(
+            static parameters =>
+            {
+                // Every parameter constrained to the next, and the last back to the first.
+                for (int index = 0; index < parameters.Length; index++)
+                    parameters[index].SetInterfaceConstraints(parameters[(index + 1) % parameters.Length]);
+            },
+            names,
+            onType: true);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var surface = ApiSurfaceExtractor.Extract(pe);
+            stopwatch.Stop();
+
+            var type = Assert.Single(surface.Types, candidate => candidate.Name.StartsWith("ChainSample", StringComparison.Ordinal));
+            Assert.Equal(Length, type.TypeParameters.Count);
+
+            // Nothing is knowable from a chain that only leads back to itself.
+            Assert.All(
+                type.TypeParameters,
+                typeParameter => Assert.Equal(TypeParameterTypeKind.Undetermined, typeParameter.TypeKind));
+
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"Classifying a {Length}-parameter cyclic chain took {stopwatch.Elapsed}.");
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
+    /// <summary>
+    /// The same bound, through the other consumer. <c>MetadataDeclarationQuery</c>
+    /// classifies parameters independently of <c>ApiSurfaceExtractor</c>, so it needs its
+    /// own proof that it shares one chain state across a parameter list rather than
+    /// allocating one per parameter, which rewalks the chain's whole tail.
+    /// </summary>
+    [Fact]
+    public void ConstraintRestatement_ClassifiesALongChainWithoutRewalkingItInDeclarationQuery()
+    {
+        const int Length = 4000;
+        string[] names = [.. Enumerable.Range(0, Length).Select(index => $"T{index}")];
+        string dllPath = EmitConstraintChainSample(
+            static parameters =>
+            {
+                for (int index = 0; index < parameters.Length - 1; index++)
+                    parameters[index].SetInterfaceConstraints(parameters[index + 1]);
+            },
+            names,
+            onType: true);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(dllPath));
+            var reader = pe.GetMetadataReader();
+            var typeDefinition = reader.TypeDefinitions
+                .Select(reader.GetTypeDefinition)
+                .Single(candidate => reader.GetString(candidate.Name) == "ChainSample");
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var typeParameters = MetadataDeclarationQuery.GetTypeParameters(reader, typeDefinition);
+            stopwatch.Stop();
+
+            Assert.Equal(Length, typeParameters.Count);
+            Assert.All(
+                typeParameters,
+                typeParameter => Assert.Equal(TypeParameterTypeKind.NeitherReferenceNorValue, typeParameter.TypeKind));
+
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"Reading a {Length}-parameter constraint chain took {stopwatch.Elapsed}.");
+        }
+        finally
+        {
+            File.Delete(dllPath);
+        }
+    }
+
+    /// <summary>
     /// Emits one assembly declaring its own <c>System.Enum</c> alongside a generic
     /// virtual method constrained to it, so the constraint is a same-module
     /// TypeDefinition rather than a cross-assembly TypeReference.
@@ -1035,7 +1174,8 @@ public class ApiOutputFormatterTests
     /// </summary>
     static string EmitConstraintChainSample(
         Action<System.Reflection.Emit.GenericTypeParameterBuilder[]> constrain,
-        params string[] names)
+        string[] names,
+        bool onType = false)
     {
         var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
             new System.Reflection.AssemblyName("ChainEmit"), typeof(object).Assembly);
@@ -1043,16 +1183,25 @@ public class ApiOutputFormatterTests
         var tb = module.DefineType(
             "ChainSample",
             System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
-        var mb = tb.DefineMethod(
-            "Pick",
-            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Virtual);
-        var typeParameters = mb.DefineGenericParameters(names);
-        constrain(typeParameters);
-        mb.SetReturnType(typeParameters[0]);
-        mb.SetParameters(typeParameters[0]);
-        var il = mb.GetILGenerator();
-        il.Emit(System.Reflection.Emit.OpCodes.Ldarg_1);
-        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+
+        if (onType)
+        {
+            constrain(tb.DefineGenericParameters(names));
+        }
+        else
+        {
+            var mb = tb.DefineMethod(
+                "Pick",
+                System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Virtual);
+            var typeParameters = mb.DefineGenericParameters(names);
+            constrain(typeParameters);
+            mb.SetReturnType(typeParameters[0]);
+            mb.SetParameters(typeParameters[0]);
+            var il = mb.GetILGenerator();
+            il.Emit(System.Reflection.Emit.OpCodes.Ldarg_1);
+            il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        }
+
         tb.CreateType();
 
         string path = Path.Combine(Path.GetTempPath(), $"chain-{Guid.NewGuid():N}.dll");

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -762,6 +762,76 @@ public class ApiOutputFormatterTests
     }
 
     /// <summary>
+    /// Every row of the restatement table, through the real chain over real compiled
+    /// metadata. An override may not repeat its inherited constraints (CS0460) but must
+    /// restate exactly one fact about each type parameter, because that fact decides
+    /// whether `T?` binds as a nullable reference type or as Nullable&lt;T&gt;. Omitting
+    /// it is CS0453/CS0115/CS0534; naming the wrong one is CS8822 or CS8665.
+    /// </summary>
+    /// <remarks>
+    /// The rows cannot be told apart by constraint spelling, which is why this runs
+    /// against compiler-produced metadata rather than a hand-built model: `Enumish` and
+    /// `Named` are both class constraints, and `Interface` and `Named` are both named
+    /// type constraints, yet each pair needs opposite restatements. This is the gate for
+    /// <c>TypeParameterKindClassifier</c>; the writer's reduction from the classified
+    /// kind is gated separately by
+    /// <c>CSharpDeclarationWriterTests.OverrideGenericMethod_RestatesWhatTheClassifiedKindRequires</c>.
+    /// </remarks>
+    [Theory]
+    // No constraint, and constraints that prove nothing about T being a reference or
+    // value type. `default` is required: omitting the clause does not compile.
+    [InlineData(nameof(RestatementRowFixture.None), "default")]
+    [InlineData(nameof(RestatementRowFixture.NotNull), "default")]
+    [InlineData(nameof(RestatementRowFixture.Ctor), "default")]
+    // An interface constraint proves nothing either -- T may still be a struct.
+    [InlineData(nameof(RestatementRowFixture.Interface), "default")]
+    // System.Enum is the trap: it is a class, but it is one of the three base types
+    // that does not make T known to be a reference type, so `class` here is CS8665.
+    [InlineData(nameof(RestatementRowFixture.Enumish), "default")]
+    // Any other named class constraint does make T known to be a reference type.
+    [InlineData(nameof(RestatementRowFixture.Named), "class")]
+    public void ConstraintRestatement_MatchesWhatCSharpRequires(string memberName, string expected)
+    {
+        string path = typeof(RestatementRowFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(RestatementRowFixture).FullName);
+        var member = Assert.Single(type.Members, candidate => candidate.Name == memberName);
+        var collected = Assert.Single(MemberCodeProvider.Collect(
+            type,
+            [member],
+            path,
+            overloadIndex: 0,
+            new MemberCodeProvider.Request(
+                DecompiledSource: true,
+                AnnotatedSource: false,
+                CostOverlay: false,
+                SemanticsOverlay: false,
+                IL: false,
+                Attributes: false,
+                Calls: false,
+                Callers: false,
+                CallGraph: false,
+                UnsafeOperations: false)));
+        var sections = new MemberCodeView();
+
+        Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, collected.Code));
+        Assert.Contains(
+            $"{memberName}<T>(T? value) where T : {expected}",
+            sections.DecompiledSourceCode.Content,
+            StringComparison.Ordinal);
+
+        var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
+        Assert.NotNull(typeSource);
+        Assert.Contains(
+            $"{memberName}<T>(T? value) where T : {expected}",
+            typeSource,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The same chain must reduce, not drop, the constraints an override inherits.
     /// C# allows exactly a bare `class` or `struct` to be restated, and that carve-out
     /// decides how `T?` binds: without it `T?` becomes Nullable&lt;T&gt; and the render
@@ -1147,4 +1217,40 @@ public class ConstraintFixture : ConstraintFixtureBase, IConstraintFixture
 public interface IConstraintFixture
 {
     void Wrap<T>(T? value) where T : struct;
+}
+
+/// <summary>
+/// One row per line of the restatement table an override has to satisfy. The rows are
+/// distinguished by what the base constrains, not by how the constraint is spelled:
+/// <see cref="Enumish"/> and <see cref="Named"/> are both class constraints in
+/// metadata, yet C# requires opposite restatements for them.
+/// </summary>
+public class RestatementRowBase
+{
+    public virtual T? None<T>(T? value) => value;
+
+    public virtual T? NotNull<T>(T? value) where T : notnull => value;
+
+    public virtual T? Interface<T>(T? value) where T : IConstraintFixture => value;
+
+    public virtual T? Enumish<T>(T? value) where T : Enum => value;
+
+    public virtual T? Named<T>(T? value) where T : ConstraintFixtureBase => value;
+
+    public virtual T? Ctor<T>(T? value) where T : new() => value;
+}
+
+public class RestatementRowFixture : RestatementRowBase
+{
+    public override T? None<T>(T? value) where T : default => value;
+
+    public override T? NotNull<T>(T? value) where T : default => value;
+
+    public override T? Interface<T>(T? value) where T : default => value;
+
+    public override T? Enumish<T>(T? value) where T : default => value;
+
+    public override T? Named<T>(T? value) where T : class => value;
+
+    public override T? Ctor<T>(T? value) where T : default => value;
 }


### PR DESCRIPTION
Fixes #3721.

An override or explicit interface implementation may not repeat its inherited constraints — that is CS0460 — but it **must** restate exactly one fact about each type parameter, because that fact decides whether `T?` in the signature binds as a nullable reference type or as `Nullable<T>`. #3714 emitted that restatement only for the `class`/`struct` rows. Every other row rendered no clause at all, and did not compile.

## Before / after

Rendering an override of each table row, then compiling the render back against the real base assembly:

| | csc errors |
| --- | --- |
| base `origin/main` (`5c6ca5f93`) | **20** |
| this PR | **0** |

```diff
-    public override T? Unconstrained<T>(T? v) => v;
-    public override T? NotNull<T>(T? v) => v;
-    public override T? Iface<T>(T? v) => v;
-    public override T? EnumC<T>(T? v) => v;
-    public override T? NamedClass<T>(T? v) => v;
+    public override T? Unconstrained<T>(T? v) where T : default => v;
+    public override T? NotNull<T>(T? v) where T : default => v;
+    public override T? Iface<T>(T? v) where T : default => v;
+    public override T? EnumC<T>(T? v) where T : default => v;
+    public override T? NamedClass<T>(T? v) where T : class => v;
     public override T? RefC<T>(T? v) where T : class => v;
```

The unchanged tail of that diff is the point: the rows #3714 already handled are byte-identical, and nothing else in the render moves.

## Why this could not be decided in the C# layer

The required restatement is not recoverable from the constraint spelling:

- `System.Enum` is a class, yet requires `default`; **any other** named class requires `class`. A name-based guess gets that row exactly backwards (CS8665).
- An interface constraint and a class constraint are both *named type* constraints, yet need opposite answers.

So Metadata classifies the type parameter and the C# layer reduces from the classified fact. `TypeParameter` gains `TypeKind`, decided by the new `TypeParameterKindClassifier`: attribute flags first, then the constraint types, treating `System.Object`, `System.ValueType` and `System.Enum` as proving nothing.

## Non-action boundary

- **`Undetermined` emits no clause**, rendering exactly as before. Guessing an unclassifiable constraint would be CS8822 or CS8665 — worse than incomplete.
- **The cross-assembly row is deliberately left open**, filed as #3730. Classifying a named constraint needs the constraint type's `TypeAttributes.Interface`, which requires a `TypeDefinition`; a constraint type in another assembly arrives as a `TypeReference`, and `ApiSurfaceExtractor.Extract(PEReader)` has no resolution context. Giving it one is an architectural change to that contract, not a classifier tweak. Scanned across **5,362 assemblies / 45,032 generic-override type parameters**:

  | Constraint shape | Count | Status |
  | --- | ---: | --- |
  | no constraint at all | 42,869 (95.2%) | **fixed here** |
  | `class`/`struct` attribute flag | 954 (2.1%) | already worked (#3714) |
  | named, same-module `TypeDefinition` | 409 (0.9%) | **fixed here** |
  | named, `TypeSpecification` | 69 (0.2%) | fixed when the generic definition is same-module |
  | named, cross-assembly `TypeReference` | 731 (1.6%) | **#3730**, unchanged from base |
  | type-parameter constraint (`where T : U`) | 0 | does not occur in practice |

  Correcting the record: an earlier measurement of this reported *zero* unclassified constraints. That scan covered only `Microsoft.NETCore.App`, which is the one population where a cross-assembly constraint reference cannot appear, because corlib's own types are same-module `TypeDefinition`s. The number above is the one to trust.
- `TypeKind` is `[JsonIgnore]`, matching `StructuredConstraints`. **No serialized shape changes**, so no schema or output-contract churn.
- Two *parameter-type* defects visible in the fixture (`Nullable<T?>` for `T?` under `where T : struct`, and a spurious `?` on an `unmanaged` parameter) are **byte-identical on base** — pre-existing and out of scope. Filed separately.

## Evidence

- New gate `ApiOutputFormatterTests.ConstraintRestatement_MatchesWhatCSharpRequires` — one theory row per table line, over **compiler-produced metadata**, through both the single-member and whole-type rendering paths. Compiled fixtures, not a hand-built model, precisely because the rows are indistinguishable by spelling.
- `CSharpDeclarationWriterTests.OverrideGenericMethod_RestatesWhatTheClassifiedKindRequires` owns the reduction from the classified kind, including the `Undetermined` no-clause row.
- **Both tampers bite.** Removing the `System.Enum` carve-out fails **only** that row (1/6). Making the writer drop `default` fails **exactly** the five rows that need it (5/6), plus the writer theory.
- Suites (Release): CLI 2853/1/14 — the 1 is the known pre-existing `Layout_Count_CountsFilesRatherThanRenderedTreeLines`; decompiler `--gate fast` 4496/0; `Area=RoundTrip` 568/0; `Area=Corpus` 367/0; `Area=Validity` 103/0; CSharp 459/0; Metadata 1397/0/5; MetadataRendering 187/0; Services 360/0; Analysis 584/0.

## Review

High risk — a shared Metadata model fact plus a changed default rendering of every generic override. Two-model adversarial review to follow.
