### PR TITLE
Restore ordered returned call arguments

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5272,6 +5272,28 @@ public sealed class CtorChainSamples : CtorChainBase
     public CtorChainSamples(long value) : this(value.ToString()) { }
 }
 
+public class NamedCtorArgumentOrderBase
+{
+    protected NamedCtorArgumentOrderBase(int before, int after)
+    {
+        Before = before;
+        After = after;
+    }
+
+    public int Before { get; }
+    public int After { get; }
+}
+
+public sealed class NamedCtorArgumentOrder : NamedCtorArgumentOrderBase
+{
+    public NamedCtorArgumentOrder(int value)
+        : base(after: Mutate(ref value), before: value)
+    {
+    }
+
+    static int Mutate(ref int value) => value++;
+}
+
 /// <summary>Lock shapes the lock-sugar pass must raise, including static-field, instance-field, and parameter receivers.</summary>
 public sealed class LockFixtureSamples
 {

--- a/src/ILInspector.Decompiler.Tests/ConstructorChainArgumentOrderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorChainArgumentOrderTests.cs
@@ -112,6 +112,57 @@ public class ConstructorChainArgumentOrderTests
         function.CheckInvariant();
     }
 
+    // Named constructor arguments can force source-order evaluation into a
+    // positional base call: Mutate(ref x) runs before the later read of x even
+    // though x is positional argument 1. Folding the spill after that read would
+    // reverse the observable order.
+    [Fact]
+    public void MutatedInlineArgumentLeftOfSpill_DoesNotInline()
+    {
+        var mutate = new MethodRef(Derived, "Mutate", Int32, [TypeRef.ByRef(Int32)], HasThis: false);
+        var call = ChainCall(2, new LoadArgument(1, "x", Int32), new LoadStackSlot(0, Int32));
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Call(mutate, isVirtual: false,
+            [new LoadArgumentAddress(1, "x", Int32)])));
+        block.Add(new ExpressionStatement(call));
+        block.Add(new Return(null));
+        var container = new BlockContainer();
+        container.Add(block);
+        var function = new IrFunction(
+            ".ctor",
+            Derived,
+            new MethodSignature(
+                Void,
+                [new Parameter("x", Int32)],
+                HasThis: true,
+                GenericParameterCount: 0),
+            [],
+            container)
+        {
+            BaseType = Base,
+        };
+
+        RunPass(function);
+
+        Assert.Equal(1, StackStores(function));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CompilerNamedArguments_MutationBeforeRead_DeclinesUnsafeFold()
+    {
+        using var source = MetadataSource.Open(typeof(NamedCtorArgumentOrder).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(NamedCtorArgumentOrder).FullName!, ".ctor");
+        Assert.NotNull(function);
+
+        IrPasses.Run(function);
+        var result = CSharpPrinter.Print(function);
+
+        Assert.Null(result.ConstructorChain);
+        Assert.Contains("direct constructor call", result.Output);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
     // Reorder-trivial spills (constants) read nothing and have no effect, so a
     // reversed pure shape still inlines — only order-sensitive values are gated.
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -837,6 +837,39 @@ public class ExpressionInliningPassTests
         function.CheckInvariant();
     }
 
+    // raised-mutation sibling: IncrementDecrementPass can consume a
+    // StoreArgument and leave x++ as the only writer witness. The shared
+    // inventory must still keep the earlier inline x read as a barrier.
+    [Fact]
+    public void ReturnedCall_RunIncrementingEarlierArgument_StaysSpilled()
+    {
+        var second = new MethodRef(Holder, "Second", Int32, [], HasThis: false);
+        var combine = new MethodRef(Holder, "Combine", Int32, [Int32, Int32, Int32], HasThis: false);
+        var body = new BlockContainer();
+        var block = new Block(0);
+        body.Add(block);
+        block.Add(new StoreStackSlot(0, new IncrementDecrement(
+            new LoadArgument(0, "x", Int32),
+            isIncrement: true,
+            isPrefix: false)));
+        block.Add(new StoreStackSlot(1, new Call(second, isVirtual: false, [])));
+        block.Add(new Return(new Call(combine, isVirtual: false,
+            [new LoadArgument(0, "x", Int32), new LoadStackSlot(0, Int32), new LoadStackSlot(1, Int32)])));
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [new Parameter("x", Int32)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ExpressionInliningPass(slotsOnly: true).Run(function, PassContext.None);
+
+        Assert.True(HasStoreStackSlot(function, 0));
+        Assert.True(HasStoreStackSlot(function, 1));
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count());
+        function.CheckInvariant();
+    }
+
     // type-witness near miss: the slot load's object type carries a required
     // reconciliation for the int-producing store. Folding would erase it.
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -644,6 +644,24 @@ public class ExpressionInliningPassTests
             body);
     }
 
+    static IrFunction ReturningInt32(params IrNode[] statements)
+        => ReturningInt32([], statements);
+
+    static IrFunction ReturningInt32(ImmutableArray<TypeRef> locals, params IrNode[] statements)
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        foreach (var statement in statements)
+            block.Add(statement);
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            locals,
+            body);
+    }
+
     static bool HasStoreLocal(IrFunction function, int index)
         => function.Descendants.OfType<StoreLocal>().Any(store => store.Index == index);
 
@@ -707,6 +725,111 @@ public class ExpressionInliningPassTests
         new ExpressionInliningPass().Run(function, PassContext.None);
 
         Assert.False(HasStoreLocal(function, 0));
