### PR TITLE
Own Roslyn lambda cache fields in the compiler-generated correspondence

### DIFF
--- a/src/ILInspector.Instructions.Tests/CompilerGeneratedOrdinalTests.cs
+++ b/src/ILInspector.Instructions.Tests/CompilerGeneratedOrdinalTests.cs
@@ -1943,6 +1943,77 @@ public class CompilerGeneratedOrdinalTests
         Assert.Equal(IlBodyDiffOutcome.Exact, Compare(oldPe, newPe, IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).Outcome);
         Assert.Equal(IlBodyDiffOutcome.OperandDiff, Compare(oldPe, newPe, ComposedNormalization).Outcome);
     }
+
+    /// <summary>
+    /// The name a folded cache field is spelled with cannot be forged by a field that is
+    /// simply named that way in metadata.
+    /// </summary>
+    /// <remarks>
+    /// The composed name is substituted into the compared operand text, so it shares a
+    /// namespace with every raw name that text can carry. Before this was separated with
+    /// <c>KeySeparator</c> the composition was plain concatenation, so a field literally
+    /// named <c>&lt;&gt;9__&lt;Run&gt;b__0_0</c> rendered identically to the surrogate
+    /// built for <c>&lt;&gt;9__0_0</c> whose sibling is <c>&lt;Run&gt;b__0_0</c>, and two
+    /// assemblies that differ reported <c>Exact</c>. Roslyn does not emit such a name;
+    /// this file's contract is that hostile metadata cannot manufacture a false
+    /// <c>Exact</c> either.
+    /// </remarks>
+    [Fact]
+    public void LambdaCacheFieldName_CannotBeForgedByARawFieldName()
+    {
+        byte[] oldImage = BuildImage(
+            "Probe",
+            [new Member("Keep", CompilerGenerated: false)],
+            generatedTypes: ["<>c"],
+            generatedTypeMethodNames: ["<Run>b__0_0"],
+            generatedTypeFieldNames: ["<>9__0_0"]);
+        byte[] newImage = BuildImage(
+            "Probe",
+            [new Member("Keep", CompilerGenerated: false)],
+            generatedTypes: ["<>c"],
+            generatedTypeMethodNames: ["<Other>b__9_0"],
+            generatedTypeFieldNames: ["<>9__<Run>b__0_0"]);
+
+        Assert.Equal(["<>9__0_0"], ReadFieldNames(oldImage, "<>c"));
+        Assert.Equal(["<>9__<Run>b__0_0"], ReadFieldNames(newImage, "<>c"));
+
+        using var oldPe = new PEReader(new MemoryStream(oldImage));
+        using var newPe = new PEReader(new MemoryStream(newImage));
+
+        Assert.Equal(IlBodyDiffOutcome.OperandDiff, Compare(oldPe, newPe, IlBodyDiffNormalization.None).Outcome);
+        Assert.Equal(IlBodyDiffOutcome.OperandDiff, Compare(oldPe, newPe, ComposedNormalization).Outcome);
+    }
+
+    /// <summary>
+    /// A recognized cache field that the correspondence does not own still must not fall
+    /// through to the per-side rewrite.
+    /// </summary>
+    /// <remarks>
+    /// This is the gate named by <c>FieldNameOutsideCorrespondence</c>, and it exists
+    /// because the gate previously named there could not see this path at all: reducing
+    /// that function to <c>NormalizeMemberName</c> left the whole suite green. The type
+    /// here carries no generated attribute, so the field never enters the correspondence
+    /// and the outside path is the only thing standing between two different containing
+    /// methods' slots and a common <c>&lt;&gt;9__#_0</c>.
+    /// </remarks>
+    [Fact]
+    public void DeclinedLambdaCacheField_StaysOutOfThePerSideRewrite()
+    {
+        byte[] Image(string method, string field) => BuildImage(
+            "Probe",
+            [new Member("Keep", CompilerGenerated: false)],
+            generatedTypes: ["<>c"],
+            typesAttributed: false,
+            generatedTypeMethodNames: [method],
+            generatedTypeFieldNames: [field]);
+
+        using var oldPe = new PEReader(new MemoryStream(Image("<Run>b__0_0", "<>9__0_0")));
+        using var newPe = new PEReader(new MemoryStream(Image("<Run>b__4_0", "<>9__4_0")));
+
+        Assert.Equal(IlBodyDiffOutcome.OperandDiff, Compare(oldPe, newPe, IlBodyDiffNormalization.None).Outcome);
+        Assert.Equal(IlBodyDiffOutcome.Exact, Compare(oldPe, newPe, IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).Outcome);
+        Assert.Equal(IlBodyDiffOutcome.OperandDiff, Compare(oldPe, newPe, ComposedNormalization).Outcome);
+    }
     readonly record struct Member(
         string Name,
         bool CompilerGenerated,

--- a/src/ILInspector.Instructions.Tests/CompilerGeneratedOrdinalTests.cs
+++ b/src/ILInspector.Instructions.Tests/CompilerGeneratedOrdinalTests.cs
@@ -212,6 +212,13 @@ public class CompilerGeneratedOrdinalTests
     /// The negative cases pin that depth matching did not widen ownership: the
     /// <c>&lt;&gt;</c>-prefixed anonymous shapes still report a closing angle of 1 and
     /// stay disowned, which is what keeps unrelated closures from merging.
+    ///
+    /// The lambda cache field <c>&lt;&gt;9__N_K</c> is the one <c>&lt;&gt;</c>-prefixed
+    /// shape this correspondence does own, and it is owned on a different basis: not on
+    /// its own name, which carries no containing method and would merge unrelated
+    /// closures exactly as the others would, but through the sibling lambda method it
+    /// pairs with. Ownership here is what keeps the per-side rewrite off it; the fold
+    /// itself is decided in the field loop.
     /// </summary>
     [Fact]
     public void GeneratedNameWhoseContainingNameIsItselfGenerated_IsStillOwned()
@@ -227,9 +234,16 @@ public class CompilerGeneratedOrdinalTests
         // Unchanged by depth matching: the anonymous shapes stay disowned. Asked under
         // `Any`, which is the weakest refusal available, so these also pin that the
         // entity-kind split did not widen ownership anywhere.
-        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any));
         Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>c__DisplayClass1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any));
         Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>c", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any));
+
+        // The lambda cache field is owned under `Any` so the per-side rewrite keeps off
+        // it, and under `Field` so the field loop's grammar check agrees with the guard.
+        // It stays disowned under `Method` and `Type`, the kinds Roslyn never emits it on.
+        Assert.NotNull(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any));
+        Assert.NotNull(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Field));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Method));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Type));
 
         // A containing name that never closes is not a form at all.
         Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<<Run>g__Local|0_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any));
@@ -1633,6 +1647,302 @@ public class CompilerGeneratedOrdinalTests
         }
         throw new InvalidOperationException($"no method named {name}");
     }
