### PR TITLE
Preserve enclosing break ownership in switch raisers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedGuardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedGuardTests.cs
@@ -73,6 +73,60 @@ static class SharedGuardSwitchFixture
     Done:
         return result;
     }
+
+    public static int ExitEnclosingLoopFromDenseDefault(int value)
+    {
+        int result = 0;
+        do
+        {
+            switch (value)
+            {
+                case 0:
+                    result += 1;
+                    break;
+                case 1:
+                    result += 2;
+                    break;
+                case 2:
+                    result += 3;
+                    break;
+                case 3:
+                    result += 4;
+                    break;
+                default:
+                    result += 100;
+                    goto Done;
+            }
+            result++;
+        }
+        while (result < 30);
+    Done:
+        return result;
+    }
+
+    public static int ExitEnclosingLoopFromStringDefault(string value)
+    {
+        int result = 0;
+        do
+        {
+            switch (value)
+            {
+                case "a":
+                    result += 1;
+                    break;
+                case "b":
+                    result += 2;
+                    break;
+                default:
+                    result += 100;
+                    goto Done;
+            }
+            result++;
+        }
+        while (result < 30);
+    Done:
+        return result;
+    }
 }
 
 [Trait("Area", "Pass")]
@@ -80,6 +134,7 @@ public class SwitchRaisingSharedGuardTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
     static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
 
@@ -240,6 +295,46 @@ public class SwitchRaisingSharedGuardTests
     }
 
     [Fact]
+    public void CompilerProducedDenseDefaultContainingEnclosingLoopBreak_RemainsFlat()
+    {
+        using var source = MetadataSource.Open(typeof(SharedGuardSwitchFixture).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(SharedGuardSwitchFixture).FullName!,
+            nameof(SharedGuardSwitchFixture.ExitEnclosingLoopFromDenseDefault));
+        Assert.NotNull(function);
+        Assert.Single(function.Descendants.OfType<SwitchBranch>());
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<Switch>());
+        Assert.Single(function.Descendants.OfType<SwitchBranch>());
+        Assert.Single(function.Descendants.OfType<DoWhileLoop>());
+    }
+
+    [Fact]
+    public void CompilerProducedStringDefaultContainingEnclosingLoopBreak_RemainsFlat()
+    {
+        using var source = MetadataSource.Open(typeof(SharedGuardSwitchFixture).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(SharedGuardSwitchFixture).FullName!,
+            nameof(SharedGuardSwitchFixture.ExitEnclosingLoopFromStringDefault));
+        Assert.NotNull(function);
+        Assert.Empty(function.Descendants.OfType<SwitchBranch>());
+        Assert.NotEmpty(function.Descendants.OfType<ConditionalBranch>());
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<Switch>());
+        Assert.Empty(function.Descendants.OfType<SwitchBranch>());
+        Assert.NotEmpty(function.Descendants.OfType<ConditionalBranch>());
+        Assert.Single(function.Descendants.OfType<DoWhileLoop>());
+    }
+
+    [Fact]
     public void SharedDefaultSiblingCaseContainingEnclosingLoopBreak_RemainsFlat()
     {
         var loopBody = new BlockContainer();
@@ -315,6 +410,175 @@ public class SwitchRaisingSharedGuardTests
         var nestedLoop = Assert.Single(function.Descendants.OfType<WhileLoop>());
         Assert.Single(nestedLoop.Descendants.OfType<Break>());
     }
