### PR TITLE
Serialize pre-merge compile-back gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,17 +697,15 @@ jobs:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.decompiler == 'true'
     runs-on: ubuntu-26.04
-    # Job timeout raised 45 -> 55 with the step timeout below (#3495 follow-up).
+    # Job timeout raised 55 -> 65 with the step timeout below (#3827).
     # The two must move together: the design depends on the *step* timeout
     # firing first, with enough of the job budget left for the checker and the
     # artifact upload to still run and fail loudly. Measured on this job: setup
-    # and build are 2m54s, so a step that burns its full 35 gives up around
-    # minute 38. That would still fit a 45-minute job, but with only ~7 minutes
-    # covering the checker, the artifact upload, and any runner-side variance in
-    # setup and build -- thin enough that a slow runner could turn the loud
-    # failure this job exists to produce back into a silent cancel. 55 makes the
-    # gap unambiguous. A healthy run finishes in 24m35s.
-    timeout-minutes: 55
+    # and build are 2m54s, so a step that burns its full 45 gives up around
+    # minute 48. A 65-minute job leaves ~17 minutes for the checker, artifact
+    # upload, and runner-side setup/build variance, preserving the deliberate
+    # gap that keeps a hung gate loud instead of cancelling the job.
+    timeout-minutes: 65
     env:
       DOTNET_INSPECT_TIPS: q
     steps:
@@ -771,16 +769,16 @@ jobs:
       # or truncated report, and fails the job loudly. Do not raise this to the
       # job timeout.
       #
-      # 35 is sized to a measurement, not a guess, and the measurement is from
-      # this job on this runner: the 6-class preset runs 44 tests in 21m30s
-      # (build 2m37s, discovery 2s, checker 4s, job total 24m35s). 35 leaves
-      # ~63% headroom over that while staying 20 minutes under the job timeout,
-      # which is what keeps a hang loud.
+      # Serializing the five compile-back workload classes (#3827) removes the
+      # Roslyn reference-binding overlap but necessarily raises wall time. The
+      # 45-test preset is 17m14s locally, up from 11m42s in parallel. The prior
+      # same-machine local-to-CI factor was 1.84x (21m30s / 11m42s), predicting
+      # ~31m45s on this runner. 45 leaves ~42% headroom while staying 20 minutes
+      # under the job timeout, which is what keeps a hang loud.
       #
-      # Raising this from 25 was required, not cosmetic: at 21m30s the old
-      # budget had 3m30s of margin, so a slightly slow runner would have hit a
-      # timeout on a perfectly healthy run. Re-measure and re-tune both numbers
-      # together whenever a class is added to the preset.
+      # The first PR run is the check on that projection; replace it with the
+      # measured CI duration before merge. Re-measure and re-tune both numbers
+      # together whenever the preset or its collection topology changes.
       #
       # --no-build is required, not an optimization. Without it `dotnet run`
       # builds implicitly, which would (a) break the guarantee that this run and
@@ -790,7 +788,7 @@ jobs:
       - name: Run decompiler gates
         id: gates
         continue-on-error: true
-        timeout-minutes: 35
+        timeout-minutes: 45
         run: |
           dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
             --gate pre-merge -xml "$RUNNER_TEMP/decompiler-gates.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -700,11 +700,12 @@ jobs:
     # Job timeout raised 55 -> 65 with the step timeout below (#3827).
     # The two must move together: the design depends on the *step* timeout
     # firing first, with enough of the job budget left for the checker and the
-    # artifact upload to still run and fail loudly. Measured on this job: setup
-    # and build are 2m54s, so a step that burns its full 45 gives up around
-    # minute 48. A 65-minute job leaves ~17 minutes for the checker, artifact
-    # upload, and runner-side setup/build variance, preserving the deliberate
-    # gap that keeps a hung gate loud instead of cancelling the job.
+    # artifact upload to still run and fail loudly. Measured on this job: the
+    # gate starts around minute 3, so a step that burns its full 45 gives up
+    # around minute 48. A 65-minute job leaves ~17 minutes for the checker,
+    # artifact upload, and runner-side setup/build variance, preserving the
+    # deliberate gap that keeps a hung gate loud instead of cancelling the job.
+    # A healthy serialized run finishes in 30m37s.
     timeout-minutes: 65
     env:
       DOTNET_INSPECT_TIPS: q
@@ -771,14 +772,13 @@ jobs:
       #
       # Serializing the five compile-back workload classes (#3827) removes the
       # Roslyn reference-binding overlap but necessarily raises wall time. The
-      # 45-test preset is 17m14s locally, up from 11m42s in parallel. The prior
-      # same-machine local-to-CI factor was 1.84x (21m30s / 11m42s), predicting
-      # ~31m45s on this runner. 45 leaves ~42% headroom while staying 20 minutes
+      # first PR run measured the 45-test preset at 27m24s on this runner
+      # (build 2m38s, discovery 1s, checker 4s, job total 30m37s), up from
+      # 21m30s in parallel. 45 leaves ~64% headroom while staying 20 minutes
       # under the job timeout, which is what keeps a hang loud.
       #