+
+    /// <summary>
+    /// The premise the whole cache-field fold rests on: Roslyn emits <c>&lt;&gt;9__N_K</c>
+    /// in lockstep with <c>&lt;Name&gt;b__N_K</c> on the same type, so every cache field
+    /// has exactly one sibling lambda method and vice versa.
+    /// </summary>
+    /// <remarks>
+    /// The names below are not invented. They are the complete generated membership of
+    /// <c>&lt;&gt;c</c> from a Release build of a class whose seven methods between them
+    /// cover plain lambdas, several lambdas in one method, an overload pair, a capturing
+    /// lambda, an async method and a nested lambda. Eight fields, eight methods, and the
+    /// tails match one for one with nothing left over on either side.
+    /// <para>
+    /// Also present on <c>&lt;&gt;c</c> in that build, and deliberately in the negative
+    /// list here, is the singleton <c>&lt;&gt;9</c>. The capturing and async cases put
+    /// their lambdas on <c>&lt;&gt;c__DisplayClassN_K</c> and <c>&lt;M&gt;d__N</c>
+    /// instead, where the lambda method is named <c>&lt;Name&gt;b__K</c> with no scope
+    /// ordinal and no cache field is emitted at all -- so those never reach this pairing.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void LambdaCacheFields_PairOneToOneWithTheirLambdaMethods()
+    {
+        string[] fields =
+        [
+            "<>9__0_0", "<>9__0_1", "<>9__0_2", "<>9__1_0",
+            "<>9__3_0", "<>9__5_0", "<>9__6_1", "<>9__6_0",
+        ];
+        string[] methods =
+        [
+            "<Run>b__0_0", "<Run>b__0_1", "<Run>b__0_2", "<Other>b__1_0",
+            "<Overload>b__3_0", "<AsyncOne>b__5_0", "<Nested>b__6_0", "<Nested>b__6_1",
+        ];
+
+        var fieldTails = fields
+            .Select(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail)
+            .ToList();
+        var methodTails = methods
+            .Select(CompilerGeneratedOrdinalCorrespondence.TryLambdaMethodTail)
+            .ToList();
+
+        Assert.All(fieldTails, Assert.NotNull);
+        Assert.All(methodTails, Assert.NotNull);
+        Assert.Equal(fieldTails.Count, fieldTails.Distinct().Count());
+        Assert.Equal(methodTails.Count, methodTails.Distinct().Count());
+        Assert.Equal(methodTails.Order(), fieldTails.Order());
+    }
+
+    /// <summary>
+    /// The other generated fields Roslyn puts on these types are not cache fields, and
+    /// eliding their ordinals would be wrong: <c>&lt;&gt;u__N</c> numbers a real awaiter
+    /// slot, and none of them has a sibling method to take a name from.
+    /// </summary>
+    [Fact]
+    public void NeighbouringGeneratedFields_AreNotMistakenForLambdaCaches()
+    {
+        // Observed on <>c and on <M>d__N in the same build as the pairing test above.
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>9"));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>1__state"));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>t__builder"));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>u__1"));
+
+        // Shapes the grammar must refuse rather than half-parse.
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>9__"));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>9__0"));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>9__0_"));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>9___0"));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>9__00_0"));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<>9__0_0_0"));
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail("<Run>b__0_0"));
+    }
+
+    /// <summary>
+    /// The behavioral claim: a cache field whose scope ordinal shifted folds, because its
+    /// sibling lambda method establishes that the two denote the same closure slot.
+    /// </summary>
+    [Fact]
+    public void LambdaCacheFieldWhoseScopeOrdinalShifted_Folds()
+    {
+        Assert.Equal(IlBodyDiffOutcome.Exact, CompareCacheField(
+            oldMethod: "<Run>b__0_0", oldField: "<>9__0_0",
+            newMethod: "<Run>b__4_0", newField: "<>9__4_0").Outcome);
+    }
+
+    /// <summary>
+    /// The slot ordinal <c>K</c> is evidence and is preserved, so two cache slots of the
+    /// same containing method stay apart.
+    /// </summary>
+    [Fact]
+    public void LambdaCacheFieldsDifferingInSlot_DoNotFold()
+    {
+        Assert.Equal(IlBodyDiffOutcome.OperandDiff, CompareCacheField(
+            oldMethod: "<Run>b__0_0", oldField: "<>9__0_0",
+            newMethod: "<Run>b__0_1", newField: "<>9__0_1").Outcome);
+    }
+
+    /// <summary>
+    /// The point of pairing rather than folding the field on its own name. Both sides
+    /// spell the field <c>&lt;&gt;9__0_0</c>, so the per-side rewrite's <c>&lt;&gt;9__#_0</c>
+    /// key cannot tell them apart -- but they cache lambdas of different containing
+    /// methods, and the sibling supplies exactly that discriminator.
+    /// </summary>
+    [Fact]
+    public void LambdaCacheFieldsOfDifferentContainingMethods_DoNotFold()
+    {
+        Assert.Equal(IlBodyDiffOutcome.OperandDiff, CompareCacheField(
+            oldMethod: "<Run>b__0_0", oldField: "<>9__0_0",
+            newMethod: "<Other>b__0_0", newField: "<>9__0_0").Outcome);
+    }
+
+    /// <summary>
+    /// A cache field pairs only within its own type. Sharing the sibling map across types
+    /// would let a field borrow an unrelated type's lambda method, which is the field
+    /// analogue of the declaring-type mark leak.
+    /// </summary>
+    [Fact]
+    public void LambdaCacheFields_DoNotPairAcrossTypes()
+    {
+        // Sibling is indexed *before* Holder on purpose. With the type order reversed the
+        // test passes whether or not the map is per type, because the sibling method has
+        // not been seen yet when the field is reached -- a vacuous pass this fixture was
+        // rewritten to avoid after the tamper failed to fail.
+        byte[] image = BuildImage(
+            "Probe",
+            [new Member("Keep", CompilerGenerated: false)],
+            generatedTypes: ["Sibling", "Holder"],
+            generatedTypeMethodNames: ["<Run>b__0_0", "M"],
+            generatedTypeFieldNames: ["<>9__0_0"],
+            fieldsOnGeneratedTypeIndex: 1);
+
+        using var pe = new PEReader(new MemoryStream(image));
+        var reader = pe.GetMetadataReader();
+
+        // The fixture presents the case: the field is on Holder, the only lambda method
+        // is on Sibling, and the tails would otherwise match.
+        Assert.Equal("<>9__0_0", Assert.Single(ReadFieldNames(image, "Holder")));
+        Assert.Equal("<Run>b__0_0", Assert.Single(ReadMethodNames(image, "Sibling")));
+
+        var (side, _) = CompilerGeneratedOrdinalCorrespondence.Build(reader, reader);
+        Assert.False(side.TryGetFieldName(FieldNamed(reader, "<>9__0_0"), out _));
+    }
+
+    /// <summary>
+    /// Ownership is what keeps the per-side rewrite off a cache field the correspondence
+    /// declined to fold. Without it the rewrite folds <c>&lt;&gt;9__N_K</c> on the
+    /// containing-method-blind <c>&lt;&gt;9__#_K</c> key and reports Exact for the two
+    /// unrelated closures of
+    /// <see cref="LambdaCacheFieldsOfDifferentContainingMethods_DoNotFold"/>.
+    /// </summary>
+    [Fact]
+    public void LambdaCacheFields_AreNotLeftToThePerSideRewrite()
+    {
+        Assert.True(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal(
+            "<>9__1_0",
+            CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any) is not null);
+
+        // The rewrite alone does fold them -- which is the behavior being kept away from
+        // the composed contract, not a defect of the rewrite on its own terms.
+        Assert.Equal(IlBodyDiffOutcome.Exact, CompareCacheField(
+            oldMethod: "<Run>b__0_0", oldField: "<>9__0_0",
+            newMethod: "<Other>b__0_0", newField: "<>9__0_0",
+            normalization: IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).Outcome);
+    }
+
+    static IlBodyDiffResult CompareCacheField(
+        string oldMethod,
+        string oldField,
+        string newMethod,
+        string newField,
+        IlBodyDiffNormalization normalization = ComposedNormalization)
+    {
+        byte[] o = BuildImage("Probe", [new Member("Keep", CompilerGenerated: false)],
+            generatedTypes: ["<>c"], generatedTypeMethodNames: [oldMethod],
+            generatedTypeFieldNames: [oldField]);
+        byte[] n = BuildImage("Probe", [new Member("Keep", CompilerGenerated: false)],
+            generatedTypes: ["<>c"], generatedTypeMethodNames: [newMethod],
+            generatedTypeFieldNames: [newField]);
+        using var oldPe = new PEReader(new MemoryStream(o));
+        using var newPe = new PEReader(new MemoryStream(n));
+        return Compare(oldPe, newPe, normalization);
+    }
+
+    const IlBodyDiffNormalization ComposedNormalization =
+        IlBodyDiffNormalization.NormalizeVariableLayout
+        | IlBodyDiffNormalization.NormalizeCurrentAssemblyScope
+        | IlBodyDiffNormalization.NormalizePlatformAssemblyScope
+        | IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals
+        | IlBodyDiffNormalization.NormalizeCompilerGeneratedOrdinals;
+
+    static FieldDefinitionHandle FieldNamed(MetadataReader reader, string name)
+    {
+        foreach (var handle in reader.FieldDefinitions)
+        {
+            if (reader.GetString(reader.GetFieldDefinition(handle).Name) == name)
+                return handle;
+        }
+        throw new InvalidOperationException($"no field named {name}");
+    }
+
+    static List<string> ReadFieldNames(byte[] image, string typeName)
+    {
+        using var pe = new PEReader(new MemoryStream(image));
+        var reader = pe.GetMetadataReader();
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(handle);
+            if (reader.GetString(type.Name) != typeName)
+                continue;
+            return type.GetFields()
+                .Select(f => reader.GetString(reader.GetFieldDefinition(f).Name))
+                .ToList();
+        }
+        throw new InvalidOperationException($"no type named {typeName}");
+    }
+
+    /// <summary>
+    /// The field analogue of the defect slice 1 fixed for methods, and the case the
+    /// per-side rewrite gets wrong. Two overloads share a containing name, so their
+    /// lambdas <c>&lt;Overload&gt;b__2_0</c> and <c>&lt;Overload&gt;b__3_0</c> differ only
+    /// in the scope ordinal, and their cache fields <c>&lt;&gt;9__2_0</c> and
+    /// <c>&lt;&gt;9__3_0</c> differ only there too. Eliding that ordinal on either name
+    /// alone merges the two overloads' caches.
+    /// </summary>
+    /// <remarks>
+    /// The correspondence gets this right without a rule of its own: the two sibling
+    /// methods collide on one key, so the method path finds them ambiguous and folds
+    /// neither, and each field is then named for its sibling's <em>raw</em> name, which
+    /// still tells the two apart. The safety is inherited rather than re-derived, which
+    /// is the point of naming a field for whatever its sibling resolved to.
+    /// </remarks>
+    [Fact]
+    public void LambdaCacheFieldsOfTwoOverloads_StayApart()
+    {
+        byte[] image = BuildImage(
+            "Probe",
+            [new Member("Keep", CompilerGenerated: false)],
+            generatedTypes: ["<>c"],
+            generatedTypeMethodNames: ["<Overload>b__2_0"],
+            firstGeneratedTypeExtraMethods: ["<Overload>b__3_0"],
+            generatedTypeFieldNames: ["<>9__2_0", "<>9__3_0"]);
+
+        using var pe = new PEReader(new MemoryStream(image));
+        var reader = pe.GetMetadataReader();
+
+        // The fixture presents the case: both lambdas and both caches on one type.
+        Assert.Equal(
+            ["<Overload>b__2_0", "<Overload>b__3_0"],
+            ReadMethodNames(image, "<>c").Order());
+        Assert.Equal(
+            ["<>9__2_0", "<>9__3_0"],
+            ReadFieldNames(image, "<>c").Order());
+
+        var (side, _) = CompilerGeneratedOrdinalCorrespondence.Build(reader, reader);
+
+        // Neither sibling folds -- they collide on one key -- so neither cache may be
+        // given a name that loses the ordinal telling the overloads apart.
+        Assert.False(side.TryGetMethodName(MethodNamed(reader, "<Overload>b__2_0"), out _));
+        Assert.False(side.TryGetMethodName(MethodNamed(reader, "<Overload>b__3_0"), out _));
+
+        Assert.True(side.TryGetFieldName(FieldNamed(reader, "<>9__2_0"), out string first));
+        Assert.True(side.TryGetFieldName(FieldNamed(reader, "<>9__3_0"), out string second));
+        Assert.NotEqual(first, second);
+        Assert.DoesNotContain(CompilerGeneratedOrdinalCorrespondence.OrdinalPlaceholder, first);
+        Assert.DoesNotContain(CompilerGeneratedOrdinalCorrespondence.OrdinalPlaceholder, second);
+    }
+
+    /// <summary>
+    /// The behavioral claim of this slice, end to end: a body caching one overload's
+    /// lambda and a body caching the other's stop reporting <c>Exact</c>.
+    /// </summary>
+    /// <remarks>
+    /// The <c>rewriteOnly</c> assertion is what ships on main for these fields, and it is
+    /// the defect: the per-side rewrite folds <c>&lt;&gt;9__2_0</c> and
+    /// <c>&lt;&gt;9__3_0</c> to a common <c>&lt;&gt;9__#_0</c> with no two-sided evidence,
+    /// so two different overloads' caches compare equal. It is asserted rather than
+    /// merely described so that the improvement is pinned against a measured baseline
+    /// instead of a remembered one.
+    /// </remarks>
+    [Fact]
+    public void OverloadCacheFields_StopReportingExactUnderTheCorrespondence()
+    {
+        byte[] Image(string[] fields) => BuildImage(
+            "Probe",
+            [new Member("Keep", CompilerGenerated: false)],
+            generatedTypes: ["<>c"],
+            generatedTypeMethodNames: ["<Overload>b__2_0"],
+            firstGeneratedTypeExtraMethods: ["<Overload>b__3_0"],
+            generatedTypeFieldNames: fields);
+
+        using var oldPe = new PEReader(new MemoryStream(Image(["<>9__2_0", "<>9__3_0"])));
+        using var newPe = new PEReader(new MemoryStream(Image(["<>9__3_0", "<>9__2_0"])));
+
+        Assert.Equal(IlBodyDiffOutcome.OperandDiff, Compare(oldPe, newPe, IlBodyDiffNormalization.None).Outcome);
+        Assert.Equal(IlBodyDiffOutcome.Exact, Compare(oldPe, newPe, IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).Outcome);
+        Assert.Equal(IlBodyDiffOutcome.OperandDiff, Compare(oldPe, newPe, ComposedNormalization).Outcome);
+    }
     readonly record struct Member(
         string Name,
         bool CompilerGenerated,
@@ -1769,7 +2079,10 @@ public class CompilerGeneratedOrdinalTests
         GenericParameterAttributes? declaringTypeConstraint = null,
         bool declaringTypeAttributed = false,
         string? corruptAttributeOnType = null,
-        string[]? generatedTypeMethodNames = null)
+        string[]? generatedTypeMethodNames = null,
+        string[]? generatedTypeFieldNames = null,
+        int fieldsOnGeneratedTypeIndex = 0,
+        string[]? firstGeneratedTypeExtraMethods = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -1818,6 +2131,23 @@ public class CompilerGeneratedOrdinalTests
             ? default
             : AttributeCtor("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
 
+        string[] extraFirstMethods = firstGeneratedTypeExtraMethods ?? [];
+        var fieldSignature = metadata.GetOrAddBlob(new byte[] { 0x06, 0x08 });
+        string[] extraFields = generatedTypeFieldNames ?? [];
+        var extraFieldHandles = new List<FieldDefinitionHandle>();
+        foreach (string fieldName in extraFields)
+        {
+            extraFieldHandles.Add(metadata.AddFieldDefinition(
+                FieldAttributes.Public | FieldAttributes.Static,
+                metadata.GetOrAddString(fieldName),
+                fieldSignature));
+        }
+
+        // Every type before the first generated one starts its FieldList at row 1 and so
+        // owns an empty range, because the range runs to the next type's start. The first
+        // generated type owns rows 1..K; every type after it starts at K+1.
+        var afterFields = MetadataTokens.FieldDefinitionHandle(extraFields.Length + 1);
+
         metadata.AddTypeDefinition(
             TypeAttributes.NotPublic,
             default,
@@ -1833,8 +2163,10 @@ public class CompilerGeneratedOrdinalTests
             MetadataTokens.FieldDefinitionHandle(1),
             MetadataTokens.MethodDefinitionHandle(1));
 
-        // Each generated type owns exactly one method, laid out after the caller and the
-        // members so the MethodList ranges stay contiguous and ascending.
+        // Each generated type owns one method, except the first, which may own further
+        // methods so a fixture can put two lambdas on one type. Rows are laid out after
+        // the caller and the members so the MethodList ranges stay contiguous and
+        // ascending, and each type's start is the running total of what precedes it.
         // GenericParam rows are emitted in one sorted pass below rather than as their
         // owners are declared: the table is sorted by coded owner, and TypeDef and
         // MethodDef interleave under TypeOrMethodDef exactly as they do for
@@ -1854,8 +2186,9 @@ public class CompilerGeneratedOrdinalTests
                 default,
                 metadata.GetOrAddString(extraTypes[i]),
                 default,
-                MetadataTokens.FieldDefinitionHandle(1),
-                MetadataTokens.MethodDefinitionHandle(members.Length + 2 + i)));
+                i <= fieldsOnGeneratedTypeIndex ? MetadataTokens.FieldDefinitionHandle(1) : afterFields,
+                MetadataTokens.MethodDefinitionHandle(
+                    members.Length + 2 + i + (i == 0 ? 0 : extraFirstMethods.Length))));
 
             int arity = generatedTypeArities is { } arities && i < arities.Length ? arities[i] : 0;            for (int g = 0; g < arity; g++)
                 genericParameters.Add((generatedTypeHandles[i], g,
@@ -1876,8 +2209,9 @@ public class CompilerGeneratedOrdinalTests
                 metadata.GetOrAddString(localAttributeNamespace),
                 metadata.GetOrAddString(localAttributeName),
                 default,
-                MetadataTokens.FieldDefinitionHandle(1),
-                MetadataTokens.MethodDefinitionHandle(members.Length + 2 + extraTypes.Length));
+                afterFields,
+                MetadataTokens.MethodDefinitionHandle(
+                    members.Length + 2 + extraTypes.Length + extraFirstMethods.Length));
         }
 
         var signature = metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 });
