### PR TITLE
Keep guarded switch defaults reachable

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1355,6 +1355,15 @@ public class CfgSampleClass
         return result;
     }
 
+    // #3514 compile-back witness: the shared default is reached by the failed
+    // `int` guard and by the failed `string` type test through a goto trampoline.
+    public static int GuardedTypeAfterSibling(object value) => value switch
+    {
+        string text => text.Length,
+        int number when number > 0 => number,
+        _ => -1
+    };
+
     // A diamond whose false arm carries an internal guard that branches straight
     // to the shared merge — `if (y > 0) goto done;` from inside the false arm,
     // the merge lying past the false arm's lexical boundary. The merge ends in a

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1356,11 +1356,11 @@ public class CfgSampleClass
     }
 
     // #3514 compile-back witness: the shared default is reached by the failed
-    // `int` guard and by the failed `string` type test through a goto trampoline.
+    // `Exception` guard and by the failed type test through a goto trampoline.
     public static int GuardedTypeAfterSibling(object value) => value switch
     {
         string text => text.Length,
-        int number when number > 0 => number,
+        Exception error when error.Message.Length > 0 => error.Message.Length,
         _ => -1
     };
 

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -55,6 +55,11 @@ public class FidelityGateTests
         // different branch structure like the sparse-switch over-render docket.
         "ByteRangeSearchTree",
         "GotoCommonExit",
+        // #3514: the compiler-backed reference-type switch witness proves the
+        // missing shared default is restored and the body compiles, but the
+        // valid nested-if form re-lowers with direct returns rather than csc's
+        // original result-temp convergence.
+        "GuardedTypeAfterSibling",
         // This hand-written await-enumerator loop recompiles through the same
         // runtime-async shape but schedules the receiver load after the
         // enumerator-local initialization rather than before it.
@@ -494,9 +499,6 @@ public class FidelityGateTests
         "StaticLocalFunctionCalledTwice",
         "StaticLocalFunctionWithLocal",
         "TwoLocalFunctionQuadrants",
-        // #3514: structuring keeps the shared switch default reachable from a
-        // direct guard failure and a sibling type-test trampoline.
-        "GuardedTypeAfterSibling",
     };
 
     static readonly Lazy<IReadOnlyList<FidelityCheck.CompileBackResult>> Results = new(() =>

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -494,6 +494,9 @@ public class FidelityGateTests
         "StaticLocalFunctionCalledTwice",
         "StaticLocalFunctionWithLocal",
         "TwoLocalFunctionQuadrants",
+        // #3514: structuring keeps the shared switch default reachable from a
+        // direct guard failure and a sibling type-test trampoline.
+        "GuardedTypeAfterSibling",
     };
 
     static readonly Lazy<IReadOnlyList<FidelityCheck.CompileBackResult>> Results = new(() =>

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -47,6 +47,10 @@ public class LoweredFidelityGateTests
         // different branch structure like the sparse-switch over-render docket.
         "ByteRangeSearchTree",
         "GotoCommonExit",
+        // #3514: the restored trailing default makes the reference-type switch
+        // witness valid, while the lowered nested-if form recompiles through
+        // direct returns instead of the original result-temp convergence.
+        "GuardedTypeAfterSibling",
         "ManualAwaitEnumeratorLoop",
         // RuntimeInlineArrayForeach is the runtime-style inline-array enumerator
         // frontier from #1045: the lowered view is representable, but recompiles
@@ -236,9 +240,6 @@ public class LoweredFidelityGateTests
         "StaticLocalFunctionWithLocal",
         "TwoLocalFunctionQuadrants",
         "WhileNestedContinueKeepsArmExclusive",
-        // #3514: structuring keeps the shared switch default reachable from a
-        // direct guard failure and a sibling type-test trampoline.
-        "GuardedTypeAfterSibling",
     };
 
     static readonly Lazy<IReadOnlyList<FidelityCheck.CompileBackResult>> Results = new(() =>

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -236,6 +236,9 @@ public class LoweredFidelityGateTests
         "StaticLocalFunctionWithLocal",
         "TwoLocalFunctionQuadrants",
         "WhileNestedContinueKeepsArmExclusive",
+        // #3514: structuring keeps the shared switch default reachable from a
+        // direct guard failure and a sibling type-test trampoline.
+        "GuardedTypeAfterSibling",
     };
 
     static readonly Lazy<IReadOnlyList<FidelityCheck.CompileBackResult>> Results = new(() =>

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
@@ -50,7 +50,7 @@ public static class ScatteredReturnDispatchSample
     public static int GuardedTypeAfterSibling(object value) => value switch
     {
         string text => text.Length,
-        int number when number > 0 => number,
+        Exception error when error.Message.Length > 0 => error.Message.Length,
         _ => -1
     };
 

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
@@ -24,10 +24,11 @@ public enum DispatchKind
 /// guard — otherwise the <c>i &lt;= 0</c> path falls off the end of a non-void
 /// method (CS0177: <c>out</c> parameter unassigned).
 ///
-/// The <see cref="PlainAnd"/> and <see cref="ThrowTernaryChain"/> canaries are the
-/// close negatives: contiguous short-circuit <c>&amp;&amp;</c> guard chains whose
-/// shared return must stay combined under one condition (the #640 fidelity
-/// canary), not unrolled into duplicated returns.
+/// The <see cref="PlainAnd"/>, <see cref="LoopBeforeAndChain"/>, and
+/// <see cref="ThrowTernaryChain"/> canaries are the close negatives: contiguous
+/// short-circuit <c>&amp;&amp;</c> guard chains whose shared return must stay
+/// combined under one condition (the #640 fidelity canary), not unrolled into
+/// duplicated returns.
 /// </summary>
 public static class ScatteredReturnDispatchSample
 {
@@ -122,6 +123,29 @@ public static class ScatteredReturnDispatchSample
     public static int PlainAnd(int a, int b)
     {
         if (a > 0 && b > 0)
+        {
+            return 1;
+        }
+
+        return 2;
+    }
+
+    // Review canary: the loop exit falls through to a goto of the same return
+    // used by the later && chain. The loop test is not a dispatch guard and
+    // must not widen the chain's predecessor span.
+    public static int LoopBeforeAndChain(int[] items, int key, int a, int b)
+    {
+        if (key > 3)
+        {
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i] > 1)
+                {
+                    return items[i];
+                }
+            }
+        }
+        else if (a > 0 && b > 0)
         {
             return 1;
         }

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
@@ -44,6 +44,15 @@ public static class ScatteredReturnDispatchSample
         _ => Fail(out x)
     };
 
