### PR TITLE
Document package source fidelity model

### DIFF
--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -5,6 +5,11 @@ derived platform packs. [Version resolution](version-resolution.md) owns which
 package coordinate is selected and when network lookup occurs; this document
 owns how content for an exact coordinate becomes visible safely.
 
+The publication and filesystem sections describe the current implementation.
+The source-authorization and provenance sections describe the target contract
+from the [package source model](package-source-model.md) and identify current
+deviations explicitly.
+
 ## Source conformance
 
 Content that dotnet-inspect downloaded is scoped to the source that supplied it.
@@ -28,56 +33,72 @@ should be read with them in mind:
 - in-flight acquisitions are shared only between callers with the same source
   configuration.
 
-### The NuGet global folder is outside this boundary
+### The NuGet global folder is a payload cache
 
-`~/.nuget/packages` is read eagerly, ahead of source scoping, and a package
-found there answers regardless of the configured sources. This is deliberate.
-That folder holds what the user restored, not what dotnet-inspect fetched, and
-binding to it eagerly is what makes an inspection agree with the bytes a build
-actually consumed — the fidelity argument and the performance argument point the
-same way. The scoping above governs content dotnet-inspect acquired, where the
-tool chose the source and is accountable for the choice.
+`~/.nuget/packages` does not supply version candidates. Once an exact coordinate
+has been selected, it may supply the payload only when
+`.nupkg.metadata.source` matches a source authorized for that coordinate. For a
+discovered coordinate, that means a feed that reported the version. For a
+pinned coordinate, it means any source eligible for the package id.
 
-The rule is therefore *strict conformance to the sources dotnet-inspect fetched
-from*, not *strict conformance to everything on the machine*. Callers that need
-only configured sources to answer pass `--no-nuget-cache`, which drops the
-folder from lookup. Note that NuGet does record an installed package's source in
-`.nupkg.metadata`; the folder is treated as source-blind by choice, not for want
-of the data.
+This makes the folder a local replica of the recorded feed rather than a
+source-blind authority. Missing, ambiguous, or mismatched source metadata is a
+cache miss. `--no-nuget-cache` removes the layer entirely.
 
-### Known deviation: precedence between two entitled sources
+Source-blind, restore-compatible reuse is not a separate mode. The same
+producer check applies to every package request. `--no-nuget-cache` controls
+whether the global payload layer participates; it does not enable a stricter
+policy than the default.
 
-Slots are consulted in configured order, so when two configured feeds both have
-the coordinate cached, the higher-precedence one answers, as it would on a cold
-run. The case that still differs is when the higher-precedence feed holds the
-package but has no cached slot: a cold run downloads from it, a warm run answers
-from the lower-precedence feed's slot. Both are entitlement-correct — the caller
-reads both feeds — so this is precedence, not source confusion. Closing it
-requires probing the network on every request, which would defeat cache-first and
-offline operation, so it is left open deliberately and tracked as part of the
-broader source-support design.
+Feed authorization is independent of how the active source set was expressed.
+A source inherited from `nuget.config`, added after `<clear/>`, or selected by
+`--source` authorizes the same matching payload. `<clear/>` removes inherited
+authorizations, so their cached payloads become unavailable until the
+corresponding source is added back.
 
