### PR TITLE
Run CI on every pull request, whatever it targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,26 @@ name: CI
 on:
   push:
     branches: [main]
-  # The base-branch filter also decides whether a *stacked* PR gets CI at all.
-  # A PR retargeted from `main` onto a long-lived feature branch silently stops
-  # matching `[main]`, so it reports no checks rather than failing ones -- and
-  # once `ci-required` is a required check, "no checks reported" is
-  # indistinguishable at a glance from "not run yet".
+  # Deliberately unfiltered by base branch. A base-branch filter decides whether
+  # a *stacked* PR gets CI at all: a PR retargeted from `main` onto a long-lived
+  # branch silently stops matching, so it reports no checks rather than failing
+  # ones -- and "no checks reported" is indistinguishable at a glance from "not
+  # run yet", while `ci-required` counts a job that never ran as nothing to
+  # block on.
   #
-  # The list must therefore cover every prefix a *base* can have, which is every
+  # An allow list here has to name every prefix a *base* can have, which is every
   # prefix a branch can have, since any branch under review can be stacked on.
-  # `feature/**` alone left `fix/**` uncovered, and that is not a hypothetical
-  # gap: #3684 opened onto `fix/3628-...` and reported no checks at all.
+  # That is not a list that can be maintained, and each way of getting it wrong
+  # is silent: `[main]` alone missed every stacked PR, adding `feature/**` still
+  # left `fix/**` uncovered (#3684 opened onto `fix/3628-...` and reported no
+  # checks), and adding `fix/**` still left #3558 -- open onto
+  # `prototype/wasm-command-ui` -- mergeable with zero checks (#3706).
+  #
+  # So the filter is gone rather than extended. Every pull request runs CI
+  # whatever it targets. The cost is CI on PRs between side branches; the cost
+  # of the allow list was PRs that merge with no CI at all and look clean doing
+  # it.
   pull_request:
-    branches: [main, 'feature/**', 'fix/**']
 
 env:
   DOTNET_NOLOGO: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,11 +384,13 @@ round:
   bottom open slice takes `origin/main` as its base, and rebasing an upper slice
   onto `main` pulls in work its parent has not landed and makes the slice's diff
   report its parent's changes as its own.
-- **Every slice in a stack must report CI.** Stack branches use the `feature/`
-  prefix, so a child PR targeting its parent branch schedules the same CI as a
+- **Every slice in a stack must report CI.** `ci.yml` applies no base-branch
+  filter, so a child PR targeting its parent branch schedules the same CI as a
   bottom slice targeting `main`. If `gh pr checks` reports no checks for a