+
+    [Fact]
+    public void DenseDefaultContainingNestedLoopBreak_StillRaises()
+    {
+        var function = BuildDenseSwitchWithOwnedBreak(
+            "DenseLoop",
+            NestedBreakLoop());
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Empty(function.Descendants.OfType<SwitchBranch>());
+        var nestedLoop = Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.Single(nestedLoop.Descendants.OfType<Break>());
+    }
+
+    [Fact]
+    public void DenseDefaultContainingNestedSwitchBreak_StillRaises()
+    {
+        var function = BuildDenseSwitchWithOwnedBreak(
+            "DenseSwitch",
+            NestedBreakSwitch());
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var switches = function.Descendants.OfType<Switch>().ToList();
+        Assert.Equal(2, switches.Count);
+        Assert.Empty(function.Descendants.OfType<SwitchBranch>());
+        var nestedSwitch = Assert.Single(
+            switches,
+            node => node.Value is Constant);
+        Assert.Single(nestedSwitch.Descendants.OfType<Break>());
+    }
+
+    [Fact]
+    public void StringDefaultContainingNestedLoopBreak_StillRaises()
+    {
+        var function = BuildStringEqualitySwitchWithNestedLoopBreak();
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Empty(function.Descendants.OfType<SwitchBranch>());
+        var nestedLoop = Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.Single(nestedLoop.Descendants.OfType<Break>());
+    }
+
+    static IrFunction BuildDenseSwitchWithOwnedBreak(
+        string name,
+        IrNode nestedOwner)
+    {
+        var body = new BlockContainer();
+
+        var dispatch = new Block(0);
+        dispatch.Add(new SwitchBranch(
+            new LoadArgument(0, "value", s_int),
+            [0x10, 0x20]));
+        body.Add(dispatch);
+
+        var defaultBlock = new Block(4);
+        defaultBlock.Add(nestedOwner);
+        defaultBlock.Add(new Branch(0x30));
+        body.Add(defaultBlock);
+
+        var case0 = new Block(0x10);
+        case0.Add(new StoreLocal(0, s_int, new Constant(1, s_int)));
+        case0.Add(new Branch(0x30));
+        body.Add(case0);
+
+        var case1 = new Block(0x20);
+        case1.Add(new StoreLocal(0, s_int, new Constant(2, s_int)));
+        case1.Add(new Branch(0x30));
+        body.Add(case1);
+
+        var join = new Block(0x30);
+        join.Add(new Return(new LoadLocal(0, s_int)));
+        body.Add(join);
+
+        return Function(
+            name,
+            [new Parameter("value", s_int)],
+            body);
+    }
+
+    static IrFunction BuildStringEqualitySwitchWithNestedLoopBreak()
+    {
+        var body = new BlockContainer();
+        var equals = new MethodRef(
+            s_string,
+            "op_Equality",
+            s_bool,
+            [s_string, s_string],
+            HasThis: false);
+        IrExpression Is(string value) => new Call(
+            equals,
+            isVirtual: false,
+            [
+                new LoadArgument(0, "value", s_string),
+                new Constant(value, s_string),
+            ]);
+
+        var firstTest = new Block(0);
+        firstTest.Add(new ConditionalBranch(Is("a"), 0x20));
+        body.Add(firstTest);
+
+        var secondTest = new Block(8);
+        secondTest.Add(new ConditionalBranch(Is("b"), 0x30));
+        body.Add(secondTest);
+
+        var defaultBlock = new Block(0x10);
+        defaultBlock.Add(NestedBreakLoop());
+        defaultBlock.Add(new Branch(0x40));
+        body.Add(defaultBlock);
+
+        var caseA = new Block(0x20);
+        caseA.Add(new StoreLocal(0, s_int, new Constant(1, s_int)));
+        caseA.Add(new Branch(0x40));
+        body.Add(caseA);
+
+        var caseB = new Block(0x30);
+        caseB.Add(new StoreLocal(0, s_int, new Constant(2, s_int)));
+        caseB.Add(new Branch(0x40));
+        body.Add(caseB);
+
+        var join = new Block(0x40);
+        join.Add(new Return(new LoadLocal(0, s_int)));
+        body.Add(join);
+
+        return Function(
+            "String",
+            [new Parameter("value", s_string)],
+            body);
+    }
+
+    static WhileLoop NestedBreakLoop()
+    {
+        var body = new Block();
+        body.Add(new Break());
+        return new WhileLoop(new Constant(true, s_bool), body);
+    }
+
+    static Switch NestedBreakSwitch()
+    {
+        var block = new Block();
+        block.Add(new Break());
+        var body = new BlockContainer();
+        body.Add(block);
+        return new Switch(
+            new Constant(0, s_int),
+            [new SwitchSection([], isDefault: true, body)]);
+    }
+
+    static IrFunction Function(
+        string name,
+        Parameter[] parameters,
+        BlockContainer body)
+        => new(
+            name,
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(
+                s_int,
+                [.. parameters],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [s_int],
+            body);
 
     static IrFunction BuildSharedGuardSwitch(
         bool guardTargetsCaseBody = false,

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -178,6 +178,8 @@ public sealed class SwitchRaisingPass : IIrPass
         foreach (var region in regions.Values)
             if (!ExitsAreUnconditional(blocks, region, offsetToIndex))
                 return false;
+        if (regions.Values.Any(region => ContainsBreakTargetingOutsideRegion(blocks, region)))
+            return false;
 
         // Nothing outside the switch (the block s aside, which dispatches) may
         // enter the owned blocks — including a leave from another container.
@@ -1677,6 +1679,8 @@ public sealed class SwitchRaisingPass : IIrPass
         foreach (var region in regions.Values)
             if (!ExitsAreUnconditional(blocks, region, offsetToIndex))
                 return false;
+        if (regions.Values.Any(region => ContainsBreakTargetingOutsideRegion(blocks, region)))
+            return false;
 
         if (!OnlyReachedByChain(blocks, owned, s, dispatchEnd, leaveTargets))
             return false;


### PR DESCRIPTION
- Fixes #3836
- Declines dense-integer and string-switch raising when reparenting would steal an enclosing loop's `break`
- Card revision: `745d919f0323ce32cc0bbdee4e6503f32e456933`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — all three switch-statement raisers now apply the same break-ownership rule, so an enclosing-loop exit cannot silently become a switch exit.

### Benchmark target

Benchmark target: `ILInspector.Decompiler.Tests.dll` at `745d919f0323ce32cc0bbdee4e6503f32e456933`

```bash
dotnet-inspect member SharedGuardSwitchFixture ExitEnclosingLoopFromDenseDefault \
  --library artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll \
  --all -S "Decompiled Source" --bare
```

### Original source

```csharp
public static int ExitEnclosingLoopFromDenseDefault(int value)
{
    int result = 0;
    do
    {
        switch (value)
        {
            case 0:
                result += 1;
                break;
            case 1:
                result += 2;
                break;
            case 2:
                result += 3;
                break;
            case 3:
                result += 4;
                break;
            default:
                result += 100;
                goto Done;
        }
        result++;
    }
    while (result < 30);
Done:
    return result;
}
```

### Before

```csharp
public static int ExitEnclosingLoopFromDenseDefault(int value)
{
    int result = 0;
    do
    {
        switch (value)
        {
            case 0:
                result++;
                break;
            case 1:
                result += 2;
                break;
            case 2:
                result += 3;
                break;
            case 3:
                result += 4;
                break;
            default:
                result += 100;
                break;
        }
        result++;
    }
    while (result < 30);
    return result;
}
```

- Valid: True
- Correct: False — an unmatched value returns `101`, while the original returns `100`
- IL fidelity: False
- Taste applied: None
- Commit: `5890a0f33e34f47ca9f0282a7b4a2190ff660d60`

### After

```csharp
public static int ExitEnclosingLoopFromDenseDefault(int value)
{
    int __switchValue0 = default;
    int result;

    result = 0;
    do
    {
        __switchValue0 = (int)(value);
        if (__switchValue0 == 0) goto IL_001A;
        if (__switchValue0 == 1) goto IL_0020;
        if (__switchValue0 == 2) goto IL_0026;
        if (__switchValue0 == 3) goto IL_002C;
        goto IL_0032;
        IL_001A:
        result++;
        goto IL_0039;
        IL_0020:
        result += 2;
        goto IL_0039;
        IL_0026:
        result += 3;
        goto IL_0039;
        IL_002C:
        result += 4;
        goto IL_0039;
        IL_0032:
        result += 100;
        break;
        IL_0039:
        result++;
    }
    while (result < 30);
    return result;
}
```

- Valid: True
- Correct: True
- IL fidelity: False — focused product compile-back reports `OpcodeDiff`
- Taste applied: None
- Commit: `745d919f0323ce32cc0bbdee4e6503f32e456933`

The fallback is intentionally less raised: correctness wins until the IR can preserve an explicitly enclosing owner across reparenting.

### Fully raised

```csharp
public static int ExitEnclosingLoopFromDenseDefault(int value)
{
    int result = 0;
    do
    {
        switch (value)
        {
            case 0:
                result++;
                break;
            case 1:
                result += 2;
                break;
            case 2:
                result += 3;
                break;
            case 3:
                result += 4;
                break;
            default:
                result += 100;
                goto Done;
        }
        result++;
    }
    while (result < 30);
Done:
    return result;
}
```

- Required tracking issue: #3860 — preserve or reconstruct the enclosing-owner exit while still raising dense and string switches

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused ownership tests | 8 passed | 13 passed |
| Decompiler fast suite | 4,585 passed | 4,590 passed |
| Pre-merge fidelity gates | 45 passed | 45 passed |
| Complete non-corpus suite | 4,467 passed | 4,472 passed |
| Dense real witness | Valid but wrong: `100` becomes `101` | Valid and correct |
| String real witness | Incorrectly reparents the same enclosing break | Remains flat and correct |

Removing either new guard independently makes its corresponding compiler-produced witness fail while the other still passes. Breaks owned by nested loops and nested switches retain positive raising coverage.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the pinned PR-quick subset has zero rate movement and no pass bugs; the sampled population changed only through 32 additions paired with 32 removals, with no comparable method-output delta.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly; 15 assemblies and 1,500 methods.

| Metric | Change |
| ------ | ------ |
| Detected lowering residue (population differs) | 234 (15.60%) → 233 (15.53%) |
| Conditional-branch residue (population differs) | 40 (2.67%) → 40 (2.67%) |
| Forward-merge stops (population differs) | 27 (1.80%) → 27 (1.80%) |
| Pass bugs ↓ | 0 → 0 (0) |

Pinned-subset gate: detected lowering residue `16.83% → 16.83%` (0 pp); conditional-branch residue `3.00% → 3.00%` (0 pp); fidelity sampling differs.

Changed-method compile-back attempted all 32 current sampled additions: 9 exact, 2 opcode diffs, 1 unrelated recompile failure, and 20 unsupported generated members. The delta contained no baseline/current comparable method, so the compiler-produced dense and string witnesses provide the targeted semantic evidence; both are compile-back checkable (`OpcodeDiff`), valid, and behavior-correct after this change.
