### PR TITLE
Remove duplicate xUnit theory rows

### DIFF
--- a/tests/ILInspector.Metadata.Tests/MethodHasBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MethodHasBodyTests.cs
@@ -15,8 +15,8 @@ public class MethodHasBodyTests
     static string CoreLibPath => typeof(object).Assembly.Location;
 
     [Theory]
+    // -1 is the same runtime value as unchecked((int)0xFFFFFFFF), so one row covers both spellings.
     [InlineData(-1)]
-    [InlineData(unchecked((int)0xFFFFFFFF))]
     [InlineData(0x7F000001)]
     public void InvalidToken_IsUnknown_AndDoesNotThrow(int token)
     {

--- a/tests/ILInspector.Metadata.Tests/SourceLinkProvenanceTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SourceLinkProvenanceTests.cs
@@ -927,12 +927,11 @@ public class SourceLinkProvenanceTests
     /// </para>
     /// </remarks>
     [Theory]
-    // Project supplied; the account is a path segment.
+    // Project supplied; the account is a path segment. A team is dropped and produces this
+    // same URL, so the generator's Project and Project_Team cases collapse to one reader row.
     [InlineData("https://dev.azure.com/account/project/_apis/git/repositories/repo/items", "account/project", "repo")]
     // No project in the repository URL: the generator uses the repository name as the project.
     [InlineData("https://dev.azure.com/account/repo/_apis/git/repositories/repo/items", "account/repo", "repo")]
-    // A team in the repository URL is dropped rather than emitted.
-    [InlineData("https://dev.azure.com/account/project/_apis/git/repositories/repo/items", "account/project", "repo")]
     // A '.git' suffix is part of the repository name and is preserved.
     [InlineData("https://dev.azure.com/org/project/_apis/git/repositories/repo.git/items", "org/project", "repo.git")]
     // The legacy spelling: the account is the host label, so only the project precedes '_apis'.


### PR DESCRIPTION
Removes two byte-for-byte duplicate theory inputs that xUnit1025 now rejects in CI. The retained rows exercise the same runtime values and expected outcomes, so test behavior and coverage are unchanged.

This unblocks #3429, whose Linux and Windows jobs currently stop on the SourceLink duplicate before executing tests. The metadata build also exposed the equivalent `-1` / `unchecked((int)0xFFFFFFFF)` duplicate in `MethodHasBodyTests`, so this removes both analyzer failures together.

**Validation**

- `dotnet build dotnet-inspect.slnx -c Release --nologo`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — 1420 total, 0 failed, 5 skipped

**Review tier:** trivial; no adversarial review. The change only collapses identical serialized theory arguments and keeps comments recording why the source generator cases map to one reader row.