### PR TITLE
Unify caller graph traversal domains

### DIFF
--- a/docs/design/call-graph-projection.md
+++ b/docs/design/call-graph-projection.md
@@ -90,7 +90,12 @@ The projection owns everything a host must not re-invent in JavaScript:
 - **Deterministic ids/ordering.** The focus is id `0`; remaining ids are assigned
   in first-seen order over a caller depth-first walk, then a callee walk. Nodes
   are emitted in id order and edges in first-seen order, so the same input
-  always yields an identical projection.
+  always yields an identical projection. Both the cheap assembly-local caller
+  tree and the catalog caller tree order inbound edges by assembly name,
+  qualified member identity, physical definition identity, and call-site
+  offset. Requesting an otherwise noncontributing catalog scope therefore does
+  not change sibling order, revisit placement, or which nodes fit in a bounded
+  traversal.
 - **Cycles and duplicates.** The bounded tree marks re-encountered members
   `AlreadyShown`; the projection collapses them onto the existing node and still
   records the edge, so a cycle `A → B → A` is two edges between two nodes.

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -832,44 +832,98 @@ public class LibraryBodyIndexTests
             => node.Perf?.Source == source || node.Children.Any(child => HasSource(child, source));
     }
 
-    // #3331: the scoped and unscoped builders key the reverse graph differently (structural member
-    // identity vs assembly-local tokens) and do not produce the same tree. Prefiltering scope
-    // assemblies on assembly identity therefore must not be allowed to decide which builder runs,
-    // or narrowing a scope to nothing would silently change the answer instead of just costing
-    // less. An empty-but-supplied scope list means "cross-assembly walk requested, nothing
-    // survived"; only a null list means "no scope requested".
-    //
-    // The catalog graph owns cross-assembly identity and deterministic ordering. Prefiltering
-    // every additional assembly away must still select that requested domain.
+    // #3351: requesting a catalog scope that contributes no callers must not change the
+    // same-assembly tree. The catalog graph remains selected for a scoped request, but its local
+    // node identity, ordering, revisit, and budget behavior must agree with the cheap token graph.
     [Fact]
