### PR TITLE
Rename the bound source line currency

### DIFF
--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -322,7 +322,7 @@ carried as structure:
   `ILInstructionText` from the `Metadata` disassembler as a `SourceLine` (text +
   IL offset) before joining, adopting the currency without pulling the
   decompiler-pipeline decoder into the raw view.
-- **`AnnotatedSourceLine(string Text, int Offset, SourceLineKind Kind,
+- **`BoundSourceLine(string Text, int Offset, SourceLineKind Kind,
   IReadOnlyList<Annotation> Annotations)`** — the interleave currency. It carries
   its annotations as *structure* (not baked into `Text`) so the merge printer has
   placement freedom, plus a `Kind`.
@@ -352,12 +352,12 @@ difference is the intermediate — a producer *filters* to one lane, Research
 *correlates* several — and **both end in the same currency**: an ordered line
 stream that a dumb printer renders to text. The interleave is the landed instance —
 `ResearchViews.CorrelateMixedSource` folds the C# body, its statement-line map, the
-annotations, and the IL lines into one ordered `AnnotatedSourceLine` stream (owning
+annotations, and the IL lines into one ordered `BoundSourceLine` stream (owning
 the range-containment bucketing), and `RenderMixedStream` frames each line by
 `Kind`, reading indent straight from the C# line's leading whitespace. The
 cost/semantics/annotated-source **overlays** are the degenerate single-medium case
 of the same join: `ResearchViews.CorrelateOverlay` anchors the fact groups onto
-their printed C# lines and emits a C#-only `AnnotatedSourceLine` stream (empty IL
+their printed C# lines and emits a C#-only `BoundSourceLine` stream (empty IL
 operand), which `RenderOverlayStream` renders by splicing a trailing `// …` comment
 onto each annotated line — the same `correlate → render` shape as the interleave,
 one medium instead of two. Three

--- a/src/ILInspector.Decompiler/SourceLine.cs
+++ b/src/ILInspector.Decompiler/SourceLine.cs
@@ -32,7 +32,7 @@ public readonly record struct SourceLine(string Text, int Offset);
 
 /// <summary>
 /// Rich line currency for the correlation layer: an ordered
-/// <see cref="AnnotatedSourceLine"/> stream is the interleave substrate. Each line
+/// <see cref="BoundSourceLine"/> stream is the interleave substrate. Each line
 /// carries its bare <paramref name="Text"/>, an anchoring IL <paramref name="Offset"/>
 /// (<c>-1</c> when unanchored), its <paramref name="Kind"/>
 /// (<see cref="SourceLineKind.CSharp"/> vs <see cref="SourceLineKind.Il"/> — the one
@@ -46,14 +46,14 @@ public readonly record struct SourceLine(string Text, int Offset);
 /// <see cref="Offset"/> keeps each line addressable for diff, body subset, and the
 /// mixed IL+C# view.
 /// </summary>