+        function.CheckInvariant();
+    }
+
+    // ordered argument run: csc can evaluate multiple effectful call arguments
+    // onto the stack, then spill each into a synthetic slot while a later
+    // argument is reconstructed. Folding the whole run into the returned call in
+    // store order restores the original left-to-right evaluation.
+    [Fact]
+    public void ReturnedCall_OrderedEffectfulStackSlotRun_InlinesAsUnit()
+    {
+        var first = new MethodRef(Holder, "First", Int32, [], HasThis: false);
+        var second = new MethodRef(Holder, "Second", Int32, [], HasThis: false);
+        var combine = new MethodRef(Holder, "Combine", Int32, [Int32, Int32], HasThis: false);
+        var function = ReturningInt32(
+            new StoreStackSlot(0, new Call(first, isVirtual: false, [])),
+            new StoreStackSlot(1, new Call(second, isVirtual: false, [])),
+            new Return(new Call(combine, isVirtual: false,
+                [new LoadStackSlot(0, Int32), new LoadStackSlot(1, Int32)])));
+
+        new ExpressionInliningPass(slotsOnly: true).Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        var call = Assert.IsType<Call>(Assert.Single(function.Descendants.OfType<Return>()).Value);
+        Assert.Equal(["First", "Second"], call.Arguments.Cast<Call>().Select(argument => argument.Callee.Name));
+        function.CheckInvariant();
+    }
+
+    // evaluation-order near miss: the same stores cannot fold when an effectful
+    // inline argument runs before their loads. Moving First()/Second() after
+    // Prefix() would change call and exception order.
+    [Fact]
+    public void ReturnedCall_EffectfulPrefixBeforeStackSlotRun_StaysSpilled()
+    {
+        var first = new MethodRef(Holder, "First", Int32, [], HasThis: false);
+        var second = new MethodRef(Holder, "Second", Int32, [], HasThis: false);
+        var prefix = new MethodRef(Holder, "Prefix", Int32, [], HasThis: false);
+        var combine = new MethodRef(Holder, "Combine", Int32, [Int32, Int32, Int32], HasThis: false);
+        var function = ReturningInt32(
+            new StoreStackSlot(0, new Call(first, isVirtual: false, [])),
+            new StoreStackSlot(1, new Call(second, isVirtual: false, [])),
+            new Return(new Call(combine, isVirtual: false,
+                [new Call(prefix, isVirtual: false, []), new LoadStackSlot(0, Int32), new LoadStackSlot(1, Int32)])));
+
+        new ExpressionInliningPass(slotsOnly: true).Run(function, PassContext.None);
+
+        Assert.True(HasStoreStackSlot(function, 0));
+        Assert.True(HasStoreStackSlot(function, 1));
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count());
+        function.CheckInvariant();
+    }
+
+    // hidden-operation near miss: the second load is nested under an array
+    // literal, whose allocation runs before its elements. It is not a direct call
+    // argument, so folding Second() into that element would move it after the
+    // allocation and change exception/allocation order.
+    [Fact]
+    public void ReturnedCall_StackSlotRunNestedUnderArrayLiteral_StaysSpilled()
+    {
+        var intArray = TypeRef.SzArray(Int32);
+        var first = new MethodRef(Holder, "First", Int32, [], HasThis: false);
+        var second = new MethodRef(Holder, "Second", Int32, [], HasThis: false);
+        var combine = new MethodRef(Holder, "Combine", Int32, [Int32, intArray], HasThis: false);
+        var function = ReturningInt32(
+            new StoreStackSlot(0, new Call(first, isVirtual: false, [])),
+            new StoreStackSlot(1, new Call(second, isVirtual: false, [])),
+            new Return(new Call(combine, isVirtual: false,
+                [
+                    new LoadStackSlot(0, Int32),
+                    new ArrayLiteral(Int32, intArray, [new LoadStackSlot(1, Int32)]),
+                ])));
+
+        new ExpressionInliningPass(slotsOnly: true).Run(function, PassContext.None);
+
+        Assert.True(HasStoreStackSlot(function, 0));
+        Assert.True(HasStoreStackSlot(function, 1));
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count());
+        function.CheckInvariant();
+    }
+
+    // slots-only boundary: an adjacent user local may feed the same returned
+    // call, but the ordered-run mode owns only compiler spill slots. The local
+    // load is an order barrier, so the all-or-nothing fold must preserve both the
+    // source-carrying local and the slot run after it.
+    [Fact]
+    public void ReturnedCall_OrderedStackSlotRun_DoesNotConsumePrecedingUserLocal()
+    {
+        var first = new MethodRef(Holder, "First", Int32, [], HasThis: false);
+        var second = new MethodRef(Holder, "Second", Int32, [], HasThis: false);
+        var third = new MethodRef(Holder, "Third", Int32, [], HasThis: false);
+        var combine = new MethodRef(Holder, "Combine", Int32, [Int32, Int32, Int32], HasThis: false);
+        var function = ReturningInt32(
+            [Int32],
+            new StoreLocal(0, Int32, new Call(first, isVirtual: false, [])),
+            new StoreStackSlot(0, new Call(second, isVirtual: false, [])),
+            new StoreStackSlot(1, new Call(third, isVirtual: false, [])),
+            new Return(new Call(combine, isVirtual: false,
+                [new LoadLocal(0, Int32), new LoadStackSlot(0, Int32), new LoadStackSlot(1, Int32)])));
+
+        new ExpressionInliningPass(slotsOnly: true).Run(function, PassContext.None);
+
+        Assert.True(HasStoreLocal(function, 0));
+        Assert.True(HasStoreStackSlot(function, 0));
+        Assert.True(HasStoreStackSlot(function, 1));
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count());
         function.CheckInvariant();
     }
 

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -805,6 +805,60 @@ public class ExpressionInliningPassTests
         function.CheckInvariant();
     }
 