-  stack slice, the slice is not green: verify the branch naming and workflow
-  scheduling before review.
+  stack slice, the slice is not green and something is wrong with workflow
+  scheduling — investigate it rather than accepting the silence, because a PR
+  that triggers no workflow reports nothing for `ci-required` to block on and
+  displays as MERGEABLE and CLEAN (#3706).
 
 Do not integrate main under a reviewer mid-read. When integration is what moved
 the head, say so on the PR and name the merge commit, so the re-review reads as
@@ -519,7 +521,8 @@ until it is unreviewable, and over parallel PRs that race in the same files.
 - **Name the stack in every PR**: the slice's position, its parent PR, and the
   enumerated residual, which is the non-action boundary the PR-summary rule
   already requires.
-- **Name every slice branch `feature/<name>`** so child PRs targeting it run CI.
+- **Name every slice branch descriptively.** No prefix is required for CI:
+  `ci.yml` applies no base-branch filter, so a PR runs CI whatever it targets.
 - **One branch and one worktree per slice**, branched from the parent slice, and
   targeted at the parent branch (`gh pr create --base <parent-branch>`).
 - **Merge bottom-up, one at a time**, then confirm the next PR retargeted and

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -22,12 +22,15 @@ with the fixed-head review rule.
   boundary the PR-summary rule already requires, so declare them: a reviewer
   should read a declared residual as scope rather than as a defect. Each slice's
   residual is the next slice's opening move; keep it enumerated.
-- **Name every slice branch `feature/<name>`.** CI runs for PRs targeting
-  `main` or a `feature/**` branch, so this prefix ensures every layer receives
-  CI before and after its parent lands.
+- **Name every slice branch descriptively.** No prefix is required for CI:
+  `ci.yml` deliberately applies no base-branch filter, so a PR runs CI whatever
+  it targets. That was not always true — an allow list of base prefixes has to
+  name every prefix a base can have, and each way of getting it wrong left a
+  slice mergeable with no checks at all (#3684, #3558), so the filter was
+  removed rather than extended (#3706).
 - **One branch and one worktree per slice**, as for any PR. Branch slice N+1
   from slice N's branch rather than `origin/main`:
-  `git worktree add -b feature/<name> <path> <parent-branch>`.
+  `git worktree add -b <slice-branch> <path> <parent-branch>`.
 - **Target the parent branch** so the PR diff shows only its own slice:
   `gh pr create --base <parent-branch>`.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost


### PR DESCRIPTION
## Conclusion

`ci.yml` filtered pull requests by base branch, so a PR whose base did not match the allow list ran **no CI at all** — and reported no checks rather than failing ones, leaving it MERGEABLE and CLEAN with nothing behind it. The filter is removed; every pull request now runs CI whatever it targets.

Fixes #3706.

## Why removed rather than extended

The comment that sat above the filter made the argument itself:

> The list must therefore cover every prefix a *base* can have, which is every prefix a branch can have, since any branch under review can be stacked on.

A list with that requirement cannot be maintained, and every way of getting it wrong is silent. It had already been wrong twice, each time discovered only after a PR had gone unprotected:

| Filter | What it missed |
| --- | --- |
| `[main]` | every stacked PR |
| `[main, 'feature/**']` | `fix/**` — #3684 opened onto `fix/3628-...`, reported no checks |
| `[main, 'feature/**', 'fix/**']` | #3558, open onto `prototype/wasm-command-ui` |

Extending it a third time would fix the instance and leave the mechanism.

## Evidence

Current exposure, measured against the filter as it stands on `main`:

```
gh pr list --state open --limit 60 --json number,baseRefName \
  -q '.[] | [.number, .baseRefName] | @tsv'
```

Of 19 open PRs, 18 have a base of `main` or `fix/**` and are covered. **#3558**, based on `prototype/wasm-command-ui`, is not, and is mergeable right now with zero checks.

Validation of the change:

- the workflow parses, and the trigger is now unfiltered — `python3 -c "import yaml; ..."` reports `pull_request: None` (an empty trigger, which matches every pull request) with `push: {'branches': ['main']}` unchanged and all 9 jobs intact;
- `npx markdownlint-cli docs/stacked-prs.md` — clean;
- a repository-wide grep confirms no other reference to the removed prefixes survives.

## Compatibility and non-action boundary

- **`push` is deliberately untouched.** It remains `branches: [main]`. That is a branch list, not a base list: it names the branch being pushed to, is not affected by where a PR is targeted, and can only be wrong loudly.
- **No job's own path filter changes.** Which jobs run for a given diff is unchanged; only whether the workflow is triggered at all.
- **`ci-required` is unchanged.** It still aggregates `ci.yml` and still counts `skipped` as passing. This PR does not alter that behavior — it removes the case where the aggregate had nothing to aggregate.
- **The cost is real and accepted:** PRs between side branches now consume CI. That is the intended trade against PRs merging with no CI at all.
- **`docs/stacked-prs.md` is updated** because it required slice branches to be named `feature/<name>` *specifically* to satisfy this filter. That requirement no longer exists, and leaving it would have documented a constraint the workflow no longer imposes.

## Review

Trivial in mechanism — a deleted line and the comment and doc that justified it — but its blast radius is every PR in the repository, so it is not a "state why it is trivial" change. Requesting a single round.

The concrete attack points for a reviewer: that an empty `pull_request:` really does match every base (rather than none); that removing the key does not disturb the `concurrency` group, which keys on `github.event.pull_request.number`; and that no job in the workflow reads `github.base_ref` in a way that assumed the old allow list.