-    public void BuildCallerTree_PrefilteringScopeAssembliesNeverChangesTheTree()
+    public void BuildCallerTree_NonContributingCatalogScopeMatchesSameAssemblyTree()
     {
         var index = LibraryBodyIndex.Open(typeof(LibraryBodyIndex).Assembly.Location);
 
         // A fixture that does not reference the analysis assembly, so it can never contribute a
         // caller. Opening it and prefiltering it away must be indistinguishable.
         var nonContributing = LibraryBodyIndex.Open(FixtureCatalog.AnalysisCallerGraphLookalikeCaller.AssemblyPath());
+        using CatalogCallGraphScope scopeOpened =
+            CatalogCallGraphTestExtensions.CreateScope(index, [nonContributing]);
+        using CatalogCallGraphScope scopePrefilteredAway =
+            CatalogCallGraphTestExtensions.CreateScope(index, []);
 
-        int discriminating = 0;
         int visited = 0;
-        foreach (var method in index.Methods.Take(60))
+        int alreadyShown = 0;
+        int truncated = 0;
+        int loopEdges = 0;
+        var mismatches = new List<string>();
+        (int MaxDepth, int MaxNodes)[] traversals =
+            [(2, 50), (3, 5)];
+        foreach (var method in index.DeclaredMethods)
         {
-            var noScopeRequested = FlattenCallTree(index.BuildCallerTree(method.MetadataToken, callerScopes: null, maxDepth: 2, maxNodes: 50));
-            var scopeOpened = FlattenCallTree(index.BuildCallerTree(method.MetadataToken, new[] { nonContributing }, maxDepth: 2, maxNodes: 50));
-            var scopePrefilteredAway = FlattenCallTree(index.BuildCallerTree(method.MetadataToken, Array.Empty<LibraryBodyIndex>(), maxDepth: 2, maxNodes: 50));
+            foreach ((int maxDepth, int maxNodes) in traversals)
+            {
+                CallTreeNode tokenTree = index.BuildCallerTree(
+                    method.MetadataToken,
+                    maxDepth,
+                    maxNodes);
+                var noScopeRequested = FlattenCallTree(
+                    tokenTree,
+                    includePerf: true);
+                var opened = FlattenCallTree(
+                    scopeOpened.BuildCallerTree(
+                        index,
+                        method.MetadataToken,
+                        maxDepth,
+                        maxNodes),
+                    includePerf: true);
+                var prefilteredAway = FlattenCallTree(
+                    scopePrefilteredAway.BuildCallerTree(
+                        index,
+                        method.MetadataToken,
+                        maxDepth,
+                        maxNodes),
+                    includePerf: true);
 
-            Assert.Equal(scopeOpened, scopePrefilteredAway);
+                Assert.Equal(opened, prefilteredAway);
+                if (!noScopeRequested.SequenceEqual(prefilteredAway))
+                {
+                    mismatches.Add(
+                        $"{method.DeclaringType.Name}.{method.Name} "
+                        + $"(depth {maxDepth}, nodes {maxNodes})"
+                        + $"{Environment.NewLine}same assembly:"
+                        + $"{Environment.NewLine}{string.Join(Environment.NewLine, noScopeRequested)}"
+                        + $"{Environment.NewLine}catalog:"
+                        + $"{Environment.NewLine}{string.Join(Environment.NewLine, prefilteredAway)}");
+                }
 
-            visited++;
-            if (!noScopeRequested.SequenceEqual(scopePrefilteredAway))
-                discriminating++;
+                alreadyShown += CountStatus(
+                    tokenTree,
+                    CallTreeStatus.AlreadyShown);
+                truncated += CountStatus(
+                    tokenTree,
+                    CallTreeStatus.Truncated);
+                loopEdges += CountLoopEdges(tokenTree);
+                visited++;
+            }
         }
 
         Assert.True(visited > 0, "expected to visit methods");
+        Assert.True(alreadyShown > 0, "expected to compare revisit placement");
+        Assert.True(truncated > 0, "expected to compare budget truncation");
+        Assert.True(loopEdges > 0, "expected to compare loop-edge retention");
         Assert.True(
-            discriminating > 0,
-            "no method distinguished the catalog graph from the same-assembly graph, "
-                + "so this test cannot gate the prefilter's identity-domain choice");
+            mismatches.Count == 0,
+            $"{mismatches.Count} mismatches:{Environment.NewLine}"
+                + string.Join(
+                    $"{Environment.NewLine}---{Environment.NewLine}",
+                    mismatches));
+
+        static int CountStatus(
+            CallTreeNode node,
+            CallTreeStatus status) =>
+            (node.Status == status ? 1 : 0)
+                + node.Children.Sum(child => CountStatus(child, status));
+
+        static int CountLoopEdges(CallTreeNode node) =>
+            (node.Perf?.InLoop == true ? 1 : 0)
+                + node.Children.Sum(CountLoopEdges);
     }
 
     // #3331: the same claim against the cross-assembly fixtures the matcher tests use — an assembly
@@ -1281,17 +1335,45 @@ public class LibraryBodyIndexTests
         Assert.Equal(2, tree.Perf?.Fanout);
     }
 