@@ -1914,7 +2248,13 @@ public class CompilerGeneratedOrdinalTests
         // The first member is always method 2: method 1 is the caller emitted below.
         // With generated types present the caller instead targets the first such type's
         // method, so the rendered operand carries that type's name.
-        if (callReferenceNamed is not null)
+        if (extraFieldHandles.Count > 0)
+        {
+            caller.OpCode(ILOpCode.Ldsfld);
+            caller.Token(extraFieldHandles[0]);
+            caller.OpCode(ILOpCode.Pop);
+        }
+        else if (callReferenceNamed is not null)
             caller.Call(reference);
         else if (extraTypes.Length > 0)
             caller.Call(MetadataTokens.MethodDefinitionHandle(members.Length + 2));
@@ -1939,6 +2279,15 @@ public class CompilerGeneratedOrdinalTests
             var encoder = new InstructionEncoder(il, new ControlFlowBuilder());
             encoder.OpCode(ILOpCode.Ret);
             extraOffsets[i] = bodies.AddMethodBody(encoder);
+        }
+
+        var extraFirstOffsets = new int[extraFirstMethods.Length];
+        for (int i = 0; i < extraFirstMethods.Length; i++)
+        {
+            var il = new BlobBuilder();
+            var encoder = new InstructionEncoder(il, new ControlFlowBuilder());
+            encoder.OpCode(ILOpCode.Ret);
+            extraFirstOffsets[i] = bodies.AddMethodBody(encoder);
         }
 
         int localCtorOffset = -1;
