### PR TITLE
Report refused package-search feeds accurately

### DIFF
--- a/src/DotnetInspector.Packages/NuGetSourceCompat.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceCompat.cs
@@ -313,6 +313,7 @@ public static class NuGetSearchService
 
         foreach (NuGetSource source in sources)
         {
+            using var failureScope = FeedFailureTelemetry.Scope();
             string? searchUrl;
             try
             {
@@ -326,12 +327,12 @@ public static class NuGetSearchService
 
             if (searchUrl is null)
             {
-                // Distinguishing "index unreachable" from "index has no search resource" needs
-                // typed HTTP failures, which HttpRetryHelper does not yet surface (issue #3417,
-                // bug 1). Until then the message stays honest about covering both.
-                failures.Add(
-                    $"{source.Name}: no searchable endpoint for '{source.Url}' "
-                    + "(service index unavailable, or advertises no SearchQueryService)");
+                IReadOnlyList<FeedFailure> sourceFailures =
+                    FeedFailureTelemetry.Current!.Failures;
+                failures.Add(sourceFailures.Count > 0
+                    ? DescribeServiceIndexFailure(source, sourceFailures)
+                    : $"{source.Name}: no searchable endpoint for '{source.Url}' "
+                        + "(service index unavailable, or advertises no SearchQueryService)");
                 continue;
             }
 
@@ -371,6 +372,22 @@ public static class NuGetSearchService
         }
 
         return new NuGetSearchOutcome(results.Take(take).ToList(), failures);
+    }
+
+    private static string DescribeServiceIndexFailure(
+        NuGetSource source,
+        IReadOnlyList<FeedFailure> failures)
+    {
+        string reason = failures.Any(f => f.Kind == FeedFailureKind.Authentication)
+            ? "source requires credentials"
+            : failures.Any(f => f.Kind == FeedFailureKind.Authorization)
+                ? "source denied access"
+                : "service index unavailable";
+        string observations = string.Join(
+            "; ",
+            failures.Select(f => $"{f.Url} — {f.StatusText} while {f.PhaseText}"));
+
+        return $"{source.Name}: {reason} ({observations})";
     }
 
     public static async Task<List<NuGetSearchResult>> SearchByPrefixAsync(

--- a/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
+++ b/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
@@ -102,6 +102,54 @@ public class NuGetSearchSourcesTests
 
         Assert.Contains("No configured NuGet source could be searched", ex.Message);
         Assert.Contains("no searchable endpoint", ex.Message);
+        Assert.DoesNotContain("requires credentials", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized, "requires credentials")]
+    [InlineData(HttpStatusCode.Forbidden, "denied access")]
+    [InlineData(HttpStatusCode.BadRequest, "service index unavailable")]
+    public async Task SearchAsync_RefusedServiceIndex_ReportsTypedFailure(
+        HttpStatusCode status,
+        string expectedReason)
+    {
+        var handler = new RouteHandler();
+        handler.RespondWith(IndexUrl, status);
+        using var client = new HttpClient(handler);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await NuGetSearchService.SearchAsync(
+                client, "Contoso", sourceOptions: new NuGetSourceOptions { Sources = [IndexUrl] }));
+
+        Assert.Contains(expectedReason, ex.Message);
+        Assert.Contains($"HTTP {(int)status} {status}", ex.Message);
+        Assert.Contains("reading the service index", ex.Message);
+        Assert.DoesNotContain("no searchable endpoint", ex.Message);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ServiceIndexFailures_AreAttributedPerSource()
+    {
+        const string refusedIndex = "https://refused.example/v3/index.json";
+        const string unsearchableIndex = "https://unsearchable.example/v3/index.json";
+
+        var handler = new RouteHandler
+        {
+            [unsearchableIndex] = """{"version":"3.0.0","resources":[]}"""
+        };
+        handler.RespondWith(refusedIndex, HttpStatusCode.Unauthorized);
+        using var client = new HttpClient(handler);
+        using var config = new TempNuGetConfig(
+            [("refused", refusedIndex), ("unsearchable", unsearchableIndex)]);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await NuGetSearchService.SearchAsync(
+                client, "Contoso", sourceOptions: new NuGetSourceOptions { ConfigFile = config.Path }));
+
+        Assert.Contains("refused: source requires credentials", ex.Message);
+        Assert.Contains(
+            $"unsearchable: no searchable endpoint for '{unsearchableIndex}'",
+            ex.Message);
     }
 
     [Fact]
@@ -808,12 +856,16 @@ public class NuGetSearchSourcesTests
     /// </summary>
     private sealed class RouteHandler : HttpMessageHandler
     {
-        private readonly Dictionary<string, string> _routes = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, (HttpStatusCode Status, string Body)> _routes =
+            new(StringComparer.OrdinalIgnoreCase);
         private readonly List<(string Url, AuthenticationHeaderValue? Auth)> _requests = [];
 
-        public string this[string url] { set => _routes[url] = value; }
+        public string this[string url] { set => _routes[url] = (HttpStatusCode.OK, value); }
 
         public IReadOnlyList<string> Requested => _requests.Select(r => r.Url).ToList();
+
+        public void RespondWith(string url, HttpStatusCode status, string body = "") =>
+            _routes[url] = (status, body);
 
         public AuthenticationHeaderValue? AuthFor(string url) =>
             _requests.FirstOrDefault(r => WithoutQuery(r.Url).Equals(url, StringComparison.OrdinalIgnoreCase)).Auth;
@@ -824,8 +876,10 @@ public class NuGetSearchSourcesTests
             string url = request.RequestUri!.ToString();
             _requests.Add((url, request.Headers.Authorization));
 
-            HttpResponseMessage response = _routes.TryGetValue(WithoutQuery(url), out string? body)
-                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) }
+            HttpResponseMessage response = _routes.TryGetValue(
+                WithoutQuery(url),
+                out (HttpStatusCode Status, string Body) route)
+                ? new HttpResponseMessage(route.Status) { Content = new StringContent(route.Body) }
                 : new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("") };
 
             response.RequestMessage = request;


### PR DESCRIPTION
## Summary

A refused NuGet service index is now reported as an access failure instead of being misdiagnosed as a feed with no search endpoint.

- collect typed HTTP failures independently for each configured source
- report `401` as requiring credentials, `403` as denied access, and other recorded failures as an unavailable service index
- preserve the existing inclusive fallback when the source produced no typed HTTP failure
- retain redacted URL, HTTP status, and service-index phase evidence in the diagnostic

Fixes #3572.

## Evidence

```text
dotnet run --project src/dotnet-inspect.Tests -c Release -- -class '*NuGetSearchSourcesTests*'
Total: 71, Errors: 0, Failed: 0, Skipped: 0
```

Coverage includes 401/403/400 responses, a readable index with no `SearchQueryService`, and a two-source case proving one feed's refusal is not attributed to the next feed.

## Compatibility

Successful search behavior and genuinely unsearchable feeds are unchanged. This PR only narrows diagnostics when existing typed failure telemetry observed an HTTP failure while reading that source's service index.