### PR TITLE
Respect value-type constraints when applying nullability

### DIFF
--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -430,16 +430,16 @@ internal sealed class ByRefTypeNode(TypeNode elementType) : TypeNode
 }
 
 /// <summary>Generic type or method parameters (T, TKey, etc.).</summary>
-internal sealed class GenericParameterNode(string name) : TypeNode
+internal sealed class GenericParameterNode(string name, bool hasValueTypeConstraint) : TypeNode
 {
-    public override bool IsReferenceType => false; // unknown; annotation still applies
+    public override bool IsReferenceType => false;
 
     public override string Render(bool canonicalTuples) => IsNullableAnnotated ? $"{name}?" : name;
 
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
         byte b = ConsumeByte(bytes, ref position, defaultByte);
-        if (b == 2) IsNullableAnnotated = true;
+        if (!hasValueTypeConstraint && b == 2) IsNullableAnnotated = true;
     }
 
     public override void ApplyDynamic(byte[]? flags, ref int position)

--- a/src/ILInspector.Metadata/TypeNodeProvider.cs
+++ b/src/ILInspector.Metadata/TypeNodeProvider.cs
@@ -80,13 +80,17 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
     public TypeNode GetGenericMethodParameter(GenericContext? context, int index)
     {
         string name = NameDecoder.GetGenericMethodParameter(context, index);
-        return new GenericParameterNode(name);
+        return new GenericParameterNode(
+            name,
+            hasValueTypeConstraint: context?.HasMethodParameterValueTypeConstraint(index) == true);
     }
 
     public TypeNode GetGenericTypeParameter(GenericContext? context, int index)
     {
         string name = NameDecoder.GetGenericTypeParameter(context, index);
-        return new GenericParameterNode(name);
+        return new GenericParameterNode(
+            name,
+            hasValueTypeConstraint: context?.HasTypeParameterValueTypeConstraint(index) == true);
     }
 
     public TypeNode GetFunctionPointerType(MethodSignature<TypeNode> signature) => new FunctionPointerTypeNode(signature);

--- a/src/ILInspector.MetadataPrimitives/GenericContext.cs
+++ b/src/ILInspector.MetadataPrimitives/GenericContext.cs
@@ -1,30 +1,60 @@
+using System.Reflection;
 using System.Reflection.Metadata;
 
 namespace ILInspector.Metadata;
 
 /// <summary>
-/// Context for resolving generic type parameter names during signature decoding.
+/// Context for resolving generic type parameter names and constraint flags during
+/// signature decoding.
 /// </summary>
 public class GenericContext
 {
+    readonly IReadOnlyList<bool> _typeValueTypeConstraints;
+    readonly IReadOnlyList<bool> _methodValueTypeConstraints;
+
     public IReadOnlyList<string> TypeParameters { get; }
     public IReadOnlyList<string> MethodParameters { get; }
 
     public GenericContext(IReadOnlyList<string> typeParameters, IReadOnlyList<string> methodParameters)
+        : this(typeParameters, methodParameters, [], [])
+    {
+    }
+
+    GenericContext(
+        IReadOnlyList<string> typeParameters,
+        IReadOnlyList<string> methodParameters,
+        IReadOnlyList<bool> typeValueTypeConstraints,
+        IReadOnlyList<bool> methodValueTypeConstraints)
     {
         TypeParameters = typeParameters;
         MethodParameters = methodParameters;
+        _typeValueTypeConstraints = typeValueTypeConstraints;
+        _methodValueTypeConstraints = methodValueTypeConstraints;
     }
+
+    /// <summary>
+    /// Whether the indexed type parameter carries the metadata value-type constraint
+    /// flag. This decides whether a nullable annotation may be applied to the parameter itself:
+    /// for <c>where T : struct</c>, source <c>T?</c> is represented structurally as
+    /// <c>System.Nullable&lt;T&gt;</c>, never as an annotation on <c>T</c>.
+    /// </summary>
+    public bool HasTypeParameterValueTypeConstraint(int index)
+        => HasValueTypeConstraint(_typeValueTypeConstraints, index);
+
+    /// <summary>
+    /// Whether the indexed method parameter carries the metadata value-type constraint
+    /// flag. See <see cref="HasTypeParameterValueTypeConstraint"/>.
+    /// </summary>
+    public bool HasMethodParameterValueTypeConstraint(int index)
+        => HasValueTypeConstraint(_methodValueTypeConstraints, index);
 
     /// <summary>
     /// Creates a context for a type definition (type parameters only).
     /// </summary>
     public static GenericContext ForType(MetadataReader reader, TypeDefinition typeDef)
     {
-        var typeParams = typeDef.GetGenericParameters()
-            .Select(h => reader.GetString(reader.GetGenericParameter(h).Name))
-            .ToList();
-        return new GenericContext(typeParams, []);
+        var typeParameters = ReadParameters(reader, typeDef.GetGenericParameters());
+        return new GenericContext(typeParameters.Names, [], typeParameters.ValueTypeConstraints, []);
     }
 
     /// <summary>
@@ -32,12 +62,31 @@ public class GenericContext
     /// </summary>
     public static GenericContext ForMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition methodDef)
     {
-        var typeParams = typeDef.GetGenericParameters()
-            .Select(h => reader.GetString(reader.GetGenericParameter(h).Name))
-            .ToList();
-        var methodParams = methodDef.GetGenericParameters()
-            .Select(h => reader.GetString(reader.GetGenericParameter(h).Name))
-            .ToList();
-        return new GenericContext(typeParams, methodParams);
+        var typeParameters = ReadParameters(reader, typeDef.GetGenericParameters());
+        var methodParameters = ReadParameters(reader, methodDef.GetGenericParameters());
+        return new GenericContext(
+            typeParameters.Names,
+            methodParameters.Names,
+            typeParameters.ValueTypeConstraints,
+            methodParameters.ValueTypeConstraints);
     }
