### PR TITLE
Replace platform forwarder probes with typed catalogs

### DIFF
--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -63,8 +63,10 @@ var (selectedPath, _)      = TfmSelector.SelectHighestTfmAssembly(...);        /
 ```
 
 The bare `path` is handed to inspection, which then **re-opens the file and re-derives** some
-of what was just discarded (for example `InspectAsync` re-probes
-`PlatformResolver.IsFacadeOnlyAssembly(path)` and re-reads name/version from metadata).
+of what was just discarded. Facade classification no longer interprets raw
+forwarder rows in Services -- it consumes a Metadata-owned declaration
+inventory and retains a typed outcome and Finding -- but the path handoff still
+causes that inventory and name/version facts to be read again.
 
 Where provenance *is* needed downstream, it is smuggled as loose extra parameters rather
 than bundled:

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -6,15 +6,16 @@
 
 ## Status
 
-Design and staged implementation plan for replacing the current collection of
+Design and staged implementation plan for replacing the former collection of
 type-forwarder helpers and spelling-based caller matching with one structured
 reference-to-definition system.
 
-The first implementation slice provides the structured lookup name, validated
-row tokens, closed declaration outcomes, and bounded single-image metadata
-probe. It migrates no production caller. That boundary follows the
-primitive-first approach used by `InertString` in
-[#3636](https://github.com/richlander/dotnet-inspect/pull/3636): establish the
+Slices 1 through 4 are implemented: declaration, acquisition, resolution,
+definition consumers, source/API consumers, platform lookup, and facade
+classification now use structured contracts. Direct caller correspondence and
+graph cleanup remain. The delivery continues to follow the primitive-first
+approach used by `InertString` in
+[#3636](https://github.com/richlander/dotnet-inspect/pull/3636): establish each
 value, its invariants, and its gates before asking consumers to depend on it.
 
 ## The problem
@@ -2312,11 +2313,12 @@ Source and API consumers receive `ResolvedAssemblyReference` or
 - `SourceEnricher` and `SourceFileCollector` do not construct sibling paths.
 - `ApiServices.ResolveForwardedTypes` resolves each structured type through the
   engine and opens the returned descriptor.
-- `PlatformResolver.FindLibraryContainingType` becomes a typed platform-catalog
+- The former `PlatformResolver.FindLibraryContainingType` is replaced by a
+  typed platform-catalog
   query. Its trusted ref-pack index returns all defining and forwarding
   candidates deterministically; explicit platform source policy selects one or
   reports ambiguity. It never returns a first-enumerated simple-name string.
-- `PlatformResolver.IsFacadeOnlyAssembly` moves to a Metadata-owned surface
+- The former `PlatformResolver.IsFacadeOnlyAssembly` moves to a Metadata-owned surface
   classification that consumes typed declaration inventory. Classification is
   not cross-assembly resolution, but Services may not interpret raw forwarder
   rows after the architecture gate lands.
@@ -2512,6 +2514,13 @@ This slice lands as two independently complete consumer migrations:
   `LibraryMetadataService`, and `RouterCommandDefinition`; replace
   `PlatformResolver.FindLibraryContainingType` with the typed platform catalog
   and move `IsFacadeOnlyAssembly` to Metadata-owned classification.
+
+Both 4a and 4b are delivered. The platform catalog retains structured names,
+declaration kind, assembly identity, provenance, and descriptors; its explicit
+policy prefers definitions and reports multiple preferred candidates as
+ambiguity. Surface classification is derived from the same Metadata-produced
+declaration inventory and projects rejection as a failed Finding rather than a
+non-facade answer.
 
 Claim: forwarded source and API resolution consume descriptors and cannot turn
 an inspected assembly name into a path.

--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -924,84 +924,49 @@ public static class PlatformResolver
     }
 
     /// <summary>
-    /// Scans all platform ref assemblies in the runtime framework to find which
-    /// library contains a given type. Returns the library name (without .dll), or null.
+    /// Resolves a user type pattern against the trusted runtime reference-pack
+    /// catalog without choosing a first-enumerated assembly.
     /// </summary>
-    public static string? FindLibraryContainingType(string typeName)
+    public static PlatformTypeLookupOutcome LookupType(string typeName)
     {
         var frameworks = GetInstalledFrameworks();
         var runtime = frameworks.FirstOrDefault(f => f.ShortName == "runtime");
-        if (runtime == null) return null;
-
-        var refPath = GetRefAssemblyPath(runtime.Path, runtime.LatestVersion);
-        if (refPath == null) return null;
-
-        var normalized = ILInspector.Metadata.TypeMatcher.Normalize(typeName);
-        string? forwarderMatch = null;
-
-        // Prefer assemblies with actual type definitions over type forwarders.
-        // e.g., Dictionary`2 is defined in System.Collections, not mscorlib (which only forwards).
-        foreach (var dll in Directory.GetFiles(refPath, "*.dll"))
+        if (runtime == null)
         {
-            if (ILInspector.Metadata.TypeForwardResolver.DefinesType(dll, normalized))
-                return System.IO.Path.GetFileNameWithoutExtension(dll);
-            if (forwarderMatch == null && ILInspector.Metadata.TypeForwardResolver.ForwardsType(dll, normalized))
-                forwarderMatch = System.IO.Path.GetFileNameWithoutExtension(dll);
+            return new PlatformTypeLookupOutcome.Rejected(
+                new PlatformTypeLookupFailure(
+                    PlatformTypeLookupFailureKind.CatalogUnavailable,
+                    "The runtime reference catalog is unavailable."));
         }
 
-        return forwarderMatch;
+        var refPath = GetRefAssemblyPath(runtime.Path, runtime.LatestVersion);
+        if (refPath == null)
+        {
+            return new PlatformTypeLookupOutcome.Rejected(
+                new PlatformTypeLookupFailure(
+                    PlatformTypeLookupFailureKind.CatalogUnavailable,
+                    "The runtime reference catalog is unavailable."));
+        }
+
+        return PlatformTypeCatalog.Lookup(
+            typeName,
+            refPath,
+            runtime.ShortName,
+            runtime.LatestVersion);
     }
 
     /// <summary>
-    /// Returns true when an assembly is a facade-only surface: it has metadata,
-    /// one or more type forwarders, and no meaningful public type definitions.
+    /// Classifies a platform assembly through Metadata's typed declaration
+    /// inventory. The path is acquisition input, never metadata-derived.
     /// </summary>
-    public static bool IsFacadeOnlyAssembly(string assemblyPath)
-    {
-        try
-        {
-            using var stream = File.OpenRead(assemblyPath);
-            using var peReader = new PEReader(stream);
-            if (!peReader.HasMetadata)
-                return false;
-
-            var reader = peReader.GetMetadataReader();
-            bool hasForwarders = false;
-            foreach (var handle in reader.ExportedTypes)
-            {
-                if (reader.GetExportedType(handle).IsForwarder)
-                {
-                    hasForwarders = true;
-                    break;
-                }
-            }
-
-            if (!hasForwarders)
-                return false;
-
-            foreach (var handle in reader.TypeDefinitions)
-            {
-                var typeDef = reader.GetTypeDefinition(handle);
-                if (IsMeaningfulPublicType(reader, typeDef))
-                    return false;
-            }
-
-            return true;
-        }
-        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
-        {
-            return false;
-        }
-    }
-
-    private static bool IsMeaningfulPublicType(MetadataReader reader, TypeDefinition typeDef)
-    {
-        if (!typeDef.IsPublic)
-            return false;
-
-        var name = reader.GetString(typeDef.Name);
-        return name.Length > 0 && !TypeFilters.IsCompilerGenerated(name);
-    }
+    public static AssemblySurfaceClassificationOutcome ClassifyAssemblySurface(
+        string assemblyPath) =>
+        AssemblySurfaceClassifier.Classify(
+            assemblyPath,
+            AssemblyResolutionProvenance.Platform(
+                "InstalledPlatform",
+                frameworkVersion: null,
+                "PlatformResolver"));
 
     /// <summary>
     /// Lightweight type existence check using raw metadata.

