### PR TITLE
Raise void-returning lambdas

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -166,6 +166,52 @@ public class LambdaRaisingPassTests
         Assert.DoesNotContain("b__", output);                // no un-raised lambda-method reference
     }
 
+    [Fact]
+    public void CapturingVoidExpressionBody_RaisesAndElidesLocalEnvironment()
+    {
+        string output = PrintRaised(
+            nameof(VoidLambdaRaisingSamples.CapturingVoidExpressionLambda),
+            typeof(VoidLambdaRaisingSamples));
+
+        Assert.Contains("Action<int> action = x => Console.WriteLine(x + n);", output);
+        Assert.Contains("consume.Invoke(action, n);", output);
+        Assert.DoesNotContain("DisplayClass", output);
+        Assert.DoesNotContain("new Action", output);
+        Assert.DoesNotContain("b__", output);
+    }
+
+    [Fact]
+    public void CapturingVoidStatementBody_RaisesWithoutImplicitReturn()
+    {
+        string output = PrintRaised(
+            nameof(VoidLambdaRaisingSamples.CapturingVoidStatementLambda),
+            typeof(VoidLambdaRaisingSamples));
+
+        Assert.Contains("return x =>\n{", output);
+        Assert.Contains("Console.WriteLine(x);", output);
+        Assert.Contains("Console.WriteLine(n);", output);
+        Assert.DoesNotContain("return;", output);
+        Assert.DoesNotContain("new Action", output);
+    }
+
+    [Fact]
+    public void EmptyVoidBody_RaisesAsEmptyLambda()
+        => Assert.Equal(
+            "return () => { };",
+            PrintRaised(nameof(VoidLambdaRaisingSamples.EmptyVoidLambda), typeof(VoidLambdaRaisingSamples)));
+
+    [Fact]
+    public void VoidBodyWithNestedControlFlow_StaysLowered()
+    {
+        string output = PrintRaised(
+            nameof(VoidLambdaRaisingSamples.VoidLambdaWithConditional),
+            typeof(VoidLambdaRaisingSamples));
+
+        Assert.DoesNotContain("=>", output);
+        Assert.Contains("new Action", output);
+        Assert.Contains("b__", output);
+    }
+
     // Negative: the captured parameter is reassigned in the outer body, a second
     // store to the hoisted field. The single-store guard must keep the
     // environment lowered so the mutation is not lost to value substitution.
@@ -494,6 +540,37 @@ public class LambdaRaisingPassTests
             [],
             body);
     }
+}
+
+public static class VoidLambdaRaisingSamples
+{
+    // The captured parameter is also consumed by the outer body, keeping the
+    // display class in a local like NLOptNet.AddLessOrEqualZeroConstraints.
+    public static void CapturingVoidExpressionLambda(
+        int n,
+        System.Action<System.Action<int>, int> consume)
+    {
+        System.Action<int> action = x => System.Console.WriteLine(x + n);
+        consume(action, n);
+    }
+
+    public static System.Action<int> CapturingVoidStatementLambda(int n)
+        => x =>
+        {
+            System.Console.WriteLine(x);
+            System.Console.WriteLine(n);
+        };
+
+    public static System.Action EmptyVoidLambda() => () => { };
+
+    // A close negative: the current lambda slice admits straight-line bodies,
+    // not nested control flow.
+    public static System.Action<int> VoidLambdaWithConditional()
+        => x =>
+        {
+            if (x > 0)
+                System.Console.WriteLine(x);
+        };
 }
 
 // Negative fixtures for LambdaRaisingPass: a captured variable mutated after the

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -157,6 +157,9 @@ public sealed partial class CSharpPrinter
             _statementIndent = enclosingIndent;
         }
 
+        if (statements.Count == 0)
+            return $"{parameters} => {{ }}";
+
         return statements.Count > 1
             ? LambdaBlockText(parameters, string.Join("\n", statements))
             : $"{parameters} => {{ {string.Join(" ", statements)} }}";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -3001,12 +3001,18 @@ public sealed class Lambda : IrExpression
     }
 
     /// <summary>
