### PR TITLE
Clear fault isolation when a compile-back floor supersedes the RTS compile

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackFloorFaultIsolationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackFloorFaultIsolationTests.cs
@@ -1,0 +1,100 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Gates the invariant that a compile-back floor never carries fault-isolation
+/// evidence forward from the RTS compile it supersedes (#3783).
+/// </summary>
+/// <remarks>
+/// <see cref="ReturnToSender.Result.FaultIsolation"/> is produced only by
+/// <see cref="ReturnToSender.TryIsolateRecompileFailure"/>, on a result whose
+/// status is <see cref="FidelityCheck.CompileBackStatus.RecompileFail"/>. The
+/// floor replaces that status with an independent compile-back verdict, so a
+/// retained isolation would attribute a fault to a row that compiled.
+/// </remarks>
+[Trait("Area", "RoundTrip")]
+public class CompileBackFloorFaultIsolationTests
+{
+    [Fact]
+    public void WithCompileBackFloor_ClearsFaultIsolationFromTheSupersededCompile()
+    {
+        var failed = FailedResult(new ReturnToSender.FaultIsolationResult(
+            ReturnToSender.FaultIsolationKind.ShellOrClosureDefect,
+            "/src/Widget.cs",
+            "CS0246: missing closure type"));
+
+        var rescued = ReturnToSender.WithCompileBackFloor(failed, Floor(FidelityCheck.CompileBackStatus.Exact));
+
+        Assert.Null(rescued.FaultIsolation);
+        Assert.True(rescued.UsedCompileBackFloor);
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, rescued.Status);
+    }
+
+    [Fact]
+    public void WithCompileBackFloor_ClearsBodyDefectIsolationToo()
+    {
+        var failed = FailedResult(new ReturnToSender.FaultIsolationResult(
+            ReturnToSender.FaultIsolationKind.BodyDefect,
+            "/src/Widget.cs",
+            "authored body compiled in the same RTS shell"));
+
+        var rescued = ReturnToSender.WithCompileBackFloor(failed, Floor(FidelityCheck.CompileBackStatus.OpcodeDiff));
+
+        Assert.Null(rescued.FaultIsolation);
+    }
+
+    [Fact]
+    public void WithCompileBackFloor_RecordsTheSupersededVerdictAsProvenance()
+    {
+        var failed = FailedResult(new ReturnToSender.FaultIsolationResult(
+            ReturnToSender.FaultIsolationKind.ShellOrClosureDefect,
+            "/src/Widget.cs",
+            "CS0246: missing closure type")
+        {
+            Method = ReturnToSender.FaultIsolationMethod.SpanMeasured,
+        });
+
+        var rescued = ReturnToSender.WithCompileBackFloor(failed, Floor(FidelityCheck.CompileBackStatus.Exact));
+
+        Assert.Contains("superseded-fault-isolation: ShellOrClosureDefect (SpanMeasured)", rescued.Detail);
+    }
+
+    [Fact]
+    public void WithCompileBackFloor_LeavesDetailUnmarkedWhenNothingWasIsolated()
+    {
+        var failed = FailedResult(faultIsolation: null);
+
+        var rescued = ReturnToSender.WithCompileBackFloor(failed, Floor(FidelityCheck.CompileBackStatus.Exact));
+
+        Assert.Null(rescued.FaultIsolation);
+        Assert.DoesNotContain("superseded-fault-isolation", rescued.Detail);
+    }
+
+    static ReturnToSender.Result FailedResult(ReturnToSender.FaultIsolationResult? faultIsolation)
+        => new(
+            new CompileBackReconstructionPlan(
+                "/tmp/Widget.dll",
+                new CompileBackMethodIdentity("Widgets.Widget", "Spin", 0, "()"),
+                new CompileBackModuleRequirement([], [], []),
+                [],
+                [],
+                []),
+            "class Widget { void Spin() { } }",
+            FidelityCheck.CompileBackStatus.RecompileFail,
+            OriginalOpcodes: "nop ret",
+            RecompiledOpcodes: "",
+            Detail: "CS0103: the name 'q' does not exist",
+            FaultIsolation: faultIsolation);
+
+    static FidelityCheck.CompileBackResult Floor(FidelityCheck.CompileBackStatus status)
+        => new(
+            "Widgets.Widget",
+            "Spin",
+            0,
+            "()",
+            status,
+            OriginalOpcodes: "nop ret",
+            RecompiledOpcodes: "nop ret",
+            Detail: null);
+}