--- a/src/DotnetInspector.Services/PlatformTypeCatalog.cs
+++ b/src/DotnetInspector.Services/PlatformTypeCatalog.cs
@@ -1,0 +1,333 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// Validated user lookup pattern for platform type discovery. It deliberately
+/// remains distinct from an exact <see cref="MetadataTypeDefinitionName"/>.
+/// </summary>
+public sealed class PlatformTypeLookupPattern
+{
+    PlatformTypeLookupPattern(string normalized) => Normalized = normalized;
+
+    internal string Normalized { get; }
+
+    public static PlatformTypeLookupPatternResult Create(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return new PlatformTypeLookupPatternResult.Rejected(
+                new PlatformTypeLookupFailure(
+                    PlatformTypeLookupFailureKind.InvalidPattern,
+                    "A platform type lookup pattern is required."));
+        }
+
+        return new PlatformTypeLookupPatternResult.Valid(
+            new PlatformTypeLookupPattern(TypeMatcher.Normalize(value.Trim())));
+    }
+
+    internal bool Matches(MetadataTypeDefinitionName name) =>
+        TypeMatcher.Matches(name.ToMetadataFullName(), Normalized);
+
+    internal bool IsExact(MetadataTypeDefinitionName name)
+    {
+        string candidate = NormalizeLookup(name.ToMetadataFullName());
+        string pattern = NormalizeLookup(Normalized);
+        return candidate.Equals(pattern, StringComparison.OrdinalIgnoreCase)
+            || TypeMatcher.GetSimpleName(candidate).Equals(
+                pattern,
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal int GenericArity => TypeMatcher.GetPatternArity(Normalized);
+
+    static string NormalizeLookup(string value) =>
+        TypeMatcher.Normalize(value).Replace('+', '.');
+}
+
+/// <summary>The result of validating a platform type lookup pattern.</summary>
+public abstract class PlatformTypeLookupPatternResult
+{
+    private protected PlatformTypeLookupPatternResult()
+    {
+    }
+
+    public sealed class Valid : PlatformTypeLookupPatternResult
+    {
+        internal Valid(PlatformTypeLookupPattern pattern) => Pattern = pattern;
+
+        public PlatformTypeLookupPattern Pattern { get; }
+    }
+
+    public sealed class Rejected : PlatformTypeLookupPatternResult
+    {
+        internal Rejected(PlatformTypeLookupFailure failure) => Failure = failure;
+
+        public PlatformTypeLookupFailure Failure { get; }
+    }
+}
+
+public enum PlatformTypeDeclarationKind
+{
+    Definition,
+    Forwarder,
+}
+
+/// <summary>
+/// One deterministic platform-catalog match. The descriptor, structured type
+/// name, and declaration kind remain separate evidence.
+/// </summary>
+public sealed record PlatformTypeLookupCandidate(
+    ResolvedAssemblyReference Assembly,
+    MetadataTypeDefinitionName Type,
+    PlatformTypeDeclarationKind DeclarationKind);
+
+public enum PlatformTypeLookupFailureKind
+{
+    InvalidPattern,
+    CatalogUnavailable,
+    InvalidAssembly,
+}
+
+public sealed record PlatformTypeLookupFailure(
+    PlatformTypeLookupFailureKind Kind,
+    string Detail);
+
+/// <summary>
+/// Closed platform source-selection outcome. Only <see cref="Resolved"/>
+/// supplies a descriptor; callers must handle ambiguity and rejection.
+/// </summary>
+public abstract class PlatformTypeLookupOutcome
+{
+    private protected PlatformTypeLookupOutcome()
+    {
+    }
+
+    public sealed class Resolved : PlatformTypeLookupOutcome
+    {
+        internal Resolved(PlatformTypeLookupCandidate candidate) =>
+            Candidate = candidate;
+
+        public PlatformTypeLookupCandidate Candidate { get; }
+    }
+
+    public sealed class Missing : PlatformTypeLookupOutcome
+    {
+        internal Missing()
+        {
+        }
+    }
+
+    public sealed class Ambiguous : PlatformTypeLookupOutcome
+    {
+        internal Ambiguous(
+            ImmutableArray<PlatformTypeLookupCandidate> candidates) =>
+            Candidates = candidates;
+
+        public ImmutableArray<PlatformTypeLookupCandidate> Candidates { get; }
+    }
+
+    public sealed class Rejected : PlatformTypeLookupOutcome
+    {
+        internal Rejected(PlatformTypeLookupFailure failure) => Failure = failure;
+
+        public PlatformTypeLookupFailure Failure { get; }
+    }
+}
+
+/// <summary>
+/// Trusted reference-pack index. Metadata produces each declaration inventory;
+/// this service owns platform discovery, caching, and source-selection policy.
+/// </summary>
+internal sealed class PlatformTypeCatalog
+{
+    static readonly ConcurrentDictionary<
+        string,
+        Lazy<PlatformTypeCatalogResult>> Cache =
+            new(StringComparer.Ordinal);
+
+    readonly ImmutableArray<PlatformTypeLookupCandidate> _entries;
+
+    PlatformTypeCatalog(
+        ImmutableArray<PlatformTypeLookupCandidate> entries) =>
+        _entries = entries;
+
+    internal static PlatformTypeLookupOutcome Lookup(
+        string typeName,
+        string referencePath,
+        string framework,
+        string frameworkVersion)
+    {
+        PlatformTypeLookupPatternResult patternResult =
+            PlatformTypeLookupPattern.Create(typeName);
+        if (patternResult is PlatformTypeLookupPatternResult.Rejected invalid)
+            return new PlatformTypeLookupOutcome.Rejected(invalid.Failure);
+
+        string fullReferencePath = Path.GetFullPath(referencePath);
+        PlatformTypeCatalogResult catalogResult = Cache.GetOrAdd(
+            fullReferencePath,
+            path => new Lazy<PlatformTypeCatalogResult>(
+                () => Build(path, framework, frameworkVersion),
+                LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+        if (catalogResult is PlatformTypeCatalogResult.Rejected rejected)
+            return new PlatformTypeLookupOutcome.Rejected(rejected.Failure);
+
+        var catalog =
+            ((PlatformTypeCatalogResult.Ready)catalogResult).Catalog;
+        return catalog.Select(
+            ((PlatformTypeLookupPatternResult.Valid)patternResult).Pattern);
+    }
+
+    PlatformTypeLookupOutcome Select(PlatformTypeLookupPattern pattern)
+    {
+        ImmutableArray<PlatformTypeLookupCandidate> matches =
+        [
+            .. _entries.Where(candidate => pattern.Matches(candidate.Type)),
+        ];
+        if (matches.IsEmpty)
+            return new PlatformTypeLookupOutcome.Missing();
+
+        ImmutableArray<PlatformTypeLookupCandidate> definitions =
+        [
+            .. matches.Where(candidate =>
+                candidate.DeclarationKind
+                    == PlatformTypeDeclarationKind.Definition),
+        ];
+        ImmutableArray<PlatformTypeLookupCandidate> selected =
+            definitions.IsEmpty ? matches : definitions;
+        if (pattern.GenericArity >= 0)
+        {
+            ImmutableArray<PlatformTypeLookupCandidate> sameArity =
+            [
+                .. selected.Where(candidate =>
+                    TypeMatcher.GetGenericArity(
+                        candidate.Type.ToMetadataFullName())
+                    == pattern.GenericArity),
+            ];
+            if (!sameArity.IsEmpty)
+                selected = sameArity;
+        }
+
+        ImmutableArray<PlatformTypeLookupCandidate> exact =
+        [
+            .. selected.Where(candidate => pattern.IsExact(candidate.Type)),
+        ];
+        if (!exact.IsEmpty)
+            selected = exact;
+
+        return selected.Length == 1
+            ? new PlatformTypeLookupOutcome.Resolved(selected[0])
+            : new PlatformTypeLookupOutcome.Ambiguous(selected);
+    }
+
+    static PlatformTypeCatalogResult Build(
+        string referencePath,
+        string framework,
+        string frameworkVersion)
+    {
+        if (!Directory.Exists(referencePath))
+        {
+            return Rejected(
+                PlatformTypeLookupFailureKind.CatalogUnavailable,
+                "The platform reference catalog is unavailable.");
+        }
+
+        try
+        {
+            var entries =
+                ImmutableArray.CreateBuilder<PlatformTypeLookupCandidate>();
+            foreach (string path in Directory
+                .EnumerateFiles(referencePath, "*.dll")
+                .OrderBy(static path => path, StringComparer.Ordinal))
+            {
+                ResolvedAssemblyReference assembly =
+                    ResolvedAssemblyReference.CreateFromPath(
+                        path,
+                        AssemblyResolutionProvenance.Platform(
+                            framework,
+                            frameworkVersion,
+                            "PlatformTypeCatalog"));
+                if (AssemblyTypeDeclarationInventoryReader.Read(assembly)
+                    is not AssemblyTypeDeclarationInventoryOutcome.Read read)
+                {
+                    return Rejected(
+                        PlatformTypeLookupFailureKind.InvalidAssembly,
+                        "A platform reference assembly could not be inventoried.");
+                }
+
+                foreach (MetadataTypeDefinitionName definition
+                    in read.Inventory.Definitions)
+                {
+                    entries.Add(new PlatformTypeLookupCandidate(
+                        assembly,
+                        definition,
+                        PlatformTypeDeclarationKind.Definition));
+                }
+
+                foreach (MetadataTypeDefinitionName forwarder
+                    in read.Inventory.Forwarders)
+                {
+                    entries.Add(new PlatformTypeLookupCandidate(
+                        assembly,
+                        forwarder,
+                        PlatformTypeDeclarationKind.Forwarder));
+                }
+            }
+
+            return new PlatformTypeCatalogResult.Ready(
+                new PlatformTypeCatalog(
+                    entries
+                        .OrderBy(
+                            static candidate => candidate.Assembly.Identity.Name,
+                            StringComparer.Ordinal)
+                        .ThenBy(
+                            static candidate =>
+                                candidate.Type.ToMetadataFullName(),
+                            StringComparer.Ordinal)
+                        .ThenBy(
+                            static candidate => candidate.DeclarationKind)
+                        .ThenBy(
+                            static candidate => candidate.Assembly.Path,
+                            StringComparer.Ordinal)
+                        .ToImmutableArray()));
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException)
+        {
+            return Rejected(
+                PlatformTypeLookupFailureKind.CatalogUnavailable,
+                "The platform reference catalog could not be built.");
+        }
+    }
+
+    static PlatformTypeCatalogResult.Rejected Rejected(
+        PlatformTypeLookupFailureKind kind,
+        string detail) =>
+        new(new PlatformTypeLookupFailure(kind, detail));
+
+    abstract class PlatformTypeCatalogResult
+    {
+        private protected PlatformTypeCatalogResult()
+        {
+        }
+
+        internal sealed class Ready : PlatformTypeCatalogResult
+        {
+            internal Ready(PlatformTypeCatalog catalog) => Catalog = catalog;
+
+            internal PlatformTypeCatalog Catalog { get; }
+        }
+
+        internal sealed class Rejected : PlatformTypeCatalogResult
+        {
+            internal Rejected(PlatformTypeLookupFailure failure) =>
+                Failure = failure;
+
+            internal PlatformTypeLookupFailure Failure { get; }
+        }
+    }
+}

--- a/src/DotnetInspector.Services/PlatformTypeCatalog.cs
+++ b/src/DotnetInspector.Services/PlatformTypeCatalog.cs
@@ -166,13 +166,27 @@ internal sealed class PlatformTypeCatalog
             return new PlatformTypeLookupOutcome.Rejected(invalid.Failure);
 
         string fullReferencePath = Path.GetFullPath(referencePath);
-        PlatformTypeCatalogResult catalogResult = Cache.GetOrAdd(
+        Lazy<PlatformTypeCatalogResult> cachedCatalog = Cache.GetOrAdd(
             fullReferencePath,
             path => new Lazy<PlatformTypeCatalogResult>(
                 () => Build(path, framework, frameworkVersion),
-                LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        PlatformTypeCatalogResult catalogResult = cachedCatalog.Value;
         if (catalogResult is PlatformTypeCatalogResult.Rejected rejected)
+        {
+            if (rejected.Failure.Kind
+                == PlatformTypeLookupFailureKind.CatalogUnavailable)
+            {
+                // Remove only the failed Lazy observed by this caller; a
+                // concurrent retry may already have installed a replacement.
+                ((ICollection<KeyValuePair<
+                    string,
+                    Lazy<PlatformTypeCatalogResult>>>)Cache).Remove(
+                        new(fullReferencePath, cachedCatalog));
+            }
+
             return new PlatformTypeLookupOutcome.Rejected(rejected.Failure);
+        }
 
         var catalog =
             ((PlatformTypeCatalogResult.Ready)catalogResult).Catalog;
@@ -206,9 +220,11 @@ internal sealed class PlatformTypeCatalog
                         candidate.Type.ToMetadataFullName())
                     == pattern.GenericArity),
             ];
-            if (!sameArity.IsEmpty)
-                selected = sameArity;
+            selected = sameArity;
         }
+
+        if (selected.IsEmpty)
+            return new PlatformTypeLookupOutcome.Missing();
 
         ImmutableArray<PlatformTypeLookupCandidate> exact =
         [

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using ILInspector.CSharp;
+using ILInspector.Findings;
 
 namespace ILInspector.Metadata;
 
@@ -166,6 +167,17 @@ public class ApiSurface
     /// types were resolved from target assemblies.
     /// </summary>
     public bool IsTypeForwardingAssembly { get; set; }
+
+    /// <summary>
+    /// Typed classification evidence retained for consumers that must
+    /// distinguish a non-facade surface from a failed classification.
+    /// </summary>
+    [JsonIgnore]
+    public AssemblySurfaceClassificationOutcome? SurfaceClassification { get; set; }
+
+    [JsonIgnore]
+    public FindingInspection<AssemblySurfaceClassification>?
+        SurfaceClassificationInspection { get; set; }
 }
 
 public sealed record ApiSurfaceInspectionFailure(

--- a/src/ILInspector.Metadata/AssemblyTypeDeclarationInventory.cs
+++ b/src/ILInspector.Metadata/AssemblyTypeDeclarationInventory.cs
@@ -1,0 +1,258 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Reader-independent definition and forwarding declarations from one
+/// acquisition-issued assembly descriptor.
+/// </summary>
+public sealed class AssemblyTypeDeclarationInventory
+{
+    internal AssemblyTypeDeclarationInventory(
+        AssemblyReferenceIdentity identity,
+        ImmutableArray<MetadataTypeDefinitionName> definitions,
+        ImmutableArray<MetadataTypeDefinitionName> forwarders,
+        int meaningfulPublicTypeCount)
+    {
+        Identity = identity;
+        Definitions = definitions;
+        Forwarders = forwarders;
+        MeaningfulPublicTypeCount = meaningfulPublicTypeCount;
+    }
+
+    public AssemblyReferenceIdentity Identity { get; }
+    public ImmutableArray<MetadataTypeDefinitionName> Definitions { get; }
+    public ImmutableArray<MetadataTypeDefinitionName> Forwarders { get; }
+    public int MeaningfulPublicTypeCount { get; }
+}
+
+/// <summary>The typed result of reading one declaration inventory.</summary>
+public abstract class AssemblyTypeDeclarationInventoryOutcome
+{
+    private protected AssemblyTypeDeclarationInventoryOutcome()
+    {
+    }
+
+    public sealed class Read : AssemblyTypeDeclarationInventoryOutcome
+    {
+        internal Read(AssemblyTypeDeclarationInventory inventory) =>
+            Inventory = inventory;
+
+        public AssemblyTypeDeclarationInventory Inventory { get; }
+    }
+
+    public sealed class Rejected : AssemblyTypeDeclarationInventoryOutcome
+    {
+        internal Rejected(CandidateOpenFailure failure) => Failure = failure;
+
+        public CandidateOpenFailure Failure { get; }
+    }
+}
+
+/// <summary>
+/// Copies type declaration facts from an authoritative descriptor stream.
+/// Acquisition and directory discovery remain outside Metadata.
+/// </summary>
+public static class AssemblyTypeDeclarationInventoryReader
+{
+    public static AssemblyTypeDeclarationInventoryOutcome Read(
+        ResolvedAssemblyReference assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        try
+        {
+            using Stream stream = assembly.OpenRead();
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+            {
+                return Rejected(
+                    CandidateOpenFailureKind.InvalidImage,
+                    "The selected image has no managed metadata.");
+            }
+
+            MetadataReader reader = peReader.GetMetadataReader();
+            AssemblyReferenceIdentity actual =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(reader);
+            if (actual != assembly.Identity)
+            {
+                return Rejected(
+                    CandidateOpenFailureKind.InvalidImage,
+                    "The opened image identity does not match the acquisition descriptor.");
+            }
+
+            var definitions =
+                ImmutableArray.CreateBuilder<MetadataTypeDefinitionName>();
+            int meaningfulPublicTypeCount = 0;
+            foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
+            {
+                TypeDefinition definition = reader.GetTypeDefinition(handle);
+                if (MetadataTypeDefinitionNameReader.Read(reader, handle)
+                    is not MetadataTypeDefinitionNameReadResult.Read read)
+                {
+                    return Rejected(
+                        CandidateOpenFailureKind.InvalidImage,
+                        "A type definition name could not be decoded.");
+                }
+
+                definitions.Add(read.Name);
+                if (definition.IsPublic
+                    && !TypeFilters.IsCompilerGenerated(
+                        reader.GetString(definition.Name)))
+                {
+                    meaningfulPublicTypeCount++;
+                }
+            }
+
+            var forwarders =
+                ImmutableArray.CreateBuilder<MetadataTypeDefinitionName>();
+            foreach (ExportedTypeHandle handle in reader.ExportedTypes)
+            {
+                ExportedType exported = reader.GetExportedType(handle);
+                if (!exported.IsForwarder)
+                    continue;
+
+                if (MetadataTypeDefinitionNameReader.Read(reader, handle)
+                    is not MetadataTypeDefinitionNameReadResult.Read read)
+                {
+                    return Rejected(
+                        CandidateOpenFailureKind.InvalidImage,
+                        "A forwarded type name could not be decoded.");
+                }
+
+                forwarders.Add(read.Name);
+            }
+
+            return new AssemblyTypeDeclarationInventoryOutcome.Read(
+                new AssemblyTypeDeclarationInventory(
+                    actual,
+                    definitions.ToImmutable(),
+                    forwarders.ToImmutable(),
+                    meaningfulPublicTypeCount));
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException)
+        {
+            return Rejected(
+                CandidateOpenFailureKind.Unreadable,
+                "The selected image could not be read.");
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentOutOfRangeException)
+        {
+            return Rejected(
+                CandidateOpenFailureKind.InvalidImage,
+                "The selected image metadata is invalid.");
+        }
+    }
+
+    static AssemblyTypeDeclarationInventoryOutcome.Rejected Rejected(
+        CandidateOpenFailureKind kind,
+        string detail) =>
+        new(new CandidateOpenFailure(kind, detail));
+}
+
+public enum AssemblySurfaceKind
+{
+    Implementation,
+    Facade,
+}
+
+/// <summary>
+/// Metadata-owned surface classification derived from a complete typed
+/// declaration inventory.
+/// </summary>
+public sealed record AssemblySurfaceClassification(
+    AssemblySurfaceKind Kind,
+    int ForwarderCount,
+    int MeaningfulPublicTypeCount);
+
+/// <summary>The typed result of classifying one assembly surface.</summary>
+public abstract class AssemblySurfaceClassificationOutcome
+{
+    private protected AssemblySurfaceClassificationOutcome()
+    {
+    }
+
+    public sealed class Classified : AssemblySurfaceClassificationOutcome
+    {
+        internal Classified(AssemblySurfaceClassification classification) =>
+            Classification = classification;
+
+        public AssemblySurfaceClassification Classification { get; }
+    }
+
+    public sealed class Rejected : AssemblySurfaceClassificationOutcome
+    {
+        internal Rejected(CandidateOpenFailure failure) => Failure = failure;
+
+        public CandidateOpenFailure Failure { get; }
+    }
+}
+
+public static class AssemblySurfaceClassifier
+{
+    public static AssemblySurfaceClassificationOutcome Classify(
+        string assemblyPath,
+        AssemblyResolutionProvenance provenance)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
+        ArgumentNullException.ThrowIfNull(provenance);
+        try
+        {
+            return Classify(
+                ResolvedAssemblyReference.CreateFromPath(
+                    assemblyPath,
+                    provenance));
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException)
+        {
+            return new AssemblySurfaceClassificationOutcome.Rejected(
+                new CandidateOpenFailure(
+                    CandidateOpenFailureKind.Unreadable,
+                    "The selected assembly could not be read."));
+        }
+        catch (BadImageFormatException)
+        {
+            return new AssemblySurfaceClassificationOutcome.Rejected(
+                new CandidateOpenFailure(
+                    CandidateOpenFailureKind.InvalidImage,
+                    "The selected assembly is not a valid managed image."));
+        }
+    }
+
+    public static AssemblySurfaceClassificationOutcome Classify(
+        ResolvedAssemblyReference assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        return AssemblyTypeDeclarationInventoryReader.Read(assembly) switch
+        {
+            AssemblyTypeDeclarationInventoryOutcome.Read read =>
+                Classify(read.Inventory),
+            AssemblyTypeDeclarationInventoryOutcome.Rejected rejected =>
+                new AssemblySurfaceClassificationOutcome.Rejected(
+                    rejected.Failure),
+            _ => throw new InvalidOperationException(
+                "Unknown declaration inventory outcome."),
+        };
+    }
+
+    public static AssemblySurfaceClassificationOutcome.Classified Classify(
+        AssemblyTypeDeclarationInventory inventory)
+    {
+        ArgumentNullException.ThrowIfNull(inventory);
+        bool isFacade = inventory.Forwarders.Length > 0
+            && inventory.MeaningfulPublicTypeCount == 0;
+        return new AssemblySurfaceClassificationOutcome.Classified(
+            new AssemblySurfaceClassification(
+                isFacade
+                    ? AssemblySurfaceKind.Facade
+                    : AssemblySurfaceKind.Implementation,
+                inventory.Forwarders.Length,
+                inventory.MeaningfulPublicTypeCount));
+    }
+}

--- a/src/ILInspector.Metadata/AssemblyTypeDeclarationInventory.cs
+++ b/src/ILInspector.Metadata/AssemblyTypeDeclarationInventory.cs
@@ -110,9 +110,35 @@ public static class AssemblyTypeDeclarationInventoryReader
                 ImmutableArray.CreateBuilder<MetadataTypeDefinitionName>();
             foreach (ExportedTypeHandle handle in reader.ExportedTypes)
             {
-                ExportedType exported = reader.GetExportedType(handle);
-                if (!exported.IsForwarder)
+                var traversal =
+                    MetadataRelationshipTraversal
+                        .WalkExportedTypeImplementationChain(reader, handle);
+                if (traversal is
+                    RelationshipTraversalResult<
+                        RelationshipChain<ExportedTypeHandle>>.Rejected)
+                {
+                    return Rejected(
+                        CandidateOpenFailureKind.InvalidImage,
+                        "An exported type relationship could not be decoded.");
+                }
+
+                RelationshipChain<ExportedTypeHandle> chain =
+                    ((RelationshipTraversalResult<
+                        RelationshipChain<ExportedTypeHandle>>.Completed)
+                            traversal).Value;
+                if (chain.Terminal.Kind != HandleKind.AssemblyReference)
                     continue;
+
+                // ECMA-335 marks the root as a forwarder; nested rows point to
+                // that root without carrying tdForwarder themselves.
+                ExportedType root =
+                    reader.GetExportedType(chain.Handles[0]);
+                if (!root.IsForwarder)
+                {
+                    return Rejected(
+                        CandidateOpenFailureKind.InvalidImage,
+                        "An assembly-forwarded type chain is not marked as a forwarder.");
+                }
 
                 if (MetadataTypeDefinitionNameReader.Read(reader, handle)
                     is not MetadataTypeDefinitionNameReadResult.Read read)

--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -23,6 +23,44 @@ public static partial class MetadataFindings
     public static readonly FindingDescriptor AssemblyAttributeDescriptor =
         new("metadata.assembly-attribute", "Assembly or module attribute");
 
+    public static readonly FindingDescriptor AssemblySurfaceDescriptor =
+        new("metadata.assembly-surface", "Assembly surface classification");
+
+    /// <summary>
+    /// Projects a typed surface-classification outcome onto the Finding spine.
+    /// A rejected inventory remains a failed inspection rather than an
+    /// implementation-shaped result.
+    /// </summary>
+    public static FindingInspection<AssemblySurfaceClassification>
+        InspectAssemblySurface(
+            AssemblySurfaceClassificationOutcome outcome,
+            FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return outcome switch
+        {
+            AssemblySurfaceClassificationOutcome.Classified classified =>
+                new FindingInspection<AssemblySurfaceClassification>.Complete(
+                [
+                    new Finding<AssemblySurfaceClassification>(
+                        subject,
+                        AssemblySurfaceDescriptor,
+                        new FindingKey("surface"),
+                        classified.Classification),
+                ]),
+            AssemblySurfaceClassificationOutcome.Rejected rejected =>
+                new FindingInspection<AssemblySurfaceClassification>.Failed(
+                    new InspectionError(
+                        subject,
+                        AssemblySurfaceDescriptor,
+                        rejected.Failure.Detail)),
+            _ => throw new InvalidOperationException(
+                "Unknown assembly surface classification outcome."),
+        };
+    }
+
     public static FindingInspection<AssemblyReference> InspectAssemblyReferences(
         IEnumerable<AssemblyReference> references,
         FindingSubject subject)

--- a/src/ILInspector.Metadata/MetadataTypeDefinitionName.cs
+++ b/src/ILInspector.Metadata/MetadataTypeDefinitionName.cs
@@ -62,6 +62,19 @@ public sealed class MetadataTypeDefinitionName : IEquatable<MetadataTypeDefiniti
     public string Namespace { get; }
     public ImmutableArray<string> Segments { get; }
 
+    /// <summary>
+    /// Projects this lookup name to the dotted spelling used by metadata
+    /// search surfaces. The structured value remains authoritative for exact
+    /// declaration lookup.
+    /// </summary>
+    public string ToMetadataFullName()
+    {
+        string typeName = string.Join('.', Segments);
+        return Namespace.Length == 0
+            ? typeName
+            : $"{Namespace}.{typeName}";
+    }
+
     public static MetadataTypeDefinitionNameResult Create(
         string? @namespace,
         ImmutableArray<string> segments)

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2984,7 +2984,7 @@ public partial class CommandExecutionTests
             return;
         }
 
-        Assert.SkipUnless(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath),
+        Assert.SkipUnless(IsFacadeAssembly(assemblyPath),
             "System.Runtime is not facade-only in this runtime.");
 
         var (exit, output, runError) = await RunAppAsync(
@@ -3005,7 +3005,7 @@ public partial class CommandExecutionTests
             return;
         }
 
-        Assert.False(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+        Assert.False(IsFacadeAssembly(assemblyPath));
 
         var (exit, output, runError) = await RunAppAsync(
             "type", "--platform", "System.Text.Json", "--tips", "q");
@@ -3014,6 +3014,11 @@ public partial class CommandExecutionTests
         Assert.Empty(runError);
         Assert.DoesNotContain("This is a type-forwarding library", output);
     }
+
+    private static bool IsFacadeAssembly(string assemblyPath) =>
+        PlatformResolver.ClassifyAssemblySurface(assemblyPath)
+            is AssemblySurfaceClassificationOutcome.Classified classified
+        && classified.Classification.Kind == AssemblySurfaceKind.Facade;
 
     [Fact]
     public async Task Type_SingleType_SelectSection_RendersSectionNotShape()
@@ -8787,7 +8792,7 @@ public partial class CommandExecutionTests
             return;
         }
 
-        Assert.SkipUnless(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath),
+        Assert.SkipUnless(IsFacadeAssembly(assemblyPath),
             "System.Runtime.CompilerServices.Unsafe is not facade-only in this runtime.");
 
         var (exit, output, runError) = await RunAppAsync(
@@ -8808,7 +8813,7 @@ public partial class CommandExecutionTests
             return;
         }
 
-        Assert.False(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+        Assert.False(IsFacadeAssembly(assemblyPath));
 
         var (exit, output, runError) = await RunAppAsync(
             "library", "System.Text.Json", "-S", "Library Info", "--tips", "q");
@@ -8878,7 +8883,7 @@ public partial class CommandExecutionTests
             return;
         }
 
-        Assert.SkipUnless(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath),
+        Assert.SkipUnless(IsFacadeAssembly(assemblyPath),
             "System.Runtime is not facade-only in this runtime.");
 
         var (selectExit, selectOutput, selectError) = await RunAppAsync(
@@ -11513,7 +11518,7 @@ public partial class CommandExecutionTests
             return;
         }
 
-        Assert.SkipUnless(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath),
+        Assert.SkipUnless(IsFacadeAssembly(assemblyPath),
             "System.Runtime.CompilerServices.Unsafe is not facade-only in this runtime.");
 
         var (exit, output, runError) = await RunAppAsync(
@@ -11536,7 +11541,7 @@ public partial class CommandExecutionTests
             return;
         }
 
-        Assert.False(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+        Assert.False(IsFacadeAssembly(assemblyPath));
 
         var (exit, output, runError) = await RunAppAsync(
             "System.Text.Json", "--markdown", "-v:q", "--tips", "q");

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3015,6 +3015,17 @@ public partial class CommandExecutionTests
         Assert.DoesNotContain("This is a type-forwarding library", output);
     }
 
+    [Fact]
+    public async Task BareQualifiedPlatformType_WithLeafCollision_RoutesExactly()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.IO.File", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("ambiguous", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("System.IO.File", output);
+    }
+
     private static bool IsFacadeAssembly(string assemblyPath) =>
         PlatformResolver.ClassifyAssemblySurface(assemblyPath)
             is AssemblySurfaceClassificationOutcome.Classified classified

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 using DotnetInspector.Services;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Tests;
 
