### PR TITLE
Expose product-owned API kind facets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
       - name: Run services tests
         run: dotnet run --project src/DotnetInspector.Services.Tests -c Release
 
-      - name: Run inspection workspace tests
+      - name: Run inspection query tests
         run: dotnet run --project src/DotnetInspector.Queries.Tests -c Release
 
       # NuGetFetch is the HTTP and credential layer. Its live-network tests are tagged
@@ -477,6 +477,10 @@ jobs:
       - name: Run services tests
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: dotnet run --project src/DotnetInspector.Services.Tests -c Release
+
+      - name: Run query tests
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project src/DotnetInspector.Queries.Tests -c Release
 
   # net10.0 fallback build coverage. The official non-AOT "any" package targets
   # the net10.0 LTS floor (Directory.Build.props), but the full test lane builds

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ Tests use xUnit executable projects. **Use `dotnet run`, not `dotnet test`**;
 | Analysis | `dotnet run --project src/ILInspector.Analysis.Tests -c Release` |
 | Decompiler | `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` |
 | C# text | `dotnet run --project tests/CSharpText.Tests -c Release` |
-| Inspection workspace | `dotnet run --project src/DotnetInspector.Queries.Tests -c Release` |
+| Inspection queries | `dotnet run --project src/DotnetInspector.Queries.Tests -c Release` |
 | Shared services | `dotnet run --project src/DotnetInspector.Services.Tests -c Release` |
 | Metadata and SourceLink | `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` |
 | Metadata rendering and `mdi` | `dotnet run --project tests/DotnetInspector.MetadataRendering.Tests -c Release` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -602,6 +602,7 @@ Research overlay bridge, and the application layer:
 │                                                             │
 │  Workspace and binding-consistent assembly context groups   │
 │  Typed per-assembly and group-query coordination             │
+│  ApiInventoryQuery          type/member inventory facets    │
 ├─────────────────────────────────────────────────────────────┤
 │  ILInspector.Research (Fact overlay bridge)                 │
 │                                                             │
@@ -822,6 +823,7 @@ src/dotnet-inspect/
 
 src/DotnetInspector.Services/   # Shared, app-agnostic services
 src/DotnetInspector.Packages/   # NuGet domain provider
+src/DotnetInspector.Queries/    # Typed inspection requests and results
 src/ILInspector.Metadata/       # PE/assembly domain provider
 src/ILInspector.CSharp/         # C# spelling and namespace/type views
 src/ILInspector.ControlFlow/    # Shared control-flow/dataflow kernels

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -394,8 +394,8 @@ the L2 project split still need migration.
 
 The structural fix is completing L1. Outside the metadata, direct-reference,
 extension-method, custom-attribute, manifest-resource, type-forwarder,
-union-type, switch, and SourceLink canaries, collection is still neither typed
-nor demand-driven:
+union-type, switch, SourceLink, and type/member inventory canaries, collection
+is still neither typed nor demand-driven:
 
 - Data collection **mutates a shared aggregate** rather than returning typed
   results for most scanner families, so a consumer cannot yet take those
@@ -410,10 +410,10 @@ nor demand-driven:
   cannot call the residual `LibraryMetadataService` orchestration. The
   implemented queries themselves take a borrowed content owner, not a path.
 
-Converting collection into typed, demand-driven, content-shaped queries is
-therefore the migration path for the split, not a follow-up to it. L2 is close
-to a project move as query coverage expands; the descriptor contract is already
-Markout-free apart from its name binding.
+Converting the remaining collection into typed, demand-driven, content-shaped
+queries is therefore the migration path for the split, not a follow-up to it.
+L2 is close to a project move as query coverage expands; the descriptor contract is
+already Markout-free apart from its name binding.
 
 ## Non-goals
 

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -66,6 +66,18 @@ of repeated in every row.
 | `ApiType`, `ApiMember`, `ApiParameter` | Materialized, JSON-capable API output | API inventory, presentation fields, and persisted identity projections | Reader-local resolution or body identity |
 | `MemberTargetSelector` | One member-selection request | The user's member question, including overload and digest syntax | Evidence that selection succeeded |
 