--- a/src/ILInspector.Decompiler.Tests/CompileBackFloorFaultIsolationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackFloorFaultIsolationTests.cs
@@ -60,6 +60,12 @@ public class CompileBackFloorFaultIsolationTests
         Assert.Contains("superseded-fault-isolation: ShellOrClosureDefect (SpanMeasured)", rescued.Detail);
     }
 
+    /// <summary>
+    /// Negative case for the provenance marker only: it must be emitted conditionally,
+    /// not unconditionally. This test deliberately does not assert that
+    /// <c>FaultIsolation</c> is null — with a null input that would hold with or
+    /// without the clearing, and the two tests above are what gate the clearing.
+    /// </summary>
     [Fact]
     public void WithCompileBackFloor_LeavesDetailUnmarkedWhenNothingWasIsolated()
     {
@@ -67,7 +73,6 @@ public class CompileBackFloorFaultIsolationTests
 
         var rescued = ReturnToSender.WithCompileBackFloor(failed, Floor(FidelityCheck.CompileBackStatus.Exact));
 
-        Assert.Null(rescued.FaultIsolation);
         Assert.DoesNotContain("superseded-fault-isolation", rescued.Detail);
     }
 

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -5648,6 +5648,14 @@ public class ReturnToSenderPrototypeTests
     /// source index is substituted so the lookup succeeds with a null body. Without
     /// the substitution a miss would return null for the wrong reason and prove nothing.
     /// </para>
+    /// <para>
+    /// This gates the common path only. Isolation resolves its source member with
+    /// <c>CorpusMethodIdentity.SignatureText</c> while the index is keyed by
+    /// <c>SignatureIdentity</c>, so its signature lookup always misses and falls
+    /// back to the ordinal (#3804). Where those disagree the two sides can select
+    /// different overloads, and this invariant does not cover that case. The floor
+    /// clearing does not depend on it either way.
+    /// </para>
     /// </remarks>
     [Fact]
     public void TryIsolateRecompileFailure_ReturnsNullWhenTheSourceMemberHasNoAuthoredBody()

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -5629,6 +5629,64 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    /// <summary>
+    /// Gates the invariant the compile-back floor's safety argument rests on (#3783):
+    /// fault isolation is never produced for a source member with no authored body.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A bodyless source member is exactly the input that drives
+    /// <c>ReturnToSenderSourceProbe.AddBodylessSourceResult</c>, which is a second
+    /// producer of <see cref="ReturnToSenderSourceOutcome.Invalid"/> reachable with a
+    /// successful floor status. That path could only contaminate `invalidBreakdown`
+    /// if such a row could also carry attribution — and it cannot, because the
+    /// producer below requires an authored body while the bodyless path requires the
+    /// absence of one. The two are mutually exclusive on the same index lookup.
+    /// </para>
+    /// <para>
+    /// This test isolates that guard: the request and assembly are real, and only the
+    /// source index is substituted so the lookup succeeds with a null body. Without
+    /// the substitution a miss would return null for the wrong reason and prove nothing.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void TryIsolateRecompileFailure_ReturnsNullWhenTheSourceMemberHasNoAuthoredBody()
+    {
+        const string assemblySource = """
+            public class Class1
+            {
+                public int M() { return 42; }
+            }
+            """;
+        var sourcePath = WriteTempSource("Bodyless.cs", assemblySource, out var sourceDirectory);
+        var assemblyPath = CompileFixture(assemblySource, sourceDirectory);
+        try
+        {
+            var bodyless = ReturnToSenderSourceIndex.FromMembers(
+            [
+                new ReturnToSenderSourceMember("Class1", "M", 0, "", sourcePath, Body: null),
+            ]);
+
+            // Same target and same rejected body that yields BodyDefect against a
+            // real index; only the authored body is absent.
+            Assert.Null(TryIsolateRecompileFailureForMethod(
+                assemblyPath,
+                sourcePath,
+                "return Missing.Symbol;",
+                sourceIndexOverride: bodyless));
+
+            Assert.NotNull(TryIsolateRecompileFailureForMethod(
+                assemblyPath,
+                sourcePath,
+                "return Missing.Symbol;"));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            TryDeleteDirectory(sourceDirectory);
+        }
+    }
+
     static string WriteTempSource(string fileName, string source, out string directory)
     {
         directory = Path.Combine(Path.GetTempPath(), $"rts-signature-{Guid.NewGuid():N}");
@@ -5652,7 +5710,8 @@ public class ReturnToSenderPrototypeTests
     static ReturnToSender.FaultIsolationResult? TryIsolateRecompileFailureForMethod(
         string assemblyPath,
         string sourcePath,
-        string rejectedTargetBody)
+        string rejectedTargetBody,
+        ReturnToSenderSourceIndex? sourceIndexOverride = null)
     {
         using var pe = new PEReader(File.OpenRead(assemblyPath));
         var reader = pe.GetMetadataReader();
@@ -5675,7 +5734,7 @@ public class ReturnToSenderPrototypeTests
             SignatureText: "",
             ClosureRoots: new HashSet<TypeDefinitionHandle> { typeHandle },
             ClosureFacts: new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>());
