### PR TITLE
Revert disproportionate sweep mutation gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,13 @@ explicitly includes hostile in-process callers, require the invariant for
 well-behaved code that follows the design — not for arbitrary code that bypasses
 or misuses its abstractions.
 
+Mutation testing is evidence, not an admission rule. A mutation surviving the
+suite does not by itself justify another gate: require a plausible regression
+of promised behavior that existing contract-level coverage misses. Prefer one
+outcome-level test over tests coupled to every branch or call site, and do not
+add fixture seams solely to make each intentional-looking weakening
+independently red.
+
 Prefer simple, auditable enforcement over making every abstraction a fortress
 against rogue callers. `InertString` is the model: code that uses the type
 properly gets its invariant, while bypasses and misuse are deliberately easy to

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -248,7 +248,9 @@ public class EvilPoolSweepGateTests
 
         // The run carried on to rank 2 and pooled it, and the pool is that alone.
         Assert.Equal("selected", world.ReportedStatus(sweep));
-        world.AssertOnlyTheSubjectWasPooled(sweep);
+        Assert.Equal([world.SubjectDestination], PooledAssemblies(world.OutputDirectory));
+        Assert.Equal(world.FixtureSha256, Sha256Of(world.SubjectDestination));
+        Assert.Equal(1, world.ReportedManifest(sweep)["SelectedPackageCount"]!.GetValue<int>());
 
         world.AssertNoTemporaryLeftBehind();
     }
@@ -277,28 +279,6 @@ public class EvilPoolSweepGateTests
         Assert.Equal("pin-mismatch", world.ReportedStatus(sweep));
 
         world.AssertOnlyTheLeadWasPooled(sweep);
-        world.AssertNoTemporaryLeftBehind();
-    }
-
-    /// <summary>
-    /// A TFM mismatch at rank 1 refuses that package without suppressing rank 2.
-    ///
-    /// <para>The subject-side case above cannot distinguish <c>continue</c> from
-    /// <c>break</c>, because its mismatch is the last iteration. Putting the mismatch on
-    /// the lead makes the distinction observable: the subject behind it must still be
-    /// selected and be the pool's sole content.</para>
-    /// </summary>
-    [Fact]
-    public void ASweepWhoseFirstPinMismatchesStillPoolsTheSecondPackage()
-    {
-        using var world = SweepWorld.Create(leadTfm: "net10.0");
-
-        var sweep = world.Run();
-
-        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a rank-1 pin naming the wrong TFM"));
-        Assert.Equal("pin-mismatch", world.ReportedStatus(sweep, LeadPackage));
-        Assert.Equal("selected", world.ReportedStatus(sweep));
-        world.AssertOnlyTheSubjectWasPooled(sweep);
         world.AssertNoTemporaryLeftBehind();
     }
 
@@ -459,39 +439,6 @@ public class EvilPoolSweepGateTests
             // even in a directory it could not have written -- and nothing in the class
             // read the value that would have said otherwise.
             Assert.Equal("none", world.ReportedWriteTemporary(sweep));