-"Entitled" here means the source appears in the caller's configured sources.
-dotnet-inspect does not yet consult `<packageSourceMapping>`, which would narrow
-entitlement further, to the feeds mapped to a particular package id.
+The current implementation is more permissive: it reads global-folder content
+without checking provenance and some cache-first paths scan installed versions
+as candidates. Separating candidate discovery from provenance-matched payload
+fulfillment is tracked by
+[#3752](https://github.com/richlander/dotnet-inspect/issues/3752).
+
+### Selection between two eligible sources
+
+Source declaration order is not feed precedence. When two sources are eligible
+for one package id, either source may supply an exact coordinate. A
+source-bound cache slot may therefore answer without probing an uncached
+eligible source that appears earlier in configuration. This preserves
+cache-first and offline operation and matches NuGet's contract: package source
+mapping, not declaration order, limits which feed may serve an id.
+
+"Authorized" currently means the source appears in the caller's active sources.
+After `<packageSourceMapping>` and candidate provenance are implemented, the
+payload producer must also be selected by the winning mapping pattern and, for
+a discovered coordinate, have reported that version. See the
+[package source model](package-source-model.md) for the end-to-end contract.
 
 A source is identified by a digest of its canonical URL, and canonicalization is
 shared with the credential scope's `IsSameEndpoint` rather than reimplemented, so
 one URL cannot mean two things in one tool. Scheme, host, default port,
-percent-escape casing and a trailing path slash fold, because the URI grammar
-defines them as equivalent; path and query case do not, because `/FeedA` and
-`/feeda` can be different feeds on a case-sensitive server. The digest keeps
-source URLs out of cache paths and makes every identity a valid path segment. It
-is opacity rather than confidentiality: a feed URL is low entropy, and a local
-reader who can see these paths can already see which packages were cached.
+percent-escape casing, and an empty root path versus `/` fold because the URI
+grammar defines them as equivalent. Path and query case do not fold:
+`/FeedA` and `/feeda` can name different resources. A non-root trailing slash
+must likewise remain distinct, but the current cache identity incorrectly folds
+`/feed` and `/feed/`. Correcting it requires a cache namespace migration and is
+tracked by [#3737](https://github.com/richlander/dotnet-inspect/issues/3737).
+The digest keeps source URLs out of cache paths and makes every identity a
+valid path segment. It is opacity rather than confidentiality: a feed URL is
+low entropy, and a local reader who can see these paths can already see which
+packages were cached.
 
 ## Guarantees
 
 The cache model provides:
 
 - content scoped to the source that supplied it;
-- one shared acquisition task per exact coordinate *and source configuration*
-  within a process;
+- producer-feed and payload-location provenance on every opened package;
+- one shared acquisition task per exact coordinate, authorized-producer set,
+  cache root, and acquisition policy within a process;
 - complete-tree visibility through marked, atomic directory publication;
 - convergence on one valid winner when processes publish concurrently; and
 - no lock ordering between package coordinates.
@@ -114,12 +135,18 @@ work, but it permits duplicate download and extraction.
 ## Process-local single-flight
 
 The process-wide in-flight registry is keyed by one exact package coordinate
-together with the caller's ordered source list. Concurrent callers receive the
-same task only when both match. Callers configured for different sources would
-otherwise be handed each other's bytes, which is the same confusion the cache
-scoping prevents, arriving by a different route. The
-registry entry is removed after completion, whether acquisition succeeds or
-fails, because the committed filesystem entry remains authoritative and is
+together with the canonical authorized-producer set, cache root, and the
+acquisition policy that affects whether a result is legal, including
+payload-cache and network permission. Raw source options are insufficient:
+callers can name the same active feeds while package source mapping or
+candidate discovery authorizes different producers. Concurrent callers receive
+the same task only when those authorization inputs match, and every waiter
+revalidates the returned producer. The current ordered-source-list key must
+migrate with the broader source-policy work in
+[#3752](https://github.com/richlander/dotnet-inspect/issues/3752).
+
+The registry entry is removed after completion, whether acquisition succeeds
+or fails, because the committed filesystem entry remains authoritative and is
 revalidated by later requests.
 
 The acquisition factory only downloads, extracts, validates, and commits its

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -87,9 +87,8 @@ must likewise remain distinct, but the current cache identity incorrectly folds
 `/feed` and `/feed/`. Correcting it requires a cache namespace migration and is
 tracked by [#3737](https://github.com/richlander/dotnet-inspect/issues/3737).
 The digest keeps source URLs out of cache paths and makes every identity a
-valid path segment. It is opacity rather than confidentiality: a feed URL is
-low entropy, and a local reader who can see these paths can already see which
-packages were cached.
+valid path segment. It is a path-safe identifier, not a security boundary;
+source authorization comes from the source policy, not from hiding cache keys.
 
 ## Guarantees
 

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -209,6 +209,102 @@ cache, while discovery also requires an eligible local-folder feed or
 source-scoped candidate cache. `--isolated` combines a separate app-cache root
 with exclusion of the global packages folder.
 
+## Worked examples
+
+Unless one is shown, these examples assume the complete configuration
+hierarchy contains no package-source configuration, administrator default
+source, or package source mapping.
+
+### Pinned package, default source
+
+```bash
+dotnet-inspect package Foo@1.2.3
+```
+
+The caller supplied the exact coordinate, so no candidate query is needed.
+NuGet.org is the implicit eligible source. If
+`global-packages/foo/1.2.3/.nupkg.metadata` records NuGet.org, dotnet-inspect
+opens that payload without network access:
+
+```text
+Producer: nuget.org
+Payload location: global-packages
+```
+
+If the metadata is absent or records another feed, the global entry is a miss.
+An authorized NuGet.org slot in the dotnet-inspect app cache may still answer.
+dotnet-inspect downloads `Foo@1.2.3` from NuGet.org only when no authorized
+payload cache answers, then commits it to that app-cache slot.
+
+### Bare package, default source
+
+```bash
+dotnet-inspect package Foo
+```
+
+The command must first determine which version `Foo` means. NuGet.org is the
+implicit candidate source:
+
+1. Use NuGet.org's source-scoped candidate cache when it is fresh.
+2. Otherwise, query NuGet.org and select the latest stable version.
+3. Retain NuGet.org as the feed that reported the selected coordinate.
+4. Open an app-cache or global-packages payload only when its producer is
+   NuGet.org; otherwise download the payload from NuGet.org.
+
+An installed `Foo@1.2.3` payload does not by itself make `1.2.3` a candidate.
+With an empty candidate cache, this command queries NuGet.org even when that
+payload is already in global packages. The network candidate query may still be
+followed by a local payload hit.
+
+### One explicit source
+
+```bash
+dotnet-inspect package Foo \
+  --source https://feed-a.example/v3/index.json
+```
+
+Only feed A supplies candidates. If discovery selects `Foo@1.2.3` and A
+reported it, a cached payload recorded from A may answer. A global-packages
+entry recorded from NuGet.org or feed B is ignored, even though its id and
+version match.
+
+The pinned form skips A's candidate query but keeps the same payload rule:
+
+```bash
+dotnet-inspect package Foo@1.2.3 \
+  --source https://feed-a.example/v3/index.json
+```
+
+### Equivalent `nuget.config`
+
+When no administrator default source is active, this configuration has the
+same source authority as `--source` naming feed A:
+
+```xml
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="feed-a"
+         value="https://feed-a.example/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+Feed A supplies candidates and authorizes payloads recorded from A. `<clear/>`
+removes ordinary inherited feeds and their cached-payload authority; it does
+not remove administrator sources from `NuGetDefaults.Config`, which must be
+disabled through `disabledPackageSources`. It also does not disable payload
+caching for a source subsequently added to the configuration.
+
+### Offline operation
+
+| Request | Cached state | Result |
+| --- | --- | --- |
+| `Foo@1.2.3 --offline` | Authorized payload | Succeeds without candidate metadata. |
+| `Foo --offline` | Fresh candidate list selects `1.2.3`; authorized payload exists | Succeeds entirely from caches. |
+| `Foo --offline` | Payload exists, but candidate metadata is absent | Fails because content cannot introduce a version candidate. |
+| `Foo --offline` | Fresh candidate metadata exists, but no authorized payload exists | Fails because network payload acquisition is prohibited. |
+
 ## Feed-relative inspection
 
 Package inspection is feed-relative. An id and version identify the NuGet

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -1,0 +1,371 @@
+# Package source model
+
+This document defines what it means for dotnet-inspect to support NuGet package
+sources. It covers source configuration, package source mapping, local stores,
+source-bound caches, package discovery, exact payload acquisition, and
+NuGet.org-specific enrichment.
+
+It is the target contract. The
+[implementation boundaries](#implementation-boundaries) section distinguishes
+the behavior already present from the work needed to complete the model.
+
+The central rule is:
+
+> Feeds authorize package candidates. Caches may fulfill an authorized exact
+> coordinate, but they do not introduce candidates and their payload must
+> retain the identity of the feed that supplied it.
+
+NuGet does not define the declaration order of HTTP sources as precedence. It
+queries applicable sources and may obtain an exact package from any of them.
+[Package Source Mapping][package-source-mapping] is the mechanism for limiting
+which sources may serve a package id. dotnet-inspect follows that division:
+configuration establishes the active sources, mapping narrows them for each
+package id, and source provenance protects downloaded content after acquisition.
+
+## Terms
+
+| Term | Meaning |
+| --- | --- |
+| Coordinate | A package id and exact version. |
+| Active source | A source selected by configuration and command-line options. |
+| Eligible source | An active source permitted to serve a particular package id after package source mapping. |
+| Candidate source | An eligible source that reported a particular coordinate during version discovery. |
+| Producer | The eligible source that supplied the bytes for a coordinate, or the `explicit-local-input` origin for a directly named `.nupkg`. |
+| Candidate cache | Source-scoped version metadata that can answer discovery without contacting its feed. |
+| Payload cache | Exact package content retained with the identity of its producer. |
+| Source-bound content | Content dotnet-inspect fetched and recorded against its producer. |
+| Payload location | Where the inspected bytes were opened: an explicit file, global packages, the dotnet-inspect cache, a local feed, or a network response. |
+| Enrichment endpoint | A service such as a symbol server or NuGet.org aggregate metadata API that is not itself a package source. |
+
+Source identity has two parts with different purposes:
+
+- the configured source name is what `<packageSourceMapping>` refers to; and
+- the canonical HTTP endpoint or local directory identifies the producer in
+  caches.
+
+Names do not prove two feeds are the same. HTTP endpoint canonicalization does
+not make path or query case-insensitive or discard a non-root trailing slash.
+Local sources use a separate identity: config-relative paths resolve from the
+declaring config's directory, CLI-relative paths resolve from the working
+directory, and path and `file://` spellings normalize to one absolute directory.
+Dot segments and trailing directory separators fold; path case follows the
+platform. Symlinks are not resolved merely to establish identity. HTTP and
+local identities occupy distinct namespaces. The cache identity rules are
+detailed in [cache concurrency and publication](cache-concurrency.md).
+
+Credentials are an access mechanism, not a durable source identity. Cache
+eligibility does not retain a token, depend on token lifetime, or prove that the
+caller could authenticate again. Multiple configured names for one canonical
+endpoint remain aliases through package source mapping, then collapse to one
+content producer. If eligible aliases define conflicting credential
+configurations, resolution fails rather than choosing a credential
+arbitrarily. A feed that serves different bytes for one coordinate at one
+endpoint based on the caller's identity is not compatible with this
+immutable-source assumption; it needs distinct source endpoints to keep those
+content domains separate. Credentials selected for a configured endpoint may
+be sent to package resources discovered on the same origin (scheme, host, and
+port), but never to a cross-origin resource advertised by the feed.
+
+## Resolving active and eligible sources
+
+Without source options, dotnet-inspect resolves the same effective
+configuration hierarchy as NuGet restore for the working directory. That
+includes applicable defaults, computer-level, user-level, and directory-level
+configs. Ordinary collections merge in NuGet precedence order with `<clear/>`,
+disabled sources, and nearer re-enablement. Administrator sources from
+`NuGetDefaults.Config` are different: `<clear/>` cannot remove them, but a
+nearer `disabledPackageSources` entry can disable or re-enable them. NuGet.org
+is the fallback only when the complete hierarchy contains no package-source
+configuration. A configuration that deliberately resolves to an empty active
+set does not authorize NuGet.org; source resolution fails without disclosing
+the requested package id.
+
+An explicitly named `--nugetconfig` is a source-selection act, not absence of
+configuration. Only that file supplies configuration, and the implicit
+NuGet.org fallback is suppressed. The file must exist, be valid, and declare a
+usable source; an empty selected file fails rather than searching a feed the
+caller did not name.
+
+Only the final active source set matters downstream. Sources produced by
+`nuget.config` merging are semantically identical to the same endpoints named
+with repeated `--source`: they supply the same candidates and authorize the
+same producer-matched payload-cache entries.
+
+`<clear/>` removes inherited source authorization. With no subsequent source,
+there are no candidates and no `global-packages` entry has an authorized
+producer. Adding a source back enables that feed and payloads whose recorded
+producer matches it. This has the same effect as `--no-nuget-cache` on entries
+belonging to removed sources, but the mechanisms remain distinct:
+`--no-nuget-cache` disables the global payload cache even for active sources.
+
+The command-line source options compose as follows:
+
+| Option | Effect |
+| --- | --- |
+| `--source URL` | Replaces configured package sources. Repeat it to select more than one. |
+| `--add-source URL` | Adds a source to the active set. |
+| `--nugetconfig PATH` | Selects one config instead of config discovery. |
+
+Source replacement does not disable package source mapping. Mapping is loaded
+from configuration independently and then applied to the active sources. Under
+the target model, matching follows NuGet: mapping keys are compared with active
+source names case-insensitively. A URL supplied through `--source` or
+`--add-source` retains every configured-name alias when it matches that
+producer. Mapping selects the package-specific aliases before they collapse to
+one producer. An unmatched URL uses the URL itself as its source name.
+
+This distinction matters when an override names an endpoint that configuration
+does not. If a config maps `Contoso.*` to a source named `contoso`, an unmatched
+URL override is not named `contoso`; no source is eligible and the command
+reports a mapping failure. A URL override that matches the configured
+`contoso` endpoint keeps that name and remains eligible.
+
+### Package source mapping
+
+When `<packageSourceMapping>` is absent, every active source is eligible for
+every package id. When it is present, every id must match a pattern. Matching is
+case-insensitive and uses NuGet's precedence:
+
+1. An exact package id wins.
+2. Otherwise, the longest matching prefix ending in `*` wins.
+3. `*` is the least-specific prefix and acts as a default.
+
+Only sources declaring the winning pattern are eligible. The same winning
+pattern may appear under more than one source, in which case all of those
+active sources are eligible. A package that matches no pattern, or whose mapped
+source names are not active, fails as a mapping error before candidate or
+payload lookup.
+
+Mapping is evaluated independently for every package id. It therefore applies
+to top-level packages, transitive dependencies, RID companion packages,
+platform packs, tool-wrapper redirects, routing probes, and search results. A
+dependency does not inherit its parent's producer.
+
+Configured local-folder feeds are ordinary sources under this rule. They must
+be active and mapped like HTTP feeds. The NuGet global packages folder is not a
+configured feed; it is a provenance-bearing payload cache.
+
+## Candidates before payloads
+
+Source declaration order does not decide version selection and is not a
+security boundary. Version discovery combines source-scoped candidate lists
+from all eligible feeds, and selecting one version uses semantic-version
+ordering. Each coordinate retains the feeds that reported it.
+
+Content caches are not candidate lists. A version present only in
+`global-packages` or the dotnet-inspect package-content cache does not appear in
+`Name`, `--versions`, wildcard, or range resolution. A source-scoped version
+list cache may answer for its feed because it stores that feed's discovery
+result, not because package bytes happen to exist locally.
+
+After discovery selects an exact coordinate, a payload cache may answer only
+for an authorized producer:
+
+- for a discovered coordinate, the authorized producers are the candidate
+  sources that reported that version; and
+- for a pinned coordinate, the caller supplied the candidate, so every eligible
+  source is an authorized producer.
+
+A source-bound app-cache slot may answer only when its producer is in that set.
+A `global-packages` entry may answer only when `.nupkg.metadata.source` resolves
+to a source in that set. Missing, ambiguous, or mismatched provenance is a cache
+miss. The payload is then requested from an authorized producer and cached
+under that producer's identity.
+
+When payload sources must be queried, configured local-folder feeds are
+considered before HTTP feeds, matching NuGet's documented source tiers. No
+precedence is promised among sources in the same tier. If one exact producer
+matters, configure or map the package id to one source.
+
+## Candidate and payload stores
+
+| Store | Supplies candidates | Supplies payloads | Source rule | Bypass |
+| --- | --- | --- | --- | --- |
+| Explicit local `.nupkg` | The named coordinate only | Yes | Producer is `explicit-local-input`; feed resolution does not apply | Choose a different input. |
+| Source-scoped version cache | Yes | No | Answers only for the feed that produced the cached list | `@latest` or cache clearing. |
+| NuGet global packages folder | No | Yes | `.nupkg.metadata.source` must be an authorized producer | `--no-nuget-cache`. |
+| dotnet-inspect package cache | No | Yes | Its producer slot must be authorized | Clear or isolate the app cache. |
+| Configured local-folder feed | Yes | Yes | Must be active and eligible | Remove it from the active source set. |
+| HTTP feed | Yes | Yes | Must be active and eligible | Remove it from the active source set or use `--offline`. |
+
+NuGet restore uses the global folder more permissively: an exact hit skips
+source lookup and package source mapping. dotnet-inspect instead uses the
+optional `.nupkg.metadata.source` field as an authorization requirement. This
+is necessary for `--source A` to mean that A supplies both the candidate and
+the bytes.
+
+There is no restore-like compatibility mode. Source fidelity is the only
+payload policy. In the common case it adds no network work because the recorded
+producer remains active and eligible. A miss occurs when provenance is absent,
+the source was removed or mapped out, or another source supplied the same
+coordinate. Those are precisely the cases where source-blind reuse would make
+the result ambiguous. After a strict miss, the source-scoped dotnet-inspect
+cache serves later requests.
+
+`--no-nuget-cache` disables the global payload cache but retains
+dotnet-inspect's source-bound payload and candidate caches. `--offline` forbids
+network access: a pinned coordinate can succeed from an authorized payload
+cache, while discovery also requires an eligible local-folder feed or
+source-scoped candidate cache. `--isolated` combines a separate app-cache root
+with exclusion of the global packages folder.
+
+## Feed-relative inspection
+
+Package inspection is feed-relative. An id and version identify the NuGet
+coordinate, but they do not establish which bytes dotnet-inspect examined when
+multiple feeds publish that coordinate.
+
+Standard package provenance therefore reports:
+
+- the producer feed whose payload is being inspected, or
+  `explicit-local-input` for a directly named `.nupkg`; and
+- the payload location used for this invocation, such as `global-packages`,
+  the source-scoped dotnet-inspect cache, a local feed, or a fresh network
+  response.
+
+These are independent. A package opened from `global-packages` still reports
+NuGet.org or a custom feed as its producer. A package fetched from a feed and
+then committed to the app cache keeps the same producer on later runs.
+
+Version discovery exposes feed observations before a payload is selected:
+`--versions-with-feed` reports every feed carrying each version. Exact
+feed inspection selects one authorized producer and reports it. Direct file
+inspection reports its explicit local origin instead; neither path presents
+source-free provenance. Comparing differing payloads from multiple feeds is an
+explicit future audit operation rather than hidden work in ordinary inspection.
+
+## Operation contracts
+
+Every operation that deals in package identities uses the same eligible-source
+calculation. It may differ only in how answers from that set are combined.
+
+| Operation | Contract |
+| --- | --- |
+| Latest or wildcard version | Query every eligible source or its candidate cache and select the highest matching semantic version. Content caches do not participate. |
+| Version enumeration or range | Return the union from eligible source candidate lists. `--versions-with-feed` retains one row per version and reporting feed. |
+| Discovered payload acquisition | Use a payload cache only when its producer reported the selected coordinate. On a miss, query those candidate sources and record the successful producer. |
+| Pinned payload acquisition | The caller supplies the coordinate. Use a payload cache or source only when its producer is eligible for the package id. |
+| Nuspec and dependency traversal | Apply mapping to each dependency id, including cache reads and nuspec-only requests. |
+| Search | Search active sources with a search capability, then retain a result only when the reporting source is eligible for that result's package id. Carry source failures rather than presenting partial results as complete. |
+| Routing and qualified-name probes | Use the caller's source options and mapping for package-existence and fallback probes. A probe cannot see a source the eventual command cannot use. |
+| RID, platform-pack, and wrapper follow-up | Recalculate eligibility for every newly named package id. |
+| Project restored-assets context | Bind to the assets and local package content selected by the existing restore; do not reinterpret its graph through current source options. |
+
+Candidate caches are source-specific inputs, not merged authority. A cached
+version list for one endpoint may replace a request to that endpoint, but the
+answer is recomposed across the current eligible set and retains candidate
+provenance. Package content cache keys include the producer endpoint. Mapping
+and candidate authorization are evaluated before a payload cache entry can
+answer.
+
+### Failure semantics
+
+Source failures are not package absence:
+
+- no mapping match, or no active source named by the winning mapping, is a
+  mapping error;
+- authentication and transport failures identify the unreadable source;
+- `not found` means every source required to establish absence was read and
+  none supplied the package; and
+- an operation claiming a complete aggregate, such as latest-version
+  resolution, cannot silently claim an authoritative result while an eligible
+  source is unreadable.
+
+A pinned exact coordinate may succeed from one of several eligible sources
+without proving that every peer source is readable. Aggregate operations must
+either fail or mark an answer partial when an eligible source could change it.
+
+## Enrichment is a separate capability
+
+Package-source authority does not automatically authorize traffic to unrelated
+services.
+
+NuGet.org registration, catalog, download-count, deprecation, verification, and
+vulnerability services may be queried for a package id only when NuGet.org is
+eligible for that id. Merely listing NuGet.org somewhere in the active config
+is insufficient when package source mapping assigns the id elsewhere. This
+prevents a private package identity from being disclosed to NuGet.org.
+
+PDB acquisition has its own provenance:
+
+- embedded and adjacent PDBs belong to the selected package or library;
+- NuGet.org has known producer-specific `.snupkg` download routes;
+- custom and local feeds have no standard NuGet symbol-package download
+  resource, so `.snupkg` acquisition from those producers is unsupported until
+  an explicit endpoint contract exists;
+- NuGet and Microsoft symbol servers are explicit enrichment endpoints, not
+  package sources, and successful results record the server; and
+- SourceLink URLs come from the inspected artifact and are governed by the
+  untrusted-data and network-capability policies, not package source mapping.
+
+Configuring a private package source therefore never grants permission to probe
+NuGet.org for that package's `.snupkg`. Conversely, allowing a symbol-server
+probe does not make that server eligible to supply package bytes.
+
+## Implementation boundaries
+
+The source-policy seam should resolve one typed result containing:
+
+- the active sources, with configured names, canonical endpoints, credentials,
+  and local/HTTP capability;
+- the package-id-specific eligible sources after mapping;
+- source-scoped candidate results and their reporting feeds;
+- the payload-cache policy and authorized producer set; and
+- diagnostics for unmatched mappings and unavailable required sources.
+
+Consumers should not independently parse source options, resolve config, or
+decide whether a cache key is allowed. Version discovery, package extraction,
+nuspec reads, search, routing, metadata enrichment, RID verification, and
+symbols should consume that shared result.
+
+The current implementation already source-scopes downloaded package content,
+aggregates versions across sources, and threads caller options through routing
+probes. The remaining implementation work includes:
+
+- honoring `<packageSourceMapping>` across every operation
+  ([#3722](https://github.com/richlander/dotnet-inspect/issues/3722));
+- completing config and override semantics, including intentional empty source
+  sets, the complete NuGet config hierarchy, disabled-source merging, and
+  preservation of all configured-name aliases for explicit endpoints
+  ([#3739](https://github.com/richlander/dotnet-inspect/issues/3739));
+- preserving non-root trailing slashes in producer identity and fencing cache
+  entries written under the currently aliased identity
+  ([#3737](https://github.com/richlander/dotnet-inspect/issues/3737));
+- representing configured order structurally for stable presentation and
+  diagnostics, without treating it as precedence
+  ([#3724](https://github.com/richlander/dotnet-inspect/issues/3724));
+- carrying payload producer provenance through package inspection indexes,
+  projected platform packs, and package-associated symbols
+  ([#3738](https://github.com/richlander/dotnet-inspect/issues/3738));
+- separating candidate caches from payload caches and requiring
+  provenance-matched `global-packages` payloads
+  ([#3752](https://github.com/richlander/dotnet-inspect/issues/3752));
+- exposing producer feed and payload location as standard package provenance;
+- defining canonical local-source identity and acquiring packages and nuspecs
+  from configured folder feeds
+  ([#3759](https://github.com/richlander/dotnet-inspect/issues/3759));
+- making aggregate failures authoritative or explicitly partial; and
+- separating package-producer symbol lookup from public symbol-server
+  enrichment.
+
+## NuGet precedents
+
+- [Package Source Mapping][package-source-mapping] defines mapping patterns,
+  pattern precedence, transitive application, multiple eligible sources, and
+  the global-packages-folder exception.
+- [Package installation process][package-installation-process] documents that
+  local sources precede HTTP sources and that multiple sources are consulted to
+  find the best version.
+- [Managing the global packages and cache folders][nuget-cache-folders]
+  documents the global-folder-first lookup.
+- NuGet's
+  [`RemoteWalkContext`](https://github.com/NuGet/NuGet.Client/blob/c82ceb9ad93dc8fdcb51fb6807c8e8c70f1443e8/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs)
+  applies mapping by package id and active source name.
+- NuGet's
+  [`ResolverUtility`](https://github.com/NuGet/NuGet.Client/blob/c82ceb9ad93dc8fdcb51fb6807c8e8c70f1443e8/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs)
+  separates local and HTTP source tiers and does not make HTTP declaration
+  order a precedence contract.
+
+[nuget-cache-folders]: https://learn.microsoft.com/nuget/consume-packages/managing-the-global-packages-and-cache-folders
+[package-installation-process]: https://learn.microsoft.com/nuget/concepts/package-installation-process
+[package-source-mapping]: https://learn.microsoft.com/nuget/consume-packages/package-source-mapping

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -4,6 +4,11 @@ dotnet-inspect uses Docker-style version tags to balance freshness against
 latency. Version discovery is cached briefly; package contents are cached
 permanently by exact version.
 
+The command modes and listing rules describe current behavior. Candidate-source
+and payload-provenance rules describe the target
+[package source model](package-source-model.md); its implementation boundaries
+identify current deviations.
+
 ## Four modes
 
 | Syntax | Behavior | Network I/O |
@@ -16,27 +21,33 @@ permanently by exact version.
 
 ### Pinned (`Name@version`)
 
-The version is treated as immutable. If the package is already in the NuGet
-global cache (`~/.nuget/packages`) or the app cache, it is used immediately.
-No network request is made. If the version has never been downloaded, it is
-fetched once and cached permanently.
+The version is treated as immutable and the caller supplies the candidate. If
+the package is already in a payload cache under an eligible producer, it is
+used immediately. A global-folder entry qualifies only when its
+`.nupkg.metadata.source` matches an eligible feed. No network request is made
+on a qualifying hit. Otherwise, the package is fetched from an eligible source
+and cached permanently under that producer.
 
 ### Latest stable (`Name`)
 
 This is the default and the most common case. Resolution follows this order:
 
-1. **Version cache** — check the version-resolution cache (1-hour TTL). If a
-   cached version string exists, use it.
+1. **Version cache** — check each eligible feed's version-resolution cache
+   (1-hour TTL) for a source-scoped candidate list.
 2. **Network** — if the version cache misses, query NuGet for the latest stable
    version.
-3. **Package cache** — after resolving the version, use the NuGet global cache
-   or app package cache for that exact version; download only if missing.
+3. **Package cache** — after resolving the version and retaining the feeds that
+   reported it, use only a payload cached under one of those producers;
+   otherwise download from one of them.
 
 Adding `--preview`/`--prerelease` switches step 1/2 to a separate prerelease-aware
 version cache/feed query and may resolve to a preview version.
 
-For platform ref packs (e.g., `Microsoft.NETCore.App.Ref`), the same strategy
-applies: if a pack directory exists on disk, use it without querying NuGet.
+SDK-installed ref and runtime packs are direct platform inputs, not NuGet
+package candidates, and may be selected from the installed SDK/runtime. A pack
+projected into dotnet-inspect's `packs-v2` cache is different: it is a
+source-derived payload. Its version comes from an eligible feed or candidate
+cache, and the projected payload must retain that producer's authorization.
 
 Package metadata (publish date, downloads, deprecation, vulnerabilities) is
 also cached with a 1-hour TTL.
@@ -46,6 +57,11 @@ when `api.nuget.org` is present in the resolved source list; a custom-only feed
 does not leak its package identity to NuGet.org or reuse a NuGet.org metadata
 cache entry for a same-named private package. Package acquisition and RID
 companion-package verification continue to follow the configured sources.
+
+This describes the current gate. The target
+[package source model](package-source-model.md#enrichment-is-a-separate-capability)
+narrows it further when package source mapping is enabled: NuGet.org must be
+eligible for the package id, not merely active somewhere in configuration.
 
 ### Always check (`Name@latest`)
 
@@ -234,7 +250,7 @@ read as listed.
 
 | Cache | Location | TTL | Written by |
 | --- | --- | --- | --- |
-| NuGet global cache | `~/.nuget/packages/{name}/{version}/` | Permanent | `dotnet restore`, NuGet client |
+| NuGet global cache | `~/.nuget/packages/{name}/{version}/` | Permanent | `dotnet restore`, NuGet client; payload-only, with producer in `.nupkg.metadata` |
 | App package cache | `$LOCAL_APP_DATA/dotnet-inspect/package-content-v4/{name}/{version}/{source}/` | Permanent | dotnet-inspect |
 | Platform packs | `$LOCAL_APP_DATA/dotnet-inspect/packs-v2/{pack}/{version}/` | Permanent | dotnet-inspect |
 | Version resolution | `$LOCAL_APP_DATA/dotnet-inspect/versions-v2/` | 1 hour | dotnet-inspect |
@@ -245,8 +261,9 @@ read as listed.
 The app package cache carries a `{source}` segment because cached content is
 scoped to the source that supplied it; see
 [Source conformance](cache-concurrency.md#source-conformance). The NuGet global
-cache has no such segment — it is source-blind by NuGet's own design, and
-dotnet-inspect reads it as an ambient local store rather than as a feed.
+cache has no such segment. The target source model reads its
+`.nupkg.metadata.source` before using it as a payload replica of an authorized
+feed.
 
 ## Network download/cache behavior
 
@@ -256,7 +273,7 @@ offline mode, and unsupported local feed URLs are not cached as misses.
 
 | Download or check | Cache behavior |
 | --- | --- |
-| Pinned package `.nupkg` extraction | Uses NuGet global cache or app package cache permanently; downloads only when missing. |
+| Pinned package `.nupkg` extraction | Uses a global or app payload only when its recorded producer is eligible; downloads otherwise. |
 | Bare package version resolution | Uses the version-resolution cache with a 1-hour TTL, then NuGet; package caches are used only after the version is resolved. |
 | Bare package `--preview` resolution | Uses a separate prerelease-aware version-resolution cache with a 1-hour TTL, then NuGet. |
 | Wildcard version resolution | Uses the same version-list cache as `--versions` with a 1-hour TTL for nuget.org-backed sources. |
@@ -284,37 +301,38 @@ immutable work, but readers observe only a marked, atomically published winner.
 Platform-pack projection uses the same model in a separate cache namespace.
 
 Cache identity is the cache root, normalized package id, version, and the source
-that supplied the bytes. Source order selects the producer on a miss. See
+that supplied the bytes. A discovered coordinate may be fulfilled only by a
+feed that reported it; a pinned coordinate may be fulfilled by any eligible
+feed. See the
 [cache concurrency and publication](cache-concurrency.md) for the
 single-flight boundary, dependency-overlap safety, filesystem rename semantics,
 failure model, and NuGet, Docker, and Git precedents.
 
-The NuGet global folder is deliberately outside this scheme. It is read eagerly,
-before source scoping is considered, because it is not a feed dotnet-inspect
-fetched from: the user populated it, normally by restoring, and binding to it is
-what makes inspection agree with what a build actually consumed. `--no-nuget-cache`
-excludes it for callers that need only configured sources to answer.
+The NuGet global folder participates only in payload fulfillment. Its recorded
+source must be authorized for the exact coordinate; installed versions do not
+expand the candidate set. `--no-nuget-cache` excludes it entirely.
 
 ## Multiple sources
 
-Sources are consulted in configured order, and the two version operations combine
-them differently.
+The active sources form an eligible set, not a precedence list. Package source
+mapping may narrow that set for a package id; see the
+[package source model](package-source-model.md). Version operations combine all
+eligible sources.
 
 | Operation | Combination | Order sensitive |
 | --- | --- | --- |
-| `--latest-version` | First source that carries the package answers; later sources are not consulted. | Yes |
+| `--latest-version` | Highest semantic version carried by any eligible source. | No |
 | `--versions` | Union across all sources, deduplicated. | No |
 | `--versions-with-feed` | Union across all sources, one row per (version, feed). | No |
 
-First-source-wins for `--latest-version` is deliberate: it is the same precedence
-rule restore uses, and it lets a private feed shadow a public one. The corollary
-is that `--add-source` cannot change `--latest-version` for a package that also
-exists on nuget.org, because the added source lands after the default. To
-override, pass `--source` explicitly and put the preferred feed first.
+An added private or nightly feed can therefore raise the latest-version answer
+even when NuGet.org also carries the package. Source declaration order cannot
+make one feed shadow another. Use package source mapping, or select a single
+source, when only one feed may answer for an id.
 
-Because `--versions` unions and `--latest-version` does not, the two can disagree.
-`--versions-with-feed` exists to make that disagreement legible: it shows which
-feed each version actually came from.
+`--versions-with-feed` keeps provenance that the merged views discard. It shows
+which feeds carry each coordinate, including a coordinate published by more than
+one feed.
 
 ### Listing status across sources
 
@@ -344,11 +362,13 @@ request deduplication is covered separately in
 
 | Docker command | dotnet-inspect command | Version behavior |
 | --- | --- | --- |
-| `docker run nginx:1.25` | `dotnet-inspect package System.Text.Json@10.0.0` | Uses a pinned, reproducible coordinate. |
-| `docker run nginx` | `dotnet-inspect package System.Text.Json` | Uses the newest locally cached stable version, or resolves from NuGet when absent. |
+| `docker run nginx:1.25` | `dotnet-inspect package System.Text.Json@10.0.0` | Fixes the version; producer provenance determines the bytes. |
+| `docker run nginx` | `dotnet-inspect package System.Text.Json` | Resolves the newest stable candidate from selected feeds, then uses a matching cached payload when available. |
 | `docker pull nginx` | `dotnet-inspect package System.Text.Json@latest` | Always checks NuGet for the current version. |
 
-NuGet packages are immutable once published (a given version string always
-refers to the same content), so pinned versions never go stale. The bare-name
-default optimizes for the interactive CLI use case where sub-second response
-time matters more than always having the absolute latest version.
+A pinned version does not by itself guarantee byte reproducibility across
+feeds: two feeds may publish different payloads for one coordinate. A pinned
+coordinate plus one authorized producer, or another verified content identity,
+is reproducible. The bare-name default optimizes for the interactive CLI use
+case where sub-second response time matters more than always having the
+absolute latest version.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -60,6 +60,8 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
 - [Member Index](design/member-index.md): overload selector and digest contract.
 - [Member target resolution](design/member-target-resolution.md): typed member selector, anchor, and body-target resolution.
 - [Member ordering](design/member-order.md): canonical type/member section order and member-kind mapping.
+- [Package source model](design/package-source-model.md): source eligibility,
+  mapping, local stores, source-bound caches, selection, and enrichment.
 - [Version resolution](design/version-resolution.md): package/platform version and cache behavior.
 - [Cache concurrency and publication](design/cache-concurrency.md): process-local single-flight, atomic publication, dependency overlap, and filesystem guarantees.
 - [Skill guidance taste](../taste/skill-guidance.md): how to maintain the embedded agent skill.

--- a/docs/pdb-acquisition.md
+++ b/docs/pdb-acquisition.md
@@ -38,10 +38,21 @@ Look for a `.pdb` file next to the library with the same base name. Common when 
 
 ### 3. Symbol package (.snupkg)
 
-For NuGet packages, download the corresponding `.snupkg` from:
+The current implementation downloads a NuGet package's corresponding `.snupkg`
+from:
 
 - `https://globalcdn.nuget.org/symbol-packages/{id}.{version}.snupkg`
 - `https://api.nuget.org/v3-flatcontainer/{id}/{version}/{id}.{version}.snupkg`
+
+That lookup is not yet source-conformant for packages acquired from another
+feed. Under the target
+[package source model](design/package-source-model.md#enrichment-is-a-separate-capability),
+these known routes are available only when NuGet.org produced the package, and
+the derived PDB remains tied to that producer. NuGet V3 defines no standard
+symbol-package download resource for custom or local feeds, so `.snupkg`
+acquisition from those producers is unsupported until an explicit endpoint
+contract exists. This migration is tracked by
+[#3738](https://github.com/richlander/dotnet-inspect/issues/3738).
 
 ### 4. Symbol servers
 
@@ -107,6 +118,12 @@ Downloaded PDBs are cached locally to avoid repeated downloads:
 
 - **Symbol packages**: `~/.dotnet-inspect/symbols/{package}/{version}/{filename}.pdb`
 - **Symbol server**: `~/.dotnet-inspect/symbols/{pdbname}/{key}/{pdbname}`
+
+Those are the current source-blind paths. The target model scopes a
+package-associated PDB by package producer and a symbol-server PDB by server
+identity, or persists equivalent provenance beside the entry, so a warm hit
+reports and enforces the same origin as the initial acquisition. This migration
+is part of [#3738](https://github.com/richlander/dotnet-inspect/issues/3738).
 
 ## Error handling
 


### PR DESCRIPTION
## Summary

- define candidate discovery and payload fulfillment as separate, source-scoped phases
- require provenance-matched package caches and make strict source fidelity the only package policy
- specify config hierarchy, source mapping, local feeds, concurrency, derived-cache, symbol, and feed-relative output contracts
- reconcile cache, version-resolution, PDB, and architecture overview documentation with the target model and current implementation gaps

This PR changes documentation only. Implementation is tracked by #3722, #3724, #3737, #3738, #3739, #3752, and #3759.

## Validation

- `markdownlint` on every changed Markdown file

Closes #3723
