### PR TITLE
Drive RTS member discovery from product API surfaces

### DIFF
--- a/src/CSharpText/OperatorNames.cs
+++ b/src/CSharpText/OperatorNames.cs
@@ -5,6 +5,92 @@ namespace CSharpText;
 /// </summary>
 public static class OperatorNames
 {
+    public static bool IsOperatorMethodName(string name) =>
+        name is "op_Implicit"
+            or "op_Explicit"
+            or "op_CheckedImplicit"
+            or "op_CheckedExplicit"
+            or "op_Addition"
+            or "op_Subtraction"
+            or "op_Multiply"
+            or "op_Division"
+            or "op_Modulus"
+            or "op_UnaryPlus"
+            or "op_UnaryNegation"
+            or "op_Increment"
+            or "op_Decrement"
+            or "op_BitwiseAnd"
+            or "op_BitwiseOr"
+            or "op_ExclusiveOr"
+            or "op_OnesComplement"
+            or "op_LeftShift"
+            or "op_RightShift"
+            or "op_UnsignedRightShift"
+            or "op_Equality"
+            or "op_Inequality"
+            or "op_LessThan"
+            or "op_GreaterThan"
+            or "op_LessThanOrEqual"
+            or "op_GreaterThanOrEqual"
+            or "op_True"
+            or "op_False"
+            or "op_LogicalNot"
+            or "op_AdditionAssignment"
+            or "op_SubtractionAssignment"
+            or "op_MultiplicationAssignment"
+            or "op_DivisionAssignment"
+            or "op_ModulusAssignment"
+            or "op_BitwiseAndAssignment"
+            or "op_BitwiseOrAssignment"
+            or "op_ExclusiveOrAssignment"
+            or "op_LeftShiftAssignment"
+            or "op_RightShiftAssignment"
+            or "op_UnsignedRightShiftAssignment"
+            or "op_IncrementAssignment"
+            or "op_DecrementAssignment"
+            or "op_Exponent"
+            or "op_IntegerDivision"
+            or "op_Concatenate"
+            or "op_Like"
+        || name.StartsWith("op_Checked", StringComparison.Ordinal)
+            && (MapBinaryOrUnary(name["op_Checked".Length..]) is not null
+                || MapCheckedAssignment(name["op_Checked".Length..]) is not null);
+
+    public static bool IsAssignmentOperatorMethodName(string name)
+    {
+        if (name.StartsWith("op_Checked", StringComparison.Ordinal))
+            return MapCheckedAssignment(name["op_Checked".Length..]) is not null;
+        return name.StartsWith("op_", StringComparison.Ordinal)
+            && MapAssignment(name["op_".Length..]) is not null;
+    }
+
+    public static bool IsCSharpInstanceAssignmentOperator(
+        string methodName,
+        bool isStatic,
+        bool isPublic,
+        string returnType,
+        int parameterCount)
+    {
+        if (isStatic || !isPublic || returnType != "void")
+            return false;
+
+        string? suffix = methodName.StartsWith("op_Checked", StringComparison.Ordinal)
+            ? MapCheckedAssignment(methodName["op_Checked".Length..]) is null
+                ? null
+                : methodName["op_Checked".Length..]
+            : methodName.StartsWith("op_", StringComparison.Ordinal)
+                && MapAssignment(methodName["op_".Length..]) is not null
+                    ? methodName["op_".Length..]
+                    : null;
+        if (suffix is null)
+            return false;
+
+        int expectedParameterCount = suffix is "IncrementAssignment" or "DecrementAssignment"
+            ? 0
+            : 1;
+        return parameterCount == expectedParameterCount;
+    }
+
     /// <summary>
     /// Converts an IL operator method name to its C# display form.
     /// Non-operator names are returned unchanged.
@@ -28,10 +114,12 @@ public static class OperatorNames
         if (name.StartsWith("op_Checked", StringComparison.Ordinal))
         {
             var inner = name["op_Checked".Length..];
-            var symbol = MapBinaryOrUnary(inner);
+            var symbol = MapBinaryOrUnary(inner) ?? MapCheckedAssignment(inner);
             if (symbol is not null)
                 return $"checked operator {symbol}";
         }
+        if (MapAssignment(name["op_".Length..]) is { } assignmentSymbol)
+            return $"operator {assignmentSymbol}";
 
         return name switch
         {
@@ -94,6 +182,35 @@ public static class OperatorNames
         _ => null
     };
 
+    public static string? MapAssignment(string suffix) => suffix switch
+    {
+        "AdditionAssignment" => "+=",
+        "SubtractionAssignment" => "-=",
+        "MultiplicationAssignment" => "*=",
+        "DivisionAssignment" => "/=",
+        "ModulusAssignment" => "%=",
+        "BitwiseAndAssignment" => "&=",
+        "BitwiseOrAssignment" => "|=",
+        "ExclusiveOrAssignment" => "^=",
+        "LeftShiftAssignment" => "<<=",
+        "RightShiftAssignment" => ">>=",
+        "UnsignedRightShiftAssignment" => ">>>=",
+        "IncrementAssignment" => "++",
+        "DecrementAssignment" => "--",
+        _ => null,
+    };
+
+    public static string? MapCheckedAssignment(string suffix) => suffix switch
+    {
+        "AdditionAssignment" => "+=",
+        "SubtractionAssignment" => "-=",
+        "MultiplicationAssignment" => "*=",
+        "DivisionAssignment" => "/=",
+        "IncrementAssignment" => "++",
+        "DecrementAssignment" => "--",
+        _ => null,
+    };
+
     /// <summary>
     /// The unchecked operator method name paired with a checked operator method
     /// name — <c>op_CheckedAddition → op_Addition</c>, <c>op_CheckedExplicit →
@@ -112,6 +229,28 @@ public static class OperatorNames
             return null;
 
         string inner = methodName["op_Checked".Length..];
-        return MapBinaryOrUnary(inner) is null ? null : $"op_{inner}";
+        return MapBinaryOrUnary(inner) is null && MapCheckedAssignment(inner) is null
+            ? null
+            : $"op_{inner}";
+    }
+
+    /// <summary>
+    /// The checked operator method name paired with an unchecked operator method
+    /// name, or null when C# defines no checked sibling for that operator.
+    /// </summary>
+    public static string? CheckedOperator(string methodName)
+    {
+        if (methodName is "op_Explicit")
+            return "op_CheckedExplicit";
+        if (!methodName.StartsWith("op_", StringComparison.Ordinal)
+            || methodName.StartsWith("op_Checked", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        string inner = methodName["op_".Length..];
+        return MapBinaryOrUnary(inner) is null && MapCheckedAssignment(inner) is null
+            ? null
+            : $"op_Checked{inner}";
     }
 }

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1296,7 +1296,106 @@ public sealed class CSharpDeclarationWriterTests
     public void MemberDeclaration_FormatsOperatorsWithTupleReturns(string name, string signature, string expected)
     {
         var type = new ApiType { Namespace = "Samples", Name = "Tuples", Kind = "class" };
-        var member = new ApiMember { Name = name, Kind = "method", Signature = signature, IsStatic = true };
+        var member = new ApiMember { Name = name, Kind = "operator", Signature = signature, IsStatic = true };
+
+        Assert.Equal(expected, CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+    }
+
+    [Fact]
+    public void MemberDeclaration_LeavesOrdinaryOperatorNamedMemberAsMethod()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Tuples", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "op_AdditionAssignment",
+            Kind = "method",
+            Signature = "void op_AdditionAssignment(int other)",
+        };
+
+        Assert.Equal(
+            "public void op_AdditionAssignment(int other)",
+            CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+    }
+
+    [Theory]
+    [InlineData(
+        "op_AdditionAssignment",
+        "void op_AdditionAssignment(Samples.Tuples other)",
+        "public void operator +=(Samples.Tuples other)")]
+    [InlineData(
+        "op_CheckedAdditionAssignment",
+        "void op_CheckedAdditionAssignment(Samples.Tuples other)",
+        "public void operator checked +=(Samples.Tuples other)")]
+    [InlineData(
+        "op_ModulusAssignment",
+        "void op_ModulusAssignment(Samples.Tuples other)",
+        "public void operator %=(Samples.Tuples other)")]
+    [InlineData(
+        "op_CheckedMultiplicationAssignment",
+        "void op_CheckedMultiplicationAssignment(Samples.Tuples other)",
+        "public void operator checked *=(Samples.Tuples other)")]
+    [InlineData(
+        "op_IncrementAssignment",
+        "void op_IncrementAssignment()",
+        "public void operator ++()")]
+    public void MemberDeclaration_FormatsInstanceAssignmentOperators(
+        string name,
+        string signature,
+        string expected)
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Tuples", Kind = "class" };
+        var member = new ApiMember { Name = name, Kind = "operator", Signature = signature };
+
+        Assert.Equal(expected, CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+    }
+
+    [Theory]
+    [InlineData(
+        "op_CheckedModulusAssignment",
+        "void op_CheckedModulusAssignment(int other)",
+        false,
+        null,
+        "public void op_CheckedModulusAssignment(int other)")]
+    [InlineData(
+        "op_AdditionAssignment",
+        "Samples.Tuples op_AdditionAssignment(Samples.Tuples left, Samples.Tuples right)",
+        true,
+        null,
+        "public static Samples.Tuples op_AdditionAssignment(Samples.Tuples left, Samples.Tuples right)")]
+    [InlineData(
+        "op_AdditionAssignment",
+        "Samples.Tuples op_AdditionAssignment(int other)",
+        false,
+        null,
+        "public Samples.Tuples op_AdditionAssignment(int other)")]
+    [InlineData(
+        "op_AdditionAssignment",
+        "void op_AdditionAssignment(int left, int right)",
+        false,
+        null,
+        "public void op_AdditionAssignment(int left, int right)")]
+    [InlineData(
+        "op_AdditionAssignment",
+        "void op_AdditionAssignment(int other)",
+        false,
+        "private",
+        "private void op_AdditionAssignment(int other)")]
+    public void MemberDeclaration_LeavesNonCSharpAssignmentShapesAsMethods(
+        string name,
+        string signature,
+        bool isStatic,
+        string? accessibility,
+        string expected)
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Tuples", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = name,
+            Kind = "operator",
+            Signature = signature,
+            IsStatic = isStatic,
+            Accessibility = accessibility,
+        };
 
         Assert.Equal(expected, CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
     }

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1024,9 +1024,10 @@ internal static class CSharpDeclarationWriter
             var typeName = FormatConstructorTypeName(type.Name);
             signature = $"{typeName}{FormatConstructorCall(signature)}";
         }
-        else if (member.Name.StartsWith("op_", StringComparison.Ordinal))
+        else if (member.Kind == "operator"
+            && member.Name.StartsWith("op_", StringComparison.Ordinal))
         {
-            signature = FormatOperatorSignature(signature, member.Name);
+            signature = FormatOperatorSignature(signature, member);
         }
         else if (member.Kind is "method" or "extension-method" or "explicit-interface-implementation"
             && !IsExplicitInterfaceEvent(member))
@@ -1739,7 +1740,7 @@ internal static class CSharpDeclarationWriter
             signature = $"{FormatConstructorTypeName(type.Name)}({parameters})";
             return true;
         }
-        if (member.Kind == "method"
+        if (member.Kind is "method" or "operator"
             && methodParameters is not { Count: > 0 }
             && model.MemberName is { Length: > 0 } memberName
             && model.ReturnType is { Length: > 0 } returnType)
@@ -1782,8 +1783,8 @@ internal static class CSharpDeclarationWriter
             return true;
         }
 
-        // Keep extension projections, explicit implementations, operators, and
-        // unsupported event shapes on compatibility text until the remaining
+        // Keep extension projections, explicit implementations, and unsupported
+        // event shapes on compatibility text until the remaining
         // declaration-level facts are represented in ApiSignature.
         return false;
 
@@ -2117,16 +2118,33 @@ internal static class CSharpDeclarationWriter
     /// occurrence is identified as the whole-token one immediately followed by <c>(</c>
     /// rather than by textual position.
     /// </remarks>
-    static string FormatOperatorSignature(string signature, string methodName)
+    static string FormatOperatorSignature(string signature, ApiMember member)
     {
+        string methodName = member.Name;
         if (!TryFindMemberNameBeforeParameterList(signature, methodName, out int nameIndex, out int parenStart))
             return signature;
 
         var returnType = signature[..nameIndex].TrimEnd();
         var parameters = signature[parenStart..];
+        if (OperatorNames.IsAssignmentOperatorMethodName(methodName))
+        {
+            int parameterCount = member.SignatureModel?.ParameterCount
+                ?? OperatorParameterCount(parameters);
+            bool isPublic = member.Accessibility is null or "public";
+            if (!OperatorNames.IsCSharpInstanceAssignmentOperator(
+                    methodName,
+                    member.IsStatic,
+                    isPublic,
+                    returnType,
+                    parameterCount))
+            {
+                return signature;
+            }
+        }
 
         if (methodName.StartsWith("op_Checked", StringComparison.Ordinal)
-            && OperatorNames.MapBinaryOrUnary(methodName["op_Checked".Length..]) is { } checkedSymbol)
+            && (OperatorNames.MapBinaryOrUnary(methodName["op_Checked".Length..])
+                ?? OperatorNames.MapCheckedAssignment(methodName["op_Checked".Length..])) is { } checkedSymbol)
             return $"{returnType} operator checked {checkedSymbol}{parameters}";
 
         return methodName switch
@@ -2136,6 +2154,16 @@ internal static class CSharpDeclarationWriter
             "op_CheckedExplicit" => $"explicit operator checked {returnType}{parameters}",
             _ => $"{returnType} {OperatorNames.FormatDisplayName(methodName)}{parameters}"
         };