@@ -173,7 +174,7 @@ public class PlatformResolverTests
     }
 
     [Fact]
-    public void IsFacadeOnlyAssembly_UnsafeFacade_ReturnsTrue()
+    public void ClassifyAssemblySurface_UnsafeFacade_ReturnsFacade()
     {
         var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Runtime.CompilerServices.Unsafe");
         if (assemblyPath == null || error != null)
@@ -182,11 +183,18 @@ public class PlatformResolverTests
             return;
         }
 
-        Assert.True(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+        var classified = Assert.IsType<
+            AssemblySurfaceClassificationOutcome.Classified>(
+                PlatformResolver.ClassifyAssemblySurface(assemblyPath));
+        Assert.Equal(
+            AssemblySurfaceKind.Facade,
+            classified.Classification.Kind);
+        Assert.True(classified.Classification.ForwarderCount > 0);
+        Assert.Equal(0, classified.Classification.MeaningfulPublicTypeCount);
     }
 
     [Fact]
-    public void IsFacadeOnlyAssembly_SystemTextJson_ReturnsFalse()
+    public void ClassifyAssemblySurface_SystemTextJson_ReturnsImplementation()
     {
         var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Text.Json");
         if (assemblyPath == null || error != null)
@@ -195,7 +203,91 @@ public class PlatformResolverTests
             return;
         }
 
