### PR TITLE
Align sweep gate with manifest invalidation

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -169,14 +169,15 @@ public class EvilPoolSweepGateTests
     }
 
     /// <summary>
-    /// A sweep that cannot write its manifest refuses the output directory.
+    /// A sweep that cannot invalidate its manifest refuses before changing the pool.
     ///
-    /// <para>The assembly record and pool reconciliation both precede this write. The
-    /// stale file makes that ordering observable: reaching the manifest write is not
-    /// enough if the sweep can return before reconciling the pool it would describe.</para>
+    /// <para>A directory at the manifest path makes deletion fail. The planted stale
+    /// assembly must remain while new package bytes and <c>assemblies.txt</c> stay absent,
+    /// proving invalidation precedes the first mutation rather than merely producing the
+    /// expected diagnostic after changing the pool.</para>
     /// </summary>
     [Fact]
-    public void ASweepThatCannotWriteItsManifestRefusesTheOutputDirectory()
+    public void ASweepThatCannotInvalidateItsManifestRefusesBeforeMutation()
     {
         using var world = SweepWorld.Create();
         Directory.CreateDirectory(world.ManifestPath);
@@ -192,12 +193,14 @@ public class EvilPoolSweepGateTests
             sweep.ExitCode == 2,
             world.Explain(sweep, "a directory standing at the manifest path"));
         Assert.Contains(
-            $"Could not write '{world.ManifestPath}'",
+            $"Could not invalidate prior manifest '{world.ManifestPath}'",
             sweep.Errors,
             StringComparison.Ordinal);
 
-        Assert.True(File.Exists(world.PooledListPath), "the sweep did not write its assembly record.");
-        Assert.False(File.Exists(stale), "the sweep attempted the manifest write before reconciling the pool.");
+        Assert.False(File.Exists(world.LeadDestination), "the sweep pooled the lead before invalidation.");
+        Assert.False(File.Exists(world.SubjectDestination), "the sweep pooled the subject before invalidation.");
+        Assert.False(File.Exists(world.PooledListPath), "the sweep wrote its assembly record before invalidation.");
+        Assert.True(File.Exists(stale), "the sweep reconciled the pool before invalidation.");
     }
 
     /// <summary>


### PR DESCRIPTION
## Outcome

Repairs the PR CI gate broken by #3789. A directory at `manifest.json` now blocks the sweep at **prior-manifest invalidation**, before the first pool or `assemblies.txt` mutation; the test no longer expects the obsolete later manifest-write failure.

The gate now proves the ordering contract directly:

- stderr reports `Could not invalidate prior manifest`;
- neither requested package is pooled;
- `assemblies.txt` is not written;
- the planted stale pool entry remains because reconciliation never began.

No product code changes.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method ILInspector.Decompiler.Tests.EvilPoolSweepGateTests.ASweepThatCannotInvalidateItsManifestRefusesBeforeMutation` — 1/1
- Linux and Windows failures reproduced on #3782: both fail only the old assertion with the new invalidation diagnostic
- `git diff --check`

## Review tier

Trivial; no adversarial review. This changes one stale test expectation and its directly coupled ordering assertions to match the already-merged, separately reviewed #3789 behavior. It changes no product or harness mechanism.

Fixes #3803.