-    static List<string> FlattenCallTree(CallTreeNode root)
+    static List<string> FlattenCallTree(
+        CallTreeNode root,
+        bool includePerf = false)
     {
         var lines = new List<string>();
         void Walk(CallTreeNode node, int depth)
         {
-            lines.Add($"{depth}|{node.Member.Name}|{node.Status}|{node.Perf?.Source ?? ""}");
+            lines.Add(includePerf
+                ? $"{depth}|{MemberIdentity(node.Member)}"
+                    + $"|kind={node.Kind}"
+                    + $"|status={node.Status}"
+                    + $"|fanin={node.Perf?.Fanin}"
+                    + $"|max-depth={node.Perf?.MaxDepth}"
+                    + $"|in-loop={node.Perf?.InLoop}"
+                    + $"|root-kind={node.Perf?.RootKind}"
+                    + $"|source={node.Perf?.Source}"
+                : $"{depth}|{node.Member.Name}|{node.Status}|"
+                    + $"{node.Perf?.Source ?? ""}");
             foreach (var child in node.Children)
                 Walk(child, depth + 1);
         }
         Walk(root, 0);
         return lines;
+
+        static string MemberIdentity(MemberRef member) =>
+            $"{GenericMemberIdentity.KeyFragment(member.DeclaringType)}"
+            + $"::{member.Name}"
+            + $"|arity={member.GenericArity}"
+            + $"|parameters={TypeKeys(member.ParameterTypes)}"
+            + $"|return={GenericMemberIdentity.KeyFragment(member.ReturnType)}"
+            + $"|type-arguments={TypeKeys(member.TypeArguments)}"
+            + $"|has-this={member.HasThis}"
+            + $"|signature-header={member.SignatureHeader}"
+            + $"|required-parameters={member.RequiredParameterCount}"
+            + $"|open-parameters={TypeKeys(member.OpenParameterTypes)}"
+            + $"|open-return={GenericMemberIdentity.KeyFragment(member.OpenSignatureReturn)}";
+
+        static string TypeKeys(IEnumerable<TypeRef> types) =>
+            string.Join(",", types.Select(GenericMemberIdentity.KeyFragment));
     }
 
     // #1741 (unit): the key fragment for a type includes its assembly, so same-FQN types