-        var sourceIndex = ReturnToSenderSourceIndex.TryCreate([sourcePath]);
+        var sourceIndex = sourceIndexOverride ?? ReturnToSenderSourceIndex.TryCreate([sourcePath]);
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
         var compileOptions = new CSharpCompilationOptions(
             OutputKind.DynamicallyLinkedLibrary,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -920,10 +920,19 @@ static class ReturnToSender
     /// </para>
     /// <para>
     /// The gate for both behaviors is <c>CompileBackFloorFaultIsolationTests</c>.
-    /// Clearing here cannot change the invalid breakdown, because a row carrying
-    /// isolation necessarily had an authored body and so cannot reach the bodyless
-    /// invalid path; that invariant's gate is
+    /// Clearing is correct regardless of which source member the isolation was
+    /// measured against: if it described this row's member, it described the
+    /// discarded compile rather than the floor's verdict, and if lookup divergence
+    /// made it describe a different member, it never applied to this row at all.
+    /// </para>
+    /// <para>
+    /// On the common path a row carrying isolation had an authored body and so
+    /// cannot reach the bodyless invalid path, which keeps the invalid breakdown
+    /// stable; that invariant's gate is
     /// <c>ReturnToSenderPrototypeTests.TryIsolateRecompileFailure_ReturnsNullWhenTheSourceMemberHasNoAuthoredBody</c>.
+    /// It is an invariant of the common path only, not of every input: isolation
+    /// resolves its source member by a different signature format than the probe
+    /// (see #3804), so the two can select different overloads.
     /// </para>
     /// </remarks>
     internal static Result WithCompileBackFloor(Result result, FidelityCheck.CompileBackResult floor)

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -912,8 +912,18 @@ static class ReturnToSender
     /// </para>
     /// <para>
     /// The superseded verdict is preserved in <see cref="Result.Detail"/> as
-    /// provenance of the discarded attempt. The gate for both behaviors is
-    /// <c>CompileBackFloorFaultIsolationTests</c>.
+    /// provenance of the discarded attempt, which the standalone RTS report
+    /// surfaces through <c>ExampleLayerAndDetail</c>'s
+    /// <see cref="Result.UsedCompileBackFloor"/> branch. It is not visible in
+    /// authored-corpus rows: <c>ReturnToSenderSourceProbe</c> overwrites
+    /// <see cref="Result.Detail"/> before emitting them.
+    /// </para>
+    /// <para>
+    /// The gate for both behaviors is <c>CompileBackFloorFaultIsolationTests</c>.
+    /// Clearing here cannot change the invalid breakdown, because a row carrying
+    /// isolation necessarily had an authored body and so cannot reach the bodyless
+    /// invalid path; that invariant's gate is
+    /// <c>ReturnToSenderPrototypeTests.TryIsolateRecompileFailure_ReturnsNullWhenTheSourceMemberHasNoAuthoredBody</c>.
     /// </para>
     /// </remarks>
     internal static Result WithCompileBackFloor(Result result, FidelityCheck.CompileBackResult floor)

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -898,11 +898,31 @@ static class ReturnToSender
         => !string.IsNullOrWhiteSpace(result.Source)
            && !string.IsNullOrWhiteSpace(result.TargetBody);
 
-    static Result WithCompileBackFloor(Result result, FidelityCheck.CompileBackResult floor)
+    /// <summary>
+    /// Replaces a failed RTS compile with an independent compile-back result.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Result.FaultIsolation"/> is measured only against a
+    /// <see cref="FidelityCheck.CompileBackStatus.RecompileFail"/> compile (see
+    /// <see cref="TryIsolateRecompileFailure"/>, the sole producer). The floor
+    /// supersedes exactly that compile, so the isolation cannot describe the
+    /// status reported here and is cleared rather than carried forward; keeping
+    /// it would attribute a fault to a row whose compile-back succeeded.
+    /// </para>
+    /// <para>
+    /// The superseded verdict is preserved in <see cref="Result.Detail"/> as
+    /// provenance of the discarded attempt. The gate for both behaviors is
+    /// <c>CompileBackFloorFaultIsolationTests</c>.
+    /// </para>
+    /// </remarks>
+    internal static Result WithCompileBackFloor(Result result, FidelityCheck.CompileBackResult floor)
     {
         string originalFailure = string.IsNullOrWhiteSpace(result.Detail)
             ? result.Status.ToString()
             : $"{result.Status}: {result.Detail}";
+        if (result.FaultIsolation is { } superseded)
+            originalFailure = $"{originalFailure}; superseded-fault-isolation: {superseded.Kind} ({superseded.Method})";
         string floorDetail = string.IsNullOrWhiteSpace(floor.Detail)
             ? $"compile-back-floor: {originalFailure}"
             : $"compile-back-floor: {floor.Detail}; rts: {originalFailure}";
@@ -914,6 +934,7 @@ static class ReturnToSender
             Detail = floorDetail,
             CompileBackFloor = floor,
             FidelityDiff = floor.FidelityDiff,
+            FaultIsolation = null,
         };
     }
 