+    // argument-stability near miss: Mutate(ref x) runs before the returned call
+    // loads x. Folding it into a later argument would load x first and pass the
+    // pre-mutation value. An addressed parameter is therefore an order barrier.
+    [Fact]
+    public void ReturnedCall_RunMutatingEarlierArgument_StaysSpilled()
+    {
+        var mutate = new MethodRef(Holder, "Mutate", Int32, [TypeRef.ByRef(Int32)], HasThis: false);
+        var second = new MethodRef(Holder, "Second", Int32, [], HasThis: false);
+        var combine = new MethodRef(Holder, "Combine", Int32, [Int32, Int32, Int32], HasThis: false);
+        var body = new BlockContainer();
+        var block = new Block(0);
+        body.Add(block);
+        block.Add(new StoreStackSlot(0, new Call(mutate, isVirtual: false,
+            [new LoadArgumentAddress(0, "x", Int32)])));
+        block.Add(new StoreStackSlot(1, new Call(second, isVirtual: false, [])));
+        block.Add(new Return(new Call(combine, isVirtual: false,
+            [new LoadArgument(0, "x", Int32), new LoadStackSlot(0, Int32), new LoadStackSlot(1, Int32)])));
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [new Parameter("x", Int32)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ExpressionInliningPass(slotsOnly: true).Run(function, PassContext.None);
+
+        Assert.True(HasStoreStackSlot(function, 0));
+        Assert.True(HasStoreStackSlot(function, 1));
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count());
+        function.CheckInvariant();
+    }
+
+    // type-witness near miss: the slot load's object type carries a required
+    // reconciliation for the int-producing store. Folding would erase it.
+    [Fact]
+    public void ReturnedCall_StackSlotTypeMismatch_StaysSpilled()
+    {
+        var first = new MethodRef(Holder, "First", Int32, [], HasThis: false);
+        var second = new MethodRef(Holder, "Second", Int32, [], HasThis: false);
+        var combine = new MethodRef(Holder, "Combine", Int32, [Object, Int32], HasThis: false);
+        var function = ReturningInt32(
+            new StoreStackSlot(0, new Call(first, isVirtual: false, [])),
+            new StoreStackSlot(1, new Call(second, isVirtual: false, [])),
+            new Return(new Call(combine, isVirtual: false,
+                [new LoadStackSlot(0, Object), new LoadStackSlot(1, Int32)])));
+
+        new ExpressionInliningPass(slotsOnly: true).Run(function, PassContext.None);
+
+        Assert.True(HasStoreStackSlot(function, 0));
+        Assert.True(HasStoreStackSlot(function, 1));
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count());
+        function.CheckInvariant();
+    }
+
     // slots-only boundary: an adjacent user local may feed the same returned
     // call, but the ordered-run mode owns only compiler spill slots. The local
     // load is an order barrier, so the all-or-nothing fold must preserve both the

--- a/src/ILInspector.Decompiler.Tests/ExpressionTreeLambdaTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionTreeLambdaTests.cs
@@ -344,6 +344,7 @@ public class ExpressionTreeLambdaTests
         var output = CSharpPrinter.Print(function).Output;
         Assert.Contains("Expression.Lambda<Func<int, bool>>", output);
         Assert.Contains("Expression.GreaterThan", output);
+        Assert.DoesNotContain("S_", output);
         Assert.DoesNotContain("=>", output);
     }
 

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -70,15 +70,14 @@ public class FidelityGateTests
         // raises into nested if/else, the same honest comparison-tree over-render
         // as the other sparse-switch entries — valid, not opcode-exact.
         "SlotDiamondDispatch",
-        // The next three became compile-checkable only when the fidelity harness
+        // The next two became compile-checkable only when the fidelity harness
         // began reconstructing sibling properties as property syntax (#1412): a
-        // body's `obj.X` / object-initializer / `?.X = v` cannot bind to a bare
+        // body's `obj.X` / `?.X = v` cannot bind to a bare
         // `get_X`/`set_X` method, so these were silently recompile-failing before.
         // The newly-visible diffs are honest decompiler over-renders, not harness
         // artifacts (verified by opcode dump): a flipped short-circuit branch with
         // a temp slot, and reused-slot temporaries — valid C#, not opcode-exact.
         "NullConditionalPropertyAssignment",
-        "ObjectInitializerArgumentBeforeShortCircuit",
         "ReusedSlotStringListCount",
         // SwitchStoreThenUse is the #1710 ConditionalStoreChainPass fold: a
         // compare-chain switch assigning a local folds to a nested conditional
@@ -113,42 +112,11 @@ public class FidelityGateTests
         // honest pre-existing body over-renders (ref/in/out call sites, positional
         // patterns, slot/ternary merges, null-coalescing assignment).
         "FloatPositionalPattern",
-        // Expression-tree factory fixtures are valid and Full, but SDK preview6
-        // compile-back reshapes the manually emitted Expression.* calls around
-        // stack-slot/local temporaries. This is toolchain drift in an existing
-        // over-render frontier, not a new daily product regression.
-        "ManualSimpleExpressionTreeFactory",
-        // The manual factory fixtures below DECLINE and decompile to honest
-        // Expression.* factory-call C# with clean locals: the malformed/shared-graph
-        // near misses (reused parameter identity, duplicate names, unspellable name),
-        // the canonical graphs returned through Expression/LambdaExpression/object
-        // sinks, and the constant-only arithmetic graphs Roslyn would fold. Like
-        // ManualSimpleExpressionTreeFactory, their emitted Expression.* calls
-        // recompile through SDK preview compile-back reshaping of stack-slot/local
-        // temporaries — a valid over-render, not opcode-exact. Verified by running
-        // the Speed=Slow fidelity gate locally.
-        "ManualCanonicalReturnedAsExpression",
-        "ManualCanonicalReturnedAsLambdaExpression",
-        "ManualCanonicalReturnedAsObject",
+        // These malformed/shared-graph near misses keep honest Expression.*
+        // factory calls, but their parameter-alias locals still recompile through
+        // a different stack shape.
         "ManualReusedParameterFactory",
         "ManualDuplicateNameFactory",