@@ -1999,6 +2348,20 @@ public class CompilerGeneratedOrdinalTests
                 signature,
                 extraOffsets[extraIndex],
                 MetadataTokens.ParameterHandle(1));
+
+            if (extraIndex != 0)
+                continue;
+
+            for (int e = 0; e < extraFirstMethods.Length; e++)
+            {
+                metadata.AddMethodDefinition(
+                    MethodAttributes.Public | MethodAttributes.Static,
+                    MethodImplAttributes.IL,
+                    metadata.GetOrAddString(extraFirstMethods[e]),
+                    signature,
+                    extraFirstOffsets[e],
+                    MetadataTokens.ParameterHandle(1));
+            }
         }
 
         if (definesAttributeLocally)

--- a/src/ILInspector.Instructions.Tests/CompilerGeneratedOrdinalTests.cs
+++ b/src/ILInspector.Instructions.Tests/CompilerGeneratedOrdinalTests.cs
@@ -213,12 +213,11 @@ public class CompilerGeneratedOrdinalTests
     /// <c>&lt;&gt;</c>-prefixed anonymous shapes still report a closing angle of 1 and
     /// stay disowned, which is what keeps unrelated closures from merging.
     ///
-    /// The lambda cache field <c>&lt;&gt;9__N_K</c> is the one <c>&lt;&gt;</c>-prefixed
-    /// shape this correspondence does own, and it is owned on a different basis: not on
-    /// its own name, which carries no containing method and would merge unrelated
-    /// closures exactly as the others would, but through the sibling lambda method it
-    /// pairs with. Ownership here is what keeps the per-side rewrite off it; the fold
-    /// itself is decided in the field loop.
+    /// The lambda cache field <c>&lt;&gt;9__N_K</c> is folded by this correspondence,
+    /// but not owned by <c>TryElideOrdinal</c>: it carries no containing method, so
+    /// there is nothing here to elide. It folds through the sibling lambda method it
+    /// pairs with, decided in the field loop, and the per-side rewrite is kept off it
+    /// by <c>FieldNameOutsideCorrespondence</c>.
     /// </summary>
     [Fact]
     public void GeneratedNameWhoseContainingNameIsItselfGenerated_IsStillOwned()
@@ -237,11 +236,14 @@ public class CompilerGeneratedOrdinalTests
         Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>c__DisplayClass1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any));
         Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>c", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any));
 
-        // The lambda cache field is owned under `Any` so the per-side rewrite keeps off
-        // it, and under `Field` so the field loop's grammar check agrees with the guard.
-        // It stays disowned under `Method` and `Type`, the kinds Roslyn never emits it on.
-        Assert.NotNull(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any));
-        Assert.NotNull(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Field));
+        // The lambda cache field stays disowned here on every kind, including `Any`.
+        // It is the one form this correspondence folds without owning it in this
+        // function: its name carries no containing method, so `TryElideOrdinal` has
+        // nothing to elide, and the field path keeps the per-side rewrite off it
+        // directly in FieldNameOutsideCorrespondence rather than through this guard.
+        // An earlier revision of this slice claimed ownership here as well; review
+        // showed that branch changed no end-to-end outcome, so it is gone.
+        Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any));
         Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Method));
         Assert.Null(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal("<>9__1_0", CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Type));
 
@@ -1790,25 +1792,36 @@ public class CompilerGeneratedOrdinalTests
     }
 
     /// <summary>
-    /// Ownership is what keeps the per-side rewrite off a cache field the correspondence
-    /// declined to fold. Without it the rewrite folds <c>&lt;&gt;9__N_K</c> on the
-    /// containing-method-blind <c>&lt;&gt;9__#_K</c> key and reports Exact for the two
-    /// unrelated closures of
-    /// <see cref="LambdaCacheFieldsOfDifferentContainingMethods_DoNotFold"/>.
+    /// The per-side rewrite folds two unrelated closures' cache fields together; the
+    /// composed contract does not.
     /// </summary>
