### PR TITLE
Make EvilPool sweep sources hermetic

### DIFF
--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -460,6 +460,24 @@ string? cacheBasePath = Environment.GetEnvironmentVariable("DOTNET_INSPECT_CACHE
 if (isolated && cacheBasePath == null)
     cacheBasePath = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-{sessionName}");
 
+NuGetSourceOptions? sourceOptions = null;
+string? nugetConfig = Environment.GetEnvironmentVariable("DOTNET_INSPECT_SWEEP_NUGET_CONFIG");
+if (!string.IsNullOrWhiteSpace(nugetConfig))
+{
+    // Sweep-specific rather than a restore setting: the file-based app still restores
+    // with the caller's ordinary NuGet configuration, while package acquisition uses
+    // this explicit boundary. EvilPoolSweepGateTests deletes the named file in one case
+    // so losing either the environment forwarding or this read fails visibly.
+    if (NuGetSourceResolver.DescribeConfigProblem(nugetConfig) is string problem)
+    {
+        Console.Error.WriteLine(problem);
+        Environment.ExitCode = 2;
+        return;
+    }
+
+    sourceOptions = new NuGetSourceOptions { ConfigFile = nugetConfig };
+}
+
 HttpClientFactory.Initialize(offline);
 NuGetCache.Initialize("dotnet-inspect", cacheBasePath, skipNuGetCache: isolated);
 
@@ -490,6 +508,7 @@ foreach (var entry in selected)
                 HttpClientFactory.Shared,
                 entry.Package,
                 tempDirPrefix: "decompiler-package-sweep",
+                sourceOptions: sourceOptions,
                 version: honorPin ? pin!.Version : null,
                 forceLatest: !honorPin);
         }

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Xml.Linq;
 using DotnetInspector.Packages;
 using Xunit;
 
@@ -36,12 +37,12 @@ namespace ILInspector.Decompiler.Tests;
 /// It resolves its inputs from the repository root above its working directory, so a
 /// directory holding a <c>dotnet-inspect.slnx</c> and a <c>docs/data</c> feeds a real run
 /// a package list and pin of this suite's choosing -- no product path override is
-/// involved. It is pointed at a scratch cache holding two synthetic packages and told to
-/// stay offline, so <em>it</em> acquires over no network and reads no shared cache, and
-/// nothing it pools or acquires comes from outside the scratch directory. Offline is what
-/// keeps that honest: a case that stopped being served from the seeded cache would reach
-/// for the network and fail here rather than quietly passing on whatever the machine
-/// happened to have.</para>
+/// involved. It is pointed at a scratch cache holding two synthetic packages, given an
+/// explicit source config owned by that world, and told to stay offline, so <em>it</em>
+/// acquires over no network and reads no shared cache, and nothing it pools or acquires
+/// comes from outside the scratch directory. Offline is what keeps that honest: a case
+/// that stopped being served from the seeded cache would reach for the network and fail
+/// here rather than quietly passing on whatever the machine happened to have.</para>
 ///
 /// <para>The claim stops there, deliberately. Each case launches the sweep with
 /// <c>dotnet run</c>, and a file-based app is restored and built before it runs, which
@@ -56,19 +57,11 @@ namespace ILInspector.Decompiler.Tests;
 [Trait("Area", "Corpus")]
 public class EvilPoolSweepGateTests
 {
-    /// <summary>
-    /// Identity of the source these fixtures speak for. Cached content is scoped
-    /// to the source that committed it, so a test that seeds the cache by hand
-    /// must use the same source the code under test resolves — otherwise the
-    /// seeded entry is correctly invisible.
-    /// </summary>
-    private static readonly string TestSourceKey =
-        NuGetCache.GetSourceKey("https://api.nuget.org/v3/index.json");
-
     const string FixturePackage = "sweep.fixture";
     const string FixtureVersion = "1.0.0";
     const string FixtureTfm = "net8.0";
     const string FixtureAssembly = "Sweep.Fixture.dll";
+    const string NuGetOrgSource = "https://api.nuget.org/v3/index.json";
 
     // A second package, ranked ahead of the one each case is about, which every sweep here
     // pools successfully before reaching the subject. See SweepWorld for why the subject is
@@ -135,6 +128,23 @@ public class EvilPoolSweepGateTests
             entry["AssemblyPath"]!.GetValue<string>());
 
         world.AssertNoTemporaryLeftBehind();
