### PR TITLE
Expose collision-safe C# using sets

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -79,6 +79,59 @@ public sealed class CSharpFormatterTests
     }
 
     [Fact]
+    public void FormatsBareMemberTypesWithNamespaceSet()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "FieldWriter",
+            Kind = "class"
+        };
+        var constructor = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            SignatureModel = new ApiSignature
+            {
+                Parameters =
+                [
+                    new ApiParameter { Type = "System.IO.TextWriter", Name = "writer" },
+                    new ApiParameter { Type = "Markout.Formatting.IFieldFormatter", Name = "formatter" },
+                    new ApiParameter
+                    {
+                        Type = "Markout.MarkoutWriterOptions?",
+                        Name = "options",
+                        HasDefault = true,
+                        DefaultValueText = "null"
+                    }
+                ]
+            }
+        };
+        var formatter = new CSharpFormatter(new CSharpFormatOptions
+        {
+            TypeNamePolicy = CSharpTypeNamePolicy.ShortWithUsings
+        });
+
+        var declaration = formatter.FormatMemberUnit(type, constructor);
+
+        Assert.Equal(
+            """
+            using Markout;
+            using Markout.Formatting;
+            using System.IO;
+
+            public FieldWriter(TextWriter writer, IFieldFormatter formatter, MarkoutWriterOptions? options = null)
+            """,
+            declaration.Text);
+        Assert.Equal(
+            ["Markout", "Markout.Formatting", "System.IO"],
+            declaration.Usings);
+        Assert.DoesNotContain(
+            declaration.Usings,
+            value => value.StartsWith("using ", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void FormatsParameterListsWithAttributesDefaultsAndEscapedKeywords()
     {
         var parameters = new ApiParameter[]

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -721,7 +721,62 @@ public sealed class CSharpTypePrinterTests
         var result = _printer.Print(new CSharpTypePrintRequest(type));
 
         Assert.Contains("using System.Threading.Tasks;", result.Source, StringComparison.Ordinal);
+        Assert.Equal(["System.Threading.Tasks"], result.Usings);
         Assert.Contains("public Task Run();", result.Units[0].Source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FullMemberUsesBareTypesBackedByNamespaceSet()
+    {
+        var type = CreateEmptyType("Samples", "FieldWriter");
+        var constructor = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            SignatureModel = new ApiSignature
+            {
+                Parameters =
+                [
+                    new ApiParameter { Type = "System.IO.TextWriter", Name = "writer" },
+                    new ApiParameter { Type = "Markout.Formatting.IFieldFormatter", Name = "formatter" },
+                    new ApiParameter
+                    {
+                        Type = "Markout.MarkoutWriterOptions?",
+                        Name = "options",
+                        HasDefault = true,
+                        DefaultValueText = "null"
+                    }
+                ]
+            }
+        };
+        type.Members.Add(constructor);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(
+                    constructor,
+                    CSharpBodyPolicy.Full,
+                    new CSharpBlockBody(
+                        """
+                        this.writer = writer;
+                        this.formatter = formatter;
+                        _options = options ?? new MarkoutWriterOptions();
+                        """))
+            ]));
+
+        Assert.Equal(
+            ["Markout", "Markout.Formatting", "System.IO"],
+            result.Usings);
+        Assert.Contains(
+            "public FieldWriter(TextWriter writer, IFieldFormatter formatter, MarkoutWriterOptions? options = null)",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+        Assert.StartsWith(
+            "using Markout;\nusing Markout.Formatting;\nusing System.IO;\n",
+            result.Source,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -763,6 +818,7 @@ public sealed class CSharpTypePrinterTests
 
         Assert.DoesNotContain("using Alpha;", result.Source, StringComparison.Ordinal);
         Assert.DoesNotContain("using Beta;", result.Source, StringComparison.Ordinal);
+        Assert.Empty(result.Usings);
         Assert.Contains(
             "public Alpha.Widget Convert(Beta.Widget value);",
             result.Units[0].Source,

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Text;
 using ILInspector.Metadata;
 using ILInspector.Text;
@@ -44,7 +45,7 @@ internal sealed record CSharpDeclarationOptions
 
 internal sealed record CSharpRenderedDeclaration(
     string Source,
-    IReadOnlyList<string> Usings,
+    ImmutableSortedSet<string> Usings,
     IReadOnlyList<string> Diagnostics);
 
 /// <summary>
@@ -2070,7 +2071,7 @@ internal static class CSharpDeclarationWriter
 
     sealed record TypeNamePlan(
         IReadOnlyDictionary<string, string> Replacements,
-        IReadOnlyList<string> GeneratedUsings,
+        ImmutableSortedSet<string> GeneratedUsings,
         IReadOnlyList<string> Diagnostics)
     {
         public string Apply(string text)
@@ -2083,7 +2084,10 @@ internal static class CSharpDeclarationWriter
         public static TypeNamePlan Create(IEnumerable<string> references, CSharpDeclarationOptions options)
         {
             if (options.TypeNameMode == CSharpTypeNameMode.Qualified)
-                return new TypeNamePlan(new Dictionary<string, string>(), [], []);
+                return new TypeNamePlan(
+                    new Dictionary<string, string>(),
+                    ImmutableSortedSet.Create<string>(StringComparer.Ordinal),
+                    []);
 
             var typeRefs = references
                 .Select(TypeRef.TryCreate)
@@ -2122,7 +2126,10 @@ internal static class CSharpDeclarationWriter
                     generatedUsings.Add(typeRef.Namespace);
             }
 
-            return new TypeNamePlan(replacements, generatedUsings.ToList(), diagnostics);
+            return new TypeNamePlan(
+                replacements,
+                generatedUsings.ToImmutableSortedSet(StringComparer.Ordinal),
+                diagnostics);
         }
 
         static string ReplaceIdentifierToken(string text, string token, string replacement)

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Text;
 using ILInspector.Metadata;
 
@@ -32,9 +33,14 @@ public sealed record CSharpFormatOptions
     public bool OmitPropertyAccessors { get; init; }
 }
 
+/// <summary>
+/// A rendered declaration and the namespace imports its shortened type names
+/// require. <paramref name="Usings"/> contains raw namespace identities, not
+/// rendered <c>using ...;</c> lines.
+/// </summary>
 public sealed record CSharpFormattedDeclaration(
     string Text,
-    IReadOnlyList<string> Usings,
+    ImmutableSortedSet<string> Usings,
     IReadOnlyList<string> Diagnostics);
 
 /// <summary>
@@ -519,7 +525,7 @@ public sealed class CSharpFormatter
         };
 
     static CSharpFormattedDeclaration ToFormattedDeclaration(CSharpRenderedDeclaration declaration)
-        => new(declaration.Source, declaration.Usings.ToArray(), declaration.Diagnostics.ToArray());
+        => new(declaration.Source, declaration.Usings, declaration.Diagnostics.ToArray());
 
     static string FormatTypeParameter(TypeParameter parameter, bool includeVariance)
         => includeVariance && parameter.Variance is { } variance

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -295,16 +295,28 @@ public sealed record CSharpTypePrintResult
 
     public CSharpTypePrintResult(
         ImmutableArray<CSharpTypeSourceUnit> units,
+        ImmutableSortedSet<string> usings,
         ImmutableArray<CSharpTypePrintDiagnostic> diagnostics,
         Func<string> sourceFactory)
     {
+        ArgumentNullException.ThrowIfNull(usings);
         ArgumentNullException.ThrowIfNull(sourceFactory);
         Units = units;
+        Usings = usings;
         Diagnostics = diagnostics;
         _source = new Lazy<string>(sourceFactory);
     }
 
     public ImmutableArray<CSharpTypeSourceUnit> Units { get; }
+
+    /// <summary>
+    /// The raw namespace names required by the shortened references in
+    /// <see cref="Units"/>, plus any namespaces explicitly supplied in
+    /// <see cref="CSharpTypePrintOptions.Usings"/>. Values are de-duplicated and
+    /// ordinal-sorted namespace identities, not rendered <c>using ...;</c> lines.
+    /// Empty when using emission is disabled.
+    /// </summary>
+    public ImmutableSortedSet<string> Usings { get; }
 
     public ImmutableArray<CSharpTypePrintDiagnostic> Diagnostics { get; }
 
@@ -320,8 +332,9 @@ public sealed record CSharpTypePrintResult
     public bool Equals(CSharpTypePrintResult? other)
         => other is not null
             && Units.SequenceEqual(other.Units)
+            && Usings.SetEquals(other.Usings)
             && Diagnostics.SequenceEqual(other.Diagnostics);
 
     public override int GetHashCode()
-        => HashCode.Combine(Units.Length, Diagnostics.Length);
+        => HashCode.Combine(Units.Length, Usings.Count, Diagnostics.Length);
 }

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -48,6 +48,9 @@ public sealed class CSharpTypePrinter
         }
 
         var derivedUsings = ComputeDerivedUsings(preparedTypes, options);