+    /// <remarks>
+    /// This is the measured baseline behind
+    /// <see cref="LambdaCacheFieldsOfDifferentContainingMethods_DoNotFold"/>: the rewrite
+    /// keys on the containing-method-blind <c>&lt;&gt;9__#_K</c>, so it merges every
+    /// method's slot K. That is not a defect of the rewrite on its own terms -- it is the
+    /// behavior this slice keeps away from the composed contract, and asserting it here
+    /// means the improvement is pinned against something measured rather than remembered.
+    /// <para>
+    /// An earlier revision also asserted that <c>TryElideOrdinal</c> claimed
+    /// <c>&lt;&gt;9__N_K</c> under <c>Any</c>, on the theory that the ownership guard was
+    /// what held the rewrite off. Review showed that branch changed no end-to-end outcome
+    /// -- <c>FieldNameOutsideCorrespondence</c> does that work -- so both the branch and
+    /// the assertion are gone. <c>DeclinedLambdaCacheField_StaysOutOfThePerSideRewrite</c>
+    /// is the gate that actually covers it.
+    /// </para>
+    /// </remarks>
     [Fact]
     public void LambdaCacheFields_AreNotLeftToThePerSideRewrite()
     {
-        Assert.True(CompilerGeneratedOrdinalCorrespondence.TryElideOrdinal(
-            "<>9__1_0",
-            CompilerGeneratedOrdinalCorrespondence.GeneratedNameKind.Any) is not null);
-
-        // The rewrite alone does fold them -- which is the behavior being kept away from
-        // the composed contract, not a defect of the rewrite on its own terms.
         Assert.Equal(IlBodyDiffOutcome.Exact, CompareCacheField(
             oldMethod: "<Run>b__0_0", oldField: "<>9__0_0",
             newMethod: "<Other>b__0_0", newField: "<>9__0_0",
             normalization: IlBodyDiffNormalization.NormalizeSynthesizedMemberOrdinals).Outcome);
+
+        Assert.Equal(IlBodyDiffOutcome.OperandDiff, CompareCacheField(
+            oldMethod: "<Run>b__0_0", oldField: "<>9__0_0",
+            newMethod: "<Other>b__0_0", newField: "<>9__0_0").Outcome);
     }
 
     static IlBodyDiffResult CompareCacheField(

--- a/src/ILInspector.Instructions/CompilerGeneratedOrdinals.cs
+++ b/src/ILInspector.Instructions/CompilerGeneratedOrdinals.cs
@@ -351,7 +351,17 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
                 string siblingName = resolvedMethods.TryGetValue(sibling, out var elided)
                     ? elided
                     : reader.GetString(reader.GetMethodDefinition(sibling).Name);
-                named[fieldHandle] = LambdaCacheFieldPrefix + siblingName;
+
+                // KeySeparator, not bare concatenation, and for the reason spelled out on
+                // OrdinalPlaceholder: this string is substituted into the compared operand
+                // text, so it shares a namespace with every raw name that text can carry.
+                // Without an unspellable mark the composition is forgeable -- a field
+                // actually named `<>9__<Run>b__0_0` renders identically to the surrogate
+                // built for `<>9__0_0` whose sibling is `<Run>b__0_0`, and a real
+                // difference reports Exact. The folded branch already carries NUL inside
+                // OrdinalPlaceholder; it is the raw branch that is otherwise spellable.
+                // Gated by LambdaCacheFieldName_CannotBeForgedByARawFieldName.
+                named[fieldHandle] = LambdaCacheFieldPrefix + KeySeparator + siblingName;
             }
 
             return named;

--- a/src/ILInspector.Instructions/CompilerGeneratedOrdinals.cs
+++ b/src/ILInspector.Instructions/CompilerGeneratedOrdinals.cs
@@ -360,7 +360,15 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
                 // built for `<>9__0_0` whose sibling is `<Run>b__0_0`, and a real
                 // difference reports Exact. The folded branch already carries NUL inside
                 // OrdinalPlaceholder; it is the raw branch that is otherwise spellable.
-                // Gated by LambdaCacheFieldName_CannotBeForgedByARawFieldName.
+                //
+                // Two gates, because one claim is concrete and the other general.
+                // LambdaCacheFieldName_CannotBeForgedByARawFieldName pins that *this*
+                // composition is not bare concatenation, and fails if the separator is
+                // dropped. It does not pin that the separator is unspellable -- give
+                // KeySeparator a spellable value and that test still passes, because its
+                // forged name is written against NUL. The unspellability itself is
+                // KeySeparatorCannotBeSpelledByAMetadataName, which drives its assertion
+                // from the constant and so fails for any spellable value.
                 named[fieldHandle] = LambdaCacheFieldPrefix + KeySeparator + siblingName;
             }
 
@@ -441,13 +449,6 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
         Method,
 
         /// <summary>
-        /// A name read from a field definition. Only Roslyn's lambda cache field
-        /// <c>&lt;&gt;9__N_K</c> is read on this kind, and it does not fold on its own
-        /// name -- see <see cref="TryLambdaCacheFieldTail"/>.
-        /// </summary>
-        Field,
-
-        /// <summary>
         /// Either kind. Used only by the ownership guard, which asks whether a
         /// name belongs to this correspondence at all so the per-side rewrite
         /// can keep off it. Answering broadly there costs at most a false
@@ -467,21 +468,12 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
         // empty pair of brackets, so their ordinal is their only discriminator and
         // eliding it would merge unrelated closures. Depth matching still reports 1 for
         // those, so they are rejected here exactly as before.
-        // The lambda cache field opens with an empty pair of brackets and so is refused
-        // by the depth check below. It is nonetheless owned: the field loop folds it
-        // through its sibling lambda method rather than on its own name. Claiming it for
-        // the ownership guard is what stops the per-side rewrite folding `<>9__N_K` on
-        // the weaker `<>9__#_K` key while the correspondence is also in force. The
-        // returned text is never rendered -- only the guard and the field loop's own
-        // grammar check consume this branch, and the field's rendered name comes from
-        // TryLambdaCacheFieldTail's sibling. Gated by
-        // LambdaCacheFields_AreNotLeftToThePerSideRewrite.
-        if (kind is GeneratedNameKind.Any or GeneratedNameKind.Field
-            && TryLambdaCacheFieldTail(name) is not null)
-        {
-            return $"{LambdaCacheFieldPrefix}{OrdinalPlaceholder}";
-        }
-
+        //
+        // `<>9__N_K` is refused here like the others, and is still folded -- but by the
+        // field loop, through the sibling lambda method it pairs with, never on its own
+        // name. Nothing about that fold passes through this function, and the per-side
+        // rewrite is kept off the field by FieldNameOutsideCorrespondence rather than by
+        // this guard.
         int close = FindClosingAngle(name);
         if (close <= 1)
             return null;

--- a/src/ILInspector.Instructions/CompilerGeneratedOrdinals.cs
+++ b/src/ILInspector.Instructions/CompilerGeneratedOrdinals.cs
@@ -141,7 +141,9 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
 {
     /// <summary>The identity correspondence: nothing folds.</summary>
     public static readonly CompilerGeneratedOrdinalCorrespondence Empty =
-        new(new Dictionary<MethodDefinitionHandle, string>(), new Dictionary<TypeDefinitionHandle, string>());
+        new(new Dictionary<MethodDefinitionHandle, string>(),
+            new Dictionary<TypeDefinitionHandle, string>(),
+            new Dictionary<FieldDefinitionHandle, string>());
 
     /// <summary>
     /// The separator between key segments. It is NUL for the same reason the ordinal
@@ -223,13 +225,16 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
 
     readonly Dictionary<MethodDefinitionHandle, string> _methods;
     readonly Dictionary<TypeDefinitionHandle, string> _types;
+    readonly Dictionary<FieldDefinitionHandle, string> _fields;
 
     CompilerGeneratedOrdinalCorrespondence(
         Dictionary<MethodDefinitionHandle, string> methods,
-        Dictionary<TypeDefinitionHandle, string> types)
+        Dictionary<TypeDefinitionHandle, string> types,
+        Dictionary<FieldDefinitionHandle, string> fields)
     {
         _methods = methods;
         _types = types;
+        _fields = fields;
     }
 
     /// <summary>The ordinal-free name to compare this method under, when it has one.</summary>