+    }
+
+    static int OperatorParameterCount(string parameters)
+    {
+        if (parameters.Length == 0 || parameters[0] != '(')
+            return -1;
+        int close = Matching(parameters, 0, '(', ')');
+        if (close != parameters.Length - 1)
+            return -1;
+        return SplitTopLevel(parameters[1..close]).Count();
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1,3 +1,8 @@
+using System.Reflection.PortableExecutable;
+using AssemblyName = System.Reflection.AssemblyName;
+using MethodAttributes = System.Reflection.MethodAttributes;
+using ParameterAttributes = System.Reflection.ParameterAttributes;
+using TypeAttributes = System.Reflection.TypeAttributes;
 using DotnetInspector.Fixtures;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
@@ -28,6 +33,74 @@ public class IrImporterTests
 
     static Block SingleBlock(IrFunction function)
         => (Block)Assert.Single(function.Body.Children);
+
+    [Fact]
+    public void InstanceAssignmentOperatorRejectsRefAndOutButAcceptsIn()
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"instance-operator-ref-kinds-{Guid.NewGuid():N}.dll");
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new AssemblyName("InstanceOperatorRefKinds"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("InstanceOperatorRefKinds");
+        var readOnlyConstructor = typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute)
+            .GetConstructor(Type.EmptyTypes)!;
+        foreach (var (typeName, attributes, isReadOnly) in new[]
+        {
+            ("RefOperator", ParameterAttributes.None, false),
+            ("OutOperator", ParameterAttributes.Out, false),
+            ("InOperator", ParameterAttributes.In, true),
+        })
+        {
+            var type = module.DefineType(
+                typeName,
+                TypeAttributes.Public | TypeAttributes.Class);
+            var method = type.DefineMethod(
+                "op_AdditionAssignment",
+                MethodAttributes.Public | MethodAttributes.SpecialName,
+                typeof(void),
+                [typeof(int).MakeByRefType()]);
+            var parameter = method.DefineParameter(1, attributes, "value");
+            if (isReadOnly)
+            {
+                parameter.SetCustomAttribute(
+                    new System.Reflection.Emit.CustomAttributeBuilder(
+                        readOnlyConstructor,
+                        []));
+            }
+            method.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+            type.CreateType();
+        }
+        assembly.Save(path);
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var reader = System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader(peReader);
+            var facts = reader.TypeDefinitions
+                .Select(handle => reader.GetTypeDefinition(handle))
+                .Where(type => reader.GetString(type.Name).EndsWith("Operator", StringComparison.Ordinal))
+                .ToDictionary(
+                    type => reader.GetString(type.Name),
+                    type =>
+                    {
+                        var method = Assert.Single(
+                            type.GetMethods(),
+                            handle => reader.GetString(reader.GetMethodDefinition(handle).Name)
+                                == "op_AdditionAssignment");
+                        return IrImporter.ResolveMethod(reader, method, GenericScope.Empty).IsOperator;
+                    });
+
+            Assert.Equal(MetadataFactState.No, facts["RefOperator"]);
+            Assert.Equal(MetadataFactState.No, facts["OutOperator"]);
+            Assert.Equal(MetadataFactState.Yes, facts["InOperator"]);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 
     [Fact]
     public void PublicOnlyResolution_SkipsNonPublicSameNameOverload()

--- a/src/ILInspector.Decompiler.Tests/PrintedBodyMapTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrintedBodyMapTests.cs
@@ -123,6 +123,88 @@ public class PrintedBodyMapTests
     }
 
     [Fact]
+    public void OperatorProjectionRequiresValidatedInstanceAssignmentShape()
+    {
+        var valueType = TypeRef.Definition(
+            "Fixture",
+            "",
+            "Vec",
+            ValueTypeHint.ValueType);
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var method = new MethodRef(
+            valueType,
+            "op_AdditionAssignment",
+            voidType,
+            [valueType],
+            HasThis: true)
+        {
+            IsOperator = MetadataFactState.Yes,
+            IsSpecialName = true,
+        };
+        Call InstanceCall(MethodRef callee, bool includeOther = true)
+            => new(
+                callee,
+                isVirtual: false,
+                includeOther
+                    ? [new LoadArgument(0, "value", valueType), new LoadArgument(1, "other", valueType)]
+                    : [new LoadArgument(0, "value", valueType)]);
+
+        Assert.Equal(
+            "AssignmentStatement",
+            AnnotatedSourceNodeKindProjection.OperatorKind(InstanceCall(method)));
+        Assert.Null(AnnotatedSourceNodeKindProjection.OperatorKind(
+            InstanceCall(method with { IsOperator = MetadataFactState.No })));
+        Assert.Null(AnnotatedSourceNodeKindProjection.OperatorKind(
+            InstanceCall(method with { IsSpecialName = false })));
+        Assert.Null(AnnotatedSourceNodeKindProjection.OperatorKind(InstanceCall(method, includeOther: false)));
+    }
+
+    [Fact]
+    public void CheckedInstanceAssignmentPublishesCheckedStatementRange()
+    {
+        using var source = MetadataSource.Open(typeof(PrintedBodyMapTests).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(PrintedBodyMapTests).FullName!,
+            nameof(CheckedInstanceAssignment));
+        Assert.NotNull(function);
+        CSharpPrinter.PrintRaised(function!, out var ranges);
+
+        var map = PrintedBodyMap.Create(ranges);
+        var statement = Assert.Single(
+            map.Nodes,
+            node => node.Kind == "CheckedStatement"
+                && Text(map, node.Extent).Contains("+=", StringComparison.Ordinal));
+
+        Assert.Contains("checked {", Text(map, statement.Extent), StringComparison.Ordinal);
+    }
+
+    static int CheckedInstanceAssignment(PrintedInstanceAssignmentValue other)
+    {
+        var value = default(PrintedInstanceAssignmentValue);
+        checked
+        {
+            value += other;
+        }
+        return value.Value;
+    }
+
+    public struct PrintedInstanceAssignmentValue
+    {
+        public int Value;
+
+        public void operator +=(PrintedInstanceAssignmentValue other)
+        {
+            Value += other.Value;
+        }
+
+        public void operator checked +=(PrintedInstanceAssignmentValue other)
+        {
+            Value = checked(Value + other.Value);
+        }
+    }
+
+    [Fact]
     public void ReplayToleratesKindsAddedByANewerProducer()
     {
         var map = new PrintedBodyMap(

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitFixture.cs
@@ -7,8 +7,34 @@ public enum SkeletonFlags
     B = 2,
 }
 
+public class SkeletonInstanceAssignmentHazard
+{
+    public int Value;
+
+    public void operator +=(int other)
+    {
+        Value += other;
+    }
+}
+
+public class SkeletonOrdinaryOperatorNameHazard
+{
+    public int Value;
+
+    public void op_AdditionAssignment(int other)
+    {
+        Value += other;
+    }
+
+    public int Invoke(int other)
+    {
+        op_AdditionAssignment(other);
+        return Value;
+    }
+}
+
 /// <summary>
-/// Exercises two whole-module skeleton-emit hazards the changed-method fidelity
+/// Exercises whole-module skeleton-emit hazards the changed-method fidelity
 /// check must survive (#1282), used by <see cref="SkeletonEmitTests"/>:
 /// <list type="bullet">
 /// <item>a non-generic <b>explicit interface implementation</b> (IL name
@@ -16,8 +42,12 @@ public enum SkeletonFlags
 /// stub is invalid C# (CS0106) and poisons the whole-module compile;</item>
 /// <item>a <b>const enum field</b>: its metadata value is the integer underlying,
 /// so a `public const SkeletonFlags F = 1;` stub is CS0266 without a cast.</item>
+/// <item>a C# 14 <b>instance assignment operator</b> on a sibling type: forcing
+/// <c>static</c> onto its skeleton declaration is CS0106.</item>
+/// <item>an ordinary method whose name resembles an operator: spelling it as an
+/// operator makes its direct call illegal (CS0571).</item>
 /// </list>
-/// Both live on a sibling type so the failure surfaces when any method in the
+/// The sibling hazards ensure the failure surfaces when any method in the
 /// module is fidelity-checked.
 /// </summary>
 public class SkeletonEmitFixture : IDisposable

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -19,7 +19,7 @@ public class SkeletonEmitTests
     const string FixtureType = "ILInspector.Decompiler.Tests.SkeletonEmitFixture";
 
     [Fact]
-    public void SkeletonCompilesPastExplicitImplAndConstEnum()
+    public void SkeletonCompilesPastWholeModuleHazards()
     {
         var sum = Assert.Single(FidelityCheck.Evaluate(
             typeof(SkeletonEmitFixture).Assembly.Location,
@@ -27,8 +27,9 @@ public class SkeletonEmitTests
             method => method.Method == "Sum"));
 
         // The point is that the whole-module skeleton compiles: an unhandled
-        // explicit impl (CS0106) or const enum (CS0266) would surface here as a
-        // RecompileFail/ContextFail, not as the clean opcode comparison below.
+        // explicit impl / instance assignment operator (CS0106) or const enum
+        // (CS0266) would surface here as a RecompileFail/ContextFail, not as the
+        // clean opcode comparison below.
         Assert.False(sum.Status is FidelityCheck.CompileBackStatus.RecompileFail
             or FidelityCheck.CompileBackStatus.ContextFail,
             $"Skeleton failed to compile for {FixtureType}.Sum: {sum.Status} / {sum.Detail}");
@@ -49,6 +50,18 @@ public class SkeletonEmitTests
         {
             File.Delete(path);
         }
+    }
+
+    [Fact]
+    public void SkeletonPreservesOrdinaryOperatorNamedMethods()
+    {
+        const string Type = "ILInspector.Decompiler.Tests.SkeletonOrdinaryOperatorNameHazard";
+        var result = Assert.Single(FidelityCheck.Evaluate(
+            typeof(SkeletonEmitFixture).Assembly.Location,
+            type => type == Type,
+            method => method.Method == "Invoke"));
+
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
     }
 
     [Theory]

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -179,6 +179,10 @@ internal sealed class CrossAssemblyTypeResolver
             DeclaringType = UpgradeTypeReference(method.DeclaringType),
             ReturnType = UpgradeTypeReference(method.ReturnType),
             ParameterTypes = [.. method.ParameterTypes.Select(UpgradeTypeReference)],
+            DefinitionReturnType = method.DefinitionReturnType is null
+                ? null
+                : UpgradeTypeReference(method.DefinitionReturnType),
+            DefinitionParameterTypes = [.. method.DefinitionParameterTypes.Select(UpgradeTypeReference)],
             TypeArguments = [.. method.TypeArguments.Select(UpgradeTypeReference)],
         };
 
@@ -335,7 +339,13 @@ internal sealed class CrossAssemblyTypeResolver
                     FactState(typeCompilerGenerated),
                     FactState(IsDelegateType(reader, typeDef)),
                     FactState(MethodDefinitionFacts.HasExtensionAttribute(reader, method)),
-                    FactState(MethodDefinitionFacts.IsOperator(method, callee.Name, callee.HasThis)),
+                    FactState(MethodDefinitionFacts.IsOperator(
+                        method,
+                        callee.Name,
+                        callee.HasThis,
+                        callee.ReturnType,
+                        callee.ParameterTypes,
+                        parameterRefKinds)),
                     MethodDefinitionFacts.ReadAccessorKind(reader, typeDef, methodHandle));
             }
 
@@ -422,18 +432,44 @@ internal sealed class CrossAssemblyTypeResolver
             ? callee.DeclaringType.TypeArguments
             : [];
         var methodArguments = callee.TypeArguments;
-        var returnType = signature.ReturnType.Instantiate(typeArguments, methodArguments);
-        if (!SameSignatureType(returnType, callee.ReturnType, allowCoreLibraryAliases))
+        var definitionReturnType = callee.DefinitionReturnType;
+        if (definitionReturnType is not null
+            && !SameSignatureType(signature.ReturnType, definitionReturnType, allowCoreLibraryAliases))
+        {
             return false;
+        }
+        var returnType = signature.ReturnType.Instantiate(typeArguments, methodArguments);
+        if (definitionReturnType is null
+            && !SameSignatureType(returnType, callee.ReturnType, allowCoreLibraryAliases))
+        {
+            return false;
+        }
 
         if (signature.ParameterTypes.Length != callee.ParameterTypes.Length)
             return false;
+        bool hasDefinitionParameters = !callee.DefinitionParameterTypes.IsDefaultOrEmpty;
+        if (hasDefinitionParameters
+            && signature.ParameterTypes.Length != callee.DefinitionParameterTypes.Length)
+        {
+            return false;
+        }
         var parameters = ImmutableArray.CreateBuilder<TypeRef>(signature.ParameterTypes.Length);
         for (int i = 0; i < signature.ParameterTypes.Length; i++)
         {
-            var parameter = signature.ParameterTypes[i].Instantiate(typeArguments, methodArguments);
-            if (!SameSignatureType(parameter, callee.ParameterTypes[i], allowCoreLibraryAliases))
+            if (hasDefinitionParameters
+                && !SameSignatureType(
+                    signature.ParameterTypes[i],
+                    callee.DefinitionParameterTypes[i],
+                    allowCoreLibraryAliases))
+            {
                 return false;
+            }
+            var parameter = signature.ParameterTypes[i].Instantiate(typeArguments, methodArguments);
+            if (!hasDefinitionParameters
+                && !SameSignatureType(parameter, callee.ParameterTypes[i], allowCoreLibraryAliases))
+            {
+                return false;
+            }
             parameters.Add(parameter);
         }
 
@@ -806,7 +842,6 @@ internal sealed class CrossAssemblyTypeResolver
 
     static bool NeedsOperatorFact(MethodRef method)
         => method.IsOperator == MetadataFactState.Unknown
-            && !method.HasThis
             && method.Name.StartsWith("op_", StringComparison.Ordinal);
 
     static bool NeedsAccessorFact(MethodRef method)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/AnnotatedSourceNodeKindProjection.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/AnnotatedSourceNodeKindProjection.cs
