### PR TITLE
Add the portable annotated source-line contract

### DIFF
--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -309,8 +309,8 @@ base to factor out.
 
 What the four producers *do* share is the **line**. A rendered body is an ordered
 line stream, and the correlation layer joins two such streams on the IL offset.
-Two line types carry this, split by whether annotations are baked into the text or
-carried as structure:
+Three line types carry this, split by whether the line is a fast display value,
+an in-process correlation value, or a portable consumer value:
 
 - **`SourceLine(string Text, int Offset)`** — the fast, medium-neutral line. Both
   the C# and IL fast paths are just display-ready text plus an anchor, so one type
@@ -323,17 +323,24 @@ carried as structure:
   IL offset) before joining, adopting the currency without pulling the
   decompiler-pipeline decoder into the raw view.
 - **`BoundSourceLine(string Text, int Offset, SourceLineKind Kind,
-  IReadOnlyList<Annotation> Annotations)`** — the interleave currency. It carries
-  its annotations as *structure* (not baked into `Text`) so the merge printer has
-  placement freedom, plus a `Kind`.
+  IReadOnlyList<IAnnotation> Annotations)`** — the in-process interleave currency.
+  It carries bound annotations as *structure* (not baked into `Text`) so the merge
+  printer owns their presentation, plus a `Kind`.
+- **`AnnotatedSourceLine(string Text, int Offset, SourceLineKind Kind,
+  IReadOnlyList<PrintedAnnotationSpan> Annotations)`** — the portable form a
+  consumer can retain, serialize, filter, and render without the IR graph or
+  `IAnnotation` instances. Annotation extents use the coordinate space of the
+  containing stream; the producer rebases them when it interleaves lines.
 
 `SourceLineKind` is just **`{ CSharp, Il }`** — the one bit the merge frames on.
 It is deliberately *not* a structural taxonomy (no `BlockOpen`/`Statement`/depth):
 the containment tree already exists as `IrNode` (`Children` + `SourceOffset`), and
 the line stream is its *flat rendered projection*. Each medium pretty-prints its
-own lines — indentation, braces, IL comment-column alignment, and inline
-annotations already live in `Text` — so the correlation layer owns only the
-*cross-medium* framing, for which `Medium` is exactly enough.
+own lines — indentation, braces, IL comment-column alignment, and medium-owned
+commentary such as local and stack state already live in `Text`. Research facts
+do not: every line kind carries them as data, and only a renderer turns them into
+labels. The correlation layer therefore owns cross-medium framing and annotation
+presentation, for which `Kind` plus the structured fact list is exactly enough.
 
 The printer carries a separate structural coordinate plane. Its bound
 `PrintedRangeMap` records exact character ranges while the IR graph is alive;
@@ -365,7 +372,9 @@ stream that a dumb printer renders to text. The interleave is the landed instanc
 `ResearchViews.CorrelateMixedSource` folds the C# body, its statement-line map, the
 annotations, and the IL lines into one ordered `BoundSourceLine` stream (owning
 the range-containment bucketing), and `RenderMixedStream` frames each line by
-`Kind`, reading indent straight from the C# line's leading whitespace. The
+`Kind`, reading indent straight from the C# line's leading whitespace. Both C#
+and IL facts remain structured through correlation; the default renderer chooses
+side comments for IL only when it renders the stream. The
 cost/semantics/annotated-source **overlays** are the degenerate single-medium case
 of the same join: `ResearchViews.CorrelateOverlay` anchors the fact groups onto
 their printed C# lines and emits a C#-only `BoundSourceLine` stream (empty IL

--- a/src/ILInspector.Decompiler.Tests/PrintedBodyMapTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrintedBodyMapTests.cs
@@ -130,6 +130,64 @@ public class PrintedBodyMapTests
     }
 
     [Fact]
+    public void PortableAnnotatedLineSnapshotsAndReplaysStructuredFacts()
+    {
+        var annotations = new List<PrintedAnnotationSpan>
+        {
+            new(
+                "alloc.box",
+                "Allocation",
+                AnnotationConditionality.CachedOnce,
+                "Box",
+                new PrintedExtent(3, 7, 3, 10),
+                "int",
+                12),
+        };
+        var line = new AnnotatedSourceLine(
+            "IL_000C: box int32",
+            12,
+            SourceLineKind.Il,
+            annotations);
+
+        annotations.Clear();
+
+        var fact = Assert.Single(line.Annotations);
+        Assert.Equal("alloc.box", fact.Descriptor);
+        Assert.DoesNotContain("alloc.box", line.Text);
+
+        string json = JsonSerializer.Serialize(line);
+        var replayed = JsonSerializer.Deserialize<AnnotatedSourceLine>(json);
+        Assert.Equal(line, replayed);
+
+        var clean = new AnnotatedSourceLine(line.Text, line.Offset, line.Kind, []);
+        Assert.Equal(line.Text, clean.Text);
+        Assert.Empty(clean.Annotations);
+
+        Type[] portablePropertyTypes =
+        [
+            typeof(string),
+            typeof(int),
+            typeof(SourceLineKind),
+            typeof(IReadOnlyList<PrintedAnnotationSpan>),
+        ];
+        foreach (var property in typeof(AnnotatedSourceLine).GetProperties())
+            Assert.Contains(property.PropertyType, portablePropertyTypes);
+    }
+
+    [Fact]
+    public void PortableAnnotatedLineRejectsInvalidConstruction()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new AnnotatedSourceLine(null!, 0, SourceLineKind.CSharp, []));
+        Assert.Throws<ArgumentNullException>(
+            () => new AnnotatedSourceLine("", 0, SourceLineKind.CSharp, null!));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new AnnotatedSourceLine("", -2, SourceLineKind.CSharp, []));
+        Assert.Throws<ArgumentException>(
+            () => new AnnotatedSourceLine("", 0, (SourceLineKind)42, []));
+    }
+
+    [Fact]
     public void SurvivesSerialisationAndReplays()
     {
         var (_, ranges) = Print(nameof(AllocSampleClass.SumList));

--- a/src/ILInspector.Decompiler/SourceLine.cs
+++ b/src/ILInspector.Decompiler/SourceLine.cs
@@ -5,9 +5,9 @@ using ILInspector.Decompiler.Annotations;
 /// <summary>
 /// Which language a line came from. This is the only discriminator the
 /// correlation layer needs: each medium pretty-prints its own lines (indent,
-/// braces, IL alignment, inline annotations already live in the text), so the
-/// merge owns nothing but the cross-medium framing — and framing an IL line
-/// differs from a C# line by exactly this bit.
+/// braces, IL alignment, and medium-owned commentary), so the merge owns
+/// nothing but the cross-medium framing and research-annotation rendering —
+/// and framing an IL line differs from a C# line by exactly this bit.
 /// </summary>
 public enum SourceLineKind
 {
@@ -56,5 +56,76 @@ public sealed record BoundSourceLine(
     public BoundSourceLine(string Text, int Offset, SourceLineKind Kind)
         : this(Text, Offset, Kind, [])
     {
+    }
+}
+
+/// <summary>
+/// Portable line currency for consumers outside the decompiler process. Each
+/// line carries annotation data rather than rendered labels, so a consumer can
+/// choose a gesture, filter facts, or render clean text without parsing
+/// <paramref name="Text"/>.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="BoundSourceLine"/>, this type contains no
+/// <see cref="IAnnotation"/> references. Annotation extents use the coordinate
+/// space of the containing stream; constructing that stream and rebasing its
+/// extents is the producer's responsibility.
+/// </remarks>
+public sealed record AnnotatedSourceLine
+{
+    /// <summary>Creates a portable annotated source line.</summary>
+    /// <param name="Text">The medium's rendered line without research annotations.</param>
+    /// <param name="Offset">The anchoring IL offset, or <c>-1</c> when unanchored.</param>
+    /// <param name="Kind">The language this line came from.</param>
+    /// <param name="Annotations">Portable annotations attached to this line.</param>
+    public AnnotatedSourceLine(
+        string Text,
+        int Offset,
+        SourceLineKind Kind,
+        IReadOnlyList<PrintedAnnotationSpan> Annotations)
+    {
+        ArgumentNullException.ThrowIfNull(Text);
+        ArgumentNullException.ThrowIfNull(Annotations);
+        if (Offset < -1)
+            throw new ArgumentOutOfRangeException(nameof(Offset), Offset, "A line offset must be -1 or non-negative.");
+        if (!Enum.IsDefined(Kind))
+            throw new ArgumentException($"Unknown source line kind: {Kind}.", nameof(Kind));
+
+        this.Text = Text;
+        this.Offset = Offset;
+        this.Kind = Kind;
+        this.Annotations = Array.AsReadOnly(Annotations.ToArray());
+    }
+
+    /// <summary>The medium's rendered line without research annotations.</summary>
+    public string Text { get; }
+
+    /// <summary>The anchoring IL offset, or <c>-1</c> when unanchored.</summary>
+    public int Offset { get; }
+
+    /// <summary>The language this line came from.</summary>
+    public SourceLineKind Kind { get; }
+
+    /// <summary>Portable annotations attached to this line.</summary>
+    public IReadOnlyList<PrintedAnnotationSpan> Annotations { get; }
+
+    /// <inheritdoc/>
+    public bool Equals(AnnotatedSourceLine? other)
+        => other is not null
+            && Text == other.Text
+            && Offset == other.Offset
+            && Kind == other.Kind
+            && Annotations.SequenceEqual(other.Annotations);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Text);
+        hash.Add(Offset);
+        hash.Add(Kind);
+        foreach (var annotation in Annotations)
+            hash.Add(annotation);
+        return hash.ToHashCode();
     }
 }

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -177,6 +177,77 @@ public class ResearchFactRegistryTests
     }
 
     [Fact]
+    public void MixedStreamKeepsIlFactsStructuredUntilRendering()
+    {
+        using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);
+        var imported = IrImporter.Import(
+            source,
+            typeof(ResearchFixture).FullName!,
+            nameof(ResearchFixture.BoxInt))
+            ?? throw new InvalidOperationException("fixture method has no IL body");
+        var marker = new Annotation(
+            new AnnotationDescriptor("test.portable", AnnotationCategory.Cost, "portable marker"),
+            SourceOffset: 0,
+            Detail: "not-in-text");
+
+        var result = CSharpPrinter.PrintRaised(imported, out var printedRanges);
+        string output = Assert.IsType<string>(result.Output);
+        var ilLines = IlProjection.RenderIlBodyLines(
+            source,
+            typeof(ResearchFixture).FullName!,
+            nameof(ResearchFixture.BoxInt),
+            overloadIndex: 0,
+            publicOnly: false);
+
+        var stream = ResearchViews.CorrelateMixedSource(
+            imported,
+            output,
+            printedRanges,
+            [marker],
+            ilLines);
+
+        var ilLine = Assert.Single(
+            stream,
+            line => line.Kind == SourceLineKind.Il && line.Annotations.Contains(marker));
+        Assert.DoesNotContain("test.portable", ilLine.Text);
+        Assert.DoesNotContain("not-in-text", ilLine.Text);
+
+        string rendered = ResearchViews.RenderMixedStream(
+            stream,
+            AnnotationGestureSelector.SideOnly);
+        string label = AnnotationText.Format(marker);
+        int comment = ilLine.Text.IndexOf("//", StringComparison.Ordinal);
+        Assert.True(comment >= 0, "The fixture must exercise an IL producer comment.");
+        string prefix = ilLine.Text[..comment].TrimEnd();
+        string suffix = ilLine.Text[(comment + 2)..].Trim();
+        Assert.Contains($"{prefix}  // {label}; {suffix}", rendered);
+    }
+
+    [Theory]
+    [InlineData(
+        "IL_0000: ldarg.0",
+        "return value;\n    // IL_0000: ldarg.0  // test.portable(not-in-text)")]
+    [InlineData(
+        "IL_0000: ldarg.0  // arg:value",
+        "return value;\n    // IL_0000: ldarg.0  // test.portable(not-in-text); arg:value")]
+    public void MixedRendererPreservesIlSideAnnotationBytes(string ilText, string expected)
+    {
+        var marker = new Annotation(
+            new AnnotationDescriptor("test.portable", AnnotationCategory.Cost, "portable marker"),
+            SourceOffset: 0,
+            Detail: "not-in-text");
+        BoundSourceLine[] stream =
+        [
+            new("return value;", 0, SourceLineKind.CSharp),
+            new(ilText, 0, SourceLineKind.Il, [marker]),
+        ];
+
+        Assert.Equal(
+            expected,
+            ResearchViews.RenderMixedStream(stream, AnnotationGestureSelector.SideOnly));
+    }
+
+    [Fact]
     public void MemberProjection_CollectsFactsOnceForRequestedViews()
     {
         using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -302,8 +302,9 @@ public static partial class ResearchViews
     // and the offset -> line bucketing live here, in the producer, so the printer
     // stays dumb. C# lines carry their resolved annotations as structure (the
     // printer bakes the trailing "// ..." comment); IL lines carry their offset and
-    // already fact-annotated text.
-    static IReadOnlyList<BoundSourceLine> CorrelateMixedSource(
+    // resolved annotations as structure too. Medium-owned IL commentary (locals,
+    // stack state) remains part of the IL producer's text.
+    internal static IReadOnlyList<BoundSourceLine> CorrelateMixedSource(
         IrFunction imported,
         string csText,
         PrintedRangeMap printedRanges,
@@ -325,8 +326,8 @@ public static partial class ResearchViews
         }
 
         var factsByOffset = FactsByOffset(annotations);
-        var ilByLine = new Dictionary<int, List<(int Offset, string Text)>>();
-        var ilBeforeLine = new Dictionary<int, List<(int Offset, string Text)>>();
+        var ilByLine = new Dictionary<int, List<(int Offset, string Text, IReadOnlyList<IAnnotation> Annotations)>>();
+        var ilBeforeLine = new Dictionary<int, List<(int Offset, string Text, IReadOnlyList<IAnnotation> Annotations)>>();
         foreach (var instr in annotatedInstrLines)
         {
             if (AnnotationAnchor.Best(spans, instr.Offset) is not { } owner)
@@ -336,7 +337,7 @@ public static partial class ResearchViews
             // here and not in TryGetPrintedLine is the point: an annotation whose
             // owner is silent must stay unplaced rather than claim a line it did
             // not print, but IL only has to be rendered in the right order.
-            Dictionary<int, List<(int Offset, string Text)>> bucket;
+            Dictionary<int, List<(int Offset, string Text, IReadOnlyList<IAnnotation> Annotations)>> bucket;
             int line;
             if (AnnotationAnchor.TryGetPrintedLine(owner, printedRanges, out line))
                 bucket = ilByLine;
@@ -346,7 +347,10 @@ public static partial class ResearchViews
                 continue;
             if (!bucket.TryGetValue(line, out var list))
                 bucket[line] = list = [];
-            list.Add((instr.Offset, AddFactsToAnnotatedLine(instr.Text, factsByOffset.GetValueOrDefault(instr.Offset))));
+            list.Add((
+                instr.Offset,
+                instr.Text,
+                factsByOffset.GetValueOrDefault(instr.Offset) ?? []));
         }
 
         var csLines = RenderCSharpBodyLines(csText, printedRanges);
@@ -354,8 +358,8 @@ public static partial class ResearchViews
         for (int i = 0; i < csLines.Count; i++)
         {
             if (ilBeforeLine.TryGetValue(i, out var preamble))
-                foreach (var (offset, text) in preamble)
-                    stream.Add(new BoundSourceLine(text, offset, SourceLineKind.Il));
+                foreach (var (offset, text, ilAnnotations) in preamble)
+                    stream.Add(new BoundSourceLine(text, offset, SourceLineKind.Il, ilAnnotations));
 
             var csLine = csLines[i];
             var lineAnnotations = annotationsByLine.TryGetValue(i, out var annos)
@@ -368,8 +372,8 @@ public static partial class ResearchViews
                 lineAnnotations));
 
             if (ilByLine.TryGetValue(i, out var ils))
-                foreach (var (offset, text) in ils)
-                    stream.Add(new BoundSourceLine(text, offset, SourceLineKind.Il));
+                foreach (var (offset, text, ilAnnotations) in ils)
+                    stream.Add(new BoundSourceLine(text, offset, SourceLineKind.Il, ilAnnotations));
         }
         return stream;
     }
@@ -411,7 +415,7 @@ public static partial class ResearchViews
     // structured annotations into a trailing "// ..." comment; IL lines are framed
     // as "// ..." comments indented under the preceding C# line, reading the indent
     // straight from that line's leading whitespace.
-    static string RenderMixedStream(
+    internal static string RenderMixedStream(
         IReadOnlyList<BoundSourceLine> stream,
         AnnotationGestureSelector gestures,
         IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null)
@@ -424,7 +428,11 @@ public static partial class ResearchViews
         {
             if (line.Kind == SourceLineKind.Il)
             {
-                sb.AppendLf($"{csIndent}    // {line.Text}");
+                // This renderer's established IL gesture is a side comment.
+                // Keeping the facts structured until here lets a portable
+                // consumer choose differently without making this slice invent
+                // caret geometry for already-comment-framed IL.
+                sb.AppendLf($"{csIndent}    // {RenderSideAnnotations(line.Text, line.Annotations)}");
                 continue;
             }
 
@@ -627,9 +635,9 @@ public static partial class ResearchViews
                 group => group.Key,
                 group => (IReadOnlyList<IAnnotation>)[.. group.OrderBy(annotation => annotation.Descriptor.Id, StringComparer.Ordinal)]);
 
-    static string AddFactsToAnnotatedLine(string line, IReadOnlyList<IAnnotation>? facts)
+    static string RenderSideAnnotations(string line, IReadOnlyList<IAnnotation> facts)
     {
-        if (facts is not { Count: > 0 })
+        if (facts.Count == 0)
             return line;
         string factText = AnnotationText.Format(facts);
         int comment = line.IndexOf("//", StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

Add slice 4 of #3570: the consumer-facing `AnnotatedSourceLine` contract and renderer-owned IL research annotations.

- `AnnotatedSourceLine` carries bare text, IL offset, C#/IL kind, and portable `PrintedAnnotationSpan` data. It snapshots caller input, round-trips through JSON, and uses structural equality.
- `CorrelateMixedSource` now keeps research facts structured on IL `BoundSourceLine` values instead of welding them into `Text`.
- `RenderMixedStream` is the only place that formats those IL facts. Its established side-comment output remains byte-identical, including lines that already contain IL producer commentary such as argument/local/stack state.
- `PrintedBodyMap.Lines` intentionally remains the C# coordinate plane. Moving interleaved lines into that property here would mix body-global extents with stream line indices and duplicate annotation ownership; slice 5 owns the producer, extent rebasing, JSON/CLI wiring, and cross-medium harness gates.

## Contract

`BoundSourceLine` remains the in-process correlation type (`IAnnotation` references). `AnnotatedSourceLine` is the portable consumer type (`PrintedAnnotationSpan` values). Research annotations never live in either type’s `Text`; only a renderer prints them. Medium-owned IL commentary remains part of the IL producer text.

The current mixed renderer deliberately preserves side comments for IL. This slice does not invent IL-caret geometry; keeping the facts structured makes that a later consumer choice rather than a string-parsing problem.

## Gates

- full solution build succeeds
- full decompiler suite: **4,788 passed**, 0 failed
- full Research suite after merging current `main`: **135 passed**, 0 failed
- focused portable-line gates: **17 passed**, 0 failed
- exact renderer gates cover IL text both with and without existing `//` producer commentary
- changed Markdown passes `markdownlint`

Standard adversarial round required after current-head CI: GPT-5.6 Sol plus Claude Opus.

Part of #3570.