-        }
-        finally
-        {
-            RestoreWritable(destinationDirectory);
-        }
-
-        world.AssertNoTemporaryLeftBehind();
-    }
-
-    /// <summary>
-    /// A copy failure at rank 1 fails that package without suppressing rank 2.
-    ///
-    /// <para>The subject-side case above gates the failure accounting, but its copy is the
-    /// last iteration and cannot distinguish <c>continue</c> from <c>break</c>. Refusing
-    /// writes to the lead's destination makes the subject behind it the witness.</para>
-    /// </summary>
-    [Fact]
-    public void ASweepWhoseFirstCopyFailsStillPoolsTheSecondPackage()
-    {
-        using var world = SweepWorld.Create();
-
-        string destinationDirectory = Path.GetDirectoryName(world.LeadDestination)!;
-        Directory.CreateDirectory(destinationDirectory);
-        MakeUnwritable(destinationDirectory);
-
-        try
-        {
-            var sweep = world.Run();
-
-            Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a rank-1 copy that cannot be written"));
-            Assert.Equal("copy-failed", world.ReportedStatus(sweep, LeadPackage));
-            Assert.Equal("selected", world.ReportedStatus(sweep));
-            world.AssertOnlyTheSubjectWasPooled(sweep);
         }
         finally
         {
@@ -1123,29 +1070,6 @@ public class EvilPoolSweepGateTests
     }
 
     /// <summary>
-    /// An acquisition failure at rank 1 fails that package without suppressing rank 2.
-    ///
-    /// <para>The isolation case above asks for the missing package at rank 2, where
-    /// <c>continue</c> and <c>break</c> are indistinguishable. Removing the lead's
-    /// committed package makes the subject behind it the witness that acquisition failure
-    /// remains local to one iteration.</para>
-    /// </summary>
-    [Fact]
-    public void ASweepWhoseFirstAcquisitionFailsStillPoolsTheSecondPackage()
-    {
-        using var world = SweepWorld.Create();
-        world.RemoveLeadPackageFromCache();
-
-        var sweep = world.Run();
-
-        Assert.True(sweep.ExitCode == 1, world.Explain(sweep, "a rank-1 package the cache no longer holds"));
-        Assert.Equal("acquisition-failed", world.ReportedStatus(sweep, LeadPackage));
-        Assert.Equal("selected", world.ReportedStatus(sweep));
-        world.AssertOnlyTheSubjectWasPooled(sweep);
-        world.AssertNoTemporaryLeftBehind();
-    }
-
-    /// <summary>
     /// Present in the shared NuGet cache of any machine that has built this repository,
     /// and on nuget.org: reachable by either isolation knob's absence, and by neither's
     /// presence. Which is what makes it the probe
@@ -1408,16 +1332,11 @@ public class EvilPoolSweepGateTests
             ?? throw new InvalidOperationException("The cache has not been seeded yet.");
 
         /// <summary>
-        /// Builds the world. <paramref name="version"/>, <paramref name="tfm"/>, and
-        /// <paramref name="leadTfm"/> are what the <em>pin</em> claims; the packages in the
-        /// cache are always the real ones, so a case that changes them is changing the pin
-        /// alone.
+        /// Builds the world. <paramref name="version"/> and <paramref name="tfm"/> are what
+        /// the <em>pin</em> claims; the package in the cache is always the real one, so a
+        /// case that changes them is changing the pin alone.
         /// </summary>
-        public static SweepWorld Create(
-            string? version = null,
-            string? tfm = null,
-            string? status = null,
-            string? leadTfm = null)
+        public static SweepWorld Create(string? version = null, string? tfm = null, string? status = null)
         {
             string scratch = Directory.CreateTempSubdirectory("evil-sweep-gate").FullName;
             try
@@ -1429,11 +1348,7 @@ public class EvilPoolSweepGateTests
                 var world = new SweepWorld(scratch, cacheDirectory, bytes);
 
                 world.SeedCache();
-                world.WriteInputs(
-                    version ?? FixtureVersion,
-                    tfm ?? FixtureTfm,
-                    status ?? "pinned",
-                    leadTfm ?? FixtureTfm);
+                world.WriteInputs(version ?? FixtureVersion, tfm ?? FixtureTfm, status ?? "pinned");
                 return world;
             }
             catch
@@ -1459,19 +1374,6 @@ public class EvilPoolSweepGateTests
             _leadCachedAssemblyPath = Commit(LeadPackage, LeadAssembly, LeadBytes);
             _cachedAssemblyPath = Commit(FixturePackage, FixtureAssembly, FixtureBytes);
             CommitWithoutLibrary(EmptyPackage);
-        }
-
-        /// <summary>
-        /// Removes the lead through the cache path the product owns, so an offline sweep
-        /// reaches its ordinary acquisition-failure result rather than a harness-shaped
-        /// approximation of a missing package.
-        /// </summary>
-        public void RemoveLeadPackageFromCache()
-        {
-            string packagePath =
-                NuGetCache.GetPackageCachePath(LeadPackage, FixtureVersion, TestSourceKey);
-            Assert.True(Directory.Exists(packagePath), $"the lead package is not cached at {packagePath}.");
-            Directory.Delete(packagePath, recursive: true);
         }
 
         /// <summary>
