### PR TITLE
Emit LF from the remaining artifact framing paths

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -5509,7 +5509,7 @@ public partial class CommandExecutionTests
 
             Assert.Equal(0, exit);
             Assert.True(File.Exists(path), "--out was ignored: the requested file was never written.");
-            Assert.Equal(8, int.Parse(File.ReadAllText(path).Trim(), CultureInfo.InvariantCulture));
+            Assert.Equal("8\n", File.ReadAllText(path));
             Assert.Empty(output.Trim());
         }
         finally
@@ -12751,7 +12751,7 @@ public partial class CommandExecutionTests
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
-            Assert.Equal("package docs\n", output.ReplaceLineEndings("\n"));
+            Assert.Equal("package docs\n", output);
         }
         finally
         {
@@ -12769,7 +12769,7 @@ public partial class CommandExecutionTests
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
-            Assert.Equal("readme\n", output.ReplaceLineEndings("\n"));
+            Assert.Equal("readme\n", output);
         }
         finally
         {
@@ -12789,7 +12789,7 @@ public partial class CommandExecutionTests
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
-            Assert.Equal("readme\n", output.ReplaceLineEndings("\n"));
+            Assert.Equal("readme\n", output);
         }
         finally
         {
@@ -13797,6 +13797,8 @@ public partial class CommandExecutionTests
 
             Assert.Equal(0, exit);
             var line = Assert.Single(output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            Assert.DoesNotContain('\r', output);
+            Assert.EndsWith("\n", output, StringComparison.Ordinal);
             using var document = JsonDocument.Parse(line);
 
             // Which document was selected is part of the payload rather than a side channel, so
@@ -14468,7 +14470,7 @@ public partial class CommandExecutionTests
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
-            Assert.Equal("2\n", output.ReplaceLineEndings("\n"));
+            Assert.Equal("2\n", output);
         }
         finally
         {
@@ -14509,6 +14511,30 @@ public partial class CommandExecutionTests
             Assert.Contains("# README body", output);
             Assert.DoesNotContain("# Agent guidance", output);
             Assert.DoesNotContain("# PROJECT body", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Project_Readme_JsonlUsesLfFraming()
+    {
+        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+            new ProjectDocPackage("Test.Project.Readme.Jsonl", "2.0.0", "README.md", "# README body"));
+
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "project", projectPath, "--readme", "Test.Project.Readme.Jsonl", "--jsonl");
+
+            Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+            Assert.Empty(error);
+            Assert.DoesNotContain('\r', output);
+            Assert.EndsWith("\n", output, StringComparison.Ordinal);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("# README body", document.RootElement.GetProperty("content").GetString());
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14542,6 +14542,73 @@ public partial class CommandExecutionTests
         }
     }
 