+
+    static (List<string> Names, List<bool> ValueTypeConstraints) ReadParameters(
+        MetadataReader reader,
+        GenericParameterHandleCollection handles)
+    {
+        List<string> names = [];
+        List<bool> valueTypeConstraints = [];
+        foreach (var handle in handles)
+        {
+            var parameter = reader.GetGenericParameter(handle);
+            names.Add(reader.GetString(parameter.Name));
+            valueTypeConstraints.Add(
+                (parameter.Attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0);
+        }
+        return (names, valueTypeConstraints);
+    }
+
+    static bool HasValueTypeConstraint(IReadOnlyList<bool> constraints, int index)
+        => index >= 0 && index < constraints.Count && constraints[index];
 }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -1509,6 +1509,71 @@ public class ApiOutputFormatterTests
         Assert.Contains("where T : struct", typeSource, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Both decompiled-source routes preserve the compiler-produced distinction between
+    /// structural <c>Nullable&lt;T&gt;</c> and bare <c>T</c> under a value-type constraint.
+    /// This is the end-to-end gate for issue #3729; applying the enclosing nullable context
+    /// to <c>T</c> produces invalid <c>Nullable&lt;T?&gt;</c> and changes bare <c>T</c> to
+    /// <c>T?</c>.
+    /// </summary>
+    [Fact]
+    public void ValueConstrainedGenericParameters_IgnoreNullableAnnotationBytes()
+    {
+        string path = typeof(ValueTypeNullabilityFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(ValueTypeNullabilityFixture).FullName);
+
+        foreach (var member in type.Members.Where(candidate =>
+                     candidate.Name is nameof(ValueTypeNullabilityFixture.NullableValue)
+                         or nameof(ValueTypeNullabilityFixture.PlainValue)))
+        {
+            var collected = Assert.Single(MemberCodeProvider.Collect(
+                type,
+                [member],
+                path,
+                overloadIndex: 0,
+                new MemberCodeProvider.Request(
+                    DecompiledSource: true,
+                    AnnotatedSource: false,
+                    CostOverlay: false,
+                    SemanticsOverlay: false,
+                    IL: false,
+                    Attributes: false,
+                    Calls: false,
+                    Callers: false,
+                    CallGraph: false,
+                    UnsafeOperations: false)));
+            var sections = new MemberCodeView();
+            Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, collected.Code));
+
+            if (member.Name == nameof(ValueTypeNullabilityFixture.NullableValue))
+            {
+                Assert.Contains("Nullable<T> value", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+                Assert.DoesNotContain("T?>", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+            }
+            else
+            {
+                Assert.Contains("PlainValue<T>(T value", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+                Assert.DoesNotContain("PlainValue<T>(T? value", sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+            }
+        }
+
+        var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
+        Assert.NotNull(typeSource);
+        Assert.Contains("Nullable<T> value", typeSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("T?>", typeSource, StringComparison.Ordinal);
+        var plainStart = typeSource.IndexOf("PlainValue<T>", StringComparison.Ordinal);
+        Assert.True(plainStart >= 0);
+        var plainEnd = typeSource.IndexOf('{', plainStart);
+        Assert.True(plainEnd > plainStart);
+        var plainDeclaration = typeSource[plainStart..plainEnd];
+        Assert.Contains("T value", plainDeclaration, StringComparison.Ordinal);
+        Assert.DoesNotContain("T? value", plainDeclaration, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -605,6 +605,152 @@ public class ApiSurfaceExtractorTests
             });
     }
 
+    /// <summary>
+    /// Nullable context bytes do not annotate a parameter carrying the metadata value-type
+    /// constraint flag, whether it belongs to a method or type. Unconstrained parameters
+    /// remain eligible. This is the extraction gate for issue #3729: removing the flag
+    /// from <c>GenericContext</c> produces <c>Nullable&lt;T?&gt;</c>, <c>Handler&lt;T?&gt;</c>,
+    /// and a spurious bare <c>T?</c>.
+    /// </summary>
+    [Fact]
+    public void Extract_DoesNotApplyNullableAnnotationsToValueConstrainedParameters()
+    {
+        using var stream = File.OpenRead(typeof(ValueTypeNullabilityFixture).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(ValueTypeNullabilityFixture).FullName);
+        var nullable = Assert.Single(
+            type.Members,
+            candidate => candidate.Name == nameof(ValueTypeNullabilityFixture.NullableValue));
+        var plain = Assert.Single(
+            type.Members,
+            candidate => candidate.Name == nameof(ValueTypeNullabilityFixture.PlainValue));
+        var open = Assert.Single(
+            type.Members,
+            candidate => candidate.Name == nameof(ValueTypeNullabilityFixture.Open));
+
+        Assert.Contains("System.Nullable<T> value", nullable.Signature, StringComparison.Ordinal);
+        Assert.Contains("Handler<T> message", nullable.Signature, StringComparison.Ordinal);
+        Assert.DoesNotContain("T?>", nullable.Signature, StringComparison.Ordinal);
+
+        Assert.Contains("(T value,", plain.Signature, StringComparison.Ordinal);
+        Assert.Contains("Handler<T> message", plain.Signature, StringComparison.Ordinal);
+        Assert.DoesNotContain("T?", plain.Signature, StringComparison.Ordinal);
+        Assert.Contains("Open<T>(T? value)", open.Signature, StringComparison.Ordinal);
+
+        var valueContainer = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(ValueTypeNullabilityContainer<>).FullName);
+        var valueField = Assert.Single(
+            valueContainer.Members,
+            candidate => candidate.Name == nameof(ValueTypeNullabilityContainer<int>.Value));
+        var maybeField = Assert.Single(
+            valueContainer.Members,
+            candidate => candidate.Name == nameof(ValueTypeNullabilityContainer<int>.Maybe));
+        Assert.Equal("T", valueField.ReturnType);
+        Assert.Equal("System.Nullable<T>", maybeField.ReturnType);
+
+        var openContainer = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(OpenNullabilityContainer<>).FullName);
+        var openMaybeField = Assert.Single(
+            openContainer.Members,
+            candidate => candidate.Name == nameof(OpenNullabilityContainer<int>.Maybe));
+        Assert.Equal("T?", openMaybeField.ReturnType);
+    }
+
+    /// <summary>
+    /// The same rule applies to a declaring type's parameter. The compiler fixture above
+    /// gates real method metadata; this synthesized seam case isolates a type-level
+    /// <c>NullableContextAttribute(2)</c>, which causes <c>T?</c> and
+    /// <c>Nullable&lt;T?&gt;</c> if <c>GenericContext.ForType</c> drops the constraint flag.
+    /// </summary>
+    [Fact]
+    public void Extract_DoesNotApplyNullableContextToValueConstrainedTypeParameter()
+    {
+        string path = EmitValueConstrainedTypeNullableContextSample();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var type = Assert.Single(
+                surface.Types,
+                candidate => candidate.Name.StartsWith(
+                    "ValueConstrainedType",
+                    StringComparison.Ordinal));
+            var value = Assert.Single(type.Members, candidate => candidate.Name == "Value");
+            var maybe = Assert.Single(type.Members, candidate => candidate.Name == "Maybe");
+
+            Assert.Equal("T", value.ReturnType);
+            Assert.Equal("System.Nullable<T>", maybe.ReturnType);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    static string EmitValueConstrainedTypeNullableContextSample()
+    {
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("ValueConstrainedTypeEmit"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("ValueConstrainedTypeEmit");
+
+        var attributeBuilder = module.DefineType(
+            "System.Runtime.CompilerServices.NullableContextAttribute",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class
+                | System.Reflection.TypeAttributes.Sealed,
+            typeof(Attribute));
+        var attributeConstructor = attributeBuilder.DefineConstructor(
+            System.Reflection.MethodAttributes.Public,
+            System.Reflection.CallingConventions.Standard,
+            [typeof(byte)]);
+        var attributeIl = attributeConstructor.GetILGenerator();
+        attributeIl.Emit(System.Reflection.Emit.OpCodes.Ldarg_0);
+        attributeIl.Emit(
+            System.Reflection.Emit.OpCodes.Call,
+            typeof(Attribute).GetConstructor(
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                Type.EmptyTypes,
+                modifiers: null)!);
+        attributeIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var nullableContextAttribute = attributeBuilder.CreateType();
+
+        var typeBuilder = module.DefineType(
+            "ValueConstrainedType",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        typeBuilder.SetCustomAttribute(new System.Reflection.Emit.CustomAttributeBuilder(
+            nullableContextAttribute.GetConstructor([typeof(byte)])!,
+            [(byte)2]));
+        var parameter = Assert.Single(typeBuilder.DefineGenericParameters("T"));
+        parameter.SetGenericParameterAttributes(
+            System.Reflection.GenericParameterAttributes.NotNullableValueTypeConstraint
+                | System.Reflection.GenericParameterAttributes.DefaultConstructorConstraint);
+        parameter.SetBaseTypeConstraint(typeof(ValueType));
+        typeBuilder.DefineField(
+            "Value",
+            parameter,
+            System.Reflection.FieldAttributes.Public);
+        typeBuilder.DefineField(
+            "Maybe",
+            typeof(Nullable<>).MakeGenericType(parameter),
+            System.Reflection.FieldAttributes.Public);
+        typeBuilder.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"value-constrained-type-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
     [Fact]
     public void Extract_ExtractsCovariance()
     {

--- a/src/dotnet-inspect.Tests/ValueTypeNullabilityFixture.cs
+++ b/src/dotnet-inspect.Tests/ValueTypeNullabilityFixture.cs
@@ -1,0 +1,57 @@
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Compiler-produced witness for nullable byte application to value-constrained generic
+/// parameters. The nullable fields make Roslyn select a nullable enclosing context, while
+/// the methods distinguish structural <see cref="Nullable{T}"/> from a bare parameter.
+/// </summary>
+public static class ValueTypeNullabilityFixture
+{
+    public static string? A;
+    public static string? B;
+    public static string? C;
+
+    public readonly struct Handler<T>
+    {
+        public Handler(T? value)
+        {
+        }
+    }
+
+    public static void NullableValue<T>(
+        T? value,
+        Handler<T> message,
+        string? path = null) where T : struct
+    {
+    }
+
+    public static void PlainValue<T>(
+        T value,
+        Handler<T> message,
+        string? path = null) where T : unmanaged
+    {
+    }
+
+    public static void Open<T>(T? value)
+    {
+    }
+}
+
+public sealed class ValueTypeNullabilityContainer<T> where T : struct
+{
+    public string? A;
+    public string? B;
+    public string? C;
+    public string? D;
+    public T Value;
+    public T? Maybe;
+}
+
+public sealed class OpenNullabilityContainer<T>
+{
+    public string? A;
+    public string? B;
+    public string? C;
+    public string? D;
+    public T? Maybe;
+}


### PR DESCRIPTION
- Fixes #3729
- Stops nullable context metadata from annotating value-constrained generic parameters
- Card revision: `4d1cf9808f9802cd67562aa30990f5d9c1a2249e`

## Change

> Should we accept this change?

**Conclusion: PASS** — the change replaces invalid or signature-changing
`T?` annotations with the structural nullable form encoded by metadata, while
preserving nullable annotations for unconstrained generic parameters.

### Benchmark target

Benchmark target:
`runtime.linux-x64.Microsoft.DotNet.ILCompiler@9.0.17`
(`framework/System.Memory.dll`)

dotnet-inspect command:

```bash
dotnet-inspect member System.Runtime.InteropServices.SequenceMarshal \
  --library ~/.nuget/packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/9.0.17/framework/System.Memory.dll \
  TryRead -S "Decompiled Source"
```

### Original source

Acquired from the package PDB with the same member selector and
`-S "Original Source"`:

```csharp
public static bool TryRead<T>(ref SequenceReader<byte> reader, out T value) where T : unmanaged
{
    return reader.TryRead<T>(out value);
}
```

### Before

Acquired at the exact PR base:

```csharp
public static bool TryRead<T>(ref System.Buffers.SequenceReader<byte> reader, out T? value) where T : unmanaged => reader.TryRead<T>(out value);
```

- Valid: False
- Correct: False
- IL fidelity: False
- Taste applied: None
- Commit: `e5ca5d974d3ef5a8c4752229da8efcdf9618338d`

For a value-constrained parameter, `T?` denotes `Nullable<T>` rather than a
nullable annotation on `T`. The rendered `out T?` therefore changes the
signature and cannot be passed to the body's `out T` call (`CS1503`).

### After

Acquired at the exact PR head:

```csharp
public static bool TryRead<T>(ref System.Buffers.SequenceReader<byte> reader, out T value) where T : unmanaged => reader.TryRead<T>(out value);
```

- Valid: True
- Correct: True
- IL fidelity: not currently checkable
- Taste applied: None
- Commit: `4d1cf9808f9802cd67562aa30990f5d9c1a2249e`

The render now matches both the authoritative source and the metadata
signature. No exact compile-back comparison was run for this package artifact,
so the opcode-fidelity verdict remains explicitly unclaimed.

### Fully raised

The After decompilation is in the fully raised state.

## Root cause and scope

`TypeNode.ApplyNullability` correctly consumes nullable bytes in preorder, but
`GenericParameterNode` treated byte `2` as an annotation without considering
the parameter's metadata constraints. Under `where T : struct` or
`where T : unmanaged`, source `T?` is encoded structurally as `Nullable<T>`;
the inner `T` must not also be annotated.

`GenericContext` now retains
`GenericParameterAttributes.NotNullableValueTypeConstraint` for both type and
method parameters. `TypeNodeProvider` passes that fact to
`GenericParameterNode`, which still consumes the nullable byte for positional
alignment but suppresses the annotation for a value-constrained parameter.

No spelling heuristic, inspected-assembly loading, or Roslyn dependency was
added. Manually constructed contexts without constraint facts retain their
previous behavior. The separate pre-existing nullable-context presence and
enclosing-type inheritance defect found during review is tracked by #3770.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused issue gates | Not present | 3 passed |
| Decompiler fast gate | 4,541 passed | 4,541 passed |
| `SequenceMarshal.TryRead<T>` | Invalid/signature-changing `out T?` | Source-faithful `out T` |
| Same-artifact SRM scan | 232 findings | 0 findings |

The SRM scan inspected the same 22,203 assemblies and 39,028
value-constrained generic parameters at both revisions. Compiler-produced and
synthesized fixtures cover method and type generic-parameter paths,
respectively; close negatives preserve unconstrained `T?`. Tamper checks proved
both paths non-vacuous.

Real corrected witnesses also include Razor's
`Microsoft.AspNetCore.Razor.Assumed.NotNull<T>`, where
`Nullable<T?>` and `ThrowIfNullInterpolatedStringHandler<T?>` now render as
`Nullable<T>` and `ThrowIfNullInterpolatedStringHandler<T>`. Razor's SourceLink
source confirms that the intended nullable value-type form is structural.

## Review

MAI-Code and Claude Opus 5 reviewed exact head `4d1cf9808`; both returned clean
final verdicts with no blocking findings. The full reconciliation, including
the #3770 non-action boundary, is recorded in the fixed-head review comment.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build
dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build
dotnet run --project src/ILInspector.CSharp.Tests -c Release --no-build
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build
dotnet run --project src/DotnetInspector.Services.Tests -c Release --no-build
dotnet run --project tests/DotnetInspector.MetadataRendering.Tests -c Release --no-build
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- --gate fast
```