+    // #3514 witness: the default has one direct guard-failure edge and one
+    // type-test-failure edge routed through a pure goto trampoline.
+    public static int GuardedTypeAfterSibling(object value) => value switch
+    {
+        string text => text.Length,
+        int number when number > 0 => number,
+        _ => -1
+    };
+
     static bool Win(int v, out int x) { x = v; return true; }
 
     static bool Fail(out int x) { x = 0; return false; }

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
@@ -16,26 +16,33 @@ namespace ILInspector.Decompiler.Tests;
 /// The discriminator that recognizes this shape (an interior block entered by a
 /// jump from before the guard span) must not fire on a contiguous short-circuit
 /// <c>&amp;&amp;</c> guard chain, which threads entirely within its own span and
-/// must stay combined under one condition — the #640 fidelity canary. The two
-/// canaries below (<see cref="ScatteredReturnDispatchSample.PlainAnd"/> and
+/// must stay combined under one condition — the #640 fidelity canary. The
+/// canaries below (<see cref="ScatteredReturnDispatchSample.PlainAnd"/>,
+/// <see cref="ScatteredReturnDispatchSample.LoopBeforeAndChain"/>, and
 /// <see cref="ScatteredReturnDispatchSample.ThrowTernaryChain"/>) pin that the
 /// shared return is not unrolled and the condition stays a single <c>&amp;&amp;</c>.
 /// </summary>
 [Trait("Area", "Pass")]
 public class ScatteredReturnDispatchStructuringTests
 {
-    static IrFunction Raised(string methodName)
+    static IrFunction Raised(Type type, string methodName)
     {
-        using var source = MetadataSource.Open(typeof(ScatteredReturnDispatchSample).Assembly.Location);
-        var function = IrImporter.Import(source, typeof(ScatteredReturnDispatchSample).FullName!, methodName);
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(source, type.FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
         function!.CheckInvariant();
         return function;
     }
 
+    static IrFunction Raised(string methodName) =>
+        Raised(typeof(ScatteredReturnDispatchSample), methodName);
+
     static string Print(string methodName) =>
         CSharpPrinter.Print(Raised(methodName)).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+    static string Print(Type type, string methodName) =>
+        CSharpPrinter.Print(Raised(type, methodName)).Output!.ReplaceLineEndings("\n").TrimEnd();
 
     // ── Compiler-backed positive ───────────────────────────────────────────
 
@@ -82,6 +89,25 @@ public class ScatteredReturnDispatchStructuringTests
         // Two contiguous guards on the shared `return 2` stay one condition.
         Assert.Contains("if (a > 0 && b > 0)", output);
         Assert.EndsWith("return 2;", output);
+    }
+
+    [Fact]
+    public void LoopExitTrampoline_DoesNotWidenLaterShortCircuitChain()
+    {
+        string output = Print(nameof(ScatteredReturnDispatchSample.LoopBeforeAndChain));
+
+        Assert.Contains("if (a > 0 && b > 0)", output);
+        Assert.EndsWith("return 2;", output);
+    }
+
+    [Fact]
+    public void ValidTrailingDefault_DoesNotBecomeAnEarlyReturn()
+    {
+        string output = Print(typeof(MemberIdentity), nameof(MemberIdentity.GetAppendFormattedFormat));
+
+        Assert.Contains("if (second.Equals(MemberIdentity.s_string))", output);
+        Assert.DoesNotContain("if (!second.Equals(MemberIdentity.s_string))", output);
+        Assert.EndsWith("return null;", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
@@ -60,6 +60,18 @@ public class ScatteredReturnDispatchStructuringTests
         Assert.DoesNotContain("goto", output);
     }
 
+    [Fact]
+    public void TypeTestTrampolineAndGuardFailure_ShareDefaultWithoutLosingReturn()
+    {
+        string output = Print(nameof(ScatteredReturnDispatchSample.GuardedTypeAfterSibling));
+
+        Assert.StartsWith("return value switch", output);
+        Assert.Contains("int number when number > 0 => number", output);
+        Assert.Contains("_ => -1", output);
+        Assert.EndsWith("};", output);
+        Assert.DoesNotContain("goto", output);
+    }
+
     // ── Compiler-backed negatives (the #640 canary) ────────────────────────
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
@@ -72,10 +72,10 @@ public class ScatteredReturnDispatchStructuringTests
     {
         string output = Print(nameof(ScatteredReturnDispatchSample.GuardedTypeAfterSibling));
 
-        Assert.StartsWith("return value switch", output);
-        Assert.Contains("int number when number > 0 => number", output);
-        Assert.Contains("_ => -1", output);
-        Assert.EndsWith("};", output);
+        Assert.Contains("if (V_3 is Exception error)", output);
+        Assert.Contains("if (error.Message.Length > 0)", output);
+        Assert.Equal(2, output.Split("return -1;", StringSplitOptions.None).Length - 1);
+        Assert.EndsWith("return -1;", output);
         Assert.DoesNotContain("goto", output);
     }
 

--- a/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
@@ -59,27 +59,14 @@ public class ValidityCoverageReportingTests
         // return-tail candidate now keeps the interleaved default-goto default
         // as the region's trailing terminator, so it returns instead of falling
         // off the end.
-        //
-        // SwapIdiomPass::MatchCarrier is an *addition*, not a regression: the pass
-        // itself landed in #3234, after this census was last refreshed in #3003, and
-        // no previously pinned row changed. It is the first method in this assembly
-        // whose switch-expression default (`_ => null`) is reachable from two edges at
-        // once — a failing `when` guard and a failing type test on the sibling arm:
-        //
-        //     StoreStackSlot slot = V_3 as StoreStackSlot;
-        //     if (slot is null)
-        //     {
-        //         if (V_3 is StoreLocal local)
-        //         {
-        //             if (IsHiddenLocal(...)) { return new HiddenLocalCarrier(...); }
-        //             return null;   // #2959 duplicated the shared return here …
-        //         }
-        //                            // … but not onto the type-test-failure edge,
-        //     }                      // so this block falls off the end (CS0161).
-        //     else { return new StackSlotCarrier(...); }
-        //
-        // Tracked as #3514. Pinned rather than fixed so the release gates unblock;
-        // removing the row is the acceptance criterion for that fix.
+        // #3514 removed four siblings: BooleanFoldingPass::
+        // IsNullableCoalesceExpressionContext, DeconstructionAssignmentPass::
+        // TryMatchTupleSeed, IndexFromEndPass::LengthReceiver, and SwapIdiomPass::
+        // MatchCarrier. Each switch-expression default was reached by one direct
+        // `when`-guard failure and one sibling type-test failure routed through a
+        // pure goto trampoline. Structuring now counts that source conditional as
+        // a scattered-dispatch predecessor and keeps the shared default reachable
+        // from both paths.
         string[] expected =
 #if DEBUG
         [
@@ -88,11 +75,7 @@ public class ValidityCoverageReportingTests
 #else
         [
             "ILInspector.Decompiler.MemberBodyProducer::DecompileBody",
-            "ILInspector.Decompiler.Pipeline.BooleanFoldingPass::IsNullableCoalesceExpressionContext",
             "ILInspector.Decompiler.Pipeline.CSharpPrinter::ForLoopIncrementText",
-            "ILInspector.Decompiler.Pipeline.DeconstructionAssignmentPass::TryMatchTupleSeed",
-            "ILInspector.Decompiler.Pipeline.IndexFromEndPass::LengthReceiver",
-            "ILInspector.Decompiler.Pipeline.SwapIdiomPass::MatchCarrier",
         ];
 #endif
         Assert.Equal(expected, actual);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -197,16 +197,22 @@ public sealed class StructuringPass : IIrPass
         foreach (var block in blocks)
         {
             int offset = block.StartOffset;
+            var dispatchPredecessors = ScatteredDispatchPredecessors(
+                blocks,
+                offset,
+                conditionalPredecessorIndices,
+                branchPredecessorIndices,
+                jumpPredecessorIndices);
             if ((unconditionalTargets.Contains(offset)
                     && !UnconditionalPredecessorsAreDissolvableTrampolines(blocks, offset, branchPredecessorIndices, switchTargets))
                 || fallenInto.Contains(offset)
-                || conditionalTargetCounts.GetValueOrDefault(offset) < 2
+                || dispatchPredecessors.Count < 2
                 || !IsTerminatorBlock(block)
                 || block.Children[^1] is not Return)
             {
                 continue;
             }
-            if (IsScatteredDispatch(blocks, conditionalPredecessorIndices[offset], branchTargets, jumpPredecessorIndices))
+            if (IsScatteredDispatch(blocks, dispatchPredecessors, branchTargets, jumpPredecessorIndices))
                 scatteredReturnDispatchTargets.Add(offset);
         }
 
@@ -1267,6 +1273,48 @@ public sealed class StructuringPass : IIrPass
                 return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// Conditional guards that route to <paramref name="offset"/>, either
+    /// directly or through a pure fall-through <c>goto offset</c> trampoline.
+    /// The latter is how csc lowers a failed type test before a later guarded
+    /// switch arm: the conditional takes the matching arm and its fallthrough
+    /// block forwards to the shared default. Count that source conditional as a
+    /// dispatch predecessor only when no explicit jump also enters the
+    /// trampoline, so duplicating the default cannot erase another path.
+    /// </summary>
+    static List<int> ScatteredDispatchPredecessors(
+        IReadOnlyList<Block> blocks,
+        int offset,
+        Dictionary<int, List<int>> conditionalPredecessorIndices,
+        Dictionary<int, List<int>> branchPredecessorIndices,
+        Dictionary<int, List<int>> jumpPredecessorIndices)
+    {
+        var predecessors = conditionalPredecessorIndices.TryGetValue(offset, out var direct)
+            ? direct.ToHashSet()
+            : [];
+        if (!branchPredecessorIndices.TryGetValue(offset, out var trampolines))
+            return [.. predecessors];
+
+        foreach (int trampolineIndex in trampolines)
+        {
+            if (trampolineIndex == 0
+                || blocks[trampolineIndex].Children is not [Branch branch]
+                || branch.TargetOffset != offset
+                || jumpPredecessorIndices.ContainsKey(blocks[trampolineIndex].StartOffset))
+            {
+                continue;
+            }
+
+            int guardIndex = trampolineIndex - 1;
+            if (blocks[guardIndex].Children.Count > 0
+                && blocks[guardIndex].Children[^1] is ConditionalBranch)
+            {
+                predecessors.Add(guardIndex);
+            }
+        }
+        return [.. predecessors];
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -1279,9 +1279,11 @@ public sealed class StructuringPass : IIrPass
     /// Conditional guards that route to <paramref name="offset"/>, either
     /// directly or through a pure fall-through <c>goto offset</c> trampoline.
     /// The latter is how csc lowers a failed type test before a later guarded
-    /// switch arm: the conditional takes the matching arm and its fallthrough
-    /// block forwards to the shared default. Count that source conditional as a
-    /// dispatch predecessor only when no explicit jump also enters the
+    /// switch arm: the conditional jumps forward over the trampoline into its
+    /// matching arm, while fallthrough forwards to the shared default. Only add
+    /// that missing predecessor when the target has exactly one direct guard;
+    /// targets already having a complete predecessor span must not be widened by
+    /// an unrelated loop-exit trampoline. No explicit jump may enter the
     /// trampoline, so duplicating the default cannot erase another path.
     /// </summary>
     static List<int> ScatteredDispatchPredecessors(
@@ -1294,22 +1296,29 @@ public sealed class StructuringPass : IIrPass
         var predecessors = conditionalPredecessorIndices.TryGetValue(offset, out var direct)
             ? direct.ToHashSet()
             : [];
-        if (!branchPredecessorIndices.TryGetValue(offset, out var trampolines))
+        if (predecessors.Count != 1
+            || !branchPredecessorIndices.TryGetValue(offset, out var trampolines))
+        {
             return [.. predecessors];
+        }
 
         foreach (int trampolineIndex in trampolines)
         {
+            var trampoline = blocks[trampolineIndex];
             if (trampolineIndex == 0
-                || blocks[trampolineIndex].Children is not [Branch branch]
+                || trampoline.Children is not [Branch branch]
                 || branch.TargetOffset != offset
-                || jumpPredecessorIndices.ContainsKey(blocks[trampolineIndex].StartOffset))
+                || jumpPredecessorIndices.ContainsKey(trampoline.StartOffset))
             {
                 continue;
             }
 
             int guardIndex = trampolineIndex - 1;
             if (blocks[guardIndex].Children.Count > 0
-                && blocks[guardIndex].Children[^1] is ConditionalBranch)
+                && blocks[guardIndex].Children[^1] is ConditionalBranch guard
+                && blocks[guardIndex].Descendants.OfType<IsInstance>().Any()
+                && guard.TargetOffset > trampoline.StartOffset
+                && guard.TargetOffset < offset)
             {
                 predecessors.Add(guardIndex);
             }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -1296,11 +1296,29 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             IrExpression defaultValue;
             IReadOnlyList<Arm> innerArms;
             if (current + 4 == children.Count
-                && children[current + 3] is Return { Value: { } tailDefault }
-                && TryReturnArms(firstIf.Then.Children, valueStore.Index, out var tailArms))
+                && children[current + 3] is Return { Value: { } tailDefault })
             {
                 defaultValue = tailDefault;
-                innerArms = tailArms;
+                if (TryReturnArms(firstIf.Then.Children, valueStore.Index, out var tailArms))
+                {
+                    innerArms = tailArms;
+                }
+                else if (TryReturnArmsWithDefault(
+                        firstIf.Then.Children,
+                        valueStore.Index,
+                        out var duplicatedDefaultArms,
+                        out var duplicatedDefault)
+                    && SameTailExpression(tailDefault, duplicatedDefault))
+                {
+                    // Structuring duplicates a scattered default into the guarded
+                    // arm and keeps the same tail for a sibling type-test
+                    // trampoline. Consume the proven-identical clone once.
+                    innerArms = duplicatedDefaultArms;
+                }
+                else
+                {
+                    return false;
+                }
             }
             else if (current + 3 == children.Count
                 && TryReturnArmsWithDefault(firstIf.Then.Children, valueStore.Index, out var embeddedArms, out var embeddedDefault))


### PR DESCRIPTION
- Fixes #3514
- Row: shared switch default reached by a `when` guard and sibling type-test trampoline
- Evidence revision: `d10b9877`

## Fix

> Should we accept this row fix?

**Conclusion:** **PASS** — the `Full` render no longer falls off the end, four same-root CS0161 rows leave the exact census, and the reduced compiler-produced shape is valid on both compile-back rails with its expected `OpcodeDiff` pinned.

False `Full` claim:

```csharp
IrNode V_3 = node;
StoreStackSlot slot = V_3 as StoreStackSlot;
if (slot is null)
{
    if (V_3 is StoreLocal local)
    {
        if (IsHiddenLocal(function, local.Index))
        {
            return new HiddenLocalCarrier(local.Index) { SavedValue = local.Value };
        }
        return null;
    }
}
else
{
    return new StackSlotCarrier(slot.Slot) { SavedValue = slot.Value };
}
```

Fixed output:

```csharp
IrNode V_3 = node;
StoreStackSlot slot = V_3 as StoreStackSlot;
if (slot is null)
{
    if (V_3 is StoreLocal local)
    {
        if (IsHiddenLocal(function, local.Index))
        {
            return new HiddenLocalCarrier(local.Index) { SavedValue = local.Value };
        }
        return null;
    }
}
else
{
    return new StackSlotCarrier(slot.Slot) { SavedValue = slot.Value };
}
return null;
```

## Root cause and scope

- **Root cause:** scattered-return classification counted only conditionals that directly targeted the shared default. A failed sibling type test reaches that default through a pure fall-through `goto default` trampoline, so only the later guard was counted and one path lost its return.
- **Fix shape:** count the immediately preceding conditional only when the target has exactly one direct guard, the source contains the expected `IsInstance` type test, its matching arm jumps forward between the trampoline and default, and no explicit jump enters the trampoline. Keep the required trailing default and let union-switch raising consume an embedded duplicate only when `SameTailExpression` proves both defaults identical.
- **Scope boundary:** this does not generalize through arbitrary branch chains or explicit-jump trampolines, and it does not touch the two unrelated CS0161 census rows.

## Witnesses

| Witness | Before | After |
| --- | --- | --- |
| `SwapIdiomPass::MatchCarrier` | `Full`, CS0161 path falls off the end | final `return null;`; valid `Full` |
| `BooleanFoldingPass::IsNullableCoalesceExpressionContext` | pinned CS0161 | valid; row removed |
| `DeconstructionAssignmentPass::TryMatchTupleSeed` | pinned CS0161 | valid; row removed |
| `IndexFromEndPass::LengthReceiver` | pinned CS0161 | valid; row removed |
| `GuardedTypeAfterSibling` reduced fixture | shared default path omitted on main | raised and lowered compile-back validity with pinned expected `OpcodeDiff` |

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass; the same three metadata-test nullability warnings occur on clean main |
| Focused tests | 20/20 across structuring, raised/lowered fidelity, and exact validity census |
| Decompiler fast suite | 4,576 total; 0 failed; 8 expected Windows privilege/filesystem skips |
| Reduced fixture validity | valid on the focused structuring rail |
| Reduced fixture fidelity | valid on both compile-back rails; expected `OpcodeDiff` remains pinned |
| #640 review witnesses | CoreLib `ResolveAssemblyToPath` and self `GetAppendFormattedFormat` exactly match main |
| Real witness validity | `MatchCarrier` now returns on every path |
| CS0161 exact census | 6 rows on main to 2 unrelated rows; no additions |

## Corpus validity

> Did this row fix introduce new sampled corpus regressions?

**Conclusion:** **PASS** — an exact-base risky card over one frozen 1,500-method input set has zero aggregate movement and an empty per-method delta. The quick sample does not contain the repaired methods, so the targeted compiler-produced fixture and exhaustive decompiler-assembly CS0161 census are the decisive correctness evidence.

| Metric | Clean main | PR |
| --- | ---: | ---: |
| Detected lowering residue | 234 (15.60%) | 234 (15.60%) |
| Conditional-branch residue | 40 (2.67%) | 40 (2.67%) |
| Forward-merge stops | 27 (1.80%) | 27 (1.80%) |
| Pass bugs | 0 | 0 |
| Changed sampled methods | - | 0 |

The card intentionally does not sample aggregate validity or fidelity; the changed shape instead has exhaustive CS0161-census coverage plus raised and lowered compile-back validity checks with an expected, pinned `OpcodeDiff`.

## Out of scope / sibling rows

- `MemberBodyProducer::DecompileBody` and `CSharpPrinter::ForLoopIncrementText` remain pinned because they have separate root causes.

## Validation

```powershell
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src\ILInspector.Decompiler.Tests -c Release --no-build -- -class '*ScatteredReturnDispatchStructuringTests' -class '*FidelityGateTests' -class '*LoweredFidelityGateTests' -class '*ValidityCoverageReportingTests'
dotnet run --project src\ILInspector.Decompiler.Tests -c Release --no-build -- --gate fast
```