-        "ManualUnspellableNameFactory",
-        "ManualConstantOnlyAddFactory",
-        // ManualConstantOnlyComparisonFactory belongs to the same constant-only
-        // manual-factory group, but arrived later (#3053) than the group's docket
-        // entry and so was never added. Its diff is the group's diff — compile-back
-        // reshapes the hand-emitted Expression.* calls around stack-slot temporaries
-        // (added stloc/stloc + ldloc/ldloc, no opcode-kind change elsewhere). It is
-        // an omission unmasked by running this Speed=Slow gate, not a new regression:
-        // the raise itself is pinned by
-        // ExpressionTreeLambdaTests.ManualConstantOnlyComparisonFactory_StaysFactoryCalls,
-        // which stays green. Tracked as #3502.
-        "ManualConstantOnlyComparisonFactory",
-        "ManualConstantOnlySubtractFactory",
-        "ManualConstantOnlyMultiplyFactory",
-        "ManualNestedConstantSubtreeFactory",
-        "ManualConstantOnlyDivideByZeroFactory",
-        "ManualConstantOnlyRemainderOverflowFactory",
         "ManualPositionalPatternLookalike",
         "MergedReferenceSlot",
         "MergedTernaryDeclaration",
@@ -496,6 +464,24 @@ public class FidelityGateTests
         "GenericRefKindCallSites",
         "LocalBodyLambda",
         "ManualParameterPlusConstantFactory",
+        // #3502: the late inliner now restores an ordered run of stack-held
+        // arguments directly into a returned call. These factory calls and the
+        // object-initializer near miss all lose their synthetic spill locals and
+        // recompile Exact; pin both the intended comparison fix and every measured
+        // sibling promotion.
+        "ManualCanonicalReturnedAsExpression",
+        "ManualCanonicalReturnedAsLambdaExpression",
+        "ManualCanonicalReturnedAsObject",
+        "ManualConstantOnlyAddFactory",
+        "ManualConstantOnlyComparisonFactory",
+        "ManualConstantOnlyDivideByZeroFactory",
+        "ManualConstantOnlyMultiplyFactory",
+        "ManualConstantOnlyRemainderOverflowFactory",
+        "ManualConstantOnlySubtractFactory",
+        "ManualNestedConstantSubtreeFactory",
+        "ManualSimpleExpressionTreeFactory",
+        "ManualUnspellableNameFactory",
+        "ObjectInitializerArgumentBeforeShortCircuit",
         "NonCapturingLambda",
         "OrBoolIntMix",
         "OrBoolUintMix",

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -57,12 +57,11 @@ public class LoweredFidelityGateTests
         "SlotDiamondDispatch",
         // Newly compile-checkable only once the harness reconstructs sibling
         // properties as property syntax (#1412): a body's `obj.X` /
-        // object-initializer / `?.X = v` cannot bind to a bare `get_X`/`set_X`
+        // `?.X = v` cannot bind to a bare `get_X`/`set_X`
         // method, so these were silently recompile-failing before. The diffs are
         // honest decompiler over-renders (flipped short-circuit branch with a temp
         // slot; reused-slot temporaries), not harness artifacts.
         "NullConditionalPropertyAssignment",
-        "ObjectInitializerArgumentBeforeShortCircuit",
         "ReusedSlotStringListCount",
         // SwitchStoreThenUse (#1743) is a known opcode-diff in the sibling sugared
         // FidelityGateTests docket — the ConditionalStoreChainPass ternary
@@ -93,29 +92,11 @@ public class LoweredFidelityGateTests
         // in-parameter operators rendered as illegal `ref`). Now compile-checked,
         // showing honest pre-existing over-renders. Same set as the sugared docket.
         "FloatPositionalPattern",
-        // Expression-tree factory fixtures are valid and Full, but SDK preview6
-        // compile-back reshapes the manually emitted Expression.* calls around
-        // stack-slot/local temporaries. Same preview drift as the sugared gate.
-        "ManualSimpleExpressionTreeFactory",
-        // Same expression-tree docket as the sugared gate: the manual factory
-        // fixtures below decline to honest Expression.* factory-call C# whose
-        // emitted calls recompile through the same preview compile-back temporary
-        // reshaping. Verified by running the Speed=Slow lowered fidelity gate locally.
-        "ManualCanonicalReturnedAsExpression",
-        "ManualCanonicalReturnedAsLambdaExpression",
-        "ManualCanonicalReturnedAsObject",
+        // These malformed/shared-graph near misses keep honest Expression.*
+        // factory calls, but their parameter-alias locals still recompile through
+        // a different stack shape.
         "ManualReusedParameterFactory",
         "ManualDuplicateNameFactory",
