### PR TITLE
Handle signatures without Param rows

### DIFF
--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -614,9 +614,10 @@ public static class MetadataDeclarationQuery
             var attributes = parameterInfo.Attributes.ToList();
             string? defaultValueText = null;
             var hasDefault = false;
-            if (TryFormatAttributedParameterDefault(
+            if (parameterInfo.CustomAttributes is { } customAttributes
+                && TryFormatAttributedParameterDefault(
                     reader,
-                    parameterInfo.CustomAttributes,
+                    customAttributes,
                     out var attributedDefaultValue,
                     out var attributedDefaultAttributes))
             {
@@ -670,7 +671,7 @@ public static class MetadataDeclarationQuery
         string? RefKind,
         IReadOnlyList<string> Attributes,
         Parameter? DefaultParameter,
-        CustomAttributeHandleCollection CustomAttributes);
+        CustomAttributeHandleCollection? CustomAttributes);
 
     static ParameterInfo GetParameterInfo(MetadataReader reader, ParameterHandleCollection handles, int sequenceNumber)
     {
@@ -702,7 +703,7 @@ public static class MetadataDeclarationQuery
                 attributes);
         }
 
-        return new ParameterInfo(null, false, null, [], null, default);
+        return new ParameterInfo(null, false, null, [], null, null);
     }
 
     static IReadOnlyList<string> ReturnAttributes(MetadataReader reader, ParameterHandleCollection handles)

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -1,7 +1,8 @@
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
-using System.Reflection;
 using ILInspector.Metadata;
 
 namespace ILInspector.Metadata.Tests;
@@ -52,6 +53,40 @@ public sealed class MetadataDeclarationQueryTests
         Assert.Equal("System.Decimal", parameter.Type);
         Assert.True(parameter.HasDefault);
         Assert.Equal("5m", parameter.DefaultValueText);
+    }
+
+    [Fact]
+    public void MethodDeclaration_SynthesizesParameterWhenParamRowIsAbsent()
+    {
+        string path = EmitMethodWithoutParamRow();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            var typeHandle = reader.TypeDefinitions.Single(handle =>
+                reader.GetString(reader.GetTypeDefinition(handle).Name) == "MissingParamSample");
+            var type = reader.GetTypeDefinition(typeHandle);
+            var method = type.GetMethods()
+                .Select(reader.GetMethodDefinition)
+                .Single(candidate => reader.GetString(candidate.Name) == "Echo");
+
+            Assert.Empty(method.GetParameters());
+
+            var declaration = MetadataDeclarationQuery.GetMethod(reader, type, method);
+            var parameter = Assert.Single(declaration.Signature.Parameters);
+
+            Assert.Equal("arg0", parameter.Name);
+            Assert.Equal("int", parameter.Type);
+            Assert.Empty(parameter.Attributes);
+            Assert.False(parameter.HasDefault);
+            Assert.Null(parameter.DefaultValueText);
+            Assert.Null(declaration.SignatureDecodeStatus);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     [Fact]
@@ -268,6 +303,27 @@ public sealed class MetadataDeclarationQueryTests
         Assert.True(exact.HasRequiredModifier("System.Runtime.CompilerServices", "IsVolatile"));
         Assert.False(wrongNamespace.HasRequiredModifier("System.Runtime.CompilerServices", "IsVolatile"));
         Assert.False(globalNamespace.HasRequiredModifier("System.Runtime.CompilerServices", "IsVolatile"));
+    }
+
+    static string EmitMethodWithoutParamRow()
+    {
+        var assemblyName = new AssemblyName("MissingParamRow");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        var type = module.DefineType("MissingParamSample", TypeAttributes.Public);
+        var method = type.DefineMethod(
+            "Echo",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(int),
+            [typeof(int)]);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+        type.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"MissingParamRow-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
     }
 
     static TypeDefinition GetTypeDefinition(Type type)


### PR DESCRIPTION
Fixes #3735.

## Change

**Conclusion: PASS** — method signatures whose optional `Param` row is absent
now produce an ordinary synthesized parameter instead of throwing
`NullReferenceException`.

Before:

```text
System.NullReferenceException
  at CustomAttributeHandleCollection.Enumerator.get_Current()
  at MetadataDeclarationQuery.TryFormatAttributedParameterDefault(...)
```

After:

```csharp
public static int Echo(int arg0);
```

The emitted witness has one signature parameter and zero `Param` rows. The
result preserves the signature type, synthesizes the existing fallback name
`arg0`, and correctly reports no attributes or default value.

## Root cause and fix

ECMA-335 permits omitting a `Param` row when a parameter has no name, flags,
default, or custom attributes. `GetParameterInfo` represented that absence with
`default(CustomAttributeHandleCollection)`, but SRM's default collection is not
an enumerable empty collection: enumeration dereferences its missing reader.

`ParameterInfo` now represents custom-attribute collection absence explicitly
with a nullable value. Attributed-default inspection runs only when a metadata
row supplied a real collection. Existing named parameters, attributed
defaults, ordinary constants, `ref` kinds, and parameter attributes retain
their existing paths.

This is a legal omitted-row case, not a decode failure, so the declaration
remains non-degraded. The change does not catch or convert unrelated malformed
metadata failures into successful output.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass, 0 errors |
| Missing-`Param` emitted fixture | Pass |
| Metadata suite | 1,422 passed |

The regression gate asserts that the emitted method truly has zero `Param`
rows before calling the product, preventing a fixture that accidentally gains
a row from passing vacuously. Existing attributed-default tests remain close
negative coverage for the non-null collection path.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
source eng/activate-iltools.sh --mdv
dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build
```
