### PR TITLE
Support type decompilation in browser Wasm

### DIFF
--- a/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
+++ b/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
@@ -85,7 +85,7 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
 {
     readonly object _gate = new();
     readonly InspectionAcquisitionPlanOptions _options;
-    readonly SemaphoreSlim _sourceOpenGate;
+    readonly SynchronousConcurrencyGate _sourceOpenGate;
     readonly Dictionary<AssemblyAcquisitionRegistration, CandidateEntry>
         _entriesByRegistration =
             new(ReferenceEqualityComparer.Instance);
@@ -101,7 +101,7 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
         _options.Validate();
         CatalogId = new AssemblyCatalogId(Guid.NewGuid());
         _sourceOpenGate =
-            new SemaphoreSlim(_options.MaxConcurrentSourceOpens);
+            new SynchronousConcurrencyGate(_options.MaxConcurrentSourceOpens);
     }
 
     internal AssemblyCatalogId CatalogId { get; }
@@ -202,7 +202,7 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
 
     CandidateRegistrationResult ReadInventory(CandidateEntry entry)
     {
-        _sourceOpenGate.Wait();
+        _sourceOpenGate.Enter();
         try
         {
             using Stream stream = OpenSource(entry.Candidate.Assembly);
@@ -333,7 +333,7 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
         }
         finally
         {
-            _sourceOpenGate.Release();
+            _sourceOpenGate.Exit();
         }
     }
 
@@ -343,7 +343,7 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
         if (inventoryResult is CandidateRegistrationResult.Rejected rejected)
             return new CandidateSessionResult.Rejected(rejected.Failure);
 
-        _sourceOpenGate.Wait();
+        _sourceOpenGate.Enter();
         long reservedBytes = 0;
         try
         {
@@ -413,7 +413,7 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
         }
         finally
         {
-            _sourceOpenGate.Release();
+            _sourceOpenGate.Exit();
         }
     }
 
@@ -527,7 +527,6 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
 
         foreach (AssemblyInspectionSession session in sessions)
             session.Dispose();
-        _sourceOpenGate.Dispose();
     }
 
     sealed class CandidateEntry

--- a/src/ILInspector.Metadata/SynchronousConcurrencyGate.cs
+++ b/src/ILInspector.Metadata/SynchronousConcurrencyGate.cs
@@ -1,0 +1,51 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Bounds concurrent work for synchronous metadata APIs.
+/// </summary>
+internal sealed class SynchronousConcurrencyGate
+{
+    static readonly TimeSpan CancellationPollInterval =
+        TimeSpan.FromMilliseconds(50);
+
+    readonly object _gate = new();
+    readonly int _capacity;
+    int _available;
+
+    internal SynchronousConcurrencyGate(int capacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+        _capacity = capacity;
+        _available = capacity;
+    }
+
+    internal void Enter(CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            while (_available == 0)
+            {
+                // SemaphoreSlim.Wait throws on single-threaded Browser/Wasm
+                // even when entry is uncontended. A single-threaded host cannot
+                // reach this contention-only monitor wait.
+                Monitor.Wait(_gate, CancellationPollInterval);
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            _available--;
+        }
+    }
+
+    internal void Exit()
+    {
+        lock (_gate)
+        {
+            if (_available == _capacity)
+                throw new SemaphoreFullException();
+
+            _available++;
+            Monitor.Pulse(_gate);
+        }
+    }
+}

--- a/src/ILInspector.Metadata/TypeResolutionContext.cs
+++ b/src/ILInspector.Metadata/TypeResolutionContext.cs
@@ -65,7 +65,7 @@ public sealed record TypeResolutionContextOptions
 public sealed class TypeResolutionCatalog : IDisposable
 {
     readonly object _gate = new();
-    readonly SemaphoreSlim _generationGate = new(1, 1);
+    readonly SynchronousConcurrencyGate _generationGate = new(1);
     readonly InspectionAcquisitionPlan _acquisition;
     readonly Dictionary<DeclarationCacheKey, TypeDeclarationResult>
         _declarations = [];
@@ -248,7 +248,7 @@ public sealed class TypeResolutionCatalog : IDisposable
         ArgumentNullException.ThrowIfNull(bindingRequests);
         ArgumentNullException.ThrowIfNull(requests);
 
-        _generationGate.Wait(cancellationToken);
+        _generationGate.Enter(cancellationToken);
         try
         {
             lock (_gate)
@@ -266,7 +266,7 @@ public sealed class TypeResolutionCatalog : IDisposable
         }
         finally
         {
-            _generationGate.Release();
+            _generationGate.Exit();
         }
     }
 
@@ -359,7 +359,7 @@ public sealed class TypeResolutionCatalog : IDisposable
     /// <summary>Releases every retained candidate session owned by the catalog.</summary>
     public void Dispose()
     {
-        _generationGate.Wait();
+        _generationGate.Enter();
         try
         {
             lock (_gate)
@@ -373,7 +373,7 @@ public sealed class TypeResolutionCatalog : IDisposable
         }
         finally
         {
-            _generationGate.Release();
+            _generationGate.Exit();
         }
     }
 


### PR DESCRIPTION
Fixes whole-type decompilation in the single-threaded browser/Wasm host. `System.Text.Json.JsonSerializer` now produces its full decompiled listing instead of `DEC0001: ... PlatformNotSupportedException`.

The metadata acquisition and type-resolution paths now use a monitor-backed synchronous counting gate. Desktop concurrency limits and cancellation remain unchanged; the browser host avoids `SemaphoreSlim.Wait`, which is unsupported even for uncontended entry.

Validation:
- Browser/Wasm `QueryTypeSource` for `System.Text.Json@10.0.0` / `System.Text.Json.JsonSerializer`: 109,582-character source listing, no `DEC0001`
- `ILInspector.Metadata.Tests`: 1,422 passed
- Release solution build
- Desktop `type System.Text.Json.JsonSerializer -S "Decompiled Source"`