### PR DESCRIPTION
- Fixes #3783
- Changes harness-only: a compile-back floor no longer carries fault-isolation
  evidence forward from the RTS compile it supersedes. Product output unchanged.
- Evidence revision: `0451c32a` (both adversarial reviews clean at this head)

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — 1,267 EVIL rows reported a fault attribution for a
compile-back that *succeeded*; the floor path copied `FaultIsolation` from the
discarded compile, and clearing it removes the false attribution while leaving
every headline metric bit-identical.

### Root cause (proof by construction, not sampling)

`Result.FaultIsolation` has exactly **one** producer in the harness:

- assigned at `ReturnToSender.cs:1704`, inside `TryIsolateRecompileFailure`,
- on a `Result` constructed literally with `Status = RecompileFail` (line 1697),
- reached from exactly one call site (line 1686), on the recompile-failure path.

There is no `with { FaultIsolation = ... }` anywhere in the file. The only
mutation that changes `Status` on such a `Result` is `WithCompileBackFloor`
(~line 901), and `NeedsCompileBackFloor` admits only `RecompileFail` /
`ContextFail`. Therefore **a row whose status is not `RecompileFail` yet carries
attribution is reachable only through the floor path** — no sampling required.

The 2026-07-28 EVIL run agrees exactly: `RecompileFail` is 5132/5132 attributed
(100%, matching the single call site), and 1,267 non-`RecompileFail` rows carry
attribution — Exact 742, OpcodeDiff 382, OperandDiff 143. All three are floor
statuses.