--- a/src/ILInspector.Analysis/CallTree.cs
+++ b/src/ILInspector.Analysis/CallTree.cs
@@ -65,6 +65,10 @@ public sealed record CallTreePerf(
 
 static class CallTreeMember
 {
+    internal static string ToQualifiedDisplayString(
+        MethodIdentity method) =>
+        $"{method.DeclaringType.ToQualifiedDisplayString()}::{method.Name}";
+
     internal static MemberRef FromDefinition(MethodIdentity method) =>
         new(
             method.DeclaringType,
@@ -82,4 +86,23 @@ static class CallTreeMember
             OpenParameterTypes = method.ParameterTypes,
             OpenReturnType = method.ReturnType,
         };
+}
+
+static class CallTreeOrdering
+{
+    internal static IOrderedEnumerable<T> OrderCallers<T>(
+        IEnumerable<T> edges,
+        Func<T, string> assemblyName,
+        Func<T, string> qualifiedDisplayName,
+        Func<T, int> parameterCount,
+        Func<T, Guid> moduleVersionId,
+        Func<T, int> methodToken,
+        Func<T, int> ilOffset) =>
+        edges
+            .OrderBy(assemblyName, StringComparer.Ordinal)
+            .ThenBy(qualifiedDisplayName, StringComparer.Ordinal)
+            .ThenBy(parameterCount)
+            .ThenBy(moduleVersionId)
+            .ThenBy(methodToken)
+            .ThenBy(ilOffset);
 }

--- a/src/ILInspector.Analysis/CatalogCallGraphScope.cs
+++ b/src/ILInspector.Analysis/CatalogCallGraphScope.cs
@@ -1049,20 +1049,13 @@ public sealed class CatalogCallGraphScope : IDisposable
 
         static IOrderedEnumerable<StoredEdge> OrderReverseEdges(
             IEnumerable<StoredEdge> edges) =>
-            edges
-                .OrderBy(
+            CallTreeOrdering.OrderCallers(
+                    edges,
                     edge => edge.Caller.Participant.Assembly.Identity.Name,
-                    StringComparer.Ordinal)
-                .ThenBy(
                     edge => edge.Caller.Member.ToQualifiedDisplayString(),
-                    StringComparer.Ordinal)
-                .ThenBy(
-                    edge => edge.Caller.Member.ParameterTypes.Length)
-                .ThenBy(
-                    edge => edge.Caller.Evidence.Storage.ModuleVersionId)
-                .ThenBy(
-                    edge => edge.Caller.Evidence.Storage.MethodToken)
-                .ThenBy(
+                    edge => edge.Caller.Member.ParameterTypes.Length,
+                    edge => edge.Caller.Evidence.Storage.ModuleVersionId,
+                    edge => edge.Caller.Evidence.Storage.MethodToken,
                     edge => edge.Callee.Evidence.Storage.ILOffset);
 
         sealed class PlanEntry(

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1064,7 +1064,15 @@ public sealed class LibraryBodyIndex
             .Where(group => group.Key != 0)
             .ToDictionary(
                 group => group.Key,
-                group => group
+                group => CallTreeOrdering.OrderCallers(
+                        group,
+                        call => call.Caller.AssemblyName,
+                        call => CallTreeMember.ToQualifiedDisplayString(
+                            call.Caller),
+                        call => call.Caller.ParameterTypes.Length,
+                        call => call.Caller.ModuleVersionId,
+                        call => call.Caller.MetadataToken,
+                        call => call.ILOffset)
                     .GroupBy(call => call.Caller.MetadataToken)
                     .Select(callerGroup => callerGroup.FirstOrDefault(call => call.InLoop) ?? callerGroup.First())
                     .ToImmutableArray(),
@@ -1490,11 +1498,11 @@ public sealed class LibraryBodyIndex
     /// </summary>
     public CallTreeNode BuildCallerTree(int rootMethodToken, int maxDepth = 3, int maxNodes = 25)
     {
-        var root = Methods.FirstOrDefault(method => method.MetadataToken == rootMethodToken);
-        // When the selected method has no body of its own (abstract/interface/extern) it is
-        // absent from Methods, but its callers reference it by operand token and carry the
-        // resolved callee signature. Recover the root label from any such inbound edge so the
-        // graph names the member instead of printing a bare token.
+        var root = DeclaredMethods.FirstOrDefault(
+            method => method.MetadataToken == rootMethodToken);
+        // DeclaredMethods supplies the label even when the selected method has no body of its
+        // own. For a token with no local declaration, recover the label from an inbound edge so
+        // the graph can still name the member instead of printing a bare token.
         var rootMember = root is { } identity
             ? CallTreeMember.FromDefinition(identity)
             : DirectCalls.FirstOrDefault(call => call.CalleeDefinitionToken == rootMethodToken
@@ -1536,7 +1544,15 @@ public sealed class LibraryBodyIndex
                     .Where(group => group.Key != 0)
                     .ToDictionary(
                         group => group.Key,
-                        group => group
+                        group => CallTreeOrdering.OrderCallers(
+                                group,
+                                call => call.Caller.AssemblyName,
+                                call => CallTreeMember.ToQualifiedDisplayString(
+                                    call.Caller),
+                                call => call.Caller.ParameterTypes.Length,
+                                call => call.Caller.ModuleVersionId,
+                                call => call.Caller.MetadataToken,
+                                call => call.ILOffset)
                             .GroupBy(call => call.Caller.MetadataToken)
                             .Select(callerGroup => callerGroup.FirstOrDefault(call => call.InLoop) ?? callerGroup.First())
                             .ToImmutableArray(),


### PR DESCRIPTION
## Outcome

Same-assembly caller trees are now identical whether they use the cheap token traversal or a catalog scope with no contributing external callers. Both paths share the catalog's semantic caller-edge order, so sibling order, revisit placement, loop retention, and budget truncation no longer depend on whether a scope was requested.

Bodiless declared roots also take their label from `DeclaredMethods`, matching catalog definitions instead of falling back to an unsupported token when no inbound edge exists.

Closes #3351.

## Evidence

- The acceptance gate compares every declared Analysis method through token traversal, an opened noncontributing scope, and a prefiltered-empty catalog scope.
- It exercises both normal and tight budgets and requires non-vacuous `AlreadyShown`, `Truncated`, and loop-edge cases.
- The pre-fix gate reported eight ordering mismatches in the first 60 methods; after ordering was aligned, the expanded gate exposed and then pinned two bodiless-root labeling mismatches.
- Catalog traversal ordering itself is unchanged; only the assembly-local path adopts that existing semantic order.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`: passed
- `ILInspector.Analysis.Tests`: 567/567
- Focused CLI call-graph tests: 30/30
- `markdownlint docs/design/call-graph-projection.md`: passed
- Full CLI suite: 3033 total, 14 known baseline failures, 40 environment/tooling skips

## Compatibility boundary

The cheap token path remains cheap and cached; it does not construct or retain a catalog. Cross-library callers, correspondence identity, projection, and Mermaid reuse are unchanged. The intentional user-visible change is deterministic sibling ordering on unscoped caller trees plus correct labels for declared bodiless roots.