### PR TITLE
Improve offline package version guidance

### DIFF
--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -40,6 +40,13 @@ This is the default and the most common case. Resolution follows this order:
    reported it, use only a payload cached under one of those producers;
    otherwise download from one of them.
 
+When usable local package versions exist but freshness metadata has expired, the
+network lookup has a one-second budget. A timeout remains a visible resolution
+failure rather than silently selecting stale content, but the diagnostic lists
+the newest local versions and shows an exact `Name@Version` command that works
+without version discovery. Explicit `Name@latest` keeps its always-check
+behavior and is not subject to this shortened budget.
+
 Adding `--preview`/`--prerelease` switches step 1/2 to a separate prerelease-aware
 version cache/feed query and may resolve to a preview version.
 
@@ -274,7 +281,7 @@ offline mode, and unsupported local feed URLs are not cached as misses.
 | Download or check | Cache behavior |
 | --- | --- |
 | Pinned package `.nupkg` extraction | Uses a global or app payload only when its recorded producer is eligible; downloads otherwise. |
-| Bare package version resolution | Uses the version-resolution cache with a 1-hour TTL, then NuGet; package caches are used only after the version is resolved. |
+| Bare package version resolution | Uses the version-resolution cache with a 1-hour TTL, then NuGet. When usable local versions exist, an uncached network lookup is bounded to one second and timeout diagnostics offer exact local pins; package caches are still used only after a version is resolved. |
 | Bare package `--preview` resolution | Uses a separate prerelease-aware version-resolution cache with a 1-hour TTL, then NuGet. |
 | Wildcard version resolution | Uses the same version-list cache as `--versions` with a 1-hour TTL for nuget.org-backed sources. |
 | Addressable package range | Uses the version-list cache to resolve the vector; package caches are consulted only after a caller selects a cell. |

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -378,56 +378,96 @@ public static class NuGetCache
         string packageName,
         IReadOnlyList<string>? allowedSourceKeys)
     {
-        var normalizedName = packageName.ToLowerInvariant();
+        return GetCachedVersions(
+            packageName,
+            allowedSourceKeys,
+            includePrerelease: false,
+            limit: 1).FirstOrDefault();
+    }
 
