### PR TITLE
Migrate source consumers to structured type resolution

### DIFF
--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -2501,12 +2501,17 @@ changing their successful results.
 
 ### Slice 4: source and API consumers
 
-- Migrate `PdbContext`, `SourceLinkService`, `SourceEnricher`,
-  `SourceFileCollector`, `ApiServices`, `SourceResolver`,
-  `LibraryMetadataService`, and `RouterCommandDefinition`.
-- Migrate `PlatformResolver.FindLibraryContainingType` to the typed platform
-  catalog and `IsFacadeOnlyAssembly` to Metadata-owned classification.
-- Delete forwarder-target sibling-path construction.
+This slice lands as two independently complete consumer migrations:
+
+- **4a -- descriptor opening and path-sink deletion:** teach `PdbContext` and
+  `SourceLinkService` to open acquisition descriptors through `OpenRead`;
+  migrate `SourceEnricher` and `ApiServices` to exact structured names and
+  resolved descriptors; delete `SourceFileCollector`'s unreachable forwarded
+  fallback and every forwarder-target sibling-path construction.
+- **4b -- platform lookup and classification:** migrate `SourceResolver`,
+  `LibraryMetadataService`, and `RouterCommandDefinition`; replace
+  `PlatformResolver.FindLibraryContainingType` with the typed platform catalog
+  and move `IsFacadeOnlyAssembly` to Metadata-owned classification.
 
 Claim: forwarded source and API resolution consume descriptors and cannot turn
 an inspected assembly name into a path.

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -181,6 +181,13 @@ public sealed record ApiSurfaceInspectionFailure(
 public class TypeForwarder
 {
     /// <summary>
+    /// Exact metadata lookup name retained for structured definition resolution.
+    /// It is omitted from serialized API surfaces, which predate this currency.
+    /// </summary>
+    [JsonIgnore]
+    public MetadataTypeDefinitionName? DefinitionName { get; set; }
+
+    /// <summary>
     /// Full name of the forwarded type.
     /// </summary>
     public string TypeName { get; set; } = "";

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -625,6 +625,13 @@ public static class ApiSurfaceExtractor
 
                 surface.TypeForwarders.Add(new TypeForwarder
                 {
+                    DefinitionName =
+                        MetadataTypeDefinitionNameReader.Read(
+                            reader,
+                            exportedTypeHandle)
+                        is MetadataTypeDefinitionNameReadResult.Read read
+                            ? read.Name
+                            : null,
                     TypeName = fullName,
                     TargetAssembly = targetAssembly
                 });

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -86,10 +86,11 @@ public record MethodExceptionRegionInfo(
 public class PdbContext : IDisposable
 {
     private readonly PEReader _peReader;
-    private readonly FileStream _peStream;
+    private readonly Stream _peStream;
     private readonly bool _entireImagePrefetched;
     private readonly Action<string>? _log;
-    private readonly string _assemblyPath;
+    private readonly string? _assemblyPath;
+    private readonly string _assemblyDisplayName;
 
     private MetadataReaderProvider? _pdbProvider;
     private MetadataReader? _pdbReader;
@@ -103,7 +104,14 @@ public class PdbContext : IDisposable
     /// <summary>
     /// The path to the assembly file that was opened.
     /// </summary>
-    public string AssemblyPath => _assemblyPath;
+    public string AssemblyPath => _assemblyPath
+        ?? throw new InvalidOperationException(
+            "This assembly was opened from a descriptor without a filesystem path.");
+
+    /// <summary>
+    /// The acquisition-owned path, when the descriptor supplied one.
+    /// </summary>
+    public string? AssemblyPathOrNull => _assemblyPath;
 
     /// <summary>
     /// The log callback, if any.
@@ -180,9 +188,10 @@ public class PdbContext : IDisposable
     public bool HasSourceLink => SourceLinkJson != null;
 
     private PdbContext(
-        FileStream peStream,
+        Stream peStream,
         PEReader peReader,
-        string assemblyPath,
+        string? assemblyPath,
+        string assemblyDisplayName,
         Action<string>? log,
         bool entireImagePrefetched)
     {
@@ -190,9 +199,12 @@ public class PdbContext : IDisposable
         _peReader = peReader;
         _entireImagePrefetched = entireImagePrefetched;
         _assemblyPath = assemblyPath;
+        _assemblyDisplayName = assemblyDisplayName;
         _log = log;
         FileSize = peStream.Length;
-        LastWriteTimeUtc = File.GetLastWriteTimeUtc(peStream.SafeFileHandle);
+        LastWriteTimeUtc = peStream is FileStream fileStream
+            ? File.GetLastWriteTimeUtc(fileStream.SafeFileHandle)
+            : default;
     }
 
     /// <summary>
@@ -203,16 +215,27 @@ public class PdbContext : IDisposable
         => Open(assemblyPath, log, PEStreamOptions.Default);
 
     /// <summary>
-    /// This context's open reader, lent to <see cref="AssemblyInspectionSession.Borrow"/> so the
-    /// facet surface reads the same bytes this context read instead of reopening
-    /// <see cref="AssemblyPath"/>. Internal because the reader is metadata-internal; borrowers go
-    /// through the session.
+    /// Opens an acquisition descriptor through its authoritative stream factory.
+    /// The optional path is used only for adjacent PDB discovery and file metadata.
     /// </summary>
+    public static PdbContext Open(
+        ResolvedAssemblyReference assembly,
+        Action<string>? log = null)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        return Open(
+            assembly.OpenRead(),
+            assembly.Path,
+            assembly.Identity.Name,
+            log,
+            PEStreamOptions.Default);
+    }
+
     /// <summary>
     /// This context's open reader, lent to <see cref="AssemblyInspectionSession.Borrow"/> so the
     /// facet surface reads the same bytes this context read instead of reopening
-    /// <see cref="AssemblyPath"/>. Internal because the reader is metadata-internal; borrowers go
-    /// through the session. Throws rather than lending an already-released reader.
+    /// the source. Internal because the reader is metadata-internal; borrowers go
+    /// through the session.
     /// </summary>
     internal PEReader BorrowedPEReader
     {
@@ -246,8 +269,20 @@ public class PdbContext : IDisposable
         string assemblyPath,
         Action<string>? log,
         PEStreamOptions streamOptions)
+        => Open(
+            File.OpenRead(assemblyPath),
+            assemblyPath,
+            Path.GetFileName(assemblyPath),
+            log,
+            streamOptions);
+
+    static PdbContext Open(
+        Stream stream,
+        string? assemblyPath,
+        string assemblyDisplayName,
+        Action<string>? log,
+        PEStreamOptions streamOptions)
     {
-        var stream = File.OpenRead(assemblyPath);
         PEReader peReader;
         try
         {
@@ -263,6 +298,7 @@ public class PdbContext : IDisposable
             stream,
             peReader,
             assemblyPath,
+            assemblyDisplayName,
             log,
             (streamOptions & PEStreamOptions.PrefetchEntireImage) != 0);
 
@@ -332,7 +368,7 @@ public class PdbContext : IDisposable
             {
                 provider.Dispose();
                 stream.Dispose();
-                _log?.Invoke($"Portable PDB identity mismatch: {Path.GetFileName(pdbFilePath)} does not match {Path.GetFileName(_assemblyPath)}");
+                _log?.Invoke($"Portable PDB identity mismatch: {Path.GetFileName(pdbFilePath)} does not match {_assemblyDisplayName}");
                 return;
             }
 
@@ -782,54 +818,6 @@ public class PdbContext : IDisposable
             : null;
 
     /// <summary>
-    /// Finds a type forwarder target assembly name for a given type.
-    /// </summary>
-    public string? FindTypeForwarder(string typeName)
-    {
-        if (!_peReader.HasMetadata)
-            return null;
-
-        var reader = _peReader.GetMetadataReader();
-        foreach (var exportedTypeHandle in reader.ExportedTypes)
-        {
-            var exportedType = reader.GetExportedType(exportedTypeHandle);
-            if (!exportedType.IsForwarder)
-                continue;
-
-            var fullName = reader.GetFullTypeName(exportedType);
-
-            if (fullName.Equals(typeName, StringComparison.OrdinalIgnoreCase))
-            {
-                if (exportedType.Implementation.Kind == HandleKind.AssemblyReference)
-                {
-                    var assemblyRef = reader.GetAssemblyReference((AssemblyReferenceHandle)exportedType.Implementation);
-                    return reader.GetString(assemblyRef.Name);
-                }
-            }
-        }
-        return null;
-    }
-
-    /// <summary>
-    /// Resolves the assembly path that actually implements a type, following type forwarders.
-    /// Returns null if the type is defined in this assembly (not forwarded).
-    /// Looks for the target assembly DLL in the same directory as this assembly.
-    /// </summary>
-    public string? ResolveImplementationAssemblyPath(string typeName)
-    {
-        var targetAssemblyName = FindTypeForwarder(typeName);
-        if (targetAssemblyName == null)
-            return null;
-
-        var dir = Path.GetDirectoryName(_assemblyPath);
-        if (dir == null)
-            return null;
-
-        var targetPath = Path.Combine(dir, targetAssemblyName + ".dll");
-        return File.Exists(targetPath) ? targetPath : null;
-    }
-
-    /// <summary>
     /// Enumerates all source documents in the PDB for strict verification.
     /// </summary>
     public IEnumerable<SourceDocument> EnumerateSourceDocuments()
@@ -1160,6 +1148,8 @@ public class PdbContext : IDisposable
     private void TryLoadLocalPdb()
     {
         if (HasPdb)
+            return;
+        if (_assemblyPath is null)
             return;
 
         var pdbPath = Path.ChangeExtension(_assemblyPath, ".pdb");

--- a/src/ILInspector.Metadata/SourceLinkService.cs
+++ b/src/ILInspector.Metadata/SourceLinkService.cs
@@ -52,6 +52,19 @@ public class SourceLinkService : IDisposable
     }
 
     /// <summary>
+    /// Opens an acquisition descriptor through its authoritative stream factory.
+    /// </summary>
+    public static SourceLinkService Open(
+        ResolvedAssemblyReference assembly,
+        Action<string>? log = null,
+        ISourceLinkIndexCache? cache = null)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        var context = PdbContext.Open(assembly, log);
+        return new SourceLinkService(context, cache ?? DefaultCache);
+    }
+
+    /// <summary>
     /// Opens an assembly with its complete PE image prefetched for shared
     /// parallel body analysis.
     /// </summary>
@@ -122,29 +135,6 @@ public class SourceLinkService : IDisposable
     public IReadOnlyList<SourceDocument> GetEmbeddedFiles()
     {
         return GetTrackedFiles().Where(d => d.IsEmbedded).ToList();
-    }
-
-    // --- Type resolution ---
-
-    /// <summary>
-    /// Resolves the assembly path that actually implements a type, following type forwarders.
-    /// Returns null if the type is defined in this assembly (not forwarded).
-    /// </summary>
-    public string? ResolveImplementationAssemblyPath(string typeName)
-        => _context.ResolveImplementationAssemblyPath(typeName);
-
-    /// <summary>
-    /// Opens a new SourceLinkService for the assembly that implements the given type,
-    /// following type forwarders. Returns null if the type is not forwarded.
-    /// The caller is responsible for disposing the returned service and acquiring its PDB.
-    /// </summary>
-    public SourceLinkService? OpenImplementation(string typeName)
-    {
-        var implPath = _context.ResolveImplementationAssemblyPath(typeName);
-        if (implPath == null)
-            return null;
-
-        return Open(implPath, _context.Log);
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3363,7 +3363,9 @@ public partial class CommandExecutionTests
 
         Assert.Equal(0, fieldsExit);
         Assert.Contains("# System.Text.Json", fieldsOutput, StringComparison.Ordinal);
-        Assert.Contains("Types: 89", fieldsOutput, StringComparison.Ordinal);
+        // Structured resolution reaches ParamCollectionAttribute through the
+        // platform policy instead of dropping it with the sibling-only probe.
+        Assert.Contains("Types: 90", fieldsOutput, StringComparison.Ordinal);
         Assert.DoesNotContain("Methods:", fieldsOutput, StringComparison.Ordinal);
 
         // --columns is the same surface and was the case the first fix missed: it does not filter
@@ -3380,7 +3382,7 @@ public partial class CommandExecutionTests
             "type", "--platform", "System.Text.Json", "-v:q", "-S", SectionNames.ApiInfo, "--tips", "q");
 
         Assert.Equal(0, bothExit);
-        Assert.Contains("| Types | 89 |", bothOutput, StringComparison.Ordinal);
+        Assert.Contains("| Types | 90 |", bothOutput, StringComparison.Ordinal);
         Assert.DoesNotContain("Library: System.Text.Json.dll |", bothOutput, StringComparison.Ordinal);
     }
 
@@ -3683,7 +3685,7 @@ public partial class CommandExecutionTests
     public async Task Type_Listing_ApiInfo_DoesNotGrowWithTheAssembly()
     {
         // Bounded means the row set does not depend on the target. CoreLib lists 1353 types and
-        // System.Text.Json lists 89; the three counts are counts rather than enumerations, so each
+        // System.Text.Json lists 90; the three counts are counts rather than enumerations, so each
         // contributes exactly one row at either size. A future field that enumerated anything would
         // fail here rather than quietly making the overview unbounded.
         var (bigExit, big, _) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
+++ b/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
@@ -1,0 +1,232 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+public class SourceForwarderResolutionTests
+{
+    const TypeAttributes Forwarder = (TypeAttributes)0x00200000;
+
+    [Fact]
+    public void ResolutionSession_FollowsLegitimateAcquiredSibling()
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string facadePath = Path.Combine(directory, "Facade.dll");
+            string targetPath = Path.Combine(directory, "Target.dll");
+            File.WriteAllBytes(
+                facadePath,
+                BuildAssembly("Facade", new AssemblyReferenceIdentity(
+                    "Target",
+                    new Version(1, 0, 0, 0),
+                    null,
+                    null)));
+            File.WriteAllBytes(targetPath, BuildAssembly("Target"));
+
+            using var resolution = new TypeDefinitionResolutionSession(
+                facadePath,
+                isPlatformAssembly: false);
+            TypeResolutionOutcome outcome = resolution.Resolve(TypeName());
+
+            var resolved = Assert.IsType<TypeResolutionOutcome.Resolved>(outcome);
+            Assert.Single(resolved.Hops);
+            Assert.Equal(
+                Path.GetFullPath(targetPath),
+                resolved.Definition.Assembly.Assembly.Path);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolutionSession_DoesNotTurnHostileAssemblyNameIntoPath()
+    {
+        string parent = CreateDirectory();
+        string directory = Path.Combine(parent, "input");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string facadePath = Path.Combine(directory, "Facade.dll");
+            File.WriteAllBytes(
+                facadePath,
+                BuildAssembly("Facade", new AssemblyReferenceIdentity(
+                    "../payload",
+                    new Version(1, 0, 0, 0),
+                    null,
+                    null)));
+            File.WriteAllBytes(
+                Path.Combine(parent, "payload.dll"),
+                BuildAssembly("../payload", definesType: true));
+
+            using var resolution = new TypeDefinitionResolutionSession(
+                facadePath,
+                isPlatformAssembly: false);
+            TypeResolutionOutcome outcome = resolution.Resolve(TypeName());
+
+            Assert.IsType<TypeResolutionOutcome.UnboundBinding>(outcome);
+        }
+        finally
+        {
+            Directory.Delete(parent, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ApiServices_OpensResolvedDescriptorForForwardedType()
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string facadePath = Path.Combine(directory, "Facade.dll");
+            string targetPath = Path.Combine(directory, "Target.dll");
+            File.WriteAllBytes(
+                facadePath,
+                BuildAssembly("Facade", new AssemblyReferenceIdentity(
+                    "Target",
+                    new Version(1, 0, 0, 0),
+                    null,
+                    null)));
+            File.WriteAllBytes(targetPath, BuildAssembly("Target"));
+            ApiSurface api =
+                AssemblyReader.ExtractApiSurface(facadePath)!;
+
+            ApiServices.ResolveForwardedTypes(
+                api,
+                facadePath,
+                new VerboseLogger(enabled: false),
+                includeAll: false);
+
+            ApiType type = Assert.Single(api.Types);
+            Assert.True(type.IsForwarded);
+            Assert.Equal(Path.GetFullPath(targetPath), type.SourceAssemblyPath);
+            Assert.NotNull(type.DefinitionName);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ApiServices_DoesNotOpenTraversalTarget()
+    {
+        string parent = CreateDirectory();
+        string directory = Path.Combine(parent, "input");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string facadePath = Path.Combine(directory, "Facade.dll");
+            File.WriteAllBytes(
+                facadePath,
+                BuildAssembly("Facade", new AssemblyReferenceIdentity(
+                    "../payload",
+                    new Version(1, 0, 0, 0),
+                    null,
+                    null)));
+            File.WriteAllBytes(
+                Path.Combine(parent, "payload.dll"),
+                BuildAssembly("../payload", definesType: true));
+            ApiSurface api =
+                AssemblyReader.ExtractApiSurface(facadePath)!;
+
+            ApiServices.ResolveForwardedTypes(
+                api,
+                facadePath,
+                new VerboseLogger(enabled: false),
+                includeAll: false);
+
+            Assert.Empty(api.Types);
+        }
+        finally
+        {
+            Directory.Delete(parent, recursive: true);
+        }
+    }
+
+    static MetadataTypeDefinitionName TypeName() =>
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create("N", ["Type"])).Name;
+
+    static string CreateDirectory()
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-source-forwarder-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    static byte[] BuildAssembly(
+        string assemblyName,
+        AssemblyReferenceIdentity? forwardTarget = null,
+        bool definesType = false)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString($"{assemblyName}.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(assemblyName),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        if (definesType || forwardTarget is null)
+        {
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Type"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+        }
+
+        if (forwardTarget is not null)
+        {
+            AssemblyReferenceHandle target = metadata.AddAssemblyReference(
+                metadata.GetOrAddString(forwardTarget.Name),
+                forwardTarget.Version!,
+                culture: default,
+                publicKeyOrToken: default,
+                flags: default,
+                hashValue: default);
+            metadata.AddExportedType(
+                TypeAttributes.Public | Forwarder,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Type"),
+                target,
+                typeDefinitionId: 0);
+        }
+
+        var builder = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        builder.Serialize(image);
+        return image.ToArray();
+    }
+}

--- a/src/dotnet-inspect.Tests/UntrustedLibraryViewContainmentTests.cs
+++ b/src/dotnet-inspect.Tests/UntrustedLibraryViewContainmentTests.cs
@@ -1424,6 +1424,7 @@ public class LibraryViewShapeDerivedContainmentTests
         "MemberRef.ReturnType (TypeRef): no public constructor",
         "MethodIdentity.DeclaringType (TypeRef): no public constructor",
         "MethodIdentity.ReturnType (TypeRef): no public constructor",
+        "TypeForwarder.DefinitionName (MetadataTypeDefinitionName): no public constructor",
         "TypeParameter.DisplayName (String): string with no setter",
     ];
 

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -608,11 +608,17 @@ public static class TypeCommand
             if (api == null)
                 continue;
 
-            ApiServices.ResolveForwardedTypes(api, assemblyPath, logger, options.IncludeAll);
+            ApiServices.ResolveForwardedTypes(
+                api,
+                assemblyPath,
+                logger,
+                options.IncludeAll,
+                isPlatformAssembly: true,
+                options);
 
             foreach (var type in api.Types.Where(t => fullNames.Contains(t.FullName)))
             {
-                type.SourceAssemblyPath = assemblyPath;
+                type.SourceAssemblyPath ??= assemblyPath;
                 merged.Types.Add(type);
             }
         }

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -34,7 +34,13 @@ internal static class ApiServices
         if (api == null || apiDllPath == null)
             return null;
 
-        ResolveForwardedTypes(api, apiDllPath, logger, includeAll);
+        ResolveForwardedTypes(
+            api,
+            apiDllPath,
+            logger,
+            includeAll,
+            isPlatformAssembly: runtimeAssemblyPath is not null,
+            targetFramework: selectedTfm);
 
         if (!string.IsNullOrEmpty(packagePath))
         {
@@ -152,44 +158,81 @@ internal static class ApiServices
     /// Resolves types from forwarded assemblies and merges them into the API surface.
     /// Like curl -L, this follows type forwarders to their target assemblies.
     /// </summary>
-    internal static void ResolveForwardedTypes(ApiSurface api, string dllPath, VerboseLogger logger, bool includeAll)
+    internal static void ResolveForwardedTypes(
+        ApiSurface api,
+        string dllPath,
+        VerboseLogger logger,
+        bool includeAll,
+        bool isPlatformAssembly = false,
+        ApiOptions? options = null,
+        string? targetFramework = null)
     {
         if (api.TypeForwarders.Count == 0)
             return;
 
-        var assemblyDir = Path.GetDirectoryName(dllPath);
-        if (assemblyDir == null)
-            return;
+        using var resolution = new TypeDefinitionResolutionSession(
+            dllPath,
+            isPlatformAssembly,
+            options?.ProjectAssetsPath,
+            options?.Tfm ?? targetFramework,
+            options?.PlatformFramework);
+        Dictionary<
+            AssemblyAcquisitionRegistration,
+            (ResolvedAssemblyReference Assembly,
+                HashSet<MetadataTypeDefinitionName> Types)> byAssembly = [];
 
-        var byAssembly = api.TypeForwarders
-            .GroupBy(f => f.TargetAssembly)
-            .ToDictionary(g => g.Key, g => g.Select(f => f.TypeName).ToHashSet(StringComparer.OrdinalIgnoreCase));
-
-        logger.Log($"Resolving {api.TypeForwarders.Count} forwarded types from {byAssembly.Count} libraries...");
-
-        int resolvedCount = 0;
-
-        foreach (var (targetAssembly, forwardedTypeNames) in byAssembly)
+        foreach (TypeForwarder forwarder in api.TypeForwarders)
         {
-            var targetPath = Path.Combine(assemblyDir, targetAssembly + ".dll");
-            if (!File.Exists(targetPath))
+            if (forwarder.DefinitionName is null)
             {
-                logger.Log($"Target library '{targetAssembly}' not found, skipping.");
+                logger.Log(
+                    $"Forwarded type '{forwarder.TypeName}' has no valid structured metadata name.");
                 continue;
             }
 
+            TypeResolutionOutcome outcome =
+                resolution.Resolve(forwarder.DefinitionName);
+            if (outcome is not TypeResolutionOutcome.Resolved resolved
+                || resolved.Hops.IsDefaultOrEmpty)
+            {
+                logger.Log(
+                    $"Could not resolve forwarded type '{forwarder.TypeName}': {outcome.GetType().Name}.");
+                continue;
+            }
+
+            ResolvedAssemblyReference assembly =
+                resolved.Definition.Assembly.Assembly;
+            if (!byAssembly.TryGetValue(
+                    assembly.Registration,
+                    out var group))
+            {
+                group = (assembly, []);
+                byAssembly.Add(assembly.Registration, group);
+            }
+            group.Types.Add(resolved.Definition.Type);
+        }
+
+        logger.Log(
+            $"Resolving {api.TypeForwarders.Count} forwarded types from {byAssembly.Count} acquired libraries...");
+        int resolvedCount = 0;
+        foreach (var (_, group) in byAssembly)
+        {
             try
             {
-                var targetApi = AssemblyReader.ExtractApiSurface(targetPath, includeAll);
+                using Stream stream = group.Assembly.OpenRead();
+                var targetApi = AssemblyReader.ExtractApiSurface(
+                    stream,
+                    includeAll);
                 if (targetApi == null)
                     continue;
 
                 foreach (var type in targetApi.Types)
                 {
-                    if (forwardedTypeNames.Contains(type.FullName))
+                    if (type.DefinitionName is not null
+                        && group.Types.Contains(type.DefinitionName))
                     {
                         type.IsForwarded = true;
-                        type.SourceAssemblyPath = targetPath;
+                        type.SourceAssemblyPath = group.Assembly.Path;
                         api.Types.Add(type);
                         api.PublicMethodCount += type.Members.Count(DotnetInspector.Sections.ApiMemberSectionDescriptors.IsMethodLike);
                         api.PublicPropertyCount += type.Members.Count(m => m.Kind == "property");
@@ -199,9 +242,16 @@ internal static class ApiServices
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (
+                ex is IOException
+                    or UnauthorizedAccessException
+                    or BadImageFormatException
+                    or InvalidOperationException
+                    or NotSupportedException
+                    or ArgumentException)
             {
-                logger.Log($"Error reading '{targetAssembly}': {ex.Message}");
+                logger.Log(
+                    $"Error reading resolved assembly '{group.Assembly.Identity.Name}': {ex.Message}");
             }
         }
 

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -280,8 +280,6 @@ internal static class LibraryMetadataService
                 inspection.SourceFiles = await SourceFileCollector.CollectAsync(
                     service,
                     path,
-                    logger,
-                    httpClient,
                     browsableUrls: options.BrowsableUrls,
                     typeFilter: options.TypeFilter);
             }

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -26,17 +26,60 @@ internal static class SourceEnricher
         bool cacheOnly = false)
     {
         if (!context.NeedsPdb) return;
+        if (context.AssemblyPathOrNull is not { } assemblyPath)
+        {
+            log?.Invoke(
+                "External PDB acquisition is unavailable because the resolved assembly descriptor has no filesystem path.");
+            return;
+        }
 
         var downloader = new SymbolPackageDownloader(httpClient);
         var result = await downloader.DownloadPdbAsync(
             context.PdbId!.Guid, context.PdbId.Age, context.PdbId.PdbFileName,
-            context.PdbId.IsPortable, context.AssemblyPath,
+            context.PdbId.IsPortable, assemblyPath,
             packageName, packageVersion, log, isPlatformAssembly, cacheOnly);
 
         if (result.PdbFilePath != null)
             context.LoadPdbFromFile(result.PdbFilePath, "Symbol Package", result.SymbolServer);
         else if (result.WindowsPdbDetected)
             context.WindowsPdbDetected = true;
+    }
+
+    /// <summary>
+    /// Acquires symbols using the provenance of the descriptor that supplied the
+    /// authoritative assembly bytes.
+    /// </summary>
+    internal static Task AcquirePdbAsync(
+        PdbContext context,
+        ResolvedAssemblyReference assembly,
+        HttpClient httpClient,
+        Action<string>? log,
+        bool cacheOnly = false)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        string? packageName = null;
+        string? packageVersion = null;
+        bool isPlatformAssembly = false;
+
+        switch (assembly.Provenance)
+        {
+            case AssemblyResolutionProvenance.PackageAsset package:
+                packageName = package.PackageId;
+                packageVersion = package.PackageVersion;
+                break;
+            case AssemblyResolutionProvenance.PlatformAsset:
+                isPlatformAssembly = true;
+                break;
+        }
+
+        return AcquirePdbAsync(
+            context,
+            httpClient,
+            packageName,
+            packageVersion,
+            isPlatformAssembly,
+            log,
+            cacheOnly);
     }
 
     // ===== Verbosity-Aware Enrichment Gateways =====
@@ -144,108 +187,27 @@ internal static class SourceEnricher
             var sourceInfo = service.ResolveTypeSource(typeName);
             if (sourceInfo == null)
             {
-                var forwardTarget = context.FindTypeForwarder(typeName);
-                if (forwardTarget != null)
+                if (apiType.DefinitionName is not null
+                    && await TryEnrichFromForwardedAssemblyAsync(
+                        apiType,
+                        typeName,
+                        apiType.DefinitionName,
+                        dllPath,
+                        options,
+                        logger,
+                        httpClient))
                 {
-                    logger.Log($"Type '{typeName}' is forwarded to '{forwardTarget}'.");
-
-                    var forwardedResult = await TryEnrichFromForwardedAssemblyAsync(
-                        apiType, typeName, forwardTarget, dllPath, options, logger, httpClient);
-                    if (forwardedResult)
-                        return;
+                    return;
                 }
 
                 logger.Log($"Could not find type definition for '{typeName}'.");
                 return;
             }
-            if (sourceInfo != null)
-            {
-                apiType.SourceFilePath = sourceInfo.SourceFilePath;
-                apiType.SourceUrl = sourceInfo.SourceUrl;
-                apiType.GitHubBrowseUrl = sourceInfo.GitHubBrowseUrl;
-                apiType.SourceLineNumber = sourceInfo.LineNumber;
-                apiType.SourceResolution = sourceInfo.ResolutionMethod.ToString();
-
-                if (sourceInfo.AdditionalSourceFiles.Count > 0)
-                {
-                    apiType.AdditionalSourceFiles = sourceInfo.AdditionalSourceFiles
-                        .Select(f => new PartialSourceFileInfo
-                        {
-                            FilePath = f.FilePath,
-                            SourceUrl = f.SourceUrl,
-                            GitHubBrowseUrl = f.GitHubBrowseUrl
-                        })
-                        .ToList();
-                    logger.Log($"Found partial type with {sourceInfo.AdditionalSourceFiles.Count + 1} source files");
-                }
-
-                logger.Log($"Source ({sourceInfo.ResolutionMethod}): {sourceInfo.SourceFilePath}:{sourceInfo.LineNumber}");
-            }
-
-            if ((options.ShowDocs || options.ShowSamples) && sourceInfo?.SourceUrl != null)
-            {
-                var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
-                var parser = new DocCommentParser();
-
-                List<(string Url, string FilePath)> sourceFilesToFetch =
-                [
-                    (sourceInfo.SourceUrl, sourceInfo.SourceFilePath ?? "")
-                ];
-
-                foreach (var additionalFile in sourceInfo.AdditionalSourceFiles)
-                {
-                    if (additionalFile.SourceUrl != null)
-                    {
-                        sourceFilesToFetch.Add((additionalFile.SourceUrl, additionalFile.FilePath));
-                    }
-                }
-
-                List<(string Content, string Url, string FilePath)> allSourceContents = [];
-                string? primaryNamespace = null;
-                bool isPrimaryPartial = false;
-
-                foreach (var (url, filePath) in sourceFilesToFetch)
-                {
-                    logger.Log($"Fetching source from: {url}");
-                    string? content = await fetcher.FetchSourceAsync(url);
-
-                    if (content != null)
-                    {
-                        logger.Log($"Fetched {content.Length} bytes from {Path.GetFileName(filePath)}");
-
-                        if (allSourceContents.Count == 0)
-                        {
-                            isPrimaryPartial = IsPartialTypeDeclaration(content, apiType.Name);
-                            primaryNamespace = ExtractNamespace(content);
-                            allSourceContents.Add((content, url, filePath));
-                        }
-                        else if (isPrimaryPartial)
-                        {
-                            bool isMatchingPartial = IsPartialTypeDeclaration(content, apiType.Name);
-                            string? fileNamespace = ExtractNamespace(content);
-
-                            if (isMatchingPartial && fileNamespace == primaryNamespace)
-                            {
-                                allSourceContents.Add((content, url, filePath));
-                                logger.Log($"Validated matching partial in {Path.GetFileName(filePath)}");
-                            }
-                            else
-                            {
-                                logger.Log($"Skipping {Path.GetFileName(filePath)} - not a matching partial type");
-                            }
-                        }
-                    }
-                    else
-                    {
-                        logger.Log($"Could not fetch source from: {url}");
-                    }
-                }
-
-                if (allSourceContents.Count > 0)
-                {
-                    MergePartialTypeDocumentation(apiType, allSourceContents, parser, options, logger);
-                }
-            }
+            await ApplySourceInfoAsync(
+                apiType,
+                sourceInfo,
+                options,
+                logger);
         }
         catch (Exception ex)
         {
@@ -722,27 +684,153 @@ internal static class SourceEnricher
     private static async Task<bool> TryEnrichFromForwardedAssemblyAsync(
         ApiType apiType,
         string typeName,
-        string targetAssemblyName,
+        MetadataTypeDefinitionName definitionName,
         string originalDllPath,
         ApiOptions options,
         VerboseLogger logger,
         HttpClient httpClient)
     {
-        var runtimeDir = Path.GetDirectoryName(originalDllPath);
-        if (runtimeDir == null)
-            return false;
-
-        var targetDllPath = Path.Combine(runtimeDir, targetAssemblyName + ".dll");
-        if (!File.Exists(targetDllPath))
+        using var resolution = new TypeDefinitionResolutionSession(
+            originalDllPath,
+            isPlatformAssembly: !string.IsNullOrEmpty(
+                options.PlatformAssembly),
+            options);
+        TypeResolutionOutcome outcome = resolution.Resolve(definitionName);
+        if (outcome is not TypeResolutionOutcome.Resolved resolved
+            || resolved.Hops.IsDefaultOrEmpty)
         {
-            logger.Log($"Target library '{targetAssemblyName}' not found at '{targetDllPath}'.");
+            if (outcome is not TypeResolutionOutcome.NotFound)
+            {
+                logger.Log(
+                    $"Could not resolve forwarded definition for '{typeName}': {outcome.GetType().Name}.");
+            }
             return false;
         }
 
-        logger.Log($"Following type forwarder to '{targetAssemblyName}'...");
+        ResolvedAssemblyReference implementation =
+            resolved.Definition.Assembly.Assembly;
+        logger.Log(
+            $"Following {outcome.Hops.Length} type-forwarding hop(s) to '{implementation.Identity.Name}'.");
 
-        await EnrichTypeWithSourceInfoAsync(apiType, typeName, targetDllPath, options, logger, httpClient);
+        using var service = SourceLinkService.Open(implementation, logger.Log);
+        await AcquirePdbAsync(
+            service.Context,
+            implementation,
+            httpClient,
+            logger.Log);
+        if (!service.HasPdb || !service.HasSourceLink)
+            return false;
+
+        SourceLinkResolver.TypeSourceInfo? sourceInfo =
+            service.ResolveTypeSource(typeName);
+        if (sourceInfo is null)
+            return false;
+
+        await ApplySourceInfoAsync(apiType, sourceInfo, options, logger);
         return true;
+    }
+
+    private static async Task ApplySourceInfoAsync(
+        ApiType apiType,
+        SourceLinkResolver.TypeSourceInfo sourceInfo,
+        ApiOptions options,
+        VerboseLogger logger)
+    {
+        apiType.SourceFilePath = sourceInfo.SourceFilePath;
+        apiType.SourceUrl = sourceInfo.SourceUrl;
+        apiType.GitHubBrowseUrl = sourceInfo.GitHubBrowseUrl;
+        apiType.SourceLineNumber = sourceInfo.LineNumber;
+        apiType.SourceResolution = sourceInfo.ResolutionMethod.ToString();
+
+        if (sourceInfo.AdditionalSourceFiles.Count > 0)
+        {
+            apiType.AdditionalSourceFiles = sourceInfo.AdditionalSourceFiles
+                .Select(f => new PartialSourceFileInfo
+                {
+                    FilePath = f.FilePath,
+                    SourceUrl = f.SourceUrl,
+                    GitHubBrowseUrl = f.GitHubBrowseUrl
+                })
+                .ToList();
+            logger.Log(
+                $"Found partial type with {sourceInfo.AdditionalSourceFiles.Count + 1} source files");
+        }
+
+        logger.Log(
+            $"Source ({sourceInfo.ResolutionMethod}): {sourceInfo.SourceFilePath}:{sourceInfo.LineNumber}");
+
+        if (!(options.ShowDocs || options.ShowSamples)
+            || sourceInfo.SourceUrl is null)
+        {
+            return;
+        }
+
+        var fetcher = new SourceFetcher(
+            DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
+        var parser = new DocCommentParser();
+        List<(string Url, string FilePath)> sourceFilesToFetch =
+        [
+            (sourceInfo.SourceUrl, sourceInfo.SourceFilePath ?? "")
+        ];
+
+        foreach (var additionalFile in sourceInfo.AdditionalSourceFiles)
+        {
+            if (additionalFile.SourceUrl is not null)
+                sourceFilesToFetch.Add(
+                    (additionalFile.SourceUrl, additionalFile.FilePath));
+        }
+
+        List<(string Content, string Url, string FilePath)> allSourceContents = [];
+        string? primaryNamespace = null;
+        bool isPrimaryPartial = false;
+
+        foreach ((string url, string filePath) in sourceFilesToFetch)
+        {
+            logger.Log($"Fetching source from: {url}");
+            string? content = await fetcher.FetchSourceAsync(url);
+            if (content is null)
+            {
+                logger.Log($"Could not fetch source from: {url}");
+                continue;
+            }
+
+            logger.Log(
+                $"Fetched {content.Length} bytes from {Path.GetFileName(filePath)}");
+            if (allSourceContents.Count == 0)
+            {
+                isPrimaryPartial =
+                    IsPartialTypeDeclaration(content, apiType.Name);
+                primaryNamespace = ExtractNamespace(content);
+                allSourceContents.Add((content, url, filePath));
+            }
+            else if (isPrimaryPartial)
+            {
+                bool isMatchingPartial =
+                    IsPartialTypeDeclaration(content, apiType.Name);
+                string? fileNamespace = ExtractNamespace(content);
+                if (isMatchingPartial && fileNamespace == primaryNamespace)
+                {
+                    allSourceContents.Add((content, url, filePath));
+                    logger.Log(
+                        $"Validated matching partial in {Path.GetFileName(filePath)}");
+                }
+                else
+                {
+                    logger.Log(
+                        $"Skipping {Path.GetFileName(filePath)} - not a matching partial type");
+                }
+            }
+        }
+
+        if (allSourceContents.Count > 0)
+        {
+            MergePartialTypeDocumentation(
+                apiType,
+                allSourceContents,
+                parser,
+                options,
+                logger);
+        }
     }
 
     private static bool IsPartialTypeDeclaration(string sourceContent, string typeName)

--- a/src/dotnet-inspect/Inspectors/SourceFileCollector.cs
+++ b/src/dotnet-inspect/Inspectors/SourceFileCollector.cs
@@ -8,58 +8,54 @@ namespace DotnetInspector.Inspectors;
 
 internal static class SourceFileCollector
 {
-    public static async Task<List<SourceFileInfo>> CollectAsync(
+    public static Task<List<SourceFileInfo>> CollectAsync(
         SourceLinkService service,
         string assemblyPath,
-        VerboseLogger logger,
-        HttpClient httpClient,
         bool includeAll = false,
         bool browsableUrls = false,
         string? typeFilter = null)
     {
         if (!service.HasPdb || !service.HasSourceLink)
-            return [];
+            return Task.FromResult<List<SourceFileInfo>>([]);
 
         var api = AssemblyReader.ExtractApiSurface(assemblyPath, includeAll, typesOnly: true);
         if (api == null)
-            return [];
+            return Task.FromResult<List<SourceFileInfo>>([]);
 
         List<SourceFileInfo> rows = [];
-        Dictionary<string, SourceLinkService> implementationServices = new(StringComparer.OrdinalIgnoreCase);
-
-        try
+        foreach (var type in api.Types.OrderBy(
+            t => t.FullName,
+            StringComparer.Ordinal))
         {
-            foreach (var type in api.Types.OrderBy(t => t.FullName, StringComparer.Ordinal))
+            var typeDisplayName =
+                MetadataTypeNameFormatter.FormatFullName(type);
+            if (!string.IsNullOrWhiteSpace(typeFilter)
+                && !TypeMatcher.MatchesTypeFilter(type.FullName, typeFilter)
+                && !TypeMatcher.MatchesTypeFilter(typeDisplayName, typeFilter))
             {
-                var typeDisplayName = MetadataTypeNameFormatter.FormatFullName(type);
-                if (!string.IsNullOrWhiteSpace(typeFilter)
-                    && !TypeMatcher.MatchesTypeFilter(type.FullName, typeFilter)
-                    && !TypeMatcher.MatchesTypeFilter(typeDisplayName, typeFilter))
-                    continue;
+                continue;
+            }
 
-                var sourceInfo = service.ResolveTypeSource(type.FullName);
-                if (sourceInfo == null)
-                    sourceInfo = await ResolveForwardedTypeSourceAsync(type.FullName, service, implementationServices, httpClient, logger);
+            var sourceInfo = service.ResolveTypeSource(type.FullName);
+            if (sourceInfo == null)
+            {
+                rows.Add(new SourceFileInfo(typeDisplayName, null));
+                continue;
+            }
 
-                if (sourceInfo == null)
-                {
-                    rows.Add(new SourceFileInfo(typeDisplayName, null));
-                    continue;
-                }
+            rows.Add(new SourceFileInfo(
+                typeDisplayName,
+                SelectUrl(sourceInfo, browsableUrls)));
 
-                rows.Add(new SourceFileInfo(typeDisplayName, SelectUrl(sourceInfo, browsableUrls)));
-
-                foreach (var partial in sourceInfo.AdditionalSourceFiles)
-                    rows.Add(new SourceFileInfo(typeDisplayName, SelectUrl(partial, browsableUrls)));
+            foreach (var partial in sourceInfo.AdditionalSourceFiles)
+            {
+                rows.Add(new SourceFileInfo(
+                    typeDisplayName,
+                    SelectUrl(partial, browsableUrls)));
             }
         }
-        finally
-        {
-            foreach (var implementationService in implementationServices.Values)
-                implementationService.Dispose();
-        }
 
-        return rows;
+        return Task.FromResult(rows);
     }
 
     public static async Task<List<SourceFileInfo>> CollectFromAssemblyAsync(
@@ -81,36 +77,12 @@ internal static class SourceFileCollector
             packageVersion,
             isPlatformAssembly,
             logger.Log);
-        return await CollectAsync(service, assemblyPath, logger, httpClient, includeAll, browsableUrls, typeFilter);
-    }
-
-    private static async Task<SourceLinkResolver.TypeSourceInfo?> ResolveForwardedTypeSourceAsync(
-        string typeName,
-        SourceLinkService service,
-        Dictionary<string, SourceLinkService> implementationServices,
-        HttpClient httpClient,
-        VerboseLogger logger)
-    {
-        var implementationPath = service.ResolveImplementationAssemblyPath(typeName);
-        if (implementationPath == null)
-            return null;
-
-        if (!implementationServices.TryGetValue(implementationPath, out var implementationService))
-        {
-            implementationService = SourceLinkService.Open(implementationPath, logger.Log);
-            await SourceEnricher.AcquirePdbAsync(
-                implementationService.Context,
-                httpClient,
-                packageName: null,
-                packageVersion: null,
-                isPlatformAssembly: true,
-                logger.Log);
-            implementationServices[implementationPath] = implementationService;
-        }
-
-        return implementationService.HasPdb && implementationService.HasSourceLink
-            ? implementationService.ResolveTypeSource(typeName)
-            : null;
+        return await CollectAsync(
+            service,
+            assemblyPath,
+            includeAll,
+            browsableUrls,
+            typeFilter);
     }
 
     private static string? SelectUrl(SourceLinkResolver.TypeSourceInfo info, bool browsableUrls)

--- a/src/dotnet-inspect/Inspectors/TypeDefinitionResolutionSession.cs
+++ b/src/dotnet-inspect/Inspectors/TypeDefinitionResolutionSession.cs
@@ -1,0 +1,76 @@
+using DotnetInspector.Options;
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// CLI inspection-lifetime owner for structured type resolution from one acquired
+/// assembly. Consumers receive Metadata outcomes and acquisition descriptors rather
+/// than reconstructing assembly paths from metadata names.
+/// </summary>
+internal sealed class TypeDefinitionResolutionSession : IDisposable
+{
+    readonly ResolvedAssemblyReference _root;
+    readonly AssemblyReferenceBindingPolicy _policy;
+    readonly TypeResolutionCatalog _catalog = new();
+
+    public TypeDefinitionResolutionSession(
+        string assemblyPath,
+        bool isPlatformAssembly,
+        ApiOptions? options = null)
+        : this(
+            assemblyPath,
+            isPlatformAssembly,
+            options?.ProjectAssetsPath,
+            options?.Tfm,
+            options?.PlatformFramework)
+    {
+    }
+
+    public TypeDefinitionResolutionSession(
+        string assemblyPath,
+        bool isPlatformAssembly,
+        string? projectAssetsPath,
+        string? targetFramework,
+        string? platformFramework = null)
+    {
+        _root = ResolvedAssemblyReference.CreateFromPath(
+            assemblyPath,
+            isPlatformAssembly
+                ? AssemblyResolutionProvenance.Platform(
+                    platformFramework ?? "InstalledPlatform",
+                    frameworkVersion: null,
+                    "TypeDefinitionResolutionSession")
+                : AssemblyResolutionProvenance.Local(
+                    "TypeDefinitionResolutionSession"));
+
+        var resolver = new AssemblyDependencyResolver(
+            new AssemblyDependencyResolutionOptions(assemblyPath)
+            {
+                ProjectAssetsPath = projectAssetsPath,
+                TargetFramework = targetFramework,
+                IncludeDepsJsonAssets = false,
+                IncludeAspNetCoreSharedFramework = false,
+                PreferImplementationAssemblies = true,
+                AllowPlatformAssemblyVersionRollForward = true,
+            });
+        _policy = new AssemblyReferenceBindingPolicy(resolver);
+    }
+
+    public TypeResolutionOutcome Resolve(MetadataTypeDefinitionName type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        var request = TypeResolutionRequest.FromAssembly(
+            _root,
+            AssemblyResolutionScope.Any,
+            type);
+        using TypeResolutionContext context = _catalog.CreateContext(
+            _policy,
+            [_root],
+            [request]);
+        return context.Resolve(request);
+    }
+
+    public void Dispose() => _catalog.Dispose();
+}

--- a/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
+++ b/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
@@ -1,0 +1,53 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+public class PdbContextDescriptorTests
+{
+    [Fact]
+    public void OpenDescriptor_UsesAuthoritativeStreamInsteadOfPath()
+    {
+        string authoritativePath = typeof(PdbContextDescriptorTests).Assembly.Location;
+        string informationalPath = typeof(PdbContext).Assembly.Location;
+        byte[] authoritativeImage = File.ReadAllBytes(authoritativePath);
+        AssemblyReferenceIdentity identity = ReadIdentity(authoritativeImage);
+        var descriptor = ResolvedAssemblyReference.Create(
+            identity,
+            informationalPath,
+            () => new MemoryStream(authoritativeImage, writable: false),
+            AssemblyResolutionProvenance.Local("test"));
+
+        using var context = PdbContext.Open(descriptor);
+
+        Assert.Equal(identity.Name, context.ExtractAssemblyInfo().AssemblyName);
+        Assert.Equal(informationalPath, context.AssemblyPathOrNull);
+    }
+
+    [Fact]
+    public void OpenDescriptor_StreamOnlyImageRemainsUsable()
+    {
+        byte[] image = File.ReadAllBytes(
+            typeof(PdbContextDescriptorTests).Assembly.Location);
+        AssemblyReferenceIdentity identity = ReadIdentity(image);
+        var descriptor = ResolvedAssemblyReference.Create(
+            identity,
+            path: null,
+            () => new MemoryStream(image, writable: false),
+            AssemblyResolutionProvenance.Local("test"));
+
+        using var context = PdbContext.Open(descriptor);
+
+        Assert.Equal(identity.Name, context.ExtractAssemblyInfo().AssemblyName);
+        Assert.Null(context.AssemblyPathOrNull);
+        Assert.Throws<InvalidOperationException>(() => context.AssemblyPath);
+    }
+
+    static AssemblyReferenceIdentity ReadIdentity(byte[] image)
+    {
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        return AssemblyReferenceIdentity.FromAssemblyDefinition(
+            peReader.GetMetadataReader());
+    }
+}


### PR DESCRIPTION
## Summary

Source and API consumers now resolve forwarded types through the Metadata-owned structured engine and open only acquisition-issued descriptors. Raw `AssemblyRef` names no longer become filesystem paths, closing the local-read/PDB-acquisition sink in #3441 without adding another path-component allow list.

- Carry exact `MetadataTypeDefinitionName` identity from `ExportedType` extraction to source/API sinks.
- Add an inspection-lifetime resolution session over the product acquisition policy and catalog.
- Make `ResolvedAssemblyReference.OpenRead` authoritative for PE/PDB inspection; descriptor paths remain optional acquisition provenance used only where filesystem access is inherently required.
- Migrate `ApiServices` and `SourceEnricher`, preserve resolved source assembly paths, and remove the unreachable `SourceFileCollector` forwarding fallback.
- Add real-PE positive and hostile-traversal gates plus stream-authority and stream-only descriptor gates.

This also follows complete platform forwarding chains, exposing `ParamCollectionAttribute` in the `System.Text.Json` surface (90 types instead of 89).

## Boundary

This is type-forwarding Slice 4a: descriptor opening and path-sink deletion. Platform type lookup, facade classification, and source routing remain Slice 4b; this PR intentionally does not replace `PlatformResolver.FindLibraryContainingType` or `IsFacadeOnlyAssembly`.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `source eng/activate-iltools.sh --mdv && dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — 1,407 passed
- `source eng/activate-iltools.sh --mdv && dotnet run --project src/dotnet-inspect.Tests -c Release` — 2,910 run; 2,905 passed, 4 platform-dependent skips, 1 unrelated existing local-fixture failure in `Layout_Count_CountsFilesRatherThanRenderedTreeLines` because `Newtonsoft.Json.nuspec` is absent
- Focused forwarding, hostile traversal, descriptor authority, containment, and platform-count gates pass
- `npx markdownlint-cli docs/design/type-forwarding-resolution.md`

Closes #3441