-        "ManualUnspellableNameFactory",
-        "ManualConstantOnlyAddFactory",
-        // Same group, added later (#3053) and never docketed on either rail; see the
-        // matching entry in FidelityGateTests.KnownDiffs. Tracked as #3502.
-        "ManualConstantOnlyComparisonFactory",
-        "ManualConstantOnlySubtractFactory",
-        "ManualConstantOnlyMultiplyFactory",
-        "ManualNestedConstantSubtreeFactory",
-        "ManualConstantOnlyDivideByZeroFactory",
-        "ManualConstantOnlyRemainderOverflowFactory",
         "ManualPositionalPatternLookalike",
         "MergedReferenceSlot",
         "MergedTernaryDeclaration",
@@ -228,6 +209,22 @@ public class LoweredFidelityGateTests
         "Issue2830_ForLoopNestedContinue",
         "Issue2861_ForLoopTryAndCatchContinues",
         "ManualParameterPlusConstantFactory",
+        // #3502: the late inliner now restores an ordered run of stack-held
+        // arguments directly into a returned call. Pin the intended comparison
+        // fix and every sibling row measured Exact on this rail.
+        "ManualCanonicalReturnedAsExpression",
+        "ManualCanonicalReturnedAsLambdaExpression",
+        "ManualCanonicalReturnedAsObject",
+        "ManualConstantOnlyAddFactory",
+        "ManualConstantOnlyComparisonFactory",
+        "ManualConstantOnlyDivideByZeroFactory",
+        "ManualConstantOnlyMultiplyFactory",
+        "ManualConstantOnlyRemainderOverflowFactory",
+        "ManualConstantOnlySubtractFactory",
+        "ManualNestedConstantSubtreeFactory",
+        "ManualSimpleExpressionTreeFactory",
+        "ManualUnspellableNameFactory",
+        "ObjectInitializerArgumentBeforeShortCircuit",
         "OrBoolIntMix",
         "OrBoolUintMix",
         "RecursiveLocalFunction",

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainArgumentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainArgumentPass.cs
@@ -37,7 +37,14 @@ public sealed class ConstructorChainArgumentPass : IIrPass
         }
 
         var usage = SpilledReceiverFold.CountPlaces(function);
-        SpilledReceiverFold.TryFold(statement, call, usage, context, "inline spilled base/this constructor argument");
+        var orderSensitiveArguments = SpilledReceiverFold.OrderSensitiveArguments(function);
+        SpilledReceiverFold.TryFold(
+            statement,
+            call,
+            usage,
+            context,
+            "inline spilled base/this constructor argument",
+            orderSensitiveArguments: orderSensitiveArguments);
     }
 
     static Call? FindChainCall(IrFunction function)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -68,6 +68,16 @@ public sealed class ExpressionInliningPass : IIrPass
     static bool InlineReturnedCallArgumentRunOnce(IrFunction function, PassContext context)
     {
         var usage = SpilledReceiverFold.CountPlaces(function);
+        var unstableArguments = new HashSet<int>();
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case LoadArgumentAddress address: unstableArguments.Add(address.Index); break;
+                case StoreArgument store: unstableArguments.Add(store.Index); break;
+            }
+        }
+
         foreach (var @return in function.Descendants.OfType<Return>())
         {
             if (@return is not { Parent: Block block, Value: Call call })
@@ -107,7 +117,8 @@ public sealed class ExpressionInliningPass : IIrPass
                 usage,
                 context,
                 "inline ordered stack-slot run into returned call arguments",
-                stackSlotsOnly: true))
+                stackSlotsOnly: true,
+                orderSensitiveArguments: unstableArguments))
             {
                 return true;
             }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -22,6 +22,14 @@ namespace ILInspector.Decompiler.Pipeline;
 /// the interference scan keeps a value that reads a place from crossing a write
 /// to it.</para>
 ///
+/// <para>A third mode collapses a contiguous run of two or more synthetic
+/// stack-slot stores back into the direct arguments of a returned call. This is
+/// the multi-argument form of the same compiler spill: each stored value was
+/// evaluated in argument order and held on the evaluation stack until the call.
+/// The fold is all-or-nothing and uses
+/// <see cref="SpilledReceiverFold.RunPreservesEffectOrder"/> to require the
+/// direct argument loads to remain unconditional and in store order.</para>
+///
 /// <para><c>slotsOnly</c> restricts <see cref="InlineOnce"/> to synthetic stack
 /// slots (never user locals). This is the F2 mode (#2386): the pass runs a third
 /// time late in the pipeline — before <see cref="SlotMaterializationPass"/> — to
@@ -50,9 +58,61 @@ public sealed class ExpressionInliningPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        while (InlineOnce(function, context, _slotsOnly) || InlineLiveRangeOnce(function, context))
+        while (InlineReturnedCallArgumentRunOnce(function, context)
+            || InlineOnce(function, context, _slotsOnly)
+            || InlineLiveRangeOnce(function, context))
         {
         }