@@ -1534,11 +1436,7 @@ public class EvilPoolSweepGateTests
             return committed;
         }
 
-        void WriteInputs(
-            string pinnedVersion,
-            string pinnedTfm,
-            string pinnedStatus,
-            string leadTfm)
+        void WriteInputs(string pinnedVersion, string pinnedTfm, string pinnedStatus)
         {
             string data = Path.Combine(FakeRoot, "docs", "data");
             Directory.CreateDirectory(data);
@@ -1547,19 +1445,12 @@ public class EvilPoolSweepGateTests
             // the two files beside it instead of the committed ones.
             File.WriteAllText(Path.Combine(FakeRoot, "dotnet-inspect.slnx"), "");
 
-            WriteListAndPin(
-                data,
-                FixturePackage,
-                pinnedVersion,
-                pinnedTfm,
-                FixtureSha256,
-                pinnedStatus,
-                leadTfm: leadTfm);
+            WriteListAndPin(data, FixturePackage, pinnedVersion, pinnedTfm, FixtureSha256, pinnedStatus);
         }
 
         /// <summary>
-        /// Writes the list and the pin the sweep reads: the lead at rank 1 and the subject
-        /// at rank 2, each with whatever this case is asking for.
+        /// Writes the list and the pin the sweep reads: the lead at rank 1, always correct,
+        /// and the subject at rank 2 with whatever this case is asking for.
         ///
         /// <para>A <c>no-library</c> pin carries no hash, because there is no assembly for
         /// one to describe -- which is what <c>EvilPoolPinTests</c> holds the committed pin
@@ -1572,8 +1463,7 @@ public class EvilPoolSweepGateTests
             string? tfm,
             string sha256,
             string status = "pinned",
-            string? detail = null,
-            string leadTfm = FixtureTfm)
+            string? detail = null)
         {
             var list = new JsonArray(
                 new JsonObject
@@ -1596,7 +1486,7 @@ public class EvilPoolSweepGateTests
                     {
                         ["package"] = LeadPackage,
                         ["version"] = FixtureVersion,
-                        ["tfm"] = leadTfm,
+                        ["tfm"] = FixtureTfm,
                         ["status"] = "pinned",
                         ["detail"] = null,
                         ["sha256"] = LeadSha256,
@@ -1686,17 +1576,6 @@ public class EvilPoolSweepGateTests
         {
             Assert.Equal([LeadDestination], PooledAssemblies(OutputDirectory));
             Assert.Equal(LeadSha256, Sha256Of(LeadDestination));
-            Assert.Equal(1, ReportedManifest(sweep)["SelectedPackageCount"]!.GetValue<int>());
-        }
-
-        /// <summary>
-        /// The pool holds the subject's assembly and nothing else -- what a case asserts
-        /// when rank 1 was refused and rank 2 still ran.
-        /// </summary>
-        public void AssertOnlyTheSubjectWasPooled((int ExitCode, string Output, string Errors) sweep)
-        {
-            Assert.Equal([SubjectDestination], PooledAssemblies(OutputDirectory));
-            Assert.Equal(FixtureSha256, Sha256Of(SubjectDestination));
             Assert.Equal(1, ReportedManifest(sweep)["SelectedPackageCount"]!.GetValue<int>());
         }
 


### PR DESCRIPTION
Reverts #3753's per-site mutation coverage while preserving the outcome-level contract that one package failure does not abort the sweep.

The existing rank-1 SHA mismatch case still proves rank 2 is selected, is the pool's sole content, and is the sole selected manifest entry. This removes the three additional rank-1 TFM, copy, and acquisition cases plus the fixture seams added only to distinguish `continue` from `break`; product behavior is unchanged.

`AGENTS.md` now makes the proportionality rule explicit: a surviving mutation warrants a gate only when it models a plausible regression of promised behavior that existing contract-level coverage misses. Prefer outcome-level coverage over per-branch or per-call-site mutation completeness.

Validation:

- `source eng/activate-iltools.sh && dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.EvilPoolSweepGateTests"` — 24 passed
- `npx markdownlint-cli AGENTS.md`
