### PR TITLE
Pin one review seat, free the other, and stop re-spending clean rounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,35 +366,53 @@ round:
   and re-run the validation the change claims; the resulting head is what you
   hand out. Reviewing a stale head spends the review on code that is not what
   will merge, and defers conflict resolution to *after* the reviews are clean —
-  where the resolution is itself unreviewed.
-- **The PR is mergeable and green.** Use `gh pr view <n> --json
-  mergeable,mergeStateStatus` for conflicts and `gh pr checks <n> --required`
-  for the gating runs; when the repository marks no check required, `--required`
-  reports none and exits non-zero, so fall back to plain `gh pr checks <n>`.
-  Exit `0` means nothing failed and nothing is outstanding; exit `8` means
-  checks are still running, which is not green — wait with `--watch`. A
-  `skipping` result is terminal and does not block: a path-filtered job that
-  skipped will never become a pass, so waiting on it waits forever. It is also
-  not evidence of anything. Never cite a skipped job as proof your change was
-  validated, and if a change should have triggered a job that skipped, treat the
-  path filter as the bug.
+  where the resolution is itself unreviewed. Once the reviews *are* clean, this
+  reverses: see [Clean reviews are not spent by main
+  moving](#clean-reviews-are-not-spent-by-main-moving).
+- **The PR is mergeable and green.** `gh pr view <n> --json
+  mergeable,mergeStateStatus` for conflicts; `gh pr checks <n> --required` for
+  the gating runs, falling back to plain `gh pr checks <n>` when the repository
+  marks none required, in which case `--required` reports none and exits
+  non-zero. Exit `0` is green; exit `8` means checks are still running — wait
+  with `--watch`. `skipping` is terminal and does not block, but it is also not
+  evidence: never cite a skipped job as validation, and if a change should have
+  triggered a job that skipped, the path filter is the bug. After a push,
+  confirm the run you are reading is the one for the head you are handing out —
+  `gh pr checks --watch` can return exit `0` against the *previous* head's run
+  before the new one registers, so check the run's `headSha`.
 - **Every PR in a stack meets all of the above**, not only the slice under
   review — a red or conflicted parent is a red or conflicted base for everything
   above it. A slice rebases onto its parent, never onto `main`: only the stack's
   bottom open slice takes `origin/main` as its base, and rebasing an upper slice
   onto `main` pulls in work its parent has not landed and makes the slice's diff
-  report its parent's changes as its own.
-- **Every slice in a stack must report CI.** `ci.yml` applies no base-branch
-  filter, so a child PR targeting its parent branch schedules the same CI as a
-  bottom slice targeting `main`. If `gh pr checks` reports no checks for a
-  stack slice, the slice is not green and something is wrong with workflow
-  scheduling — investigate it rather than accepting the silence, because a PR
-  that triggers no workflow reports nothing for `ci-required` to block on and
-  displays as MERGEABLE and CLEAN (#3706).
+  report its parent's changes as its own. `ci.yml` applies no base-branch
+  filter, so every slice schedules the same CI wherever it targets; a slice
+  reporting *no* checks is therefore not green but a scheduling bug to
+  investigate, since a PR that triggers no workflow leaves `ci-required` nothing
+  to block on and displays as MERGEABLE and CLEAN (#3706).
 
 Do not integrate main under a reviewer mid-read. When integration is what moved
 the head, say so on the PR and name the merge commit, so the re-review reads as
 a confirmation rather than a second full pass.
+
+### Clean reviews are not spent by main moving
+
+When every reviewer the tier requires has come back clean at the current head
+and `origin/main` has since moved, **stop and ask.** Do not integrate main, and
+do not open another round on your own initiative.
+
+Ask with an analysis of what actually landed: which commits touch files this
+change touches, which behavior this change relies on that they alter, and any
+conflict a textual merge would resolve silently but wrongly. Say plainly when
+the answer is that nothing in the range interacts with this change — that is the
+common case and it is the most useful thing you can report. The user decides
+whether the integrated main warrants another round.
+
+This is the one place the settled-branch rule yields, and it has to, or the
+budget is unbounded: on a busy `main`, a round takes longer than the interval
+between commits, so integrate-and-re-review by reflex never converges. A pair of
+clean reviews is a result. Unrelated commits landing behind it do not retract
+it.
 
 ### A quick read is not a round
 
@@ -411,39 +429,39 @@ the branch settles. When you cite its findings, say which it was.
 ### How many reviewers, and from which models
 
 **How much review a PR needs is a function of its triviality and risk alone —
-never the kind of change it makes.** If you are unsure which tier applies,
-escalate: default to more review, not less.
+never the kind of change it makes.** If you are unsure whether a change is
+trivial, escalate: default to review, not none.
 
 | Tier | Requirement |
 | --- | --- |
 | Trivial | No review. State why the change is trivial. |
-| Medium risk | One reviewer, always **GPT** at the highest available version and quality level. |
-| Higher risk — typical for a substantial feature | Two reviewers from two different model families. |
-
-Higher risk means subtle correctness, security, or compatibility risk, or a
-large or uncertain blast radius.
+| Everything else | **GPT-5.6 Sol**, always, plus one other roster reviewer. |
 
 Adversarial-review roster — this list is the single source of truth, and
 scenario docs should reference it rather than restating it:
 
+- **GPT-5.6 Sol** — the fixed seat, in every round
 - Claude Opus
 - Gemini Pro
-- GPT
+- GPT, other versions
 
-**Always use the highest version a model offers** — if both Opus 4.8 and Opus 5
-are available, use Opus 5. For GPT, also select the highest available quality
-level. In the two-reviewer tier, do not review with your own model when another
-listed family is available.
+The second seat may be **any** of these, including the model you authored the
+change with. Reviewing with your own model is explicitly allowed: the fixed seat
+already guarantees a second perspective, and refusing an otherwise-available
+reviewer cost more than it bought.
+
+**Use the highest version and quality level a model offers** in the second seat
+— given both Opus 4.8 and Opus 5, use Opus 5. The GPT-5.6 Sol seat is a
+deliberate pin rather than a "highest available" slot; when it should move, move
+it here.
 
 These tiers assume a harness — such as the GitHub Copilot CLI — that can
-delegate to any family in the roster. A harness exposing only its own vendor's
-models changes how the reviewers are obtained, never the bar. For the
-medium-risk tier, use GPT when the harness offers it; otherwise request a GPT
-review from the user. For the two-reviewer tier, use an available roster family
-and **request the other, different-family reviewer from the user**, not marking
-the PR ready until both reviews arrive.
+delegate to any roster model. A harness exposing only its own vendor's models
+changes how reviewers are obtained, never the bar: run the reviewer it has and
+**request GPT-5.6 Sol from the user**, not marking the PR ready until that
+review arrives.
 
-A **round** evaluates one settled head with every reviewer required by its tier.
+A **round** evaluates one settled head with every reviewer its tier requires.
 Two reviewers in the same round count as one round, not two.
 
 ### Running the round

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,9 +396,11 @@ round:
   onto `main` pulls in work its parent has not landed and makes the slice's diff
   report its parent's changes as its own. `ci.yml` applies no base-branch
   filter, so every slice schedules the same CI wherever it targets; a slice
-  reporting *no* checks is therefore not green but a scheduling bug to
-  investigate, since a PR that triggers no workflow leaves `ci-required` nothing
-  to block on and displays as MERGEABLE and CLEAN (#3706).
+  reporting *no* checks is therefore not green. Re-query after the registration
+  window and verify the current head; if no matching workflow run appears, that
+  is a scheduling bug to investigate, since a PR that triggers no workflow
+  leaves `ci-required` nothing to block on and displays as MERGEABLE and CLEAN
+  (#3706).
 
 Do not integrate main under a reviewer mid-read. When integration is what moved
 the head, say so on the PR and name the merge commit, so the re-review reads as
@@ -409,10 +411,12 @@ a confirmation rather than a second full pass.
 For a PR that targets `main` — including the bottom slice of a stack — when
 every reviewer the tier requires has come back clean at the current head and
 `origin/main` has since moved, **stop and ask.** Do not integrate main, and do
-not open another round on your own initiative. If any reviewer had a finding,
-the author changed the head, or an upper slice's parent moved, this exception
-does not apply: resolve or restack, integrate the effective base, and review the
-new head normally.
+not open another round on your own initiative. Evaluate this from the latest
+clean result: an earlier finding that was fixed and then reviewed clean does not
+disqualify it. If a finding remains unresolved, or the head changed after that
+clean result because of an author change, conflict resolution, or restack, the
+exception does not apply: resolve or restack, integrate the effective base, and
+review the new head normally.
 
 Ask with an analysis of what actually landed: which commits touch files this
 change touches, which behavior this change relies on that they alter, and any
@@ -431,7 +435,7 @@ The user decides which continuation the evidence warrants:
 
 The first continuation is the sole exception to the fixed-head review rule; it
 does not authorize carrying reviews across author changes, conflict-resolution
-changes, or a restack.
+changes, or a restack that occurred after the recorded reviewed head.
 
 This is the one place the settled-branch rule yields, and it has to, or the
 budget is unbounded: on a busy `main`, a round takes longer than the interval

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,16 +375,20 @@ round:
   rather than read it as clear. For the gating runs, `gh pr checks <n>
   --required`, which on a PR targeting `main` resolves to `ci-required` — the
   only check the ruleset requires. Exit `0` is green; exit `8` means checks are
-  still running, so wait with `--watch`; exit `1` reporting *no* required checks
-  means the ruleset does not cover this base, which is the stacked-PR case
-  below, not a pass — fall back to plain `gh pr checks <n>` there. Do not read
+  still running, so wait with `--watch`. Exit `1` reporting *no* required
+  checks is inconclusive: the aggregate may not have registered yet, or the
+  ruleset may not cover the PR's base. Fall back to plain `gh pr checks <n>`
+  and inspect the base separately; a PR targeting `main` is not green until its
+  current-head `ci-required` has passed. Do not read
   `mergeStateStatus` as check state: it is a composite, and it reports `CLEAN`
-  for a PR with no checks at all (#3706). `skipping` is terminal and does not block, but it is also not
-  evidence: never cite a skipped job as validation, and if a change should have
-  triggered a job that skipped, the path filter is the bug. After a push,
-  confirm the run you are reading is the one for the head you are handing out —
-  `gh pr checks --watch` can return exit `0` against the *previous* head's run
-  before the new one registers, so check the run's `headSha`.
+  for a PR with no checks at all (#3706). `skipping` is terminal and does not
+  block, but it is also not evidence: never cite a skipped job as validation,
+  and if a change should have triggered a job that skipped, the path filter is
+  the bug. After a push, compare `headRefOid` from `gh pr view <n> --json
+  headRefName,headRefOid` with `headSha` from `gh run list --branch
+  <headRefName> --event pull_request --json databaseId,headSha,status,conclusion`,
+  then watch that run by id. `gh pr checks --watch` can otherwise return exit
+  `0` against the previous head's run before the new one registers.
 - **Every PR in a stack meets all of the above**, not only the slice under
   review — a red or conflicted parent is a red or conflicted base for everything
   above it. A slice rebases onto its parent, never onto `main`: only the stack's
@@ -402,16 +406,32 @@ a confirmation rather than a second full pass.
 
 ### Clean reviews are not spent by main moving
 
-When every reviewer the tier requires has come back clean at the current head
-and `origin/main` has since moved, **stop and ask.** Do not integrate main, and
-do not open another round on your own initiative.
+For a PR that targets `main` — including the bottom slice of a stack — when
+every reviewer the tier requires has come back clean at the current head and
+`origin/main` has since moved, **stop and ask.** Do not integrate main, and do
+not open another round on your own initiative. If any reviewer had a finding,
+the author changed the head, or an upper slice's parent moved, this exception
+does not apply: resolve or restack, integrate the effective base, and review the
+new head normally.
 
 Ask with an analysis of what actually landed: which commits touch files this
 change touches, which behavior this change relies on that they alter, and any
 conflict a textual merge would resolve silently but wrongly. Say plainly when
 the answer is that nothing in the range interacts with this change — that is the
-common case and it is the most useful thing you can report. The user decides
-whether the integrated main warrants another round.
+common case and it is the most useful thing you can report.
+
+The user decides which continuation the evidence warrants:
+
+- If the range is non-interacting, the user may direct you to integrate main,
+  re-run the claimed validation and current-head CI, and carry the clean reviews
+  forward without another round. Record the reviewed head, old and new main
+  tips, the non-interaction analysis, and the user's decision on the PR.
+- If the range can affect the change, integrate main and run a new round at the
+  resulting head.
+
+The first continuation is the sole exception to the fixed-head review rule; it
+does not authorize carrying reviews across author changes, conflict-resolution
+changes, or a restack.
 
 This is the one place the settled-branch rule yields, and it has to, or the
 budget is unbounded: on a busy `main`, a round takes longer than the interval
@@ -433,8 +453,9 @@ the branch settles. When you cite its findings, say which it was.
 
 ### How many reviewers, and from which models
 
-**How much review a PR needs is a function of its triviality and risk alone —
-never the kind of change it makes.** If you are unsure whether a change is
+The review gate has one threshold: trivial changes may skip review; everything
+else gets the standard round. Risk scales how deeply the reviewers attack the
+change, not how the round is staffed. If you are unsure whether a change is
 trivial, escalate: default to review, not none.
 
 | Tier | Requirement |
@@ -463,10 +484,10 @@ deliberate pin rather than a "highest available" slot; when it should move, move
 it here.
 
 These tiers assume a harness — such as the GitHub Copilot CLI — that can
-delegate to any roster model. A harness exposing only its own vendor's models
-changes how reviewers are obtained, never the bar: run the reviewer it has and
-**request GPT-5.6 Sol from the user**, not marking the PR ready until that
-review arrives.
+delegate to the roster. A harness with only some roster models changes how the
+round is obtained, never the bar: run the roster reviewer it has and request
+every missing seat from the user. An out-of-roster model may provide a quick
+read but does not fill a seat.
 
 A **round** evaluates one settled head with every reviewer its tier requires.
 Two reviewers in the same round count as one round, not two.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,12 +369,17 @@ round:
   where the resolution is itself unreviewed. Once the reviews *are* clean, this
   reverses: see [Clean reviews are not spent by main
   moving](#clean-reviews-are-not-spent-by-main-moving).
-- **The PR is mergeable and green.** `gh pr view <n> --json
-  mergeable,mergeStateStatus` for conflicts; `gh pr checks <n> --required` for
-  the gating runs, falling back to plain `gh pr checks <n>` when the repository
-  marks none required, in which case `--required` reports none and exits
-  non-zero. Exit `0` is green; exit `8` means checks are still running — wait
-  with `--watch`. `skipping` is terminal and does not block, but it is also not
+- **The PR is mergeable and green** — two questions, two commands. For
+  conflicts, `gh pr view <n> --json mergeable`: `CONFLICTING` blocks, and
+  `UNKNOWN` means GitHub has not finished computing the merge, so re-query
+  rather than read it as clear. For the gating runs, `gh pr checks <n>
+  --required`, which on a PR targeting `main` resolves to `ci-required` — the
+  only check the ruleset requires. Exit `0` is green; exit `8` means checks are
+  still running, so wait with `--watch`; exit `1` reporting *no* required checks
+  means the ruleset does not cover this base, which is the stacked-PR case
+  below, not a pass — fall back to plain `gh pr checks <n>` there. Do not read
+  `mergeStateStatus` as check state: it is a composite, and it reports `CLEAN`
+  for a PR with no checks at all (#3706). `skipping` is terminal and does not block, but it is also not
   evidence: never cite a skipped job as validation, and if a change should have
   triggered a job that skipped, the path filter is the bug. After a push,
   confirm the run you are reading is the one for the head you are handing out —
@@ -443,7 +448,6 @@ scenario docs should reference it rather than restating it:
 - **GPT-5.6 Sol** — the fixed seat, in every round
 - Claude Opus
 - Gemini Pro
-- GPT, other versions
 
 The second seat may be **any** of these, including the model you authored the
 change with. Reviewing with your own model is explicitly allowed: the fixed seat

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,10 +449,13 @@ scenario docs should reference it rather than restating it:
 - Claude Opus
 - Gemini Pro
 
-The second seat may be **any** of these, including the model you authored the
-change with. Reviewing with your own model is explicitly allowed: the fixed seat
-already guarantees a second perspective, and refusing an otherwise-available
-reviewer cost more than it bought.
+**Strongly prefer a second seat from a different model family than the one that
+authored the change.** Two families fail differently, and an author reviewing
+its own work brings the same blind spot that produced the bug — the second seat
+exists for the perspective the first cannot have. Reuse of your own model is
+permitted rather than blocking, because the fixed seat already guarantees one
+independent perspective, but treat it as the fallback when no other roster
+reviewer is available, and say on the PR which case applied.
 
 **Use the highest version and quality level a model offers** in the second seat
 — given both Opus 4.8 and Opus 5, use Opus 5. The GPT-5.6 Sol seat is a

--- a/NIGHTSHIFT.md
+++ b/NIGHTSHIFT.md
@@ -96,11 +96,11 @@ theme into orders:
 
 ## How this composes with the repo's review gate
 
-`AGENTS.md` sets the repo's review policy: how much adversarial review a change needs scales with its
-triviality and risk — from none for a trivial change, to a single review, to two reviews from two
-different models for a high-risk one. **Nightshift is the stricter bar and it governs the shift:** a
-Nightshift **order** does **not** take the reduced tiers — **every order clears the two-clean gate on
-its final head**, two clean reviews from two different models, regardless of how small the order looks.
+`AGENTS.md` sets the repo's review policy: trivial changes need none; every other change gets the
+standard round with GPT-5.6 Sol and one other roster reviewer. **Nightshift is the stricter bar and it
+governs the shift:** a Nightshift **order** does **not** take the trivial exception — **every order
+clears the two-clean gate on its final head**, two clean reviews from two different models, regardless
+of how small the order looks.
 Scale the review *effort* to the blast radius, but never waive the two-clean bar itself. Keep the
 repo's readiness convention: when all merge-blocking validation and required review are complete, the
 clearance note is `Ready to merge`.

--- a/agents/ladder-tester.md
+++ b/agents/ladder-tester.md
@@ -37,8 +37,8 @@ switching from tester to implementer.
 ## Review
 
 Ladder PRs that add or change fixture/corpus coverage, guards, success bars, or
-rung-completion claims need adversarial review before merge (the reviewers the
-AGENTS.md "Adversarial review" tier table requires).
+rung-completion claims are non-trivial for review-policy purposes and need the
+AGENTS.md "Adversarial review" tier table's standard round before merge.
 The review should try to falsify the rung bar and guard: missing constructs,
 too-weak success criteria, unguarded regression paths, and over-broad completion
 claims.

--- a/agents/ladder-tester.md
+++ b/agents/ladder-tester.md
@@ -37,8 +37,8 @@ switching from tester to implementer.
 ## Review
 
 Ladder PRs that add or change fixture/corpus coverage, guards, success bars, or
-rung-completion claims need cross-model adversarial review before merge (two
-reviewers from the AGENTS.md "Adversarial Review" roster, never your own model).
+rung-completion claims need adversarial review before merge (the reviewers the
+AGENTS.md "Adversarial review" tier table requires).
 The review should try to falsify the rung bar and guard: missing constructs,
 too-weak success criteria, unguarded regression paths, and over-broad completion
 claims.

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -531,10 +531,9 @@ Report:
 4. per-method delta artifact;
 5. changed-method fidelity result, or a clear statement that changed methods are
    not currently checkable;
-6. cross-model adversarial review summary with resolution commit links (two
-   reviewers from the AGENTS.md
-   [Adversarial Review](../AGENTS.md#adversarial-review) roster, never your own
-   model).
+6. adversarial review summary with resolution commit links, staffed according
+   to the AGENTS.md
+   [Adversarial Review](../AGENTS.md#adversarial-review) tier table.
 
 For #1175-class retained-label work, the changed-method population must include
 the forward-merge / structuring-residual methods the PR changes. A green global

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -325,9 +325,8 @@ milestone.
 Use a separate **Decompiler Adversarial Reviewer** role when the concern is not
 "is the queue metadata honest?" but "is this raise actually sound?" The curator
 keeps the map current; the adversarial reviewer tries to falsify the map's
-claims. Pick two reviewers from the model roster in the AGENTS.md
-[Adversarial Review](../AGENTS.md#adversarial-review) section, never your own
-model.
+claims. Staff it with the reviewers the AGENTS.md
+[Adversarial review](../AGENTS.md#adversarial-review) tier table requires.
 
 This is different from simply "creating adversarial fixtures." A fixture is one
 artifact the review may produce; the role is the upstream proof audit that

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -97,8 +97,8 @@ pass as routine.
 ## Review inside a stack
 
 **Review depth is per-slice, by that slice's own risk**, not the stack's total
-size. A long stack does not make a trivial slice risky, and a small slice in a
-risky area still earns the two-reviewer tier.
+size. A long stack does not make a trivial slice non-trivial, and every
+non-trivial slice gets the standard review round.
 
 **A slice's head moves for reasons other than findings** — a restack, or a
 retarget after the parent lands. The fixed-head rule applies to those the same


### PR DESCRIPTION
## Conclusion

Three requested changes to the adversarial-review guidance in `AGENTS.md`, plus the consolidation they made possible. Documentation only — no product, test, or workflow file changes.

## The three changes

### 1. A fixed GPT-5.6 Sol seat, in every round

The tier table scaled reviewer *count* with risk. It no longer does:

| Before | After |
| --- | --- |
| Trivial → none | Trivial → none |
| Medium risk → one reviewer (GPT, highest available) | — |
| Higher risk → two reviewers, two different families | Everything else → **GPT-5.6 Sol**, always, plus one other roster reviewer |

The "higher risk means subtle correctness, security, or compatibility risk, or a large or uncertain blast radius" paragraph and the "if you are unsure which tier applies, escalate" instruction both go with it: with one non-trivial tier there is no longer a tier to be unsure about. The remaining judgement call — is this trivial? — keeps its escalation rule.

The GPT-5.6 Sol seat is written as a **deliberate pin**, explicitly not a "highest available version" slot, with a note saying to move it here when it should move. The existing "use the highest version and quality level a model offers" rule now governs the second seat only. Flagging this as the one part of the change that will go stale on its own: it names a specific version, by design, so it needs an edit when Sol is superseded rather than drifting silently.

### 2. The different-family requirement is removed

"In the two-reviewer tier, do not review with your own model when another listed family is available" is gone, replaced by an explicit permission, since a silent removal would read as an oversight to the next person:

> The second seat may be **any** of these, including the model you authored the change with.

This also collapses the harness paragraph. It previously had to explain what a single-vendor harness should do in each of two tiers and which family it was missing; now it runs the reviewer it has and requests the fixed seat from the user.

### 3. Clean reviews are not spent by main moving

New subsection. The settled-branch gate said to integrate `origin/main` before *every* round, including subsequent ones. When reviews are already clean, that now reverses: **stop and ask, do not integrate, do not open another round.**

The ask must carry an analysis of what landed — which commits touch files this change touches, which behavior it relies on that they alter, and any conflict a textual merge would resolve silently but wrongly — and the guidance says explicitly to state plainly when nothing in the range interacts, since that is the common case and the most useful answer. The user decides whether another round is warranted.

The rationale is recorded because the rule looks like a weakening and is not: on a busy `main` a round takes longer than the interval between commits, so reflexive integrate-and-re-review never converges, and each loop retracts a result that was already earned.

The `origin/main` bullet in the settled-branch gate now links forward to this subsection, so the two are not read in isolation.

## Consolidation

The section is read before every review, so length is a real cost. Net across `AGENTS.md` is **+17 lines while adding a ~20-line subsection**, so the rest is a net reduction:

- **Merged the two stacked-PR bullets.** "Every PR in a stack meets all of the above" and "Every slice in a stack must report CI" had drifted into overlapping after the base-branch filter was removed in #3731. 13 lines → 10, with no rule dropped.
- **Tightened the `gh pr checks` mechanics.** Every mechanic is kept — `--required` exiting non-zero when nothing is required, exit `0` vs exit `8`, `skipping` being terminal and not evidence — in fewer words.
- **Stopped two other documents restating the roster rule.** `docs/decompiler-quality.md` said "pick two reviewers from the model roster … never your own model" and `agents/ladder-tester.md` said "two reviewers … never your own model". Both now point at the tier table. Both would otherwise have contradicted this PR the moment it merged, which is the argument the roster section already makes for being the single source of truth.

## One addition beyond the request

The green bullet now records a hazard hit this week: `gh pr checks --watch` can return exit `0` against the **previous** head's run before the new one registers, so a push followed immediately by a watch can report stale green. It caught me on #3731, where the first watch reported run `30826236086` (head `0bbc770fe`) as green after I had already pushed `1786b9052`.

It is one clause in a bullet, in the gate it affects, but it is an addition rather than a consolidation — **say the word and I will drop it.**

## Non-action boundary

- **Nightshift is deliberately untouched.** `NIGHTSHIFT.md:103` and `.github/skills/nightshift/SKILL.md:87` still require "two clean reviews from two different models". `AGENTS.md` states that Nightshift is opt-in with its own stricter gates, and this requirement is strictly stricter, so it remains coherent. It is now the only place in the repository requiring family diversity — worth a decision, and I did not want to make it silently inside a PR about the default workflow.
- **Historical records left alone.** `docs/design/fact-planned-compile-back-harness.md` and `docs/design/type-spelling-identity-display.md` name the models that reviewed past work. Those are records of what happened, not guidance.
- **No change to what a round *is*, or to "Running the round".** Prompt contents, worktree isolation, reproduction-before-acting, and public reconciliation are all unchanged.
- **No change to the trivial tier**, which still requires stating why the change is trivial.

## Validation

- `npx markdownlint-cli AGENTS.md docs/decompiler-quality.md agents/ladder-tester.md` — clean.
- Verified the new intra-document link resolves: heading `### Clean reviews are not spent by main moving` → anchor `#clean-reviews-are-not-spent-by-main-moving`.
- Grepped the repository for surviving contradictions (`two different model`, `different-family`, `own model`, `Medium risk`, `Higher risk`): the only remaining hits are the intended new text and the Nightshift documents named above.

Documentation-only, making no measured behavior claim, so per `AGENTS.md` this needs Markdown validation rather than product builds or tests.

## Review

Not trivial — it changes the rule that governs how everything else in the repository gets reviewed — so it takes the standard tier: GPT-5.6 Sol plus one other. Under the policy this PR itself installs, that would be its own requirement; under the policy currently on `main` it is the two-reviewer tier. Same outcome either way.

Attack points for a reviewer: whether change 3 can be read as licence to skip integration before a *first* round (it should not be); whether removing the risk-tier row loses a distinction worth keeping; and whether the merged stacked-PR bullet dropped any rule from either original.