-        // Newest non-prerelease, structurally-valid version across both caches.
-        bool IsNuGetCacheValid(string dir) =>
-            IsCachedPackageValid(dir, normalizedName);
-        bool IsAppCacheValid(string dir)
+    /// <summary>
+    /// Returns cached package versions, newest first, without touching the network.
+    /// App-cache entries are included only when they were committed by a source the
+    /// caller is currently configured to read.
+    /// </summary>
+    public static IReadOnlyList<string> GetCachedVersions(
+        string packageName,
+        IReadOnlyList<string>? allowedSourceKeys,
+        bool includePrerelease = true,
+        int? limit = null)
+    {
+        var normalizedName = packageName.ToLowerInvariant();
+        var versions = new Dictionary<NuGetVersion, string>();
+
+        void AddVersions(string root, Func<string, string, bool> isValid)
         {
-            // A version directory now holds one slot per source. The version
-            // counts as cached only if a source this caller reads from
-            // committed it.
-            string version = Path.GetFileName(dir);
-            foreach (var sourceKey in allowedSourceKeys ?? [])
+            if (!Directory.Exists(root))
+                return;
+
+            try
             {
-                if (IsCommittedPackageValid(
-                        Path.Combine(dir, sourceKey),
-                        normalizedName,
-                        version,
-                        sourceKey))
+                foreach (var dir in Directory.GetDirectories(root))
                 {
-                    return true;
+                    string version = Path.GetFileName(dir);
+                    if (!NuGetVersion.TryParse(version, out var parsed)
+                        || (!includePrerelease && parsed.IsPrerelease)
+                        || !isValid(dir, version))
+                    {
+                        continue;
+                    }
+
+                    versions.TryAdd(parsed, version);
                 }
             }
-
-            return false;
+            catch (IOException)
+            {
+                // A cache that cannot be enumerated contributes no suggestions.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // A cache that cannot be enumerated contributes no suggestions.
+            }
         }
-        VersionDir? best = null;
 
-        // Check NuGet global cache — skip in isolated mode
         if (!_skipNuGetCache)
         {
-            best = VersionDirectory.Higher(best, VersionDirectory.SelectBest(
+            AddVersions(
                 Path.Combine(GetNuGetCachePath(), normalizedName),
-                includePrerelease: false,
-                IsNuGetCacheValid));
+                (dir, _) => IsCachedPackageValid(dir, normalizedName));
         }
 
-        // Check app cache
         try
         {
-            best = VersionDirectory.Higher(best, VersionDirectory.SelectBest(
+            AddVersions(
                 Path.Combine(GetPackageContentCachePath(), normalizedName),
-                includePrerelease: false,
-                IsAppCacheValid));
+                (dir, version) =>
+                {
+                    foreach (var sourceKey in allowedSourceKeys ?? [])
+                    {
+                        if (IsCommittedPackageValid(
+                                Path.Combine(dir, sourceKey),
+                                normalizedName,
+                                version,
+                                sourceKey))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                });
         }
         catch (InvalidOperationException)
         {
-            // App cache not initialized
+            // App cache not initialized.
         }
 
-        return best?.DirName;
+        IEnumerable<string> ordered = versions
+            .OrderByDescending(pair => pair.Key)
+            .Select(pair => pair.Value);
+        if (limit is { } count)
+            ordered = ordered.Take(count);
+        return ordered.ToArray();
     }
 
     /// <summary>

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -53,6 +53,8 @@ public sealed record PackageReferenceTarget(
 public static class PackageExtractor
 {
     private const int MaxToolWrapperRedirectHops = 8;
+    private static readonly TimeSpan CachedVersionResolutionTimeout =
+        TimeSpan.FromSeconds(1);
 
     private static readonly AsyncCache<PackageAcquisitionRequest, PackageExtractionOutcome>
         s_packageRequests = new();
@@ -214,6 +216,12 @@ public static class PackageExtractor
 
         // Resolve NuGet sources
         var sources = NuGetSourceResolver.ResolveSources(sourceOptions);
+        IReadOnlyList<string> cachedVersions = version == null
+            ? NuGetCache.GetCachedVersions(
+                packageName,
+                NuGetSourceResolver.SourceKeys(sources),
+                includePrerelease)
+            : [];
 
         // Resolve wildcard version patterns (e.g., 11.0.0-preview*)
         if (version != null && version.Contains('*'))
@@ -228,11 +236,53 @@ public static class PackageExtractor
         // Get version if not specified
         if (version == null)
         {
-            version = await GetLatestVersionAsync(client, packageName, sources, log, skipCache: forceLatest, includePrerelease: includePrerelease).ConfigureAwait(false);
+            CancellationTokenSource? latestTimeout = null;
+            if (!forceLatest && !HttpClientFactory.IsOffline && cachedVersions.Count > 0)
+            {
+                latestTimeout = new CancellationTokenSource(
+                    CachedVersionResolutionTimeout);
+            }
+
+            try
+            {
+                version = await GetLatestVersionCoreAsync(
+                    client,
+                    packageName,
+                    sources,
+                    log,
+                    skipCache: forceLatest,
+                    includePrerelease: includePrerelease,
+                    cancellationToken: latestTimeout?.Token ?? default)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (latestTimeout?.IsCancellationRequested == true)
+            {
+                return PackageExtractionOutcome.Error(
+                    DescribeCachedVersionFallback(
+                        packageName,
+                        cachedVersions,
+                        offline: false));
+            }
+            finally
+            {
+                latestTimeout?.Dispose();
+            }
+
             if (version == null)
             {
                 if (HttpClientFactory.IsOffline)
+                {
+                    if (cachedVersions.Count > 0)
+                    {
+                        return PackageExtractionOutcome.Error(
+                            DescribeCachedVersionFallback(
+                                packageName,
+                                cachedVersions,
+                                offline: true));
+                    }
+
                     return PackageExtractionOutcome.Error($"Package '{packageName}' is not available offline; no cached version was found.");
+                }
 
                 return PackageExtractionOutcome.Error(
                     (FeedFailureTelemetry.Current?.DescribeFailure(packageName)
@@ -265,6 +315,26 @@ public static class PackageExtractor
             // This is an in-flight registry. The committed filesystem entry is
             // authoritative and is revalidated by every later request.
             static _ => false).ConfigureAwait(false);
+    }
+
+    private static string DescribeCachedVersionFallback(
+        string packageName,
+        IReadOnlyList<string> cachedVersions,
+        bool offline)
+    {
+        const int DisplayLimit = 5;
+        string displayed = string.Join(", ", cachedVersions.Take(DisplayLimit));
+        string remainder = cachedVersions.Count > DisplayLimit
+            ? $" (+{cachedVersions.Count - DisplayLimit} more)"
+            : "";
+        string reason = offline
+            ? $"Package '{packageName}' cannot resolve its latest version while offline."
+            : $"Package '{packageName}' could not resolve its latest version before the online lookup timed out.";
+
+        return $"{reason}{Environment.NewLine}" +
+            $"Locally cached versions: {displayed}{remainder}{Environment.NewLine}" +
+            $"Use an exact version to skip version discovery, for example: " +
+            $"dotnet-inspect package {packageName}@{cachedVersions[0]}";
     }
 
     private static async Task<PackageExtractionOutcome> AcquireResolvedPackageAsync(
@@ -553,8 +623,14 @@ public static class PackageExtractor
     private static Task<string?> GetPackageBaseAddressAsync(
         HttpClient client,
         NuGetSource source,
-        Action<string>? log)
-        => GetServiceIndexResourceAsync(client, source, "PackageBaseAddress", log);
+        Action<string>? log,
+        CancellationToken cancellationToken = default)
+        => GetServiceIndexResourceAsync(
+            client,
+            source,
+            "PackageBaseAddress",
+            log,
+            cancellationToken);
 
     /// <summary>
     /// Discovers the SearchQueryService endpoint from a V3 service index. Returns null when the
@@ -565,7 +641,12 @@ public static class PackageExtractor
         HttpClient client,
         NuGetSource source,
         Action<string>? log = null)
-        => GetServiceIndexResourceAsync(client, source, "SearchQueryService", log);
+        => GetServiceIndexResourceAsync(
+            client,
+            source,
+            "SearchQueryService",
+            log,
+            cancellationToken: default);
 
     /// <summary>
     /// Reads a V3 service index and returns the <c>@id</c> of the first resource whose
@@ -576,7 +657,8 @@ public static class PackageExtractor
         HttpClient client,
         NuGetSource source,
         string resourceTypePrefix,
-        Action<string>? log)
+        Action<string>? log,
+        CancellationToken cancellationToken)
     {
         // Skip non-HTTP sources (e.g. local folder feeds from NuGet.Config).
         // Passing a file: URL or raw filesystem path to HttpClient throws
@@ -603,6 +685,7 @@ public static class PackageExtractor
 
         string? json = await HttpRetryHelper.GetStringWithRetryAsync(
             client, indexUrl, auth: NuGetCredentialScope.AuthFor(source, indexUrl, log),
+            cancellationToken: cancellationToken,
             trafficKind: NetworkTrafficKind.PackageSourceDiscovery).ConfigureAwait(false);
         if (json == null)
             return null;
@@ -708,13 +791,30 @@ public static class PackageExtractor
             VersionCacheCategory);
     }
 
-    public static async Task<string?> GetLatestVersionAsync(
+    public static Task<string?> GetLatestVersionAsync(
         HttpClient client,
         string packageName,
         List<NuGetSource> sources,
         Action<string>? log,
         bool skipCache = false,
         bool includePrerelease = false)
+        => GetLatestVersionCoreAsync(
+            client,
+            packageName,
+            sources,
+            log,
+            skipCache,
+            includePrerelease,
+            cancellationToken: default);
+
+    private static async Task<string?> GetLatestVersionCoreAsync(
+        HttpClient client,
+        string packageName,
+        List<NuGetSource> sources,
+        Action<string>? log,
+        bool skipCache,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
     {
         string normalizedName = packageName.ToLowerInvariant();
         string cacheKey = includePrerelease ? $"{normalizedName}-prerelease" : normalizedName;
@@ -755,7 +855,13 @@ public static class PackageExtractor
             }
             else
             {
-                version = await GetLatestVersionFromSourceAsync(client, normalizedName, source, log, includePrerelease).ConfigureAwait(false);
+                version = await GetLatestVersionFromSourceAsync(
+                    client,
+                    normalizedName,
+                    source,
+                    log,
+                    includePrerelease,
+                    cancellationToken).ConfigureAwait(false);
                 if (version != null && canCache && source.IsNuGetOrg)
                 {
                     using var cacheScope = NetworkTelemetry.Scope(NetworkTrafficKind.PackageVersionList);
@@ -843,27 +949,42 @@ public static class PackageExtractor
         HttpClient client,
         string packageName,
         NuGetSource source,
-        Action<string>? log)
+        Action<string>? log,
+        CancellationToken cancellationToken = default)
     {
         // Try flat-container index first
         var flatContainerUrl = source.GetFlatContainerUrl();
         if (flatContainerUrl != null)
         {
             string indexUrl = $"{flatContainerUrl}/{packageName}/index.json";
-            var versions = await FetchVersionListAsync(client, indexUrl, log, NuGetCredentialScope.AuthFor(source, indexUrl, log)).ConfigureAwait(false);
+            var versions = await FetchVersionListAsync(
+                client,
+                indexUrl,
+                log,
+                NuGetCredentialScope.AuthFor(source, indexUrl, log),
+                cancellationToken).ConfigureAwait(false);
             if (versions != null)
                 return versions;
         }
 
         // Fall back to V3 service index discovery
-        var baseAddress = await GetPackageBaseAddressAsync(client, source, log).ConfigureAwait(false);
+        var baseAddress = await GetPackageBaseAddressAsync(
+            client,
+            source,
+            log,
+            cancellationToken).ConfigureAwait(false);
         if (baseAddress != null)
         {
             if (!baseAddress.EndsWith('/'))
                 baseAddress += "/";
 
             string indexUrl = $"{baseAddress}{packageName}/index.json";
-            var versions = await FetchVersionListAsync(client, indexUrl, log, NuGetCredentialScope.AuthFor(source, indexUrl, log)).ConfigureAwait(false);
+            var versions = await FetchVersionListAsync(
+                client,
+                indexUrl,
+                log,
+                NuGetCredentialScope.AuthFor(source, indexUrl, log),
+                cancellationToken).ConfigureAwait(false);
             if (versions != null)
                 return versions;
         }
@@ -873,11 +994,13 @@ public static class PackageExtractor
 
     private static async Task<List<string>?> FetchVersionListAsync(
         HttpClient client, string indexUrl, Action<string>? log,
-        AuthenticationHeaderValue? auth = null)
+        AuthenticationHeaderValue? auth = null,
+        CancellationToken cancellationToken = default)
     {
         log?.Invoke($"Fetching versions from: {indexUrl}");
         string? json = await HttpRetryHelper.GetStringWithRetryAsync(
             client, indexUrl, auth: auth,
+            cancellationToken: cancellationToken,
             trafficKind: NetworkTrafficKind.PackageVersionList).ConfigureAwait(false);
         if (json == null) return null;
 
@@ -929,13 +1052,23 @@ public static class PackageExtractor
         HttpClient client,
         string packageName,
         NuGetSource source,
-        Action<string>? log)
+        Action<string>? log,
+        CancellationToken cancellationToken = default)
     {
-        var versions = await FetchAllVersionsFromSourceAsync(client, packageName, source, log).ConfigureAwait(false);
+        var versions = await FetchAllVersionsFromSourceAsync(
+            client,
+            packageName,
+            source,
+            log,
+            cancellationToken).ConfigureAwait(false);
         if (versions == null || !source.IsNuGetOrg)
             return (versions, Authoritative: true);
 
-        var unlisted = await FetchUnlistedVersionsFromNuGetOrgAsync(client, packageName, log).ConfigureAwait(false);
+        var unlisted = await FetchUnlistedVersionsFromNuGetOrgAsync(
+            client,
+            packageName,
+            log,
+            cancellationToken).ConfigureAwait(false);
         if (unlisted == null)
             return (versions, Authoritative: false);
         if (unlisted.Count == 0)
@@ -960,13 +1093,15 @@ public static class PackageExtractor
     private static async Task<HashSet<NuGet.Versioning.NuGetVersion>?> FetchUnlistedVersionsFromNuGetOrgAsync(
         HttpClient client,
         string packageName,
-        Action<string>? log)
+        Action<string>? log,
+        CancellationToken cancellationToken = default)
     {
         string indexUrl = $"{NuGetOrgRegistrationBase}/{packageName}/index.json";
         log?.Invoke($"Fetching listing status from: {indexUrl}");
 
         string? json = await HttpRetryHelper.GetStringWithRetryAsync(
             client, indexUrl,
+            cancellationToken: cancellationToken,
             trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
         if (json == null)
             return null;
@@ -991,6 +1126,7 @@ public static class PackageExtractor
                 {
                     string? pageJson = await HttpRetryHelper.GetStringWithRetryAsync(
                         client, pageUrl,
+                        cancellationToken: cancellationToken,
                         trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
                     if (pageJson == null)
                         return null;
@@ -1071,12 +1207,17 @@ public static class PackageExtractor
         string packageName,
         NuGetSource source,
         Action<string>? log,
-        bool includePrerelease)
+        bool includePrerelease,
+        CancellationToken cancellationToken)
     {
         // For nuget.org, use the search API — returns latest version directly without listing all versions
         if (source.IsNuGetOrg && !includePrerelease)
         {
-            var version = await GetLatestVersionFromSearchAsync(client, packageName, log).ConfigureAwait(false);
+            var version = await GetLatestVersionFromSearchAsync(
+                client,
+                packageName,
+                log,
+                cancellationToken).ConfigureAwait(false);
             if (version != null)
                 return version;
         }
@@ -1090,7 +1231,12 @@ public static class PackageExtractor
         // index below.
         if (source.IsNuGetOrg)
         {
-            var (listed, authoritative) = await FetchListedVersionsFromSourceAsync(client, packageName, source, log).ConfigureAwait(false);
+            var (listed, authoritative) = await FetchListedVersionsFromSourceAsync(
+                client,
+                packageName,
+                source,
+                log,
+                cancellationToken).ConfigureAwait(false);
             if (listed != null && authoritative)
                 return PickLatest(listed, includePrerelease);
             return null;
@@ -1103,13 +1249,22 @@ public static class PackageExtractor
             string indexUrl = $"{flatContainerUrl}/{packageName}/index.json";
             log?.Invoke($"Fetching versions from: {indexUrl}");
 
-            var version = await ParseVersionIndexAsync(client, indexUrl, NuGetCredentialScope.AuthFor(source, indexUrl, log), includePrerelease).ConfigureAwait(false);
+            var version = await ParseVersionIndexAsync(
+                client,
+                indexUrl,
+                NuGetCredentialScope.AuthFor(source, indexUrl, log),
+                includePrerelease,
+                cancellationToken).ConfigureAwait(false);
             if (version != null)
                 return version;
         }
 
         // Fall back to V3 service index discovery
-        var baseAddress = await GetPackageBaseAddressAsync(client, source, log).ConfigureAwait(false);
+        var baseAddress = await GetPackageBaseAddressAsync(
+            client,
+            source,
+            log,
+            cancellationToken).ConfigureAwait(false);
         if (baseAddress != null)
         {
             if (!baseAddress.EndsWith('/'))
@@ -1118,7 +1273,12 @@ public static class PackageExtractor
             string indexUrl = $"{baseAddress}{packageName}/index.json";
             log?.Invoke($"Fetching versions from: {indexUrl}");
 
-            var version = await ParseVersionIndexAsync(client, indexUrl, NuGetCredentialScope.AuthFor(source, indexUrl, log), includePrerelease).ConfigureAwait(false);
+            var version = await ParseVersionIndexAsync(
+                client,
+                indexUrl,
+                NuGetCredentialScope.AuthFor(source, indexUrl, log),
+                includePrerelease,
+                cancellationToken).ConfigureAwait(false);
             if (version != null)
                 return version;
         }
@@ -1129,7 +1289,8 @@ public static class PackageExtractor
     private static async Task<string?> GetLatestVersionFromSearchAsync(
         HttpClient client,
         string packageName,
-        Action<string>? log)
+        Action<string>? log,
+        CancellationToken cancellationToken)
     {
         string searchUrl = $"https://azuresearch-usnc.nuget.org/query?q=packageid:{packageName}&take=1&prerelease=false";
         log?.Invoke($"Fetching latest version from: {searchUrl}");
@@ -1138,6 +1299,7 @@ public static class PackageExtractor
         {
             string? json = await HttpRetryHelper.GetStringWithRetryAsync(
                 client, searchUrl,
+                cancellationToken: cancellationToken,
                 trafficKind: NetworkTrafficKind.PackageSearch).ConfigureAwait(false);
             if (json == null)
                 return null;
@@ -1153,6 +1315,10 @@ public static class PackageExtractor
                 }
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             log?.Invoke($"Search API failed: {ex.Message}");
@@ -1164,10 +1330,12 @@ public static class PackageExtractor
     private static async Task<string?> ParseVersionIndexAsync(
         HttpClient client, string indexUrl,
         AuthenticationHeaderValue? auth = null,
-        bool includePrerelease = false)
+        bool includePrerelease = false,
+        CancellationToken cancellationToken = default)
     {
         string? json = await HttpRetryHelper.GetStringWithRetryAsync(
             client, indexUrl, auth: auth,
+            cancellationToken: cancellationToken,
             trafficKind: NetworkTrafficKind.PackageVersionList).ConfigureAwait(false);
         if (json == null)
             return null;

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Net;
 
@@ -683,6 +684,85 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         Assert.Equal("2.0.0", NuGetCache.TryGetLatestCachedVersion(packageName, [publicFeedKey, privateFeedKey]));
     }
 
+    [Fact]
+    public void GetCachedVersions_ReturnsNewestUsableVersionsForConfiguredSources()
+    {
+        string packageName = $"versionhints.test.{Guid.NewGuid():N}";
+        string privateFeedKey = NuGetCache.GetSourceKey("https://private.invalid/v3/index.json");
+        string publicFeedKey = NuGetCache.GetSourceKey("https://api.nuget.org/v3/index.json");
+
+        foreach (var (version, sourceKey) in
+            new[]
+            {
+                ("1.0.0", publicFeedKey),
+                ("2.0.0-preview.1", publicFeedKey),
+                ("3.0.0", privateFeedKey),
+            })
+        {
+            string staged = CreateExtractedPackage(
+                Path.Combine(_testRoot, $"hint-stage-{version}"),
+                packageName,
+                "payload",
+                payloadCount: 1);
+            NuGetCache.CommitPackage(
+                staged,
+                nupkgPath: null,
+                packageName,
+                version,
+                sourceKey);
+        }
+
+        Assert.Equal(
+            ["2.0.0-preview.1", "1.0.0"],
+            NuGetCache.GetCachedVersions(packageName, [publicFeedKey]));
+        Assert.Equal(
+            ["3.0.0", "2.0.0-preview.1", "1.0.0"],
+            NuGetCache.GetCachedVersions(packageName, [publicFeedKey, privateFeedKey]));
+        Assert.Equal(
+            ["1.0.0"],
+            NuGetCache.GetCachedVersions(
+                packageName,
+                [publicFeedKey],
+                includePrerelease: false));
+    }
+
+    [Fact]
+    public async Task ExtractPackageAsync_LatestLookupTimesOutEarlyAndOffersCachedPins()
+    {
+        string packageName = $"versiontimeout.test.{Guid.NewGuid():N}";
+        foreach (string version in new[] { "1.0.0", "2.0.0" })
+        {
+            string staged = CreateExtractedPackage(
+                Path.Combine(_testRoot, $"timeout-stage-{version}"),
+                packageName,
+                "payload",
+                payloadCount: 1);
+            NuGetCache.CommitPackage(
+                staged,
+                nupkgPath: null,
+                packageName,
+                version,
+                TestSourceKey);
+        }
+
+        using var client = new HttpClient(new NeverAnsweringHandler());
+        var stopwatch = Stopwatch.StartNew();
+
+        PackageExtractionOutcome outcome = await PackageExtractor.ExtractPackageAsync(
+            client,
+            packageName,
+            sourceOptions: s_nugetOrgSource);
+
+        stopwatch.Stop();
+        Assert.False(outcome.IsSuccess);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(3), stopwatch.Elapsed.ToString());
+        Assert.Contains("online lookup timed out", outcome.ErrorMessage);
+        Assert.Contains("Locally cached versions: 2.0.0, 1.0.0", outcome.ErrorMessage);
+        Assert.Contains(
+            $"dotnet-inspect package {packageName}@2.0.0",
+            outcome.ErrorMessage);
+    }
+
     [Theory]
     [InlineData("https://pkgs.invalid/v3/index.json", "https://pkgs.invalid/v3/index.json/")]
     [InlineData("https://pkgs.invalid/v3/index.json", "HTTPS://PKGS.INVALID/v3/index.json")]
@@ -1192,6 +1272,17 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             response.RequestMessage = request;
             response.Content ??= new StringContent(string.Empty);
             return Task.FromResult(response);
+        }
+    }
+
+    private sealed class NeverAnsweringHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("The request should have been canceled.");
         }
     }
 

