### PR TITLE
Reconstruct enum switch offsets

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EnumSwitchOffsetRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumSwitchOffsetRaisingTests.cs
@@ -8,6 +8,7 @@ public class EnumSwitchOffsetRaisingTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_uint = TypeRef.CoreLib("System", "UInt32");
+    static readonly TypeRef s_byte = TypeRef.CoreLib("System", "Byte");
     static readonly TypeRef s_enum = TypeRef.Definition("Synthetic", "Samples", "Boundary");
 
     [Fact]
@@ -68,7 +69,97 @@ public class EnumSwitchOffsetRaisingTests
     }
 
     [Fact]
-    public void UnknownShapeNamedEnum_ReconstructsOffsetLikeSwitchLabelRendering()
+    public void NarrowBackingInRange_ReconstructsOffset()
+    {
+        var function = Build(
+            new Binary(
+                BinaryKind.Subtract,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgument(0, "value", s_enum),
+                new Constant(250, s_int)),
+            s_byte,
+            new Dictionary<long, string>
+            {
+                [250] = "First",
+                [251] = "Second",
+            });
+
+        var node = Raise(function);
+
+        Assert.IsType<LoadArgument>(node.Value);
+        Assert.Equal([250, 251], Labels(node));
+    }
+
+    [Fact]
+    public void NarrowBackingOverflow_RemainsInGoverningExpression()
+    {
+        var function = Build(
+            new Binary(
+                BinaryKind.Subtract,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgument(0, "value", s_enum),
+                new Constant(256, s_int)),
+            s_byte);
+
+        var node = Raise(function);
+
+        Assert.IsType<Binary>(node.Value);
+        Assert.Equal([0, 1], Labels(node));
+    }
+
+    [Theory]
+    [InlineData("Int64")]
+    [InlineData("UInt64")]
+    public void WideBacking_RemainsInGoverningExpression(string underlyingName)
+    {
+        var function = Build(
+            new Binary(
+                BinaryKind.Subtract,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgument(0, "value", s_enum),
+                new Constant(24, s_int)),
+            TypeRef.CoreLib("System", underlyingName));
+
+        var node = Raise(function);
+
+        Assert.IsType<Binary>(node.Value);
+        Assert.Equal([0, 1], Labels(node));
+    }
+
+    [Fact]
+    public void IndirectEnumOperand_ReconstructsOffsetFromPointeeType()
+    {
+        var enumByRef = TypeRef.ByRef(s_enum);
+        var function = Build(
+            new Binary(
+                BinaryKind.Subtract,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadIndirect(s_int, new LoadArgument(0, "value", enumByRef)),
+                new Constant(24, s_int)),
+            s_int,
+            new Dictionary<long, string>
+            {
+                [24] = "First",
+                [25] = "Second",
+            },
+            valueParameterType: enumByRef);
+
+        var node = Raise(function);
+
+        Assert.IsType<LoadIndirect>(node.Value);
+        Assert.Equal([24, 25], Labels(node));
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("switch (value)", output);
+        Assert.Contains("case Boundary.First:", output);
+        Assert.Contains("case Boundary.Second:", output);
+    }
+
+    [Fact]
+    public void UnknownShapeNamedEnum_RemainsInGoverningExpressionWithoutBackingProof()
     {
         var function = Build(
             new Binary(
@@ -82,12 +173,8 @@ public class EnumSwitchOffsetRaisingTests
 
         var node = Raise(function);
 
-        Assert.IsType<LoadArgument>(node.Value);
-        Assert.Equal([24, 25], Labels(node));
-        string output = CSharpPrinter.Print(function).Output!;
-        Assert.Contains("switch (value)", output);
-        Assert.Contains("case (Boundary)24:", output);
-        Assert.Contains("case (Boundary)25:", output);
+        Assert.IsType<Binary>(node.Value);
+        Assert.Equal([0, 1], Labels(node));
     }
 
     [Fact]
@@ -160,7 +247,8 @@ public class EnumSwitchOffsetRaisingTests
         IrExpression value,
         TypeRef underlying,
         IReadOnlyDictionary<long, string>? members = null,
-        bool declareEnumShape = true)
+        bool declareEnumShape = true,
+        TypeRef? valueParameterType = null)
     {
         var body = new BlockContainer();
 
@@ -186,7 +274,7 @@ public class EnumSwitchOffsetRaisingTests
             new MethodSignature(
                 s_int,
                 [
-                    new Parameter("value", s_enum),
+                    new Parameter("value", valueParameterType ?? s_enum),
                     new Parameter("offset", s_int),
                 ],
                 HasThis: false,
@@ -197,7 +285,9 @@ public class EnumSwitchOffsetRaisingTests
             TypeShapes = declareEnumShape
                 ? new Dictionary<TypeRef, TypeShape> { [s_enum] = TypeShape.Enum }
                 : new Dictionary<TypeRef, TypeShape>(),
-            EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [s_enum] = underlying },
+            EnumUnderlyingTypes = declareEnumShape
+                ? new Dictionary<TypeRef, TypeRef> { [s_enum] = underlying }
+                : new Dictionary<TypeRef, TypeRef>(),
             EnumMembers = members is null
                 ? new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>()
                 : new Dictionary<TypeRef, IReadOnlyDictionary<long, string>> { [s_enum] = members },
@@ -218,6 +308,7 @@ public class EnumSwitchOffsetFidelityTests
         {
             nameof(SharedGuardSwitchFixture.Check),
             nameof(SharedGuardSwitchFixture.Classify),
+            nameof(SharedGuardSwitchFixture.ClassifyRef),
         };
         var results = FidelityCheck.Evaluate(
                 typeof(SharedGuardSwitchFixture).Assembly.Location,
@@ -228,6 +319,8 @@ public class EnumSwitchOffsetFidelityTests
         Assert.Equal(methods.Count, results.Count);
         var classify = Assert.Single(results, result => result.Method == nameof(SharedGuardSwitchFixture.Classify));
         Assert.Equal(FidelityCheck.CompileBackStatus.Exact, classify.Status);
+        var classifyRef = Assert.Single(results, result => result.Method == nameof(SharedGuardSwitchFixture.ClassifyRef));
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, classifyRef.Status);
 
         // Check has a pre-existing unsigned-comparison residual in the guard
         // before its switch. Pin that as the only difference so this gate still

--- a/src/ILInspector.Decompiler.Tests/EnumSwitchOffsetRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumSwitchOffsetRaisingTests.cs
@@ -1,0 +1,241 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "Pass")]
+public class EnumSwitchOffsetRaisingTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_uint = TypeRef.CoreLib("System", "UInt32");
+    static readonly TypeRef s_enum = TypeRef.Definition("Synthetic", "Samples", "Boundary");
+
+    [Fact]
+    public void SubtractOffset_WrapsSignedLabelsWithoutChangingDispatch()
+    {
+        var function = Build(
+            new Binary(
+                BinaryKind.Subtract,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgument(0, "value", s_enum),
+                new Constant(int.MaxValue, s_int)),
+            s_int,
+            new Dictionary<long, string>
+            {
+                [int.MaxValue] = "Max",
+                [int.MinValue] = "Min",
+            });
+
+        var node = Raise(function);
+
+        Assert.IsType<LoadArgument>(node.Value);
+        Assert.Equal(
+            [int.MaxValue, int.MinValue],
+            node.Sections.SelectMany(section => section.Labels).Select(label => Assert.IsType<int>(label.Value)));
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("switch (value)", output);
+        Assert.Contains("case Boundary.Max:", output);
+        Assert.Contains("case Boundary.Min:", output);
+    }
+
+    [Fact]
+    public void AddOffset_WrapsUnsignedLabelsWithoutChangingDispatch()
+    {
+        var function = Build(
+            new Binary(
+                BinaryKind.Add,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgument(0, "value", s_enum),
+                new Constant(1, s_int)),
+            s_uint,
+            new Dictionary<long, string>
+            {
+                [0] = "Zero",
+            });
+
+        var node = Raise(function);
+
+        Assert.IsType<LoadArgument>(node.Value);
+        Assert.Equal(
+            [-1, 0],
+            node.Sections.SelectMany(section => section.Labels).Select(label => Assert.IsType<int>(label.Value)));
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("switch (value)", output);
+        Assert.Contains("case unchecked((Boundary)(-1)):", output);
+        Assert.Contains("case Boundary.Zero:", output);
+    }
+
+    [Fact]
+    public void UnknownShapeNamedEnum_ReconstructsOffsetLikeSwitchLabelRendering()
+    {
+        var function = Build(
+            new Binary(
+                BinaryKind.Subtract,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgument(0, "value", s_enum),
+                new Constant(24, s_int)),
+            s_int,
+            declareEnumShape: false);
+
+        var node = Raise(function);
+
+        Assert.IsType<LoadArgument>(node.Value);
+        Assert.Equal([24, 25], Labels(node));
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("switch (value)", output);
+        Assert.Contains("case (Boundary)24:", output);
+        Assert.Contains("case (Boundary)25:", output);
+    }
+
+    [Fact]
+    public void CheckedArithmetic_RemainsInGoverningExpression()
+    {
+        var function = Build(
+            new Binary(
+                BinaryKind.Subtract,
+                isChecked: true,
+                isUnsigned: false,
+                new LoadArgument(0, "value", s_enum),
+                new Constant(24, s_int)),
+            s_int);
+
+        var node = Raise(function);
+
+        var binary = Assert.IsType<Binary>(node.Value);
+        Assert.True(binary.IsChecked);
+        Assert.Equal([0, 1], Labels(node));
+    }
+
+    [Fact]
+    public void VariableOffset_RemainsInGoverningExpression()
+    {
+        var function = Build(
+            new Binary(
+                BinaryKind.Subtract,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgument(0, "value", s_enum),
+                new LoadArgument(1, "offset", s_int)),
+            s_int);
+
+        var node = Raise(function);
+
+        Assert.IsType<Binary>(node.Value);
+        Assert.Equal([0, 1], Labels(node));
+    }
+
+    [Fact]
+    public void PrimitiveArithmetic_RemainsInGoverningExpression()
+    {
+        var function = Build(
+            new Binary(
+                BinaryKind.Subtract,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgument(1, "offset", s_int),
+                new Constant(24, s_int)),
+            s_int);
+
+        var node = Raise(function);
+
+        Assert.IsType<Binary>(node.Value);
+        Assert.Equal([0, 1], Labels(node));
+    }
+
+    static Switch Raise(IrFunction function)
+    {
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        Assert.Empty(function.Descendants.OfType<SwitchBranch>());
+        return Assert.Single(function.Descendants.OfType<Switch>());
+    }
+
+    static int[] Labels(Switch node)
+        => [.. node.Sections.SelectMany(section => section.Labels).Select(label => Assert.IsType<int>(label.Value))];
+
+    static IrFunction Build(
+        IrExpression value,
+        TypeRef underlying,
+        IReadOnlyDictionary<long, string>? members = null,
+        bool declareEnumShape = true)
+    {
+        var body = new BlockContainer();
+
+        var dispatch = new Block(0);
+        dispatch.Add(new SwitchBranch(value, [0x10, 0x20]));
+        body.Add(dispatch);
+
+        var defaultBlock = new Block(4);
+        defaultBlock.Add(new Return(new Constant(-1, s_int)));
+        body.Add(defaultBlock);
+
+        var firstCase = new Block(0x10);
+        firstCase.Add(new Return(new Constant(10, s_int)));
+        body.Add(firstCase);
+
+        var secondCase = new Block(0x20);
+        secondCase.Add(new Return(new Constant(20, s_int)));
+        body.Add(secondCase);
+
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Holder"),
+            new MethodSignature(
+                s_int,
+                [
+                    new Parameter("value", s_enum),
+                    new Parameter("offset", s_int),
+                ],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [],
+            body)
+        {
+            TypeShapes = declareEnumShape
+                ? new Dictionary<TypeRef, TypeShape> { [s_enum] = TypeShape.Enum }
+                : new Dictionary<TypeRef, TypeShape>(),
+            EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [s_enum] = underlying },
+            EnumMembers = members is null
+                ? new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>()
+                : new Dictionary<TypeRef, IReadOnlyDictionary<long, string>> { [s_enum] = members },
+        };
+    }
+}
+
+[Collection(FidelityGateCollection.Name)]
+public class EnumSwitchOffsetFidelityTests
+{
+    [Fact]
+    [Trait("Speed", "Slow")]
+    [Trait("Area", "Fidelity")]
+    public void CompilerProducedEnumSwitches_PreserveSwitchOpcodesOnCompileBack()
+    {
+        string fixtureType = typeof(SharedGuardSwitchFixture).FullName!;
+        var methods = new HashSet<string>
+        {
+            nameof(SharedGuardSwitchFixture.Check),
+            nameof(SharedGuardSwitchFixture.Classify),
+        };
+        var results = FidelityCheck.Evaluate(
+                typeof(SharedGuardSwitchFixture).Assembly.Location,
+                type => type == fixtureType)
+            .Where(result => methods.Contains(result.Method))
+            .ToList();
+
+        Assert.Equal(methods.Count, results.Count);
+        var classify = Assert.Single(results, result => result.Method == nameof(SharedGuardSwitchFixture.Classify));
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, classify.Status);
+
+        // Check has a pre-existing unsigned-comparison residual in the guard
+        // before its switch. Pin that as the only difference so this gate still
+        // proves the reconstructed switch recompiles to the original sub/switch.
+        var check = Assert.Single(results, result => result.Method == nameof(SharedGuardSwitchFixture.Check));
+        Assert.Equal(FidelityCheck.CompileBackStatus.OpcodeDiff, check.Status);
+        Assert.Equal(
+            check.OriginalOpcodes.Replace("ble.un", "ble", StringComparison.Ordinal),
+            check.RecompiledOpcodes);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedGuardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedGuardTests.cs
@@ -61,6 +61,18 @@ static class SharedGuardSwitchFixture
             _ => -1,
         };
 
