### PR TITLE
Honor caller sources in routing probes

### DIFF
--- a/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
@@ -207,6 +207,7 @@ public class SharedParsersTests
     {
         var split = SharedParsers.TrySplitQualifiedTypeMember(
             "String.GenericChoice<T>",
+            sourceKeys: [],
             allowPlatformPrefixFallback: true);
 
         Assert.NotNull(split);

--- a/src/dotnet-inspect.Tests/SourceResolverTests.cs
+++ b/src/dotnet-inspect.Tests/SourceResolverTests.cs
@@ -6,6 +6,8 @@ namespace DotnetInspector.Tests;
 [Collection("Console")]
 public class SourceResolverTests
 {
+    private static readonly IReadOnlyList<string> NoSourceKeys = [];
+
     public SourceResolverTests()
     {
         NuGetCache.Initialize("dotnet-inspect");
@@ -40,7 +42,8 @@ public class SourceResolverTests
         SkipIfCoreLibUnavailable();
 
         var source = await SourceResolver.ResolveAsync(
-            [input], explicitPackage: null, explicitAssembly: null, explicitPlatform: null, verbose: false);
+            [input], explicitPackage: null, explicitAssembly: null, explicitPlatform: null,
+            NoSourceKeys, verbose: false);
 
         Assert.Equal("System.Private.CoreLib", source.PlatformAssembly);
         Assert.Equal(expectedTypeName, source.TypeName);
@@ -54,7 +57,8 @@ public class SourceResolverTests
         SkipIfCoreLibUnavailable();
 
         var source = await SourceResolver.ResolveAsync(
-            ["Func"], explicitPackage: null, explicitAssembly: null, explicitPlatform: null, verbose: false);
+            ["Func"], explicitPackage: null, explicitAssembly: null, explicitPlatform: null,
+            NoSourceKeys, verbose: false);
 
         Assert.Equal("Func", source.PackagePath);
         Assert.Null(source.PlatformAssembly);
@@ -67,7 +71,8 @@ public class SourceResolverTests
         SkipIfCoreLibUnavailable();
 
         var source = await SourceResolver.ResolveAsync(
-            ["Definitely.NotACoreLibType"], explicitPackage: null, explicitAssembly: null, explicitPlatform: null, verbose: false);
+            ["Definitely.NotACoreLibType"], explicitPackage: null, explicitAssembly: null, explicitPlatform: null,
+            NoSourceKeys, verbose: false);
 
         Assert.Equal("Definitely.NotACoreLibType", source.PackagePath);
         Assert.Null(source.PlatformAssembly);
@@ -80,7 +85,8 @@ public class SourceResolverTests
         SkipIfCoreLibUnavailable();
 
         var source = await SourceResolver.ResolveAsync(
-            ["string"], explicitPackage: "Example.Package", explicitAssembly: null, explicitPlatform: null, verbose: false);
+            ["string"], explicitPackage: "Example.Package", explicitAssembly: null, explicitPlatform: null,
+            NoSourceKeys, verbose: false);
 
         Assert.Equal("Example.Package", source.PackagePath);
         Assert.Equal("string", source.TypeName);
@@ -95,6 +101,7 @@ public class SourceResolverTests
             explicitPackage: null,
             explicitAssembly: null,
             explicitPlatform: null,
+            NoSourceKeys,
             verbose: false,
             tryQualifiedTypeName: true);
 
@@ -111,6 +118,7 @@ public class SourceResolverTests
             explicitPackage: null,
             explicitAssembly: null,
             explicitPlatform: null,
+            NoSourceKeys,
             verbose: false,
             tryQualifiedTypeName: true);
 
@@ -127,6 +135,7 @@ public class SourceResolverTests
             explicitPackage: null,
             explicitAssembly: null,
             explicitPlatform: null,
+            NoSourceKeys,
             verbose: false,
             tryQualifiedTypeName: true);
 