+#### `DotnetInspector.Queries`
+
+| Currency | Scope | Answers | Does not answer |
+| --- | --- | --- | --- |
+| `ApiFacetDescriptor`, `ApiTypeInventoryResult`, `ApiMemberInventoryResult` | One materialized API inventory query | Stable filter identity, labels, ordering, defaults, counts, and the selected projection | Raw metadata kind or member identity |
+
+`ApiType.Kind` and `ApiMember.Kind` remain raw product facts. Consumers do not
+parse them or own a parallel grouping vocabulary: `ApiInventoryQuery` maps each
+item into one product-owned kind facet and accepts the returned opaque IDs for
+filtering. Unknown IDs and unclassified producer values fail visibly rather
+than becoming an empty inventory.
+
 #### `ILInspector.Analysis`
 
 | Currency | Scope | Answers | Does not answer |

--- a/eng/CiChangeDetection/WorkflowContract.Consumers.cs
+++ b/eng/CiChangeDetection/WorkflowContract.Consumers.cs
@@ -144,6 +144,8 @@ internal static partial class WorkflowContract
                 "${{ !cancelled() && steps.build.outcome == 'success' }}",
             ["test-windows/Run services tests"] =
                 "${{ !cancelled() && steps.build.outcome == 'success' }}",
+            ["test-windows/Run query tests"] =
+                "${{ !cancelled() && steps.build.outcome == 'success' }}",
             ["decompiler-gates/Upload gate report"] = "always()",
             ["csharp-diff-smoke/Upload C# Diff smoke artifact"] = "always()",
             ["il-diff-smoke/Upload IL Diff smoke artifact"] = "always()",

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -131,6 +131,84 @@ public class ApiInventoryQueryTests
                 new ApiMemberInventoryRequest([operatorFacet.Id]))
             .Members,
             member => member.Name == "op_Addition");
+
+        var targetType = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(InventoryFixture).FullName);
+        var projected = Assert.Single(
+            targetType.Members,
+            member => member.Name == "op_Addition"
+                && member.DeclaringType == typeof(InventoryExtensions).FullName);
+        Assert.Equal("extension-method", projected.Kind);
+
+        var targetResult = ApiInventoryQuery.Members(targetType);
+        var extensionFacet = Assert.Single(
+            targetResult.KindFacets,
+            facet => facet.SingularLabel == "extension method");
+        Assert.Contains(
+            ApiInventoryQuery.Members(
+                targetType,
+                new ApiMemberInventoryRequest([extensionFacet.Id]))
+            .Members,
+            member => ReferenceEquals(member, projected));
+    }
+
+    [Fact]
+    public void Members_StaticConstructorUsesConstructorFacet()
+    {
+        using var inspection = AssemblyInspectionSession.Open(
+            typeof(ApiInventoryQueryTests).Assembly.Location);
+        var surface = inspection.ApiSurface(includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(InventoryFixture).FullName);
+        var staticConstructor = Assert.Single(
+            type.Members,
+            member => member.Name == ".cctor");
+
+        Assert.Equal("method", staticConstructor.Kind);
+
+        var result = ApiInventoryQuery.Members(type);
+        var constructorFacet = Assert.Single(
+            result.KindFacets,
+            facet => facet.SingularLabel == "constructor");
+        var methodFacet = Assert.Single(
+            result.KindFacets,
+            facet => facet.SingularLabel == "method");
+
+        Assert.Contains(
+            ApiInventoryQuery.Members(
+                type,
+                new ApiMemberInventoryRequest([constructorFacet.Id]))
+            .Members,
+            member => ReferenceEquals(member, staticConstructor));
+        Assert.DoesNotContain(
+            ApiInventoryQuery.Members(
+                type,
+                new ApiMemberInventoryRequest([methodFacet.Id]))
+            .Members,
+            member => ReferenceEquals(member, staticConstructor));
+    }
+
+    [Fact]
+    public void Types_PreservesPartialInspectionFailures()
+    {
+        var failure = new ApiSurfaceInspectionFailure(
+            "relationship",
+            0x02000001,
+            MetadataTypeNameFailureMechanism.Relationship,
+            "base-type",
+            "cycle");
+        var surface = new ApiSurface
+        {
+            Types = [new ApiType { Name = "C", Kind = "class" }],
+            InspectionFailures = [failure]
+        };
+
+        var result = ApiInventoryQuery.Types(surface);
+
+        Assert.Equal([failure], result.InspectionFailures);
+        Assert.NotSame(surface.InspectionFailures, result.InspectionFailures);
     }
 
     [Fact]
@@ -181,6 +259,8 @@ public sealed class InventoryFixture : IInventoryFixture
     public event EventHandler? Changed;
 
     public InventoryFixture() { }