-      # The first PR run is the check on that projection; replace it with the
-      # measured CI duration before merge. Re-measure and re-tune both numbers
-      # together whenever the preset or its collection topology changes.
+      # Re-measure and re-tune both numbers together whenever the preset or its
+      # collection topology changes.
       #
       # --no-build is required, not an optimization. Without it `dotnet run`
       # builds implicitly, which would (a) break the guarantee that this run and

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -452,6 +452,17 @@ truncated report.
 along in the preset it guards. Two different reasons keep the rest out, and only
 one of them is cost.
 
+The five workload classes share `FidelityGateCollection` and therefore run
+serially even though this test assembly allows two parallel collections. That
+boundary is intentional: run 30885078644 overlapped the newly gated Printer
+compile-back with Cluster capture for 7m01s and the lowered gate for another
+33s, then Roslyn threw from
+`CommonReferenceManager.ResolveReferencedAssembly`; the failed-job rerun
+passed. `GateExpectedClassesTests` is excluded because it is a fast reflection
+guard with no compile-back work.
+`PreMergeWorkloadClasses_ShareFidelityGateCollection` derives the workload set
+from the preset and fails if a future gate class escapes the collection.
+
 **Excluded on cost.** `SkeletonEmitTests` is the most expensive class in the
 suite (~630s on CI, #3495) and wants the emit-bound residual addressed first.
 Note it deliberately asserts the *whole-module* skeleton compiles, so it cannot

--- a/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
@@ -66,6 +66,7 @@ namespace ILInspector.Decompiler.Tests;
 /// </para>
 /// </summary>
 [Trait("Area", "Fidelity")]
+[Collection(FidelityGateCollection.Name)]
 public sealed class ByteNeutralityGateTests
 {
     static string AssemblyPath => typeof(ByteNeutralityGateTests).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
@@ -25,6 +25,7 @@ namespace ILInspector.Decompiler.Tests;
 /// </summary>
 [Trait("Speed", "Slow")]
 [Trait("Area", "Fidelity")]
+[Collection(FidelityGateCollection.Name)]
 public class ClusterCaptureTests
 {
     const string FixtureType = "ILInspector.Decompiler.Tests.CfgSampleClass";

--- a/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GateExpectedClassesTests.cs
@@ -22,13 +22,7 @@ public class GateExpectedClassesTests
     [Fact]
     public void ExpectedClassesFile_MatchesThePreMergePresetExactly()
     {
-        GatePreset preset = Assert.Single(Program.Presets, p => p.Name == "pre-merge");
-
-        var fromPreset = preset.Args
-            .Select((arg, i) => (arg, i))
-            .Where(x => x.arg == "-class")
-            .Select(x => preset.Args[x.i + 1])
-            .ToHashSet(StringComparer.Ordinal);
+        var fromPreset = PreMergeClassNames().ToHashSet(StringComparer.Ordinal);
 
         Assert.NotEmpty(fromPreset);
 
@@ -87,13 +81,7 @@ public class GateExpectedClassesTests
     [Fact]
     public void PreMergeGateClasses_ContainOnlyPlainFacts()
     {
-        GatePreset preset = Assert.Single(Program.Presets, p => p.Name == "pre-merge");
-
-        var classNames = preset.Args
-            .Select((arg, i) => (arg, i))
-            .Where(x => x.arg == "-class")
-            .Select(x => preset.Args[x.i + 1])
-            .ToList();
+        var classNames = PreMergeClassNames();
 
         Assert.NotEmpty(classNames);
 
@@ -159,6 +147,74 @@ public class GateExpectedClassesTests
                 + "validated against what the run produced rather than trusted:"
                 + Environment.NewLine
                 + string.Join(Environment.NewLine, offenders.Select(o => "  " + o)));
+    }
+
+    /// <summary>
+    /// Serializes every workload class selected by <c>--gate pre-merge</c>.
+    ///
+    /// <para>The runner uses two parallel threads. The original raised and lowered
+    /// fidelity gates already shared <see cref="FidelityGateCollection"/>, but newer
+    /// compile-back gates did not, so two <c>FidelityCheck</c> workloads over the same
+    /// fixture assembly could overlap. Run 30885078644 observed Roslyn throw from
+    /// <c>CommonReferenceManager.ResolveReferencedAssembly</c>: the failing Printer test
+    /// overlapped Cluster capture for 7m01s, then the lowered gate for its final 33s.
+    /// The failed-job rerun passed.</para>
+    ///
+    /// <para>This test derives the workload set from the preset rather than maintaining
+    /// another allow list. The only exception is this class itself: it is the fast
+    /// plumbing guard that rides in the preset it validates and performs no compile-back
+    /// work. Any future workload class added to the preset must join the collection
+    /// explicitly, or this always-run guard fails before the slow lane can become
+    /// intermittently concurrent again.</para>
+    /// </summary>
+    [Fact]
+    public void PreMergeWorkloadClasses_ShareFidelityGateCollection()
+    {
+        string guardClass = typeof(GateExpectedClassesTests).FullName!;
+        var workloads = PreMergeClassNames()
+            .Where(className => className != guardClass)
+            .ToList();
+
+        Assert.NotEmpty(workloads);
+
+        var offenders = new List<string>();
+        foreach (string className in workloads)
+        {
+            Type type = typeof(Program).Assembly.GetType(className)
+                ?? throw new InvalidOperationException(
+                    $"The pre-merge preset names '{className}', which does not exist in the test assembly.");
+
+            CollectionAttribute? collection = type
+                .GetCustomAttributes<CollectionAttribute>(inherit: true)
+                .SingleOrDefault();
+
+            if (collection?.Name != FidelityGateCollection.Name)
+            {
+                string collectionName = collection?.Name is { Length: > 0 } name
+                    ? name
+                    : "no collection";
+                offenders.Add(
+                    $"{className} [{collectionName}]");
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            $"Every pre-merge workload class must use [Collection({nameof(FidelityGateCollection)}.Name)] "
+                + "so compile-back gates cannot overlap under xUnit's parallel runner:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, offenders.Select(o => "  " + o)));
+    }
+
+    private static List<string> PreMergeClassNames()
+    {
+        GatePreset preset = Assert.Single(Program.Presets, p => p.Name == "pre-merge");
+
+        return preset.Args
+            .Select((arg, i) => (arg, i))
+            .Where(x => x.arg == "-class")
+            .Select(x => preset.Args[x.i + 1])
+            .ToList();
     }
 
     // Fails rather than skips when the source tree is absent. A skip here would

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -8,6 +8,7 @@ namespace ILInspector.Decompiler.Tests;
 
 // Issue #1479: printer operand positions that bypassed the precedence-wrapping
 // Operand helper, reassociating compound operands into invalid/wrong C# at Full.
+[Collection(FidelityGateCollection.Name)]
 public class PrinterPrecedenceTests
 {
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");


### PR DESCRIPTION
## Outcome

Serialize every compile-back workload in the PR `pre-merge` preset through the
existing `FidelityGateCollection`, closing the concurrency boundary that
produced a transient internal Roslyn reference-manager exception.

## What failed

Run 30885078644 executed all 44 then-gated tests, but
`PrinterPrecedenceTests.StoreElement_CompoundArrayReceiver_RecompilesExactly`
failed inside Roslyn:

```text
System.NullReferenceException
  Microsoft.CodeAnalysis.CommonReferenceManager.ResolveReferencedAssembly(...)
```

The XML establishes the overlap:

| workload | interval | overlap with failed Printer test |
| --- | --- | --- |
| `ClusterCaptureTests` | 06:48:26–06:58:53 | **7m01s** |
| failing Printer test | 06:51:52–06:59:26 | — |
| `LoweredFidelityGateTests` | 06:58:53–07:04:10 | final **33s** |

The failed-job rerun passed. This was not a fidelity mismatch; it was transient
reference binding under two concurrent `FidelityCheck` workloads over the same
fixture assembly.

## Change

- Add `ByteNeutralityGateTests`, `ClusterCaptureTests`, and
  `PrinterPrecedenceTests` to the collection already used by
  `FidelityGateTests` and `LoweredFidelityGateTests`.
- Keep only `GateExpectedClassesTests` outside it: that class is the fast
  reflection/plumbing guard and performs no compile-back work.
- Add `PreMergeWorkloadClasses_ShareFidelityGateCollection`, derived directly
  from the preset. A future workload class cannot silently escape the
  serialization boundary.
- Retune the gate step/job timeouts together from **35/55 to 45/65**.

No exception catch or retry was added. A real Roslyn exception remains a loud
failure; this removes the unsupported overlap that provoked it.

## Evidence

- Release solution build: 0 errors.
- Exact CI sequence: **45/45 pass**, **6/6 expected classes**, checker exit 0.
- Serialized local gate wall: **17m14s**, up from 11m42s in parallel.
- Previous local-to-CI factor: 1.84×, predicting ~31m45s; the first PR CI run is
  the check and will replace the projection before merge.
- Guard: 3/3 pass.
- Mutation: removing Printer's collection attribute fails with
  `PrinterPrecedenceTests [no collection]`; restoring passes.
- `ci.yml`: parses, 65-minute job, 45-minute gate step,
  `continue-on-error: true`, 8 steps.
- Markdown lint: clean.

## Compatibility / non-action boundary

This changes only test scheduling and CI budgets. Product and harness behavior
are unchanged. It deliberately does not catch `NullReferenceException`, retry
arbitrary Roslyn failures, disable xUnit parallelism globally, or serialize
unrelated test collections.

Fixes #3827