+    public static int ClassifyRef(ref SharedGuardAlgorithm algorithm)
+        => algorithm switch
+        {
+            SharedGuardAlgorithm.Dense24 => 0,
+            SharedGuardAlgorithm.Dense25 => 1,
+            SharedGuardAlgorithm.Dense26 => 2,
+            SharedGuardAlgorithm.Dense27 => 3,
+            SharedGuardAlgorithm.Dense28 => 4,
+            SharedGuardAlgorithm.Dense29 => 5,
+            _ => -1,
+        };
+
     public static int ExitLoopFromDefault(int value, bool skip)
     {
         int result = 0;
@@ -206,6 +218,30 @@ public class SwitchRaisingSharedGuardTests
         Assert.Contains("SharedGuardAlgorithm.Dense29 => 5", output);
         Assert.Contains("_ => -1", output);
         Assert.DoesNotContain("Dense24Alias", output);
+        Assert.DoesNotContain("algorithm - 24", output);
+    }
+
+    [Fact]
+    public void CompilerProducedRefEnumSwitchExpression_ReconstructsOffsetIntoMemberLabels()
+    {
+        using var source = MetadataSource.Open(typeof(SharedGuardSwitchFixture).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(SharedGuardSwitchFixture).FullName!,
+            nameof(SharedGuardSwitchFixture.ClassifyRef));
+        Assert.NotNull(function);
+        Assert.Single(function.Descendants.OfType<SwitchBranch>());
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+
+        var node = Assert.Single(function.Descendants.OfType<SwitchExpression>());
+        Assert.IsType<LoadLocal>(node.Value);
+        Assert.Empty(function.Descendants.OfType<SwitchBranch>());
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("return V_1 switch", output);
+        Assert.Contains("SharedGuardAlgorithm.Dense24 => 0", output);
+        Assert.Contains("SharedGuardAlgorithm.Dense29 => 5", output);
         Assert.DoesNotContain("algorithm - 24", output);
     }
 