+
+    static InventoryFixture() { }
 
     ~InventoryFixture() { }
 

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -102,6 +102,38 @@ public class ApiInventoryQueryTests
     }
 
     [Fact]
+    public void Members_CompilerProducedExtensionOperatorHasOneKindFacet()
+    {
+        using var inspection = AssemblyInspectionSession.Open(
+            typeof(ApiInventoryQueryTests).Assembly.Location);
+        var surface = inspection.ApiSurface(includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(InventoryExtensions).FullName);
+        var extensionOperator = Assert.Single(
+            type.Members,
+            member => member.Name == "op_Addition");
+
+        Assert.Equal("operator", extensionOperator.Kind);
+        Assert.True(extensionOperator.IsExtension);
+
+        var result = ApiInventoryQuery.Members(type);
+
+        var operatorFacet = Assert.Single(
+            result.KindFacets,
+            facet => facet.SingularLabel == "operator" && facet.Count == 1);
+        Assert.Single(
+            result.KindFacets,
+            facet => facet.SingularLabel == "extension method" && facet.Count == 1);
+        Assert.Single(
+            ApiInventoryQuery.Members(
+                type,
+                new ApiMemberInventoryRequest([operatorFacet.Id]))
+            .Members,
+            member => member.Name == "op_Addition");
+    }
+
+    [Fact]
     public void Selection_RejectsUnknownFacetIds()
     {
         var surface = new ApiSurface
@@ -163,6 +195,8 @@ public sealed class InventoryFixture : IInventoryFixture
 public static class InventoryExtensions
 {
     public static void Extend(this InventoryFixture fixture) => fixture.Method();
+
+    public static void op_Addition(this InventoryFixture fixture) => fixture.Method();
 }
 
 public struct InventoryStruct;

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -238,7 +238,15 @@ public class ApiInventoryQueryTests
         {
             Name = "Future",
             Kind = "class",
-            Members = [new ApiMember { Name = "Future", Kind = "future-kind" }]
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Future",
+                    Kind = "future-kind",
+                    IsConst = true
+                }
+            ]
         };
 
         Assert.Throws<InvalidOperationException>(() => ApiInventoryQuery.Types(surface));

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -1,0 +1,171 @@
+using DotnetInspector.Queries;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries.Tests;
+
+public class ApiInventoryQueryTests
+{
+    [Fact]
+    public void Types_DescriptorsDriveOrderedFiltering()
+    {
+        var surface = new ApiSurface
+        {
+            Types =
+            [
+                new ApiType { Name = "C", Kind = "class" },
+                new ApiType { Name = "S", Kind = "struct" },
+                new ApiType { Name = "I", Kind = "interface" },
+                new ApiType { Name = "E", Kind = "enum" },
+                new ApiType { Name = "D", Kind = "delegate" },
+                new ApiType { Name = "C2", Kind = "class" },
+            ]
+        };
+
+        var result = ApiInventoryQuery.Types(surface);
+
+        Assert.Equal(
+            ["class", "struct", "interface", "enum", "delegate"],
+            result.KindFacets.Select(facet => facet.SingularLabel));
+        Assert.Equal([2, 1, 1, 1, 1], result.KindFacets.Select(facet => facet.Count));
+        Assert.True(result.KindFacets.Select(facet => facet.Weight).SequenceEqual(
+            result.KindFacets.Select(facet => facet.Weight).Order()));
+        Assert.All(result.KindFacets, facet => Assert.True(facet.IsDefault));
+        Assert.Equal(surface.Types, result.Types);
+
+        foreach (var facet in result.KindFacets)
+        {
+            var filtered = ApiInventoryQuery.Types(
+                surface,
+                new ApiTypeInventoryRequest([facet.Id]));
+            Assert.Equal(facet.Count, filtered.Types.Count);
+        }
+
+        var firstTwo = result.KindFacets.Take(2).Select(facet => facet.Id).ToList();
+        var combined = ApiInventoryQuery.Types(
+            surface,
+            new ApiTypeInventoryRequest(firstTwo));
+        Assert.Equal(3, combined.Types.Count);
+
+        var defaults = ApiInventoryQuery.Types(
+            surface,
+            new ApiTypeInventoryRequest([]));
+        Assert.Equal(surface.Types, defaults.Types);
+    }
+
+    [Fact]
+    public void Members_RealMetadataShapesHaveProductOwnedFacets()
+    {
+        using var inspection = AssemblyInspectionSession.Open(
+            typeof(ApiInventoryQueryTests).Assembly.Location);
+        var surface = inspection.ApiSurface(includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(InventoryFixture).FullName);
+
+        var result = ApiInventoryQuery.Members(type);
+
+        Assert.Equal(
+            [
+                "constructor",
+                "finalizer",
+                "constant",
+                "field",
+                "property",
+                "method",
+                "operator",
+                "extension method",
+                "explicit implementation",
+                "event",
+            ],
+            result.KindFacets.Select(facet => facet.SingularLabel));
+
+        foreach (var facet in result.KindFacets)
+        {
+            var filtered = ApiInventoryQuery.Members(
+                type,
+                new ApiMemberInventoryRequest([facet.Id]));
+            Assert.Equal(facet.Count, filtered.Members.Count);
+        }
+
+        var constant = Assert.Single(result.KindFacets, facet => facet.SingularLabel == "constant");
+        var constants = ApiInventoryQuery.Members(
+            type,
+            new ApiMemberInventoryRequest([constant.Id]));
+        Assert.Contains(constants.Members, member => member.Name == nameof(InventoryFixture.Constant));
+        Assert.All(constants.Members, member => Assert.True(member.IsConst));
+
+        var extension = Assert.Single(result.KindFacets, facet => facet.SingularLabel == "extension method");
+        var extensions = ApiInventoryQuery.Members(
+            type,
+            new ApiMemberInventoryRequest([extension.Id]));
+        Assert.Contains(extensions.Members, member => member.Name == nameof(InventoryExtensions.Extend));
+    }
+
+    [Fact]
+    public void Selection_RejectsUnknownFacetIds()
+    {
+        var surface = new ApiSurface
+        {
+            Types = [new ApiType { Name = "C", Kind = "class" }]
+        };
+
+        var error = Assert.Throws<ArgumentException>(() =>
+            ApiInventoryQuery.Types(
+                surface,
+                new ApiTypeInventoryRequest(["consumer-invented-kind"])));
+
+        Assert.Contains("consumer-invented-kind", error.Message);
+    }
+
+    [Fact]
+    public void Classification_RejectsUnknownProducerKinds()
+    {
+        var surface = new ApiSurface
+        {
+            Types = [new ApiType { Name = "Future", Kind = "future-kind" }]
+        };
+        var type = new ApiType
+        {
+            Name = "Future",
+            Kind = "class",
+            Members = [new ApiMember { Name = "Future", Kind = "future-kind" }]
+        };
+
+        Assert.Throws<InvalidOperationException>(() => ApiInventoryQuery.Types(surface));
+        Assert.Throws<InvalidOperationException>(() => ApiInventoryQuery.Members(type));
+    }
+}
+
+public interface IInventoryFixture
+{
+    void Explicit();
+}
+
+public sealed class InventoryFixture : IInventoryFixture
+{
+    public const int Constant = 1;
+    public int Field;
+    public int Property { get; set; }
+    public event EventHandler? Changed;
+
+    public InventoryFixture() { }
+
+    ~InventoryFixture() { }
+
+    public void Method() => Changed?.Invoke(this, EventArgs.Empty);
+
+    void IInventoryFixture.Explicit() { }
+
+    public static InventoryFixture operator +(InventoryFixture left, InventoryFixture right)
+        => left;
+}
+
+public static class InventoryExtensions
+{
+    public static void Extend(this InventoryFixture fixture) => fixture.Method();
+}
+
+public struct InventoryStruct;
+public interface IInventoryType;
+public enum InventoryEnum;
+public delegate void InventoryDelegate();