@@ -1,3 +1,5 @@
+using CSharpText;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
@@ -162,8 +164,31 @@ internal static class AnnotatedSourceNodeKindProjection
     /// </summary>
     internal static string? OperatorKind(Call call)
     {
-        if (call.Callee.HasThis
-            || (call.Callee.IsOperator == MetadataFactState.No || !call.Callee.IsSpecialName)
+        if (call.Callee.HasThis)
+        {
+            if (call.Callee.IsOperator != MetadataFactState.Yes || !call.Callee.IsSpecialName)
+                return null;
+
+            string instanceName = call.Callee.Name;
+            bool isChecked = instanceName.StartsWith("op_Checked", StringComparison.Ordinal);
+            string? suffix = isChecked
+                ? instanceName["op_Checked".Length..]
+                : instanceName.StartsWith("op_", StringComparison.Ordinal)
+                    ? instanceName["op_".Length..]
+                    : null;
+            string? symbol = suffix is null
+                ? null
+                : isChecked
+                    ? OperatorNames.MapCheckedAssignment(suffix)
+                    : OperatorNames.MapAssignment(suffix);
+            bool isIncrement = suffix is "IncrementAssignment" or "DecrementAssignment";
+            int expectedArgumentCount = isIncrement ? 1 : 2;
+            return symbol is not null && call.Arguments.Count == expectedArgumentCount
+                ? "AssignmentStatement"
+                : null;
+        }
+
+        if ((call.Callee.IsOperator == MetadataFactState.No || !call.Callee.IsSpecialName)
                 && !MemberIdentity.IsKnownCoreLibraryOperator(call.Callee))
         {
             return null;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -690,6 +690,8 @@ public sealed partial class CSharpPrinter
         string typeArguments = call.Callee.TypeArguments.IsEmpty
             ? ""
             : $"<{string.Join(", ", call.Callee.TypeArguments.Select(TypeText))}>";
+        if (IsInstanceAssignmentOperatorCall(call))
+            return OperatorSpelling(call)!;
         if (!call.Callee.HasThis)
         {
             // C# compiles user-defined operators TO these calls; the

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3106,6 +3106,8 @@ public sealed partial class CSharpPrinter
             // A user-defined checked ++/-- as a statement spells checked(x++),
             // which is CS0201 in statement position; use a checked { ... } block.
             IncrementDecrement { IsChecked: true } id => CheckedIncrementStatement(e, id),
+            Call call when IsCheckedInstanceAssignmentOperatorCall(call)
+                => CheckedInstanceAssignmentStatement(e, call),
             // C# requires an expression statement to be an invocation, object
             // creation, await, or inc/decrement. A bare value — a stack slot
             // discarded by an IL `pop`, a comparison, the caught exception, an
@@ -5299,9 +5301,17 @@ public sealed partial class CSharpPrinter
         _ => false,
     };
 
-    /// <summary>True when a non-instance call renders as a C# operator (`a != b`, `-x`) rather than a method invocation — the compound form that must parenthesize as an operand.</summary>
+    /// <summary>True when a call renders as C# operator syntax rather than a method invocation.</summary>
     bool IsOperatorCall(Call call)
         => AnnotatedSourceNodeKindProjection.OperatorKind(call) is not null;
+
+    bool IsInstanceAssignmentOperatorCall(Call call)
+        => call.Callee.HasThis
+            && AnnotatedSourceNodeKindProjection.OperatorKind(call) == "AssignmentStatement";
+
+    bool IsCheckedInstanceAssignmentOperatorCall(Call call)
+        => IsInstanceAssignmentOperatorCall(call)
+            && call.Callee.Name.StartsWith("op_Checked", StringComparison.Ordinal);
 
     /// <summary>
     /// The direct idiom for a negated operator-spelled equality/inequality
@@ -5379,15 +5389,23 @@ public sealed partial class CSharpPrinter
     /// </summary>
     bool IsStatementExpression(IrExpression expression) => expression switch
     {
-        Call call => !IsOperatorCall(call),
+        Call call => IsInstanceAssignmentOperatorCall(call) || !IsOperatorCall(call),
         CallIndirect or NewObject or IncrementDecrement or AwaitExpression or LocalFunctionInvocation => true,
         _ => false,
     };
 
-    static Precedence? OperatorCallPrecedence(Call call)
+    Precedence? OperatorCallPrecedence(Call call)
     {
         var arguments = call.Arguments;
         string name = call.Callee.Name;
+        if (IsInstanceAssignmentOperatorCall(call))
+        {
+            if (name.StartsWith("op_Checked", StringComparison.Ordinal))
+                return null;
+            return name is "op_IncrementAssignment" or "op_DecrementAssignment"
+                ? Precedence.Primary
+                : Precedence.Assignment;
+        }
         if (name.StartsWith("op_Checked", StringComparison.Ordinal))
             name = "op_" + name["op_Checked".Length..];
 
@@ -5429,7 +5447,53 @@ public sealed partial class CSharpPrinter
     /// <summary>The operator form of an op_* call, or null when the name has no spelling (op_True/op_False and friends stay as calls).</summary>
     string? OperatorSpelling(Call call)
     {
+        if (!_checkedContext || OperatorNames.CheckedOperator(call.Callee.Name) is null)
+            return OperatorSpellingCore(call);
+
+        _checkedContext = false;
+        try
+        {
+            string? spelling = OperatorSpellingCore(call);
+            return spelling is null ? null : $"unchecked({spelling})";
+        }
+        finally
+        {
+            _checkedContext = true;
+        }
+    }
+
+    string? OperatorSpellingCore(Call call)
+    {
         var arguments = call.Arguments;
+
+        if (call.Callee.HasThis && arguments.Count >= 1)
+        {
+            string name = call.Callee.Name;
+            bool isChecked = name.StartsWith("op_Checked", StringComparison.Ordinal);
+            string? suffix = isChecked
+                ? name["op_Checked".Length..]
+                : name.StartsWith("op_", StringComparison.Ordinal)
+                    ? name["op_".Length..]
+                    : null;
+            string? symbol = suffix is null
+                ? null
+                : isChecked
+                    ? OperatorNames.MapCheckedAssignment(suffix)
+                    : OperatorNames.MapAssignment(suffix);
+            if (symbol is null)
+                return null;
+
+            bool isIncrement = suffix is "IncrementAssignment" or "DecrementAssignment";
+            if (isIncrement ? arguments.Count != 1 : arguments.Count != 2)
+                return null;
+
+            string RenderSpelling() => isIncrement
+                ? $"{OperatorOperand(arguments[0])}{symbol}"
+                : $"{OperatorOperand(arguments[0])} {symbol} {InstanceAssignmentRightOperand(call)}";
+            return !isChecked
+                ? RenderSpelling()
+                : WrapChecked(RenderSpelling);
+        }
 
         // User-defined checked operators (C# 11). The metadata name encodes the
         // checked overload (op_CheckedAddition, op_CheckedSubtraction, ...); the
@@ -5470,6 +5534,38 @@ public sealed partial class CSharpPrinter
             };
         }
         return null;
+    }
+
+    string InstanceAssignmentRightOperand(Call call)
+    {
+        IrExpression argument = call.Arguments[1];
+        if (call.Callee.ParameterTypes.IsDefaultOrEmpty)
+            return OperatorOperand(argument);
+
+        TypeRef parameter = call.Callee.ParameterTypes[0];
+        TypeRef valueParameter = parameter.Kind == TypeRefKind.ByRef
+            ? parameter.ElementType!
+            : parameter;
+        if (OperatorOverloadFidelityCast(argument, valueParameter) is { } fidelityCast)
+            return fidelityCast;
+        return parameter.Kind == TypeRefKind.ByRef
+            ? OperatorOperand(argument)
+            : CoerceText(argument, parameter);
+    }
+
+    string? OperatorOverloadFidelityCast(IrExpression argument, TypeRef parameter)
+    {
+        if (!IsConcreteReferenceParameter(parameter))
+            return null;
+        string parameterText = TypeText(parameter);
+        if (argument is Constant { Value: null })
+            return $"({parameterText})null";
+        var argumentType = EffectiveType(argument);
+        if (argumentType?.Kind == TypeRefKind.ByRef)
+            argumentType = argumentType.ElementType;
+        if (argumentType is null || argumentType.Equals(parameter))
+            return null;
+        return $"({parameterText}){OperatorOperand(argument)}";
     }
 
     /// <summary>
@@ -5843,6 +5939,21 @@ public sealed partial class CSharpPrinter
         {
             _printedRanges = printedRanges;
             _expressionText = expressionText;
+        }
+    }
+
+    string CheckedInstanceAssignmentStatement(ExpressionStatement owner, Call call)
+    {
+        _printedRanges?.SetNodeKind(owner, "CheckedStatement");
+        bool saved = _checkedContext;
+        _checkedContext = true;
+        try
+        {
+            return $"checked {{ {OperatorSpelling(call)}; }}";
+        }
+        finally
+        {
+            _checkedContext = saved;
         }
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -2126,7 +2126,13 @@ public static class IrImporter
                 return new MethodRef(declaring, methodName, signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance)
                 {
                     IsSpecialName = (method.Attributes & System.Reflection.MethodAttributes.SpecialName) != 0,
-                    IsOperator = FactState(MethodDefinitionFacts.IsOperator(method, methodName, signature.Header.IsInstance)),
+                    IsOperator = FactState(MethodDefinitionFacts.IsOperator(
+                        method,
+                        methodName,
+                        signature.Header.IsInstance,
+                        signature.ReturnType,
+                        signature.ParameterTypes,
+                        parameterRefKinds)),
                     AccessorKind = MethodDefinitionFacts.ReadAccessorKind(reader, declaringType, (MethodDefinitionHandle)handle),
                     ParameterRefKinds = parameterRefKinds.Kinds,
                     ParameterRefKindsFacts = parameterRefKinds.State,
@@ -2153,7 +2159,14 @@ public static class IrImporter
                 var typeArguments = declaring.Kind == TypeRefKind.GenericInstance ? declaring.TypeArguments : [];
                 string memberName = reader.GetString(member.Name);
                 var parameterTypes = ImmutableArray.CreateRange(signature.ParameterTypes.Select(p => p.Instantiate(typeArguments, [])));
-                var memberFacts = MemberReferenceDefinitionFacts(reader, member, memberName, signature.Header.IsInstance, parameterTypes);
+                var returnType = signature.ReturnType.Instantiate(typeArguments, []);
+                var memberFacts = MemberReferenceDefinitionFacts(
+                    reader,
+                    member,
+                    memberName,
+                    signature.Header.IsInstance,
+                    returnType,
+                    parameterTypes);
                 bool trustedPlatform = IsTrustedPlatformMemberReference(reader, member.Parent);
                 var accessorKind = MemberReferenceAccessorKind(reader, member, memberName);
                 if (accessorKind == AccessorKind.Unknown && trustedPlatform)
@@ -2167,7 +2180,7 @@ public static class IrImporter
                 return new MethodRef(
                     declaring,
                     memberName,
-                    signature.ReturnType.Instantiate(typeArguments, []),
+                    returnType,
                     parameterTypes,
                     signature.Header.IsInstance)
                 {
@@ -2188,6 +2201,8 @@ public static class IrImporter
                     // otherwise be lost; recover it from the underlying MethodDef.
                     ParameterRefKinds = memberFacts.ParameterRefKinds.Kinds,
                     ParameterRefKindsFacts = memberFacts.ParameterRefKinds.State,
+                    DefinitionReturnType = signature.ReturnType,
+                    DefinitionParameterTypes = signature.ParameterTypes,
                     IsOperator = memberFacts.IsOperator,
                     CompilerGenerated = memberFacts.CompilerGenerated,
                     DeclaringTypeCompilerGenerated = memberFacts.DeclaringTypeCompilerGenerated,
@@ -2204,7 +2219,10 @@ public static class IrImporter
                 return generic with
                 {
                     TypeArguments = methodArguments,
-                    DefinitionParameterTypes = generic.ParameterTypes,
+                    DefinitionReturnType = generic.DefinitionReturnType ?? generic.ReturnType,
+                    DefinitionParameterTypes = generic.DefinitionParameterTypes.IsDefaultOrEmpty
+                        ? generic.ParameterTypes
+                        : generic.DefinitionParameterTypes,
                     ReturnType = generic.ReturnType.Instantiate([], methodArguments),
                     ParameterTypes = [.. generic.ParameterTypes.Select(p => p.Instantiate([], methodArguments))],
                 };
@@ -2321,6 +2339,7 @@ public static class IrImporter
         MemberReference member,
         string memberName,
         bool hasThis,
+        TypeRef returnType,
         ImmutableArray<TypeRef> parameterTypes)
     {
         var fallbackRefKinds = parameterTypes.Any(p => p.Kind == TypeRefKind.ByRef)
@@ -2348,7 +2367,13 @@ public static class IrImporter
                     : fallbackRefKinds;
                 return (
                     parameterRefKinds,
-                    FactState(MethodDefinitionFacts.IsOperator(method, memberName, hasThis)),
+                    FactState(MethodDefinitionFacts.IsOperator(
+                        method,
+                        memberName,
+                        hasThis,
+                        returnType,
+                        parameterTypes,
+                        parameterRefKinds)),
                     FactState(MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, method.GetCustomAttributes())),
                     typeCompilerGenerated);
             }
@@ -2603,7 +2628,13 @@ public static class IrImporter
                 return new FieldRef(declaring, name, fieldType)
                 {
                     BackingPropertyName = MemberReferenceBackingPropertyName(reader, member, name),
-                    DeclaringTypeCompilerGenerated = MemberReferenceDefinitionFacts(reader, member, name, false, []).DeclaringTypeCompilerGenerated,
+                    DeclaringTypeCompilerGenerated = MemberReferenceDefinitionFacts(
+                        reader,
+                        member,
+                        name,
+                        false,
+                        TypeRef.Unsupported("field member reference"),
+                        []).DeclaringTypeCompilerGenerated,
                     IsDynamic = MemberReferenceFieldIsDynamic(reader, member, name),
                 };
             }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -95,6 +95,13 @@ public sealed record MethodRef(
     public ImmutableArray<TypeRef> DefinitionParameterTypes { get; init; } = [];
 
     /// <summary>
+    /// The generic member definition's return type before declaring-type or
+    /// method type-argument substitution. Paired with
+    /// <see cref="DefinitionParameterTypes"/> for exact MethodDef identity.
+    /// </summary>
+    public TypeRef? DefinitionReturnType { get; init; }
+
+    /// <summary>
     /// Per-parameter call-site ref-kind (ref/out/in), aligned 1:1 with
     /// <see cref="ParameterTypes"/>. Populated for callees resolved as a
     /// MethodDef, from the parameter rows (IsReadOnlyAttribute / the Out flag),

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using CSharpText;
 
 namespace ILInspector.Decompiler.Pipeline;
 
@@ -84,10 +85,53 @@ internal static class MethodDefinitionFacts
     internal static bool IsUnmanagedCallersOnly(MetadataReader reader, MethodDefinition method)
         => HasAttribute(reader, method.GetCustomAttributes(), "System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute");
 
-    internal static bool IsOperator(MethodDefinition method, string methodName, bool hasThis)
-        => !hasThis
-            && methodName.StartsWith("op_", StringComparison.Ordinal)
-            && (method.Attributes & System.Reflection.MethodAttributes.SpecialName) != 0;
+    internal static bool IsOperator(
+        MethodDefinition method,
+        string methodName,
+        bool hasThis,
+        TypeRef returnType,
+        ImmutableArray<TypeRef> parameterTypes,
+        ParameterRefKindResult parameterRefKinds)
+    {
+        if (method.GetGenericParameters().Count != 0
+            || !OperatorNames.IsOperatorMethodName(methodName)
+            || (method.Attributes & System.Reflection.MethodAttributes.SpecialName) == 0)
+        {
+            return false;
+        }
+
+        if (!hasThis)
+            return true;
+
+        var access = method.Attributes & System.Reflection.MethodAttributes.MemberAccessMask;
+        if (!OperatorNames.IsCSharpInstanceAssignmentOperator(
+            methodName,
+            isStatic: false,
+            isPublic: access == System.Reflection.MethodAttributes.Public,
+            returnType is { Namespace: "System", Name: "Void" } ? "void" : "",
+            parameterTypes.Length))
+        {
+            return false;
+        }
+
+        if (!parameterTypes.Any(type => type.Kind == TypeRefKind.ByRef))
+            return true;
+        if (parameterRefKinds.State != ParameterRefKindFacts.Known
+            || parameterRefKinds.Kinds.Length != parameterTypes.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < parameterTypes.Length; i++)
+        {
+            if (parameterTypes[i].Kind == TypeRefKind.ByRef
+                && parameterRefKinds.Kinds[i] != ArgumentRefKind.In)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
 
     internal static AccessorKind ReadAccessorKind(MetadataReader reader, TypeDefinition declaringType, MethodDefinitionHandle method)
     {

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -17,9 +18,16 @@ public static class ApiSurfaceExtractor
     private const string DateTimeConstantAttributeName = "System.Runtime.CompilerServices.DateTimeConstant";
 
     public static ApiSurface Extract(PEReader peReader, bool includeAll = false, bool typesOnly = false, bool includeCompilerGenerated = false)
+        => Extract(peReader.GetMetadataReader(), includeAll, typesOnly, includeCompilerGenerated);
+
+    public static ApiSurface Extract(MetadataReader reader, bool includeAll = false, bool typesOnly = false, bool includeCompilerGenerated = false)
     {
         var surface = new ApiSurface();
-        var reader = peReader.GetMetadataReader();
+        var currentScope = ReadCurrentScope(reader, surface);
+        var localTypes = currentScope is null
+            ? []
+            : LocalTypes(reader, currentScope);
+        var accessorMethods = AccessorMethods(reader, surface);
 
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
@@ -152,8 +160,11 @@ public static class ApiSurfaceExtractor
             {
             apiType.Members = [];
 
-            var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
-
+            var explicitImplementationBodies = GetExplicitImplementationBodies(
+                reader,
+                typeDef,
+                currentScope,
+                localTypes);
             // Methods whose explicit `.override` MethodImpl targets
             // `System.Object::Finalize` — i.e. genuine class finalizers, the
             // slot the C# `~Type()` destructor compiles to.
@@ -165,23 +176,39 @@ public static class ApiSurfaceExtractor
                 var method = reader.GetMethodDefinition(methodHandle);
                 var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
                 var isExplicitInterfaceImplementation = explicitImplementationBodies.Contains(methodHandle);
-                if (methodAccess != MethodAttributes.Public && !includeAll && !isExplicitInterfaceImplementation)
-                    continue;
-
                 string methodName = reader.GetString(method.Name);
+                var isOwnedAccessor = accessorMethods.Contains(methodHandle);
+                var isRetainedExplicitImplementation = isExplicitInterfaceImplementation
+                    && (!isOwnedAccessor
+                        || methodAccess != MethodAttributes.Public
+                        || methodName.Contains('.', StringComparison.Ordinal));
+                var isFinalizer = apiType.Kind == "class"
+                    && method.GetGenericParameters().Count == 0
+                    && (objectFinalizeOverrides.Contains(methodHandle)
+                        || IsImplicitObjectFinalizeOverride(reader, typeDefHandle, method));
+                if (methodAccess != MethodAttributes.Public
+                    && !includeAll
+                    && !isRetainedExplicitImplementation
+                    && !isFinalizer)
+                {
+                    continue;
+                }
 
-                // Skip property accessors and event accessors
-                if (methodName.StartsWith("get_") || methodName.StartsWith("set_") ||
-                    methodName.StartsWith("add_") || methodName.StartsWith("remove_"))
+                // Ordinary accessors are represented by their owning property/event.
+                // Explicit-interface accessors remain method entries because whole-type
+                // decompilation consumes their bodies. Preserve legal ordinary methods
+                // whose names or flags merely resemble accessors.
+                if (isOwnedAccessor && !isRetainedExplicitImplementation)
                     continue;
 
                 // Skip compiler-generated methods (lambdas, state machines, etc.)
-                if (methodName.StartsWith("<"))
+                if (methodName.StartsWith("<") && !includeCompilerGenerated)
                     continue;
 
                 // Skip EditorBrowsable(Never) methods unless --all; obsolete are surfaced with marker.
                 if (!includeAll
-                    && !isExplicitInterfaceImplementation
+                    && !isRetainedExplicitImplementation
+                    && !isFinalizer
                     && AttributeReader.HasEditorBrowsableNeverAttribute(reader, method.GetCustomAttributes()))
                     continue;
 
@@ -194,7 +221,7 @@ public static class ApiSurfaceExtractor
                     && OperatorNames.IsOperatorMethodName(methodName);
                 var isVirtual = (methodAttributes & MethodAttributes.Virtual) != 0;
                 var isNewSlot = (methodAttributes & MethodAttributes.NewSlot) != 0;
-                var isOverride = isVirtual && !isNewSlot && !isExplicitInterfaceImplementation;
+                var isOverride = isVirtual && !isNewSlot && !isRetainedExplicitImplementation && !isFinalizer;
 
                 // A class finalizer is the `object.Finalize` override the C#
                 // `~Type()` destructor compiles to. It is detected by the
@@ -214,11 +241,6 @@ public static class ApiSurfaceExtractor
                 // A finalizer is never generic, so a method that overrides
                 // object.Finalize while declaring its own type parameters is still
                 // rejected — rendering it `~Type()` would erase `<T>`.
-                var isFinalizer = apiType.Kind == "class"
-                    && method.GetGenericParameters().Count == 0
-                    && (objectFinalizeOverrides.Contains(methodHandle)
-                        || IsImplicitObjectFinalizeOverride(reader, typeDefHandle, method));
-
                 var member = new ApiMember
                 {
                     Name = methodName,
@@ -226,14 +248,8 @@ public static class ApiSurfaceExtractor
                     {
                         ".ctor" => "constructor",
                         _ when isOperator => "operator",
-                        // A finalizer compiles to a `Finalize` method carrying an
-                        // explicit `.override System.Object::Finalize` MethodImpl,
-                        // so it also lands in `explicitImplementationBodies`. Classify
-                        // it as its own kind before the explicit-interface arm so it
-                        // is not filed under Explicit Interface Implementations; the
-                        // MethodImpl still (correctly) suppresses its accessibility.
                         _ when isFinalizer => "finalizer",
-                        _ when isExplicitInterfaceImplementation => "explicit-interface-implementation",
+                        _ when isRetainedExplicitImplementation => "explicit-interface-implementation",
                         _ => "method"
                     },
                     IsStatic = (methodAttributes & MethodAttributes.Static) != 0,
@@ -255,7 +271,9 @@ public static class ApiSurfaceExtractor
                     MetadataToken = MetadataTokens.GetToken(methodHandle),
                     IsUnsafe = HasUnsafeSignature(signature.Text)
                         || AttributeReader.HasRequiresUnsafeAttribute(reader, method.GetCustomAttributes()),
-                    Accessibility = isExplicitInterfaceImplementation && !isOperator ? null : GetAccessibility(methodAccess),
+                    Accessibility = isFinalizer || isRetainedExplicitImplementation && !isOperator
+                        ? null
+                        : GetAccessibility(methodAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
                     Attributes = RenderMemberAttributes(reader, method.GetCustomAttributes())
@@ -475,13 +493,15 @@ public static class ApiSurfaceExtractor
                 var evt = reader.GetEventDefinition(eventHandle);
                 var accessors = evt.GetAccessors();
 
-                // Check if adder exists
-                if (accessors.Adder.IsNil)
+                var representativeHandle = !accessors.Adder.IsNil
+                    ? accessors.Adder
+                    : accessors.Remover;
+                if (representativeHandle.IsNil)
                     continue;
 
-                var adder = reader.GetMethodDefinition(accessors.Adder);
-                var adderAccess = adder.Attributes & MethodAttributes.MemberAccessMask;
-                if (adderAccess != MethodAttributes.Public && !includeAll)
+                var representative = reader.GetMethodDefinition(representativeHandle);
+                var representativeAccess = representative.Attributes & MethodAttributes.MemberAccessMask;
+                if (representativeAccess != MethodAttributes.Public && !includeAll)
                     continue;
 
                 // Skip EditorBrowsable(Never) events unless --all; obsolete are surfaced with marker.
@@ -494,7 +514,7 @@ public static class ApiSurfaceExtractor
                     evt.Type,
                     GenericContext.ForType(reader, typeDef));
                 var eventNullableBytes = NullabilityReader.GetNullableBytes(reader, evt.GetCustomAttributes());
-                eventNullableBytes ??= NullabilityReader.GetParameterNullableBytes(reader, adder.GetParameters(), 1);
+                eventNullableBytes ??= NullabilityReader.GetParameterNullableBytes(reader, representative.GetParameters(), 1);
                 if (eventNullableBytes is { Length: > 0 } && eventNullableBytes[0] == 2 && !eventType.EndsWith("?", StringComparison.Ordinal))
                     eventType += "?";
                 // A `dynamic` event handler (e.g. EventHandler<dynamic>) or a
@@ -527,9 +547,9 @@ public static class ApiSurfaceExtractor
                         eventType = eventNode.Render();
                     }
                 }
-                var adderAttributes = adder.Attributes;
-                var isVirtualEvent = (adderAttributes & MethodAttributes.Virtual) != 0;
-                var isOverrideEvent = isVirtualEvent && (adderAttributes & MethodAttributes.NewSlot) == 0;
+                var representativeAttributes = representative.Attributes;
+                var isVirtualEvent = (representativeAttributes & MethodAttributes.Virtual) != 0;
+                var isOverrideEvent = isVirtualEvent && (representativeAttributes & MethodAttributes.NewSlot) == 0;
 
                 var member = new ApiMember
                 {
@@ -542,12 +562,12 @@ public static class ApiSurfaceExtractor
                         ReturnType = eventType,
                         MemberName = reader.GetString(evt.Name)
                     },
-                    IsStatic = (adderAttributes & MethodAttributes.Static) != 0,
+                    IsStatic = (representativeAttributes & MethodAttributes.Static) != 0,
                     IsVirtual = isVirtualEvent,
-                    IsAbstract = (adderAttributes & MethodAttributes.Abstract) != 0,
+                    IsAbstract = (representativeAttributes & MethodAttributes.Abstract) != 0,
                     IsOverride = isOverrideEvent,
-                    IsSealed = isOverrideEvent && (adderAttributes & MethodAttributes.Final) != 0,
-                    Accessibility = GetAccessibility(adderAccess),
+                    IsSealed = isOverrideEvent && (representativeAttributes & MethodAttributes.Final) != 0,
+                    Accessibility = GetAccessibility(representativeAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
                     AdderToken = accessors.Adder.IsNil
@@ -660,6 +680,203 @@ public static class ApiSurfaceExtractor
 
         return surface;
     }
+
+    static HashSet<MethodDefinitionHandle> AccessorMethods(
+        MetadataReader reader,
+        ApiSurface surface)
+    {
+        var methods = new HashSet<MethodDefinitionHandle>();
+        foreach (var propertyHandle in reader.PropertyDefinitions)
+        {
+            try
+            {
+                var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+                if (!accessors.Getter.IsNil)
+                    methods.Add(accessors.Getter);
+                if (!accessors.Setter.IsNil)
+                    methods.Add(accessors.Setter);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+            {
+                AddInspectionFailure(
+                    surface,
+                    "property accessors",
+                    propertyHandle,
+                    MetadataTypeNameFailure.Malformed(propertyHandle, ex.Message));
+            }
+        }
+        foreach (var eventHandle in reader.EventDefinitions)
+        {
+            try
+            {
+                var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+                if (!accessors.Adder.IsNil)
+                    methods.Add(accessors.Adder);
+                if (!accessors.Remover.IsNil)
+                    methods.Add(accessors.Remover);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+            {
+                AddInspectionFailure(
+                    surface,
+                    "event accessors",
+                    eventHandle,
+                    MetadataTypeNameFailure.Malformed(eventHandle, ex.Message));
+            }
+        }
+        methods.UnionWith(ExtensionPropertyImplementationMethods(reader, surface));
+        return methods;
+    }
+
+    static HashSet<MethodDefinitionHandle> ExtensionPropertyImplementationMethods(
+        MetadataReader reader,
+        ApiSurface surface)
+    {
+        HashSet<MethodDefinitionHandle> methods = [];
+        foreach (var extensionClassHandle in reader.TypeDefinitions)
+        {
+            try
+            {
+                var extensionClass = reader.GetTypeDefinition(extensionClassHandle);
+                if (!AttributeReader.HasExtensionAttribute(
+                        reader,
+                        extensionClass.GetCustomAttributes()))
+                {
+                    continue;
+                }
+
+                foreach (var groupingTypeHandle in extensionClass.GetNestedTypes())
+                {
+                    var groupingType = reader.GetTypeDefinition(groupingTypeHandle);
+                    if (!AttributeReader.HasExtensionAttribute(
+                            reader,
+                            groupingType.GetCustomAttributes()))
+                    {
+                        continue;
+                    }
+
+                    foreach (var propertyHandle in groupingType.GetProperties())
+                    {
+                        var property = reader.GetPropertyDefinition(propertyHandle);
+                        var accessors = property.GetAccessors();
+                        if (!TryGetExtensionMarkerName(
+                                reader,
+                                property,
+                                accessors,
+                                out string? markerName))
+                        {
+                            continue;
+                        }
+
+                        var markerTypeHandle = groupingType.GetNestedTypes().FirstOrDefault(handle =>
+                            reader.StringComparer.Equals(
+                                reader.GetTypeDefinition(handle).Name,
+                                markerName!));
+                        if (markerTypeHandle.IsNil)
+                            continue;
+                        var markerType = reader.GetTypeDefinition(markerTypeHandle);
+                        var markerMethodHandle = markerType.GetMethods().FirstOrDefault(handle =>
+                            reader.StringComparer.Equals(
+                                reader.GetMethodDefinition(handle).Name,
+                                "<Extension>$"));
+                        if (markerMethodHandle.IsNil)
+                            continue;
+
+                        var context = GenericContext.ForType(reader, markerType);
+                        if (!GuardedSignatureText.MethodText(
+                                reader,
+                                reader.GetMethodDefinition(markerMethodHandle),
+                                context).TryGetValue(out var markerSignature)
+                            || markerSignature.ParameterTypes.Length != 1
+                            || !GuardedSignatureText.PropertyText(
+                                reader,
+                                property,
+                                context).TryGetValue(out var propertySignature))
+                        {
+                            continue;
+                        }
+
+                        string propertyName = reader.GetString(property.Name);
+                        int implementationGenericArity = groupingType.GetGenericParameters().Count;
+                        foreach (var methodHandle in extensionClass.GetMethods())
+                        {
+                            var method = reader.GetMethodDefinition(methodHandle);
+                            string methodName = reader.GetString(method.Name);
+                            bool getter = !accessors.Getter.IsNil
+                                && methodName == $"get_{propertyName}";
+                            bool setter = !accessors.Setter.IsNil
+                                && methodName == $"set_{propertyName}";
+                            if (!getter && !setter)
+                                continue;
+                            if (!GuardedSignatureText.MethodText(
+                                    reader,
+                                    method,
+                                    GenericContext.ForMethod(reader, extensionClass, method))
+                                .TryGetValue(out var implementationSignature))
+                            {
+                                continue;
+                            }
+
+                            var markerAccessorHandle = getter
+                                ? accessors.Getter
+                                : accessors.Setter;
+                            bool isStaticExtensionMember = reader
+                                .GetMethodDefinition(markerAccessorHandle)
+                                .Attributes.HasFlag(MethodAttributes.Static);
+                            IEnumerable<string> expectedParameters =
+                                isStaticExtensionMember
+                                    ? propertySignature.ParameterTypes
+                                    : new[] { markerSignature.ParameterTypes[0] }
+                                        .Concat(propertySignature.ParameterTypes);
+                            if (setter)
+                                expectedParameters = expectedParameters.Append(
+                                    propertySignature.ReturnType);
+                            if (implementationSignature.ParameterTypes.SequenceEqual(
+                                    expectedParameters,
+                                    StringComparer.Ordinal)
+                                && method.GetGenericParameters().Count == implementationGenericArity
+                                && (getter
+                                    ? implementationSignature.ReturnType
+                                        == propertySignature.ReturnType
+                                    : implementationSignature.ReturnType == "void"))
+                            {
+                                methods.Add(methodHandle);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+            {
+                AddInspectionFailure(
+                    surface,
+                    "extension property accessors",
+                    extensionClassHandle,
+                    MetadataTypeNameFailure.Malformed(extensionClassHandle, ex.Message));
+            }
+        }
+        return methods;
+    }
+
+    static bool TryGetExtensionMarkerName(
+        MetadataReader reader,
+        PropertyDefinition property,
+        PropertyAccessors accessors,
+        out string? markerName)
+        => AttributeReader.TryGetExtensionMarkerName(
+                reader,
+                property.GetCustomAttributes(),
+                out markerName)
+            || !accessors.Getter.IsNil
+            && AttributeReader.TryGetExtensionMarkerName(
+                reader,
+                reader.GetMethodDefinition(accessors.Getter).GetCustomAttributes(),
+                out markerName)
+            || !accessors.Setter.IsNil
+            && AttributeReader.TryGetExtensionMarkerName(
+                reader,
+                reader.GetMethodDefinition(accessors.Setter).GetCustomAttributes(),
+                out markerName);
 
     private static byte? GetEffectiveNullable(
         MetadataReader reader, CustomAttributeHandleCollection attributes, byte nullableContext)
@@ -832,17 +1049,363 @@ public static class ApiSurfaceExtractor
     }
 
     private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(
-        MetadataReader reader, TypeDefinition typeDef)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> localTypes)
     {
         HashSet<MethodDefinitionHandle> handles = [];
         foreach (var implementationHandle in typeDef.GetMethodImplementations())
         {
             var implementation = reader.GetMethodImplementation(implementationHandle);
-            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition)
+            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition
+                && TargetsImplementedInterface(
+                    reader,
+                    typeDef,
+                    implementation.MethodDeclaration,
+                    currentScope,
+                    localTypes) is not InterfaceMethodImplOwnership.ProvenNonInterface)
+            {
                 handles.Add((MethodDefinitionHandle)implementation.MethodBody);
+            }
         }
 
         return handles;
+    }
+
+    private enum InterfaceMethodImplOwnership
+    {
+        ProvenNonInterface,
+        ProvenInterface,
+        UnresolvedExternalInheritance,
+    }
+
+    private static InterfaceMethodImplOwnership TargetsImplementedInterface(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        EntityHandle declaration,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> localTypes)
+    {
+        EntityHandle declaringType = declaration.Kind switch
+        {
+            HandleKind.MethodDefinition => reader
+                .GetMethodDefinition((MethodDefinitionHandle)declaration)
+                .GetDeclaringType(),
+            HandleKind.MemberReference => reader
+                .GetMemberReference((MemberReferenceHandle)declaration)
+                .Parent,
+            _ => default,
+        };
+        if (declaringType.Kind is not (
+                HandleKind.TypeDefinition
+                or HandleKind.TypeReference
+                or HandleKind.TypeSpecification))
+        {
+            return InterfaceMethodImplOwnership.ProvenNonInterface;
+        }
+
+        if (declaringType.Kind == HandleKind.TypeDefinition
+            && !reader.GetTypeDefinition((TypeDefinitionHandle)declaringType)
+                .Attributes.HasFlag(TypeAttributes.Interface))
+        {
+            return InterfaceMethodImplOwnership.ProvenNonInterface;
+        }
+
+        foreach (var handle in typeDef.GetInterfaceImplementations())
+        {
+            if (reader.GetInterfaceImplementation(handle).Interface == declaringType)
+                return InterfaceMethodImplOwnership.ProvenInterface;
+        }
+
+        var declarationIdentity = TryGetNamedTypeIdentity(
+            reader,
+            declaringType,
+            currentScope);
+        if (IsSystemObjectType(reader, declaringType)
+            || TargetsClassHierarchy(
+                reader,
+                typeDef,
+                declaringType,
+                declarationIdentity,
+                currentScope,
+                localTypes))
+        {
+            return InterfaceMethodImplOwnership.ProvenNonInterface;
+        }
+
+        var pending = new Queue<EntityHandle>();
+        foreach (var handle in typeDef.GetInterfaceImplementations())
+            pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
+
+        HashSet<MetadataNamedTypeIdentity> visited = [];
+        bool hasUnresolvedExternalOwnership = declarationIdentity is null
+            || !localTypes.ContainsKey(declarationIdentity);
+        while (pending.TryDequeue(out var interfaceType))
+        {
+            if (interfaceType == declaringType)
+                return InterfaceMethodImplOwnership.ProvenInterface;
+            if (TryGetNamedTypeIdentity(reader, interfaceType, currentScope) is not { } interfaceIdentity)
+            {
+                hasUnresolvedExternalOwnership = true;
+                continue;
+            }
+            if (!visited.Add(interfaceIdentity))
+            {
+                continue;
+            }
+            if (declarationIdentity is not null
+                && interfaceIdentity == declarationIdentity)
+                return InterfaceMethodImplOwnership.ProvenInterface;
+
+            // Same-module definitions let us close inherited InterfaceImpl edges.
+            // External inheritance cannot be proven from this reader alone. Keep
+            // that uncertainty distinct from a proven class MethodImpl so default
+            // extraction does not silently drop a possible explicit implementation.
+            if (!localTypes.TryGetValue(interfaceIdentity, out var interfaceHandle))
+            {
+                hasUnresolvedExternalOwnership = true;
+                continue;
+            }
+            var interfaceDefinition = reader.GetTypeDefinition(interfaceHandle);
+            foreach (var handle in interfaceDefinition.GetInterfaceImplementations())
+                pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
+        }
+
+        return hasUnresolvedExternalOwnership
+            ? InterfaceMethodImplOwnership.UnresolvedExternalInheritance
+            : InterfaceMethodImplOwnership.ProvenNonInterface;
+    }
+
+    private static bool TargetsClassHierarchy(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        EntityHandle declaringType,
+        MetadataNamedTypeIdentity? declarationIdentity,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> localTypes)
+    {
+        EntityHandle baseType = typeDef.BaseType;
+        HashSet<TypeDefinitionHandle> visited = [];
+        while (!baseType.IsNil)
+        {
+            if (baseType == declaringType)
+                return true;
+            if (declarationIdentity is not null
+                && TryGetNamedTypeIdentity(reader, baseType, currentScope) == declarationIdentity)
+            {
+                return true;
+            }
+            if (baseType.Kind == HandleKind.TypeSpecification)
+            {
+                if (TryGetNamedTypeIdentity(reader, baseType, currentScope) is not { } baseIdentity
+                    || !localTypes.TryGetValue(baseIdentity, out var baseDefinition))
+                {
+                    return false;
+                }
+                baseType = baseDefinition;
+            }
+            if (baseType.Kind != HandleKind.TypeDefinition
+                || !visited.Add((TypeDefinitionHandle)baseType))
+            {
+                return false;
+            }
+
+            baseType = reader.GetTypeDefinition((TypeDefinitionHandle)baseType).BaseType;
+        }
+
+        return false;
+    }
+
+    private static Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> LocalTypes(
+        MetadataReader reader,
+        MetadataTypeScope currentScope)
+    {
+        Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> types = [];
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            if (ReadDefinitionIdentity(reader, handle, currentScope) is { } identity)
+                types.TryAdd(identity, handle);
+        }
+
+        return types;
+    }
+
+    private static MetadataNamedTypeIdentity? TryGetNamedTypeIdentity(
+        MetadataReader reader,
+        EntityHandle handle,
+        MetadataTypeScope? currentScope) =>
+        handle.Kind switch
+        {
+            HandleKind.TypeDefinition => currentScope is null
+                ? null
+                : ReadDefinitionIdentity(
+                    reader,
+                    (TypeDefinitionHandle)handle,
+                    currentScope),
+            HandleKind.TypeReference => ReadReferenceIdentity(
+                reader,
+                (TypeReferenceHandle)handle,
+                currentScope),
+            HandleKind.TypeSpecification => GuardedProviderDecode.TypeSpec(
+                reader,
+                (TypeSpecificationHandle)handle,
+                new NamedTypeIdentityProvider(currentScope),
+                context: null,
+                fallback: null),
+            _ => null,
+        };
+
+    private static MetadataNamedTypeIdentity? ReadDefinitionIdentity(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        MetadataTypeScope currentScope) =>
+        MetadataTypeDefinitionNameReader.Read(reader, handle)
+            is MetadataTypeDefinitionNameReadResult.Read read
+                ? new(read.Name, currentScope)
+                : null;
+
+    private static MetadataNamedTypeIdentity? ReadReferenceIdentity(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        MetadataTypeScope? currentScope)
+    {
+        if (MetadataTypeDefinitionNameReader.Read(reader, handle)
+                is not MetadataTypeDefinitionNameReadResult.Read read
+            || ReferenceScope(reader, handle, currentScope) is not { } scope)
+        {
+            return null;
+        }
+
+        return new(read.Name, scope);
+    }
+
+    private static MetadataTypeScope CurrentScope(MetadataReader reader) =>
+        reader.IsAssembly
+            ? new(AssemblyReferenceIdentity.FromAssemblyDefinition(reader), null)
+            : new(null, reader.GetString(reader.GetModuleDefinition().Name));
+
+    private static MetadataTypeScope? ReadCurrentScope(
+        MetadataReader reader,
+        ApiSurface surface)
+    {
+        try
+        {
+            return CurrentScope(reader);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            EntityHandle subject = MetadataTokens.EntityHandle(
+                reader.IsAssembly ? 0x20000001 : 0x00000001);
+            AddInspectionFailure(
+                surface,
+                "module identity",
+                subject,
+                MetadataTypeNameFailure.Malformed(subject, ex.Message));
+            return null;
+        }
+    }
+
+    private static MetadataTypeScope? ReferenceScope(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        MetadataTypeScope? currentScope)
+    {
+        Span<TypeReferenceHandle> rootToLeaf =
+            stackalloc TypeReferenceHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkTypeReferenceResolutionScope(
+                reader,
+                handle,
+                rootToLeaf,
+                out _,
+                out EntityHandle terminal,
+                out _))
+        {
+            return null;
+        }
+        if (terminal.IsNil)
+            return null;
+
+        return terminal.Kind switch
+        {
+            HandleKind.ModuleDefinition => currentScope,
+            HandleKind.ModuleReference => new(
+                null,
+                reader.GetString(
+                    reader.GetModuleReference((ModuleReferenceHandle)terminal).Name)),
+            HandleKind.AssemblyReference => new(
+                AssemblyReferenceIdentity.From(
+                    reader,
+                    (AssemblyReferenceHandle)terminal),
+                null),
+            _ => null,
+        };
+    }
+
+    private sealed record MetadataTypeScope(
+        AssemblyReferenceIdentity? Assembly,
+        string? Module);
+
+    private sealed record MetadataNamedTypeIdentity(
+        MetadataTypeDefinitionName Name,
+        MetadataTypeScope Scope);
+
+    private sealed class NamedTypeIdentityProvider :
+        ISignatureTypeProvider<MetadataNamedTypeIdentity?, object?>
+    {
+        private readonly MetadataTypeScope? currentScope;
+
+        internal NamedTypeIdentityProvider(MetadataTypeScope? currentScope) =>
+            this.currentScope = currentScope;
+
+        public MetadataNamedTypeIdentity? GetTypeFromDefinition(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            byte rawTypeKind) =>
+            currentScope is null
+                ? null
+                : ReadDefinitionIdentity(reader, handle, currentScope);
+
+        public MetadataNamedTypeIdentity? GetTypeFromReference(
+            MetadataReader reader,
+            TypeReferenceHandle handle,
+            byte rawTypeKind) =>
+            ReadReferenceIdentity(reader, handle, currentScope);
+
+        public MetadataNamedTypeIdentity? GetTypeFromSpecification(
+            MetadataReader reader,
+            object? context,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind) =>
+            GuardedProviderDecode.TypeSpec(
+                reader,
+                handle,
+                this,
+                context,
+                fallback: null);
+
+        public MetadataNamedTypeIdentity? GetGenericInstantiation(
+            MetadataNamedTypeIdentity? genericType,
+            ImmutableArray<MetadataNamedTypeIdentity?> typeArguments) =>
+            // Interface ownership follows the generic type definition while the
+            // MethodImpl signature remains responsible for constructed arguments.
+            genericType;
+
+        public MetadataNamedTypeIdentity? GetModifiedType(
+            MetadataNamedTypeIdentity? modifier,
+            MetadataNamedTypeIdentity? unmodifiedType,
+            bool isRequired) =>
+            unmodifiedType;
+
+        public MetadataNamedTypeIdentity? GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
+        public MetadataNamedTypeIdentity? GetSZArrayType(MetadataNamedTypeIdentity? elementType) => null;
+        public MetadataNamedTypeIdentity? GetArrayType(MetadataNamedTypeIdentity? elementType, ArrayShape shape) => null;
+        public MetadataNamedTypeIdentity? GetByReferenceType(MetadataNamedTypeIdentity? elementType) => null;
+        public MetadataNamedTypeIdentity? GetPointerType(MetadataNamedTypeIdentity? elementType) => null;
+        public MetadataNamedTypeIdentity? GetPinnedType(MetadataNamedTypeIdentity? elementType) => elementType;
+        public MetadataNamedTypeIdentity? GetGenericTypeParameter(object? context, int index) => null;
+        public MetadataNamedTypeIdentity? GetGenericMethodParameter(object? context, int index) => null;
+        public MetadataNamedTypeIdentity? GetFunctionPointerType(MethodSignature<MetadataNamedTypeIdentity?> signature) => null;
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -187,9 +187,11 @@ public static class ApiSurfaceExtractor
 
                 var isObsolete = AttributeReader.TryGetObsoleteAttribute(reader, method.GetCustomAttributes(), out var obsoleteMessage);
 
-                var signature = GetMethodSignature(reader, typeDef, method, typeNullableContext);
-                var isOperator = IsOperatorMethodName(methodName);
                 var methodAttributes = method.Attributes;
+                var signature = GetMethodSignature(reader, typeDef, method, typeNullableContext);
+                var isOperator = methodAttributes.HasFlag(MethodAttributes.SpecialName)
+                    && method.GetGenericParameters().Count == 0
+                    && OperatorNames.IsOperatorMethodName(methodName);
                 var isVirtual = (methodAttributes & MethodAttributes.Virtual) != 0;
                 var isNewSlot = (methodAttributes & MethodAttributes.NewSlot) != 0;
                 var isOverride = isVirtual && !isNewSlot && !isExplicitInterfaceImplementation;
@@ -1187,9 +1189,6 @@ public static class ApiSurfaceExtractor
         token = blob;
         return true;
     }
-
-    private static bool IsOperatorMethodName(string methodName) =>
-        methodName.StartsWith("op_", StringComparison.Ordinal);
 
     private static void AttachLocalExtensionMethods(ApiSurface surface)
     {

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using ILInspector.CSharp;
 using ILInspector.Metadata;
@@ -22,7 +23,7 @@ public class ApiSurfaceExtractorTests
         using var stream = File.OpenRead(assemblyPath);
         using var peReader = new PEReader(stream);
 
-        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var surface = ApiSurfaceExtractor.Extract(peReader);
 
         // Find a method with known parameters
         var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
@@ -55,6 +56,48 @@ public class ApiSurfaceExtractorTests
         var staticMethod = testType.Members.FirstOrDefault(m => m.Name == nameof(SampleKeywordParameterHost.Static));
         Assert.NotNull(staticMethod);
         Assert.Equal("int Static(int @params, int @void)", staticMethod.Signature);
+    }
+
+    [Fact]
+    public void Extract_FinalizerHasNoSourceModifiers()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == nameof(SampleFinalizerHost));
+        var finalizer = Assert.Single(type.Members, member => member.Kind == "finalizer");
+        Assert.True(finalizer.IsFinalizer);
+        Assert.Null(finalizer.Accessibility);
+        Assert.False(finalizer.IsOverride);
+        Assert.False(finalizer.IsSealed);
+    }
+
+    [Fact]
+    public void Extract_DoesNotLeakExtensionPropertyImplementationAccessor()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(SampleExtensionPropertyHost));
+        var ordinaryInstanceOverload = Assert.Single(
+            type.Members,
+            member => member.Name == "get_IsEven");
+        Assert.Equal(1, ordinaryInstanceOverload.SignatureModel?.TypeParameters.Count);
+        Assert.DoesNotContain(type.Members, member => member.Name == "get_Echo");
+        Assert.DoesNotContain(type.Members, member => member.Name == "set_Echo");
+        Assert.DoesNotContain(type.Members, member => member.Name == "get_Zero");
+        var ordinaryGenericOverload = Assert.Single(
+            type.Members,
+            member => member.Name == "get_GenericValue");
+        Assert.Equal(2, ordinaryGenericOverload.SignatureModel?.TypeParameters.Count);
     }
 
     [Fact]
@@ -1210,13 +1253,288 @@ public class ApiSurfaceExtractorTests
         Assert.Contains(
             surface.Types,
             t => (t.MetadataName ?? "").Contains("DisplayClass")
-                 && t.Members.Any(m => m.Kind == "field"));
+                 && t.Members.Any(m => m.Kind == "field")
+                 && t.Members.Any(m => m.Name.StartsWith("<", StringComparison.Ordinal)));
 
         // Auto-property backing fields (<Prop>k__BackingField) are never surfaced as fields, even
         // once compiler-generated members are opted in.
         Assert.DoesNotContain(
             surface.Types.SelectMany(t => t.Members),
             m => m.Kind == "field" && m.Name.EndsWith("k__BackingField", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_LinksExplicitInterfaceAccessorsToOwningMembers()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(ExplicitSurfaceFixture));
+
+        var property = Assert.Single(
+            type.Members,
+            member => member.Kind == "property"
+                && member.Name.EndsWith(".Value", StringComparison.Ordinal));
+        var @event = Assert.Single(
+            type.Members,
+            member => member.Kind == "event"
+                && member.Name.EndsWith(".Changed", StringComparison.Ordinal));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(".Run", StringComparison.Ordinal));
+        Assert.Contains(type.Members, member =>
+            member.MetadataToken == property.GetterToken
+            && member.Name.Contains(".get_", StringComparison.Ordinal));
+        Assert.Contains(type.Members, member =>
+            member.MetadataToken == @event.AdderToken
+            && member.Name.Contains(".add_", StringComparison.Ordinal));
+        Assert.Contains(type.Members, member =>
+            member.MetadataToken == @event.RemoverToken
+            && member.Name.Contains(".remove_", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_PreservesStandaloneAccessorPrefixedMethods()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(AccessorPrefixMethodFixture));
+
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "get_Unused");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "set_Unused");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "add_Unused");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "remove_Unused");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "op_Custom");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "op_AdditionAssignment");
+    }
+
+    [Fact]
+    public void Extract_PreservesUnownedSpecialNameAccessorMethod()
+    {
+        var path = EmitUnownedSpecialNameAccessorMethod();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "SpecialNameFixture");
+
+            Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "get_Value");
+            Assert.Contains(
+                type.Members,
+                member => member.Kind == "operator" && member.Name == "op_AdditionAssignment");
+            Assert.Contains(
+                type.Members,
+                member => member.Kind == "method" && member.Name == "op_IncrementAssignment");
+            Assert.DoesNotContain(type.Members, member => member.Kind == "property");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_DoesNotDuplicateMethodImplBackedOrdinaryAccessor()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(CovariantSurfaceDerived));
+        var property = Assert.Single(
+            type.Members,
+            member => member.Kind == "property" && member.Name == "Value");
+
+        Assert.DoesNotContain(type.Members, member => member.MetadataToken == property.GetterToken);
+        Assert.DoesNotContain(type.Members, member => member.Name == "get_Value");
+    }
+
+    [Fact]
+    public void Extract_PreservesOtherAndRaiserMethodSemantics()
+    {
+        var path = EmitUnownedSpecialNameAccessorMethod();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "SemanticsFixture");
+
+            Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "OtherProperty");
+            Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "RaiseChanged");
+            Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "OtherEvent");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_ClassifiesInterfaceMethodImplRowsByAccessorOwnership()
+    {
+        var path = EmitPrivateUnqualifiedInterfaceAccessor();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+            var method = Assert.Single(
+                type.Members,
+                member => member.Name == "get_Value");
+            var ordinaryMethod = Assert.Single(
+                type.Members,
+                member => member.Name == "MappedMethod");
+
+            Assert.Equal("explicit-interface-implementation", method.Kind);
+            Assert.Equal("explicit-interface-implementation", ordinaryMethod.Kind);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_PreservesAccessorsImplementingInheritedInterfaces()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(InheritedInterfaceSurfaceFixture));
+
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.Contains("get_Value", StringComparison.Ordinal));
+
+        var genericType = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(GenericInheritedInterfaceSurfaceFixture));
+        Assert.Contains(
+            genericType.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.Contains("get_Value", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_PreservesAccessorWhenOnlyDerivedInterfaceIsListed()
+    {
+        var path = EmitInheritedInterfaceAccessor();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+
+            Assert.Contains(
+                type.Members,
+                member => member.Kind == "explicit-interface-implementation"
+                    && member.Name == "get_Value");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_PreservesImplementationInheritedThroughExternalInterface()
+    {
+        var path = EmitExternalInheritedInterfaceImplementation();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+            var member = Assert.Single(
+                type.Members,
+                candidate => candidate.Name == "ICollectionGetEnumerator");
+
+            Assert.Equal("explicit-interface-implementation", member.Kind);
+            Assert.Null(member.Accessibility);
+
+            Assert.DoesNotContain(
+                type.Members,
+                candidate => candidate.Name == "MappedToExternalBase");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_PreservesMethodImplWhenInterfaceScopeIsUnresolved()
+    {
+        using var stream = new MemoryStream(EmitUnresolvedInterfaceIdentityImplementation());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+        var member = Assert.Single(type.Members, candidate => candidate.Name == "Mapped");
+
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Null(member.Accessibility);
+    }
+
+    [Fact]
+    public void Extract_PreservesMethodImplWhenDeclarationIdentityIsUnresolved()
+    {
+        using var stream = new MemoryStream(EmitUnresolvedMethodImplDeclarationIdentity());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+        var member = Assert.Single(type.Members, candidate => candidate.Name == "Mapped");
+
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Null(member.Accessibility);
+    }
+
+    [Fact]
+    public void Extract_MetadataReaderOverloadMatchesPeReaderSurface()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var fromPe = ApiSurfaceExtractor.Extract(
+            peReader,
+            includeAll: true,
+            includeCompilerGenerated: true);
+        var fromMetadata = ApiSurfaceExtractor.Extract(
+            peReader.GetMetadataReader(),
+            includeAll: true,
+            includeCompilerGenerated: true);
+
+        Assert.Equal(
+            fromPe.Types.Select(type => type.DefinitionName).ToArray(),
+            fromMetadata.Types.Select(type => type.DefinitionName).ToArray());
+        Assert.Equal(
+            fromPe.Types.SelectMany(type => type.Members).Select(member => member.Name).ToArray(),
+            fromMetadata.Types.SelectMany(type => type.Members).Select(member => member.Name).ToArray());
     }
 
     [Fact]
@@ -1305,6 +1623,484 @@ public class ApiSurfaceExtractorTests
             .SurfaceFieldHandles(reader, typeDef, includeAll: true, includeCompilerGenerated)
             .Select(h => reader.GetString(reader.GetFieldDefinition(h).Name))
             .ToHashSet(StringComparer.Ordinal);
+
+    static string EmitUnownedSpecialNameAccessorMethod()
+    {
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("UnownedSpecialNameAccessor"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("UnownedSpecialNameAccessor");
+        var type = module.DefineType(
+            "SpecialNameFixture",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        var method = type.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Static
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var compoundAssignment = type.DefineMethod(
+            "op_AdditionAssignment",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(void),
+            [type]);
+        compoundAssignment.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        var genericAssignment = type.DefineMethod(
+            "op_IncrementAssignment",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(void),
+            Type.EmptyTypes);
+        genericAssignment.DefineGenericParameters("T");
+        genericAssignment.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        type.CreateType();
+
+        var semanticsType = module.DefineType(
+            "SemanticsFixture",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        var otherProperty = DefineVoidMethod(semanticsType, "OtherProperty");
+        var property = semanticsType.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        property.AddOtherMethod(otherProperty);
+        var raiser = DefineVoidMethod(semanticsType, "RaiseChanged");
+        var otherEvent = DefineVoidMethod(semanticsType, "OtherEvent");
+        var @event = semanticsType.DefineEvent(
+            "Changed",
+            System.Reflection.EventAttributes.None,
+            typeof(Action));
+        @event.SetRaiseMethod(raiser);
+        @event.AddOtherMethod(otherEvent);
+        semanticsType.CreateType();
+
+        var path = Path.Combine(Path.GetTempPath(), $"unowned-special-name-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+
+        static System.Reflection.Emit.MethodBuilder DefineVoidMethod(
+            System.Reflection.Emit.TypeBuilder type,
+            string name)
+        {
+            var method = type.DefineMethod(
+                name,
+                System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+                typeof(void),
+                Type.EmptyTypes);
+            method.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+            return method;
+        }
+    }
+
+    static string EmitPrivateUnqualifiedInterfaceAccessor()
+    {
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("PrivateUnqualifiedInterfaceAccessor"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("PrivateUnqualifiedInterfaceAccessor");
+        var contract = module.DefineType(
+            "IContract",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract);
+        var contractGetter = contract.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var contractProperty = contract.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        contractProperty.SetGetMethod(contractGetter);
+        var contractMethod = contract.DefineMethod(
+            "ContractMethod",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual,
+            typeof(int),
+            Type.EmptyTypes);
+
+        var implementation = module.DefineType(
+            "Implementation",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        implementation.AddInterfaceImplementation(contract);
+        var implementationGetter = implementation.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var il = implementationGetter.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var implementationProperty = implementation.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        implementationProperty.SetGetMethod(implementationGetter);
+        implementation.DefineMethodOverride(implementationGetter, contractGetter);
+        var implementationMethod = implementation.DefineMethod(
+            "MappedMethod",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            typeof(int),
+            Type.EmptyTypes);
+        var methodIl = implementationMethod.GetILGenerator();
+        methodIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_2);
+        methodIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        implementation.DefineMethodOverride(implementationMethod, contractMethod);
+
+        contract.CreateType();
+        implementation.CreateType();
+
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"private-unqualified-interface-accessor-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitInheritedInterfaceAccessor()
+    {
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("InheritedInterfaceAccessor"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("InheritedInterfaceAccessor");
+        var baseInterface = module.DefineType(
+            "IBase",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract);
+        var baseGetter = baseInterface.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var baseProperty = baseInterface.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        baseProperty.SetGetMethod(baseGetter);
+
+        var derivedInterface = module.DefineType(
+            "IDerived",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract);
+        derivedInterface.AddInterfaceImplementation(baseInterface);
+
+        var implementation = module.DefineType(
+            "Implementation",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        implementation.AddInterfaceImplementation(derivedInterface);
+        var implementationGetter = implementation.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var il = implementationGetter.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var implementationProperty = implementation.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        implementationProperty.SetGetMethod(implementationGetter);
+        implementation.DefineMethodOverride(implementationGetter, baseGetter);
+
+        baseInterface.CreateType();
+        derivedInterface.CreateType();
+        implementation.CreateType();
+
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"inherited-interface-accessor-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitExternalInheritedInterfaceImplementation()
+    {
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("ExternalInheritedInterfaceImplementation"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("ExternalInheritedInterfaceImplementation");
+        var intermediateBase = module.DefineType(
+            "IntermediateBase",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Abstract
+                | System.Reflection.TypeAttributes.Class,
+            typeof(System.IO.Stream));
+        intermediateBase.DefineGenericParameters("T");
+        var implementation = module.DefineType(
+            "Implementation",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Abstract
+                | System.Reflection.TypeAttributes.Class,
+            intermediateBase.MakeGenericType(typeof(int)));
+        implementation.AddInterfaceImplementation(typeof(System.Collections.ICollection));
+        var body = implementation.DefineMethod(
+            "ICollectionGetEnumerator",
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            typeof(System.Collections.IEnumerator),
+            Type.EmptyTypes);
+        var il = body.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldnull);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        implementation.DefineMethodOverride(
+            body,
+            typeof(System.Collections.IEnumerable).GetMethod("GetEnumerator")!);
+        var classOverride = implementation.DefineMethod(
+            "MappedToExternalBase",
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            typeof(void),
+            Type.EmptyTypes);
+        var classOverrideIl = classOverride.GetILGenerator();
+        classOverrideIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        implementation.DefineMethodOverride(
+            classOverride,
+            typeof(System.IO.Stream).GetMethod(nameof(System.IO.Stream.Flush), Type.EmptyTypes)!);
+        intermediateBase.CreateType();
+        implementation.CreateType();
+
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"external-inherited-interface-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static byte[] EmitUnresolvedInterfaceIdentityImplementation()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("UnresolvedInterface.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("UnresolvedInterface"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        var coreLib = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        var objectRef = metadata.AddTypeReference(
+            coreLib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+        var targetInterface = metadata.AddTypeReference(
+            coreLib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("IDisposable"));
+        var unresolvedInterfaceSignature = new BlobBuilder();
+        unresolvedInterfaceSignature.WriteByte(0x1d);
+        unresolvedInterfaceSignature.WriteByte(0x12);
+        unresolvedInterfaceSignature.WriteCompressedInteger(
+            (MetadataTokens.GetRowNumber(targetInterface) << 2) | 1);
+        var unresolvedInterface = metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(unresolvedInterfaceSignature));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var derivedInterface = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IDerived"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var implementation = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            objectRef,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var instructions = new BlobBuilder();
+        var encoder = new InstructionEncoder(instructions, new ControlFlowBuilder());
+        encoder.OpCode(ILOpCode.Ret);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = new MethodBodyStreamEncoder(methodBodies)
+            .AddMethodBody(encoder, maxStack: 0);
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x01);
+        var signatureHandle = metadata.GetOrAddBlob(signature);
+        var body = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signatureHandle,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var declaration = metadata.AddMemberReference(
+            targetInterface,
+            metadata.GetOrAddString("Dispose"),
+            signatureHandle);
+        metadata.AddInterfaceImplementation(derivedInterface, unresolvedInterface);
+        metadata.AddInterfaceImplementation(implementation, derivedInterface);
+        metadata.AddMethodImplementation(implementation, body, declaration);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static byte[] EmitUnresolvedMethodImplDeclarationIdentity()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("UnresolvedDeclaration.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("UnresolvedDeclaration"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        var coreLib = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        var objectRef = metadata.AddTypeReference(
+            coreLib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var targetInterface = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("ITarget"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var implementation = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            objectRef,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var malformedParentSignature = new BlobBuilder();
+        malformedParentSignature.WriteByte(0x1d);
+        malformedParentSignature.WriteByte(0x12);
+        malformedParentSignature.WriteCompressedInteger(
+            MetadataTokens.GetRowNumber(targetInterface) << 2);
+        var malformedDeclarationParent = metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(malformedParentSignature));
+
+        var instructions = new BlobBuilder();
+        var encoder = new InstructionEncoder(instructions, new ControlFlowBuilder());
+        encoder.OpCode(ILOpCode.Ret);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = new MethodBodyStreamEncoder(methodBodies)
+            .AddMethodBody(encoder, maxStack: 0);
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x01);
+        var signatureHandle = metadata.GetOrAddBlob(signature);
+        var body = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signatureHandle,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var declaration = metadata.AddMemberReference(
+            malformedDeclarationParent,
+            metadata.GetOrAddString("Mapped"),
+            signatureHandle);
+        metadata.AddInterfaceImplementation(implementation, targetInterface);
+        metadata.AddMethodImplementation(implementation, body, declaration);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
 
     // Emits (via Reflection.Emit) types that exercise every branch of the field-inclusion
     // primitive: an ordinary field, a user field that merely contains "__BackingField", a genuine
@@ -1532,6 +2328,77 @@ public class SampleCustomEventHost
     }
 }
 
+public interface IExplicitSurfaceFixture
+{
+    int Value { get; }
+    event Action Changed;
+    void Run();
+}
+
+public sealed class ExplicitSurfaceFixture : IExplicitSurfaceFixture
+{
+    int IExplicitSurfaceFixture.Value => 42;
+
+    event Action IExplicitSurfaceFixture.Changed
+    {
+        add { }
+        remove { }
+    }
+
+    void IExplicitSurfaceFixture.Run()
+    {
+    }
+}
+
+public sealed class AccessorPrefixMethodFixture
+{
+    public int get_Unused() => 1;
+    public void set_Unused(int value) { }
+    public void add_Unused(int value) { }
+    public void remove_Unused(int value) { }
+    public int op_Custom() => 2;
+    public void op_AdditionAssignment(int value) { }
+}
+
+public class CovariantSurfaceBase
+{
+    public virtual object Value => "base";
+}
+
+public sealed class CovariantSurfaceDerived : CovariantSurfaceBase
+{
+    public override string Value => "derived";
+}
+
+public interface IInheritedSurfaceBase
+{
+    int Value { get; }
+}
+
+public interface IInheritedSurfaceDerived : IInheritedSurfaceBase
+{
+}
+
+public sealed class InheritedInterfaceSurfaceFixture : IInheritedSurfaceDerived
+{
+    int IInheritedSurfaceBase.Value => 1;
+}
+
+public interface IGenericInheritedSurfaceBase<T>
+{
+    T Value { get; }
+}
+
+public interface IGenericInheritedSurfaceDerived<T> : IGenericInheritedSurfaceBase<T>
+{
+}
+
+public sealed class GenericInheritedInterfaceSurfaceFixture :
+    IGenericInheritedSurfaceDerived<int>
+{
+    int IGenericInheritedSurfaceBase<int>.Value => 1;
+}
+
 /// <summary>
 /// Sample class used for testing signature extraction.
 /// </summary>
@@ -1603,6 +2470,36 @@ public class SampleKeywordParameterHost
 
     public static int Static(int @params, int @void) => @params + @void;
 }
+
+public sealed class SampleFinalizerHost
+{
+    ~SampleFinalizerHost() { }
+}
+
+public static class SampleExtensionPropertyHost
+{
+    extension(int number)
+    {
+        public bool IsEven => number % 2 == 0;
+        public int Echo
+        {
+            get => number;
+            set { }
+        }
+        public static int Zero => 0;
+    }
+
+    public static bool get_IsEven<T>(int number) => true;
+
+    extension<T>(SampleExtensionBox<T> value)
+    {
+        public T GenericValue => default!;
+    }
+
+    public static T get_GenericValue<T, TOther>(SampleExtensionBox<T> value) => default!;
+}
+
+public sealed class SampleExtensionBox<T> { }
 
 [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class SampleTypeAttributeHost

--- a/src/dotnet-inspect.Tests/OperatorApiSurfaceTests.cs
+++ b/src/dotnet-inspect.Tests/OperatorApiSurfaceTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+public sealed class OperatorApiSurfaceTests
+{
+    [Fact]
+    public void Extract_ClassifiesOnlyRecognizedNonGenericSpecialNameOperators()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"operator-surface-{Guid.NewGuid():N}.dll");
+        var assembly = new PersistedAssemblyBuilder(
+            new AssemblyName("OperatorSurface"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("OperatorSurface");
+        var type = module.DefineType(
+            "OperatorSurface",
+            TypeAttributes.Public | TypeAttributes.Class);
+
+        DefineMethod(type, "op_AdditionAssignment", MethodAttributes.Public, typeof(int));
+        DefineMethod(
+            type,
+            "op_AdditionAssignment",
+            MethodAttributes.Public | MethodAttributes.SpecialName,
+            typeof(string));
+        var generic = DefineMethod(
+            type,
+            "op_IncrementAssignment",
+            MethodAttributes.Public | MethodAttributes.SpecialName);
+        generic.DefineGenericParameters("T");
+        DefineMethod(
+            type,
+            "op_Custom",
+            MethodAttributes.Public | MethodAttributes.SpecialName);
+        type.CreateType();
+        assembly.Save(path);
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var members = Assert.Single(surface.Types, candidate => candidate.Name == "OperatorSurface").Members;
+
+            var assignments = members
+                .Where(member => member.Name == "op_AdditionAssignment")
+                .Select(member => member.Kind)
+                .Order()
+                .ToArray();
+            Assert.Equal(["method", "operator"], assignments);
+            Assert.Contains(members, member => member.Name == "op_IncrementAssignment" && member.Kind == "method");
+            Assert.Contains(members, member => member.Name == "op_Custom" && member.Kind == "method");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+
+        static MethodBuilder DefineMethod(
+            TypeBuilder type,
+            string name,
+            MethodAttributes attributes,
+            params Type[] parameterTypes)
+        {
+            var method = type.DefineMethod(name, attributes, typeof(void), parameterTypes);
+            method.GetILGenerator().Emit(OpCodes.Ret);
+            return method;
+        }
+    }
+}

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1153,6 +1153,44 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void PopulateMemberSections_FormatsOnlyTypedOperatorsAsOperators()
+    {
+        var type = new ApiType
+        {
+            Name = "Ord",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Kind = "method",
+                    Name = "op_AdditionAssignment",
+                    Signature = "void op_AdditionAssignment(int value)"
+                },
+                new ApiMember
+                {
+                    Kind = "operator",
+                    Name = "op_AdditionAssignment",
+                    Signature = "void op_AdditionAssignment(Ord value)"
+                }
+            ]
+        };
+        var methods = new MethodsView();
+        var operators = new OperatorsView();
+
+        ApiOutputFormatter.PopulateMemberSections(
+            new TypeView(), methods, operators, new ExplicitInterfaceImplementationsView(),
+            new ExtensionMethodsView(), new EventsView(), type, new MemberOptions());
+
+        Assert.Equal("op_AdditionAssignment", Assert.Single(methods.Rows!).Name);
+        Assert.Equal("operator +=", Assert.Single(operators.Rows!).Name);
+
+        var (table, _) = ApiOutputFormatter.BuildTypeTableView(type, new ApiOptions());
+        Assert.Contains(table.Rows!, row => row.Kind.Contains("method") && row.Name == "op_AdditionAssignment");
+        Assert.Contains(table.Rows!, row => row.Kind.Contains("operator") && row.Name == "operator +=");
+    }
+
+    [Fact]
     public async Task WriteSignatureDecodeWarning_EmitsNothingWhenNoMemberDegraded()
     {
         Assert.Empty(await CaptureErrorAsync(() => ApiOutputFormatter.WriteSignatureDecodeWarning(new TypeView())));

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -463,7 +463,7 @@ public static class ApiOutputFormatter
         bool topFieldsOnly = options.Verbosity == Verbosity.Quiet
             || (options is TypeOptions { MarkdownExplicitlySet: true } && !memberDetail);
         var title = memberDetail
-            ? $"{FormatGenericFullName(type)}.{OperatorNames.FormatDisplayName(selectedMember!.Name)}"
+            ? $"{FormatGenericFullName(type)}.{FormatMemberDisplayName(selectedMember!)}"
             : $"{FormatGenericFullName(type)}{packageInfo}";
 
         return new TypeView
@@ -572,13 +572,13 @@ public static class ApiOutputFormatter
                             : expandOverloads
                                 ? group
                                     .GroupBy(m => m.Name)
-                                    .OrderBy(g => OperatorNames.FormatDisplayName(g.Key), StringComparer.Ordinal)
+                                    .OrderBy(g => FormatMemberDisplayName(g.First()), StringComparer.Ordinal)
                                     .SelectMany(overloads => overloads
                                         .OrderBy(GetMemberSignatureSortKey, StringComparer.Ordinal)
                                         .Select(member => new List<ApiMember> { member }))
                             : group
                                 .GroupBy(m => m.Name)
-                                .OrderBy(g => OperatorNames.FormatDisplayName(g.Key), StringComparer.Ordinal)
+                                .OrderBy(g => FormatMemberDisplayName(g.First()), StringComparer.Ordinal)
                                 .Select(overloads => overloads
                                     .OrderBy(GetMemberSignatureSortKey, StringComparer.Ordinal)
                                     .ToList()))
@@ -616,14 +616,14 @@ public static class ApiOutputFormatter
             {
                 var groups = members
                     .GroupBy(m => m.Name)
-                    .OrderBy(g => OperatorNames.FormatDisplayName(g.Key), StringComparer.Ordinal)
+                    .OrderBy(g => FormatMemberDisplayName(g.First()), StringComparer.Ordinal)
                     .ToList();
 
                 if (expandOverloads)
                 {
                     return groups
                         .SelectMany(g => g.OrderBy(GetMemberSignatureSortKey, StringComparer.Ordinal))
-                        .Select(m => new TreeNode(CSharpIdentifier.ContainRenderedText(m.Signature ?? OperatorNames.FormatDisplayName(m.Name))))
+                        .Select(m => new TreeNode(CSharpIdentifier.ContainRenderedText(m.Signature ?? FormatMemberDisplayName(m))))
                         .ToList();
                 }
 
@@ -634,9 +634,9 @@ public static class ApiOutputFormatter
                             .OrderBy(GetMemberSignatureSortKey, StringComparer.Ordinal)
                             .ToList();
                         if (ordered.Count == 1)
-                            return new TreeNode(CSharpIdentifier.ContainRenderedText(ordered[0].Signature ?? OperatorNames.FormatDisplayName(ordered[0].Name)));
+                            return new TreeNode(CSharpIdentifier.ContainRenderedText(ordered[0].Signature ?? FormatMemberDisplayName(ordered[0])));
 
-                        var displayName = OperatorNames.FormatDisplayName(g.Key);
+                        var displayName = FormatMemberDisplayName(ordered[0]);
                         return new TreeNode($"{displayName} ({ordered.Count} overloads)");
                     })
                     .ToList();
@@ -647,7 +647,7 @@ public static class ApiOutputFormatter
                 .Select(m => new TreeNode(
                     m.IsFinalizer
                         ? ShapeDestructorSpelling(declaringTypeName)
-                        : CSharpIdentifier.ContainRenderedText(m.Signature ?? OperatorNames.FormatDisplayName(m.Name))))
+                        : CSharpIdentifier.ContainRenderedText(m.Signature ?? FormatMemberDisplayName(m))))
                 .ToList();
         }
 
@@ -804,7 +804,7 @@ public static class ApiOutputFormatter
 
         var rows = enumMembers.Select(m => new EnumValueRow
         {
-            Name = OperatorNames.FormatDisplayName(m.Name),
+            Name = FormatMemberDisplayName(m),
             Value = m.EnumValue.ToString()!,
             Description = hasAnyDocs ? (m.Documentation.Summary ?? "") : null
         }).ToList();
@@ -892,7 +892,7 @@ public static class ApiOutputFormatter
                 var digest = ApiMemberIdentity.GetMemberAnchor(type, m).Fingerprint;
                 return new MemberRow(
                     select,
-                    OperatorNames.FormatDisplayName(m.Name),
+                    FormatMemberDisplayName(m),
                     MarkoutInline.Code(digest),
                     MarkoutInline.Code(sigDisplay),
                     hasDocs ? (m.Documentation.Summary ?? "") : null);
@@ -1162,7 +1162,7 @@ public static class ApiOutputFormatter
                 {
                     var rows = byName.Select(e =>
                         new ConstructorSummaryRow(
-                            OperatorNames.FormatDisplayName(e.members[0].Name),
+                            FormatMemberDisplayName(e.members[0]),
                             e.members.Count.ToString(),
                             SignatureDecodeMarker(e.members))).ToList();
                     if (hasOverloads)
@@ -1175,7 +1175,7 @@ public static class ApiOutputFormatter
                 {
                     var rows = byName.Select(e =>
                         new ConstructorSummaryRow(
-                            OperatorNames.FormatDisplayName(e.members[0].Name),
+                            FormatMemberDisplayName(e.members[0]),
                             e.members.Count.ToString(),
                             SignatureDecodeMarker(e.members))).ToList();
                     view.FinalizerSummaryRows = rows;
@@ -1185,7 +1185,7 @@ public static class ApiOutputFormatter
                 {
                     var rows = byName.Select(e =>
                         new MethodSummaryRow(
-                            OperatorNames.FormatDisplayName(e.members[0].Name),
+                            FormatMemberDisplayName(e.members[0]),
                             MemberReturnType(e.members[0]),
                             e.members.Count.ToString(),
                             SignatureDecodeMarker(e.members))).ToList();
@@ -1201,7 +1201,7 @@ public static class ApiOutputFormatter
                     {
                         var m = e.members[0];
                         return new PropertySummaryRow(
-                            OperatorNames.FormatDisplayName(m.Name),
+                            FormatMemberDisplayName(m),
                             MemberReturnType(m),
                             MemberAccessors(m),
                             SignatureDecodeMarker(e.members));
@@ -1213,7 +1213,7 @@ public static class ApiOutputFormatter
                 {
                     var rows = byName.Select(e =>
                         new FieldSummaryRow(
-                            OperatorNames.FormatDisplayName(e.members[0].Name),
+                            FormatMemberDisplayName(e.members[0]),
                             CSharpIdentifier.ContainRenderedText(e.members[0].ReturnType ?? ""),
                             SignatureDecodeMarker(e.members))).ToList();
                     view.FieldSummaryRows = rows;
@@ -1225,7 +1225,7 @@ public static class ApiOutputFormatter
                     {
                         var m = e.members[0];
                         return new EventSummaryRow(
-                            OperatorNames.FormatDisplayName(m.Name),
+                            FormatMemberDisplayName(m),
                             CSharpIdentifier.ContainRenderedText(m.ReturnType ?? m.Signature ?? ""));
                     }).ToList();
                     eventsView.SummaryRows = rows;
@@ -2750,7 +2750,12 @@ public static class ApiOutputFormatter
     /// </remarks>
     internal static string GetMemberDisplaySignature(ApiType type, ApiMember member)
         => CSharpIdentifier.ContainRenderedText(
-            member.Signature ?? $"{FormatGenericFullName(type)}.{OperatorNames.FormatDisplayName(member.Name)}");
+            member.Signature ?? $"{FormatGenericFullName(type)}.{FormatMemberDisplayName(member)}");
+
+    internal static string FormatMemberDisplayName(ApiMember member)
+        => member.Kind == "operator"
+            ? OperatorNames.FormatDisplayName(member.Name)
+            : CSharpIdentifier.ContainRenderedText(member.Name);
 
     private static string GetMemberSelectorName(ApiMember member)
         => ApiMemberIdentity.GetMemberSelectorName(member);
@@ -2847,7 +2852,7 @@ public static class ApiOutputFormatter
                 _ => ""
             };
             var kindLabel = m.Accessibility != null ? $"{m.Accessibility} {e.kind}" : e.kind;
-            return new ApiTableRow(kindLabel, OperatorNames.FormatDisplayName(m.Name), returnType, detail);
+            return new ApiTableRow(kindLabel, FormatMemberDisplayName(m), returnType, detail);
         }).ToList();
 
         return (new ApiTypeTableView { Rows = rows }, truncated);

--- a/tests/CSharpText.Tests/OperatorNamesTests.cs
+++ b/tests/CSharpText.Tests/OperatorNamesTests.cs
@@ -62,17 +62,78 @@ public class OperatorNamesTests
         => Assert.Equal(expected, OperatorNames.FormatDisplayName(input));
 
     [Theory]
+    [InlineData("op_AdditionAssignment", "operator +=")]
+    [InlineData("op_CheckedAdditionAssignment", "checked operator +=")]
+    [InlineData("op_ModulusAssignment", "operator %=")]
+    [InlineData("op_CheckedMultiplicationAssignment", "checked operator *=")]
+    [InlineData("op_IncrementAssignment", "operator ++")]
+    [InlineData("op_CheckedIncrementAssignment", "checked operator ++")]
+    public void Assignment_operators(string input, string expected)
+        => Assert.Equal(expected, OperatorNames.FormatDisplayName(input));
+
+    [Theory]
     [InlineData("ToString")]
     [InlineData("GetHashCode")]
     [InlineData("Equals")]
     [InlineData("get_Length")]
     [InlineData("set_Value")]
+    [InlineData("op_CheckedModulusAssignment")]
+    [InlineData("op_CheckedBitwiseAndAssignment")]
+    [InlineData("op_CheckedUnsignedRightShiftAssignment")]
     public void Non_operator_names_pass_through(string input)
         => Assert.Equal(input, OperatorNames.FormatDisplayName(input));
 
     [Fact]
     public void Unknown_op_prefix_passes_through()
         => Assert.Equal("op_SomeFutureOp", OperatorNames.FormatDisplayName("op_SomeFutureOp"));
+
+    [Theory]
+    [InlineData("op_AdditionAssignment")]
+    [InlineData("op_CheckedAdditionAssignment")]
+    [InlineData("op_CheckedMultiplicationAssignment")]
+    [InlineData("op_IncrementAssignment")]
+    [InlineData("op_CheckedIncrementAssignment")]
+    [InlineData("op_Exponent")]
+    [InlineData("op_IntegerDivision")]
+    [InlineData("op_Concatenate")]
+    [InlineData("op_Like")]
+    public void Recognizes_language_operator_names(string input)
+        => Assert.True(OperatorNames.IsOperatorMethodName(input));
+
+    [Theory]
+    [InlineData("op_Custom")]
+    [InlineData("op_SomeFutureOp")]
+    [InlineData("op_CheckedModulusAssignment")]
+    [InlineData("op_CheckedBitwiseAndAssignment")]
+    [InlineData("op_CheckedUnsignedRightShiftAssignment")]
+    public void Rejects_unknown_op_prefix_names(string input)
+        => Assert.False(OperatorNames.IsOperatorMethodName(input));
+
+    [Theory]
+    [InlineData("op_AdditionAssignment", false, true, "void", 1, true)]
+    [InlineData("op_CheckedMultiplicationAssignment", false, true, "void", 1, true)]
+    [InlineData("op_IncrementAssignment", false, true, "void", 0, true)]
+    [InlineData("op_AdditionAssignment", true, true, "void", 1, false)]
+    [InlineData("op_AdditionAssignment", false, false, "void", 1, false)]
+    [InlineData("op_AdditionAssignment", false, true, "int", 1, false)]
+    [InlineData("op_AdditionAssignment", false, true, "void", 2, false)]
+    [InlineData("op_IncrementAssignment", false, true, "void", 1, false)]
+    [InlineData("op_CheckedModulusAssignment", false, true, "void", 1, false)]
+    public void CSharp_instance_assignment_operator_shape(
+        string name,
+        bool isStatic,
+        bool isPublic,
+        string returnType,
+        int parameterCount,
+        bool expected)
+        => Assert.Equal(
+            expected,
+            OperatorNames.IsCSharpInstanceAssignmentOperator(
+                name,
+                isStatic,
+                isPublic,
+                returnType,
+                parameterCount));
 
     [Theory]
     [InlineData("op_CheckedAddition", "op_Addition")]
@@ -84,6 +145,9 @@ public class OperatorNamesTests
     [InlineData("op_CheckedUnaryNegation", "op_UnaryNegation")]
     [InlineData("op_CheckedExplicit", "op_Explicit")]
     [InlineData("op_CheckedImplicit", "op_Implicit")]
+    [InlineData("op_CheckedAdditionAssignment", "op_AdditionAssignment")]
+    [InlineData("op_CheckedMultiplicationAssignment", "op_MultiplicationAssignment")]
+    [InlineData("op_CheckedIncrementAssignment", "op_IncrementAssignment")]
     public void UncheckedOperator_maps_checked_operator_to_its_sibling(string input, string expected)
         => Assert.Equal(expected, OperatorNames.UncheckedOperator(input));
 
@@ -91,9 +155,25 @@ public class OperatorNamesTests
     [InlineData("op_Addition")]
     [InlineData("op_Explicit")]
     [InlineData("op_CheckedModulus")]
+    [InlineData("op_CheckedModulusAssignment")]
+    [InlineData("op_CheckedBitwiseAndAssignment")]
+    [InlineData("op_CheckedUnsignedRightShiftAssignment")]
     [InlineData("op_Checked")]
     [InlineData("get_Length")]
     [InlineData("ToString")]
     public void UncheckedOperator_returns_null_for_non_checked_or_unpaired_names(string input)
         => Assert.Null(OperatorNames.UncheckedOperator(input));
+
+    [Theory]
+    [InlineData("op_Addition", "op_CheckedAddition")]
+    [InlineData("op_Explicit", "op_CheckedExplicit")]
+    [InlineData("op_AdditionAssignment", "op_CheckedAdditionAssignment")]
+    [InlineData("op_Implicit", null)]
+    [InlineData("op_Modulus", null)]
+    [InlineData("op_Equality", null)]
+    [InlineData("get_Length", null)]
+    public void CheckedOperator_maps_only_operators_with_checked_siblings(
+        string input,
+        string? expected)
+        => Assert.Equal(expected, OperatorNames.CheckedOperator(input));
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -3895,10 +3895,20 @@ static class FidelityCheck
             ? slotModifier
             : (isAbstractStub || emitClassVirtual ? "virtual " : "");
         if (!IsStaticClass(typeDef)
+            && method.Attributes.HasFlag(MethodAttributes.SpecialName)
+            && method.GetGenericParameters().Count == 0
             && name.StartsWith("op_", StringComparison.Ordinal)
-            && OperatorDeclaration(name, returnType, parameters) is { } operatorDeclaration)
+            && OperatorDeclaration(
+                name,
+                returnType,
+                parameters,
+                isStatic,
+                sig.ParameterTypes.Length) is { } operatorDeclaration)
         {
-            sb.AppendLine($"{pad}public {unsafeModifier}static {operatorDeclaration} {{{body}}}");
+            string operatorStaticModifier = OperatorNames.IsAssignmentOperatorMethodName(name)
+                ? ""
+                : "static ";
+            sb.AppendLine($"{pad}public {unsafeModifier}{operatorStaticModifier}{operatorDeclaration} {{{body}}}");
             return;
         }
         sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : instanceModifier)}{asyncModifier}{returnType} {Identifier(name)}{genParams}({parameters}){whereClauses} {{{body}}}");
@@ -3944,10 +3954,27 @@ static class FidelityCheck
         };
     }
 