-    /// The single returned expression when the body is one block ending in a
-    /// bare <c>return expr;</c> — the expression-bodied form <c>p =&gt; expr</c>.
-    /// Null when the body needs the block form <c>p =&gt; { ... }</c>.
+    /// The single returned expression, or the single side-effect expression of
+    /// a void body after its implicit trailing return has been removed — the
+    /// expression-bodied form <c>p =&gt; expr</c>. Null when the body needs the
+    /// block form <c>p =&gt; { ... }</c>.
     /// </summary>
     public IrExpression? ExpressionBody
-        => Body.Blocks is [{ Children: [Return { Value: { } value }] }] ? value : null;
+        => Body.Blocks switch
+        {
+            [{ Children: [Return { Value: { } value }] }] => value,
+            [{ Children: [ExpressionStatement { Expression: var expression }] }] => expression,
+            _ => null,
+        };
 
     public override string Describe()
         => $"Lambda {DelegateType.ToDisplayString()} ({Parameters.Length} params)";

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ClosureCoverage.cs
@@ -34,7 +34,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 internal static class ClosureCoverage
 {
-    [Completeness(CompletenessLevel.Partial, "expression, simple block, non-capturing local-bound bodies, and parameter-capturing local-bound bodies; outer-local capturing local-bound bodies still owed")]
+    [Completeness(CompletenessLevel.Partial, "value- and void-expression bodies, simple blocks, non-capturing local-bound bodies, and parameter-capturing local-bound bodies; outer-local capturing local-bound bodies still owed")]
     public static LambdaRaisingPass Lambda => new();
 
     [Completeness(CompletenessLevel.Partial, "static local functions with expression/simple block/local-bodied forms, plus capturing (ref struct display-class env, substituted back) zero-local local functions, declared back into the host method and called by their source name; capturing local-bodied, recursive, nested, and shared-environment local functions still owed")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -28,7 +28,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// delegate targets is left as-is.</item>
 /// </list>
 /// <para>In all cases the body must carry compiler-generated metadata evidence
-/// and be a single <c>return expr;</c> or a simple block ending in a return.
+/// and be a single <c>return expr;</c>, a void expression, or a simple block
+/// ending in a return.
 /// Captured outer locals still keep the zero-local guard: local-bearing lambda
 /// bodies print in a nested lambda scope, where an outer local slot would be
 /// ambiguous. A no-op when the seam is absent (stage dumps, the
@@ -361,6 +362,10 @@ public sealed class LambdaRaisingPass : IIrPass
         if (!IsPrintableBody(body, allowLocals))
             return null;
 
+        if (IsVoid(body.Signature.ReturnType)
+            && body.Body.Blocks is [{ Children: [.., Return { Value: null } trailingReturn] }])
+            trailingReturn.Detach();
+
         var container = body.Body;
         container.Detach();
 
@@ -401,8 +406,9 @@ public sealed class LambdaRaisingPass : IIrPass
         for (int i = 0; i < statements.Count; i++)
         {
             var statement = statements[i];
-            if (statement is Return { Value: not null })
-                return i == statements.Count - 1;
+            if (statement is Return returnStatement)
+                return i == statements.Count - 1
+                    && (returnStatement.Value is not null || IsVoid(body.Signature.ReturnType));
             if (statement is ExpressionStatement)
                 continue;
             if (allowLocalStatements && statement is StoreLocal)
@@ -415,4 +421,6 @@ public sealed class LambdaRaisingPass : IIrPass
 
         return false;
     }
+
+    static bool IsVoid(TypeRef type) => type is { Namespace: "System", Name: "Void" };
 }


### PR DESCRIPTION
## Change

> Should we accept this change?

**Conclusion:** **PASS** — compiler-generated void lambdas now reconstruct as lambdas without weakening the existing straight-line body guard.

### Benchmark target

Benchmark target: `NLOptNet@1.4.3`

dotnet-inspect command:

```bash
dotnet-inspect member NLoptNet.NLoptSolver --package NLOptNet@1.4.3 AddLessOrEqualZeroConstraints:1 -S "Decompiled Source" --readable-names
```

### Original source

```csharp
public void AddLessOrEqualZeroConstraints(Action<double[], double[], double[]> constraints, double[] tolerances)
{
    CheckInequalityConstraintAvailability();
    nlopt_mfunc mfunc = (m, results, n, values, gradient, data) => Evaluate((int)n, values, gradient, (int)m, results, constraints);
    _mfuncCache.Add((constraints, mfunc));

    var res = nlopt_add_inequality_mconstraint(_opt, (uint)tolerances.Length, mfunc, IntPtr.Zero, tolerances);
    if (res != NloptResult.SUCCESS)
        throw new ArgumentException("Unable to add the constraints. Result: " + res, "constraint");
}
```

### Before

```csharp
public void AddLessOrEqualZeroConstraints(System.Action<double[], double[], double[]> constraints, double[] tolerances)
{
    ___c__DisplayClass22_0 V_0 = new();
    V_0.___4__this = this;
    V_0.constraints = constraints;
    CheckInequalityConstraintAvailability();
    nlopt_mfunc nlopt_mfunc = new nlopt_mfunc(V_0.__AddLessOrEqualZeroConstraints_b__0);
    _mfuncCache.Add((V_0.constraints, nlopt_mfunc));
    NloptResult nloptResult = nlopt_add_inequality_mconstraint(_opt, (uint)tolerances.Length, nlopt_mfunc, nint.Zero, tolerances);
    if (nloptResult != NloptResult.SUCCESS)
    {
        throw new ArgumentException(string.Concat("Unable to add the constraints. Result: ", nloptResult.ToString()), "constraint");
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: not currently checkable for this package witness
- Taste applied: readable local names only; byte-preserving
- Commit: `5890a0f3`

### After

```csharp
public void AddLessOrEqualZeroConstraints(System.Action<double[], double[], double[]> constraints, double[] tolerances)
{
    CheckInequalityConstraintAvailability();
    nlopt_mfunc nlopt_mfunc = (m, results, n, values, gradient, data) => Evaluate((int)n, values, gradient, (int)m, results, constraints);
    _mfuncCache.Add((constraints, nlopt_mfunc));
    NloptResult nloptResult = nlopt_add_inequality_mconstraint(_opt, (uint)tolerances.Length, nlopt_mfunc, nint.Zero, tolerances);
    if (nloptResult != NloptResult.SUCCESS)
    {
        throw new ArgumentException(string.Concat("Unable to add the constraints. Result: ", nloptResult.ToString()), "constraint");
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: not currently checkable for this package witness
- Taste applied: readable local names only; byte-preserving
- Commit: `7c45f7e1`

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| `LambdaRaisingPassTests` | 24 passed |
| Decompiler pass suite | 1,498 passed |
| Decompiler pre-merge gate | 45 passed |
| Real witness | NLOptNet display class removed; authored lambda shape recovered |

## Decompiler quality

**Conclusion:** **PASS** — the PR quick pinned subset is unchanged with no pass bugs; aggregate lowering residue improves by one sampled method.

| Metric | Baseline | PR |
| --- | ---: | ---: |
| Detected lowering residue | 234 (15.60%) | 233 (15.53%) |
| Conditional-branch residue | 40 (2.67%) | 40 (2.67%) |
| Forward-merge stops | 27 (1.80%) | 27 (1.80%) |
| Pass bugs | 0 | 0 |

The pass now admits a terminal `return;` only for synthesized methods whose metadata return type is `System.Void`, removes that implicit return before rendering, and retains the existing decline for nested control flow. Coverage includes captured expression bodies, multi-statement bodies, empty bodies, and a conditional-body near miss.