--- a/src/DotnetInspector.Queries/ApiInventoryQuery.cs
+++ b/src/DotnetInspector.Queries/ApiInventoryQuery.cs
@@ -1,0 +1,208 @@
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// One product-owned filter facet for an API inventory.
+/// </summary>
+/// <param name="Id">
+/// Stable opaque identity. Consumers retain and submit this value without interpreting it.
+/// </param>
+/// <param name="SingularLabel">Display label for one result.</param>
+/// <param name="PluralLabel">Display label for zero or multiple results.</param>
+/// <param name="Weight">Producer-owned display order.</param>
+/// <param name="Count">Number of items in the unfiltered inventory that belong to this facet.</param>
+/// <param name="IsDefault">Whether this facet participates when no explicit selection is supplied.</param>
+public sealed record ApiFacetDescriptor(
+    string Id,
+    string SingularLabel,
+    string PluralLabel,
+    int Weight,
+    int Count,
+    bool IsDefault);
+
+/// <summary>
+/// Selects type-kind facets. Null or empty means the producer-declared defaults.
+/// </summary>
+public sealed record ApiTypeInventoryRequest(
+    IReadOnlyCollection<string>? KindFacetIds = null);
+
+/// <summary>
+/// Type inventory and the available type-kind facets for its unfiltered input.
+/// </summary>
+public sealed record ApiTypeInventoryResult(
+    IReadOnlyList<ApiType> Types,
+    IReadOnlyList<ApiFacetDescriptor> KindFacets);
+
+/// <summary>
+/// Selects member-kind facets. Null or empty means the producer-declared defaults.
+/// </summary>
+public sealed record ApiMemberInventoryRequest(
+    IReadOnlyCollection<string>? KindFacetIds = null);
+
+/// <summary>
+/// Member inventory and the available member-kind facets for its unfiltered input.
+/// </summary>
+public sealed record ApiMemberInventoryResult(
+    IReadOnlyList<ApiMember> Members,
+    IReadOnlyList<ApiFacetDescriptor> KindFacets);
+
+/// <summary>
+/// Product-owned type and member inventory queries.
+/// </summary>
+/// <remarks>
+/// Raw <see cref="ApiType.Kind"/> and <see cref="ApiMember.Kind"/> values remain metadata facts.
+/// This query owns the filter identity, grouping, labels, order, defaults, and application so a
+/// consumer never has to parse or classify those facts.
+/// </remarks>
+public static class ApiInventoryQuery
+{
+    sealed record FacetDefinition<T>(
+        string Id,
+        string SingularLabel,
+        string PluralLabel,
+        int Weight,
+        bool IsDefault,
+        Func<T, bool> Matches);
+
+    static readonly IReadOnlyList<FacetDefinition<ApiType>> TypeKindFacets =
+    [
+        new("api.type-kind.class", "class", "classes", 100, true, type => type.Kind == "class"),
+        new("api.type-kind.struct", "struct", "structs", 200, true, type => type.Kind == "struct"),
+        new("api.type-kind.interface", "interface", "interfaces", 300, true, type => type.Kind == "interface"),
+        new("api.type-kind.enum", "enum", "enums", 400, true, type => type.Kind == "enum"),
+        new("api.type-kind.delegate", "delegate", "delegates", 500, true, type => type.Kind == "delegate"),
+    ];
+
+    static readonly IReadOnlyList<FacetDefinition<ApiMember>> MemberKindFacets =
+    [
+        new("api.member-kind.constructor", "constructor", "constructors", 100, true,
+            member => member.Kind == "constructor"),
+        new("api.member-kind.finalizer", "finalizer", "finalizers", 200, true,
+            member => member.Kind == "finalizer"),
+        new("api.member-kind.constant", "constant", "constants", 300, true,
+            member => member.IsConst),
+        new("api.member-kind.field", "field", "fields", 400, true,
+            member => member.Kind == "field" && !member.IsConst),
+        new("api.member-kind.property", "property", "properties", 500, true,
+            member => member.Kind == "property"),
+        new("api.member-kind.method", "method", "methods", 600, true,
+            member => member.Kind == "method" && !member.IsExtension),
+        new("api.member-kind.operator", "operator", "operators", 700, true,
+            member => member.Kind == "operator"),
+        new("api.member-kind.extension-method", "extension method", "extension methods", 800, true,
+            member => member.Kind == "extension-method" || member.IsExtension),
+        new("api.member-kind.explicit-implementation", "explicit implementation", "explicit implementations", 900, true,
+            member => member.Kind == "explicit-interface-implementation"),
+        new("api.member-kind.event", "event", "events", 1000, true,
+            member => member.Kind == "event"),
+    ];
+
+    /// <summary>
+    /// Returns the available ordered type-kind descriptors and the projection selected by their
+    /// opaque IDs.
+    /// </summary>
+    public static ApiTypeInventoryResult Types(
+        ApiSurface surface,
+        ApiTypeInventoryRequest? request = null)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+
+        var descriptors = Describe(surface.Types, TypeKindFacets, "type");
+        var selected = SelectIds(request?.KindFacetIds, TypeKindFacets);
+        var types = surface.Types
+            .Where(type => selected.Contains(Classify(type, TypeKindFacets, "type")))
+            .ToList();
+        return new ApiTypeInventoryResult(types, descriptors);
+    }
+
+    /// <summary>
+    /// Returns the available ordered member-kind descriptors and the projection selected by their
+    /// opaque IDs.
+    /// </summary>
+    public static ApiMemberInventoryResult Members(
+        ApiType type,
+        ApiMemberInventoryRequest? request = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        var descriptors = Describe(type.Members, MemberKindFacets, "member");
+        var selected = SelectIds(request?.KindFacetIds, MemberKindFacets);
+        var members = type.Members
+            .Where(member => selected.Contains(Classify(member, MemberKindFacets, "member")))
+            .ToList();
+        return new ApiMemberInventoryResult(members, descriptors);
+    }
+
+    static IReadOnlyList<ApiFacetDescriptor> Describe<T>(
+        IReadOnlyList<T> items,
+        IReadOnlyList<FacetDefinition<T>> definitions,
+        string subject)
+    {
+        Dictionary<string, int> counts = new(StringComparer.Ordinal);
+        foreach (var item in items)
+        {
+            var id = Classify(item, definitions, subject);
+            counts[id] = counts.GetValueOrDefault(id) + 1;
+        }
+
+        return definitions
+            .Where(definition => counts.ContainsKey(definition.Id))
+            .Select(definition => new ApiFacetDescriptor(
+                definition.Id,
+                definition.SingularLabel,
+                definition.PluralLabel,
+                definition.Weight,
+                counts[definition.Id],
+                definition.IsDefault))
+            .ToList();
+    }
+
+    static HashSet<string> SelectIds<T>(
+        IReadOnlyCollection<string>? requested,
+        IReadOnlyList<FacetDefinition<T>> definitions)
+    {
+        var known = definitions.Select(definition => definition.Id).ToHashSet(StringComparer.Ordinal);
+        if (requested is null || requested.Count == 0)
+        {
+            return definitions
+                .Where(definition => definition.IsDefault)
+                .Select(definition => definition.Id)
+                .ToHashSet(StringComparer.Ordinal);
+        }
+
+        var selected = requested.ToHashSet(StringComparer.Ordinal);
+        var unknown = selected.Where(id => !known.Contains(id)).Order(StringComparer.Ordinal).ToList();
+        if (unknown.Count > 0)
+        {
+            throw new ArgumentException(
+                $"Unknown facet ID{(unknown.Count == 1 ? "" : "s")}: {string.Join(", ", unknown)}.",
+                nameof(requested));
+        }
+
+        return selected;
+    }
+
+    static string Classify<T>(
+        T item,
+        IReadOnlyList<FacetDefinition<T>> definitions,
+        string subject)
+    {
+        FacetDefinition<T>? match = null;
+        foreach (var definition in definitions)
+        {
+            if (!definition.Matches(item))
+                continue;
+            if (match is not null)
+            {
+                throw new InvalidOperationException(
+                    $"The product-owned facet catalog classifies this {subject} more than once.");
+            }
+            match = definition;
+        }
+
+        return match?.Id
+            ?? throw new InvalidOperationException(
+                $"The product-owned facet catalog does not classify this {subject}.");
+    }
+}