@@ -239,6 +244,10 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
     /// <summary>The ordinal-free name to compare this type under, when it has one.</summary>
     public bool TryGetTypeName(TypeDefinitionHandle handle, out string name)
         => _types.TryGetValue(handle, out name!);
+
+    /// <summary>The ordinal-free name to compare this field under, when it has one.</summary>
+    public bool TryGetFieldName(FieldDefinitionHandle handle, out string name)
+        => _fields.TryGetValue(handle, out name!);
 
     /// <summary>
     /// Builds the correspondence for each side. A member folds only when its ordinal-free
@@ -312,11 +321,47 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
             newTypes[counterpart] = newIndex.TypeNames[counterpart];
         }
 
-        if (oldMethods.Count == 0 && oldTypes.Count == 0)
+        // A cache field is named for whatever its sibling lambda method resolved to, so
+        // the two agree by construction rather than by a second key that could disagree
+        // with the first. The composition is what makes the field safe in both
+        // directions. When the sibling folded, both sides spell the field with the
+        // sibling's elided name and the field folds with it. When the sibling did not --
+        // because its key was ambiguous, or because the two sides' lambdas belong to
+        // different containing methods -- both sides spell the field with the sibling's
+        // *raw* name, which still differs exactly when the siblings differ.
+        //
+        // Falling back to the field's own raw name instead would be unsound, and this is
+        // the one place where declining to fold is not automatically the safe answer: two
+        // unrelated closures can carry the identical field name `<>9__0_0` while their
+        // siblings are `<Run>b__0_0` and `<Other>b__0_0`, so a raw fallback reports Exact
+        // for a real difference. Gated by
+        // LambdaCacheFieldsOfDifferentContainingMethods_DoNotFold, which fails with a raw
+        // fallback and passes with this composition.
+        var oldFields = Resolve(oldReader, oldIndex, oldMethods);
+        var newFields = Resolve(newReader, newIndex, newMethods);
+
+        static Dictionary<FieldDefinitionHandle, string> Resolve(
+            MetadataReader reader,
+            SideIndex index,
+            Dictionary<MethodDefinitionHandle, string> resolvedMethods)
+        {
+            var named = new Dictionary<FieldDefinitionHandle, string>();
+            foreach (var (fieldHandle, sibling) in index.FieldSiblings)
+            {
+                string siblingName = resolvedMethods.TryGetValue(sibling, out var elided)
+                    ? elided
+                    : reader.GetString(reader.GetMethodDefinition(sibling).Name);
+                named[fieldHandle] = LambdaCacheFieldPrefix + siblingName;
+            }
+
+            return named;
+        }
+
+        if (oldMethods.Count == 0 && oldTypes.Count == 0 && oldFields.Count == 0)
             return (Empty, Empty);
 
-        return (new CompilerGeneratedOrdinalCorrespondence(oldMethods, oldTypes),
-                new CompilerGeneratedOrdinalCorrespondence(newMethods, newTypes));
+        return (new CompilerGeneratedOrdinalCorrespondence(oldMethods, oldTypes, oldFields),
+                new CompilerGeneratedOrdinalCorrespondence(newMethods, newTypes, newFields));
     }
 
     /// <summary>
@@ -386,6 +431,13 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
         Method,
 
         /// <summary>
+        /// A name read from a field definition. Only Roslyn's lambda cache field
+        /// <c>&lt;&gt;9__N_K</c> is read on this kind, and it does not fold on its own
+        /// name -- see <see cref="TryLambdaCacheFieldTail"/>.
+        /// </summary>
+        Field,
+
+        /// <summary>
         /// Either kind. Used only by the ownership guard, which asks whether a
         /// name belongs to this correspondence at all so the per-side rewrite
         /// can keep off it. Answering broadly there costs at most a false
@@ -405,6 +457,21 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
         // empty pair of brackets, so their ordinal is their only discriminator and
         // eliding it would merge unrelated closures. Depth matching still reports 1 for
         // those, so they are rejected here exactly as before.
+        // The lambda cache field opens with an empty pair of brackets and so is refused
+        // by the depth check below. It is nonetheless owned: the field loop folds it
+        // through its sibling lambda method rather than on its own name. Claiming it for
+        // the ownership guard is what stops the per-side rewrite folding `<>9__N_K` on
+        // the weaker `<>9__#_K` key while the correspondence is also in force. The
+        // returned text is never rendered -- only the guard and the field loop's own
+        // grammar check consume this branch, and the field's rendered name comes from
+        // TryLambdaCacheFieldTail's sibling. Gated by
+        // LambdaCacheFields_AreNotLeftToThePerSideRewrite.
+        if (kind is GeneratedNameKind.Any or GeneratedNameKind.Field
+            && TryLambdaCacheFieldTail(name) is not null)
+        {
+            return $"{LambdaCacheFieldPrefix}{OrdinalPlaceholder}";
+        }
+
         int close = FindClosingAngle(name);
         if (close <= 1)
             return null;
@@ -452,6 +519,69 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
         return ElideScopeOrdinal(rest[(bar + 1)..]) is { } localOrdinals
             ? $"{containing}g__{local}|{localOrdinals}"
             : null;
+    }
+
+    internal const string LambdaCacheFieldPrefix = "<>9__";
+
+    /// <summary>
+    /// The raw <c>N_K</c> tail of Roslyn's lambda cache field <c>&lt;&gt;9__N_K</c>, or
+    /// null when the name is not that form.
+    /// </summary>
+    /// <remarks>
+    /// This field is the one owned form that cannot fold on its own name. It opens with
+    /// an empty pair of brackets, so after eliding the renumbered scope ordinal <c>N</c>
+    /// nothing distinguishes one containing method's cache slot from another's:
+    /// <c>&lt;&gt;9__0_0</c> and <c>&lt;&gt;9__1_0</c> would both spell
+    /// <c>&lt;&gt;9__#_0</c>, and two unrelated closures would merge. What makes it
+    /// foldable is that Roslyn emits it in lockstep with a sibling lambda method
+    /// <c>&lt;Name&gt;b__N_K</c> on the same type, whose containing name supplies exactly
+    /// the discriminator the field lacks. The tail returned here is what pairs the two.
+    /// <para>
+    /// Measured rather than assumed: a build of a type with lambdas in seven methods --
+    /// plain, overloaded, capturing, async and nested -- emits eight
+    /// <c>&lt;&gt;9__N_K</c> fields on <c>&lt;&gt;c</c> and exactly eight matching
+    /// <c>&lt;Name&gt;b__N_K</c> methods, a 1:1 pairing with no unmatched member on
+    /// either side. Pinned by <c>LambdaCacheFields_PairOneToOneWithTheirLambdaMethods</c>.
+    /// </para>
+    /// <para>
+    /// The tail is accepted exactly when <see cref="ElideScopeOrdinal"/> accepts it, so
+    /// the field grammar cannot drift from the method grammar it pairs against. That
+    /// also excludes the neighbouring generated fields Roslyn puts on these types --
+    /// <c>&lt;&gt;9</c> (the singleton, no tail), <c>&lt;&gt;1__state</c>,
+    /// <c>&lt;&gt;t__builder</c> and the awaiter slots <c>&lt;&gt;u__N</c>, whose ordinal
+    /// discriminates a real slot and which have no sibling method to pair with. Gated by
+    /// <c>NeighbouringGeneratedFields_AreNotMistakenForLambdaCaches</c>.
+    /// </para>
+    /// </remarks>
+    internal static string? TryLambdaCacheFieldTail(string name)
+    {
+        if (name is null || !name.StartsWith(LambdaCacheFieldPrefix, StringComparison.Ordinal))
+            return null;
+
+        string tail = name[LambdaCacheFieldPrefix.Length..];
+        return ElideScopeOrdinal(tail) is not null ? tail : null;
+    }
+
+    /// <summary>
+    /// The raw <c>N_K</c> tail of a lambda method <c>&lt;Name&gt;b__N_K</c>, or null when
+    /// the name is not that form. This is the key side of the pairing described on
+    /// <see cref="TryLambdaCacheFieldTail"/>.
+    /// </summary>
+    internal static string? TryLambdaMethodTail(string name)
+    {
+        if (name is null || name.Length < 4 || name[0] != '<')
+            return null;
+
+        int close = FindClosingAngle(name);
+        if (close <= 1)
+            return null;
+
+        var rest = name.AsSpan(close + 1);
+        if (!rest.StartsWith("b__", StringComparison.Ordinal))
+            return null;
+
+        string tail = rest[3..].ToString();
+        return ElideScopeOrdinal(tail) is not null ? tail : null;
     }
 
     /// <summary>