--- a/src/dotnet-inspect.Tests/PackageExtractorOfflineTests.cs
+++ b/src/dotnet-inspect.Tests/PackageExtractorOfflineTests.cs
@@ -47,4 +47,36 @@ public sealed class PackageExtractorOfflineTests : IDisposable
         Assert.Contains("no cached package", outcome.ErrorMessage);
         Assert.DoesNotContain("not found", outcome.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task ExtractPackageAsync_OfflineWithCachedVersions_OffersExactPins()
+    {
+        string packageName = $"Cached.Offline.{Guid.NewGuid():N}";
+        string sourceKey = NuGetCache.GetSourceKey("https://api.nuget.org/v3/index.json");
+        foreach (string version in new[] { "1.0.0", "2.0.0" })
+        {
+            string staged = Path.Combine(_cacheDir, $"staged-{version}");
+            Directory.CreateDirectory(staged);
+            File.WriteAllText(
+                Path.Combine(staged, $"{packageName}.nuspec"),
+                "<package />");
+            NuGetCache.CommitPackage(
+                staged,
+                nupkgPath: null,
+                packageName,
+                version,
+                sourceKey);
+        }
+
+        var outcome = await PackageExtractor.ExtractPackageAsync(
+            Core.HttpClientFactory.Shared,
+            packageName);
+
+        Assert.False(outcome.IsSuccess);
+        Assert.Contains("cannot resolve its latest version while offline", outcome.ErrorMessage);
+        Assert.Contains("Locally cached versions: 2.0.0, 1.0.0", outcome.ErrorMessage);
+        Assert.Contains(
+            $"dotnet-inspect package {packageName}@2.0.0",
+            outcome.ErrorMessage);
+    }
 }


### PR DESCRIPTION
Bare package inspection now stops latest-version discovery after one second when usable local package versions already exist, then reports exact cached pins instead of waiting through the normal network timeout. Offline mode reports the same pins immediately.

The change preserves freshness and source provenance: it does not silently select a stale cached payload, and explicit `Name@latest` retains its always-check behavior. Suggested app-cache versions remain restricted to currently configured sources.

Validation:
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.PackageAcquisitionConcurrencyTests -class DotnetInspector.Tests.PackageExtractorOfflineTests -reporter quiet`
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -- -class DotnetInspector.Services.Tests.VersionCacheTests -class DotnetInspector.Services.Tests.SourcePrecedenceTests -reporter quiet`
- `npx markdownlint-cli docs/design/version-resolution.md`
- real CLI canary: `package System.Text.Json --offline` returned five local exact pins in 0.25s