+    }
+
+    /// <summary>
+    /// The explicit source boundary is required and its loss is a stated refusal, not a
+    /// fallback to ambient sources or a raw process failure.
+    /// </summary>
+    [Fact]
+    public void ASweepRefusesWhenItsExplicitSourceConfigDisappears()
+    {
+        using var world = SweepWorld.Create();
+        File.Delete(world.NuGetConfigPath);
+
+        var sweep = world.Run();
+
+        Assert.True(sweep.ExitCode == 2, world.Explain(sweep, "a missing explicit source config"));
+        Assert.Contains($"NuGet config file not found: '{world.NuGetConfigPath}'.", sweep.Errors);
+        Assert.False(File.Exists(world.ManifestPath));
     }
 
     /// <summary>
@@ -1394,6 +1404,15 @@ public class EvilPoolSweepGateTests
 
         public string CacheDirectory { get; }
 
+        /// <summary>
+        /// The fixture-owned source whose identity scopes the synthetic cache entries.
+        /// It is intentionally not nuget.org, so ambient configuration cannot make a
+        /// missing explicit-config boundary pass by coincidence.
+        /// </summary>
+        public string FixtureSource => Path.Combine(Scratch, "source");
+
+        public string NuGetConfigPath => Path.Combine(Scratch, "config", "sweep.config");
+
         public byte[] FixtureBytes { get; }
 
         /// <summary>The lead package's assembly, pooled ahead of the subject in every case.</summary>
@@ -1454,6 +1473,7 @@ public class EvilPoolSweepGateTests
                 string cacheDirectory = Path.Combine(scratch, "cache");
                 var world = new SweepWorld(scratch, cacheDirectory, bytes);
 
+                world.WriteSourceConfig();
                 world.SeedCache();
                 world.WriteInputs(version ?? FixtureVersion, tfm ?? FixtureTfm, status ?? "pinned");
                 return world;
@@ -1463,6 +1483,28 @@ public class EvilPoolSweepGateTests
                 Directory.Delete(scratch, recursive: true);
                 throw;
             }
+        }
+
+        void WriteSourceConfig()
+        {
+            Directory.CreateDirectory(FixtureSource);
+            Directory.CreateDirectory(Path.GetDirectoryName(NuGetConfigPath)!);
+
+            new XDocument(
+                new XElement(
+                    "configuration",
+                    new XElement(
+                        "packageSources",
+                        new XElement("clear"),
+                        new XElement(
+                            "add",
+                            new XAttribute("key", "evil-sweep-fixture"),
+                            new XAttribute("value", FixtureSource)),
+                        new XElement(
+                            "add",
+                            new XAttribute("key", "nuget.org"),
+                            new XAttribute("value", NuGetOrgSource)))))
+                .Save(NuGetConfigPath);
         }
 
         void SeedCache()
@@ -1510,7 +1552,12 @@ public class EvilPoolSweepGateTests
         /// <c>!IsSelected</c> arm has something to be about.
         /// </summary>
         void CommitWithoutLibrary(string package) =>
-            NuGetCache.CommitPackage(Stage(package), null, package, FixtureVersion, TestSourceKey);
+            NuGetCache.CommitPackage(
+                Stage(package),
+                null,
+                package,
+                FixtureVersion,
+                NuGetCache.GetSourceKey(FixtureSource));
 
         /// <summary>
         /// Stages one synthetic package and commits it, answering with the path the product
@@ -1528,10 +1575,11 @@ public class EvilPoolSweepGateTests
             Directory.CreateDirectory(Path.Combine(staged, "lib", FixtureTfm));
             File.WriteAllBytes(Path.Combine(staged, "lib", FixtureTfm, assembly), bytes);
 