--- a/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedGuardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedGuardTests.cs
@@ -7,7 +7,12 @@ enum SharedGuardAlgorithm
     Low6 = 6,
     Low7 = 7,
     Dense24 = 24,
+    Dense24Alias = Dense24,
     Dense25 = 25,
+    Dense26 = 26,
+    Dense27 = 27,
+    Dense28 = 28,
+    Dense29 = 29,
     Dense30 = 30,
     Dense31 = 31,
     Dense32 = 32,
@@ -43,6 +48,18 @@ static class SharedGuardSwitchFixture
                 throw new ArgumentException();
         }
     }
+
+    public static int Classify(SharedGuardAlgorithm algorithm)
+        => algorithm switch
+        {
+            SharedGuardAlgorithm.Dense24 => 0,
+            SharedGuardAlgorithm.Dense25 => 1,
+            SharedGuardAlgorithm.Dense26 => 2,
+            SharedGuardAlgorithm.Dense27 => 3,
+            SharedGuardAlgorithm.Dense28 => 4,
+            SharedGuardAlgorithm.Dense29 => 5,
+            _ => -1,
+        };
 
     public static int ExitLoopFromDefault(int value, bool skip)
     {
@@ -153,13 +170,43 @@ public class SwitchRaisingSharedGuardTests
         IrPasses.Run(function);
         function.CheckInvariant();
 
-        Assert.Single(function.Descendants.OfType<Switch>());
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Single(node.Sections, section => section.IsDefault);
+        Assert.Contains(node.Sections, section => section.Labels.Length > 1);
         Assert.Empty(function.Descendants.OfType<SwitchBranch>());
         string output = CSharpPrinter.Print(function).Output!;
-        Assert.Contains("switch (algorithm - 24)", output);
+        Assert.Contains("switch (algorithm)", output);
+        Assert.Contains("case SharedGuardAlgorithm.Dense24:", output);
+        Assert.DoesNotContain("Dense24Alias", output);
+        Assert.DoesNotContain("algorithm - 24", output);
         Assert.DoesNotContain("__switchValue", output);
         Assert.DoesNotContain("goto", output);
         Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
+    public void CompilerProducedEnumSwitchExpression_ReconstructsOffsetIntoMemberLabels()
+    {
+        using var source = MetadataSource.Open(typeof(SharedGuardSwitchFixture).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(SharedGuardSwitchFixture).FullName!,
+            nameof(SharedGuardSwitchFixture.Classify));
+        Assert.NotNull(function);
+        Assert.Single(function.Descendants.OfType<SwitchBranch>());
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<SwitchExpression>());
+        Assert.Empty(function.Descendants.OfType<SwitchBranch>());
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("algorithm switch", output);
+        Assert.Contains("SharedGuardAlgorithm.Dense24 => 0", output);
+        Assert.Contains("SharedGuardAlgorithm.Dense29 => 5", output);
+        Assert.Contains("_ => -1", output);
+        Assert.DoesNotContain("Dense24Alias", output);
+        Assert.DoesNotContain("algorithm - 24", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -493,7 +493,14 @@ public sealed class SwitchRaisingPass : IIrPass
     static IrExpression ValueBlockExpr(Block block) => ((StoreLocal)block.Children[0]).Value;
 
     /// <summary>Replaces a value-producing jump table with <c>return v switch { … };</c>: the arms group case labels by their value block, and the default arm is supplied by the recognizer.</summary>
-    static void BuildSwitchExpression(BlockContainer container, int s, SwitchBranch sw, int[] caseTargets, IrExpression defaultArm, int join, Stepper stepper)
+    static void BuildSwitchExpression(
+        BlockContainer container,
+        int s,
+        SwitchBranch sw,
+        int[] caseTargets,
+        IrExpression defaultArm,
+        int join,
+        Stepper stepper)
     {
         var all = container.Blocks.ToList();
 
@@ -501,13 +508,14 @@ public sealed class SwitchRaisingPass : IIrPass
         for (int i = 0; i < caseTargets.Length; i++)
             (labelsByTarget.TryGetValue(caseTargets[i], out var list) ? list : labelsByTarget[caseTargets[i]] = []).Add(i);
 
+        var value = DetachSwitchValue(sw, out int labelOffset);
+        sw.Detach();
+
         var arms = new List<SwitchExpressionArm>();
         foreach (var (target, labels) in labelsByTarget.OrderBy(kv => kv.Value.Min()))
-            arms.Add(new SwitchExpressionArm([.. labels], isDefault: false, (IrExpression)ValueBlockExpr(all[target]).Clone()));
+            arms.Add(new SwitchExpressionArm([.. labels.Select(label => OffsetLabel(label, labelOffset))],
+                isDefault: false, (IrExpression)ValueBlockExpr(all[target]).Clone()));
         arms.Add(new SwitchExpressionArm([], isDefault: true, defaultArm));
-
-        var value = (IrExpression)sw.DetachChildren()[0];
-        sw.Detach();
 
         foreach (var block in all)
             block.Detach();
@@ -1234,12 +1242,66 @@ public sealed class SwitchRaisingPass : IIrPass
         _ => [],
     };
 
-    /// <summary>Jump-table indices as <c>int</c> case-label constants.</summary>
-    static ImmutableArray<Constant> IntLabels(IEnumerable<int> indices)
-        => [.. indices.Select(IntConst)];
+    /// <summary>Jump-table indices shifted back to semantic <c>int</c> case-label constants.</summary>
+    static ImmutableArray<Constant> IntLabels(IEnumerable<int> indices, int labelOffset)
+        => [.. indices.Select(index => IntConst(OffsetLabel(index, labelOffset)))];
 
     /// <summary>A single <c>int</c> case-label constant.</summary>
     static Constant IntConst(int value) => new(value, TypeRef.CoreLib("System", "Int32"));
+
+    static int OffsetLabel(int index, int labelOffset) => unchecked(index + labelOffset);
+
+    /// <summary>
+    /// Removes an unchecked enum add/subtract normalization and returns the
+    /// corresponding modulo-32-bit label offset. Checked or unproven enum
+    /// arithmetic remains intact because removing it can change exceptions or
+    /// reinterpret a non-enum operation. Enum identity uses imported shape
+    /// evidence when available and the printer's conservative unresolved named
+    /// switch-value rule for cross-assembly enums.
+    /// </summary>
+    static IrExpression DetachSwitchValue(
+        SwitchBranch sw,
+        out int labelOffset)
+    {
+        labelOffset = 0;
+        var value = sw.Value;
+        if (value is not Binary
+            {
+                Kind: BinaryKind.Add or BinaryKind.Subtract,
+                IsChecked: false,
+                Left: var left,
+                Right: Constant { Value: int constant },
+            } binary
+            || left.ResultType is not { } leftType
+            || OwningFunction(sw) is not { } function
+            || !IsEnumSwitchType(leftType, function.TypeShapes))
+        {
+            return (IrExpression)sw.DetachChildren()[0];
+        }
+
+        labelOffset = binary.Kind == BinaryKind.Subtract
+            ? constant
+            : unchecked(-constant);
+        sw.DetachChildren();
+        return (IrExpression)binary.DetachChildren()[0];
+    }
+
+    static bool IsEnumSwitchType(TypeRef type, IReadOnlyDictionary<TypeRef, TypeShape> typeShapes)
+    {
+        if (typeShapes.GetValueOrDefault(type) == TypeShape.Enum)
+            return true;
+        return type is { Kind: TypeRefKind.Definition, Name: not ("Boolean" or "String") }
+            && typeShapes.GetValueOrDefault(type) == TypeShape.Unknown
+            && !TypeFamilies.IsNumericPrimitive(type);
+    }
+
+    static IrFunction? OwningFunction(IrNode node)
+    {
+        for (var ancestor = node.Parent; ancestor is not null; ancestor = ancestor.Parent)
+            if (ancestor is IrFunction function)
+                return function;
+        return null;
+    }
 
     /// <summary>A single <c>string</c> case-label constant.</summary>
     static Constant StringConst(string value) => new(value, TypeRef.CoreLib("System", "String"));
@@ -1913,20 +1975,21 @@ public sealed class SwitchRaisingPass : IIrPass
         for (int i = 0; i < caseTargets.Length; i++)
             (labelsByTarget.TryGetValue(caseTargets[i], out var list) ? list : labelsByTarget[caseTargets[i]] = []).Add(i);
 
+        var value = DetachSwitchValue(sw, out int labelOffset);
+        sw.Detach();
+
         foreach (var block in all)
             block.Detach();
 
         var sections = new List<SwitchSection>();
         foreach (var (target, labels) in labelsByTarget.OrderBy(kv => kv.Value.Min()))
-            sections.Add(new SwitchSection(IntLabels(labels), isDefault: target == defaultSharesTarget,
+            sections.Add(new SwitchSection(IntLabels(labels, labelOffset), isDefault: target == defaultSharesTarget,
                 SectionBody(regions[target].Select(i => all[i]).ToList(), joinOffset)));
         if (defaultBodyHead is { } dh)
             sections.Add(new SwitchSection([], isDefault: true,
                 SectionBody(regions[dh].Select(i => all[i]).ToList(), joinOffset)));
 
         var switchBlock = all[s];
-        var value = (IrExpression)sw.DetachChildren()[0];
-        sw.Detach();
         switchBlock.Add(new Switch(value, sections));
 
         var rebuilt = new BlockContainer();
@@ -1980,6 +2043,9 @@ public sealed class SwitchRaisingPass : IIrPass
         for (int i = 0; i < caseTargets.Length; i++)
             (labelsByTarget.TryGetValue(caseTargets[i], out var list) ? list : labelsByTarget[caseTargets[i]] = []).Add(i);
 
+        var value = DetachSwitchValue(sw, out int labelOffset);
+        sw.Detach();
+
         // Clone the shared terminator before detaching: the default falls into a
         // single-block terminating case, which C# cannot do, so its body is
         // duplicated into the default section.
@@ -1994,10 +2060,10 @@ public sealed class SwitchRaisingPass : IIrPass
         foreach (var (target, labels) in labelsByTarget.OrderBy(kv => kv.Value.Min()))
         {
             if (target == join)
-                sections.Add(new SwitchSection(IntLabels(labels),
+                sections.Add(new SwitchSection(IntLabels(labels, labelOffset),
                     isDefault: defaultSharesTarget && target == defaultIndex, EmptyBreakBody()));
             else
-                sections.Add(new SwitchSection(IntLabels(labels),
+                sections.Add(new SwitchSection(IntLabels(labels, labelOffset),
                     isDefault: defaultSharesTarget && target == defaultIndex,
                     SectionBody(regions[target].Select(i => all[i]).ToList(), joinOffset)));
         }
@@ -2006,8 +2072,6 @@ public sealed class SwitchRaisingPass : IIrPass
                 DefaultSectionBody(regions[defaultIndex].Select(i => all[i]).ToList(), joinOffset, duplicatedTerminator)));
 
         var switchBlock = all[s];
-        var value = (IrExpression)sw.DetachChildren()[0];
-        sw.Detach();
         switchBlock.Add(new Switch(value, sections));
 
         var rebuilt = new BlockContainer();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -1257,7 +1257,8 @@ public sealed class SwitchRaisingPass : IIrPass
     /// arithmetic remains intact because removing it can change exceptions or
     /// reinterpret a non-enum operation. Enum identity uses imported shape
     /// evidence when available and the printer's conservative unresolved named
-    /// switch-value rule for cross-assembly enums.
+    /// switch-value rule for cross-assembly enums; known backing width is still
+    /// required so shifted labels cannot truncate to different enum values.
     /// </summary>
     static IrExpression DetachSwitchValue(
         SwitchBranch sw,
@@ -1272,18 +1273,39 @@ public sealed class SwitchRaisingPass : IIrPass
                 Left: var left,
                 Right: Constant { Value: int constant },
             } binary
-            || left.ResultType is not { } leftType
             || OwningFunction(sw) is not { } function
-            || !IsEnumSwitchType(leftType, function.TypeShapes))
+            || SwitchEnumType(left, function.TypeShapes) is not { } enumType
+            || !function.EnumUnderlyingTypes.TryGetValue(enumType, out var underlyingType))
         {
             return (IrExpression)sw.DetachChildren()[0];
         }
 
-        labelOffset = binary.Kind == BinaryKind.Subtract
+        int candidateOffset = binary.Kind == BinaryKind.Subtract
             ? constant
             : unchecked(-constant);
+        if (!LabelsFitBackingType(sw.TargetOffsets.Length, candidateOffset, underlyingType))
+            return (IrExpression)sw.DetachChildren()[0];
+
+        labelOffset = candidateOffset;
         sw.DetachChildren();
         return (IrExpression)binary.DetachChildren()[0];
+    }
+
+    static TypeRef? SwitchEnumType(
+        IrExpression value,
+        IReadOnlyDictionary<TypeRef, TypeShape> typeShapes)
+    {
+        var type = value is LoadIndirect
+        {
+            Address.ResultType:
+            {
+                Kind: TypeRefKind.ByRef or TypeRefKind.Pointer,
+                ElementType: { } pointee,
+            },
+        }
+            ? pointee
+            : value.ResultType;
+        return type is not null && IsEnumSwitchType(type, typeShapes) ? type : null;
     }
 
     static bool IsEnumSwitchType(TypeRef type, IReadOnlyDictionary<TypeRef, TypeShape> typeShapes)
@@ -1293,6 +1315,41 @@ public sealed class SwitchRaisingPass : IIrPass
         return type is { Kind: TypeRefKind.Definition, Name: not ("Boolean" or "String") }
             && typeShapes.GetValueOrDefault(type) == TypeShape.Unknown
             && !TypeFamilies.IsNumericPrimitive(type);
+    }
+
+    static bool LabelsFitBackingType(int labelCount, int labelOffset, TypeRef backingType)
+    {
+        if (backingType is
+            {
+                Kind: TypeRefKind.Definition,
+                Assembly: TypeRef.CoreLibrary,
+                Namespace: "System",
+                Name: "Int32" or "UInt32",
+            })
+        {
+            return true;
+        }
+
+        for (int index = 0; index < labelCount; index++)
+        {
+            int label = OffsetLabel(index, labelOffset);
+            bool fits = backingType is
+            {
+                Kind: TypeRefKind.Definition,
+                Assembly: TypeRef.CoreLibrary,
+                Namespace: "System",
+            } ? backingType.Name switch
+            {
+                "SByte" => label is >= sbyte.MinValue and <= sbyte.MaxValue,
+                "Byte" => label is >= byte.MinValue and <= byte.MaxValue,
+                "Int16" => label is >= short.MinValue and <= short.MaxValue,
+                "UInt16" => label is >= ushort.MinValue and <= ushort.MaxValue,
+                _ => false,
+            } : false;
+            if (!fits)
+                return false;
+        }
+        return true;
     }
 
     static IrFunction? OwningFunction(IrNode node)


### PR DESCRIPTION
Fixes #3844

Reconstructs compiler-normalized enum jump tables as direct enum switches with
semantic member labels.

Card revision: `aa67be5b`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the raiser now folds only proven unchecked enum
`+/- int-constant` normalization into modulo-32-bit case labels, preserving the
IL switch dispatch while recovering the authored enum surface.

The same helper covers statement switches, case-target-join switches, and
value-producing switch expressions. Checked arithmetic, variable offsets, and
primitive arithmetic remain unchanged.

### Benchmark target

Benchmark target: `NLOptNet@1.4.3`, `lib/netstandard2.0/NLoptNet.dll`
(`sha256:66d6d6faa4256f35333afce05634b39e8dcd9d08fb1ce2e04955bfac1cb5b805`)

```bash
dotnet-inspect member NLoptNet.NLoptSolver CheckEqualityConstraintAvailability \
  --library NLoptNet.dll --all -S "Decompiled Source" --bare --offline -T:q
```

### Original IL

No PDB/source server is present in the package, so the product's raw IL section
is the authoritative source anchor.

```text
IL_0000: ldarg.0
IL_0001: call         NLoptNet.NLoptSolver::get_Algorithm()
IL_0006: stloc.0
IL_0007: ldloc.0
IL_0008: ldc.i4.s     25
IL_000A: sub
IL_000B: switch       (IL_0072, IL_0050, IL_0050, IL_0050, IL_0050, IL_0072, IL_0072, IL_0072, IL_0072, IL_0050, IL_0072, IL_0072, IL_0072, IL_0050, IL_0050, IL_0072)
IL_0050: ldstr        "Algorithm "
IL_0055: ldloca.s     0
IL_0057: constrained. NLoptNet.NLoptAlgorithm
IL_005D: callvirt     System.Object::ToString()
IL_0062: ldstr        " does not support equality constraint."
IL_0067: call         System.String::Concat(string, string, string)
IL_006C: newobj       System.ArgumentException::.ctor(string)
IL_0071: throw
IL_0072: ret
```

### Before

```csharp
protected void CheckEqualityConstraintAvailability()
{
    NLoptAlgorithm V_0 = Algorithm;
    switch (V_0 - 25)
    {
        case NLoptAlgorithm.GN_DIRECT:
        case NLoptAlgorithm.GN_DIRECT_L_RAND_NOSCAL:
        case NLoptAlgorithm.GN_ORIG_DIRECT:
        case NLoptAlgorithm.GN_ORIG_DIRECT_L:
        case NLoptAlgorithm.GD_STOGO:
        case NLoptAlgorithm.LD_LBFGS_NOCEDAL:
        case NLoptAlgorithm.LD_LBFGS:
        case NLoptAlgorithm.LN_PRAXIS:
        case NLoptAlgorithm.LD_TNEWTON:
            return;
        case NLoptAlgorithm.GN_DIRECT_L:
        case NLoptAlgorithm.GN_DIRECT_L_RAND:
        case NLoptAlgorithm.GN_DIRECT_NOSCAL:
        case NLoptAlgorithm.GN_DIRECT_L_NOSCAL:
        case NLoptAlgorithm.GD_STOGO_RAND:
        case NLoptAlgorithm.LD_VAR1:
        case NLoptAlgorithm.LD_VAR2:
        default:
            throw new ArgumentException(string.Concat("Algorithm ", V_0.ToString(), " does not support equality constraint."));
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: False (`OpcodeDiff`; the switch still recompiles to `sub` +
  `switch`, but the reconstruction adds a spill and branch)
- Taste applied: None
- Commit: `50046669ab6556c2dd49ec27da016dda682a4950`

### After

```csharp
protected void CheckEqualityConstraintAvailability()
{
    NLoptAlgorithm V_0 = Algorithm;
    switch (V_0)
    {
        case NLoptAlgorithm.LN_COBYLA:
        case NLoptAlgorithm.LN_AUGLAG:
        case NLoptAlgorithm.LD_AUGLAG:
        case NLoptAlgorithm.LN_AUGLAG_EQ:
        case NLoptAlgorithm.LD_AUGLAG_EQ:
        case NLoptAlgorithm.GN_ISRES:
        case NLoptAlgorithm.AUGLAG:
        case NLoptAlgorithm.AUGLAG_EQ:
        case NLoptAlgorithm.LD_SLSQP:
            return;
        case NLoptAlgorithm.LN_NEWUOA:
        case NLoptAlgorithm.LN_NEWUOA_BOUND:
        case NLoptAlgorithm.LN_NELDERMEAD:
        case NLoptAlgorithm.LN_SBPLX:
        case NLoptAlgorithm.LN_BOBYQA:
        case NLoptAlgorithm.G_MLSL:
        case NLoptAlgorithm.G_MLSL_LDS:
        default:
            throw new ArgumentException(string.Concat("Algorithm ", V_0.ToString(), " does not support equality constraint."));
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: False (`OpcodeDiff`; the original `sub` + `switch` sequence is
  preserved, with only a section-layout branch remaining)
- Taste applied: None
- Commit: `aa67be5b`

### Fully raised

The After decompilation is in the fully raised state.

### Style oracle

- Declared facet: runtime `.editorconfig` has
  `csharp_indent_switch_labels = true` (line 39) and
  `csharp_style_prefer_switch_expression = true:suggestion` (line 93), but is
  silent on enum normalization arithmetic and member-label recovery.
- Revealed facet: runtime writes direct enum switches with member labels, for
  example
  `src/coreclr/tools/aot/ILCompiler.ReadyToRun/Interop/IL/Marshaller.ReadyToRun.cs:11-19`
  and
  `src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/RecipientInfo.cs:16-24`.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass; 3 existing nullable warnings | Pass; same 3 warnings |
| Focused switch tests | 13 passed | 27 passed |
| Decompiler fast suite | 4,590 passed | 4,603 passed |
| Full non-corpus suite | — | Running on final review-fix head |
| Compiler switch-expression fidelity | Not present | Exact |
| Compiler statement fidelity | Not present | `sub` + `switch` preserved; only the fixture's pre-existing guard/section residual remains |
| Real witness | normalized arithmetic and wrong semantic member names | direct enum switch with correct members |

The real NLOpt method remains compile-back checkable and improves from
`sub; stloc; ldloc; switch; br` to `sub; switch; br`; the original is
`sub; switch`.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the pinned gate has no regressions, no pass bugs,
and no behavioral per-method deltas.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly; 15 assemblies and
1,500 methods.

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 16.83% | 16.83% | 0 pp |
| Conditional-branch residue (-) | 3.00% | 3.00% | 0 pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — all pinned-subset rates are unchanged.

### Aggregate context

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Detected lowering residue (-) | 234 / 15.60% | 232 / 15.47% |
| Conditional-branch residue (-) | 40 / 2.67% | 40 / 2.67% |
| Forward-merge stops (-) | 27 / 1.80% | 27 / 1.80% |
| Pass bugs (-) | 0 | 0 |

The aggregate population differs because rebuilt repo assemblies produced 32
paired additions and 32 removals. The full method delta contains no behavioral
row changes.

## Compatibility and non-action boundary

- The rewrite is restricted to unchecked `Add`/`Subtract`, an `int` constant,
  and an enum governing operand with known underlying-type evidence. Direct
  indirect loads recover enum identity from their by-ref/pointer pointee.
- Labels use unchecked 32-bit arithmetic, matching the IL switch's modulo-32
  dispatch for signed and unsigned enum representations. Narrow enum backings
  are folded only when every shifted label remains representable without
  truncation; wide or unresolved backings are declined.
- Default routing and sparse/repeated target grouping are unchanged.
- Enum aliases keep the first metadata-declared member name, matching existing
  printer behavior.
- Checked arithmetic, variable arithmetic, primitive arithmetic, and other
  binary operators are deliberately not folded.