+    /// <summary>
+    /// This extends <see cref="OutputFormatterTests.ArtifactNewlineGate_ProductOwnedFramingUsesLf"/>
+    /// through the command-only JSONL builders whose output cannot be exercised at the formatter
+    /// seam. Each artifact must keep LF framing when <c>--out</c> writes it to a file.
+    /// </summary>
+    [Fact]
+    public async Task ArtifactNewlineGate_CommandJsonlFilesUseLf()
+    {
+        const string agents = """
+            ---
+            name: newline gate
+            ---
+            agents body
+            """;
+        var (projectPath, projectTempDir) = CreateProjectWithPackageDocs(
+            new ProjectDocPackage(
+                "Test.Project.NewlineGate",
+                "1.0.0",
+                "README.md",
+                "readme",
+                agents,
+                [new ProjectSkillDoc("skills/newline/SKILL.md", "skill body")]));
+        var (packagePath, packageTempDir) = CreateLocalReadmePackage(
+            "Test.Package.NewlineGate",
+            "README.md",
+            "readme",
+            "agents body");
+
+        try
+        {
+            var agentsOutput = Path.Combine(projectTempDir, "agents.jsonl");
+            var skillsOutput = Path.Combine(projectTempDir, "skills.jsonl");
+            var contentOutput = Path.Combine(packageTempDir, "content.jsonl");
+
+            var (agentsExit, agentsStdout, agentsError) = await RunAppAsync(
+                "project", projectPath, "--agents-index", "--jsonl", "--out", agentsOutput);
+            var (skillsExit, skillsStdout, skillsError) = await RunAppAsync(
+                "project", projectPath, "-S", "Skills", "--jsonl", "--out", skillsOutput);
+            var (contentExit, contentStdout, contentError) = await RunAppAsync(
+                "package", packagePath, "--path", "@agents", "--content", "--jsonl", "--out", contentOutput);
+
+            Assert.Equal(0, agentsExit);
+            Assert.Equal(0, skillsExit);
+            Assert.Equal(0, contentExit);
+            Assert.Empty(agentsStdout);
+            Assert.Empty(skillsStdout);
+            Assert.Empty(contentStdout);
+            Assert.Empty(agentsError);
+            Assert.Empty(skillsError);
+            Assert.Empty(contentError);
+
+            foreach (var path in new[] { agentsOutput, skillsOutput, contentOutput })
+            {
+                var artifact = File.ReadAllText(path);
+                Assert.DoesNotContain('\r', artifact);
+                Assert.EndsWith("\n", artifact, StringComparison.Ordinal);
+                using var _ = JsonDocument.Parse(
+                    Assert.Single(artifact.Split('\n', StringSplitOptions.RemoveEmptyEntries)));
+            }
+        }
+        finally
+        {
+            Directory.Delete(projectTempDir, recursive: true);
+            Directory.Delete(packageTempDir, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task Project_Readme_FallsBackToProjectMd()
     {

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -19,6 +19,43 @@ namespace DotnetInspector.Tests;
 [Collection("Console")]
 public class OutputFormatterTests
 {
+    /// <summary>
+    /// This is the named non-vacuity gate for product-owned artifact framing. It fails when the
+    /// count-file writer or printable-document JSONL writer inherits CRLF from the Windows host
+    /// instead of emitting the repository's LF artifact contract.
+    /// </summary>
+    [Fact]
+    public void ArtifactNewlineGate_ProductOwnedFramingUsesLf()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("artifact-newline-gate-");
+        try
+        {
+            var countPath = Path.Combine(tempDirectory.FullName, "count.txt");
+            CountOutput.WriteCount(7, countPath);
+
+            var printPath = Path.Combine(tempDirectory.FullName, "print.jsonl");
+            var printExit = PrintProjectionOutput.Write(
+                [new PrintableDocument(1, "Docs", "README", "README.md", null, "body")],
+                new PrintProjectionOptions(
+                    Row: null,
+                    JsonOutput: false,
+                    Jsonl: true,
+                    JsonArray: false,
+                    Bare: false,
+                    OutputPath: printPath));
+
+            Assert.Equal(0, printExit);
+            Assert.Equal("7\n", File.ReadAllText(countPath));
+            Assert.Equal(
+                "{\"row\":1,\"section\":\"Docs\",\"label\":\"README\",\"path\":\"README.md\",\"content\":\"body\"}\n",
+                File.ReadAllText(printPath));
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
     [Fact]
     public void ResourceTriageFailure_IsVisible()
     {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -2017,7 +2017,7 @@ public class PackageCommand
 
     private static int WriteBarePackageText(string content, string? outputPath)
     {
-        var output = content.EndsWith('\n') ? content : content + Environment.NewLine;
+        var output = content.EndsWith('\n') ? content : content + '\n';
         if (!string.IsNullOrEmpty(outputPath))
             File.WriteAllText(outputPath, output);
         else

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1822,7 +1822,9 @@ public class PackageCommand
     {
         var builder = new StringBuilder();
         foreach (var row in rows)
-            builder.AppendLine(JsonSerializer.Serialize(row, PackageFileContentJsonContext.Default.PackageFileContent));
+            builder
+                .Append(JsonSerializer.Serialize(row, PackageFileContentJsonContext.Default.PackageFileContent))
+                .Append('\n');
         return builder.ToString();
     }
 

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -286,7 +286,9 @@ public class ProjectCommand
     {
         var builder = new StringBuilder();
         foreach (var row in rows)
-            builder.AppendLine(JsonSerializer.Serialize(row, ProjectCommandCompactJsonContext.Default.ProjectAgentsIndexRow));
+            builder
+                .Append(JsonSerializer.Serialize(row, ProjectCommandCompactJsonContext.Default.ProjectAgentsIndexRow))
+                .Append('\n');
         return builder.ToString();
     }
 
@@ -383,7 +385,9 @@ public class ProjectCommand
     {
         var builder = new StringBuilder();
         foreach (var row in rows)
-            builder.AppendLine(JsonSerializer.Serialize(row, ProjectCommandCompactJsonContext.Default.ProjectSkillRow));
+            builder
+                .Append(JsonSerializer.Serialize(row, ProjectCommandCompactJsonContext.Default.ProjectSkillRow))
+                .Append('\n');
         return builder.ToString();
     }
 

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -346,7 +346,7 @@ public class ProjectCommand
             ProjectionAudit.MarkHonored(ProjectionAudit.Count);
 
         var output = options.Count
-            ? rows.Count.ToString(CultureInfo.InvariantCulture) + Environment.NewLine
+            ? rows.Count.ToString(CultureInfo.InvariantCulture) + '\n'
             : options.JsonOutput
                 ? JsonSerializer.Serialize(rows.ToArray(), ProjectCommandJsonContext.Default.ProjectSkillRowArray)
                 : options.Jsonl
@@ -541,7 +541,7 @@ public class ProjectCommand
         var output = options.JsonOutput
             ? JsonSerializer.Serialize(document, ProjectCommandJsonContext.Default.ProjectPackageDocument)
             : options.Jsonl
-                ? JsonSerializer.Serialize(document, ProjectCommandCompactJsonContext.Default.ProjectPackageDocument) + Environment.NewLine
+                ? JsonSerializer.Serialize(document, ProjectCommandCompactJsonContext.Default.ProjectPackageDocument) + '\n'
                 : document.Content;
 
         WriteOutput(output, options.OutputPath);

--- a/src/dotnet-inspect/Output/CacheOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/CacheOutputFormatter.cs
@@ -1,35 +1,9 @@
 namespace DotnetInspector.Output;
 
 /// <summary>
-/// Formats cache command output for display.
+/// Formats cache sizes for display.
 /// </summary>
 public static class CacheOutputFormatter
 {
-    public static string FormatCacheInfo(string location, List<(string Name, long Size, int Count)> categories, long totalSize)
-    {
-        List<string> lines = [];
-        lines.Add($"Cache location: {location}");
-        lines.Add("");
-
-        if (categories.Count == 0)
-        {
-            lines.Add("Cache is empty.");
-            return string.Join(Environment.NewLine, lines);
-        }
-
-        foreach (var category in categories)
-        {
-            var label = category.Name == "Packages" ? "packages" : "files";
-            lines.Add($"{category.Name + ":",-10}{FormatSize(category.Size)} ({category.Count} {label})");
-        }
-
-        lines.Add("");
-        lines.Add($"{"Total:",-10}{FormatSize(totalSize)}");
-        lines.Add("");
-        lines.Add("Run 'dotnet-inspect cache clear' to clear the cache.");
-
-        return string.Join(Environment.NewLine, lines);
-    }
-
     public static string FormatSize(long bytes) => ByteSizeFormatter.FormatBytes(bytes);
 }

--- a/src/dotnet-inspect/Output/CountOutput.cs
+++ b/src/dotnet-inspect/Output/CountOutput.cs
@@ -86,7 +86,7 @@ public static class CountOutput
         if (string.IsNullOrEmpty(outputPath))
             Console.WriteLine(text);
         else
-            File.WriteAllText(outputPath, text + Environment.NewLine);
+            File.WriteAllText(outputPath, text + '\n');
     }
 
     public static void WriteCountFromMarkdown(string markdown)

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -153,7 +153,8 @@ public static class OutputFormatter
     /// This is deliberately *not* the terminator used by <see cref="WriteLimitedMarkdown"/>: those
     /// callers still receive CRLF interiors from the string-returning <c>MarkoutSerializer</c>
     /// overloads, so switching only their terminator would introduce the very mixing described
-    /// above. Interior and terminator have to move together, tracked in #3596.
+    /// above. Interior and terminator have to move together; that coherent platform-native
+    /// terminal path is outside this artifact-framing helper's contract.
     /// </remarks>
     public static void WriteLfLine(TextWriter output, string payload)
     {

--- a/src/dotnet-inspect/Output/PrintProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/PrintProjectionOutput.cs
@@ -107,7 +107,7 @@ public static class PrintProjectionOutput
         if (options.Jsonl)
         {
             WriteOutput(
-                JsonSerializer.Serialize(selected, PrintProjectionJsonContext.Default.PrintableDocument) + Environment.NewLine,
+                JsonSerializer.Serialize(selected, PrintProjectionJsonContext.Default.PrintableDocument) + '\n',
                 options.OutputPath);
             return 0;
         }


### PR DESCRIPTION
## Summary

Closes #3596 by making every remaining tool-owned artifact separator and terminator emit LF on every platform, including three JSONL builders found during adversarial review, and by adding named non-vacuity gates through the real `--out` paths.

The genuine mixed-ending seam was `package --bare`: LF content without a final newline gained an ambient CRLF terminator on Windows. Counts written with `--out`, printable-document JSONL, project skill counts, project readme JSONL, project AGENTS/skill JSONL, and package-content JSONL also inherited the host newline, making their bytes platform-dependent. They now all use LF framing.

`CacheOutputFormatter.FormatCacheInfo` contained the issue's last two direct line joins, but had no product caller—the shipping cache command has long rendered through Markout. This removes that dead plaintext formatter rather than adding vacuous coverage for code users cannot reach.

## Contract boundary

- Raw package/readme content remains byte-preserved. The package bare path adds one LF only when shipped content has no final LF; existing content, including its own line endings, is not normalized.
- Human-facing diagnostics remain platform-native.
- `WriteLimitedMarkdown` remains a coherent platform-native terminal path: its Markout interior and terminator are both CRLF on Windows. Switching only its terminator would create mixing, so it is outside this artifact-framing change.

## Gates

- `ArtifactNewlineGate_ProductOwnedFramingUsesLf` renders count-file and printable-document JSONL artifacts and asserts exact LF-framed bytes.
- `ArtifactNewlineGate_CommandJsonlFilesUseLf` executes project AGENTS JSONL, project skills JSONL, and package-content JSONL through `--out`; each artifact must contain no CR, end in LF, contain one valid JSONL record, and leave stdout/stderr empty.
- Existing command tests no longer normalize line endings before asserting, and project readme JSONL has direct coverage.

## Windows evidence

Built and run with .NET SDK `11.0.100-preview.6.26359.118` in Release.

- `dotnet build dotnet-inspect.slnx -c Release` — succeeded
- `OutputFormatterTests` — 130 passed
- all 9 newline gate/changed-path tests on the final head — 9 passed
- full `CommandExecutionTests` — 856 total, 2 failed, 1 skipped
- full `dotnet-inspect.Tests` — 2966 total, 4 failed, 38 skipped

All four failures reproduce individually on clean `origin/main` at the same base commit and are unrelated to output framing:

- `CommandErrorOwnershipTests.CompiledIl_SpellsASeverityPrefixOnlyWhereAccountedFor` — `PE image does not have metadata`
- `CommandErrorOwnershipTests.CompiledIl_ReachesStderrOnlyWhereAccountedFor` — `PE image does not have metadata`
- `CommandExecutionTests.Type_Listing_ApiInfo_RestatesTheInlineIdentityLineExactly`
- `CommandExecutionTests.Type_PlatformPrefixBrowse_ListingSectionName_IsSelectable`

PR CI is green on the final exact head: `ci-required`, Ubuntu test, decompiler gates, build-net10, and changes all pass.

No Markdown or command-surface documentation changes are required; this makes the existing cross-platform artifact contract true at the residual seams.
