### PR TITLE
Define sweep assembly list byte format

### DIFF
--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -728,9 +728,13 @@ foreach (var entry in selected)
 
 assemblies.Sort(StringComparer.Ordinal);
 string assembliesPath = Path.Combine(outputDirectory, "assemblies.txt");
+// This is an interchange file for shell tooling, so its bytes are part of the
+// contract: UTF-8 without a BOM, one LF-terminated path per line. ReplaceTextOrReport
+// supplies the encoding; EvilPoolSweepGateTests.ASweepPoolsTheBytesThePinNames gates
+// the complete file.
 string? unwritable = (await ReplaceTextOrReport(
     assembliesPath,
-    string.Concat(assemblies.Select(assembly => assembly + Environment.NewLine)))).Error;
+    string.Concat(assemblies.Select(assembly => assembly + '\n')))).Error;
 if (unwritable is not null)
 {
     Console.Error.WriteLine(unwritable);
@@ -852,6 +856,8 @@ var manifest = new PackageSweepManifest(
     RemovedFromPool: removedFromPool,
     Unreconciled: unreconciled);
 string manifestPath = Path.Combine(outputDirectory, "manifest.json");
+// JSON values are the manifest contract; terminal whitespace is not. This newline is
+// text-file convenience and is deliberately not gated.
 unwritable = (await ReplaceTextOrReport(
     manifestPath,
     JsonSerializer.Serialize(manifest, jsonContext.PackageSweepManifest) + Environment.NewLine)).Error;
@@ -928,6 +934,9 @@ if (refreshPin)
     Console.WriteLine($"Recorded {recorded.Length} pinned packages in {Path.GetRelativePath(root, pinPath)}.");
 }
 
+// Console output is operator convenience, not an output protocol. The manifest and
+// exit code are the stable contract; the wording and presence of these diagnostics are
+// deliberately not gated.
 Console.WriteLine(
     $"Selected {assemblies.Count} of {selected.Length} requested packages; "
     + $"manifest: {Path.Combine(outputDirectory, "manifest.json")}");

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using DotnetInspector.Packages;
@@ -103,11 +104,12 @@ public class EvilPoolSweepGateTests
         Assert.True(File.Exists(pooled), $"the sweep exited 0 without pooling '{pooled}'");
         Assert.Equal(world.FixtureSha256, Sha256Of(pooled));
 
-        // The pool is only reproducible if what the sweep reports is what it wrote -- both
-        // packages, in rank order, and no third thing.
-        Assert.Equal(
-            [world.LeadDestination, pooled],
-            File.ReadAllLines(world.PooledListPath).Where(line => line.Length > 0));
+        // This list crosses from .NET into shell tooling, so its exact bytes are the
+        // protocol: BOM-less UTF-8, LF separators, and a terminating LF. Reading lines
+        // would accept UTF-16 and a missing terminator and leave that contract ungated.
+        byte[] expectedList = Encoding.UTF8.GetBytes(
+            $"{world.LeadDestination}\n{pooled}\n");
+        Assert.Equal(expectedList, File.ReadAllBytes(world.PooledListPath));
 
         // And the count agrees with the record. Nothing read this aggregate before, so a
         // successful two-package pool could report zero selected -- measured.


### PR DESCRIPTION
## What

`assemblies.txt` is now a byte-stable interchange file: BOM-less UTF-8, one path per LF-terminated line, including a final LF. The successful sweep fixture asserts the complete byte sequence rather than decoding lines.

## Why

The file crosses from the .NET sweep into shell tooling. UTF-16, platform-native CRLF, or a missing final terminator should not silently satisfy a test that only compares decoded paths.

## Contract boundary

`manifest.json` terminal whitespace and operator-facing console prose remain deliberately non-contractual. The manifest values and process exit code are the stable machine-readable surface.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`: succeeded
- `EvilPoolSweepGateTests` at `1a97c13a`: 21 passed, 1 shared-cache precondition skipped
- Full Release decompiler suite with `ilasm`/`ildasm` at pre-integration head `00665a88`: 4,751 passed, 1 shared-cache precondition skipped

Closes #3720