-public sealed record AnnotatedSourceLine(
+public sealed record BoundSourceLine(
     string Text,
     int Offset,
     SourceLineKind Kind,
     IReadOnlyList<IAnnotation> Annotations)
 {
     /// <summary>A line with no annotations attached.</summary>
-    public AnnotatedSourceLine(string Text, int Offset, SourceLineKind Kind)
+    public BoundSourceLine(string Text, int Offset, SourceLineKind Kind)
         : this(Text, Offset, Kind, [])
     {
     }

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -298,12 +298,12 @@ public static partial class ResearchViews
 
     // The correlation layer: fold the printed C# body, its statement-line map, the
     // resolved annotations, and the IL instruction lines into one ordered
-    // AnnotatedSourceLine stream. The range containment (Best over statement spans)
+    // BoundSourceLine stream. The range containment (Best over statement spans)
     // and the offset -> line bucketing live here, in the producer, so the printer
     // stays dumb. C# lines carry their resolved annotations as structure (the
     // printer bakes the trailing "// ..." comment); IL lines carry their offset and
     // already fact-annotated text.
-    static IReadOnlyList<AnnotatedSourceLine> CorrelateMixedSource(
+    static IReadOnlyList<BoundSourceLine> CorrelateMixedSource(
         IrFunction imported,
         string csText,
         PrintedRangeMap printedRanges,
@@ -350,18 +350,18 @@ public static partial class ResearchViews
         }
 
         var csLines = RenderCSharpBodyLines(csText, printedRanges);
-        var stream = new List<AnnotatedSourceLine>(csLines.Count);
+        var stream = new List<BoundSourceLine>(csLines.Count);
         for (int i = 0; i < csLines.Count; i++)
         {
             if (ilBeforeLine.TryGetValue(i, out var preamble))
                 foreach (var (offset, text) in preamble)
-                    stream.Add(new AnnotatedSourceLine(text, offset, SourceLineKind.Il));
+                    stream.Add(new BoundSourceLine(text, offset, SourceLineKind.Il));
 
             var csLine = csLines[i];
             var lineAnnotations = annotationsByLine.TryGetValue(i, out var annos)
                 ? (IReadOnlyList<IAnnotation>)annos
                 : [];
-            stream.Add(new AnnotatedSourceLine(
+            stream.Add(new BoundSourceLine(
                 csLine.Text,
                 csLine.Offset,
                 SourceLineKind.CSharp,
@@ -369,7 +369,7 @@ public static partial class ResearchViews
 
             if (ilByLine.TryGetValue(i, out var ils))
                 foreach (var (offset, text) in ils)
-                    stream.Add(new AnnotatedSourceLine(text, offset, SourceLineKind.Il));
+                    stream.Add(new BoundSourceLine(text, offset, SourceLineKind.Il));
         }
         return stream;
     }
@@ -377,7 +377,7 @@ public static partial class ResearchViews
     // The scalar fast path: project a printed C# body into offset-anchored lines.
     // Each SourceLine carries its trimmed text and the smallest source offset among
     // the statements that start on it (-1 when the line owns no statement, e.g. a
-    // brace or blank). The correlation layer builds its richer AnnotatedSourceLine
+    // brace or blank). The correlation layer builds its richer BoundSourceLine
     // stream on top of this, and scalar "just give me the body" consumers can take
     // it directly for line-addressable diff and body-subset anchoring.
     static IReadOnlyList<SourceLine> RenderCSharpBodyLines(
@@ -412,7 +412,7 @@ public static partial class ResearchViews
     // as "// ..." comments indented under the preceding C# line, reading the indent
     // straight from that line's leading whitespace.
     static string RenderMixedStream(
-        IReadOnlyList<AnnotatedSourceLine> stream,
+        IReadOnlyList<BoundSourceLine> stream,
         AnnotationGestureSelector gestures,
         IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null)
     {
@@ -502,12 +502,12 @@ public static partial class ResearchViews
     }
 
     // The C#-only correlation: anchor each annotation group to its printed C# line
-    // and emit an ordered AnnotatedSourceLine stream (Kind=CSharp, no IL). This is
+    // and emit an ordered BoundSourceLine stream (Kind=CSharp, no IL). This is
     // the degenerate single-medium case of CorrelateMixedSource — same currency and
     // shape, with an empty IL operand — so the overlay views (cost, semantics,
     // annotated source) flow through the same produce -> print pipeline as the
     // interleave instead of splicing comments into a raw string.
-    static IReadOnlyList<AnnotatedSourceLine> CorrelateOverlay(
+    static IReadOnlyList<BoundSourceLine> CorrelateOverlay(
         IrFunction raised,
         string output,
         PrintedRangeMap printedRanges,
@@ -535,9 +535,9 @@ public static partial class ResearchViews
         }
 
         var textLines = output.Replace("\r\n", "\n").Split('\n');
-        var stream = new List<AnnotatedSourceLine>(textLines.Length);
+        var stream = new List<BoundSourceLine>(textLines.Length);
         for (int i = 0; i < textLines.Length; i++)
-            stream.Add(new AnnotatedSourceLine(
+            stream.Add(new BoundSourceLine(
                 textLines[i],
                 lineOffsets.GetValueOrDefault(i, -1),
                 SourceLineKind.CSharp,
@@ -553,7 +553,7 @@ public static partial class ResearchViews
     // for byte (no split/rejoin normalization).
     static string RenderOverlayStream(
         string output,
-        IReadOnlyList<AnnotatedSourceLine> stream,
+        IReadOnlyList<BoundSourceLine> stream,
         AnnotationGestureSelector gestures,
         IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null)
     {


### PR DESCRIPTION
## Summary

Rename the correlation layer's `AnnotatedSourceLine` to `BoundSourceLine`.

This frees `AnnotatedSourceLine` for the later portable consumer-facing line
contract while making the existing type's role explicit: it is bound to the
producer's IL offsets, source medium, and internal `IAnnotation` values.

## Scope

This PR intentionally lands alone. It is a mechanical rename only:

- record shape and constructors are unchanged
- all Research correlation and rendering call sites use `BoundSourceLine`
- the owning design note uses the new name
- no `AnnotatedSourceLine` reference remains

Keeping this separate matters because the three-argument construction in
`ResearchViews` would compile against either the old bound type or the future
portable type, despite those types having different mobility semantics. A
combined rename and portable-model change could therefore compile cleanly
against the wrong type.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`: succeeds
- `ILInspector.Research.Tests`: 132 passed
- `markdownlint`: clean

## Review tier

Trivial; no adversarial review. This is a closed-world identifier rename with no
behavior, shape, serialization, or accessibility change. Compilation catches
missed code references, and repository-wide search confirms the old identifier
is absent.

Part of #3570.