@@ -542,8 +672,9 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
         public required Dictionary<string, TypeDefinitionHandle> Types { get; init; }
         public required HashSet<string> AmbiguousTypes { get; init; }
         public required Dictionary<TypeDefinitionHandle, string> TypeNames { get; init; }
+        public required Dictionary<FieldDefinitionHandle, MethodDefinitionHandle> FieldSiblings { get; init; }
 
-        public bool IsEmpty => Methods.Count == 0 && Types.Count == 0;
+        public bool IsEmpty => Methods.Count == 0 && Types.Count == 0 && FieldSiblings.Count == 0;
 
         public static SideIndex For(MetadataReader reader)
             => s_cache.GetValue(reader, static r => Create(r));
@@ -578,6 +709,7 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
                     Types = [],
                     AmbiguousTypes = [],
                     TypeNames = [],
+                    FieldSiblings = [],
                 };
             }
         }
@@ -590,6 +722,7 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
             var types = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
             var ambiguousTypes = new HashSet<string>(StringComparer.Ordinal);
             var typeNames = new Dictionary<TypeDefinitionHandle, string>();
+            var fieldSiblings = new Dictionary<FieldDefinitionHandle, MethodDefinitionHandle>();
 
             foreach (var typeHandle in reader.TypeDefinitions)
             {
@@ -630,6 +763,13 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
                 // suite green. It is not load-bearing for either property above.
                 bool? typeIsGenerated = null;
 
+                // Per type for the same reason the mark is: a cache field pairs only with
+                // a lambda method on its own type, and a map shared across types would
+                // let a field borrow an unrelated type's method name. Gated by
+                // LambdaCacheFields_DoNotPairAcrossTypes.
+                Dictionary<string, MethodDefinitionHandle>? lambdaSiblings = null;
+                HashSet<string>? ambiguousSiblings = null;
+
                 foreach (var methodHandle in type.GetMethods())
                 {
                     var method = reader.GetMethodDefinition(methodHandle);
@@ -648,6 +788,17 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
                         continue;
 
                     methodNames[methodHandle] = elided;
+
+                    // The pairing side of the lambda cache field. Recorded only for
+                    // methods that were themselves found eligible, so a field can never
+                    // borrow a name the method path refused to fold.
+                    if (TryLambdaMethodTail(methodName) is { } siblingTail)
+                    {
+                        lambdaSiblings ??= new Dictionary<string, MethodDefinitionHandle>(StringComparer.Ordinal);
+                        if (!lambdaSiblings.TryAdd(siblingTail, methodHandle))
+                            (ambiguousSiblings ??= new HashSet<string>(StringComparer.Ordinal)).Add(siblingTail);
+                    }
+
                     // A method records its arity twice, in GenericParam and in its
                     // signature, and nothing in the format ties the two together. The
                     // operand renderer reads the signature, so a well-formed generic
@@ -663,6 +814,40 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
                             method.GetGenericParameters().Count,
                         methodHandle);
                 }
+
+                if (lambdaSiblings is null)
+                    continue;
+
+                foreach (var fieldHandle in type.GetFields())
+                {
+                    var field = reader.GetFieldDefinition(fieldHandle);
+                    if (TryLambdaCacheFieldTail(reader.GetString(field.Name)) is not { } tail)
+                        continue;
+
+                    // Fail closed on an ambiguous pairing. Roslyn does not emit two lambda
+                    // methods sharing a tail on one type -- the scope ordinal is the
+                    // containing member index, so a shared tail implies a shared containing
+                    // method and hence a shared name -- but hand-written or hostile IL can,
+                    // and then the field has no single sibling to take its name from.
+                    if (ambiguousSiblings?.Contains(tail) == true
+                        || !lambdaSiblings.TryGetValue(tail, out var sibling))
+                    {
+                        continue;
+                    }
+
+                    typeIsGenerated ??= HasCompilerGeneratedAttribute(reader, type.GetCustomAttributes());
+                    if (!typeIsGenerated.Value
+                        && !HasCompilerGeneratedAttribute(reader, field.GetCustomAttributes()))
+                    {
+                        continue;
+                    }
+
+                    // Only the pairing is recorded here. What the field is *called* is
+                    // decided in Build, from whatever the method correspondence resolved
+                    // its sibling to, so the field inherits the method's two-sided
+                    // guarantee rather than repeating it on a weaker key of its own.
+                    fieldSiblings[fieldHandle] = sibling;
+                }
             }
 
             return new SideIndex
@@ -673,6 +858,7 @@ public sealed class CompilerGeneratedOrdinalCorrespondence
                 Types = types,
                 AmbiguousTypes = ambiguousTypes,
                 TypeNames = typeNames,
+                FieldSiblings = fieldSiblings,
             };
         }
 

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1069,7 +1069,9 @@ public static class IlBodyDiff
         // fall through to the per-side rewrite, which folds `<>9__N_K` to `<>9__#_K` on
         // strictly weaker evidence -- that key drops the containing method entirely, so it
         // merges every method's slot K. Declining is a false positive; folding there is a
-        // masked difference. Gated by LambdaCacheFields_AreNotLeftToThePerSideRewrite.
+        // masked difference. Gated by
+        // DeclinedLambdaCacheField_StaysOutOfThePerSideRewrite, which drives this function
+        // end to end through Compare and fails if it is reduced to the rewrite.
         string FieldNameOutsideCorrespondence(string raw)
             => (normalization & IlBodyDiffNormalization.NormalizeCompilerGeneratedOrdinals) != 0
                 && CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail(raw) is not null

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -942,7 +942,7 @@ public static class IlBodyDiff
                 out var decoded)
                 ? decoded
                 : GuardedProviderDecode.RejectedIdentity(reader, field.Signature);
-            return $"{fieldType} {FormatType(field.GetDeclaringType())}::{NormalizeMemberName(reader.GetString(field.Name), SynthesizedMemberKind.Field)}";
+            return $"{fieldType} {FormatType(field.GetDeclaringType())}::{FieldName(handle, field)}";
         }
 
         string FormatFieldMemberReference(MemberReferenceHandle handle)
@@ -959,7 +959,11 @@ public static class IlBodyDiff
                 out var decoded)
                 ? decoded
                 : GuardedProviderDecode.RejectedIdentity(reader, member.Signature);
-            return $"{fieldType} {FormatMemberParent(member.Parent)}::{NormalizeMemberName(reader.GetString(member.Name), SynthesizedMemberKind.Field)}";
+            // A MemberReference names a field the correspondence never indexed, so an
+            // owned name arriving this way is declined rather than folded -- the same
+            // accepted cost, in the same direction, that MethodNameOutsideCorrespondence
+            // documents for methods.
+            return $"{fieldType} {FormatMemberParent(member.Parent)}::{FieldNameOutsideCorrespondence(reader.GetString(member.Name))}";
         }
 
         string FormatCall(MethodSignature<string> signature, string parent, string name, string? genericArgs)
@@ -1051,6 +1055,26 @@ public static class IlBodyDiff
             // real difference (#3645). Only names outside `d__`/`g__` fall through.
             return MethodNameOutsideCorrespondence(reader.GetString(method.Name));
         }
