### PR TITLE
Metadata: issue unresolved binding join currency

### DIFF
--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -2169,9 +2169,19 @@ permissiveness rule to keep synchronized with the matcher.
   assembly/module/current origin instead of collapsing failures into one
   bucket.
 
+`TypeResolutionOutcome.UnboundBinding` and
+`TypeResolutionOutcome.Unavailable` carry an opaque, non-hashable
+`UnresolvedBindingReference` minted beside the terminal cached binding answer.
+Candidate-open failures remain `Rejected` and never receive that reference.
+`TypeResolutionCatalog.ProjectUnresolvedBindingKey` projects a current
+reference into `UnresolvedBindingKey`; its closed result distinguishes
+`Issued`, `IncomparableCatalogs`, and `StaleGeneration`.
+
 `UnresolvedBindingKey` has the same internal-constructor and generation scope
 as `DefinitionJoinToken`; it cannot survive or compare across a generation
-advance.
+advance. The catalog issues one key for one complete binding request in one
+generation, whether policy authoritatively found no candidate
+(`UnboundBinding`) or could not provide one (`Unavailable`).
 
 `TypeResolutionCatalog.ProjectDefinitionJoinToken` returns a closed
 `DefinitionJoinTokenProjection` result. `Issued` carries the token;
@@ -2273,12 +2283,14 @@ public sealed class UnresolvedBindingKey : IEquatable<UnresolvedBindingKey>
 }
 ```
 
-The constructor and `(catalog, generation, value)` fields are internal. Equality
-and hashing use that triple plus `Kind`; class-scoped `Evidence` is excluded.
-The catalog returns one token class for every definition correspondence class
-in a frozen generation. Duplicate-artifact tokens deliberately join but retain
-an indeterminate kind; consumers cannot construct an exact token or change an
-issued token's kind.
+The constructors and `(catalog, generation, value)` fields are internal.
+Definition-token equality and hashing use that triple plus `Kind`;
+class-scoped `Evidence` is excluded. Unresolved-binding-key equality and
+hashing use the triple. The catalog returns one token class for every definition
+correspondence class and one unresolved key for every eligible complete binding
+request in a frozen generation. Duplicate-artifact tokens deliberately join but
+retain an indeterminate kind; consumers cannot construct an exact token or
+change an issued token's kind.
 
 Named types nested under generic instances, arrays, byrefs, and pointers use the
 same recursive correspondence projection. Replacing only the declaring
@@ -2294,9 +2306,11 @@ Graph joins hash only catalog-issued join tokens, never
 When both sides have the same degraded key under one catalog and binding scope,
 the graph likewise retains an `IndeterminateCorrespondence` edge and emits
 incomplete-graph evidence; it does not report exact definition correspondence.
-`NotFound`, ambiguous, rejected, or cross-catalog uses do not degraded-join.
-Every non-success remains attached to its storage node, never enters a shared
-unresolved bucket, and never becomes an ordinary "no edge."
+Both `UnboundBinding` and `Unavailable` are eligible because each preserves the
+complete terminal binding request. `NotFound`, ambiguous, rejected, or
+cross-catalog uses do not degraded-join. Every non-success remains attached to
+its storage node, never enters a shared unresolved bucket, and never becomes an
+ordinary "no edge."
 
 Today's graph joins on canonical simple assembly names and therefore merges
 version, culture, token, and several core-library facade spellings. The
@@ -2578,9 +2592,10 @@ definition keys, with no spelling alias model.
 Slice 6 is in progress under
 [#3780](https://github.com/richlander/dotnet-inspect/issues/3780). Metadata
 currently issues generation-scoped `DefinitionJoinToken` values for exact and
-duplicate-indeterminate TypeDef correspondence classes. Unavailable binding
-keys, member-level correspondence, graph migration, and cache-lifetime binding
-remain to be delivered.
+duplicate-indeterminate TypeDef correspondence classes and
+`UnresolvedBindingKey` values for complete unbound or unavailable binding
+requests. Member-level correspondence, graph migration, and cache-lifetime
+binding remain to be delivered.
 
 Claim: direct callers and transitive call graphs share one definition identity.
 
@@ -2605,6 +2620,10 @@ Claim: direct callers and transitive call graphs share one definition identity.
   `UnresolvedBindingKey` values agree across `Equals`, `==`, `!=`, and hashing.
 - Every `DefinitionJoinTokenProjection` arm is produced by a focused gate;
   cross-catalog and stale keys never receive an `Issued` result.
+- Every `UnresolvedBindingKeyProjection` arm is produced by a focused gate;
+  only `UnboundBinding` and genuine policy `Unavailable` outcomes expose its
+  opaque projection input, and cross-catalog or stale references never receive
+  an `Issued` result.
 - Independently constructed equal reference and intrinsic-core-library
   `AssemblyBindingTarget` values compare and hash equally and hit one binding
   cache entry per source domain.

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -149,6 +149,9 @@ correspondence remains the unfinished Slice 6 boundary.
 | `DefinitionCorrespondence` | One catalog comparison operation | Same, different, indeterminate duplicate, incomparable-catalog, or stale-generation verdict | Boolean equality, persistence, or display identity |
 | `DefinitionJoinTokenProjection` | One catalog projection operation | Whether a current definition key received join currency or was rejected as cross-catalog/stale | Definition comparison, persistence, or fallback joining |
 | `DefinitionJoinToken` | One frozen catalog generation | Hashable exact-or-indeterminate definition class for graph joins | Display, persistence, or reconstruction from addresses |
+| `UnresolvedBindingReference` | One frozen catalog generation | What the catalog may project for a terminal unbound or unavailable binding | Hashing, sorting, persistence, or use by rejected/open-failure outcomes |
+| `UnresolvedBindingKeyProjection` | One catalog projection operation | Whether a current unresolved binding reference received join currency or was rejected as cross-catalog/stale | Type correspondence, persistence, or permission to exact-join |
+| `UnresolvedBindingKey` | One frozen catalog generation | Hashable complete unresolved binding request for degraded graph correspondence | Type identity without a structured name, exact correspondence, or reconstruction from target fields |
 
 The table separates four axes that are often collapsed:
 
@@ -179,6 +182,7 @@ Conversions are operations with an owner, not implicit casts:
 | `TypeResolutionOutcome.Resolved` | `ResolvedTypeDefinition` parts | Metadata returns the opaque key for correspondence and address for durable re-location; consumers do not reconstruct either |
 | `ResolvedTypeDefinitionKey` pair | `DefinitionCorrespondence` | Only the issuing catalog compares keys |
 | `ResolvedTypeDefinitionKey` | `DefinitionJoinTokenProjection` | `TypeResolutionCatalog.ProjectDefinitionJoinToken` issues a token only for a current-generation key; cross-catalog and stale keys remain typed result arms |
+| `UnresolvedBindingReference` | `UnresolvedBindingKeyProjection` | `TypeResolutionCatalog.ProjectUnresolvedBindingKey` issues a key only for a current-generation reference minted on `UnboundBinding` or genuine policy `Unavailable`; cross-catalog and stale references remain typed result arms |
 | `TypeNode` | display, canonical, XML-doc, or digest spelling | The owning projection chooses its erasure policy; no projection is recovered from another |
 | `ApiMember` | `MemberAnchor` | `ApiMemberIdentity` owns canonical signature and digest construction |
 | `MemberTargetSelector` | `ResolvedMemberTarget` | `MemberTargetResolver` returns the anchor, API handle, body target, or typed diagnostic |

--- a/src/ILInspector.Metadata/TypeResolution.cs
+++ b/src/ILInspector.Metadata/TypeResolution.cs
@@ -334,6 +334,28 @@ public sealed class ResolvedTypeDefinitionKey
 }
 
 /// <summary>
+/// Opaque reference to one unresolved assembly binding in one frozen catalog
+/// generation. Only the issuing catalog may project it into hashable join
+/// currency.
+/// </summary>
+public sealed class UnresolvedBindingReference
+{
+    internal UnresolvedBindingReference(
+        AssemblyCatalogId catalog,
+        AssemblyCatalogGenerationId generation,
+        BindingKey binding)
+    {
+        Catalog = catalog;
+        Generation = generation;
+        Binding = binding;
+    }
+
+    internal AssemblyCatalogId Catalog { get; }
+    internal AssemblyCatalogGenerationId Generation { get; }
+    internal BindingKey Binding { get; }
+}
+
+/// <summary>
 /// Describes how strongly a catalog-issued definition token establishes
 /// correspondence.
 /// </summary>
@@ -437,6 +459,97 @@ public abstract class DefinitionJoinTokenProjection
         }
 
         public AssemblyCatalogGenerationId DefinitionGeneration { get; }
+        public AssemblyCatalogGenerationId CurrentGeneration { get; }
+    }
+}
+
+/// <summary>
+/// Hashable catalog currency for one unresolved assembly-binding request in
+/// one frozen generation.
+/// </summary>
+public sealed class UnresolvedBindingKey : IEquatable<UnresolvedBindingKey>
+{
+    readonly Guid _value;
+
+    internal UnresolvedBindingKey(
+        AssemblyCatalogId catalog,
+        AssemblyCatalogGenerationId generation,
+        Guid value)
+    {
+        Catalog = catalog;
+        Generation = generation;
+        _value = value;
+    }
+
+    internal AssemblyCatalogId Catalog { get; }
+    internal AssemblyCatalogGenerationId Generation { get; }
+    internal Guid Value => _value;
+
+    public bool Equals(UnresolvedBindingKey? other) =>
+        other is not null
+        && Catalog == other.Catalog
+        && ReferenceEquals(Generation, other.Generation)
+        && _value == other._value;
+
+    public override bool Equals(object? obj) =>
+        obj is UnresolvedBindingKey other && Equals(other);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(Catalog, Generation, _value);
+
+    public static bool operator ==(
+        UnresolvedBindingKey? left,
+        UnresolvedBindingKey? right) =>
+        Equals(left, right);
+
+    public static bool operator !=(
+        UnresolvedBindingKey? left,
+        UnresolvedBindingKey? right) =>
+        !Equals(left, right);
+}
+
+/// <summary>
+/// Catalog-owned result of projecting an opaque unresolved binding reference
+/// into hashable join currency.
+/// </summary>
+public abstract class UnresolvedBindingKeyProjection
+{
+    private protected UnresolvedBindingKeyProjection()
+    {
+    }
+
+    public sealed class Issued : UnresolvedBindingKeyProjection
+    {
+        internal Issued(UnresolvedBindingKey key) => Key = key;
+
+        public UnresolvedBindingKey Key { get; }
+    }
+
+    public sealed class IncomparableCatalogs : UnresolvedBindingKeyProjection
+    {
+        internal IncomparableCatalogs(
+            AssemblyCatalogId catalog,
+            AssemblyCatalogId bindingCatalog)
+        {
+            Catalog = catalog;
+            BindingCatalog = bindingCatalog;
+        }
+
+        public AssemblyCatalogId Catalog { get; }
+        public AssemblyCatalogId BindingCatalog { get; }
+    }
+
+    public sealed class StaleGeneration : UnresolvedBindingKeyProjection
+    {
+        internal StaleGeneration(
+            AssemblyCatalogGenerationId bindingGeneration,
+            AssemblyCatalogGenerationId currentGeneration)
+        {
+            BindingGeneration = bindingGeneration;
+            CurrentGeneration = currentGeneration;
+        }
+
+        public AssemblyCatalogGenerationId BindingGeneration { get; }
         public AssemblyCatalogGenerationId CurrentGeneration { get; }
     }
 }
@@ -709,16 +822,23 @@ public abstract class TypeResolutionOutcome
     public sealed class UnboundBinding : TypeResolutionOutcome
     {
         internal UnboundBinding(
+            UnresolvedBindingReference binding,
             AssemblyBindingTarget target,
             AssemblyBindingOrigin origin,
             AssemblyResolutionScope scope,
             ImmutableArray<TypeForwardingHop> hops) : base(hops)
         {
+            Binding = binding;
             Target = target;
             Origin = origin;
             Scope = scope;
         }
 
+        /// <summary>
+        /// Opaque catalog input for projecting this unresolved binding into
+        /// hashable join currency.
+        /// </summary>
+        public UnresolvedBindingReference Binding { get; }
         public AssemblyBindingTarget Target { get; }
         public AssemblyBindingOrigin Origin { get; }
         public AssemblyResolutionScope Scope { get; }
@@ -730,18 +850,25 @@ public abstract class TypeResolutionOutcome
     public sealed class Unavailable : TypeResolutionOutcome
     {
         internal Unavailable(
+            UnresolvedBindingReference binding,
             AssemblyBindingTarget target,
             AssemblyBindingOrigin origin,
             AssemblyResolutionScope scope,
             AssemblyBindingFailure failure,
             ImmutableArray<TypeForwardingHop> hops) : base(hops)
         {
+            Binding = binding;
             Target = target;
             Origin = origin;
             Scope = scope;
             Failure = failure;
         }
 
+        /// <summary>
+        /// Opaque catalog input for projecting this unresolved binding into
+        /// hashable join currency.
+        /// </summary>
+        public UnresolvedBindingReference Binding { get; }
         public AssemblyBindingTarget Target { get; }
         public AssemblyBindingOrigin Origin { get; }
         public AssemblyResolutionScope Scope { get; }

--- a/src/ILInspector.Metadata/TypeResolutionContext.cs
+++ b/src/ILInspector.Metadata/TypeResolutionContext.cs
@@ -15,6 +15,22 @@ readonly record struct PolicyCacheKey(
     AssemblyBindingPolicyVersion PolicyVersion,
     object RequestKey);
 
+readonly record struct AssemblyBindingDomainKey(
+    bool IsGlobal,
+    AssemblyCandidateId Candidate)
+{
+    internal static AssemblyBindingDomainKey Global => new(true, default);
+
+    internal static AssemblyBindingDomainKey FromCandidate(
+        AssemblyCandidateId candidate) =>
+        new(false, candidate);
+}
+
+sealed record BindingKey(
+    AssemblyBindingDomainKey Domain,
+    AssemblyBindingTarget Target,
+    AssemblyResolutionScope Scope);
+
 /// <summary>
 /// Resource and traversal limits shared by all generations in a
 /// <see cref="TypeResolutionCatalog"/>.
@@ -75,6 +91,8 @@ public sealed class TypeResolutionCatalog : IDisposable
         _resolutions = [];
     readonly Dictionary<DefinitionClassKey, DefinitionJoinToken>
         _definitionJoinTokens = [];
+    readonly Dictionary<BindingKey, UnresolvedBindingKey>
+        _unresolvedBindingKeys = [];
     readonly TypeResolutionContextOptions _options;
     AssemblyCatalogGenerationId? _latestGeneration;
     ImmutableDictionary<AssemblyCandidateId, FrozenCandidate>
@@ -202,6 +220,48 @@ public sealed class TypeResolutionCatalog : IDisposable
                 evidence);
             _definitionJoinTokens.Add(definitionClass, token);
             return new DefinitionJoinTokenProjection.Issued(token);
+        }
+    }
+
+    /// <summary>
+    /// Issues the hashable correspondence key for one unresolved binding in
+    /// the latest frozen generation.
+    /// </summary>
+    public UnresolvedBindingKeyProjection ProjectUnresolvedBindingKey(
+        UnresolvedBindingReference binding)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (binding.Catalog != Id)
+            {
+                return new UnresolvedBindingKeyProjection.IncomparableCatalogs(
+                    Id,
+                    binding.Catalog);
+            }
+
+            if (!ReferenceEquals(binding.Generation, _latestGeneration))
+            {
+                return new UnresolvedBindingKeyProjection.StaleGeneration(
+                    binding.Generation,
+                    _latestGeneration!);
+            }
+
+            if (_unresolvedBindingKeys.TryGetValue(
+                    binding.Binding,
+                    out UnresolvedBindingKey? existing))
+            {
+                return new UnresolvedBindingKeyProjection.Issued(existing);
+            }
+
+            var key = new UnresolvedBindingKey(
+                Id,
+                binding.Generation,
+                Guid.NewGuid());
+            _unresolvedBindingKeys.Add(binding.Binding, key);
+            return new UnresolvedBindingKeyProjection.Issued(key);
         }
     }
 
@@ -386,6 +446,7 @@ public sealed class TypeResolutionCatalog : IDisposable
             _latestCandidates = frozen.ToImmutable();
             _latestGeneration = generation;
             _definitionJoinTokens.Clear();
+            _unresolvedBindingKeys.Clear();
         }
     }
 
@@ -884,11 +945,11 @@ public sealed class TypeResolutionContext : IDisposable
         out BindingKey key,
         out TypeResolutionFailure? failure)
     {
-        BindingDomainKey domain;
+        AssemblyBindingDomainKey domain;
         switch (origin)
         {
             case AssemblyBindingOrigin.GlobalOrigin:
-                domain = BindingDomainKey.Global;
+                domain = AssemblyBindingDomainKey.Global;
                 break;
             case AssemblyBindingOrigin.RequestingAssembly requesting:
                 if (!candidates.TryGetValue(
@@ -908,7 +969,7 @@ public sealed class TypeResolutionContext : IDisposable
                     return false;
                 }
 
-                domain = BindingDomainKey.FromCandidate(candidate!.Id);
+                domain = AssemblyBindingDomainKey.FromCandidate(candidate!.Id);
                 break;
             default:
                 throw new InvalidOperationException(
@@ -1020,21 +1081,6 @@ public sealed class TypeResolutionContext : IDisposable
                     "Unknown assembly-binding origin."),
             };
     }
-
-    readonly record struct BindingDomainKey(
-        bool IsGlobal,
-        AssemblyCandidateId Candidate)
-    {
-        internal static BindingDomainKey Global => new(true, default);
-        internal static BindingDomainKey FromCandidate(
-            AssemblyCandidateId candidate) =>
-            new(false, candidate);
-    }
-
-    sealed record BindingKey(
-        BindingDomainKey Domain,
-        AssemblyBindingTarget Target,
-        AssemblyResolutionScope Scope);
 
     sealed class Builder
     {
@@ -1607,6 +1653,10 @@ public sealed class TypeResolutionContext : IDisposable
                     return true;
                 case AssemblyBindingOutcome.Missing:
                     outcome = new TypeResolutionOutcome.UnboundBinding(
+                        new UnresolvedBindingReference(
+                            _acquisition.CatalogId,
+                            _generation,
+                            key),
                         target,
                         origin,
                         scope,
@@ -1625,6 +1675,10 @@ public sealed class TypeResolutionContext : IDisposable
                     else
                     {
                         outcome = new TypeResolutionOutcome.Unavailable(
+                            new UnresolvedBindingReference(
+                                _acquisition.CatalogId,
+                                _generation,
+                                key),
                             target,
                             origin,
                             scope,
@@ -1864,9 +1918,32 @@ public sealed class TypeResolutionContext : IDisposable
 
         TypeResolutionOutcome Reproject(TypeResolutionOutcome outcome)
         {
-            if (outcome is not TypeResolutionOutcome.Resolved resolved)
-                return outcome;
+            return outcome switch
+            {
+                TypeResolutionOutcome.Resolved resolved =>
+                    Reproject(resolved),
+                TypeResolutionOutcome.UnboundBinding unbound =>
+                    new TypeResolutionOutcome.UnboundBinding(
+                        Reproject(unbound.Binding),
+                        unbound.Target,
+                        unbound.Origin,
+                        unbound.Scope,
+                        unbound.Hops),
+                TypeResolutionOutcome.Unavailable unavailable =>
+                    new TypeResolutionOutcome.Unavailable(
+                        Reproject(unavailable.Binding),
+                        unavailable.Target,
+                        unavailable.Origin,
+                        unavailable.Scope,
+                        unavailable.Failure,
+                        unavailable.Hops),
+                _ => outcome,
+            };
+        }
 
+        TypeResolutionOutcome.Resolved Reproject(
+            TypeResolutionOutcome.Resolved resolved)
+        {
             ResolvedTypeDefinition definition = resolved.Definition;
             var key = new ResolvedTypeDefinitionKey(
                 _acquisition.CatalogId,
@@ -1881,5 +1958,12 @@ public sealed class TypeResolutionContext : IDisposable
                     definition.Type),
                 resolved.Hops);
         }
+
+        UnresolvedBindingReference Reproject(
+            UnresolvedBindingReference binding) =>
+            new(
+                _acquisition.CatalogId,
+                _generation,
+                binding.Binding);
     }
 }

--- a/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
@@ -462,6 +462,347 @@ public class TypeResolutionContextTests
                 .ToHashSet());
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void UnresolvedBindingKey_IsStableForOneCompleteBinding(
+        bool policyUnavailable)
+    {
+        byte[] ownerImage = BuildAssembly("Owner", definesType: false);
+        ResolvedAssemblyReference owner = Descriptor(ownerImage);
+        AssemblyBindingOrigin origin =
+            AssemblyBindingOrigin.FromAssembly(owner);
+        AssemblyReferenceIdentity target = Identity("Missing");
+        TypeResolutionRequest firstRequest =
+            TypeResolutionRequest.FromReference(
+                target,
+                origin,
+                AssemblyResolutionScope.Any,
+                TypeName());
+        TypeResolutionRequest secondRequest =
+            TypeResolutionRequest.FromReference(
+                target,
+                origin,
+                AssemblyResolutionScope.Any,
+                TypeName("Other"));
+        AssemblyBindingFailure? failure = policyUnavailable
+            ? new AssemblyBindingFailure(
+                AssemblyBindingFailureKind.CandidateUnavailable)
+            : null;
+        var policy = new RecordingPolicy(
+            _ => failure is null
+                ? AssemblyBindingSelection.NotFound()
+                : AssemblyBindingSelection.CannotSelect(failure));
+        using var catalog = new TypeResolutionCatalog();
+        using TypeResolutionContext context = catalog.CreateContext(
+            policy,
+            [owner],
+            [firstRequest, secondRequest]);
+
+        TypeResolutionOutcome firstOutcome = context.Resolve(firstRequest);
+        TypeResolutionOutcome secondOutcome = context.Resolve(secondRequest);
+        if (failure is null)
+        {
+            Assert.IsType<TypeResolutionOutcome.UnboundBinding>(firstOutcome);
+            Assert.IsType<TypeResolutionOutcome.UnboundBinding>(secondOutcome);
+        }
+        else
+        {
+            Assert.Same(
+                failure,
+                Assert.IsType<TypeResolutionOutcome.Unavailable>(firstOutcome)
+                    .Failure);
+            Assert.Same(
+                failure,
+                Assert.IsType<TypeResolutionOutcome.Unavailable>(secondOutcome)
+                    .Failure);
+        }
+
+        UnresolvedBindingKey first = IssuedBindingKey(
+            catalog,
+            UnresolvedBinding(firstOutcome));
+        UnresolvedBindingKey second = IssuedBindingKey(
+            catalog,
+            UnresolvedBinding(secondOutcome));
+        var equivalent = new UnresolvedBindingKey(
+            first.Catalog,
+            first.Generation,
+            first.Value);
+
+        Assert.Same(first, second);
+        Assert.Equal(first, equivalent);
+        Assert.True(first == equivalent);
+        Assert.False(first != equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+        Assert.Contains(
+            equivalent,
+            new HashSet<UnresolvedBindingKey> { first });
+        Assert.Single(policy.Requests);
+    }
+
+    [Fact]
+    public void UnresolvedBindingKey_PreservesEveryBindingCoordinate()
+    {
+        byte[] firstOwnerImage =
+            BuildAssembly("FirstOwner", definesType: false);
+        byte[] secondOwnerImage =
+            BuildAssembly("SecondOwner", definesType: false);
+        ResolvedAssemblyReference firstOwner = Descriptor(firstOwnerImage);
+        ResolvedAssemblyReference secondOwner = Descriptor(secondOwnerImage);
+        AssemblyBindingOrigin firstOrigin =
+            AssemblyBindingOrigin.FromAssembly(firstOwner);
+        AssemblyReferenceIdentity target = Identity("Target");
+        TypeResolutionRequest baseline =
+            TypeResolutionRequest.FromReference(
+                target,
+                firstOrigin,
+                AssemblyResolutionScope.Any,
+                TypeName());
+        TypeResolutionRequest equivalent =
+            TypeResolutionRequest.FromReference(
+                new AssemblyReferenceIdentity(
+                    "Target",
+                    new Version(1, 0, 0, 0),
+                    null,
+                    null),
+                AssemblyBindingOrigin.FromAssembly(firstOwner),
+                AssemblyResolutionScope.Any,
+                TypeName("Equivalent"));
+        TypeResolutionRequest[] closeNegatives =
+        [
+            TypeResolutionRequest.FromReference(
+                new AssemblyReferenceIdentity(
+                    "Other",
+                    new Version(1, 0, 0, 0),
+                    null,
+                    null),
+                firstOrigin,
+                AssemblyResolutionScope.Any,
+                TypeName()),
+            TypeResolutionRequest.FromReference(
+                new AssemblyReferenceIdentity(
+                    "Target",
+                    new Version(2, 0, 0, 0),
+                    null,
+                    null),
+                firstOrigin,
+                AssemblyResolutionScope.Any,
+                TypeName()),
+            TypeResolutionRequest.FromReference(
+                new AssemblyReferenceIdentity(
+                    "Target",
+                    new Version(1, 0, 0, 0),
+                    "fr",
+                    null),
+                firstOrigin,
+                AssemblyResolutionScope.Any,
+                TypeName()),
+            TypeResolutionRequest.FromReference(
+                new AssemblyReferenceIdentity(
+                    "Target",
+                    new Version(1, 0, 0, 0),
+                    null,
+                    "0011223344556677"),
+                firstOrigin,
+                AssemblyResolutionScope.Any,
+                TypeName()),
+            TypeResolutionRequest.FromReference(
+                target,
+                AssemblyBindingOrigin.FromAssembly(secondOwner),
+                AssemblyResolutionScope.Any,
+                TypeName()),
+            TypeResolutionRequest.FromReference(
+                target,
+                AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Any,
+                TypeName()),
+            TypeResolutionRequest.FromReference(
+                target,
+                firstOrigin,
+                AssemblyResolutionScope.Platform,
+                TypeName()),
+            TypeResolutionRequest.FromCoreLibrary(
+                firstOwner,
+                AssemblyResolutionScope.Any,
+                TypeName()),
+        ];
+        TypeResolutionRequest[] requests =
+            [baseline, equivalent, .. closeNegatives];
+        using var catalog = new TypeResolutionCatalog();
+        using TypeResolutionContext context = catalog.CreateContext(
+            new RecordingPolicy(_ => AssemblyBindingSelection.NotFound()),
+            [firstOwner, secondOwner],
+            requests);
+
+        UnresolvedBindingKey baselineKey = IssuedBindingKey(
+            catalog,
+            Assert.IsType<TypeResolutionOutcome.UnboundBinding>(
+                context.Resolve(baseline)).Binding);
+        UnresolvedBindingKey equivalentKey = IssuedBindingKey(
+            catalog,
+            Assert.IsType<TypeResolutionOutcome.UnboundBinding>(
+                context.Resolve(equivalent)).Binding);
+        UnresolvedBindingKey[] negativeKeys = closeNegatives
+            .Select(request => IssuedBindingKey(
+                catalog,
+                Assert.IsType<TypeResolutionOutcome.UnboundBinding>(
+                    context.Resolve(request)).Binding))
+            .ToArray();
+
+        Assert.Same(baselineKey, equivalentKey);
+        Assert.Equal(
+            negativeKeys.Length,
+            negativeKeys.Distinct().Count());
+        Assert.DoesNotContain(baselineKey, negativeKeys);
+    }
+
+    [Fact]
+    public void UnresolvedBindingKey_UsesTheTerminalForwardedBinding()
+    {
+        AssemblyReferenceIdentity target = Identity("Missing");
+        byte[] facadeImage = BuildAssembly(
+            "Facade",
+            definesType: false,
+            forwardTarget: target);
+        ResolvedAssemblyReference facade = Descriptor(facadeImage);
+        TypeResolutionRequest forwarded =
+            TypeResolutionRequest.FromAssembly(
+                facade,
+                AssemblyResolutionScope.Any,
+                TypeName());
+        TypeResolutionRequest direct =
+            TypeResolutionRequest.FromReference(
+                target,
+                AssemblyBindingOrigin.FromAssembly(facade),
+                AssemblyResolutionScope.Any,
+                TypeName("Other"));
+        TypeResolutionRequest differentScope =
+            TypeResolutionRequest.FromReference(
+                target,
+                AssemblyBindingOrigin.FromAssembly(facade),
+                AssemblyResolutionScope.Platform,
+                TypeName());
+        using var catalog = new TypeResolutionCatalog();
+        using TypeResolutionContext context = catalog.CreateContext(
+            new RecordingPolicy(_ => AssemblyBindingSelection.NotFound()),
+            [facade],
+            [forwarded, direct, differentScope]);
+
+        var forwardedOutcome =
+            Assert.IsType<TypeResolutionOutcome.UnboundBinding>(
+                context.Resolve(forwarded));
+        var directOutcome =
+            Assert.IsType<TypeResolutionOutcome.UnboundBinding>(
+                context.Resolve(direct));
+        var scopedOutcome =
+            Assert.IsType<TypeResolutionOutcome.UnboundBinding>(
+                context.Resolve(differentScope));
+
+        Assert.Single(forwardedOutcome.Hops);
+        Assert.Same(
+            IssuedBindingKey(catalog, forwardedOutcome.Binding),
+            IssuedBindingKey(catalog, directOutcome.Binding));
+        Assert.NotEqual(
+            IssuedBindingKey(catalog, forwardedOutcome.Binding),
+            IssuedBindingKey(catalog, scopedOutcome.Binding));
+    }
+
+    [Fact]
+    public async Task UnresolvedBindingKey_ConcurrentIssuanceReturnsOneKey()
+    {
+        byte[] ownerImage = BuildAssembly("Owner", definesType: false);
+        ResolvedAssemblyReference owner = Descriptor(ownerImage);
+        TypeResolutionRequest request =
+            TypeResolutionRequest.FromReference(
+                Identity("Missing"),
+                AssemblyBindingOrigin.FromAssembly(owner),
+                AssemblyResolutionScope.Any,
+                TypeName());
+        using var catalog = new TypeResolutionCatalog();
+        using TypeResolutionContext context = catalog.CreateContext(
+            new RecordingPolicy(_ => AssemblyBindingSelection.NotFound()),
+            [owner],
+            [request]);
+        UnresolvedBindingReference binding =
+            Assert.IsType<TypeResolutionOutcome.UnboundBinding>(
+                context.Resolve(request)).Binding;
+
+        UnresolvedBindingKey[] keys = await Task.WhenAll(
+            Enumerable.Range(0, 32)
+                .Select(_ => Task.Run(
+                    () => IssuedBindingKey(catalog, binding),
+                    TestContext.Current.CancellationToken)));
+
+        Assert.All(keys, key => Assert.Same(keys[0], key));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void UnresolvedBindingKey_RejectsCrossCatalogAndStaleReferences(
+        bool policyUnavailable)
+    {
+        byte[] ownerImage = BuildAssembly("Owner", definesType: false);
+        ResolvedAssemblyReference owner = Descriptor(ownerImage);
+        TypeResolutionRequest request =
+            TypeResolutionRequest.FromReference(
+                Identity("Missing"),
+                AssemblyBindingOrigin.FromAssembly(owner),
+                AssemblyResolutionScope.Any,
+                TypeName());
+        var failure = new AssemblyBindingFailure(
+            AssemblyBindingFailureKind.CandidateUnavailable);
+        var policy = new RecordingPolicy(
+            _ => policyUnavailable
+                ? AssemblyBindingSelection.CannotSelect(failure)
+                : AssemblyBindingSelection.NotFound());
+        using var firstCatalog = new TypeResolutionCatalog();
+        using var secondCatalog = new TypeResolutionCatalog();
+        using TypeResolutionContext first =
+            firstCatalog.CreateContext(policy, [owner], [request]);
+        TypeResolutionOutcome oldOutcome = first.Resolve(request);
+        UnresolvedBindingReference oldBinding =
+            UnresolvedBinding(oldOutcome);
+        UnresolvedBindingKey oldKey =
+            IssuedBindingKey(firstCatalog, oldBinding);
+
+        var incomparable = Assert.IsType<
+            UnresolvedBindingKeyProjection.IncomparableCatalogs>(
+                secondCatalog.ProjectUnresolvedBindingKey(oldBinding));
+        Assert.Equal(secondCatalog.Id, incomparable.Catalog);
+        Assert.Equal(firstCatalog.Id, incomparable.BindingCatalog);
+
+        using TypeResolutionContext current =
+            firstCatalog.CreateContext(policy, [owner], [request]);
+        TypeResolutionOutcome currentOutcome = current.Resolve(request);
+        UnresolvedBindingReference currentBinding =
+            UnresolvedBinding(currentOutcome);
+        UnresolvedBindingKey currentKey =
+            IssuedBindingKey(firstCatalog, currentBinding);
+        var stale = Assert.IsType<
+            UnresolvedBindingKeyProjection.StaleGeneration>(
+                firstCatalog.ProjectUnresolvedBindingKey(oldBinding));
+
+        Assert.NotSame(oldOutcome, currentOutcome);
+        Assert.NotSame(oldBinding, currentBinding);
+        Assert.Same(oldKey.Generation, stale.BindingGeneration);
+        Assert.Same(currentKey.Generation, stale.CurrentGeneration);
+        Assert.NotEqual(oldKey, currentKey);
+        Assert.NotEqual(
+            oldKey,
+            new UnresolvedBindingKey(
+                oldKey.Catalog,
+                new AssemblyCatalogGenerationId(),
+                oldKey.Value));
+        Assert.NotEqual(
+            oldKey,
+            new UnresolvedBindingKey(
+                new AssemblyCatalogId(Guid.NewGuid()),
+                oldKey.Generation,
+                oldKey.Value));
+        Assert.Single(policy.Requests);
+    }
+
     [Fact]
     public void DefinitionAddress_ResolvesOnlyAgainstMatchingModuleAndRow()
     {
@@ -1687,6 +2028,48 @@ public class TypeResolutionContextTests
                 type.GetConstructors(
                     BindingFlags.Public | BindingFlags.Instance)));
         Assert.Empty(
+            typeof(UnresolvedBindingReference)
+                .GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Empty(
+            typeof(UnresolvedBindingReference)
+                .GetFields(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Empty(
+            typeof(UnresolvedBindingReference)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Empty(
+            typeof(UnresolvedBindingKey)
+                .GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Empty(
+            typeof(UnresolvedBindingKey)
+                .GetFields(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Empty(
+            typeof(UnresolvedBindingKey)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance));
+        ConstructorInfo bindingProjectionConstructor = Assert.Single(
+            typeof(UnresolvedBindingKeyProjection)
+                .GetConstructors(
+                    BindingFlags.NonPublic | BindingFlags.Instance));
+        Assert.True(bindingProjectionConstructor.IsFamilyAndAssembly);
+        Assert.All(
+            typeof(UnresolvedBindingKeyProjection).GetNestedTypes(),
+            type => Assert.Empty(
+                type.GetConstructors(
+                    BindingFlags.Public | BindingFlags.Instance)));
+        Assert.Equal(
+            [
+                typeof(TypeResolutionOutcome.Unavailable),
+                typeof(TypeResolutionOutcome.UnboundBinding),
+            ],
+            typeof(TypeResolutionOutcome).Assembly
+                .GetExportedTypes()
+                .SelectMany(type => type.GetProperties(
+                    BindingFlags.Public | BindingFlags.Instance))
+                .Where(property =>
+                    property.PropertyType
+                        == typeof(UnresolvedBindingReference))
+                .Select(property => property.DeclaringType)
+                .OrderBy(type => type!.FullName, StringComparer.Ordinal));
+        Assert.Empty(
             typeof(ResolvedAssemblyCandidate)
                 .GetConstructors(BindingFlags.Public | BindingFlags.Instance));
     }
@@ -1696,6 +2079,23 @@ public class TypeResolutionContextTests
         ResolvedTypeDefinitionKey definition) =>
         Assert.IsType<DefinitionJoinTokenProjection.Issued>(
             catalog.ProjectDefinitionJoinToken(definition)).Token;
+
+    static UnresolvedBindingReference UnresolvedBinding(
+        TypeResolutionOutcome outcome) =>
+        outcome switch
+        {
+            TypeResolutionOutcome.UnboundBinding unbound => unbound.Binding,
+            TypeResolutionOutcome.Unavailable unavailable =>
+                unavailable.Binding,
+            _ => throw new Xunit.Sdk.XunitException(
+                "The outcome does not carry an unresolved binding."),
+        };
+
+    static UnresolvedBindingKey IssuedBindingKey(
+        TypeResolutionCatalog catalog,
+        UnresolvedBindingReference binding) =>
+        Assert.IsType<UnresolvedBindingKeyProjection.Issued>(
+            catalog.ProjectUnresolvedBindingKey(binding)).Key;
 
     [Fact]
     public async Task FrozenContext_IsConcurrentAndDoesNotReinvokePolicy()


### PR DESCRIPTION
## Outcome

Metadata now carries opaque unresolved-binding references on the two terminal outcomes that preserve a complete binding request: `UnboundBinding` and genuine policy `Unavailable`. The issuing catalog projects a current reference into generation-scoped, hashable `UnresolvedBindingKey` currency.

One complete `(source domain, structured target, resolution scope)` request receives one key per catalog generation. Type names are deliberately excluded so the later member-correspondence slice can compose `key + structured type name` without repeating binding work.

Cross-catalog and stale references return closed typed projection results. Candidate-open failures, ambiguity, declaration `NotFound`, rejection, and plan expansion never receive the opaque projection input, so they cannot enter degraded graph correspondence.

This is delivery slice 2 of #3780 and follows the same property-on-the-value pattern as `InertString` and `ResolvedTypeDefinitionKey` / `DefinitionJoinToken`. It is prerequisite work for #3632.

## Evidence

- Both `UnboundBinding` and policy `Unavailable` issue stable structural keys.
- Equal bindings shared by multiple type requests reuse one key.
- Assembly identity, source domain, target arm, and resolution scope close negatives remain distinct.
- A forwarded request and its exact terminal binding reuse one key; a different tightened scope does not.
- Cached outcomes receive fresh references after generation advance; old references are stale.
- Concurrent issuance returns one key.
- Public construction and raw binding coordinates remain unavailable; only the two eligible outcome arms expose a reference.

## Boundary

This PR does **not** add member correspondence or migrate graphs. `CatalogMemberJoinKey`, degraded member keys, total graph storage identity, incomplete-edge evidence, `ScopeGraph` catalog leases, legacy string-key removal, and workspace traversal remain later #3780/#3632 work.

## Validation

- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class ILInspector.Metadata.Tests.TypeResolutionContextTests` — 61/61
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — 1433/1433
- `dotnet build dotnet-inspect.slnx -c Release` — succeeded
- changed Markdown and `git diff --check` — clean

Part of #3780.