-        Assert.False(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath));
+        var classified = Assert.IsType<
+            AssemblySurfaceClassificationOutcome.Classified>(
+                PlatformResolver.ClassifyAssemblySurface(assemblyPath));
+        Assert.Equal(
+            AssemblySurfaceKind.Implementation,
+            classified.Classification.Kind);
+        Assert.True(
+            classified.Classification.MeaningfulPublicTypeCount > 0);
+    }
+
+    [Theory]
+    [InlineData("Dictionary<TKey,TValue>", "System.Collections")]
+    [InlineData("System.Collections.Generic.Dictionary`2", "System.Collections")]
+    [InlineData("FrozenDictionary", "System.Collections.Immutable")]
+    [InlineData("int", "System.Runtime")]
+    public void LookupType_ResolvesDefinitionDeterministically(
+        string pattern,
+        string expectedAssembly)
+    {
+        var resolved = Assert.IsType<PlatformTypeLookupOutcome.Resolved>(
+            PlatformResolver.LookupType(pattern));
+
+        Assert.Equal(
+            expectedAssembly,
+            resolved.Candidate.Assembly.Identity.Name);
+        Assert.Equal(
+            PlatformTypeDeclarationKind.Definition,
+            resolved.Candidate.DeclarationKind);
+    }
+
+    [Fact]
+    public void LookupType_MissingPattern_ReturnsMissing()
+    {
+        Assert.IsType<PlatformTypeLookupOutcome.Missing>(
+            PlatformResolver.LookupType(
+                $"Definitely.Missing.Type{Guid.NewGuid():N}"));
+    }
+
+    [Fact]
+    public void LookupType_UnqualifiedCollision_ReturnsOrderedAmbiguity()
+    {
+        var ambiguous = Assert.IsType<PlatformTypeLookupOutcome.Ambiguous>(
+            PlatformResolver.LookupType("Enumerator"));
+
+        Assert.True(ambiguous.Candidates.Length > 1);
+        Assert.Equal(
+            ambiguous.Candidates
+                .OrderBy(
+                    candidate => candidate.Assembly.Identity.Name,
+                    StringComparer.Ordinal)
+                .ThenBy(
+                    candidate => candidate.Type.ToMetadataFullName(),
+                    StringComparer.Ordinal)
+                .ThenBy(candidate => candidate.DeclarationKind)
+                .ThenBy(
+                    candidate => candidate.Assembly.Path,
+                    StringComparer.Ordinal),
+            ambiguous.Candidates);
+    }
+
+    [Fact]
+    public void LookupType_NestedSeparatorsAreEquivalent()
+    {
+        var dotted = Assert.IsType<PlatformTypeLookupOutcome.Resolved>(
+            PlatformResolver.LookupType(
+                "System.Collections.Generic.Dictionary`2.Enumerator"));
+        var plus = Assert.IsType<PlatformTypeLookupOutcome.Resolved>(
+            PlatformResolver.LookupType(
+                "System.Collections.Generic.Dictionary`2+Enumerator"));
+
+        Assert.Equal(dotted.Candidate.Type, plus.Candidate.Type);
+        Assert.Equal(
+            "System.Collections",
+            plus.Candidate.Assembly.Identity.Name);
+    }
+
+    [Fact]
+    public void LookupType_EmptyPattern_ReturnsRejected()
+    {
+        var rejected = Assert.IsType<PlatformTypeLookupOutcome.Rejected>(
+            PlatformResolver.LookupType(""));
+
+        Assert.Equal(
+            PlatformTypeLookupFailureKind.InvalidPattern,
+            rejected.Failure.Kind);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -242,6 +242,51 @@ public class PlatformResolverTests
     }
 
     [Fact]