-            NuGetCache.CommitPackage(staged, null, package, FixtureVersion, TestSourceKey);
+            string sourceKey = NuGetCache.GetSourceKey(FixtureSource);
+            NuGetCache.CommitPackage(staged, null, package, FixtureVersion, sourceKey);
 
             string committed = Path.Combine(
-                NuGetCache.GetPackageCachePath(package, FixtureVersion, TestSourceKey),
+                NuGetCache.GetPackageCachePath(package, FixtureVersion, sourceKey),
                 "lib",
                 FixtureTfm,
                 assembly);
@@ -1798,6 +1846,7 @@ public class EvilPoolSweepGateTests
             startInfo.Environment["DOTNET_INSPECT_OFFLINE"] = "1";
             startInfo.Environment["DOTNET_INSPECT_ISOLATED"] = "evil-sweep-gate";
             startInfo.Environment["DOTNET_INSPECT_CACHE_DIR"] = CacheDirectory;
+            startInfo.Environment["DOTNET_INSPECT_SWEEP_NUGET_CONFIG"] = NuGetConfigPath;
 
             // NUGET_PACKAGES is deliberately left alone, and cannot be used for isolation.
             // The sweep is a file-based app, so this subprocess restores itself before it


### PR DESCRIPTION
Closes #3796.

- **Change:** test-harness source isolation; product behavior is unchanged.
- **Evidence revision:** `3ef6f615`

## Change

`EvilPoolSweepGateTests` previously committed synthetic packages under the
nuget.org source key while the sweep subprocess derived its allowed source keys
from ambient user NuGet configuration. Disabling nuget.org made every seeded
entry correctly invisible and turned the local fast lane red.

The synthetic sweep world now owns an explicit NuGet config:

1. A fixture-local source owns the synthetic cache entries.
2. nuget.org remains second so the existing network/shared-cache isolation
   canary still detects either isolation knob being removed.
3. `DOTNET_INSPECT_SWEEP_NUGET_CONFIG` passes that config only to sweep package
   acquisition; the file-based app restore keeps the caller's ordinary NuGet
   settings.
4. An unset variable preserves real-sweep behavior.

The fixture-local source is deliberately distinct from every ambient source.
That makes the boundary non-vacuous in CI: removing either the config forwarding
or the sweep's config read makes the successful pool case fail on a source-key
mismatch.

## Failure behavior

An explicitly named config that is missing or unusable exits 2 with the existing
NuGet-config diagnostic before acquisition. A dedicated canary deletes the file
and proves the sweep neither falls back to ambient sources nor exits through a
raw exception.

## Evidence

| Check | Result |
| --- | --- |
| Baseline success case at `9ee8576a` with user-disabled nuget.org | Reproduced: both synthetic packages failed acquisition |
| Release solution build | Pass |
| Explicit source-boundary cases | 2/2 pass |
| Complete `EvilPoolSweepGateTests` | 20 pass, 8 expected Windows platform skips, 0 fail |
| Complete decompiler fast lane | 4,549 pass, 8 expected Windows platform skips, 0 fail |
| Exact-head CI run `30921119895` | Pass, including Linux/Windows tests and `ci-required` |
| MAI-Code quick read | Clean; early signal only, not a formal review round |

## Adversarial review

GPT-5.6 Sol and Claude Opus 5 both returned clean at exact head `3ef6f615`.
Both rebuilt Release and passed the complete sweep class under the ambient
nuget.org-disabled user config. Claude additionally mutation-tested removal of
the config forwarding, exercised invalid-config refusals, and verified
cross-platform source-key alignment and source order. Both review worktrees
remained clean.

## Boundaries

- Source-scoped cache authorization is unchanged and is the mechanism this fix
  relies on.
- No user or machine NuGet configuration is modified.
- The sweep remains offline and isolated in these tests.
- `NUGET_PACKAGES` remains untouched so the file-based app can restore normally.
