### PR TITLE
Honor --out for package counts

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -12720,6 +12720,57 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_Count_WritesEmbeddedLibraryAndMultiPackageRoutesToOutputFiles()
+    {
+        var (packagePath, tempDir) = CreateLocalLayoutPackage();
+        var libraryPath = Path.Combine(tempDir, "library-count.txt");
+        var allLibrariesPath = Path.Combine(tempDir, "all-libraries-count.txt");
+        var multiPackagePath = Path.Combine(tempDir, "multi-package-count.txt");
+        try
+        {
+            var (libraryBaselineExit, libraryBaseline, _) = await RunAppAsync(
+                "package", packagePath, "--library", "Layout.dll", "-S", "Library Info", "--count");
+            var (libraryExit, libraryOutput, libraryError) = await RunAppAsync(
+                "package", packagePath, "--library", "Layout.dll", "-S", "Library Info", "--count",
+                "--out", libraryPath);
+
+            Assert.Equal(0, libraryBaselineExit);
+            Assert.Equal(0, libraryExit);
+            Assert.Empty(libraryOutput);
+            Assert.Empty(libraryError);
+            Assert.Equal(libraryBaseline, File.ReadAllText(libraryPath));
+
+            var (allLibrariesBaselineExit, allLibrariesBaseline, allLibrariesBaselineError) = await RunAppAsync(
+                "package", packagePath, "--all-libraries", "-S", "Library Info", "--count");
+            var (allLibrariesExit, allLibrariesOutput, allLibrariesError) = await RunAppAsync(
+                "package", packagePath, "--all-libraries", "-S", "Library Info", "--count",
+                "--out", allLibrariesPath);
+
+            Assert.Equal(0, allLibrariesBaselineExit);
+            Assert.Equal(0, allLibrariesExit);
+            Assert.Empty(allLibrariesOutput);
+            Assert.Equal(allLibrariesBaselineError, allLibrariesError);
+            Assert.Equal(allLibrariesBaseline, File.ReadAllText(allLibrariesPath));
+
+            var (multiPackageBaselineExit, multiPackageBaseline, multiPackageBaselineError) = await RunAppAsync(
+                "package", packagePath, packagePath, "-S", "Package Info", "--tsv", "--count");
+            var (multiPackageExit, multiPackageOutput, multiPackageError) = await RunAppAsync(
+                "package", packagePath, packagePath, "-S", "Package Info", "--tsv", "--count",
+                "--out", multiPackagePath);
+
+            Assert.Equal(0, multiPackageBaselineExit);
+            Assert.Equal(0, multiPackageExit);
+            Assert.Empty(multiPackageOutput);
+            Assert.Equal(multiPackageBaselineError, multiPackageError);
+            Assert.Equal(multiPackageBaseline, File.ReadAllText(multiPackagePath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Package_LegacyFileSectionNames_StillResolve()
     {
         var (packagePath, tempDir) = CreateLocalLayoutPackage();

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -12685,6 +12685,41 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_Count_WritesScalarAndMapToTheRequestedOutputFiles()
+    {
+        var (packagePath, tempDir) = CreateLocalLayoutPackage();
+        var scalarPath = Path.Combine(tempDir, "scalar-count.txt");
+        var mapPath = Path.Combine(tempDir, "map-count.txt");
+        try
+        {
+            var (scalarExit, scalarOutput, scalarError) = await RunAppAsync(
+                "package", packagePath, "-S", "Package nuspec file", "--count", "--out", scalarPath);
+
+            Assert.Equal(0, scalarExit);
+            Assert.Empty(scalarOutput);
+            Assert.Empty(scalarError);
+            Assert.Equal("1\n", File.ReadAllText(scalarPath));
+
+            var (mapExit, mapOutput, mapError) = await RunAppAsync(
+                "package", packagePath, "-S", "@Files", "--count", "--out", mapPath);
+
+            Assert.Equal(0, mapExit);
+            Assert.Empty(mapOutput);
+            Assert.Empty(mapError);
+            var map = File.ReadAllText(mapPath);
+            Assert.StartsWith("| Section | Count |\n| ------- | ----- |\n", map);
+            Assert.Contains("| Package skill files | 0 |\n", map);
+            Assert.Contains("| Package nuspec file | 1 |\n", map);
+            Assert.Contains("| Package README file | 1 |\n", map);
+            Assert.EndsWith("\n", map, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Package_LegacyFileSectionNames_StillResolve()
     {
         var (packagePath, tempDir) = CreateLocalLayoutPackage();

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -612,8 +612,9 @@ public class PackageCommand
             // different payload than the one -D displays.
             if (options.Count && !effectiveDiscovery)
             {
-                ProjectionAudit.MarkHonored(ProjectionAudit.Count);
-                Console.WriteLine(OutputFormatter.FormatResult(result, options, pipeline));
+                CountOutput.WriteCountResult(
+                    OutputFormatter.FormatResult(result, options, pipeline),
+                    options.OutputPath);
                 return 0;
             }
 
@@ -818,7 +819,9 @@ public class PackageCommand
 
         if (options.Count)
         {
-            CountOutput.WriteCount(CountMultiPackageRows(results, rowSection, options));
+            CountOutput.WriteCount(
+                CountMultiPackageRows(results, rowSection, options),
+                options.OutputPath);
             return 0;
         }
 
@@ -2253,7 +2256,7 @@ public class PackageCommand
             // An empty match is still an answer to --count, and returning without projecting
             // would report the absence as unprojected output.
             if (libraryOptions.Count)
-                CountOutput.WriteCount(0);
+                CountOutput.WriteCount(0, options.OutputPath);
             return 0;
         }
 
@@ -2266,7 +2269,7 @@ public class PackageCommand
 
         var markdown = RenderAllLibrariesMarkdown(packageName, version, inspections, sections, libraryOptions, pipeline);
         if (libraryOptions.Count)
-            CountOutput.WriteCountFromMarkdown(markdown);
+            CountOutput.WriteCountFromMarkdown(markdown, options.OutputPath);
         else
             Console.WriteLine(markdown);
         return 0;
@@ -2304,6 +2307,7 @@ public class PackageCommand
             Fields = options.Fields,
             Schema = options.Schema,
             Count = options.Count,
+            OutputPath = options.OutputPath,
             Rows = options.Rows,
             SourceOptions = options.SourceOptions,
             NoHeader = options.NoHeader,

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -217,6 +217,11 @@ public record LibraryOptions : IProjectionOptions
     /// </summary>
     public bool Count { get; init; }
 
+    /// <summary>
+    /// Path to write a projected payload to instead of stdout.
+    /// </summary>
+    public string? OutputPath { get; init; }
+
     public bool Print { get; init; }
 
     public bool Value { get; init; }

--- a/src/dotnet-inspect/Output/CountOutput.cs
+++ b/src/dotnet-inspect/Output/CountOutput.cs
@@ -84,20 +84,28 @@ public static class CountOutput
     /// </summary>
     public static void WriteCount(int count, string? outputPath)
     {
-        ProjectionAudit.MarkHonored(ProjectionAudit.Count);
         // Invariant: a count is machine-readable output, so it must not pick up
         // culture-specific digits or grouping from the ambient locale.
-        var text = count.ToString(CultureInfo.InvariantCulture);
-        if (string.IsNullOrEmpty(outputPath))
-            Console.WriteLine(text);
-        else
-            File.WriteAllText(outputPath, text + '\n');
+        WriteCountResult(count.ToString(CultureInfo.InvariantCulture), outputPath);
     }
 
-    public static void WriteCountFromMarkdown(string markdown)
+    /// <summary>
+    /// Writes an already-rendered scalar or per-section count to <paramref name="outputPath"/>,
+    /// or to stdout when it is null.
+    /// </summary>
+    public static void WriteCountResult(string result, string? outputPath)
     {
         ProjectionAudit.MarkHonored(ProjectionAudit.Count);
-        Console.WriteLine(CountMarkdownTableRows(markdown));
+        var text = result.TrimEnd('\r', '\n') + '\n';
+        if (string.IsNullOrEmpty(outputPath))
+            Console.Write(text);
+        else
+            File.WriteAllText(outputPath, text);
+    }
+
+    public static void WriteCountFromMarkdown(string markdown, string? outputPath = null)
+    {
+        WriteCount(CountMarkdownTableRows(markdown), outputPath);
     }
 
     /// <summary>
@@ -162,10 +170,10 @@ public static class CountOutput
     {
         var counts = CountMarkdownTableRowsBySection(markdown);
         var builder = new System.Text.StringBuilder();
-        builder.AppendLine("| Section | Count |");
-        builder.AppendLine("| ------- | ----- |");
+        builder.Append("| Section | Count |\n");
+        builder.Append("| ------- | ----- |\n");
         foreach (var section in orderedSections)
-            builder.AppendLine($"| {section} | {counts.GetValueOrDefault(section)} |");
+            builder.Append($"| {section} | {counts.GetValueOrDefault(section)} |\n");
 
         return builder.ToString().TrimEnd();
     }
@@ -174,9 +182,11 @@ public static class CountOutput
     /// Emits a per-section count map (<c>| Section | Count |</c>) over <paramref name="orderedSections"/>,
     /// reporting 0 for sections absent from the rendered markdown.
     /// </summary>
-    public static void WriteCountMapFromMarkdown(string markdown, IReadOnlyList<string> orderedSections)
+    public static void WriteCountMapFromMarkdown(
+        string markdown,
+        IReadOnlyList<string> orderedSections,
+        string? outputPath = null)
     {
-        ProjectionAudit.MarkHonored(ProjectionAudit.Count);
-        Console.WriteLine(RenderCountMapFromMarkdown(markdown, orderedSections));
+        WriteCountResult(RenderCountMapFromMarkdown(markdown, orderedSections), outputPath);
     }
 }

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -366,11 +366,11 @@ public static class OutputFormatter
             var ordered = ResolveCountMapSections(pipeline, options.IncludeSections, options.FixedOverview);
             if (ordered != null)
             {
-                CountOutput.WriteCountMapFromMarkdown(markdown, ordered);
+                CountOutput.WriteCountMapFromMarkdown(markdown, ordered, options.OutputPath);
             }
             else
             {
-                CountOutput.WriteCountFromMarkdown(markdown);
+                CountOutput.WriteCountFromMarkdown(markdown, options.OutputPath);
             }
             return;
         }
@@ -534,11 +534,11 @@ public static class OutputFormatter
             var ordered = ResolveCountMapSections(pipeline, options.IncludeSections, options.FixedOverview);
             if (ordered != null)
             {
-                CountOutput.WriteCountMapFromMarkdown(markdown, ordered);
+                CountOutput.WriteCountMapFromMarkdown(markdown, ordered, options.OutputPath);
             }
             else
             {
-                CountOutput.WriteCountFromMarkdown(markdown);
+                CountOutput.WriteCountFromMarkdown(markdown, options.OutputPath);
             }
             return;
         }


### PR DESCRIPTION
## Summary

- route scalar and per-section `package --count` output to `--out` instead of silently falling back to stdout
- carry the destination through multi-package and embedded-library count paths
- centralize count framing as BOM-less UTF-8 with an LF terminator

Closes #3758

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- focused package/count output tests (5 passed)
- full CLI suite: 3008 passed, 14 skipped, one timing-sensitive cyclic-constraint benchmark exceeded its suite-load threshold; the benchmark passed immediately in isolation

## Compatibility

Count content and stdout behavior are unchanged when `--out` is absent. This does not add `--out` to commands that do not already expose it.