+    }
+
+    static bool InlineReturnedCallArgumentRunOnce(IrFunction function, PassContext context)
+    {
+        var usage = SpilledReceiverFold.CountPlaces(function);
+        foreach (var @return in function.Descendants.OfType<Return>())
+        {
+            if (@return is not { Parent: Block block, Value: Call call })
+                continue;
+
+            int runLength = 0;
+            bool directArgumentsOnly = true;
+            for (int i = @return.ChildIndex - 1; i >= 0; i--)
+            {
+                if (block.Children[i] is not StoreStackSlot store
+                    || SpilledReceiverFold.SpillLoadInside(store, call, usage) is not LoadStackSlot load)
+                {
+                    break;
+                }
+
+                runLength++;
+                // Direct arguments are stronger than the shared helper requires:
+                // no conditional or hidden-operation parent can sit between the
+                // call and the load, so moving the stored value crosses only the
+                // other arguments covered by RunPreservesEffectOrder.
+                if (!call.Arguments.Any(argument => ReferenceEquals(argument, load))
+                    || !Equals(store.Value.ResultType, load.ResultType))
+                {
+                    directArgumentsOnly = false;
+                    break;
+                }
+            }
+
+            // A single adjacent spill is already owned by InlineOnce. This mode
+            // exists for an ordered argument run that must fold as one unit.
+            if (runLength < 2 || !directArgumentsOnly)
+                continue;
+
+            if (SpilledReceiverFold.TryFold(
+                @return,
+                call,
+                usage,
+                context,
+                "inline ordered stack-slot run into returned call arguments",
+                stackSlotsOnly: true))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     static bool InlineOnce(IrFunction function, PassContext context, bool slotsOnly)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -68,15 +68,7 @@ public sealed class ExpressionInliningPass : IIrPass
     static bool InlineReturnedCallArgumentRunOnce(IrFunction function, PassContext context)
     {
         var usage = SpilledReceiverFold.CountPlaces(function);
-        var unstableArguments = new HashSet<int>();
-        foreach (var node in function.Descendants)
-        {
-            switch (node)
-            {
-                case LoadArgumentAddress address: unstableArguments.Add(address.Index); break;
-                case StoreArgument store: unstableArguments.Add(store.Index); break;
-            }
-        }
+        var orderSensitiveArguments = SpilledReceiverFold.OrderSensitiveArguments(function);
 
         foreach (var @return in function.Descendants.OfType<Return>())
         {
@@ -118,7 +110,7 @@ public sealed class ExpressionInliningPass : IIrPass
                 context,
                 "inline ordered stack-slot run into returned call arguments",
                 stackSlotsOnly: true,
-                orderSensitiveArguments: unstableArguments))
+                orderSensitiveArguments: orderSensitiveArguments))
             {
                 return true;
             }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FluentChainRecompositionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FluentChainRecompositionPass.cs
@@ -39,15 +39,16 @@ public sealed class FluentChainRecompositionPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        var orderSensitiveArguments = SpilledReceiverFold.OrderSensitiveArguments(function);
         // Fold to a fixpoint: each successful fold removes at least one spill
         // store, so the loop strictly shrinks the function and terminates. Usage
         // is recomputed each round because a fold moves loads into the sink.
-        while (FoldOne(function, context))
+        while (FoldOne(function, context, orderSensitiveArguments))
         {
         }
     }
 
-    static bool FoldOne(IrFunction function, PassContext context)
+    static bool FoldOne(IrFunction function, PassContext context, IReadOnlySet<int> orderSensitiveArguments)
     {
         var usage = SpilledReceiverFold.CountPlaces(function);
         foreach (var node in function.Descendants)
@@ -58,7 +59,13 @@ public sealed class FluentChainRecompositionPass : IIrPass
             {
                 continue;
             }
-            if (SpilledReceiverFold.TryFold(statement, sink, usage, context, "re-compose spilled fluent chain link"))
+            if (SpilledReceiverFold.TryFold(
+                statement,
+                sink,
+                usage,
+                context,
+                "re-compose spilled fluent chain link",
+                orderSensitiveArguments: orderSensitiveArguments))
                 return true;
         }
         return false;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SpilledReceiverFold.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SpilledReceiverFold.cs
@@ -28,7 +28,9 @@ static class SpilledReceiverFold
     /// current <see cref="CountPlaces"/> snapshot — a consumer that folds to a
     /// fixpoint must recompute it between folds because a fold moves loads.
     /// <paramref name="stackSlotsOnly"/> prevents the run from consuming an