--- a/src/DotnetInspector.Queries/ApiInventoryQuery.cs
+++ b/src/DotnetInspector.Queries/ApiInventoryQuery.cs
@@ -91,7 +91,8 @@ public static class ApiInventoryQuery
         new("api.member-kind.operator", "operator", "operators", 700, true,
             member => member.Kind == "operator"),
         new("api.member-kind.extension-method", "extension method", "extension methods", 800, true,
-            member => member.Kind == "extension-method" || member.IsExtension),
+            member => member.Kind == "extension-method"
+                || (member.IsExtension && member.Kind == "method")),
         new("api.member-kind.explicit-implementation", "explicit implementation", "explicit implementations", 900, true,
             member => member.Kind == "explicit-interface-implementation"),
         new("api.member-kind.event", "event", "events", 1000, true,

--- a/src/DotnetInspector.Queries/ApiInventoryQuery.cs
+++ b/src/DotnetInspector.Queries/ApiInventoryQuery.cs
@@ -32,7 +32,8 @@ public sealed record ApiTypeInventoryRequest(
 /// </summary>
 public sealed record ApiTypeInventoryResult(
     IReadOnlyList<ApiType> Types,
-    IReadOnlyList<ApiFacetDescriptor> KindFacets);
+    IReadOnlyList<ApiFacetDescriptor> KindFacets,
+    IReadOnlyList<ApiSurfaceInspectionFailure> InspectionFailures);
 
 /// <summary>
 /// Selects member-kind facets. Null or empty means the producer-declared defaults.
@@ -77,7 +78,7 @@ public static class ApiInventoryQuery
     static readonly IReadOnlyList<FacetDefinition<ApiMember>> MemberKindFacets =
     [
         new("api.member-kind.constructor", "constructor", "constructors", 100, true,
-            member => member.Kind == "constructor"),
+            IsConstructor),
         new("api.member-kind.finalizer", "finalizer", "finalizers", 200, true,
             member => member.Kind == "finalizer"),
         new("api.member-kind.constant", "constant", "constants", 300, true,
@@ -87,7 +88,7 @@ public static class ApiInventoryQuery
         new("api.member-kind.property", "property", "properties", 500, true,
             member => member.Kind == "property"),
         new("api.member-kind.method", "method", "methods", 600, true,
-            member => member.Kind == "method" && !member.IsExtension),
+            member => member.Kind == "method" && !member.IsExtension && !IsStaticConstructor(member)),
         new("api.member-kind.operator", "operator", "operators", 700, true,
             member => member.Kind == "operator"),
         new("api.member-kind.extension-method", "extension method", "extension methods", 800, true,
@@ -114,7 +115,7 @@ public static class ApiInventoryQuery
         var types = surface.Types
             .Where(type => selected.Contains(Classify(type, TypeKindFacets, "type")))
             .ToList();
-        return new ApiTypeInventoryResult(types, descriptors);
+        return new ApiTypeInventoryResult(types, descriptors, [.. surface.InspectionFailures]);
     }
 
     /// <summary>
@@ -206,4 +207,10 @@ public static class ApiInventoryQuery
             ?? throw new InvalidOperationException(
                 $"The product-owned facet catalog does not classify this {subject}.");
     }