+        var effectiveUsings = options.IncludeUsings
+            ? options.Usings.Concat(derivedUsings).ToImmutableSortedSet(StringComparer.Ordinal)
+            : ImmutableSortedSet.Create<string>(StringComparer.Ordinal);
 
         var units = ImmutableArray.CreateBuilder<CSharpTypeSourceUnit>();
         foreach (var group in preparedTypes.GroupBy(type => type.Namespace, StringComparer.Ordinal))
@@ -70,8 +73,9 @@ public sealed class CSharpTypePrinter
         var unitList = units.ToImmutable();
         return new CSharpTypePrintResult(
             unitList,
+            effectiveUsings,
             diagnostics.ToImmutable(),
-            () => ComposeSource(unitList, derivedUsings, options));
+            () => ComposeSource(unitList, effectiveUsings, options));
     }
 
     /// <summary>
@@ -108,7 +112,7 @@ public sealed class CSharpTypePrinter
 
     static string ComposeSource(
         ImmutableArray<CSharpTypeSourceUnit> units,
-        IReadOnlyList<string> derivedUsings,
+        ImmutableSortedSet<string> usings,
         CSharpTypePrintOptions options)
     {
         var sb = new System.Text.StringBuilder();
@@ -118,11 +122,8 @@ public sealed class CSharpTypePrinter
             sb.AppendLf($"[assembly: {attribute}]");
         foreach (var attribute in options.ModuleAttributes)
             sb.AppendLf($"[module: {attribute}]");
-        if (options.IncludeUsings)
-        {
-            foreach (var ns in options.Usings.Concat(derivedUsings).Select(CSharpFormatter.EscapeNamespace).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal))
-                sb.AppendLf($"using {ns};");
-        }
+        foreach (var ns in usings.Select(CSharpFormatter.EscapeNamespace))
+            sb.AppendLf($"using {ns};");
         foreach (var unit in units)
             sb.AppendLf(unit.Source);
 


### PR DESCRIPTION
## Summary

C# declaration and type-print results now expose immutable, ordinal-sorted sets of raw namespace identities alongside their rendered source. Collision-safe shortening remains identity-preserving: distinct types with the same simple name stay qualified, and no alias directives are synthesized.

The complete type printer uses the same returned set to optionally prepend rendered `using` directives, keeping structured imports and composed source aligned. Existing qualified/default spelling behavior is preserved.

## Evidence

- `dotnet run --project src/ILInspector.CSharp.Tests -c Release` — 462 passed
- `dotnet build dotnet-inspect.slnx -c Release` — succeeded

## Compatibility and boundary

- `CSharpFormattedDeclaration.Usings` changes from `IReadOnlyList<string>` to `ImmutableSortedSet<string>`.
- `CSharpTypePrintResult` gains `Usings`; equality includes set membership.
- This change does not unify `CSharpTypePrintOptions.ShortenTypeNames` with `CSharpTypeNamePolicy`; #3768 tracks that follow-up.
- This change does not generate `using X = ...` aliases. Ambiguous references remain qualified.