-    static string? OperatorDeclaration(string name, string returnType, string parameters)
+    static string? OperatorDeclaration(
+        string name,
+        string returnType,
+        string parameters,
+        bool isStatic,
+        int parameterCount)
     {
+        if (OperatorNames.IsAssignmentOperatorMethodName(name)
+            && !OperatorNames.IsCSharpInstanceAssignmentOperator(
+                name,
+                isStatic,
+                isPublic: true,
+                returnType,
+                parameterCount))
+        {
+            return null;
+        }
+
         if (name.StartsWith("op_Checked", StringComparison.Ordinal)
-            && OperatorNames.MapBinaryOrUnary(name["op_Checked".Length..]) is { } checkedSymbol)
+            && (OperatorNames.MapBinaryOrUnary(name["op_Checked".Length..])
+                ?? OperatorNames.MapCheckedAssignment(name["op_Checked".Length..])) is { } checkedSymbol)
             return $"{returnType} operator checked {checkedSymbol}({parameters})";
 
         return name switch


### PR DESCRIPTION
Advances #3091 and #2777

**Conclusion: PASS** — product metadata now owns accessor membership, finalizer disclosure, extension-property implementation methods, and proven MethodImpl ownership without silently dropping unresolved external declarations.

## Stack

- Slice 3 of 4
- Parent: #4142
- Child: #4143
- Base: `feature/rts-operator-identity`
- Residual: #4143 moves RTS reconstruction onto this product-owned inventory.

## Change

- Adds the `MetadataReader` extraction entry point and complete typed member inventory.
- Tracks accessor ownership by metadata handle rather than name prefixes.
- Distinguishes interface MethodImpl ownership from class overrides, including generic bases and finalizers.
- Preserves unresolved external MethodImpl declarations as visible inspection evidence.
- Handles extension-property implementation accessors with generic-arity identity.
- Reuses one immutable assembly surface index across consumers.

## Scope and safety

This slice changes only `ApiSurfaceExtractor` and its direct product tests. RTS orchestration is intentionally deferred to #4143.

## Evidence

- Product test project builds independently at `2fe5a768c`.
- All 63 `ApiSurfaceExtractorTests` pass.
- The cross-platform `BodyShapeSearchMetadataTests.Search_DefaultIncludesNestedExternalExplicitInterface` regression now passes.
- The complete reconstructed stack builds and passes the full 5,214-case oracle-backed decompiler suite with zero failures or skips.

Evidence revision: `2fe5a768c`