--- a/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
+++ b/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
@@ -1,0 +1,275 @@
+using System.Collections.Concurrent;
+using System.Net;
+
+using DotnetInspector.CommandLine;
+using DotnetInspector.Core;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public sealed class SourceScopedRoutingTests : IDisposable
+{
+    private const string ExcludedSource = "https://excluded.invalid/v3/index.json";
+
+    private readonly string _testRoot = Path.Combine(
+        Path.GetTempPath(),
+        $"dotnet-inspect-source-routing-{Guid.NewGuid():N}");
+    private readonly IReadOnlyList<string> _ambientSourceKeys;
+
+    public SourceScopedRoutingTests()
+    {
+        DotnetInspector.Core.HttpClientFactory.Initialize(offline: true);
+        DotnetInspector.Core.HttpClientFactory.ResetSharedForTesting();
+        NuGetCache.Initialize(
+            "dotnet-inspect-test",
+            Path.Combine(_testRoot, "cache"),
+            skipNuGetCache: true);
+        _ambientSourceKeys = NuGetSourceResolver.ResolveSourceKeys(null);
+        Assert.NotEmpty(_ambientSourceKeys);
+        Assert.DoesNotContain(NuGetCache.GetSourceKey(ExcludedSource), _ambientSourceKeys);
+    }
+
+    public void Dispose()
+    {
+        DotnetInspector.Core.HttpClientFactory.Initialize(offline: false);
+        DotnetInspector.Core.HttpClientFactory.ResetSharedForTesting();
+        NuGetCache.Initialize("dotnet-inspect");
+        if (Directory.Exists(_testRoot))
+            Directory.Delete(_testRoot, recursive: true);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Router_DoesNotUseCachedPackageFromSourceExcludedByCaller(bool useConfig)
+    {
+        string packageName = $"System.RouteScope{Guid.NewGuid():N}";
+        SeedPackage(packageName);
+
+        string[] sourceArgs;
+        if (useConfig)
+        {
+            string configPath = Path.Combine(_testRoot, "excluded.nuget.config");
+            File.WriteAllText(configPath, $"""
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="excluded" value="{ExcludedSource}" />
+                  </packageSources>
+                </configuration>
+                """);
+            sourceArgs = ["--nugetconfig", configPath];
+        }
+        else
+        {
+            sourceArgs = ["--source", ExcludedSource];
+        }
+
+        var observations = await RunAppAsync([packageName, .. sourceArgs]);
+
+        var rewrite = Assert.Single(
+            observations,
+            observation => observation.Stage == "router-rewrite");
+        string rewritten = rewrite.Detail[(rewrite.Detail.IndexOf(" -> ", StringComparison.Ordinal) + 4)..];
+        Assert.StartsWith($"type {packageName}", rewritten);
+        Assert.Contains(string.Join(' ', sourceArgs), rewrite.Detail);
+    }
+
+    [Fact]
+    public async Task Router_QueriesCallerSourceForPackageExistence()
+    {
+        string packageName = $"System.QueryScope{Guid.NewGuid():N}";
+        var requests = new ConcurrentQueue<string>();
+
+        DotnetInspector.Core.HttpClientFactory.SetAuthenticationDecorator(
+            innerHandler => new RouterFeedHandler(packageName, requests, innerHandler));
+        DotnetInspector.Core.HttpClientFactory.Initialize(offline: false);
+        DotnetInspector.Core.HttpClientFactory.ResetSharedForTesting();
+        try
+        {
+            var observations = await RunAppAsync(
+                [packageName, "--source", ExcludedSource]);
+
+            var rewrite = Assert.Single(
+                observations,
+                observation => observation.Stage == "router-rewrite");
+            string rewritten = rewrite.Detail[
+                (rewrite.Detail.IndexOf(" -> ", StringComparison.Ordinal) + 4)..];
+            Assert.StartsWith($"package {packageName}", rewritten);
+            Assert.Contains(
+                requests,
+                url => url.Equals(
+                    $"{RouterFeedHandler.FlatContainer}{packageName.ToLowerInvariant()}/index.json",
+                    StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(
+                requests,
+                url => url.Contains(packageName, StringComparison.OrdinalIgnoreCase)
+                    && !url.StartsWith(
+                        RouterFeedHandler.FlatContainer,
+                        StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DotnetInspector.Core.HttpClientFactory.SetAuthenticationDecorator(null);
+            DotnetInspector.Core.HttpClientFactory.Initialize(offline: true);
+            DotnetInspector.Core.HttpClientFactory.ResetSharedForTesting();
+        }
+    }
+
+    [Fact]
+    public async Task Router_InvalidNuGetConfig_ReportsCleanParseError()
+    {
+        string missingConfig = Path.Combine(_testRoot, "missing.nuget.config");
+
+        var (exit, output, error) = await RunCommandAsync(
+            [$"System.InvalidConfig{Guid.NewGuid():N}", "--nugetconfig", missingConfig]);
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains($"NuGet config file not found: '{missingConfig}'.", error);
+        Assert.DoesNotContain("FileNotFoundException", error);
+        Assert.DoesNotContain(" at DotnetInspector.", error);
+    }
+
+    [Fact]
+    public async Task Router_MissingSourceValue_ReportsCleanParseError()
+    {
+        var (exit, output, error) = await RunCommandAsync(
+            [$"System.MissingSource{Guid.NewGuid():N}", "--source"]);
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Required argument missing for option: '--source'.", error);
+        Assert.DoesNotContain("InvalidOperationException", error);
+        Assert.DoesNotContain(" at System.CommandLine.", error);
+    }
+
+    [Theory]
+    [InlineData("type", "Widget")]
+    [InlineData("member", "Widget.Render")]
+    public async Task QualifiedName_DoesNotSplitAtPackageCachedOnlyUnderExcludedSource(
+        string command,
+        string suffix)
+    {
+        string packageName = $"RouteScope{Guid.NewGuid():N}.Package";
+        string qualifiedName = $"{packageName}.{suffix}";
+        SeedPackage(packageName);
+
+        Assert.NotNull(SourceResolver.TryResolveQualifiedTypeName(
+            qualifiedName,
+            _ambientSourceKeys,
+            allowPlatformPrefixFallback: false));
+
+        var observations = await RunAppAsync(
+            [command, qualifiedName, "--source", ExcludedSource]);
+
+        Assert.DoesNotContain(
+            observations,
+            observation => observation.Stage == "qualified-type-split"
+                && observation.Detail.Contains(
+                    $"package-cache={packageName}",
+                    StringComparison.Ordinal));
+    }
+
+    private void SeedPackage(string packageName)
+    {
+        string staged = Path.Combine(_testRoot, $"stage-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(staged);
+        File.WriteAllText(
+            Path.Combine(staged, $"{packageName.ToLowerInvariant()}.nuspec"),
+            "<package />");
+        Directory.CreateDirectory(Path.Combine(staged, "payload"));
+        File.WriteAllText(Path.Combine(staged, "payload", "content.txt"), packageName);
+        NuGetCache.CommitPackage(
+            staged,
+            nupkgPath: null,
+            packageName,
+            version: "1.0.0",
+            _ambientSourceKeys[0]);
+    }
+
+    private static async Task<IReadOnlyList<BreadcrumbObservation>> RunAppAsync(string[] args)
+    {
+        var observations = new ConcurrentQueue<BreadcrumbObservation>();
+        using var subscription = BreadcrumbTelemetry.Subscribe(
+            new BreadcrumbObserver(observations));
+
+        await ConsoleCapture.RunAsync(async () =>
+        {
+            args = CommandLineBuilder.PreprocessArgs(args);
+            var parseResult = CommandLineBuilder.CreateRootCommand().Parse(args);
+            Assert.Empty(parseResult.Errors);
+            return await CommandLineBuilder.InvokeAsync(parseResult);
+        });
+
+        return [.. observations];
+    }
+
+    private static Task<(int Exit, string Output, string Error)> RunCommandAsync(string[] args)
+        => ConsoleCapture.RunAsync(async () =>
+        {
+            args = CommandLineBuilder.PreprocessArgs(args);
+            var parseResult = CommandLineBuilder.CreateRootCommand().Parse(args);
+            Assert.Empty(parseResult.Errors);
+            return await CommandLineBuilder.InvokeAsync(parseResult);
+        });
+
+    private sealed class BreadcrumbObserver(
+        ConcurrentQueue<BreadcrumbObservation> observations)
+        : IObserver<BreadcrumbObservation>
+    {
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(BreadcrumbObservation value)
+            => observations.Enqueue(value);
+    }
+
+    private sealed class RouterFeedHandler(
+        string packageName,
+        ConcurrentQueue<string> requests,
+        HttpMessageHandler innerHandler)
+        : DelegatingHandler(innerHandler)
+    {
+        public const string FlatContainer = "https://excluded.invalid/v3/flat2/";
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string url = request.RequestUri!.GetLeftPart(UriPartial.Path);
+            requests.Enqueue(url);
+
+            string? body = url switch
+            {
+                ExcludedSource => $$"""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "{{FlatContainer}}", "@type": "PackageBaseAddress/3.0.0" }
+                      ]
+                    }
+                    """,
+                _ when url.Equals(
+                    $"{FlatContainer}{packageName.ToLowerInvariant()}/index.json",
+                    StringComparison.OrdinalIgnoreCase) => """{"versions":["1.0.0"]}""",
+                _ => null,
+            };
+
+            var response = new HttpResponseMessage(
+                body is null ? HttpStatusCode.NotFound : HttpStatusCode.OK)
+            {
+                Content = new StringContent(body ?? ""),
+                RequestMessage = request,
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
 using DotnetInspector.Inspectors;
@@ -17,7 +18,7 @@ namespace DotnetInspector.CommandLine;
 /// </summary>
 public static class RouterCommandDefinition
 {
-    public static Command Create(RootCommand rootCommand)
+    public static Command Create(RootCommand rootCommand, SharedOptions opts)
     {
         var routerCommand = new Command("router", "Auto-route bare input to a real command")
         {
@@ -42,6 +43,21 @@ public static class RouterCommandDefinition
                 return 0;
             }
 
+            // The router intentionally captures all options as raw tokens so the rewritten
+            // command remains the authority on their semantics. Parse a package-shaped probe
+            // with the shared option instances to obtain the caller's NuGet scope without
+            // maintaining a second command-line parser here.
+            var sourceParseResult = rootCommand.Parse([PackageCommand.Name, .. tokens]);
+            var sourceErrors = GetSourceOptionErrors(sourceParseResult, opts);
+            if (sourceErrors.Count > 0)
+            {
+                foreach (var error in sourceErrors)
+                    CommandError.Write(error.Message);
+                return 1;
+            }
+
+            var sourceOptions = opts.ParseNuGetSourceOptions(sourceParseResult);
+
             if (TryGetCommandTypoSuggestion(tokens[0]) is { } suggestion)
             {
                 CommandError.Write($"Unknown command '{tokens[0]}'.");
@@ -59,7 +75,7 @@ public static class RouterCommandDefinition
             }
 
             RequestTelemetry.Breadcrumb("router-hit", string.Join(' ', tokens));
-            var rewritten = await RouterTokenRewriter.RewriteAsync(tokens);
+            var rewritten = await RouterTokenRewriter.RewriteAsync(tokens, sourceOptions);
             RequestTelemetry.Breadcrumb(
                 "router-rewrite",
                 $"{string.Join(' ', tokens)} -> {string.Join(' ', rewritten)}");
@@ -77,6 +93,34 @@ public static class RouterCommandDefinition
         });
 
         return routerCommand;
+    }
+
+    private static List<ParseError> GetSourceOptionErrors(
+        ParseResult parseResult,
+        SharedOptions opts)
+    {
+        OptionResult? source = parseResult.GetResult(opts.Source);
+        OptionResult? additionalSource = parseResult.GetResult(opts.AddSource);
+        OptionResult? config = parseResult.GetResult(opts.NuGetConfig);
+
+        return
+        [
+            .. parseResult.Errors.Where(error =>
+                IsWithin(error.SymbolResult, source)
+                || IsWithin(error.SymbolResult, additionalSource)
+                || IsWithin(error.SymbolResult, config)),
+        ];
+    }
+
+    private static bool IsWithin(SymbolResult? result, SymbolResult? ancestor)
+    {
+        for (; result != null; result = result.Parent)
+        {
+            if (ReferenceEquals(result, ancestor))
+                return true;
+        }
+
+        return false;
     }
 
     private static readonly string[] CommandSuggestionNames =
@@ -128,7 +172,9 @@ public static class RouterCommandDefinition
 
     private static class RouterTokenRewriter
     {
-        public static async Task<string[]> RewriteAsync(string[] tokens)
+        public static async Task<string[]> RewriteAsync(
+            string[] tokens,
+            NuGetSourceOptions sourceOptions)
         {
             var target = tokens[0];
             var tail = tokens[1..];
@@ -161,6 +207,7 @@ public static class RouterCommandDefinition
             if (hasVersionQuery || target.Contains('@'))
                 return ["package", .. tokens];
 
+            var sourceKeys = NuGetSourceResolver.ResolveSourceKeys(sourceOptions);
             var context = new CommandContext(verbose: false);
             if (PlatformResolver.IsPlatformCandidate(target))
             {
@@ -178,7 +225,10 @@ public static class RouterCommandDefinition
             }
 
             var allowPlatformPrefixFallback = PlatformResolver.IsPlatformCandidate(target);
-            var memberSplit = SharedParsers.TrySplitQualifiedTypeMember(target, allowPlatformPrefixFallback);
+            var memberSplit = SharedParsers.TrySplitQualifiedTypeMember(
+                target,
+                sourceKeys,
+                allowPlatformPrefixFallback);
             if (memberSplit != null)
             {
                 var probe = memberSplit.Value.Probe;
@@ -204,7 +254,7 @@ public static class RouterCommandDefinition
             var memberFind = await TypeFindIfMissResolver.ResolvePlatformMemberAsync(
                 target,
                 includeAll: false,
-                sourceOptions: NuGetSourceOptions.Default,
+                sourceOptions,
                 context.HttpClient,
                 context.Logger);
             if (memberFind.Status == TypeFindIfMissStatus.Found)
@@ -213,7 +263,10 @@ public static class RouterCommandDefinition
                 return ["member", match.FullName, "--platform", match.Library, .. FrameworkArgs(match.Source), "-m", memberFind.MemberSelector, .. tail];
             }
 
-            var typeProbe = SourceResolver.TryResolveQualifiedTypeName(target, allowPlatformPrefixFallback);
+            var typeProbe = SourceResolver.TryResolveQualifiedTypeName(
+                target,
+                sourceKeys,
+                allowPlatformPrefixFallback);
             if (typeProbe != null)
             {
                 if (typeProbe.Kind == SourceResolver.LocalSourceKind.Platform
@@ -234,7 +287,7 @@ public static class RouterCommandDefinition
             var typeFind = await TypeFindIfMissResolver.ResolvePlatformAsync(
                 target,
                 includeAll: false,
-                sourceOptions: NuGetSourceOptions.Default,
+                sourceOptions,
                 context.HttpClient,
                 context.Logger);
             if (typeFind.Status == TypeFindIfMissStatus.Found)
@@ -246,7 +299,7 @@ public static class RouterCommandDefinition
 
             if (PlatformResolver.IsPlatformCandidate(target))
             {
-                if (await PackageExistsAsync(target, context))
+                if (await PackageExistsAsync(target, sourceKeys, sourceOptions, context))
                     return ["package", .. tokens];
 
                 return ["type", target, .. tail];
@@ -262,11 +315,15 @@ public static class RouterCommandDefinition
         private static string[] FrameworkArgs(string source)
             => string.IsNullOrWhiteSpace(source) ? [] : ["--framework", source];
 
-        private static async Task<bool> PackageExistsAsync(string packageName, CommandContext context)
+        private static async Task<bool> PackageExistsAsync(
+            string packageName,
+            IReadOnlyList<string> sourceKeys,
+            NuGetSourceOptions sourceOptions,
+            CommandContext context)
         {
             if (NuGetCache.TryGetLatestCachedVersion(
                     packageName,
-                    NuGetSourceResolver.ResolveSourceKeys(null)) != null)
+                    sourceKeys) != null)
                 return true;
 
             try
@@ -277,7 +334,7 @@ public static class RouterCommandDefinition
                     includePrerelease: true,
                     limit: 1,
                     log: context.Logger.Log,
-                    sourceOptions: NuGetSourceOptions.Default);
+                    sourceOptions);
                 return versions is { Count: > 0 };
             }
             catch (Exception ex)

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using DotnetInspector.Options;
+using DotnetInspector.Packages;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
@@ -92,6 +93,7 @@ public static class MemberOptionsParser
         var projectSourcePath = !sourceInputs.HasExplicitSource && projectValues.Length > 0
             ? projectValues[0]
             : null;
+        var sourceOptions = opts.ParseNuGetSourceOptions(parseResult);
 
         // Handle projection discovery or help
         if (sourceInputs.Args.Length == 0 && !sourceInputs.HasExplicitSource && projectSourcePath is null)
@@ -100,6 +102,10 @@ public static class MemberOptionsParser
                 return new Discovery(opts.ParseDiscover(parseResult), opts.ParseTree(parseResult));
             return new ShowHelp();
         }
+
+        IReadOnlyList<string> sourceKeys = projectSourcePath is not null
+            ? []
+            : NuGetSourceResolver.ResolveSourceKeys(sourceOptions);
 
         // Extract positional members
         List<string> positionalMembers = [];
@@ -133,7 +139,7 @@ public static class MemberOptionsParser
         else
         {
             sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
-                sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: false);
+                sourceInputs, sourceKeys, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: false);
             source = sourceSelection.Source;
         }
 
@@ -157,6 +163,7 @@ public static class MemberOptionsParser
         {
             var split = SharedParsers.TrySplitQualifiedTypeMember(
                 source.PackagePath,
+                sourceKeys,
                 allowPlatformPrefixFallback: true);
             if (split != null)
             {
@@ -180,6 +187,7 @@ public static class MemberOptionsParser
         {
             var probe = SourceResolver.TryResolveQualifiedTypeName(
                 source.PackagePath,
+                sourceKeys,
                 allowPlatformPrefixFallback: true);
             if (probe != null)
             {
@@ -320,7 +328,7 @@ public static class MemberOptionsParser
             Schema = opts.ParseSchema(parseResult),
             Verbose = parseResult.GetValue(opts.Verbose),
             Verbosity = opts.ParseVerbosity(parseResult),
-            SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
+            SourceOptions = sourceOptions
         };
 
         options = options with

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -56,12 +56,13 @@ public static class SharedParsers
 
     public static async Task<SourceSelection> ResolveSourceSelectionAsync(
         SourceSelectionInputs inputs,
+        IReadOnlyList<string> sourceKeys,
         bool verbose,
         bool tryQualifiedTypeName)
     {
         var source = await SourceResolver.ResolveAsync(
             inputs.Args, inputs.ExplicitPackage, inputs.ExplicitAssembly, inputs.ExplicitPlatform,
-            verbose, tryQualifiedTypeName).ConfigureAwait(false);
+            sourceKeys, verbose, tryQualifiedTypeName).ConfigureAwait(false);
 
         return new SourceSelection(
             inputs.Args,
@@ -95,6 +96,7 @@ public static class SharedParsers
 
     internal static (SourceResolver.LocalProbeResult Probe, string MemberName)? TrySplitQualifiedTypeMember(
         string value,
+        IReadOnlyList<string> sourceKeys,
         bool allowPlatformPrefixFallback)
     {
         for (var i = value.Length - 1; i > 0; i--)
@@ -107,7 +109,10 @@ public static class SharedParsers
             if (string.IsNullOrWhiteSpace(memberName))
                 continue;
 
-            var probe = SourceResolver.TryResolveQualifiedTypeName(typeCandidate, allowPlatformPrefixFallback);
+            var probe = SourceResolver.TryResolveQualifiedTypeName(
+                typeCandidate,
+                sourceKeys,
+                allowPlatformPrefixFallback);
             if (probe != null)
                 return (probe, memberName);
 

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using DotnetInspector.Options;
+using DotnetInspector.Packages;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
@@ -88,6 +89,7 @@ public static class TypeOptionsParser
         var projectPath = parseResult.GetValue(args.ProjectOption);
         bool hasProjectSource = !string.IsNullOrWhiteSpace(projectPath);
         bool hasNonProjectSource = sourceInputs.HasExplicitSource;
+        var sourceOptions = opts.ParseNuGetSourceOptions(parseResult);
 
         // Handle projection discovery or help
         if (sourceInputs.Args.Length == 0 && !sourceInputs.HasExplicitSource && !hasProjectSource)
@@ -99,6 +101,10 @@ public static class TypeOptionsParser
 
         if (hasProjectSource && hasNonProjectSource)
             return new VersionError("--project cannot be combined with --package, --library, or --platform.");
+
+        IReadOnlyList<string> sourceKeys = hasProjectSource
+            ? []
+            : NuGetSourceResolver.ResolveSourceKeys(sourceOptions);
 
         // Check for unrecognized options in positional args
         var badOption = sourceInputs.Args.FirstOrDefault(a => a.StartsWith('-'));
@@ -128,7 +134,7 @@ public static class TypeOptionsParser
         else
         {
             sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
-                sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
+                sourceInputs, sourceKeys, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
             source = sourceSelection.Source;
         }
 
@@ -211,7 +217,7 @@ public static class TypeOptionsParser
             Schema = opts.ParseSchema(parseResult),
             Verbose = parseResult.GetValue(opts.Verbose),
             Verbosity = opts.ParseVerbosity(parseResult),
-            SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
+            SourceOptions = sourceOptions
         });
 
         options = options with

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -183,7 +183,7 @@ public static class CommandLineBuilder
         rootCommand.Subcommands.Add(ProjectCommandDefinitions.CreateProjectCommand(opts));
 
         // Router command (hidden, implicit default for bare names)
-        rootCommand.Subcommands.Add(RouterCommandDefinition.Create(rootCommand));
+        rootCommand.Subcommands.Add(RouterCommandDefinition.Create(rootCommand, opts));
 
         // Skill command
         rootCommand.Subcommands.Add(UtilityCommandDefinitions.CreateSkillCommand(opts));

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -55,7 +55,9 @@ public static class SourceResolver
     /// against local sources: dotnet hive, dotnet-inspect cache, NuGet global cache.
     /// Returns the first hit with its remainder, or null if nothing matches locally.
     /// </summary>
-    internal static LocalProbeResult? TryProbeLocalQualifiedName(string name)
+    internal static LocalProbeResult? TryProbeLocalQualifiedName(
+        string name,
+        IReadOnlyList<string> sourceKeys)
     {
         // Require at least 2 dots (e.g., System.Text.Json.JsonSerializer).
         // Single-dot names like "System.CommandLine" are ambiguous: could be
@@ -67,10 +69,6 @@ public static class SourceResolver
         if (dotCount < 2) return null;
 
         string? platformCandidate = null;
-
-        // Resolved once: this walks the directory tree for nuget.config files
-        // and parses each one, and the answer cannot change between candidates.
-        var sourceKeys = NuGetSourceResolver.ResolveSourceKeys(null);
 
         for (int i = name.Length - 1; i >= 0; i--)
         {
@@ -130,9 +128,12 @@ public static class SourceResolver
     /// Resolves a dotted source-qualified type name using the shared precedence:
     /// exact local type match first, then a typo-friendly platform prefix match.
     /// </summary>
-    internal static LocalProbeResult? TryResolveQualifiedTypeName(string name, bool allowPlatformPrefixFallback)
+    internal static LocalProbeResult? TryResolveQualifiedTypeName(
+        string name,
+        IReadOnlyList<string> sourceKeys,
+        bool allowPlatformPrefixFallback)
     {
-        var probe = TryProbeLocalQualifiedName(name);
+        var probe = TryProbeLocalQualifiedName(name, sourceKeys);
         if (probe != null || !allowPlatformPrefixFallback)
             return probe;
 
@@ -219,6 +220,7 @@ public static class SourceResolver
     /// <param name="explicitPackage">Explicit --package value.</param>
     /// <param name="explicitAssembly">Explicit --library value.</param>
     /// <param name="explicitPlatform">Explicit --platform value.</param>
+    /// <param name="sourceKeys">Cache source identities the caller is configured to read.</param>
     /// <param name="verbose">Whether to log verbose messages.</param>
     /// <param name="tryQualifiedTypeName">Whether to attempt parsing qualified type names (Type command only).</param>
     /// <returns>Resolved source information.</returns>
@@ -227,6 +229,7 @@ public static class SourceResolver
         string? explicitPackage,
         string? explicitAssembly,
         string? explicitPlatform,
+        IReadOnlyList<string> sourceKeys,
         bool verbose,
         bool tryQualifiedTypeName = false)
     {
@@ -355,7 +358,10 @@ public static class SourceResolver
                 if (tryQualifiedTypeName && typeName == null
                     && packagePath != null && platformAssembly == null && assemblyPath == null)
                 {
-                    var probe = TryResolveQualifiedTypeName(bareName, allowPlatformPrefixFallback: true);
+                    var probe = TryResolveQualifiedTypeName(
+                        bareName,
+                        sourceKeys,
+                        allowPlatformPrefixFallback: true);
                     if (probe != null)
                     {
                         typeName = probe.Remainder;


### PR DESCRIPTION
Fixes #3728

## Summary

- resolve bare-router cache keys and package-existence queries from the caller's
  `--source`, `--add-source`, or `--nugetconfig` options
- require caller-resolved source keys for qualified type/member cache probes
- preserve clean parse-time errors for invalid source options before routing
  performs source resolution
- add source-isolated routing tests for bare, type, and member paths

## Validation

- `dotnet build src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release --no-restore`
- `SourceScopedRoutingTests`: 7 passed
- `SourceResolverTests`: 29 passed
- `CommandExecutionTests/Router*`: 32 passed
- five targeted mutations were each caught by the new tests
- two clean adversarial reviews after the parse-error finding was fixed
