### PR TITLE
Update browser title with active package

### DIFF
--- a/prototypes/inspect-web/index.html
+++ b/prototypes/inspect-web/index.html
@@ -7,7 +7,7 @@
       name="description"
       content="A type-first, keyboard-driven browser prototype for dotnet-inspect."
     />
-    <title>System.Text.Json types — dotnet-inspect</title>
+    <title>dotnet-inspect -- Inspect any .NET package, right in the browser.</title>
     <link rel="stylesheet" href="/src/styles.css" />
     <link rel="preload" id="webassembly" />
     <script type="importmap"></script>

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -5059,6 +5059,7 @@ function buildStateUrl(base = location.href) {
 // back/forward buttons authoritative and avoids flooding browser history on every render.
 function syncUrl() {
   if (!state.package || state.loading) return;
+  document.title = `dotnet-inspect -- ${packageDisplayName(state.package)}`;
   try {
     history.replaceState(null, "", buildStateUrl().toString());
   } catch {
@@ -5164,6 +5165,7 @@ async function copyText(value, confirmation) {
 // (shared #spotlight-input / #spotlight-chips / #spotlight-results ids), so results, scope
 // chips, NuGet discovery, and result picking all behave exactly like the modal Spotlight.
 function renderHomeView() {
+  document.title = "dotnet-inspect -- Inspect any .NET package, right in the browser.";
   const results = spotlightResults();
   state.spotlightIndex = Math.min(state.spotlightIndex, Math.max(results.length - 1, 0));
   app.innerHTML = `


### PR DESCRIPTION
## Summary

- use the home H1 copy as the initial and home-page browser title
- show `dotnet-inspect -- <current package>` whenever the package URL is synchronized
- restore the home title on in-app navigation back home

## Evidence

- Release browser-Wasm publish succeeds
- browser regression covers home → System.Text.Json → Mono.Cecil → home, with title and URL assertions and no runtime exceptions

## Review

Trivial presentation change: two direct title assignments coupled to the existing home render and URL synchronization paths; no product behavior, identity, query, or data-shape changes. Adversarial review is not required.