### Aggregate before/after

Real-data A/B, Humanizer 3.0.10 **net10.0**, 856 corpus rows, same DLL, harness
built at base vs head:

```text
Before:  856 rows,  55 carry fault isolation for a SUCCEEDED compile-back
After:   856 rows,   0
```

Every other field is unchanged. Headline metrics are identical on both sides:

| Metric | Before | After |
| --- | ---: | ---: |
| correct (ValidMatch) | 231 | 231 |
| validDifferent | 602 | 602 |
| invalid | 23 | 23 |
| invalidBreakdown product / harness / unclassified | 12 / 11 / 0 | 12 / 11 / 0 |
| rows with any field changed | — | 55 |
| fields changed on those rows | — | `faultIsolation`, `faultIsolationMethod` |

The 55 is Humanizer's exact share of the full run's 1,267.

## Scope and safety

- **Root cause:** `WithCompileBackFloor` does
  `result with { Status = floor.Status, ... }` without clearing `FaultIsolation`,
  so evidence measured against the *discarded* compile is reported against the
  *floor's* verdict.
- **Fix shape:** RTS orchestration/bookkeeping. Clear `FaultIsolation` on the
  floor path; record the superseded verdict in `Detail` as provenance of the
  discarded attempt. `WithCompileBackFloor` becomes `internal` so the gate can
  exercise it directly.