+
+        string FieldName(FieldDefinitionHandle handle, FieldDefinition field)
+        {
+            if (correspondence.TryGetFieldName(handle, out var elided))
+                return elided;
+
+            return FieldNameOutsideCorrespondence(reader.GetString(field.Name));
+        }
+
+        // The field analogue of MethodNameOutsideCorrespondence, and for the same reason:
+        // a lambda cache field the correspondence recognized but declined to fold must not
+        // fall through to the per-side rewrite, which folds `<>9__N_K` to `<>9__#_K` on
+        // strictly weaker evidence -- that key drops the containing method entirely, so it
+        // merges every method's slot K. Declining is a false positive; folding there is a
+        // masked difference. Gated by LambdaCacheFields_AreNotLeftToThePerSideRewrite.
+        string FieldNameOutsideCorrespondence(string raw)
+            => (normalization & IlBodyDiffNormalization.NormalizeCompilerGeneratedOrdinals) != 0
+                && CompilerGeneratedOrdinalCorrespondence.TryLambdaCacheFieldTail(raw) is not null
+                    ? raw
+                    : NormalizeMemberName(raw, SynthesizedMemberKind.Field);
 
         // The two options split the synthesized name space when both are requested: the
         // correspondence owns `d__`, `g__` and `b__`, and the per-side rewrite keeps


### PR DESCRIPTION
Slice 2 of 3 on #3645. Moves Roslyn's lambda cache field `<>9__N_K` off the per-side rewrite and onto the two-sided correspondence, so a cache field folds only when there is evidence that both sides denote the same closure slot. Two overloads' caches stop comparing `Exact`.

**Fidelity is unchanged at 68/0.** This is a soundness change, not a corpus-movement one: it removes a way to report a false `Exact`, and no corpus fixture is currently hitting that way. The claim is measured below, not asserted.

## The field is the one owned form that cannot fold on its own name

`<>9__N_K` opens with an empty pair of brackets. After eliding the renumbered scope ordinal `N`, nothing is left to distinguish one containing method's slot from another's — `<>9__0_0` and `<>9__1_0` both spell `<>9__#_0`. That is exactly what the per-side rewrite does today, and it is why two overloads' caches compare equal now.

What makes the field foldable is a fact about Roslyn rather than about the name: the field is emitted in lockstep with a sibling lambda method `<Name>b__N_K` on the same type, and the sibling's containing name carries precisely the discriminator the field lacks.

Measured on a fresh Release build covering plain, repeated, overloaded, capturing, `async` and nested lambdas:

| `<>c` fields | `<>c` methods |
| --- | --- |
| `<>9__0_0` `<>9__0_1` `<>9__0_2` `<>9__1_0` `<>9__3_0` `<>9__5_0` `<>9__6_0` `<>9__6_1` | `<Run>b__0_0` `<Run>b__0_1` `<Run>b__0_2` `<Other>b__1_0` `<Overload>b__3_0` `<AsyncOne>b__5_0` `<Nested>b__6_0` `<Nested>b__6_1` |

Eight and eight, 1:1, nothing unmatched. `<>9` itself carries no tail. Capturing lambdas land on `<>c__DisplayClassN_K` with a single-ordinal method `<Name>b__K` and **no cache field at all**, so they never reach the pairing. The pairing is pinned by `LambdaCacheFields_PairOneToOneWithTheirLambdaMethods`.

## The design, and the first attempt that my own test killed

A field is named for whatever its sibling **resolved** to, not keyed independently:

- sibling folded → both sides spell the field with the sibling's elided name, and the field folds with it;
- sibling did not fold → both sides spell it with the sibling's **raw** name, which still differs exactly when the siblings do.

The first version instead gave the field its own two-sided key and fell back to the field's raw name when the key found no counterpart — the same shape every other form in this file uses. **`LambdaCacheFieldsOfDifferentContainingMethods_DoNotFold` caught it.** For cache fields, declining to fold is *not* automatically safe: two unrelated closures can carry the identical name `<>9__0_0` while their siblings are `<Run>b__0_0` and `<Other>b__0_0`, so falling back to the raw name reports `Exact` for a real difference. Methods do not have this property — their raw names differ whenever their ordinals do — and I had generalised from them without checking. Safety is now *inherited* from the method path rather than re-derived on a weaker key.

The overload case then needs no rule of its own and gets none: the two siblings collide on one key, the method path finds them ambiguous and folds neither, and each field inherits its sibling's raw name.

## Evidence

`OverloadCacheFields_StopReportingExactUnderTheCorrespondence` measures the headline claim end to end through `IlBodyDiff.Compare`, and asserts the pre-change baseline rather than describing it:

| normalization | outcome |
| --- | --- |
| `None` | `OperandDiff` |
| `NormalizeSynthesizedMemberOrdinals` (what ships on main) | **`Exact`** |
| composed (this PR) | `OperandDiff` |

Tamper table — each tamper fails only what it should:

| tamper | fails |
| --- | --- |
| field named from its own raw name | `LambdaCacheFieldsOfDifferentContainingMethods_DoNotFold`, `LambdaCacheFieldWhoseScopeOrdinalShifted_Folds` |
| sibling map shared across types | `LambdaCacheFields_DoNotPairAcrossTypes` |
| drop `KeySeparator` from the composition | `LambdaCacheFieldName_CannotBeForgedByARawFieldName` |
| reduce `FieldNameOutsideCorrespondence` to the per-side rewrite | `DeclinedLambdaCacheField_StaysOutOfThePerSideRewrite` |

**One of these tests was vacuous when first written and the tamper passed.** The cross-type fixture declared the sibling's type *after* the field's, so the sibling map was empty when the field was reached whatever its scope — the test would have held with the bug present. The fixture now declares them in the order that exercises the leak. This is the same class of hole a reviewer found in #3707 round 3; reviewers should assume more of it here.

`TryLambdaCacheFieldTail` and `TryLambdaMethodTail` both validate through `ElideScopeOrdinal`, so the field grammar cannot drift from the method grammar it pairs against. Hazards the grammar must reject and does: `<>9` (no tail), `<>1__state`, `<>t__builder`, `<>u__N` (awaiter slots — a real ordinal with no sibling).

## Validation

Built `-c Release`, 0 errors. Instructions **306/0**, Analysis 578/0, Services 360/0, Metadata 1405/0, MetadataRendering 187/0, decompiler fast 4500/0, **`Area=Fidelity` 68/0 — unchanged**.

## Residual (slice 3)

`NormalizeSynthesizedMemberOrdinals` and the `SynthesizedOrdinals` class still exist and still rewrite every generated form the correspondence does not own. Slice 3 deletes them, drops the flag from `FidelityCheck`, bumps `CurrentContractVersion` to 3, and regenerates the four `contractVersion: 1` corpus baselines. Not folded in here: it is a contract bump with a baseline regeneration attached, and it should not ride on a soundness fix.

Not in scope, filed separately: #3751 (`IlDiffPrinter`'s NUL stripping makes rendered operands non-injective — display only, comparison correct), #3661 (renderer rows — function pointers, rank-1 arrays), #3588, #3640.

## Corrections after review

Two claims in the original description are **withdrawn**, both found by review and both corrected in the branch:

1. *"`<>9__N_K` is claimed by the ownership guard so the per-side rewrite keeps off it."* Wrong. No product caller ever passed `GeneratedNameKind.Field`, and the guard's only consumer passes method names. Deleting the branch failed only two direct unit tests of `TryElideOrdinal` and no end-to-end comparison. `FieldNameOutsideCorrespondence` does that work and is now gated for it; the branch and the `Field` enum value are deleted (`204fed9ba`).
2. The composition was **forgeable**: `"<>9__" + siblingName` by plain concatenation collided with a field literally named `<>9__<Run>b__0_0`, giving composed `Exact` where `None` said `OperandDiff`. Now separated with the unspellable `KeySeparator` (`ae5130a72`).

Full reconciliations are in the round-1 and round-2 comments below.

