### PR TITLE
Gate record durability before pool reconcile

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -588,6 +588,47 @@ public class EvilPoolSweepGateTests
     }
 
     /// <summary>
+    /// A sweep does not reconcile the pool until its new record is durable.
+    ///
+    /// <para>The first run leaves a complete pool and the record that names it. The second
+    /// run would record only the lead, but its <c>assemblies.txt</c> replacement is made to
+    /// fail after the replacement temporary has been written. That failure exits 2 before
+    /// the manifest write, so the first run's record and manifest remain the durable
+    /// description of the pool. Reconciliation before the failed write would delete the
+    /// subject from under that surviving description.</para>
+    ///
+    /// <para>A directory planted at the record path is the deterministic cross-platform
+    /// way to make the atomic move fail. The fixture moves the first record aside and moves
+    /// that same file back after the failed run; it does not reconstruct the expectation.
+    /// <see cref="SweepWorld.AssertPoolMatchesRecord"/> then derives the expected pool from
+    /// the restored durable record, so moving reconciliation ahead of the write makes this
+    /// case fail on the missing subject.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepDoesNotReconcileBeforeItsRecordIsDurable()
+    {
+        using var world = SweepWorld.Create();
+
+        var first = world.Run();
+        Assert.True(first.ExitCode == 0, world.Explain(first, "a first sweep with a matching pin"));
+        world.AssertPoolMatchesRecord(removals: []);
+
+        world.PinInstead(FixturePackage, "9.9.9", FixtureTfm);
+
+        string savedRecord = Path.Combine(world.Scratch, "assemblies.first.txt");
+        File.Move(world.PooledListPath, savedRecord);
+        Directory.CreateDirectory(world.PooledListPath);
+
+        var second = world.Run();
+
+        Directory.Delete(world.PooledListPath);
+        File.Move(savedRecord, world.PooledListPath);
+
+        Assert.True(second.ExitCode == 2, world.Explain(second, "an assemblies.txt that cannot be replaced"));
+        world.AssertPoolMatchesRecord(removals: []);
+    }
+
+    /// <summary>
     /// A sweep removes a link planted in the pool as a link, rather than deleting what is
     /// on the far side of it.
     ///


### PR DESCRIPTION
Fixes #3718

## Change

**Conclusion: PASS** - the sweep now has a two-run regression gate proving that
pool reconciliation cannot run before the new `assemblies.txt` is durable.

The first run writes a complete pool and record. The second run would retain
only the lead package, but a directory at the record path forces the atomic
record replacement to fail with exit 2. The fixture restores the exact first
record and uses `AssertPoolMatchesRecord` to prove that the failed run did not
delete the subject still named by that durable record.

This is deliberately test-only: it preserves current sweep behavior and adds no
new recovery or fallback path.

## Evidence

- `EvilPoolSweepGateTests`: 20 total, 0 failed, 1 ambient shared-cache skip.
- Destructive-order mutation: moving `ReconcilePool` before the record write
  fails the new test because rank 2 is missing while the surviving record still
  names it.
- Full `ILInspector.Decompiler.Tests`: 4,753 total, 0 failed, 1 ambient
  shared-cache skip.
- `dotnet build dotnet-inspect.slnx -c Release`: pass with 9 pre-existing
  warnings.