-    /// adjacent user local.
+    /// adjacent user local. <paramref name="orderSensitiveArguments"/> names
+    /// parameter slots whose address escapes or whose value is reassigned, so a
+    /// moved effect cannot cross a read that it may change.
     /// </summary>
     public static bool TryFold(
         IrNode statement,
@@ -36,7 +38,8 @@ static class SpilledReceiverFold
         IReadOnlyDictionary<(bool IsSlot, int Index), Place> usage,
         PassContext context,
         string stepLabel,
-        bool stackSlotsOnly = false)
+        bool stackSlotsOnly = false,
+        IReadOnlySet<int>? orderSensitiveArguments = null)
     {
         if (statement.Parent is not Block block)
             return false;
@@ -62,7 +65,7 @@ static class SpilledReceiverFold
         // already-folded effect is dropped downstream. If the run is not
         // order-safe, leave every spill in place — an un-folded chain degrades
         // honestly rather than emit reordered C#.
-        if (!RunPreservesEffectOrder(run, sink))
+        if (!RunPreservesEffectOrder(run, sink, orderSensitiveArguments))
             return false;
 
         foreach (var (store, load, _) in run)
@@ -84,9 +87,14 @@ static class SpilledReceiverFold
     /// arm, which would make an always-run store conditional), and (2) reached, in
     /// the call's evaluation order, in store order and before any inline argument's
     /// own order-sensitive read or effect. Effect-free, place-free spills
-    /// (constants) reorder invisibly and constrain nothing.
+    /// (constants) reorder invisibly and constrain nothing. Argument loads are
+    /// likewise barriers when <paramref name="orderSensitiveArguments"/> says
+    /// their storage is mutable or escaped.
     /// </summary>
-    public static bool RunPreservesEffectOrder(List<(IrNode Store, IrNode Load, IrExpression Value)> run, Call call)
+    public static bool RunPreservesEffectOrder(
+        List<(IrNode Store, IrNode Load, IrExpression Value)> run,
+        Call call,
+        IReadOnlySet<int>? orderSensitiveArguments = null)
     {
         var storeRank = new Dictionary<IrNode, int>(ReferenceEqualityComparer.Instance);
         var spillLoads = new HashSet<IrNode>(ReferenceEqualityComparer.Instance);
@@ -128,7 +136,7 @@ static class SpilledReceiverFold
                 return;  // a trivial spill load folds to a constant: no barrier
             foreach (var child in node.Children)
                 Visit(child);
-            if (IsOrderSensitive(node))
+            if (IsOrderSensitive(node, orderSensitiveArguments))
                 sawBarrier = true;
         }
 
@@ -218,14 +226,21 @@ static class SpilledReceiverFold
 
     /// <summary>
     /// True unless <paramref name="node"/> is provably reorder-pure — i.e. anything
-    /// other than a constant, <c>sizeof</c>, <c>ldtoken</c>, or an argument/receiver
-    /// load. Everything else (place reads, calls, stores, allocations, casts and
-    /// other potentially-throwing or order-sensitive operations) is treated as a
-    /// barrier, so a moved value can never cross it. Deny-list by design: an
-    /// unrecognized node is conservatively a barrier rather than silently reorderable.
+    /// other than a constant, <c>sizeof</c>, <c>ldtoken</c>, or a stable
+    /// argument/receiver load. An argument whose storage is mutable or escaped
+    /// remains a barrier. Everything else (place reads, calls, stores, allocations,
+    /// casts and other potentially-throwing or order-sensitive operations) is
+    /// treated as a barrier, so a moved value can never cross it. Deny-list by
+    /// design: an unrecognized node is conservatively a barrier rather than
+    /// silently reorderable.
     /// </summary>
-    static bool IsOrderSensitive(IrNode node)
-        => node is not (Constant or SizeOf or LoadToken or LoadArgument);
+    static bool IsOrderSensitive(IrNode node, IReadOnlySet<int>? orderSensitiveArguments)
+        => node switch
+        {
+            Constant or SizeOf or LoadToken => false,
+            LoadArgument argument => orderSensitiveArguments?.Contains(argument.Index) == true,
+            _ => true,
+        };
 
     public static Dictionary<(bool IsSlot, int Index), Place> CountPlaces(IrFunction function)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SpilledReceiverFold.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SpilledReceiverFold.cs
@@ -2,19 +2,21 @@ namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
 /// Shared effect-order-preserving argument-run fold, extracted verbatim from
-/// <see cref="ConstructorChainArgumentPass"/> so its two consumers — the
-/// constructor-chain lift and <see cref="FluentChainRecompositionPass"/> — reason
+/// <see cref="ConstructorChainArgumentPass"/> so the constructor-chain lift and
+/// <see cref="FluentChainRecompositionPass"/> reason
 /// about the same soundness condition rather than maintaining parallel copies.
 ///
 /// The shape both passes fold is identical: a sink <see cref="Call"/> preceded in
 /// its block by a contiguous run of single-use spill stores whose one load each
-/// sits inside the call. Folding collapses each spill back into the call. The
+/// sits inside the call. <see cref="ExpressionInliningPass"/> additionally uses
+/// the fold for a stack-slot-only run of direct returned-call arguments. Folding
+/// collapses each spill back into the call. The
 /// move is only performed when it provably reorders no effect —
 /// <see cref="RunPreservesEffectOrder"/> is the gate, all-or-nothing per run.
 ///
-/// What differs between the two consumers is only which call is the sink and how
-/// it is found; the fold arithmetic and its safety proof are the same, and live
-/// here.
+/// Callers differ only in which call is the sink, how it is found, and whether
+/// user locals are eligible; the fold arithmetic and its safety proof are the
+/// same, and live here.
 /// </summary>
 static class SpilledReceiverFold
 {
@@ -25,13 +27,16 @@ static class SpilledReceiverFold
     /// when a non-empty run was folded. <paramref name="usage"/> is the caller's
     /// current <see cref="CountPlaces"/> snapshot — a consumer that folds to a
     /// fixpoint must recompute it between folds because a fold moves loads.
+    /// <paramref name="stackSlotsOnly"/> prevents the run from consuming an
+    /// adjacent user local.
     /// </summary>
     public static bool TryFold(
         IrNode statement,
         Call sink,
         IReadOnlyDictionary<(bool IsSlot, int Index), Place> usage,
         PassContext context,
-        string stepLabel)
+        string stepLabel,
+        bool stackSlotsOnly = false)
     {
         if (statement.Parent is not Block block)
             return false;
@@ -41,6 +46,8 @@ static class SpilledReceiverFold
         var run = new List<(IrNode Store, IrNode Load, IrExpression Value)>();
         for (int i = statement.ChildIndex - 1; i >= 0; i--)
         {
+            if (stackSlotsOnly && block.Children[i] is not StoreStackSlot)
+                break;
             if (SpillLoadInside(block.Children[i], sink, usage) is not { } load)
                 break;
             run.Add((block.Children[i], load, (IrExpression)block.Children[i].Children[0]));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SpilledReceiverFold.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SpilledReceiverFold.cs
@@ -21,6 +21,40 @@ namespace ILInspector.Decompiler.Pipeline;
 static class SpilledReceiverFold
 {
     /// <summary>
+    /// Argument slots whose value may change while an effectful spill is moved:
+    /// direct stores, raised increments/decrements, address escapes, and
+    /// deconstruction targets. Keep this inventory aligned with
+    /// <c>ExpressionInliningPass.WritesNode</c>'s argument cases.
+    /// </summary>
+    public static HashSet<int> OrderSensitiveArguments(IrFunction function)
+    {
+        var arguments = new HashSet<int>();
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case StoreArgument store:
+                    arguments.Add(store.Index);
+                    break;
+                case IncrementDecrement { Target: LoadArgument argument }:
+                    arguments.Add(argument.Index);
+                    break;
+                case LoadArgumentAddress address:
+                    arguments.Add(address.Index);
+                    break;
+                case DeconstructionAssignment deconstruction:
+                    foreach (var target in deconstruction.Targets)
+                    {
+                        if (target.Kind == DeconstructionTargetKind.Argument)
+                            arguments.Add(target.ArgumentIndex);
+                    }
+                    break;
+            }
+        }
+        return arguments;
+    }
+
+    /// <summary>
     /// Folds the maximal contiguous run of single-use spill stores immediately
     /// preceding <paramref name="statement"/> whose one load sits inside
     /// <paramref name="sink"/>, when doing so preserves effect order. Returns true


### PR DESCRIPTION
- Fixes #3502
- Changes ordered stack-held arguments to recompose directly into returned calls without reordering effects
- Card revision: `c68fa153f59a37c920fccfdcacbdd698b68c48d2`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the four synthetic spill operations are gone, both
compile-back rails report `Exact`, and the effect-order guards retain the close
negative shapes.

### Benchmark target

Benchmark target:
`ILInspector.Decompiler.Tests.CfgSampleClass::ManualConstantOnlyComparisonFactory`
at `7060ee9ba15c6e5d9e15bc2d434a393452355293`

dotnet-inspect command:

```bash
dotnet-inspect member ILInspector.Decompiler.Tests.CfgSampleClass \
  ManualConstantOnlyComparisonFactory \
  --library ILInspector.Decompiler.Tests.dll \
  -S "Decompiled Source"
```

### Original source

```csharp
public static System.Linq.Expressions.Expression<System.Func<int, bool>> ManualConstantOnlyComparisonFactory()
{
    var x = System.Linq.Expressions.Expression.Parameter(typeof(int), "x");
    return System.Linq.Expressions.Expression.Lambda<System.Func<int, bool>>(
        System.Linq.Expressions.Expression.GreaterThan(
            System.Linq.Expressions.Expression.Constant(2, typeof(int)),
            System.Linq.Expressions.Expression.Constant(3, typeof(int))),
        x);
}
```

### Before

```csharp
public static System.Linq.Expressions.Expression<System.Func<int, bool>> ManualConstantOnlyComparisonFactory()
{
    ParameterExpression x = Expression.Parameter(typeof(int), "x");
    BinaryExpression S_257 = Expression.GreaterThan(Expression.Constant(2, typeof(int)), Expression.Constant(3, typeof(int)));
    ParameterExpression[] S_256 = new ParameterExpression[] { x };
    return Expression.Lambda<Func<int, bool>>(S_257, S_256);
}
```

- Valid: True
- Correct: True
- IL fidelity: False — two `stloc` and two `ldloc` operations are added
- Taste applied: None
- Commit: `7060ee9ba15c6e5d9e15bc2d434a393452355293`

### After

```csharp
public static System.Linq.Expressions.Expression<System.Func<int, bool>> ManualConstantOnlyComparisonFactory()
{
    ParameterExpression x = Expression.Parameter(typeof(int), "x");
    return Expression.Lambda<Func<int, bool>>(Expression.GreaterThan(Expression.Constant(2, typeof(int)), Expression.Constant(3, typeof(int))), new ParameterExpression[] { x });
}
```

- Valid: True
- Correct: True
- IL fidelity: True — `Exact` on the sugared and lowered rails
- Taste applied: None
- Commit: `c68fa153f59a37c920fccfdcacbdd698b68c48d2`

### Fully raised

The After decompilation is in the fully raised state. The constant-only
expression-tree graph intentionally remains in honest factory-call form because
raising it to `x => 2 > 3` would let Roslyn fold the comparison and change the
tree.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| `ExpressionInliningPassTests` | 33 passed | 40 passed |
| Focused spill-fold tests | 44 passed | 53 passed |
| Decompiler fast suite | 4,549 passed, 8 expected Windows skips | 4,558 passed, 8 expected Windows skips |
| Sugared fidelity docket | Pass; target `OpcodeDiff` | Pass; target `Exact` |
| Lowered fidelity docket | Pass; target `OpcodeDiff` | Pass; target `Exact` |
| Real witness | Four added spill operations | No added operations |

The bidirectional docket gates promoted every row that became exact: the target,
11 sibling expression-tree factory methods, and
`ObjectInitializerArgumentBeforeShortCircuit`.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the 15-assembly PR quick sensor stayed within all
baseline tolerances and reported zero pass bugs.

### PR quick gate

Run: hash-stable 100-method sample over 15 assemblies (1,500 methods); validity
and corpus fidelity were intentionally disabled by the PR quick profile.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Detected lowering residue (-) | 251 (16.73%) | 232 (15.47%) |
| Conditional-branch residue (-) | 46 (3.07%) | 40 (2.67%) |
| Forward-merge stops (-) | 32 (2.13%) | 27 (1.80%) |
| Pass bugs (-) | 0 | 0 |

> **Conclusion:** **PASS** — corpus sensor matched baseline tolerances; aggregate
> populations differ, so the rate movement is advisory rather than attributed
> to this change.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --no-restore
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class ILInspector.Decompiler.Tests.ExpressionInliningPassTests \
  -class ILInspector.Decompiler.Tests.ConstructorChainArgumentOrderTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -class ILInspector.Decompiler.Tests.FidelityGateTests \
  -class ILInspector.Decompiler.Tests.LoweredFidelityGateTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  --gate fast
```
