### PR TITLE
Gate sweep metadata write exit codes

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -136,6 +136,69 @@ public class EvilPoolSweepGateTests
     }
 
     /// <summary>
+    /// A sweep that cannot write its assembly record refuses the output directory.
+    ///
+    /// <para>Exit 1 means the sweep ran and the corpus is short a package. This failure
+    /// is different: both packages were pooled, but the operator-supplied output path
+    /// prevented the record that makes them consumable from being written. Exit 2 keeps
+    /// that bad-output refusal distinct from a package failure.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepThatCannotWriteItsAssemblyRecordRefusesTheOutputDirectory()
+    {
+        using var world = SweepWorld.Create();
+        Directory.CreateDirectory(world.PooledListPath);
+
+        var sweep = world.Run();
+
+        Assert.True(
+            sweep.ExitCode == 2,
+            world.Explain(sweep, "a directory standing at the assembly record path"));
+        Assert.Contains(
+            $"Could not write '{world.PooledListPath}'",
+            sweep.Errors,
+            StringComparison.Ordinal);
+
+        // The run reached the record write after pooling both packages; this is not an
+        // earlier refusal that happened to return the same exit code.
+        Assert.True(File.Exists(world.LeadDestination), "the lead was not pooled.");
+        Assert.True(File.Exists(world.SubjectDestination), "the subject was not pooled.");
+        Assert.False(File.Exists(world.ManifestPath), "the sweep wrote a manifest without its assembly record.");
+    }
+
+    /// <summary>
+    /// A sweep that cannot write its manifest refuses the output directory.
+    ///
+    /// <para>The assembly record and pool reconciliation both precede this write. The
+    /// stale file makes that ordering observable: reaching the manifest write is not
+    /// enough if the sweep can return before reconciling the pool it would describe.</para>
+    /// </summary>
+    [Fact]
+    public void ASweepThatCannotWriteItsManifestRefusesTheOutputDirectory()
+    {
+        using var world = SweepWorld.Create();
+        Directory.CreateDirectory(world.ManifestPath);
+
+        string stale = Path.Combine(
+            world.OutputDirectory, "packages", "999-sweep.stale", "1.0.0", "Sweep.Stale.dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(stale)!);
+        File.WriteAllBytes(stale, world.FixtureBytes);
+
+        var sweep = world.Run();
+
+        Assert.True(
+            sweep.ExitCode == 2,
+            world.Explain(sweep, "a directory standing at the manifest path"));
+        Assert.Contains(
+            $"Could not write '{world.ManifestPath}'",
+            sweep.Errors,
+            StringComparison.Ordinal);
+
+        Assert.True(File.Exists(world.PooledListPath), "the sweep did not write its assembly record.");
+        Assert.False(File.Exists(stale), "the sweep attempted the manifest write before reconciling the pool.");
+    }
+
+    /// <summary>
     /// Bytes the pin does not name are refused, and are not left in the pool.
     ///
     /// <para>The defect this replays: the pin recorded a version and a TFM, which describe


### PR DESCRIPTION
The EVIL package sweep's exit-2 contract is now gated at both metadata writes: an unusable `assemblies.txt` or `manifest.json` destination is distinguished from a package/run failure at exit 1.

## Evidence

- Plants a directory at each metadata destination and requires the sweep's specific write refusal at exit 2.
- Proves the `assemblies.txt` case reaches the write after pooling both packages.
- Proves the `manifest.json` case writes the assembly record and reconciles a stale pool file before attempting the manifest.
- Mutating both metadata exits from 2 to 1 produces exactly two failures, one per new case.

## Compatibility

No product behavior changes; this holds the existing exit-code and operation-ordering contracts in place.

## Validation

`dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.EvilPoolSweepGateTests`

Closes #3717