+    public void LookupType_ExplicitMissingGenericArity_ReturnsMissing()
+    {
+        Assert.IsType<PlatformTypeLookupOutcome.Missing>(
+            PlatformResolver.LookupType("Dictionary<T1,T2,T3>"));
+    }
+
+    [Fact]
+    public void PlatformTypeCatalog_UnavailableDirectory_IsRetried()
+    {
+        string referencePath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-platform-catalog-{Guid.NewGuid():N}");
+        string typeName = typeof(PlatformResolverTests).FullName!;
+        try
+        {
+            var rejected = Assert.IsType<PlatformTypeLookupOutcome.Rejected>(
+                PlatformTypeCatalog.Lookup(
+                    typeName,
+                    referencePath,
+                    "test",
+                    "1.0.0"));
+            Assert.Equal(
+                PlatformTypeLookupFailureKind.CatalogUnavailable,
+                rejected.Failure.Kind);
+
+            Directory.CreateDirectory(referencePath);
+            File.Copy(
+                typeof(PlatformResolverTests).Assembly.Location,
+                Path.Combine(referencePath, "CatalogFixture.dll"));
+
+            Assert.IsType<PlatformTypeLookupOutcome.Resolved>(
+                PlatformTypeCatalog.Lookup(
+                    typeName,
+                    referencePath,
+                    "test",
+                    "1.0.0"));
+        }
+        finally
+        {
+            if (Directory.Exists(referencePath))
+                Directory.Delete(referencePath, recursive: true);
+        }
+    }
+
+    [Fact]
     public void LookupType_UnqualifiedCollision_ReturnsOrderedAmbiguity()
     {
         var ambiguous = Assert.IsType<PlatformTypeLookupOutcome.Ambiguous>(

--- a/src/dotnet-inspect.Tests/SourceResolverTests.cs
+++ b/src/dotnet-inspect.Tests/SourceResolverTests.cs
@@ -111,6 +111,28 @@ public class SourceResolverTests
     }
 
     [Fact]
+    public void TryResolveQualifiedTypeName_AmbiguousCatalogFallbackReportsFailure()
+    {
+        var (assemblyPath, _, _, error) =
+            PlatformResolver.ResolveAssembly("System.Numerics");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Numerics not available: {error}");
+            return;
+        }
+
+        string? failure = null;
+        var probe = SourceResolver.TryResolveQualifiedTypeName(
+            "System.Numerics.Enumerator",
+            NoSourceKeys,
+            allowPlatformPrefixFallback: true,
+            message => failure = message);
+
+        Assert.Null(probe);
+        Assert.Contains("ambiguous", failure, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task ResolveAsync_PackageTypeSyntax_DoesNotUseRootPlatformFallback()
     {
         var source = await SourceResolver.ResolveAsync(

--- a/src/dotnet-inspect.Tests/SourceResolverTests.cs
+++ b/src/dotnet-inspect.Tests/SourceResolverTests.cs
@@ -132,6 +132,27 @@ public class SourceResolverTests
         Assert.Contains("ambiguous", failure, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("System.IO.File", "System.Runtime")]
+    [InlineData("System.Threading.ThreadState", "System.Threading.Thread")]
+    public void TryResolveQualifiedTypeName_UsesQualifiedCatalogIdentity(
+        string typeName,
+        string expectedAssembly)
+    {
+        string? failure = null;
+        var probe = SourceResolver.TryResolveQualifiedTypeName(
+            typeName,
+            NoSourceKeys,
+            allowPlatformPrefixFallback: true,
+            message => failure = message);
+
+        Assert.Null(failure);
+        Assert.NotNull(probe);
+        Assert.Equal(expectedAssembly, probe.SourceName);
+        Assert.Equal(typeName, probe.Remainder);
+        Assert.Equal(SourceResolver.LocalSourceKind.Platform, probe.Kind);
+    }
+
     [Fact]
     public async Task ResolveAsync_PackageTypeSyntax_DoesNotUseRootPlatformFallback()
     {

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -217,18 +217,38 @@ public static class RouterCommandDefinition
                     context.Logger.Log);
                 if (resolvedPath != null && resolvedError == null)
                 {
-                    if (target.Count(c => c == '.') >= 2 && PlatformResolver.IsFacadeOnlyAssembly(resolvedPath))
-                        return ["type", target, .. tail];
+                    AssemblySurfaceClassificationOutcome classification =
+                        PlatformResolver.ClassifyAssemblySurface(resolvedPath);
+                    if (classification
+                        is AssemblySurfaceClassificationOutcome.Rejected rejected)
+                    {
+                        CommandError.Write(
+                            $"Could not classify the platform assembly surface ({rejected.Failure.Kind}).");
+                        return tokens;
+                    }
 
-                    return ["library", target, .. tail];
+                    bool isFacade =
+                        ((AssemblySurfaceClassificationOutcome.Classified)
+                            classification).Classification.Kind
+                        == AssemblySurfaceKind.Facade;
+                    return target.Count(c => c == '.') >= 2 && isFacade
+                        ? ["type", target, .. tail]
+                        : ["library", target, .. tail];
                 }
             }
 
             var allowPlatformPrefixFallback = PlatformResolver.IsPlatformCandidate(target);
+            string? platformLookupFailure = null;
             var memberSplit = SharedParsers.TrySplitQualifiedTypeMember(
                 target,
                 sourceKeys,
-                allowPlatformPrefixFallback);
+                allowPlatformPrefixFallback,
+                message => platformLookupFailure = message);
+            if (platformLookupFailure is not null)
+            {
+                CommandError.Write(platformLookupFailure);
+                return tokens;
+            }
             if (memberSplit != null)
             {
                 var probe = memberSplit.Value.Probe;
@@ -266,7 +286,13 @@ public static class RouterCommandDefinition
             var typeProbe = SourceResolver.TryResolveQualifiedTypeName(
                 target,
                 sourceKeys,
-                allowPlatformPrefixFallback);
+                allowPlatformPrefixFallback,
+                message => platformLookupFailure = message);
+            if (platformLookupFailure is not null)
+            {
+                CommandError.Write(platformLookupFailure);
+                return tokens;
+            }
             if (typeProbe != null)
             {
                 if (typeProbe.Kind == SourceResolver.LocalSourceKind.Platform

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -161,10 +161,14 @@ public static class MemberOptionsParser
             && positionalMembers.Count == 0
             && optionMembers.Length == 0)
         {
+            string? platformLookupFailure = null;
             var split = SharedParsers.TrySplitQualifiedTypeMember(
                 source.PackagePath,
                 sourceKeys,
-                allowPlatformPrefixFallback: true);
+                allowPlatformPrefixFallback: true,
+                message => platformLookupFailure = message);
+            if (platformLookupFailure is not null)
+                return new VersionError(platformLookupFailure);
             if (split != null)
             {
                 positionalMembers.Add(split.Value.MemberName);
@@ -185,10 +189,14 @@ public static class MemberOptionsParser
             && source.PlatformAssembly == null
             && source.AssemblyPath == null)
         {
+            string? platformLookupFailure = null;
             var probe = SourceResolver.TryResolveQualifiedTypeName(
                 source.PackagePath,
                 sourceKeys,
-                allowPlatformPrefixFallback: true);
+                allowPlatformPrefixFallback: true,
+                message => platformLookupFailure = message);
+            if (platformLookupFailure is not null)
+                return new VersionError(platformLookupFailure);
             if (probe != null)
             {
                 if (source.TypeName != null)

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -97,7 +97,8 @@ public static class SharedParsers
     internal static (SourceResolver.LocalProbeResult Probe, string MemberName)? TrySplitQualifiedTypeMember(
         string value,
         IReadOnlyList<string> sourceKeys,
-        bool allowPlatformPrefixFallback)
+        bool allowPlatformPrefixFallback,
+        Action<string>? reportPlatformLookupFailure = null)
     {
         for (var i = value.Length - 1; i > 0; i--)
         {
@@ -109,10 +110,17 @@ public static class SharedParsers
             if (string.IsNullOrWhiteSpace(memberName))
                 continue;
 
+            string? platformLookupFailure = null;
             var probe = SourceResolver.TryResolveQualifiedTypeName(
                 typeCandidate,
                 sourceKeys,
-                allowPlatformPrefixFallback);
+                allowPlatformPrefixFallback,
+                message => platformLookupFailure = message);
+            if (platformLookupFailure is not null)
+            {
+                reportPlatformLookupFailure?.Invoke(platformLookupFailure);
+                return null;
+            }
             if (probe != null)
                 return (probe, memberName);
 

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -258,8 +258,14 @@ internal static class ApiServices
 
         if (resolvedCount > 0)
         {
+            AssemblyResolutionProvenance provenance = isPlatformAssembly
+                ? AssemblyResolutionProvenance.Platform(
+                    "InstalledPlatform",
+                    frameworkVersion: null,
+                    "ApiServices")
+                : AssemblyResolutionProvenance.Local("ApiServices");
             api.SurfaceClassification =
-                PlatformResolver.ClassifyAssemblySurface(dllPath);
+                AssemblySurfaceClassifier.Classify(dllPath, provenance);
             api.SurfaceClassificationInspection =
                 MetadataFindings.InspectAssemblySurface(
                     api.SurfaceClassification,

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -3,6 +3,7 @@ using ILInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Services;
+using ILInspector.Findings;
 
 namespace DotnetInspector.Inspectors;
 
@@ -257,7 +258,25 @@ internal static class ApiServices
 
         if (resolvedCount > 0)
         {
-            api.IsTypeForwardingAssembly = PlatformResolver.IsFacadeOnlyAssembly(dllPath);
+            api.SurfaceClassification =
+                PlatformResolver.ClassifyAssemblySurface(dllPath);
+            api.SurfaceClassificationInspection =
+                MetadataFindings.InspectAssemblySurface(
+                    api.SurfaceClassification,
+                    new FindingSubject(
+                        Path.GetFullPath(dllPath),
+                        Path.GetFileName(dllPath)));
+            api.IsTypeForwardingAssembly =
+                api.SurfaceClassification
+                    is AssemblySurfaceClassificationOutcome.Classified classified
+                && classified.Classification.Kind
+                    == AssemblySurfaceKind.Facade;
+            if (api.SurfaceClassification
+                is AssemblySurfaceClassificationOutcome.Rejected rejected)
+            {
+                logger.Log(
+                    $"Could not classify the forwarding surface: {rejected.Failure.Kind}.");
+            }
             api.PublicTypeCount = api.Types.Count;
             api.Types = api.Types.OrderBy(t => t.FullName).ToList();
             logger.Log($"Resolved {resolvedCount} types from forwarded libraries.");

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -79,11 +79,25 @@ internal static class LibraryMetadataService
 
             var needsAuditSignals = scanners?.Contains(LibrarySections.ScannerAuditSignals) == true;
 
+            AssemblySurfaceClassificationOutcome? surfaceClassification =
+                isPlatformAssembly
+                    ? PlatformResolver.ClassifyAssemblySurface(path)
+                    : null;
             var inspection = new LibraryInspection
             {
                 FileName = Path.GetFileName(path),
                 FileType = "dll",
-                IsFacadeAssembly = isPlatformAssembly ? PlatformResolver.IsFacadeOnlyAssembly(path) : null,
+                IsFacadeAssembly = surfaceClassification
+                    is AssemblySurfaceClassificationOutcome.Classified classified
+                        ? classified.Classification.Kind
+                            == AssemblySurfaceKind.Facade
+                        : null,
+                SurfaceClassification = surfaceClassification,
+                SurfaceClassificationInspection = surfaceClassification is null
+                    ? null
+                    : MetadataFindings.InspectAssemblySurface(
+                        surfaceClassification,
+                        FindingSubjectFor(path)),
                 UseDependenciesView = options.IncludeDependencies,
                 PerformanceTriageOptions = options.PerformanceTriage
             };

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -119,6 +119,21 @@ public class LibraryInspection
     public bool? IsFacadeAssembly { get; set; }
 
     /// <summary>
+    /// Typed classification evidence for platform assemblies. Presentation
+    /// continues to project the compatible nullable facade field.
+    /// </summary>
+    [JsonIgnore]
+    public AssemblySurfaceClassificationOutcome? SurfaceClassification { get; set; }
+
+    /// <summary>
+    /// Finding projection of <see cref="SurfaceClassification"/> for composed
+    /// inspection and failure reporting.
+    /// </summary>
+    [JsonIgnore]
+    public FindingInspection<AssemblySurfaceClassification>?
+        SurfaceClassificationInspection { get; set; }
+
+    /// <summary>
     /// File last modified timestamp.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -112,17 +112,24 @@ public static class SourceResolver
         // System.Runtime, not System.Numerics).
         if (platformCandidate != null)
         {
-            switch (PlatformResolver.LookupType(platformCandidate))
+            PlatformTypeLookupOutcome lookup =
+                PlatformResolver.LookupType(name);
+            if (lookup is PlatformTypeLookupOutcome.Missing)
+                lookup = PlatformResolver.LookupType(platformCandidate);
+
+            switch (lookup)
             {
                 case PlatformTypeLookupOutcome.Resolved resolved:
                     string runtimeLibrary =
                         resolved.Candidate.Assembly.Identity.Name;
+                    string exactTypeName =
+                        resolved.Candidate.Type.ToMetadataFullName();
                     RequestTelemetry.Breadcrumb(
                         "qualified-type-split",
-                        $"{name} -> platform={runtimeLibrary}; type={platformCandidate}");
+                        $"{name} -> platform={runtimeLibrary}; type={exactTypeName}");
                     return new LocalProbeResult(
                         runtimeLibrary,
-                        platformCandidate,
+                        exactTypeName,
                         LocalSourceKind.Platform);
                 case PlatformTypeLookupOutcome.Missing:
                     break;

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -57,7 +57,8 @@ public static class SourceResolver
     /// </summary>
     internal static LocalProbeResult? TryProbeLocalQualifiedName(
         string name,
-        IReadOnlyList<string> sourceKeys)
+        IReadOnlyList<string> sourceKeys,
+        Action<string>? reportPlatformLookupFailure = null)
     {
         // Require at least 2 dots (e.g., System.Text.Json.JsonSerializer).
         // Single-dot names like "System.CommandLine" are ambiguous: could be
@@ -111,13 +112,28 @@ public static class SourceResolver
         // System.Runtime, not System.Numerics).
         if (platformCandidate != null)
         {
-            var runtimeLib = PlatformResolver.FindLibraryContainingType(platformCandidate);
-            if (runtimeLib != null)
+            switch (PlatformResolver.LookupType(platformCandidate))
             {
-                RequestTelemetry.Breadcrumb(
-                    "qualified-type-split",
-                    $"{name} -> platform={runtimeLib}; type={platformCandidate}");
-                return new LocalProbeResult(runtimeLib, platformCandidate, LocalSourceKind.Platform);
+                case PlatformTypeLookupOutcome.Resolved resolved:
+                    string runtimeLibrary =
+                        resolved.Candidate.Assembly.Identity.Name;
+                    RequestTelemetry.Breadcrumb(
+                        "qualified-type-split",
+                        $"{name} -> platform={runtimeLibrary}; type={platformCandidate}");
+                    return new LocalProbeResult(
+                        runtimeLibrary,
+                        platformCandidate,
+                        LocalSourceKind.Platform);
+                case PlatformTypeLookupOutcome.Missing:
+                    break;
+                case PlatformTypeLookupOutcome.Ambiguous ambiguous:
+                    reportPlatformLookupFailure?.Invoke(
+                        $"Platform type lookup is ambiguous across {ambiguous.Candidates.Length} candidates.");
+                    break;
+                case PlatformTypeLookupOutcome.Rejected rejected:
+                    reportPlatformLookupFailure?.Invoke(
+                        $"Platform type lookup failed ({rejected.Failure.Kind}).");
+                    break;
             }
         }
 
@@ -131,10 +147,21 @@ public static class SourceResolver
     internal static LocalProbeResult? TryResolveQualifiedTypeName(
         string name,
         IReadOnlyList<string> sourceKeys,
-        bool allowPlatformPrefixFallback)
+        bool allowPlatformPrefixFallback,
+        Action<string>? reportPlatformLookupFailure = null)
     {
-        var probe = TryProbeLocalQualifiedName(name, sourceKeys);
-        if (probe != null || !allowPlatformPrefixFallback)
+        bool platformLookupFailed = false;
+        var probe = TryProbeLocalQualifiedName(
+            name,
+            sourceKeys,
+            message =>
+            {
+                platformLookupFailed = true;
+                reportPlatformLookupFailure?.Invoke(message);
+            });
+        if (probe != null
+            || platformLookupFailed
+            || !allowPlatformPrefixFallback)
             return probe;
 
         return TryProbePlatformQualifiedPrefix(name);
@@ -291,14 +318,16 @@ public static class SourceResolver
                 
                 if (!mightBeTypeDotMember)
                 {
-                    var library = PlatformResolver.FindLibraryContainingType(packagePath);
-                    if (library != null)
+                    PlatformTypeLookupOutcome lookup =
+                        PlatformResolver.LookupType(packagePath);
+                    if (lookup is PlatformTypeLookupOutcome.Resolved resolved)
                     {
                         typeName = packagePath;
                         packagePath = null;
-                        platformAssembly = library;
+                        platformAssembly =
+                            resolved.Candidate.Assembly.Identity.Name;
                     }
-                    else
+                    else if (lookup is PlatformTypeLookupOutcome.Missing)
                     {
                         // Convert backtick notation back to C#-style for display
                         var displayName = MetadataTypeNameFormatter.FormatGenericTypeName(packagePath);
@@ -306,6 +335,32 @@ public static class SourceResolver
                             packagePath, assemblyPath, platformAssembly, null, null,
                             VersionError: true,
                             VersionErrorMessage: $"'{displayName}' looks like a type name but was not found in platform libraries. Specify the source: 'source <package> \"{displayName}\"'.");
+                    }
+                    else if (lookup
+                        is PlatformTypeLookupOutcome.Ambiguous ambiguous)
+                    {
+                        return new ResolvedSource(
+                            packagePath,
+                            assemblyPath,
+                            platformAssembly,
+                            null,
+                            null,
+                            VersionError: true,
+                            VersionErrorMessage:
+                                $"The platform type name is ambiguous across {ambiguous.Candidates.Length} candidates. Use --platform to select its source.");
+                    }
+                    else if (lookup
+                        is PlatformTypeLookupOutcome.Rejected rejected)
+                    {
+                        return new ResolvedSource(
+                            packagePath,
+                            assemblyPath,
+                            platformAssembly,
+                            null,
+                            null,
+                            VersionError: true,
+                            VersionErrorMessage:
+                                $"Platform type lookup failed ({rejected.Failure.Kind}). Specify the source explicitly.");
                     }
                 }
             }
@@ -358,10 +413,23 @@ public static class SourceResolver
                 if (tryQualifiedTypeName && typeName == null
                     && packagePath != null && platformAssembly == null && assemblyPath == null)
                 {
+                    string? platformLookupFailure = null;
                     var probe = TryResolveQualifiedTypeName(
                         bareName,
                         sourceKeys,
-                        allowPlatformPrefixFallback: true);
+                        allowPlatformPrefixFallback: true,
+                        message => platformLookupFailure = message);
+                    if (platformLookupFailure is not null)
+                    {
+                        return new ResolvedSource(
+                            packagePath,
+                            assemblyPath,
+                            platformAssembly,
+                            null,
+                            null,
+                            VersionError: true,
+                            VersionErrorMessage: platformLookupFailure);
+                    }
                     if (probe != null)
                     {
                         typeName = probe.Remainder;

--- a/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
+++ b/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using ILInspector.Findings;
 
 namespace ILInspector.Metadata.Tests;
 
@@ -41,6 +42,82 @@ public class PdbContextDescriptorTests
         Assert.Equal(identity.Name, context.ExtractAssemblyInfo().AssemblyName);
         Assert.Null(context.AssemblyPathOrNull);
         Assert.Throws<InvalidOperationException>(() => context.AssemblyPath);
+    }
+
+    [Fact]
+    public void DeclarationInventory_UsesAuthoritativeDescriptorStream()
+    {
+        string authoritativePath =
+            typeof(PdbContextDescriptorTests).Assembly.Location;
+        string informationalPath = typeof(PdbContext).Assembly.Location;
+        byte[] authoritativeImage = File.ReadAllBytes(authoritativePath);
+        AssemblyReferenceIdentity identity = ReadIdentity(authoritativeImage);
+        var descriptor = ResolvedAssemblyReference.Create(
+            identity,
+            informationalPath,
+            () => new MemoryStream(authoritativeImage, writable: false),
+            AssemblyResolutionProvenance.Local("test"));
+
+        var read = Assert.IsType<
+            AssemblyTypeDeclarationInventoryOutcome.Read>(
+                AssemblyTypeDeclarationInventoryReader.Read(descriptor));
+
+        Assert.Equal(identity, read.Inventory.Identity);
+        Assert.Contains(
+            read.Inventory.Definitions,
+            name => name.ToMetadataFullName()
+                == typeof(PdbContextDescriptorTests).FullName);
+    }
+
+    [Fact]
+    public void DeclarationInventory_RejectsDescriptorIdentityMismatch()
+    {
+        byte[] authoritativeImage = File.ReadAllBytes(
+            typeof(PdbContextDescriptorTests).Assembly.Location);
+        AssemblyReferenceIdentity wrongIdentity =
+            ReadIdentity(File.ReadAllBytes(typeof(PdbContext).Assembly.Location));
+        var descriptor = ResolvedAssemblyReference.Create(
+            wrongIdentity,
+            path: null,
+            () => new MemoryStream(authoritativeImage, writable: false),
+            AssemblyResolutionProvenance.Local("test"));
+
+        var rejected = Assert.IsType<
+            AssemblyTypeDeclarationInventoryOutcome.Rejected>(
+                AssemblyTypeDeclarationInventoryReader.Read(descriptor));
+
+        Assert.Equal(
+            CandidateOpenFailureKind.InvalidImage,
+            rejected.Failure.Kind);
+    }
+
+    [Fact]
+    public void SurfaceClassification_ProjectsSuccessAndFailureToFindings()
+    {
+        string path = typeof(PdbContextDescriptorTests).Assembly.Location;
+        AssemblySurfaceClassificationOutcome classified =
+            AssemblySurfaceClassifier.Classify(
+                path,
+                AssemblyResolutionProvenance.Local("test"));
+        var subject = new FindingSubject(path, Path.GetFileName(path));
+
+        var complete = Assert.IsType<
+            FindingInspection<AssemblySurfaceClassification>.Complete>(
+                MetadataFindings
+                    .InspectAssemblySurface(classified, subject).Value);
+        Assert.Single(complete.Findings);
+        Assert.Equal(
+            AssemblySurfaceKind.Implementation,
+            complete.Findings[0].Payload.Kind);
+
+        var rejected = new AssemblySurfaceClassificationOutcome.Rejected(
+            new CandidateOpenFailure(
+                CandidateOpenFailureKind.InvalidImage,
+                "Invalid metadata."));
+        Assert.IsType<
+            FindingInspection<AssemblySurfaceClassification>.Failed>(
+                MetadataFindings
+                    .InspectAssemblySurface(rejected, subject).Value);
     }
 
     static AssemblyReferenceIdentity ReadIdentity(byte[] image)

--- a/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
+++ b/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using ILInspector.Findings;
 
@@ -92,6 +94,27 @@ public class PdbContextDescriptorTests
     }
 
     [Fact]
+    public void DeclarationInventory_IncludesNestedForwardedTypes()
+    {
+        byte[] image = BuildNestedForwarderAssembly();
+        AssemblyReferenceIdentity identity = ReadIdentity(image);
+        var descriptor = ResolvedAssemblyReference.Create(
+            identity,
+            path: null,
+            () => new MemoryStream(image, writable: false),
+            AssemblyResolutionProvenance.Local("test"));
+
+        var read = Assert.IsType<
+            AssemblyTypeDeclarationInventoryOutcome.Read>(
+                AssemblyTypeDeclarationInventoryReader.Read(descriptor));
+
+        Assert.Contains(
+            read.Inventory.Forwarders,
+            name => name.Namespace == "N"
+                && name.Segments.SequenceEqual(["Outer", "Inner"]));
+    }
+
+    [Fact]
     public void SurfaceClassification_ProjectsSuccessAndFailureToFindings()
     {
         string path = typeof(PdbContextDescriptorTests).Assembly.Location;
@@ -126,5 +149,59 @@ public class PdbContextDescriptorTests
         using var peReader = new PEReader(stream);
         return AssemblyReferenceIdentity.FromAssemblyDefinition(
             peReader.GetMetadataReader());
+    }
+
+    static byte[] BuildNestedForwarderAssembly()
+    {
+        const TypeAttributes Forwarder = (TypeAttributes)0x00200000;
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("NestedForwarder.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("NestedForwarder"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        AssemblyReferenceHandle target = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Target"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        ExportedTypeHandle outer = metadata.AddExportedType(
+            TypeAttributes.Public | Forwarder,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("Outer"),
+            target,
+            typeDefinitionId: 0);
+        metadata.AddExportedType(
+            TypeAttributes.NestedPublic,
+            default,
+            metadata.GetOrAddString("Inner"),
+            outer,
+            typeDefinitionId: 0);
+
+        var builder = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        builder.Serialize(image);
+        return image.ToArray();
     }
 }


### PR DESCRIPTION
## Summary

Platform type discovery and facade routing now consume structured, typed evidence instead of first-file-wins strings and raw forwarder-row probes. This completes type-forwarding Slice 4.

- Add a Metadata-owned, descriptor-authoritative declaration inventory carrying exact `MetadataTypeDefinitionName` definitions and forwarders.
- Derive facade classification from that inventory, retain rejected outcomes, and project classification onto the Finding spine.
- Replace `FindLibraryContainingType` with a cached, deterministic platform reference catalog and closed `Resolved` / `Missing` / `Ambiguous` / `Rejected` outcomes.
- Preserve lookup behavior for generic arity, exact and unqualified names, case, nested `+`/`.` spelling, and primitive aliases. Policy prefers definitions, then matching arity and exact names; true collisions remain explicit ambiguity.
- Migrate `SourceResolver`, member parsing, router rewriting, `LibraryMetadataService`, and `ApiServices` without reducing rejection to `null`/`false` or choosing a first-enumerated source.
- Delete `PlatformResolver.FindLibraryContainingType` and `IsFacadeOnlyAssembly`.

## Compatibility

Existing successful routing remains intact, including exact non-generic selection when a generic family shares the name (`FrozenDictionary`) and facade/non-facade output. Unqualified collisions such as `Enumerator` now report ambiguity instead of depending on filesystem or metadata enumeration order.

## Boundary

This completes source/API consumer Slice 4. Direct caller definition correspondence remains Slice 5. #3671 remains separate: this PR builds a live trusted ref-pack lookup catalog; it does not define or serialize the non-authoritative platform availability index or pre-baked context recipes requested there.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `source eng/activate-iltools.sh --mdv && dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — 1,410 passed
- `source eng/activate-iltools.sh --mdv && dotnet run --project src/DotnetInspector.Services.Tests -c Release` — 360 passed
- `source eng/activate-iltools.sh --mdv && dotnet run --project src/dotnet-inspect.Tests -c Release` — 2,919 run; 2,914 passed, 4 platform-dependent skips, 1 unrelated existing local-fixture failure in `Layout_Count_CountsFilesRatherThanRenderedTreeLines` because `Newtonsoft.Json.nuspec` is absent
- Focused platform lookup, exact/generic ranking, ambiguity propagation, source/parser, facade routing, classification/Finding, descriptor authority, identity mismatch, and containment gates pass
- `npx markdownlint-cli docs/design/type-forwarding-resolution.md docs/design/assembly-inspection-query.md`