- **Product impact:** none. No product assembly is touched.
- **Why clearing is correct, unconditionally:** the isolation was measured
  against the compile the floor *discards*. If it described this row's own source
  member, it describes a verdict that no longer applies. If lookup divergence made
  it describe a *different* member (#3804), it never applied to this row at all.
  Either way it must not be reported against the floor's verdict.
- **Why the invalid breakdown does not move:** on the common path a row can only
  carry `FaultIsolation` if the source lookup returned an **authored body**, while
  the bodyless invalid path (`AddBodylessSourceResult`) requires the **absence** of
  one, and the record-source branch is reached only when the lookup failed outright
  — which already forces isolation to null. Gate:
  `TryIsolateRecompileFailure_ReturnsNullWhenTheSourceMemberHasNoAuthoredBody`.
  Corroborated on the full 12,000-row EVIL run: **0** rows are `Invalid` with a
  floor status, **0** bodyless rows exist, and all 1,267 touched rows are
  `ValidDifferent` (1068) or `ValidMatch` (199) with `invalidKind` None.

  > **Boundary, found in review round 2 and stated plainly.** That invariant covers
  > the common path, not every input: isolation resolves its source member by a
  > different signature format than the probe, so its signature lookup always misses
  > and falls back to the ordinal. Where source and metadata overload order disagree
  > the two can select different members. That is a **pre-existing** defect, filed as
  > **#3804**, and it is broader than this PR — it can misattribute any overloaded
  > target, floor or not. It does not block this change because clearing is correct
  > either way, per the bullet above.

  > An earlier revision argued this from status filtering — that floor-rescued rows
  > are never `Invalid`. **That proof was false** and both reviewers caught it. The
  > conclusion held; the reasoning did not.

- **RTS boundary:** not applicable in the C#-knowledge sense — this changes only
  how RTS records its own verdict provenance. No C# spelling or shape decision is
  added to the harness.

### Known boundary (stated plainly)

`ReturnToSenderSourceProbe` overwrites `Detail` with the classifier string on
`ValidDifferent` rows (`Detail: classificationDetail`) and with `null` on
`ValidMatch`. So the new `superseded-fault-isolation: ...` provenance **is not
visible in benchmark JSON** — the A/B confirms `detail` is unchanged on all 55
rows.

It is not dead code, but the mechanism first named here was wrong. `FailureReason`
returns hardcoded strings for the floor statuses and never reads `Detail` for
them. The marker is surfaced by `ExampleLayerAndDetail`'s `UsedCompileBackFloor`
branch (`ReturnToSender.cs:418`), by the A/B report, and by the catalog JSON.
Making floor provenance visible in corpus rows is tracked as follow-up on #3783.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass (full `dotnet-inspect.slnx -c Release`) |
| Focused tests | `CompileBackFloorFaultIsolationTests` 4/4 passed; `*TryIsolateRecompileFailure*` 3/3 passed |
| Gate is non-vacuous | **Tamper check 1**: removing only `FaultIsolation = null,` fails exactly the 2 tests asserting the cleared value. **Tamper check 2**: relaxing the authored-body guard to `sourceMember.Body ?? "return 42;"` fails exactly the new invariant gate (1 of 3) |
| Decompiler `Area=RoundTrip` | 573 passed, 0 failed, **0 skipped** (oracles active via `source eng/activate-iltools.sh`) |
| ReturnToSender A/B | Humanizer 3.0.10 net10.0, 856 rows: 55 leaked -> 0; all headline metrics identical; exactly 2 fields changed on exactly 55 rows |
| Real witness | Every one of the 55 is a row whose compile-back **succeeded** yet reported `ShellOrClosureDefect` |
| Full decompiler suite | 4797 total, 2 failed — **both pre-existing and unrelated**, see below |

### The two full-suite failures are not mine

`git diff <merge-base> --stat` for this branch is a single file,
`tools/DecompilerHarness/ReturnToSender.cs` (+22/-1), plus the new test file.

1. `ExpressionTreeLambdaTests.LookalikeExpressionAssembly_StaysFactoryCalls` —
   `FileNotFoundException: Expected built fixture 'decompiler.expression-tree-spoof'`.
   A missing build artifact. Building
   `src/ILInspector.Decompiler.Fixtures.ExpressionTreeSpoof` makes it pass.
2. `EvilPoolPinTests.TheSweepReadsAPinFileTheSameWayInBothModes` — macOS temp-path
   symlink normalization: the validator reports `/var/folders/...` and the sweep
   reports `/private/var/folders/...`, and the test compares the strings. Purely
   environmental; this change cannot influence `Path.GetTempPath()` resolution.

After building the fixture, re-running both classes leaves only failure 2
(42 tests, 1 failed).

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Floor provenance invisible in corpus rows | Filed as follow-up on #3783 | The probe overwrites `Detail`; surfacing it needs a dedicated row field, which is a schema change |
| No fault isolation for `ValidDifferent` at all | Filed as #3784 | 5,244 rows (44% of corpus) have no product-vs-harness signal; that is the substantive prize and should be `methodologyVersion 3`, sequenced after this lands |
| `invalidBreakdown` recount | Not needed | Argued from the code and confirmed by A/B: floor rows are never `Invalid`, so the headline was never contaminated |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| GPT-5.6 Sol (fixed seat) | **CLEAN** at `0451c32a` | R1 Medium: the "floor rows are never `Invalid`" proof is false; also supplied the authored-body invariant and the vacuous assertion in test 4. R2 Medium: that invariant leaks via signature-format divergence. R3: verified the scope-out, doc accuracy, #3804 pre-existing across all four revisions, `Area=RoundTrip` 573/0/0 |
| Gemini 3.1 Pro | **CLEAN** at `0451c32a` | R1 Critical "`invalidBreakdown` WILL regress" — **dismissed on evidence**; R1 dead-marker finding **withdrawn by the reviewer** in R2. R2: same divergence finding as GPT, independently. R3: called the scope-out "mathematically sound", confirmed no overclaims and #3804 pre-existing at `f5132686` |

Both reviewers independently converged on the round-2 divergence finding, which
is now filed as **#3804** and scoped out of this PR with reasons.

**Review conclusion:** **PASS** — two independent adversarial reviews clean on
the fixed head `0451c32a`. Merge remains gated on @richlander's approval.

## Validation

```bash
source eng/activate-iltools.sh
dotnet build dotnet-inspect.slnx -c Release --configfile ./nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*CompileBackFloorFaultIsolationTests*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=RoundTrip"
```