+
+    static bool IsConstructor(ApiMember member)
+        => member.Kind == "constructor" || IsStaticConstructor(member);
+
+    static bool IsStaticConstructor(ApiMember member)
+        => member is { Kind: "method", Name: ".cctor" };
 }

--- a/src/DotnetInspector.Queries/ApiInventoryQuery.cs
+++ b/src/DotnetInspector.Queries/ApiInventoryQuery.cs
@@ -82,7 +82,7 @@ public static class ApiInventoryQuery
         new("api.member-kind.finalizer", "finalizer", "finalizers", 200, true,
             member => member.Kind == "finalizer"),
         new("api.member-kind.constant", "constant", "constants", 300, true,
-            member => member.IsConst),
+            member => member.Kind == "field" && member.IsConst),
         new("api.member-kind.field", "field", "fields", 400, true,
             member => member.Kind == "field" && !member.IsConst),
         new("api.member-kind.property", "property", "properties", 500, true,


### PR DESCRIPTION
## Change

**Conclusion:** type and member inventories now expose product-owned kind facets and apply opaque selected IDs without requiring consumers to parse `ApiType.Kind`, `ApiMember.Kind`, or modifier strings.

This is **slice 1/3** of the descriptor stack:

1. **This PR — #3863:** establish `DotnetInspector.Queries` and kind-facet descriptors/filtering.
2. **Residual — #3864:** effective inspection view descriptors.
3. **Residual — #3865:** accessibility facet descriptors/filtering.

Parent: `main`. The later slices will target this branch in order.

The descriptors own stable IDs, singular/plural labels, weights, counts, and default selection. The closed product catalog classifies classes, structs, interfaces, enums, delegates, constructors, finalizers, constants, fields, properties, methods, operators, extension methods, explicit implementations, and events. Unknown selected IDs and unclassified producer values fail visibly.

## Evidence

- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release` — 4 passed.
- `dotnet build dotnet-inspect.slnx -c Release` — succeeded.
- The real-metadata fixture proves every current member shape is descriptor-driven and each descriptor count equals the result of applying its returned ID.

## Compatibility and boundary

Raw `ApiType.Kind` / `ApiMember.Kind` facts remain unchanged. This slice does not alter CLI defaults or output. Per the requested scope, browser adoption on `prototype/wasm-command-ui` is deferred; this PR supplies the product API that adoption will consume.

Closes #3863