### PR TITLE
Gate sweep SHA-256 hex validation

### DIFF
--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -1366,6 +1366,15 @@ static string? FindRepositoryRoot(string start)
     return null;
 }
 
+// Unverified, deliberately: no black-box input accepted by the sweep makes this
+// transform a value. IsBarePackageId refuses separators, and its one special-segment
+// spelling, "..", is rank-prefixed before this call. Pinned versions have passed
+// IsBareVersion, which refuses separators and ".."; resolved versions have already
+// survived PackageExtractor's path construction and cache-coordinate validation.
+// Measured for #3719: replacing this helper with identity leaves EvilPoolSweepGateTests
+// and EvilPoolPinTests green. Keep it as defense in depth behind those checks: both
+// sides guard the same path-traversal outcome, and sanitizing again is the cheap side
+// to be wrong on.
 static string SafePathSegment(string value)
 {
     var invalid = Path.GetInvalidFileNameChars().ToHashSet();

--- a/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
@@ -88,6 +88,8 @@ public class EvilPoolPinTests
                 pin => pin["packages"]![FirstIndexOf(pin, "pinned")]!["sha256"] = null),
             ("a pinned entry whose sha256 is not 64 lowercase hex", "sha",
                 pin => pin["packages"]![FirstIndexOf(pin, "pinned")]!["sha256"] = "NOTAHASH"),
+            ("a pinned entry whose sha256 is 64 non-hex characters", "sha",
+                pin => pin["packages"]![FirstIndexOf(pin, "pinned")]!["sha256"] = new string('z', 64)),
             ("a no-library entry carrying an assembly hash", "no-library-hash",
                 pin => pin["packages"]![FirstIndexOf(pin, "no-library")]!["sha256"] = new string('0', 64)),
             ("a status the sweep does not know", "status",


### PR DESCRIPTION
The sweep's lowercase-hex SHA-256 check now has a non-vacuous specimen, and the unreachable `SafePathSegment` defense explicitly records that it is unverified.

## Evidence

- Adds a 64-character non-hex pin alongside the existing wrong-length pin. Replacing `IsSha256` with its length check alone now fails on exactly that case.
- Records why accepted package IDs and versions cannot exercise `SafePathSegment`. Replacing the helper with identity leaves both relevant test classes green.

## Compatibility

No product behavior changes. `SafePathSegment` remains as defense in depth; only its coverage status is documented.

## Validation

`dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.EvilPoolPinTests -class ILInspector.Decompiler.Tests.EvilPoolSweepGateTests`

Closes #3719
